### PR TITLE
Improve Linux runtime diagnostics

### DIFF
--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -278,9 +278,10 @@ matching Fedora RPM was installed, rebooted into the new deployment, and retry
 from Desktop Mode first.
 
 `Environment variable WAYLAND_DISPLAY has not been defined` usually points to a
-windowed Wayland runtime being launched without a parent Wayland session. It is
-expected after a failed manual environment experiment, but it is not the intended
-headless flow.
+windowed Wayland runtime being launched without a parent Wayland session. In
+private Headless Stream mode, Polaris can still start its own `labwc` socket for
+the client; treat the message as a desktop-preview or portal-capture clue unless
+the client stream itself fails to connect.
 
 `Couldn't scale frame ... src_fmt=bgr0 ... src_stride=0` means Polaris received a
 CPU BGR0 frame without a valid row pitch. Use a release newer than `v1.0.4`, where
@@ -312,6 +313,13 @@ For performance reports, though, treat `capture_transport=shm
 frame_residency=cpu frame_format=bgra8`, `target_residency=cpu`, or `Build
 features: cuda=disabled` with NVENC as important clues because they mean Polaris
 is taking a CPU copy/upload path.
+
+For NVIDIA true-headless performance testing, the fast path should report
+`Build features: cuda=enabled`, `capture_transport=dmabuf frame_residency=gpu`,
+and `target_device=cuda target_residency=gpu`. In the web UI or
+`/polaris/v1/session/status`, `capture.reason=headless_extcopy_dmabuf` is the
+desired true-headless marker; `headless_shm_fallback` means the stream can still
+be healthy, but it is using the conservative CPU-side capture path.
 
 `display_preview: Failed to capture cage screenshot` affects the web dashboard
 preview path. It does not mean the Moonlight/Nova stream failed if the client is

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -136,6 +136,12 @@ journalctl --user -u polaris -b --no-pager | grep -E 'Thread priority|RealtimeKi
 Installing and running RealtimeKit can also allow priority elevation without granting broad
 capabilities to the Polaris binary.
 
+Packaged Linux user units are ordered with `graphical-session.target` and pass through common
+desktop environment variables such as `WAYLAND_DISPLAY`, `XDG_RUNTIME_DIR`, and
+`DBUS_SESSION_BUS_ADDRESS`. In private Headless Stream mode, a missing parent `WAYLAND_DISPLAY`
+is logged as a limited desktop-preview/portal warning instead of a stream startup failure because
+Polaris starts its own `labwc` Wayland socket for the client session.
+
 ## NVIDIA KMS capture issues
 
 If KMS capture gives a black screen on NVIDIA, confirm the kernel is using:
