### PR TITLE
Prefer linear extcopy modifiers for headless DMA-BUF

### DIFF
--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -1414,19 +1414,49 @@ namespace wl {
     target.destroy();
 
     bool used_implicit_modifier = false;
+    bool attempted_linear_modifier = false;
     if (!chosen_format.modifiers.empty()) {
-      target.bo = gbm_bo_create_with_modifiers2(
-        gbm_device,
-        frame_width,
-        frame_height,
-        chosen_format.format,
-        chosen_format.modifiers.data(),
-        chosen_format.modifiers.size(),
-        GBM_BO_USE_RENDERING
-      );
+      auto requested_modifiers = chosen_format.modifiers;
+      auto linear_it = std::find(requested_modifiers.begin(), requested_modifiers.end(), DRM_FORMAT_MOD_LINEAR);
+      if (linear_it != requested_modifiers.end()) {
+        const std::uint64_t linear_modifier = *linear_it;
+        requested_modifiers.erase(linear_it);
+        attempted_linear_modifier = true;
+
+        BOOST_LOG(info) << "Extcopy DMA-BUF capture: preferring linear modifier advertised by capture constraints"sv;
+        target.bo = gbm_bo_create_with_modifiers2(
+          gbm_device,
+          frame_width,
+          frame_height,
+          chosen_format.format,
+          &linear_modifier,
+          1,
+          GBM_BO_USE_RENDERING
+        );
+      }
+
+      if (!target.bo && !requested_modifiers.empty()) {
+        if (attempted_linear_modifier) {
+          BOOST_LOG(info) << "Extcopy DMA-BUF capture: linear modifier allocation failed; retrying remaining advertised modifiers"sv;
+        }
+
+        target.bo = gbm_bo_create_with_modifiers2(
+          gbm_device,
+          frame_width,
+          frame_height,
+          chosen_format.format,
+          requested_modifiers.data(),
+          requested_modifiers.size(),
+          GBM_BO_USE_RENDERING
+        );
+      }
     }
 
     if (!target.bo && chosen_format.implicit_modifier) {
+      if (attempted_linear_modifier) {
+        BOOST_LOG(info) << "Extcopy DMA-BUF capture: linear modifier allocation failed; retrying implicit modifier allocation"sv;
+      }
+
       used_implicit_modifier = true;
       target.bo = gbm_bo_create(
         gbm_device,


### PR DESCRIPTION
## Summary
- Prefer an advertised linear DMA-BUF modifier when allocating headless ext-image-copy-capture buffers.
- Fall back to the remaining advertised modifiers, then implicit GBM allocation if linear allocation is unavailable.
- Add log lines that make the selected fallback path visible in issue #49 retests.

## Why
Issue #49 now appears to include an AMD headless path where ext-image-copy advertises `DRM_FORMAT_MOD_LINEAR`, but GBM selects an AMD-specific tiled modifier. The compositor accepts the buffer creation and then fails the first frame copy with `reason=0`, causing Polaris to fall back to SHM/CPU capture.

Trying linear first mirrors the safer nested labwc DMA-BUF path and should keep the stream on the GPU-resident capture path when the compositor/driver combination cannot complete frame copies into the tiled modifier.

## Validation
- Built on Linux test host with CUDA enabled:
  `cmake -S . -B build-issue49 -G Ninja -DCMAKE_BUILD_TYPE=Release -DPOLARIS_ENABLE_CUDA=ON -DCUDA_FAIL_ON_MISSING=ON && cmake --build build-issue49 -j$(nproc)`
- Ran `ctest --output-on-failure`; no tests were registered in that build tree.

## Retest Notes
For #49, the key signal is whether AMD headless sessions now log `Extcopy DMA-BUF capture: preferring linear modifier advertised by capture constraints` and then report `capture_transport=dmabuf frame_residency=gpu` instead of `headless_shm_fallback`.