### PR TITLE
Prevent welcome credential save hang

### DIFF
--- a/src_assets/common/assets/web/views/WelcomeView.vue
+++ b/src_assets/common/assets/web/views/WelcomeView.vue
@@ -263,29 +263,37 @@ function finishWizard() {
   document.location.reload()
 }
 
-function save() {
+async function save() {
   if (passwordData.newPassword !== passwordData.confirmNewPassword) {
     error.value = "Password mismatch"
     return
   }
   error.value = null
   loading.value = true
-  fetch("./api/password", {
-    headers: { 'Content-Type': 'application/json' },
-    method: 'POST',
-    body: JSON.stringify(passwordData),
-  }).then((r) => {
-    loading.value = false
-    if (r.status === 200) {
-      r.json().then((rj) => {
-        success.value = rj.status
-        if (success.value !== true) {
-          error.value = rj.error
-        }
-      })
-    } else {
+
+  try {
+    const response = await fetch("./api/password", {
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      body: JSON.stringify(passwordData),
+    })
+
+    if (response.status !== 200) {
       error.value = "Internal Server Error"
+      return
     }
-  })
+
+    const payload = await response.json()
+    success.value = payload.status
+
+    if (success.value !== true) {
+      error.value = payload.error
+    }
+  } catch (e) {
+    error.value = "Internal Server Error"
+  } finally {
+    loading.value = false
+  }
 }
 </script>


### PR DESCRIPTION
## Summary

Fixes #32.

- restore the welcome wizard credential save handler to an async `try/catch/finally` flow
- include credentials on the first-run `/api/password` request
- guarantee the `Saving...` state is cleared when the request fails or returns an error

## Why

The first-run credential wizard in 1.0.8 used a bare `fetch().then(...)` chain. If the browser-side password request failed, rejected, or failed while parsing the response, the `loading` flag was never reset, leaving the Save button stuck on `Saving...`.

## Validation

- `git diff --check HEAD`
- `npm run lint`
- `npm run build`