### PR TITLE
Fix missing BGR0 input stride

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Polaris combines an isolated compositor runtime, GPU-aware capture, a modern web
 </div>
 
 > [!IMPORTANT]
-> Polaris is a Linux host today. Fedora 42, Fedora 43, Ubuntu 24.04, and Arch Linux have direct `v1.0.3` release packages. Bazzite can use the Fedora RPM through `rpm-ostree`, but that path is still experimental while real-hardware validation continues. Other Debian-family distros remain source-build oriented for now.
+> Polaris is a Linux host today. Fedora 42, Fedora 43, and Arch Linux are the most validated direct `v1.0.3` release package paths. Bazzite and Ubuntu 24.04 packages exist for testing, but they are extremely experimental, less validated on real hardware, and more prone to breaking across distro, compositor, driver, and GPU combinations. Other Debian-family distros remain source-build oriented for now.
 
 > [!NOTE]
-> `v1.0.3` is the current public Polaris release line. The host, web console, Fedora RPMs, Ubuntu DEB, and Arch package are ready for broader testing, but this is still an early public surface. Expect some distro, GPU, and client edge cases while compatibility keeps expanding.
+> `v1.0.3` is the current public Polaris release line. The host, web console, Fedora RPMs, and Arch package are ready for broader testing. The Bazzite rpm-ostree path and Ubuntu DEB are earlier validation paths and should be treated as much more fragile.
 
 ## Quick Start
 
@@ -56,12 +56,12 @@ sudo polaris --setup-host
 polaris
 ```
 
-### Experimental install: Bazzite
+### Extremely experimental install: Bazzite
 
 ```bash
 fedora_version="$(rpm -E %fedora)"
 wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
-sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm" labwc wlr-randr
 systemctl reboot
 
 # After reboot:
@@ -69,9 +69,9 @@ sudo polaris --setup-host
 polaris
 ```
 
-Bazzite is Fedora-based but immutable, so Polaris is installed as a layered RPM and requires a reboot before the command is available. See the [Bazzite install guide](docs/bazzite.md) for caveats, rollback, and validation notes.
+Bazzite is Fedora-based but immutable, so Polaris is installed as a layered RPM and requires a reboot before the command is available. This path is extremely experimental and more likely to break than Fedora or Arch because Game Mode, Desktop Mode, rpm-ostree layering, and GPU capture all need separate real-hardware validation. See the [Bazzite install guide](docs/bazzite.md) for caveats, rollback, and validation notes.
 
-### Fastest install: Ubuntu 24.04 DEB
+### Extremely experimental install: Ubuntu 24.04 DEB
 
 ```bash
 wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb
@@ -80,7 +80,7 @@ sudo polaris --setup-host
 polaris
 ```
 
-The Ubuntu DEB asset is published with `v1.0.3` and later. See the [Ubuntu install guide](docs/ubuntu.md) for package status, source build fallback, and validation notes.
+The Ubuntu DEB asset is published with `v1.0.3` and later, but it is extremely experimental and more prone to breaking than the Fedora and Arch package paths. See the [Ubuntu install guide](docs/ubuntu.md) for package status, source build fallback, and validation notes.
 
 ### Source build: Debian, dev machines, or custom setups
 
@@ -115,14 +115,14 @@ polaris
 
 ### Recommended package path
 
-If you are on Fedora, Bazzite, Ubuntu, or Arch and just want Polaris running, use the GitHub release package for your distro before considering source builds. These package paths install the host binary, web console assets, desktop metadata, and user service file; host integration remains explicit so the installer does not silently change input or KMS permissions.
+If you are on Fedora or Arch and just want Polaris running, use the GitHub release package for your distro before considering source builds. Bazzite and Ubuntu packages are available for testers, but they are extremely experimental and more prone to breaking. These package paths install the host binary, web console assets, desktop metadata, and user service file; host integration remains explicit so the installer does not silently change input or KMS permissions.
 
 | Public release asset | Use it for |
 |---|---|
 | `Polaris-fedora42-x86_64.rpm` | Fedora 42 x86_64 hosts |
 | `Polaris-fedora43-x86_64.rpm` | Fedora 43 x86_64 hosts |
-| `Polaris-fedora42-x86_64.rpm` or `Polaris-fedora43-x86_64.rpm` via `rpm-ostree` | Bazzite x86_64 hosts, experimental |
-| `Polaris-ubuntu24.04-x86_64.deb` | Ubuntu 24.04 x86_64 hosts |
+| `Polaris-fedora42-x86_64.rpm` or `Polaris-fedora43-x86_64.rpm` via `rpm-ostree` | Bazzite x86_64 hosts, extremely experimental |
+| `Polaris-ubuntu24.04-x86_64.deb` | Ubuntu 24.04 x86_64 hosts, extremely experimental |
 | `Polaris-arch-x86_64.pkg.tar.zst` | Arch Linux x86_64 hosts |
 
 ```bash
