### PR TITLE
Expose game runtime metadata

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1801,6 +1801,18 @@ namespace confighttp {
         game["already_imported"] = already;
         if (!lutris_game.runner.empty()) {
           game["runner"] = lutris_game.runner;
+          if (boost::iequals(lutris_game.runner, "wine")) {
+            game["platform"] = "windows";
+            game["runtime"] = "wine";
+          } else if (boost::iequals(lutris_game.runner, "proton")) {
+            game["platform"] = "windows";
+            game["runtime"] = "proton";
+          } else if (boost::iequals(lutris_game.runner, "linux")) {
+            game["platform"] = "linux";
+            game["runtime"] = "native";
+          } else if (boost::iequals(lutris_game.runner, "steam")) {
+            game["runtime"] = "steam";
+          }
         }
         auto image_path = lutris_game.image_path.empty() ?
           game_library::find_lutris_image_path(lutris_game.slug, lutris_roots) :
@@ -2023,6 +2035,12 @@ namespace confighttp {
         }
 
         // Persist game classification metadata
+        if (game.contains("platform") && game["platform"].is_string()) {
+          app["platform"] = game["platform"];
+        }
+        if (game.contains("runtime") && game["runtime"].is_string()) {
+          app["runtime"] = game["runtime"];
+        }
         if (game.contains("game_category") && game["game_category"].is_string()) {
           app["game-category"] = game["game_category"];
         }

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -370,6 +370,7 @@ namespace confighttp::validation {
       "gamepad"sv,
       "id"sv,
       "image-path"sv,
+      "lutris-runner"sv,
       "name"sv,
       "output"sv,
       "steam-appid"sv,
@@ -401,6 +402,22 @@ namespace confighttp::validation {
       "lutris"sv,
       "manual"sv,
       "steam"sv,
+    };
+    constexpr std::array platform_values {
+      ""sv,
+      "linux"sv,
+      "macos"sv,
+      "unknown"sv,
+      "windows"sv,
+    };
+    constexpr std::array runtime_values {
+      ""sv,
+      "native"sv,
+      "proton"sv,
+      "steam"sv,
+      "umu"sv,
+      "unknown"sv,
+      "wine"sv,
     };
     constexpr std::array category_values {
       ""sv,
@@ -481,6 +498,30 @@ namespace confighttp::validation {
 
         if (!contains(source_values, std::string_view {value.get<std::string>()})) {
           error = "source must be one of manual, steam, lutris, or heroic";
+          return false;
+        }
+        continue;
+      }
+
+      if (key == "platform") {
+        if (!validate_safe_string(key, value, error)) {
+          return false;
+        }
+
+        if (!contains(platform_values, std::string_view {value.get<std::string>()})) {
+          error = "platform must be one of linux, macos, unknown, or windows";
+          return false;
+        }
+        continue;
+      }
+
+      if (key == "runtime") {
+        if (!validate_safe_string(key, value, error)) {
+          return false;
+        }
+
+        if (!contains(runtime_values, std::string_view {value.get<std::string>()})) {
+          error = "runtime must be one of native, proton, steam, umu, unknown, or wine";
           return false;
         }
         continue;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -143,6 +143,147 @@ namespace nvhttp {
       return value;
     }
 
+    std::string trim_copy(std::string value) {
+      auto is_space = [](unsigned char c) {
+        return std::isspace(c) != 0;
+      };
+      value.erase(value.begin(), std::find_if(value.begin(), value.end(), [&](unsigned char c) {
+        return !is_space(c);
+      }));
+      value.erase(std::find_if(value.rbegin(), value.rend(), [&](unsigned char c) {
+        return !is_space(c);
+      }).base(), value.end());
+      return value;
+    }
+
+    std::string normalized_token(std::string value) {
+      return lower_copy(trim_copy(std::move(value)));
+    }
+
+    std::string app_command_blob(const proc::ctx_t &app) {
+      std::string blob = app.cmd;
+      for (const auto &cmd : app.detached) {
+        if (!blob.empty()) {
+          blob += '\n';
+        }
+        blob += cmd;
+      }
+      return blob;
+    }
+
+    std::string infer_runtime_label(const std::string &runtime) {
+      const auto normalized = normalized_token(runtime);
+      if (normalized == "native") {
+        return "Native";
+      }
+      if (normalized == "proton") {
+        return "Proton";
+      }
+      if (normalized == "wine") {
+        return "Wine";
+      }
+      if (normalized == "steam") {
+        return "Steam";
+      }
+      if (normalized == "umu") {
+        return "UMU";
+      }
+      return {};
+    }
+
+    std::string infer_platform_label(const std::string &platform) {
+      const auto normalized = normalized_token(platform);
+      if (normalized == "linux") {
+        return "Linux";
+      }
+      if (normalized == "windows") {
+        return "Windows";
+      }
+      if (normalized == "macos") {
+        return "macOS";
+      }
+      return {};
+    }
+
+    struct app_runtime_metadata_t {
+      std::string source;
+      std::string launcher_detail;
+      std::string platform;
+      std::string runtime;
+    };
+
+    app_runtime_metadata_t infer_app_runtime_metadata(const proc::ctx_t &app) {
+      app_runtime_metadata_t metadata;
+      metadata.source = normalized_token(app.source);
+      if (metadata.source.empty()) {
+        metadata.source = app.steam_appid.empty() ? "manual" : "steam";
+      }
+
+      metadata.platform = normalized_token(app.platform);
+      metadata.runtime = normalized_token(app.runtime);
+      metadata.launcher_detail = normalized_token(app.lutris_runner);
+
+      const auto commands = app_command_blob(app);
+      const auto lower_commands = lower_copy(commands);
+      const bool has_wine = lower_commands.find("wine") != std::string::npos;
+      const bool has_proton = lower_commands.find("proton") != std::string::npos ||
+                              lower_commands.find("steamcompat") != std::string::npos ||
+                              lower_commands.find("steam_compat") != std::string::npos;
+      const bool has_umu = lower_commands.find("umu-run") != std::string::npos;
+
+      if (metadata.source == "lutris") {
+        const auto runner = metadata.launcher_detail;
+        if (metadata.runtime.empty()) {
+          if (runner == "wine") {
+            metadata.runtime = "wine";
+          } else if (runner == "proton") {
+            metadata.runtime = "proton";
+          } else if (runner == "linux") {
+            metadata.runtime = "native";
+          } else if (runner == "steam") {
+            metadata.runtime = "steam";
+          } else if (!runner.empty()) {
+            metadata.runtime = runner;
+          }
+        }
+        if (metadata.platform.empty()) {
+          if (metadata.runtime == "wine" || metadata.runtime == "proton") {
+            metadata.platform = "windows";
+          } else if (metadata.runtime == "native") {
+            metadata.platform = "linux";
+          }
+        }
+      } else if (metadata.source == "steam") {
+        if (metadata.runtime.empty()) {
+          metadata.runtime = (has_proton || has_umu) ? "proton" : "steam";
+        }
+        if (metadata.platform.empty() && metadata.runtime == "proton") {
+          metadata.platform = "windows";
+        }
+      } else {
+        if (metadata.runtime.empty()) {
+          if (has_umu || has_proton) {
+            metadata.runtime = "proton";
+          } else if (has_wine) {
+            metadata.runtime = "wine";
+          }
+        }
+        if (metadata.platform.empty()) {
+          if (metadata.runtime == "wine" || metadata.runtime == "proton") {
+            metadata.platform = "windows";
+          }
+        }
+      }
+
+      if (metadata.runtime.empty()) {
+        metadata.runtime = "unknown";
+      }
+      if (metadata.platform.empty()) {
+        metadata.platform = "unknown";
+      }
+      return metadata;
+    }
+
     bool is_poor_quality_grade(const std::string &grade) {
       const auto normalized = lower_copy(grade);
       return normalized == "d" || normalized == "f";
@@ -4012,11 +4153,16 @@ namespace nvhttp {
           if (name_lower.find(query_lower) == std::string::npos) continue;
         }
 
+        const auto metadata = infer_app_runtime_metadata(app);
+
         // Source filter
         if (!source_filter.empty()) {
-          bool is_steam = !app.steam_appid.empty();
-          if (source_filter == "steam" && !is_steam) continue;
-          if (source_filter == "other" && is_steam) continue;
+          const auto normalized_source_filter = normalized_token(source_filter);
+          if (normalized_source_filter == "other") {
+            if (metadata.source == "steam" || metadata.source == "lutris" || metadata.source == "heroic") continue;
+          } else if (metadata.source != normalized_source_filter) {
+            continue;
+          }
         }
 
         // Pagination
@@ -4027,10 +4173,15 @@ namespace nvhttp {
         game["id"] = app.uuid;
         game["app_id"] = app.id;
         game["name"] = app.name;
-        game["source"] = app.steam_appid.empty() ? "other" : "steam";
+        game["source"] = metadata.source;
+        game["launcher_source"] = metadata.source;
+        game["launcher_detail"] = metadata.launcher_detail;
+        game["platform"] = metadata.platform;
+        game["runtime"] = metadata.runtime;
+        game["platform_label"] = infer_platform_label(metadata.platform);
+        game["runtime_label"] = infer_runtime_label(metadata.runtime);
         game["steam_appid"] = app.steam_appid;
         game["category"] = app.game_category;
-        game["source"] = app.source;
         game["installed"] = true;
         game["hdr_supported"] = advertised_codec_support.hevc_mode == 3;
         game["cover_url"] = "/polaris/v1/games/" + app.uuid + "/cover";

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -4182,6 +4182,9 @@ namespace proc {
           ctx.steam_appid = app_node.value("steam-appid", "");
           ctx.game_category = app_node.value("game-category", "");
           ctx.source = app_node.value("source", ctx.steam_appid.empty() ? "manual" : "steam");
+          ctx.lutris_runner = app_node.value("lutris-runner", "");
+          ctx.platform = app_node.value("platform", "");
+          ctx.runtime = app_node.value("runtime", "");
           ctx.last_launched = app_node.value("last-launched", (int64_t)0);
           if (app_node.contains("genres") && app_node["genres"].is_array()) {
             for (const auto &g : app_node["genres"]) {

--- a/src/process.h
+++ b/src/process.h
@@ -93,6 +93,9 @@ namespace proc {
     std::string steam_appid;
     std::string game_category;  // "fast_action", "cinematic", "desktop", "vr", or ""
     std::string source;         // "steam", "lutris", "heroic", or "manual"
+    std::string lutris_runner;
+    std::string platform;       // "linux", "windows", "unknown", or ""
+    std::string runtime;        // "native", "proton", "wine", "steam", "unknown", or ""
     std::vector<std::string> genres;
     std::map<std::string, std::string> env_vars;  // per-app environment variables
     int64_t last_launched = 0;  // unix timestamp (seconds since epoch)

--- a/tests/unit/test_confighttp_validation.cpp
+++ b/tests/unit/test_confighttp_validation.cpp
@@ -60,6 +60,9 @@ TEST(AppValidationTests, AcceptsAWellFormedAppPayload) {
     {"prep-cmd", {{{"do", "echo start"}, {"undo", "echo stop"}, {"elevated", false}}}},
     {"detached", {"mangohud --dlsym"}},
     {"game-category", "fast_action"},
+    {"lutris-runner", "wine"},
+    {"platform", "windows"},
+    {"runtime", "wine"},
     {"source", "manual"}
   };
 
@@ -98,4 +101,26 @@ TEST(AppValidationTests, RejectsUnexpectedCommandShapes) {
   std::string error;
   EXPECT_FALSE(confighttp::validation::validate_app_payload(payload, error));
   EXPECT_NE(error.find("unsupported field"), std::string::npos);
+}
+
+TEST(AppValidationTests, RejectsUnknownPlatformMetadata) {
+  nlohmann::json payload = {
+    {"name", "Broken App"},
+    {"platform", "solaris"}
+  };
+
+  std::string error;
+  EXPECT_FALSE(confighttp::validation::validate_app_payload(payload, error));
+  EXPECT_NE(error.find("platform must be one of"), std::string::npos);
+}
+
+TEST(AppValidationTests, RejectsUnknownRuntimeMetadata) {
+  nlohmann::json payload = {
+    {"name", "Broken App"},
+    {"runtime", "dosbox"}
+  };
+
+  std::string error;
+  EXPECT_FALSE(confighttp::validation::validate_app_payload(payload, error));
+  EXPECT_NE(error.find("runtime must be one of"), std::string::npos);
 }

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -99,7 +99,7 @@ TEST(LutrisLibraryScannerTests, ScansMultipleXdgDirectories) {
     "slug: data-game\n"
     "runner: wine\n");
 
-  const auto games = game_library::scan_lutris_games({config_dir, data_dir});
+  const auto games = game_library::scan_lutris_games(std::vector<std::filesystem::path> {config_dir, data_dir});
   ASSERT_EQ(games.size(), 2);
   EXPECT_EQ(games[0].slug, "config-game");
   EXPECT_EQ(games[1].slug, "data-game");

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -133,7 +133,11 @@ TEST(ProcessMigrationTests, ParseNormalizesSteamBigPictureLaunchAndAddsCleanupUn
 
   ASSERT_NE(steam_ctx, parsed_apps.end());
   ASSERT_EQ(steam_ctx->detached.size(), 1);
+#ifdef __linux__
   EXPECT_EQ(steam_ctx->detached.front(), "setsid steam -gamepadui");
+#else
+  EXPECT_EQ(steam_ctx->detached.front(), "setsid steam steam://open/bigpicture");
+#endif
   EXPECT_TRUE(steam_ctx->cmd.empty());
   ASSERT_FALSE(steam_ctx->prep_cmds.empty());
   EXPECT_EQ(steam_ctx->prep_cmds.back().undo_cmd, "setsid steam -shutdown");
@@ -335,6 +339,8 @@ TEST(ProcessMigrationTests, ParsePreservesLutrisImportMetadataAndSource) {
       {"source", "lutris"},
       {"lutris-slug", "lutris-game"},
       {"lutris-runner", "wine"},
+      {"platform", "windows"},
+      {"runtime", "wine"},
       {"detached", {"setsid lutris lutris:rungame/lutris-game"}},
       {"gamepad", "ds5"},
       {"game-category", "cinematic"},
@@ -364,6 +370,9 @@ TEST(ProcessMigrationTests, ParsePreservesLutrisImportMetadataAndSource) {
 
   ASSERT_NE(lutris_ctx, parsed_apps.end());
   EXPECT_EQ(lutris_ctx->source, "lutris");
+  EXPECT_EQ(lutris_ctx->lutris_runner, "wine");
+  EXPECT_EQ(lutris_ctx->platform, "windows");
+  EXPECT_EQ(lutris_ctx->runtime, "wine");
   EXPECT_EQ(lutris_ctx->gamepad, "ds5");
   EXPECT_EQ(lutris_ctx->game_category, "cinematic");
   ASSERT_EQ(lutris_ctx->detached.size(), 1);


### PR DESCRIPTION
## Summary

Adds first-class launcher/runtime metadata for Polaris game entries so Nova can distinguish Steam, Lutris, Heroic/manual apps and show whether a game is Linux/native, Windows via Wine/Proton, or unknown.

## Changes

- Persist `platform`, `runtime`, and `lutris-runner` app metadata during import/parse.
- Infer and return `source`, `launcher_source`, `launcher_detail`, `platform`, `runtime`, and display labels from `/polaris/v1/games`.
- Mark Lutris discoveries with runtime/platform metadata for Wine, Proton, Linux/native, and Steam-backed entries.
- Validate app metadata fields explicitly instead of relying on generic string pass-through.
- Fix native test coverage exposed by enabling the C++ suites on macOS.

## Validation

- `npm run lint`
- `npm test`
- `cmake --build build --target polaris -j2`
- `cmake --build build --target test_polaris test_polaris_config -j2`
- `ctest --test-dir build -R '^(test_polaris|test_polaris_config)$' --output-on-failure`