### PR TITLE
Stop desktop Steam before headless cage launches

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -293,6 +293,13 @@ namespace proc {
       return steam_big_picture_command_prefix(reference_cmd) + "steam -shutdown";
     }
 
+#ifdef __linux__
+    std::string canonical_steam_prelaunch_shutdown_command(const std::string &reference_cmd) {
+      return steam_big_picture_command_prefix(reference_cmd.empty() ? "steam" : reference_cmd) +
+             "bash -lc \"steam -shutdown >/dev/null 2>&1 || true; sleep 2\"";
+    }
+#endif
+
     std::string canonical_steam_library_bootstrap_command(const std::string &reference_cmd) {
       return steam_big_picture_command_prefix(reference_cmd.empty() ? "steam" : reference_cmd) + "steam -gamepadui";
     }
@@ -356,19 +363,59 @@ namespace proc {
              command_contains_steam_gamepadui_flag(cmd);
     }
 
-    bool prep_cmd_closes_steam_big_picture(const proc::cmd_t &cmd) {
-      return command_contains_steam_big_picture_close(cmd.do_cmd) ||
-             command_contains_steam_big_picture_close(cmd.undo_cmd);
-    }
-
     bool command_requests_steam_shutdown(const std::string &cmd) {
       return boost::icontains(cmd, "steam -shutdown");
     }
 
-    bool prep_cmd_stops_steam(const proc::cmd_t &cmd) {
-      return prep_cmd_closes_steam_big_picture(cmd) ||
-             command_requests_steam_shutdown(cmd.do_cmd) ||
+    bool prep_cmd_do_stops_steam(const proc::cmd_t &cmd) {
+      return command_contains_steam_big_picture_close(cmd.do_cmd) ||
+             command_requests_steam_shutdown(cmd.do_cmd);
+    }
+
+    bool prep_cmd_undo_stops_steam(const proc::cmd_t &cmd) {
+      return command_contains_steam_big_picture_close(cmd.undo_cmd) ||
              command_requests_steam_shutdown(cmd.undo_cmd);
+    }
+
+    std::string steam_launch_reference_command(const proc::ctx_t &ctx) {
+      if (!ctx.detached.empty()) {
+        return ctx.detached.front();
+      }
+
+      if (!ctx.cmd.empty()) {
+        return ctx.cmd;
+      }
+
+      return "steam";
+    }
+
+    void ensure_steam_prelaunch_shutdown(proc::ctx_t &ctx, const char *label) {
+#ifdef __linux__
+      if (!config::video.linux_display.use_cage_compositor) {
+        return;
+      }
+
+      if (std::any_of(ctx.prep_cmds.begin(), ctx.prep_cmds.end(), prep_cmd_do_stops_steam)) {
+        return;
+      }
+
+      auto shutdown_cmd = canonical_steam_prelaunch_shutdown_command(steam_launch_reference_command(ctx));
+      BOOST_LOG(info) << "process: added " << label << " pre-launch shutdown command [" << shutdown_cmd << ']';
+      ctx.prep_cmds.emplace_back(std::move(shutdown_cmd), ""s, false);
+#else
+      (void) ctx;
+      (void) label;
+#endif
+    }
+
+    void ensure_steam_cleanup_undo(proc::ctx_t &ctx, const char *label) {
+      if (std::any_of(ctx.prep_cmds.begin(), ctx.prep_cmds.end(), prep_cmd_undo_stops_steam)) {
+        return;
+      }
+
+      auto shutdown_cmd = canonical_steam_shutdown_command(steam_launch_reference_command(ctx));
+      BOOST_LOG(info) << "process: added " << label << " cleanup undo command [" << shutdown_cmd << ']';
+      ctx.prep_cmds.emplace_back(""s, std::move(shutdown_cmd), false);
     }
 
     bool is_steam_library_app(const proc::ctx_t &ctx) {
@@ -448,22 +495,8 @@ namespace proc {
         }
       }
 
-      if (std::any_of(ctx.prep_cmds.begin(), ctx.prep_cmds.end(), prep_cmd_stops_steam)) {
-        return;
-      }
-
-      std::string reference_cmd;
-      if (!ctx.detached.empty()) {
-        reference_cmd = ctx.detached.front();
-      } else if (!ctx.cmd.empty()) {
-        reference_cmd = ctx.cmd;
-      } else {
-        reference_cmd = "steam";
-      }
-
-      auto shutdown_cmd = canonical_steam_shutdown_command(reference_cmd);
-      BOOST_LOG(info) << "process: added Steam Big Picture cleanup undo command [" << shutdown_cmd << ']';
-      ctx.prep_cmds.emplace_back(""s, std::move(shutdown_cmd), false);
+      ensure_steam_prelaunch_shutdown(ctx, "Steam Big Picture");
+      ensure_steam_cleanup_undo(ctx, "Steam Big Picture");
     }
 
     void normalize_steam_library_app(proc::ctx_t &ctx) {
@@ -530,22 +563,8 @@ namespace proc {
         }
       }
 
