### PR TITLE
Reject incomplete HDR metadata

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,10 +64,15 @@ KMS/DRM display path with an HDR-capable output reporting `HDR_OUTPUT_METADATA`,
 request and a 10-bit-capable encoder. A valid true HDR session logs:
 
 ```text
-HDR metadata: available=true
+HDR metadata: available=true usable=true
 Color coding: HDR (Rec. 2020 + SMPTE 2084 PQ)
 HDR decision: ... display_hdr=true hdr_metadata_available=true stream_hdr_enabled=true
 ```
+
+If the log says `HDR metadata: available=true usable=false`, Polaris found an HDR
+metadata blob but the static metadata is incomplete, such as a custom EDID with a
+zero max luminance value. Polaris treats that stream as SDR instead of tagging it
+as HDR with unusable metadata.
 
 Headless labwc/wlroots sessions are intentionally treated as SDR until the headless display path can
 truthfully provide HDR metadata. In that mode, `hdr_mode = 2` can still be useful to test Main10/P010

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -176,13 +176,15 @@ client HDR requests until SDR colors are correct, then test HEVC Main 8-bit befo
 For true HDR, look for all of these lines in the same launch:
 
 ```text
-HDR metadata: available=true
+HDR metadata: available=true usable=true
 Color coding: HDR (Rec. 2020 + SMPTE 2084 PQ)
 HDR decision: ... display_hdr=true hdr_metadata_available=true stream_hdr_enabled=true
 ```
 
 If `stream_hdr_enabled=false`, Polaris is being conservative: the client may have requested HDR or Main10,
 but the active Linux display path did not provide enough metadata to advertise a real HDR stream.
+If `usable=false`, the display path exposed an HDR metadata blob, but Polaris rejected it because core
+static metadata such as display primaries or max display luminance was missing.
 
 ## Support bundle and logs
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -11,6 +11,7 @@
 #include <fcntl.h>
 #include <fstream>
 #include <list>
+#include <string>
 #include <thread>
 
 // lib includes
@@ -336,9 +337,48 @@ namespace video {
       std::optional<SS_HDR_METADATA> metadata;
     };
 
