### PR TITLE
Add Linux true HDR metadata gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,13 @@ Yes, if the client explicitly requests a 10-bit path and the active encoder/runt
 </details>
 
 <details>
+<summary><b>Can Polaris stream true HDR on Linux?</b></summary>
+
+Yes, but Polaris only advertises true HDR when the active capture path reports HDR display metadata. For now, validate this on a KMS/DRM path with an HDR-capable output exposing `HDR_OUTPUT_METADATA`; headless labwc/wlroots sessions remain honest SDR until that runtime can provide real metadata. A valid true HDR session logs `hdr_metadata_available=true` and `stream_hdr_enabled=true`.
+
+</details>
+
+<details>
 <summary><b>Can multiple people watch the same stream?</b></summary>
 
 Yes. Set `max_sessions` above `1`. Polaris tracks owner vs viewer roles explicitly, and passive watch mode is designed so a second client can observe without taking over the session. Viewers must match the active owner profile rather than silently creating a different downgraded stream.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Gate true HDR streaming on display HDR metadata instead of client dynamic-range requests alone
+- Add Linux true HDR diagnostics to logs, session status, and support data
+- Document the KMS/DRM HDR validation path and current headless labwc SDR behavior
+
 ## v1.0.9
 
 Patch release focused on Linux headless color correctness and support clarity.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,10 +54,24 @@ Stream when you want a stream-only runtime that leaves the host desktop layout a
 
 ## Linux HDR and Main10
 
-On Linux, treat sessions that log `Display is HDR: false` as SDR even if the client requests HDR.
+On Linux, treat sessions that log `stream_hdr_enabled=false` as SDR even if the client requests HDR.
 Forcing `hdr_mode = 2` can still select a 10-bit HEVC/Main10 or P010 encode path, but that does not
 create a true HDR source when the captured display path is SDR and may produce incorrect colors on
 some VAAPI stacks.
+
+True Linux HDR requires the active capture path to expose HDR display metadata. Today that means a
+KMS/DRM display path with an HDR-capable output reporting `HDR_OUTPUT_METADATA`, plus a client HDR
+request and a 10-bit-capable encoder. A valid true HDR session logs:
+
+```text
+HDR metadata: available=true
+Color coding: HDR (Rec. 2020 + SMPTE 2084 PQ)
+HDR decision: ... display_hdr=true hdr_metadata_available=true stream_hdr_enabled=true
+```
+
+Headless labwc/wlroots sessions are intentionally treated as SDR until the headless display path can
+truthfully provide HDR metadata. In that mode, `hdr_mode = 2` can still be useful to test Main10/P010
+encode support, but Polaris will not advertise true HDR to the client without metadata.
 
 For AMD VAAPI hosts, validate SDR first:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -103,6 +103,11 @@ nvidia_drm.modeset=1
 
 If you do not need DRM/KMS capture, keep using the default compositor and portal paths instead.
 
+If a manually copied test binary still logs `Failed to gain CAP_SYS_ADMIN` after `setcap`, check the
+mount options for the binary path. File capabilities are ignored on `nosuid` mounts, so `/tmp`
+builds can be misleading; copy the test binary to a normal path such as `/usr/local/bin` before
+applying `setcap`.
+
 ## VAAPI or software encode fallback
 
 If Polaris cannot hold the preferred hardware path, open Mission Control or Troubleshooting and
@@ -111,10 +116,21 @@ need to guess from a black-box client session.
 
 ## Linux HDR or Main10 has wrong colors
 
-If the log says `Display is HDR: false`, treat that stream as SDR. A client HDR request or
+If the log says `stream_hdr_enabled=false`, treat that stream as SDR. A client HDR request or
 `hdr_mode = 2` can still move the encoder into a 10-bit/P010 path, but it does not make a non-HDR
 Linux capture path into a true HDR source. On AMD VAAPI systems, keep `hdr_mode = 0` and disable
 client HDR requests until SDR colors are correct, then test HEVC Main 8-bit before testing Main10.
