### PR TITLE
Isolate Linux headless audio routing

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,6 +93,21 @@ sudo usermod -aG input "$USER"
 
 Then sign out and back in.
 
+## Local desktop audio is captured during a headless stream
+
+In headless `labwc` sessions, Polaris routes launched apps to the Polaris virtual sink and captures
+that sink directly instead of changing the user's global default audio output. The healthy log path
+looks like:
+
+```text
+Linux audio isolation: routing launched apps to virtual sink [sink-sunshine-stereo] without changing the user's default sink
+Linux audio isolation: capturing virtual sink without changing the user's default sink
+```
+
+If local Plasma/GNOME audio is still mixed into the stream, include the audio section of the logs
+and whether the client requested host audio. Host-audio mode intentionally captures the host sink,
+so same-user local apps can still be part of that stream.
+
 ## NVIDIA KMS capture issues
 
 If KMS capture gives a black screen on NVIDIA, confirm the kernel is using:

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -170,46 +170,27 @@ namespace audio {
       return;
     }
 
-    // Order of priority:
-    // 1. Virtual sink
-    // 2. Audio sink
-    // 3. Host
-    std::string *sink = &ref->sink.host;
-    if (!config::audio.sink.empty()) {
-      sink = &config::audio.sink;
-    }
+    const bool host_audio = config.flags[config_t::HOST_AUDIO];
+    const auto sink = select_sink_name(*ref.get(), stream.channelCount, host_audio);
+    const bool route_without_default = should_route_session_sink_without_default(*ref.get(), sink, host_audio);
 
-    // Prefer the virtual sink if host playback is disabled or there's no other sink
-    if (ref->sink.null && (!config.flags[config_t::HOST_AUDIO] || sink->empty())) {
-      auto &null = *ref->sink.null;
-      switch (stream.channelCount) {
-        case 2:
-          sink = &null.stereo;
-          break;
-        case 6:
-          sink = &null.surround51;
-          break;
-        case 8:
-          sink = &null.surround71;
-          break;
-      }
-    }
-
-    BOOST_LOG(info) << "Selected audio sink: "sv << *sink;
+    BOOST_LOG(info) << "Selected audio sink: "sv << sink;
 
     // Only the first to start a session may change the default sink
     if (!ref->sink_flag->exchange(true, std::memory_order_acquire)) {
       // If the selected sink is different than the current one, change sinks.
-      ref->restore_sink = ref->sink.host != *sink;
-      if (ref->restore_sink) {
-        if (control->set_sink(*sink)) {
+      ref->restore_sink = !route_without_default && ref->sink.host != sink;
+      if (route_without_default) {
+        BOOST_LOG(info) << "Linux audio isolation: capturing virtual sink without changing the user's default sink"sv;
+      } else if (ref->restore_sink) {
+        if (control->set_sink(sink)) {
           return;
         }
       }
     }
 
     auto frame_size = config.packetDuration * stream.sampleRate / 1000;
-    auto mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size);
+    auto mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size, sink);
     if (!mic) {
       return;
     }
@@ -247,7 +228,7 @@ namespace audio {
             BOOST_LOG(info) << "Reinitializing audio capture"sv;
             mic.reset();
             do {
-              mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size);
+              mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size, sink);
               if (!mic) {
                 BOOST_LOG(warning) << "Couldn't re-initialize audio input"sv;
               }
