### PR TITLE
Improve labwc startup diagnostics

### DIFF
--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -254,7 +254,7 @@ sudo rpm-ostree uninstall -r polaris
 
 ## Known Bazzite Log Messages
 
-`labwc: No new Wayland socket appeared within 5s` means the isolated `labwc`
+`labwc: No new Wayland socket appeared within 10s` means the isolated `labwc`
 runtime failed to start or exited before creating its Wayland socket. Confirm the
 matching Fedora RPM was installed, rebooted into the new deployment, and retry
 from Desktop Mode first.

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -71,6 +71,22 @@ sudo polaris --setup-host --enable-kms
 
 The default compositor and portal paths do not require granting KMS capability.
 
+## Headless Labwc Checks
+
+If a headless stream reports that video capture failed, confirm that the helper
+programs used by the private labwc runtime are installed and visible to Polaris:
+
+```bash
+command -v labwc wlr-randr Xwayland xdpyinfo
+labwc --version
+```
+
+`labwc: Required executable [labwc] was not found in PATH` means the package or
+source install is missing the isolated compositor runtime. `labwc: Exited before
+creating a Wayland socket` means labwc started but failed before it could expose
+the stream-only Wayland socket; check the installed labwc/wlroots stack and retry
+from a normal Wayland desktop session first.
+
 ## Validation Checklist
 
 Please include these details when reporting Ubuntu issues:

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -20,9 +20,11 @@
 #include "../../logging.h"
 
 #include <atomic>
+#include <cerrno>
 #include <cctype>
 #include <chrono>
 #include <cstdio>
+#include <dirent.h>
 #include <functional>
 #include <fstream>
 #include <cstdlib>
