### PR TITLE
Fix Polaris config save isolation

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1518,6 +1518,7 @@ namespace config {
 
   int parse(int argc, char *argv[]) {
     std::unordered_map<std::string, std::string> cmd_vars;
+    bool config_file_from_cli = false;
 #ifdef _WIN32
     bool shortcut_launch = false;
     bool service_admin_launch = false;
@@ -1555,6 +1556,7 @@ namespace config {
         auto pos = std::find(line, line_end, '=');
         if (pos == line_end) {
           sunshine.config_file = line;
+          config_file_from_cli = true;
         } else {
           TUPLE_EL(var, 1, parse_option(line, line_end));
           if (!var) {
@@ -1577,14 +1579,22 @@ namespace config {
     bool config_loaded = false;
     try {
       // Create appdata folder if it does not exist
-      file_handler::make_directory(platf::appdata().string());
+      const auto appdata_dir = platf::appdata();
+      file_handler::make_directory(appdata_dir.string());
 
-      // Migration: if the new polaris.conf doesn't exist but the old sunshine.conf does, use the old path
-      if (!fs::exists(sunshine.config_file)) {
-        auto old_config = platf::appdata().string() + "/sunshine.conf";
+      // Migration: if an older Polaris build left a Sunshine-named config in
+      // Polaris's own config directory, copy it to polaris.conf once. Keep the
+      // active config path on polaris.conf so future saves are independent.
+      if (!config_file_from_cli && !fs::exists(sunshine.config_file)) {
+        const auto old_config = appdata_dir / "sunshine.conf";
         if (fs::exists(old_config)) {
-          BOOST_LOG(info) << "Migrating config: using existing " << old_config << " (rename to " << sunshine.config_file << " when convenient)";
-          sunshine.config_file = old_config;
+          std::error_code ec;
+          fs::copy_file(old_config, sunshine.config_file, fs::copy_options::none, ec);
+          if (ec) {
+            BOOST_LOG(warning) << "Could not migrate legacy config " << old_config << " to " << sunshine.config_file << ": " << ec.message();
+          } else {
+            BOOST_LOG(info) << "Migrated legacy config from " << old_config << " to " << sunshine.config_file;
+          }
         }
       }
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2367,7 +2367,12 @@ namespace confighttp {
         }
         config_stream << key << " = " << value << std::endl;
       }
-      file_handler::write_file(config::sunshine.config_file.c_str(), config_stream.str());
+      if (file_handler::write_file(config::sunshine.config_file.c_str(), config_stream.str()) != 0) {
+        const std::string message = "Failed to write config file: " + config::sunshine.config_file;
+        BOOST_LOG(error) << "SaveConfig: "sv << message;
+        bad_request(response, request, message);
+        return;
+      }
       output_tree["status"] = true;
       send_response(response, output_tree);
     } catch (std::exception &e) {

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -277,15 +277,18 @@ namespace platf {
         config_path = fs::path(homedir) / ".config/polaris"sv;
       }
 
-      // Migration: if the new polaris config dir doesn't exist but old sunshine dir does,
-      // copy the contents and remove the old directory (no more symlink dance).
-      // If polaris dir IS a symlink to sunshine, resolve it to a real directory.
+      migrate_envvar = getenv("POLARIS_MIGRATE_CONFIG");
+      const bool explicit_migration = migrate_envvar && strcmp(migrate_envvar, "1") == 0;
+
+      // Migration: only copy a Sunshine config directory when explicitly requested.
+      // Polaris and Sunshine can be installed side by side, so the default startup
+      // path must not move or delete Sunshine's active configuration.
       {
         std::error_code ec;
         fs::path old_sunshine_path = config_path.parent_path() / "sunshine";
 
-        // Case 1: polaris dir is a symlink to sunshine — replace with real copy
-        if (fs::is_symlink(config_path, ec) && fs::exists(old_sunshine_path, ec)) {
+        // Case 1: polaris dir is a symlink to sunshine — replace with real copy.
+        if (explicit_migration && fs::is_symlink(config_path, ec) && fs::exists(old_sunshine_path, ec)) {
           std::cout << "Migrating config: replacing symlink with real directory" << std::endl;
           fs::remove(config_path, ec);  // remove the symlink itself
           if (!ec) {
@@ -295,34 +298,28 @@ namespace platf {
             fs::copy(old_sunshine_path, config_path,
                      fs::copy_options::recursive | fs::copy_options::overwrite_existing, ec);
           }
-          if (!ec) {
-            fs::remove_all(old_sunshine_path, ec);  // clean up old dir
-            if (ec) {
-              std::cout << "Note: could not remove old sunshine dir: " << ec.message() << std::endl;
-            }
-          }
         }
-        // Case 2: polaris dir doesn't exist at all, sunshine does — copy over
-        else if (!fs::exists(config_path, ec) && fs::exists(old_sunshine_path, ec)) {
+        // Case 2: polaris dir doesn't exist at all, sunshine does — copy over.
+        else if (explicit_migration && !fs::exists(config_path, ec) && fs::exists(old_sunshine_path, ec)) {
           std::cout << "Migrating config from " << old_sunshine_path << " to " << config_path << std::endl;
           fs::create_directories(config_path, ec);
           if (!ec) {
             fs::copy(old_sunshine_path, config_path,
                      fs::copy_options::recursive | fs::copy_options::overwrite_existing, ec);
           }
-          if (!ec) {
-            fs::remove_all(old_sunshine_path, ec);
-          }
           if (ec) {
             std::cout << "Migration warning: " << ec.message() << std::endl;
             config_path = old_sunshine_path;  // fallback
           }
+        } else if (!fs::exists(config_path, ec) && fs::exists(old_sunshine_path, ec)) {
+          std::cout << "Found Sunshine config at " << old_sunshine_path
+                    << "; Polaris will create a separate config at " << config_path
+                    << ". Set POLARIS_MIGRATE_CONFIG=1 to copy Sunshine settings." << std::endl;
         }
       }
 
       // migrate from the old config location if necessary
-      migrate_envvar = getenv("POLARIS_MIGRATE_CONFIG");
-      if (migrate_config && found && migrate_envvar && strcmp(migrate_envvar, "1") == 0) {
+      if (migrate_config && found && explicit_migration) {
         std::error_code ec;
         fs::path old_config_path = fs::path(homedir) / ".config/sunshine"sv;
         if (old_config_path != config_path && fs::exists(old_config_path, ec)) {
@@ -336,16 +333,6 @@ namespace platf {
               // Copy the old directory into the new location
               // NB: We use a copy instead of a move so that cross-volume migrations work
               fs::copy(old_config_path, config_path, fs::copy_options::recursive | fs::copy_options::copy_symlinks, ec);
-            }
-            if (!ec) {
-              // If the copy was successful, delete the original directory
-              fs::remove_all(old_config_path, ec);
-              if (ec) {
-                std::cerr << "Failed to clean up old config directory: " << ec.message() << std::endl;
-
-                // This is not fatal. Next time we start, we'll warn the user to delete the old one.
-                ec.clear();
-              }
             }
             if (ec) {
               std::cerr << "Migration failed: " << ec.message() << std::endl;

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -219,6 +219,7 @@ let restartReloadTimeout = null
 let restartReloadInterval = null
 let restartReloadFallbackTimeout = null
 const writeOnlySecrets = {
+  api_key: { presentFlag: 'has_api_key' },
   ai_api_key: { presentFlag: 'has_ai_api_key', clearFlag: 'clear_ai_api_key' },
   steamgriddb_api_key: { presentFlag: 'has_steamgriddb_api_key', clearFlag: 'clear_steamgriddb_api_key' },
 }
@@ -688,7 +689,6 @@ function serialize() {
 
 function finalizeWriteOnlySecrets(configCopy) {
   Object.entries(writeOnlySecrets).forEach(([secretKey, meta]) => {
-    const hasStoredSecret = !!config.value?.[meta.presentFlag]
     const clearRequested = !!config.value?.[meta.clearFlag]
     const nextValue = configCopy[secretKey]
 
@@ -697,7 +697,7 @@ function finalizeWriteOnlySecrets(configCopy) {
       return
     }
 
-    if (hasStoredSecret && !nextValue) {
+    if (!nextValue) {
       delete configCopy[secretKey]
     }
   })
@@ -761,9 +761,15 @@ function save() {
       try {
         const text = (await r.text()).trim()
         if (text) {
-          errorMessage = r.status === 403
-            ? `${text}. Refresh Polaris and try again.`
-            : text
+          try {
+            const parsed = JSON.parse(text)
+            errorMessage = parsed?.error || text
+          } catch {
+            errorMessage = text
+          }
+          if (r.status === 403) {
+            errorMessage = `${errorMessage}. Refresh Polaris and try again.`
+          }
         }
       } catch {
         // Fall back to the generic message when the response body cannot be read.

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -113,7 +113,7 @@ TEST(ProcessMigrationTests, ParseNormalizesSteamBigPictureLaunchAndAddsCleanupUn
 
   ASSERT_NE(steam_ctx, parsed_apps.end());
   ASSERT_EQ(steam_ctx->detached.size(), 1);
-  EXPECT_EQ(steam_ctx->detached.front(), "setsid steam steam://open/bigpicture");
+  EXPECT_EQ(steam_ctx->detached.front(), "setsid steam -gamepadui");
   EXPECT_TRUE(steam_ctx->cmd.empty());
   ASSERT_FALSE(steam_ctx->prep_cmds.empty());
   EXPECT_EQ(steam_ctx->prep_cmds.back().undo_cmd, "setsid steam -shutdown");


### PR DESCRIPTION
Fixes #10.

## Summary
- Stop default startup migration from taking over or deleting `~/.config/sunshine`.
- Keep Polaris writes in `polaris/polaris.conf`, with a one-time local legacy import only from `polaris/sunshine.conf` when present.
- Preserve write-only config values in the web UI and surface save failures from `/api/config`.
- Refresh the Steam Big Picture migration test expectation.

## Validation
- `cmake --build build-local --parallel 4`
- `npm run lint`
- `npm test`
- `build-local/tests/test_polaris`
- `build-local/tests/test_polaris_config`
- `build-local/tests/test_polaris_http` (8 passed, 2 skipped external-download cases)

Manual check: started Polaris with an isolated `XDG_CONFIG_HOME` containing an existing `sunshine/sunshine.conf`, confirmed Polaris created and wrote `polaris/polaris.conf`, and confirmed the Sunshine config remained unchanged.