@@ -266,6 +247,44 @@ namespace audio {
   audio_ctx_ref_t get_audio_ctx_ref() {
     static auto control_shared {safe::make_shared<audio_ctx_t>(start_audio_control, stop_audio_control)};
     return control_shared.ref();
+  }
+
+  std::string select_sink_name(const audio_ctx_t &ctx, int channels, bool host_audio) {
+    // Order of priority:
+    // 1. Virtual sink, when host playback is disabled or no host sink exists
+    // 2. Explicit audio sink
+    // 3. Host/default sink
+    std::string sink = config::audio.sink.empty() ? ctx.sink.host : config::audio.sink;
+
+    if (ctx.sink.null && (!host_audio || sink.empty())) {
+      const auto &null = *ctx.sink.null;
+      switch (channels) {
+        case 6:
+          return null.surround51;
+        case 8:
+          return null.surround71;
+        case 2:
+        default:
+          return null.stereo;
+      }
+    }
+
+    return sink;
+  }
+
+  bool sink_is_virtual(const audio_ctx_t &ctx, const std::string &sink) {
+    return ctx.sink.null &&
+           (sink == ctx.sink.null->stereo ||
+            sink == ctx.sink.null->surround51 ||
+            sink == ctx.sink.null->surround71);
+  }
+
+  bool should_route_session_sink_without_default(const audio_ctx_t &ctx, const std::string &sink, bool host_audio) {
+#ifdef __linux__
+    return !host_audio && config::audio.sink.empty() && sink_is_virtual(ctx, sink);
+#else
+    return false;
+#endif
   }
 
   bool is_audio_ctx_sink_available(const audio_ctx_t &ctx) {

--- a/src/audio.h
+++ b/src/audio.h
@@ -10,6 +10,7 @@
 #include "utility.h"
 
 #include <bitset>
+#include <string>
 
 namespace audio {
   enum stream_config_e : int {
@@ -78,6 +79,12 @@ namespace audio {
   using audio_ctx_ref_t = safe::shared_t<audio_ctx_t>::ptr_t;
 
   void capture(safe::mail_t mail, config_t config, void *channel_data);
+
+  std::string select_sink_name(const audio_ctx_t &ctx, int channels, bool host_audio);
+
+  bool sink_is_virtual(const audio_ctx_t &ctx, const std::string &sink);
+
+  bool should_route_session_sink_without_default(const audio_ctx_t &ctx, const std::string &sink, bool host_audio);
 
   /**
    * @brief Get the reference to the audio context.

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -667,7 +667,7 @@ namespace platf {
   public:
     virtual int set_sink(const std::string &sink) = 0;
 
-    virtual std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size) = 0;
+    virtual std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &sink) = 0;
 
     /**
      * @brief Check if the audio sink is available in the system.

--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -858,6 +858,21 @@ namespace platf {
           sink.null = std::make_optional(sink_t::null_t {stereo, surround51, surround71});
         }
 
+        if (!sink.host.empty()) {
+          const auto current_default = get_default_sink_name();
+          const bool virtual_sink_promoted =
+            current_default == stereo ||
+            current_default == surround51 ||
+            current_default == surround71;
+
+          if (virtual_sink_promoted && current_default != sink.host) {
+            BOOST_LOG(info) << "Linux audio isolation: restoring original default sink ["sv
+                            << sink.host << "] after virtual sink creation promoted ["sv
+                            << current_default << ']';
+            set_sink(sink.host);
+          }
+        }
+
         return std::make_optional(std::move(sink));
       }
 
@@ -914,15 +929,19 @@ namespace platf {
         return monitor_name;
       }
 
-      std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size) override {
+      std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &selected_sink) override {
         // Sink choice priority:
-        // 1. Config sink
-        // 2. Last sink swapped to (Usually virtual in this case)
-        // 3. Default Sink
+        // 1. Selected session sink
+        // 2. Config sink
+        // 3. Last sink swapped to (Usually virtual in this case)
+        // 4. Default Sink
         // An attempt was made to always use default to match the switching mechanic,
         // but this happens right after the swap so the default returned by PA was not
         // the new one just set!
-        auto sink_name = config::audio.sink;
+        auto sink_name = selected_sink;
+        if (sink_name.empty()) {
+          sink_name = config::audio.sink;
+        }
         if (sink_name.empty()) {
           sink_name = requested_sink;
         }

--- a/src/platform/macos/microphone.mm
+++ b/src/platform/macos/microphone.mm
@@ -49,7 +49,8 @@ namespace platf {
       return 0;
     }
 
-    std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size) override {
+    std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &sink) override {
+      (void) sink;
       auto mic = std::make_unique<av_mic_t>();
       const char *audio_sink = "";
 

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -761,7 +761,8 @@ namespace platf::audio {
       return std::nullopt;
     }
 
-    std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size) override {
+    std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &sink) override {
+      (void) sink;
       auto mic = std::make_unique<mic_wasapi_t>();
 
       if (mic->init(sample_rate, frame_size, channels)) {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -894,6 +894,17 @@ namespace proc {
       return std::nullopt;
     }
 
+    int normalized_audio_channel_count(int channel_count) {
+      switch (channel_count) {
+        case 6:
+        case 8:
+          return channel_count;
+        case 2:
+        default:
+          return 2;
+      }
+    }
+
     void restore_env_var(const char *key, const std::optional<std::string> &value) {
       if (value) {
         platf::set_env(key, *value);
@@ -1864,6 +1875,25 @@ namespace proc {
     }
     _session_env_keys.clear();
 
+#ifdef __linux__
+    _audio_context = {};
+    if (config::audio.stream) {
+      _audio_context = audio::get_audio_ctx_ref();
+      if (_audio_context) {
+        const auto session_audio_channels = normalized_audio_channel_count(channelCount);
+        const auto sink = audio::select_sink_name(*_audio_context.get(), session_audio_channels, launch_session->host_audio);
+        if (audio::should_route_session_sink_without_default(*_audio_context.get(), sink, launch_session->host_audio)) {
+          set_session_env_var(_env, _session_env_keys, "PULSE_SINK", sink);
+          set_session_env_var(_env, _session_env_keys, "POLARIS_SESSION_AUDIO_SINK", sink);
+          BOOST_LOG(info) << "Linux audio isolation: routing launched apps to virtual sink ["sv
+                          << sink << "] without changing the user's default sink"sv;
+        }
+      } else {
+        BOOST_LOG(warning) << "Linux audio isolation: audio control unavailable; launched apps will use the current default sink"sv;
+      }
+    }
+#endif
+
     // If MangoHud is enabled, also set DLSYM mode for safer Vulkan hooking
     // (prevents crashes in Wine utilities like d3ddriverquery64.exe)
     if (_app.env_vars.count("MANGOHUD") && _app.env_vars.at("MANGOHUD") == "1") {
@@ -2517,9 +2547,11 @@ namespace proc {
       platf::unset_env(key);
     }
     for (const auto &key : _session_env_keys) {
+      _env.erase(key);
       platf::unset_env(key);
     }
     _session_env_keys.clear();
+    _audio_context = {};
 
 #ifdef __linux__
     // Stop labwc compositor — this kills all games running inside it.

--- a/src/process.h
+++ b/src/process.h
@@ -28,6 +28,7 @@
 
 // local includes
 #include "config.h"
+#include "audio.h"
 #include "platform/common.h"
 #include "rtsp.h"
 #include "utility.h"
@@ -171,6 +172,7 @@ namespace proc {
 
     std::shared_ptr<rtsp_stream::launch_session_t> _launch_session;
     std::shared_ptr<config::input_t> _saved_input_config;
+    audio::audio_ctx_ref_t _audio_context;
 
     std::vector<ctx_t> _apps;
     ctx_t _app;

--- a/tests/unit/test_audio.cpp
+++ b/tests/unit/test_audio.cpp
@@ -5,8 +5,22 @@
 #include "../tests_common.h"
 
 #include <src/audio.h>
+#include <src/config.h>
 
 using namespace audio;
+
+namespace {
+  audio_ctx_t make_sink_context() {
+    audio_ctx_t ctx {};
+    ctx.sink.host = "alsa_output.host";
+    ctx.sink.null = platf::sink_t::null_t {
+      "sink-sunshine-stereo",
+      "sink-sunshine-surround51",
+      "sink-sunshine-surround71",
+    };
+    return ctx;
+  }
+}
 
 struct AudioTest: PlatformTestSuite, testing::WithParamInterface<std::tuple<std::basic_string_view<char>, config_t>> {
   void SetUp() override {
@@ -65,4 +79,50 @@ TEST_P(AudioTest, TestEncode) {
 
   timer.join();
   capture.join();
+}
+
+TEST(AudioSinkSelectionTest, SelectsVirtualSinkWhenHostAudioIsDisabled) {
+  auto old_sink = config::audio.sink;
+  config::audio.sink.clear();
+  auto ctx = make_sink_context();
+
+  const auto sink = audio::select_sink_name(ctx, 2, false);
+
+  EXPECT_EQ(sink, "sink-sunshine-stereo");
+  EXPECT_TRUE(audio::sink_is_virtual(ctx, sink));
+#ifdef __linux__
+  EXPECT_TRUE(audio::should_route_session_sink_without_default(ctx, sink, false));
+#else
+  EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, false));
+#endif
+
+  config::audio.sink = old_sink;
+}
+
+TEST(AudioSinkSelectionTest, SelectsHostSinkWhenHostAudioIsEnabled) {
+  auto old_sink = config::audio.sink;
+  config::audio.sink.clear();
+  auto ctx = make_sink_context();
+
+  const auto sink = audio::select_sink_name(ctx, 2, true);
+
+  EXPECT_EQ(sink, "alsa_output.host");
+  EXPECT_FALSE(audio::sink_is_virtual(ctx, sink));
+  EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, true));
+
+  config::audio.sink = old_sink;
+}
+
+TEST(AudioSinkSelectionTest, ExplicitConfiguredSinkKeepsDefaultRoutingBehavior) {
+  auto old_sink = config::audio.sink;
+  config::audio.sink = "alsa_output.configured";
+  auto ctx = make_sink_context();
+
+  const auto sink = audio::select_sink_name(ctx, 2, false);
+
+  EXPECT_EQ(sink, "sink-sunshine-stereo");
+  EXPECT_TRUE(audio::sink_is_virtual(ctx, sink));
+  EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, false));
+
+  config::audio.sink = old_sink;
 }


### PR DESCRIPTION
## Summary

- Route Linux headless session apps to the Polaris virtual audio sink with `PULSE_SINK`.
- Capture the selected virtual sink directly instead of changing the user's global default sink.
- Restore the original host default if PipeWire/WirePlumber auto-promotes a newly created Polaris null sink.
- Keep explicit audio-sink and host-audio behavior on the existing default-switch/capture paths.
- Add sink-selection unit coverage and a troubleshooting note for the new healthy log path.

## Why

Fixes #22 follow-up.

When local Plasma and a Polaris headless session run under the same user, changing the user's default sink to `sink-sunshine-*` can pull newly started local desktop audio into the stream and mute the local user. Headless session apps should be routed to the stream sink without moving the user's global audio default.

## Validation

- `git diff --check`
- Linux clean temp checkout at `/tmp/polaris-audio-isolation`
- `cmake -S . -B build-tests -DBUILD_TESTS=ON -DBUILD_FULL_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPOLARIS_ENABLE_CUDA=OFF`
- `cmake --build build-tests --target test_polaris_audio polaris -j$(nproc)`
- `./build-tests/tests/test_polaris_audio --gtest_color=no` passed: 7 tests
- Live Retroid Pocket 6 headless stream smoke with host audio disabled

Observed healthy stream logs:

```text
Linux audio isolation: routing launched apps to virtual sink [sink-sunshine-stereo] without changing the user's default sink
Selected audio sink: sink-sunshine-stereo
Linux audio isolation: capturing virtual sink without changing the user's default sink
Attempting PipeWire audio capture for source: sink-sunshine-stereo.monitor
PipeWire audio capture initialized: 2 channels, 48000 Hz (active=true)
```

During the active stream, `pactl get-default-sink` stayed on `alsa_output.usb-Topping_DX5_II-00.pro-output-0`; after shutdown it was still restored there. The first smoke run exposed PipeWire/WirePlumber auto-promoting the virtual sink, so this PR now restores the original default immediately if virtual sink creation causes that promotion.

Host-audio mode is intentionally unchanged and can still capture same-user local desktop audio.