@@ -71,11 +73,72 @@ namespace cage_display_router {
 
   static std::string runtime_dir() {
     const char *xdg = getenv("XDG_RUNTIME_DIR");
-    return xdg ? xdg : "/run/user/1000";
+    return (xdg && *xdg) ? xdg : "/run/user/" + std::to_string(getuid());
   }
 
   static std::string socket_path(const std::string &socket_name) {
     return runtime_dir() + "/" + socket_name;
+  }
+
+  static bool executable_accessible(const std::string &path) {
+    return !path.empty() && access(path.c_str(), X_OK) == 0;
+  }
+
+  static std::string resolve_executable(const std::string &name) {
+    if (name.find('/') != std::string::npos) {
+      return executable_accessible(name) ? name : "";
+    }
+
+    const char *path_env = getenv("PATH");
+    std::string path = (path_env && *path_env) ? path_env : "/usr/local/bin:/usr/bin:/bin";
+    size_t start = 0;
+
+    while (start <= path.size()) {
+      const auto end = path.find(':', start);
+      auto dir = path.substr(start, end == std::string::npos ? std::string::npos : end - start);
+      if (dir.empty()) {
+        dir = ".";
+      }
+
+      const auto candidate = dir + "/" + name;
+      if (executable_accessible(candidate)) {
+        return candidate;
+      }
+
+      if (end == std::string::npos) {
+        break;
+      }
+      start = end + 1;
+    }
+
+    return "";
+  }
+
+  static bool is_wayland_socket_name(std::string_view name) {
+    constexpr std::string_view prefix = "wayland-";
+    if (name.size() <= prefix.size() || name.substr(0, prefix.size()) != prefix) {
+      return false;
+    }
+
+    for (char ch : name.substr(prefix.size())) {
+      if (!std::isdigit(static_cast<unsigned char>(ch))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  static std::string describe_child_status(int status) {
+    if (WIFEXITED(status)) {
+      return "exited with status " + std::to_string(WEXITSTATUS(status));
+    }
+
+    if (WIFSIGNALED(status)) {
+      return "terminated by signal " + std::to_string(WTERMSIG(status));
+    }
+
+    return "changed state before startup completed";
   }
 
   template<typename Predicate>
@@ -104,25 +167,54 @@ namespace cage_display_router {
   static std::set<std::string> snapshot_wayland_sockets() {
     std::set<std::string> sockets;
     auto runtime = runtime_dir();
-    for (int n = 0; n < 50; ++n) {
-      std::string name = "wayland-" + std::to_string(n);
-      std::string path = runtime + "/" + name;
-      if (access(path.c_str(), F_OK) == 0) {
-        sockets.insert(name);
+
+    DIR *dir = opendir(runtime.c_str());
+    if (!dir) {
+      BOOST_LOG(debug) << "labwc: Could not inspect runtime directory ["sv << runtime
+                       << "]: "sv << std::strerror(errno);
+      return sockets;
+    }
+
+    while (auto *entry = readdir(dir)) {
+      std::string name = entry->d_name;
+      if (!is_wayland_socket_name(name)) {
+        continue;
+      }
+
+      const auto path = runtime + "/" + name;
+      struct stat statbuf {};
+      if (stat(path.c_str(), &statbuf) == 0 && S_ISSOCK(statbuf.st_mode)) {
+        sockets.insert(std::move(name));
       }
     }
+
+    closedir(dir);
     return sockets;
   }
 
   /**
    * @brief Find which new Wayland socket appeared after cage started.
    */
-  static std::string find_new_socket(const std::set<std::string> &before, int max_wait_ms = 5000) {
+  static std::string find_new_socket(
+    const std::set<std::string> &before,
+    int max_wait_ms = 10000,
+    std::optional<int> *exit_status = nullptr
+  ) {
     const auto poll_interval = 50ms;
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(max_wait_ms);
     while (std::chrono::steady_clock::now() < deadline) {
-      if (cage_pid > 0 && kill(cage_pid, 0) != 0) {
-        return "";
+      if (cage_pid > 0) {
+        int status = 0;
+        const auto ret = waitpid(cage_pid, &status, WNOHANG);
+        if (ret == cage_pid) {
+          if (exit_status) {
+            *exit_status = status;
+          }
+          return "";
+        }
+        if (ret < 0 && errno == ECHILD) {
+          return "";
+        }
       }
 
       auto current = snapshot_wayland_sockets();
@@ -268,6 +360,10 @@ namespace cage_display_router {
   ) {
     return output_reports_current_mode(wlr_randr_output, output_name, width, height);
   }
+
+  bool is_wayland_socket_name_for_tests(std::string_view name) {
+    return is_wayland_socket_name(name);
+  }
 #endif
 
   // -----------------------------------------------------------------------
@@ -302,6 +398,29 @@ namespace cage_display_router {
     }
     BOOST_LOG(info) << "labwc: Starting in "sv << (headless ? "headless"sv : "windowed"sv)
                     << " mode — resolution="sv << width << "x"sv << height;
+
+    const auto labwc_path = resolve_executable("labwc");
+    if (labwc_path.empty()) {
+      BOOST_LOG(error) << "labwc: Required executable [labwc] was not found in PATH; install labwc and restart Polaris"sv;
+      return false;
+    }
+
+    const auto wlr_randr_path = resolve_executable("wlr-randr");
+    if (wlr_randr_path.empty()) {
+      BOOST_LOG(error) << "labwc: Required executable [wlr-randr] was not found in PATH; install wlr-randr and restart Polaris"sv;
+      return false;
+    }
+
+    if (headless && !game_cmd.empty()) {
+      if (resolve_executable("Xwayland").empty()) {
+        BOOST_LOG(warning) << "labwc: Xwayland was not found in PATH; X11 games and Steam may fail inside the headless runtime"sv;
+      }
+      if (resolve_executable("xdpyinfo").empty()) {
+        BOOST_LOG(warning) << "labwc: xdpyinfo was not found in PATH; Polaris cannot wait for labwc XWayland readiness"sv;
+      }
+    }
+
+    BOOST_LOG(info) << "labwc: Using executable ["sv << labwc_path << ']';
 
     // Config directory for kiosk-mode rc.xml (no decorations, maximize all)
     std::string config_dir = std::string(getenv("HOME") ? getenv("HOME") : "/tmp") + "/.config/labwc-polaris";
@@ -346,6 +465,8 @@ namespace cage_display_router {
 
     // Snapshot existing sockets to detect the new one labwc creates
     auto sockets_before = snapshot_wayland_sockets();
+    BOOST_LOG(info) << "labwc: Watching runtime directory ["sv << runtime_dir()
+                    << "] for a new Wayland socket"sv;
 
     // Save and clear MangoHud env vars before fork — MangoHud crashes labwc
     // if injected into the compositor. Will be re-set for the game via startup cmd.
@@ -406,11 +527,11 @@ namespace cage_display_router {
       }
 
       // labwc -C: config dir for rc.xml, -s: startup command (game)
-      execl("/usr/bin/labwc", "labwc",
+      execl(labwc_path.c_str(), "labwc",
         "-C", config_dir.c_str(),
         "-s", ("bash -c '" + startup_cmd + "'").c_str(),
         nullptr);
-      _exit(1);
+      _exit(errno == ENOENT ? 127 : 126);
     } else if (pid > 0) {
       cage_pid = pid;
       // Restore MangoHud in parent (was cleared to prevent labwc crash)
@@ -423,9 +544,17 @@ namespace cage_display_router {
     }
 
     // Discover which Wayland socket cage created (it auto-picks the next available)
-    cage_wayland_socket = find_new_socket(sockets_before, 5000);
+    std::optional<int> labwc_exit_status;
+    cage_wayland_socket = find_new_socket(sockets_before, 10000, &labwc_exit_status);
     if (cage_wayland_socket.empty()) {
-      BOOST_LOG(error) << "labwc: No new Wayland socket appeared within 5s"sv;
+      if (labwc_exit_status) {
+        BOOST_LOG(error) << "labwc: Exited before creating a Wayland socket ("sv
+                         << describe_child_status(*labwc_exit_status)
+                         << "); check labwc, wlroots, and headless runtime dependencies"sv;
+      } else {
+        BOOST_LOG(error) << "labwc: No new Wayland socket appeared within 10s in ["sv
+                         << runtime_dir() << ']';
+      }
       stop();
       return false;
     }

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -165,6 +165,11 @@ namespace cage_display_router {
     int width,
     int height
   );
+
+  /**
+   * @brief Test helper for Wayland socket file name filtering.
+   */
+  bool is_wayland_socket_name_for_tests(std::string_view name);
 #endif
 
 }  // namespace cage_display_router

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -167,6 +167,17 @@ TEST(CageDisplayRouterPolicyTests, OutputModeParserRejectsNonCurrentRequestedMod
     1080
   ));
 }
+
+TEST(CageDisplayRouterPolicyTests, WaylandSocketNameParserAcceptsNumberedSocketsOnly) {
+  EXPECT_TRUE(cage_display_router::is_wayland_socket_name_for_tests("wayland-0"));
+  EXPECT_TRUE(cage_display_router::is_wayland_socket_name_for_tests("wayland-50"));
+  EXPECT_TRUE(cage_display_router::is_wayland_socket_name_for_tests("wayland-123"));
+
+  EXPECT_FALSE(cage_display_router::is_wayland_socket_name_for_tests("wayland-"));
+  EXPECT_FALSE(cage_display_router::is_wayland_socket_name_for_tests("wayland-1.lock"));
+  EXPECT_FALSE(cage_display_router::is_wayland_socket_name_for_tests("pipewire-0"));
+  EXPECT_FALSE(cage_display_router::is_wayland_socket_name_for_tests("nested-wayland-1"));
+}
 #endif
 #else
 TEST(CageDisplayRouterPolicyTests, LinuxOnly) {


### PR DESCRIPTION
## Summary
- resolve `labwc` and `wlr-randr` from PATH before starting the private compositor
- report missing helpers and early labwc exits separately from true Wayland socket timeouts
- enumerate actual `wayland-*` sockets in `XDG_RUNTIME_DIR` instead of assuming `wayland-0` through `wayland-49`
- extend the labwc socket wait to 10 seconds and update Debian/Bazzite troubleshooting docs

## Context
Discussion: https://github.com/papi-ux/polaris/discussions/11

The reported failure showed repeated `labwc: No new Wayland socket appeared within 5s` and `Temporary cage runtime failed to start for deferred capability probe` messages on PikaOS. The old path hid whether labwc was missing, exited immediately, chose a socket outside the fixed scan range, or simply missed the short timeout.

## Validation
- `git diff --check`
- Fedora CUDA build: `~/bin/polaris-remote.sh cmake --build build -j8`
- Fedora targeted test: `build/tests/test_polaris_platform --gtest_filter="CageDisplayRouterPolicyTests.*"`