### PR TITLE
Support resumable disconnect sessions and vulnerability cleanup

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -18,7 +18,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
 
     # Enable dead code elimination via linker gc-sections
     list(APPEND POLARIS_COMPILE_OPTIONS -ffunction-sections -fdata-sections)
-    add_link_options(-Wl,--gc-sections)
+    if(APPLE)
+        add_link_options(-Wl,-dead_strip)
+    else()
+        add_link_options(-Wl,--gc-sections)
+    endif()
 
     # Reduce symbol table bloat and enable hidden visibility optimization
     list(APPEND POLARIS_COMPILE_OPTIONS -fvisibility=hidden -fvisibility-inlines-hidden)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3383,9 +3383,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -601,6 +601,7 @@ namespace config {
 
   stream_t stream {
     10s,  // ping_timeout
+    300s,  // disconnect_resume_timeout
 
     APPS_JSON_PATH,
 
@@ -1365,6 +1366,12 @@ namespace config {
     int_between_f(vars, "ping_timeout", to, {-1, std::numeric_limits<int>::max()});
     if (to != -1) {
       stream.ping_timeout = std::chrono::milliseconds(to);
+    }
+
+    int disconnect_resume_timeout_seconds = -1;
+    int_between_f(vars, "disconnect_resume_timeout_seconds", disconnect_resume_timeout_seconds, {-1, 24 * 60 * 60});
+    if (disconnect_resume_timeout_seconds != -1) {
+      stream.disconnect_resume_timeout = std::chrono::seconds(disconnect_resume_timeout_seconds);
     }
 
     int_between_f(vars, "lan_encryption_mode", stream.lan_encryption_mode, {0, 2});

--- a/src/config.h
+++ b/src/config.h
@@ -199,6 +199,7 @@ namespace config {
 
   struct stream_t {
     std::chrono::milliseconds ping_timeout;
+    std::chrono::seconds disconnect_resume_timeout;
 
     std::string file_apps;
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -35,6 +35,7 @@
 
 // local includes
 #include "config.h"
+#include "adaptive_bitrate.h"
 #include "browser_stream.h"
 #include "confighttp.h"
 #include "confighttp_validation.h"
@@ -223,6 +224,24 @@ namespace confighttp {
         } catch (...) {
         }
       }
+    }
+
+    std::string bool_config_value(bool enabled) {
+      return enabled ? "enabled"s : "disabled"s;
+    }
+
+    bool json_config_enabled(const nlohmann::json &value) {
+      if (value.is_boolean()) {
+        return value.get<bool>();
+      }
+      if (value.is_number_integer()) {
+        return value.get<int>() != 0;
+      }
+      if (value.is_string()) {
+        const auto text = boost::algorithm::to_lower_copy(value.get<std::string>());
+        return text == "enabled" || text == "true" || text == "1" || text == "yes";
+      }
+      return false;
     }
 
     std::vector<std::string> steam_library_launch_commands(const std::string &appid) {
@@ -2573,6 +2592,8 @@ namespace confighttp {
     output_tree["has_ai_api_key"] = output_tree.value("has_ai_api_key", false);
     output_tree["has_steamgriddb_api_key"] = output_tree.value("has_steamgriddb_api_key", false);
     output_tree["has_api_key"] = output_tree.value("has_api_key", false);
+    output_tree["adaptive_bitrate_enabled"] = bool_config_value(adaptive_bitrate::is_enabled());
+    output_tree["ai_enabled"] = bool_config_value(ai_optimizer::is_enabled());
     send_response(response, output_tree);
   }
 
@@ -2685,6 +2706,12 @@ namespace confighttp {
         BOOST_LOG(error) << "SaveConfig: "sv << message;
         bad_request(response, request, message);
         return;
+      }
+      if (input_tree.contains("adaptive_bitrate_enabled")) {
+        adaptive_bitrate::set_enabled(json_config_enabled(input_tree["adaptive_bitrate_enabled"]));
+      }
+      if (input_tree.contains("ai_enabled")) {
+        ai_optimizer::set_enabled(json_config_enabled(input_tree["ai_enabled"]));
       }
       output_tree["status"] = true;
       send_response(response, output_tree);

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2089,6 +2089,7 @@ namespace confighttp {
       std::string uuid = input_tree.value("uuid", "");
       std::string name = input_tree.value("name", "");
       std::string display_mode = input_tree.value("display_mode", "");
+      int target_bitrate_kbps = input_tree.value("target_bitrate_kbps", 0);
       bool enable_legacy_ordering = input_tree.value("enable_legacy_ordering", true);
       bool allow_client_commands = input_tree.value("allow_client_commands", true);
       bool always_use_virtual_display = input_tree.value("always_use_virtual_display", false);
@@ -2099,6 +2100,7 @@ namespace confighttp {
         uuid,
         name,
         display_mode,
+        target_bitrate_kbps,
         do_cmds,
         undo_cmds,
         perm,
@@ -2474,6 +2476,67 @@ namespace confighttp {
     output_tree["status"] = true;
     output_tree["platform"] = POLARIS_PLATFORM;
     output_tree["version"] = PROJECT_VERSION;
+
+    const auto stream_display_mode_label = [](const std::string &selection) {
+      if (selection == "headless_stream") {
+        return "Headless Stream"s;
+      }
+      if (selection == "host_virtual_display") {
+        return "Host Virtual Display"s;
+      }
+      if (selection == "windowed_stream") {
+        return "GPU-Native Test"s;
+      }
+      return "Desktop Display"s;
+    };
+    const auto configured_stream_display_mode = []() {
+      const auto &linux_display = config::video.linux_display;
+      if (!linux_display.headless_mode) {
+        return "desktop_display"s;
+      }
+      if (!linux_display.use_cage_compositor) {
+        return "host_virtual_display"s;
+      }
+      if (linux_display.prefer_gpu_native_capture) {
+        return "windowed_stream"s;
+      }
+      return "headless_stream"s;
+    };
+    const auto stats = stream_stats::get_current();
+    const auto configured_mode = configured_stream_display_mode();
+    auto effective_mode = configured_mode;
+    if (stats.streaming) {
+      if (stats.runtime_gpu_native_override_active) {
+        effective_mode = "windowed_stream";
+      } else if (proc::proc.virtual_display) {
+        effective_mode = "host_virtual_display";
+      } else if (stats.runtime_effective_headless) {
+        effective_mode = "headless_stream";
+      } else {
+        effective_mode = "desktop_display";
+      }
+    }
+    const bool client_settings_relaunch_required =
+      stats.streaming && configured_mode != effective_mode;
+    output_tree["client_settings_available"] = true;
+    output_tree["client_settings_v1"] = true;
+    output_tree["client_settings_endpoint"] = "/polaris/v1/client-settings";
+    output_tree["client_settings_sync_mode"] = "bidirectional";
+    output_tree["client_settings_authority"] = "polaris_effective_runtime";
+    output_tree["client_settings_relaunch_required"] = client_settings_relaunch_required;
+    output_tree["client_settings_stream_display_mode"] = configured_mode;
+    output_tree["client_settings_effective_stream_display_mode"] = effective_mode;
+    output_tree["client_settings_stream_display_mode_label"] = stream_display_mode_label(configured_mode);
+    output_tree["client_settings_effective_stream_display_mode_label"] = stream_display_mode_label(effective_mode);
+    output_tree["client_settings_live_fields"] = nlohmann::json::array({
+      "target_bitrate_kbps",
+      "adaptive_bitrate_enabled",
+      "ai_optimizer_enabled"
+    });
+    output_tree["client_settings_restart_fields"] = nlohmann::json::array({
+      "stream_display_mode",
+      "display_mode"
+    });
 #ifdef _WIN32
     output_tree["vdisplayStatus"] = (int)proc::vDisplayDriverStatus;
 #endif
@@ -2571,6 +2634,18 @@ namespace confighttp {
                key == "runtime_requested_headless"sv ||
                key == "runtime_effective_headless"sv ||
                key == "runtime_gpu_native_override_active"sv ||
+               key == "client_settings_available"sv ||
+               key == "client_settings_v1"sv ||
+               key == "client_settings_endpoint"sv ||
+               key == "client_settings_sync_mode"sv ||
+               key == "client_settings_authority"sv ||
+               key == "client_settings_relaunch_required"sv ||
+               key == "client_settings_stream_display_mode"sv ||
+               key == "client_settings_effective_stream_display_mode"sv ||
+               key == "client_settings_stream_display_mode_label"sv ||
+               key == "client_settings_effective_stream_display_mode_label"sv ||
+               key == "client_settings_live_fields"sv ||
+               key == "client_settings_restart_fields"sv ||
                key == "stream_display_mode"sv;
       };
       std::string validation_error;
@@ -4553,11 +4628,11 @@ namespace confighttp {
     server.resource["^/api/recording/stop$"]["POST"] = withCsrf(stopRecording);
     server.resource["^/api/recording/save-replay$"]["POST"] = withCsrf(saveReplay);
     server.resource["^/api/recording/status$"]["GET"] = getRecordingStatus;
+#ifdef __linux__
     server.resource["^/api/browser-stream/status$"]["GET"] = getBrowserStreamStatus;
     server.resource["^/api/browser-stream/session/start$"]["POST"] = withCsrf(postBrowserStreamStart);
     server.resource["^/api/browser-stream/session/stop$"]["POST"] = withCsrf(postBrowserStreamStop);
     server.resource["^/api/webrtc/status$"]["GET"] = getBrowserStreamStatus;
-#ifdef __linux__
     server.resource["^/api/display/screenshot$"]["GET"] = getDisplayScreenshot;
     server.resource["^/api/display/stream$"]["GET"] = getDisplayStream;
     server.resource["^/api/vdisplay/status$"]["GET"] = getVDisplayStatus;

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -4734,6 +4734,7 @@ namespace confighttp {
       case session_state_e::cage_starting: return "cage_starting";
       case session_state_e::game_launching: return "game_launching";
       case session_state_e::streaming: return "streaming";
+      case session_state_e::paused: return "paused";
       case session_state_e::tearing_down: return "tearing_down";
       default: return "unknown";
     }

--- a/src/confighttp.h
+++ b/src/confighttp.h
@@ -30,6 +30,7 @@ namespace confighttp {
     cage_starting,   ///< Cage compositor spawning
     game_launching,  ///< Game process starting inside cage
     streaming,       ///< Stream active, frames flowing
+    paused,          ///< No active clients, app kept alive for resume
     tearing_down,    ///< Cleanup in progress
   };
 

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -112,6 +112,7 @@ namespace confighttp::validation {
       "dd_manual_refresh_rate"sv,
       "dd_manual_resolution"sv,
       "dd_mode_remapping"sv,
+      "disconnect_resume_timeout_seconds"sv,
       "dd_refresh_rate_option"sv,
       "dd_resolution_option"sv,
       "dd_wa_hdr_toggle_delay"sv,

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -104,6 +104,7 @@ namespace crypto {
     std::string cert;
     std::string client_family;
     std::string display_mode;
+    int target_bitrate_kbps = 0;
     std::list<command_entry_t> do_cmds;
     std::list<command_entry_t> undo_cmds;
     PERM perm;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3902,7 +3902,12 @@ namespace nvhttp {
               write_json({{"error", "adaptive_bitrate_enabled must be a boolean"}}, SimpleWeb::StatusCode::client_error_bad_request);
               return;
             }
-            adaptive_bitrate::set_enabled(body["adaptive_bitrate_enabled"].get<bool>());
+            const bool enabled = body["adaptive_bitrate_enabled"].get<bool>();
+            if (!persist_config_values({{"adaptive_bitrate_enabled", bool_config_value(enabled)}})) {
+              write_json({{"error", "failed to persist adaptive bitrate setting"}}, SimpleWeb::StatusCode::server_error_internal_server_error);
+              return;
+            }
+            adaptive_bitrate::set_enabled(enabled);
           }
 
           if (body.contains("ai_optimizer_enabled")) {
@@ -3910,7 +3915,12 @@ namespace nvhttp {
               write_json({{"error", "ai_optimizer_enabled must be a boolean"}}, SimpleWeb::StatusCode::client_error_bad_request);
               return;
             }
-            ai_optimizer::set_enabled(body["ai_optimizer_enabled"].get<bool>());
+            const bool enabled = body["ai_optimizer_enabled"].get<bool>();
+            if (!persist_config_values({{"ai_enabled", bool_config_value(enabled)}})) {
+              write_json({{"error", "failed to persist AI Optimizer setting"}}, SimpleWeb::StatusCode::server_error_internal_server_error);
+              return;
+            }
+            ai_optimizer::set_enabled(enabled);
           }
 
           if (stream_display_mode) {
@@ -4347,6 +4357,14 @@ namespace nvhttp {
         }
 
         const bool enabled = body["enabled"].get<bool>();
+        if (!persist_config_values({{"adaptive_bitrate_enabled", bool_config_value(enabled)}})) {
+          nlohmann::json err;
+          err["error"] = "failed to persist adaptive bitrate setting";
+          SimpleWeb::CaseInsensitiveMultimap headers;
+          headers.emplace("Content-Type", "application/json");
+          response->write(SimpleWeb::StatusCode::server_error_internal_server_error, err.dump(), headers);
+          return;
+        }
         adaptive_bitrate::set_enabled(enabled);
         BOOST_LOG(info) << "Adaptive bitrate toggled via Polaris API: " << (enabled ? "enabled" : "disabled");
 
@@ -4396,6 +4414,14 @@ namespace nvhttp {
         }
 
         const bool enabled = body["enabled"].get<bool>();
+        if (!persist_config_values({{"ai_enabled", bool_config_value(enabled)}})) {
+          nlohmann::json err;
+          err["error"] = "failed to persist AI Optimizer setting";
+          SimpleWeb::CaseInsensitiveMultimap headers;
+          headers.emplace("Content-Type", "application/json");
+          response->write(SimpleWeb::StatusCode::server_error_internal_server_error, err.dump(), headers);
+          return;
+        }
         ai_optimizer::set_enabled(enabled);
 
         nlohmann::json output;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -314,50 +314,6 @@ namespace nvhttp {
       return true;
     }
 
-    std::string stream_display_mode_label() {
-#ifdef __linux__
-      return stream_display_policy::resolve(
-        stream_display_policy::input_t {
-          host_virtual_display_available(),
-          video::active_encoder_requires_gpu_native_capture(),
-          cage_display_router::runtime_state().gpu_native_override_active,
-        }
-      ).label;
-#else
-      return proc::proc.virtual_display ? "Host Virtual Display" : "Desktop Display";
-#endif
-    }
-
-    std::string stream_display_mode_selection() {
-#ifdef __linux__
-      return stream_display_policy::resolve(
-        stream_display_policy::input_t {
-          host_virtual_display_available(),
-          video::active_encoder_requires_gpu_native_capture(),
-          cage_display_router::runtime_state().gpu_native_override_active,
-        }
-      ).selection;
-#else
-      return proc::proc.virtual_display ? "host_virtual_display" : "desktop_display";
-#endif
-    }
-
-    std::string stream_display_mode_reason() {
-#ifdef __linux__
-      return stream_display_policy::resolve(
-        stream_display_policy::input_t {
-          host_virtual_display_available(),
-          video::active_encoder_requires_gpu_native_capture(),
-          cage_display_router::runtime_state().gpu_native_override_active,
-        }
-      ).reason;
-#else
-      return proc::proc.virtual_display ?
-        "Polaris is streaming from a host virtual display." :
-        "Polaris is streaming from the current desktop session.";
-#endif
-    }
-
     nlohmann::json stream_display_mode_options_json() {
       nlohmann::json modes = nlohmann::json::array();
       for (const auto &selection : {
@@ -444,10 +400,16 @@ namespace nvhttp {
       status["direction"] = "bidirectional";
       status["endpoint"] = "/polaris/v1/client-settings";
       status["source_of_truth"] = "polaris_effective_runtime";
-      status["state"] = relaunch_required ? "pending_relaunch" : "synced";
-      status["message"] = relaunch_required ?
-        "Desired settings are saved and will become effective after the active stream relaunches." :
-        "Desired settings match the current Polaris runtime state.";
+      status["state"] =
+        relaunch_required ? "pending_relaunch" :
+        adaptive_active ? "adaptive_active" :
+        "synced";
+      status["message"] =
+        relaunch_required ?
+          "Desired settings are saved and will become effective after the active stream relaunches." :
+        adaptive_active ?
+          "Adaptive bitrate is enabled; Polaris is adjusting the effective bitrate in real time under the saved paired-client limit." :
+          "Desired settings match the current Polaris runtime state.";
       status["fields"] = std::move(fields);
       return status;
     }
@@ -670,9 +632,10 @@ namespace nvhttp {
 
       nlohmann::json policy;
       policy["version"] = 1;
-      policy["mode"] = stream_display_mode_selection();
-      policy["mode_label"] = stream_display_mode_label();
-      policy["mode_reason"] = stream_display_mode_reason();
+      const auto policy_stream_display_mode = effective_stream_display_mode_selection(stats);
+      policy["mode"] = policy_stream_display_mode;
+      policy["mode_label"] = stream_display_mode_label_for_selection(policy_stream_display_mode);
+      policy["mode_reason"] = stream_display_mode_reason_for_selection(policy_stream_display_mode);
       policy["source"] = source;
       policy["source_label"] = stream_policy_source_label(source);
       policy["optimization_source"] = stats.optimization_source;
@@ -3647,7 +3610,7 @@ namespace nvhttp {
       tuning["mangohud_configured"] = proc::proc.current_app_has_mangohud();
 
       auto &display_mode = output["display_mode"];
-      const auto stream_display_mode = stream_display_mode_selection();
+      const auto stream_display_mode = effective_stream_display_mode_selection(stats);
       display_mode["virtual_display"] = proc::proc.virtual_display;
       display_mode["requested_headless"] = stats.runtime_requested_headless;
       display_mode["effective_headless"] = stats.runtime_effective_headless;
@@ -3660,8 +3623,8 @@ namespace nvhttp {
         proc::proc.session_display_mode_is_explicit() ?
           (proc::proc.virtual_display ? "virtual_display" : "headless") :
           "auto";
-      display_mode["label"] = stream_display_mode_label();
-      display_mode["reason"] = stream_display_mode_reason();
+      display_mode["label"] = stream_display_mode_label_for_selection(stream_display_mode);
+      display_mode["reason"] = stream_display_mode_reason_for_selection(stream_display_mode);
       display_mode["paired_display_mode_override"] = named_cert_p->display_mode;
       display_mode["paired_display_mode_locked"] = !named_cert_p->display_mode.empty();
       display_mode["paired_target_bitrate_kbps"] = named_cert_p->target_bitrate_kbps;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -344,6 +344,7 @@ namespace nvhttp {
       const auto effective_display_mode = policy.value("selected_display_mode", std::string {});
       const auto effective_bitrate_kbps = policy.value("target_bitrate_kbps", 0);
       const bool adaptive_active = adaptive_bitrate::is_enabled() && stats.adaptive_target_bitrate_kbps > 0;
+      const auto disconnect_resume_timeout_seconds = config::stream.disconnect_resume_timeout.count();
 
       nlohmann::json fields = nlohmann::json::object();
       fields["stream_display_mode"] = {
@@ -389,6 +390,15 @@ namespace nvhttp {
         {"scope", "host"},
         {"desired", ai_optimizer::is_enabled()},
         {"effective", ai_optimizer::is_enabled()},
+        {"status", "synced"},
+        {"live", true},
+        {"requires_relaunch", false}
+      };
+      fields["disconnect_resume_timeout_seconds"] = {
+        {"direction", "read_write"},
+        {"scope", "host"},
+        {"desired", disconnect_resume_timeout_seconds},
+        {"effective", disconnect_resume_timeout_seconds},
         {"status", "synced"},
         {"live", true},
         {"requires_relaunch", false}
@@ -685,6 +695,7 @@ namespace nvhttp {
       desired["target_bitrate_kbps"] = client.target_bitrate_kbps;
       desired["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
       desired["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
+      desired["disconnect_resume_timeout_seconds"] = config::stream.disconnect_resume_timeout.count();
 
       nlohmann::json effective;
       effective["stream_display_mode"] = effective_mode;
@@ -695,6 +706,7 @@ namespace nvhttp {
       effective["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
       effective["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
       effective["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
+      effective["disconnect_resume_timeout_seconds"] = config::stream.disconnect_resume_timeout.count();
       effective["capture_path"] = policy.value("capture_path", std::string {});
       effective["capture_gpu_native"] = policy.value("capture_gpu_native", false);
 
@@ -703,6 +715,7 @@ namespace nvhttp {
         std::to_string(client.target_bitrate_kbps) + "|" +
         (adaptive_bitrate::is_enabled() ? "1" : "0") + "|" +
         (ai_optimizer::is_enabled() ? "1" : "0") + "|" +
+        std::to_string(config::stream.disconnect_resume_timeout.count()) + "|" +
         effective_mode;
 
       nlohmann::json settings;
@@ -717,7 +730,8 @@ namespace nvhttp {
         {"display_mode_override", true},
         {"target_bitrate_override", true},
         {"adaptive_bitrate_control", true},
-        {"ai_optimizer_control", true}
+        {"ai_optimizer_control", true},
+        {"disconnect_resume_timeout_control", true}
       };
       settings["sync_status"] = build_client_settings_sync_status(
         client,
@@ -3488,6 +3502,7 @@ namespace nvhttp {
       features["device_profiles"] = true;
       features["stream_policy_v1"] = true;
       features["client_settings_v1"] = true;
+      features["disconnect_resume_v1"] = true;
       features["cursor_visibility_control"] = true;
       features["lock_screen_control"] = false;
 #ifdef __linux__
@@ -3504,7 +3519,8 @@ namespace nvhttp {
           "display_mode",
           "target_bitrate_kbps",
           "adaptive_bitrate_enabled",
-          "ai_optimizer_enabled"
+          "ai_optimizer_enabled",
+          "disconnect_resume_timeout_seconds"
         })}
       };
 
@@ -3573,11 +3589,15 @@ namespace nvhttp {
         client_role != "viewer" &&
         !shutdown_requested &&
         stats.streaming;
-      const bool quit_allowed =
-        host_tuning_allowed &&
-        proc::proc.allow_client_commands &&
-        named_cert_p->allow_client_commands &&
+      const bool session_command_allowed =
+        owned_by_client &&
+        client_role != "viewer" &&
+        !shutdown_requested &&
         proc::proc.running() > 0;
+      const bool quit_allowed =
+        session_command_allowed &&
+        proc::proc.allow_client_commands &&
+        named_cert_p->allow_client_commands;
 
       // Game info
       output["game_id"] = proc::proc.running();
@@ -3884,6 +3904,23 @@ namespace nvhttp {
               return;
             }
             ai_optimizer::set_enabled(enabled);
+          }
+
+          if (body.contains("disconnect_resume_timeout_seconds")) {
+            if (!body["disconnect_resume_timeout_seconds"].is_number_integer()) {
+              write_json({{"error", "disconnect_resume_timeout_seconds must be an integer"}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+            const int timeout_seconds = body["disconnect_resume_timeout_seconds"].get<int>();
+            if (timeout_seconds < 0 || timeout_seconds > 24 * 60 * 60) {
+              write_json({{"error", "disconnect_resume_timeout_seconds must be between 0 and 86400"}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+            if (!persist_config_values({{"disconnect_resume_timeout_seconds", std::to_string(timeout_seconds)}})) {
+              write_json({{"error", "failed to persist disconnect resume timeout setting"}}, SimpleWeb::StatusCode::server_error_internal_server_error);
+              return;
+            }
+            config::stream.disconnect_resume_timeout = std::chrono::seconds(timeout_seconds);
           }
 
           if (stream_display_mode) {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -13,10 +13,13 @@
 #include <cstdlib>
 #include <filesystem>
 #include <format>
+#include <functional>
 #include <mutex>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <string>
 
@@ -185,6 +188,132 @@ namespace nvhttp {
 
     bool is_mobile_client_type(const std::optional<device_db::device_t> &device_profile);
 
+    std::string bool_config_value(bool enabled) {
+      return enabled ? "enabled"s : "disabled"s;
+    }
+
+    bool persist_config_values(const std::unordered_map<std::string, std::string> &updates) {
+      if (updates.empty()) {
+        return true;
+      }
+
+      auto vars = config::parse_config(file_handler::read_file(config::sunshine.config_file.c_str()));
+      for (const auto &[key, value] : updates) {
+        vars[key] = value;
+      }
+
+      std::stringstream config_stream;
+      for (const auto &[key, value] : vars) {
+        if (value.empty()) {
+          continue;
+        }
+        config_stream << key << " = " << value << std::endl;
+      }
+
+      if (file_handler::write_file(config::sunshine.config_file.c_str(), config_stream.str()) != 0) {
+        BOOST_LOG(error) << "client_settings: failed to write config file: "sv << config::sunshine.config_file;
+        return false;
+      }
+
+      return true;
+    }
+
+    std::string configured_stream_display_mode_selection() {
+      const auto &linux_display = config::video.linux_display;
+      if (!linux_display.headless_mode) {
+        return "desktop_display";
+      }
+      if (!linux_display.use_cage_compositor) {
+        return "host_virtual_display";
+      }
+      if (linux_display.prefer_gpu_native_capture) {
+        return "windowed_stream";
+      }
+      return "headless_stream";
+    }
+
+    std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats) {
+      if (!stats.streaming) {
+        return configured_stream_display_mode_selection();
+      }
+      if (stats.runtime_gpu_native_override_active) {
+        return "windowed_stream";
+      }
+      if (proc::proc.virtual_display) {
+        return "host_virtual_display";
+      }
+      if (stats.runtime_effective_headless) {
+        return "headless_stream";
+      }
+      return "desktop_display";
+    }
+
+    std::string stream_display_mode_label_for_selection(const std::string &selection) {
+      if (selection == "headless_stream") {
+        return "Headless Stream";
+      }
+      if (selection == "host_virtual_display") {
+        return "Host Virtual Display";
+      }
+      if (selection == "windowed_stream") {
+        return "GPU-Native Test";
+      }
+      return "Desktop Display";
+    }
+
+    std::string stream_display_mode_reason_for_selection(const std::string &selection) {
+      if (selection == "headless_stream") {
+        return "Polaris will stream from the private headless compositor runtime.";
+      }
+      if (selection == "host_virtual_display") {
+        return host_virtual_display_available() ?
+          "Polaris will create or use a host virtual display for this stream." :
+          "Polaris requested a host virtual display, but no backend is currently available.";
+      }
+      if (selection == "windowed_stream") {
+        return "Polaris may run the private compositor windowed when that is needed to keep capture GPU-native.";
+      }
+      return "Polaris will stream from the current desktop session.";
+    }
+
+    bool apply_stream_display_mode_selection(const std::string &selection,
+                                             std::string &error) {
+      bool headless = false;
+      bool cage = false;
+      bool gpu_native = false;
+
+      if (selection == "headless_stream") {
+        headless = true;
+        cage = true;
+      } else if (selection == "host_virtual_display") {
+        headless = true;
+      } else if (selection == "desktop_display") {
+        // Defaults already describe desktop display.
+      } else if (selection == "windowed_stream") {
+        headless = true;
+        cage = true;
+        gpu_native = true;
+      } else {
+        error = "stream_display_mode must be headless_stream, desktop_display, host_virtual_display, or windowed_stream";
+        return false;
+      }
+
+      config::video.linux_display.headless_mode = headless;
+      config::video.linux_display.use_cage_compositor = cage;
+      config::video.linux_display.prefer_gpu_native_capture = gpu_native;
+
+      if (!persist_config_values({
+            {"headless_mode", bool_config_value(headless)},
+            {"linux_use_cage_compositor", bool_config_value(cage)},
+            {"linux_prefer_gpu_native_capture", bool_config_value(gpu_native)}
+          })) {
+        error = "failed to persist stream display mode";
+        return false;
+      }
+
+      return true;
+    }
+
     std::string stream_display_mode_label() {
 #ifdef __linux__
       return stream_display_policy::resolve(
@@ -227,6 +356,100 @@ namespace nvhttp {
         "Polaris is streaming from a host virtual display." :
         "Polaris is streaming from the current desktop session.";
 #endif
+    }
+
+    nlohmann::json stream_display_mode_options_json() {
+      nlohmann::json modes = nlohmann::json::array();
+      for (const auto &selection : {
+             "headless_stream"s,
+             "desktop_display"s,
+             "host_virtual_display"s,
+             "windowed_stream"s
+           }) {
+        modes.push_back({
+          {"value", selection},
+          {"label", stream_display_mode_label_for_selection(selection)},
+          {"available", selection != "host_virtual_display" || host_virtual_display_available()},
+          {"restart_required", true},
+          {"reason", stream_display_mode_reason_for_selection(selection)}
+        });
+      }
+      return modes;
+    }
+
+    nlohmann::json build_client_settings_sync_status(const crypto::named_cert_t &client,
+                                                     const stream_stats::stats_t &stats,
+                                                     const nlohmann::json &policy,
+                                                     const std::string &configured_mode,
+                                                     const std::string &effective_mode,
+                                                     bool relaunch_required) {
+      const bool paired_display_override = !client.display_mode.empty();
+      const bool paired_bitrate_override = client.target_bitrate_kbps > 0;
+      const auto effective_display_mode = policy.value("selected_display_mode", std::string {});
+      const auto effective_bitrate_kbps = policy.value("target_bitrate_kbps", 0);
+      const bool adaptive_active = adaptive_bitrate::is_enabled() && stats.adaptive_target_bitrate_kbps > 0;
+
+      nlohmann::json fields = nlohmann::json::object();
+      fields["stream_display_mode"] = {
+        {"direction", "read_write"},
+        {"scope", "host"},
+        {"desired", configured_mode},
+        {"effective", effective_mode},
+        {"status", relaunch_required ? "pending_relaunch" : "synced"},
+        {"live", false},
+        {"requires_relaunch", relaunch_required}
+      };
+      fields["display_mode"] = {
+        {"direction", "read_write"},
+        {"scope", "paired_client"},
+        {"desired", client.display_mode},
+        {"effective", effective_display_mode},
+        {"status", paired_display_override && stats.streaming && effective_display_mode != client.display_mode ? "pending_next_launch" : "synced"},
+        {"live", false},
+        {"requires_relaunch", paired_display_override && stats.streaming && effective_display_mode != client.display_mode}
+      };
+      fields["target_bitrate_kbps"] = {
+        {"direction", "read_write"},
+        {"scope", "paired_client"},
+        {"desired", client.target_bitrate_kbps},
+        {"effective", effective_bitrate_kbps},
+        {"status", adaptive_active ? "adaptive_active" : "synced"},
+        {"live", true},
+        {"requires_relaunch", false},
+        {"adaptive_target_bitrate_kbps", stats.adaptive_target_bitrate_kbps},
+        {"paired_override_active", paired_bitrate_override}
+      };
+      fields["adaptive_bitrate_enabled"] = {
+        {"direction", "read_write"},
+        {"scope", "host"},
+        {"desired", adaptive_bitrate::is_enabled()},
+        {"effective", adaptive_bitrate::is_enabled()},
+        {"status", "synced"},
+        {"live", true},
+        {"requires_relaunch", false}
+      };
+      fields["ai_optimizer_enabled"] = {
+        {"direction", "read_write"},
+        {"scope", "host"},
+        {"desired", ai_optimizer::is_enabled()},
+        {"effective", ai_optimizer::is_enabled()},
+        {"status", "synced"},
+        {"live", true},
+        {"requires_relaunch", false}
+      };
+
+      nlohmann::json status;
+      status["available"] = true;
+      status["version"] = 1;
+      status["direction"] = "bidirectional";
+      status["endpoint"] = "/polaris/v1/client-settings";
+      status["source_of_truth"] = "polaris_effective_runtime";
+      status["state"] = relaunch_required ? "pending_relaunch" : "synced";
+      status["message"] = relaunch_required ?
+        "Desired settings are saved and will become effective after the active stream relaunches." :
+        "Desired settings match the current Polaris runtime state.";
+      status["fields"] = std::move(fields);
+      return status;
     }
 
     double stream_policy_target_fps(const stream_stats::stats_t &stats) {
@@ -372,6 +595,7 @@ namespace nvhttp {
                                             const nlohmann::json &health) {
       const auto device_profile = device_db::get_device(client.name);
       const bool paired_display_override = !client.display_mode.empty();
+      const bool paired_bitrate_override = client.target_bitrate_kbps > 0;
       const double target_fps = stream_policy_target_fps(stats);
       const int selected_width = stats.width > 0 ? stats.width : 0;
       const int selected_height = stats.height > 0 ? stats.height : 0;
@@ -399,8 +623,9 @@ namespace nvhttp {
       const int target_bitrate_kbps =
         stats.adaptive_target_bitrate_kbps > 0 ? stats.adaptive_target_bitrate_kbps :
         stats.bitrate_kbps > 0 ? stats.bitrate_kbps :
+        paired_bitrate_override ? client.target_bitrate_kbps :
         device_profile ? device_profile->ideal_bitrate_kbps : 0;
-      const std::string source = paired_display_override ? "paired_client" :
+      const std::string source = (paired_display_override || paired_bitrate_override) ? "paired_client" :
         (!stats.optimization_source.empty() ? stats.optimization_source :
           (device_profile ? "device_db" : "default"));
 
@@ -459,6 +684,8 @@ namespace nvhttp {
       );
       policy["paired_display_mode_override"] = client.display_mode;
       policy["paired_display_mode_locked"] = paired_display_override;
+      policy["paired_target_bitrate_kbps"] = client.target_bitrate_kbps;
+      policy["paired_target_bitrate_locked"] = paired_bitrate_override;
       policy["target_fps"] = policy_fps;
       policy["target_bitrate_kbps"] = target_bitrate_kbps;
       policy["preferred_codec"] = stats.codec;
@@ -476,6 +703,69 @@ namespace nvhttp {
       policy["warnings"] = std::move(warnings);
       policy["has_warnings"] = !policy["warnings"].empty();
       return policy;
+    }
+
+    nlohmann::json build_client_settings_json(const crypto::named_cert_t &client,
+                                              const stream_stats::stats_t &stats,
+                                              const nlohmann::json &health) {
+      const auto policy = build_stream_policy_json(client, stats, health);
+      const auto configured_mode = configured_stream_display_mode_selection();
+      const auto effective_mode = effective_stream_display_mode_selection(stats);
+      const bool relaunch_required =
+        rtsp_stream::session_count() != 0 && configured_mode != effective_mode;
+
+      nlohmann::json desired;
+      desired["stream_display_mode"] = configured_mode;
+      desired["stream_display_mode_label"] = stream_display_mode_label_for_selection(configured_mode);
+      desired["stream_display_mode_reason"] = stream_display_mode_reason_for_selection(configured_mode);
+      desired["display_mode"] = client.display_mode;
+      desired["target_bitrate_kbps"] = client.target_bitrate_kbps;
+      desired["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
+      desired["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
+
+      nlohmann::json effective;
+      effective["stream_display_mode"] = effective_mode;
+      effective["stream_display_mode_label"] = stream_display_mode_label_for_selection(effective_mode);
+      effective["stream_display_mode_reason"] = stream_display_mode_reason_for_selection(effective_mode);
+      effective["display_mode"] = policy.value("selected_display_mode", std::string {});
+      effective["target_bitrate_kbps"] = policy.value("target_bitrate_kbps", 0);
+      effective["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
+      effective["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
+      effective["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
+      effective["capture_path"] = policy.value("capture_path", std::string {});
+      effective["capture_gpu_native"] = policy.value("capture_gpu_native", false);
+
+      const std::string revision_seed =
+        configured_mode + "|" + client.display_mode + "|" +
+        std::to_string(client.target_bitrate_kbps) + "|" +
+        (adaptive_bitrate::is_enabled() ? "1" : "0") + "|" +
+        (ai_optimizer::is_enabled() ? "1" : "0") + "|" +
+        effective_mode;
+
+      nlohmann::json settings;
+      settings["version"] = 1;
+      settings["revision"] = std::to_string(std::hash<std::string> {}(revision_seed));
+      settings["desired"] = std::move(desired);
+      settings["effective"] = std::move(effective);
+      settings["policy"] = policy;
+      settings["health"] = health;
+      settings["capabilities"] = {
+        {"modes", stream_display_mode_options_json()},
+        {"display_mode_override", true},
+        {"target_bitrate_override", true},
+        {"adaptive_bitrate_control", true},
+        {"ai_optimizer_control", true}
+      };
+      settings["sync_status"] = build_client_settings_sync_status(
+        client,
+        stats,
+        policy,
+        configured_mode,
+        effective_mode,
+        relaunch_required
+      );
+      settings["relaunch_required"] = relaunch_required;
+      return settings;
     }
 
     bool is_mobile_client_type(const std::optional<device_db::device_t> &device_profile) {
@@ -1065,39 +1355,41 @@ namespace nvhttp {
 
     nlohmann::json launch_mode_contract_for_app(const proc::ctx_t &app) {
       const bool app_prefers_virtual_display = app.virtual_display;
-      const std::string preferred_mode = app_prefers_virtual_display ? "virtual_display" : "headless";
+      const std::string preferred_mode = app_prefers_virtual_display ? "host_virtual_display" : "headless_stream";
       std::string recommended_mode = preferred_mode;
       std::string mode_reason;
 
       auto allowed_modes = nlohmann::json::array();
-      allowed_modes.push_back("headless");
+      allowed_modes.push_back("headless_stream");
+      allowed_modes.push_back("desktop_display");
+      allowed_modes.push_back("windowed_stream");
       if (host_virtual_display_available()) {
-        allowed_modes.push_back("virtual_display");
+        allowed_modes.push_back("host_virtual_display");
       }
 
       const bool steam_big_picture = boost::iequals(boost::trim_copy(app.name), "Steam Big Picture");
 
       if (app_prefers_virtual_display && host_virtual_display_available()) {
-        recommended_mode = "virtual_display";
+        recommended_mode = "host_virtual_display";
         mode_reason = steam_big_picture ?
           "Steam Big Picture is configured to prefer a dedicated virtual display on this host." :
           "This app is configured to prefer a dedicated virtual display on the host.";
       } else if (app_prefers_virtual_display && !host_virtual_display_available()) {
-        recommended_mode = "headless";
+        recommended_mode = "headless_stream";
         mode_reason =
-          "This app prefers Virtual Display, but Polaris does not currently have a virtual display backend available, so the non-virtual path is recommended.";
+          "This app prefers Host Virtual Display, but Polaris does not currently have a virtual display backend available, so Headless Stream is recommended.";
       } else if (host_prefers_headless()) {
-        recommended_mode = "headless";
+        recommended_mode = "headless_stream";
         mode_reason =
-          "Headless is recommended because this Polaris host is already configured for headless streaming.";
+          "Headless Stream is recommended because this Polaris host is already configured for headless streaming.";
       } else if (host_virtual_display_available()) {
-        recommended_mode = "headless";
+        recommended_mode = "headless_stream";
         mode_reason =
-          "This app defaults to the non-virtual path. Virtual Display is available when you want a dedicated display for the session.";
+          "This app defaults to Headless Stream. Host Virtual Display is available when you want a dedicated display for the session.";
       } else {
-        recommended_mode = "headless";
+        recommended_mode = "headless_stream";
         mode_reason =
-          "This app defaults to the non-virtual path on this host.";
+          "This app defaults to Headless Stream on this host.";
       }
 
       nlohmann::json launch_mode;
@@ -1401,6 +1693,7 @@ namespace nvhttp {
         named_cert_node["uuid"] = named_cert_p->uuid;
         named_cert_node["client_family"] = named_cert_p->client_family;
         named_cert_node["display_mode"] = named_cert_p->display_mode;
+        named_cert_node["target_bitrate_kbps"] = named_cert_p->target_bitrate_kbps;
         named_cert_node["perm"] = static_cast<uint32_t>(named_cert_p->perm);
         named_cert_node["enable_legacy_ordering"] = named_cert_p->enable_legacy_ordering;
         named_cert_node["allow_client_commands"] = named_cert_p->allow_client_commands;
@@ -1482,6 +1775,7 @@ namespace nvhttp {
             named_cert_p->uuid = uuid_util::uuid_t::generate().string();
             named_cert_p->client_family = "";
             named_cert_p->display_mode = "";
+            named_cert_p->target_bitrate_kbps = 0;
             named_cert_p->perm = PERM::_all;
             named_cert_p->enable_legacy_ordering = true;
             named_cert_p->allow_client_commands = true;
@@ -1501,6 +1795,7 @@ namespace nvhttp {
         named_cert_p->uuid = el.value("uuid", "");
         named_cert_p->client_family = el.value("client_family", "");
         named_cert_p->display_mode = el.value("display_mode", "");
+        named_cert_p->target_bitrate_kbps = util::get_non_string_json_value<int>(el, "target_bitrate_kbps", 0);
         named_cert_p->perm = (PERM)(util::get_non_string_json_value<uint32_t>(el, "perm", (uint32_t)PERM::_all)) & PERM::_all;
         named_cert_p->enable_legacy_ordering = el.value("enable_legacy_ordering", true);
         named_cert_p->allow_client_commands = el.value("allow_client_commands", true);
@@ -1628,6 +1923,11 @@ namespace nvhttp {
     launch_session->user_locked_display_mode = !named_cert_p->display_mode.empty();
     launch_session->user_locked_virtual_display = client_display_mode_explicit || named_cert_p->always_use_virtual_display;
     launch_session->scale_factor = util::from_view(get_arg(args, "scaleFactor", "100"));
+    if (named_cert_p->target_bitrate_kbps > 0) {
+      launch_session->paired_target_bitrate_kbps = named_cert_p->target_bitrate_kbps;
+    } else {
+      launch_session->paired_target_bitrate_kbps.reset();
+    }
 
     if (!launch_session->watch_only) {
       launch_session->client_do_cmds = named_cert_p->do_cmds;
@@ -2332,6 +2632,7 @@ namespace nvhttp {
       named_cert_node["uuid"] = named_cert->uuid;
       named_cert_node["client_family"] = named_cert->client_family;
       named_cert_node["display_mode"] = named_cert->display_mode;
+      named_cert_node["target_bitrate_kbps"] = named_cert->target_bitrate_kbps;
       named_cert_node["perm"] = static_cast<uint32_t>(named_cert->perm);
       named_cert_node["enable_legacy_ordering"] = named_cert->enable_legacy_ordering;
       named_cert_node["allow_client_commands"] = named_cert->allow_client_commands;
@@ -3223,11 +3524,26 @@ namespace nvhttp {
       features["session_lifecycle"] = true;
       features["device_profiles"] = true;
       features["stream_policy_v1"] = true;
+      features["client_settings_v1"] = true;
       features["cursor_visibility_control"] = true;
       features["lock_screen_control"] = false;
 #ifdef __linux__
       features["lock_screen_control"] = true;
 #endif
+
+      output["client_settings"] = {
+        {"version", 1},
+        {"endpoint", "/polaris/v1/client-settings"},
+        {"direction", "bidirectional"},
+        {"source_of_truth", "polaris_effective_runtime"},
+        {"fields", nlohmann::json::array({
+          "stream_display_mode",
+          "display_mode",
+          "target_bitrate_kbps",
+          "adaptive_bitrate_enabled",
+          "ai_optimizer_enabled"
+        })}
+      };
 
       // Capture info
       auto &capture = output["capture"];
@@ -3348,6 +3664,8 @@ namespace nvhttp {
       display_mode["reason"] = stream_display_mode_reason();
       display_mode["paired_display_mode_override"] = named_cert_p->display_mode;
       display_mode["paired_display_mode_locked"] = !named_cert_p->display_mode.empty();
+      display_mode["paired_target_bitrate_kbps"] = named_cert_p->target_bitrate_kbps;
+      display_mode["paired_target_bitrate_locked"] = named_cert_p->target_bitrate_kbps > 0;
 
       // Capture info
       auto &capture_info = output["capture"];
@@ -3390,6 +3708,11 @@ namespace nvhttp {
       );
       output["health"] = health;
       output["stream_policy"] = build_stream_policy_json(
+        *named_cert_p,
+        stats,
+        health
+      );
+      output["client_settings"] = build_client_settings_json(
         *named_cert_p,
         stats,
         health
@@ -3453,6 +3776,7 @@ namespace nvhttp {
             named_cert_p->uuid,
             named_cert_p->name,
             display_mode,
+            named_cert_p->target_bitrate_kbps,
             named_cert_p->do_cmds,
             named_cert_p->undo_cmds,
             named_cert_p->perm,
@@ -3493,6 +3817,150 @@ namespace nvhttp {
         SimpleWeb::CaseInsensitiveMultimap headers;
         headers.emplace("Content-Type", "application/json");
         response->write(SimpleWeb::StatusCode::server_error_internal_server_error, err.dump(), headers);
+      }
+    };
+
+    auto polarisClientSettings = [](resp_https_t response, req_https_t request) {
+      print_req<PolarisHTTPS>(request);
+
+      const auto named_cert_p = get_verified_cert(request);
+      if (!named_cert_p) {
+        response->write(SimpleWeb::StatusCode::client_error_unauthorized);
+        return;
+      }
+
+      auto write_json = [&](const nlohmann::json &body,
+                            SimpleWeb::StatusCode status = SimpleWeb::StatusCode::success_ok) {
+        SimpleWeb::CaseInsensitiveMultimap headers;
+        headers.emplace("Content-Type", "application/json");
+        response->write(status, body.dump(), headers);
+      };
+
+      try {
+        if (request->method == "POST") {
+          std::string body_str(std::istreambuf_iterator<char>(request->content), {});
+          const auto body = body_str.empty() ? nlohmann::json::object() : nlohmann::json::parse(body_str);
+
+          std::optional<std::string> stream_display_mode;
+          if (body.contains("stream_display_mode")) {
+            if (!body["stream_display_mode"].is_string()) {
+              write_json({{"error", "stream_display_mode must be a string"}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+
+            std::string error;
+            stream_display_mode = body["stream_display_mode"].get<std::string>();
+            if (*stream_display_mode != "headless_stream" &&
+                *stream_display_mode != "desktop_display" &&
+                *stream_display_mode != "host_virtual_display" &&
+                *stream_display_mode != "windowed_stream") {
+              error = "stream_display_mode must be headless_stream, desktop_display, host_virtual_display, or windowed_stream";
+              write_json({{"error", error}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+          }
+
+          std::string display_mode = named_cert_p->display_mode;
+          if (body.value("clear_display_mode", false)) {
+            display_mode.clear();
+          } else if (body.contains("display_mode")) {
+            if (!body["display_mode"].is_string()) {
+              write_json({{"error", "display_mode must be a string"}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+            display_mode = body["display_mode"].get<std::string>();
+          }
+
+          int width = 0;
+          int height = 0;
+          double fps = 0.0;
+          if (!display_mode.empty() && !parse_stream_policy_display_mode(display_mode, width, height, fps)) {
+            write_json(
+              {{"error", "display_mode must use WIDTHxHEIGHTxFPS, for example 1920x1080x120"}},
+              SimpleWeb::StatusCode::client_error_bad_request
+            );
+            return;
+          }
+
+          int target_bitrate_kbps = named_cert_p->target_bitrate_kbps;
+          if (body.value("clear_target_bitrate", false)) {
+            target_bitrate_kbps = 0;
+          } else if (body.contains("target_bitrate_kbps")) {
+            if (!body["target_bitrate_kbps"].is_number_integer()) {
+              write_json({{"error", "target_bitrate_kbps must be an integer"}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+            target_bitrate_kbps = body["target_bitrate_kbps"].get<int>();
+            if (target_bitrate_kbps != 0 && (target_bitrate_kbps < 1000 || target_bitrate_kbps > 300000)) {
+              write_json({{"error", "target_bitrate_kbps must be 0 or between 1000 and 300000"}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+          }
+
+          if (body.contains("adaptive_bitrate_enabled")) {
+            if (!body["adaptive_bitrate_enabled"].is_boolean()) {
+              write_json({{"error", "adaptive_bitrate_enabled must be a boolean"}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+            adaptive_bitrate::set_enabled(body["adaptive_bitrate_enabled"].get<bool>());
+          }
+
+          if (body.contains("ai_optimizer_enabled")) {
+            if (!body["ai_optimizer_enabled"].is_boolean()) {
+              write_json({{"error", "ai_optimizer_enabled must be a boolean"}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+            ai_optimizer::set_enabled(body["ai_optimizer_enabled"].get<bool>());
+          }
+
+          if (stream_display_mode) {
+            std::string error;
+            if (!apply_stream_display_mode_selection(*stream_display_mode, error)) {
+              write_json({{"error", error}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+          }
+
+          if (target_bitrate_kbps > 0) {
+            adaptive_bitrate::set_base_bitrate(target_bitrate_kbps);
+          }
+
+          const bool updated = update_device_info(
+            named_cert_p->uuid,
+            named_cert_p->name,
+            display_mode,
+            target_bitrate_kbps,
+            named_cert_p->do_cmds,
+            named_cert_p->undo_cmds,
+            named_cert_p->perm,
+            named_cert_p->enable_legacy_ordering,
+            named_cert_p->allow_client_commands,
+            named_cert_p->always_use_virtual_display
+          );
+
+          if (!updated) {
+            write_json({{"error", "paired client not found"}}, SimpleWeb::StatusCode::client_error_not_found);
+            return;
+          }
+        }
+
+        const auto stats = stream_stats::get_current();
+        const auto health = build_session_health_json(
+          stats,
+          proc::proc.virtual_display,
+          named_cert_p->name,
+          proc::proc.get_last_run_app_name()
+        );
+
+        nlohmann::json output;
+        output["status"] = true;
+        output["client_settings"] = build_client_settings_json(*named_cert_p, stats, health);
+        output["sync_status"] = output["client_settings"]["sync_status"];
+        output["stream_policy"] = output["client_settings"]["policy"];
+        output["health"] = health;
+        write_json(output);
+      } catch (std::exception &e) {
+        write_json({{"error", e.what()}}, SimpleWeb::StatusCode::server_error_internal_server_error);
       }
     };
 
@@ -3814,7 +4282,8 @@ namespace nvhttp {
     // Real-time bitrate adjustment from client
     auto polarisSetBitrate = [](resp_https_t response, req_https_t request) {
       print_req<PolarisHTTPS>(request);
-      if (!get_verified_cert(request)) {
+      const auto named_cert_p = get_verified_cert(request);
+      if (!named_cert_p) {
         response->write(SimpleWeb::StatusCode::client_error_unauthorized);
         return;
       }
@@ -3836,6 +4305,15 @@ namespace nvhttp {
         nlohmann::json output;
         output["status"] = true;
         output["bitrate_kbps"] = bitrate_kbps;
+        const auto stats = stream_stats::get_current();
+        const auto health = build_session_health_json(
+          stats,
+          proc::proc.virtual_display,
+          named_cert_p->name,
+          proc::proc.get_last_run_app_name()
+        );
+        output["client_settings"] = build_client_settings_json(*named_cert_p, stats, health);
+        output["sync_status"] = output["client_settings"]["sync_status"];
         SimpleWeb::CaseInsensitiveMultimap headers;
         headers.emplace("Content-Type", "application/json");
         response->write(output.dump(), headers);
@@ -3850,7 +4328,8 @@ namespace nvhttp {
 
     auto polarisSetAdaptiveBitrate = [](resp_https_t response, req_https_t request) {
       print_req<PolarisHTTPS>(request);
-      if (!get_verified_cert(request)) {
+      const auto named_cert_p = get_verified_cert(request);
+      if (!named_cert_p) {
         response->write(SimpleWeb::StatusCode::client_error_unauthorized);
         return;
       }
@@ -3874,7 +4353,16 @@ namespace nvhttp {
         nlohmann::json output;
         output["status"] = true;
         output["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
-        output["adaptive_target_bitrate_kbps"] = stream_stats::get_current().adaptive_target_bitrate_kbps;
+        const auto stats = stream_stats::get_current();
+        output["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
+        const auto health = build_session_health_json(
+          stats,
+          proc::proc.virtual_display,
+          named_cert_p->name,
+          proc::proc.get_last_run_app_name()
+        );
+        output["client_settings"] = build_client_settings_json(*named_cert_p, stats, health);
+        output["sync_status"] = output["client_settings"]["sync_status"];
         SimpleWeb::CaseInsensitiveMultimap headers;
         headers.emplace("Content-Type", "application/json");
         response->write(output.dump(), headers);
@@ -3889,7 +4377,8 @@ namespace nvhttp {
 
     auto polarisSetAiOptimizer = [](resp_https_t response, req_https_t request) {
       print_req<PolarisHTTPS>(request);
-      if (!get_verified_cert(request)) {
+      const auto named_cert_p = get_verified_cert(request);
+      if (!named_cert_p) {
         response->write(SimpleWeb::StatusCode::client_error_unauthorized);
         return;
       }
@@ -3913,6 +4402,15 @@ namespace nvhttp {
         output["status"] = true;
         output["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
         output["effective"] = ai_optimizer::is_enabled();
+        const auto stats = stream_stats::get_current();
+        const auto health = build_session_health_json(
+          stats,
+          proc::proc.virtual_display,
+          named_cert_p->name,
+          proc::proc.get_last_run_app_name()
+        );
+        output["client_settings"] = build_client_settings_json(*named_cert_p, stats, health);
+        output["sync_status"] = output["client_settings"]["sync_status"];
         SimpleWeb::CaseInsensitiveMultimap headers;
         headers.emplace("Content-Type", "application/json");
         response->write(output.dump(), headers);
@@ -4203,6 +4701,8 @@ namespace nvhttp {
     https_server.resource["^/polaris/v1/optimize$"]["GET"] = polarisOptimize;
     https_server.resource["^/polaris/v1/capabilities$"]["GET"] = polarisCapabilities;
     https_server.resource["^/polaris/v1/session/status$"]["GET"] = polarisSessionStatus;
+    https_server.resource["^/polaris/v1/client-settings$"]["GET"] = polarisClientSettings;
+    https_server.resource["^/polaris/v1/client-settings$"]["POST"] = polarisClientSettings;
     https_server.resource["^/polaris/v1/stream-policy$"]["GET"] = polarisStreamPolicy;
     https_server.resource["^/polaris/v1/stream-policy$"]["POST"] = polarisStreamPolicy;
     https_server.resource["^/polaris/v1/session/bitrate$"]["POST"] = polarisSetBitrate;
@@ -4312,6 +4812,7 @@ namespace nvhttp {
     const std::string& uuid,
     const std::string& name,
     const std::string& display_mode,
+    const int target_bitrate_kbps,
     const cmd_list_t& do_cmds,
     const cmd_list_t& undo_cmds,
     const crypto::PERM newPerm,
@@ -4328,6 +4829,7 @@ namespace nvhttp {
       if (named_cert_p->uuid == uuid) {
         named_cert_p->name = name;
         named_cert_p->display_mode = display_mode;
+        named_cert_p->target_bitrate_kbps = target_bitrate_kbps;
         named_cert_p->perm = newPerm;
         named_cert_p->do_cmds = do_cmds;
         named_cert_p->undo_cmds = undo_cmds;

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -271,6 +271,8 @@ namespace nvhttp {
    *
    * @param[in]  uuid       The uuid string
    * @param[in]  name       New name
+   * @param[in]  display_mode  Per-client display mode override
+   * @param[in]  target_bitrate_kbps  Per-client bitrate override
    * @param[in]  do_cmds    The do commands
    * @param[in]  undo_cmds  The undo commands
    * @param[in]  newPerm    New permission
@@ -284,6 +286,7 @@ namespace nvhttp {
     const std::string& uuid,
     const std::string& name,
     const std::string& display_mode,
+    const int target_bitrate_kbps,
     const cmd_list_t& do_cmds,
     const cmd_list_t& undo_cmds,
     const crypto::PERM newPerm,

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -33,7 +33,7 @@
 
 using namespace std::literals;
 namespace fs = std::filesystem;
-namespace bp = boost::process;
+namespace bp = boost::process::v1;
 
 namespace platf {
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1781,9 +1781,17 @@ namespace proc {
     optimization_locks_t optimization_locks;
     optimization_locks.display_mode = launch_session->user_locked_display_mode || !launch_session->enable_sops;
     optimization_locks.virtual_display = launch_session->user_locked_virtual_display;
-    optimization_locks.bitrate = config::video.max_bitrate > 0;
+    optimization_locks.bitrate = config::video.max_bitrate > 0 || launch_session->paired_target_bitrate_kbps.has_value();
 
     resolved_session_optimization_t resolved_optimization;
+    if (launch_session->paired_target_bitrate_kbps.has_value()) {
+      resolved_optimization.target_bitrate_kbps = *launch_session->paired_target_bitrate_kbps;
+      resolved_optimization.bitrate_source = "paired_client";
+      note_layer(resolved_optimization, "paired_client");
+      BOOST_LOG(info) << "Client profile: overriding bitrate to "sv
+                      << *launch_session->paired_target_bitrate_kbps << " kbps";
+    }
+
     auto client_profile = client_profiles::get_client_profile(launch_session->device_name);
     if (client_profile) {
       BOOST_LOG(info) << "Applying client profile for \""sv << launch_session->device_name << '"';

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -1115,19 +1115,12 @@ namespace rtsp_stream {
       config.monitor.enableIntraRefresh = util::from_view(args.at("x-ss-video[0].intraRefresh"sv));
 
       if (session.preferred_codec) {
-        int preferred_video_format = config.monitor.videoFormat;
-        if (*session.preferred_codec == "h264") {
-          preferred_video_format = 0;
-        } else if (*session.preferred_codec == "hevc") {
-          preferred_video_format = 1;
-        } else if (*session.preferred_codec == "av1") {
-          preferred_video_format = 2;
-        }
-
-        if (preferred_video_format != config.monitor.videoFormat) {
-          BOOST_LOG(info) << "Session codec override: preferring "sv << *session.preferred_codec
-                          << " over client requested format "sv << config.monitor.videoFormat;
-          config.monitor.videoFormat = preferred_video_format;
+        const auto client_requested_codec = codec_name_for_video_format(config.monitor.videoFormat);
+        if (client_requested_codec != *session.preferred_codec) {
+          BOOST_LOG(info) << "Session codec preference ["sv << *session.preferred_codec
+                          << "] differs from client requested codec ["sv << client_requested_codec
+                          << "]; honoring client request for this RTSP session"sv;
+          session.preferred_codec.reset();
         }
       }
 

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -57,6 +57,7 @@ namespace rtsp_stream {
     bool user_locked_display_mode;
     bool user_locked_virtual_display;
     uint32_t scale_factor;
+    std::optional<int> paired_target_bitrate_kbps;
     std::optional<int> target_bitrate_kbps;
     std::optional<int> nvenc_tune;
     std::optional<std::string> preferred_codec;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -6,7 +6,9 @@
 // standard includes
 #include <fstream>
 #include <future>
+#include <atomic>
 #include <queue>
+#include <thread>
 
 // lib includes
 #include <boost/endian/arithmetic.hpp>
@@ -38,10 +40,6 @@ extern "C" {
 #include "thread_safe.h"
 #include "utility.h"
 #include "confighttp.h"
-
-#ifdef __linux__
-#include "platform/linux/cage_display_router.h"
-#endif
 
 #define IDX_START_A 0
 #define IDX_START_B 1
@@ -93,22 +91,45 @@ using asio::ip::udp;
 using namespace std::literals;
 
 namespace stream {
+  namespace session {
+    extern std::atomic_uint running_sessions;
+  }
 
   namespace {
-    bool should_terminate_on_last_client_disconnect() {
-#ifdef __linux__
-      if (!config::video.linux_display.use_cage_compositor) {
-        return false;
+    std::atomic_uint64_t disconnect_resume_timeout_generation {0};
+
+    void cancel_disconnect_resume_timeout() {
+      ++disconnect_resume_timeout_generation;
+    }
+
+    void schedule_disconnect_resume_timeout(std::string app_name) {
+      const auto timeout = config::stream.disconnect_resume_timeout;
+      if (timeout.count() <= 0) {
+        return;
       }
 
-      const auto runtime_state = cage_display_router::runtime_state();
-      return cage_display_router::is_running() &&
-             (runtime_state.effective_headless ||
-              runtime_state.requested_headless ||
-              runtime_state.gpu_native_override_active);
-#else
-      return false;
-#endif
+      const auto generation = ++disconnect_resume_timeout_generation;
+      BOOST_LOG(info) << "Paused session for ["sv << app_name << "] will remain resumable for "sv
+                      << timeout.count() << " second(s)"sv;
+
+      std::thread([generation, timeout, app_name = std::move(app_name)] {
+        std::this_thread::sleep_for(timeout);
+
+        if (disconnect_resume_timeout_generation.load(std::memory_order_relaxed) != generation ||
+            session::running_sessions.load(std::memory_order_relaxed) != 0 ||
+            !proc::proc.running() ||
+            proc::proc.session_shutdown_requested()) {
+          return;
+        }
+
+        BOOST_LOG(info) << "Paused session resume timeout expired for ["sv << app_name
+                        << "]; terminating app"sv;
+        confighttp::set_session_state(confighttp::session_state_e::tearing_down);
+        confighttp::emit_session_event("stream_resume_timeout", "Paused session timed out");
+        proc::proc.terminate();
+        confighttp::set_session_state(confighttp::session_state_e::idle);
+        confighttp::emit_session_event("stream_ended", "Paused session timed out");
+      }).detach();
     }
   }  // namespace
 
@@ -2193,14 +2214,14 @@ namespace stream {
 
       if (remaining == 0) {
         bool revert_display_config {config::video.dd.config_revert_on_disconnect};
+        bool paused_for_resume = false;
         if (proc::proc.running()) {
           if (proc::proc.session_shutdown_requested()) {
             BOOST_LOG(info) << "Skipping pause because host shutdown is already in progress"sv;
-          } else if (should_terminate_on_last_client_disconnect()) {
-            BOOST_LOG(info) << "Last client disconnected from isolated cage runtime; terminating app instead of pausing"sv;
-            proc::proc.terminate();
           } else {
             proc::proc.pause();
+            paused_for_resume = proc::proc.running() > 0;
+            revert_display_config = !paused_for_resume && revert_display_config;
           }
         } else {
           // We have no app running and also no clients anymore.
@@ -2215,8 +2236,15 @@ namespace stream {
 
         // Clear stream stats when all sessions end
         stream_stats::update_stream_active(false);
-        confighttp::set_session_state(confighttp::session_state_e::idle);
-        confighttp::emit_session_event("stream_ended", "All sessions ended");
+        if (paused_for_resume) {
+          confighttp::set_session_state(confighttp::session_state_e::paused);
+          confighttp::emit_session_event("stream_paused", "Session paused; reconnect to resume");
+          schedule_disconnect_resume_timeout(proc::proc.get_last_run_app_name());
+        } else {
+          cancel_disconnect_resume_timeout();
+          confighttp::set_session_state(confighttp::session_state_e::idle);
+          confighttp::emit_session_event("stream_ended", "All sessions ended");
+        }
       }
     }
 
@@ -2310,6 +2338,7 @@ namespace stream {
       // If this is the first session, invoke the platform callbacks
       auto session_num = ++running_sessions;
       if (session_num == 1) {
+        cancel_disconnect_resume_timeout();
         platf::streaming_will_start();
         proc::proc.resume();
       }

--- a/src_assets/common/assets/web/Checkbox.vue
+++ b/src_assets/common/assets/web/Checkbox.vue
@@ -105,23 +105,23 @@ const defValue = parsedDefaultPropValue ? "_common.enabled_def_cbox" : "_common.
 
 <template>
   <div :class="[props.class, { 'checkbox-field--compact': props.compact }]" :data-setting-key="props.id" class="checkbox-field">
-    <label :for="props.id" class="checkbox-field-control">
+    <label :for="props.id" class="checkbox-field-control flex items-start gap-2">
       <input type="checkbox"
-             class="checkbox-field-input"
+             class="checkbox-field-input mt-1 shrink-0"
              :id="props.id"
              v-model="model"
              :true-value="checkboxValues.truthy"
              :false-value="checkboxValues.falsy" />
-      <span class="checkbox-field-copy">
-        <span class="checkbox-field-title-row">
-          <span class="text-silver cursor-pointer checkbox-field-label">
+      <span class="checkbox-field-copy flex min-w-0 flex-col gap-1">
+        <span class="checkbox-field-title-row flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <span class="text-silver cursor-pointer checkbox-field-label leading-snug">
             {{ $t(labelField) }}
           </span>
-          <span class="text-xs text-storm checkbox-field-default" v-if="showDefValue">
+          <span class="text-xs leading-snug text-storm checkbox-field-default" v-if="showDefValue">
             {{ $t(defValue) }}
           </span>
         </span>
-        <span class="text-sm text-storm checkbox-field-desc" v-if="showDesc">
+        <span class="text-sm leading-relaxed text-storm checkbox-field-desc" v-if="showDesc">
           {{ $t(descField) }}
           <slot></slot>
         </span>

--- a/src_assets/common/assets/web/client-settings-sync.js
+++ b/src_assets/common/assets/web/client-settings-sync.js
@@ -1,0 +1,82 @@
+export const CLIENT_SETTINGS_RESPONSE_ONLY_KEYS = [
+  'client_settings_available',
+  'client_settings_v1',
+  'client_settings_endpoint',
+  'client_settings_sync_mode',
+  'client_settings_authority',
+  'client_settings_relaunch_required',
+  'client_settings_stream_display_mode',
+  'client_settings_effective_stream_display_mode',
+  'client_settings_stream_display_mode_label',
+  'client_settings_effective_stream_display_mode_label',
+  'client_settings_live_fields',
+  'client_settings_restart_fields',
+]
+
+export function isTruthySetting(value) {
+  return value === true || value === 'true' || value === 'enabled' || value === 1 || value === '1'
+}
+
+export function resolveStreamDisplayMode(config = {}) {
+  const headless = isTruthySetting(config.headless_mode)
+  const cage = isTruthySetting(config.linux_use_cage_compositor)
+  const gpuNative = isTruthySetting(config.linux_prefer_gpu_native_capture)
+
+  if (headless && cage && gpuNative) return 'windowed_stream'
+  if (headless && cage) return 'headless_stream'
+  if (headless) return 'host_virtual_display'
+  return 'desktop_display'
+}
+
+export function resolveClientSettingsSync(config = {}) {
+  const available = isTruthySetting(config.client_settings_available) || isTruthySetting(config.client_settings_v1)
+  const relaunchRequired = isTruthySetting(config.client_settings_relaunch_required)
+  const desiredMode = config.client_settings_stream_display_mode || resolveStreamDisplayMode(config)
+  const effectiveMode = config.client_settings_effective_stream_display_mode || desiredMode
+
+  let state = 'unavailable'
+  if (available) {
+    state = relaunchRequired ? 'pending_relaunch' : 'synced'
+  }
+
+  return {
+    available,
+    state,
+    endpoint: config.client_settings_endpoint || '/polaris/v1/client-settings',
+    mode: config.client_settings_sync_mode || (available ? 'bidirectional' : 'unavailable'),
+    authority: config.client_settings_authority || 'polaris_effective_runtime',
+    desiredMode,
+    effectiveMode,
+    desiredModeLabel: config.client_settings_stream_display_mode_label || labelForStreamDisplayMode(desiredMode),
+    effectiveModeLabel: config.client_settings_effective_stream_display_mode_label || labelForStreamDisplayMode(effectiveMode),
+    relaunchRequired,
+    liveFields: normalizeFieldList(config.client_settings_live_fields),
+    restartFields: normalizeFieldList(config.client_settings_restart_fields),
+  }
+}
+
+export function labelForStreamDisplayMode(mode) {
+  if (mode === 'headless_stream') return 'Headless Stream'
+  if (mode === 'host_virtual_display') return 'Host Virtual Display'
+  if (mode === 'windowed_stream') return 'GPU-Native Test'
+  return 'Desktop Display'
+}
+
+export function normalizeFieldList(value) {
+  if (Array.isArray(value)) return value
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      if (Array.isArray(parsed)) return parsed
+    } catch {}
+    return value.split(',').map((item) => item.trim()).filter(Boolean)
+  }
+  return []
+}
+
+export function stripClientSettingsResponseOnly(config = {}) {
+  for (const key of CLIENT_SETTINGS_RESPONSE_ONLY_KEYS) {
+    delete config[key]
+  }
+  return config
+}

--- a/src_assets/common/assets/web/client-settings-sync.test.js
+++ b/src_assets/common/assets/web/client-settings-sync.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveClientSettingsSync,
+  resolveStreamDisplayMode,
+  stripClientSettingsResponseOnly,
+} from './client-settings-sync'
+
+describe('client settings sync helpers', () => {
+  it('maps legacy display flags to the canonical stream display mode', () => {
+    expect(resolveStreamDisplayMode({
+      headless_mode: 'enabled',
+      linux_use_cage_compositor: 'enabled',
+      linux_prefer_gpu_native_capture: 'disabled',
+    })).toBe('headless_stream')
+
+    expect(resolveStreamDisplayMode({
+      headless_mode: 'enabled',
+      linux_use_cage_compositor: 'disabled',
+    })).toBe('host_virtual_display')
+
+    expect(resolveStreamDisplayMode({
+      headless_mode: 'enabled',
+      linux_use_cage_compositor: 'enabled',
+      linux_prefer_gpu_native_capture: 'enabled',
+    })).toBe('windowed_stream')
+  })
+
+  it('reports unavailable hosts clearly', () => {
+    const sync = resolveClientSettingsSync({})
+
+    expect(sync.available).toBe(false)
+    expect(sync.state).toBe('unavailable')
+    expect(sync.mode).toBe('unavailable')
+  })
+
+  it('reports pending relaunch when Polaris desired and effective modes differ', () => {
+    const sync = resolveClientSettingsSync({
+      client_settings_available: true,
+      client_settings_relaunch_required: true,
+      client_settings_stream_display_mode: 'headless_stream',
+      client_settings_effective_stream_display_mode: 'desktop_display',
+    })
+
+    expect(sync.available).toBe(true)
+    expect(sync.state).toBe('pending_relaunch')
+    expect(sync.relaunchRequired).toBe(true)
+    expect(sync.desiredModeLabel).toBe('Headless Stream')
+    expect(sync.effectiveModeLabel).toBe('Desktop Display')
+  })
+
+  it('strips server-only client-settings fields before config save', () => {
+    const config = stripClientSettingsResponseOnly({
+      headless_mode: 'enabled',
+      client_settings_available: true,
+      client_settings_endpoint: '/polaris/v1/client-settings',
+    })
+
+    expect(config).toEqual({ headless_mode: 'enabled' })
+  })
+})

--- a/src_assets/common/assets/web/components/QuickControls.vue
+++ b/src_assets/common/assets/web/components/QuickControls.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { ref, onMounted, onUnmounted, inject } from 'vue'
+import { computed, ref, onMounted, onUnmounted, inject } from 'vue'
 import { useToast } from '../composables/useToast'
+import { CLIENT_SETTINGS_RESPONSE_ONLY_KEYS, resolveClientSettingsSync } from '../client-settings-sync'
 
 const config = ref({})
 const pendingKey = ref(null)
@@ -41,6 +42,7 @@ const responseOnlyConfigKeys = [
   'runtime_effective_headless',
   'runtime_gpu_native_override_active',
   'stream_display_mode',
+  ...CLIENT_SETTINGS_RESPONSE_ONLY_KEYS,
 ]
 
 function isEnabled(key) {
@@ -155,6 +157,23 @@ const visibleToggles = () => (
     ? toggles.filter((toggle) => compactToggleKeys.includes(toggle.key))
     : toggles
 )
+
+const clientSettingsSync = computed(() => resolveClientSettingsSync(config.value))
+const syncBadgeKey = computed(() => {
+  if (!clientSettingsSync.value.available) return 'quick_controls.sync_unavailable_badge'
+  if (clientSettingsSync.value.relaunchRequired) return 'quick_controls.sync_pending_badge'
+  return 'quick_controls.sync_ready_badge'
+})
+const syncCopyKey = computed(() => {
+  if (!clientSettingsSync.value.available) return 'quick_controls.sync_unavailable_desc'
+  if (clientSettingsSync.value.relaunchRequired) return 'quick_controls.sync_pending_desc'
+  return 'quick_controls.sync_ready_desc'
+})
+const syncBadgeTone = computed(() => {
+  if (!clientSettingsSync.value.available) return 'border-amber-300/30 bg-amber-300/10 text-amber-200'
+  if (clientSettingsSync.value.relaunchRequired) return 'border-amber-300/30 bg-amber-300/10 text-amber-200'
+  return 'border-green-400/30 bg-green-400/10 text-green-300'
+})
 </script>
 
 <template>
@@ -165,7 +184,10 @@ const visibleToggles = () => (
         <div v-if="!props.compact" class="mt-1 text-[11px] text-storm">{{ $t('quick_controls.helper') }}</div>
         <div v-else class="mt-1 text-[11px] text-storm">Fast stream toggles.</div>
       </div>
-      <div class="control-chip whitespace-nowrap">{{ $t('quick_controls.live_default_badge') }}</div>
+      <div class="control-chip whitespace-nowrap" :class="syncBadgeTone">{{ $t(syncBadgeKey) }}</div>
+    </div>
+    <div v-if="!props.compact" class="rounded-lg border border-storm/20 bg-void/25 px-3 py-2 text-[11px] leading-relaxed text-storm">
+      {{ $t(syncCopyKey) }}
     </div>
     <button
       v-for="t in visibleToggles()"
@@ -197,7 +219,8 @@ const visibleToggles = () => (
       </div>
     </button>
     <div v-if="props.compact" class="pt-1 text-[11px] text-storm/90">
-      More host controls in <router-link to="/config" class="text-ice no-underline hover:text-ice/80">Settings</router-link>.
+      {{ $t(syncBadgeKey) }}.
+      <router-link to="/config" class="text-ice no-underline hover:text-ice/80">Settings</router-link>.
     </div>
     <div v-if="pendingKey" class="pt-1 text-center text-[11px] text-storm">{{ $t('quick_controls.saving') }}</div>
   </div>

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -7,6 +7,7 @@ import DisplayOutputSelector from './audiovideo/DisplayOutputSelector.vue'
 import DisplayDeviceOptions from "./audiovideo/DisplayDeviceOptions.vue";
 import VirtualDisplayStatus from "./audiovideo/VirtualDisplayStatus.vue";
 import Checkbox from "../../Checkbox.vue";
+import { resolveClientSettingsSync } from '../../client-settings-sync'
 
 const $t = inject('i18n').t;
 
@@ -79,6 +80,35 @@ const streamDisplayMode = computed(() => {
 const selectedStreamDisplayMode = computed(() => (
   streamDisplayModes.find((mode) => mode.id === streamDisplayMode.value) || streamDisplayModes[0]
 ))
+
+const clientSettingsSync = computed(() => resolveClientSettingsSync(config.value))
+const clientSettingsSyncBadge = computed(() => {
+  if (!clientSettingsSync.value.available) return 'Unavailable'
+  if (clientSettingsSync.value.relaunchRequired) return 'Pending relaunch'
+  return 'Bidirectional'
+})
+const clientSettingsSyncTone = computed(() => {
+  if (!clientSettingsSync.value.available || clientSettingsSync.value.relaunchRequired) {
+    return 'border-amber-300/30 bg-amber-300/10 text-amber-200'
+  }
+  return 'border-green-400/30 bg-green-400/10 text-green-300'
+})
+const clientSettingsSyncCopy = computed(() => {
+  if (!clientSettingsSync.value.available) {
+    return 'Nova cannot see the Polaris client-settings endpoint on this host yet.'
+  }
+  if (clientSettingsSync.value.relaunchRequired) {
+    return 'Nova and Polaris agree on the saved display choice, but the active stream is still using the previous runtime path.'
+  }
+  return 'Nova can push desired settings and Polaris reports the effective runtime state back to the client.'
+})
+const clientSettingsRows = computed(() => [
+  { label: 'Display mode', value: clientSettingsSync.value.desiredModeLabel, note: 'Next stream' },
+  { label: 'Effective mode', value: clientSettingsSync.value.effectiveModeLabel, note: clientSettingsSync.value.relaunchRequired ? 'Pending' : 'Synced' },
+  { label: 'Bitrate limit', value: 'Live', note: 'Client write' },
+  { label: 'Adaptive Bitrate', value: 'Live', note: 'Host + Nova' },
+  { label: 'AI Optimizer', value: 'Live', note: 'Host + Nova' },
+])
 
 function setEnabledConfig(key, enabled) {
   config.value[key] = enabled ? 'enabled' : 'disabled'
@@ -172,6 +202,23 @@ const validateFallbackMode = (event) => {
 
           <div class="settings-warning-surface">
             {{ selectedStreamDisplayMode.restartCopy }}
+          </div>
+
+          <div class="settings-subtle-surface">
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <div class="section-kicker">Nova Sync</div>
+                <div class="mt-2 text-sm leading-relaxed text-storm">{{ clientSettingsSyncCopy }}</div>
+              </div>
+              <span class="meta-pill shrink-0" :class="clientSettingsSyncTone">{{ clientSettingsSyncBadge }}</span>
+            </div>
+            <div class="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+              <div v-for="row in clientSettingsRows" :key="row.label" class="rounded-lg border border-storm/20 bg-void/25 px-3 py-2">
+                <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-storm">{{ row.label }}</div>
+                <div class="mt-1 text-sm font-medium text-silver">{{ row.value }}</div>
+                <div class="mt-1 text-[11px] text-storm">{{ row.note }}</div>
+              </div>
+            </div>
           </div>
 
           <div class="grid gap-3 xl:grid-cols-3">

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -699,6 +699,12 @@
     "disabled_now": "disabled",
     "live_badge": "Live",
     "live_default_badge": "Live by default",
+    "sync_ready_badge": "Nova sync ready",
+    "sync_pending_badge": "Sync pending",
+    "sync_unavailable_badge": "Sync unavailable",
+    "sync_ready_desc": "Nova can update live bitrate, Adaptive Bitrate, and AI Optimizer settings here; display mode changes apply on the next stream.",
+    "sync_pending_desc": "Polaris saved the requested display mode and will apply it after the active stream relaunches.",
+    "sync_unavailable_desc": "This host has not advertised the Nova client-settings endpoint yet.",
     "restart_badge": "Restart",
     "items": {
       "headless_mode": {

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -228,6 +228,7 @@ import AiOptimizer from '../configs/tabs/AiOptimizer.vue'
 import ContainerEncoders from '../configs/tabs/ContainerEncoders.vue'
 import Skeleton from '../components/Skeleton.vue'
 import { useToast } from '../composables/useToast'
+import { CLIENT_SETTINGS_RESPONSE_ONLY_KEYS, stripClientSettingsResponseOnly } from '../client-settings-sync'
 
 const { toast } = useToast()
 const i18n = inject('i18n')
@@ -240,6 +241,7 @@ const restarted = ref(false)
 const saving = ref(false)
 const restarting = ref(false)
 const config = ref(null)
+const responseOnlyConfig = ref({})
 const currentTab = ref("general")
 const vdisplayStatus = ref("1")
 const global_prep_cmd = ref([])
@@ -661,6 +663,15 @@ function clearSearchHighlight() {
   }
 }
 
+function captureResponseOnlyConfig(source) {
+  responseOnlyConfig.value = {}
+  for (const key of CLIENT_SETTINGS_RESPONSE_ONLY_KEYS) {
+    if (source[key] !== undefined) {
+      responseOnlyConfig.value[key] = source[key]
+    }
+  }
+}
+
 function resolveSearchTarget(optionKey) {
   if (!settingsContentRef.value || !optionKey) return null
   const escaped = escapeSelector(optionKey)
@@ -729,6 +740,8 @@ function serialize() {
   if (Array.isArray(configCopy.trusted_subnets)) {
     configCopy.trusted_subnets = configCopy.trusted_subnets.filter(s => s && s.trim()).join(',')
   }
+
+  stripClientSettingsResponseOnly(configCopy)
 
   return configCopy
 }
@@ -821,7 +834,7 @@ function resetLocalChanges() {
   if (!initialSerialized.value) return
   const serialized = JSON.parse(initialSerialized.value)
   Object.keys(config.value).forEach((key) => { delete config.value[key] })
-  Object.assign(config.value, serialized)
+  Object.assign(config.value, serialized, responseOnlyConfig.value)
   global_prep_cmd.value = Array.isArray(serialized.global_prep_cmd) ? serialized.global_prep_cmd : []
   global_state_cmd.value = Array.isArray(serialized.global_state_cmd) ? serialized.global_state_cmd : []
   server_cmd.value = Array.isArray(serialized.server_cmd) ? serialized.server_cmd : []
@@ -834,6 +847,7 @@ fetch("./api/config", { credentials: 'include' })
   .then((r) => r.json())
   .then((r) => {
     config.value = r
+    captureResponseOnlyConfig(config.value)
     platform.value = config.value.platform
 
     if (platform.value === "windows") {

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -386,11 +386,14 @@
               <div class="flex items-center justify-between gap-3">
                 <div>
                   <div class="eyebrow-label">{{ $t('dashboard.quick_controls') }}</div>
-                  <div class="mt-2 text-sm leading-relaxed text-storm">Keep the active stream stable. Use Settings for host-wide toggles.</div>
+                  <div class="mt-2 text-sm leading-relaxed text-storm">{{ clientSettingsSyncCopy }}</div>
                 </div>
-                <router-link to="/config" class="text-[11px] font-medium text-ice no-underline hover:text-ice/80">
-                  Settings
-                </router-link>
+                <div class="flex shrink-0 items-center gap-2">
+                  <span class="meta-pill whitespace-nowrap" :class="clientSettingsSyncTone">{{ clientSettingsSyncLabel }}</span>
+                  <router-link to="/config" class="text-[11px] font-medium text-ice no-underline hover:text-ice/80">
+                    Settings
+                  </router-link>
+                </div>
               </div>
               <div class="mt-4">
                 <QuickControls compact @change="handleQuickControlChange" />
@@ -601,6 +604,7 @@ import Skeleton from '../components/Skeleton.vue'
 import GaugeArc from '../components/GaugeArc.vue'
 import QuickControls from '../components/QuickControls.vue'
 import { useI18n } from 'vue-i18n'
+import { resolveClientSettingsSync } from '../client-settings-sync'
 
 const { stats } = useStreamStats(1000)
 const { gpu, displays, audio, sessionType } = useSystemStats(3000)
@@ -618,6 +622,7 @@ const version = ref('')
 const headlessEnabled = ref(false)
 const discoveryEnabled = ref(false)
 const pairingEnabled = ref(false)
+const clientSettingsSync = ref(resolveClientSettingsSync({}))
 const { t } = useI18n()
 
 const actionSummary = computed(() => {
@@ -744,6 +749,33 @@ function handleQuickControlChange({ key, enabled }) {
       break
   }
 }
+
+function refreshClientSettingsSync(configPayload) {
+  clientSettingsSync.value = resolveClientSettingsSync(configPayload || {})
+}
+
+const clientSettingsSyncLabel = computed(() => {
+  if (!clientSettingsSync.value.available) return 'Sync unavailable'
+  if (clientSettingsSync.value.relaunchRequired) return 'Sync pending'
+  return 'Nova sync ready'
+})
+
+const clientSettingsSyncTone = computed(() => {
+  if (!clientSettingsSync.value.available || clientSettingsSync.value.relaunchRequired) {
+    return 'border-amber-300/30 bg-amber-300/10 text-amber-200'
+  }
+  return 'border-green-400/30 bg-green-400/10 text-green-300'
+})
+
+const clientSettingsSyncCopy = computed(() => {
+  if (!clientSettingsSync.value.available) {
+    return 'Nova-facing client settings are unavailable on this Polaris build.'
+  }
+  if (clientSettingsSync.value.relaunchRequired) {
+    return 'A requested display mode is saved and will become active after the stream relaunches.'
+  }
+  return 'Nova-facing controls are available for live bitrate, Adaptive Bitrate, AI Optimizer, and next-stream display choices.'
+})
 
 const connectedClients = computed(() => {
   if (!stats.value?.streaming) return []
@@ -1434,6 +1466,7 @@ async function fetchSystemInfo() {
     ])
     if (configRes.ok) {
       const config = await configRes.json()
+      refreshClientSettingsSync(config)
       systemInfo.gpuName = config.adapter_name || ''
       systemInfo.gpuDriver = config.gpu_driver || ''
       systemInfo.version = config.version || ''
@@ -1701,6 +1734,7 @@ onMounted(async () => {
     const res = await fetch('./api/config', { credentials: 'include' })
     if (res.ok) {
       const data = await res.json()
+      refreshClientSettingsSync(data)
       version.value = data.version || '0.0.0'
       headlessEnabled.value = data.headless_mode === 'enabled'
       discoveryEnabled.value = data.enable_discovery !== 'disabled'


### PR DESCRIPTION
## Summary
- Preserve isolated cage sessions on Disconnect so clients can leave and rejoin without ending the game.
- Add explicit End handling for clients that should terminate the app/runtime.
- Update the npm lockfile fast-uri resolution to 3.1.2 to address the open Dependabot alerts.

## Verification
- npm audit --audit-level=low
- npm test
- npm run lint
- ./gradlew :app:assembleNonRoot_gameDebug in Nova against the paired client branch
- git diff --check