### PR TITLE
Clarify credential reset restart flow

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,15 @@ If you lose access to the web UI credentials:
 polaris --creds new-username new-password
 ```
 
+Run the command as the same user account that runs Polaris, then restart Polaris before signing in
+with the new credentials:
+
+```bash
+systemctl --user restart polaris
+```
+
+If Polaris is running in the foreground, stop it and start it again instead.
+
 ## Host setup helper
 
 To re-run the host setup steps explicitly:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,6 +11,20 @@ Reset the web UI username and password:
 polaris --creds new-username new-password
 ```
 
+Run this as the same user account that runs Polaris. Do not use `sudo` unless Polaris itself runs
+as root, because that can update a different config directory.
+
+Restart Polaris after changing credentials. A running Polaris process keeps the previous credentials
+in memory until restart.
+
+For packaged user-service installs:
+
+```bash
+systemctl --user restart polaris
+```
+
+For foreground sessions, stop Polaris and start it again.
+
 ## Web UI does not load
 
 1. Confirm Polaris is running.

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3157,7 +3157,7 @@ namespace confighttp {
       if (!http::verify_user_password(username, password, &needs_upgrade)) {
         write_login_error(
           SimpleWeb::StatusCode::client_error_unauthorized,
-          "Invalid username or password. If you forgot your credentials, reset them on the host with the --creds command.",
+          "Invalid username or password. If you reset credentials with --creds, restart Polaris before signing in again.",
           true
         );
         return;

--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -166,7 +166,16 @@ namespace args {
       help(name);
     }
 
-    http::save_user_creds(config::sunshine.credentials_file, argv[0], argv[1]);
+    const auto status = http::save_user_creds(config::sunshine.credentials_file, argv[0], argv[1]);
+    if (status != 0) {
+      return status;
+    }
+
+    BOOST_LOG(info) << "Credentials file: "sv << config::sunshine.credentials_file;
+    BOOST_LOG(info) << "Restart any running Polaris process before signing in with the new web credentials."sv;
+#ifdef __linux__
+    BOOST_LOG(info) << "If Polaris runs as a user service, run [systemctl --user restart polaris]."sv;
+#endif
 
     return 0;
   }

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -142,7 +142,7 @@ namespace http {
       return -1;
     }
 
-    BOOST_LOG(info) << "New credentials have been created"sv;
+    BOOST_LOG(info) << "New web UI credentials have been saved"sv;
     return 0;
   }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -297,7 +297,7 @@ namespace logging {
       << "    Note: The configuration will be created if it doesn't exist."sv << std::endl
       << std::endl
       << "    --help                    | print help"sv << std::endl
-      << "    --creds username password | set user credentials for the Web manager"sv << std::endl
+      << "    --creds username password | set Web UI credentials; restart Polaris afterwards"sv << std::endl
 #ifdef __linux__
       << "    --setup-host [--enable-kms] | apply Linux udev/modules setup explicitly"sv << std::endl
 #endif

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -564,11 +564,13 @@
     "steps": {
       "open_terminal": "Open a terminal on the host machine running Polaris.",
       "run_command": "Run the command that matches how Polaris is installed on that host.",
-      "return_login": "Return here and sign in with the new username and password."
+      "return_login": "Restart Polaris, then return here and sign in with the new username and password."
     },
     "notes": {
       "full_path": "If `polaris` is not on your PATH, use the full path to the executable instead.",
       "source_build": "Source builds often use `./build/polaris` from the repository root.",
+      "same_user": "Run the command as the same user account that runs Polaris. Do not use sudo unless Polaris itself runs as root.",
+      "restart": "A running Polaris process keeps the old credentials in memory until it is restarted.",
       "keep_safe": "Store the new credentials somewhere safe. Polaris does not expose a remote self-service reset flow."
     }
   },

--- a/src_assets/common/assets/web/views/RecoveryView.vue
+++ b/src_assets/common/assets/web/views/RecoveryView.vue
@@ -52,6 +52,8 @@
           <ul class="space-y-1 text-sm text-storm list-disc list-inside">
             <li>{{ $t('recovery.notes.full_path') }}</li>
             <li>{{ $t('recovery.notes.source_build') }}</li>
+            <li>{{ $t('recovery.notes.same_user') }}</li>
+            <li>{{ $t('recovery.notes.restart') }}</li>
             <li>{{ $t('recovery.notes.keep_safe') }}</li>
           </ul>
         </div>
@@ -86,19 +88,19 @@ const commandVariants = computed(() => [
     id: 'installed',
     title: t('recovery.commands.installed_title'),
     description: t('recovery.commands.installed_desc'),
-    command: 'polaris --creds <new-username> <new-password>',
+    command: 'polaris --creds new-username new-password',
   },
   {
     id: 'source',
     title: t('recovery.commands.source_title'),
     description: t('recovery.commands.source_desc'),
-    command: './build/polaris --creds <new-username> <new-password>',
+    command: './build/polaris --creds new-username new-password',
   },
   {
     id: 'appimage',
     title: t('recovery.commands.appimage_title'),
     description: t('recovery.commands.appimage_desc'),
-    command: './polaris.AppImage --creds <new-username> <new-password>',
+    command: './polaris.AppImage --creds new-username new-password',
   },
 ])
 


### PR DESCRIPTION
## Summary

- Tell users that `polaris --creds` updates the credentials file but a running Polaris process must be restarted before the new login works
- Print the credentials file path and restart guidance after successful CLI credential reset
- Return a nonzero status if the CLI credential save fails
- Remove shell-confusing angle-bracket placeholders from the recovery page commands
- Update login error text, recovery page notes, troubleshooting docs, and configuration docs with same-user and restart guidance

## Root Cause

The reset command writes the credentials file, but the running web server keeps credentials loaded in memory. The existing recovery instructions did not say to restart Polaris, and the browser recovery page used `<new-username>` / `<new-password>` placeholders that can be misread or treated as shell redirection.

## Validation

- `git diff --check`
- `cmake --build /tmp/polaris-stride-tests --target test_polaris test_polaris_http -j2`
- `/tmp/polaris-stride-tests/tests/test_polaris`
- `/tmp/polaris-stride-tests/tests/test_polaris_http`
- `npm run lint`
- `npm test`

Fixes #17