### PR TITLE
Improve headless performance diagnostics

### DIFF
--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -39,6 +39,7 @@ set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
             ${CPACK_DEB_PLATFORM_PACKAGE_DEPENDS} \
             debianutils, \
+            grim, \
             labwc, \
             libcap2, \
             libcurl4, \
@@ -59,6 +60,7 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
             xwayland")
 set(CPACK_RPM_PACKAGE_REQUIRES "\
             ${CPACK_RPM_PLATFORM_PACKAGE_REQUIRES} \
+            grim, \
             labwc, \
             libcap >= 2.22, \
             libcurl >= 7.0, \

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -102,13 +102,13 @@ echo 'options evdi initial_device_count=1' | sudo tee /etc/modprobe.d/evdi-polar
 
 Polaris needs host-level integration: the binary, web assets, desktop metadata,
 the user service, udev rules for virtual input, and compositor helpers such as
-`labwc`, `wlr-randr`, Xwayland, and `xdpyinfo`. On Bazzite, layering the RPM is
+`grim`, `labwc`, `wlr-randr`, Xwayland, and `xdpyinfo`. On Bazzite, layering the RPM is
 cleaner than running Polaris from a toolbox, distrobox, or unpacked archive
 because the package manager can install those host dependencies into the booted
 deployment.
 
 The Polaris RPM declares the headless runtime dependencies, so the install
-command should not need separate `labwc` or `wlr-randr` arguments.
+command should not need separate `grim`, `labwc`, or `wlr-randr` arguments.
 
 ## Recommended Bazzite Optimization
 
@@ -305,16 +305,19 @@ connector. On Bazzite with a pre-created device, the connector should look like
 
 `wlr: Using RAM capture path because this build does not include a GPU-native
 uploader for the selected encoder` and `capture will incur an extra CPU-side
-copy/conversion path` are expected with the current headless labwc runtime. They
-are performance notes, not startup failures. Confirm the stream is healthy by
-looking for `session_event: stream_active`, `CLIENT CONNECTED`, `Selected monitor
-[Headless output 1]`, and `Found H.264 encoder: h264_nvenc [nvenc]`.
-The `capture_transport=shm frame_residency=cpu frame_format=bgra8` warning is
-acceptable when the stream works.
+copy/conversion path` are not startup failures. Confirm the stream is connected
+by looking for `session_event: stream_active`, `CLIENT CONNECTED`, `Selected
+monitor [Headless output 1]`, and `Found H.264 encoder: h264_nvenc [nvenc]`.
+For performance reports, though, treat `capture_transport=shm
+frame_residency=cpu frame_format=bgra8`, `target_residency=cpu`, or `Build
+features: cuda=disabled` with NVENC as important clues because they mean Polaris
+is taking a CPU copy/upload path.
 
 `display_preview: Failed to capture cage screenshot` affects the web dashboard
 preview path. It does not mean the Moonlight/Nova stream failed if the client is
-already connected and receiving frames.
+already connected and receiving frames. Polaris rate-limits repeated preview
+capture failures, but if the preview itself matters, include `command -v grim`
+with the report.
 
 If local Plasma receives remote mouse or keyboard input while using headless
 labwc, treat that as an input-isolation bug and include the validation details
@@ -328,7 +331,8 @@ Please include these details when reporting Bazzite issues:
 - Desktop Mode or Game Mode
 - GPU model and driver stack
 - Polaris RPM asset used, such as `Polaris-fedora44-x86_64.rpm`
-- output of `command -v polaris labwc wlr-randr`
+- output of `command -v polaris grim labwc wlr-randr`
+- the `Build features: cuda=...` line
 - output of `getcap /usr/local/bin/polaris-kms`
 - output of `systemctl --user cat polaris`
 - whether `sudo polaris --setup-host` completed successfully
@@ -336,6 +340,7 @@ Please include these details when reporting Bazzite issues:
 - whether the web UI opens at `https://127.0.0.1:47990`
 - client used for pairing, such as Steam Deck Moonlight, Android Moonlight, or Nova
 - active capture path shown in the Polaris dashboard
+- requested client resolution, FPS, codec, and whether the web UI preview was open
 - whether headless mode and virtual display behavior worked after a reboot
 
 ## Current Status

--- a/docs/building.md
+++ b/docs/building.md
@@ -61,6 +61,7 @@ fallback paths, and validation notes before using either experimental path.
 | PipeWire | Audio capture |
 | Wayland client libs | Linux compositor integration |
 | Node.js 18+ | Web UI build |
+| grim | Dashboard preview capture for labwc/Wayland |
 | labwc | Isolated stream compositor |
 | wlr-randr | Configure the isolated stream output mode |
 | Xwayland and xdpyinfo | Launch and detect X11 clients inside labwc |
@@ -75,7 +76,7 @@ Run this from the cloned Polaris checkout so `dnf builddep` can read the package
 ```bash
 sudo dnf install dnf-plugins-core git
 sudo dnf builddep -y packaging/linux/fedora/Polaris.spec
-sudo dnf install labwc wlr-randr xorg-x11-server-Xwayland xdpyinfo
+sudo dnf install grim labwc wlr-randr xorg-x11-server-Xwayland xdpyinfo
 ```
 
 #### Arch
@@ -86,7 +87,7 @@ sudo pacman -S --needed base-devel git cmake ninja appstream appstream-glib \
   wayland-protocols libdrm libcap libnotify libayatana-appindicator \
   libpulse libva libx11 libxcb libxfixes libxi libxrandr libxtst \
   miniupnpc nlohmann-json numactl avahi opus libmfx mesa which nodejs npm \
-  labwc wlr-randr xorg-xwayland xorg-xdpyinfo cuda
+  grim labwc wlr-randr xorg-xwayland xorg-xdpyinfo cuda
 ```
 
 ### Build and install

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -123,6 +123,15 @@ mount options for the binary path. File capabilities are ignored on `nosuid` mou
 builds can be misleading; copy the test binary to a normal path such as `/usr/local/bin` before
 applying `setcap`.
 
+For low-FPS NVIDIA headless reports, check `Build features: cuda=...` first. If the log says
+`cuda=disabled` and later shows `Attempting to use NVENC without CUDA support. Reverting back to
+GPU -> RAM -> GPU`, the stream is taking an extra CPU copy/upload path. Use a CUDA-enabled package
+or rebuild with `-DPOLARIS_ENABLE_CUDA=ON` before comparing headless performance against Sunshine.
+
+`display_preview: Failed to capture cage screenshot` is the web dashboard preview path, not the
+stream capture path. Repeated failures are rate-limited in the log. If the preview is missing,
+confirm `grim` is installed with `command -v grim`.
+
 ## VAAPI or software encode fallback
 
 If Polaris cannot hold the preferred hardware path, open Mission Control or Troubleshooting and

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -37,7 +37,7 @@ sudo apt-get install -y \
   libva-dev libminiupnpc-dev libnotify-dev nlohmann-json3-dev \
   libappindicator3-dev libgtk-3-dev \
   libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
-  wayland-protocols labwc wlr-randr xwayland x11-utils nodejs npm
+  wayland-protocols grim labwc wlr-randr xwayland x11-utils nodejs npm
 
 git clone --recursive https://github.com/papi-ux/polaris.git
 cd polaris

--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -21,6 +21,7 @@ depends=(
   'avahi'
   'boost-libs'
   'curl'
+  'grim'
   'labwc'
   'libayatana-appindicator'
   'libcap'

--- a/packaging/linux/fedora/Polaris.spec
+++ b/packaging/linux/fedora/Polaris.spec
@@ -87,6 +87,7 @@ BuildRequires: gcc-c++
 %global cuda_dir %{_builddir}/cuda
 
 Requires: labwc
+Requires: grim
 Requires: libayatana-appindicator3 >= 0.5.3
 Requires: libcap >= 2.22
 Requires: libcurl >= 7.0

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -8,6 +8,8 @@
 
 // standard includes
 #include <array>
+#include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <format>
 #include <fstream>
@@ -264,6 +266,16 @@ namespace confighttp {
     }
 
 #ifdef __linux__
+    constexpr auto PREVIEW_FAILURE_LOG_BACKOFF = std::chrono::seconds(60);
+
+    struct preview_failure_log_state_t {
+      std::chrono::steady_clock::time_point last_log {};
+      std::uint32_t suppressed_count = 0;
+    };
+
+    std::mutex preview_failure_log_mutex;
+    std::unordered_map<std::string, preview_failure_log_state_t> preview_failure_log_state;
+
     std::string preview_xdg_runtime_dir() {
       if (const char *xdg = std::getenv("XDG_RUNTIME_DIR"); xdg && *xdg) {
         return xdg;
@@ -305,6 +317,57 @@ namespace confighttp {
       }
       cmd << shell_escape(outfile) << " 2>/dev/null";
       return cmd.str();
+    }
+
+    std::string preview_failure_log_key(const std::string &capture_kind,
+                                        const std::string &socket_name,
+                                        const std::string &output_name) {
+      return capture_kind + "|" + socket_name + "|" + output_name;
+    }
+
+    void clear_cage_preview_capture_failure(const std::string &capture_kind,
+                                            const std::string &socket_name,
+                                            const std::string &output_name) {
+      std::lock_guard lock(preview_failure_log_mutex);
+      preview_failure_log_state.erase(preview_failure_log_key(capture_kind, socket_name, output_name));
+    }
+
+    void log_cage_preview_capture_failure(const std::string &capture_kind,
+                                          const std::string &socket_name,
+                                          const std::string &output_name) {
+      const auto now = std::chrono::steady_clock::now();
+      std::uint32_t suppressed_count = 0;
+      bool should_log = false;
+
+      {
+        std::lock_guard lock(preview_failure_log_mutex);
+        auto &state = preview_failure_log_state[preview_failure_log_key(capture_kind, socket_name, output_name)];
+        if (state.last_log.time_since_epoch().count() == 0 ||
+            now - state.last_log >= PREVIEW_FAILURE_LOG_BACKOFF) {
+          suppressed_count = state.suppressed_count;
+          state.suppressed_count = 0;
+          state.last_log = now;
+          should_log = true;
+        } else {
+          ++state.suppressed_count;
+        }
+      }
+
+      if (!should_log) {
+        return;
+      }
+
+      std::ostringstream message;
+      message << "display_preview: Failed to capture cage " << capture_kind
+              << " on socket " << socket_name
+              << " output=" << (output_name.empty() ? "(auto)" : output_name)
+              << "; preview capture is separate from the active stream, suppressing repeats for "
+              << PREVIEW_FAILURE_LOG_BACKOFF.count() << "s";
+      if (suppressed_count > 0) {
+        message << " (" << suppressed_count << " repeat"
+                << (suppressed_count == 1 ? "" : "s") << " suppressed)";
+      }
+      BOOST_LOG(warning) << message.str();
     }
 #endif
 
@@ -3245,10 +3308,9 @@ namespace confighttp {
         cage_capture_required = true;
         if (std::system(cmd.c_str()) == 0) {
           captured = true;
+          clear_cage_preview_capture_failure("screenshot", cage_socket, preview_output);
         } else {
-          BOOST_LOG(warning) << "display_preview: Failed to capture cage screenshot on socket "sv
-                             << cage_socket << " output="sv
-                             << (preview_output.empty() ? "(auto)"sv : preview_output);
+          log_cage_preview_capture_failure("screenshot", cage_socket, preview_output);
         }
       }
     }
@@ -3262,7 +3324,9 @@ namespace confighttp {
     if (!captured) {
       nlohmann::json err;
       err["status"] = false;
-      err["error"] = "Screenshot capture failed";
+      err["error"] = cage_capture_required ?
+        "Preview capture failed; the active stream may still be healthy" :
+        "Screenshot capture failed";
       send_response(response, err);
       return;
     }
@@ -3344,10 +3408,9 @@ namespace confighttp {
             cage_capture_required = true;
             if (std::system(cmd.c_str()) == 0) {
               captured = true;
+              clear_cage_preview_capture_failure("MJPEG frame", cage_socket, preview_output);
             } else {
-              BOOST_LOG(warning) << "display_preview: Failed to capture cage MJPEG frame on socket "sv
-                                 << cage_socket << " output="sv
-                                 << (preview_output.empty() ? "(auto)"sv : preview_output);
+              log_cage_preview_capture_failure("MJPEG frame", cage_socket, preview_output);
               break;
             }
           }

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -175,6 +175,14 @@ namespace nvhttp {
 #endif
     }
 
+    bool build_has_cuda() {
+#ifdef POLARIS_BUILD_CUDA
+      return true;
+#else
+      return false;
+#endif
+    }
+
     bool is_mobile_client_type(const std::optional<device_db::device_t> &device_profile) {
       if (!device_profile) {
         return false;
@@ -369,9 +377,13 @@ namespace nvhttp {
         stats.dropped_frame_ratio >= 0.04 ||
         fps_gap >= 4.0;
       const bool capture_fallback =
-        stats.capture_residency == platf::frame_residency_e::cpu ||
-        stats.encode_target_residency == platf::frame_residency_e::cpu ||
-        stats.capture_transport == platf::frame_transport_e::shm;
+        stream_stats::capture_path_uses_cpu_copy(stats);
+      const auto capture_path = stream_stats::capture_path_summary(stats);
+      const auto active_encoder_name = video::active_encoder_name();
+      const bool nvenc_cuda_disabled_path =
+        active_encoder_name == "nvenc" &&
+        !build_has_cuda() &&
+        capture_fallback;
       const bool encoder_risk = stats.encode_time_ms >= 11.0 || stats.avg_frame_age_ms >= 18.0;
       const bool hdr_source_missing = stats.dynamic_range > 0 && !stats.stream_hdr_enabled;
       const bool hdr_risk = stats.stream_hdr_enabled && (pacing_risk || encoder_risk);
@@ -396,7 +408,11 @@ namespace nvhttp {
       }
       if (capture_fallback) {
         issues.push_back("capture_fallback");
-        recommendations.push_back("Prefer the GPU-native capture path or the headless compositor path on this host.");
+        recommendations.push_back("Current capture or encode upload path is using a CPU-side copy; check capture transport, residency, and encoder target residency.");
+      }
+      if (nvenc_cuda_disabled_path) {
+        issues.push_back("nvenc_cuda_disabled");
+        recommendations.push_back("Use a CUDA-enabled Polaris build/package before judging NVIDIA headless performance.");
       }
       if (encoder_risk) {
         issues.push_back("encoder_load");
@@ -420,6 +436,7 @@ namespace nvhttp {
       else if (hdr_risk) primary_issue = "hdr_path";
       else if (virtual_display_risk) primary_issue = "virtual_display_path";
       else if (decoder_risk) primary_issue = "decoder_path";
+      else if (nvenc_cuda_disabled_path) primary_issue = "nvenc_cuda_disabled";
       else if (capture_fallback) primary_issue = "capture_fallback";
       else if (pacing_risk) primary_issue = "frame_pacing";
       else if (encoder_risk) primary_issue = "encoder_load";
@@ -428,6 +445,7 @@ namespace nvhttp {
         static_cast<int>(network_risk) +
         static_cast<int>(pacing_risk) +
         static_cast<int>(capture_fallback) +
+        static_cast<int>(nvenc_cuda_disabled_path) +
         static_cast<int>(encoder_risk) +
         static_cast<int>(hdr_risk) +
         static_cast<int>(decoder_risk) +
@@ -472,6 +490,7 @@ namespace nvhttp {
         hdr_risk ? "The current HDR path looks unstable." :
         virtual_display_risk ? "The virtual display path is likely adding pacing overhead." :
         decoder_risk ? "The current codec path looks harder on this client than expected." :
+        nvenc_cuda_disabled_path ? "The NVIDIA path is using a CUDA-disabled CPU copy fallback." :
         "The stream needs a safer pacing or encode path.";
       health["issues"] = std::move(issues);
       health["recommendations"] = std::move(recommendations);
@@ -482,7 +501,12 @@ namespace nvhttp {
       health["hdr_risk"] = hdr_risk ? "elevated" : "normal";
       health["hdr_source"] = hdr_source_missing ? "missing" : (stats.stream_hdr_enabled ? "metadata" : "sdr");
       health["network_risk"] = network_risk ? "elevated" : "normal";
-      health["relaunch_recommended"] = hdr_risk || decoder_risk || virtual_display_risk;
+      health["capture_path"] = capture_path;
+      health["capture_cpu_copy"] = capture_fallback;
+      health["capture_gpu_native"] = stream_stats::capture_path_is_gpu_native(stats);
+      health["active_encoder"] = active_encoder_name.empty() ? "unknown" : active_encoder_name;
+      health["cuda_build"] = build_has_cuda();
+      health["relaunch_recommended"] = hdr_risk || decoder_risk || virtual_display_risk || nvenc_cuda_disabled_path;
       if (safe_codec) {
         health["safe_codec"] = *safe_codec;
       }
@@ -2888,6 +2912,9 @@ namespace nvhttp {
       output["server"] = "polaris";
       output["version"] = PROJECT_VERSION;
 
+      auto &build = output["build"];
+      build["cuda"] = build_has_cuda();
+
       // Feature flags
       auto &features = output["features"];
       features["ai_optimizer"] = ai_optimizer::is_enabled();
@@ -2945,6 +2972,8 @@ namespace nvhttp {
       output["state"] = session_state;
       output["streaming_active"] = stats.streaming;
       output["shutdown_requested"] = shutdown_requested;
+      auto &build = output["build"];
+      build["cuda"] = build_has_cuda();
 #ifdef __linux__
       output["cage_pid"] = cage_display_router::get_pid();
       output["screen_locked"] = session_manager::is_screen_locked();
@@ -3029,9 +3058,13 @@ namespace nvhttp {
       capture_info["transport"] = platf::from_frame_transport(stats.capture_transport);
       capture_info["residency"] = platf::from_frame_residency(stats.capture_residency);
       capture_info["format"] = platf::from_frame_format(stats.capture_format);
+      capture_info["path"] = stream_stats::capture_path_summary(stats);
+      capture_info["cpu_copy"] = stream_stats::capture_path_uses_cpu_copy(stats);
+      capture_info["gpu_native"] = stream_stats::capture_path_is_gpu_native(stats);
 
       // Encoder info
       auto &encoder = output["encoder"];
+      encoder["active_backend"] = video::active_encoder_name().empty() ? "unknown" : video::active_encoder_name();
       encoder["codec"] = stats.codec;
       encoder["bitrate_kbps"] = stats.bitrate_kbps;
       encoder["fps"] = stats.fps;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2418,9 +2418,8 @@ namespace proc {
           stats.dropped_frame_ratio >= 0.04 ||
           fps_gap >= 4.0;
         const bool capture_fallback =
-          stats.capture_residency == platf::frame_residency_e::cpu ||
-          stats.encode_target_residency == platf::frame_residency_e::cpu ||
-          stats.capture_transport == platf::frame_transport_e::shm;
+          stream_stats::capture_path_uses_cpu_copy(stats);
+        const auto capture_path = stream_stats::capture_path_summary(stats);
         const bool encoder_risk = stats.encode_time_ms >= 11.0 || stats.avg_frame_age_ms >= 18.0;
         const bool hdr_risk = stats.dynamic_range > 0 && (pacing_risk || encoder_risk);
         const std::string codec_lower = boost::algorithm::to_lower_copy(session.last_codec);
@@ -2431,11 +2430,15 @@ namespace proc {
         session.last_network_risk = network_risk ? "elevated" : "normal";
         session.last_decoder_risk = decoder_risk ? "elevated" : "normal";
         session.last_hdr_risk = hdr_risk ? "elevated" : "normal";
-        session.last_capture_path =
-          _launch_session->virtual_display ? "virtual_display" :
-          capture_fallback ? "cpu_fallback" :
-          stats.runtime_effective_headless ? "headless" :
-          "desktop";
+        if (_launch_session->virtual_display) {
+          session.last_capture_path = capture_fallback ? "virtual_display_" + capture_path : "virtual_display";
+        } else if (capture_fallback) {
+          session.last_capture_path = capture_path;
+        } else if (stats.runtime_effective_headless) {
+          session.last_capture_path = "headless";
+        } else {
+          session.last_capture_path = capture_path == "gpu_native" ? "gpu_native" : "desktop";
+        }
         if (network_risk) session.last_primary_issue = "network_jitter";
         else if (hdr_risk) session.last_primary_issue = "hdr_path";
         else if (virtual_display_risk) session.last_primary_issue = "virtual_display_path";

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -93,6 +93,9 @@ namespace stream_stats {
     j["capture_transport"] = platf::from_frame_transport(capture_transport);
     j["capture_residency"] = platf::from_frame_residency(capture_residency);
     j["capture_format"] = platf::from_frame_format(capture_format);
+    j["capture_path"] = capture_path_summary(*this);
+    j["capture_cpu_copy"] = capture_path_uses_cpu_copy(*this);
+    j["capture_gpu_native"] = capture_path_is_gpu_native(*this);
     j["encode_target_device"] = encode_target_device;
     j["encode_target_residency"] = platf::from_frame_residency(encode_target_residency);
     j["encode_target_format"] = platf::from_frame_format(encode_target_format);
@@ -151,6 +154,47 @@ namespace stream_stats {
     j["active_sessions"] = static_cast<int>(clients.size());
 
     return j.dump();
+  }
+
+  bool capture_path_uses_cpu_copy(const stats_t &stats) {
+    return
+      stats.capture_transport == platf::frame_transport_e::shm ||
+      stats.capture_residency == platf::frame_residency_e::cpu ||
+      stats.encode_target_residency == platf::frame_residency_e::cpu;
+  }
+
+  bool capture_path_is_gpu_native(const stats_t &stats) {
+    return
+      stats.capture_transport == platf::frame_transport_e::dmabuf &&
+      stats.capture_residency == platf::frame_residency_e::gpu &&
+      stats.encode_target_residency == platf::frame_residency_e::gpu;
+  }
+
+  std::string capture_path_summary(const stats_t &stats) {
+    const bool capture_unknown =
+      stats.capture_transport == platf::frame_transport_e::unknown &&
+      stats.capture_residency == platf::frame_residency_e::unknown &&
+      stats.encode_target_residency == platf::frame_residency_e::unknown;
+    if (capture_unknown) {
+      return "unknown";
+    }
+    if (stats.capture_transport == platf::frame_transport_e::shm) {
+      return "shm_cpu_capture";
+    }
+    if (stats.capture_residency == platf::frame_residency_e::cpu) {
+      return "cpu_capture";
+    }
+    if (stats.encode_target_residency == platf::frame_residency_e::cpu) {
+      return "cpu_encode_upload";
+    }
+    if (capture_path_is_gpu_native(stats)) {
+      return "gpu_native";
+    }
+    if (stats.capture_transport == platf::frame_transport_e::dmabuf &&
+        stats.capture_residency == platf::frame_residency_e::gpu) {
+      return "gpu_capture";
+    }
+    return "mixed_or_unknown";
   }
 
   void update_stream_active(bool active, const std::string &client_name, const std::string &client_ip) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -115,6 +115,24 @@ namespace stream_stats {
   };
 
   /**
+   * @brief Whether the current capture/encode path requires a CPU-side copy.
+   * @param stats Current stream statistics snapshot.
+   */
+  bool capture_path_uses_cpu_copy(const stats_t &stats);
+
+  /**
+   * @brief Whether both capture and encode conversion are GPU-resident.
+   * @param stats Current stream statistics snapshot.
+   */
+  bool capture_path_is_gpu_native(const stats_t &stats);
+
+  /**
+   * @brief Human-readable capture path classification for diagnostics.
+   * @param stats Current stream statistics snapshot.
+   */
+  std::string capture_path_summary(const stats_t &stats);
+
+  /**
    * @brief Update stream active state.
    * @param active Whether streaming is active.
    * @param client_name Name of the connected client.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -131,6 +131,7 @@ set(TEST_AUDIO_SOURCES
 
 set(TEST_STREAM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_stream.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_stream_stats.cpp
 )
 
 set(TEST_VIDEO_SOURCES

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file tests/unit/test_stream_stats.cpp
+ * @brief Test src/stream_stats.*.
+ */
+
+#include <src/stream_stats.h>
+
+#include <gtest/gtest.h>
+
+TEST(StreamStatsCapturePathTests, UnknownWhenNoPathMetadataExists) {
+  stream_stats::stats_t stats {};
+
+  EXPECT_EQ(stream_stats::capture_path_summary(stats), "unknown");
+  EXPECT_FALSE(stream_stats::capture_path_uses_cpu_copy(stats));
+  EXPECT_FALSE(stream_stats::capture_path_is_gpu_native(stats));
+}
+
+TEST(StreamStatsCapturePathTests, DetectsShmCpuCapture) {
+  stream_stats::stats_t stats {};
+  stats.capture_transport = platf::frame_transport_e::shm;
+  stats.capture_residency = platf::frame_residency_e::cpu;
+  stats.encode_target_residency = platf::frame_residency_e::cpu;
+
+  EXPECT_EQ(stream_stats::capture_path_summary(stats), "shm_cpu_capture");
+  EXPECT_TRUE(stream_stats::capture_path_uses_cpu_copy(stats));
+  EXPECT_FALSE(stream_stats::capture_path_is_gpu_native(stats));
+}
+
+TEST(StreamStatsCapturePathTests, DetectsCpuEncodeUpload) {
+  stream_stats::stats_t stats {};
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::cpu;
+
+  EXPECT_EQ(stream_stats::capture_path_summary(stats), "cpu_encode_upload");
+  EXPECT_TRUE(stream_stats::capture_path_uses_cpu_copy(stats));
+  EXPECT_FALSE(stream_stats::capture_path_is_gpu_native(stats));
+}
+
+TEST(StreamStatsCapturePathTests, DetectsFullyGpuNativePath) {
+  stream_stats::stats_t stats {};
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+
+  EXPECT_EQ(stream_stats::capture_path_summary(stats), "gpu_native");
+  EXPECT_FALSE(stream_stats::capture_path_uses_cpu_copy(stats));
+  EXPECT_TRUE(stream_stats::capture_path_is_gpu_native(stats));
+}


### PR DESCRIPTION
## Summary

- Rate-limit repeated cage preview capture failures so dashboard preview polling does not spam logs during otherwise healthy streams.
- Add shared capture-path diagnostics for SHM/CPU capture, CPU encoder upload, GPU-native capture, and CUDA-disabled NVENC fallback.
- Document the Linux headless performance markers testers should include, and add `grim` as a Linux runtime/package dependency for dashboard preview capture.

## Validation

- `git diff --check`
- `g++ -std=c++23 -I. -Ithird-party/googletest/googletest/include -fsyntax-only tests/unit/test_stream_stats.cpp` was attempted, but this local environment is missing Boost headers (`boost/core/noncopyable.hpp`).

## Notes

This targets #44. The stream path and dashboard preview path remain separate; preview capture failure should not imply the active Moonlight/Nova stream failed.