### PR TITLE
Improve Linux stream runtime policy

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -2,6 +2,10 @@
 
 add_compile_definitions(POLARIS_PLATFORM="linux")
 
+if(POLARIS_ENABLE_WEBRTC)
+    list(APPEND POLARIS_DEFINITIONS POLARIS_ENABLE_WEBRTC=1)
+endif()
+
 # AppImage
 if(${POLARIS_BUILD_APPIMAGE})
     # use relative assets path for AppImage
@@ -314,6 +318,8 @@ list(APPEND PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/linux/session_manager.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/cage_display_router.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/cage_display_router.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/stream_display_policy.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/stream_display_policy.cpp"
         "${CMAKE_SOURCE_DIR}/third-party/glad/src/egl.c"
         "${CMAKE_SOURCE_DIR}/third-party/glad/src/gl.c"
         "${CMAKE_SOURCE_DIR}/third-party/glad/include/EGL/eglplatform.h"

--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -68,4 +68,6 @@ elseif(UNIX)  # Linux
             "Enable native PipeWire audio support." ON)
     option(POLARIS_ENABLE_PORTAL
             "Enable XDG Desktop Portal screen capture if available." ON)
+    option(POLARIS_ENABLE_WEBRTC
+            "Enable experimental browser WebRTC streaming support." OFF)
 endif()

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -25,6 +25,7 @@ const routes = [
   { name: 'apps-new', hash: '#/apps?new=1', text: /Application Editor|New App/i },
   { name: 'apps-import', hash: '#/apps?import=1&scan=1', text: /Stage imports|Library/i },
   { name: 'pairing', hash: '#/pin', heading: /pair/i },
+  { name: 'webrtc', hash: '#/webrtc', heading: /^WebRTC$/i },
   { name: 'troubleshooting', hash: '#/troubleshooting', heading: /^Troubleshooting$/i },
   { name: 'welcome', hash: '#/welcome', heading: /Welcome to Polaris/i },
 ]

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -575,6 +575,7 @@ namespace config {
     "1920x1080x60",  // fallback_mode
     false, // isolated Display
     false, // ignore_encoder_probe_failure
+    false, // webrtc_browser_streaming
 
     {     // ai_optimizer
       false,  // enabled
@@ -1318,6 +1319,7 @@ namespace config {
     string_f(vars, "fallback_mode", video.fallback_mode);
     bool_f(vars, "isolated_virtual_display_option", video.isolated_virtual_display_option);
     bool_f(vars, "ignore_encoder_probe_failure", video.ignore_encoder_probe_failure);
+    bool_f(vars, "webrtc_browser_streaming", video.webrtc_browser_streaming);
 
     // AI Optimizer
     bool_f(vars, "ai_enabled", video.ai_optimizer.enabled);

--- a/src/config.h
+++ b/src/config.h
@@ -169,6 +169,7 @@ namespace config {
     std::string fallback_mode;
     bool isolated_virtual_display_option;
     bool ignore_encoder_probe_failure;
+    bool webrtc_browser_streaming;
 
     struct ai_optimizer_t {
       bool enabled = false;

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -73,6 +73,7 @@
   #include "platform/linux/virtual_display.h"
   #include "platform/linux/session_manager.h"
   #include "platform/linux/cage_display_router.h"
+  #include "platform/linux/stream_display_policy.h"
   #include "platform/linux/wayland.h"
 #endif
 
@@ -3497,10 +3498,77 @@ namespace confighttp {
 
     bool available = cached_backend != virtual_display::backend_e::NONE;
     output_tree["available"] = available;
+    const auto runtime_state = cage_display_router::runtime_state();
+    const auto display_policy = stream_display_policy::resolve(stream_display_policy::input_t {
+      available,
+      video::active_encoder_requires_gpu_native_capture(),
+      runtime_state.gpu_native_override_active,
+    });
     output_tree["backend"] = virtual_display::backend_name(cached_backend);
     output_tree["backend_id"] = static_cast<int>(cached_backend);
+    output_tree["configured_adapter"] = config::video.adapter_name;
+    output_tree["policy_mode"] = display_policy.selection;
+    output_tree["policy_label"] = display_policy.label;
+    output_tree["policy_reason"] = display_policy.reason;
+    output_tree["runtime_backend"] = runtime_state.backend_name;
+    output_tree["runtime_effective_headless"] = runtime_state.effective_headless;
 
     send_response(response, output_tree);
+  }
+
+  void getWebRtcStatus(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+
+    print_req(request);
+
+#ifdef POLARIS_ENABLE_WEBRTC
+    constexpr bool webrtc_build_enabled = true;
+#else
+    constexpr bool webrtc_build_enabled = false;
+#endif
+
+    nlohmann::json output;
+    output["status"] = true;
+    output["build_enabled"] = webrtc_build_enabled;
+    output["config_enabled"] = config::video.webrtc_browser_streaming;
+    output["available"] = false;
+    output["state"] =
+      !output["build_enabled"].get<bool>() ? "not_built" :
+      !config::video.webrtc_browser_streaming ? "disabled" :
+      "backend_pending";
+    output["message"] =
+      !output["build_enabled"].get<bool>() ?
+        "This Polaris build was not compiled with WebRTC browser streaming support." :
+      !config::video.webrtc_browser_streaming ?
+        "WebRTC browser streaming is disabled in configuration." :
+        "WebRTC browser streaming is configured, but the media/signaling backend is not active yet.";
+    output["moonlight_compatible_path"] = true;
+    output["lan_only"] = true;
+    output["input_plan"] = "RTCDataChannel keyboard, pointer, and gamepad input";
+
+    send_response(response, output);
+  }
+
+  void postWebRtcUnavailable(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+    print_req(request);
+
+#ifdef POLARIS_ENABLE_WEBRTC
+    constexpr bool webrtc_build_enabled = true;
+#else
+    constexpr bool webrtc_build_enabled = false;
+#endif
+
+    nlohmann::json output;
+    output["status"] = false;
+    output["error"] = "WebRTC browser streaming is not available in this build yet";
+    output["build_enabled"] = webrtc_build_enabled;
+    output["config_enabled"] = config::video.webrtc_browser_streaming;
+    send_response(response, output);
   }
 
   /**
@@ -4234,6 +4302,7 @@ namespace confighttp {
     server.resource["^/login/?$"]["GET"] = getSpaPage;
     server.resource["^/recover/?$"]["GET"] = getSpaPage;
     server.resource["^/troubleshooting/?$"]["GET"] = getSpaPage;
+    server.resource["^/webrtc/?$"]["GET"] = getSpaPage;
     // Login is exempt from CSRF (it's the entry point; rate limiting protects it instead)
     server.resource["^/api/login"]["POST"] = login;
     server.resource["^/api/logout$"]["POST"] = withCsrf(logout);
@@ -4286,6 +4355,10 @@ namespace confighttp {
     server.resource["^/api/recording/stop$"]["POST"] = withCsrf(stopRecording);
     server.resource["^/api/recording/save-replay$"]["POST"] = withCsrf(saveReplay);
     server.resource["^/api/recording/status$"]["GET"] = getRecordingStatus;
+    server.resource["^/api/webrtc/status$"]["GET"] = getWebRtcStatus;
+    server.resource["^/api/webrtc/session/start$"]["POST"] = withCsrf(postWebRtcUnavailable);
+    server.resource["^/api/webrtc/session/answer$"]["POST"] = withCsrf(postWebRtcUnavailable);
+    server.resource["^/api/webrtc/session/stop$"]["POST"] = withCsrf(postWebRtcUnavailable);
 #ifdef __linux__
     server.resource["^/api/display/screenshot$"]["GET"] = getDisplayScreenshot;
     server.resource["^/api/display/stream$"]["GET"] = getDisplayStream;

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -202,6 +202,7 @@ namespace confighttp::validation {
       "upnp"sv,
       "vaapi_strict_rc_buffer"sv,
       "virtual_sink"sv,
+      "webrtc_browser_streaming"sv,
       "vt_coder"sv,
       "vt_realtime"sv,
       "vt_software"sv,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,8 @@
 #ifdef _WIN32
   #include "platform/windows/misc.h"
   #include "platform/windows/virtual_display.h"
+#elif __linux__
+  #include "platform/linux/stream_display_policy.h"
 #endif
 
 #define PROBE_DISPLAY_UUID "38F72B96-B00C-4F21-8B6C-E1BFF1602B0E"
@@ -380,7 +382,7 @@ int main(int argc, char *argv[]) {
 
   bool defer_encoder_probe_until_cage = false;
 #ifdef __linux__
-  defer_encoder_probe_until_cage = config::video.linux_display.use_cage_compositor;
+  defer_encoder_probe_until_cage = stream_display_policy::resolve(stream_display_policy::input_t {}).should_defer_encoder_probe;
 #endif
 
   if (defer_encoder_probe_until_cage) {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -53,13 +53,14 @@
 #include "device_db.h"
 #include "confighttp.h"
 #include "stream_stats.h"
+#include "video.h"
 #ifdef __linux__
   #include "platform/linux/cage_display_router.h"
   #include "platform/linux/session_manager.h"
+  #include "platform/linux/stream_display_policy.h"
   #include "platform/linux/virtual_display.h"
 #endif
 #include "uuid.h"
-#include "video.h"
 #include "zwpad.h"
 
 #ifdef _WIN32
@@ -168,9 +169,7 @@ namespace nvhttp {
 
     bool host_prefers_headless() {
 #ifdef __linux__
-      return
-        config::video.linux_display.use_cage_compositor &&
-        config::video.linux_display.headless_mode;
+      return stream_display_policy::resolve(stream_display_policy::input_t {}).mode == stream_display_policy::mode_e::HEADLESS;
 #else
       return false;
 #endif
@@ -188,17 +187,13 @@ namespace nvhttp {
 
     std::string stream_display_mode_label() {
 #ifdef __linux__
-      const auto &linux_display = config::video.linux_display;
-      if (!linux_display.headless_mode) {
-        return "Desktop Display";
-      }
-      if (!linux_display.use_cage_compositor) {
-        return "Host Virtual Display";
-      }
-      if (linux_display.prefer_gpu_native_capture) {
-        return "Windowed Stream";
-      }
-      return "Headless Stream";
+      return stream_display_policy::resolve(
+        stream_display_policy::input_t {
+          host_virtual_display_available(),
+          video::active_encoder_requires_gpu_native_capture(),
+          cage_display_router::runtime_state().gpu_native_override_active,
+        }
+      ).label;
 #else
       return proc::proc.virtual_display ? "Host Virtual Display" : "Desktop Display";
 #endif
@@ -206,19 +201,31 @@ namespace nvhttp {
 
     std::string stream_display_mode_selection() {
 #ifdef __linux__
-      const auto &linux_display = config::video.linux_display;
-      if (!linux_display.headless_mode) {
-        return "desktop_display";
-      }
-      if (!linux_display.use_cage_compositor) {
-        return "host_virtual_display";
-      }
-      if (linux_display.prefer_gpu_native_capture) {
-        return "windowed_stream";
-      }
-      return "headless_stream";
+      return stream_display_policy::resolve(
+        stream_display_policy::input_t {
+          host_virtual_display_available(),
+          video::active_encoder_requires_gpu_native_capture(),
+          cage_display_router::runtime_state().gpu_native_override_active,
+        }
+      ).selection;
 #else
       return proc::proc.virtual_display ? "host_virtual_display" : "desktop_display";
+#endif
+    }
+
+    std::string stream_display_mode_reason() {
+#ifdef __linux__
+      return stream_display_policy::resolve(
+        stream_display_policy::input_t {
+          host_virtual_display_available(),
+          video::active_encoder_requires_gpu_native_capture(),
+          cage_display_router::runtime_state().gpu_native_override_active,
+        }
+      ).reason;
+#else
+      return proc::proc.virtual_display ?
+        "Polaris is streaming from a host virtual display." :
+        "Polaris is streaming from the current desktop session.";
 #endif
     }
 
@@ -434,6 +441,7 @@ namespace nvhttp {
       policy["version"] = 1;
       policy["mode"] = stream_display_mode_selection();
       policy["mode_label"] = stream_display_mode_label();
+      policy["mode_reason"] = stream_display_mode_reason();
       policy["source"] = source;
       policy["source_label"] = stream_policy_source_label(source);
       policy["optimization_source"] = stats.optimization_source;
@@ -3329,6 +3337,7 @@ namespace nvhttp {
           (proc::proc.virtual_display ? "virtual_display" : "headless") :
           "auto";
       display_mode["label"] = stream_display_mode_label();
+      display_mode["reason"] = stream_display_mode_reason();
       display_mode["paired_display_mode_override"] = named_cert_p->display_mode;
       display_mode["paired_display_mode_locked"] = !named_cert_p->display_mode.empty();
 

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -45,6 +45,7 @@ namespace cage_display_router {
 
   static pid_t cage_pid = 0;
   static std::string cage_wayland_socket;  // e.g., "wayland-5"
+  static std::string cage_x11_display;  // e.g., ":1"
   static std::atomic_bool headless_ram_capture_warning_logged {false};
   static std::atomic_bool windowed_ram_capture_warning_logged {false};
   static std::atomic<int> windowed_gpu_native_probe_result {0};
@@ -129,6 +130,20 @@ namespace cage_display_router {
     return true;
   }
 
+  static bool is_x11_socket_name(std::string_view name) {
+    if (name.size() <= 1 || name.front() != 'X') {
+      return false;
+    }
+
+    for (char ch : name.substr(1)) {
+      if (!std::isdigit(static_cast<unsigned char>(ch))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   static std::string describe_child_status(int status) {
     if (WIFEXITED(status)) {
       return "exited with status " + std::to_string(WEXITSTATUS(status));
@@ -192,6 +207,32 @@ namespace cage_display_router {
     return sockets;
   }
 
+  static std::set<std::string> snapshot_x11_displays() {
+    std::set<std::string> displays;
+
+    DIR *dir = opendir("/tmp/.X11-unix");
+    if (!dir) {
+      BOOST_LOG(debug) << "labwc: Could not inspect X11 socket directory: "sv << std::strerror(errno);
+      return displays;
+    }
+
+    while (auto *entry = readdir(dir)) {
+      std::string name = entry->d_name;
+      if (!is_x11_socket_name(name)) {
+        continue;
+      }
+
+      const auto path = "/tmp/.X11-unix/"s + name;
+      struct stat statbuf {};
+      if (stat(path.c_str(), &statbuf) == 0 && S_ISSOCK(statbuf.st_mode)) {
+        displays.insert(":" + name.substr(1));
+      }
+    }
+
+    closedir(dir);
+    return displays;
+  }
+
   /**
    * @brief Find which new Wayland socket appeared after cage started.
    */
@@ -221,6 +262,24 @@ namespace cage_display_router {
       for (auto &s : current) {
         if (before.find(s) == before.end()) {
           return s;  // This socket is new
+        }
+      }
+      std::this_thread::sleep_for(poll_interval);
+    }
+    return "";
+  }
+
+  static std::string find_new_x11_display(
+    const std::set<std::string> &before,
+    int max_wait_ms = 3000
+  ) {
+    const auto poll_interval = 50ms;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(max_wait_ms);
+    while (std::chrono::steady_clock::now() < deadline) {
+      auto current = snapshot_x11_displays();
+      for (auto &display : current) {
+        if (before.find(display) == before.end()) {
+          return display;
         }
       }
       std::this_thread::sleep_for(poll_interval);
@@ -381,6 +440,7 @@ namespace cage_display_router {
     // Reset stale state
     cage_pid = 0;
     cage_wayland_socket.clear();
+    cage_x11_display.clear();
 
     bool requested_headless = config::video.linux_display.headless_mode;
     bool headless = requested_headless && !force_windowed;
@@ -465,6 +525,7 @@ namespace cage_display_router {
 
     // Snapshot existing sockets to detect the new one labwc creates
     auto sockets_before = snapshot_wayland_sockets();
+    auto x11_displays_before = snapshot_x11_displays();
     BOOST_LOG(info) << "labwc: Watching runtime directory ["sv << runtime_dir()
                     << "] for a new Wayland socket"sv;
 
@@ -572,6 +633,13 @@ namespace cage_display_router {
                          << " before startup continued"sv;
     }
 
+    cage_x11_display = find_new_x11_display(x11_displays_before, 3000);
+    if (!cage_x11_display.empty()) {
+      BOOST_LOG(info) << "labwc: XWayland display ready — "sv << cage_x11_display;
+    } else {
+      BOOST_LOG(debug) << "labwc: XWayland display was not observed during startup; X11 follow-up commands will rely on Wayland only"sv;
+    }
+
     BOOST_LOG(info) << "labwc: Ready — "sv
                     << (headless ? "headless compositor active, socket="sv
                                  : "window visible on desktop, socket="sv)
@@ -590,10 +658,15 @@ namespace cage_display_router {
 
     // Set WAYLAND_DISPLAY so the game renders inside cage.
     // Also unset AT_SPI_BUS_ADDRESS to avoid at-spi2 interference (Fedora 43 Steam fix).
-    std::string wrapped = "WAYLAND_DISPLAY=" + cage_wayland_socket +
-                          " AT_SPI_BUS_ADDRESS= " + cmd;
+    std::string wrapped = "WAYLAND_DISPLAY=" + cage_wayland_socket + " ";
+    if (!cage_x11_display.empty()) {
+      wrapped += "DISPLAY=" + cage_x11_display + " ";
+    }
+    wrapped += "AT_SPI_BUS_ADDRESS= " + cmd;
     BOOST_LOG(info) << "labwc: Wrapping command with WAYLAND_DISPLAY="sv
-                    << cage_wayland_socket;
+                    << cage_wayland_socket
+                    << (cage_x11_display.empty() ? ""sv : " DISPLAY="sv)
+                    << cage_x11_display;
     return wrapped;
   }
 
@@ -626,6 +699,7 @@ namespace cage_display_router {
     BOOST_LOG(info) << "labwc: Stopped"sv;
     cage_pid = 0;
     cage_wayland_socket.clear();
+    cage_x11_display.clear();
     cage_runtime_state = {
       .requested_headless = false,
       .effective_headless = false,
@@ -653,6 +727,10 @@ namespace cage_display_router {
 
   std::string get_wayland_socket() {
     return cage_wayland_socket;
+  }
+
+  std::string get_x11_display() {
+    return cage_x11_display;
   }
 
   platf::runtime_state_t runtime_state() {

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -93,6 +93,12 @@ namespace cage_display_router {
   std::string get_wayland_socket();
 
   /**
+   * @brief Returns the XWayland display exposed by cage (e.g., ":1").
+   * Empty string if cage has not started XWayland.
+   */
+  std::string get_x11_display();
+
+  /**
    * @brief Returns the current runtime state for the labwc backend.
    */
   platf::runtime_state_t runtime_state();

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -1,0 +1,92 @@
+/**
+ * @file src/platform/linux/stream_display_policy.cpp
+ * @brief Linux stream display policy resolver.
+ */
+
+#include "stream_display_policy.h"
+
+#include "src/config.h"
+#include "virtual_display.h"
+
+namespace stream_display_policy {
+
+  namespace {
+    resolved_t desktop_policy() {
+      return {
+        mode_e::DESKTOP,
+        "desktop_display",
+        "Desktop Display",
+        "Polaris is streaming from the current desktop session.",
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+      };
+    }
+  }  // namespace
+
+  resolved_t resolve(const input_t &input) {
+    const auto &linux_display = config::video.linux_display;
+    const bool requested_headless = linux_display.headless_mode;
+    const bool use_cage_runtime = linux_display.use_cage_compositor;
+
+    if (!requested_headless) {
+      return desktop_policy();
+    }
+
+    resolved_t result;
+    result.requested_headless = true;
+    result.use_cage_runtime = use_cage_runtime;
+    result.should_defer_encoder_probe = use_cage_runtime;
+    result.should_probe_against_runtime = use_cage_runtime;
+
+    if (!use_cage_runtime) {
+      result.mode = mode_e::HOST_VIRTUAL_DISPLAY;
+      result.selection = "host_virtual_display";
+      result.label = "Host Virtual Display";
+      result.reason = input.virtual_display_available ?
+        "Polaris will create or use a host virtual display for this stream." :
+        "Polaris requested a host virtual display, but no backend is currently available.";
+      result.effective_headless = false;
+      result.use_host_virtual_display = true;
+      result.should_defer_encoder_probe = false;
+      result.should_probe_against_runtime = false;
+      return result;
+    }
+
+    const bool gpu_native_test =
+      linux_display.prefer_gpu_native_capture ||
+      input.active_encoder_requires_gpu_native_capture ||
+      input.runtime_gpu_native_override_active;
+
+    if (gpu_native_test) {
+      result.mode = mode_e::GPU_NATIVE_TEST;
+      result.selection = "windowed_stream";
+      result.label = "GPU-Native Test";
+      result.reason = input.runtime_gpu_native_override_active ?
+        "Polaris is running the private compositor windowed so capture can stay GPU-native." :
+        "Polaris may override hidden headless at runtime if that is required for DMA-BUF/CUDA capture.";
+      result.effective_headless = !input.runtime_gpu_native_override_active;
+      return result;
+    }
+
+    result.mode = mode_e::HEADLESS;
+    result.selection = "headless_stream";
+    result.label = "Headless Stream";
+    result.reason = "Polaris will stream from the private headless compositor runtime.";
+    result.effective_headless = true;
+    return result;
+  }
+
+  resolved_t resolve_current(bool active_encoder_requires_gpu_native_capture,
+                             bool runtime_gpu_native_override_active) {
+    return resolve(input_t {
+      virtual_display::is_available(),
+      active_encoder_requires_gpu_native_capture,
+      runtime_gpu_native_override_active,
+    });
+  }
+
+}  // namespace stream_display_policy

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -1,0 +1,41 @@
+/**
+ * @file src/platform/linux/stream_display_policy.h
+ * @brief Resolves the effective Linux stream display runtime.
+ */
+#pragma once
+
+#include <string>
+
+namespace stream_display_policy {
+
+  enum class mode_e {
+    DESKTOP,
+    HEADLESS,
+    HOST_VIRTUAL_DISPLAY,
+    GPU_NATIVE_TEST,
+  };
+
+  struct input_t {
+    bool virtual_display_available = false;
+    bool active_encoder_requires_gpu_native_capture = false;
+    bool runtime_gpu_native_override_active = false;
+  };
+
+  struct resolved_t {
+    mode_e mode = mode_e::DESKTOP;
+    std::string selection;
+    std::string label;
+    std::string reason;
+    bool requested_headless = false;
+    bool effective_headless = false;
+    bool use_cage_runtime = false;
+    bool use_host_virtual_display = false;
+    bool should_defer_encoder_probe = false;
+    bool should_probe_against_runtime = false;
+  };
+
+  resolved_t resolve(const input_t &input);
+  resolved_t resolve_current(bool active_encoder_requires_gpu_native_capture = false,
+                             bool runtime_gpu_native_override_active = false);
+
+}  // namespace stream_display_policy

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -548,6 +548,85 @@ namespace virtual_display {
       return {};
     }
 
+    static bool supported_gpu_driver(const std::string &driver) {
+      return driver == "nvidia" || driver == "amdgpu" || driver == "i915";
+    }
+
+    static std::string drm_device_sysfs_path(const std::string &drm_node) {
+      if (drm_node.empty()) {
+        return {};
+      }
+
+      fs::path node_path {drm_node};
+      std::string node_name = node_path.filename().string();
+      if (node_name.empty()) {
+        node_name = drm_node;
+      }
+
+      if (node_name.find("card") != 0 && node_name.find("renderD") != 0) {
+        return {};
+      }
+
+      const auto device_path = fs::path("/sys/class/drm") / node_name / "device";
+      try {
+        if (fs::exists(device_path)) {
+          return fs::canonical(device_path).string();
+        }
+      } catch (const std::exception &e) {
+        BOOST_LOG(debug) << "Virtual display: failed to resolve adapter sysfs path for ["
+                         << drm_node << "]: " << e.what();
+      }
+
+      return {};
+    }
+
+    static std::string configured_gpu_sysfs_path() {
+      const auto &adapter_name = config::video.adapter_name;
+      if (adapter_name.empty()) {
+        return {};
+      }
+
+      auto path = drm_device_sysfs_path(adapter_name);
+      if (!path.empty()) {
+        BOOST_LOG(info) << "Virtual display: using configured adapter ["sv
+                        << adapter_name << "] at "sv << path;
+        return path;
+      }
+
+      BOOST_LOG(info) << "Virtual display: configured adapter ["sv
+                      << adapter_name
+                      << "] is not a DRM node; falling back to DRM GPU discovery"sv;
+      return {};
+    }
+
+    static std::string first_supported_gpu_sysfs_path() {
+      try {
+        for (const auto &entry : fs::directory_iterator("/sys/class/drm/")) {
+          std::string name = entry.path().filename().string();
+          if (name.find("card") != 0 || name.find('-') != std::string::npos) {
+            continue;
+          }
+
+          auto driver_link = entry.path() / "device" / "driver" / "module";
+          if (!fs::exists(driver_link)) {
+            continue;
+          }
+
+          auto driver = fs::read_symlink(driver_link).filename().string();
+          if (supported_gpu_driver(driver)) {
+            auto path = fs::canonical(entry.path() / "device").string();
+            BOOST_LOG(info) << "Virtual display: attaching EVDI to discovered GPU ["
+                            << name << "] driver=" << driver << " path=" << path;
+            return path;
+          }
+        }
+      } catch (const std::exception &e) {
+        BOOST_LOG(warning) << "Virtual display: error finding GPU sysfs path: "sv << e.what();
+      }
+
+      return {};
+    }
+
     /**
      * @brief Create a virtual display using EVDI.
      */
@@ -569,25 +648,9 @@ namespace virtual_display {
 
       // Find the GPU's sysfs device path to attach the EVDI device to.
       // evdi_open_attached_to(nullptr) crashes with strlen(nullptr) on some libevdi versions.
-      std::string gpu_sysfs_path;
-      try {
-        for (const auto &entry : fs::directory_iterator("/sys/class/drm/")) {
-          std::string name = entry.path().filename().string();
-          // Look for cardN (not cardN-DP-1 etc)
-          if (name.find("card") == 0 && name.find('-') == std::string::npos) {
-            auto driver_link = entry.path() / "device" / "driver" / "module";
-            if (fs::exists(driver_link)) {
-              auto driver = fs::read_symlink(driver_link).filename().string();
-              if (driver == "nvidia" || driver == "amdgpu" || driver == "i915") {
-                gpu_sysfs_path = fs::canonical(entry.path() / "device").string();
-                BOOST_LOG(info) << "Virtual display: attaching EVDI to GPU at "sv << gpu_sysfs_path;
-                break;
-              }
-            }
-          }
-        }
-      } catch (const std::exception &e) {
-        BOOST_LOG(warning) << "Virtual display: error finding GPU sysfs path: "sv << e.what();
+      std::string gpu_sysfs_path = configured_gpu_sysfs_path();
+      if (gpu_sysfs_path.empty()) {
+        gpu_sysfs_path = first_supported_gpu_sysfs_path();
       }
 
       // Try to open an existing EVDI device first (created via modprobe initial_device_count=1).

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <iomanip>
 #include <mutex>
+#include <set>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -62,6 +63,9 @@
   #include "platform/linux/virtual_display.h"
   #include "platform/linux/session_manager.h"
   #include "platform/linux/cage_display_router.h"
+  #include "platform/linux/stream_display_policy.h"
+  #include <dirent.h>
+  #include <signal.h>
   #include <unistd.h>
 #elif __APPLE__
   #include <mach-o/dyld.h>
@@ -364,6 +368,179 @@ namespace proc {
     bool command_requests_steam_shutdown(const std::string &cmd) {
       return boost::icontains(cmd, "steam -shutdown");
     }
+
+#ifdef __linux__
+    std::string strip_leading_setsid_for_cage(std::string cmd) {
+      auto trimmed = boost::trim_left_copy(cmd);
+      if (!boost::istarts_with(trimmed, "setsid")) {
+        return cmd;
+      }
+
+      if (trimmed.size() > 6 && !std::isspace(static_cast<unsigned char>(trimmed[6]))) {
+        return cmd;
+      }
+
+      auto rest = trimmed.substr(std::min<size_t>(trimmed.size(), 6));
+      boost::trim_left(rest);
+
+      if (boost::istarts_with(rest, "-f")) {
+        if (rest.size() == 2 || std::isspace(static_cast<unsigned char>(rest[2]))) {
+          rest = rest.substr(std::min<size_t>(rest.size(), 2));
+          boost::trim_left(rest);
+        }
+      } else if (boost::istarts_with(rest, "--fork")) {
+        if (rest.size() == 6 || std::isspace(static_cast<unsigned char>(rest[6]))) {
+          rest = rest.substr(std::min<size_t>(rest.size(), 6));
+          boost::trim_left(rest);
+        }
+      }
+
+      return rest.empty() ? cmd : rest;
+    }
+
+    std::string cage_runtime_command(const std::string &cmd) {
+      auto sanitized = strip_leading_setsid_for_cage(cmd);
+      if (sanitized != cmd) {
+        BOOST_LOG(info) << "process: stripped leading setsid for cage runtime command ["
+                        << cmd << "] -> [" << sanitized << ']';
+      }
+      return sanitized;
+    }
+
+    bool is_proc_pid_dir(std::string_view name) {
+      return !name.empty() && std::all_of(name.begin(), name.end(), [](char ch) {
+        return std::isdigit(static_cast<unsigned char>(ch));
+      });
+    }
+
+    std::string read_proc_text(pid_t pid, std::string_view file_name) {
+      std::ifstream file("/proc/" + std::to_string(pid) + "/" + std::string(file_name), std::ios::binary);
+      if (!file) {
+        return {};
+      }
+
+      std::ostringstream buffer;
+      buffer << file.rdbuf();
+      return buffer.str();
+    }
+
+    bool proc_text_contains_steam_appid(const std::string &text, const std::string &appid) {
+      if (appid.empty() || text.empty()) {
+        return false;
+      }
+
+      return text.find("SteamLaunch AppId=" + appid) != std::string::npos ||
+             text.find("SteamAppId=" + appid) != std::string::npos ||
+             text.find("SteamGameId=" + appid) != std::string::npos ||
+             text.find("steam://rungameid/" + appid) != std::string::npos ||
+             (text.find("-applaunch") != std::string::npos && text.find(appid) != std::string::npos);
+    }
+
+    std::vector<pid_t> steam_app_pids(const std::string &appid) {
+      std::vector<pid_t> pids;
+      DIR *dir = opendir("/proc");
+      if (!dir) {
+        return pids;
+      }
+
+      while (auto *entry = readdir(dir)) {
+        const std::string name = entry->d_name;
+        if (!is_proc_pid_dir(name)) {
+          continue;
+        }
+
+        const auto pid = static_cast<pid_t>(std::strtol(name.c_str(), nullptr, 10));
+        if (pid <= 1 || pid == getpid()) {
+          continue;
+        }
+
+        if (proc_text_contains_steam_appid(read_proc_text(pid, "cmdline"), appid) ||
+            proc_text_contains_steam_appid(read_proc_text(pid, "environ"), appid)) {
+          pids.emplace_back(pid);
+        }
+      }
+
+      closedir(dir);
+      return pids;
+    }
+
+    std::string steam_appid_for_context(const proc::ctx_t &ctx) {
+      if (!ctx.steam_appid.empty()) {
+        return ctx.steam_appid;
+      }
+
+      if (auto appid = extract_steam_appid_from_command(ctx.cmd)) {
+        return *appid;
+      }
+
+      for (const auto &cmd : ctx.detached) {
+        if (auto appid = extract_steam_appid_from_command(cmd)) {
+          return *appid;
+        }
+      }
+
+      return {};
+    }
+
+    void terminate_steam_app_processes(const proc::ctx_t &ctx) {
+      const auto appid = steam_appid_for_context(ctx);
+      if (appid.empty()) {
+        return;
+      }
+
+      auto pids = steam_app_pids(appid);
+      if (pids.empty()) {
+        return;
+      }
+
+      std::set<pid_t> groups;
+      for (auto pid : pids) {
+        const auto pgid = getpgid(pid);
+        if (pgid > 1 && pgid != getpgrp()) {
+          groups.insert(pgid);
+        }
+      }
+
+      BOOST_LOG(info) << "process: terminating Steam app ["sv << appid
+                      << "] process groups="sv << groups.size()
+                      << " matched_pids="sv << pids.size();
+
+      for (auto pgid : groups) {
+        kill(-pgid, SIGTERM);
+      }
+      for (auto pid : pids) {
+        kill(pid, SIGTERM);
+      }
+
+      for (int i = 0; i < 20; ++i) {
+        if (steam_app_pids(appid).empty()) {
+          return;
+        }
+        std::this_thread::sleep_for(100ms);
+      }
+
+      pids = steam_app_pids(appid);
+      if (!pids.empty()) {
+        BOOST_LOG(warning) << "process: Steam app ["sv << appid
+                           << "] did not exit after SIGTERM; sending SIGKILL"sv;
+      }
+
+      groups.clear();
+      for (auto pid : pids) {
+        const auto pgid = getpgid(pid);
+        if (pgid > 1 && pgid != getpgrp()) {
+          groups.insert(pgid);
+        }
+      }
+
+      for (auto pgid : groups) {
+        kill(-pgid, SIGKILL);
+      }
+      for (auto pid : pids) {
+        kill(pid, SIGKILL);
+      }
+    }
+#endif
 
     bool prep_cmd_undo_stops_steam(const proc::cmd_t &cmd) {
       return command_contains_steam_big_picture_close(cmd.undo_cmd) ||
@@ -1639,18 +1816,24 @@ namespace proc {
 
 #elif __linux__
 
-    // Linux virtual display creation — analogous to Windows SUDOVDA path above
-    // Skip if linux_auto_manage_displays is enabled (user manages displays via kscreen-doctor config)
-    bool using_headless_cage =
-      config::video.linux_display.headless_mode &&
-      config::video.linux_display.use_cage_compositor;
+    // Linux virtual display creation — analogous to Windows SUDOVDA path above.
+    // Resolve the display runtime once so launch, encoder probing, and UI report
+    // the same effective policy.
+    const auto display_policy = stream_display_policy::resolve_current(
+      video::active_encoder_requires_gpu_native_capture()
+    );
+    const bool using_headless_cage =
+      display_policy.requested_headless &&
+      display_policy.use_cage_runtime;
+    const bool should_use_linux_virtual_display =
+      display_policy.use_host_virtual_display ||
+      launch_session->virtual_display ||
+      (!launch_session->user_locked_virtual_display && _app.virtual_display);
 
     if (
-      !using_headless_cage &&
+      !display_policy.use_cage_runtime &&
       !config::video.linux_display.auto_manage_displays && (
-        config::video.linux_display.headless_mode // Headless mode
-        || launch_session->virtual_display // User requested virtual display
-        || (!launch_session->user_locked_virtual_display && _app.virtual_display) // App default when client didn't explicitly choose
+        should_use_linux_virtual_display
       )
     ) {
       if (isLinuxVDisplayAvailable()) {
@@ -1690,10 +1873,10 @@ namespace proc {
         launch_session->virtual_display = false;
       }
     } else if (using_headless_cage) {
-      // labwc headless mode already provides its own HEADLESS-* output.
-      // Creating an additional Linux virtual display here only adds setup
-      // overhead and can confuse output selection.
-      BOOST_LOG(info) << "Linux virtual display: skipped because labwc headless compositor owns the streaming output"sv;
+      BOOST_LOG(info) << "Linux virtual display: skipped because "sv
+                      << display_policy.label
+                      << " owns the streaming output ("sv
+                      << display_policy.reason << ")"sv;
     }
 
     display_device::configure_display(config::video, *launch_session);
@@ -1721,7 +1904,8 @@ namespace proc {
     // due to hotplugging, driver crash, primary monitor change,
     // or any number of other factors).
 #ifdef __linux__
-    const bool delay_encoder_probe_until_cage = config::video.linux_display.use_cage_compositor;
+    const bool delay_encoder_probe_until_cage =
+      stream_display_policy::resolve(stream_display_policy::input_t {}).should_defer_encoder_probe;
 #else
     constexpr bool delay_encoder_probe_until_cage = false;
 #endif
@@ -2132,7 +2316,7 @@ namespace proc {
     // Start cage with the first detached command as its primary client.
     // Cage is a kiosk compositor — it only displays its main process fullscreen.
     if (config::video.linux_display.use_cage_compositor && !_app.detached.empty()) {
-      std::string game_cmd = _app.detached[0];
+      std::string game_cmd = cage_runtime_command(_app.detached[0]);
       if (!start_cage_with_runtime_fallback(game_cmd)) {
         BOOST_LOG(error) << "session_manager: Failed to start cage with game"sv;
         confighttp::emit_session_event("error", "Failed to start cage compositor");
@@ -2144,19 +2328,24 @@ namespace proc {
       }
       // Launch remaining detached commands (if any) with cage's WAYLAND_DISPLAY
       for (size_t i = 1; i < _app.detached.size(); ++i) {
-        auto &cmd = _app.detached[i];
+        auto cmd = cage_runtime_command(_app.detached[i]);
         auto cmd_env = _env;
         auto cage_socket = cage_display_router::get_wayland_socket();
         if (!cage_socket.empty()) {
           cmd_env["WAYLAND_DISPLAY"] = cage_socket;
           cmd_env["AT_SPI_BUS_ADDRESS"] = "";
-          cmd_env.erase("DISPLAY");
+          auto cage_display = cage_display_router::get_x11_display();
+          if (!cage_display.empty()) {
+            cmd_env["DISPLAY"] = cage_display;
+          } else {
+            cmd_env.erase("DISPLAY");
+          }
         }
         boost::filesystem::path working_dir = _app.working_dir.empty() ?
                                                 find_working_directory(cmd, cmd_env) :
                                                 boost::filesystem::path(_app.working_dir);
         BOOST_LOG(info) << "Spawning ["sv << cmd << "] in ["sv << working_dir << ']';
-        auto child = platf::run_command(_app.elevated, true, cmd, working_dir, cmd_env, _pipe.get(), ec, nullptr);
+        auto child = platf::run_command(_app.elevated, true, cmd, working_dir, cmd_env, _pipe.get(), ec, &_process_group);
         if (ec) {
           BOOST_LOG(warning) << "Couldn't spawn ["sv << cmd << "]: System: "sv << ec.message();
         } else {
@@ -2192,12 +2381,21 @@ namespace proc {
     std::string effective_cmd = _app.cmd;
     auto launch_env = _env;
     if (config::video.linux_display.use_cage_compositor && cage_display_router::is_running() && !_app.cmd.empty()) {
+      effective_cmd = cage_runtime_command(_app.cmd);
       auto cage_socket = cage_display_router::get_wayland_socket();
       if (!cage_socket.empty()) {
         launch_env["WAYLAND_DISPLAY"] = cage_socket;
         launch_env["AT_SPI_BUS_ADDRESS"] = "";
-        launch_env.erase("DISPLAY");
-        BOOST_LOG(info) << "cage: Set WAYLAND_DISPLAY="sv << cage_socket << " and cleared DISPLAY for app command"sv;
+        auto cage_display = cage_display_router::get_x11_display();
+        if (!cage_display.empty()) {
+          launch_env["DISPLAY"] = cage_display;
+          BOOST_LOG(info) << "cage: Set WAYLAND_DISPLAY="sv << cage_socket
+                          << " DISPLAY="sv << cage_display
+                          << " for app command"sv;
+        } else {
+          launch_env.erase("DISPLAY");
+          BOOST_LOG(info) << "cage: Set WAYLAND_DISPLAY="sv << cage_socket << " and cleared DISPLAY for app command"sv;
+        }
       }
     }
 #else
@@ -2573,6 +2771,7 @@ namespace proc {
     // and keep running after the stream ends.
     if (config::video.linux_display.use_cage_compositor) {
       cage_display_router::stop();
+      terminate_steam_app_processes(_app);
     }
 #endif
 
@@ -2588,6 +2787,16 @@ namespace proc {
                         << cmd.undo_cmd << ']';
         continue;
       }
+
+#ifdef __linux__
+      if (config::video.linux_display.use_cage_compositor &&
+          !steam_appid_for_context(_app).empty() &&
+          command_requests_steam_shutdown(cmd.undo_cmd)) {
+        BOOST_LOG(info) << "Skipping Steam shutdown undo after isolated cage Steam app cleanup ["sv
+                        << cmd.undo_cmd << ']';
+        continue;
+      }
+#endif
 
       boost::filesystem::path working_dir = _app.working_dir.empty() ?
                                               find_working_directory(cmd.undo_cmd, _env) :

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -102,7 +102,10 @@ namespace stream {
       }
 
       const auto runtime_state = cage_display_router::runtime_state();
-      return cage_display_router::is_running() && runtime_state.effective_headless;
+      return cage_display_router::is_running() &&
+             (runtime_state.effective_headless ||
+              runtime_state.requested_headless ||
+              runtime_state.gpu_native_override_active);
 #else
       return false;
 #endif
@@ -2194,7 +2197,7 @@ namespace stream {
           if (proc::proc.session_shutdown_requested()) {
             BOOST_LOG(info) << "Skipping pause because host shutdown is already in progress"sv;
           } else if (should_terminate_on_last_client_disconnect()) {
-            BOOST_LOG(info) << "Last client disconnected from headless cage runtime; terminating app instead of pausing"sv;
+            BOOST_LOG(info) << "Last client disconnected from isolated cage runtime; terminating app instead of pausing"sv;
             proc::proc.terminate();
           } else {
             proc::proc.pause();

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -19,6 +19,10 @@
 #include "config.h"
 #include "logging.h"
 #include "stream_stats.h"
+#ifdef __linux__
+  #include "platform/linux/cage_display_router.h"
+  #include "platform/linux/stream_display_policy.h"
+#endif
 
 namespace stream_stats {
 
@@ -55,6 +59,15 @@ namespace stream_stats {
     }
 
     const char *stream_display_mode_label() {
+#ifdef __linux__
+      static thread_local std::string label;
+      label = stream_display_policy::resolve(stream_display_policy::input_t {
+        false,
+        false,
+        cage_display_router::runtime_state().gpu_native_override_active,
+      }).label;
+      return label.c_str();
+#else
       const auto &linux_display = config::video.linux_display;
       if (!linux_display.headless_mode) {
         return "Desktop Display";
@@ -66,6 +79,7 @@ namespace stream_stats {
         return "Windowed Stream";
       }
       return "Headless Stream";
+#endif
     }
 
     long long percentile_value(std::vector<long long> values, double percentile) {

--- a/src_assets/common/assets/web/App.vue
+++ b/src_assets/common/assets/web/App.vue
@@ -191,6 +191,11 @@ const navSections = computed(() => {
           icon: '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/></svg>',
           label: i18nReady ? t('navbar.pairing') : 'Pairing',
         },
+        {
+          to: '/webrtc',
+          icon: '<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h10a4 4 0 014 4v2a4 4 0 01-4 4H7a4 4 0 01-4-4v-2a4 4 0 014-4z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-2-2l2 2-2 2"/></svg>',
+          label: i18nReady ? t('navbar.webrtc') : 'WebRTC',
+        },
       ],
     },
     {

--- a/src_assets/common/assets/web/configs/tabs/Advanced.vue
+++ b/src_assets/common/assets/web/configs/tabs/Advanced.vue
@@ -78,6 +78,13 @@ const config = ref(props.config)
                 default="false"
       ></Checkbox>
 
+      <Checkbox class="mb-3"
+                id="webrtc_browser_streaming"
+                locale-prefix="config"
+                v-model="config.webrtc_browser_streaming"
+                default="false"
+      ></Checkbox>
+
       <div class="mb-3">
         <label for="hevc_mode" class="block text-sm font-medium text-storm mb-1">{{ $t('config.hevc_mode') }}</label>
         <select id="hevc_mode" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.hevc_mode">

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -36,6 +36,7 @@ const streamDisplayModes = [
     title: 'Headless Stream',
     badge: 'Recommended',
     copy: 'Recommended. Starts apps inside a private hidden compositor. It does not mirror your current desktop.',
+    note: 'Best isolation path. On some wlroots headless outputs this can fall back to SHM/RAM capture instead of DMA-BUF.',
     restartCopy: 'Requires restart. Polaris will stream an isolated hidden runtime, not the existing KDE or GNOME session.',
   },
   {
@@ -43,6 +44,7 @@ const streamDisplayModes = [
     title: 'Host Virtual Display',
     badge: 'Compatibility',
     copy: 'Compatibility mode. Creates a display the operating system can see. Your desktop may rearrange or remember it.',
+    note: 'Use this when the hidden compositor path is not available or the desktop needs to own the virtual output.',
     restartCopy: 'Requires restart. KDE, GNOME, or display tools may see this as a monitor.',
   },
   {
@@ -50,14 +52,16 @@ const streamDisplayModes = [
     title: 'Desktop Display',
     badge: 'Visible desktop',
     copy: 'Streams from your current desktop session when you want the visible KDE, GNOME, or wlroots desktop.',
+    note: 'Useful for quick validation, but it is not isolated from the host desktop.',
     restartCopy: 'Requires restart. Polaris will stream from the current desktop session.',
   },
   {
     id: 'windowed_stream',
-    title: 'Windowed Stream',
+    title: 'GPU-Native Test',
     badge: 'Experimental',
-    copy: 'Experimental. Shows the private stream runtime as a desktop window when testing GPU-native capture.',
-    restartCopy: 'Requires restart. Windowed Stream is experimental and should stay limited to GPU-native capture testing.',
+    copy: 'Requests a private stream runtime and allows Polaris to run it windowed when that is needed to preserve DMA-BUF/CUDA capture.',
+    note: 'This is the fast-path validation mode. It can look less "headless" on purpose so capture stays GPU-resident.',
+    restartCopy: 'Requires restart. GPU-Native Test may override hidden headless into a windowed labwc runtime to avoid the SHM/RAM copy path.',
   },
 ]
 
@@ -160,11 +164,29 @@ const validateFallbackMode = (event) => {
                 </span>
               </div>
               <div class="mt-3 text-sm leading-relaxed text-storm">{{ mode.copy }}</div>
+              <div class="mt-3 rounded-md border border-storm/20 bg-void/25 px-2.5 py-2 text-xs leading-relaxed text-storm">
+                {{ mode.note }}
+              </div>
             </button>
           </div>
 
           <div class="settings-warning-surface">
             {{ selectedStreamDisplayMode.restartCopy }}
+          </div>
+
+          <div class="grid gap-3 xl:grid-cols-3">
+            <div class="surface-muted p-3">
+              <div class="text-xs font-semibold uppercase tracking-[0.16em] text-accent">Isolation</div>
+              <div class="mt-2 text-sm leading-relaxed text-storm">Headless Stream keeps apps off your real desktop and is the default stability target.</div>
+            </div>
+            <div class="surface-muted p-3">
+              <div class="text-xs font-semibold uppercase tracking-[0.16em] text-green-300">GPU path</div>
+              <div class="mt-2 text-sm leading-relaxed text-storm">GPU-Native Test favors DMA-BUF and CUDA/NVENC residency, even if that means a visible labwc window.</div>
+            </div>
+            <div class="surface-muted p-3">
+              <div class="text-xs font-semibold uppercase tracking-[0.16em] text-amber-200">FPS target</div>
+              <div class="mt-2 text-sm leading-relaxed text-storm">A 120 FPS client target still needs the game/output to render above 60 FPS; Polaris will show the live gap on the dashboard.</div>
+            </div>
           </div>
 
           <details class="settings-disclosure rounded-lg border border-storm/30 bg-deep/30">
@@ -212,7 +234,7 @@ const validateFallbackMode = (event) => {
 
               <div class="surface-muted p-4">
                 <div class="text-sm font-medium text-silver">GPU-native capture preference</div>
-                <div class="mt-1 text-sm text-storm">Existing linux_prefer_gpu_native_capture config key. Enabled only by Windowed Stream.</div>
+                <div class="mt-1 text-sm text-storm">Existing linux_prefer_gpu_native_capture config key. Enabled by GPU-Native Test. When active, Polaris may run labwc windowed instead of truly hidden so capture can stay on the GPU.</div>
                 <div class="mt-3 rounded bg-deep/60 px-2 py-1 font-mono text-xs text-storm">linux_prefer_gpu_native_capture</div>
                 <label class="mt-4 flex items-center justify-between gap-4">
                   <span class="text-xs uppercase tracking-[0.18em] text-storm">Experimental</span>

--- a/src_assets/common/assets/web/main.js
+++ b/src_assets/common/assets/web/main.js
@@ -36,6 +36,7 @@ const routes = [
   { path: '/', component: DashboardView },
   { path: '/info', component: () => import(/* webpackChunkName: "home" */ './views/HomeView.vue') },
   { path: '/apps', component: () => import(/* webpackChunkName: "apps" */ './views/AppsView.vue') },
+  { path: '/webrtc', component: () => import(/* webpackChunkName: "webrtc" */ './views/WebRtcView.vue') },
   { path: '/config', component: () => import(/* webpackChunkName: "config" */ './views/ConfigView.vue') },
   { path: '/pin', component: () => import(/* webpackChunkName: "pin" */ './views/PinView.vue') },
   { path: '/password', component: () => import(/* webpackChunkName: "password" */ './views/PasswordView.vue') },

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -369,6 +369,8 @@
     "high_resolution_scrolling_desc": "When enabled, Polaris will pass through high resolution scroll events from Moonlight clients. This can be useful to disable for older applications that scroll too fast with high resolution scroll events.",
     "ignore_encoder_probe_failure": "Ignore Encoder Probe Failure",
     "ignore_encoder_probe_failure_desc": "Allow streaming to continue even if probing for encoders fails. This may result in streaming failure if no encoder is available.",
+    "webrtc_browser_streaming": "WebRTC Browser Streaming",
+    "webrtc_browser_streaming_desc": "Experimental LAN browser streaming surface. Requires a WebRTC-enabled Polaris build and remains separate from Moonlight/Nova streaming.",
     "install_steam_audio_drivers": "Install Steam Audio Drivers",
     "install_steam_audio_drivers_desc": "If Steam is installed, this will automatically install the Steam Streaming Speakers driver to support 5.1/7.1 surround sound and muting host audio.",
     "isolated_virtual_display_option": "Move the Virtual Display to the bottom right-most corner of the display layout",
@@ -663,7 +665,8 @@
     "theme_switch_oled": "Switch to OLED Dark Galaxy",
     "theme_switch_polaris": "Switch to Space Whale",
     "toggle_theme": "Theme",
-    "troubleshoot": "Troubleshooting"
+    "troubleshoot": "Troubleshooting",
+    "webrtc": "WebRTC"
   },
   "command_palette": {
     "placeholder": "Type a command, route, or setting...",

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -386,6 +386,7 @@ const tabs = ref([
       "envvar_compatibility_mode": "disabled",
       "legacy_ordering": "disabled",
       "ignore_encoder_probe_failure": "disabled",
+      "webrtc_browser_streaming": "disabled",
       "hevc_mode": 0,
       "av1_mode": 0,
       "capture": "",

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -51,6 +51,21 @@
             <span class="meta-pill">{{ viewerCountLabel }}</span>
             <span class="meta-pill">{{ qualitySummaryLabel }}</span>
             <span class="meta-pill" :class="runtimeModeTone">{{ runtimeEffectiveMode }}</span>
+            <span class="meta-pill" :class="captureGpuNativeTone">{{ capturePathLabel }}</span>
+          </div>
+        </div>
+
+        <div v-if="streamPathNotices.length" class="grid gap-2 md:grid-cols-2">
+          <div
+            v-for="notice in streamPathNotices"
+            :key="notice.key"
+            class="rounded-lg border px-3 py-2"
+            :class="notice.surfaceClass"
+          >
+            <div class="text-[11px] font-semibold uppercase tracking-[0.16em]" :class="notice.titleClass">
+              {{ notice.title }}
+            </div>
+            <div class="mt-1 text-sm leading-relaxed text-silver">{{ notice.message }}</div>
           </div>
         </div>
 
@@ -756,8 +771,34 @@ function titleizeToken(value) {
   return String(value)
     .split(/[_-]+/)
     .filter(Boolean)
-    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .map((part) => {
+      const token = part.toLowerCase()
+      const labels = {
+        av1: 'AV1',
+        bgra8: 'BGRA8',
+        cpu: 'CPU',
+        cuda: 'CUDA',
+        dmabuf: 'DMA-BUF',
+        drm: 'DRM',
+        gpu: 'GPU',
+        h264: 'H.264',
+        hevc: 'HEVC',
+        kms: 'KMS',
+        nv12: 'NV12',
+        nvenc: 'NVENC',
+        p010: 'P010',
+        shm: 'SHM',
+        vaapi: 'VAAPI',
+        yuv420p: 'YUV420P',
+      }
+      return labels[token] || part.charAt(0).toUpperCase() + part.slice(1)
+    })
     .join(' ')
+}
+
+function metricNumber(value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
 }
 
 function modeLabelFromBool(value) {
@@ -808,6 +849,15 @@ const runtimeOverrideLabel = computed(() => {
 const runtimeOverrideTone = computed(() => {
   if (!stats.value?.streaming) return 'text-storm'
   return stats.value?.runtime_gpu_native_override_active ? 'text-amber-300' : 'text-green-400'
+})
+
+const headlessGpuNativeOverrideActive = computed(() => {
+  if (!stats.value?.streaming) return false
+  const effectiveKnown = stats.value?.runtime_effective_headless !== undefined && stats.value?.runtime_effective_headless !== null
+  return Boolean(stats.value?.runtime_requested_headless) &&
+    effectiveKnown &&
+    !Boolean(stats.value?.runtime_effective_headless) &&
+    Boolean(stats.value?.runtime_gpu_native_override_active)
 })
 
 const nestedLabwcShmFallbackActive = computed(() => {
@@ -906,6 +956,64 @@ const runtimePathNoteTone = computed(() => {
   if (stats.value?.capture_cpu_copy) return 'text-orange-300'
   if (stats.value?.capture_gpu_native) return 'text-green-400'
   return 'text-amber-300'
+})
+
+const fpsTargetGap = computed(() => {
+  if (!stats.value?.streaming) return null
+  const encoded = metricNumber(stats.value?.fps)
+  const target = metricNumber(stats.value?.session_target_fps || stats.value?.requested_client_fps)
+
+  if (target < 90 || encoded <= 0 || encoded >= target * 0.85) return null
+  return { encoded, target }
+})
+
+const streamPathNotices = computed(() => {
+  if (!stats.value?.streaming) return []
+
+  const notices = []
+  const transport = captureTransportLabel.value
+  const residency = captureResidencyLabel.value
+  const encodeTarget = encodeTargetLabel.value
+
+  if (headlessGpuNativeOverrideActive.value) {
+    notices.push({
+      key: 'gpu-native-override',
+      title: 'GPU-native override',
+      message: 'Polaris requested headless, but is running windowed labwc so DMA-BUF/CUDA capture can stay GPU-resident.',
+      surfaceClass: 'border-amber-300/25 bg-amber-300/10',
+      titleClass: 'text-amber-200',
+    })
+  }
+
+  if (stats.value?.capture_gpu_native) {
+    notices.push({
+      key: 'gpu-native-active',
+      title: 'GPU-native path active',
+      message: `Capture is ${transport}/${residency} and encode target is ${encodeTarget}. This is the fast path.`,
+      surfaceClass: 'border-green-400/25 bg-green-400/10',
+      titleClass: 'text-green-300',
+    })
+  } else if (stats.value?.capture_cpu_copy) {
+    notices.push({
+      key: 'cpu-copy-active',
+      title: 'CPU copy path active',
+      message: `Capture is ${transport}/${residency}. Expect lower headroom than the DMA-BUF/CUDA path.`,
+      surfaceClass: 'border-orange-300/25 bg-orange-300/10',
+      titleClass: 'text-orange-200',
+    })
+  }
+
+  if (fpsTargetGap.value) {
+    notices.push({
+      key: 'fps-target-gap',
+      title: 'FPS target gap',
+      message: `Client target is ${fpsTargetGap.value.target.toFixed(0)} FPS; encoder is averaging ${fpsTargetGap.value.encoded.toFixed(1)} FPS. Check game caps, VSync, or launch flags before treating this as a capture fallback.`,
+      surfaceClass: 'border-ice/25 bg-ice/10',
+      titleClass: 'text-ice',
+    })
+  }
+
+  return notices
 })
 
 const liveSessionTitle = computed(() => (
@@ -1156,18 +1264,28 @@ const recommendations = computed(() => {
   else if (s.packet_loss > 0.5)
     recs.push({ color: 'text-yellow-400', message: `Minor packet loss (${s.packet_loss.toFixed(1)}%) — stream may have occasional artifacts.` })
 
-  if (s.fps < 55 && s.fps > 0)
+  if (fpsTargetGap.value)
+    recs.push({ color: 'text-ice', message: `Client requested ${fpsTargetGap.value.target.toFixed(0)} FPS, but encode is near ${fpsTargetGap.value.encoded.toFixed(1)} FPS. Check the game's frame cap, VSync, or idle/menu throttling first.` })
+  else if (s.fps < 55 && s.fps > 0)
     recs.push({ color: 'text-yellow-400', message: `FPS dropped to ${s.fps.toFixed(1)} — GPU may be overloaded. Consider lowering resolution or quality.` })
 
   if (s.latency_ms > 40)
     recs.push({ color: 'text-yellow-400', message: `Latency is ${s.latency_ms.toFixed(0)}ms — check network path or try wired connection.` })
 
-  if (gpu.value && gpu.value.utilization_pct < 30 && s.encode_time_ms < 4)
+  if (fpsTargetGap.value && gpu.value && gpu.value.utilization_pct < 30 && s.encode_time_ms < 4)
+    recs.push({ color: 'text-green-400', message: `GPU and encoder headroom are available (${gpu.value.utilization_pct}% GPU, ${s.encode_time_ms.toFixed(1)}ms encode), so this looks more like an app/output cap than encoder pressure.` })
+  else if (gpu.value && gpu.value.utilization_pct < 30 && s.encode_time_ms < 4)
     recs.push({ color: 'text-green-400', message: `GPU utilization is low (${gpu.value.utilization_pct}%) with fast encode — you have headroom for higher resolution or quality.` })
 
   // Stream display mode recommendations
   if (!s.headless_mode && s.streaming)
     recs.push({ color: 'text-accent', message: `Use Headless Stream in Audio/Video settings for hidden stream-only sessions that leave the desktop layout alone.` })
+
+  if (headlessGpuNativeOverrideActive.value)
+    recs.push({ color: 'text-amber-300', message: `GPU-native override is active: Polaris requested headless but is using windowed labwc to preserve the GPU-resident capture path.` })
+
+  if (s.capture_cpu_copy)
+    recs.push({ color: 'text-orange-300', message: `Capture is crossing system memory. Use GPU-Native Test with CUDA/NVENC when validating high-FPS headroom.` })
 
   // AI optimizer recommendations
   if (!s.ai_enabled && s.streaming)

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -303,6 +303,41 @@ function formatResolution(width, height) {
   return `${width}x${height}`
 }
 
+function hasRuntimeOverride(s) {
+  const effectiveKnown = s.runtime_effective_headless !== undefined && s.runtime_effective_headless !== null
+  return Boolean(s.runtime_requested_headless) &&
+    effectiveKnown &&
+    !Boolean(s.runtime_effective_headless) &&
+    Boolean(s.runtime_gpu_native_override_active)
+}
+
+function runtimeModeDescription(s) {
+  if (s.stream_display_mode) return s.stream_display_mode
+  return `${yesNo(s.runtime_effective_headless)} effective / ${yesNo(s.runtime_requested_headless)} requested`
+}
+
+function runtimeOverrideDescription(s) {
+  if (hasRuntimeOverride(s)) {
+    return 'GPU-native override active: requested headless, running windowed labwc'
+  }
+  return s.runtime_gpu_native_override_active ? 'GPU-native override active' : 'None'
+}
+
+function fpsTargetGapDescription(s) {
+  const encoded = Number(s.fps)
+  const target = Number(s.session_target_fps || s.requested_client_fps)
+
+  if (!Number.isFinite(encoded) || !Number.isFinite(target) || target < 90 || encoded <= 0) {
+    return 'None'
+  }
+
+  if (encoded >= target * 0.85) {
+    return 'None'
+  }
+
+  return `${formatFps(encoded)} encoded against ${formatFps(target)} target`
+}
+
 function normalizeIssueLine(line) {
   return line.replace(/^\[[^\]]+\]:\s*/, '').replace(/^\w+:\s*/, '').replace(/\s+/g, ' ').trim()
 }
@@ -364,7 +399,9 @@ const sessionSnapshotItems = computed(() => {
     { label: 'Active Sessions', value: `${s.active_sessions ?? 0}` },
     { label: 'Requested FPS', value: formatFps(s.requested_client_fps) },
     { label: 'Runtime Backend', value: s.runtime_backend || '(unknown)' },
-    { label: 'Stream Display Mode', value: s.stream_display_mode || `${yesNo(s.runtime_effective_headless)} effective / ${yesNo(s.runtime_requested_headless)} requested` },
+    { label: 'Stream Display Mode', value: runtimeModeDescription(s) },
+    { label: 'Runtime Override', value: runtimeOverrideDescription(s) },
+    { label: 'FPS Target Gap', value: fpsTargetGapDescription(s) },
     { label: 'Capture Path', value: s.capture_path || 'unknown' },
     { label: 'Capture Transport', value: `${s.capture_transport || 'unknown'} / ${s.capture_residency || 'unknown'} / ${s.capture_format || 'unknown'}` },
     { label: 'Encode Target', value: `${s.encode_target_device || 'unknown'} / ${s.encode_target_residency || 'unknown'} / ${s.encode_target_format || 'unknown'}` },

--- a/src_assets/common/assets/web/views/WebRtcView.vue
+++ b/src_assets/common/assets/web/views/WebRtcView.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="space-y-5">
+    <section class="settings-section">
+      <div class="settings-section-header">
+        <div class="section-kicker">Browser Stream</div>
+        <h2 class="settings-section-title">WebRTC</h2>
+      </div>
+
+      <div class="grid gap-3 md:grid-cols-3">
+        <div class="rounded-lg border border-storm/20 bg-deep/40 p-4">
+          <div class="text-xs font-semibold uppercase text-storm">Build</div>
+          <div class="mt-2 text-lg font-semibold text-silver">{{ status.build_enabled ? 'Enabled' : 'Not built' }}</div>
+        </div>
+        <div class="rounded-lg border border-storm/20 bg-deep/40 p-4">
+          <div class="text-xs font-semibold uppercase text-storm">Config</div>
+          <div class="mt-2 text-lg font-semibold text-silver">{{ status.config_enabled ? 'Enabled' : 'Disabled' }}</div>
+        </div>
+        <div class="rounded-lg border border-storm/20 bg-deep/40 p-4">
+          <div class="text-xs font-semibold uppercase text-storm">Runtime</div>
+          <div class="mt-2 text-lg font-semibold text-silver">{{ status.available ? 'Ready' : 'Pending' }}</div>
+        </div>
+      </div>
+
+      <div class="mt-4 rounded-lg border border-amber-300/30 bg-amber-300/10 p-4 text-sm text-silver">
+        {{ status.message || 'WebRTC browser streaming status is loading.' }}
+      </div>
+
+      <div class="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="focus-ring rounded-lg border border-storm/25 bg-deep px-4 py-2 text-sm font-medium text-silver transition-colors hover:border-ice/40 hover:text-ice"
+          @click="refresh"
+        >
+          Refresh
+        </button>
+        <router-link
+          to="/config"
+          class="focus-ring rounded-lg bg-ice px-4 py-2 text-sm font-semibold text-void transition-colors hover:bg-ice/90"
+        >
+          Open Settings
+        </router-link>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+
+const status = ref({
+  build_enabled: false,
+  config_enabled: false,
+  available: false,
+  message: '',
+})
+
+async function refresh() {
+  try {
+    const response = await fetch('./api/webrtc/status', { credentials: 'include' })
+    if (!response.ok) {
+      status.value = {
+        build_enabled: false,
+        config_enabled: false,
+        available: false,
+        message: 'Unable to load WebRTC status.',
+      }
+      return
+    }
+    status.value = await response.json()
+  } catch {
+    status.value = {
+      build_enabled: false,
+      config_enabled: false,
+      available: false,
+      message: 'Unable to load WebRTC status.',
+    }
+  }
+}
+
+onMounted(refresh)
+</script>


### PR DESCRIPTION
## Summary
- centralize Linux stream display policy for desktop, headless cage, host virtual display, and GPU-native test modes
- expose the effective stream policy/reason through the UI and Nova-facing status payloads
- improve isolated labwc sessions by detecting XWayland, routing Steam/app commands into the cage runtime, stripping leading `setsid`, and cleaning up Steam app process groups on disconnect
- add a guarded WebRTC browser-streaming status/config surface without enabling a media backend yet
- prefer configured/discovered DRM GPU attachment for Linux virtual display setup

## Verification
- Fedora CUDA build: `cmake -S . -B build-cuda-smoke -G Ninja -DCMAKE_BUILD_TYPE=Release -DPOLARIS_ENABLE_CUDA=ON -DCUDA_FAIL_ON_MISSING=ON` then `cmake --build build-cuda-smoke -j$(nproc)`
- `ctest --test-dir build-cuda-smoke --output-on-failure` (no tests were registered in this build config)
- `git diff --cached --check`
- Runtime smoke on Fedora + Retroid Pocket 6: Slay the Spire 2 and Indiana Jones launched through headless labwc at 1920x1080x120, used SHM capture into CUDA/NVENC encode, PipeWire audio stayed active, controller attached, and disconnecting from Indy tore down labwc/game processes without global Steam shutdown