### PR TITLE
Add Bazzite and Ubuntu install guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,6 +37,8 @@ body:
       description: How is Polaris installed on the host?
       options:
         - Fedora RPM
+        - Bazzite rpm-ostree
+        - Ubuntu DEB
         - Arch package
         - Source build
         - Local package build
@@ -49,7 +51,7 @@ body:
     attributes:
       label: Host OS
       description: Linux distribution and version running Polaris.
-      placeholder: e.g. Fedora 42, Arch Linux, Debian 13
+      placeholder: e.g. Fedora 43, Bazzite stable, Ubuntu 24.04, Arch Linux, Debian 13
     validations:
       required: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,6 @@ jobs:
   ubuntu-build:
     name: Ubuntu build
     needs: web-checks
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-24.04
     env:
       CCACHE_DIR: ~/.cache/ccache
@@ -301,8 +300,11 @@ jobs:
           cmake -B build -G Ninja \
             -DBUILD_TESTS=ON \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DPOLARIS_ASSETS_DIR=share/polaris \
+            -DPOLARIS_EXECUTABLE_PATH=/usr/bin/polaris \
             -DPOLARIS_ENABLE_CUDA=OFF \
             -DCUDA_FAIL_ON_MISSING=OFF
 
@@ -323,6 +325,71 @@ jobs:
 
       - name: Run fast C++ tests
         run: ctest --test-dir build/tests --output-on-failure -R '^test_polaris$'