@@ -147,7 +147,7 @@ sudo polaris --setup-host
 ```bash
 fedora_version="$(rpm -E %fedora)"
 wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
-sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm" labwc wlr-randr
 systemctl reboot
 
 # After reboot:
@@ -256,8 +256,8 @@ systemctl --user enable --now polaris
 | Linux host OS | Supported | Polaris is Linux-first today |
 | Fedora 42 | Recommended | Official release asset: `Polaris-fedora42-x86_64.rpm` |
 | Fedora 43 | Recommended | Official release asset: `Polaris-fedora43-x86_64.rpm` |
-| Bazzite | Experimental | Use the matching Fedora RPM through `rpm-ostree`; see [Bazzite install guide](docs/bazzite.md) |
-| Ubuntu 24.04 | Package path | Official release asset: `Polaris-ubuntu24.04-x86_64.deb`; source build also works |
+| Bazzite | Extremely experimental | Use the matching Fedora RPM through `rpm-ostree`; see [Bazzite install guide](docs/bazzite.md) |
+| Ubuntu 24.04 | Extremely experimental | Official release asset: `Polaris-ubuntu24.04-x86_64.deb`; source build also works, but this path needs more real-hardware validation |
 | Arch Linux | Recommended | Official release asset: `Polaris-arch-x86_64.pkg.tar.zst`; source and local PKGBUILD generation are also supported |
 | Debian-family distros | Supported from source | Less turnkey than Fedora right now |
 | NVIDIA / NVENC | Best-tested | Main fast path and most validated encoder/runtime combination |
@@ -268,8 +268,8 @@ systemctl --user enable --now polaris
 ## Known Limitations
 
 - Polaris is not a Windows host today. Linux is the supported platform.
-- Bazzite support is experimental until desktop/gamemode, AMD/NVIDIA, and Steam Deck client flows are validated on real hardware.
-- Ubuntu 24.04 DEB packaging is new and needs broader real-hardware validation; other Debian-family distros are still source-build oriented.
+- Bazzite support is extremely experimental until Desktop Mode, Game Mode, AMD/NVIDIA, and Steam Deck client flows are validated on real hardware.
+- Ubuntu 24.04 DEB packaging is extremely experimental and needs broader real-hardware validation; other Debian-family distros are still source-build oriented.
 - Fedora 42, Fedora 43, Ubuntu 24.04, and Arch Linux have direct x86_64 release package assets today.
 - NVIDIA/NVENC is the most heavily validated hardware path. Other encode backends work, but they are not equally battle-tested.
 - Some UX surfaced in Nova, such as explicit launch recommendations, watch mode polish, and live tuning, depends on the Nova client.

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -3,9 +3,16 @@
 Bazzite is Fedora-based, but it is an immutable rpm-ostree system rather than a normal
 DNF-managed Fedora install. Polaris can use the matching Fedora RPM as a layered system package.
 
-This path is experimental until it has been validated on real Bazzite Desktop Mode and Game Mode
-hardware. Use it when you want to test Polaris as a Bazzite host and are comfortable with
-rpm-ostree package layering.
+This path is extremely experimental until it has been validated on real Bazzite Desktop Mode and
+Game Mode hardware. It is much more prone to breaking than the Fedora and Arch package paths
+because rpm-ostree layering, Desktop Mode, Game Mode, gamescope, and GPU capture all need separate
+validation. Use it only when you want to test Polaris as a Bazzite host and are comfortable with
+debugging and rolling back rpm-ostree package layering.
+
+> [!WARNING]
+> Treat the Bazzite package path as a tester path, not a stable recommended install. Bazzite updates,
+> Game Mode behavior, compositor changes, and GPU driver differences can break this flow while
+> support is still being validated.
 
 ## Install
 
@@ -28,9 +35,9 @@ GameStream-compatible client.
 
 ## First validation path
 
-Start in Desktop Mode first. Game Mode and Deck-style gamescope sessions are still experimental as
-host environments, and they can hide display, portal, and environment details that are easier to
-debug from Desktop Mode.
+Start in Desktop Mode first. Game Mode and Deck-style gamescope sessions are especially
+experimental as host environments, and they can hide display, portal, and environment details that
+are easier to debug from Desktop Mode.
 
 The recommended Bazzite test path is:
 
@@ -119,5 +126,5 @@ Please include these details when reporting Bazzite issues:
 ## Current Status
 
 Fedora 42 and Fedora 43 RPMs are release-tested in CI. Bazzite uses those same RPM assets, but
-the immutable install flow and Steam Deck-oriented runtime behavior need separate validation before
-this path is marked recommended.
+the immutable install flow and Steam Deck-oriented runtime behavior need separate real-hardware
+validation before this path is marked recommended.

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -3,7 +3,7 @@
 Bazzite is Fedora-based, but it is an immutable rpm-ostree system rather than a normal
 DNF-managed Fedora install. Polaris can use the matching Fedora RPM as a layered system package.
 
-This path is experimental until it has been validated on real Bazzite desktop and gamemode
+This path is experimental until it has been validated on real Bazzite Desktop Mode and Game Mode
 hardware. Use it when you want to test Polaris as a Bazzite host and are comfortable with
 rpm-ostree package layering.
 
@@ -12,7 +12,7 @@ rpm-ostree package layering.
 ```bash
 fedora_version="$(rpm -E %fedora)"
 wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
-sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm" labwc wlr-randr
 systemctl reboot
 ```
 
@@ -25,6 +25,27 @@ polaris
 
 Open `https://localhost:47990`, create the web UI password, and pair Moonlight, Nova, or another
 GameStream-compatible client.
+
+## First validation path
+
+Start in Desktop Mode first. Game Mode and Deck-style gamescope sessions are still experimental as
+host environments, and they can hide display, portal, and environment details that are easier to
+debug from Desktop Mode.
+
+The recommended Bazzite test path is:
+
+```ini
+headless_mode = enabled
+linux_use_cage_compositor = true
+linux_prefer_gpu_native_capture = enabled
+```
+
+This path creates an isolated `labwc` runtime for the stream. It does not target a physical HDMI
+dummy plug. If you want to test a physical dummy plug instead, leave headless/labwc disabled and
+test it as a normal host display.
+
+Do not manually export `WAYLAND_DISPLAY` when testing headless mode. Polaris starts `labwc` with
+its own Wayland socket and routes launched apps into that socket.
 
 ## Optional setup
 
@@ -42,6 +63,20 @@ sudo polaris --setup-host --enable-kms
 
 The default compositor and portal paths do not require granting KMS capability.
 
+## Known Bazzite log messages
+
+`labwc: No new Wayland socket appeared within 5s` means the isolated `labwc` runtime failed to
+start or exited before creating its Wayland socket. Confirm `labwc` and `wlr-randr` are layered,
+rebooted into the new deployment, and retry from Desktop Mode first.
+
+`Environment variable WAYLAND_DISPLAY has not been defined` usually points to a windowed Wayland
+runtime being launched without a parent Wayland session. It is expected to appear after a failed
+manual environment experiment, but it is not the intended headless flow.
+
+`Couldn't scale frame ... src_fmt=bgr0 ... src_stride=0` means Polaris received a CPU BGR0 frame
+without a valid row pitch. This is a Polaris capture/conversion bug, not a user configuration
+mistake.
+
 ## Update
 
 Download the newer Fedora RPM from the latest release and layer it again:
@@ -50,7 +85,7 @@ Download the newer Fedora RPM from the latest release and layer it again:
 fedora_version="$(rpm -E %fedora)"
 wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
 sudo rpm-ostree uninstall polaris
-sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+sudo rpm-ostree install "./Polaris-fedora${fedora_version}-x86_64.rpm" labwc wlr-randr
 systemctl reboot
 ```
 
@@ -72,8 +107,9 @@ systemctl --user disable --now polaris
 Please include these details when reporting Bazzite issues:
 
 - Bazzite image name and version from `rpm-ostree status`
-- desktop mode or gamemode
+- Desktop Mode or Game Mode
 - GPU model and driver stack
+- output of `command -v labwc wlr-randr`
 - whether `sudo polaris --setup-host` completed successfully
 - whether the web UI opens at `https://localhost:47990`
 - client used for pairing, such as Steam Deck Moonlight, Android Moonlight, or Nova

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,11 +1,11 @@
 # Building Polaris
 
