### PR TITLE
Fix web config save failures

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -925,6 +925,18 @@ namespace confighttp {
     response->write(code, tree.dump(), headers);
   }
 
+  void forbidden(resp_https_t response, [[maybe_unused]] req_https_t request, const std::string &error_message = "Forbidden") {
+    constexpr SimpleWeb::StatusCode code = SimpleWeb::StatusCode::client_error_forbidden;
+    nlohmann::json tree;
+    tree["status_code"] = static_cast<int>(code);
+    tree["status"] = false;
+    tree["error"] = error_message;
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    append_json_security_headers(headers);
+
+    response->write(code, tree.dump(), headers);
+  }
+
 
   /**
    * @brief Validate the request content type and send bad request when mismatch.
@@ -987,6 +999,7 @@ namespace confighttp {
     }
     SimpleWeb::CaseInsensitiveMultimap headers;
     headers.emplace("Content-Type", "text/html; charset=utf-8");
+    headers.emplace("Cache-Control", "no-store");
     append_common_security_headers(headers);
     response->write(content, headers);
   }
@@ -4191,7 +4204,7 @@ namespace confighttp {
                           auth_header->second.substr(0, 7) == "Bearer ";
         if (!has_bearer && !hasVerifiedClientCert(request) && !validateCsrf(request)) {
           BOOST_LOG(warning) << "CSRF token validation failed for "sv << request->path;
-          bad_request(response, request, "CSRF token missing or invalid");
+          forbidden(response, request, "CSRF token missing or invalid");
           return;
         }
         handler(response, request);

--- a/src_assets/common/assets/web/config-defaults.test.js
+++ b/src_assets/common/assets/web/config-defaults.test.js
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('config defaults', () => {
+  it('keeps GPU-native capture disabled by default so enabling it persists', () => {
+    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/ConfigView.vue'), 'utf8')
+
+    expect(source).toContain('"linux_prefer_gpu_native_capture": "disabled"')
+  })
+})

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -329,7 +329,7 @@ const tabs = ref([
       "dd_mode_remapping": {"mixed": [], "resolution_only": [], "refresh_rate_only": []},
       "dd_wa_hdr_toggle": "disabled",
       "headless_mode": "disabled",
-      "linux_prefer_gpu_native_capture": "enabled",
+      "linux_prefer_gpu_native_capture": "disabled",
       "linux_capture_profile": "disabled",
       "double_refreshrate": "disabled",
       "max_bitrate": 0,


### PR DESCRIPTION
## Summary

- return a 403 response for failed CSRF validation so the existing web UI token-refresh retry path can recover after server restarts or stale pages
- serve the SPA shell with `Cache-Control: no-store` so browsers do not reuse an index page with an old injected CSRF token
- align the `linux_prefer_gpu_native_capture` UI default with the backend default (`disabled`) so enabling the option is included in config saves
- add a focused web regression test for the GPU-native capture default

## Validation

- `git diff --check`
- `npm test -- --run src_assets/common/assets/web/router-helpers.test.js src_assets/common/assets/web/config-defaults.test.js`
- `npx eslint src_assets/common/assets/web/config-defaults.test.js src_assets/common/assets/web/views/ConfigView.vue src_assets/common/assets/web/router-helpers.js`
- `npm run build`

## Notes

This addresses the web config-save and persistence parts of #47. The VAAPI/headless DMA-BUF behavior still needs a fresh retest after the GPU-native preference can be saved reliably.