+
+      - name: Build DEB package
+        run: cpack -G DEB --config ./build/CPackConfig.cmake
+
+      - name: Smoke test Ubuntu DEB package
+        run: |
+          set -euo pipefail
+
+          deb_path="$(find build/cpack_artifacts -maxdepth 1 -type f -name '*.deb' | sort | head -n 1)"
+          if [ -z "$deb_path" ]; then
+            echo "No binary DEB was produced" >&2
+            exit 1
+          fi
+
+          dpkg-deb --info "$deb_path" | tee build/cpack_artifacts/package-info.txt
+          dpkg-deb --field "$deb_path" Depends | tee build/cpack_artifacts/package-depends.txt
+          dpkg-deb --contents "$deb_path" | tee build/cpack_artifacts/package-files.txt
+
+          sudo apt-get install -y "./$deb_path"
+          package_name="$(dpkg-deb --field "$deb_path" Package)"
+          binary="$(dpkg -L "$package_name" | awk '$0 == "/usr/bin/polaris" || /\/usr\/bin\/polaris-[^/]+$/ { print; exit }')"
+          if [ -z "$binary" ]; then
+            echo "Installed Polaris binary was not found" >&2
+            exit 1
+          fi
+
+          readelf -d "$binary" | tee build/cpack_artifacts/package-needed.txt
+          ldd "$binary" | tee build/cpack_artifacts/package-ldd.txt
+          if grep -Fq "not found" build/cpack_artifacts/package-ldd.txt; then
+            echo "Installed Ubuntu DEB has unresolved shared-library dependencies" >&2
+            exit 1
+          fi
+
+          polaris --version | tee build/cpack_artifacts/package-version.txt
+
+      - name: Summarize Ubuntu DEB validation
+        if: always()
+        run: |
+          {
+            echo "## Ubuntu 24.04 DEB validation"
+            echo
+            echo "- Build tree directory: \`build/\`"
+            echo "- DEB output directory: \`build/cpack_artifacts/\`"
+            echo "- DEB artifacts and generated CPack metadata are uploaded from this job."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Ubuntu DEB artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ubuntu-24.04-deb-artifacts
+          path: |
+            build/cpack_artifacts/*.deb
+          if-no-files-found: warn
+
+      - name: Upload Ubuntu DEB metadata
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ubuntu-24.04-deb-metadata
+          path: |
+            build/cpack_artifacts/package-*.txt
+            build/cpack_artifacts/_CPack_Packages/Linux/DEB/**/*.out
+            build/cpack_artifacts/_CPack_Packages/Linux/DEB/**/*.err
+          if-no-files-found: warn
 
   fedora-rpm-build:
     name: Fedora ${{ matrix.fedora }} RPM build
@@ -481,6 +548,7 @@ jobs:
     name: Release assets
     needs:
       - arch-build
+      - ubuntu-build
       - fedora-rpm-build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
@@ -505,6 +573,12 @@ jobs:
         with:
           name: fedora-43-rpm-artifacts
           path: release-assets/raw/fedora43
+
+      - name: Download Ubuntu 24.04 DEB artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ubuntu-24.04-deb-artifacts
+          path: release-assets/raw/ubuntu24.04
 
       - name: Prepare release asset names
         run: |
@@ -579,6 +653,18 @@ jobs:
           copy_fedora_rpms 42 release-assets/raw/fedora42
           copy_fedora_rpms 43 release-assets/raw/fedora43
 
+          ubuntu_debs=()
+          for deb_path in release-assets/raw/ubuntu24.04/*.deb; do
+            ubuntu_debs+=("$deb_path")
+          done
+
+          if [ "${#ubuntu_debs[@]}" -eq 0 ]; then
+            echo "No binary DEBs were produced for Ubuntu 24.04" >&2
+            exit 1
+          fi
+
+          cp "${ubuntu_debs[0]}" "release-assets/final/Polaris-ubuntu24.04-x86_64.deb"
+
           ls -la release-assets/final
 
       - name: Upload release assets to GitHub release
@@ -599,8 +685,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          asset_count=$(gh release view "${GITHUB_REF_NAME}" --json assets --jq '[.assets[].name | select(. == "Polaris-fedora42-x86_64.rpm" or . == "Polaris-fedora43-x86_64.rpm" or . == "Polaris-arch-x86_64.pkg.tar.zst")] | length')
-          if [ "${asset_count}" -ne 3 ]; then
-            echo "Expected Fedora 42, Fedora 43, and Arch binary release assets on ${GITHUB_REF_NAME}, found ${asset_count}" >&2
+          asset_count=$(gh release view "${GITHUB_REF_NAME}" --json assets --jq '[.assets[].name | select(. == "Polaris-fedora42-x86_64.rpm" or . == "Polaris-fedora43-x86_64.rpm" or . == "Polaris-ubuntu24.04-x86_64.deb" or . == "Polaris-arch-x86_64.pkg.tar.zst")] | length')
+          if [ "${asset_count}" -ne 4 ]; then
+            echo "Expected Fedora 42, Fedora 43, Ubuntu 24.04, and Arch binary release assets on ${GITHUB_REF_NAME}, found ${asset_count}" >&2
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Polaris combines an isolated compositor runtime, GPU-aware capture, a modern web
 </div>
 
 > [!IMPORTANT]
-> Polaris is a Linux host today. Fedora 42, Fedora 43, and Arch Linux have direct `v1.0.1` release packages; Debian-family and other distro installs are still source-build oriented.
+> Polaris is a Linux host today. Fedora 42, Fedora 43, and Arch Linux have direct `v1.0.2` release packages. Bazzite can use the Fedora RPM through `rpm-ostree`, but that path is still experimental while real-hardware validation continues. Ubuntu 24.04 DEB packaging is staged for the next tagged release; Debian-family distros remain source-build oriented until that asset is published.
 
 > [!NOTE]
-> `v1.0.1` is the current public Polaris release line. The host, web console, Fedora RPM, and Arch package are ready for broader testing, but this is still an early public surface. Expect some distro, GPU, and client edge cases while compatibility keeps expanding.
+> `v1.0.2` is the current public Polaris release line. The host, web console, Fedora RPM, and Arch package are ready for broader testing, but this is still an early public surface. Expect some distro, GPU, and client edge cases while compatibility keeps expanding.
 
 ## Quick Start
 
@@ -55,6 +55,32 @@ sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst
 sudo polaris --setup-host
 polaris
 ```
+
+### Experimental install: Bazzite
+
+```bash
+fedora_version="$(rpm -E %fedora)"
+wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
+sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+systemctl reboot
+
+# After reboot:
+sudo polaris --setup-host
+polaris
+```
+
+Bazzite is Fedora-based but immutable, so Polaris is installed as a layered RPM and requires a reboot before the command is available. See the [Bazzite install guide](docs/bazzite.md) for caveats, rollback, and validation notes.
+
+### Upcoming install: Ubuntu 24.04 DEB
+
+```bash
+wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb
+sudo polaris --setup-host
+polaris
+```
+
+The Ubuntu DEB asset is staged for the next tagged release. Until that release exists, use the source build path below. See the [Ubuntu install guide](docs/ubuntu.md) for package status, source build fallback, and validation notes.
 
 ### Source build: Debian, dev machines, or custom setups
 
@@ -89,12 +115,14 @@ polaris
 
 ### Recommended package path
 
-If you are on Fedora or Arch and just want Polaris running, use the GitHub release package for your distro before considering source builds. Both package paths install the host binary, web console assets, desktop metadata, and user service file; host integration remains explicit so the installer does not silently change input or KMS permissions.
+If you are on Fedora, Bazzite, Ubuntu, or Arch and just want Polaris running, use the GitHub release package for your distro before considering source builds. These package paths install the host binary, web console assets, desktop metadata, and user service file; host integration remains explicit so the installer does not silently change input or KMS permissions.
 
 | Public release asset | Use it for |
 |---|---|
 | `Polaris-fedora42-x86_64.rpm` | Fedora 42 x86_64 hosts |
 | `Polaris-fedora43-x86_64.rpm` | Fedora 43 x86_64 hosts |
+| `Polaris-fedora42-x86_64.rpm` or `Polaris-fedora43-x86_64.rpm` via `rpm-ostree` | Bazzite x86_64 hosts, experimental |
+| `Polaris-ubuntu24.04-x86_64.deb` | Ubuntu 24.04 x86_64 hosts, next tagged release |
 | `Polaris-arch-x86_64.pkg.tar.zst` | Arch Linux x86_64 hosts |
 
 ```bash
@@ -107,6 +135,22 @@ sudo polaris --setup-host
 ```bash
 wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-arch-x86_64.pkg.tar.zst
 sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst
+sudo polaris --setup-host
+```
+
+```bash
+wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb
+sudo polaris --setup-host
+```
+
+```bash
+fedora_version="$(rpm -E %fedora)"
+wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
+sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+systemctl reboot
+
+# After reboot:
 sudo polaris --setup-host
 ```
 
@@ -212,6 +256,8 @@ systemctl --user enable --now polaris
 | Linux host OS | Supported | Polaris is Linux-first today |
 | Fedora 42 | Recommended | Official release asset: `Polaris-fedora42-x86_64.rpm` |
 | Fedora 43 | Recommended | Official release asset: `Polaris-fedora43-x86_64.rpm` |
+| Bazzite | Experimental | Use the matching Fedora RPM through `rpm-ostree`; see [Bazzite install guide](docs/bazzite.md) |
+| Ubuntu 24.04 | Upcoming package path | `Polaris-ubuntu24.04-x86_64.deb` is staged for the next tagged release; source build works today |
 | Arch Linux | Recommended | Official release asset: `Polaris-arch-x86_64.pkg.tar.zst`; source and local PKGBUILD generation are also supported |
 | Debian-family distros | Supported from source | Less turnkey than Fedora right now |
 | NVIDIA / NVENC | Best-tested | Main fast path and most validated encoder/runtime combination |
@@ -222,7 +268,9 @@ systemctl --user enable --now polaris
 ## Known Limitations
 
 - Polaris is not a Windows host today. Linux is the supported platform.
-- Debian-family distros are still source-build oriented. Fedora 42, Fedora 43, and Arch Linux have direct x86_64 release package assets.
+- Bazzite support is experimental until desktop/gamemode, AMD/NVIDIA, and Steam Deck client flows are validated on real hardware.
+- Ubuntu 24.04 DEB packaging is staged for the next tagged release; other Debian-family distros are still source-build oriented.
+- Fedora 42, Fedora 43, and Arch Linux have direct x86_64 release package assets today.
 - NVIDIA/NVENC is the most heavily validated hardware path. Other encode backends work, but they are not equally battle-tested.
 - Some UX surfaced in Nova, such as explicit launch recommendations, watch mode polish, and live tuning, depends on the Nova client.
 - MangoHud can still be risky on Steam Big Picture and some Steam/Proton launches.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,13 +5,16 @@ Polaris is public and usable today, but it is still early. This roadmap is meant
 ## Current Focus
 
 - Keep Fedora and Arch release packages reliable.
+- Validate Bazzite as the next host install path using the Fedora RPM through rpm-ostree.
+- Promote Ubuntu 24.04 from source-build support to a tested DEB release path.
 - Tighten Linux compositor, capture, and encoder behavior across more GPUs and distros.
 - Improve Mission Control diagnostics so failures are easier to understand without digging through logs.
 - Keep Nova integration clear while preserving compatibility with standard Moonlight clients.
 
 ## Near-Term Work
 
-- Broader Debian-family install guidance and source-build cleanup.
+- Bazzite desktop-mode and gamemode validation, especially Bazzite host to Steam Deck/Moonlight clients.
+- Ubuntu DEB validation on real desktop hosts, followed by broader Debian-family install guidance.
 - More runtime diagnostics for VAAPI and software encode paths.
 - Clearer recovery flows when Steam, MangoHud, or compositor startup misbehaves.
 - More examples for safe web UI deployment on trusted networks.
@@ -25,12 +28,14 @@ Polaris is public and usable today, but it is still early. This roadmap is meant
 ## Known Limits
 
 - Polaris is Linux-host-only today.
-- Fedora 42 and Arch have the most polished install path; other distros are source-build oriented.
+- Fedora 42, Fedora 43, and Arch have the most polished install paths; Bazzite is experimental; Ubuntu 24.04 packaging is staged; other distros are source-build oriented.
 - NVIDIA/NVENC is the most heavily validated encoder path.
 - Some richer live-session behavior depends on Nova.
 
 ## Useful Feedback
 
+- Bazzite rpm-ostree status, desktop/gamemode state, and Steam Deck client results.
+- Ubuntu package/source-build results with GPU, driver, desktop environment, and display server details.
 - Distro, GPU, driver, and compositor details for successful installs.
 - Logs and screenshots for failed pairing, launch, capture, or encoder setup.
 - Reports that compare Nova with another Moonlight-compatible client on the same host.

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -1,0 +1,87 @@
+# Bazzite Install Guide
+
+Bazzite is Fedora-based, but it is an immutable rpm-ostree system rather than a normal
+DNF-managed Fedora install. Polaris can use the matching Fedora RPM as a layered system package.
+
+This path is experimental until it has been validated on real Bazzite desktop and gamemode
+hardware. Use it when you want to test Polaris as a Bazzite host and are comfortable with
+rpm-ostree package layering.
+
+## Install
+
+```bash
+fedora_version="$(rpm -E %fedora)"
+wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
+sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+systemctl reboot
+```
+
+After reboot:
+
+```bash
+sudo polaris --setup-host
+polaris
+```
+
+Open `https://localhost:47990`, create the web UI password, and pair Moonlight, Nova, or another
+GameStream-compatible client.
+
+## Optional setup
+
+Enable the user service if you want Polaris to start in the background:
+
+```bash
+systemctl --user enable --now polaris
+```
+
+Only enable DRM/KMS capture if you specifically need it:
+
+```bash
+sudo polaris --setup-host --enable-kms
+```
+
+The default compositor and portal paths do not require granting KMS capability.
+
+## Update
+
+Download the newer Fedora RPM from the latest release and layer it again:
+
+```bash
+fedora_version="$(rpm -E %fedora)"
+wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
+sudo rpm-ostree uninstall polaris
+sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+systemctl reboot
+```
+
+## Uninstall
+
+```bash
+sudo rpm-ostree uninstall polaris
+systemctl reboot
+```
+
+If you enabled the user service, disable it before uninstalling:
+
+```bash
+systemctl --user disable --now polaris
+```
+
+## Validation Checklist
+
+Please include these details when reporting Bazzite issues:
+
+- Bazzite image name and version from `rpm-ostree status`
+- desktop mode or gamemode
+- GPU model and driver stack
+- whether `sudo polaris --setup-host` completed successfully
+- whether the web UI opens at `https://localhost:47990`
+- client used for pairing, such as Steam Deck Moonlight, Android Moonlight, or Nova
+- active capture path shown in the Polaris dashboard
+- whether headless mode and virtual display behavior worked after a reboot
+
+## Current Status
+
+Fedora 42 and Fedora 43 RPMs are release-tested in CI. Bazzite uses those same RPM assets, but
+the immutable install flow and Steam Deck-oriented runtime behavior need separate validation before
+this path is marked recommended.

--- a/docs/building.md
+++ b/docs/building.md
@@ -3,7 +3,9 @@
 Polaris is a Linux-first host today. The fastest install paths are the Fedora RPM and Arch
 package from the [latest release](https://github.com/papi-ux/polaris/releases/latest). Source
 builds remain the right path for Debian-family distros and local development, and Arch also
-supports a local package-build flow in addition to the published package asset.
+supports a local package-build flow in addition to the published package asset. Bazzite can use
+the Fedora RPM through `rpm-ostree`, but that install path is experimental until real-hardware
+validation is complete. Ubuntu 24.04 DEB packaging is staged for the next tagged release.
 
 ## Release packages
 
@@ -22,7 +24,28 @@ sudo polaris --setup-host
 polaris
 ```
 
+```bash
+wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb
+sudo polaris --setup-host
+polaris
+```
+
+```bash
+fedora_version="$(rpm -E %fedora)"
+wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
+sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+systemctl reboot
+
+# After reboot:
+sudo polaris --setup-host
+polaris
+```
+
 The web UI will be available at `https://localhost:47990`.
+
+See the [Bazzite install guide](bazzite.md) and [Ubuntu install guide](ubuntu.md) for caveats,
+fallback paths, and validation notes.
 
 ## Source Build
 
@@ -118,6 +141,9 @@ The public release assets are currently:
 
 - `Polaris-fedora42-x86_64.rpm`
 - `Polaris-fedora43-x86_64.rpm`
+- `Polaris-ubuntu24.04-x86_64.deb`
 - `Polaris-arch-x86_64.pkg.tar.zst`
 
-Debian-family and other distro paths are still source-build oriented for now.
+Bazzite installs use the matching Fedora RPM through `rpm-ostree` for now. Ubuntu 24.04 DEB
+packaging is staged for the next tagged release; other Debian-family distro paths are still
+source-build oriented.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,16 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## Unreleased
+
+Highlights:
+
+- Added an experimental Bazzite install path using the Fedora RPM through `rpm-ostree`
+- Added a Bazzite validation checklist for desktop mode, gamemode, GPU, pairing, and headless behavior
+- Added Ubuntu 24.04 DEB packaging for the next tagged release: `Polaris-ubuntu24.04-x86_64.deb`
+- Added an Ubuntu install guide with package, source-build fallback, and validation notes
+- Polaris config saves now stay isolated from legacy Sunshine config paths
+
 ## v1.0.2
 
 Patch release focused on validated Linux release packages.
@@ -52,4 +62,5 @@ Current official public assets:
 
 - `Polaris-fedora42-x86_64.rpm`
 - `Polaris-fedora43-x86_64.rpm`
+- `Polaris-ubuntu24.04-x86_64.deb`
 - `Polaris-arch-x86_64.pkg.tar.zst`

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -1,0 +1,86 @@
+# Ubuntu Install Guide
+
+Ubuntu 24.04 is the first Debian-family target for a direct Polaris DEB package. The CI path now
+builds and smoke-tests `Polaris-ubuntu24.04-x86_64.deb`, and the asset will be published with the
+next tagged Polaris release.
+
+Until that release exists, use the source build path below.
+
+## Release Package
+
+```bash
+wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb
+sudo polaris --setup-host
+polaris
+```
+
+Open `https://localhost:47990`, create the web UI password, and pair Moonlight, Nova, or another
+GameStream-compatible client.
+
+## Source Build Fallback
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential ccache cmake git ninja-build \
+  libboost-all-dev libssl-dev libevdev-dev \
+  libpulse-dev libopus-dev libcurl4-openssl-dev \
+  libdrm-dev libgbm-dev libcap-dev libwayland-dev \
+  libpipewire-0.3-dev libx11-dev libxrandr-dev \
+  libxfixes-dev libxi-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev \
+  libva-dev libminiupnpc-dev libnotify-dev nlohmann-json3-dev \
+  libappindicator3-dev libgtk-3-dev \
+  libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
+  wayland-protocols nodejs npm
+
+git clone --recursive https://github.com/papi-ux/polaris.git
+cd polaris
+npm ci --no-audit --fund=false
+cmake -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DPOLARIS_ENABLE_CUDA=OFF \
+  -DCUDA_FAIL_ON_MISSING=OFF
+cmake --build build -j"$(nproc)"
+sudo cmake --install build
+sudo polaris --setup-host
+polaris
+```
+
+Use `-DPOLARIS_ENABLE_CUDA=ON` only when the CUDA toolkit is installed and you specifically want a
+CUDA-enabled local build.
+
+## Optional Setup
+
+Enable the user service if you want Polaris to start in the background:
+
+```bash
+systemctl --user enable --now polaris
+```
+
+Only enable DRM/KMS capture if you specifically need it:
+
+```bash
+sudo polaris --setup-host --enable-kms
+```
+
+The default compositor and portal paths do not require granting KMS capability.
+
+## Validation Checklist
+
+Please include these details when reporting Ubuntu issues:
+
+- Ubuntu version from `lsb_release -a`
+- package install or source build
+- GPU model and driver stack
+- desktop environment and display server, such as GNOME Wayland or KDE Wayland
+- whether `sudo polaris --setup-host` completed successfully
+- whether the web UI opens at `https://localhost:47990`
+- client used for pairing, such as Steam Deck Moonlight, Android Moonlight, or Nova
+- active capture path shown in the Polaris dashboard
+- whether headless mode and virtual display behavior worked after a reboot
+
+## Current Status
+
+Ubuntu 24.04 builds and fast C++ tests run in CI. The DEB package is now built, installed, checked
+for unresolved shared-library dependencies, and staged for release upload on tagged builds.

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -42,6 +42,7 @@ PY
 expected_assets=(
   "Polaris-fedora42-x86_64.rpm"
   "Polaris-fedora43-x86_64.rpm"
+  "Polaris-ubuntu24.04-x86_64.deb"
   "Polaris-arch-x86_64.pkg.tar.zst"
 )
 


### PR DESCRIPTION
## Summary
- Add an experimental Bazzite install guide using the Fedora RPM through `rpm-ostree`.
- Add an Ubuntu 24.04 install guide with DEB package commands, source-build fallback, and validation notes.
- Build and smoke-test an Ubuntu 24.04 DEB in CI, upload DEB artifacts, and include `Polaris-ubuntu24.04-x86_64.deb` in tagged release asset publishing.
- Surface Bazzite and Ubuntu in the README, install matrix, compatibility table, known limitations, roadmap, bug report template, and changelog.
- Refresh stale README public release wording from `v1.0.1` to `v1.0.2`.

## Validation
- `bash scripts/check-public-docs.sh`
- `git diff --check HEAD~1..HEAD`
- YAML parse for `.github/workflows/build.yml` and `.github/ISSUE_TEMPLATE/bug_report.yml`

No issue or Reddit comments were posted.