-Polaris is a Linux-first host today. The fastest install paths are the Fedora RPM, Ubuntu 24.04
-DEB, and Arch package from the [latest release](https://github.com/papi-ux/polaris/releases/latest).
-Source builds remain the right path for other Debian-family distros and local development, and
-Arch also supports a local package-build flow in addition to the published package asset. Bazzite
-can use the Fedora RPM through `rpm-ostree`, but that install path is experimental until
-real-hardware validation is complete.
+Polaris is a Linux-first host today. The most validated install paths are the Fedora RPM and Arch
+package from the [latest release](https://github.com/papi-ux/polaris/releases/latest). Source builds
+remain the right path for other Debian-family distros and local development, and Arch also supports
+a local package-build flow in addition to the published package asset. Bazzite can use the Fedora
+RPM through `rpm-ostree`, and Ubuntu 24.04 has a DEB package, but both of those package paths are
+extremely experimental and more prone to breaking until real-hardware validation is broader.
 
 ## Release packages
 
@@ -45,7 +45,7 @@ polaris
 The web UI will be available at `https://localhost:47990`.
 
 See the [Bazzite install guide](bazzite.md) and [Ubuntu install guide](ubuntu.md) for caveats,
-fallback paths, and validation notes.
+fallback paths, and validation notes before using either experimental path.
 
 ## Source Build
 
@@ -145,4 +145,5 @@ The public release assets are currently:
 - `Polaris-arch-x86_64.pkg.tar.zst`
 
 Bazzite installs use the matching Fedora RPM through `rpm-ostree` for now. Ubuntu 24.04 has a
-direct DEB package; other Debian-family distro paths are still source-build oriented.
+direct DEB package. Both are extremely experimental tester paths; other Debian-family distro paths
+are still source-build oriented.

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -1,8 +1,15 @@
 # Ubuntu Install Guide
 
-Ubuntu 24.04 is the first Debian-family target for a direct Polaris DEB package. The CI path
-builds and smoke-tests `Polaris-ubuntu24.04-x86_64.deb`, and the asset is published with `v1.0.3`
-and later Polaris releases.
+Ubuntu 24.04 is the first Debian-family target for a direct Polaris DEB package. This path is
+extremely experimental and much more prone to breaking than the Fedora and Arch package paths while
+real-hardware validation is still limited. The CI path builds and smoke-tests
+`Polaris-ubuntu24.04-x86_64.deb`, and the asset is published with `v1.0.3` and later Polaris
+releases.
+
+> [!WARNING]
+> Treat the Ubuntu DEB as a tester package for now, not a stable recommended install. Ubuntu desktop
+> environment differences, GPU driver packaging, compositor behavior, and Debian-family dependency
+> drift can break this flow while support is still being validated.
 
 ## Release Package
 
@@ -81,4 +88,6 @@ Please include these details when reporting Ubuntu issues:
 ## Current Status
 
 Ubuntu 24.04 builds and fast C++ tests run in CI. The DEB package is built, installed, checked for
-unresolved shared-library dependencies, and published on tagged builds.
+unresolved shared-library dependencies, and published on tagged builds. That CI coverage proves the
+package builds and installs, but the Ubuntu host runtime still needs broader real-hardware testing
+before this path is marked recommended.

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -206,6 +206,25 @@ namespace video {
       }
     }
 
+    int software_frame_input_linesize(const platf::img_t &img, const AVFrame *frame) {
+      if (img.row_pitch > 0) {
+        return img.row_pitch;
+      }
+
+      if (img.pixel_pitch > 0 && img.width > 0) {
+        return img.pixel_pitch * img.width;
+      }
+
+      if (!frame) {
+        return 0;
+      }
+
+      const auto linesize = av_image_get_linesize((AVPixelFormat) frame->format, frame->width, 0);
+      return linesize > 0 ? linesize : 0;
+    }
+
+    std::atomic_bool warned_missing_software_input_stride {false};
+
     platf::frame_residency_e frame_residency_from_mem_type(platf::mem_type_e mem_type) {
       switch (mem_type) {
         case platf::mem_type_e::system:
@@ -592,9 +611,30 @@ namespace video {
       // If we need to add aspect ratio padding, we need to scale into an intermediate output buffer
       bool requires_padding = (sw_frame->width != sws_output_frame->width || sw_frame->height != sws_output_frame->height);
 
+      const auto input_linesize = software_frame_input_linesize(img, sws_input_frame.get());
+      if (!img.data || input_linesize <= 0) {
+        BOOST_LOG(error)
+          << "Software frame converter received invalid CPU frame"
+          << " data="sv << (img.data ? "present"sv : "missing"sv)
+          << " row_pitch="sv << img.row_pitch
+          << " pixel_pitch="sv << img.pixel_pitch
+          << " img="sv << img.width << 'x' << img.height
+          << " src_fmt="sv << av_get_pix_fmt_name((AVPixelFormat) sws_input_frame->format)
+          << " src="sv << sws_input_frame->width << 'x' << sws_input_frame->height;
+        return -1;
+      }
+
+      if (img.row_pitch <= 0 && !warned_missing_software_input_stride.exchange(true)) {
+        BOOST_LOG(warning)
+          << "Software frame converter received a CPU frame without row pitch; inferred stride ["
+          << input_linesize << "] for format ["
+          << av_get_pix_fmt_name((AVPixelFormat) sws_input_frame->format)
+          << "]";
+      }
+
       // Setup the input frame using the caller's img_t
       sws_input_frame->data[0] = img.data;
-      sws_input_frame->linesize[0] = img.row_pitch;
+      sws_input_frame->linesize[0] = input_linesize;
 
       // Perform color conversion and scaling to the final size
       auto status = sws_scale_frame(sws.get(), requires_padding ? sws_output_frame.get() : sw_frame.get(), sws_input_frame.get());
@@ -4339,6 +4379,25 @@ namespace video {
 
   std::chrono::milliseconds reset_display_retry_delay_for_tests(int attempt) {
     return reset_display_retry_delay(attempt);
+  }
+
+  int software_frame_input_linesize_for_tests(
+    int row_pitch,
+    int pixel_pitch,
+    int image_width,
+    int frame_width,
+    int av_pixel_format
+  ) {
+    platf::img_t img;
+    img.row_pitch = row_pitch;
+    img.pixel_pitch = pixel_pitch;
+    img.width = image_width;
+
+    AVFrame frame {};
+    frame.width = frame_width;
+    frame.format = av_pixel_format;
+
+    return software_frame_input_linesize(img, &frame);
   }
 #endif
 

--- a/src/video.h
+++ b/src/video.h
@@ -550,5 +550,13 @@ namespace video {
   std::string current_encoder_topology_key_for_tests();
 
   std::chrono::milliseconds reset_display_retry_delay_for_tests(int attempt);
+
+  int software_frame_input_linesize_for_tests(
+    int row_pitch,
+    int pixel_pitch,
+    int image_width,
+    int frame_width,
+    int av_pixel_format
+  );
 #endif
 }  // namespace video

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -94,6 +94,14 @@ TEST(VideoCacheTests, ResetDisplayRetryDelayBackoffCapsAtTwoHundredMilliseconds)
   EXPECT_EQ(video::reset_display_retry_delay_for_tests(3), std::chrono::milliseconds(200));
 }
 
+TEST(VideoFrameConversionTests, InfersPackedBgr0InputStrideWhenRowPitchIsMissing) {
+  EXPECT_EQ(video::software_frame_input_linesize_for_tests(0, 0, 0, 2560, AV_PIX_FMT_BGR0), 10240);
+}
+
+TEST(VideoFrameConversionTests, PrefersCaptureProvidedRowPitch) {
+  EXPECT_EQ(video::software_frame_input_linesize_for_tests(8192, 4, 1920, 1920, AV_PIX_FMT_BGR0), 8192);
+}
+
 TEST(VideoCacheTests, EncoderProbeCachePersistsCodecModesAndInvalidatesOnTopologyMismatch) {
   const auto cache_dir = std::filesystem::temp_directory_path() / "polaris-encoder-cache-tests";
   const auto cache_path = cache_dir / "encoder_cache.txt";


### PR DESCRIPTION
## Summary

- Infer a packed CPU-frame input stride when BGR0/BGRA-style frames arrive without `row_pitch`
- Keep capture-provided row pitch preferred when it is available
- Add regression coverage for the missing BGR0 stride case
- Update the Bazzite guide with `labwc`/`wlr-randr` layering, Desktop Mode-first validation, and notes for the reported log messages
- Mark Bazzite and Ubuntu package/install paths as extremely experimental in the README, building docs, and install guides

## Root Cause

The software frame converter passed `img.row_pitch` directly to FFmpeg. Some headless labwc fallback captures can produce BGR0 CPU frames with `row_pitch = 0`, which caused `sws_scale_frame()` to reject the frame with `src_stride=0` before NVENC/HEVC encode could proceed.

## Validation

- `git diff --check`
- Built `test_polaris_video` in `/tmp/polaris-stride-tests` with CUDA disabled for this host
- `/tmp/polaris-stride-tests/tests/test_polaris_video` passed: 8 passed, 1 VAAPI test skipped because VAAPI is unavailable on this host

Fixes #15