### PR TITLE
Preserve labwc refresh rate for streaming

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -23,6 +23,7 @@
 #include <cerrno>
 #include <cctype>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <dirent.h>
 #include <functional>
@@ -306,7 +307,8 @@ namespace cage_display_router {
     std::string_view wlr_randr_output,
     std::string_view output_name,
     int width,
-    int height
+    int height,
+    int refresh_hz = 0
   ) {
     const std::string mode = std::to_string(width) + "x" + std::to_string(height);
     std::istringstream stream(std::string {wlr_randr_output});
@@ -333,7 +335,23 @@ namespace cage_display_router {
 
       if (line.find(mode) != std::string::npos &&
           (line.find("current") != std::string::npos || line.find('*') != std::string::npos)) {
-        return true;
+        if (refresh_hz <= 0) {
+          return true;
+        }
+
+        const auto hz_pos = line.find(" Hz");
+        const auto comma_pos = line.rfind(',', hz_pos);
+        if (hz_pos == std::string::npos || comma_pos == std::string::npos || comma_pos >= hz_pos) {
+          continue;
+        }
+
+        try {
+          const auto refresh_value = std::stod(line.substr(comma_pos + 1, hz_pos - comma_pos - 1));
+          if (std::abs(refresh_value - static_cast<double>(refresh_hz)) < 0.5) {
+            return true;
+          }
+        } catch (...) {
+        }
       }
     }
 
@@ -345,6 +363,7 @@ namespace cage_display_router {
     const std::string &output_name,
     int width,
     int height,
+    int refresh_hz,
     int max_wait_ms = 5000
   ) {
     return wait_for_condition(
@@ -353,9 +372,17 @@ namespace cage_display_router {
       50ms,
       [&]() {
         auto outputs = exec_capture("WAYLAND_DISPLAY=" + socket_name + " wlr-randr 2>/dev/null");
-        return output_reports_current_mode(outputs, output_name, width, height);
+        return output_reports_current_mode(outputs, output_name, width, height, refresh_hz);
       }
     );
+  }
+
+  static std::string format_wlr_custom_mode(int width, int height, int refresh_hz) {
+    auto mode = std::to_string(width) + "x" + std::to_string(height);
+    if (refresh_hz > 0) {
+      mode += "@" + std::to_string(refresh_hz) + "Hz";
+    }
+    return mode;
   }
 
   bool should_attempt_windowed_gpu_native_probe(
@@ -415,9 +442,14 @@ namespace cage_display_router {
     std::string_view wlr_randr_output,
     std::string_view output_name,
     int width,
-    int height
+    int height,
+    int refresh_hz
   ) {
-    return output_reports_current_mode(wlr_randr_output, output_name, width, height);
+    return output_reports_current_mode(wlr_randr_output, output_name, width, height, refresh_hz);
+  }
+
+  std::string format_wlr_custom_mode_for_tests(int width, int height, int refresh_hz) {
+    return format_wlr_custom_mode(width, height, refresh_hz);
   }
 
   bool is_wayland_socket_name_for_tests(std::string_view name) {
@@ -429,7 +461,7 @@ namespace cage_display_router {
   // Public API
   // -----------------------------------------------------------------------
 
-  bool start(int width, int height, const std::string &game_cmd, bool force_windowed) {
+  bool start(int width, int height, int refresh_hz, const std::string &game_cmd, bool force_windowed) {
     const auto startup_begin = std::chrono::steady_clock::now();
 
     if (cage_pid > 0 && is_running()) {
@@ -457,7 +489,8 @@ namespace cage_display_router {
       BOOST_LOG(warning) << "labwc: Headless mode overridden to windowed mode to preserve GPU-native capture"sv;
     }
     BOOST_LOG(info) << "labwc: Starting in "sv << (headless ? "headless"sv : "windowed"sv)
-                    << " mode — resolution="sv << width << "x"sv << height;
+                    << " mode — resolution="sv << width << "x"sv << height
+                    << "@"sv << refresh_hz << "Hz"sv;
 
     const auto labwc_path = resolve_executable("labwc");
     if (labwc_path.empty()) {
@@ -484,7 +517,7 @@ namespace cage_display_router {
 
     // Config directory for kiosk-mode rc.xml (no decorations, maximize all)
     std::string config_dir = std::string(getenv("HOME") ? getenv("HOME") : "/tmp") + "/.config/labwc-polaris";
-    std::string mode = std::to_string(width) + "x" + std::to_string(height);
+    const std::string mode = format_wlr_custom_mode(width, height, refresh_hz);
 
     // Build startup command: set resolution then run the game
     // In headless mode, the output name is HEADLESS-1 instead of WL-1
@@ -627,9 +660,9 @@ namespace cage_display_router {
       return false;
     }
 
-    if (!wait_for_requested_mode(cage_wayland_socket, output_name, width, height, 5000)) {
+    if (!wait_for_requested_mode(cage_wayland_socket, output_name, width, height, refresh_hz, 5000)) {
       BOOST_LOG(warning) << "labwc: Output ["sv << output_name << "] did not settle to "
-                         << width << "x"sv << height
+                         << width << "x"sv << height << "@"sv << refresh_hz << "Hz"sv
                          << " before startup continued"sv;
     }
 

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -45,13 +45,14 @@ namespace cage_display_router {
    *
    * @param width    Resolution width inside cage (default 1920)
    * @param height   Resolution height inside cage (default 1080)
+   * @param refresh_hz Refresh rate inside cage (default 60)
    * @param game_cmd Optional game command to run as cage's primary client
    * @param force_windowed Force the compositor to run windowed even if headless
    *                       mode is configured. Used when GPU-native capture must
    *                       take priority over invisibility.
    * @return true if cage started successfully and wayland socket is available
    */
-  bool start(int width = 1920, int height = 1080, const std::string &game_cmd = "", bool force_windowed = false);
+  bool start(int width = 1920, int height = 1080, int refresh_hz = 60, const std::string &game_cmd = "", bool force_windowed = false);
 
   /**
    * @brief Wrap a command to run inside the cage compositor.
@@ -169,8 +170,14 @@ namespace cage_display_router {
     std::string_view wlr_randr_output,
     std::string_view output_name,
     int width,
-    int height
+    int height,
+    int refresh_hz = 0
   );
+
+  /**
+   * @brief Test helper for formatting a wlr-randr custom mode string.
+   */
+  std::string format_wlr_custom_mode_for_tests(int width, int height, int refresh_hz);
 
   /**
    * @brief Test helper for Wayland socket file name filtering.

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2191,6 +2191,7 @@ namespace proc {
         cage_display_router::cached_windowed_gpu_native_probe_result() :
         std::optional<bool> {};
     bool force_windowed_cage_for_gpu_native = false;
+    const int cage_refresh_hz = std::max(pacing_target_fps, 1);
 
     const int gpu_native_probe_fps = std::max(pacing_target_fps, 1);
     const video::config_t gpu_native_probe_config {
@@ -2223,7 +2224,7 @@ namespace proc {
         cage_display_router::stop();
       }
 
-      if (!cage_display_router::start(render_width, render_height, startup_cmd, force_windowed)) {
+      if (!cage_display_router::start(render_width, render_height, cage_refresh_hz, startup_cmd, force_windowed)) {
         return false;
       }
 

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -152,6 +152,40 @@ TEST(CageDisplayRouterPolicyTests, OutputModeParserRecognizesRequestedCurrentMod
   ));
 }
 
+TEST(CageDisplayRouterPolicyTests, OutputModeParserRecognizesRequestedCurrentRefresh) {
+  constexpr std::string_view output = R"(HEADLESS-1 "Headless output 1"
+  Enabled: yes
+  Modes:
+    1920x1080 px, 60.000000 Hz
+    1920x1080 px, 120.000000 Hz (current)
+)";
+
+  EXPECT_TRUE(cage_display_router::output_reports_current_mode_for_tests(
+    output,
+    "HEADLESS-1",
+    1920,
+    1080,
+    120
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, OutputModeParserRejectsWrongCurrentRefresh) {
+  constexpr std::string_view output = R"(HEADLESS-1 "Headless output 1"
+  Enabled: yes
+  Modes:
+    1920x1080 px, 60.000000 Hz (current)
+    1920x1080 px, 120.000000 Hz
+)";
+
+  EXPECT_FALSE(cage_display_router::output_reports_current_mode_for_tests(
+    output,
+    "HEADLESS-1",
+    1920,
+    1080,
+    120
+  ));
+}
+
 TEST(CageDisplayRouterPolicyTests, OutputModeParserRejectsNonCurrentRequestedMode) {
   constexpr std::string_view output = R"(HEADLESS-1 "Headless output 1"
   Enabled: yes
@@ -166,6 +200,13 @@ TEST(CageDisplayRouterPolicyTests, OutputModeParserRejectsNonCurrentRequestedMod
     1920,
     1080
   ));
+}
+
+TEST(CageDisplayRouterPolicyTests, FormatWlrCustomModeIncludesRefresh) {
+  EXPECT_EQ(
+    cage_display_router::format_wlr_custom_mode_for_tests(1920, 1080, 120),
+    "1920x1080@120Hz"
+  );
 }
 
 TEST(CageDisplayRouterPolicyTests, WaylandSocketNameParserAcceptsNumberedSocketsOnly) {


### PR DESCRIPTION
## Summary
- Pass the selected session refresh rate into labwc startup.
- Apply wlr-randr custom modes as width x height @ refresh Hz instead of resolution only.
- Validate labwc mode readiness against both resolution and refresh rate.

## Smoke test
- Built CUDA-enabled Polaris on Fedora.
- Installed and restarted /usr/local/bin/polaris-smoke.
- Verified Retroid Pocket 6 sessions for Indiana Jones and Phasmophobia start at 1920x1080@120Hz.
- Confirmed live cage output reports 1920x1080 px, 120.000000 Hz (current).