### PR TITLE
Updated how check boxes look

### DIFF
--- a/src_assets/common/assets/web/Checkbox.vue
+++ b/src_assets/common/assets/web/Checkbox.vue
@@ -105,18 +105,18 @@ const defValue = parsedDefaultPropValue ? "_common.enabled_def_cbox" : "_common.
 
 <template>
   <div :class="[props.class, { 'checkbox-field--compact': props.compact }]" :data-setting-key="props.id" class="checkbox-field">
-    <label :for="props.id" class="checkbox-field-control">
-      <div class="checkbox-field-toggle">
+    <label :for="props.id" class="checkbox-field-control flex items-start gap-2">
+      <span class="checkbox-field-toggle">
         <input type="checkbox"
                class="checkbox-field-input"
                :id="props.id"
                v-model="model"
                :true-value="checkboxValues.truthy"
                :false-value="checkboxValues.falsy" />
-      </div>
-      <span class="checkbox-field-copy">
-        <span class="checkbox-field-title-row">
-          <span class="text-silver cursor-pointer checkbox-field-label">
+      </span>
+      <span class="checkbox-field-copy flex min-w-0 flex-col gap-1">
+        <span class="checkbox-field-title-row flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <span class="text-silver cursor-pointer checkbox-field-label leading-snug">
             {{ $t(labelField) }}
           </span>
           <span class="text-xs text-storm checkbox-field-default" v-if="showDefValue">

--- a/src_assets/common/assets/web/Checkbox.vue
+++ b/src_assets/common/assets/web/Checkbox.vue
@@ -106,12 +106,14 @@ const defValue = parsedDefaultPropValue ? "_common.enabled_def_cbox" : "_common.
 <template>
   <div :class="[props.class, { 'checkbox-field--compact': props.compact }]" :data-setting-key="props.id" class="checkbox-field">
     <label :for="props.id" class="checkbox-field-control">
-      <input type="checkbox"
-             class="checkbox-field-input"
-             :id="props.id"
-             v-model="model"
-             :true-value="checkboxValues.truthy"
-             :false-value="checkboxValues.falsy" />
+      <div class="checkbox-field-toggle">
+        <input type="checkbox"
+               class="checkbox-field-input"
+               :id="props.id"
+               v-model="model"
+               :true-value="checkboxValues.truthy"
+               :false-value="checkboxValues.falsy" />
+      </div>
       <span class="checkbox-field-copy">
         <span class="checkbox-field-title-row">
           <span class="text-silver cursor-pointer checkbox-field-label">

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -132,6 +132,9 @@
 [data-theme="oled"] .checkbox-field-input:checked {
   background: rgb(168, 200, 255);
 }
+[data-theme="oled"] .checkbox-field-input:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.85);
+}
 [data-theme="oled"] aside .border-b,
 [data-theme="oled"] aside .border-t {
   border-color: rgba(255, 255, 255, 0.04) !important;
@@ -271,7 +274,7 @@ textarea {
 }
 
 .checkbox-field-input:focus-visible {
-  outline: 2px solid rgba(59, 130, 246, 0.85);
+  outline: 2px solid rgb(168, 164, 255);
   outline-offset: 2px;
 }
 

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -270,6 +270,11 @@ textarea {
   transition: transform 0.2s ease;
 }
 
+.checkbox-field-input:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.85);
+  outline-offset: 2px;
+}
+
 .checkbox-field-input:checked {
   background: rgb(124, 115, 255);
 }

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -121,6 +121,20 @@
 [data-theme="oled"] aside {
   border-color: transparent !important;
 }