+    bool hdr_metadata_has_display_primaries(const SS_HDR_METADATA &metadata) {
+      for (const auto &primary : metadata.displayPrimaries) {
+        if (primary.x == 0 || primary.y == 0) {
+          return false;
+        }
+      }
+
+      return metadata.whitePoint.x != 0 && metadata.whitePoint.y != 0;
+    }
+
+    bool hdr_metadata_has_mastering_luminance(const SS_HDR_METADATA &metadata) {
+      return metadata.maxDisplayLuminance != 0;
+    }
+
+    bool hdr_metadata_is_usable(const SS_HDR_METADATA &metadata) {
+      return hdr_metadata_has_display_primaries(metadata) &&
+             hdr_metadata_has_mastering_luminance(metadata);
+    }
+
+    std::string hdr_metadata_rejection_reason(const SS_HDR_METADATA &metadata) {
+      const bool missing_primaries = !hdr_metadata_has_display_primaries(metadata);
+      const bool missing_luminance = !hdr_metadata_has_mastering_luminance(metadata);
+
+      if (missing_primaries && missing_luminance) {
+        return "display primaries/white point and max display luminance are missing";
+      }
+
+      if (missing_primaries) {
+        return "display primaries/white point are missing";
+      }
+
+      if (missing_luminance) {
+        return "max display luminance is missing";
+      }
+
+      return "metadata is incomplete";
+    }
+
     void log_hdr_metadata_summary(const SS_HDR_METADATA &metadata) {
       BOOST_LOG(info)
         << "HDR metadata: available=true"
+        << " usable="sv << (hdr_metadata_is_usable(metadata) ? "true" : "false")
         << " max_luminance="sv << metadata.maxDisplayLuminance
         << " min_luminance="sv << metadata.minDisplayLuminance
         << " max_cll="sv << metadata.maxContentLightLevel
@@ -352,8 +392,15 @@ namespace video {
       if (config.dynamicRange > 0 && probe.display_hdr) {
         SS_HDR_METADATA metadata {};
         if (disp.get_hdr_metadata(metadata)) {
-          probe.metadata = metadata;
           log_hdr_metadata_summary(metadata);
+          if (hdr_metadata_is_usable(metadata)) {
+            probe.metadata = metadata;
+          } else {
+            BOOST_LOG(warning)
+              << "HDR decision: client_dynamic_range="sv << config.dynamicRange
+              << " display_hdr=true hdr_metadata_available=false stream_hdr_enabled=false; treating stream as SDR because "
+              << hdr_metadata_rejection_reason(metadata);
+          }
         } else {
           BOOST_LOG(warning)
             << "HDR decision: client_dynamic_range="sv << config.dynamicRange
@@ -4463,6 +4510,10 @@ namespace video {
 
   std::chrono::milliseconds reset_display_retry_delay_for_tests(int attempt) {
     return reset_display_retry_delay(attempt);
+  }
+
+  bool hdr_metadata_is_usable_for_tests(const SS_HDR_METADATA &metadata) {
+    return hdr_metadata_is_usable(metadata);
   }
 
   int software_frame_input_linesize_for_tests(

--- a/src/video.h
+++ b/src/video.h
@@ -554,6 +554,8 @@ namespace video {
 
   std::chrono::milliseconds reset_display_retry_delay_for_tests(int attempt);
 
+  bool hdr_metadata_is_usable_for_tests(const SS_HDR_METADATA &metadata);
+
   int software_frame_input_linesize_for_tests(
     int row_pitch,
     int pixel_pitch,

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -94,6 +94,43 @@ TEST(VideoColorSpaceTests, ClientHdrRequestWithDisplayMetadataEnablesTrueHdr) {
   EXPECT_EQ(colorspace.bit_depth, 10);
 }
 
+namespace {
+  SS_HDR_METADATA usable_hdr_metadata() {
+    SS_HDR_METADATA metadata {};
+    metadata.displayPrimaries[0].x = 34000;
+    metadata.displayPrimaries[0].y = 16000;
+    metadata.displayPrimaries[1].x = 13250;
+    metadata.displayPrimaries[1].y = 34500;
+    metadata.displayPrimaries[2].x = 7500;
+    metadata.displayPrimaries[2].y = 3000;
+    metadata.whitePoint.x = 15635;
+    metadata.whitePoint.y = 16450;
+    metadata.maxDisplayLuminance = 1000;
+    metadata.minDisplayLuminance = 1;
+    return metadata;
+  }
+}  // namespace
+
+TEST(VideoHdrMetadataTests, AcceptsMetadataWithPrimariesAndMasteringLuminance) {
+  auto metadata = usable_hdr_metadata();
+
+  EXPECT_TRUE(video::hdr_metadata_is_usable_for_tests(metadata));
+}
+
+TEST(VideoHdrMetadataTests, RejectsMetadataWithoutMasteringLuminance) {
+  auto metadata = usable_hdr_metadata();
+  metadata.maxDisplayLuminance = 0;
+
+  EXPECT_FALSE(video::hdr_metadata_is_usable_for_tests(metadata));
+}
+
+TEST(VideoHdrMetadataTests, RejectsMetadataWithoutDisplayPrimaries) {
+  auto metadata = usable_hdr_metadata();
+  metadata.displayPrimaries[1].x = 0;
+
+  EXPECT_FALSE(video::hdr_metadata_is_usable_for_tests(metadata));
+}
+
 TEST(VideoCacheTests, DriverVersionCacheHitRequiresMatchingBinaryMetadata) {
   const auto cache_dir = std::filesystem::temp_directory_path() / "polaris-video-cache-tests";
   const auto cache_path = cache_dir / "driver_version_cache.txt";


### PR DESCRIPTION
## Summary
- require usable HDR static metadata before advertising true HDR
- log HDR metadata as available/usable so zero-luminance EDIDs are obvious
- document the new usable HDR marker and add regression coverage for incomplete metadata

Refs #35

## Validation
- `git diff --check`
- Not run: local C++ test build (`cmake` is not installed on this Mac shell)