### PR TITLE
Build Arch release package with CUDA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,12 +156,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           useradd -m builder
+          pacman -S --noconfirm --needed cuda
           install -d "$CCACHE_DIR"
           chown -R builder:builder "$GITHUB_WORKSPACE"
           chown -R builder:builder "$CCACHE_DIR"
           su builder -c "git config --global protocol.file.allow always"
           su builder -c "git config --global --add safe.directory '$GITHUB_WORKSPACE'"
-          su builder -c "cd '$GITHUB_WORKSPACE/arch-pkgbuild' && makepkg --nodeps --noconfirm --nocheck"
+          su builder -c "cd '$GITHUB_WORKSPACE/arch-pkgbuild' && _use_cuda=true makepkg --nodeps --noconfirm --nocheck"
 
       - name: Smoke test Arch package
         if: startsWith(github.ref, 'refs/tags/v')
@@ -177,6 +178,16 @@ jobs:
           tar -xOf "$pkg_path" .BUILDINFO | tee arch-pkgbuild/package-buildinfo.txt
           tar -xOf "$pkg_path" .PKGINFO | tee arch-pkgbuild/package-pkginfo.txt
 
+          if ! grep -Fq "installed = cuda-" arch-pkgbuild/package-buildinfo.txt; then
+            echo "Arch package was not built with CUDA installed" >&2
+            exit 1
+          fi
+
+          if ! grep -Fq "optdepend = cuda: Nvidia GPU encoding support" arch-pkgbuild/package-pkginfo.txt; then
+            echo "Arch package metadata does not advertise CUDA/Nvidia GPU encoding support" >&2
+            exit 1
+          fi
+
           boost_version="$(pacman -Q boost-libs | awk '{ print $2 }' | sed 's/-.*$//')"
           if ! grep -Fq "installed = boost-libs-${boost_version}-" arch-pkgbuild/package-buildinfo.txt; then
             echo "Arch package was not built against installed boost-libs ${boost_version}" >&2
@@ -188,6 +199,12 @@ jobs:
           binary="$(find "$extract_dir/usr/bin" -maxdepth 1 -type f -name 'polaris-*' -perm -111 | sort | head -n 1)"
           if [ -z "$binary" ]; then
             echo "Packaged Polaris binary was not found" >&2
+            exit 1
+          fi
+
+          strings "$binary" > arch-pkgbuild/package-strings.txt
+          if ! grep -Fq "Couldn't initialize cuda" arch-pkgbuild/package-strings.txt; then
+            echo "Packaged Polaris binary does not contain CUDA support" >&2
             exit 1
           fi
 

--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -80,6 +80,10 @@ if [[ "${_use_cuda::1}" == "d" ]] && pacman -Qi cuda &> /dev/null; then
 fi
 
 if [[ "${_use_cuda::1}" == "t" ]]; then
+  makedepends+=(
+    'cuda'
+  )
+
   optdepends+=(
     'cuda: Nvidia GPU encoding support'
   )
@@ -187,6 +191,8 @@ build() {
     if [[ "${_use_cuda::1}" != "t" ]]; then
       _cmake_options+=(-DPOLARIS_ENABLE_CUDA=OFF -DCUDA_FAIL_ON_MISSING=OFF)
     else
+      _cmake_options+=(-DPOLARIS_ENABLE_CUDA=ON -DCUDA_FAIL_ON_MISSING=ON)
+
       # If cuda has just been installed, its variables will not be available in the environment
       # therefore, set them manually to the expected values on Arch Linux
       if [ -z "${CUDA_PATH:-}" ] && pacman -Qi cuda &> /dev/null; then
@@ -198,6 +204,7 @@ build() {
         export CUDACXX="${CUDA_PATH}/bin/nvcc"
         export NVCC_CCBIN="${NVCC_CCBIN:-/usr/bin/g++}"
         _cmake_options+=(-DCMAKE_CUDA_COMPILER:FILEPATH="${CUDA_PATH}/bin/nvcc")
+        _cmake_options+=(-DCMAKE_CUDA_HOST_COMPILER:FILEPATH="$(command -v "${CXX}")")
       fi
     fi
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,6 +181,14 @@ int main(int argc, char *argv[]) {
   // if anything is logged prior to this point, it will appear in stdout, but not in the log viewer in the UI
   // the version should be printed to the log before anything else
   BOOST_LOG(info) << PROJECT_NAME << " version: " << PROJECT_VERSION << " commit: " << PROJECT_VERSION_COMMIT;
+#ifdef __linux__
+  #ifdef POLARIS_BUILD_CUDA
+  constexpr auto linux_cuda_build_feature = "enabled"sv;
+  #else
+  constexpr auto linux_cuda_build_feature = "disabled"sv;
+  #endif
+  BOOST_LOG(info) << "Build features: cuda="sv << linux_cuda_build_feature;
+#endif
 
   // Log publisher metadata
   log_publisher_data();


### PR DESCRIPTION
## Summary

- Force the official tagged Arch package build to install CUDA and build with `_use_cuda=true`.
- Make the Arch `PKGBUILD` declare CUDA as a make dependency when CUDA support is enabled.
- Add release smoke checks that verify CUDA was installed during package build, advertised in package metadata, and compiled into the packaged binary.
- Log Linux CUDA build support at startup so support bundles make non-CUDA package reports easier to diagnose.

Fixes #20.

## Validation

- `git diff --check`
- `bash -n packaging/linux/Arch/PKGBUILD`
- YAML parse of `.github/workflows/build.yml`

## Notes

This does not change the non-tag PR Arch build, which still uses `POLARIS_ENABLE_CUDA=OFF` for fast CI. It changes the tagged release package path so Nvidia users get the CUDA/NVENC fast path in the published Arch asset.