+[data-theme="oled"] .checkbox-field {
+  background: rgba(168, 200, 255, 0.08);
+  border-color: rgba(168, 200, 255, 0.16);
+}
+[data-theme="oled"] .checkbox-field:hover {
+  background: rgba(168, 200, 255, 0.16);
+  border-color: rgba(168, 200, 255, 0.3);
+}
+[data-theme="oled"] .checkbox-field:hover::before {
+  background: transparent;
+}
+[data-theme="oled"] .checkbox-field-input:checked {
+  background: rgb(168, 200, 255);
+}
 [data-theme="oled"] aside .border-b,
 [data-theme="oled"] aside .border-t {
   border-color: rgba(255, 255, 255, 0.04) !important;
@@ -192,6 +206,109 @@ textarea {
 }
 .card-interactive:active {
   transform: translateY(0);
+}
+
+.checkbox-field {
+  position: relative;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: rgba(124, 115, 255, 0.08);
+  border: 1px solid rgba(124, 115, 255, 0.16);
+  transition: all 0.15s ease;
+}
+
+.checkbox-field::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 10%;
+  height: 80%;
+  width: 3px;
+  border-radius: 4px;
+  background: transparent;
+  transition: background 0.2s ease;
+}
+
+.checkbox-field:hover {
+  background: rgba(124, 115, 255, 0.16);
+  border-color: rgba(124, 115, 255, 0.3);
+  transform: translateY(-1px);
+}
+
+/* .checkbox-field:hover::before {
+  background: transparent;
+} */
+
+.checkbox-field-control {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.checkbox-field-toggle {
+  flex-shrink: 0;
+}
+
+.checkbox-field-copy {
+  flex: 1;
+  min-width: 0;
+}
+
+.checkbox-field-input {
+  appearance: none;
+  width: 42px;
+  height: 24px;
+  background: #2a2a2a;
+  border-radius: 999px;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.checkbox-field-input::after {
+  content: "";
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  top: 3px;
+  left: 3px;
+  border-radius: 50%;
+  background: white;
+  transition: transform 0.2s ease;
+}
+
+.checkbox-field-input:checked {
+  background: rgb(124, 115, 255);
+}
+
+.checkbox-field-input:checked::after {
+  transform: translateX(18px);
+}
+
+.checkbox-field-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.checkbox-field-label {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.checkbox-field-desc {
+  margin-top: 4px;
+  opacity: 0.75;
+  line-height: 1.4;
+}
+
+.checkbox-field-default {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
 }
 
 /* ── Gradient Accents ── */

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -129,9 +129,6 @@
   background: rgba(168, 200, 255, 0.16);
   border-color: rgba(168, 200, 255, 0.3);
 }
-[data-theme="oled"] .checkbox-field:hover::before {
-  background: transparent;
-}
 [data-theme="oled"] .checkbox-field-input:checked {
   background: rgb(168, 200, 255);
 }
@@ -234,10 +231,6 @@ textarea {
   border-color: rgba(124, 115, 255, 0.3);
   transform: translateY(-1px);
 }
-
-/* .checkbox-field:hover::before {
-  background: transparent;
-} */
 
 .checkbox-field-control {
   display: flex;

--- a/src_assets/common/assets/web/configs/tabs/Inputs.vue
+++ b/src_assets/common/assets/web/configs/tabs/Inputs.vue
@@ -184,25 +184,14 @@ const config = ref(props.config)
       ></Checkbox>
 
       <div v-if="config.mouse === 'enabled'" class="settings-toggle-row mb-3">
-      <div class="min-w-0">
-        <div>
-          <div class="settings-field-head !mb-0">
-            <div class="text-sm font-medium text-silver">Show host cursor</div>
-            <InfoHint size="sm" label="Show host cursor">
-              Controls whether Polaris draws the host cursor into the video stream. You can still toggle it at runtime with Ctrl+Alt+Shift+N.
-            </InfoHint>
-          </div>
-        </div>
-        <label class="relative inline-flex items-center cursor-pointer shrink-0">
-          <input
-            type="checkbox"
-            class="sr-only peer"
-            :checked="config.mouse_cursor_visible === 'enabled'"
-            @change="config.mouse_cursor_visible = $event.target.checked ? 'enabled' : 'disabled'"
-          />
-          <div class="w-9 h-5 bg-storm/40 peer-focus:outline-none rounded-full peer peer-checked:bg-accent transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full"></div>
-        </label>
-      </div>
+        <Checkbox
+          id="mouse_cursor_visible"
+          locale-prefix="config"
+          v-model="config.mouse_cursor_visible"
+          :true-value="'enabled'"
+          :false-value="'disabled'"
+          default="disabled"
+        />
       </div>
 
       <Checkbox v-if="config.mouse === 'enabled'"


### PR DESCRIPTION
## Summary

I thought check boxes looked a bit off so I improved them to look like what I'd expect them to look like.
This is how I see them on current release:
<img width="1085" height="256" alt="image" src="https://github.com/user-attachments/assets/7e28671f-e1cf-4b5d-b9ab-35e3e5c46392" />

Updated to look like this:
<img width="1028" height="490" alt="image" src="https://github.com/user-attachments/assets/41fcec2c-838e-46f8-86d5-948831c53406" />
<img width="1028" height="490" alt="image" src="https://github.com/user-attachments/assets/6aa8c0b3-b11a-44f1-9dcd-8595edef79ea" />
The value from this change is improved user experience.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [x] I included screenshots or recordings for visible UI changes, when practical.
- [x] I updated docs or release notes when user-facing behavior changed. (unsure if needed)

## Notes
I may have missed something but I couldn't get the e2e tests to pass when I run `npm run test:e2e` maybe I am missing something. As it was expecting a different port, I was unsure how to get a development version running so I built and ran it as per https://github.com/papi-ux/polaris/blob/master/docs/building.md#build-and-install. That way I was able to validate that it all looks good. But happy to further discuss and test as needed.
I am not sure a change like this requires any docs updates.

I believe that would give the user a better experience, it's consistent with the current experience and matches both themes.

## Examples and reasoning
I am by no means a user experience expert, I merely went with what I thought made sense to me and felt functional. Happy to discuss all my changes.

I aimed to match the colour schemes and toggles from the quick controls on the dashboard.

### Space Whale:

<img width="360" height="627" alt="image" src="https://github.com/user-attachments/assets/cd2f77ce-cc81-4229-aedf-06db2c49297f" />

### example:

<img width="1358" height="405" alt="image" src="https://github.com/user-attachments/assets/9b647aa7-ba4b-41ec-b99e-d8ebb34d7417" />

### OLED Galaxy:
<img width="360" height="627" alt="image" src="https://github.com/user-attachments/assets/57bbeee6-65b2-4bd1-b678-a2778145a80a" />

### example:

<img width="1358" height="405" alt="image" src="https://github.com/user-attachments/assets/970dfe89-238e-460d-853b-13d64ab0c8d7" />


### Scales correctly to mobile devices too:
<img width="406" height="517" alt="image" src="https://github.com/user-attachments/assets/5d9bcda9-4d8f-4530-95dc-5e80357e1127" />

### before:
<img width="1062" height="812" alt="image" src="https://github.com/user-attachments/assets/f908511b-a642-4bac-8d71-6b10c588d6ac" />

### after: 
<img width="1062" height="826" alt="image" src="https://github.com/user-attachments/assets/28f35b58-272d-48cb-8ee5-473bf7c0239c" />
It does make pages slightly longer but I think it makes it easier for the user.

Edit: had the wrong screenshots for the themes.