-      if (std::any_of(ctx.prep_cmds.begin(), ctx.prep_cmds.end(), prep_cmd_stops_steam)) {
-        return;
-      }
-
-      std::string shutdown_reference_cmd;
-      if (!ctx.detached.empty()) {
-        shutdown_reference_cmd = ctx.detached.front();
-      } else if (!ctx.cmd.empty()) {
-        shutdown_reference_cmd = ctx.cmd;
-      } else {
-        shutdown_reference_cmd = "steam";
-      }
-
-      auto shutdown_cmd = canonical_steam_shutdown_command(shutdown_reference_cmd);
-      BOOST_LOG(info) << "process: added Steam library cleanup undo command [" << shutdown_cmd << ']';
-      ctx.prep_cmds.emplace_back(""s, std::move(shutdown_cmd), false);
+      ensure_steam_prelaunch_shutdown(ctx, "Steam library");
+      ensure_steam_cleanup_undo(ctx, "Steam library");
     }
 
     std::optional<int> coerce_json_int(const nlohmann::json &value) {

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -7,6 +7,21 @@
 #include <src/file_handler.h>
 #include <src/process.h>
 
+#ifdef __linux__
+namespace {
+  struct linux_cage_compositor_guard_t {
+    linux_cage_compositor_guard_t():
+        use_cage_compositor(config::video.linux_display.use_cage_compositor) {}
+
+    ~linux_cage_compositor_guard_t() {
+      config::video.linux_display.use_cage_compositor = use_cage_compositor;
+    }
+
+    bool use_cage_compositor;
+  };
+}  // namespace
+#endif
+
 TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {
   const auto file_path = test_paths::root() / "legacy_apps_migration.json";
 
@@ -81,6 +96,11 @@ TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {
 }
 
 TEST(ProcessMigrationTests, ParseNormalizesSteamBigPictureLaunchAndAddsCleanupUndo) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t guard;
+  config::video.linux_display.use_cage_compositor = false;
+#endif
+
   const auto file_path = test_paths::root() / "steam_big_picture_normalization.json";
 
   const nlohmann::json apps = {
@@ -122,7 +142,63 @@ TEST(ProcessMigrationTests, ParseNormalizesSteamBigPictureLaunchAndAddsCleanupUn
   std::filesystem::remove(file_path);
 }
 
+#ifdef __linux__
+TEST(ProcessMigrationTests, ParseAddsSteamBigPicturePrelaunchShutdownForLinuxCage) {
+  linux_cage_compositor_guard_t guard;
+  config::video.linux_display.use_cage_compositor = true;
+
+  const auto file_path = test_paths::root() / "steam_big_picture_cage_prelaunch_shutdown.json";
+
+  const nlohmann::json apps = {
+    {"version", 2},
+    {"apps", {
+      {
+        {"name", "Steam Big Picture"},
+        {"uuid", "steam-big-picture-cage-prelaunch"},
+        {"cmd", ""},
+        {"detached", {"setsid steam -gamepadui"}},
+        {"prep-cmd", nlohmann::json::array()},
+        {"image-path", "./assets/steam.png"}
+      }
+    }}
+  };
+
+  ASSERT_EQ(file_handler::write_file(file_path.string().c_str(), apps.dump(2)), 0);
+
+  auto parsed_proc = proc::parse(file_path.string());
+  ASSERT_TRUE(parsed_proc.has_value());
+
+  const auto &parsed_apps = parsed_proc->get_apps();
+  const auto steam_ctx = std::find_if(parsed_apps.begin(), parsed_apps.end(), [](const auto &app) {
+    return app.name == "Steam Big Picture";
+  });
+
+  ASSERT_NE(steam_ctx, parsed_apps.end());
+  ASSERT_EQ(steam_ctx->prep_cmds.size(), 2);
+  EXPECT_NE(
+    std::find_if(steam_ctx->prep_cmds.begin(), steam_ctx->prep_cmds.end(), [](const auto &cmd) {
+      return cmd.do_cmd == "setsid bash -lc \"steam -shutdown >/dev/null 2>&1 || true; sleep 2\"" &&
+             cmd.undo_cmd.empty();
+    }),
+    steam_ctx->prep_cmds.end()
+  );
+  EXPECT_NE(
+    std::find_if(steam_ctx->prep_cmds.begin(), steam_ctx->prep_cmds.end(), [](const auto &cmd) {
+      return cmd.do_cmd.empty() && cmd.undo_cmd == "setsid steam -shutdown";
+    }),
+    steam_ctx->prep_cmds.end()
+  );
+
+  std::filesystem::remove(file_path);
+}
+#endif
+
 TEST(ProcessMigrationTests, ParseStripsSteamBigPictureMangoHudEvenWithExistingCleanupUndo) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t guard;
+  config::video.linux_display.use_cage_compositor = false;
+#endif
+
   const auto file_path = test_paths::root() / "steam_big_picture_existing_cleanup.json";
 
   const nlohmann::json apps = {
@@ -165,6 +241,11 @@ TEST(ProcessMigrationTests, ParseStripsSteamBigPictureMangoHudEvenWithExistingCl
 }
 
 TEST(ProcessMigrationTests, ParseNormalizesSteamLibraryLaunchAndAddsShutdownUndo) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t guard;
+  config::video.linux_display.use_cage_compositor = false;
+#endif
+
   const auto file_path = test_paths::root() / "steam_library_launch_normalization.json";
 
   const nlohmann::json apps = {
@@ -212,3 +293,56 @@ TEST(ProcessMigrationTests, ParseNormalizesSteamLibraryLaunchAndAddsShutdownUndo
 
   std::filesystem::remove(file_path);
 }
+
+#ifdef __linux__
+TEST(ProcessMigrationTests, ParseAddsSteamLibraryPrelaunchShutdownForLinuxCage) {
+  linux_cage_compositor_guard_t guard;
+  config::video.linux_display.use_cage_compositor = true;
+
+  const auto file_path = test_paths::root() / "steam_library_cage_prelaunch_shutdown.json";
+
+  const nlohmann::json apps = {
+    {"version", 2},
+    {"apps", {
+      {
+        {"name", "Indiana Jones and the Great Circle"},
+        {"uuid", "steam-library-cage-prelaunch"},
+        {"cmd", ""},
+        {"detached", {"setsid steam steam://rungameid/2677660"}},
+        {"prep-cmd", nlohmann::json::array()},
+        {"source", "steam"},
+        {"steam-appid", "2677660"},
+        {"image-path", "./assets/indiana.png"}
+      }
+    }}
+  };
+
+  ASSERT_EQ(file_handler::write_file(file_path.string().c_str(), apps.dump(2)), 0);
+
+  auto parsed_proc = proc::parse(file_path.string());
+  ASSERT_TRUE(parsed_proc.has_value());
+
+  const auto &parsed_apps = parsed_proc->get_apps();
+  const auto steam_ctx = std::find_if(parsed_apps.begin(), parsed_apps.end(), [](const auto &app) {
+    return app.name == "Indiana Jones and the Great Circle";
+  });
+
+  ASSERT_NE(steam_ctx, parsed_apps.end());
+  ASSERT_EQ(steam_ctx->prep_cmds.size(), 2);
+  EXPECT_NE(
+    std::find_if(steam_ctx->prep_cmds.begin(), steam_ctx->prep_cmds.end(), [](const auto &cmd) {
+      return cmd.do_cmd == "setsid bash -lc \"steam -shutdown >/dev/null 2>&1 || true; sleep 2\"" &&
+             cmd.undo_cmd.empty();
+    }),
+    steam_ctx->prep_cmds.end()
+  );
+  EXPECT_NE(
+    std::find_if(steam_ctx->prep_cmds.begin(), steam_ctx->prep_cmds.end(), [](const auto &cmd) {
+      return cmd.do_cmd.empty() && cmd.undo_cmd == "setsid steam -shutdown";
+    }),
+    steam_ctx->prep_cmds.end()
+  );
+
+  std::filesystem::remove(file_path);
+}
+#endif


### PR DESCRIPTION
## Summary
- add a Linux cage-only Steam pre-launch shutdown step before Steam Big Picture or Steam library launches
- keep the existing Steam cleanup undo command separate so sessions still shut Steam down when they end
- add process migration coverage for both non-cage behavior and Linux cage pre-launch shutdown behavior

## Root Cause
When Steam is already running on the visible desktop, `steam -gamepadui` can hand the request to that existing desktop process instead of starting inside the labwc headless runtime. That matches #19 where the normal Steam window appeared on the desktop and the headless stream returned 503.

## Validation
- `git diff --check`
- Fedora CUDA build: `~/bin/polaris-remote.sh cmake --build build -j8`
- Fedora targeted test: `build/tests/test_polaris_config --gtest_filter="ProcessMigrationTests.*Steam*"`

Fixes #19