### PR TITLE
Clarify Linux headless desktop and HDR limits

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,15 @@ max_sessions = 2
 
 These are the settings behind the recommended Headless Stream mode on a Linux host.
 
+## Linux display modes
+
+Headless Stream starts apps inside Polaris' private labwc compositor. It is intentionally isolated
+from your normal KDE, GNOME, or wlroots desktop, so the built-in Desktop entry can be empty if no
+desktop shell or app is launched inside that runtime.
+
+Use Desktop Display mode when you want to stream the visible host desktop session. Use Headless
+Stream when you want a stream-only runtime that leaves the host desktop layout alone.
+
 ## Common options
 
 | Key | Typical value | What it controls |
@@ -42,6 +51,23 @@ These are the settings behind the recommended Headless Stream mode on a Linux ho
 | `enable_discovery` | `enabled` | Advertise Polaris over mDNS |
 | `stream_audio` | `enabled` | Capture and stream audio |
 | `steamgriddb_api_key` | key | Cover art lookups for non-Steam apps |
+
+## Linux HDR and Main10
+
+On Linux, treat sessions that log `Display is HDR: false` as SDR even if the client requests HDR.
+Forcing `hdr_mode = 2` can still select a 10-bit HEVC/Main10 or P010 encode path, but that does not
+create a true HDR source when the captured display path is SDR and may produce incorrect colors on
+some VAAPI stacks.
+
+For AMD VAAPI hosts, validate SDR first:
+
+```ini
+encoder = vaapi
+hdr_mode = 0
+color_range = 1
+```
+
+Then test HEVC Main 8-bit before enabling Main10 or client HDR requests.
 
 ## AI provider settings
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -48,6 +48,11 @@ validation path; SHM/RAM capture warnings are performance notes if the client is
 `HEADLESS-1` stream. Enable GPU-native capture later only after the headless path is working on your
 driver and compositor stack.
 
+The built-in Desktop entry does not launch your existing KDE, GNOME, or wlroots desktop inside this
+private compositor. If the client connects but shows an empty or black desktop while app entries work,
+that usually means the headless runtime is alive but nothing visible has been launched in it. Use
+Desktop Display mode when you want to stream the already-running host desktop session.
+
 ## Steam Big Picture black screen or tiny window
 
 Clear Steam's HTML cache:
@@ -87,6 +92,13 @@ If you do not need DRM/KMS capture, keep using the default compositor and portal
 If Polaris cannot hold the preferred hardware path, open Mission Control or Troubleshooting and
 check the active runtime path. Polaris surfaces when capture or encode falls back so you do not
 need to guess from a black-box client session.
+
+## Linux HDR or Main10 has wrong colors
+
+If the log says `Display is HDR: false`, treat that stream as SDR. A client HDR request or
+`hdr_mode = 2` can still move the encoder into a 10-bit/P010 path, but it does not make a non-HDR
+Linux capture path into a true HDR source. On AMD VAAPI systems, keep `hdr_mode = 0` and disable
+client HDR requests until SDR colors are correct, then test HEVC Main 8-bit before testing Main10.
 
 ## Support bundle and logs
 

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -35,8 +35,8 @@ const streamDisplayModes = [
     id: 'headless_stream',
     title: 'Headless Stream',
     badge: 'Recommended',
-    copy: 'Recommended. Starts games on a hidden stream-only display. Your desktop layout is not changed.',
-    restartCopy: 'Requires restart. Polaris will start sessions on a hidden stream-only runtime.',
+    copy: 'Recommended. Starts apps inside a private hidden compositor. It does not mirror your current desktop.',
+    restartCopy: 'Requires restart. Polaris will stream an isolated hidden runtime, not the existing KDE or GNOME session.',
   },
   {
     id: 'host_virtual_display',
@@ -49,14 +49,14 @@ const streamDisplayModes = [
     id: 'desktop_display',
     title: 'Desktop Display',
     badge: 'Visible desktop',
-    copy: 'Streams from your current desktop session.',
+    copy: 'Streams from your current desktop session when you want the visible KDE, GNOME, or wlroots desktop.',
     restartCopy: 'Requires restart. Polaris will stream from the current desktop session.',
   },
   {
     id: 'windowed_stream',
     title: 'Windowed Stream',
     badge: 'Experimental',
-    copy: 'Experimental. Shows the stream runtime as a desktop window when testing GPU-native capture.',
+    copy: 'Experimental. Shows the private stream runtime as a desktop window when testing GPU-native capture.',
     restartCopy: 'Requires restart. Windowed Stream is experimental and should stay limited to GPU-native capture testing.',
   },
 ]


### PR DESCRIPTION
## Summary

Refs #35.

- clarify that Headless Stream and Windowed Stream use an isolated Polaris compositor, not the existing KDE/GNOME desktop session
- document Desktop Display as the path for streaming the visible host desktop
- document current Linux HDR/Main10 expectations when logs show `Display is HDR: false`, including an AMD VAAPI SDR-first baseline

## Why

Issue #35 showed two expectation gaps: the built-in Desktop entry can look empty in headless labwc because it does not launch a desktop shell, and forcing HDR/Main10 on a Linux SDR capture path can enter a 10-bit/P010 encode path without creating a true HDR source.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run build`