+
+For true HDR, look for all of these lines in the same launch:
+
+```text
+HDR metadata: available=true
+Color coding: HDR (Rec. 2020 + SMPTE 2084 PQ)
+HDR decision: ... display_hdr=true hdr_metadata_available=true stream_hdr_enabled=true
+```
+
+If `stream_hdr_enabled=false`, Polaris is being conservative: the client may have requested HDR or Main10,
+but the active Linux display path did not provide enough metadata to advertise a real HDR stream.
 
 ## Support bundle and logs
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -373,7 +373,8 @@ namespace nvhttp {
         stats.encode_target_residency == platf::frame_residency_e::cpu ||
         stats.capture_transport == platf::frame_transport_e::shm;
       const bool encoder_risk = stats.encode_time_ms >= 11.0 || stats.avg_frame_age_ms >= 18.0;
-      const bool hdr_risk = stats.dynamic_range > 0 && (pacing_risk || encoder_risk);
+      const bool hdr_source_missing = stats.dynamic_range > 0 && !stats.stream_hdr_enabled;
+      const bool hdr_risk = stats.stream_hdr_enabled && (pacing_risk || encoder_risk);
       const bool decoder_risk =
         (active_codec_family == "av1" || stats.encode_target_format == platf::frame_format_e::p010) &&
         (pacing_risk || fps_gap >= 4.0) &&
@@ -476,9 +477,10 @@ namespace nvhttp {
       health["recommendations"] = std::move(recommendations);
       health["safe_bitrate_kbps"] = safe_bitrate_kbps;
       health["safe_display_mode"] = (virtual_display_risk || host_prefers_headless()) ? "headless" : (current_virtual_display ? "virtual_display" : "headless");
-      health["safe_hdr"] = stats.dynamic_range > 0 && !hdr_risk;
+      health["safe_hdr"] = stats.stream_hdr_enabled && !hdr_risk;
       health["decoder_risk"] = decoder_risk ? "elevated" : "normal";
       health["hdr_risk"] = hdr_risk ? "elevated" : "normal";
+      health["hdr_source"] = hdr_source_missing ? "missing" : (stats.stream_hdr_enabled ? "metadata" : "sdr");
       health["network_risk"] = network_risk ? "elevated" : "normal";
       health["relaunch_recommended"] = hdr_risk || decoder_risk || virtual_display_risk;
       if (safe_codec) {
@@ -2972,6 +2974,12 @@ namespace nvhttp {
       output["game_uuid"] = proc::proc.get_running_app_uuid();
       output["cursor_visible"] = cursor::visible();
       output["dynamic_range"] = stats.dynamic_range;
+      auto &hdr = output["hdr"];
+      hdr["client_dynamic_range"] = stats.dynamic_range;
+      hdr["display_hdr"] = stats.display_hdr;
+      hdr["metadata_available"] = stats.hdr_metadata_available;
+      hdr["stream_hdr_enabled"] = stats.stream_hdr_enabled;
+      hdr["color_coding"] = stats.color_coding;
       output["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
       output["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
       output["ai_optimizer_enabled"] = ai_optimizer::is_enabled();

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <string>
 
 // lib includes
@@ -516,6 +517,7 @@ namespace platf {
     }
 
     video::sunshine_colorspace_t colorspace;
+    std::optional<SS_HDR_METADATA> hdr_metadata;
   };
 
   struct avcodec_encode_device_t: encode_device_t {

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -97,6 +97,10 @@ namespace stream_stats {
     j["encode_target_residency"] = platf::from_frame_residency(encode_target_residency);
     j["encode_target_format"] = platf::from_frame_format(encode_target_format);
     j["dynamic_range"] = dynamic_range;
+    j["display_hdr"] = display_hdr;
+    j["hdr_metadata_available"] = hdr_metadata_available;
+    j["stream_hdr_enabled"] = stream_hdr_enabled;
+    j["color_coding"] = color_coding;
     j["fps"] = fps;
     j["requested_client_fps"] = requested_client_fps;
     j["session_target_fps"] = session_target_fps;
@@ -343,6 +347,17 @@ namespace stream_stats {
   void update_dynamic_range(int dynamic_range) {
     std::lock_guard<std::mutex> lock(stats_mutex);
     current_stats.dynamic_range = dynamic_range;
+  }
+
+  void update_hdr_state(bool display_hdr,
+                        bool hdr_metadata_available,
+                        bool stream_hdr_enabled,
+                        const std::string &color_coding) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.display_hdr = display_hdr;
+    current_stats.hdr_metadata_available = hdr_metadata_available;
+    current_stats.stream_hdr_enabled = stream_hdr_enabled;
+    current_stats.color_coding = color_coding;
   }
 
   void update_capture_profile(const capture_profile_sample_t &sample) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -66,6 +66,10 @@ namespace stream_stats {
     platf::frame_residency_e encode_target_residency = platf::frame_residency_e::unknown;
     platf::frame_format_e encode_target_format = platf::frame_format_e::unknown;
     int dynamic_range = 0;
+    bool display_hdr = false;
+    bool hdr_metadata_available = false;
+    bool stream_hdr_enabled = false;
+    std::string color_coding;
 
     // Video (primary/first client for backward compatibility)
     double fps = 0;
@@ -234,6 +238,18 @@ namespace stream_stats {
    * @param dynamic_range Dynamic range mode from the active RTSP session.
    */
   void update_dynamic_range(int dynamic_range);
+
+  /**
+   * @brief Update the display HDR state and negotiated stream color coding.
+   * @param display_hdr Whether the active display path reports HDR.
+   * @param hdr_metadata_available Whether HDR metadata was available from the display path.
+   * @param stream_hdr_enabled Whether Polaris is advertising true HDR for the stream.
+   * @param color_coding Human-readable color coding label.
+   */
+  void update_hdr_state(bool display_hdr,
+                        bool hdr_metadata_available,
+                        bool stream_hdr_enabled,
+                        const std::string &color_coding);
 
   /**
    * @brief Record a single capture timing sample into the shared telemetry sink.

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -316,6 +316,70 @@ namespace video {
     }
 #endif
 
+    std::string_view color_coding_label(const sunshine_colorspace_t &colorspace) {
+      switch (colorspace.colorspace) {
+        case colorspace_e::bt2020:
+          return "HDR (Rec. 2020 + SMPTE 2084 PQ)"sv;
+        case colorspace_e::rec601:
+          return "SDR (Rec. 601)"sv;
+        case colorspace_e::rec709:
+          return "SDR (Rec. 709)"sv;
+        case colorspace_e::bt2020sdr:
+          return "SDR (Rec. 2020)"sv;
+        default:
+          return "unknown"sv;
+      }
+    }
+
+    struct hdr_probe_t {
+      bool display_hdr = false;
+      std::optional<SS_HDR_METADATA> metadata;
+    };
+
+    void log_hdr_metadata_summary(const SS_HDR_METADATA &metadata) {
+      BOOST_LOG(info)
+        << "HDR metadata: available=true"
+        << " max_luminance="sv << metadata.maxDisplayLuminance
+        << " min_luminance="sv << metadata.minDisplayLuminance
+        << " max_cll="sv << metadata.maxContentLightLevel
+        << " max_fall="sv << metadata.maxFrameAverageLightLevel;
+    }
+
+    hdr_probe_t probe_display_hdr(platf::display_t &disp, const config_t &config) {
+      hdr_probe_t probe;
+      probe.display_hdr = disp.is_hdr();
+
+      if (config.dynamicRange > 0 && probe.display_hdr) {
+        SS_HDR_METADATA metadata {};
+        if (disp.get_hdr_metadata(metadata)) {
+          probe.metadata = metadata;
+          log_hdr_metadata_summary(metadata);
+        } else {
+          BOOST_LOG(warning)
+            << "HDR decision: client_dynamic_range="sv << config.dynamicRange
+            << " display_hdr=true hdr_metadata_available=false stream_hdr_enabled=false; treating stream as SDR because display metadata could not be read"sv;
+        }
+      }
+
+      return probe;
+    }
+
+    hdr_info_t make_hdr_info(const platf::encode_device_t &encode_device) {
+      hdr_info_t hdr_info = std::make_unique<hdr_info_raw_t>(false);
+      if (!colorspace_is_hdr(encode_device.colorspace)) {
+        return hdr_info;
+      }
+
+      if (!encode_device.hdr_metadata) {
+        BOOST_LOG(error) << "Couldn't send HDR metadata when colorspace selection indicates it should have one"sv;
+        return hdr_info;
+      }
+
+      hdr_info->metadata = *encode_device.hdr_metadata;
+      hdr_info->enabled = true;
+      return hdr_info;
+    }
+
     std::string trim_trailing_ascii_whitespace(std::string value) {
       while (!value.empty() && (value.back() == '\n' || value.back() == '\r' || value.back() == ' ' || value.back() == '\t')) {
         value.pop_back();
@@ -2519,10 +2583,12 @@ namespace video {
     frame->colorspace = ctx->colorspace;
     frame->chroma_location = ctx->chroma_sample_location;
 
+    const auto frame_hdr_metadata = encode_device->hdr_metadata;
+
     // Attach HDR metadata to the AVFrame
     if (colorspace_is_hdr(colorspace)) {
-      SS_HDR_METADATA hdr_metadata;
-      if (disp->get_hdr_metadata(hdr_metadata)) {
+      if (frame_hdr_metadata) {
+        const auto &hdr_metadata = *frame_hdr_metadata;
         auto mdm = av_mastering_display_metadata_create_side_data(frame.get());
 
         mdm->display_primaries[0][0] = av_make_q(hdr_metadata.displayPrimaries[0].x, 50000);
@@ -2548,7 +2614,7 @@ namespace video {
           clm->MaxFALL = hdr_metadata.maxFrameAverageLightLevel;
         }
       } else {
-        BOOST_LOG(error) << "Couldn't get display hdr metadata when colorspace selection indicates it should have one";
+        BOOST_LOG(error) << "Couldn't attach HDR metadata when colorspace selection indicates it should have one";
       }
     }
 
@@ -2561,6 +2627,7 @@ namespace video {
         return nullptr;
       }
       software_encode_device->colorspace = colorspace;
+      software_encode_device->hdr_metadata = frame_hdr_metadata;
 
       encode_device_final = std::move(software_encode_device);
     } else {
@@ -3000,7 +3067,8 @@ namespace video {
   std::unique_ptr<platf::encode_device_t> make_encode_device(platf::display_t &disp, const encoder_t &encoder, const config_t &config) {
     std::unique_ptr<platf::encode_device_t> result;
 
-    auto colorspace = colorspace_from_client_config(config, disp.is_hdr());
+    const auto hdr_probe = probe_display_hdr(disp, config);
+    auto colorspace = colorspace_from_client_config(config, hdr_probe.metadata.has_value());
 
     auto pix_fmt = select_encoder_output_pix_fmt(encoder, config, colorspace);
     if (!pix_fmt) {
@@ -3012,15 +3080,16 @@ namespace video {
 
       BOOST_LOG(info) << "Creating encoder " << logging::bracket(encoder_name);
 
-      auto color_coding = colorspace.colorspace == colorspace_e::bt2020    ? "HDR (Rec. 2020 + SMPTE 2084 PQ)" :
-                          colorspace.colorspace == colorspace_e::rec601    ? "SDR (Rec. 601)" :
-                          colorspace.colorspace == colorspace_e::rec709    ? "SDR (Rec. 709)" :
-                          colorspace.colorspace == colorspace_e::bt2020sdr ? "SDR (Rec. 2020)" :
-                                                                             "unknown";
+      auto color_coding = color_coding_label(colorspace);
 
       BOOST_LOG(info) << "Color coding: " << color_coding;
       BOOST_LOG(info) << "Color depth: " << colorspace.bit_depth << "-bit";
       BOOST_LOG(info) << "Color range: " << (colorspace.full_range ? "JPEG" : "MPEG");
+      BOOST_LOG(info)
+        << "HDR decision: client_dynamic_range="sv << config.dynamicRange
+        << " display_hdr="sv << (hdr_probe.display_hdr ? "true" : "false")
+        << " hdr_metadata_available="sv << (hdr_probe.metadata ? "true" : "false")
+        << " stream_hdr_enabled="sv << (colorspace_is_hdr(colorspace) ? "true" : "false");
     }
 
     if (dynamic_cast<const encoder_platform_formats_avcodec *>(encoder.platform_formats.get())) {
@@ -3049,6 +3118,15 @@ namespace video {
 
     if (result) {
       result->colorspace = colorspace;
+      if (colorspace_is_hdr(colorspace)) {
+        result->hdr_metadata = hdr_probe.metadata;
+      }
+      stream_stats::update_hdr_state(
+        hdr_probe.display_hdr,
+        hdr_probe.metadata.has_value(),
+        colorspace_is_hdr(colorspace),
+        std::string {color_coding_label(colorspace)}
+      );
     }
 
     return result;
@@ -3073,15 +3151,7 @@ namespace video {
     ctx.touch_port_events->raise(make_port(disp, ctx.config));
 
     // Update client with our current HDR display state
-    hdr_info_t hdr_info = std::make_unique<hdr_info_raw_t>(false);
-    if (colorspace_is_hdr(encode_device->colorspace)) {
-      if (disp->get_hdr_metadata(hdr_info->metadata)) {
-        hdr_info->enabled = true;
-      } else {
-        BOOST_LOG(error) << "Couldn't get display hdr metadata when colorspace selection indicates it should have one";
-      }
-    }
-    ctx.hdr_events->raise(std::move(hdr_info));
+    ctx.hdr_events->raise(make_hdr_info(*encode_device));
 
     auto session = make_encode_session(disp, encoder, ctx.config, frame.width, frame.height, std::move(encode_device));
     if (!session) {
@@ -3342,15 +3412,7 @@ namespace video {
       touch_port_event->raise(make_port(display.get(), config));
 
       // Update client with our current HDR display state
-      hdr_info_t hdr_info = std::make_unique<hdr_info_raw_t>(false);
-      if (colorspace_is_hdr(encode_device->colorspace)) {
-        if (display->get_hdr_metadata(hdr_info->metadata)) {
-          hdr_info->enabled = true;
-        } else {
-          BOOST_LOG(error) << "Couldn't get display hdr metadata when colorspace selection indicates it should have one";
-        }
-      }
-      hdr_event->raise(std::move(hdr_info));
+      hdr_event->raise(make_hdr_info(*encode_device));
 
       encode_run(
         frame_nr,

--- a/src/video_colorspace.cpp
+++ b/src/video_colorspace.cpp
@@ -20,14 +20,12 @@ namespace video {
     return colorspace.colorspace == colorspace_e::bt2020;
   }
 
-  sunshine_colorspace_t colorspace_from_client_config(const config_t &config, bool hdr_display) {
+  sunshine_colorspace_t colorspace_from_client_config(const config_t &config, bool hdr_metadata_available) {
     sunshine_colorspace_t colorspace;
 
     /* See video::config_t declaration for details */
 
-    BOOST_LOG(info) << "Client dynamicRange: " << config.dynamicRange << ", Display is HDR: " << hdr_display;
-
-    if (config.dynamicRange > 0 && hdr_display) {
+    if (config.dynamicRange > 0 && hdr_metadata_available) {
       // Rec. 2020 with ST 2084 perceptual quantizer
       colorspace.colorspace = colorspace_e::bt2020;
     } else {

--- a/src/video_colorspace.h
+++ b/src/video_colorspace.h
@@ -28,7 +28,7 @@ namespace video {
   // Declared in video.h
   struct config_t;
 
-  sunshine_colorspace_t colorspace_from_client_config(const config_t &config, bool hdr_display);
+  sunshine_colorspace_t colorspace_from_client_config(const config_t &config, bool hdr_metadata_available);
 
   struct avcodec_colorspace_t {
     AVColorPrimaries primaries;

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -70,6 +70,30 @@ namespace {
   };
 }  // namespace
 
+TEST(VideoColorSpaceTests, ClientHdrRequestWithoutDisplayMetadataStaysSdrMain10) {
+  video::config_t config {};
+  config.encoderCscMode = 2;  // Rec. 709 SDR
+  config.dynamicRange = 1;
+
+  const auto colorspace = video::colorspace_from_client_config(config, false);
+
+  EXPECT_FALSE(video::colorspace_is_hdr(colorspace));
+  EXPECT_EQ(colorspace.colorspace, video::colorspace_e::rec709);
+  EXPECT_EQ(colorspace.bit_depth, 10);
+}
+
+TEST(VideoColorSpaceTests, ClientHdrRequestWithDisplayMetadataEnablesTrueHdr) {
+  video::config_t config {};
+  config.encoderCscMode = 2;  // ignored for true HDR
+  config.dynamicRange = 1;
+
+  const auto colorspace = video::colorspace_from_client_config(config, true);
+
+  EXPECT_TRUE(video::colorspace_is_hdr(colorspace));
+  EXPECT_EQ(colorspace.colorspace, video::colorspace_e::bt2020);
+  EXPECT_EQ(colorspace.bit_depth, 10);
+}
+
 TEST(VideoCacheTests, DriverVersionCacheHitRequiresMatchingBinaryMetadata) {
   const auto cache_dir = std::filesystem::temp_directory_path() / "polaris-video-cache-tests";
   const auto cache_path = cache_dir / "driver_version_cache.txt";


### PR DESCRIPTION
## Summary

- Gate true HDR color selection on real display HDR metadata instead of the client dynamic-range request alone.
- Preserve 10-bit Main10/P010 SDR behavior when metadata is missing, including headless labwc paths.
- Cache HDR metadata on the encode device so HDR events and AVFrame side data use the same validated metadata.
- Expose HDR decision state in stream stats/session status and update the Linux HDR docs.

## Why

Linux clients can request HDR or Main10 even when the active capture path is not a true HDR source. That is valid for 10-bit SDR testing, but Polaris should only advertise true HDR when the captured display path can provide real HDR metadata. This keeps headless SDR behavior honest while allowing KMS/DRM HDR output paths to opt into real Rec. 2020/PQ HDR.

## Validation

- `git diff --check`
- Linux temp build on `pc-papi`: `cmake --build /tmp/polaris-hdr-test/build-tests --target test_polaris_video -j$(nproc)`
- `test_polaris_video --gtest_filter="VideoColorSpaceTests.*"`: 2 passed
- Full `test_polaris_video`: 10 passed, 1 skipped (`vaapi` unavailable on this NVIDIA host)
- Linux app build: `cmake --build /tmp/polaris-hdr-test/build-tests --target polaris -j$(nproc)`
- Manual KMS HDR smoke with Pixel 10 Pro profile confirmed `hdr_metadata_available=true`, `stream_hdr_enabled=true`, `Color coding: HDR (Rec. 2020 + SMPTE 2084 PQ)`, and P010 encode conversion.