### PR TITLE
Improve Linux streaming and launcher integration

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -92,6 +92,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/ai_optimizer.cpp"
         "${CMAKE_SOURCE_DIR}/src/game_classifier.h"
         "${CMAKE_SOURCE_DIR}/src/game_classifier.cpp"
+        "${CMAKE_SOURCE_DIR}/src/game_library_scanner.h"
+        "${CMAKE_SOURCE_DIR}/src/game_library_scanner.cpp"
         "${CMAKE_SOURCE_DIR}/src/config.h"
         "${CMAKE_SOURCE_DIR}/src/config.cpp"
         "${CMAKE_SOURCE_DIR}/src/display_device.h"

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -57,6 +57,7 @@
 #include "device_db.h"
 #include "ai_optimizer.h"
 #include "game_classifier.h"
+#include "game_library_scanner.h"
 
 #include <curl/curl.h>
 
@@ -1096,6 +1097,10 @@ namespace confighttp {
    *
    * @api_examples{/api/apps| GET| null}
    */
+  std::vector<fs::path> lutris_art_roots();
+  std::string lutris_image_path_for_app_node(const nlohmann::json &app);
+  void hydrate_lutris_app_images(nlohmann::json &file_tree);
+
   void getApps(resp_https_t response, req_https_t request) {
     if (!authenticate(response, request)) {
       return;
@@ -1106,6 +1111,7 @@ namespace confighttp {
     try {
       std::string content = file_handler::read_file(config::stream.file_apps.c_str());
       nlohmann::json file_tree = nlohmann::json::parse(content);
+      hydrate_lutris_app_images(file_tree);
 
       file_tree["current_app"] = proc::proc.get_running_app_uuid();
       file_tree["host_uuid"] = http::unique_id;
@@ -1520,8 +1526,138 @@ namespace confighttp {
   }
 
   /**
-   * @brief Scan for installed Steam and Lutris games.
+   * @brief Scan for installed Steam, Lutris, and Heroic games.
    */
+  std::vector<fs::path> lutris_game_config_dirs() {
+    std::vector<fs::path> dirs;
+    const char *home = std::getenv("HOME");
+    if (!home || !*home) {
+      return dirs;
+    }
+
+    const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+    const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
+    dirs.emplace_back(
+      xdg_config_home && *xdg_config_home ?
+        fs::path(xdg_config_home) / "lutris/games" :
+        fs::path(home) / ".config/lutris/games"
+    );
+    dirs.emplace_back(
+      xdg_data_home && *xdg_data_home ?
+        fs::path(xdg_data_home) / "lutris/games" :
+        fs::path(home) / ".local/share/lutris/games"
+    );
+
+    return dirs;
+  }
+
+  std::vector<fs::path> lutris_art_roots() {
+    std::vector<fs::path> roots;
+    const char *home = std::getenv("HOME");
+    if (!home || !*home) {
+      return roots;
+    }
+
+    const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
+    const char *xdg_cache_home = std::getenv("XDG_CACHE_HOME");
+    roots.emplace_back(
+      xdg_data_home && *xdg_data_home ?
+        fs::path(xdg_data_home) / "lutris" :
+        fs::path(home) / ".local/share/lutris"
+    );
+    roots.emplace_back(
+      xdg_cache_home && *xdg_cache_home ?
+        fs::path(xdg_cache_home) / "lutris" :
+        fs::path(home) / ".cache/lutris"
+    );
+
+    return roots;
+  }
+
+  std::string lutris_image_path_for_app_node(const nlohmann::json &app) {
+    if (!app.is_object()) {
+      return {};
+    }
+
+    if (app.contains("image-path") && app["image-path"].is_string() && !app["image-path"].get<std::string>().empty()) {
+      return {};
+    }
+
+    const auto source = app.contains("source") && app["source"].is_string() ? app["source"].get<std::string>() : "";
+    if (!boost::iequals(source, "lutris")) {
+      return {};
+    }
+
+    const auto slug = app.contains("lutris-slug") && app["lutris-slug"].is_string() ? app["lutris-slug"].get<std::string>() : "";
+    if (!game_library::is_lutris_slug_safe(slug)) {
+      return {};
+    }
+
+    return game_library::find_lutris_image_path(slug, lutris_art_roots());
+  }
+
+  void hydrate_lutris_app_images(nlohmann::json &file_tree) {
+    if (!file_tree.contains("apps") || !file_tree["apps"].is_array()) {
+      return;
+    }
+
+    for (auto &app : file_tree["apps"]) {
+      auto image_path = lutris_image_path_for_app_node(app);
+      if (!image_path.empty()) {
+        app["image-path"] = image_path;
+      }
+    }
+  }
+
+  void ensure_lutris_library_app(nlohmann::json &file_tree) {
+    if (!file_tree.contains("apps") || !file_tree["apps"].is_array()) {
+      file_tree["apps"] = nlohmann::json::array();
+    }
+
+    for (const auto &app : file_tree["apps"]) {
+      if (!app.is_object()) {
+        continue;
+      }
+
+      const auto name = app.value("name", "");
+      if (boost::iequals(boost::trim_copy(name), "Lutris")) {
+        return;
+      }
+
+      const auto cmd = boost::trim_copy(app.value("cmd", ""));
+      if (boost::iequals(cmd, "setsid lutris") || boost::iequals(cmd, "lutris")) {
+        return;
+      }
+
+      if (!app.contains("detached") || !app["detached"].is_array()) {
+        continue;
+      }
+
+      for (const auto &detached : app["detached"]) {
+        if (!detached.is_string()) {
+          continue;
+        }
+        const auto value = boost::trim_copy(detached.get<std::string>());
+        if (boost::iequals(value, "setsid lutris") || boost::iequals(value, "lutris")) {
+          return;
+        }
+      }
+    }
+
+    nlohmann::json app {
+      {"name", "Lutris"},
+      {"uuid", ""},
+      {"cmd", ""},
+      {"detached", nlohmann::json::array({"setsid lutris"})},
+      {"image-path", "lutris.png"},
+      {"source", "lutris"},
+      {"auto-detach", true},
+      {"wait-all", true},
+      {"exit-timeout", 5}
+    };
+    proc::migrate_apps(&file_tree, &app);
+  }
+
   void scanGames(resp_https_t response, req_https_t request) {
     if (!authenticate(response, request)) return;
     print_req(request);
@@ -1531,6 +1667,7 @@ namespace confighttp {
 
     // Get existing apps to check for duplicates
     std::set<std::string> existing_cmds;
+    std::set<std::string> existing_lutris_slugs;
     try {
       std::string content = file_handler::read_file(config::stream.file_apps.c_str());
       auto apps_tree = nlohmann::json::parse(content);
@@ -1543,6 +1680,13 @@ namespace confighttp {
           }
           if (app.contains("cmd") && app["cmd"].is_string()) {
             existing_cmds.insert(app["cmd"].get<std::string>());
+          }
+          const auto app_source = app.contains("source") && app["source"].is_string() ? app["source"].get<std::string>() : "";
+          if (boost::iequals(app_source, "lutris")) {
+            const auto slug = app.contains("lutris-slug") && app["lutris-slug"].is_string() ? app["lutris-slug"].get<std::string>() : "";
+            if (!slug.empty()) {
+              existing_lutris_slugs.insert(slug);
+            }
           }
         }
       }
@@ -1622,52 +1766,33 @@ namespace confighttp {
     // Scan Lutris games
     nlohmann::json lutris_games = nlohmann::json::array();
     if (home) {
-      std::string lutris_db_path = std::string(home) + "/.local/share/lutris/pga.db";
-      std::string lutris_yml_dir = std::string(home) + "/.config/lutris/games/";
+      auto lutris_yml_dirs = lutris_game_config_dirs();
+      auto lutris_roots = lutris_art_roots();
 
-      // Scan Lutris YAML game configs
-      if (std::filesystem::exists(lutris_yml_dir)) {
-        for (const auto &entry : std::filesystem::directory_iterator(lutris_yml_dir)) {
-          if (!entry.is_regular_file()) continue;
-          auto fname = entry.path().filename().string();
-          if (fname.find(".yml") == std::string::npos) continue;
+      for (const auto &lutris_game : game_library::scan_lutris_library(lutris_yml_dirs)) {
+        bool already = existing_cmds.count(lutris_game.command) > 0 ||
+          existing_lutris_slugs.count(lutris_game.slug) > 0;
 
-          // Extract slug from filename (e.g., "doom-eternal.yml" -> "doom-eternal")
-          auto slug = fname.substr(0, fname.rfind('.'));
-
-          // Read the YAML file to get the game name
-          std::ifstream yml_file(entry.path());
-          std::string game_name;
-          std::string line;
-          while (std::getline(yml_file, line)) {
-            // Simple YAML parsing — find "name: ..." or "game:" section
-            if (line.find("name:") == 0 || line.find("name: ") == 0) {
-              game_name = line.substr(line.find(':') + 1);
-              // Trim whitespace and quotes
-              while (!game_name.empty() && (game_name.front() == ' ' || game_name.front() == '\'' || game_name.front() == '"'))
-                game_name.erase(0, 1);
-              while (!game_name.empty() && (game_name.back() == ' ' || game_name.back() == '\'' || game_name.back() == '"'))
-                game_name.pop_back();
-              break;
-            }
-          }
-          if (game_name.empty()) {
-            // Use slug as fallback name, replacing hyphens with spaces
-            game_name = slug;
-            std::replace(game_name.begin(), game_name.end(), '-', ' ');
-          }
-
-          std::string launch_cmd = "setsid lutris lutris:rungame/" + slug;
-          bool already = existing_cmds.count(launch_cmd) > 0;
-
-          nlohmann::json game;
-          game["name"] = game_name;
-          game["slug"] = slug;
-          game["cmd"] = launch_cmd;
-          game["source"] = "lutris";
-          game["already_imported"] = already;
-          lutris_games.push_back(game);
+        nlohmann::json game;
+        game["name"] = lutris_game.name;
+        game["slug"] = lutris_game.slug;
+        game["cmd"] = lutris_game.command;
+        game["source"] = "lutris";
+        game["already_imported"] = already;
+        if (!lutris_game.runner.empty()) {
+          game["runner"] = lutris_game.runner;
         }
+        auto image_path = lutris_game.image_path.empty() ?
+          game_library::find_lutris_image_path(lutris_game.slug, lutris_roots) :
+          lutris_game.image_path;
+        if (!image_path.empty()) {
+          game["image_path"] = image_path;
+          game["image-path"] = image_path;
+          game["cover_path"] = image_path;
+        }
+        auto cat = game_classifier::classify(lutris_game.name, {});
+        game["game_category"] = game_classifier::category_to_string(cat);
+        lutris_games.push_back(game);
       }
     }
 
@@ -1809,6 +1934,7 @@ namespace confighttp {
       nlohmann::json fileTree = nlohmann::json::parse(content);
 
       int imported = 0;
+      bool imported_lutris_game = false;
       for (const auto &game : body["games"]) {
         std::string name = game.value("name", "");
         std::string source = game.value("source", "steam");
@@ -1845,7 +1971,30 @@ namespace confighttp {
           } else {
             app["image-path"] = "https://steamcdn-a.akamaihd.net/steam/apps/" + appid + "/library_600x900_2x.jpg";
           }
-        } else if (source == "lutris" || source == "heroic") {
+        } else if (source == "lutris") {
+          std::string slug = game.value("slug", game.value("lutris-slug", ""));
+          if (!game_library::is_lutris_slug_safe(slug)) {
+            BOOST_LOG(warning) << "Skipping Lutris import for [" << name << "]: missing or unsafe slug";
+            continue;
+          }
+
+          app["lutris-slug"] = slug;
+          app["detached"] = nlohmann::json::array({ game_library::lutris_launch_command(slug) });
+
+          std::string runner = game.value("runner", game.value("lutris-runner", ""));
+          if (!runner.empty()) {
+            app["lutris-runner"] = runner;
+          }
+
+          std::string image_path = game.value("image_path", game.value("image-path", game.value("cover_path", "")));
+          if (image_path.empty()) {
+            image_path = game_library::find_lutris_image_path(slug, lutris_art_roots());
+          }
+          if (!image_path.empty()) {
+            app["image-path"] = image_path;
+          }
+          imported_lutris_game = true;
+        } else if (source == "heroic") {
           // Use the launch command provided by the scanner
           std::string cmd = game.value("cmd", "");
           if (!cmd.empty()) {
@@ -1864,6 +2013,10 @@ namespace confighttp {
         // Merge into apps file
         proc::migrate_apps(&fileTree, &app);
         imported++;
+      }
+
+      if (imported_lutris_game) {
+        ensure_lutris_library_app(fileTree);
       }
 
       // Write back
@@ -2532,6 +2685,26 @@ namespace confighttp {
         image_path = app.image_path;
         break;
       }
+    }
+
+    if (image_path.empty()) {
+      try {
+        std::string content = file_handler::read_file(config::stream.file_apps.c_str());
+        auto file_tree = nlohmann::json::parse(content);
+        if (file_tree.contains("apps") && file_tree["apps"].is_array()) {
+          for (const auto &app : file_tree["apps"]) {
+            if (!app.is_object() || app.value("name", "") != name_it->second) {
+              continue;
+            }
+
+            image_path = app.value("image-path", "");
+            if (image_path.empty()) {
+              image_path = lutris_image_path_for_app_node(app);
+            }
+            break;
+          }
+        }
+      } catch (...) {}
     }
 
     if (image_path.empty()) {

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -1,0 +1,390 @@
+/**
+ * @file src/game_library_scanner.cpp
+ * @brief Helpers for discovering third-party launcher libraries.
+ */
+#include "game_library_scanner.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdio>
+#include <fstream>
+#include <set>
+#include <string_view>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+namespace game_library {
+  namespace {
+    std::string trim_copy(std::string_view text) {
+      auto begin = text.begin();
+      auto end = text.end();
+
+      while (begin != end && std::isspace(static_cast<unsigned char>(*begin))) {
+        ++begin;
+      }
+      while (begin != end && std::isspace(static_cast<unsigned char>(*(end - 1)))) {
+        --end;
+      }
+
+      return std::string(begin, end);
+    }
+
+    std::string strip_inline_comment(std::string_view value) {
+      char quote = '\0';
+      bool seen_non_space = false;
+
+      for (std::size_t i = 0; i < value.size(); ++i) {
+        const char ch = value[i];
+        if (!seen_non_space && std::isspace(static_cast<unsigned char>(ch))) {
+          continue;
+        }
+
+        if (quote != '\0') {
+          if (ch == quote) {
+            quote = '\0';
+          }
+          continue;
+        }
+
+        if (!seen_non_space && (ch == '\'' || ch == '"')) {
+          quote = ch;
+          seen_non_space = true;
+          continue;
+        }
+
+        seen_non_space = true;
+        if (ch == '#' &&
+            (i == 0 || std::isspace(static_cast<unsigned char>(value[i - 1])))) {
+          return trim_copy(value.substr(0, i));
+        }
+      }
+
+      return trim_copy(value);
+    }
+
+    std::string decode_yaml_scalar(std::string_view raw_value) {
+      std::string value = strip_inline_comment(raw_value);
+      if (value.size() >= 2) {
+        const char first = value.front();
+        const char last = value.back();
+        if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
+          value = value.substr(1, value.size() - 2);
+        }
+      }
+
+      return trim_copy(value);
+    }
+
+    std::optional<std::pair<std::string, std::string>> parse_top_level_yaml_scalar(std::string_view raw_line) {
+      if (raw_line.empty() || raw_line.front() == '#' ||
+          std::isspace(static_cast<unsigned char>(raw_line.front()))) {
+        return std::nullopt;
+      }
+
+      const auto separator = raw_line.find(':');
+      if (separator == std::string_view::npos) {
+        return std::nullopt;
+      }
+
+      auto key = trim_copy(raw_line.substr(0, separator));
+      auto value = decode_yaml_scalar(raw_line.substr(separator + 1));
+      if (key.empty() || value.empty()) {
+        return std::nullopt;
+      }
+
+      return std::make_pair(std::move(key), std::move(value));
+    }
+
+    std::string slug_to_name(std::string slug) {
+      std::replace(slug.begin(), slug.end(), '-', ' ');
+      std::replace(slug.begin(), slug.end(), '_', ' ');
+      return slug;
+    }
+
+    bool has_supported_image_extension(const std::filesystem::path &path) {
+      auto extension = path.extension().string();
+      std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+      });
+
+      return extension == ".png" || extension == ".jpg" || extension == ".jpeg" || extension == ".webp";
+    }
+
+    std::string supported_image_path_or_empty(std::string path) {
+      path = trim_copy(path);
+      if (path.empty() || !has_supported_image_extension(path)) {
+        return {};
+      }
+
+      return path;
+    }
+
+    void append_lutris_image_candidates(
+      std::vector<std::filesystem::path> &candidates,
+      const std::filesystem::path &root,
+      const std::string &slug
+    ) {
+      const std::array<std::filesystem::path, 8> directories {
+        root / "coverart",
+        root / "banners",
+        root / "icons",
+        root / "steam/covers",
+        root / "steam/banners",
+        root / "steam/header",
+        root / "gog/banners",
+        root / "ubisoft/covers",
+      };
+      const std::array<std::string_view, 4> extensions {".jpg", ".jpeg", ".png", ".webp"};
+
+      for (const auto &directory : directories) {
+        for (const auto extension : extensions) {
+          candidates.emplace_back(directory / (slug + std::string(extension)));
+        }
+      }
+    }
+
+    void append_unique_lutris_games(
+      std::vector<lutris_game_t> &games,
+      std::set<std::string> &seen_slugs,
+      std::vector<lutris_game_t> discovered
+    ) {
+      for (auto &game : discovered) {
+        if (!seen_slugs.insert(game.slug).second) {
+          continue;
+        }
+
+        games.push_back(std::move(game));
+      }
+    }
+
+    std::string read_lutris_list_games_json() {
+    #ifdef __linux__
+      std::string output;
+      std::array<char, 4096> buffer {};
+      FILE *pipe = popen("lutris --list-games --json 2>/dev/null", "r");
+      if (!pipe) {
+        return output;
+      }
+
+      while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr) {
+        output += buffer.data();
+      }
+      pclose(pipe);
+      return output;
+    #else
+      return {};
+    #endif
+    }
+  }  // namespace
+
+  bool is_lutris_slug_safe(const std::string &slug) {
+    if (slug.empty()) {
+      return false;
+    }
+
+    return std::all_of(slug.begin(), slug.end(), [](unsigned char ch) {
+      return std::isalnum(ch) || ch == '-' || ch == '_' || ch == '.';
+    });
+  }
+
+  std::string lutris_launch_command(const std::string &slug) {
+    return "setsid lutris lutris:rungame/" + slug;
+  }
+
+  std::string find_lutris_image_path(const std::string &slug, const std::vector<std::filesystem::path> &lutris_roots) {
+    if (!is_lutris_slug_safe(slug)) {
+      return {};
+    }
+
+    std::vector<std::filesystem::path> candidates;
+    std::set<std::filesystem::path> seen_roots;
+    for (const auto &root : lutris_roots) {
+      if (root.empty() || !seen_roots.insert(root).second) {
+        continue;
+      }
+
+      append_lutris_image_candidates(candidates, root, slug);
+    }
+
+    for (const auto &candidate : candidates) {
+      std::error_code ec;
+      if (has_supported_image_extension(candidate) &&
+          std::filesystem::is_regular_file(candidate, ec)) {
+        return candidate.string();
+      }
+    }
+
+    return {};
+  }
+
+  std::vector<lutris_game_t> parse_lutris_list_games_json(std::string_view json_payload) {
+    std::vector<lutris_game_t> games;
+    if (json_payload.empty()) {
+      return games;
+    }
+
+    try {
+      const auto payload = nlohmann::json::parse(json_payload);
+      if (!payload.is_array()) {
+        return games;
+      }
+
+      for (const auto &entry : payload) {
+        if (!entry.is_object()) {
+          continue;
+        }
+
+        const auto name = entry.value("name", "");
+        const auto slug = trim_copy(entry.value("slug", ""));
+        if (name.empty() || !is_lutris_slug_safe(slug)) {
+          continue;
+        }
+
+        games.push_back(lutris_game_t {
+          .name = name,
+          .slug = slug,
+          .runner = entry.value("runner", ""),
+          .command = lutris_launch_command(slug),
+          .image_path = entry.contains("coverPath") && entry["coverPath"].is_string() ?
+            supported_image_path_or_empty(entry["coverPath"].get<std::string>()) :
+            "",
+        });
+      }
+    } catch (...) {
+      games.clear();
+    }
+
+    return games;
+  }
+
+  std::optional<lutris_game_t> parse_lutris_game_config(const std::filesystem::path &path) {
+    std::ifstream file(path);
+    if (!file) {
+      return std::nullopt;
+    }
+
+    std::string name;
+    std::string slug;
+    std::string game_slug;
+    std::string runner;
+
+    std::string line;
+    while (std::getline(file, line)) {
+      const auto scalar = parse_top_level_yaml_scalar(line);
+      if (!scalar) {
+        continue;
+      }
+
+      const auto &[key, value] = *scalar;
+      if (key == "name") {
+        name = value;
+      } else if (key == "slug") {
+        slug = value;
+      } else if (key == "game_slug") {
+        game_slug = value;
+      } else if (key == "runner") {
+        runner = value;
+      }
+    }
+
+    if (slug.empty()) {
+      slug = game_slug;
+    }
+    if (slug.empty()) {
+      slug = path.stem().string();
+    }
+    slug = trim_copy(slug);
+
+    if (!is_lutris_slug_safe(slug)) {
+      return std::nullopt;
+    }
+
+    if (name.empty()) {
+      name = slug_to_name(slug);
+    }
+
+    return lutris_game_t {
+      .name = name,
+      .slug = slug,
+      .runner = runner,
+      .command = lutris_launch_command(slug),
+    };
+  }
+
+  std::vector<lutris_game_t> scan_lutris_games(const std::filesystem::path &games_dir) {
+    return scan_lutris_games(std::vector<std::filesystem::path> {games_dir});
+  }
+
+  std::vector<lutris_game_t> scan_lutris_games(const std::vector<std::filesystem::path> &games_dirs) {
+    std::vector<lutris_game_t> games;
+    std::vector<std::filesystem::path> config_paths;
+    std::set<std::filesystem::path> lutris_roots;
+    for (const auto &games_dir : games_dirs) {
+      std::error_code ec;
+      if (!std::filesystem::is_directory(games_dir, ec)) {
+        continue;
+      }
+
+      lutris_roots.insert(games_dir.parent_path());
+
+      for (const auto &entry : std::filesystem::directory_iterator(games_dir, std::filesystem::directory_options::skip_permission_denied, ec)) {
+        if (ec) {
+          break;
+        }
+
+        std::error_code entry_ec;
+        if (!entry.is_regular_file(entry_ec)) {
+          continue;
+        }
+
+        const auto extension = entry.path().extension().string();
+        if (extension == ".yml" || extension == ".yaml") {
+          config_paths.push_back(entry.path());
+        }
+      }
+    }
+
+    std::sort(config_paths.begin(), config_paths.end());
+
+    std::set<std::string> seen_slugs;
+    for (const auto &path : config_paths) {
+      auto game = parse_lutris_game_config(path);
+      if (!game) {
+        continue;
+      }
+
+      if (!seen_slugs.insert(game->slug).second) {
+        continue;
+      }
+
+      if (game->image_path.empty()) {
+        std::vector<std::filesystem::path> roots(lutris_roots.begin(), lutris_roots.end());
+        game->image_path = find_lutris_image_path(
+          game->slug,
+          roots
+        );
+      }
+
+      games.push_back(std::move(*game));
+    }
+
+    return games;
+  }
+
+  std::vector<lutris_game_t> scan_lutris_library(const std::vector<std::filesystem::path> &games_dirs) {
+    std::vector<lutris_game_t> games;
+    std::set<std::string> seen_slugs;
+
+    append_unique_lutris_games(games, seen_slugs, parse_lutris_list_games_json(read_lutris_list_games_json()));
+    if (!games.empty()) {
+      return games;
+    }
+
+    append_unique_lutris_games(games, seen_slugs, scan_lutris_games(games_dirs));
+
+    return games;
+  }
+
+}  // namespace game_library

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -1,0 +1,32 @@
+/**
+ * @file src/game_library_scanner.h
+ * @brief Helpers for discovering third-party launcher libraries.
+ */
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace game_library {
+
+  struct lutris_game_t {
+    std::string name;
+    std::string slug;
+    std::string runner;
+    std::string command;
+    std::string image_path;
+  };
+
+  bool is_lutris_slug_safe(const std::string &slug);
+  std::string find_lutris_image_path(const std::string &slug, const std::vector<std::filesystem::path> &lutris_roots);
+  std::string lutris_launch_command(const std::string &slug);
+  std::vector<lutris_game_t> parse_lutris_list_games_json(std::string_view json_payload);
+  std::optional<lutris_game_t> parse_lutris_game_config(const std::filesystem::path &path);
+  std::vector<lutris_game_t> scan_lutris_games(const std::filesystem::path &games_dir);
+  std::vector<lutris_game_t> scan_lutris_games(const std::vector<std::filesystem::path> &games_dirs);
+  std::vector<lutris_game_t> scan_lutris_library(const std::vector<std::filesystem::path> &games_dirs);
+
+}  // namespace game_library

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -114,6 +114,11 @@ namespace input {
 
   static platf::input_t platf_input;
   static std::bitset<platf::MAX_GAMEPADS> gamepadMask {};
+  static std::mutex preallocated_gamepad_mutex;
+  static int preallocated_controller_number {-1};
+  static int preallocated_gamepad_id {-1};
+  static safe::mail_t preallocated_gamepad_mail;
+  static platf::feedback_queue_t preallocated_gamepad_feedback_queue;
 
   void free_gamepad(platf::input_t &platf_input, int id) {
     platf::gamepad_update(platf_input, id, platf::gamepad_state_t {});
@@ -194,6 +199,71 @@ namespace input {
     int32_t accumulated_vscroll_delta;
     int32_t accumulated_hscroll_delta;
   };
+
+  bool ensure_gamepad_allocated(const std::shared_ptr<input_t> &input, int controller_number, const platf::gamepad_arrival_t &arrival, const char *reason) {
+    if (!config::input.controller) {
+      return false;
+    }
+
+    if (controller_number < 0 || static_cast<std::size_t>(controller_number) >= input->gamepads.size()) {
+      BOOST_LOG(warning) << "ControllerNumber out of range ["sv << controller_number << ']';
+      return false;
+    }
+
+    auto &gamepad = input->gamepads[controller_number];
+    if (gamepad.id >= 0) {
+      return true;
+    }
+
+    auto id = alloc_id(gamepadMask);
+    if (id < 0) {
+      return false;
+    }
+
+    if (platf::alloc_gamepad(platf_input, {id, static_cast<std::uint8_t>(controller_number)}, arrival, input->feedback_queue)) {
+      free_id(gamepadMask, id);
+      return false;
+    }
+
+    gamepad.id = id;
+    if (reason && *reason) {
+      BOOST_LOG(info) << "ControllerNumber ["sv << controller_number << "] allocated for "sv << reason;
+    }
+    return true;
+  }
+
+  void preallocate_gamepad() {
+    if (!config::input.controller) {
+      return;
+    }
+
+    std::scoped_lock lock {preallocated_gamepad_mutex};
+    if (preallocated_gamepad_id >= 0 || gamepadMask.any()) {
+      return;
+    }
+
+    auto id = alloc_id(gamepadMask);
+    if (id < 0) {
+      return;
+    }
+
+    if (!preallocated_gamepad_mail) {
+      preallocated_gamepad_mail = std::make_shared<safe::mail_raw_t>();
+      preallocated_gamepad_feedback_queue = preallocated_gamepad_mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback);
+    }
+
+    constexpr int controller_number = 0;
+    if (platf::alloc_gamepad(platf_input, {id, static_cast<std::uint8_t>(controller_number)}, {}, preallocated_gamepad_feedback_queue)) {
+      free_id(gamepadMask, id);
+      BOOST_LOG(warning) << "ControllerNumber [0] could not be preallocated before app launch"sv;
+      return;
+    }
+
+    preallocated_controller_number = controller_number;
+    preallocated_gamepad_id = id;
+    platf::gamepad_update(platf_input, id, {});
+    BOOST_LOG(info) << "ControllerNumber [0] preallocated before app launch"sv;
+  }
 
   /**
    * @brief Apply shortcut based on VKEY
@@ -839,13 +909,13 @@ namespace input {
       return;
     }
 
-    if (packet->controllerNumber < 0 || packet->controllerNumber >= input->gamepads.size()) {
+    if (packet->controllerNumber < 0 || static_cast<std::size_t>(packet->controllerNumber) >= input->gamepads.size()) {
       BOOST_LOG(warning) << "ControllerNumber out of range ["sv << packet->controllerNumber << ']';
       return;
     }
 
     if (input->gamepads[packet->controllerNumber].id >= 0) {
-      BOOST_LOG(warning) << "ControllerNumber already allocated ["sv << packet->controllerNumber << ']';
+      BOOST_LOG(debug) << "ControllerNumber already allocated ["sv << packet->controllerNumber << ']';
       return;
     }
 
@@ -855,18 +925,7 @@ namespace input {
       util::endian::little(packet->supportedButtonFlags),
     };
 
-    auto id = alloc_id(gamepadMask);
-    if (id < 0) {
-      return;
-    }
-
-    // Allocate a new gamepad
-    if (platf::alloc_gamepad(platf_input, {id, packet->controllerNumber}, arrival, input->feedback_queue)) {
-      free_id(gamepadMask, id);
-      return;
-    }
-
-    input->gamepads[packet->controllerNumber].id = id;
+    ensure_gamepad_allocated(input, packet->controllerNumber, arrival, "controller arrival");
   }
 
   /**
@@ -1094,17 +1153,9 @@ namespace input {
     // If this is an event for a new gamepad, create the gamepad now. Ideally, the client would
     // send a controller arrival instead of this but it's still supported for legacy clients.
     if ((packet->activeGamepadMask & (1 << packet->controllerNumber)) && gamepad.id < 0) {
-      auto id = alloc_id(gamepadMask);
-      if (id < 0) {
+      if (!ensure_gamepad_allocated(input, packet->controllerNumber, {}, "controller input")) {
         return;
       }
-
-      if (platf::alloc_gamepad(platf_input, {id, (uint8_t) packet->controllerNumber}, {}, input->feedback_queue)) {
-        free_id(gamepadMask, id);
-        return;
-      }
-
-      gamepad.id = id;
     } else if (!(packet->activeGamepadMask & (1 << packet->controllerNumber)) && gamepad.id >= 0) {
       // If this is the final event for a gamepad being removed, free the gamepad and return.
       free_gamepad(platf_input, gamepad.id);
@@ -1696,6 +1747,26 @@ namespace input {
       mail->event<input::touch_port_t>(mail::touch_port),
       mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback)
     );
+
+    bool adopted_preallocated_gamepad = false;
+    {
+      std::scoped_lock lock {preallocated_gamepad_mutex};
+      if (preallocated_controller_number == 0 && preallocated_gamepad_id >= 0) {
+        input->gamepads[0].id = preallocated_gamepad_id;
+        preallocated_controller_number = -1;
+        preallocated_gamepad_id = -1;
+        preallocated_gamepad_mail.reset();
+        preallocated_gamepad_feedback_queue.reset();
+        adopted_preallocated_gamepad = true;
+        BOOST_LOG(info) << "ControllerNumber [0] adopted preallocated gamepad for session startup"sv;
+      }
+    }
+
+    task_pool.push([input, adopted_preallocated_gamepad]() {
+      if (adopted_preallocated_gamepad || ensure_gamepad_allocated(input, 0, {}, "session startup")) {
+        platf::gamepad_update(platf_input, input->gamepads[0].id, {});
+      }
+    });
 
     // Workaround to ensure new frames will be captured when a client connects
     task_pool.pushDelayed([]() {

--- a/src/input.h
+++ b/src/input.h
@@ -23,6 +23,7 @@ namespace input {
 
   bool probe_gamepads();
 
+  void preallocate_gamepad();
   std::shared_ptr<input_t> alloc(safe::mail_t mail);
 
   struct touch_port_t: public platf::touch_port_t {

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -50,6 +50,7 @@ namespace cage_display_router {
   static std::atomic_bool headless_ram_capture_warning_logged {false};
   static std::atomic_bool windowed_ram_capture_warning_logged {false};
   static std::atomic<int> windowed_gpu_native_probe_result {0};
+  static std::atomic<int> headless_extcopy_dmabuf_probe_result {0};
   static platf::runtime_state_t cage_runtime_state {
     .requested_headless = false,
     .effective_headless = false,
@@ -399,6 +400,10 @@ namespace cage_display_router {
     return runtime_state.gpu_native_override_active;
   }
 
+  bool should_attempt_headless_extcopy_dmabuf(const platf::runtime_state_t &runtime_state) {
+    return runtime_state.effective_headless && !runtime_state.gpu_native_override_active;
+  }
+
   std::optional<bool> cached_windowed_gpu_native_probe_result() {
     switch (windowed_gpu_native_probe_result.load()) {
       case 1:
@@ -410,8 +415,23 @@ namespace cage_display_router {
     }
   }
 
+  std::optional<bool> cached_headless_extcopy_dmabuf_probe_result() {
+    switch (headless_extcopy_dmabuf_probe_result.load()) {
+      case 1:
+        return false;
+      case 2:
+        return true;
+      default:
+        return std::nullopt;
+    }
+  }
+
   void update_windowed_gpu_native_probe_result(bool supported) {
     windowed_gpu_native_probe_result.store(supported ? 2 : 1);
+  }
+
+  void update_headless_extcopy_dmabuf_probe_result(bool supported) {
+    headless_extcopy_dmabuf_probe_result.store(supported ? 2 : 1);
   }
 
   bool should_report_headless_ram_capture_fallback(const platf::runtime_state_t &runtime_state) {
@@ -436,6 +456,7 @@ namespace cage_display_router {
     headless_ram_capture_warning_logged.store(false);
     windowed_ram_capture_warning_logged.store(false);
     windowed_gpu_native_probe_result.store(0);
+    headless_extcopy_dmabuf_probe_result.store(0);
   }
 
   bool output_reports_current_mode_for_tests(

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -121,16 +121,34 @@ namespace cage_display_router {
   bool should_attempt_gpu_native_cage_capture(const platf::runtime_state_t &runtime_state);
 
   /**
+   * @brief Returns whether a headless labwc runtime should try the
+   *        ext-image-copy-capture DMA-BUF path before falling back to SHM.
+   */
+  bool should_attempt_headless_extcopy_dmabuf(const platf::runtime_state_t &runtime_state);
+
+  /**
    * @brief Returns the cached result of the windowed GPU-native probe for the
    *        current Polaris process, if one exists.
    */
   std::optional<bool> cached_windowed_gpu_native_probe_result();
 
   /**
+   * @brief Returns the cached result of the headless ext-image-copy-capture
+   *        DMA-BUF probe for the current Polaris process, if one exists.
+   */
+  std::optional<bool> cached_headless_extcopy_dmabuf_probe_result();
+
+  /**
    * @brief Update the cached result of the windowed GPU-native probe for the
    *        current Polaris process.
    */
   void update_windowed_gpu_native_probe_result(bool supported);
+
+  /**
+   * @brief Update the cached result of the headless ext-image-copy-capture
+   *        DMA-BUF probe for the current Polaris process.
+   */
+  void update_headless_extcopy_dmabuf_probe_result(bool supported);
 
   /**
    * @brief Returns whether RAM-capture fallback logging should describe the

--- a/src/platform/linux/input/inputtino_gamepad.cpp
+++ b/src/platform/linux/input/inputtino_gamepad.cpp
@@ -26,12 +26,20 @@ namespace platf::gamepad {
     GAMEPAD_STATUS  ///< Helper to indicate the number of status
   };
 
-  auto create_xbox_one() {
+  auto create_xbox_one(int globalIndex) {
+    std::string device_id = "";
+
+    if (globalIndex >= 0 && globalIndex <= 255) {
+      device_id = std::format("02:00:00:00:10:{:02x}", globalIndex);
+    }
+
     return inputtino::XboxOneJoypad::create({.name = "Sunshine X-Box One (virtual) pad",
                                              // https://github.com/torvalds/linux/blob/master/drivers/input/joystick/xpad.c#L147
                                              .vendor_id = 0x045E,
                                              .product_id = 0x02EA,
-                                             .version = 0x0408});
+                                             .version = 0x0408,
+                                             .device_phys = device_id,
+                                             .device_uniq = device_id});
   }
 
   auto create_switch() {
@@ -119,7 +127,7 @@ namespace platf::gamepad {
     switch (selectedGamepadType) {
       case XboxOneWired:
         {
-          auto xOne = create_xbox_one();
+          auto xOne = create_xbox_one(id.globalIndex);
           if (xOne) {
             (*xOne).set_on_rumble(on_rumble_fn);
             gamepad->joypad = std::make_unique<joypads_t>(std::move(*xOne));
@@ -276,7 +284,7 @@ namespace platf::gamepad {
 
     auto ds5 = create_ds5(-1);  // Index -1 will result in a random MAC virtual device, which is fine for probing
     auto switchPro = create_switch();
-    auto xOne = create_xbox_one();
+    auto xOne = create_xbox_one(0);
 
     static std::vector gps {
       supported_gamepad_t {"auto", true, ""},

--- a/src/platform/linux/input/inputtino_wayland_virtual_input.cpp
+++ b/src/platform/linux/input/inputtino_wayland_virtual_input.cpp
@@ -153,6 +153,7 @@ namespace platf {
     zwp_virtual_keyboard_manager_v1 *keyboard_manager {nullptr};
     zwp_virtual_keyboard_v1 *keyboard {nullptr};
     std::string socket_name;
+    pid_t connected_pid {0};
     bool logged_ready {false};
     bool logged_pointer_unavailable {false};
     bool logged_keyboard_unavailable {false};
@@ -242,6 +243,7 @@ namespace platf {
         display = nullptr;
       }
       socket_name.clear();
+      connected_pid = 0;
       logged_ready = false;
     }
 
@@ -271,7 +273,12 @@ namespace platf {
         return false;
       }
 
-      if (display && socket_name == socket) {
+      const auto current_pid = cage_display_router::get_pid();
+      if (current_pid <= 0) {
+        return false;
+      }
+
+      if (display && socket_name == socket && connected_pid == current_pid) {
         return true;
       }
 
@@ -287,6 +294,7 @@ namespace platf {
       }
 
       socket_name = socket;
+      connected_pid = current_pid;
       registry = wl_display_get_registry(display);
       if (!registry) {
         disconnect();

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -722,6 +722,7 @@ namespace platf {
     const bool gpu_native_capture_supported = wl::supports_gpu_native_capture(hwdevice_type);
     bool prefer_linear_dmabuf = false;
     bool using_headless_ram_capture = false;
+    bool try_headless_extcopy_dmabuf = false;
 #ifdef __linux__
     if (!prefer_ram_capture &&
         config::video.linux_display.use_cage_compositor &&
@@ -738,6 +739,8 @@ namespace platf {
       } else if (cage_display_router::should_report_headless_ram_capture_fallback(runtime_state)) {
         prefer_ram_capture = true;
         using_headless_ram_capture = true;
+        try_headless_extcopy_dmabuf =
+          cage_display_router::should_attempt_headless_extcopy_dmabuf(runtime_state);
       } else {
         prefer_ram_capture = true;
 
@@ -765,6 +768,22 @@ namespace platf {
       }
 
       return wlr;
+    }
+
+    if (try_headless_extcopy_dmabuf && gpu_native_capture_supported) {
+      auto wlr = std::make_shared<wl::wlr_extcopy_vram_t>();
+      if (!wlr->init(hwdevice_type, display_name, config)) {
+#ifdef __linux__
+        cage_display_router::update_headless_extcopy_dmabuf_probe_result(true);
+#endif
+        BOOST_LOG(info) << "wlr: Using ext-image-copy-capture DMA-BUF for headless labwc"sv;
+        return wlr;
+      }
+
+#ifdef __linux__
+      cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+#endif
+      BOOST_LOG(info) << "wlr: Headless ext-image-copy-capture DMA-BUF unavailable; using SHM fallback"sv;
     }
 
     auto wlr = std::make_shared<wl::wlr_ram_t>();

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -46,6 +46,7 @@
 #include "confighttp.h"
 #include "process.h"
 #include "httpcommon.h"
+#include "input.h"
 #include "system_tray.h"
 #include "utility.h"
 #include "video.h"
@@ -218,6 +219,57 @@ namespace proc {
 
     bool is_steam_big_picture_name(const std::string &name) {
       return boost::iequals(boost::trim_copy(name), "Steam Big Picture");
+    }
+
+    bool is_lutris_library_app(const nlohmann::json &app) {
+      const auto app_name = json_string_member_or(app, "name");
+      if (boost::iequals(boost::trim_copy(app_name), "Lutris")) {
+        return true;
+      }
+
+      const auto cmd = boost::trim_copy(json_string_member_or(app, "cmd"));
+      if (boost::iequals(cmd, "setsid lutris") || boost::iequals(cmd, "lutris")) {
+        return true;
+      }
+
+      if (!app.contains("detached") || !app["detached"].is_array()) {
+        return false;
+      }
+
+      for (const auto &detached : app["detached"]) {
+        if (!detached.is_string()) {
+          continue;
+        }
+        const auto value = boost::trim_copy(detached.get<std::string>());
+        if (boost::iequals(value, "setsid lutris") || boost::iequals(value, "lutris")) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    bool has_lutris_game_app(const nlohmann::json &app) {
+      const auto source = json_string_member_or(app, "source");
+      if (!boost::iequals(source, "lutris")) {
+        return false;
+      }
+
+      return !json_string_member_or(app, "lutris-slug").empty();
+    }
+
+    nlohmann::json lutris_library_app() {
+      return {
+        {"name", "Lutris"},
+        {"uuid", ""},
+        {"cmd", ""},
+        {"detached", {"setsid lutris"}},
+        {"image-path", "lutris.png"},
+        {"source", "lutris"},
+        {"auto-detach", true},
+        {"wait-all", true},
+        {"exit-timeout", 5}
+      };
     }
 
     bool command_contains_steam_big_picture_open(const std::string &cmd) {
@@ -1142,6 +1194,17 @@ namespace proc {
 
       return value != "0" && value != "false" && value != "off" && value != "no";
     }
+
+    bool app_gamepad_override_is_supported(const std::string &value) {
+      if (value == "disabled"sv) {
+        return true;
+      }
+
+      const auto supported_gamepads = platf::supported_gamepads(nullptr);
+      return std::any_of(supported_gamepads.begin(), supported_gamepads.end(), [&](const auto &gamepad) {
+        return gamepad.name == value;
+      });
+    }
   }  // namespace
 
 #ifdef _WIN32
@@ -1695,14 +1758,18 @@ namespace proc {
 #endif
     });
 
-    if (!app.gamepad.empty()) {
+    if (!app.gamepad.empty() && app_gamepad_override_is_supported(app.gamepad)) {
       _saved_input_config = std::make_shared<config::input_t>(config::input);
       if (app.gamepad == "disabled") {
         config::input.controller = false;
+        BOOST_LOG(info) << "process: virtual gamepad disabled for app ["sv << app.name << ']';
       } else {
         config::input.controller = true;
         config::input.gamepad = app.gamepad;
+        BOOST_LOG(info) << "process: virtual gamepad override for app ["sv << app.name << "] set to ["sv << app.gamepad << ']';
       }
+    } else if (!app.gamepad.empty()) {
+      BOOST_LOG(warning) << "process: ignoring unsupported virtual gamepad override ["sv << app.gamepad << "] for app ["sv << app.name << ']';
     }
 
 #ifdef _WIN32
@@ -2190,6 +2257,10 @@ namespace proc {
       should_probe_windowed_cage_for_gpu_native ?
         cage_display_router::cached_windowed_gpu_native_probe_result() :
         std::optional<bool> {};
+    const auto cached_headless_extcopy_dmabuf_probe_result =
+      should_probe_windowed_cage_for_gpu_native ?
+        cage_display_router::cached_headless_extcopy_dmabuf_probe_result() :
+        std::optional<bool> {};
     bool force_windowed_cage_for_gpu_native = false;
     const int cage_refresh_hz = std::max(pacing_target_fps, 1);
 
@@ -2242,6 +2313,53 @@ namespace proc {
       return true;
     };
 
+    auto probe_headless_extcopy_dmabuf_cage = [&]() -> bool {
+      if (!should_probe_windowed_cage_for_gpu_native || rtsp_stream::session_count() != 0) {
+        return false;
+      }
+
+      auto encoder_name = video::active_encoder_name();
+      auto encoder_label = encoder_name.empty() ? "unknown" : encoder_name;
+      BOOST_LOG(info) << "session_manager: Probing headless_extcopy_dmabuf with encoder ["
+                      << encoder_label << ']';
+
+      auto stop_probe_cage = util::fail_guard([&]() {
+        if (cage_display_router::is_running()) {
+          cage_display_router::stop();
+        }
+      });
+
+      if (!start_cage_session("", false, true, false)) {
+        cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+        BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe could not initialize the compositor/encoder path"sv;
+        return false;
+      }
+
+      const auto runtime_state = cage_display_router::runtime_state();
+      if (!runtime_state.effective_headless) {
+        cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+        BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not start an effective headless runtime"sv;
+        return false;
+      }
+
+      if (!video::active_encoder_runtime_supports_config(gpu_native_probe_config)) {
+        cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+        BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not validate the active encoder configuration"sv;
+        return false;
+      }
+
+      if (cage_display_router::cached_headless_extcopy_dmabuf_probe_result() != std::optional<bool> {true}) {
+        cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+        BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not initialize DMA-BUF capture"sv;
+        return false;
+      }
+
+      cage_display_router::update_headless_extcopy_dmabuf_probe_result(true);
+      BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe succeeded with encoder ["
+                      << video::active_encoder_name() << ']';
+      return true;
+    };
+
     auto probe_windowed_gpu_native_cage = [&]() -> bool {
       if (!should_probe_windowed_cage_for_gpu_native || rtsp_stream::session_count() != 0) {
         return false;
@@ -2276,25 +2394,38 @@ namespace proc {
       return true;
     };
 
-    if (cached_windowed_gpu_native_probe_result == std::optional<bool> {true}) {
-      force_windowed_cage_for_gpu_native = true;
-      BOOST_LOG(info) << "session_manager: Reusing cached windowed GPU-native cage probe result; attempting nested DMA-BUF capture"sv;
-    } else if (cached_windowed_gpu_native_probe_result == std::optional<bool> {false}) {
-      BOOST_LOG(info) << "session_manager: Cached windowed GPU-native cage probe result indicates nested DMA-BUF capture is unavailable on this runtime; staying headless"sv;
-    } else {
-      force_windowed_cage_for_gpu_native = probe_windowed_gpu_native_cage();
+    auto resolve_windowed_gpu_native_fallback = [&]() -> bool {
+      if (cached_windowed_gpu_native_probe_result == std::optional<bool> {true}) {
+        BOOST_LOG(info) << "session_manager: Reusing cached windowed_dmabuf_override probe result"sv;
+        return true;
+      }
+
+      if (cached_windowed_gpu_native_probe_result == std::optional<bool> {false}) {
+        BOOST_LOG(info) << "session_manager: Cached windowed_dmabuf_override probe result indicates nested DMA-BUF capture is unavailable on this runtime"sv;
+        return false;
+      }
+
+      return probe_windowed_gpu_native_cage();
+    };
+
+    if (cached_headless_extcopy_dmabuf_probe_result == std::optional<bool> {true}) {
+      BOOST_LOG(info) << "session_manager: Reusing cached headless_extcopy_dmabuf probe result; keeping true headless runtime"sv;
+    } else if (cached_headless_extcopy_dmabuf_probe_result == std::optional<bool> {false}) {
+      BOOST_LOG(info) << "session_manager: Cached headless_extcopy_dmabuf probe result indicates headless DMA-BUF capture is unavailable; evaluating windowed fallback"sv;
+      force_windowed_cage_for_gpu_native = resolve_windowed_gpu_native_fallback();
+    } else if (probe_headless_extcopy_dmabuf_cage()) {
+      BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf selected; keeping true headless runtime"sv;
+    } else if (should_probe_windowed_cage_for_gpu_native) {
+      BOOST_LOG(info) << "session_manager: headless_shm_fallback would be used for true headless; evaluating windowed GPU-native fallback"sv;
+      force_windowed_cage_for_gpu_native = resolve_windowed_gpu_native_fallback();
     }
 
     auto encoder_name = video::active_encoder_name();
     auto encoder_label = encoder_name.empty() ? "unknown" : encoder_name;
     if (force_windowed_cage_for_gpu_native) {
-      BOOST_LOG(warning) << "session_manager: Headless cage requested, and runtime probing confirmed encoder ["
+      BOOST_LOG(warning) << "session_manager: windowed_dmabuf_override selected because headless_extcopy_dmabuf was unavailable and encoder ["
                          << encoder_label
-                         << "] can use a GPU-native capture path; starting labwc windowed instead"sv;
-    } else if (should_probe_windowed_cage_for_gpu_native && !cached_windowed_gpu_native_probe_result.has_value()) {
-      BOOST_LOG(info) << "session_manager: Headless cage requested with encoder ["
-                      << encoder_label
-                      << "], but the runtime probe could not validate nested DMA-BUF capture; staying headless"sv;
+                         << "] can use a GPU-native capture path"sv;
     }
 
     auto start_cage_with_runtime_fallback = [&](const std::string &startup_cmd) -> bool {
@@ -2307,12 +2438,16 @@ namespace proc {
 
       if (force_windowed_cage_for_gpu_native) {
         cage_display_router::update_windowed_gpu_native_probe_result(false);
-        BOOST_LOG(warning) << "session_manager: Windowed GPU-native cage start failed; falling back to headless RAM capture"sv;
+        BOOST_LOG(warning) << "session_manager: windowed_dmabuf_override start failed; falling back to headless_shm_fallback if headless DMA-BUF remains unavailable"sv;
         force_windowed_cage_for_gpu_native = false;
       }
 
       return start_cage_session(startup_cmd, false);
     };
+
+    if (!_app.detached.empty() || !_app.cmd.empty()) {
+      input::preallocate_gamepad();
+    }
 
     // Start cage with the first detached command as its primary client.
     // Cage is a kiosk compositor — it only displays its main process fullscreen.
@@ -3531,8 +3666,41 @@ namespace proc {
     BOOST_LOG(info) << "Migrated Steam library launch handling to v7.";
   }
 
+  void migration_v4(nlohmann::json &fileTree) {
+    static const int this_version = 8;
+    int file_version = json_int_member_or(fileTree, "version", 0);
+    if (fileTree.contains("version") && !coerce_json_int(fileTree["version"]).has_value()) {
+      BOOST_LOG(info) << "Cannot parse apps.json version while checking Lutris library migration, treating as v0.";
+    }
+
+    if (file_version >= this_version) {
+      return;
+    }
+
+    if (!fileTree.contains("apps") || !fileTree["apps"].is_array()) {
+      fileTree["version"] = this_version;
+      return;
+    }
+
+    const auto &apps = fileTree["apps"];
+    const bool has_lutris_games = std::any_of(apps.begin(), apps.end(), [](const auto &app) {
+      return has_lutris_game_app(app);
+    });
+    const bool has_lutris_launcher = std::any_of(apps.begin(), apps.end(), [](const auto &app) {
+      return is_lutris_library_app(app);
+    });
+
+    if (has_lutris_games && !has_lutris_launcher) {
+      auto app = lutris_library_app();
+      migrate_apps(&fileTree, &app);
+      BOOST_LOG(info) << "Migrated app list to add Lutris library launcher.";
+    }
+
+    fileTree["version"] = this_version;
+  }
+
   void migrate(nlohmann::json& fileTree, const std::string& fileName) {
-    int last_version = 7;
+    int last_version = 8;
 
     int file_version = json_int_member_or(fileTree, "version", 0);
     if (fileTree.contains("version") && !coerce_json_int(fileTree["version"]).has_value()) {
@@ -3542,6 +3710,7 @@ namespace proc {
     if (file_version < last_version) {
       migration_v2(fileTree);
       migration_v3(fileTree);
+      migration_v4(fileTree);
       file_handler::write_file(fileName.c_str(), fileTree.dump(4));
     }
   }

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -222,6 +222,15 @@ namespace stream_stats {
     }
 
     if (capture_path_is_gpu_native(stats)) {
+#ifdef __linux__
+      const auto &linux_display = config::video.linux_display;
+      if (stats.runtime_effective_headless && linux_display.use_cage_compositor) {
+        return "headless_extcopy_dmabuf";
+      }
+      if (stats.runtime_gpu_native_override_active) {
+        return "windowed_dmabuf_override";
+      }
+#endif
       return "gpu_native";
     }
 
@@ -231,11 +240,11 @@ namespace stream_stats {
       linux_display.prefer_gpu_native_capture;
 
     if (stats.capture_transport == platf::frame_transport_e::shm) {
+      if (stats.runtime_effective_headless && linux_display.use_cage_compositor) {
+        return "headless_shm_fallback";
+      }
       if (gpu_native_requested) {
         return "gpu_native_requested_shm_fallback";
-      }
-      if (stats.runtime_effective_headless && linux_display.use_cage_compositor) {
-        return "headless_shm_default";
       }
       return "shm_capture";
     }

--- a/src_assets/common/assets/web/composables/useGameScanner.js
+++ b/src_assets/common/assets/web/composables/useGameScanner.js
@@ -59,7 +59,10 @@ export function useGameScanner() {
             name: g.name,
             appid: g.appid || '',
             source: g.source,
+            slug: g.slug || '',
+            runner: g.runner || '',
             cmd: g.cmd || '',
+            image_path: g.image_path || g['image-path'] || g.cover_path || '',
             game_category: g.game_category || '',
             genres: g.genres || []
           }))

--- a/src_assets/common/assets/web/views/AppsView.vue
+++ b/src_assets/common/assets/web/views/AppsView.vue
@@ -351,6 +351,10 @@
               <div class="truncate text-sm font-medium text-silver">{{ game.name }}</div>
               <div v-if="game.already_imported" class="mt-1 text-xs text-storm">Already imported</div>
               <div v-else class="mt-1 text-xs text-storm">Ready to import into Polaris.</div>
+              <div v-if="game.source === 'lutris' && (game.runner || game.slug)" class="mt-2 flex flex-wrap gap-1.5 text-[11px] text-storm">
+                <span v-if="game.runner" class="control-chip">{{ game.runner }}</span>
+                <span v-if="game.slug" class="control-chip">{{ game.slug }}</span>
+              </div>
               <div v-if="game.game_category && game.game_category !== 'unknown'" class="mt-2">
                 <span class="control-chip">{{ formatCategory(game.game_category) }}</span>
               </div>

--- a/src_assets/linux/assets/apps.json
+++ b/src_assets/linux/assets/apps.json
@@ -31,6 +31,17 @@
         "setsid steam -gamepadui"
       ],
       "image-path": "steam.png"
+    },
+    {
+      "name": "Lutris",
+      "detached": [
+        "setsid lutris"
+      ],
+      "image-path": "lutris.png",
+      "source": "lutris",
+      "auto-detach": true,
+      "wait-all": true,
+      "exit-timeout": 5
     }
   ]
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ set(TEST_MAIN_SOURCE
 set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/confighttp_validation.cpp
     ${CMAKE_SOURCE_DIR}/src/file_handler.cpp
+    ${CMAKE_SOURCE_DIR}/src/game_library_scanner.cpp
     ${CMAKE_SOURCE_DIR}/src/globals.cpp
     ${CMAKE_SOURCE_DIR}/src/logging.cpp
     ${CMAKE_SOURCE_DIR}/src/rswrapper.c
@@ -79,6 +80,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_validation.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_cursor_visibility.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_file_handler.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_game_library_scanner.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_rswrapper.cpp
 )

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -55,6 +55,28 @@ TEST(CageDisplayRouterPolicyTests, HeadlessRuntimeDoesNotAttemptGpuNativeCapture
   EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state));
 }
 
+TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessAttemptsExtcopyDmabufBeforeShmFallback) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = true,
+    .gpu_native_override_active = false,
+    .backend_name = "labwc",
+  };
+
+  EXPECT_TRUE(cage_display_router::should_attempt_headless_extcopy_dmabuf(runtime_state));
+}
+
+TEST(CageDisplayRouterPolicyTests, WindowedOverrideDoesNotAttemptHeadlessExtcopyDmabuf) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+
+  EXPECT_FALSE(cage_display_router::should_attempt_headless_extcopy_dmabuf(runtime_state));
+}
+
 TEST(CageDisplayRouterPolicyTests, RequestedHeadlessWithoutOverrideStillReportsHeadlessFallback) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,
@@ -134,6 +156,28 @@ TEST(CageDisplayRouterPolicyTests, WindowedGpuNativeProbeResultCachesSuccess) {
   cage_display_router::update_windowed_gpu_native_probe_result(true);
 
   EXPECT_EQ(cage_display_router::cached_windowed_gpu_native_probe_result(), std::optional<bool> {true});
+}
+
+TEST(CageDisplayRouterPolicyTests, HeadlessExtcopyDmabufProbeResultDefaultsToUnknown) {
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+
+  EXPECT_FALSE(cage_display_router::cached_headless_extcopy_dmabuf_probe_result().has_value());
+}
+
+TEST(CageDisplayRouterPolicyTests, HeadlessExtcopyDmabufProbeResultCachesFailure) {
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+
+  cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+
+  EXPECT_EQ(cage_display_router::cached_headless_extcopy_dmabuf_probe_result(), std::optional<bool> {false});
+}
+
+TEST(CageDisplayRouterPolicyTests, HeadlessExtcopyDmabufProbeResultCachesSuccess) {
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+
+  cage_display_router::update_headless_extcopy_dmabuf_probe_result(true);
+
+  EXPECT_EQ(cage_display_router::cached_headless_extcopy_dmabuf_probe_result(), std::optional<bool> {true});
 }
 
 TEST(CageDisplayRouterPolicyTests, OutputModeParserRecognizesRequestedCurrentMode) {

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -108,7 +108,7 @@ TEST(LutrisLibraryScannerTests, ScansMultipleXdgDirectories) {
 
 TEST(LutrisLibraryScannerTests, ParsesLutrisListGamesJson) {
   const auto games = game_library::parse_lutris_list_games_json(R"json([
-    {"id": 3, "slug": "arc-raiders", "name": "ARC Raiders", "runner": "steam", "coverPath": "/home/papi/.local/share/lutris/coverart/arc-raiders.jpg"},
+    {"id": 3, "slug": "arc-raiders", "name": "ARC Raiders", "runner": "steam", "coverPath": "lutris/coverart/arc-raiders.jpg"},
     {"id": 14, "slug": "vam-vr", "name": "VaM (VR)", "runner": "wine"},
     {"id": 99, "slug": "bad slug", "name": "Unsafe", "runner": "linux"},
     {"id": 100, "slug": "missing-name", "runner": "linux"}
@@ -119,7 +119,7 @@ TEST(LutrisLibraryScannerTests, ParsesLutrisListGamesJson) {
   EXPECT_EQ(games[0].slug, "arc-raiders");
   EXPECT_EQ(games[0].runner, "steam");
   EXPECT_EQ(games[0].command, "setsid lutris lutris:rungame/arc-raiders");
-  EXPECT_EQ(games[0].image_path, "/home/papi/.local/share/lutris/coverart/arc-raiders.jpg");
+  EXPECT_EQ(games[0].image_path, "lutris/coverart/arc-raiders.jpg");
   EXPECT_EQ(games[1].name, "VaM (VR)");
   EXPECT_EQ(games[1].slug, "vam-vr");
   EXPECT_EQ(games[1].runner, "wine");

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -1,0 +1,147 @@
+#include "../tests_common.h"
+#include "../tests_paths.h"
+
+#include <src/game_library_scanner.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace {
+  std::filesystem::path lutris_test_root(const std::string &name) {
+    const auto root = test_paths::root() / "lutris_scanner" / name;
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+    return root;
+  }
+
+  void write_text(const std::filesystem::path &path, const std::string &content) {
+    std::ofstream file(path);
+    ASSERT_TRUE(file.good());
+    file << content;
+  }
+}  // namespace
+
+TEST(LutrisLibraryScannerTests, ParsesTopLevelMetadataAndBuildsCanonicalCommand) {
+  const auto root = lutris_test_root("metadata");
+  const auto config = root / "ignored-filename.yml";
+  write_text(config,
+    "name: \"Slay the Spire\"\n"
+    "slug: slay-the-spire\n"
+    "game_slug: ignored-game-slug\n"
+    "runner: wine\n"
+    "game:\n"
+    "  name: Nested name should not win\n");
+
+  const auto game = game_library::parse_lutris_game_config(config);
+  ASSERT_TRUE(game.has_value());
+  EXPECT_EQ(game->name, "Slay the Spire");
+  EXPECT_EQ(game->slug, "slay-the-spire");
+  EXPECT_EQ(game->runner, "wine");
+  EXPECT_EQ(game->command, "setsid lutris lutris:rungame/slay-the-spire");
+}
+
+TEST(LutrisLibraryScannerTests, FallsBackToGameSlugThenFilenameStem) {
+  const auto root = lutris_test_root("fallbacks");
+  const auto game_slug_config = root / "ignored.yml";
+  const auto filename_config = root / "missing-name-game.yml";
+
+  write_text(game_slug_config,
+    "name: 'Game Slug Title'\n"
+    "game_slug: game-slug-title\n");
+  write_text(filename_config, "runner: native\n");
+
+  const auto game_slug = game_library::parse_lutris_game_config(game_slug_config);
+  ASSERT_TRUE(game_slug.has_value());
+  EXPECT_EQ(game_slug->slug, "game-slug-title");
+  EXPECT_EQ(game_slug->name, "Game Slug Title");
+
+  const auto filename = game_library::parse_lutris_game_config(filename_config);
+  ASSERT_TRUE(filename.has_value());
+  EXPECT_EQ(filename->slug, "missing-name-game");
+  EXPECT_EQ(filename->name, "missing name game");
+}
+
+TEST(LutrisLibraryScannerTests, ScansDeterministicallyAndSkipsDuplicateSlugs) {
+  const auto root = lutris_test_root("scan");
+  write_text(root / "b.yml",
+    "name: Second Copy\n"
+    "slug: duplicate-game\n");
+  write_text(root / "a.yml",
+    "name: First Copy\n"
+    "slug: duplicate-game\n");
+  write_text(root / "c.yaml",
+    "name: Unique Game # inline comment\n"
+    "slug: unique-game\n"
+    "runner: linux\n");
+  write_text(root / "bad slug.yml", "name: Unsafe Slug\n");
+
+  const auto games = game_library::scan_lutris_games(root);
+  ASSERT_EQ(games.size(), 2);
+  EXPECT_EQ(games[0].name, "First Copy");
+  EXPECT_EQ(games[0].slug, "duplicate-game");
+  EXPECT_EQ(games[1].name, "Unique Game");
+  EXPECT_EQ(games[1].slug, "unique-game");
+  EXPECT_EQ(games[1].runner, "linux");
+}
+
+TEST(LutrisLibraryScannerTests, ScansMultipleXdgDirectories) {
+  const auto root = lutris_test_root("xdg_dirs");
+  const auto config_dir = root / "config";
+  const auto data_dir = root / "data";
+  std::filesystem::create_directories(config_dir);
+  std::filesystem::create_directories(data_dir);
+
+  write_text(config_dir / "config-game.yml",
+    "name: Config Game\n"
+    "slug: config-game\n");
+  write_text(data_dir / "data-game.yml",
+    "name: Data Game\n"
+    "slug: data-game\n"
+    "runner: wine\n");
+
+  const auto games = game_library::scan_lutris_games({config_dir, data_dir});
+  ASSERT_EQ(games.size(), 2);
+  EXPECT_EQ(games[0].slug, "config-game");
+  EXPECT_EQ(games[1].slug, "data-game");
+  EXPECT_EQ(games[1].runner, "wine");
+}
+
+TEST(LutrisLibraryScannerTests, ParsesLutrisListGamesJson) {
+  const auto games = game_library::parse_lutris_list_games_json(R"json([
+    {"id": 3, "slug": "arc-raiders", "name": "ARC Raiders", "runner": "steam", "coverPath": "/home/papi/.local/share/lutris/coverart/arc-raiders.jpg"},
+    {"id": 14, "slug": "vam-vr", "name": "VaM (VR)", "runner": "wine"},
+    {"id": 99, "slug": "bad slug", "name": "Unsafe", "runner": "linux"},
+    {"id": 100, "slug": "missing-name", "runner": "linux"}
+  ])json");
+
+  ASSERT_EQ(games.size(), 2);
+  EXPECT_EQ(games[0].name, "ARC Raiders");
+  EXPECT_EQ(games[0].slug, "arc-raiders");
+  EXPECT_EQ(games[0].runner, "steam");
+  EXPECT_EQ(games[0].command, "setsid lutris lutris:rungame/arc-raiders");
+  EXPECT_EQ(games[0].image_path, "/home/papi/.local/share/lutris/coverart/arc-raiders.jpg");
+  EXPECT_EQ(games[1].name, "VaM (VR)");
+  EXPECT_EQ(games[1].slug, "vam-vr");
+  EXPECT_EQ(games[1].runner, "wine");
+  EXPECT_TRUE(games[1].image_path.empty());
+}
+
+TEST(LutrisLibraryScannerTests, ValidatesSlugsBeforeBuildingCommands) {
+  EXPECT_TRUE(game_library::is_lutris_slug_safe("abc-123_game.name"));
+  EXPECT_FALSE(game_library::is_lutris_slug_safe(""));
+  EXPECT_FALSE(game_library::is_lutris_slug_safe("bad slug"));
+  EXPECT_FALSE(game_library::is_lutris_slug_safe("bad;slug"));
+}
+
+TEST(LutrisLibraryScannerTests, FindsLocalLutrisArtworkBySlug) {
+  const auto root = lutris_test_root("artwork");
+  const auto lutris_root = root / "lutris";
+  std::filesystem::create_directories(lutris_root / "coverart");
+  std::filesystem::create_directories(lutris_root / "banners");
+  write_text(lutris_root / "coverart" / "black-myth-wukong.jpg", "cover");
+  write_text(lutris_root / "banners" / "black-myth-wukong.jpg", "banner");
+
+  const auto image_path = game_library::find_lutris_image_path("black-myth-wukong", {lutris_root});
+  EXPECT_EQ(image_path, (lutris_root / "coverart" / "black-myth-wukong.jpg").string());
+  EXPECT_TRUE(game_library::find_lutris_image_path("bad slug", {lutris_root}).empty());
+}

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -56,7 +56,7 @@ TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
   ASSERT_TRUE(migrated_tree.contains("version"));
-  EXPECT_EQ(migrated_tree["version"], 7);
+  EXPECT_EQ(migrated_tree["version"], 8);
   ASSERT_TRUE(migrated_tree.contains("apps"));
   ASSERT_TRUE(migrated_tree["apps"].is_array());
   ASSERT_EQ(migrated_tree["apps"].size(), 1);
@@ -278,7 +278,7 @@ TEST(ProcessMigrationTests, ParseNormalizesSteamLibraryLaunchAndAddsShutdownUndo
   EXPECT_EQ(steam_ctx->source, "steam");
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(migrated_tree["version"], 7);
+  EXPECT_EQ(migrated_tree["version"], 8);
 
   std::filesystem::remove(file_path);
 }
@@ -320,6 +320,102 @@ TEST(ProcessMigrationTests, ParseDoesNotAddSteamLibraryPrelaunchShutdownForLinux
   ASSERT_EQ(steam_ctx->prep_cmds.size(), 1);
   EXPECT_TRUE(steam_ctx->prep_cmds.front().do_cmd.empty());
   EXPECT_EQ(steam_ctx->prep_cmds.front().undo_cmd, "setsid steam -shutdown");
+
+  std::filesystem::remove(file_path);
+}
+
+TEST(ProcessMigrationTests, ParsePreservesLutrisImportMetadataAndSource) {
+  const auto file_path = test_paths::root() / "lutris_import_metadata.json";
+
+  const nlohmann::json apps = {
+    {"version", 8},
+    {"apps", {{
+      {"name", "Lutris Game"},
+      {"uuid", "a4a9a18a-3898-4b34-9e3d-21a7a9647712"},
+      {"source", "lutris"},
+      {"lutris-slug", "lutris-game"},
+      {"lutris-runner", "wine"},
+      {"detached", {"setsid lutris lutris:rungame/lutris-game"}},
+      {"gamepad", "ds5"},
+      {"game-category", "cinematic"},
+      {"auto-detach", true},
+      {"wait-all", true},
+      {"exit-timeout", 5}
+    }}}
+  };
+
+  ASSERT_EQ(file_handler::write_file(file_path.string().c_str(), apps.dump(2)), 0);
+
+  auto parsed_proc = proc::parse(file_path.string());
+  ASSERT_TRUE(parsed_proc.has_value());
+
+  const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
+  ASSERT_TRUE(migrated_tree.contains("apps"));
+  ASSERT_EQ(migrated_tree["apps"].size(), 1);
+  const auto &migrated_app = migrated_tree["apps"][0];
+  EXPECT_EQ(migrated_app["source"], "lutris");
+  EXPECT_EQ(migrated_app["lutris-slug"], "lutris-game");
+  EXPECT_EQ(migrated_app["lutris-runner"], "wine");
+
+  const auto &parsed_apps = parsed_proc->get_apps();
+  const auto lutris_ctx = std::find_if(parsed_apps.begin(), parsed_apps.end(), [](const auto &app) {
+    return app.name == "Lutris Game";
+  });
+
+  ASSERT_NE(lutris_ctx, parsed_apps.end());
+  EXPECT_EQ(lutris_ctx->source, "lutris");
+  EXPECT_EQ(lutris_ctx->gamepad, "ds5");
+  EXPECT_EQ(lutris_ctx->game_category, "cinematic");
+  ASSERT_EQ(lutris_ctx->detached.size(), 1);
+  EXPECT_EQ(lutris_ctx->detached[0], "setsid lutris lutris:rungame/lutris-game");
+}
+
+TEST(ProcessMigrationTests, ParseAddsLutrisLauncherWhenLutrisGamesExist) {
+  const auto file_path = test_paths::root() / "lutris_launcher_migration.json";
+
+  const nlohmann::json apps = {
+    {"version", 7},
+    {"apps", {{
+      {"name", "Black Myth: Wukong"},
+      {"uuid", "45cb1d9d-90d3-6023-0800-457901181759"},
+      {"source", "lutris"},
+      {"lutris-slug", "black-myth-wukong"},
+      {"detached", {"setsid lutris lutris:rungame/black-myth-wukong"}},
+      {"auto-detach", true},
+      {"wait-all", true},
+      {"exit-timeout", 5}
+    }}}
+  };
+
+  ASSERT_EQ(file_handler::write_file(file_path.string().c_str(), apps.dump(2)), 0);
+
+  auto parsed_proc = proc::parse(file_path.string());
+  ASSERT_TRUE(parsed_proc.has_value());
+
+  const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
+  EXPECT_EQ(migrated_tree["version"], 8);
+  ASSERT_TRUE(migrated_tree.contains("apps"));
+
+  const auto &migrated_apps = migrated_tree["apps"];
+  const auto lutris_app = std::find_if(migrated_apps.begin(), migrated_apps.end(), [](const auto &app) {
+    return app.value("name", "") == "Lutris";
+  });
+
+  ASSERT_NE(lutris_app, migrated_apps.end());
+  EXPECT_EQ((*lutris_app)["source"], "lutris");
+  EXPECT_EQ((*lutris_app)["image-path"], "lutris.png");
+  ASSERT_TRUE((*lutris_app).contains("detached"));
+  ASSERT_EQ((*lutris_app)["detached"].size(), 1);
+  EXPECT_EQ((*lutris_app)["detached"][0], "setsid lutris");
+
+  const auto &parsed_apps = parsed_proc->get_apps();
+  const auto parsed_lutris = std::find_if(parsed_apps.begin(), parsed_apps.end(), [](const auto &app) {
+    return app.name == "Lutris";
+  });
+
+  ASSERT_NE(parsed_lutris, parsed_apps.end());
+  ASSERT_EQ(parsed_lutris->detached.size(), 1);
+  EXPECT_EQ(parsed_lutris->detached[0], "setsid lutris");
 
   std::filesystem::remove(file_path);
 }

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -46,7 +46,7 @@ TEST(StreamStatsCapturePathTests, DetectsShmCpuCapture) {
   stats.encode_target_residency = platf::frame_residency_e::cpu;
 
   EXPECT_EQ(stream_stats::capture_path_summary(stats), "shm_cpu_capture");
-  EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_shm_default");
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_shm_fallback");
   EXPECT_TRUE(stream_stats::capture_path_uses_cpu_copy(stats));
   EXPECT_FALSE(stream_stats::capture_path_is_gpu_native(stats));
 }
@@ -63,7 +63,7 @@ TEST(StreamStatsCapturePathTests, ExplainsGpuNativeShmFallback) {
   stats.encode_target_residency = platf::frame_residency_e::cpu;
 
   EXPECT_EQ(stream_stats::capture_path_summary(stats), "shm_cpu_capture");
-  EXPECT_EQ(stream_stats::capture_path_reason(stats), "gpu_native_requested_shm_fallback");
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_shm_fallback");
   EXPECT_TRUE(stream_stats::capture_path_uses_cpu_copy(stats));
   EXPECT_FALSE(stream_stats::capture_path_is_gpu_native(stats));
 }
@@ -88,6 +88,38 @@ TEST(StreamStatsCapturePathTests, DetectsFullyGpuNativePath) {
 
   EXPECT_EQ(stream_stats::capture_path_summary(stats), "gpu_native");
   EXPECT_EQ(stream_stats::capture_path_reason(stats), "gpu_native");
+  EXPECT_FALSE(stream_stats::capture_path_uses_cpu_copy(stats));
+  EXPECT_TRUE(stream_stats::capture_path_is_gpu_native(stats));
+}
+
+TEST(StreamStatsCapturePathTests, LabelsHeadlessExtcopyDmabufPath) {
+  LinuxDisplayConfigGuard guard;
+  config::video.linux_display.use_cage_compositor = true;
+
+  stream_stats::stats_t stats {};
+  stats.runtime_effective_headless = true;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+
+  EXPECT_EQ(stream_stats::capture_path_summary(stats), "gpu_native");
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_extcopy_dmabuf");
+  EXPECT_FALSE(stream_stats::capture_path_uses_cpu_copy(stats));
+  EXPECT_TRUE(stream_stats::capture_path_is_gpu_native(stats));
+}
+
+TEST(StreamStatsCapturePathTests, LabelsWindowedDmabufOverridePath) {
+  LinuxDisplayConfigGuard guard;
+  config::video.linux_display.use_cage_compositor = true;
+
+  stream_stats::stats_t stats {};
+  stats.runtime_gpu_native_override_active = true;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+
+  EXPECT_EQ(stream_stats::capture_path_summary(stats), "gpu_native");
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "windowed_dmabuf_override");
   EXPECT_FALSE(stream_stats::capture_path_uses_cpu_copy(stats));
   EXPECT_TRUE(stream_stats::capture_path_is_gpu_native(stats));
 }


### PR DESCRIPTION
## Summary
- add a Lutris library scanner with artwork hydration and a default Lutris launcher entry
- improve Linux headless capture path selection and diagnostics for headless ext-copy DMA-BUF vs SHM fallback
- preallocate/adopt virtual gamepads earlier and preserve per-app gamepad overrides through app migration

## Validation
- `git diff --check`
- Fedora CUDA build: `cmake --build /home/papi/Documents/github/polaris/build-cuda -j"$(nproc)"`
- Retroid smoke testing with Steam and Lutris/Wukong launch paths
- Fedora NVIDIA true-headless smoke: CUDA-enabled binary, `HEADLESS-1` at `1920x1080@120Hz`, ext-image-copy DMA-BUF capture, CUDA frame conversion, and NVENC encode confirmed in logs

## Smoke Markers
- `Build features: cuda=enabled`
- `labwc: Starting in headless mode — resolution=1920x1080@120Hz`
- `wlr: Using ext-image-copy-capture DMA-BUF for headless labwc`
- `Using frame converter [avcodec_encode_device] target_device=cuda target_residency=gpu`
- `wlr: capture_transport=dmabuf frame_residency=gpu frame_format=bgra8`

## Notes
- `ctest --test-dir /home/papi/Documents/github/polaris/build-cuda -N` reported zero registered tests in the CUDA build directory, so unit tests were not runnable from that build tree.