@@ -156,15 +162,27 @@ For low-FPS NVIDIA headless reports, check `Build features: cuda=...` first. If 
 GPU -> RAM -> GPU`, the stream is taking an extra CPU copy/upload path. Use a CUDA-enabled package
 or rebuild with `-DPOLARIS_ENABLE_CUDA=ON` before comparing headless performance against Sunshine.
 
+The expected fast-path markers for NVIDIA true-headless testing look like this:
+
+```text
+Build features: cuda=enabled
+labwc: Starting in headless mode
+wlr: Using ext-image-copy-capture DMA-BUF for headless labwc
+capture_transport=dmabuf frame_residency=gpu
+target_device=cuda target_residency=gpu
+```
+
 `display_preview: Failed to capture cage screenshot` is the web dashboard preview path, not the
 stream capture path. Repeated failures are rate-limited in the log, and the dashboard backs off
 preview refreshes after failed captures. If the preview is missing, confirm `grim` is installed with
 `command -v grim`.
 
 For capture performance, check `/polaris/v1/session/status` or `/polaris/v1/stream-policy` and look
-at `capture.path`, `capture.reason`, `capture.cpu_copy`, and `capture.gpu_native`. A reason such as
-`headless_shm_default` means the conservative SHM path is active; `gpu_native_requested_shm_fallback`
-means GPU-native capture was requested but the Wayland capture path still fell back to SHM.
+at `capture.path`, `capture.reason`, `capture.reason_message`, `capture.cpu_copy`, and
+`capture.gpu_native`. A reason such as `headless_shm_fallback` means Headless Stream is healthy
+enough to run but still using the conservative SHM/system-memory path. `headless_extcopy_dmabuf`
+is the true-headless DMA-BUF path, and `gpu_native_requested_shm_fallback` means GPU-native capture
+was requested but the Wayland capture path still fell back to SHM.
 
 ## VAAPI or software encode fallback
 

--- a/packaging/linux/polaris.service.in
+++ b/packaging/linux/polaris.service.in
@@ -1,11 +1,14 @@
 [Unit]
 Description=@PROJECT_DESCRIPTION@
+After=graphical-session.target
+PartOf=graphical-session.target
 StartLimitIntervalSec=500
 StartLimitBurst=5
 
 [Service]
 # Avoid starting Polaris before the desktop is fully initialized.
 ExecStartPre=/bin/sleep 5
+PassEnvironment=WAYLAND_DISPLAY DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE XAUTHORITY XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS
 @POLARIS_SERVICE_START_COMMAND@
 @POLARIS_SERVICE_STOP_COMMAND@
 Restart=on-failure

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -334,6 +334,12 @@ namespace nvhttp {
       if (reason == "gpu_native") {
         return "Capture and encoder conversion are GPU-resident.";
       }
+      if (reason == "headless_extcopy_dmabuf") {
+        return "True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.";
+      }
+      if (reason == "windowed_dmabuf_override") {
+        return "Polaris is using a windowed private compositor so DMA-BUF/CUDA capture can stay GPU-resident.";
+      }
       if (reason == "gpu_native_requested_shm_fallback") {
         return "GPU-native capture was requested, but the active Wayland capture fell back to SHM/system-memory frames.";
       }
@@ -343,8 +349,8 @@ namespace nvhttp {
       if (reason == "gpu_native_requested_cpu_encode_upload") {
         return "GPU-native capture was requested, but encoder upload/conversion is still CPU-resident.";
       }
-      if (reason == "headless_shm_default") {
-        return "Headless cage capture is using the conservative SHM/system-memory path.";
+      if (reason == "headless_shm_fallback" || reason == "headless_shm_default") {
+        return "Headless Stream is using the conservative SHM/system-memory path; the stream can be healthy, but high-FPS NVIDIA testing should use a CUDA-enabled GPU-native path.";
       }
       if (reason == "encoder_upload_cpu") {
         return "Capture is GPU-resident, but encoder upload/conversion crosses system memory.";
@@ -461,6 +467,7 @@ namespace nvhttp {
       policy["hdr_metadata_available"] = stats.hdr_metadata_available;
       policy["capture_path"] = capture_path;
       policy["capture_path_reason"] = capture_reason;
+      policy["capture_path_reason_message"] = capture_path_reason_message(capture_reason);
       policy["capture_cpu_copy"] = capture_cpu_copy;
       policy["capture_gpu_native"] = capture_gpu_native;
       policy["capture_transport"] = platf::from_frame_transport(stats.capture_transport);
@@ -793,6 +800,7 @@ namespace nvhttp {
       health["network_risk"] = network_risk ? "elevated" : "normal";
       health["capture_path"] = capture_path;
       health["capture_path_reason"] = capture_reason;
+      health["capture_path_reason_message"] = capture_path_reason_message(capture_reason);
       health["capture_cpu_copy"] = capture_fallback;
       health["capture_gpu_native"] = stream_stats::capture_path_is_gpu_native(stats);
       health["active_encoder"] = active_encoder_name.empty() ? "unknown" : active_encoder_name;
@@ -3349,7 +3357,9 @@ namespace nvhttp {
       capture_info["residency"] = platf::from_frame_residency(stats.capture_residency);
       capture_info["format"] = platf::from_frame_format(stats.capture_format);
       capture_info["path"] = stream_stats::capture_path_summary(stats);
-      capture_info["reason"] = stream_stats::capture_path_reason(stats);
+      const auto capture_reason = stream_stats::capture_path_reason(stats);
+      capture_info["reason"] = capture_reason;
+      capture_info["reason_message"] = capture_path_reason_message(capture_reason);
       capture_info["cpu_copy"] = stream_stats::capture_path_uses_cpu_copy(stats);
       capture_info["gpu_native"] = stream_stats::capture_path_is_gpu_native(stats);
 

--- a/src/platform/linux/session_manager.cpp
+++ b/src/platform/linux/session_manager.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "session_manager.h"
+#include "../../config.h"
 #include "../../logging.h"
 
 #include <atomic>
@@ -23,6 +24,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <string_view>
 #include <thread>
 
 using namespace std::literals;
@@ -63,11 +65,21 @@ namespace session_manager {
 
   bool validate_environment() {
     bool ok = true;
+    const bool private_headless_runtime =
+      config::video.linux_display.headless_mode &&
+      config::video.linux_display.use_cage_compositor;
 
     const char *vars[] = {"WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "XDG_RUNTIME_DIR"};
     for (auto var : vars) {
       const char *val = getenv(var);
       if (!val || val[0] == '\0') {
+        if (std::string_view {var} == "WAYLAND_DISPLAY"sv && private_headless_runtime) {
+          BOOST_LOG(info) << "session_manager: WAYLAND_DISPLAY is not set; continuing because Headless Stream "
+                          << "will start a private labwc socket. Desktop preview and portal capture may be "
+                          << "unavailable until Polaris is launched from a desktop session."sv;
+          continue;
+        }
+
         BOOST_LOG(error) << "session_manager: Required environment variable "sv
                          << var << " is not set. "
                          << "Polaris requires a graphical session. "

--- a/src/platform/linux/session_manager.h
+++ b/src/platform/linux/session_manager.h
@@ -3,7 +3,7 @@
  * @brief Session lifecycle management for Polaris streaming on Linux.
  *
  * Manages the streaming session lifecycle using the cage-as-window architecture:
- * - Environment validation (WAYLAND_DISPLAY, DBUS, XDG_RUNTIME_DIR)
+ * - Environment validation (Wayland, DBUS, XDG_RUNTIME_DIR)
  * - Lock screen inhibition via D-Bus during active sessions
  * - Minimal desktop state save/restore (no display switching)
  *
@@ -34,11 +34,11 @@ namespace session_manager {
    * @brief Validate that the session environment supports streaming.
    *
    * Checks for required environment variables:
-   * - WAYLAND_DISPLAY (Wayland compositor access)
+   * - WAYLAND_DISPLAY (Wayland compositor access; optional for private Headless Stream)
    * - DBUS_SESSION_BUS_ADDRESS (D-Bus for lock screen, KWin)
    * - XDG_RUNTIME_DIR (Wayland sockets, PipeWire)
    *
-   * @return true if all required variables are present
+   * @return true if the required variables for the selected runtime are present
    */
   bool validate_environment();
 

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -796,6 +796,26 @@ function titleizeToken(value) {
     .join(' ')
 }
 
+function captureReasonMessage(reason) {
+  const key = String(reason || '').toLowerCase()
+  const messages = {
+    gpu_native: 'Capture and encoder conversion are GPU-resident.',
+    headless_extcopy_dmabuf: 'True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.',
+    windowed_dmabuf_override: 'Windowed private compositor is preserving the DMA-BUF/CUDA capture path.',
+    headless_shm_fallback: 'Headless Stream is using SHM/system-memory capture. The stream can be healthy, but high-FPS NVIDIA testing needs the GPU-native path.',
+    headless_shm_default: 'Headless Stream is using SHM/system-memory capture. The stream can be healthy, but high-FPS NVIDIA testing needs the GPU-native path.',
+    gpu_native_requested_shm_fallback: 'GPU-native capture was requested, but Wayland capture fell back to SHM/system-memory frames.',
+    gpu_native_requested_cpu_capture: 'GPU-native capture was requested, but capture frames are CPU-resident.',
+    gpu_native_requested_cpu_encode_upload: 'GPU-native capture was requested, but encoder upload/conversion is CPU-resident.',
+    encoder_upload_cpu: 'Capture is GPU-resident, but encoder upload/conversion crosses system memory.',
+    cpu_capture: 'The active capture path is CPU-resident.',
+    shm_capture: 'The active capture path is CPU-resident.',
+    dmabuf_gpu_capture: 'Capture is using DMA-BUF/GPU frames, but the encoder path is not fully GPU-native.',
+    no_capture_metadata: 'No capture metadata has been reported yet.',
+  }
+  return messages[key] || 'The active capture and encoder path is mixed or not fully classified.'
+}
+
 function metricNumber(value) {
   const parsed = Number(value)
   return Number.isFinite(parsed) ? parsed : 0
@@ -893,6 +913,11 @@ const capturePathLabel = computed(() => {
   return titleizeToken(stats.value?.capture_path || 'unknown')
 })
 
+const captureReasonLabel = computed(() => {
+  if (!stats.value?.streaming) return '--'
+  return captureReasonMessage(stats.value?.capture_path_reason)
+})
+
 const captureCpuCopyLabel = computed(() => {
   if (!stats.value?.streaming) return '--'
   return stats.value?.capture_cpu_copy ? 'CPU copy' : 'No CPU copy'
@@ -930,17 +955,26 @@ const encodeTargetTone = computed(() => {
 
 const runtimePathNote = computed(() => {
   if (!stats.value?.streaming) return ''
+  const reason = String(stats.value?.capture_path_reason || '').toLowerCase()
 
   if (nestedLabwcShmFallbackActive.value) {
     return 'Nested labwc fallback is active: Polaris is capturing the windowed compositor through SHM instead of the GPU-native fast path.'
   }
 
+  if (reason === 'headless_shm_fallback' || reason === 'headless_shm_default') {
+    return captureReasonMessage(reason)
+  }
+
+  if (reason === 'headless_extcopy_dmabuf') {
+    return captureReasonMessage(reason)
+  }
+
   if (stats.value?.capture_cpu_copy) {
-    return 'Capture or encode is still crossing the CPU; check capture transport, capture residency, and encode target.'
+    return captureReasonMessage(reason)
   }
 
   if (stats.value?.capture_gpu_native) {
-    return 'GPU-native path is active: capture stays DMA-BUF/GPU-resident into the encoder path.'
+    return captureReasonMessage(reason)
   }
 
   if (stats.value?.runtime_gpu_native_override_active) {
@@ -989,7 +1023,7 @@ const streamPathNotices = computed(() => {
     notices.push({
       key: 'gpu-native-active',
       title: 'GPU-native path active',
-      message: `Capture is ${transport}/${residency} and encode target is ${encodeTarget}. This is the fast path.`,
+      message: `${captureReasonLabel.value} Capture is ${transport}/${residency} and encode target is ${encodeTarget}.`,
       surfaceClass: 'border-green-400/25 bg-green-400/10',
       titleClass: 'text-green-300',
     })
@@ -997,7 +1031,7 @@ const streamPathNotices = computed(() => {
     notices.push({
       key: 'cpu-copy-active',
       title: 'CPU copy path active',
-      message: `Capture is ${transport}/${residency}. Expect lower headroom than the DMA-BUF/CUDA path.`,
+      message: `${captureReasonLabel.value} Capture is ${transport}/${residency}.`,
       surfaceClass: 'border-orange-300/25 bg-orange-300/10',
       titleClass: 'text-orange-200',
     })
@@ -1285,7 +1319,7 @@ const recommendations = computed(() => {
     recs.push({ color: 'text-amber-300', message: `GPU-native override is active: Polaris requested headless but is using windowed labwc to preserve the GPU-resident capture path.` })
 
   if (s.capture_cpu_copy)
-    recs.push({ color: 'text-orange-300', message: `Capture is crossing system memory. Use GPU-Native Test with CUDA/NVENC when validating high-FPS headroom.` })
+    recs.push({ color: 'text-orange-300', message: captureReasonLabel.value })
 
   // AI optimizer recommendations
   if (!s.ai_enabled && s.streaming)

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -323,6 +323,26 @@ function runtimeOverrideDescription(s) {
   return s.runtime_gpu_native_override_active ? 'GPU-native override active' : 'None'
 }
 
+function captureReasonDescription(reason) {
+  const key = String(reason || '').toLowerCase()
+  const messages = {
+    gpu_native: 'Capture and encoder conversion are GPU-resident.',
+    headless_extcopy_dmabuf: 'True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.',
+    windowed_dmabuf_override: 'Windowed private compositor is preserving the DMA-BUF/CUDA capture path.',
+    headless_shm_fallback: 'Headless Stream is using SHM/system-memory capture; healthy streams can still show this, but high-FPS NVIDIA testing needs the GPU-native path.',
+    headless_shm_default: 'Headless Stream is using SHM/system-memory capture; healthy streams can still show this, but high-FPS NVIDIA testing needs the GPU-native path.',
+    gpu_native_requested_shm_fallback: 'GPU-native capture was requested, but Wayland capture fell back to SHM/system-memory frames.',
+    gpu_native_requested_cpu_capture: 'GPU-native capture was requested, but capture frames are CPU-resident.',
+    gpu_native_requested_cpu_encode_upload: 'GPU-native capture was requested, but encoder upload/conversion is CPU-resident.',
+    encoder_upload_cpu: 'Capture is GPU-resident, but encoder upload/conversion crosses system memory.',
+    cpu_capture: 'The active capture path is CPU-resident.',
+    shm_capture: 'The active capture path is CPU-resident.',
+    dmabuf_gpu_capture: 'Capture is using DMA-BUF/GPU frames, but the encoder path is not fully GPU-native.',
+    no_capture_metadata: 'No capture metadata has been reported yet.',
+  }
+  return messages[key] || 'The active capture and encoder path is mixed or not fully classified.'
+}
+
 function fpsTargetGapDescription(s) {
   const encoded = Number(s.fps)
   const target = Number(s.session_target_fps || s.requested_client_fps)
@@ -403,6 +423,7 @@ const sessionSnapshotItems = computed(() => {
     { label: 'Runtime Override', value: runtimeOverrideDescription(s) },
     { label: 'FPS Target Gap', value: fpsTargetGapDescription(s) },
     { label: 'Capture Path', value: s.capture_path || 'unknown' },
+    { label: 'Capture Reason', value: captureReasonDescription(s.capture_path_reason) },
     { label: 'Capture Transport', value: `${s.capture_transport || 'unknown'} / ${s.capture_residency || 'unknown'} / ${s.capture_format || 'unknown'}` },
     { label: 'Encode Target', value: `${s.encode_target_device || 'unknown'} / ${s.encode_target_residency || 'unknown'} / ${s.encode_target_format || 'unknown'}` },
     { label: 'GPU Native', value: yesNo(s.capture_gpu_native) },


### PR DESCRIPTION
## Summary
- clarify Linux user-service ordering/environment handling for desktop sessions
- treat missing parent WAYLAND_DISPLAY as non-fatal for private Headless Stream
- add capture reason messages for true-headless DMA-BUF, windowed GPU-native override, and SHM fallback paths
- surface capture reason text in session status, stream policy, Mission Control, Troubleshooting, and docs

## Validation
- npm run lint
- npm test
- bash scripts/check-public-surface.sh
- Fedora CUDA build: cmake -S . -B build-cuda -G Ninja -DCMAKE_BUILD_TYPE=Release -DPOLARIS_ENABLE_CUDA=ON -DCUDA_FAIL_ON_MISSING=ON && cmake --build build-cuda -j"$(nproc)"
- Fedora ctest: no tests were configured in build-cuda