### PR TITLE
Prepare 1.0.10 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.0.9
+project(Polaris VERSION 1.0.10
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,9 +7,16 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+## v1.0.10
+
+Patch release focused on Linux streaming diagnostics and host-session isolation.
+
 - Gate true HDR streaming on display HDR metadata instead of client dynamic-range requests alone
 - Add Linux true HDR diagnostics to logs, session status, and support data
 - Document the KMS/DRM HDR validation path and current headless labwc SDR behavior
+- Fixed Linux shader runtime path packaging so packaged builds can find shader assets correctly
+- Isolated Linux headless audio routing so Polaris can capture its virtual stream sink without leaving the host desktop default sink redirected
+- Added troubleshooting notes for Linux headless audio routing and HDR metadata validation
 
 ## v1.0.9
 


### PR DESCRIPTION
## Summary

- bump Polaris to 1.0.10
- move the current Linux HDR diagnostics notes into the 1.0.10 changelog section
- add the shader runtime path and Linux headless audio isolation fixes to the release notes

## Validation

- `git diff --check -- CMakeLists.txt docs/changelog.md`
- attempted `cmake -S . -B /tmp/polaris-release-check -DEND_BUILD=ON`, but local `cmake` is not installed on this Mac; CI will cover the build/configure path
