### PR TITLE
Fix Linux shader runtime path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -423,6 +423,10 @@ jobs:
             echo "Installed Ubuntu DEB has unresolved shared-library dependencies" >&2
             exit 1
           fi
+          if strings "$binary" | grep -Eq '/__w/|src_assets/.*/assets/shaders'; then
+            echo "Installed Ubuntu DEB binary contains a source-tree shader path" >&2
+            exit 1
+          fi
 
           polaris --version | tee build/cpack_artifacts/package-version.txt
 
@@ -617,6 +621,10 @@ jobs:
           ldd "$binary" | tee build/cpack_artifacts/package-ldd.txt
           if grep -Fq "not found" build/cpack_artifacts/package-ldd.txt; then
             echo "Installed Fedora RPM has unresolved shared-library dependencies" >&2
+            exit 1
+          fi
+          if strings "$binary" | grep -Eq '/__w/|src_assets/.*/assets/shaders'; then
+            echo "Installed Fedora RPM binary contains a source-tree shader path" >&2
             exit 1
           fi
 

--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -27,13 +27,6 @@ endif()
 
 target_link_libraries(polaris ${POLARIS_EXTERNAL_LIBRARIES} ${EXTRA_LIBS})
 target_compile_definitions(polaris PUBLIC ${POLARIS_DEFINITIONS})
-if(BUILD_TESTS)
-    if(WIN32)
-        target_compile_definitions(polaris PUBLIC POLARIS_SHADERS_DIR="${CMAKE_SOURCE_DIR}/src_assets/windows/assets/shaders/directx")
-    elseif(UNIX AND NOT APPLE)
-        target_compile_definitions(polaris PUBLIC POLARIS_SHADERS_DIR="${CMAKE_SOURCE_DIR}/src_assets/linux/assets/shaders/opengl")
-    endif()
-endif()
 set_target_properties(polaris PROPERTIES CXX_STANDARD 23
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_VERSION_MAJOR})


### PR DESCRIPTION
## Summary

- Stop adding source-tree OpenGL shader paths to the installed `polaris` binary when `BUILD_TESTS=ON`.
- Keep source-tree shader paths scoped to test targets, where they are needed for uninstalled test runs.
- Add DEB/RPM smoke guards that fail if an installed package binary contains GitHub Actions or `src_assets/.../assets/shaders` paths.

## Why

Fixes #37.

The Fedora RPM workflow configures with `BUILD_TESTS=ON`, which caused the main app target to inherit `POLARIS_SHADERS_DIR` pointing at the CI checkout. Installed RPMs then tried to load OpenGL conversion shaders from `/__w/polaris/polaris/src_assets/...`, causing VAAPI probe and runtime failures on AMD hosts even though VAAPI itself was detected correctly.

## Validation

- `git diff --check`
- Linux temp build with `BUILD_TESTS=ON`: `cmake --build /tmp/polaris-hdr-test/build-tests --target polaris -j$(nproc)`
- Verified built app binary does not contain `/__w/` or `src_assets/.../assets/shaders`; it now contains runtime shader paths only.
- Linux `test_polaris_video`: 10 passed, 1 skipped (`vaapi` unavailable on this NVIDIA host).