### PR TITLE
Refine wlgrab SHM channel swap handling

### DIFF
--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -853,7 +853,7 @@ namespace portal {
           }
         }
       } else {
-        // 4bpp format (XRGB8888/ARGB8888) — direct copy
+        // 4bpp format: direct copy (XRGB8888/ARGB8888 are already [B,G,R,X] on LE)
         int copy_bytes = std::min((int) st.stride, img_out->row_pitch);
         for (int y = 0; y < copy_h; ++y) {
           std::memcpy(img_out->data + y * img_out->row_pitch,

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -853,7 +853,7 @@ namespace portal {
           }
         }
       } else {
-        // 4bpp format: direct copy (XRGB8888/ARGB8888 are already [B,G,R,X] on LE)
+        // 4bpp format (XRGB8888/ARGB8888) — direct copy
         int copy_bytes = std::min((int) st.stride, img_out->row_pitch);
         for (int y = 0; y < copy_h; ++y) {
           std::memcpy(img_out->data + y * img_out->row_pitch,

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -3,7 +3,6 @@
  * @brief Definitions for wlgrab capture.
  */
 // standard includes
-#include <cstring>
 #include <thread>
 
 // local includes
@@ -16,6 +15,7 @@
 #include "src/video.h"
 #include "vaapi.h"
 #include "wayland.h"
+#include "wlgrab_pixel_copy.h"
 
 using namespace std::literals;
 
@@ -263,7 +263,6 @@ namespace wl {
         int copy_w = std::min((int) dmabuf.shm_info.width, img_out->width);
         int src_stride = dmabuf.shm_info.stride;
         int dst_stride = img_out->row_pitch;
-        int copy_bytes = std::min(src_stride, dst_stride);
         const bool is_3bpp = (src_stride == dmabuf.shm_info.width * 3);
 
         if (is_3bpp) {
@@ -287,31 +286,15 @@ namespace wl {
             }
           }
         } else {
-          // XBGR8888/ABGR8888 (fourcc 0x34324258/0x34324241) have memory layout
-          // [R,G,B,X] on little-endian; swap R↔B so the encoder receives [B,G,R,A].
-          // All other 4bpp formats (XRGB8888/ARGB8888) are already [B,G,R,X] and
-          // can be copied directly.
-          const uint32_t fmt = dmabuf.shm_info.format;
-          const bool needs_rb_swap = (fmt == 0x34324258 /* XBGR8888 */ ||
-                                      fmt == 0x34324241 /* ABGR8888 */);
-          if (needs_rb_swap) {
-            for (int y = 0; y < copy_h; ++y) {
-              const uint8_t *src_line = src + y * src_stride;
-              uint8_t *dst_line = dst + y * dst_stride;
-              for (int x = 0; x < copy_w; ++x) {
-                dst_line[x * 4 + 0] = src_line[x * 4 + 2];  // B ← src B
-                dst_line[x * 4 + 1] = src_line[x * 4 + 1];  // G
-                dst_line[x * 4 + 2] = src_line[x * 4 + 0];  // R ← src R
-                dst_line[x * 4 + 3] = src_line[x * 4 + 3];  // A/X
-              }
-            }
-          } else if (src_stride == dst_stride && copy_bytes == src_stride) {
-            std::memcpy(dst, src, static_cast<std::size_t>(copy_h) * copy_bytes);
-          } else {
-            for (int y = 0; y < copy_h; ++y) {
-              std::memcpy(dst + y * dst_stride, src + y * src_stride, copy_bytes);
-            }
-          }
+          copy_shm_4bpp_to_bgra(
+            src,
+            src_stride,
+            dst,
+            dst_stride,
+            copy_w,
+            copy_h,
+            dmabuf.shm_info.format
+          );
         }
 
         img_out->frame_timestamp = frame_timestamp;

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -286,11 +286,31 @@ namespace wl {
               dst_line[x * 4 + 3] = 255;
             }
           }
-        } else if (src_stride == dst_stride && copy_bytes == src_stride) {
-          std::memcpy(dst, src, static_cast<std::size_t>(copy_h) * copy_bytes);
         } else {
-          for (int y = 0; y < copy_h; ++y) {
-            std::memcpy(dst + y * dst_stride, src + y * src_stride, copy_bytes);
+          // XBGR8888/ABGR8888 (fourcc 0x34324258/0x34324241) have memory layout
+          // [R,G,B,X] on little-endian; swap R↔B so the encoder receives [B,G,R,A].
+          // All other 4bpp formats (XRGB8888/ARGB8888) are already [B,G,R,X] and
+          // can be copied directly.
+          const uint32_t fmt = dmabuf.shm_info.format;
+          const bool needs_rb_swap = (fmt == 0x34324258 /* XBGR8888 */ ||
+                                      fmt == 0x34324241 /* ABGR8888 */);
+          if (needs_rb_swap) {
+            for (int y = 0; y < copy_h; ++y) {
+              const uint8_t *src_line = src + y * src_stride;
+              uint8_t *dst_line = dst + y * dst_stride;
+              for (int x = 0; x < copy_w; ++x) {
+                dst_line[x * 4 + 0] = src_line[x * 4 + 2];  // B ← src B
+                dst_line[x * 4 + 1] = src_line[x * 4 + 1];  // G
+                dst_line[x * 4 + 2] = src_line[x * 4 + 0];  // R ← src R
+                dst_line[x * 4 + 3] = src_line[x * 4 + 3];  // A/X
+              }
+            }
+          } else if (src_stride == dst_stride && copy_bytes == src_stride) {
+            std::memcpy(dst, src, static_cast<std::size_t>(copy_h) * copy_bytes);
+          } else {
+            for (int y = 0; y < copy_h; ++y) {
+              std::memcpy(dst + y * dst_stride, src + y * src_stride, copy_bytes);
+            }
           }
         }
 

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -273,18 +273,9 @@ namespace wl {
             logged_bgr888_conversion = true;
           }
 
-          for (int y = 0; y < copy_h; ++y) {
-            const uint8_t *src_line = src + y * src_stride;
-            uint8_t *dst_line = dst + y * dst_stride;
-            for (int x = 0; x < copy_w; ++x) {
-              // Match the portal screencopy path: headless wlroots SHM frames
-              // report BGR888 but the byte order is effectively RGB.
-              dst_line[x * 4 + 0] = src_line[x * 3 + 2];
-              dst_line[x * 4 + 1] = src_line[x * 3 + 1];
-              dst_line[x * 4 + 2] = src_line[x * 3 + 0];
-              dst_line[x * 4 + 3] = 255;
-            }
-          }
+          // Match the portal screencopy path: headless wlroots SHM frames
+          // report BGR888 but the byte order is effectively RGB.
+          copy_shm_3bpp_rgb_to_bgra(src, src_stride, dst, dst_stride, copy_w, copy_h);
         } else {
           copy_shm_4bpp_to_bgra(
             src,

--- a/src/platform/linux/wlgrab_pixel_copy.h
+++ b/src/platform/linux/wlgrab_pixel_copy.h
@@ -9,16 +9,29 @@
 #include <cstdint>
 #include <cstring>
 
-#include <drm_fourcc.h>
-
 namespace wl {
-  inline bool shm_format_needs_bgra_swap(std::uint32_t format) {
-    switch (format) {
-      case DRM_FORMAT_XBGR8888:
-      case DRM_FORMAT_ABGR8888:
-        return true;
-      default:
-        return false;
+  inline void copy_shm_3bpp_rgb_to_bgra(
+    const std::uint8_t *src,
+    int src_stride,
+    std::uint8_t *dst,
+    int dst_stride,
+    int copy_width,
+    int copy_height
+  ) {
+    const int copy_pixels = std::min(copy_width, std::min(src_stride / 3, dst_stride / 4));
+    if (copy_pixels <= 0 || copy_height <= 0) {
+      return;
+    }
+
+    for (int y = 0; y < copy_height; ++y) {
+      const std::uint8_t *src_line = src + y * src_stride;
+      std::uint8_t *dst_line = dst + y * dst_stride;
+      for (int x = 0; x < copy_pixels; ++x) {
+        dst_line[x * 4 + 0] = src_line[x * 3 + 2];
+        dst_line[x * 4 + 1] = src_line[x * 3 + 1];
+        dst_line[x * 4 + 2] = src_line[x * 3 + 0];
+        dst_line[x * 4 + 3] = 255;
+      }
     }
   }
 
@@ -29,25 +42,11 @@ namespace wl {
     int dst_stride,
     int copy_width,
     int copy_height,
-    std::uint32_t format
+    std::uint32_t /* format */
   ) {
-    const int copy_bytes = std::min(src_stride, dst_stride);
-
-    if (shm_format_needs_bgra_swap(format)) {
-      // wlgrab advertises the software frame as bgra8. These SHM formats
-      // arrive in RGB byte order on little-endian hosts, so convert on copy.
-      for (int y = 0; y < copy_height; ++y) {
-        const std::uint8_t *src_line = src + y * src_stride;
-        std::uint8_t *dst_line = dst + y * dst_stride;
-
-        for (int x = 0; x < copy_width; ++x) {
-          dst_line[x * 4 + 0] = src_line[x * 4 + 2];
-          dst_line[x * 4 + 1] = src_line[x * 4 + 1];
-          dst_line[x * 4 + 2] = src_line[x * 4 + 0];
-          dst_line[x * 4 + 3] = src_line[x * 4 + 3];
-        }
-      }
-
+    const int row_bytes = copy_width * 4;
+    const int copy_bytes = std::min(row_bytes, std::min(src_stride, dst_stride));
+    if (copy_bytes <= 0 || copy_height <= 0) {
       return;
     }
 

--- a/src/platform/linux/wlgrab_pixel_copy.h
+++ b/src/platform/linux/wlgrab_pixel_copy.h
@@ -9,7 +9,21 @@
 #include <cstdint>
 #include <cstring>
 
+#include <drm_fourcc.h>
+
 namespace wl {
+  inline bool shm_4bpp_format_needs_bgra_swap(std::uint32_t format) {
+    switch (format) {
+      case DRM_FORMAT_XRGB8888:
+      case DRM_FORMAT_ARGB8888:
+      case DRM_FORMAT_XBGR8888:
+      case DRM_FORMAT_ABGR8888:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   inline void copy_shm_3bpp_rgb_to_bgra(
     const std::uint8_t *src,
     int src_stride,
@@ -42,11 +56,26 @@ namespace wl {
     int dst_stride,
     int copy_width,
     int copy_height,
-    std::uint32_t /* format */
+    std::uint32_t format
   ) {
     const int row_bytes = copy_width * 4;
     const int copy_bytes = std::min(row_bytes, std::min(src_stride, dst_stride));
     if (copy_bytes <= 0 || copy_height <= 0) {
+      return;
+    }
+
+    if (shm_4bpp_format_needs_bgra_swap(format)) {
+      const int copy_pixels = std::min(copy_width, std::min(src_stride / 4, dst_stride / 4));
+      for (int y = 0; y < copy_height; ++y) {
+        const std::uint8_t *src_line = src + y * src_stride;
+        std::uint8_t *dst_line = dst + y * dst_stride;
+        for (int x = 0; x < copy_pixels; ++x) {
+          dst_line[x * 4 + 0] = src_line[x * 4 + 2];
+          dst_line[x * 4 + 1] = src_line[x * 4 + 1];
+          dst_line[x * 4 + 2] = src_line[x * 4 + 0];
+          dst_line[x * 4 + 3] = src_line[x * 4 + 3];
+        }
+      }
       return;
     }
 

--- a/src/platform/linux/wlgrab_pixel_copy.h
+++ b/src/platform/linux/wlgrab_pixel_copy.h
@@ -1,0 +1,63 @@
+/**
+ * @file src/platform/linux/wlgrab_pixel_copy.h
+ * @brief Pixel copy helpers for wlgrab SHM capture.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include <drm_fourcc.h>
+
+namespace wl {
+  inline bool shm_format_needs_bgra_swap(std::uint32_t format) {
+    switch (format) {
+      case DRM_FORMAT_XBGR8888:
+      case DRM_FORMAT_ABGR8888:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  inline void copy_shm_4bpp_to_bgra(
+    const std::uint8_t *src,
+    int src_stride,
+    std::uint8_t *dst,
+    int dst_stride,
+    int copy_width,
+    int copy_height,
+    std::uint32_t format
+  ) {
+    const int copy_bytes = std::min(src_stride, dst_stride);
+
+    if (shm_format_needs_bgra_swap(format)) {
+      // wlgrab advertises the software frame as bgra8. These SHM formats
+      // arrive in RGB byte order on little-endian hosts, so convert on copy.
+      for (int y = 0; y < copy_height; ++y) {
+        const std::uint8_t *src_line = src + y * src_stride;
+        std::uint8_t *dst_line = dst + y * dst_stride;
+
+        for (int x = 0; x < copy_width; ++x) {
+          dst_line[x * 4 + 0] = src_line[x * 4 + 2];
+          dst_line[x * 4 + 1] = src_line[x * 4 + 1];
+          dst_line[x * 4 + 2] = src_line[x * 4 + 0];
+          dst_line[x * 4 + 3] = src_line[x * 4 + 3];
+        }
+      }
+
+      return;
+    }
+
+    if (src_stride == dst_stride && copy_bytes == src_stride) {
+      std::memcpy(dst, src, static_cast<std::size_t>(copy_height) * copy_bytes);
+      return;
+    }
+
+    for (int y = 0; y < copy_height; ++y) {
+      std::memcpy(dst + y * dst_stride, src + y * src_stride, copy_bytes);
+    }
+  }
+}  // namespace wl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,8 +81,13 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_file_handler.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_rswrapper.cpp
-    ${CMAKE_SOURCE_DIR}/tests/unit/test_wlgrab_pixel_copy.cpp
 )
+
+if (NOT WIN32 AND NOT APPLE)
+    list(APPEND TEST_FAST_SOURCES
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_wlgrab_pixel_copy.cpp
+    )
+endif()
 
 set(TEST_AUDIT_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/integration/test_config_consistency.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_file_handler.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_rswrapper.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_wlgrab_pixel_copy.cpp
 )
 
 set(TEST_AUDIT_SOURCES

--- a/tests/unit/test_wlgrab_pixel_copy.cpp
+++ b/tests/unit/test_wlgrab_pixel_copy.cpp
@@ -9,6 +9,8 @@
 #include <array>
 #include <cstdint>
 
+#include <drm_fourcc.h>
+
 namespace {
   void expect_pixel(
     const std::uint8_t *pixels,
@@ -25,22 +27,52 @@ namespace {
   }
 }  // namespace
 
-TEST(WlgrabPixelCopy, XBGR8888SwapsRedAndBlue) {
+TEST(WlgrabPixelCopy, Rgb888ExpandsToBgra) {
+  const std::array<std::uint8_t, 3> src {0x11, 0x22, 0x33};
+  std::array<std::uint8_t, 4> dst {};
+
+  wl::copy_shm_3bpp_rgb_to_bgra(src.data(), 3, dst.data(), 4, 1, 1);
+
+  expect_pixel(dst.data(), 0, 0x33, 0x22, 0x11, 0xFF);
+}
+
+TEST(WlgrabPixelCopy, Rgb888ExpansionHandlesRowsAndPadding) {
+  constexpr int width = 2;
+  constexpr int height = 2;
+  constexpr int src_stride = width * 3 + 2;
+  constexpr int dst_stride = width * 4 + 4;
+
+  std::array<std::uint8_t, src_stride * height> src {};
+  src[0] = 0x01; src[1] = 0x02; src[2] = 0x03;
+  src[3] = 0x04; src[4] = 0x05; src[5] = 0x06;
+  src[src_stride + 0] = 0x07; src[src_stride + 1] = 0x08; src[src_stride + 2] = 0x09;
+  src[src_stride + 3] = 0x0A; src[src_stride + 4] = 0x0B; src[src_stride + 5] = 0x0C;
+
+  std::array<std::uint8_t, dst_stride * height> dst {};
+  wl::copy_shm_3bpp_rgb_to_bgra(src.data(), src_stride, dst.data(), dst_stride, width, height);
+
+  expect_pixel(dst.data(), 0, 0x03, 0x02, 0x01, 0xFF);
+  expect_pixel(dst.data(), 4, 0x06, 0x05, 0x04, 0xFF);
+  expect_pixel(dst.data(), dst_stride, 0x09, 0x08, 0x07, 0xFF);
+  expect_pixel(dst.data(), dst_stride + 4, 0x0C, 0x0B, 0x0A, 0xFF);
+}
+
+TEST(WlgrabPixelCopy, XBGR8888CopiesWithoutSwap) {
   const std::array<std::uint8_t, 4> src {0x11, 0x22, 0x33, 0xFF};
   std::array<std::uint8_t, 4> dst {};
 
   wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, DRM_FORMAT_XBGR8888);
 
-  expect_pixel(dst.data(), 0, 0x33, 0x22, 0x11, 0xFF);
+  expect_pixel(dst.data(), 0, 0x11, 0x22, 0x33, 0xFF);
 }
 
-TEST(WlgrabPixelCopy, ABGR8888SwapsRedAndBlue) {
+TEST(WlgrabPixelCopy, ABGR8888CopiesWithoutSwap) {
   const std::array<std::uint8_t, 4> src {0xAA, 0xBB, 0xCC, 0x80};
   std::array<std::uint8_t, 4> dst {};
 
   wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, DRM_FORMAT_ABGR8888);
 
-  expect_pixel(dst.data(), 0, 0xCC, 0xBB, 0xAA, 0x80);
+  expect_pixel(dst.data(), 0, 0xAA, 0xBB, 0xCC, 0x80);
 }
 
 TEST(WlgrabPixelCopy, XRGB8888CopiesWithoutSwap) {
@@ -52,7 +84,7 @@ TEST(WlgrabPixelCopy, XRGB8888CopiesWithoutSwap) {
   expect_pixel(dst.data(), 0, 0x11, 0x22, 0x33, 0xFF);
 }
 
-TEST(WlgrabPixelCopy, XBGR8888SwapAppliedToEveryRowAndPixel) {
+TEST(WlgrabPixelCopy, XBGR8888CopyAppliedToEveryRowAndPixel) {
   const std::array<std::uint8_t, 16> src {
     0x10, 0x20, 0x30, 0xFF,
     0x40, 0x50, 0x60, 0xFF,
@@ -63,13 +95,13 @@ TEST(WlgrabPixelCopy, XBGR8888SwapAppliedToEveryRowAndPixel) {
 
   wl::copy_shm_4bpp_to_bgra(src.data(), 8, dst.data(), 8, 2, 2, DRM_FORMAT_XBGR8888);
 
-  expect_pixel(dst.data(), 0, 0x30, 0x20, 0x10, 0xFF);
-  expect_pixel(dst.data(), 4, 0x60, 0x50, 0x40, 0xFF);
-  expect_pixel(dst.data(), 8, 0x90, 0x80, 0x70, 0xFF);
-  expect_pixel(dst.data(), 12, 0xC0, 0xB0, 0xA0, 0xFF);
+  expect_pixel(dst.data(), 0, 0x10, 0x20, 0x30, 0xFF);
+  expect_pixel(dst.data(), 4, 0x40, 0x50, 0x60, 0xFF);
+  expect_pixel(dst.data(), 8, 0x70, 0x80, 0x90, 0xFF);
+  expect_pixel(dst.data(), 12, 0xA0, 0xB0, 0xC0, 0xFF);
 }
 
-TEST(WlgrabPixelCopy, XBGR8888SwapIgnoresSourceRowPadding) {
+TEST(WlgrabPixelCopy, XBGR8888CopyIgnoresSourceRowPadding) {
   constexpr int width = 2;
   constexpr int height = 2;
   constexpr int src_stride = width * 4 + 4;
@@ -86,8 +118,8 @@ TEST(WlgrabPixelCopy, XBGR8888SwapIgnoresSourceRowPadding) {
   std::array<std::uint8_t, dst_stride * height> dst {};
   wl::copy_shm_4bpp_to_bgra(src.data(), src_stride, dst.data(), dst_stride, width, height, DRM_FORMAT_XBGR8888);
 
-  expect_pixel(dst.data(), 0, 0x03, 0x02, 0x01, 0xFF);
-  expect_pixel(dst.data(), 4, 0x06, 0x05, 0x04, 0xFF);
-  expect_pixel(dst.data(), dst_stride, 0x09, 0x08, 0x07, 0xFF);
-  expect_pixel(dst.data(), dst_stride + 4, 0x0C, 0x0B, 0x0A, 0xFF);
+  expect_pixel(dst.data(), 0, 0x01, 0x02, 0x03, 0xFF);
+  expect_pixel(dst.data(), 4, 0x04, 0x05, 0x06, 0xFF);
+  expect_pixel(dst.data(), dst_stride, 0x07, 0x08, 0x09, 0xFF);
+  expect_pixel(dst.data(), dst_stride + 4, 0x0A, 0x0B, 0x0C, 0xFF);
 }

--- a/tests/unit/test_wlgrab_pixel_copy.cpp
+++ b/tests/unit/test_wlgrab_pixel_copy.cpp
@@ -1,0 +1,132 @@
+/**
+ * @file tests/unit/test_wlgrab_pixel_copy.cpp
+ * @brief Tests for the SHM pixel copy logic in the wlgrab screencopy path.
+ */
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+namespace {
+  // Wayland DRM fourcc values used by the SHM copy path in wlgrab.cpp.
+  constexpr uint32_t FMT_XBGR8888 = 0x34324258;
+  constexpr uint32_t FMT_ABGR8888 = 0x34324241;
+  constexpr uint32_t FMT_XRGB8888 = 0x34325258;
+
+  // Mirrors the 4bpp branch of the SHM copy path in wlgrab.cpp.
+  // Keep this in sync with that branch if the source changes.
+  //
+  // XBGR8888/ABGR8888 arrive with memory layout [R,G,B,X] on little-endian
+  // and need B↔R swapped so the encoder receives [B,G,R,X/A].
+  // All other 4bpp formats are already [B,G,R,X] and are copied directly.
+  void copy_4bpp_shm(
+    const uint8_t *src, int src_stride,
+    uint8_t *dst,       int dst_stride,
+    int copy_w, int copy_h,
+    uint32_t fmt
+  ) {
+    const int copy_bytes = std::min(src_stride, dst_stride);
+    const bool needs_rb_swap = (fmt == FMT_XBGR8888 || fmt == FMT_ABGR8888);
+    if (needs_rb_swap) {
+      for (int y = 0; y < copy_h; ++y) {
+        const uint8_t *src_line = src + y * src_stride;
+        uint8_t *dst_line = dst + y * dst_stride;
+        for (int x = 0; x < copy_w; ++x) {
+          dst_line[x * 4 + 0] = src_line[x * 4 + 2];
+          dst_line[x * 4 + 1] = src_line[x * 4 + 1];
+          dst_line[x * 4 + 2] = src_line[x * 4 + 0];
+          dst_line[x * 4 + 3] = src_line[x * 4 + 3];
+        }
+      }
+    } else if (src_stride == dst_stride && copy_bytes == src_stride) {
+      std::memcpy(dst, src, static_cast<std::size_t>(copy_h) * copy_bytes);
+    } else {
+      for (int y = 0; y < copy_h; ++y) {
+        std::memcpy(dst + y * dst_stride, src + y * src_stride, copy_bytes);
+      }
+    }
+  }
+}  // namespace
+
+// XBGR8888 on LE stores pixels as [R,G,B,X] in memory.
+// The encoder expects [B,G,R,X], so bytes 0 and 2 must be swapped.
+TEST(WlgrabPixelCopy, XBGR8888SwapsRedAndBlue) {
+  const uint8_t src[] = { 0x11 /*R*/, 0x22 /*G*/, 0x33 /*B*/, 0xFF /*X*/ };
+  uint8_t dst[4] = {};
+
+  copy_4bpp_shm(src, 4, dst, 4, 1, 1, FMT_XBGR8888);
+
+  EXPECT_EQ(dst[0], 0x33u);  // B
+  EXPECT_EQ(dst[1], 0x22u);  // G unchanged
+  EXPECT_EQ(dst[2], 0x11u);  // R
+  EXPECT_EQ(dst[3], 0xFFu);  // X unchanged
+}
+
+TEST(WlgrabPixelCopy, ABGR8888SwapsRedAndBlue) {
+  const uint8_t src[] = { 0xAA /*R*/, 0xBB /*G*/, 0xCC /*B*/, 0x80 /*A*/ };
+  uint8_t dst[4] = {};
+
+  copy_4bpp_shm(src, 4, dst, 4, 1, 1, FMT_ABGR8888);
+
+  EXPECT_EQ(dst[0], 0xCCu);  // B
+  EXPECT_EQ(dst[1], 0xBBu);  // G unchanged
+  EXPECT_EQ(dst[2], 0xAAu);  // R
+  EXPECT_EQ(dst[3], 0x80u);  // A unchanged
+}
+
+// XRGB8888 on LE stores pixels as [B,G,R,X] — already correct for the encoder.
+TEST(WlgrabPixelCopy, XRGB8888CopiesWithoutSwap) {
+  const uint8_t src[] = { 0x11, 0x22, 0x33, 0xFF };
+  uint8_t dst[4] = {};
+
+  copy_4bpp_shm(src, 4, dst, 4, 1, 1, FMT_XRGB8888);
+
+  EXPECT_EQ(dst[0], 0x11u);
+  EXPECT_EQ(dst[1], 0x22u);
+  EXPECT_EQ(dst[2], 0x33u);
+  EXPECT_EQ(dst[3], 0xFFu);
+}
+
+TEST(WlgrabPixelCopy, XBGR8888SwapAppliedToEveryRowAndPixel) {
+  // 2×2 frame, stride == width * 4 (no row padding)
+  const uint8_t src[] = {
+    0x10, 0x20, 0x30, 0xFF,  // row 0 px 0
+    0x40, 0x50, 0x60, 0xFF,  // row 0 px 1
+    0x70, 0x80, 0x90, 0xFF,  // row 1 px 0
+    0xA0, 0xB0, 0xC0, 0xFF,  // row 1 px 1
+  };
+  uint8_t dst[16] = {};
+
+  copy_4bpp_shm(src, 8, dst, 8, 2, 2, FMT_XBGR8888);
+
+  EXPECT_EQ(dst[0],  0x30u); EXPECT_EQ(dst[2],  0x10u);   // row 0 px 0
+  EXPECT_EQ(dst[4],  0x60u); EXPECT_EQ(dst[6],  0x40u);   // row 0 px 1
+  EXPECT_EQ(dst[8],  0x90u); EXPECT_EQ(dst[10], 0x70u);   // row 1 px 0
+  EXPECT_EQ(dst[12], 0xC0u); EXPECT_EQ(dst[14], 0xA0u);   // row 1 px 1
+}
+
+TEST(WlgrabPixelCopy, XBGR8888SwapWithPaddedSourceStride) {
+  // Screencopy buffers often have padding bytes at the end of each row.
+  // The swap loop uses copy_w (pixel count), not copy_bytes, so padding is ignored.
+  constexpr int W = 2;
+  constexpr int src_stride = W * 4 + 4;  // 12 bytes/row — 4 bytes padding
+  constexpr int dst_stride = W * 4;       // 8 bytes/row — tight
+
+  uint8_t src[src_stride * 2] = {};
+  src[0] = 0x01; src[1] = 0x02; src[2] = 0x03; src[3] = 0xFF;  // row 0 px 0
+  src[4] = 0x04; src[5] = 0x05; src[6] = 0x06; src[7] = 0xFF;  // row 0 px 1
+  // src[8..11]: padding — left zero, must not appear in output
+  src[src_stride + 0] = 0x07; src[src_stride + 1] = 0x08;  // row 1 px 0
+  src[src_stride + 2] = 0x09; src[src_stride + 3] = 0xFF;
+  src[src_stride + 4] = 0x0A; src[src_stride + 5] = 0x0B;  // row 1 px 1
+  src[src_stride + 6] = 0x0C; src[src_stride + 7] = 0xFF;
+
+  uint8_t dst[dst_stride * 2] = {};
+  copy_4bpp_shm(src, src_stride, dst, dst_stride, W, 2, FMT_XBGR8888);
+
+  EXPECT_EQ(dst[0], 0x03u); EXPECT_EQ(dst[2], 0x01u);  // row 0 px 0: B=src[2], R=src[0]
+  EXPECT_EQ(dst[4], 0x06u); EXPECT_EQ(dst[6], 0x04u);  // row 0 px 1
+  EXPECT_EQ(dst[dst_stride + 0], 0x09u); EXPECT_EQ(dst[dst_stride + 2], 0x07u);  // row 1 px 0
+  EXPECT_EQ(dst[dst_stride + 4], 0x0Cu); EXPECT_EQ(dst[dst_stride + 6], 0x0Au);  // row 1 px 1
+}

--- a/tests/unit/test_wlgrab_pixel_copy.cpp
+++ b/tests/unit/test_wlgrab_pixel_copy.cpp
@@ -57,34 +57,52 @@ TEST(WlgrabPixelCopy, Rgb888ExpansionHandlesRowsAndPadding) {
   expect_pixel(dst.data(), dst_stride + 4, 0x0C, 0x0B, 0x0A, 0xFF);
 }
 
-TEST(WlgrabPixelCopy, XBGR8888CopiesWithoutSwap) {
+TEST(WlgrabPixelCopy, XBGR8888SwapsRedAndBlue) {
   const std::array<std::uint8_t, 4> src {0x11, 0x22, 0x33, 0xFF};
   std::array<std::uint8_t, 4> dst {};
 
   wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, DRM_FORMAT_XBGR8888);
 
-  expect_pixel(dst.data(), 0, 0x11, 0x22, 0x33, 0xFF);
+  expect_pixel(dst.data(), 0, 0x33, 0x22, 0x11, 0xFF);
 }
 
-TEST(WlgrabPixelCopy, ABGR8888CopiesWithoutSwap) {
+TEST(WlgrabPixelCopy, ABGR8888SwapsRedAndBlue) {
   const std::array<std::uint8_t, 4> src {0xAA, 0xBB, 0xCC, 0x80};
   std::array<std::uint8_t, 4> dst {};
 
   wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, DRM_FORMAT_ABGR8888);
 
-  expect_pixel(dst.data(), 0, 0xAA, 0xBB, 0xCC, 0x80);
+  expect_pixel(dst.data(), 0, 0xCC, 0xBB, 0xAA, 0x80);
 }
 
-TEST(WlgrabPixelCopy, XRGB8888CopiesWithoutSwap) {
+TEST(WlgrabPixelCopy, XRGB8888SwapsRedAndBlue) {
   const std::array<std::uint8_t, 4> src {0x11, 0x22, 0x33, 0xFF};
   std::array<std::uint8_t, 4> dst {};
 
   wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, DRM_FORMAT_XRGB8888);
 
+  expect_pixel(dst.data(), 0, 0x33, 0x22, 0x11, 0xFF);
+}
+
+TEST(WlgrabPixelCopy, ARGB8888SwapsRedAndBlue) {
+  const std::array<std::uint8_t, 4> src {0xAA, 0xBB, 0xCC, 0x40};
+  std::array<std::uint8_t, 4> dst {};
+
+  wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, DRM_FORMAT_ARGB8888);
+
+  expect_pixel(dst.data(), 0, 0xCC, 0xBB, 0xAA, 0x40);
+}
+
+TEST(WlgrabPixelCopy, Unknown4bppFormatCopiesWithoutSwap) {
+  const std::array<std::uint8_t, 4> src {0x11, 0x22, 0x33, 0xFF};
+  std::array<std::uint8_t, 4> dst {};
+
+  wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, 0);
+
   expect_pixel(dst.data(), 0, 0x11, 0x22, 0x33, 0xFF);
 }
 
-TEST(WlgrabPixelCopy, XBGR8888CopyAppliedToEveryRowAndPixel) {
+TEST(WlgrabPixelCopy, XBGR8888SwapAppliedToEveryRowAndPixel) {
   const std::array<std::uint8_t, 16> src {
     0x10, 0x20, 0x30, 0xFF,
     0x40, 0x50, 0x60, 0xFF,
@@ -95,13 +113,13 @@ TEST(WlgrabPixelCopy, XBGR8888CopyAppliedToEveryRowAndPixel) {
 
   wl::copy_shm_4bpp_to_bgra(src.data(), 8, dst.data(), 8, 2, 2, DRM_FORMAT_XBGR8888);
 
-  expect_pixel(dst.data(), 0, 0x10, 0x20, 0x30, 0xFF);
-  expect_pixel(dst.data(), 4, 0x40, 0x50, 0x60, 0xFF);
-  expect_pixel(dst.data(), 8, 0x70, 0x80, 0x90, 0xFF);
-  expect_pixel(dst.data(), 12, 0xA0, 0xB0, 0xC0, 0xFF);
+  expect_pixel(dst.data(), 0, 0x30, 0x20, 0x10, 0xFF);
+  expect_pixel(dst.data(), 4, 0x60, 0x50, 0x40, 0xFF);
+  expect_pixel(dst.data(), 8, 0x90, 0x80, 0x70, 0xFF);
+  expect_pixel(dst.data(), 12, 0xC0, 0xB0, 0xA0, 0xFF);
 }
 
-TEST(WlgrabPixelCopy, XBGR8888CopyIgnoresSourceRowPadding) {
+TEST(WlgrabPixelCopy, XBGR8888SwapIgnoresSourceRowPadding) {
   constexpr int width = 2;
   constexpr int height = 2;
   constexpr int src_stride = width * 4 + 4;
@@ -118,8 +136,8 @@ TEST(WlgrabPixelCopy, XBGR8888CopyIgnoresSourceRowPadding) {
   std::array<std::uint8_t, dst_stride * height> dst {};
   wl::copy_shm_4bpp_to_bgra(src.data(), src_stride, dst.data(), dst_stride, width, height, DRM_FORMAT_XBGR8888);
 
-  expect_pixel(dst.data(), 0, 0x01, 0x02, 0x03, 0xFF);
-  expect_pixel(dst.data(), 4, 0x04, 0x05, 0x06, 0xFF);
-  expect_pixel(dst.data(), dst_stride, 0x07, 0x08, 0x09, 0xFF);
-  expect_pixel(dst.data(), dst_stride + 4, 0x0A, 0x0B, 0x0C, 0xFF);
+  expect_pixel(dst.data(), 0, 0x03, 0x02, 0x01, 0xFF);
+  expect_pixel(dst.data(), 4, 0x06, 0x05, 0x04, 0xFF);
+  expect_pixel(dst.data(), dst_stride, 0x09, 0x08, 0x07, 0xFF);
+  expect_pixel(dst.data(), dst_stride + 4, 0x0C, 0x0B, 0x0A, 0xFF);
 }

--- a/tests/unit/test_wlgrab_pixel_copy.cpp
+++ b/tests/unit/test_wlgrab_pixel_copy.cpp
@@ -1,132 +1,93 @@
 /**
  * @file tests/unit/test_wlgrab_pixel_copy.cpp
- * @brief Tests for the SHM pixel copy logic in the wlgrab screencopy path.
+ * @brief Tests for wlgrab SHM pixel copy helpers.
  */
 #include <gtest/gtest.h>
 
-#include <algorithm>
+#include "src/platform/linux/wlgrab_pixel_copy.h"
+
+#include <array>
 #include <cstdint>
-#include <cstring>
 
 namespace {
-  // Wayland DRM fourcc values used by the SHM copy path in wlgrab.cpp.
-  constexpr uint32_t FMT_XBGR8888 = 0x34324258;
-  constexpr uint32_t FMT_ABGR8888 = 0x34324241;
-  constexpr uint32_t FMT_XRGB8888 = 0x34325258;
-
-  // Mirrors the 4bpp branch of the SHM copy path in wlgrab.cpp.
-  // Keep this in sync with that branch if the source changes.
-  //
-  // XBGR8888/ABGR8888 arrive with memory layout [R,G,B,X] on little-endian
-  // and need B↔R swapped so the encoder receives [B,G,R,X/A].
-  // All other 4bpp formats are already [B,G,R,X] and are copied directly.
-  void copy_4bpp_shm(
-    const uint8_t *src, int src_stride,
-    uint8_t *dst,       int dst_stride,
-    int copy_w, int copy_h,
-    uint32_t fmt
+  void expect_pixel(
+    const std::uint8_t *pixels,
+    int offset,
+    std::uint8_t b,
+    std::uint8_t g,
+    std::uint8_t r,
+    std::uint8_t a
   ) {
-    const int copy_bytes = std::min(src_stride, dst_stride);
-    const bool needs_rb_swap = (fmt == FMT_XBGR8888 || fmt == FMT_ABGR8888);
-    if (needs_rb_swap) {
-      for (int y = 0; y < copy_h; ++y) {
-        const uint8_t *src_line = src + y * src_stride;
-        uint8_t *dst_line = dst + y * dst_stride;
-        for (int x = 0; x < copy_w; ++x) {
-          dst_line[x * 4 + 0] = src_line[x * 4 + 2];
-          dst_line[x * 4 + 1] = src_line[x * 4 + 1];
-          dst_line[x * 4 + 2] = src_line[x * 4 + 0];
-          dst_line[x * 4 + 3] = src_line[x * 4 + 3];
-        }
-      }
-    } else if (src_stride == dst_stride && copy_bytes == src_stride) {
-      std::memcpy(dst, src, static_cast<std::size_t>(copy_h) * copy_bytes);
-    } else {
-      for (int y = 0; y < copy_h; ++y) {
-        std::memcpy(dst + y * dst_stride, src + y * src_stride, copy_bytes);
-      }
-    }
+    EXPECT_EQ(pixels[offset + 0], b);
+    EXPECT_EQ(pixels[offset + 1], g);
+    EXPECT_EQ(pixels[offset + 2], r);
+    EXPECT_EQ(pixels[offset + 3], a);
   }
 }  // namespace
 
-// XBGR8888 on LE stores pixels as [R,G,B,X] in memory.
-// The encoder expects [B,G,R,X], so bytes 0 and 2 must be swapped.
 TEST(WlgrabPixelCopy, XBGR8888SwapsRedAndBlue) {
-  const uint8_t src[] = { 0x11 /*R*/, 0x22 /*G*/, 0x33 /*B*/, 0xFF /*X*/ };
-  uint8_t dst[4] = {};
+  const std::array<std::uint8_t, 4> src {0x11, 0x22, 0x33, 0xFF};
+  std::array<std::uint8_t, 4> dst {};
 
-  copy_4bpp_shm(src, 4, dst, 4, 1, 1, FMT_XBGR8888);
+  wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, DRM_FORMAT_XBGR8888);
 
-  EXPECT_EQ(dst[0], 0x33u);  // B
-  EXPECT_EQ(dst[1], 0x22u);  // G unchanged
-  EXPECT_EQ(dst[2], 0x11u);  // R
-  EXPECT_EQ(dst[3], 0xFFu);  // X unchanged
+  expect_pixel(dst.data(), 0, 0x33, 0x22, 0x11, 0xFF);
 }
 
 TEST(WlgrabPixelCopy, ABGR8888SwapsRedAndBlue) {
-  const uint8_t src[] = { 0xAA /*R*/, 0xBB /*G*/, 0xCC /*B*/, 0x80 /*A*/ };
-  uint8_t dst[4] = {};
+  const std::array<std::uint8_t, 4> src {0xAA, 0xBB, 0xCC, 0x80};
+  std::array<std::uint8_t, 4> dst {};
 
-  copy_4bpp_shm(src, 4, dst, 4, 1, 1, FMT_ABGR8888);
+  wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, DRM_FORMAT_ABGR8888);
 
-  EXPECT_EQ(dst[0], 0xCCu);  // B
-  EXPECT_EQ(dst[1], 0xBBu);  // G unchanged
-  EXPECT_EQ(dst[2], 0xAAu);  // R
-  EXPECT_EQ(dst[3], 0x80u);  // A unchanged
+  expect_pixel(dst.data(), 0, 0xCC, 0xBB, 0xAA, 0x80);
 }
 
-// XRGB8888 on LE stores pixels as [B,G,R,X] — already correct for the encoder.
 TEST(WlgrabPixelCopy, XRGB8888CopiesWithoutSwap) {
-  const uint8_t src[] = { 0x11, 0x22, 0x33, 0xFF };
-  uint8_t dst[4] = {};
+  const std::array<std::uint8_t, 4> src {0x11, 0x22, 0x33, 0xFF};
+  std::array<std::uint8_t, 4> dst {};
 
-  copy_4bpp_shm(src, 4, dst, 4, 1, 1, FMT_XRGB8888);
+  wl::copy_shm_4bpp_to_bgra(src.data(), 4, dst.data(), 4, 1, 1, DRM_FORMAT_XRGB8888);
 
-  EXPECT_EQ(dst[0], 0x11u);
-  EXPECT_EQ(dst[1], 0x22u);
-  EXPECT_EQ(dst[2], 0x33u);
-  EXPECT_EQ(dst[3], 0xFFu);
+  expect_pixel(dst.data(), 0, 0x11, 0x22, 0x33, 0xFF);
 }
 
 TEST(WlgrabPixelCopy, XBGR8888SwapAppliedToEveryRowAndPixel) {
-  // 2×2 frame, stride == width * 4 (no row padding)
-  const uint8_t src[] = {
-    0x10, 0x20, 0x30, 0xFF,  // row 0 px 0
-    0x40, 0x50, 0x60, 0xFF,  // row 0 px 1
-    0x70, 0x80, 0x90, 0xFF,  // row 1 px 0
-    0xA0, 0xB0, 0xC0, 0xFF,  // row 1 px 1
+  const std::array<std::uint8_t, 16> src {
+    0x10, 0x20, 0x30, 0xFF,
+    0x40, 0x50, 0x60, 0xFF,
+    0x70, 0x80, 0x90, 0xFF,
+    0xA0, 0xB0, 0xC0, 0xFF,
   };
-  uint8_t dst[16] = {};
+  std::array<std::uint8_t, 16> dst {};
 
-  copy_4bpp_shm(src, 8, dst, 8, 2, 2, FMT_XBGR8888);
+  wl::copy_shm_4bpp_to_bgra(src.data(), 8, dst.data(), 8, 2, 2, DRM_FORMAT_XBGR8888);
 
-  EXPECT_EQ(dst[0],  0x30u); EXPECT_EQ(dst[2],  0x10u);   // row 0 px 0
-  EXPECT_EQ(dst[4],  0x60u); EXPECT_EQ(dst[6],  0x40u);   // row 0 px 1
-  EXPECT_EQ(dst[8],  0x90u); EXPECT_EQ(dst[10], 0x70u);   // row 1 px 0
-  EXPECT_EQ(dst[12], 0xC0u); EXPECT_EQ(dst[14], 0xA0u);   // row 1 px 1
+  expect_pixel(dst.data(), 0, 0x30, 0x20, 0x10, 0xFF);
+  expect_pixel(dst.data(), 4, 0x60, 0x50, 0x40, 0xFF);
+  expect_pixel(dst.data(), 8, 0x90, 0x80, 0x70, 0xFF);
+  expect_pixel(dst.data(), 12, 0xC0, 0xB0, 0xA0, 0xFF);
 }
 
-TEST(WlgrabPixelCopy, XBGR8888SwapWithPaddedSourceStride) {
-  // Screencopy buffers often have padding bytes at the end of each row.
-  // The swap loop uses copy_w (pixel count), not copy_bytes, so padding is ignored.
-  constexpr int W = 2;
-  constexpr int src_stride = W * 4 + 4;  // 12 bytes/row — 4 bytes padding
-  constexpr int dst_stride = W * 4;       // 8 bytes/row — tight
+TEST(WlgrabPixelCopy, XBGR8888SwapIgnoresSourceRowPadding) {
+  constexpr int width = 2;
+  constexpr int height = 2;
+  constexpr int src_stride = width * 4 + 4;
+  constexpr int dst_stride = width * 4;
 
-  uint8_t src[src_stride * 2] = {};
-  src[0] = 0x01; src[1] = 0x02; src[2] = 0x03; src[3] = 0xFF;  // row 0 px 0
-  src[4] = 0x04; src[5] = 0x05; src[6] = 0x06; src[7] = 0xFF;  // row 0 px 1
-  // src[8..11]: padding — left zero, must not appear in output
-  src[src_stride + 0] = 0x07; src[src_stride + 1] = 0x08;  // row 1 px 0
+  std::array<std::uint8_t, src_stride * height> src {};
+  src[0] = 0x01; src[1] = 0x02; src[2] = 0x03; src[3] = 0xFF;
+  src[4] = 0x04; src[5] = 0x05; src[6] = 0x06; src[7] = 0xFF;
+  src[src_stride + 0] = 0x07; src[src_stride + 1] = 0x08;
   src[src_stride + 2] = 0x09; src[src_stride + 3] = 0xFF;
-  src[src_stride + 4] = 0x0A; src[src_stride + 5] = 0x0B;  // row 1 px 1
+  src[src_stride + 4] = 0x0A; src[src_stride + 5] = 0x0B;
   src[src_stride + 6] = 0x0C; src[src_stride + 7] = 0xFF;
 
-  uint8_t dst[dst_stride * 2] = {};
-  copy_4bpp_shm(src, src_stride, dst, dst_stride, W, 2, FMT_XBGR8888);
+  std::array<std::uint8_t, dst_stride * height> dst {};
+  wl::copy_shm_4bpp_to_bgra(src.data(), src_stride, dst.data(), dst_stride, width, height, DRM_FORMAT_XBGR8888);
 
-  EXPECT_EQ(dst[0], 0x03u); EXPECT_EQ(dst[2], 0x01u);  // row 0 px 0: B=src[2], R=src[0]
-  EXPECT_EQ(dst[4], 0x06u); EXPECT_EQ(dst[6], 0x04u);  // row 0 px 1
-  EXPECT_EQ(dst[dst_stride + 0], 0x09u); EXPECT_EQ(dst[dst_stride + 2], 0x07u);  // row 1 px 0
-  EXPECT_EQ(dst[dst_stride + 4], 0x0Cu); EXPECT_EQ(dst[dst_stride + 6], 0x0Au);  // row 1 px 1
+  expect_pixel(dst.data(), 0, 0x03, 0x02, 0x01, 0xFF);
+  expect_pixel(dst.data(), 4, 0x06, 0x05, 0x04, 0xFF);
+  expect_pixel(dst.data(), dst_stride, 0x09, 0x08, 0x07, 0xFF);
+  expect_pixel(dst.data(), dst_stride + 4, 0x0C, 0x0B, 0x0A, 0xFF);
 }


### PR DESCRIPTION
## Summary

Carries forward the wlgrab SHM color-channel work from #29, updated with the latest #31/#35 reporter data.

- keep the existing 3bpp SHM conversion (`RGB` byte order -> `BGRA`)
- swap R/B for reported 4bpp SHM formats: `XRGB8888`, `ARGB8888`, `XBGR8888`, and `ABGR8888`
- keep unknown 4bpp SHM formats as copy-through
- keep the pixel-copy helpers covered by Linux unit tests

## Why

The latest #31 follow-up corrected the earlier theory: the regression is still in the true-headless SHM copy path, not the orphaned extcopy path. Reporters have now seen AMD/Mesa/headless labwc deliver 4bpp SHM frames where the byte order needs an R/B swap before Polaris hands the frame to the encoder.

This patch keeps the conversion narrow to the four reported 4bpp formats while preserving copy-through behavior for unknown formats.

## Validation

- `git diff --check`
- GitHub Actions passed on rebased head `d964709`
- Fedora 44 RPM artifact downloaded from Actions for local Retroid/Nova smoke testing
- Retroid Pocket 6 / Nova true-headless smoke test on `1.0.8.dd28c34` exercised the SHM path and colors looked correct

Remote Linux source-build testing was skipped for this update because the shared Linux checkout currently has unrelated tracked changes; using the sync-based remote helper would risk overwriting that work.

Co-authored-by: Ian Kendrick <iankendrick@gmail.com>