### PR TITLE
Prepare Polaris v1.0.13 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.0.12
+project(Polaris VERSION 1.0.13
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,18 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+## v1.0.13
+
+Patch release focused on AI Auto Quality, Nova coordination, and Linux stream pacing diagnostics.
+
+- Added richer Nova/Polaris settings sync so launch optimization, applied stream settings, presentation state, adaptive bitrate status, and optimizer health are visible across both sides
+- Merged adaptive bitrate behavior into the AI Auto Quality path so recovery decisions can consider network pressure, host frame pacing, encode pressure, and session history together
+- Improved AI optimizer feedback handling so short low-confidence sessions do not incorrectly relax safe FPS caps or poison game profiles
+- Added safer history-based recovery profiles, including FPS fallback behavior and clearer host-render-limited session grading
+- Improved Linux headless stream reporting for DMA-BUF capture, CUDA conversion, encoder target, frame residency, and SHM/CPU fallback reasons
+- Added resumable disconnect handling and cleanup improvements for Steam and isolated cage sessions
+- Expanded optimizer, adaptive bitrate, stream stats, process migration, and web UI coverage for the new Auto Quality flow
+
 ## v1.0.12
 
 Patch release focused on corrected Fedora/Bazzite NVIDIA release assets.

--- a/src/adaptive_bitrate.cpp
+++ b/src/adaptive_bitrate.cpp
@@ -35,10 +35,31 @@ namespace adaptive_bitrate {
 
   // Timing for recovery and adjustment intervals
   static std::chrono::steady_clock::time_point last_adjustment_time;
-  static std::chrono::steady_clock::time_point last_loss_time;
+  static std::chrono::steady_clock::time_point last_pressure_time;
 
   // Track whether we have received any stats yet
   static bool initialized = false;
+  static std::string controller_state = "disabled";
+  static std::string controller_reason = "disabled";
+
+  static void set_controller_status(const std::string &state, const std::string &reason) {
+    controller_state = state;
+    controller_reason = reason;
+  }
+
+  static int clamp_target(int target, int base) {
+    target = std::clamp(target, current_config.min_bitrate_kbps, current_config.max_bitrate_kbps);
+    return std::min(target, base);
+  }
+
+  static bool interval_elapsed(std::chrono::steady_clock::time_point now) {
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_adjustment_time);
+    if (elapsed.count() < current_config.adjustment_interval_ms) {
+      return false;
+    }
+    last_adjustment_time = now;
+    return true;
+  }
 
   void update_network_stats(double packet_loss_percent, double rtt_ms) {
     if (!enabled.load(std::memory_order_relaxed)) {
@@ -54,7 +75,8 @@ namespace adaptive_bitrate {
       avg_rtt = rtt_ms;
       rtt_sample_count = 1;
       last_adjustment_time = now;
-      last_loss_time = (packet_loss_percent > 0) ? now : (now - 10s);
+      last_pressure_time = (packet_loss_percent > 0) ? now : (now - 10s);
+      set_controller_status("steady", "warming_up");
       initialized = true;
       return;
     }
@@ -72,15 +94,13 @@ namespace adaptive_bitrate {
 
     // Track when we last saw loss
     if (packet_loss_percent > 0.0) {
-      last_loss_time = now;
+      last_pressure_time = now;
     }
 
     // Check if enough time has passed for an adjustment
-    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_adjustment_time);
-    if (elapsed.count() < current_config.adjustment_interval_ms) {
+    if (!interval_elapsed(now)) {
       return;
     }
-    last_adjustment_time = now;
 
     int base = base_bitrate_kbps.load(std::memory_order_relaxed);
     int current_target = target_bitrate_kbps.load(std::memory_order_relaxed);
@@ -112,6 +132,8 @@ namespace adaptive_bitrate {
       }
 
       new_target = static_cast<int>(current_target * (1.0 - reduction_factor));
+      last_pressure_time = now;
+      set_controller_status("network_pressure", rtt_spike ? "rtt_spike" : "packet_loss");
 
       BOOST_LOG(debug) << "Adaptive bitrate: reducing "
                        << current_target << " -> " << new_target << " kbps"
@@ -121,16 +143,17 @@ namespace adaptive_bitrate {
     } else {
       // Network is healthy -- consider increasing bitrate back toward base
 
-      // Only increase if no loss for at least 5 seconds
-      auto time_since_loss = std::chrono::duration_cast<std::chrono::seconds>(now - last_loss_time);
-      if (time_since_loss.count() >= 5 && current_target < base) {
+      // Only increase if the stream has been healthy for at least 10 seconds
+      auto time_since_pressure = std::chrono::duration_cast<std::chrono::seconds>(now - last_pressure_time);
+      if (time_since_pressure.count() >= 10 && current_target < base) {
         // Gradual recovery: increase by a fraction of max_change_rate
-        // Use half the max change rate for recovery to be conservative
-        double increase_factor = max_change * 0.5;
+        // Use a smaller recovery step so reconnects and transient spikes do not bounce.
+        double increase_factor = max_change * 0.4;
         new_target = static_cast<int>(current_target * (1.0 + increase_factor));
 
         // Don't overshoot the base bitrate
         new_target = std::min(new_target, base);
+        set_controller_status("recovering", "healthy_window");
 
         BOOST_LOG(debug) << "Adaptive bitrate: recovering "
                          << current_target << " -> " << new_target << " kbps"
@@ -138,13 +161,70 @@ namespace adaptive_bitrate {
       }
     }
 
-    // Clamp to configured bounds
-    new_target = std::clamp(new_target, current_config.min_bitrate_kbps, current_config.max_bitrate_kbps);
+    if (new_target == current_target && controller_state != "network_pressure") {
+      set_controller_status("steady", "healthy");
+    }
 
-    // Also clamp to not exceed the base bitrate from the client
-    new_target = std::min(new_target, base);
+    target_bitrate_kbps.store(clamp_target(new_target, base), std::memory_order_relaxed);
+  }
 
-    target_bitrate_kbps.store(new_target, std::memory_order_relaxed);
+  void update_stream_health(double fps_ratio,
+                            double dropped_frame_ratio,
+                            double duplicate_frame_ratio,
+                            double frame_jitter_ms,
+                            double encode_time_ms,
+                            double avg_frame_age_ms) {
+    if (!enabled.load(std::memory_order_relaxed)) {
+      return;
+    }
+
+    std::lock_guard<std::mutex> lock(state_mutex);
+    auto now = std::chrono::steady_clock::now();
+    if (!initialized) {
+      last_adjustment_time = now;
+      last_pressure_time = now - 10s;
+      initialized = true;
+    }
+
+    const bool encoder_pressure = encode_time_ms >= 11.0;
+    const bool pacing_pressure =
+      (fps_ratio > 0.0 && fps_ratio < 0.88) ||
+      dropped_frame_ratio >= 0.04 ||
+      duplicate_frame_ratio >= 0.10 ||
+      frame_jitter_ms >= 2.2 ||
+      encoder_pressure;
+    if (!pacing_pressure) {
+      return;
+    }
+    if (!encoder_pressure) {
+      set_controller_status("frame_pacing_observed", "frame_pacing");
+      return;
+    }
+    if (!interval_elapsed(now)) {
+      last_pressure_time = now;
+      return;
+    }
+
+    int base = base_bitrate_kbps.load(std::memory_order_relaxed);
+    int current_target = target_bitrate_kbps.load(std::memory_order_relaxed);
+    if (base <= 0 || current_target <= 0) {
+      return;
+    }
+
+    const int new_target = clamp_target(static_cast<int>(current_target * 0.88), base);
+    last_pressure_time = now;
+    set_controller_status("encoder_pressure", "encode_load");
+    if (new_target != current_target) {
+      BOOST_LOG(debug) << "Adaptive bitrate: reducing "
+                       << current_target << " -> " << new_target << " kbps"
+                       << " (fps_ratio=" << fps_ratio
+                       << ", dropped=" << dropped_frame_ratio
+                       << ", duplicate=" << duplicate_frame_ratio
+                       << ", jitter=" << frame_jitter_ms
+                       << "ms, encode=" << encode_time_ms
+                       << "ms, age=" << avg_frame_age_ms << "ms)";
+      target_bitrate_kbps.store(new_target, std::memory_order_relaxed);
+    }
   }
 
   int get_target_bitrate_kbps() {
@@ -154,12 +234,31 @@ namespace adaptive_bitrate {
     return target_bitrate_kbps.load(std::memory_order_relaxed);
   }
 
+  state_t get_state() {
+    std::lock_guard<std::mutex> lock(state_mutex);
+    state_t state;
+    state.enabled = enabled.load(std::memory_order_relaxed);
+    state.base_bitrate_kbps = base_bitrate_kbps.load(std::memory_order_relaxed);
+    state.target_bitrate_kbps = state.enabled ? target_bitrate_kbps.load(std::memory_order_relaxed) : 0;
+    state.min_bitrate_kbps = current_config.min_bitrate_kbps;
+    state.max_bitrate_kbps = current_config.max_bitrate_kbps;
+    state.ewma_packet_loss = ewma_packet_loss;
+    state.ewma_rtt_ms = ewma_rtt;
+    state.state = state.enabled ? controller_state : "disabled";
+    state.reason = state.enabled ? controller_reason : "disabled";
+    return state;
+  }
+
   void set_base_bitrate(int kbps) {
-    base_bitrate_kbps.store(kbps, std::memory_order_relaxed);
+    const int clamped = std::clamp(kbps, current_config.min_bitrate_kbps, current_config.max_bitrate_kbps);
+    base_bitrate_kbps.store(clamped, std::memory_order_relaxed);
 
     // Initialize target to base when first set
     int expected = 0;
-    target_bitrate_kbps.compare_exchange_strong(expected, kbps, std::memory_order_relaxed);
+    if (!target_bitrate_kbps.compare_exchange_strong(expected, clamped, std::memory_order_relaxed)) {
+      int current = target_bitrate_kbps.load(std::memory_order_relaxed);
+      target_bitrate_kbps.store(clamp_target(current, clamped), std::memory_order_relaxed);
+    }
   }
 
   void set_enabled(bool enable) {
@@ -194,6 +293,8 @@ namespace adaptive_bitrate {
     avg_rtt = 0.0;
     rtt_sample_count = 0;
     initialized = false;
+    set_controller_status(enabled.load(std::memory_order_relaxed) ? "steady" : "disabled",
+                          enabled.load(std::memory_order_relaxed) ? "reset" : "disabled");
 
     base_bitrate_kbps.store(0, std::memory_order_relaxed);
     target_bitrate_kbps.store(0, std::memory_order_relaxed);

--- a/src/adaptive_bitrate.h
+++ b/src/adaptive_bitrate.h
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <string>
 
 namespace adaptive_bitrate {
 
@@ -22,6 +23,18 @@ namespace adaptive_bitrate {
     int adjustment_interval_ms = 1000; // How often to adjust
   };
 
+  struct state_t {
+    bool enabled = false;
+    int base_bitrate_kbps = 0;
+    int target_bitrate_kbps = 0;
+    int min_bitrate_kbps = 0;
+    int max_bitrate_kbps = 0;
+    double ewma_packet_loss = 0.0;
+    double ewma_rtt_ms = 0.0;
+    std::string state = "disabled";
+    std::string reason = "disabled";
+  };
+
   /**
    * @brief Feed network statistics from client loss reports.
    * @param packet_loss_percent Packet loss percentage (0-100).
@@ -30,10 +43,25 @@ namespace adaptive_bitrate {
   void update_network_stats(double packet_loss_percent, double rtt_ms);
 
   /**
+   * @brief Feed local stream health so bitrate can react to host pacing pressure.
+   */
+  void update_stream_health(double fps_ratio,
+                            double dropped_frame_ratio,
+                            double duplicate_frame_ratio,
+                            double frame_jitter_ms,
+                            double encode_time_ms,
+                            double avg_frame_age_ms);
+
+  /**
    * @brief Get the current recommended bitrate.
    * @return Target bitrate in kbps, or 0 if adaptive bitrate is disabled.
    */
   int get_target_bitrate_kbps();
+
+  /**
+   * @brief Get the current controller state for status APIs and HUDs.
+   */
+  state_t get_state();
 
   /**
    * @brief Set the base bitrate from client request.

--- a/src/ai_optimizer.cpp
+++ b/src/ai_optimizer.cpp
@@ -59,7 +59,9 @@ namespace ai_optimizer {
     constexpr const char *DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai";
     constexpr const char *DEFAULT_LOCAL_BASE_URL = "http://127.0.0.1:11434/v1";
 
-    constexpr int OPTIMIZATION_SCHEMA_VERSION = 2;
+    constexpr int OPTIMIZATION_SCHEMA_VERSION = 3;
+    constexpr int MAX_REASONABLE_SESSION_COUNT = 10000;
+    constexpr int MAX_REASONABLE_POOR_OUTCOME_COUNT = 10000;
     constexpr int LOW_CONFIDENCE_TTL_HOURS = 24;
     constexpr int MEDIUM_CONFIDENCE_TTL_HOURS = 72;
     constexpr int RECOVERY_TTL_HOURS = 12;
@@ -88,7 +90,7 @@ namespace ai_optimizer {
     std::int64_t cached_at = 0;
   };
 
-  static void load_history();
+  static bool load_history();
   static void save_history();
 
   struct http_response_t {
@@ -113,6 +115,18 @@ namespace ai_optimizer {
       ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
     }
     return value;
+  }
+
+  static bool is_frame_or_host_pacing_issue(const std::string &issue) {
+    const auto normalized = to_lower_copy(issue);
+    return normalized == "frame_pacing" || normalized == "host_render_limited";
+  }
+
+  static bool has_frame_or_host_pacing_issue(const session_history_t &session) {
+    return is_frame_or_host_pacing_issue(session.last_primary_issue) ||
+      std::any_of(session.last_issues.begin(), session.last_issues.end(), [](const std::string &issue) {
+        return is_frame_or_host_pacing_issue(issue);
+      });
   }
 
   static std::string trim_trailing_slashes(std::string value) {
@@ -332,6 +346,131 @@ namespace ai_optimizer {
     return normalized == "d" || normalized == "f";
   }
 
+  static std::string normalize_end_reason(const std::string &reason) {
+    auto normalized = to_lower_copy(reason);
+    normalized.erase(normalized.begin(), std::find_if(normalized.begin(), normalized.end(), [](unsigned char ch) {
+      return !std::isspace(ch);
+    }));
+    normalized.erase(std::find_if(normalized.rbegin(), normalized.rend(), [](unsigned char ch) {
+      return !std::isspace(ch);
+    }).base(), normalized.end());
+    if (normalized.empty()) {
+      return "disconnect";
+    }
+    return normalized;
+  }
+
+  static bool is_explicit_end_reason(const std::string &reason) {
+    const auto normalized = normalize_end_reason(reason);
+    return normalized == "end" || normalized == "user_end" || normalized == "quit";
+  }
+
+  static bool is_soft_end_reason(const std::string &reason) {
+    const auto normalized = normalize_end_reason(reason);
+    return normalized == "host_pause" ||
+      normalized == "disconnect" ||
+      normalized == "cancelled";
+  }
+
+  static bool has_confirming_soft_end_recovery_signal(const session_history_t &session) {
+    return is_soft_end_reason(session.last_end_reason) &&
+      session.last_duration_s >= 60 &&
+      session.last_sample_count >= 30 &&
+      session.last_safe_target_fps > 0.0 &&
+      has_frame_or_host_pacing_issue(session);
+  }
+
+  static bool is_low_confidence_soft_end_without_confirming_signal(const session_history_t &session) {
+    const auto confidence = to_lower_copy(session.last_sample_confidence);
+    const bool soft_end = is_soft_end_reason(session.last_end_reason);
+    return confidence == "low" &&
+      soft_end &&
+      session.poor_outcome_count <= 0 &&
+      session.consecutive_poor_outcomes <= 0 &&
+      !has_confirming_soft_end_recovery_signal(session);
+  }
+
+  static bool is_unconfirmed_poor_recovery_feedback(const session_history_t &session) {
+    return is_poor_quality_grade(latest_quality_grade(session)) &&
+      is_low_confidence_soft_end_without_confirming_signal(session);
+  }
+
+  static bool has_session_observation(const session_history_t &session) {
+    return session.avg_fps > 0.0 ||
+      session.last_fps > 0.0 ||
+      session.last_target_fps > 0.0 ||
+      session.last_updated_at > 0 ||
+      !latest_quality_grade(session).empty();
+  }
+
+  static int sanitize_session_count(const session_history_t &session) {
+    if (session.session_count > 0 &&
+        session.session_count <= MAX_REASONABLE_SESSION_COUNT) {
+      return session.session_count;
+    }
+
+    return has_session_observation(session) ? 1 : 0;
+  }
+
+  static int sanitize_poor_outcome_count(int value, int session_count) {
+    if (value < 0 ||
+        value > MAX_REASONABLE_POOR_OUTCOME_COUNT ||
+        session_count <= 0 ||
+        value > session_count) {
+      return 0;
+    }
+
+    return value;
+  }
+
+  static int sanitize_consecutive_poor_outcome_count(int value, int poor_outcome_count) {
+    if (value < 0 ||
+        value > MAX_REASONABLE_POOR_OUTCOME_COUNT ||
+        poor_outcome_count <= 0 ||
+        value > poor_outcome_count) {
+      return 0;
+    }
+
+    return value;
+  }
+
+  session_history_t sanitize_session_history(session_history_t session) {
+    session.session_count = sanitize_session_count(session);
+    session.poor_outcome_count =
+      sanitize_poor_outcome_count(session.poor_outcome_count, session.session_count);
+    session.consecutive_poor_outcomes =
+      sanitize_consecutive_poor_outcome_count(
+        session.consecutive_poor_outcomes,
+        session.poor_outcome_count
+      );
+
+    if (session.last_safe_target_fps < 0.0 ||
+        session.last_safe_target_fps > 240.0 ||
+        !std::isfinite(session.last_safe_target_fps)) {
+      session.last_safe_target_fps = 0.0;
+    }
+
+    if (is_low_confidence_soft_end_without_confirming_signal(session)) {
+      session.last_safe_target_fps = 0.0;
+      session.last_relaunch_recommended = false;
+      if (to_lower_copy(session.last_health_grade) == "degraded") {
+        session.last_health_grade = "watch";
+      }
+    }
+
+    return session;
+  }
+
+  static bool history_repair_should_persist(const session_history_t &before,
+                                            const session_history_t &after) {
+    return before.session_count != after.session_count ||
+      before.poor_outcome_count != after.poor_outcome_count ||
+      before.consecutive_poor_outcomes != after.consecutive_poor_outcomes ||
+      before.last_safe_target_fps != after.last_safe_target_fps ||
+      before.last_relaunch_recommended != after.last_relaunch_recommended ||
+      before.last_health_grade != after.last_health_grade;
+  }
+
   static bool is_control_shell_app(const std::string &app_name) {
     const auto normalized = to_lower_copy(app_name);
     return normalized.empty() ||
@@ -343,9 +482,107 @@ namespace ai_optimizer {
            normalized.find("big picture") != std::string::npos;
   }
 
-  static bool should_invalidate_cache_for_poor_quality(const std::string &app_name,
-                                                       const session_history_t &session) {
-    return is_poor_quality_grade(session.quality_grade) && !is_control_shell_app(app_name);
+  session_feedback_policy_t classify_session_feedback(
+      const std::string &app_name,
+      const session_history_t &session) {
+    session_feedback_policy_t policy;
+    policy.end_reason = normalize_end_reason(session.last_end_reason);
+
+    const bool has_quality_metrics =
+      session.avg_fps > 0.0 &&
+      (session.last_target_fps > 0.0 || session.avg_fps > 0.0);
+    if (!has_quality_metrics) {
+      policy.confidence = "ignored";
+      policy.ignored_reason = "missing_quality_metrics";
+      return policy;
+    }
+
+    const bool explicit_end = is_explicit_end_reason(policy.end_reason);
+    const bool sampled_recovery_end = has_confirming_soft_end_recovery_signal(session);
+    const bool high_signal =
+      (explicit_end || sampled_recovery_end) &&
+      session.last_duration_s >= 30 &&
+      session.last_sample_count >= 10;
+
+    policy.accepted = true;
+    policy.confidence = high_signal ? "high" : "low";
+    policy.counts_poor_outcome = high_signal && !is_control_shell_app(app_name);
+    policy.can_invalidate_cache = policy.counts_poor_outcome;
+    return policy;
+  }
+
+  std::string grade_session_quality(const session_history_t &session) {
+    const double target_fps =
+      session.last_target_fps > 0.0 ? session.last_target_fps : session.avg_fps;
+    const double fps_ratio =
+      (target_fps > 0.0 && session.avg_fps > 0.0) ?
+        std::clamp(session.avg_fps / target_fps, 0.0, 1.5) :
+        0.0;
+    const double low_ratio =
+      (target_fps > 0.0 && session.last_low_1_percent_fps > 0.0) ?
+        std::clamp(session.last_low_1_percent_fps / target_fps, 0.0, 1.5) :
+        1.5;
+    const bool has_low_percentile = session.last_low_1_percent_fps > 0.0;
+    const bool isolated_min_drop =
+      session.last_min_fps > 0.0 &&
+      target_fps > 0.0 &&
+      session.last_min_fps < target_fps * 0.45;
+    const bool min_drop_confirms_severe_pacing =
+      isolated_min_drop &&
+      (
+        !has_low_percentile ||
+        low_ratio < 0.70 ||
+        fps_ratio < 0.85 ||
+        session.last_frame_pacing_bad_pct >= 5.0
+      );
+    const bool severe_pacing =
+      (has_low_percentile && low_ratio < 0.55) ||
+      min_drop_confirms_severe_pacing ||
+      session.last_frame_pacing_bad_pct >= 20.0;
+    const bool moderate_pacing =
+      (has_low_percentile && low_ratio < 0.75) ||
+      session.last_frame_pacing_bad_pct >= 10.0;
+    const bool mild_pacing =
+      (has_low_percentile && low_ratio < 0.85) ||
+      isolated_min_drop ||
+      session.last_frame_pacing_bad_pct >= 5.0;
+
+    if (session.avg_fps <= 0.0) {
+      return "F";
+    }
+    if (severe_pacing) {
+      return "D";
+    }
+    if (moderate_pacing) {
+      return "C";
+    }
+    if (mild_pacing) {
+      return "B";
+    }
+    if (fps_ratio >= 0.95 && session.packet_loss_pct < 0.5 && session.avg_latency_ms < 20.0) {
+      return "A";
+    }
+    if (fps_ratio >= 0.85 && session.packet_loss_pct < 2.0 && session.avg_latency_ms < 40.0) {
+      return "B";
+    }
+    if (fps_ratio >= 0.70 && session.packet_loss_pct < 5.0) {
+      return "C";
+    }
+    if (fps_ratio >= 0.50) {
+      return "D";
+    }
+    return "F";
+  }
+
+  static bool should_invalidate_cache_for_poor_quality(
+      const std::string &app_name,
+      const session_history_t &session,
+      const session_feedback_policy_t &policy,
+      int consecutive_poor_outcomes) {
+    return is_poor_quality_grade(session.quality_grade) &&
+           policy.can_invalidate_cache &&
+           consecutive_poor_outcomes >= 2 &&
+           !is_control_shell_app(app_name);
   }
 
   static std::string codec_family(const std::string &codec) {
@@ -391,6 +628,123 @@ namespace ai_optimizer {
     return std::clamp(safe_kbps, 6000, std::max(6000, baseline_kbps > 0 ? baseline_kbps : safe_kbps));
   }
 
+  double derive_safe_target_fps(double target_fps,
+                                double avg_fps,
+                                double low_1_percent_fps,
+                                double min_fps,
+                                double frame_pacing_bad_pct,
+                                bool mobile_client,
+                                bool degraded_history,
+                                bool pacing_risk) {
+    if (target_fps <= 30.0) {
+      return 0.0;
+    }
+
+    const double low_signal =
+      low_1_percent_fps > 0.0 ? low_1_percent_fps :
+      min_fps > 0.0 ? min_fps :
+      avg_fps;
+    const bool severe_pacing =
+      (low_signal > 0.0 && low_signal < target_fps * 0.72) ||
+      frame_pacing_bad_pct >= 18.0 ||
+      (avg_fps > 0.0 && avg_fps < target_fps * 0.82);
+    const bool moderate_pacing =
+      (low_signal > 0.0 && low_signal < target_fps * 0.85) ||
+      frame_pacing_bad_pct >= 8.0 ||
+      (avg_fps > 0.0 && avg_fps < target_fps * 0.90);
+
+    if (target_fps >= 90.0 && (severe_pacing || moderate_pacing || pacing_risk || degraded_history)) {
+      const bool can_hold_sixty =
+        avg_fps >= 58.0 &&
+        low_signal >= 45.0 &&
+        frame_pacing_bad_pct < 18.0;
+      return can_hold_sixty ? 60.0 : 30.0;
+    }
+
+    if (severe_pacing) {
+      return 30.0;
+    }
+
+    if ((mobile_client && degraded_history && moderate_pacing) ||
+        (mobile_client && pacing_risk && moderate_pacing)) {
+      const bool can_hold_stable_40 =
+        target_fps >= 55.0 &&
+        target_fps <= 75.0 &&
+        avg_fps > 0.0 &&
+        avg_fps >= target_fps * 0.82 &&
+        low_signal > 0.0 &&
+        low_signal >= target_fps * 0.70;
+      if (can_hold_stable_40) {
+        return 40.0;
+      }
+
+      return 30.0;
+    }
+
+    return 0.0;
+  }
+
+  double effective_history_safe_target_fps(const std::string &device_name,
+                                           const session_history_t &raw_session) {
+    const auto session = sanitize_session_history(raw_session);
+    if (session.last_safe_target_fps <= 0.0) {
+      return 0.0;
+    }
+    if (is_unconfirmed_poor_recovery_feedback(session)) {
+      return 0.0;
+    }
+
+    const auto device_profile = device_db::get_device(device_name);
+    const bool mobile_client = is_mobile_client_type(device_profile);
+    const std::string quality_grade = latest_quality_grade(session);
+    const bool degraded_history =
+      session.consecutive_poor_outcomes > 0 ||
+      session.poor_outcome_count > 0 ||
+      is_poor_quality_grade(quality_grade) ||
+      to_lower_copy(session.last_health_grade) == "degraded";
+    const double target_fps = session.last_target_fps > 0.0 ? session.last_target_fps : session.last_fps;
+    const double history_fps =
+      session.avg_fps > 0.0 ? session.avg_fps : session.last_fps;
+    const double optimizer_fps =
+      history_fps > 0.0 && session.last_fps > 0.0 ? std::min(session.last_fps, history_fps) :
+      history_fps > 0.0 ? history_fps :
+      session.last_fps;
+    const double fps_gap = target_fps > 0.0 ? std::max(0.0, target_fps - session.last_fps) : 0.0;
+    const double fps_ratio =
+      (target_fps > 0.0 && session.last_fps > 0.0) ? std::clamp(session.last_fps / target_fps, 0.0, 1.5) : 0.0;
+    const bool prior_frame_pacing = has_frame_or_host_pacing_issue(session);
+    const bool client_pacing_risk =
+      (target_fps > 0.0 && session.last_low_1_percent_fps > 0.0 &&
+       session.last_low_1_percent_fps < target_fps * 0.85) ||
+      (target_fps > 0.0 && session.last_min_fps > 0.0 &&
+       session.last_min_fps < target_fps * 0.60) ||
+      session.last_frame_pacing_bad_pct >= 8.0;
+    const bool pacing_risk =
+      fps_gap >= 4.0 ||
+      (target_fps > 0.0 && fps_ratio < 0.88) ||
+      client_pacing_risk ||
+      prior_frame_pacing ||
+      is_poor_quality_grade(quality_grade);
+    const double revised_target = derive_safe_target_fps(
+      target_fps,
+      optimizer_fps,
+      session.last_low_1_percent_fps,
+      session.last_min_fps,
+      session.last_frame_pacing_bad_pct,
+      mobile_client,
+      degraded_history,
+      pacing_risk
+    );
+
+    if (session.last_safe_target_fps <= 30.5 &&
+        revised_target > session.last_safe_target_fps + 0.5 &&
+        target_fps > session.last_safe_target_fps + 0.5) {
+      return revised_target;
+    }
+
+    return session.last_safe_target_fps;
+  }
+
   static void enrich_session_reliability_context(const std::string &device_name,
                                                  const std::string &app_name,
                                                  session_history_t &session) {
@@ -404,13 +758,31 @@ namespace ai_optimizer {
       to_lower_copy(session.last_health_grade) == "degraded";
 
     const double target_fps = session.last_target_fps > 0.0 ? session.last_target_fps : session.last_fps;
+    const auto optimization_source = to_lower_copy(session.last_optimization_source);
+    const bool launched_with_history_safe =
+      optimization_source.find("history_safe") != std::string::npos;
     const double fps_gap = target_fps > 0.0 ? std::max(0.0, target_fps - session.last_fps) : 0.0;
     const double fps_ratio =
       (target_fps > 0.0 && session.last_fps > 0.0) ? std::clamp(session.last_fps / target_fps, 0.0, 1.5) : 0.0;
+    const double history_fps =
+      session.avg_fps > 0.0 ? session.avg_fps : session.last_fps;
+    const double optimizer_fps =
+      history_fps > 0.0 && session.last_fps > 0.0 ? std::min(session.last_fps, history_fps) :
+      history_fps > 0.0 ? history_fps :
+      session.last_fps;
+    const bool prior_frame_pacing = has_frame_or_host_pacing_issue(session);
     const bool network_risk = session.last_packet_loss_pct >= 0.35 || session.last_latency_ms >= 28.0;
+    const bool client_pacing_risk =
+      (target_fps > 0.0 && session.last_low_1_percent_fps > 0.0 &&
+       session.last_low_1_percent_fps < target_fps * 0.85) ||
+      (target_fps > 0.0 && session.last_min_fps > 0.0 &&
+       session.last_min_fps < target_fps * 0.60) ||
+      session.last_frame_pacing_bad_pct >= 8.0;
     const bool pacing_risk =
       fps_gap >= 4.0 ||
       (target_fps > 0.0 && fps_ratio < 0.88) ||
+      client_pacing_risk ||
+      prior_frame_pacing ||
       is_poor_quality_grade(quality_grade);
 
     const auto active_codec_family = codec_family(latest_codec(session));
@@ -435,6 +807,13 @@ namespace ai_optimizer {
     const bool hdr_risk =
       session.last_hdr_risk == "elevated" ||
       (session.last_safe_hdr.has_value() && !session.last_safe_hdr.value() && degraded_history);
+    const bool host_render_limited =
+      pacing_risk &&
+      !network_risk &&
+      !capture_fallback &&
+      !decoder_risk &&
+      !virtual_display_risk &&
+      !hdr_risk;
 
     if (session.last_network_risk.empty()) {
       session.last_network_risk = network_risk ? "elevated" : "normal";
@@ -455,13 +834,15 @@ namespace ai_optimizer {
       else if (virtual_display_risk) session.last_primary_issue = "virtual_display_path";
       else if (decoder_risk) session.last_primary_issue = "decoder_path";
       else if (capture_fallback) session.last_primary_issue = "capture_fallback";
+      else if (host_render_limited) session.last_primary_issue = "host_render_limited";
       else if (pacing_risk) session.last_primary_issue = "frame_pacing";
       else session.last_primary_issue = "steady";
     }
 
     if (session.last_issues.empty()) {
       if (network_risk) session.last_issues.push_back("network_jitter");
-      if (pacing_risk) session.last_issues.push_back("frame_pacing");
+      if (host_render_limited) session.last_issues.push_back("host_render_limited");
+      else if (pacing_risk) session.last_issues.push_back("frame_pacing");
       if (capture_fallback) session.last_issues.push_back("capture_fallback");
       if (hdr_risk) session.last_issues.push_back("hdr_path");
       if (decoder_risk) session.last_issues.push_back("decoder_path");
@@ -525,6 +906,26 @@ namespace ai_optimizer {
       }
     }
 
+    if (session.last_safe_target_fps <= 0.0 &&
+        launched_with_history_safe &&
+        target_fps > 0.0 &&
+        target_fps <= 30.0) {
+      session.last_safe_target_fps = target_fps;
+    }
+
+    if (session.last_safe_target_fps <= 0.0) {
+      session.last_safe_target_fps = derive_safe_target_fps(
+        target_fps,
+        optimizer_fps,
+        session.last_low_1_percent_fps,
+        session.last_min_fps,
+        session.last_frame_pacing_bad_pct,
+        mobile_client,
+        degraded_history,
+        pacing_risk
+      );
+    }
+
     if (!session.last_safe_hdr.has_value()) {
       if (hdr_risk) {
         session.last_safe_hdr = false;
@@ -537,7 +938,10 @@ namespace ai_optimizer {
       session.last_relaunch_recommended ||
       decoder_risk ||
       hdr_risk ||
-      virtual_display_risk;
+      virtual_display_risk ||
+      (session.last_safe_target_fps > 0.0 &&
+       target_fps > 0.0 &&
+       session.last_safe_target_fps < target_fps);
   }
 
   static config_t resolved_config(config_t config) {
@@ -568,7 +972,9 @@ namespace ai_optimizer {
     return platf::appdata() / "ai_optimization_cache.json";
   }
 
-  static session_history_t merge_history_entries(const session_history_t &lhs, const session_history_t &rhs) {
+  static session_history_t merge_history_entries(const session_history_t &raw_lhs, const session_history_t &raw_rhs) {
+    const auto lhs = sanitize_session_history(raw_lhs);
+    const auto rhs = sanitize_session_history(raw_rhs);
     if (lhs.session_count <= 0) {
       return rhs;
     }
@@ -599,6 +1005,14 @@ namespace ai_optimizer {
     merged.last_packet_loss_pct = latest.last_packet_loss_pct;
     merged.last_quality_grade = latest.last_quality_grade;
     merged.last_codec = latest.last_codec;
+    merged.last_duration_s = latest.last_duration_s;
+    merged.last_sample_count = latest.last_sample_count;
+    merged.last_low_1_percent_fps = latest.last_low_1_percent_fps;
+    merged.last_min_fps = latest.last_min_fps;
+    merged.last_frame_pacing_bad_pct = latest.last_frame_pacing_bad_pct;
+    merged.last_end_reason = latest.last_end_reason;
+    merged.last_sample_confidence = latest.last_sample_confidence;
+    merged.last_feedback_ignored_reason = latest.last_feedback_ignored_reason;
     merged.consecutive_poor_outcomes = latest.consecutive_poor_outcomes;
     merged.last_optimization_source = latest.last_optimization_source;
     merged.last_optimization_confidence = latest.last_optimization_confidence;
@@ -613,10 +1027,11 @@ namespace ai_optimizer {
     merged.last_safe_bitrate_kbps = latest.last_safe_bitrate_kbps > 0 ? latest.last_safe_bitrate_kbps : merged.last_safe_bitrate_kbps;
     merged.last_safe_codec = latest.last_safe_codec.empty() ? merged.last_safe_codec : latest.last_safe_codec;
     merged.last_safe_display_mode = latest.last_safe_display_mode.empty() ? merged.last_safe_display_mode : latest.last_safe_display_mode;
+    merged.last_safe_target_fps = latest.last_safe_target_fps > 0.0 ? latest.last_safe_target_fps : merged.last_safe_target_fps;
     merged.last_safe_hdr = latest.last_safe_hdr.has_value() ? latest.last_safe_hdr : merged.last_safe_hdr;
     merged.last_relaunch_recommended = latest.last_relaunch_recommended || merged.last_relaunch_recommended;
     merged.last_updated_at = latest.last_updated_at;
-    return merged;
+    return sanitize_session_history(merged);
   }
 
   static void load_cache() {
@@ -738,6 +1153,31 @@ namespace ai_optimizer {
     return fps > 0;
   }
 
+  static std::string display_mode_with_fps(const std::string &value, int target_fps) {
+    int width = 0;
+    int height = 0;
+    int fps = 0;
+    if (!parse_display_mode(value, width, height, fps)) {
+      return value;
+    }
+    target_fps = std::clamp(target_fps, 24, 240);
+    return std::to_string(width) + "x" + std::to_string(height) + "x" + std::to_string(target_fps);
+  }
+
+  static bool display_mode_fps_at_or_below(const std::optional<std::string> &display_mode,
+                                           double target_fps,
+                                           double tolerance_fps = 0.5) {
+    if (!display_mode || target_fps <= 0.0) {
+      return false;
+    }
+
+    int width = 0;
+    int height = 0;
+    int fps = 0;
+    return parse_display_mode(*display_mode, width, height, fps) &&
+      static_cast<double>(fps) <= target_fps + tolerance_fps;
+  }
+
   template<typename T>
   static T clamp_value(T value, T min_value, T max_value) {
     return std::max(min_value, std::min(value, max_value));
@@ -780,23 +1220,27 @@ namespace ai_optimizer {
                                       bool normalized,
                                       bool from_cache) {
     auto confidence = fallback.source == "device_db" ? "high"s : "medium"s;
+    std::optional<session_history_t> sanitized_history;
+    if (history) {
+      sanitized_history = sanitize_session_history(*history);
+    }
     if (fallback.source != "device_db" && device_name.empty()) {
       confidence = "low";
     }
     if (!game_category.empty() && game_category != "unknown") {
       confidence = confidence == "low" ? "medium" : confidence;
     }
-    if (history) {
-      const auto health_grade = to_lower_copy(history->last_health_grade);
-      if (history->poor_outcome_count > 0 ||
-          history->consecutive_poor_outcomes > 0 ||
+    if (sanitized_history) {
+      const auto health_grade = to_lower_copy(sanitized_history->last_health_grade);
+      if (sanitized_history->poor_outcome_count > 0 ||
+          sanitized_history->consecutive_poor_outcomes > 0 ||
           health_grade == "degraded" ||
-          history->last_relaunch_recommended) {
+          sanitized_history->last_relaunch_recommended) {
         confidence = "low";
       } else if (health_grade == "watch" && confidence == "high") {
         confidence = "medium";
       } else {
-        const auto grade = latest_quality_grade(*history);
+        const auto grade = latest_quality_grade(*sanitized_history);
         if (grade == "A" || grade == "B") {
           confidence = from_cache ? "high" : confidence;
         }
@@ -817,6 +1261,10 @@ namespace ai_optimizer {
                                                           bool from_cache) {
     const auto fallback = fallback_optimization_for_device(device_name, app_name);
     const auto now = unix_time_now();
+    std::optional<session_history_t> sanitized_history;
+    if (history) {
+      sanitized_history = sanitize_session_history(*history);
+    }
     std::vector<std::string> normalization_notes;
     bool normalized = false;
 
@@ -848,6 +1296,24 @@ namespace ai_optimizer {
           normalization_notes.push_back("Clamped display mode to a supported range.");
           normalized = true;
         }
+      }
+    }
+    const double effective_safe_target_fps =
+      sanitized_history ? effective_history_safe_target_fps(device_name, *sanitized_history) : 0.0;
+    if (sanitized_history &&
+        effective_safe_target_fps > 0.0 &&
+        !should_relax_history_safe_target_fps(*sanitized_history) &&
+        optimization.display_mode) {
+      int width = 0;
+      int height = 0;
+      int fps = 0;
+      const int safe_fps = static_cast<int>(std::round(effective_safe_target_fps));
+      if (parse_display_mode(*optimization.display_mode, width, height, fps) &&
+          safe_fps > 0 &&
+          safe_fps < fps) {
+        optimization.display_mode = display_mode_with_fps(*optimization.display_mode, safe_fps);
+        normalization_notes.push_back("Lowered stream FPS from session pacing feedback.");
+        normalized = true;
       }
     }
 
@@ -907,7 +1373,7 @@ namespace ai_optimizer {
     optimization.confidence = infer_confidence(
       device_name,
       game_category,
-      history,
+      sanitized_history,
       fallback,
       normalized,
       from_cache
@@ -918,9 +1384,9 @@ namespace ai_optimizer {
     if (!game_category.empty() && game_category != "unknown") {
       push_signal(optimization.signals_used, "game_category");
     }
-    if (history && history->session_count > 0) {
+    if (sanitized_history && sanitized_history->session_count > 0) {
       push_signal(optimization.signals_used, "session_history");
-      if (!history->last_primary_issue.empty() || !history->last_health_grade.empty()) {
+      if (!sanitized_history->last_primary_issue.empty() || !sanitized_history->last_health_grade.empty()) {
         push_signal(optimization.signals_used, "reliability_feedback");
       }
     }
@@ -1045,7 +1511,8 @@ namespace ai_optimizer {
       "color_range: 0=client decides, 1=limited/MPEG, 2=full/JPEG. "
       "preferred_codec: 'hevc' for most devices (better quality/bitrate), 'h264' for legacy/low-power devices, 'av1' for newest devices with AV1 decode. "
       "If previous session data shows packet loss >2% or latency >30ms, reduce bitrate. "
-      "If previous session scored A, keep current settings. If B/C, adjust. If D/F, significantly reduce quality.";
+      "If previous session scored A, keep current settings. If B/C, adjust. "
+      "If confirmed or repeated previous session feedback scored D/F, significantly reduce quality; low-confidence soft-end observations should be treated as watch signals only.";
   }
 
   static std::string build_user_prompt(
@@ -1071,78 +1538,90 @@ namespace ai_optimizer {
 
     std::string history_line;
     if (history) {
+      const auto prompt_history = sanitize_session_history(*history);
       std::ostringstream history_stream;
       history_stream << "Previous session stats (feedback for improvement):\n";
-      if (history->last_fps > 0 || history->last_latency_ms > 0 || !latest_quality_grade(*history).empty()) {
+      if (prompt_history.last_fps > 0 || prompt_history.last_latency_ms > 0 || !latest_quality_grade(prompt_history).empty()) {
         history_stream << "  Latest session: target "
-                       << static_cast<int>(std::round(history->last_target_fps > 0 ? history->last_target_fps : history->last_fps))
-                       << " FPS, achieved " << static_cast<int>(std::round(history->last_fps))
-                       << " FPS, latency " << static_cast<int>(std::round(history->last_latency_ms))
-                       << "ms, bitrate " << history->last_bitrate_kbps
-                       << "kbps, packet loss " << history->last_packet_loss_pct
-                       << "%, grade " << latest_quality_grade(*history)
-                       << ", codec " << latest_codec(*history) << "\n";
+                       << static_cast<int>(std::round(prompt_history.last_target_fps > 0 ? prompt_history.last_target_fps : prompt_history.last_fps))
+                       << " FPS, achieved " << static_cast<int>(std::round(prompt_history.last_fps))
+                       << " FPS, 1% low " << static_cast<int>(std::round(prompt_history.last_low_1_percent_fps))
+                       << " FPS, min " << static_cast<int>(std::round(prompt_history.last_min_fps))
+                       << " FPS, bad pacing " << prompt_history.last_frame_pacing_bad_pct
+                       << "%, latency " << static_cast<int>(std::round(prompt_history.last_latency_ms))
+                       << "ms, bitrate " << prompt_history.last_bitrate_kbps
+                       << "kbps, packet loss " << prompt_history.last_packet_loss_pct
+                       << "%, grade " << latest_quality_grade(prompt_history)
+                       << ", codec " << latest_codec(prompt_history) << "\n";
       }
-      history_stream << "  Rolling history: " << history->session_count
-                     << " sessions, Avg FPS " << static_cast<int>(std::round(history->avg_fps))
-                     << ", Avg Latency " << static_cast<int>(std::round(history->avg_latency_ms))
-                     << "ms, Avg Bitrate " << history->avg_bitrate_kbps
-                     << "kbps, Avg Packet Loss " << history->packet_loss_pct
-                     << "%, Poor Outcomes " << history->poor_outcome_count
-                     << ", Last Confidence " << history->last_optimization_confidence << "\n";
+      history_stream << "  Rolling history: " << prompt_history.session_count
+                     << " sessions, Avg FPS " << static_cast<int>(std::round(prompt_history.avg_fps))
+                     << ", Avg Latency " << static_cast<int>(std::round(prompt_history.avg_latency_ms))
+                     << "ms, Avg Bitrate " << prompt_history.avg_bitrate_kbps
+                     << "kbps, Avg Packet Loss " << prompt_history.packet_loss_pct
+                     << "%, Poor Outcomes " << prompt_history.poor_outcome_count
+                     << ", Last Confidence " << prompt_history.last_optimization_confidence << "\n";
 
       const bool has_reliability_context =
-        !history->last_health_grade.empty() ||
-        !history->last_primary_issue.empty() ||
-        !history->last_issues.empty() ||
-        !history->last_safe_codec.empty() ||
-        history->last_safe_bitrate_kbps > 0 ||
-        !history->last_safe_display_mode.empty() ||
-        history->last_safe_hdr.has_value();
+        !prompt_history.last_health_grade.empty() ||
+        !prompt_history.last_primary_issue.empty() ||
+        !prompt_history.last_issues.empty() ||
+        !prompt_history.last_safe_codec.empty() ||
+        prompt_history.last_safe_bitrate_kbps > 0 ||
+        !prompt_history.last_safe_display_mode.empty() ||
+        prompt_history.last_safe_target_fps > 0.0 ||
+        prompt_history.last_safe_hdr.has_value();
 
       if (has_reliability_context) {
         history_stream << "  Reliability diagnosis: health="
-                       << (history->last_health_grade.empty() ? "unknown" : history->last_health_grade)
+                       << (prompt_history.last_health_grade.empty() ? "unknown" : prompt_history.last_health_grade)
                        << ", primary issue="
-                       << (history->last_primary_issue.empty() ? "steady" : history->last_primary_issue);
-        if (!history->last_issues.empty()) {
+                       << (prompt_history.last_primary_issue.empty() ? "steady" : prompt_history.last_primary_issue);
+        if (!prompt_history.last_issues.empty()) {
           history_stream << ", issue tags=";
-          for (std::size_t i = 0; i < history->last_issues.size(); ++i) {
+          for (std::size_t i = 0; i < prompt_history.last_issues.size(); ++i) {
             if (i > 0) {
               history_stream << "/";
             }
-            history_stream << history->last_issues[i];
+            history_stream << prompt_history.last_issues[i];
           }
         }
         history_stream << "\n";
 
         history_stream << "  Risk levels: network="
-                       << (history->last_network_risk.empty() ? "unknown" : history->last_network_risk)
+                       << (prompt_history.last_network_risk.empty() ? "unknown" : prompt_history.last_network_risk)
                        << ", decoder="
-                       << (history->last_decoder_risk.empty() ? "unknown" : history->last_decoder_risk)
+                       << (prompt_history.last_decoder_risk.empty() ? "unknown" : prompt_history.last_decoder_risk)
                        << ", hdr="
-                       << (history->last_hdr_risk.empty() ? "unknown" : history->last_hdr_risk)
+                       << (prompt_history.last_hdr_risk.empty() ? "unknown" : prompt_history.last_hdr_risk)
                        << ", capture="
-                       << (history->last_capture_path.empty() ? "unknown" : history->last_capture_path)
+                       << (prompt_history.last_capture_path.empty() ? "unknown" : prompt_history.last_capture_path)
                        << "\n";
 
         history_stream << "  Safe fallback bias: bitrate="
-                       << (history->last_safe_bitrate_kbps > 0 ?
-                             std::to_string(history->last_safe_bitrate_kbps) + "kbps" :
+                       << (prompt_history.last_safe_bitrate_kbps > 0 ?
+                             std::to_string(prompt_history.last_safe_bitrate_kbps) + "kbps" :
                              std::string {"unchanged"})
                        << ", codec="
-                       << (history->last_safe_codec.empty() ? "unchanged" : history->last_safe_codec)
+                       << (prompt_history.last_safe_codec.empty() ? "unchanged" : prompt_history.last_safe_codec)
                        << ", display="
-                       << (history->last_safe_display_mode.empty() ? "unchanged" : history->last_safe_display_mode)
+                       << (prompt_history.last_safe_display_mode.empty() ? "unchanged" : prompt_history.last_safe_display_mode)
+                       << ", target_fps="
+                       << (prompt_history.last_safe_target_fps > 0.0 ?
+                             std::to_string(static_cast<int>(std::round(prompt_history.last_safe_target_fps))) :
+                             std::string {"unchanged"})
                        << ", hdr=";
-        if (history->last_safe_hdr.has_value()) {
-          history_stream << (*history->last_safe_hdr ? "keep" : "off");
+        if (prompt_history.last_safe_hdr.has_value()) {
+          history_stream << (*prompt_history.last_safe_hdr ? "keep" : "off");
         } else {
           history_stream << "unchanged";
         }
         history_stream << ", relaunch="
-                       << (history->last_relaunch_recommended ? "yes" : "no")
+                       << (prompt_history.last_relaunch_recommended ? "yes" : "no")
                        << "\n";
+      }
+      if (is_low_confidence_soft_end_without_confirming_signal(prompt_history)) {
+        history_stream << "  Feedback confidence: low soft-end observation only; do not apply recovery, resolution, or FPS downgrades from this sample unless future confirmed poor outcomes repeat.\n";
       }
 
       history_line = history_stream.str();
@@ -1694,7 +2173,11 @@ namespace ai_optimizer {
   void init(const config_t &config) {
     cfg = resolved_config(config);
     load_cache();
-    load_history();
+    const bool history_repaired = load_history();
+    if (history_repaired) {
+      save_history();
+      BOOST_LOG(info) << "ai_optimizer: Repaired invalid session history values during load"sv;
+    }
     if (cfg.enabled) {
       BOOST_LOG(info) << "ai_optimizer: Enabled provider="sv << cfg.provider
                       << ", model="sv << cfg.model
@@ -1719,19 +2202,39 @@ namespace ai_optimizer {
 
   std::optional<device_db::optimization_t> get_cached(
       const std::string &device_name, const std::string &app_name) {
-    std::lock_guard<std::mutex> lock(cache_mutex);
-    auto key = current_cache_key(device_name, app_name);
-    auto it = cache.find(key);
-    if (it == cache.end()) return std::nullopt;
+    const auto key = current_cache_key(device_name, app_name);
+    std::optional<cache_entry_t> entry;
+    {
+      std::lock_guard<std::mutex> lock(cache_mutex);
+      auto it = cache.find(key);
+      if (it == cache.end()) return std::nullopt;
 
-    const auto now = unix_time_now();
-    if (it->second.optimization.expires_at > 0 && now >= it->second.optimization.expires_at) {
-      cache.erase(it);
-      save_cache_locked();
+      const auto now = unix_time_now();
+      if (it->second.optimization.expires_at > 0 && now >= it->second.optimization.expires_at) {
+        cache.erase(it);
+        save_cache_locked();
+        return std::nullopt;
+      }
+      entry = it->second;
+    }
+
+    if (auto history = get_session_history(device_name, app_name);
+        history && should_refresh_recovery_cache_after_stable_trial(*history, entry->optimization)) {
+      std::lock_guard<std::mutex> lock(cache_mutex);
+      auto it = cache.find(key);
+      if (it != cache.end()) {
+        cache.erase(it);
+        save_cache_locked();
+      }
+      BOOST_LOG(info) << "ai_optimizer: Retired stale recovery cache for "sv
+                      << history_key(device_name, app_name)
+                      << " after stable "sv
+                      << static_cast<int>(std::round(history->last_target_fps))
+                      << " FPS trial; requesting a higher-quality recommendation"sv;
       return std::nullopt;
     }
 
-    auto optimization = it->second.optimization;
+    auto optimization = entry->optimization;
     optimization.source = "ai_cached";
     optimization.cache_status = "hit";
     return optimization;
@@ -1742,31 +2245,58 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::optional<session_history_t> &history) {
     const auto effective_history = history ? history : get_session_history(device_name, app_name);
-    if (!effective_history || effective_history->session_count <= 0) {
+    if (!effective_history) {
       return std::nullopt;
     }
 
-    const auto &session = *effective_history;
+    const auto session = sanitize_session_history(*effective_history);
+    if (session.session_count <= 0) {
+      return std::nullopt;
+    }
     const auto latest_grade = latest_quality_grade(session);
     const auto last_health_grade = to_lower_copy(session.last_health_grade);
+    if (is_unconfirmed_poor_recovery_feedback(session)) {
+      return std::nullopt;
+    }
+
     const bool has_safe_bias =
       session.last_safe_bitrate_kbps > 0 ||
       !session.last_safe_codec.empty() ||
       session.last_safe_hdr.has_value() ||
-      !session.last_safe_display_mode.empty();
+      !session.last_safe_display_mode.empty() ||
+      session.last_safe_target_fps > 0.0;
 
+    const auto primary_issue = to_lower_copy(session.last_primary_issue);
+    const bool meaningful_primary_issue =
+      !primary_issue.empty() && primary_issue != "steady";
+    const bool high_confidence_sample =
+      to_lower_copy(session.last_sample_confidence) == "high" ||
+      has_confirming_soft_end_recovery_signal(session);
+    const bool host_render_only_relaunch =
+      session.last_relaunch_recommended &&
+      (primary_issue == "host_render_limited" || primary_issue == "host_render") &&
+      session.poor_outcome_count <= 0 &&
+      session.consecutive_poor_outcomes <= 0 &&
+      !high_confidence_sample;
     const bool reliability_pressure =
       session.poor_outcome_count > 0 ||
       session.consecutive_poor_outcomes > 0 ||
-      last_health_grade == "watch" ||
-      last_health_grade == "degraded" ||
-      !session.last_primary_issue.empty();
+      (session.last_relaunch_recommended && !host_render_only_relaunch) ||
+      (
+        high_confidence_sample &&
+        (
+          last_health_grade == "watch" ||
+          last_health_grade == "degraded" ||
+          meaningful_primary_issue
+        )
+      );
 
     const bool reuse_recent_success =
       (latest_grade == "A" || latest_grade == "B") &&
       (session.last_bitrate_kbps > 0 || !session.last_codec.empty());
 
-    if (!has_safe_bias && !reuse_recent_success) {
+    if ((!has_safe_bias && !reuse_recent_success) ||
+        (!reliability_pressure && !reuse_recent_success)) {
       return std::nullopt;
     }
 
@@ -1800,6 +2330,17 @@ namespace ai_optimizer {
       optimization.virtual_display = true;
     }
 
+    const bool relax_safe_target_fps = should_relax_history_safe_target_fps(session);
+    const double effective_safe_target_fps = effective_history_safe_target_fps(device_name, session);
+    if (effective_safe_target_fps > 0.0 && !relax_safe_target_fps) {
+      const auto base_display_mode =
+        optimization.display_mode.value_or(fallback.display_mode.value_or("1280x720x60"));
+      optimization.display_mode = display_mode_with_fps(
+        base_display_mode,
+        static_cast<int>(std::round(effective_safe_target_fps))
+      );
+    }
+
     optimization.confidence =
       (latest_grade == "A" || latest_grade == "B") && !reliability_pressure ? "medium" : "low";
 
@@ -1818,6 +2359,16 @@ namespace ai_optimizer {
     if (optimization.target_bitrate_kbps) {
       reasoning << " Hold bitrate near " << *optimization.target_bitrate_kbps << "kbps.";
     }
+    if (effective_safe_target_fps > 0.0) {
+      if (relax_safe_target_fps) {
+        reasoning << " Relax the prior "
+                  << static_cast<int>(std::round(effective_safe_target_fps))
+                  << " FPS cap because that safe-target trial already ran; retry a smoother profile.";
+      } else {
+        reasoning << " Target " << static_cast<int>(std::round(effective_safe_target_fps))
+                  << " FPS on the next launch to avoid visible frame pacing drops.";
+      }
+    }
     optimization.reasoning = reasoning.str();
 
     optimization = normalize_optimization(
@@ -1832,6 +2383,169 @@ namespace ai_optimizer {
     optimization.source = "history_safe";
     optimization.cache_status = "fallback";
     return optimization;
+  }
+
+  bool should_relax_history_safe_target_fps(const session_history_t &raw_session) {
+    const auto session = sanitize_session_history(raw_session);
+    if (session.last_safe_target_fps <= 0.0 ||
+        session.last_target_fps <= 0.0) {
+      return false;
+    }
+
+    const auto confidence = to_lower_copy(session.last_sample_confidence);
+    const auto end_reason = normalize_end_reason(session.last_end_reason);
+    const bool soft_end_has_enough_signal =
+      session.last_duration_s >= 60 &&
+      session.last_sample_count >= 30;
+    const bool explicit_completed_end =
+      end_reason == "end" ||
+      end_reason == "user_end" ||
+      end_reason == "quit";
+    const bool completed_safe_trial =
+      explicit_completed_end ||
+      soft_end_has_enough_signal;
+    const bool low_confidence_soft_end =
+      confidence == "low" &&
+      (end_reason == "host_pause" || end_reason == "disconnect" || end_reason == "cancelled") &&
+      !soft_end_has_enough_signal;
+    const auto grade = latest_quality_grade(session);
+    const auto normalized_grade = to_lower_copy(grade);
+    const bool poor_grade_signal = normalized_grade == "d" || normalized_grade == "f";
+    const bool frame_pacing_issue = has_frame_or_host_pacing_issue(session);
+    if (session.last_target_fps > session.last_safe_target_fps + 0.5) {
+      if (low_confidence_soft_end && (poor_grade_signal || frame_pacing_issue)) {
+        return false;
+      }
+      return low_confidence_soft_end && session.consecutive_poor_outcomes <= 0;
+    }
+
+    if (!completed_safe_trial) {
+      return false;
+    }
+
+    const bool severe_grade =
+      !low_confidence_soft_end &&
+      poor_grade_signal;
+    const double fps_ratio =
+      session.last_fps > 0.0 ? std::clamp(session.last_fps / session.last_target_fps, 0.0, 1.5) : 0.0;
+    const bool severe_fps_miss = !low_confidence_soft_end && fps_ratio > 0.0 && fps_ratio < 0.82;
+    const bool severe_low =
+      !low_confidence_soft_end &&
+      session.last_low_1_percent_fps > 0.0 &&
+      session.last_low_1_percent_fps < session.last_target_fps * 0.65;
+    const bool severe_pacing = !low_confidence_soft_end && session.last_frame_pacing_bad_pct >= 18.0;
+
+    return !(severe_grade ||
+             severe_fps_miss ||
+             severe_low ||
+             severe_pacing ||
+             session.consecutive_poor_outcomes > 0);
+  }
+
+  bool should_graduate_history_safe_target_fps(
+      const session_history_t &raw_session,
+      double previous_safe_target_fps) {
+    const auto session = sanitize_session_history(raw_session);
+    if (previous_safe_target_fps <= 0.0 ||
+        session.last_target_fps < 55.0 ||
+        session.last_target_fps <= previous_safe_target_fps + 15.0) {
+      return false;
+    }
+    if (session.last_duration_s < 60 || session.last_sample_count < 30) {
+      return false;
+    }
+
+    const double delivered_fps =
+      session.last_fps > 0.0 ? session.last_fps : session.avg_fps;
+    if (delivered_fps <= 0.0 ||
+        delivered_fps < session.last_target_fps * 0.90) {
+      return false;
+    }
+    if (session.avg_fps > 0.0 &&
+        session.avg_fps < session.last_target_fps * 0.90) {
+      return false;
+    }
+    if (session.last_low_1_percent_fps > 0.0 &&
+        session.last_low_1_percent_fps < session.last_target_fps * 0.65) {
+      return false;
+    }
+    if (session.last_min_fps > 0.0 &&
+        session.last_min_fps < session.last_target_fps * 0.45) {
+      return false;
+    }
+    if (session.last_frame_pacing_bad_pct >= 25.0 ||
+        session.last_packet_loss_pct >= 0.35 ||
+        session.last_latency_ms >= 28.0) {
+      return false;
+    }
+
+    const auto elevated = [](const std::string &risk) {
+      return to_lower_copy(risk) == "elevated";
+    };
+    if (elevated(session.last_network_risk) ||
+        elevated(session.last_decoder_risk) ||
+        elevated(session.last_hdr_risk)) {
+      return false;
+    }
+
+    const auto capture_path = to_lower_copy(session.last_capture_path);
+    if (capture_path.find("cpu") != std::string::npos ||
+        capture_path.find("shm") != std::string::npos ||
+        capture_path.find("fallback") != std::string::npos) {
+      return false;
+    }
+
+    return true;
+  }
+
+  bool should_refresh_recovery_cache_after_stable_trial(
+      const session_history_t &raw_session,
+      const device_db::optimization_t &optimization) {
+    const auto session = sanitize_session_history(raw_session);
+    if (session.last_target_fps <= 0.0 || session.last_target_fps > 45.0) {
+      return false;
+    }
+
+    const auto grade = to_lower_copy(latest_quality_grade(session));
+    if (grade != "a" && grade != "b") {
+      return false;
+    }
+    if (session.last_duration_s < 120 || session.last_sample_count < 60) {
+      return false;
+    }
+    if (session.last_fps <= 0.0 || session.last_fps < session.last_target_fps * 0.95) {
+      return false;
+    }
+    if (session.last_low_1_percent_fps > 0.0 &&
+        session.last_low_1_percent_fps < session.last_target_fps * 0.90) {
+      return false;
+    }
+    if (session.last_min_fps > 0.0 &&
+        session.last_min_fps < session.last_target_fps * 0.85) {
+      return false;
+    }
+    if (session.last_frame_pacing_bad_pct >= 3.0 ||
+        session.last_packet_loss_pct >= 0.35 ||
+        session.last_latency_ms >= 28.0 ||
+        session.consecutive_poor_outcomes > 0) {
+      return false;
+    }
+    if (!display_mode_fps_at_or_below(optimization.display_mode, session.last_target_fps)) {
+      return false;
+    }
+
+    const auto confidence = to_lower_copy(optimization.confidence);
+    const auto reasoning = to_lower_copy(optimization.reasoning);
+    const auto normalization = to_lower_copy(optimization.normalization_reason);
+    const bool recovery_capped =
+      confidence == "low" ||
+      normalization.find("lowered stream fps") != std::string::npos ||
+      reasoning.find("pacing feedback") != std::string::npos ||
+      reasoning.find("safe-target") != std::string::npos ||
+      reasoning.find("safe target") != std::string::npos ||
+      reasoning.find("recovery") != std::string::npos;
+
+    return recovery_capped;
   }
 
   void request_async(const std::string &device_name,
@@ -2085,10 +2799,11 @@ namespace ai_optimizer {
     return platf::appdata() / "ai_session_history.json";
   }
 
-  static void load_history() {
+  static bool load_history() {
     std::lock_guard<std::mutex> lock(history_mutex);
     std::ifstream file(history_path());
-    if (!file.is_open()) return;
+    if (!file.is_open()) return false;
+    bool repaired_history = false;
     try {
       auto root = nlohmann::json::parse(file);
       for (auto &[key, val] : root.items()) {
@@ -2107,6 +2822,14 @@ namespace ai_optimizer {
         h.last_packet_loss_pct = val.value("last_packet_loss_pct", h.packet_loss_pct);
         h.last_quality_grade = val.value("last_quality_grade", h.quality_grade);
         h.last_codec = val.value("last_codec", h.codec);
+        h.last_duration_s = val.value("last_duration_s", 0);
+        h.last_sample_count = val.value("last_sample_count", 0);
+        h.last_low_1_percent_fps = val.value("last_low_1_percent_fps", 0.0);
+        h.last_min_fps = val.value("last_min_fps", 0.0);
+        h.last_frame_pacing_bad_pct = val.value("last_frame_pacing_bad_pct", 0.0);
+        h.last_end_reason = val.value("last_end_reason", "");
+        h.last_sample_confidence = val.value("last_sample_confidence", "");
+        h.last_feedback_ignored_reason = val.value("last_feedback_ignored_reason", "");
         h.poor_outcome_count = val.value("poor_outcome_count", 0);
         h.consecutive_poor_outcomes = val.value("consecutive_poor_outcomes", 0);
         h.last_optimization_source = val.value("last_optimization_source", "");
@@ -2122,6 +2845,7 @@ namespace ai_optimizer {
         h.last_safe_bitrate_kbps = val.value("last_safe_bitrate_kbps", 0);
         h.last_safe_codec = val.value("last_safe_codec", "");
         h.last_safe_display_mode = val.value("last_safe_display_mode", "");
+        h.last_safe_target_fps = val.value("last_safe_target_fps", 0.0);
         if (val.contains("last_safe_hdr") && val["last_safe_hdr"].is_boolean()) {
           h.last_safe_hdr = val["last_safe_hdr"].get<bool>();
         }
@@ -2131,7 +2855,13 @@ namespace ai_optimizer {
         auto pos = key.find(':');
         const auto device_name = pos == std::string::npos ? key : key.substr(0, pos);
         const auto app_name = pos == std::string::npos ? std::string {} : key.substr(pos + 1);
+        auto before_repair = h;
+        h = sanitize_session_history(h);
+        repaired_history = repaired_history || history_repair_should_persist(before_repair, h);
+        before_repair = h;
         enrich_session_reliability_context(device_name, app_name, h);
+        h = sanitize_session_history(h);
+        repaired_history = repaired_history || history_repair_should_persist(before_repair, h);
         const auto normalized_key = history_key(device_name, app_name);
         auto existing = session_history.find(normalized_key);
         if (existing == session_history.end()) {
@@ -2140,7 +2870,10 @@ namespace ai_optimizer {
           existing->second = merge_history_entries(existing->second, h);
         }
       }
-    } catch (...) {}
+    } catch (...) {
+      return false;
+    }
+    return repaired_history;
   }
 
   static void save_history() {
@@ -2162,6 +2895,14 @@ namespace ai_optimizer {
         {"last_packet_loss_pct", h.last_packet_loss_pct},
         {"last_quality_grade", h.last_quality_grade},
         {"last_codec", h.last_codec},
+        {"last_duration_s", h.last_duration_s},
+        {"last_sample_count", h.last_sample_count},
+        {"last_low_1_percent_fps", h.last_low_1_percent_fps},
+        {"last_min_fps", h.last_min_fps},
+        {"last_frame_pacing_bad_pct", h.last_frame_pacing_bad_pct},
+        {"last_end_reason", h.last_end_reason},
+        {"last_sample_confidence", h.last_sample_confidence},
+        {"last_feedback_ignored_reason", h.last_feedback_ignored_reason},
         {"poor_outcome_count", h.poor_outcome_count},
         {"consecutive_poor_outcomes", h.consecutive_poor_outcomes},
         {"last_optimization_source", h.last_optimization_source},
@@ -2177,6 +2918,7 @@ namespace ai_optimizer {
         {"last_safe_bitrate_kbps", h.last_safe_bitrate_kbps},
         {"last_safe_codec", h.last_safe_codec},
         {"last_safe_display_mode", h.last_safe_display_mode},
+        {"last_safe_target_fps", h.last_safe_target_fps},
         {"last_relaunch_recommended", h.last_relaunch_recommended},
         {"last_updated_at", h.last_updated_at},
         {"last_invalidated_at", h.last_invalidated_at}
@@ -2193,72 +2935,153 @@ namespace ai_optimizer {
   void record_session(const std::string &device_name,
                       const std::string &app_name,
                       const session_history_t &session) {
+    auto normalized_session = session;
+    if (normalized_session.last_target_fps <= 0.0 && normalized_session.avg_fps > 0.0) {
+      normalized_session.last_target_fps = normalized_session.avg_fps;
+    }
     const auto canonical_device = canonical_device_name(device_name);
+    enrich_session_reliability_context(canonical_device, app_name, normalized_session);
+    auto feedback_policy = classify_session_feedback(app_name, normalized_session);
+    normalized_session.last_end_reason = feedback_policy.end_reason;
+    normalized_session.last_sample_confidence = feedback_policy.confidence;
+    normalized_session.last_feedback_ignored_reason = feedback_policy.ignored_reason;
+    normalized_session = sanitize_session_history(normalized_session);
+
     auto key = history_key(canonical_device, app_name);
-    const bool poor_quality = is_poor_quality_grade(session.quality_grade);
-    const bool invalidate_cache = should_invalidate_cache_for_poor_quality(app_name, session);
+    if (!feedback_policy.accepted) {
+      BOOST_LOG(info) << "ai_optimizer: Ignoring low-signal session report for "sv << key
+                      << " end_reason="sv << normalized_session.last_end_reason
+                      << " reason="sv << feedback_policy.ignored_reason;
+      return;
+    }
+
+    const bool poor_quality = is_poor_quality_grade(normalized_session.quality_grade);
+    const bool recovery_feedback_allowed = !poor_quality || feedback_policy.counts_poor_outcome;
     int session_count_total = 0;
+    bool invalidate_cache = false;
+    bool graduated_safe_target = false;
+    double graduated_previous_safe_target_fps = 0.0;
     {
       std::lock_guard<std::mutex> lock(history_mutex);
       auto &existing = session_history[key];
+      existing = sanitize_session_history(existing);
+      const bool had_existing = existing.session_count > 0;
+      const int preserved_safe_bitrate_kbps = existing.last_safe_bitrate_kbps;
+      const std::string preserved_safe_codec = existing.last_safe_codec;
+      const std::string preserved_safe_display_mode = existing.last_safe_display_mode;
+      const double preserved_safe_target_fps = existing.last_safe_target_fps;
+      const std::optional<bool> preserved_safe_hdr = existing.last_safe_hdr;
+      const bool preserved_relaunch_recommended = existing.last_relaunch_recommended;
+      graduated_safe_target =
+        had_existing &&
+        should_graduate_history_safe_target_fps(
+          normalized_session,
+          preserved_safe_target_fps
+        );
+      if (graduated_safe_target) {
+        graduated_previous_safe_target_fps = preserved_safe_target_fps;
+      }
 
       // Rolling average with the new session
-      if (existing.session_count > 0) {
+      if (had_existing) {
         double n = existing.session_count;
-        existing.avg_fps = (existing.avg_fps * n + session.avg_fps) / (n + 1);
-        existing.avg_latency_ms = (existing.avg_latency_ms * n + session.avg_latency_ms) / (n + 1);
-        existing.avg_bitrate_kbps = static_cast<int>((existing.avg_bitrate_kbps * n + session.avg_bitrate_kbps) / (n + 1));
-        existing.packet_loss_pct = (existing.packet_loss_pct * n + session.packet_loss_pct) / (n + 1);
+        existing.avg_fps = (existing.avg_fps * n + normalized_session.avg_fps) / (n + 1);
+        existing.avg_latency_ms = (existing.avg_latency_ms * n + normalized_session.avg_latency_ms) / (n + 1);
+        existing.avg_bitrate_kbps = static_cast<int>((existing.avg_bitrate_kbps * n + normalized_session.avg_bitrate_kbps) / (n + 1));
+        existing.packet_loss_pct = (existing.packet_loss_pct * n + normalized_session.packet_loss_pct) / (n + 1);
         existing.session_count++;
       } else {
-        existing = session;
+        existing = normalized_session;
         existing.session_count = 1;
       }
-      existing.quality_grade = session.quality_grade;
-      existing.codec = session.codec;
-      existing.last_fps = session.last_fps;
-      existing.last_target_fps = session.last_target_fps;
-      existing.last_latency_ms = session.last_latency_ms;
-      existing.last_bitrate_kbps = session.last_bitrate_kbps;
-      existing.last_packet_loss_pct = session.last_packet_loss_pct;
-      existing.last_quality_grade = session.last_quality_grade;
-      existing.last_codec = session.last_codec;
+      existing.quality_grade = normalized_session.quality_grade;
+      existing.codec = normalized_session.codec;
+      existing.last_fps = normalized_session.last_fps;
+      existing.last_target_fps = normalized_session.last_target_fps;
+      existing.last_latency_ms = normalized_session.last_latency_ms;
+      existing.last_bitrate_kbps = normalized_session.last_bitrate_kbps;
+      existing.last_packet_loss_pct = normalized_session.last_packet_loss_pct;
+      existing.last_quality_grade = normalized_session.last_quality_grade;
+      existing.last_codec = normalized_session.last_codec;
+      existing.last_duration_s = normalized_session.last_duration_s;
+      existing.last_sample_count = normalized_session.last_sample_count;
+      existing.last_low_1_percent_fps = normalized_session.last_low_1_percent_fps;
+      existing.last_min_fps = normalized_session.last_min_fps;
+      existing.last_frame_pacing_bad_pct = normalized_session.last_frame_pacing_bad_pct;
+      existing.last_end_reason = normalized_session.last_end_reason;
+      existing.last_sample_confidence = normalized_session.last_sample_confidence;
+      existing.last_feedback_ignored_reason = normalized_session.last_feedback_ignored_reason;
       existing.last_updated_at = unix_time_now();
-      existing.last_optimization_source = session.last_optimization_source;
-      existing.last_optimization_confidence = session.last_optimization_confidence;
-      existing.last_recommendation_version = session.last_recommendation_version;
-      existing.last_health_grade = session.last_health_grade;
-      existing.last_primary_issue = session.last_primary_issue;
-      existing.last_issues = session.last_issues;
-      existing.last_decoder_risk = session.last_decoder_risk;
-      existing.last_hdr_risk = session.last_hdr_risk;
-      existing.last_network_risk = session.last_network_risk;
-      existing.last_capture_path = session.last_capture_path;
-      existing.last_safe_bitrate_kbps = session.last_safe_bitrate_kbps;
-      existing.last_safe_codec = session.last_safe_codec;
-      existing.last_safe_display_mode = session.last_safe_display_mode;
-      existing.last_safe_hdr = session.last_safe_hdr;
-      existing.last_relaunch_recommended = session.last_relaunch_recommended;
+      existing.last_optimization_source = normalized_session.last_optimization_source;
+      existing.last_optimization_confidence = normalized_session.last_optimization_confidence;
+      existing.last_recommendation_version = normalized_session.last_recommendation_version;
+      existing.last_health_grade = normalized_session.last_health_grade;
+      existing.last_primary_issue = normalized_session.last_primary_issue;
+      existing.last_issues = normalized_session.last_issues;
+      existing.last_decoder_risk = normalized_session.last_decoder_risk;
+      existing.last_hdr_risk = normalized_session.last_hdr_risk;
+      existing.last_network_risk = normalized_session.last_network_risk;
+      existing.last_capture_path = normalized_session.last_capture_path;
+      if (recovery_feedback_allowed) {
+        existing.last_safe_bitrate_kbps = normalized_session.last_safe_bitrate_kbps;
+        existing.last_safe_codec = normalized_session.last_safe_codec;
+        existing.last_safe_display_mode = normalized_session.last_safe_display_mode;
+        existing.last_safe_target_fps = normalized_session.last_safe_target_fps;
+        existing.last_safe_hdr = normalized_session.last_safe_hdr;
+        existing.last_relaunch_recommended = normalized_session.last_relaunch_recommended;
+      } else if (had_existing) {
+        existing.last_safe_bitrate_kbps = preserved_safe_bitrate_kbps;
+        existing.last_safe_codec = preserved_safe_codec;
+        existing.last_safe_display_mode = preserved_safe_display_mode;
+        existing.last_safe_target_fps = preserved_safe_target_fps;
+        existing.last_safe_hdr = preserved_safe_hdr;
+        existing.last_relaunch_recommended = preserved_relaunch_recommended;
+      } else {
+        existing.last_safe_bitrate_kbps = 0;
+        existing.last_safe_codec.clear();
+        existing.last_safe_display_mode.clear();
+        existing.last_safe_target_fps = 0.0;
+        existing.last_safe_hdr.reset();
+        existing.last_relaunch_recommended = false;
+      }
 
-      if (poor_quality) {
+      if (graduated_safe_target) {
+        existing.poor_outcome_count = 0;
+        existing.consecutive_poor_outcomes = 0;
+      } else if (poor_quality && feedback_policy.counts_poor_outcome) {
         existing.poor_outcome_count++;
         existing.consecutive_poor_outcomes++;
+        invalidate_cache = should_invalidate_cache_for_poor_quality(
+          app_name,
+          normalized_session,
+          feedback_policy,
+          existing.consecutive_poor_outcomes
+        );
         if (invalidate_cache) {
           existing.last_invalidated_at = unix_time_now();
         }
-      } else {
+      } else if (!poor_quality) {
         existing.consecutive_poor_outcomes = 0;
       }
 
-      enrich_session_reliability_context(canonical_device, app_name, existing);
+      if (recovery_feedback_allowed) {
+        enrich_session_reliability_context(canonical_device, app_name, existing);
+      }
+      if (graduated_safe_target) {
+        existing.last_safe_target_fps = 0.0;
+        existing.last_relaunch_recommended = false;
+      }
+      existing = sanitize_session_history(existing);
       session_count_total = existing.session_count;
     }
 
     save_history();
     BOOST_LOG(info) << "ai_optimizer: Recorded session for "sv << key
-                    << " — grade "sv << session.quality_grade
-                    << " against target "sv << session.last_target_fps
-                    << "fps, "sv << session_count_total << " sessions total"sv;
+                    << " — grade "sv << normalized_session.quality_grade
+                    << " against target "sv << normalized_session.last_target_fps
+                    << "fps, confidence="sv << normalized_session.last_sample_confidence
+                    << ", end_reason="sv << normalized_session.last_end_reason
+                    << ", "sv << session_count_total << " sessions total"sv;
 
     // Poor game sessions should force re-optimization, but low-signal control shells
     // like Desktop or Steam Big Picture should keep their existing cache entry.
@@ -2267,8 +3090,31 @@ namespace ai_optimizer {
       cache.erase(current_cache_key(canonical_device, app_name));
       save_cache_locked();
       BOOST_LOG(info) << "ai_optimizer: Poor quality — invalidated cache for "sv << key;
-    } else if (poor_quality && is_control_shell_app(app_name)) {
-      BOOST_LOG(info) << "ai_optimizer: Poor quality on control-shell session — keeping cache for "sv << key;
+    } else if (graduated_safe_target) {
+      bool removed_stale_cache = false;
+      {
+        std::lock_guard<std::mutex> lock(cache_mutex);
+        auto it = cache.find(current_cache_key(canonical_device, app_name));
+        if (it != cache.end() &&
+            display_mode_fps_at_or_below(
+              it->second.optimization.display_mode,
+              graduated_previous_safe_target_fps
+            )) {
+          cache.erase(it);
+          save_cache_locked();
+          removed_stale_cache = true;
+        }
+      }
+      BOOST_LOG(info) << "ai_optimizer: Graduated history-safe FPS cap for "sv << key
+                      << " after stable "sv
+                      << static_cast<int>(std::round(normalized_session.last_target_fps))
+                      << " FPS retry"
+                      << (removed_stale_cache ? "; cleared stale cache" : "");
+    } else if (poor_quality) {
+      BOOST_LOG(info) << "ai_optimizer: Poor quality sample preserved without cache invalidation for "sv << key
+                      << " confidence="sv << normalized_session.last_sample_confidence
+                      << " end_reason="sv << normalized_session.last_end_reason
+                      << (feedback_policy.counts_poor_outcome ? " awaiting_confirming_sample" : " low_signal_or_soft_end");
     }
   }
 
@@ -2282,6 +3128,53 @@ namespace ai_optimizer {
     auto it = session_history.find(key);
     if (it == session_history.end()) return std::nullopt;
     return it->second;
+  }
+
+  bool clear_game_profile(const std::string &device_name,
+                          const std::string &app_name) {
+    if (device_name.empty() || app_name.empty()) {
+      return false;
+    }
+
+    static std::once_flag history_load_flag;
+    std::call_once(history_load_flag, load_history);
+
+    const auto canonical_device = canonical_device_name(device_name);
+    const auto session_key = history_key(canonical_device, app_name);
+    bool removed_history = false;
+    {
+      std::lock_guard<std::mutex> lock(history_mutex);
+      removed_history = session_history.erase(session_key) > 0;
+    }
+    if (removed_history) {
+      save_history();
+    }
+
+    bool removed_cache = false;
+    {
+      std::lock_guard<std::mutex> lock(cache_mutex);
+      for (auto it = cache.begin(); it != cache.end();) {
+        if (canonical_device_name(it->second.device_name) == canonical_device &&
+            it->second.app_name == app_name) {
+          it = cache.erase(it);
+          removed_cache = true;
+        } else {
+          ++it;
+        }
+      }
+      if (removed_cache) {
+        save_cache_locked();
+      }
+    }
+
+    if (removed_history || removed_cache) {
+      BOOST_LOG(info) << "ai_optimizer: Cleared game profile for "sv
+                      << session_key
+                      << " history="sv << (removed_history ? "yes" : "no")
+                      << " cache="sv << (removed_cache ? "yes" : "no");
+    }
+
+    return removed_history || removed_cache;
   }
 
   std::string get_history_json() {
@@ -2307,6 +3200,14 @@ namespace ai_optimizer {
       entry["last_packet_loss_pct"] = h.last_packet_loss_pct;
       entry["last_quality_grade"] = h.last_quality_grade;
       entry["last_codec"] = h.last_codec;
+      entry["last_duration_s"] = h.last_duration_s;
+      entry["last_sample_count"] = h.last_sample_count;
+      entry["last_low_1_percent_fps"] = h.last_low_1_percent_fps;
+      entry["last_min_fps"] = h.last_min_fps;
+      entry["last_frame_pacing_bad_pct"] = h.last_frame_pacing_bad_pct;
+      entry["last_end_reason"] = h.last_end_reason;
+      entry["last_sample_confidence"] = h.last_sample_confidence;
+      entry["last_feedback_ignored_reason"] = h.last_feedback_ignored_reason;
       entry["poor_outcome_count"] = h.poor_outcome_count;
       entry["consecutive_poor_outcomes"] = h.consecutive_poor_outcomes;
       entry["last_optimization_source"] = h.last_optimization_source;
@@ -2322,6 +3223,7 @@ namespace ai_optimizer {
       entry["last_safe_bitrate_kbps"] = h.last_safe_bitrate_kbps;
       entry["last_safe_codec"] = h.last_safe_codec;
       entry["last_safe_display_mode"] = h.last_safe_display_mode;
+      entry["last_safe_target_fps"] = h.last_safe_target_fps;
       if (h.last_safe_hdr.has_value()) {
         entry["last_safe_hdr"] = h.last_safe_hdr.value();
       }
@@ -2331,6 +3233,180 @@ namespace ai_optimizer {
       arr.push_back(entry);
     }
     return arr.dump();
+  }
+
+  std::string get_profiles_json(const std::string &device_name) {
+    static std::once_flag history_load_flag;
+    std::call_once(history_load_flag, load_history);
+
+    const auto requested_device = canonical_device_name(device_name);
+    std::unordered_map<std::string, nlohmann::json> profiles_by_key;
+
+    {
+      std::lock_guard<std::mutex> lock(history_mutex);
+      for (const auto &[key, h] : session_history) {
+        const auto separator = key.find(':');
+        const auto profile_device = separator == std::string::npos ? key : key.substr(0, separator);
+        const auto app_name = separator == std::string::npos ? std::string {} : key.substr(separator + 1);
+        const auto canonical_device = canonical_device_name(profile_device);
+        if (!requested_device.empty() && canonical_device != requested_device) {
+          continue;
+        }
+
+        auto &entry = profiles_by_key[history_key(canonical_device, app_name)];
+        entry["device"] = canonical_device;
+        entry["game"] = app_name;
+        entry["has_history"] = true;
+        entry["can_reset"] = true;
+        entry["session_count"] = h.session_count;
+        entry["quality_grade"] = latest_quality_grade(h);
+        entry["avg_fps"] = h.avg_fps;
+        entry["avg_latency_ms"] = h.avg_latency_ms;
+        entry["avg_bitrate_kbps"] = h.avg_bitrate_kbps;
+        entry["last_fps"] = h.last_fps;
+        entry["last_target_fps"] = h.last_target_fps;
+        entry["last_low_1_percent_fps"] = h.last_low_1_percent_fps;
+        entry["last_min_fps"] = h.last_min_fps;
+        entry["last_frame_pacing_bad_pct"] = h.last_frame_pacing_bad_pct;
+        entry["last_end_reason"] = h.last_end_reason;
+        entry["last_sample_confidence"] = h.last_sample_confidence;
+        entry["last_health_grade"] = h.last_health_grade;
+        entry["last_primary_issue"] = h.last_primary_issue;
+        entry["last_issues"] = h.last_issues;
+        entry["poor_outcome_count"] = h.poor_outcome_count;
+        entry["consecutive_poor_outcomes"] = h.consecutive_poor_outcomes;
+        entry["last_safe_bitrate_kbps"] = h.last_safe_bitrate_kbps;
+        entry["last_safe_codec"] = h.last_safe_codec;
+        entry["last_safe_display_mode"] = h.last_safe_display_mode;
+        entry["last_safe_target_fps"] = h.last_safe_target_fps;
+        if (h.last_safe_hdr.has_value()) {
+          entry["last_safe_hdr"] = h.last_safe_hdr.value();
+        }
+        entry["last_relaunch_recommended"] = h.last_relaunch_recommended;
+        entry["last_updated_at"] = h.last_updated_at;
+        entry["last_invalidated_at"] = h.last_invalidated_at;
+      }
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(cache_mutex);
+      for (const auto &[key, entry] : cache) {
+        if (entry.provider != cfg.provider || entry.model != cfg.model || entry.base_url != cfg.base_url) {
+          continue;
+        }
+        const auto canonical_device = canonical_device_name(entry.device_name);
+        if (!requested_device.empty() && canonical_device != requested_device) {
+          continue;
+        }
+
+        auto &profile = profiles_by_key[history_key(canonical_device, entry.app_name)];
+        profile["device"] = canonical_device;
+        profile["game"] = entry.app_name;
+        profile["has_cache"] = true;
+        profile["can_reset"] = true;
+        profile["provider"] = entry.provider;
+        profile["model"] = entry.model;
+        profile["timestamp"] = entry.timestamp;
+        const auto &optimization = entry.optimization;
+        profile["source"] = optimization.source;
+        profile["cache_status"] = optimization.cache_status;
+        profile["confidence"] = optimization.confidence;
+        profile["reasoning"] = optimization.reasoning;
+        profile["normalization_reason"] = optimization.normalization_reason;
+        profile["signals_used"] = optimization.signals_used;
+        profile["recommendation_version"] = optimization.recommendation_version;
+        profile["generated_at"] = optimization.generated_at;
+        profile["expires_at"] = optimization.expires_at;
+        if (optimization.display_mode) {
+          profile["display_mode"] = *optimization.display_mode;
+        }
+        if (optimization.target_bitrate_kbps) {
+          profile["target_bitrate_kbps"] = *optimization.target_bitrate_kbps;
+        }
+        if (optimization.preferred_codec) {
+          profile["preferred_codec"] = *optimization.preferred_codec;
+        }
+        if (optimization.hdr.has_value()) {
+          profile["hdr"] = *optimization.hdr;
+        }
+      }
+    }
+
+    std::vector<std::string> keys;
+    keys.reserve(profiles_by_key.size());
+    for (const auto &[key, _] : profiles_by_key) {
+      keys.push_back(key);
+    }
+    std::sort(keys.begin(), keys.end());
+
+    nlohmann::json profiles = nlohmann::json::array();
+    for (const auto &key : keys) {
+      auto profile = profiles_by_key[key];
+      profile["key"] = key;
+      profile["has_history"] = profile.value("has_history", false);
+      profile["has_cache"] = profile.value("has_cache", false);
+      profiles.push_back(std::move(profile));
+    }
+
+    nlohmann::json output;
+    output["status"] = true;
+    output["device"] = requested_device;
+    output["count"] = profiles.size();
+    output["profiles"] = std::move(profiles);
+    return output.dump();
+  }
+
+  bool clear_device_profiles(const std::string &device_name) {
+    if (device_name.empty()) {
+      return false;
+    }
+
+    static std::once_flag history_load_flag;
+    std::call_once(history_load_flag, load_history);
+
+    const auto canonical_device = canonical_device_name(device_name);
+    bool removed_history = false;
+    {
+      std::lock_guard<std::mutex> lock(history_mutex);
+      for (auto it = session_history.begin(); it != session_history.end();) {
+        const auto separator = it->first.find(':');
+        const auto profile_device = separator == std::string::npos ? it->first : it->first.substr(0, separator);
+        if (canonical_device_name(profile_device) == canonical_device) {
+          it = session_history.erase(it);
+          removed_history = true;
+        } else {
+          ++it;
+        }
+      }
+    }
+    if (removed_history) {
+      save_history();
+    }
+
+    bool removed_cache = false;
+    {
+      std::lock_guard<std::mutex> lock(cache_mutex);
+      for (auto it = cache.begin(); it != cache.end();) {
+        if (canonical_device_name(it->second.device_name) == canonical_device) {
+          it = cache.erase(it);
+          removed_cache = true;
+        } else {
+          ++it;
+        }
+      }
+      if (removed_cache) {
+        save_cache_locked();
+      }
+    }
+
+    if (removed_history || removed_cache) {
+      BOOST_LOG(info) << "ai_optimizer: Cleared all optimizer profiles for "sv
+                      << canonical_device
+                      << " history="sv << (removed_history ? "yes" : "no")
+                      << " cache="sv << (removed_cache ? "yes" : "no");
+    }
+
+    return removed_history || removed_cache;
   }
 
 }  // namespace ai_optimizer

--- a/src/ai_optimizer.h
+++ b/src/ai_optimizer.h
@@ -84,6 +84,14 @@ namespace ai_optimizer {
     double last_packet_loss_pct = 0;
     std::string last_quality_grade;
     std::string last_codec;
+    int last_duration_s = 0;
+    int last_sample_count = 0;
+    double last_low_1_percent_fps = 0;
+    double last_min_fps = 0;
+    double last_frame_pacing_bad_pct = 0;
+    std::string last_end_reason;
+    std::string last_sample_confidence;
+    std::string last_feedback_ignored_reason;
     int poor_outcome_count = 0;
     int consecutive_poor_outcomes = 0;
     std::string last_optimization_source;
@@ -99,11 +107,54 @@ namespace ai_optimizer {
     int last_safe_bitrate_kbps = 0;
     std::string last_safe_codec;
     std::string last_safe_display_mode;
+    double last_safe_target_fps = 0;
     std::optional<bool> last_safe_hdr;
     bool last_relaunch_recommended = false;
     std::int64_t last_updated_at = 0;
     std::int64_t last_invalidated_at = 0;
   };
+
+  struct session_feedback_policy_t {
+    bool accepted = false;
+    bool counts_poor_outcome = false;
+    bool can_invalidate_cache = false;
+    std::string confidence;
+    std::string ignored_reason;
+    std::string end_reason;
+  };
+
+  session_feedback_policy_t classify_session_feedback(
+    const std::string &app_name,
+    const session_history_t &session);
+
+  /**
+   * @brief Derive the A/B/C/D/F quality grade for one reported session.
+   */
+  std::string grade_session_quality(const session_history_t &session);
+
+  /**
+   * @brief Normalize loaded or merged session history before it can drive Auto recovery.
+   */
+  session_history_t sanitize_session_history(session_history_t session);
+
+  /**
+   * @brief Derive a safe frame-rate target from recent pacing feedback.
+   */
+  double derive_safe_target_fps(double target_fps,
+                                double avg_fps,
+                                double low_1_percent_fps,
+                                double min_fps,
+                                double frame_pacing_bad_pct,
+                                bool mobile_client,
+                                bool degraded_history,
+                                bool pacing_risk);
+
+  /**
+   * @brief Return the FPS cap to apply from history after normalizing legacy
+   * safe-target values against the latest pacing model.
+   */
+  double effective_history_safe_target_fps(const std::string &device_name,
+                                           const session_history_t &session);
 
   /**
    * @brief Request an AI optimization asynchronously.
@@ -170,6 +221,28 @@ namespace ai_optimizer {
     const std::optional<session_history_t> &history = std::nullopt);
 
   /**
+   * @brief Return true when a history-safe FPS cap has already been trialed and
+   * should be relaxed so a smoother profile can be retried.
+   */
+  bool should_relax_history_safe_target_fps(const session_history_t &session);
+
+  /**
+   * @brief Return true when a successful higher-FPS retry should retire a
+   * stale history-safe FPS cap for this game/device pair.
+   */
+  bool should_graduate_history_safe_target_fps(
+    const session_history_t &session,
+    double previous_safe_target_fps);
+
+  /**
+   * @brief Return true when a clean low-FPS recovery trial should retire a
+   * stale cached recovery recommendation so the next launch can climb.
+   */
+  bool should_refresh_recovery_cache_after_stable_trial(
+    const session_history_t &session,
+    const device_db::optimization_t &optimization);
+
+  /**
    * @brief Get AI status as JSON string.
    */
   std::string get_status_json();
@@ -185,8 +258,28 @@ namespace ai_optimizer {
   std::string get_history_json();
 
   /**
+   * @brief Get merged cached optimization + session history profiles for one
+   * device, or all devices when device_name is empty.
+   */
+  std::string get_profiles_json(const std::string &device_name = "");
+
+  /**
    * @brief Clear the optimization cache.
    */
   void clear_cache();
+
+  /**
+   * @brief Clear cached AI optimization and session recovery state for one
+   * device+game pair. Returns true when any persisted state was removed.
+   */
+  bool clear_game_profile(const std::string &device_name,
+                          const std::string &app_name);
+
+  /**
+   * @brief Clear cached AI optimization and session recovery state for every
+   * game associated with one device. Returns true when any persisted state was
+   * removed.
+   */
+  bool clear_device_profiles(const std::string &device_name);
 
 }  // namespace ai_optimizer

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -288,7 +288,7 @@ namespace confighttp {
     }
 
 #ifdef __linux__
-    constexpr auto PREVIEW_FAILURE_LOG_BACKOFF = std::chrono::minutes(5);
+    constexpr auto PREVIEW_FAILURE_LOG_BACKOFF = std::chrono::seconds(60);
 
     struct preview_failure_log_state_t {
       std::chrono::steady_clock::time_point last_log {};
@@ -1801,18 +1801,6 @@ namespace confighttp {
         game["already_imported"] = already;
         if (!lutris_game.runner.empty()) {
           game["runner"] = lutris_game.runner;
-          if (boost::iequals(lutris_game.runner, "wine")) {
-            game["platform"] = "windows";
-            game["runtime"] = "wine";
-          } else if (boost::iequals(lutris_game.runner, "proton")) {
-            game["platform"] = "windows";
-            game["runtime"] = "proton";
-          } else if (boost::iequals(lutris_game.runner, "linux")) {
-            game["platform"] = "linux";
-            game["runtime"] = "native";
-          } else if (boost::iequals(lutris_game.runner, "steam")) {
-            game["runtime"] = "steam";
-          }
         }
         auto image_path = lutris_game.image_path.empty() ?
           game_library::find_lutris_image_path(lutris_game.slug, lutris_roots) :
@@ -2035,12 +2023,6 @@ namespace confighttp {
         }
 
         // Persist game classification metadata
-        if (game.contains("platform") && game["platform"].is_string()) {
-          app["platform"] = game["platform"];
-        }
-        if (game.contains("runtime") && game["runtime"].is_string()) {
-          app["runtime"] = game["runtime"];
-        }
         if (game.contains("game_category") && game["game_category"].is_string()) {
           app["game-category"] = game["game_category"];
         }
@@ -2547,6 +2529,8 @@ namespace confighttp {
         effective_mode = "windowed_stream";
       } else if (proc::proc.virtual_display) {
         effective_mode = "host_virtual_display";
+      } else if (configured_mode == "windowed_stream" && stats.runtime_effective_headless) {
+        effective_mode = "windowed_stream";
       } else if (stats.runtime_effective_headless) {
         effective_mode = "headless_stream";
       } else {
@@ -2610,6 +2594,7 @@ namespace confighttp {
     output_tree["has_ai_api_key"] = output_tree.value("has_ai_api_key", false);
     output_tree["has_steamgriddb_api_key"] = output_tree.value("has_steamgriddb_api_key", false);
     output_tree["has_api_key"] = output_tree.value("has_api_key", false);
+    output_tree["ai_auto_quality_enabled"] = bool_config_value(ai_optimizer::is_enabled());
     output_tree["adaptive_bitrate_enabled"] = bool_config_value(adaptive_bitrate::is_enabled());
     output_tree["ai_enabled"] = bool_config_value(ai_optimizer::is_enabled());
     send_response(response, output_tree);
@@ -2685,6 +2670,7 @@ namespace confighttp {
                key == "client_settings_effective_stream_display_mode_label"sv ||
                key == "client_settings_live_fields"sv ||
                key == "client_settings_restart_fields"sv ||
+               key == "ai_auto_quality_enabled"sv ||
                key == "stream_display_mode"sv;
       };
       std::string validation_error;
@@ -2694,6 +2680,18 @@ namespace confighttp {
         } else {
           ++it;
         }
+      }
+      if (input_tree.contains("ai_enabled") || input_tree.contains("adaptive_bitrate_enabled")) {
+        const bool has_ai_enabled = input_tree.contains("ai_enabled");
+        const bool has_adaptive_enabled = input_tree.contains("adaptive_bitrate_enabled");
+        const auto unified_value =
+          has_ai_enabled ? input_tree["ai_enabled"] : input_tree["adaptive_bitrate_enabled"];
+        if (has_ai_enabled && has_adaptive_enabled && input_tree["ai_enabled"] != input_tree["adaptive_bitrate_enabled"]) {
+          bad_request(response, request, "AI Optimizer and Adaptive Bitrate are controlled by AI Auto Quality and must match.");
+          return;
+        }
+        input_tree["ai_enabled"] = unified_value;
+        input_tree["adaptive_bitrate_enabled"] = unified_value;
       }
       if (!validation::validate_config_payload(input_tree, validation_error)) {
         bad_request(response, request, validation_error);

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -370,7 +370,6 @@ namespace confighttp::validation {
       "gamepad"sv,
       "id"sv,
       "image-path"sv,
-      "lutris-runner"sv,
       "name"sv,
       "output"sv,
       "steam-appid"sv,
@@ -402,22 +401,6 @@ namespace confighttp::validation {
       "lutris"sv,
       "manual"sv,
       "steam"sv,
-    };
-    constexpr std::array platform_values {
-      ""sv,
-      "linux"sv,
-      "macos"sv,
-      "unknown"sv,
-      "windows"sv,
-    };
-    constexpr std::array runtime_values {
-      ""sv,
-      "native"sv,
-      "proton"sv,
-      "steam"sv,
-      "umu"sv,
-      "unknown"sv,
-      "wine"sv,
     };
     constexpr std::array category_values {
       ""sv,
@@ -498,30 +481,6 @@ namespace confighttp::validation {
 
         if (!contains(source_values, std::string_view {value.get<std::string>()})) {
           error = "source must be one of manual, steam, lutris, or heroic";
-          return false;
-        }
-        continue;
-      }
-
-      if (key == "platform") {
-        if (!validate_safe_string(key, value, error)) {
-          return false;
-        }
-
-        if (!contains(platform_values, std::string_view {value.get<std::string>()})) {
-          error = "platform must be one of linux, macos, unknown, or windows";
-          return false;
-        }
-        continue;
-      }
-
-      if (key == "runtime") {
-        if (!validate_safe_string(key, value, error)) {
-          return false;
-        }
-
-        if (!contains(runtime_values, std::string_view {value.get<std::string>()})) {
-          error = "runtime must be one of native, proton, steam, umu, unknown, or wine";
           return false;
         }
         continue;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -143,150 +143,13 @@ namespace nvhttp {
       return value;
     }
 
-    std::string trim_copy(std::string value) {
-      auto is_space = [](unsigned char c) {
-        return std::isspace(c) != 0;
-      };
-      value.erase(value.begin(), std::find_if(value.begin(), value.end(), [&](unsigned char c) {
-        return !is_space(c);
-      }));
-      value.erase(std::find_if(value.rbegin(), value.rend(), [&](unsigned char c) {
-        return !is_space(c);
-      }).base(), value.end());
-      return value;
+    bool ai_auto_quality_enabled() {
+      return ai_optimizer::is_enabled();
     }
 
-    std::string normalized_token(std::string value) {
-      return lower_copy(trim_copy(std::move(value)));
-    }
-
-    std::string app_command_blob(const proc::ctx_t &app) {
-      std::string blob = app.cmd;
-      for (const auto &cmd : app.detached) {
-        if (!blob.empty()) {
-          blob += '\n';
-        }
-        blob += cmd;
-      }
-      return blob;
-    }
-
-    std::string infer_runtime_label(const std::string &runtime) {
-      const auto normalized = normalized_token(runtime);
-      if (normalized == "native") {
-        return "Native";
-      }
-      if (normalized == "proton") {
-        return "Proton";
-      }
-      if (normalized == "wine") {
-        return "Wine";
-      }
-      if (normalized == "steam") {
-        return "Steam";
-      }
-      if (normalized == "umu") {
-        return "UMU";
-      }
-      return {};
-    }
-
-    std::string infer_platform_label(const std::string &platform) {
-      const auto normalized = normalized_token(platform);
-      if (normalized == "linux") {
-        return "Linux";
-      }
-      if (normalized == "windows") {
-        return "Windows";
-      }
-      if (normalized == "macos") {
-        return "macOS";
-      }
-      return {};
-    }
-
-    struct app_runtime_metadata_t {
-      std::string source;
-      std::string launcher_detail;
-      std::string platform;
-      std::string runtime;
-    };
-
-    app_runtime_metadata_t infer_app_runtime_metadata(const proc::ctx_t &app) {
-      app_runtime_metadata_t metadata;
-      metadata.source = normalized_token(app.source);
-      if (metadata.source.empty()) {
-        metadata.source = app.steam_appid.empty() ? "manual" : "steam";
-      }
-
-      metadata.platform = normalized_token(app.platform);
-      metadata.runtime = normalized_token(app.runtime);
-      metadata.launcher_detail = normalized_token(app.lutris_runner);
-
-      const auto commands = app_command_blob(app);
-      const auto lower_commands = lower_copy(commands);
-      const bool has_wine = lower_commands.find("wine") != std::string::npos;
-      const bool has_proton = lower_commands.find("proton") != std::string::npos ||
-                              lower_commands.find("steamcompat") != std::string::npos ||
-                              lower_commands.find("steam_compat") != std::string::npos;
-      const bool has_umu = lower_commands.find("umu-run") != std::string::npos;
-
-      if (metadata.source == "lutris") {
-        const auto runner = metadata.launcher_detail;
-        if (metadata.runtime.empty()) {
-          if (runner == "wine") {
-            metadata.runtime = "wine";
-          } else if (runner == "proton") {
-            metadata.runtime = "proton";
-          } else if (runner == "linux") {
-            metadata.runtime = "native";
-          } else if (runner == "steam") {
-            metadata.runtime = "steam";
-          } else if (!runner.empty()) {
-            metadata.runtime = runner;
-          }
-        }
-        if (metadata.platform.empty()) {
-          if (metadata.runtime == "wine" || metadata.runtime == "proton") {
-            metadata.platform = "windows";
-          } else if (metadata.runtime == "native") {
-            metadata.platform = "linux";
-          }
-        }
-      } else if (metadata.source == "steam") {
-        if (metadata.runtime.empty()) {
-          metadata.runtime = (has_proton || has_umu) ? "proton" : "steam";
-        }
-        if (metadata.platform.empty() && metadata.runtime == "proton") {
-          metadata.platform = "windows";
-        }
-      } else {
-        if (metadata.runtime.empty()) {
-          if (has_umu || has_proton) {
-            metadata.runtime = "proton";
-          } else if (has_wine) {
-            metadata.runtime = "wine";
-          }
-        }
-        if (metadata.platform.empty()) {
-          if (metadata.runtime == "wine" || metadata.runtime == "proton") {
-            metadata.platform = "windows";
-          }
-        }
-      }
-
-      if (metadata.runtime.empty()) {
-        metadata.runtime = "unknown";
-      }
-      if (metadata.platform.empty()) {
-        metadata.platform = "unknown";
-      }
-      return metadata;
-    }
-
-    bool is_poor_quality_grade(const std::string &grade) {
-      const auto normalized = lower_copy(grade);
-      return normalized == "d" || normalized == "f";
+    void set_ai_auto_quality_enabled(bool enabled) {
+      ai_optimizer::set_enabled(enabled);
+      adaptive_bitrate::set_enabled(enabled);
     }
 
     std::string latest_quality_grade(const std::optional<ai_optimizer::session_history_t> &history) {
@@ -297,6 +160,168 @@ namespace nvhttp {
         return history->last_quality_grade;
       }
       return history->quality_grade;
+    }
+
+    bool confirmed_degraded_history(const std::optional<ai_optimizer::session_history_t> &history) {
+      return history &&
+        (history->poor_outcome_count > 0 || history->consecutive_poor_outcomes > 0);
+    }
+
+    std::string auto_limiting_factor_from_issue(const std::string &issue) {
+      const auto normalized = lower_copy(issue);
+      if (normalized == "network_jitter" || normalized == "network") {
+        return "network";
+      }
+      if (normalized == "host_render_limited" || normalized == "host_render") {
+        return "host_render";
+      }
+      if (normalized == "encoder_load" || normalized == "encoder") {
+        return "encoder";
+      }
+      if (normalized == "decoder_path" || normalized == "decoder") {
+        return "decoder";
+      }
+      if (normalized == "hdr_path" || normalized == "hdr") {
+        return "hdr";
+      }
+      if (normalized == "virtual_display_path" ||
+          normalized == "capture_fallback" ||
+          normalized.find("capture") != std::string::npos) {
+        return "capture";
+      }
+      if (normalized == "frame_pacing") {
+        return "pacing";
+      }
+      return "none";
+    }
+
+    std::string auto_limiting_factor_from_history(
+        const std::optional<ai_optimizer::session_history_t> &history) {
+      if (!history) {
+        return "none";
+      }
+      auto factor = auto_limiting_factor_from_issue(history->last_primary_issue);
+      if (factor != "none") {
+        return factor;
+      }
+      for (const auto &issue : history->last_issues) {
+        factor = auto_limiting_factor_from_issue(issue);
+        if (factor != "none") {
+          return factor;
+        }
+      }
+      return "none";
+    }
+
+    std::string auto_quality_blocked_reason(const std::string &limiting_factor) {
+      const auto normalized = lower_copy(limiting_factor);
+      if (normalized == "host_render") {
+        return "host_render_limited";
+      }
+      if (normalized == "network" ||
+          normalized == "encoder" ||
+          normalized == "decoder") {
+        return normalized;
+      }
+      if (normalized == "pacing" ||
+          normalized == "capture" ||
+          normalized == "hdr") {
+        return "insufficient_signal";
+      }
+      return "none";
+    }
+
+    nlohmann::json build_auto_quality_policy_json(const nlohmann::json &health,
+                                                  const adaptive_bitrate::state_t &adaptive_state,
+                                                  int encoder_bitrate_kbps) {
+      const bool auto_quality_enabled = ai_auto_quality_enabled();
+      const std::string limiting_factor = health.value("limiting_factor", std::string {"none"});
+      const std::string adaptive_state_name = lower_copy(adaptive_state.state);
+      const bool host_render_limited =
+        health.value("host_render_limited", false) ||
+        limiting_factor == "host_render" ||
+        lower_copy(health.value("primary_issue", std::string {})) == "host_render_limited";
+      const bool host_render_recovery =
+        host_render_limited &&
+        health.value("relaunch_recommended", false) &&
+        health.contains("safe_target_fps");
+      const bool blocked =
+        (!host_render_recovery && host_render_limited) ||
+        limiting_factor == "network" ||
+        limiting_factor == "encoder" ||
+        limiting_factor == "decoder";
+      const int live_bitrate_kbps =
+        adaptive_state.target_bitrate_kbps > 0 ? adaptive_state.target_bitrate_kbps : encoder_bitrate_kbps;
+      const int quality_cap_kbps =
+        adaptive_state.base_bitrate_kbps > 0 ? adaptive_state.base_bitrate_kbps : encoder_bitrate_kbps;
+      const bool bitrate_recovering =
+        !blocked &&
+        adaptive_state.enabled &&
+        adaptive_state_name == "recovering" &&
+        live_bitrate_kbps > 0 &&
+        quality_cap_kbps > 0 &&
+        live_bitrate_kbps < quality_cap_kbps;
+
+      std::string state = "holding";
+      std::string blocked_reason = "none";
+      std::string summary = "Auto Quality is holding the current profile.";
+      if (!auto_quality_enabled) {
+        state = "off";
+        summary = "Manual stream tuning is active.";
+      } else if (blocked) {
+        state = "blocked";
+        blocked_reason = auto_quality_blocked_reason(limiting_factor);
+        summary =
+          blocked_reason == "host_render_limited" ?
+            "Holding quality until the host render path reaches the stream FPS target." :
+          blocked_reason == "network" ?
+            "Holding quality while network pressure clears." :
+          blocked_reason == "encoder" ?
+            "Holding quality while encoder pressure clears." :
+          blocked_reason == "decoder" ?
+            "Holding quality while decoder pressure clears." :
+            "Holding quality until the stream has enough clean signal.";
+      } else if (host_render_recovery) {
+        state = "recovery_queued";
+        summary = "AI Recovery Profile ready for the next launch.";
+      } else if (bitrate_recovering) {
+        state = "recovering_bitrate";
+        summary = "Recovering bitrate toward the quality cap.";
+      }
+
+      nlohmann::json policy;
+      policy["enabled"] = auto_quality_enabled;
+      policy["state"] = state;
+      policy["blocked_reason"] = blocked_reason;
+      policy["live_bitrate_kbps"] = live_bitrate_kbps;
+      policy["quality_cap_kbps"] = quality_cap_kbps;
+      policy["relaunch_required"] =
+        auto_quality_enabled && state != "blocked" && health.value("relaunch_recommended", false);
+      policy["can_recover_live"] = state == "recovering_bitrate";
+      policy["summary"] = summary;
+      policy["detail"] = health.value("summary", summary);
+      policy["components"] = {
+        {"optimizer_active", ai_optimizer::is_enabled()},
+        {"adaptive_bitrate_active", adaptive_bitrate::is_enabled()},
+        {"adaptive_state", adaptive_state.state},
+        {"adaptive_reason", adaptive_state.reason},
+        {"target_bitrate_kbps", live_bitrate_kbps}
+      };
+      if (policy["relaunch_required"].get<bool>()) {
+        auto &suggested = policy["suggested_profile"];
+        suggested["target_bitrate_kbps"] = health.value("safe_bitrate_kbps", 0);
+        suggested["display_mode"] = health.value("safe_display_mode", std::string {});
+        if (health.contains("safe_target_fps")) {
+          suggested["target_fps"] = health["safe_target_fps"];
+        }
+        if (health.contains("safe_codec")) {
+          suggested["preferred_codec"] = health["safe_codec"];
+        }
+        if (health.contains("safe_hdr")) {
+          suggested["hdr"] = health["safe_hdr"];
+        }
+      }
+      return policy;
     }
 
     bool host_virtual_display_available() {
@@ -328,6 +353,258 @@ namespace nvhttp {
     }
 
     bool is_mobile_client_type(const std::optional<device_db::device_t> &device_profile);
+
+    std::mutex client_presentation_mutex;
+    std::unordered_map<std::string, nlohmann::json> client_presentation_reports;
+    std::mutex client_sync_mutex;
+    std::unordered_map<std::string, nlohmann::json> client_sync_reports;
+
+    bool valid_client_presentation_status(const std::string &status) {
+      return
+        status == "synced" ||
+        status == "pending" ||
+        status == "blocked" ||
+        status == "unknown";
+    }
+
+    bool valid_client_sync_mode(const std::string &mode) {
+      return
+        mode == "auto_safe" ||
+        mode == "manual" ||
+        mode == "off";
+    }
+
+    nlohmann::json presentation_policy_from(const nlohmann::json &policy) {
+      if (policy.contains("presentation_policy") && policy["presentation_policy"].is_object()) {
+        return policy["presentation_policy"];
+      }
+      return nlohmann::json::object();
+    }
+
+    std::string client_presentation_status_for(const std::string &client_uuid,
+                                               const nlohmann::json &policy,
+                                               bool streaming) {
+      const auto presentation_policy = presentation_policy_from(policy);
+      const bool client_action_requested = presentation_policy.value("allow_display_mode_change", false);
+      if (!streaming || !client_action_requested) {
+        return "synced";
+      }
+
+      std::lock_guard<std::mutex> lock(client_presentation_mutex);
+      const auto report_it = client_presentation_reports.find(client_uuid);
+      if (report_it == client_presentation_reports.end()) {
+        return "pending";
+      }
+
+      const double requested_refresh = presentation_policy.value("target_refresh_rate_hz", 0.0);
+      const double reported_refresh = report_it->second.value("target_refresh_rate_hz", -1.0);
+      if (requested_refresh > 0.0 &&
+          (reported_refresh <= 0.0 || std::abs(reported_refresh - requested_refresh) > 0.75)) {
+        return "pending";
+      }
+
+      const auto requested_policy = presentation_policy.value("refresh_rate_policy", std::string {});
+      const auto reported_policy = report_it->second.value("refresh_rate_policy", std::string {});
+      if (!requested_policy.empty() && !reported_policy.empty() && requested_policy != reported_policy) {
+        return "pending";
+      }
+
+      return report_it->second.value("status", std::string {"unknown"});
+    }
+
+    nlohmann::json client_presentation_report_for(const std::string &client_uuid) {
+      std::lock_guard<std::mutex> lock(client_presentation_mutex);
+      const auto report_it = client_presentation_reports.find(client_uuid);
+      return report_it == client_presentation_reports.end() ? nlohmann::json::object() : report_it->second;
+    }
+
+    nlohmann::json client_sync_report_for(const std::string &client_uuid) {
+      std::lock_guard<std::mutex> lock(client_sync_mutex);
+      const auto report_it = client_sync_reports.find(client_uuid);
+      return report_it == client_sync_reports.end() ? nlohmann::json::object() : report_it->second;
+    }
+
+    bool read_optional_string_field(const nlohmann::json &input,
+                                    const std::string &field,
+                                    nlohmann::json &output,
+                                    std::string &error,
+                                    std::size_t max_len = 256) {
+      if (!input.contains(field)) {
+        return true;
+      }
+      if (!input[field].is_string()) {
+        error = field + " must be a string";
+        return false;
+      }
+      const auto value = input[field].get<std::string>();
+      if (value.size() > max_len) {
+        error = field + " is too long";
+        return false;
+      }
+      output[field] = value;
+      return true;
+    }
+
+    bool read_optional_number_field(const nlohmann::json &input,
+                                    const std::string &field,
+                                    nlohmann::json &output,
+                                    std::string &error,
+                                    double min_value,
+                                    double max_value) {
+      if (!input.contains(field)) {
+        return true;
+      }
+      if (!input[field].is_number()) {
+        error = field + " must be a number";
+        return false;
+      }
+      const auto value = input[field].get<double>();
+      if (value < min_value || value > max_value) {
+        error = field + " is out of range";
+        return false;
+      }
+      output[field] = value;
+      return true;
+    }
+
+    bool read_optional_int_field(const nlohmann::json &input,
+                                 const std::string &field,
+                                 nlohmann::json &output,
+                                 std::string &error,
+                                 int min_value,
+                                 int max_value) {
+      if (!input.contains(field)) {
+        return true;
+      }
+      if (!input[field].is_number_integer()) {
+        error = field + " must be an integer";
+        return false;
+      }
+      const auto value = input[field].get<int>();
+      if (value < min_value || value > max_value) {
+        error = field + " is out of range";
+        return false;
+      }
+      output[field] = value;
+      return true;
+    }
+
+    bool read_optional_object_field(const nlohmann::json &input,
+                                    const std::string &field,
+                                    nlohmann::json &output,
+                                    std::string &error,
+                                    std::size_t max_dump_len = 8192) {
+      if (!input.contains(field)) {
+        return true;
+      }
+      if (!input[field].is_object()) {
+        error = field + " must be an object";
+        return false;
+      }
+      if (input[field].dump().size() > max_dump_len) {
+        error = field + " is too large";
+        return false;
+      }
+      output[field] = input[field];
+      return true;
+    }
+
+    bool update_client_presentation_report(const std::string &client_uuid,
+                                           const nlohmann::json &input,
+                                           std::string &error) {
+      if (!input.is_object()) {
+        error = "client_presentation must be an object";
+        return false;
+      }
+
+      nlohmann::json report = nlohmann::json::object();
+      if (input.contains("status") && !input["status"].is_string()) {
+        error = "client_presentation.status must be a string";
+        return false;
+      }
+      const auto status = input.value("status", std::string {"unknown"});
+      if (!valid_client_presentation_status(status)) {
+        error = "client_presentation.status must be synced, pending, blocked, or unknown";
+        return false;
+      }
+      report["status"] = status;
+
+      for (const auto &field : {"reason"s, "decoder"s, "display_mode"s, "refresh_rate_policy"s, "frame_pacing_state"s}) {
+        if (!read_optional_string_field(input, field, report, error)) {
+          return false;
+        }
+      }
+
+      for (const auto &field : {"applied_refresh_rate_hz"s, "target_refresh_rate_hz"s, "render_fps"s}) {
+        if (!read_optional_number_field(input, field, report, error, 0.0, 1000.0)) {
+          return false;
+        }
+      }
+
+      if (!read_optional_number_field(input, "dropped_frame_ratio", report, error, 0.0, 1.0)) {
+        return false;
+      }
+      if (!read_optional_int_field(input, "display_mode_id", report, error, 0, 1000000)) {
+        return false;
+      }
+
+      std::lock_guard<std::mutex> lock(client_presentation_mutex);
+      client_presentation_reports[client_uuid] = std::move(report);
+      return true;
+    }
+
+    bool update_client_sync_report(const std::string &client_uuid,
+                                   const nlohmann::json &input,
+                                   std::string &error) {
+      if (!input.is_object()) {
+        error = "client settings report must be an object";
+        return false;
+      }
+
+      nlohmann::json report = client_sync_report_for(client_uuid);
+      if (!report.is_object()) {
+        report = nlohmann::json::object();
+      }
+
+      if (input.contains("sync_mode")) {
+        if (!input["sync_mode"].is_string()) {
+          error = "sync_mode must be a string";
+          return false;
+        }
+        const auto sync_mode = input["sync_mode"].get<std::string>();
+        if (!valid_client_sync_mode(sync_mode)) {
+          error = "sync_mode must be auto_safe, manual, or off";
+          return false;
+        }
+        report["sync_mode"] = sync_mode;
+      } else if (!report.contains("sync_mode")) {
+        report["sync_mode"] = "auto_safe";
+      }
+
+      if (input.contains("manual_override")) {
+        if (!input["manual_override"].is_boolean()) {
+          error = "manual_override must be a boolean";
+          return false;
+        }
+        report["manual_override"] = input["manual_override"].get<bool>();
+      } else if (!report.contains("manual_override")) {
+        report["manual_override"] = false;
+      }
+
+      for (const auto &field : {"device_capabilities"s, "client_runtime"s, "applied_stream_settings"s}) {
+        if (!read_optional_object_field(input, field, report, error)) {
+          return false;
+        }
+      }
+
+      report["updated_at_ms"] = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()
+      ).count();
+
+      std::lock_guard<std::mutex> lock(client_sync_mutex);
+      client_sync_reports[client_uuid] = std::move(report);
+      return true;
+    }
 
     std::string bool_config_value(bool enabled) {
       return enabled ? "enabled"s : "disabled"s;
@@ -373,19 +650,23 @@ namespace nvhttp {
       return "headless_stream";
     }
 
-    std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats) {
-      if (!stats.streaming) {
-        return configured_stream_display_mode_selection();
-      }
-      if (stats.runtime_gpu_native_override_active) {
+	    std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats) {
+	      if (!stats.streaming) {
+	        return configured_stream_display_mode_selection();
+	      }
+	      const auto configured_mode = configured_stream_display_mode_selection();
+	      if (stats.runtime_gpu_native_override_active) {
+	        return "windowed_stream";
+	      }
+	      if (proc::proc.virtual_display) {
+	        return "host_virtual_display";
+	      }
+      if (configured_mode == "windowed_stream" && stats.runtime_effective_headless) {
         return "windowed_stream";
       }
-      if (proc::proc.virtual_display) {
-        return "host_virtual_display";
-      }
-      if (stats.runtime_effective_headless) {
-        return "headless_stream";
-      }
+	      if (stats.runtime_effective_headless) {
+	        return "headless_stream";
+	      }
       return "desktop_display";
     }
 
@@ -485,7 +766,16 @@ namespace nvhttp {
       const auto effective_display_mode = policy.value("selected_display_mode", std::string {});
       const auto effective_bitrate_kbps = policy.value("target_bitrate_kbps", 0);
       const bool adaptive_active = adaptive_bitrate::is_enabled() && stats.adaptive_target_bitrate_kbps > 0;
+      const auto client_presentation = client_presentation_report_for(client.uuid);
+      const auto client_sync = client_sync_report_for(client.uuid);
+      const auto presentation_policy = presentation_policy_from(policy);
+      const auto client_presentation_status =
+        client_presentation_status_for(client.uuid, policy, stats.streaming);
       const auto disconnect_resume_timeout_seconds = config::stream.disconnect_resume_timeout.count();
+      const auto sync_mode = client_sync.value("sync_mode", std::string {"auto_safe"});
+      const bool manual_override = client_sync.value("manual_override", false) || sync_mode == "manual";
+      const bool has_client_runtime = client_sync.contains("client_runtime");
+      const bool has_applied_stream_settings = client_sync.contains("applied_stream_settings");
 
       nlohmann::json fields = nlohmann::json::object();
       fields["stream_display_mode"] = {
@@ -517,8 +807,21 @@ namespace nvhttp {
         {"adaptive_target_bitrate_kbps", stats.adaptive_target_bitrate_kbps},
         {"paired_override_active", paired_bitrate_override}
       };
-      fields["adaptive_bitrate_enabled"] = {
+      fields["ai_auto_quality_enabled"] = {
         {"direction", "read_write"},
+        {"scope", "host"},
+        {"desired", ai_auto_quality_enabled()},
+        {"effective", ai_auto_quality_enabled()},
+        {"status", "synced"},
+        {"live", true},
+        {"requires_relaunch", false},
+        {"components", {
+          {"adaptive_bitrate_enabled", adaptive_bitrate::is_enabled()},
+          {"ai_optimizer_enabled", ai_optimizer::is_enabled()}
+        }}
+      };
+      fields["adaptive_bitrate_enabled"] = {
+        {"direction", "read_only"},
         {"scope", "host"},
         {"desired", adaptive_bitrate::is_enabled()},
         {"effective", adaptive_bitrate::is_enabled()},
@@ -527,7 +830,7 @@ namespace nvhttp {
         {"requires_relaunch", false}
       };
       fields["ai_optimizer_enabled"] = {
-        {"direction", "read_write"},
+        {"direction", "read_only"},
         {"scope", "host"},
         {"desired", ai_optimizer::is_enabled()},
         {"effective", ai_optimizer::is_enabled()},
@@ -544,6 +847,62 @@ namespace nvhttp {
         {"live", true},
         {"requires_relaunch", false}
       };
+      fields["client_presentation"] = {
+        {"direction", "bidirectional"},
+        {"scope", "active_client"},
+        {"desired", presentation_policy},
+        {"effective", client_presentation},
+        {"status", client_presentation_status},
+        {"live", true},
+        {"requires_relaunch", false}
+      };
+      fields["device_capabilities"] = {
+        {"direction", "client_to_host"},
+        {"scope", "active_client"},
+        {"desired", nlohmann::json::object()},
+        {"effective", client_sync.value("device_capabilities", nlohmann::json::object())},
+        {"status", client_sync.contains("device_capabilities") ? "synced" : "pending"},
+        {"live", true},
+        {"requires_relaunch", false}
+      };
+      fields["client_runtime"] = {
+        {"direction", "client_to_host"},
+        {"scope", "active_client"},
+        {"desired", nlohmann::json::object()},
+        {"effective", client_sync.value("client_runtime", nlohmann::json::object())},
+        {"status", has_client_runtime ? "synced" : "pending"},
+        {"live", true},
+        {"requires_relaunch", false}
+      };
+      fields["applied_stream_settings"] = {
+        {"direction", "client_to_host"},
+        {"scope", "active_client"},
+        {"desired", {
+          {"display_mode", effective_display_mode},
+          {"target_bitrate_kbps", effective_bitrate_kbps},
+          {"adaptive_target_bitrate_kbps", stats.adaptive_target_bitrate_kbps},
+          {"ai_auto_quality_enabled", ai_auto_quality_enabled()},
+          {"adaptive_bitrate_enabled", adaptive_bitrate::is_enabled()},
+          {"ai_optimizer_enabled", ai_optimizer::is_enabled()}
+        }},
+        {"effective", client_sync.value("applied_stream_settings", nlohmann::json::object())},
+        {"status", has_applied_stream_settings ? "synced" : "pending"},
+        {"live", true},
+        {"requires_relaunch", false}
+      };
+
+      const std::string legacy_state =
+        relaunch_required ? "pending_relaunch" :
+        client_presentation_status == "blocked" ? "client_presentation_blocked" :
+        client_presentation_status == "pending" ? "client_presentation_pending" :
+        adaptive_active ? "adaptive_active" :
+        "synced";
+      const std::string normalized_state =
+        manual_override ? "manual_override" :
+        relaunch_required ? "needs_relaunch" :
+        client_presentation_status == "blocked" ? "failed" :
+        client_presentation_status == "pending" || !has_applied_stream_settings ? "applying" :
+        "synced";
 
       nlohmann::json status;
       status["available"] = true;
@@ -551,15 +910,26 @@ namespace nvhttp {
       status["direction"] = "bidirectional";
       status["endpoint"] = "/polaris/v1/client-settings";
       status["source_of_truth"] = "polaris_effective_runtime";
-      status["state"] =
-        relaunch_required ? "pending_relaunch" :
-        adaptive_active ? "adaptive_active" :
-        "synced";
+      status["state"] = normalized_state;
+      status["legacy_state"] = legacy_state;
+      status["sync_mode"] = sync_mode;
+      status["manual_override"] = manual_override;
+      status["device_capabilities"] = client_sync.value("device_capabilities", nlohmann::json::object());
+      status["client_runtime"] = client_sync.value("client_runtime", nlohmann::json::object());
+      status["applied_stream_settings"] = client_sync.value("applied_stream_settings", nlohmann::json::object());
       status["message"] =
+        manual_override ?
+          "Manual stream overrides are active; Polaris will report guidance but will not treat Auto Safe as authoritative." :
         relaunch_required ?
           "Desired settings are saved and will become effective after the active stream relaunches." :
+        client_presentation_status == "blocked" ?
+          "Nova could not apply the requested client presentation policy; Polaris is keeping the stream stable and waiting for updated client feedback." :
+        client_presentation_status == "pending" ?
+          "Polaris published a client presentation policy and is waiting for Nova to report the applied device state." :
+        !has_applied_stream_settings ?
+          "Polaris is waiting for Nova to report the stream settings it actually applied." :
         adaptive_active ?
-          "Adaptive bitrate is enabled; Polaris is adjusting the effective bitrate in real time under the saved paired-client limit." :
+          "Auto Safe is active; Polaris is adjusting the effective bitrate in real time under the saved paired-client limit." :
           "Desired settings match the current Polaris runtime state.";
       status["fields"] = std::move(fields);
       return status;
@@ -634,6 +1004,228 @@ namespace nvhttp {
       return index == 3 && width > 0 && height > 0 && fps > 0.0;
     }
 
+    double display_mode_target_fps(const std::string &display_mode) {
+      int width = 0;
+      int height = 0;
+      double fps = 0.0;
+      if (parse_stream_policy_display_mode(display_mode, width, height, fps)) {
+        return fps;
+      }
+      return 0.0;
+    }
+
+    std::string normalize_profile_preference(std::string preference) {
+      preference = lower_copy(std::move(preference));
+      if (preference == "quality" ||
+          preference == "high_fps" ||
+          preference == "stability") {
+        return preference;
+      }
+      return "auto";
+    }
+
+    std::string profile_preference_label(const std::string &preference) {
+      if (preference == "quality") {
+        return "Prefer Quality";
+      }
+      if (preference == "high_fps") {
+        return "Prefer High FPS";
+      }
+      if (preference == "stability") {
+        return "Prefer Stability";
+      }
+      return "Auto";
+    }
+
+    nlohmann::json build_optimizer_profile_state_json(
+        const std::string &device_name,
+        const std::string &app_name,
+        const std::string &preference,
+        const nlohmann::json &optimization_json,
+        const device_db::optimization_t &effective_optimization,
+        const std::optional<ai_optimizer::session_history_t> &history,
+        const nlohmann::json &recovery_policy,
+        bool applied_history_safe) {
+      const std::string policy_state = lower_copy(recovery_policy.value("state", std::string {}));
+      const bool auto_enabled = ai_auto_quality_enabled();
+      const bool has_recovery_history =
+        history &&
+        (history->poor_outcome_count > 0 || history->consecutive_poor_outcomes > 0);
+
+      std::string state = "stable";
+      std::string label = "Quality";
+      if (!auto_enabled) {
+        state = "manual_override";
+        label = "Manual";
+      } else if (policy_state == "upgrade_available") {
+        state = "upgrade_available";
+        label = "Ready to upgrade";
+      } else if (applied_history_safe || policy_state == "recovery_queued" || has_recovery_history) {
+        state = "recovering";
+        label = "Recovery";
+      } else if (policy_state == "blocked") {
+        state = "blocked";
+        label = "Holding";
+      } else if (!history) {
+        state = "learning";
+        label = "Learning";
+      }
+
+      const auto source = optimization_json.value("source", std::string {});
+      const auto cache_status = optimization_json.value("cache_status", std::string {});
+      std::string reason = recovery_policy.value("summary", std::string {});
+      if (reason.empty()) {
+        reason = optimization_json.value("normalization_reason", std::string {});
+      }
+      if (reason.empty()) {
+        reason = optimization_json.value("reasoning_summary", optimization_json.value("reasoning", std::string {}));
+      }
+      if (reason.empty()) {
+        reason = "Auto Quality is selecting the best known profile for this device and game.";
+      }
+
+      nlohmann::json current_profile;
+      const auto display_mode = optimization_json.value(
+        "display_mode",
+        effective_optimization.display_mode.value_or(std::string {})
+      );
+      if (!display_mode.empty()) {
+        current_profile["display_mode"] = display_mode;
+        const double target_fps = display_mode_target_fps(display_mode);
+        if (target_fps > 0.0) {
+          current_profile["target_fps"] = target_fps;
+        }
+      }
+      const int target_bitrate_kbps = optimization_json.value(
+        "target_bitrate_kbps",
+        effective_optimization.target_bitrate_kbps.value_or(0)
+      );
+      if (target_bitrate_kbps > 0) {
+        current_profile["target_bitrate_kbps"] = target_bitrate_kbps;
+      }
+      const auto preferred_codec = optimization_json.value(
+        "preferred_codec",
+        effective_optimization.preferred_codec.value_or(std::string {})
+      );
+      if (!preferred_codec.empty()) {
+        current_profile["preferred_codec"] = preferred_codec;
+      }
+      if (optimization_json.contains("hdr")) {
+        current_profile["hdr"] = optimization_json["hdr"];
+      } else if (effective_optimization.hdr.has_value()) {
+        current_profile["hdr"] = *effective_optimization.hdr;
+      }
+
+      nlohmann::json last_result;
+      if (history) {
+        const auto grade = latest_quality_grade(history);
+        if (!grade.empty()) {
+          last_result["grade"] = grade;
+        }
+        last_result["session_count"] = history->session_count;
+        last_result["delivered_fps"] = history->last_fps;
+        last_result["target_fps"] = history->last_target_fps;
+        last_result["low_1_percent_fps"] = history->last_low_1_percent_fps;
+        last_result["min_fps"] = history->last_min_fps;
+        last_result["frame_pacing_bad_pct"] = history->last_frame_pacing_bad_pct;
+        last_result["primary_issue"] = history->last_primary_issue;
+        last_result["sample_confidence"] = history->last_sample_confidence;
+        last_result["updated_at"] = history->last_updated_at;
+      }
+
+      nlohmann::json profile_state;
+      profile_state["device"] = device_name;
+      profile_state["game"] = app_name;
+      profile_state["state"] = state;
+      profile_state["label"] = label;
+      profile_state["reason"] = reason;
+      profile_state["source"] = source;
+      profile_state["cache_status"] = cache_status;
+      profile_state["confidence"] = optimization_json.value("confidence", std::string {});
+      profile_state["preference"] = preference;
+      profile_state["preference_label"] = profile_preference_label(preference);
+      profile_state["preference_applied"] = preference == "auto";
+      profile_state["preference_note"] =
+        preference == "auto" ?
+          "Auto Quality may raise or lower quality based on stream health." :
+          "Preference noted. Auto Quality still prioritizes recovery when the stream cannot sustain the target.";
+      profile_state["current_profile"] = std::move(current_profile);
+      profile_state["last_result"] = std::move(last_result);
+      profile_state["actions"] = {
+        {"can_reset", history.has_value() || source != "device_db"},
+        {"can_retry_quality", state == "upgrade_available"},
+        {"can_keep_recovery", state == "recovering"},
+        {"can_change_preference", true}
+      };
+      return profile_state;
+    }
+
+    nlohmann::json build_live_profile_state_json(const nlohmann::json &health,
+                                                 const nlohmann::json &auto_quality,
+                                                 const nlohmann::json &encoder) {
+      const std::string policy_state = lower_copy(auto_quality.value("state", std::string {}));
+      std::string state = "stable";
+      std::string label = "Quality";
+      if (!auto_quality.value("enabled", ai_auto_quality_enabled())) {
+        state = "manual_override";
+        label = "Manual";
+      } else if (policy_state == "upgrade_available") {
+        state = "upgrade_available";
+        label = "Ready to upgrade";
+      } else if (policy_state == "recovery_queued" || policy_state == "recovering_bitrate") {
+        state = "recovering";
+        label = "Recovery";
+      } else if (policy_state == "blocked") {
+        state = "blocked";
+        label = "Holding";
+      } else if (health.value("grade", std::string {}) == "good") {
+        state = "stable";
+        label = "Stable";
+      }
+
+      nlohmann::json current_profile;
+      const int bitrate_kbps = encoder.value("bitrate_kbps", 0);
+      if (bitrate_kbps > 0) {
+        current_profile["target_bitrate_kbps"] = bitrate_kbps;
+      }
+      const double target_fps =
+        encoder.value("session_target_fps", 0.0) > 0.0 ?
+          encoder.value("session_target_fps", 0.0) :
+          encoder.value("encode_target_fps", 0.0);
+      if (target_fps > 0.0) {
+        current_profile["target_fps"] = target_fps;
+      }
+      const auto codec = encoder.value("codec", std::string {});
+      if (!codec.empty()) {
+        current_profile["preferred_codec"] = codec;
+      }
+
+      nlohmann::json last_result;
+      last_result["grade"] = health.value("grade", std::string {});
+      last_result["primary_issue"] = health.value("primary_issue", std::string {});
+      last_result["target_fps"] = target_fps;
+
+      nlohmann::json profile_state;
+      profile_state["state"] = state;
+      profile_state["label"] = label;
+      profile_state["reason"] = auto_quality.value("summary", health.value("summary", std::string {}));
+      profile_state["source"] = encoder.value("optimization_source", std::string {});
+      profile_state["cache_status"] = encoder.value("optimization_cache_status", std::string {});
+      profile_state["confidence"] = encoder.value("optimization_confidence", std::string {});
+      profile_state["preference"] = "auto";
+      profile_state["preference_label"] = "Auto";
+      profile_state["preference_applied"] = true;
+      profile_state["current_profile"] = std::move(current_profile);
+      profile_state["last_result"] = std::move(last_result);
+      profile_state["actions"] = {
+        {"can_reset", !profile_state["source"].get<std::string>().empty()},
+        {"can_retry_quality", state == "upgrade_available"},
+        {"can_keep_recovery", state == "recovering"},
+        {"can_change_preference", true}
+      };
+      return profile_state;
+    }
+
     std::string stream_policy_source_label(const std::string &source) {
       const auto normalized = lower_copy(source);
       if (normalized == "paired_client") {
@@ -701,6 +1293,32 @@ namespace nvhttp {
         return "No capture metadata has been reported yet.";
       }
       return "The active capture and encoder path is mixed or not fully classified.";
+    }
+
+    nlohmann::json build_client_presentation_policy_json(double policy_fps) {
+      const bool prefer_stable_multiple =
+        policy_fps > 0.0 &&
+        policy_fps <= 45.0;
+      const bool prefer_exact_refresh =
+        policy_fps > 45.0 &&
+        policy_fps <= 60.0;
+      const bool request_client_refresh = prefer_stable_multiple || prefer_exact_refresh;
+
+      return {
+        {"version", 1},
+        {"target_refresh_rate_hz", request_client_refresh ? policy_fps : 0.0},
+        {"refresh_rate_policy",
+          prefer_stable_multiple ? "stable_multiple_internal" :
+          prefer_exact_refresh ? "exact_match_internal" :
+          "client_default"},
+        {"allow_display_mode_change", request_client_refresh},
+        {"internal_display_only", true},
+        {"reason", prefer_stable_multiple ?
+          "Use an even internal display refresh multiple for capped Auto Safe streams." :
+          prefer_exact_refresh ?
+          "Match internal handheld displays to the stream FPS to avoid refresh-rate flapping." :
+          "No client display-mode change is requested for this stream target."}
+      };
     }
 
     nlohmann::json build_stream_policy_json(const crypto::named_cert_t &client,
@@ -814,6 +1432,7 @@ namespace nvhttp {
       policy["capture_transport"] = platf::from_frame_transport(stats.capture_transport);
       policy["capture_residency"] = platf::from_frame_residency(stats.capture_residency);
       policy["capture_format"] = platf::from_frame_format(stats.capture_format);
+      policy["presentation_policy"] = build_client_presentation_policy_json(policy_fps);
       policy["warnings"] = std::move(warnings);
       policy["has_warnings"] = !policy["warnings"].empty();
       return policy;
@@ -827,6 +1446,7 @@ namespace nvhttp {
       const auto effective_mode = effective_stream_display_mode_selection(stats);
       const bool relaunch_required =
         rtsp_stream::session_count() != 0 && configured_mode != effective_mode;
+      const auto client_sync = client_sync_report_for(client.uuid);
 
       nlohmann::json desired;
       desired["stream_display_mode"] = configured_mode;
@@ -834,9 +1454,12 @@ namespace nvhttp {
       desired["stream_display_mode_reason"] = stream_display_mode_reason_for_selection(configured_mode);
       desired["display_mode"] = client.display_mode;
       desired["target_bitrate_kbps"] = client.target_bitrate_kbps;
+      desired["ai_auto_quality_enabled"] = ai_auto_quality_enabled();
       desired["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
       desired["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
       desired["disconnect_resume_timeout_seconds"] = config::stream.disconnect_resume_timeout.count();
+      desired["sync_mode"] = client_sync.value("sync_mode", std::string {"auto_safe"});
+      desired["manual_override"] = client_sync.value("manual_override", false);
 
       nlohmann::json effective;
       effective["stream_display_mode"] = effective_mode;
@@ -844,12 +1467,17 @@ namespace nvhttp {
       effective["stream_display_mode_reason"] = stream_display_mode_reason_for_selection(effective_mode);
       effective["display_mode"] = policy.value("selected_display_mode", std::string {});
       effective["target_bitrate_kbps"] = policy.value("target_bitrate_kbps", 0);
+      effective["ai_auto_quality_enabled"] = ai_auto_quality_enabled();
       effective["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
       effective["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
       effective["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
       effective["disconnect_resume_timeout_seconds"] = config::stream.disconnect_resume_timeout.count();
       effective["capture_path"] = policy.value("capture_path", std::string {});
       effective["capture_gpu_native"] = policy.value("capture_gpu_native", false);
+      effective["client_presentation"] = client_presentation_report_for(client.uuid);
+      effective["device_capabilities"] = client_sync.value("device_capabilities", nlohmann::json::object());
+      effective["client_runtime"] = client_sync.value("client_runtime", nlohmann::json::object());
+      effective["applied_stream_settings"] = client_sync.value("applied_stream_settings", nlohmann::json::object());
 
       const std::string revision_seed =
         configured_mode + "|" + client.display_mode + "|" +
@@ -870,8 +1498,11 @@ namespace nvhttp {
         {"modes", stream_display_mode_options_json()},
         {"display_mode_override", true},
         {"target_bitrate_override", true},
+        {"ai_auto_quality_control", true},
         {"adaptive_bitrate_control", true},
         {"ai_optimizer_control", true},
+        {"client_presentation_reporting", true},
+        {"optimizer_sync_reporting", true},
         {"disconnect_resume_timeout_control", true}
       };
       settings["sync_status"] = build_client_settings_sync_status(
@@ -944,9 +1575,8 @@ namespace nvhttp {
       const bool prefers_headless = host_prefers_headless();
       const bool mobile_client = is_mobile_client_type(device_profile);
       const std::string quality_grade = latest_quality_grade(history);
-      const bool degraded_history =
-        (history && (history->consecutive_poor_outcomes > 0 || history->poor_outcome_count > 0)) ||
-        is_poor_quality_grade(quality_grade);
+      const bool degraded_history = confirmed_degraded_history(history);
+      const auto limiting_factor = auto_limiting_factor_from_history(history);
 
       const int baseline_bitrate_kbps =
         target_bitrate_kbps.value_or(device_profile ? device_profile->ideal_bitrate_kbps : 15000);
@@ -983,6 +1613,12 @@ namespace nvhttp {
         device_profile &&
         device_profile->hdr_capable &&
         !degraded_history;
+      const bool relax_safe_target_fps =
+        history && ai_optimizer::should_relax_history_safe_target_fps(*history);
+      const double safe_target_fps =
+        history && !relax_safe_target_fps ?
+          ai_optimizer::effective_history_safe_target_fps(device_name, *history) :
+          0.0;
 
       auto discouraged_features = nlohmann::json::array();
       auto reasons = nlohmann::json::array();
@@ -1026,18 +1662,31 @@ namespace nvhttp {
         relaunch_notes.push_back("Display-mode changes apply on the next launch.");
       }
 
+      if (safe_target_fps > 0.0) {
+        relaunch_notes.push_back(
+          "Frame-rate changes apply on the next launch."
+        );
+      }
+
       nlohmann::json stability;
-      stability["mode"] = degraded_history ? "stability_first" : "balanced";
+      stability["auto_mode"] = true;
+      stability["limiting_factor"] = limiting_factor;
+      stability["mode"] = degraded_history ? "stability_first" : "auto";
       stability["summary"] = degraded_history ?
         "Safer next launch available for this device." :
-        "Balanced profile ready with a safer fallback if you hit hitching.";
+        "Auto is optimizing for the best stream this device can sustain.";
       stability["relaunch_required"] =
         !relaunch_notes.empty() &&
         (
           !safe_hdr ||
           (safe_codec && normalized_codec && *safe_codec != *normalized_codec) ||
-          safe_virtual_display != current_virtual_display
+          safe_virtual_display != current_virtual_display ||
+          safe_target_fps > 0.0
         );
+      stability["auto_action"] =
+        degraded_history && stability["relaunch_required"].get<bool>() ?
+          "apply_recovery" :
+          degraded_history ? "suggest_recovery" : "none";
       stability["reasons"] = std::move(reasons);
       stability["discouraged_features"] = std::move(discouraged_features);
       stability["relaunch_notes"] = std::move(relaunch_notes);
@@ -1046,6 +1695,9 @@ namespace nvhttp {
       safe_profile["display_mode"] = safe_virtual_display ? "virtual_display" : "headless";
       safe_profile["target_bitrate_kbps"] = safe_bitrate_kbps;
       safe_profile["hdr"] = safe_hdr;
+      if (safe_target_fps > 0.0) {
+        safe_profile["target_fps"] = static_cast<int>(std::round(safe_target_fps));
+      }
       if (safe_codec) {
         safe_profile["preferred_codec"] = *safe_codec;
       }
@@ -1054,6 +1706,41 @@ namespace nvhttp {
         stability["last_quality_grade"] = quality_grade;
         stability["poor_outcome_count"] = history->poor_outcome_count;
         stability["consecutive_poor_outcomes"] = history->consecutive_poor_outcomes;
+        if (relax_safe_target_fps) {
+          stability["safe_target_fps_relaxed"] = true;
+        }
+      }
+
+      auto &recovery_policy = stability["recovery_policy"];
+      const bool host_render_blocked = limiting_factor == "host_render";
+      const bool host_render_recovery = host_render_blocked && safe_target_fps > 0.0;
+      recovery_policy["state"] =
+        host_render_recovery ? "recovery_queued" :
+        host_render_blocked ? "blocked" :
+        relax_safe_target_fps ? "upgrade_available" :
+        "holding";
+      recovery_policy["blocked_reason"] =
+        host_render_recovery ? "none" :
+        host_render_blocked ? "host_render_limited" :
+        degraded_history && !relax_safe_target_fps ? "insufficient_signal" :
+        "none";
+      recovery_policy["live_bitrate_kbps"] = safe_bitrate_kbps;
+      recovery_policy["quality_cap_kbps"] = baseline_bitrate_kbps;
+      recovery_policy["relaunch_required"] = stability["relaunch_required"].get<bool>();
+      recovery_policy["can_recover_live"] = false;
+      recovery_policy["summary"] =
+        host_render_recovery ?
+          "AI Recovery Profile ready for the next launch." :
+        host_render_blocked ?
+          "Holding quality until the host render path reaches the stream FPS target." :
+        relax_safe_target_fps ?
+          "Higher quality is available on the next launch." :
+        degraded_history ?
+          "Holding the safer launch profile until a clean session confirms recovery." :
+          "Auto Quality is holding the current launch profile.";
+      recovery_policy["detail"] = recovery_policy["summary"];
+      if (stability["relaunch_required"].get<bool>()) {
+        recovery_policy["suggested_profile"] = stability["safe_profile"];
       }
 
       return stability;
@@ -1098,6 +1785,22 @@ namespace nvhttp {
       const bool virtual_display_risk =
         current_virtual_display &&
         (pacing_risk || capture_fallback || hdr_risk);
+      const bool sustained_target_miss =
+        target_fps >= 24.0 &&
+        stats.fps > 0.0 &&
+        fps_gap >= std::max(2.0, target_fps * 0.06);
+      const bool host_render_limited =
+        pacing_risk &&
+        !network_risk &&
+        !capture_fallback &&
+        !nvenc_cuda_disabled_path &&
+        !encoder_risk &&
+        !hdr_risk &&
+        !decoder_risk &&
+        !virtual_display_risk &&
+        (sustained_target_miss ||
+         stats.duplicate_frame_ratio >= 0.08 ||
+         stats.dropped_frame_ratio >= 0.03);
 
       auto issues = nlohmann::json::array();
       auto recommendations = nlohmann::json::array();
@@ -1106,7 +1809,10 @@ namespace nvhttp {
         issues.push_back("network_jitter");
         recommendations.push_back("Lower bitrate or keep Adaptive Bitrate enabled.");
       }
-      if (pacing_risk) {
+      if (host_render_limited) {
+        issues.push_back("host_render_limited");
+        recommendations.push_back("Lower the game preset, render resolution, or FPS target; bitrate changes alone will not fix host-render-limited stutter.");
+      } else if (pacing_risk) {
         issues.push_back("frame_pacing");
         recommendations.push_back("Match the game frame cap to the stream FPS and avoid VRR-style sync on the streaming display.");
       }
@@ -1142,8 +1848,26 @@ namespace nvhttp {
       else if (decoder_risk) primary_issue = "decoder_path";
       else if (nvenc_cuda_disabled_path) primary_issue = "nvenc_cuda_disabled";
       else if (capture_fallback) primary_issue = capture_reason;
+      else if (host_render_limited) primary_issue = "host_render_limited";
       else if (pacing_risk) primary_issue = "frame_pacing";
       else if (encoder_risk) primary_issue = "encoder_load";
+
+      const std::string limiting_factor =
+        network_risk ? "network" :
+        hdr_risk ? "hdr" :
+        virtual_display_risk ? "capture" :
+        decoder_risk ? "decoder" :
+        nvenc_cuda_disabled_path ? "capture" :
+        capture_fallback ? "capture" :
+        host_render_limited ? "host_render" :
+        encoder_risk ? "encoder" :
+        pacing_risk ? "pacing" :
+        "none";
+      const std::string auto_action =
+        network_risk || encoder_risk ? "lower_bitrate" :
+        hdr_risk || virtual_display_risk || decoder_risk || nvenc_cuda_disabled_path || capture_fallback ? "suggest_recovery" :
+        host_render_limited ? "lower_render_profile" :
+        "none";
 
       const int concern_count =
         static_cast<int>(network_risk) +
@@ -1170,6 +1894,22 @@ namespace nvhttp {
         device_profile,
         grade != "good"
       );
+      const double safe_target_fps =
+        ai_optimizer::derive_safe_target_fps(
+          target_fps,
+          stats.fps,
+          0.0,
+          0.0,
+          0.0,
+          mobile_client,
+          grade != "good",
+          pacing_risk || host_render_limited
+        );
+      if (safe_target_fps > 0.0) {
+        recommendations.push_back(
+          "Use a lower stream FPS on the next launch if the game cannot hold the current target."
+        );
+      }
 
       auto safe_codec = active_codec_family.empty() ? std::optional<std::string> {} : std::optional<std::string> {active_codec_family};
       if (decoder_risk || (mobile_client && active_codec_family == "av1")) {
@@ -1186,6 +1926,9 @@ namespace nvhttp {
       }
 
       nlohmann::json health;
+      health["auto_mode"] = true;
+      health["limiting_factor"] = limiting_factor;
+      health["auto_action"] = auto_action;
       health["grade"] = grade;
       health["primary_issue"] = primary_issue;
       health["summary"] =
@@ -1196,16 +1939,27 @@ namespace nvhttp {
         decoder_risk ? "The current codec path looks harder on this client than expected." :
         nvenc_cuda_disabled_path ? "The NVIDIA path is using a CUDA-disabled CPU copy fallback." :
         capture_fallback ? capture_path_reason_message(capture_reason) :
+        host_render_limited ? "Host render is missing the stream FPS target; lower game render settings or stream FPS before tuning bitrate." :
         "The stream needs a safer pacing or encode path.";
       health["issues"] = std::move(issues);
       health["recommendations"] = std::move(recommendations);
       health["safe_bitrate_kbps"] = safe_bitrate_kbps;
       health["safe_display_mode"] = (virtual_display_risk || host_prefers_headless()) ? "headless" : (current_virtual_display ? "virtual_display" : "headless");
+      if (safe_target_fps > 0.0) {
+        health["safe_target_fps"] = static_cast<int>(std::round(safe_target_fps));
+      }
       health["safe_hdr"] = stats.stream_hdr_enabled && !hdr_risk;
       health["decoder_risk"] = decoder_risk ? "elevated" : "normal";
       health["hdr_risk"] = hdr_risk ? "elevated" : "normal";
       health["hdr_source"] = hdr_source_missing ? "missing" : (stats.stream_hdr_enabled ? "metadata" : "sdr");
       health["network_risk"] = network_risk ? "elevated" : "normal";
+      health["host_render_limited"] = host_render_limited;
+      if (auto_action != "none" || host_render_limited) {
+        health["recovery_profile"] = primary_issue;
+      }
+      if (target_fps > 0.0) {
+        health["render_fps_gap"] = fps_gap;
+      }
       health["capture_path"] = capture_path;
       health["capture_path_reason"] = capture_reason;
       health["capture_path_reason_message"] = capture_path_reason_message(capture_reason);
@@ -1213,10 +1967,16 @@ namespace nvhttp {
       health["capture_gpu_native"] = stream_stats::capture_path_is_gpu_native(stats);
       health["active_encoder"] = active_encoder_name.empty() ? "unknown" : active_encoder_name;
       health["cuda_build"] = build_has_cuda();
-      health["relaunch_recommended"] = hdr_risk || decoder_risk || virtual_display_risk || nvenc_cuda_disabled_path;
+      health["relaunch_recommended"] = hdr_risk || decoder_risk || virtual_display_risk ||
+        nvenc_cuda_disabled_path || safe_target_fps > 0.0;
       if (safe_codec) {
         health["safe_codec"] = *safe_codec;
       }
+      health["recovery_policy"] = build_auto_quality_policy_json(
+        health,
+        adaptive_bitrate::get_state(),
+        stats.bitrate_kbps
+      );
       return health;
     }
   }  // namespace
@@ -3635,6 +4395,8 @@ namespace nvhttp {
 
       // Feature flags
       auto &features = output["features"];
+      features["ai_auto_quality"] = ai_auto_quality_enabled();
+      features["ai_auto_quality_control"] = true;
       features["ai_optimizer"] = ai_optimizer::is_enabled();
       features["ai_optimizer_control"] = true;
       features["adaptive_bitrate_control"] = true;
@@ -3643,6 +4405,8 @@ namespace nvhttp {
       features["device_profiles"] = true;
       features["stream_policy_v1"] = true;
       features["client_settings_v1"] = true;
+      features["optimizer_sync_v1"] = true;
+      features["optimizer_profiles_v1"] = true;
       features["disconnect_resume_v1"] = true;
       features["cursor_visibility_control"] = true;
       features["lock_screen_control"] = false;
@@ -3661,6 +4425,10 @@ namespace nvhttp {
           "target_bitrate_kbps",
           "adaptive_bitrate_enabled",
           "ai_optimizer_enabled",
+          "client_presentation",
+          "device_capabilities",
+          "client_runtime",
+          "applied_stream_settings",
           "disconnect_resume_timeout_seconds"
         })}
       };
@@ -3700,6 +4468,7 @@ namespace nvhttp {
 
       // Session state from the state machine
       auto stats = stream_stats::get_current();
+      auto adaptive_state = adaptive_bitrate::get_state();
       const auto session_state = confighttp::get_session_state();
       const auto session_token = proc::proc.get_session_token();
       const bool owned_by_client =
@@ -3754,6 +4523,9 @@ namespace nvhttp {
       hdr["color_coding"] = stats.color_coding;
       output["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
       output["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
+      output["adaptive_bitrate_state"] = adaptive_state.state;
+      output["adaptive_bitrate_reason"] = adaptive_state.reason;
+      output["ai_auto_quality_enabled"] = ai_auto_quality_enabled();
       output["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
       output["mangohud_configured"] = proc::proc.current_app_has_mangohud();
 
@@ -3767,6 +4539,14 @@ namespace nvhttp {
       auto &tuning = output["tuning"];
       tuning["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
       tuning["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
+      tuning["adaptive_base_bitrate_kbps"] = adaptive_state.base_bitrate_kbps;
+      tuning["adaptive_min_bitrate_kbps"] = adaptive_state.min_bitrate_kbps;
+      tuning["adaptive_max_bitrate_kbps"] = adaptive_state.max_bitrate_kbps;
+      tuning["adaptive_bitrate_state"] = adaptive_state.state;
+      tuning["adaptive_bitrate_reason"] = adaptive_state.reason;
+      tuning["adaptive_packet_loss_ewma"] = adaptive_state.ewma_packet_loss;
+      tuning["adaptive_rtt_ewma_ms"] = adaptive_state.ewma_rtt_ms;
+      tuning["ai_auto_quality_enabled"] = ai_auto_quality_enabled();
       tuning["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
       tuning["mangohud_configured"] = proc::proc.current_app_has_mangohud();
 
@@ -3831,6 +4611,12 @@ namespace nvhttp {
         proc::proc.get_last_run_app_name()
       );
       output["health"] = health;
+      output["auto_quality"] = health.value("recovery_policy", nlohmann::json::object());
+      output["profile_state"] = build_live_profile_state_json(
+        health,
+        output["auto_quality"],
+        encoder
+      );
       output["stream_policy"] = build_stream_policy_json(
         *named_cert_p,
         stats,
@@ -4021,30 +4807,35 @@ namespace nvhttp {
             }
           }
 
-          if (body.contains("adaptive_bitrate_enabled")) {
-            if (!body["adaptive_bitrate_enabled"].is_boolean()) {
-              write_json({{"error", "adaptive_bitrate_enabled must be a boolean"}}, SimpleWeb::StatusCode::client_error_bad_request);
+          std::optional<bool> ai_auto_quality_update;
+          for (const auto &key : {
+                 "ai_auto_quality_enabled"sv,
+                 "ai_optimizer_enabled"sv,
+                 "adaptive_bitrate_enabled"sv
+               }) {
+            if (!body.contains(std::string {key})) {
+              continue;
+            }
+            if (!body[std::string {key}].is_boolean()) {
+              write_json({{"error", std::string {key} + " must be a boolean"}}, SimpleWeb::StatusCode::client_error_bad_request);
               return;
             }
-            const bool enabled = body["adaptive_bitrate_enabled"].get<bool>();
-            if (!persist_config_values({{"adaptive_bitrate_enabled", bool_config_value(enabled)}})) {
-              write_json({{"error", "failed to persist adaptive bitrate setting"}}, SimpleWeb::StatusCode::server_error_internal_server_error);
+            const bool enabled = body[std::string {key}].get<bool>();
+            if (ai_auto_quality_update && *ai_auto_quality_update != enabled) {
+              write_json({{"error", "AI Auto Quality fields must agree when provided together"}}, SimpleWeb::StatusCode::client_error_bad_request);
               return;
             }
-            adaptive_bitrate::set_enabled(enabled);
+            ai_auto_quality_update = enabled;
           }
-
-          if (body.contains("ai_optimizer_enabled")) {
-            if (!body["ai_optimizer_enabled"].is_boolean()) {
-              write_json({{"error", "ai_optimizer_enabled must be a boolean"}}, SimpleWeb::StatusCode::client_error_bad_request);
+          if (ai_auto_quality_update) {
+            if (!persist_config_values({
+                  {"ai_enabled", bool_config_value(*ai_auto_quality_update)},
+                  {"adaptive_bitrate_enabled", bool_config_value(*ai_auto_quality_update)}
+                })) {
+              write_json({{"error", "failed to persist AI Auto Quality setting"}}, SimpleWeb::StatusCode::server_error_internal_server_error);
               return;
             }
-            const bool enabled = body["ai_optimizer_enabled"].get<bool>();
-            if (!persist_config_values({{"ai_enabled", bool_config_value(enabled)}})) {
-              write_json({{"error", "failed to persist AI Optimizer setting"}}, SimpleWeb::StatusCode::server_error_internal_server_error);
-              return;
-            }
-            ai_optimizer::set_enabled(enabled);
+            set_ai_auto_quality_enabled(*ai_auto_quality_update);
           }
 
           if (body.contains("disconnect_resume_timeout_seconds")) {
@@ -4062,6 +4853,26 @@ namespace nvhttp {
               return;
             }
             config::stream.disconnect_resume_timeout = std::chrono::seconds(timeout_seconds);
+          }
+
+          if (body.contains("client_presentation")) {
+            std::string error;
+            if (!update_client_presentation_report(named_cert_p->uuid, body["client_presentation"], error)) {
+              write_json({{"error", error}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+          }
+
+          if (body.contains("sync_mode") ||
+              body.contains("manual_override") ||
+              body.contains("device_capabilities") ||
+              body.contains("client_runtime") ||
+              body.contains("applied_stream_settings")) {
+            std::string error;
+            if (!update_client_sync_report(named_cert_p->uuid, body, error)) {
+              write_json({{"error", error}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
           }
 
           if (stream_display_mode) {
@@ -4153,16 +4964,11 @@ namespace nvhttp {
           if (name_lower.find(query_lower) == std::string::npos) continue;
         }
 
-        const auto metadata = infer_app_runtime_metadata(app);
-
         // Source filter
         if (!source_filter.empty()) {
-          const auto normalized_source_filter = normalized_token(source_filter);
-          if (normalized_source_filter == "other") {
-            if (metadata.source == "steam" || metadata.source == "lutris" || metadata.source == "heroic") continue;
-          } else if (metadata.source != normalized_source_filter) {
-            continue;
-          }
+          bool is_steam = !app.steam_appid.empty();
+          if (source_filter == "steam" && !is_steam) continue;
+          if (source_filter == "other" && is_steam) continue;
         }
 
         // Pagination
@@ -4173,15 +4979,10 @@ namespace nvhttp {
         game["id"] = app.uuid;
         game["app_id"] = app.id;
         game["name"] = app.name;
-        game["source"] = metadata.source;
-        game["launcher_source"] = metadata.source;
-        game["launcher_detail"] = metadata.launcher_detail;
-        game["platform"] = metadata.platform;
-        game["runtime"] = metadata.runtime;
-        game["platform_label"] = infer_platform_label(metadata.platform);
-        game["runtime_label"] = infer_runtime_label(metadata.runtime);
+        game["source"] = app.steam_appid.empty() ? "other" : "steam";
         game["steam_appid"] = app.steam_appid;
         game["category"] = app.game_category;
+        game["source"] = app.source;
         game["installed"] = true;
         game["hdr_supported"] = advertised_codec_support.hevc_mode == 3;
         game["cover_url"] = "/polaris/v1/games/" + app.uuid + "/cover";
@@ -4508,20 +5309,25 @@ namespace nvhttp {
         }
 
         const bool enabled = body["enabled"].get<bool>();
-        if (!persist_config_values({{"adaptive_bitrate_enabled", bool_config_value(enabled)}})) {
+        if (!persist_config_values({
+              {"adaptive_bitrate_enabled", bool_config_value(enabled)},
+              {"ai_enabled", bool_config_value(enabled)}
+            })) {
           nlohmann::json err;
-          err["error"] = "failed to persist adaptive bitrate setting";
+          err["error"] = "failed to persist AI Auto Quality setting";
           SimpleWeb::CaseInsensitiveMultimap headers;
           headers.emplace("Content-Type", "application/json");
           response->write(SimpleWeb::StatusCode::server_error_internal_server_error, err.dump(), headers);
           return;
         }
-        adaptive_bitrate::set_enabled(enabled);
-        BOOST_LOG(info) << "Adaptive bitrate toggled via Polaris API: " << (enabled ? "enabled" : "disabled");
+        set_ai_auto_quality_enabled(enabled);
+        BOOST_LOG(info) << "AI Auto Quality toggled via adaptive bitrate compatibility API: " << (enabled ? "enabled" : "disabled");
 
         nlohmann::json output;
         output["status"] = true;
+        output["ai_auto_quality_enabled"] = ai_auto_quality_enabled();
         output["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
+        output["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
         const auto stats = stream_stats::get_current();
         output["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
         const auto health = build_session_health_json(
@@ -4565,19 +5371,24 @@ namespace nvhttp {
         }
 
         const bool enabled = body["enabled"].get<bool>();
-        if (!persist_config_values({{"ai_enabled", bool_config_value(enabled)}})) {
+        if (!persist_config_values({
+              {"ai_enabled", bool_config_value(enabled)},
+              {"adaptive_bitrate_enabled", bool_config_value(enabled)}
+            })) {
           nlohmann::json err;
-          err["error"] = "failed to persist AI Optimizer setting";
+          err["error"] = "failed to persist AI Auto Quality setting";
           SimpleWeb::CaseInsensitiveMultimap headers;
           headers.emplace("Content-Type", "application/json");
           response->write(SimpleWeb::StatusCode::server_error_internal_server_error, err.dump(), headers);
           return;
         }
-        ai_optimizer::set_enabled(enabled);
+        set_ai_auto_quality_enabled(enabled);
 
         nlohmann::json output;
         output["status"] = true;
+        output["ai_auto_quality_enabled"] = ai_auto_quality_enabled();
         output["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
+        output["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
         output["effective"] = ai_optimizer::is_enabled();
         const auto stats = stream_stats::get_current();
         const auto health = build_session_health_json(
@@ -4658,7 +5469,11 @@ namespace nvhttp {
         double packet_loss = body.value("packet_loss_pct", 0.0);
         std::string codec = body.value("codec", "");
         double target_fps = body.value("target_fps", 0.0);
+        double low_1_percent_fps = body.value("low_1_percent_fps", 0.0);
+        double min_fps = body.value("min_fps", 0.0);
+        double frame_pacing_bad_pct = body.value("frame_pacing_bad_pct", 0.0);
         int duration_s = body.value("duration_s", 0);
+        int samples = body.value("samples", 0);
         std::string end_reason = body.value("end_reason", "disconnect");
         std::string optimization_source = body.value("optimization_source", "");
         std::string optimization_confidence = body.value("optimization_confidence", "");
@@ -4680,6 +5495,7 @@ namespace nvhttp {
         int safe_bitrate_kbps = body.value("safe_bitrate_kbps", 0);
         std::string safe_codec = body.value("safe_codec", "");
         std::string safe_display_mode = body.value("safe_display_mode", "");
+        double safe_target_fps = body.value("safe_target_fps", 0.0);
         std::optional<bool> safe_hdr;
         if (body.contains("safe_hdr") && body["safe_hdr"].is_boolean()) {
           safe_hdr = body["safe_hdr"].get<bool>();
@@ -4702,7 +5518,9 @@ namespace nvhttp {
             if (!owner_device_name.empty()) {
               device = owner_device_name;
             }
-            proc::proc.mark_client_session_report_recorded(unique_id);
+            proc::proc.mark_client_session_report_recorded(
+              proc::proc.is_session_owner(unique_id) ? unique_id : std::string {}
+            );
             BOOST_LOG(info) << "Client session report matched active session owner; host-side duplicate recording disabled for ["
                             << device_db::canonicalize_name(device) << ":" << game << "]";
           } else {
@@ -4720,23 +5538,15 @@ namespace nvhttp {
           session.last_bitrate_kbps = avg_bitrate;
           session.last_packet_loss_pct = packet_loss;
           session.last_codec = codec;
+          session.last_duration_s = duration_s;
+          session.last_sample_count = samples;
+          session.last_low_1_percent_fps = low_1_percent_fps;
+          session.last_min_fps = min_fps;
+          session.last_frame_pacing_bad_pct = frame_pacing_bad_pct;
+          session.last_end_reason = end_reason;
           session.session_count = 1;
 
-          const double effective_target_fps = session.last_target_fps > 0.0 ? session.last_target_fps : avg_fps;
-          const double fps_ratio =
-            (effective_target_fps > 0.0 && avg_fps > 0.0) ? std::clamp(avg_fps / effective_target_fps, 0.0, 1.5) : 0.0;
-          if (avg_fps <= 0.0)
-            session.last_quality_grade = "F";
-          else if (fps_ratio >= 0.95 && packet_loss < 0.5 && avg_latency < 20.0)
-            session.last_quality_grade = "A";
-          else if (fps_ratio >= 0.85 && packet_loss < 2.0 && avg_latency < 40.0)
-            session.last_quality_grade = "B";
-          else if (fps_ratio >= 0.70 && packet_loss < 5.0)
-            session.last_quality_grade = "C";
-          else if (fps_ratio >= 0.50)
-            session.last_quality_grade = "D";
-          else
-            session.last_quality_grade = "F";
+          session.last_quality_grade = ai_optimizer::grade_session_quality(session);
           session.quality_grade = session.last_quality_grade;
           session.codec = session.last_codec;
 
@@ -4753,13 +5563,15 @@ namespace nvhttp {
           session.last_safe_bitrate_kbps = safe_bitrate_kbps;
           session.last_safe_codec = safe_codec;
           session.last_safe_display_mode = safe_display_mode;
+          session.last_safe_target_fps = safe_target_fps;
           session.last_safe_hdr = safe_hdr;
           session.last_relaunch_recommended = relaunch_recommended;
 
           ai_optimizer::record_session(device, game, session);
           BOOST_LOG(info) << "Client session report: " << device << " + " << game
                           << " → grade " << session.quality_grade
-                          << " (fps=" << avg_fps << ", lat=" << avg_latency << "ms, dur=" << duration_s << "s)";
+                          << " (fps=" << avg_fps << ", lat=" << avg_latency << "ms, dur=" << duration_s
+                          << "s, samples=" << samples << ", end=" << end_reason << ")";
         }
 
         nlohmann::json output;
@@ -4776,10 +5588,113 @@ namespace nvhttp {
       }
     };
 
+    // Clear one device+game Auto Safe / AI optimizer profile.
+    auto polarisClearOptimizerProfile = [](resp_https_t response, req_https_t request) {
+      print_req<PolarisHTTPS>(request);
+      const auto named_cert_p = get_verified_cert(request);
+      if (!named_cert_p) {
+        response->write(SimpleWeb::StatusCode::client_error_unauthorized);
+        return;
+      }
+
+      try {
+        std::string body_str(std::istreambuf_iterator<char>(request->content), {});
+        nlohmann::json body = body_str.empty() ? nlohmann::json::object() : nlohmann::json::parse(body_str);
+        auto args = request->parse_query_string();
+        std::string device = body.value("device", std::string {});
+        std::string game = body.value("game", std::string {});
+        if (device.empty() && args.count("device")) {
+          device = args.find("device")->second;
+        }
+        if (game.empty() && args.count("game")) {
+          game = args.find("game")->second;
+        }
+        if (!named_cert_p->name.empty()) {
+          device = named_cert_p->name;
+        }
+
+        if (device.empty() || game.empty()) {
+          nlohmann::json err;
+          err["error"] = "device and game are required";
+          SimpleWeb::CaseInsensitiveMultimap headers;
+          headers.emplace("Content-Type", "application/json");
+          response->write(SimpleWeb::StatusCode::client_error_bad_request, err.dump(), headers);
+          return;
+        }
+
+        const bool cleared = ai_optimizer::clear_game_profile(device, game);
+        nlohmann::json output;
+        output["status"] = true;
+        output["cleared"] = cleared;
+        output["device"] = device;
+        output["game"] = game;
+        SimpleWeb::CaseInsensitiveMultimap headers;
+        headers.emplace("Content-Type", "application/json");
+        response->write(output.dump(), headers);
+      } catch (std::exception &e) {
+        nlohmann::json err;
+        err["error"] = e.what();
+        SimpleWeb::CaseInsensitiveMultimap headers;
+        headers.emplace("Content-Type", "application/json");
+        response->write(SimpleWeb::StatusCode::server_error_internal_server_error, err.dump(), headers);
+      }
+    };
+
+    auto polarisOptimizerProfiles = [](resp_https_t response, req_https_t request) {
+      print_req<PolarisHTTPS>(request);
+      const auto named_cert_p = get_verified_cert(request);
+      if (!named_cert_p) {
+        response->write(SimpleWeb::StatusCode::client_error_unauthorized);
+        return;
+      }
+
+      try {
+        const auto device = named_cert_p->name;
+        const auto output = nlohmann::json::parse(ai_optimizer::get_profiles_json(device));
+        SimpleWeb::CaseInsensitiveMultimap headers;
+        headers.emplace("Content-Type", "application/json");
+        response->write(output.dump(), headers);
+      } catch (std::exception &e) {
+        nlohmann::json err;
+        err["error"] = e.what();
+        SimpleWeb::CaseInsensitiveMultimap headers;
+        headers.emplace("Content-Type", "application/json");
+        response->write(SimpleWeb::StatusCode::server_error_internal_server_error, err.dump(), headers);
+      }
+    };
+
+    auto polarisClearOptimizerProfiles = [](resp_https_t response, req_https_t request) {
+      print_req<PolarisHTTPS>(request);
+      const auto named_cert_p = get_verified_cert(request);
+      if (!named_cert_p) {
+        response->write(SimpleWeb::StatusCode::client_error_unauthorized);
+        return;
+      }
+
+      try {
+        const auto device = named_cert_p->name;
+        const bool cleared = ai_optimizer::clear_device_profiles(device);
+        nlohmann::json output;
+        output["status"] = true;
+        output["cleared"] = cleared;
+        output["device"] = device;
+        SimpleWeb::CaseInsensitiveMultimap headers;
+        headers.emplace("Content-Type", "application/json");
+        response->write(output.dump(), headers);
+      } catch (std::exception &e) {
+        nlohmann::json err;
+        err["error"] = e.what();
+        SimpleWeb::CaseInsensitiveMultimap headers;
+        headers.emplace("Content-Type", "application/json");
+        response->write(SimpleWeb::StatusCode::server_error_internal_server_error, err.dump(), headers);
+      }
+    };
+
     // AI optimization query — Nova asks for recommended settings before launching
     auto polarisOptimize = [](resp_https_t response, req_https_t request) {
       print_req<PolarisHTTPS>(request);
-      if (!get_verified_cert(request)) {
+      const auto named_cert_p = get_verified_cert(request);
+      if (!named_cert_p) {
         response->write(SimpleWeb::StatusCode::client_error_unauthorized);
         return;
       }
@@ -4787,12 +5702,24 @@ namespace nvhttp {
       auto args = request->parse_query_string();
       std::string device = args.count("device") ? args.find("device")->second : "";
       std::string game = args.count("game") ? args.find("game")->second : "";
+      std::string profile_preference = normalize_profile_preference(
+        args.count("preference") ? args.find("preference")->second : std::string {"auto"}
+      );
+      if (!named_cert_p->name.empty()) {
+        if (device != named_cert_p->name) {
+          BOOST_LOG(info) << "ai_optimizer: Optimize API using paired client profile ["sv
+                          << named_cert_p->name << "] for requested device ["sv
+                          << device << ']';
+          device = named_cert_p->name;
+        }
+      }
 
       nlohmann::json output;
       device_db::optimization_t effective_optimization;
       std::optional<std::string> suggested_codec;
       std::optional<int> target_bitrate_kbps;
       bool hdr_requested = false;
+      bool applied_history_safe = false;
       const auto session_history = ai_optimizer::get_session_history(device, game);
       const auto device_profile = device_db::get_device(device);
       const auto gpu_info = config::video.adapter_name.empty()
@@ -4842,6 +5769,102 @@ namespace nvhttp {
         }
       }
 
+      const bool relax_history_safe_target =
+        session_history && ai_optimizer::should_relax_history_safe_target_fps(*session_history);
+      const double effective_safe_target_fps =
+        session_history ? ai_optimizer::effective_history_safe_target_fps(device, *session_history) : 0.0;
+      const bool history_pacing_override =
+        session_history &&
+        !relax_history_safe_target &&
+        effective_safe_target_fps > 0.0 &&
+        (
+          session_history->last_target_fps <= 0.0 ||
+          effective_safe_target_fps < session_history->last_target_fps
+        );
+      if (history_pacing_override) {
+          if (auto history_opt = ai_optimizer::get_history_safe_fallback(device, game, session_history)) {
+            effective_optimization = *history_opt;
+            output = nlohmann::json::object();
+            append_optimization_json(output, *history_opt);
+            applied_history_safe = true;
+            if (history_opt->target_bitrate_kbps) {
+              target_bitrate_kbps = *history_opt->target_bitrate_kbps;
+            }
+          suggested_codec = history_opt->preferred_codec;
+          hdr_requested = history_opt->hdr.value_or(false);
+          BOOST_LOG(info) << "ai_optimizer: Optimize API using history-safe pacing fallback for \""sv
+                          << device << "\" + \""sv << game << "\" — "sv
+                          << history_opt->reasoning;
+        }
+      }
+
+      const auto append_normalization_reason = [&output, &effective_optimization](const std::string &reason) {
+        if (reason.empty()) {
+          return;
+        }
+
+        auto existing = output.value("normalization_reason", std::string {});
+        if (existing.find(reason) == std::string::npos) {
+          if (!existing.empty()) {
+            existing += ' ';
+          }
+          existing += reason;
+        }
+        output["normalization_reason"] = existing;
+        effective_optimization.normalization_reason = existing;
+      };
+
+      if (named_cert_p->target_bitrate_kbps > 0) {
+        const int paired_bitrate = named_cert_p->target_bitrate_kbps;
+        const auto optimization_confidence = lower_copy(output.value("confidence", std::string {}));
+        const auto optimization_source = lower_copy(output.value("source", std::string {}));
+        const bool optimizer_can_raise_bitrate =
+          optimization_confidence == "high" &&
+          optimization_source.find("history_safe") == std::string::npos;
+        const int selected_bitrate = target_bitrate_kbps ?
+          (optimizer_can_raise_bitrate ? *target_bitrate_kbps : std::min(*target_bitrate_kbps, paired_bitrate)) :
+          paired_bitrate;
+        if (!target_bitrate_kbps || *target_bitrate_kbps != selected_bitrate) {
+          target_bitrate_kbps = selected_bitrate;
+          effective_optimization.target_bitrate_kbps = selected_bitrate;
+          output["target_bitrate_kbps"] = selected_bitrate;
+          append_normalization_reason(
+            "Aligned launch optimization bitrate to the paired client profile."
+          );
+        }
+      }
+
+      int paired_width = 0;
+      int paired_height = 0;
+      double paired_fps = 0.0;
+      if (!named_cert_p->display_mode.empty() &&
+          parse_stream_policy_display_mode(named_cert_p->display_mode, paired_width, paired_height, paired_fps)) {
+        int current_width = 0;
+        int current_height = 0;
+        double current_fps = 0.0;
+        const auto current_display_mode =
+          effective_optimization.display_mode.value_or(output.value("display_mode", std::string {}));
+        parse_stream_policy_display_mode(current_display_mode, current_width, current_height, current_fps);
+
+        double selected_fps = current_fps;
+        if (selected_fps <= 0.0 && effective_safe_target_fps > 0.0 && !relax_history_safe_target) {
+          selected_fps = effective_safe_target_fps;
+        }
+        if (selected_fps <= 0.0) {
+          selected_fps = paired_fps;
+        }
+
+        const auto paired_display_mode =
+          format_stream_policy_display_mode(paired_width, paired_height, selected_fps);
+        if (!paired_display_mode.empty() && current_display_mode != paired_display_mode) {
+          effective_optimization.display_mode = paired_display_mode;
+          output["display_mode"] = paired_display_mode;
+          append_normalization_reason(
+            "Aligned launch optimization display mode to the paired client profile."
+          );
+        }
+      }
+
       suggested_codec = device_db::normalize_preferred_codec(
         device,
         game,
@@ -4852,7 +5875,7 @@ namespace nvhttp {
       if (suggested_codec) {
         output["preferred_codec"] = *suggested_codec;
       }
-      output["stability"] = build_stability_plan_json(
+      auto stability = build_stability_plan_json(
         device,
         game,
         device_profile,
@@ -4862,12 +5885,45 @@ namespace nvhttp {
         target_bitrate_kbps,
         hdr_requested
       );
+      if (applied_history_safe) {
+        stability["auto_action"] = "apply_recovery";
+        if (stability.value("limiting_factor", std::string {"none"}) == "none") {
+          stability["limiting_factor"] = "pacing";
+        }
+      }
+      output["stability"] = stability;
+      output["recovery_policy"] = stability.value("recovery_policy", nlohmann::json::object());
+      output["auto_mode"] = true;
+      output["limiting_factor"] = stability.value("limiting_factor", std::string {"none"});
+      output["auto_action"] = stability.value("auto_action", std::string {"none"});
       if (session_history) {
         output["last_quality_grade"] = session_history->quality_grade;
         output["poor_outcome_count"] = session_history->poor_outcome_count;
         output["consecutive_poor_outcomes"] = session_history->consecutive_poor_outcomes;
+        output["last_end_reason"] = session_history->last_end_reason;
+        output["last_sample_confidence"] = session_history->last_sample_confidence;
+        output["last_sample_count"] = session_history->last_sample_count;
+        output["last_low_1_percent_fps"] = session_history->last_low_1_percent_fps;
+        output["last_min_fps"] = session_history->last_min_fps;
+        output["last_frame_pacing_bad_pct"] = session_history->last_frame_pacing_bad_pct;
+        if (effective_safe_target_fps > 0.0 && !relax_history_safe_target) {
+          output["safe_target_fps"] = static_cast<int>(std::round(effective_safe_target_fps));
+        }
+        if (relax_history_safe_target) {
+          output["safe_target_fps_relaxed"] = true;
+        }
         output["last_invalidated_at"] = session_history->last_invalidated_at;
       }
+      output["profile_state"] = build_optimizer_profile_state_json(
+        device,
+        game,
+        profile_preference,
+        output,
+        effective_optimization,
+        session_history,
+        output.value("recovery_policy", nlohmann::json::object()),
+        applied_history_safe
+      );
 
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "application/json");
@@ -4875,6 +5931,9 @@ namespace nvhttp {
     };
 
     https_server.resource["^/polaris/v1/session/report$"]["POST"] = polarisSessionReport;
+    https_server.resource["^/polaris/v1/optimizer/profile/clear$"]["POST"] = polarisClearOptimizerProfile;
+    https_server.resource["^/polaris/v1/optimizer/profiles$"]["GET"] = polarisOptimizerProfiles;
+    https_server.resource["^/polaris/v1/optimizer/profiles/clear$"]["POST"] = polarisClearOptimizerProfiles;
     https_server.resource["^/polaris/v1/optimize$"]["GET"] = polarisOptimize;
     https_server.resource["^/polaris/v1/capabilities$"]["GET"] = polarisCapabilities;
     https_server.resource["^/polaris/v1/session/status$"]["GET"] = polarisSessionStatus;

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -564,9 +564,9 @@ namespace cage_display_router {
         // need to wait for DISPLAY to be available before launching Steam.
         startup_cmd = mode_retry_cmd +
           "for i in $(seq 1 50); do xdpyinfo >/dev/null 2>&1 && break; sleep 0.1; done; "
-          "exec " + mangohud_prefix + game_cmd;
+          + mangohud_prefix + "exec " + game_cmd;
       } else {
-        startup_cmd = mode_retry_cmd + "exec " + mangohud_prefix + game_cmd;
+        startup_cmd = mode_retry_cmd + mangohud_prefix + "exec " + game_cmd;
       }
     } else {
       startup_cmd =

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -1414,49 +1414,19 @@ namespace wl {
     target.destroy();
 
     bool used_implicit_modifier = false;
-    bool attempted_linear_modifier = false;
     if (!chosen_format.modifiers.empty()) {
-      auto requested_modifiers = chosen_format.modifiers;
-      auto linear_it = std::find(requested_modifiers.begin(), requested_modifiers.end(), DRM_FORMAT_MOD_LINEAR);
-      if (linear_it != requested_modifiers.end()) {
-        const std::uint64_t linear_modifier = *linear_it;
-        requested_modifiers.erase(linear_it);
-        attempted_linear_modifier = true;
-
-        BOOST_LOG(info) << "Extcopy DMA-BUF capture: preferring linear modifier advertised by capture constraints"sv;
-        target.bo = gbm_bo_create_with_modifiers2(
-          gbm_device,
-          frame_width,
-          frame_height,
-          chosen_format.format,
-          &linear_modifier,
-          1,
-          GBM_BO_USE_RENDERING
-        );
-      }
-
-      if (!target.bo && !requested_modifiers.empty()) {
-        if (attempted_linear_modifier) {
-          BOOST_LOG(info) << "Extcopy DMA-BUF capture: linear modifier allocation failed; retrying remaining advertised modifiers"sv;
-        }
-
-        target.bo = gbm_bo_create_with_modifiers2(
-          gbm_device,
-          frame_width,
-          frame_height,
-          chosen_format.format,
-          requested_modifiers.data(),
-          requested_modifiers.size(),
-          GBM_BO_USE_RENDERING
-        );
-      }
+      target.bo = gbm_bo_create_with_modifiers2(
+        gbm_device,
+        frame_width,
+        frame_height,
+        chosen_format.format,
+        chosen_format.modifiers.data(),
+        chosen_format.modifiers.size(),
+        GBM_BO_USE_RENDERING
+      );
     }
 
     if (!target.bo && chosen_format.implicit_modifier) {
-      if (attempted_linear_modifier) {
-        BOOST_LOG(info) << "Extcopy DMA-BUF capture: linear modifier allocation failed; retrying implicit modifier allocation"sv;
-      }
-
       used_implicit_modifier = true;
       target.bo = gbm_bo_create(
         gbm_device,

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1699,6 +1699,8 @@ namespace proc {
     placebo = true;
     _launch_session = std::move(launch_session);
     _client_session_report_recorded = false;
+    _client_session_report_recorded_at = {};
+    _client_session_report_recorded_unique_id.clear();
     if (_launch_session && _launch_session->session_token.empty()) {
       _launch_session->session_token = generate_session_token();
     }
@@ -1722,6 +1724,8 @@ namespace proc {
     _app_name = app.name;
     _launch_session = launch_session;
     _client_session_report_recorded = false;
+    _client_session_report_recorded_at = {};
+    _client_session_report_recorded_unique_id.clear();
     if (_launch_session && _launch_session->session_token.empty()) {
       _launch_session->session_token = generate_session_token();
     }
@@ -1823,12 +1827,14 @@ namespace proc {
     auto device_optimization = device_db::get_optimization(launch_session->device_name, _app.name);
     apply_optimization_layer(resolved_optimization, optimization_locks, device_optimization, "device_db");
 
+    std::optional<ai_optimizer::session_history_t> history;
+
     // AI optimizer: cached results override device DB; unknown devices get a sync request.
     if (ai_optimizer::is_enabled()) {
       std::string gpu_info = config::video.adapter_name.empty()
         ? "NVIDIA GPU (NVENC)"s
         : config::video.adapter_name;
-      auto history = ai_optimizer::get_session_history(launch_session->device_name, _app.name);
+      history = ai_optimizer::get_session_history(launch_session->device_name, _app.name);
       auto device_info = device_db::get_device(launch_session->device_name);
       auto ai_opt = ai_optimizer::get_cached(launch_session->device_name, _app.name);
       if (ai_opt) {
@@ -1876,6 +1882,41 @@ namespace proc {
                           << "\" — fired async request for next session"sv;
         }
       }
+    }
+
+    const double effective_history_safe_target_fps =
+      history ? ai_optimizer::effective_history_safe_target_fps(launch_session->device_name, *history) : 0.0;
+    if (history && effective_history_safe_target_fps > 0.0 &&
+        !ai_optimizer::should_relax_history_safe_target_fps(*history)) {
+      const int safe_fps =
+        static_cast<int>(std::round(effective_history_safe_target_fps * 1000.0));
+      if (safe_fps > 0 && launch_session->fps > safe_fps) {
+        const parsed_display_mode_t safe_display_mode {
+          static_cast<int>(launch_session->width),
+          static_cast<int>(launch_session->height),
+          safe_fps,
+        };
+        BOOST_LOG(info) << "session_optimization: history-safe pacing target lowered FPS from "sv
+                        << format_session_fps(launch_session->fps) << " to "sv
+                        << format_session_fps(safe_fps)
+                        << " for \""sv << launch_session->device_name << "\" + \""sv << _app.name << '"';
+        resolved_optimization.display_mode = safe_display_mode;
+        resolved_optimization.display_mode_source = "history_safe";
+        note_layer(resolved_optimization, "history_safe");
+        note_reasoning(
+          resolved_optimization,
+          "Recent Nova pacing feedback lowered the next launch FPS target."
+        );
+        append_normalization_reason(
+          resolved_optimization,
+          "History-safe pacing overrode the paired display-mode FPS ceiling."
+        );
+      }
+    } else if (history && effective_history_safe_target_fps > 0.0) {
+      BOOST_LOG(info) << "session_optimization: relaxing history-safe "
+                      << static_cast<int>(std::round(effective_history_safe_target_fps))
+                      << " FPS cap for \""sv << launch_session->device_name << "\" + \""sv
+                      << _app.name << "\" after a completed safe-target trial";
     }
 
     if (!optimization_locks.display_mode && resolved_optimization.display_mode.has_value()) {
@@ -2503,14 +2544,42 @@ namespace proc {
         set_session_env_var(_env, _session_env_keys, "DXVK_FRAME_RATE", std::to_string(pacing_target_fps));
       }
 
+      const int requested_fps = launch_session->requested_fps >= 1000 ?
+        static_cast<int>(std::round(static_cast<double>(launch_session->requested_fps) / 1000.0)) :
+        launch_session->requested_fps;
+      bool auto_mangohud_cap = false;
+      if (pacing_target_fps > 0 &&
+          (requested_fps <= 0 || pacing_target_fps + 1 < requested_fps) &&
+          env_value(_app, _env, "MANGOHUD").empty()) {
+        set_session_env_var(_env, _session_env_keys, "MANGOHUD", "1");
+        set_session_env_var(_env, _session_env_keys, "MANGOHUD_DLSYM", "1");
+        auto_mangohud_cap = true;
+      }
+
       if (env_flag_enabled(_app, _env, "MANGOHUD")) {
+        if (env_value(_app, _env, "MANGOHUD_DLSYM").empty()) {
+          set_session_env_var(_env, _session_env_keys, "MANGOHUD_DLSYM", "1");
+        }
+
         auto mangohud_config = env_value(_app, _env, "MANGOHUD_CONFIG");
         if (mangohud_config.find("fps_limit=") == std::string::npos) {
           if (!mangohud_config.empty() && mangohud_config.back() != ',') {
             mangohud_config += ',';
           }
           mangohud_config += "fps_limit=" + std::to_string(pacing_target_fps);
+        }
+        if (auto_mangohud_cap && mangohud_config.find("no_display") == std::string::npos) {
+          if (!mangohud_config.empty() && mangohud_config.back() != ',') {
+            mangohud_config += ',';
+          }
+          mangohud_config += "no_display";
+        }
+        if (!mangohud_config.empty()) {
           set_session_env_var(_env, _session_env_keys, "MANGOHUD_CONFIG", mangohud_config);
+        }
+        if (auto_mangohud_cap) {
+          BOOST_LOG(info) << "session_pacing: auto-enabled hidden MangoHud FPS cap target_fps="sv
+                          << pacing_target_fps;
         }
       }
 
@@ -2993,6 +3062,8 @@ namespace proc {
   void proc_t::resume() {
     BOOST_LOG(info) << "Session resuming for app [" << _app_name << "].";
     _client_session_report_recorded = false;
+    _client_session_report_recorded_at = {};
+    _client_session_report_recorded_unique_id.clear();
 
     if (!_app.state_cmds.empty()) {
       auto exec_thread = std::thread([cmd_list = _app.state_cmds, app_working_dir = _app.working_dir, _env = _env]() mutable {
@@ -3067,6 +3138,7 @@ namespace proc {
         session.last_bitrate_kbps = stats.bitrate_kbps;
         session.last_packet_loss_pct = stats.packet_loss;
         session.last_codec = stats.codec;
+        session.last_end_reason = "host_pause";
         session.session_count = 1;
         session.last_optimization_source = _launch_session->optimization_source;
         session.last_optimization_confidence = _launch_session->optimization_confidence;
@@ -3074,6 +3146,10 @@ namespace proc {
         session.last_quality_grade = grade_session_quality(stats, session.last_target_fps);
         session.quality_grade = session.last_quality_grade;
         session.codec = session.last_codec;
+        const auto device_profile = device_db::get_device(_launch_session->device_name);
+        const bool mobile_client =
+          device_profile &&
+          (device_profile->type == "handheld" || device_profile->type == "phone");
 
         const double fps_gap =
           session.last_target_fps > 0.0 ? std::max(0.0, session.last_target_fps - session.last_fps) : 0.0;
@@ -3092,6 +3168,23 @@ namespace proc {
         const bool av1_codec = codec_lower.find("av1") != std::string::npos;
         const bool decoder_risk = av1_codec && (pacing_risk || fps_gap >= 4.0) && !network_risk;
         const bool virtual_display_risk = _launch_session->virtual_display && (pacing_risk || capture_fallback || hdr_risk);
+        const double target_gap_threshold =
+          session.last_target_fps > 0.0 ? std::max(2.0, session.last_target_fps * 0.06) : 2.0;
+        const bool sustained_target_miss =
+          session.last_target_fps >= 24.0 &&
+          session.last_fps > 0.0 &&
+          fps_gap >= target_gap_threshold;
+        const bool host_render_limited =
+          pacing_risk &&
+          !network_risk &&
+          !capture_fallback &&
+          !encoder_risk &&
+          !hdr_risk &&
+          !decoder_risk &&
+          !virtual_display_risk &&
+          (sustained_target_miss ||
+           stats.duplicate_frame_ratio >= 0.08 ||
+           stats.dropped_frame_ratio >= 0.03);
 
         session.last_network_risk = network_risk ? "elevated" : "normal";
         session.last_decoder_risk = decoder_risk ? "elevated" : "normal";
@@ -3110,11 +3203,13 @@ namespace proc {
         else if (virtual_display_risk) session.last_primary_issue = "virtual_display_path";
         else if (decoder_risk) session.last_primary_issue = "decoder_path";
         else if (capture_fallback) session.last_primary_issue = "capture_fallback";
+        else if (host_render_limited) session.last_primary_issue = "host_render_limited";
         else if (pacing_risk) session.last_primary_issue = "frame_pacing";
         else if (encoder_risk) session.last_primary_issue = "encoder_load";
         else session.last_primary_issue = "steady";
         if (network_risk) session.last_issues.push_back("network_jitter");
-        if (pacing_risk) session.last_issues.push_back("frame_pacing");
+        if (host_render_limited) session.last_issues.push_back("host_render_limited");
+        else if (pacing_risk) session.last_issues.push_back("frame_pacing");
         if (capture_fallback) session.last_issues.push_back("capture_fallback");
         if (encoder_risk) session.last_issues.push_back("encoder_load");
         if (hdr_risk) session.last_issues.push_back("hdr_path");
@@ -3145,10 +3240,28 @@ namespace proc {
         session.last_safe_display_mode =
           (virtual_display_risk || config::video.linux_display.headless_mode) ? "headless" :
           (_launch_session->virtual_display ? "virtual_display" : "headless");
+        session.last_safe_target_fps = ai_optimizer::derive_safe_target_fps(
+          session.last_target_fps,
+          session.last_fps,
+          0.0,
+          0.0,
+          0.0,
+          mobile_client,
+          session.last_health_grade != "good",
+          pacing_risk || host_render_limited
+        );
         if (stats.dynamic_range > 0) {
           session.last_safe_hdr = !hdr_risk;
         }
-        session.last_relaunch_recommended = hdr_risk || decoder_risk || virtual_display_risk;
+        session.last_relaunch_recommended =
+          hdr_risk ||
+          decoder_risk ||
+          virtual_display_risk ||
+          (
+            session.last_safe_target_fps > 0.0 &&
+            session.last_target_fps > 0.0 &&
+            session.last_safe_target_fps < session.last_target_fps
+          );
 
         ai_optimizer::record_session(_launch_session->device_name, _app.name, session);
       }
@@ -3441,6 +3554,8 @@ namespace proc {
 
     if (unique_id.empty() || _launch_session->unique_id.empty() || _launch_session->unique_id == unique_id) {
       _client_session_report_recorded = true;
+      _client_session_report_recorded_at = std::chrono::steady_clock::now();
+      _client_session_report_recorded_unique_id = unique_id;
     }
   }
 
@@ -4182,9 +4297,6 @@ namespace proc {
           ctx.steam_appid = app_node.value("steam-appid", "");
           ctx.game_category = app_node.value("game-category", "");
           ctx.source = app_node.value("source", ctx.steam_appid.empty() ? "manual" : "steam");
-          ctx.lutris_runner = app_node.value("lutris-runner", "");
-          ctx.platform = app_node.value("platform", "");
-          ctx.runtime = app_node.value("runtime", "");
           ctx.last_launched = app_node.value("last-launched", (int64_t)0);
           if (app_node.contains("genres") && app_node["genres"].is_array()) {
             for (const auto &g : app_node["genres"]) {

--- a/src/process.h
+++ b/src/process.h
@@ -93,9 +93,6 @@ namespace proc {
     std::string steam_appid;
     std::string game_category;  // "fast_action", "cinematic", "desktop", "vr", or ""
     std::string source;         // "steam", "lutris", "heroic", or "manual"
-    std::string lutris_runner;
-    std::string platform;       // "linux", "windows", "unknown", or ""
-    std::string runtime;        // "native", "proton", "wine", "steam", "unknown", or ""
     std::vector<std::string> genres;
     std::map<std::string, std::string> env_vars;  // per-app environment variables
     int64_t last_launched = 0;  // unix timestamp (seconds since epoch)
@@ -193,6 +190,8 @@ namespace proc {
     std::vector<cmd_t>::const_iterator _app_prep_begin;
     bool _session_shutdown_requested = false;
     bool _client_session_report_recorded = false;
+    std::chrono::steady_clock::time_point _client_session_report_recorded_at {};
+    std::string _client_session_report_recorded_unique_id;
   };
 
   boost::filesystem::path

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2905,6 +2905,7 @@ namespace video {
       static_cast<double>(config.encodingFramerate) / 1000.0 :
       static_cast<double>(config.encodingFramerate);
     const double target_frame_interval_ms = encode_target_fps > 0.0 ? 1000.0 / encode_target_fps : 0.0;
+    int applied_adaptive_bitrate = config.bitrate;
 
     while (true) {
       // Break out of the encoding loop if any of the following are true:
@@ -3044,24 +3045,49 @@ namespace video {
             current_fps = target_fps;
           }
 
+          const double duplicate_frame_ratio =
+            frames_encoded > 0 ? static_cast<double>(duplicate_frames) / static_cast<double>(frames_encoded) : 0.0;
+          const double dropped_frame_ratio =
+            (frames_encoded + dropped_frames) > 0 ?
+              static_cast<double>(dropped_frames) / static_cast<double>(frames_encoded + dropped_frames) :
+              0.0;
+          const double avg_frame_age_ms =
+            frames_with_age > 0 ? accumulated_frame_age_ms / static_cast<double>(frames_with_age) : 0.0;
+          const double frame_jitter_ms =
+            jitter_samples > 0 ? accumulated_jitter_ms / static_cast<double>(jitter_samples) : 0.0;
+          const double fps_ratio =
+            target_fps > 0.0 && current_fps > 0.0 ? std::clamp(current_fps / target_fps, 0.0, 1.5) : 0.0;
+
+          if (adaptive_bitrate::is_enabled()) {
+            adaptive_bitrate::update_stream_health(
+              fps_ratio,
+              dropped_frame_ratio,
+              duplicate_frame_ratio,
+              frame_jitter_ms,
+              encode_duration,
+              avg_frame_age_ms
+            );
+          }
+
           // Check adaptive bitrate and update encoder if target has changed
           int effective_bitrate = config.bitrate;
           if (adaptive_bitrate::is_enabled()) {
             int target = adaptive_bitrate::get_target_bitrate_kbps();
-            if (target > 0 && target != config.bitrate) {
+            if (target > 0 && target != applied_adaptive_bitrate) {
               if (session->update_bitrate(target)) {
+                applied_adaptive_bitrate = target;
                 effective_bitrate = target;
               }
+            } else if (target > 0) {
+              effective_bitrate = applied_adaptive_bitrate;
             }
           }
 
           stream_stats::update_frame_delivery(
-            frames_encoded > 0 ? static_cast<double>(duplicate_frames) / static_cast<double>(frames_encoded) : 0.0,
-            (frames_encoded + dropped_frames) > 0 ?
-              static_cast<double>(dropped_frames) / static_cast<double>(frames_encoded + dropped_frames) :
-              0.0,
-            frames_with_age > 0 ? accumulated_frame_age_ms / static_cast<double>(frames_with_age) : 0.0,
-            jitter_samples > 0 ? accumulated_jitter_ms / static_cast<double>(jitter_samples) : 0.0
+            duplicate_frame_ratio,
+            dropped_frame_ratio,
+            avg_frame_age_ms,
+            frame_jitter_ms
           );
 
           stream_stats::update_video_stats(

--- a/src_assets/common/assets/web/Checkbox.vue
+++ b/src_assets/common/assets/web/Checkbox.vue
@@ -106,14 +106,12 @@ const defValue = parsedDefaultPropValue ? "_common.enabled_def_cbox" : "_common.
 <template>
   <div :class="[props.class, { 'checkbox-field--compact': props.compact }]" :data-setting-key="props.id" class="checkbox-field">
     <label :for="props.id" class="checkbox-field-control flex items-start gap-2">
-      <span class="checkbox-field-toggle">
-        <input type="checkbox"
-               class="checkbox-field-input"
-               :id="props.id"
-               v-model="model"
-               :true-value="checkboxValues.truthy"
-               :false-value="checkboxValues.falsy" />
-      </span>
+      <input type="checkbox"
+             class="checkbox-field-input mt-1 shrink-0"
+             :id="props.id"
+             v-model="model"
+             :true-value="checkboxValues.truthy"
+             :false-value="checkboxValues.falsy" />
       <span class="checkbox-field-copy flex min-w-0 flex-col gap-1">
         <span class="checkbox-field-title-row flex flex-wrap items-baseline gap-x-2 gap-y-1">
           <span class="text-silver cursor-pointer checkbox-field-label leading-snug">

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -121,20 +121,6 @@
 [data-theme="oled"] aside {
   border-color: transparent !important;
 }
-[data-theme="oled"] .checkbox-field {
-  background: rgba(168, 200, 255, 0.08);
-  border-color: rgba(168, 200, 255, 0.16);
-}
-[data-theme="oled"] .checkbox-field:hover {
-  background: rgba(168, 200, 255, 0.16);
-  border-color: rgba(168, 200, 255, 0.3);
-}
-[data-theme="oled"] .checkbox-field-input:checked {
-  background: rgb(168, 200, 255);
-}
-[data-theme="oled"] .checkbox-field-input:focus-visible {
-  outline: 2px solid rgba(59, 130, 246, 0.85);
-}
 [data-theme="oled"] aside .border-b,
 [data-theme="oled"] aside .border-t {
   border-color: rgba(255, 255, 255, 0.04) !important;
@@ -206,110 +192,6 @@ textarea {
 }
 .card-interactive:active {
   transform: translateY(0);
-}
-
-.checkbox-field {
-  position: relative;
-  padding: 12px 14px;
-  border-radius: 10px;
-  background: rgba(124, 115, 255, 0.08);
-  border: 1px solid rgba(124, 115, 255, 0.16);
-  transition: all 0.15s ease;
-}
-
-.checkbox-field::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 10%;
-  height: 80%;
-  width: 3px;
-  border-radius: 4px;
-  background: transparent;
-  transition: background 0.2s ease;
-}
-
-.checkbox-field:hover {
-  background: rgba(124, 115, 255, 0.16);
-  border-color: rgba(124, 115, 255, 0.3);
-  transform: translateY(-1px);
-}
-
-.checkbox-field-control {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.checkbox-field-toggle {
-  flex-shrink: 0;
-}
-
-.checkbox-field-copy {
-  flex: 1;
-  min-width: 0;
-}
-
-.checkbox-field-input {
-  appearance: none;
-  width: 42px;
-  height: 24px;
-  background: #2a2a2a;
-  border-radius: 999px;
-  position: relative;
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-
-.checkbox-field-input::after {
-  content: "";
-  position: absolute;
-  width: 18px;
-  height: 18px;
-  top: 3px;
-  left: 3px;
-  border-radius: 50%;
-  background: white;
-  transition: transform 0.2s ease;
-}
-
-.checkbox-field-input:focus-visible {
-  outline: 2px solid rgb(168, 164, 255);
-  outline-offset: 2px;
-}
-
-.checkbox-field-input:checked {
-  background: rgb(124, 115, 255);
-}
-
-.checkbox-field-input:checked::after {
-  transform: translateX(18px);
-}
-
-.checkbox-field-title-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-}
-
-.checkbox-field-label {
-  font-size: 14px;
-  font-weight: 500;
-}
-
-.checkbox-field-desc {
-  margin-top: 4px;
-  opacity: 0.75;
-  line-height: 1.4;
-}
-
-.checkbox-field-default {
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.7);
 }
 
 /* ── Gradient Accents ── */

--- a/src_assets/common/assets/web/auto-quality-state.js
+++ b/src_assets/common/assets/web/auto-quality-state.js
@@ -1,0 +1,304 @@
+export const AUTO_QUALITY_STATES = Object.freeze({
+  OFF: 'off',
+  WATCHING: 'watching',
+  OPTIMIZING: 'optimizing',
+  STABLE: 'stable',
+  RECOVERING: 'recovering',
+  MANUAL_OVERRIDE: 'manual_override',
+  NEEDS_ATTENTION: 'needs_attention',
+})
+
+function lower(value) {
+  return String(value || '').toLowerCase()
+}
+
+function numberValue(value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function enabledValue(value) {
+  return value === true || value === 'enabled' || value === 'true' || value === 1
+}
+
+function firstNumber(...values) {
+  for (const value of values) {
+    const parsed = numberValue(value)
+    if (parsed > 0) return parsed
+  }
+  return 0
+}
+
+function codecLabel(value) {
+  const raw = String(value || '')
+  const token = raw.toLowerCase()
+  if (token.includes('av1')) return 'AV1'
+  if (token.includes('hevc') || token.includes('h265')) return 'HEVC'
+  if (token.includes('h264') || token.includes('avc')) return 'H.264'
+  return raw ? raw.toUpperCase() : ''
+}
+
+function buildTargetSummary(stats, adaptiveTargetKbps) {
+  const width = numberValue(stats?.width)
+  const height = numberValue(stats?.height)
+  const resolution = stats?.capture?.resolution || (width > 0 && height > 0 ? `${width}x${height}` : '')
+  const fps = firstNumber(
+    stats?.session_target_fps,
+    stats?.encode_target_fps,
+    stats?.requested_client_fps,
+    stats?.encoder?.session_target_fps,
+    stats?.encoder?.encode_target_fps,
+    stats?.encoder?.requested_client_fps,
+  )
+  const display = resolution && fps > 0
+    ? `${resolution}@${Math.round(fps)}`
+    : resolution || (fps > 0 ? `${Math.round(fps)} FPS` : '')
+  const codec = codecLabel(stats?.codec || stats?.encoder?.codec)
+  const bitrate = firstNumber(adaptiveTargetKbps, stats?.bitrate_kbps, stats?.encoder?.bitrate_kbps)
+  const bitrateLabel = bitrate > 0 ? `up to ${Math.round(bitrate / 1000)} Mbps` : ''
+  return [display, codec, bitrateLabel].filter(Boolean).join(' · ')
+}
+
+function issueIncludes(health, ...tokens) {
+  const issues = Array.isArray(health?.issues) ? health.issues : []
+  const haystack = [
+    health?.primary_issue,
+    health?.limiting_factor,
+    health?.recovery_profile,
+    ...issues,
+  ].map(lower)
+  return tokens.some((token) => haystack.includes(token))
+}
+
+function toneClasses(tone) {
+  switch (tone) {
+    case 'stable':
+      return {
+        toneClass: 'border-green-400/30 bg-green-400/10 text-green-300',
+        panelClass: 'border-green-400/20 bg-green-400/5',
+      }
+    case 'warning':
+      return {
+        toneClass: 'border-amber-300/30 bg-amber-300/10 text-amber-200',
+        panelClass: 'border-amber-300/25 bg-amber-300/10',
+      }
+    case 'danger':
+      return {
+        toneClass: 'border-red-400/30 bg-red-400/10 text-red-300',
+        panelClass: 'border-red-400/25 bg-red-400/10',
+      }
+    case 'info':
+      return {
+        toneClass: 'border-ice/25 bg-ice/10 text-ice',
+        panelClass: 'border-ice/20 bg-ice/5',
+      }
+    default:
+      return {
+        toneClass: 'border-storm/40 bg-storm/10 text-storm',
+        panelClass: 'border-storm/30 bg-void/25',
+      }
+  }
+}
+
+function result({
+  state,
+  label,
+  compactLabel,
+  detail,
+  targetSummary,
+  tone,
+  enabled,
+  badges = [],
+}) {
+  return {
+    state,
+    label,
+    compactLabel,
+    detail,
+    targetSummary,
+    tone,
+    enabled,
+    badges,
+    ...toneClasses(tone),
+  }
+}
+
+export function resolveAutoQualityState(stats = {}, sync = {}) {
+  const health = stats?.health || {}
+  const tuning = stats?.tuning || {}
+  const capture = stats?.capture || {}
+  const encoder = stats?.encoder || {}
+  const policy = stats?.auto_quality || health?.recovery_policy || {}
+  const streaming = Boolean(stats?.streaming || stats?.streaming_active)
+  const adaptiveEnabled = enabledValue(stats?.adaptive_bitrate_enabled ?? tuning?.adaptive_bitrate_enabled)
+  const aiEnabled = enabledValue(stats?.ai_enabled ?? stats?.ai_optimizer_enabled ?? tuning?.ai_optimizer_enabled)
+  const autoEnabled = enabledValue(
+    stats?.ai_auto_quality_enabled ??
+    tuning?.ai_auto_quality_enabled ??
+    policy?.enabled ??
+    (adaptiveEnabled || aiEnabled),
+  )
+  const syncState = lower(sync?.state || stats?.sync_status?.state)
+  const adaptiveTarget = firstNumber(stats?.adaptive_target_bitrate_kbps, tuning?.adaptive_target_bitrate_kbps)
+  const adaptiveBase = firstNumber(tuning?.adaptive_base_bitrate_kbps, stats?.adaptive_base_bitrate_kbps, stats?.bitrate_kbps)
+  const adaptiveLowered = adaptiveEnabled && adaptiveTarget > 0 && adaptiveBase > 0 && adaptiveTarget < adaptiveBase
+  const targetFps = firstNumber(stats?.session_target_fps, stats?.encode_target_fps, stats?.requested_client_fps, encoder?.session_target_fps)
+  const fps = firstNumber(stats?.fps, encoder?.fps)
+  const fpsTargetMiss = targetFps > 0 && fps > 0 && fps < targetFps * 0.85
+  const captureCpuCopy = Boolean(
+    stats?.capture_cpu_copy ||
+    capture?.cpu_copy ||
+    lower(stats?.capture_transport || capture?.transport) === 'shm' ||
+    lower(stats?.capture_residency || capture?.residency) === 'cpu' ||
+    lower(stats?.encode_target_residency || encoder?.target_residency) === 'cpu',
+  )
+  const manualOverride = Boolean(
+    sync?.manualOverride ||
+    syncState === 'manual_override' ||
+    stats?.display_mode?.explicit_choice ||
+    stats?.manual_override,
+  )
+  const syncFailed = syncState === 'failed' || syncState === 'blocked' || sync?.failed
+  const degraded = lower(health?.grade) === 'degraded' || lower(health?.decoder_risk) === 'elevated'
+  const hostRenderLimited = Boolean(
+    health?.host_render_limited ||
+    issueIncludes(health, 'host_render_limited', 'host_render'),
+  )
+  const healthGrade = lower(health?.grade)
+  const healthAutoAction = lower(health?.auto_action)
+  const healthSuggestsRecovery = ['watch', 'degraded'].includes(healthGrade) ||
+    Boolean(health?.recovery_profile || health?.relaunch_recommended) ||
+    ['lower_bitrate', 'apply_recovery', 'suggest_recovery'].includes(healthAutoAction)
+  const currentBitrate = firstNumber(adaptiveTarget, stats?.bitrate_kbps, encoder?.bitrate_kbps)
+  const safeBitrate = numberValue(health?.safe_bitrate_kbps)
+  const safeBitrateApplied = healthSuggestsRecovery &&
+    safeBitrate > 0 &&
+    currentBitrate > 0 &&
+    safeBitrate < currentBitrate
+  const safeProfileApplied = Boolean(
+    safeBitrateApplied ||
+    (healthSuggestsRecovery && health?.safe_target_fps) ||
+    (healthSuggestsRecovery && health?.safe_display_mode) ||
+    health?.recovery_profile ||
+    health?.relaunch_recommended,
+  )
+  const optimizing = ['initializing', 'cage_starting', 'game_launching'].includes(lower(stats?.state)) ||
+    lower(stats?.optimization_cache_status || encoder?.optimization_cache_status) === 'miss' ||
+    syncState === 'applying'
+  const targetSummary = buildTargetSummary(stats, adaptiveTarget)
+  const badges = [
+    autoEnabled ? 'AI Auto Quality' : '',
+    adaptiveLowered ? 'Bitrate recovery' : '',
+    stats?.capture_gpu_native || capture?.gpu_native ? 'GPU-native path' : '',
+  ].filter(Boolean)
+
+  if (!autoEnabled && !manualOverride) {
+    return result({
+      state: AUTO_QUALITY_STATES.OFF,
+      label: 'Auto Quality Off',
+      compactLabel: 'Off',
+      detail: 'Manual stream tuning is active.',
+      targetSummary,
+      tone: 'muted',
+      enabled: false,
+      badges,
+    })
+  }
+
+  if (manualOverride) {
+    return result({
+      state: AUTO_QUALITY_STATES.MANUAL_OVERRIDE,
+      label: 'Manual Override',
+      compactLabel: 'Manual',
+      detail: sync?.message || 'Manual client or display settings are overriding Auto Quality.',
+      targetSummary,
+      tone: 'warning',
+      enabled: autoEnabled,
+      badges,
+    })
+  }
+
+  if (syncFailed || captureCpuCopy || degraded) {
+    const detail = health?.summary || sync?.message || (captureCpuCopy
+      ? 'The active capture path is crossing CPU/system memory.'
+      : 'Auto Quality needs a stream setting check.')
+    return result({
+      state: AUTO_QUALITY_STATES.NEEDS_ATTENTION,
+      label: captureCpuCopy ? 'Capture Attention' : 'Needs Attention',
+      compactLabel: 'Attention',
+      detail,
+      targetSummary,
+      tone: 'danger',
+      enabled: true,
+      badges,
+    })
+  }
+
+  if (optimizing) {
+    return result({
+      state: AUTO_QUALITY_STATES.OPTIMIZING,
+      label: 'Auto Quality Optimizing',
+      compactLabel: 'Optimizing',
+      detail: 'Selecting the best launch profile for this stream.',
+      targetSummary,
+      tone: 'info',
+      enabled: true,
+      badges,
+    })
+  }
+
+  if (
+    adaptiveLowered ||
+    hostRenderLimited ||
+    safeProfileApplied ||
+    fpsTargetMiss ||
+    ['lower_bitrate', 'apply_recovery', 'suggest_recovery'].includes(healthAutoAction)
+  ) {
+    const label = hostRenderLimited
+      ? 'Host Render Limited'
+      : adaptiveLowered
+        ? 'Recovering Bitrate'
+        : fpsTargetMiss
+          ? 'Recovering FPS'
+          : 'Auto Quality Recovering'
+    const detail = health?.summary || (hostRenderLimited
+      ? 'The host render path is missing the stream FPS target; lower game quality, render resolution, or FPS before tuning bitrate.'
+      : adaptiveLowered
+        ? `Bitrate is temporarily lowered to ${Math.round(adaptiveTarget / 1000)} Mbps while conditions recover.`
+        : 'Applying a safer stream profile.')
+    return result({
+      state: AUTO_QUALITY_STATES.RECOVERING,
+      label,
+      compactLabel: hostRenderLimited ? 'Host' : adaptiveLowered ? `${Math.round(adaptiveTarget / 1000)} Mbps` : 'Recovery',
+      detail,
+      targetSummary,
+      tone: 'warning',
+      enabled: true,
+      badges,
+    })
+  }
+
+  if (!streaming) {
+    return result({
+      state: AUTO_QUALITY_STATES.WATCHING,
+      label: 'Auto Quality Watching',
+      compactLabel: 'Ready',
+      detail: 'Ready to choose a balanced profile for the next stream.',
+      targetSummary,
+      tone: 'info',
+      enabled: true,
+      badges,
+    })
+  }
+
+  return result({
+    state: AUTO_QUALITY_STATES.STABLE,
+    label: 'Auto Quality Stable',
+    compactLabel: 'Stable',
+    detail: health?.summary || 'Performance and quality are holding steady.',
+    targetSummary,
+    tone: 'stable',
+    enabled: true,
+    badges,
+  })
+}

--- a/src_assets/common/assets/web/auto-quality-state.test.js
+++ b/src_assets/common/assets/web/auto-quality-state.test.js
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { AUTO_QUALITY_STATES, resolveAutoQualityState } from './auto-quality-state'
+
+function streamingStats(overrides = {}) {
+  return {
+    streaming: true,
+    width: 1920,
+    height: 1080,
+    fps: 118,
+    session_target_fps: 120,
+    bitrate_kbps: 30000,
+    adaptive_bitrate_enabled: true,
+    ai_auto_quality_enabled: true,
+    adaptive_target_bitrate_kbps: 30000,
+    ai_enabled: true,
+    codec: 'hevc_nvenc',
+    capture_transport: 'dmabuf',
+    capture_residency: 'gpu',
+    encode_target_residency: 'gpu',
+    capture_gpu_native: true,
+    health: {
+      grade: 'good',
+      summary: 'Session looks steady.',
+      safe_bitrate_kbps: 30000,
+      safe_display_mode: 'headless',
+    },
+    ...overrides,
+  }
+}
+
+describe('Auto Quality UI state', () => {
+  it('reports a healthy quality run as stable', () => {
+    const state = resolveAutoQualityState(streamingStats())
+
+    expect(state.state).toBe(AUTO_QUALITY_STATES.STABLE)
+    expect(state.label).toBe('Auto Quality Stable')
+    expect(state.targetSummary).toContain('1920x1080@120')
+    expect(state.targetSummary).toContain('HEVC')
+  })
+
+  it('turns adaptive target drops into a recovering state', () => {
+    const state = resolveAutoQualityState(streamingStats({
+      adaptive_target_bitrate_kbps: 12000,
+      adaptive_base_bitrate_kbps: 30000,
+    }))
+
+    expect(state.state).toBe(AUTO_QUALITY_STATES.RECOVERING)
+    expect(state.label).toBe('Recovering Bitrate')
+    expect(state.compactLabel).toBe('12 Mbps')
+  })
+
+  it('gives host-render-limited sessions a specific label', () => {
+    const state = resolveAutoQualityState(streamingStats({
+      fps: 82,
+      health: {
+        grade: 'watch',
+        primary_issue: 'host_render_limited',
+        host_render_limited: true,
+      },
+    }))
+
+    expect(state.state).toBe(AUTO_QUALITY_STATES.RECOVERING)
+    expect(state.label).toBe('Host Render Limited')
+    expect(state.compactLabel).toBe('Host')
+  })
+
+  it('surfaces manual override before stable stream state', () => {
+    const state = resolveAutoQualityState(streamingStats(), {
+      state: 'manual_override',
+      manualOverride: true,
+      message: 'Retroid is using a manual quality preset.',
+    })
+
+    expect(state.state).toBe(AUTO_QUALITY_STATES.MANUAL_OVERRIDE)
+    expect(state.label).toBe('Manual Override')
+    expect(state.detail).toContain('Retroid')
+  })
+
+  it('treats CPU capture as attention', () => {
+    const state = resolveAutoQualityState(streamingStats({
+      capture_gpu_native: false,
+      capture_transport: 'shm',
+      capture_residency: 'cpu',
+    }))
+
+    expect(state.state).toBe(AUTO_QUALITY_STATES.NEEDS_ATTENTION)
+    expect(state.label).toBe('Capture Attention')
+  })
+
+  it('reports Auto Quality as off when both tuning engines are disabled', () => {
+    const state = resolveAutoQualityState(streamingStats({
+      ai_auto_quality_enabled: false,
+      adaptive_bitrate_enabled: false,
+      ai_enabled: false,
+    }))
+
+    expect(state.state).toBe(AUTO_QUALITY_STATES.OFF)
+    expect(state.enabled).toBe(false)
+  })
+
+  it('prefers the unified Auto Quality field over legacy component state', () => {
+    const state = resolveAutoQualityState(streamingStats({
+      ai_auto_quality_enabled: false,
+      adaptive_bitrate_enabled: true,
+      ai_enabled: true,
+    }))
+
+    expect(state.state).toBe(AUTO_QUALITY_STATES.OFF)
+    expect(state.enabled).toBe(false)
+  })
+})

--- a/src_assets/common/assets/web/client-settings-sync.js
+++ b/src_assets/common/assets/web/client-settings-sync.js
@@ -11,6 +11,7 @@ export const CLIENT_SETTINGS_RESPONSE_ONLY_KEYS = [
   'client_settings_effective_stream_display_mode_label',
   'client_settings_live_fields',
   'client_settings_restart_fields',
+  'ai_auto_quality_enabled',
 ]
 
 export function isTruthySetting(value) {

--- a/src_assets/common/assets/web/client-settings-sync.test.js
+++ b/src_assets/common/assets/web/client-settings-sync.test.js
@@ -53,6 +53,7 @@ describe('client settings sync helpers', () => {
       headless_mode: 'enabled',
       client_settings_available: true,
       client_settings_endpoint: '/polaris/v1/client-settings',
+      ai_auto_quality_enabled: 'enabled',
     })
 
     expect(config).toEqual({ headless_mode: 'enabled' })

--- a/src_assets/common/assets/web/components/QuickControls.vue
+++ b/src_assets/common/assets/web/components/QuickControls.vue
@@ -92,6 +92,9 @@ async function toggle(key) {
 
     // Merge the toggle change
     existing[key] = newVal
+    if (key === 'ai_enabled') {
+      existing.adaptive_bitrate_enabled = newVal
+    }
     if (key === 'headless_mode' && platform === 'linux') {
       existing.linux_use_cage_compositor = newVal
       existing.linux_prefer_gpu_native_capture = 'disabled'
@@ -105,6 +108,9 @@ async function toggle(key) {
     })
     if (!response.ok) throw new Error('save-failed')
     syncKey(key, newVal)
+    if (key === 'ai_enabled') {
+      syncKey('adaptive_bitrate_enabled', newVal)
+    }
     if (key === 'headless_mode' && platform === 'linux') {
       syncKey('linux_use_cage_compositor', newVal)
       syncKey('linux_prefer_gpu_native_capture', 'disabled')
@@ -144,14 +150,13 @@ onUnmounted(() => {
 
 const toggles = [
   { key: 'headless_mode', requiresRestart: true },
-  { key: 'adaptive_bitrate_enabled', requiresRestart: false },
   { key: 'ai_enabled', requiresRestart: false },
   { key: 'stream_audio', requiresRestart: true },
   { key: 'enable_discovery', requiresRestart: false },
   { key: 'enable_pairing', requiresRestart: false },
 ]
 
-const compactToggleKeys = ['headless_mode', 'adaptive_bitrate_enabled', 'ai_enabled', 'stream_audio']
+const compactToggleKeys = ['headless_mode', 'ai_enabled', 'stream_audio']
 const visibleToggles = () => (
   props.compact
     ? toggles.filter((toggle) => compactToggleKeys.includes(toggle.key))

--- a/src_assets/common/assets/web/configs/tabs/AiOptimizer.vue
+++ b/src_assets/common/assets/web/configs/tabs/AiOptimizer.vue
@@ -198,10 +198,21 @@ const canTestDraft = computed(() => {
   return !!config.value.ai_api_key || hasStoredApiKey.value
 })
 
+const autoQualityEnabled = computed(() => (
+  config.value.ai_enabled === 'enabled' &&
+  config.value.adaptive_bitrate_enabled === 'enabled'
+))
+
+function setAutoQualityEnabled(enabled) {
+  const value = enabled ? 'enabled' : 'disabled'
+  config.value.ai_enabled = value
+  config.value.adaptive_bitrate_enabled = value
+}
+
 const draftMatchesRuntime = computed(() => {
   if (!aiStatus.value) return false
 
-  return aiStatus.value.enabled === (config.value.ai_enabled === 'enabled')
+  return aiStatus.value.enabled === autoQualityEnabled.value
     && aiStatus.value.provider === config.value.ai_provider
     && aiStatus.value.model === config.value.ai_model
     && aiStatus.value.auth_mode === config.value.ai_auth_mode
@@ -607,18 +618,18 @@ onBeforeUnmount(() => {
 
         <div class="flex items-center gap-3 rounded-2xl border border-storm/40 bg-void/30 px-4 py-3">
           <div>
-            <div class="text-xs uppercase tracking-wider text-storm">AI runtime</div>
+            <div class="text-xs uppercase tracking-wider text-storm">AI Auto Quality</div>
             <div class="text-sm font-medium text-silver mt-1">
-              {{ config.ai_enabled === 'enabled' ? 'Enabled' : 'Disabled' }}
+              {{ autoQualityEnabled ? 'Enabled' : 'Disabled' }}
             </div>
           </div>
           <button
-            @click="config.ai_enabled = config.ai_enabled === 'enabled' ? 'disabled' : 'enabled'"
+            @click="setAutoQualityEnabled(!autoQualityEnabled)"
             class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors duration-200"
-            :class="config.ai_enabled === 'enabled' ? 'bg-ice' : 'bg-storm/50'">
+            :class="autoQualityEnabled ? 'bg-ice' : 'bg-storm/50'">
             <span
               class="inline-block h-5 w-5 transform rounded-full bg-white shadow-lg transition-transform duration-200 mt-0.5"
-              :class="config.ai_enabled === 'enabled' ? 'translate-x-[22px]' : 'translate-x-0.5'"></span>
+              :class="autoQualityEnabled ? 'translate-x-[22px]' : 'translate-x-0.5'"></span>
           </button>
         </div>
       </div>

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -106,12 +106,68 @@ const clientSettingsRows = computed(() => [
   { label: 'Display mode', value: clientSettingsSync.value.desiredModeLabel, note: 'Next stream' },
   { label: 'Effective mode', value: clientSettingsSync.value.effectiveModeLabel, note: clientSettingsSync.value.relaunchRequired ? 'Pending' : 'Synced' },
   { label: 'Bitrate limit', value: 'Live', note: 'Client write' },
-  { label: 'Adaptive Bitrate', value: 'Live', note: 'Host + Nova' },
-  { label: 'AI Optimizer', value: 'Live', note: 'Host + Nova' },
+  { label: 'AI Auto Quality', value: 'Live', note: 'Host + Nova' },
+])
+
+const autoQualityEnabled = computed(() => (
+  config.value.adaptive_bitrate_enabled === 'enabled' &&
+  config.value.ai_enabled === 'enabled'
+))
+const autoQualityPartial = computed(() => (
+  config.value.adaptive_bitrate_enabled === 'enabled' ||
+  config.value.ai_enabled === 'enabled'
+))
+const autoQualityBadge = computed(() => {
+  if (autoQualityEnabled.value) return 'Enabled'
+  if (autoQualityPartial.value) return 'Partial'
+  return 'Manual'
+})
+const autoQualityTone = computed(() => {
+  if (autoQualityEnabled.value) return 'border-green-400/30 bg-green-400/10 text-green-300'
+  if (autoQualityPartial.value) return 'border-amber-300/30 bg-amber-300/10 text-amber-200'
+  return 'border-storm/40 bg-storm/10 text-storm'
+})
+const autoQualityCopy = computed(() => {
+  if (autoQualityEnabled.value) {
+    return 'Polaris will balance bitrate, per-game profile choice, and safer recovery targets without making the user choose a tuning layer.'
+  }
+  if (autoQualityPartial.value) {
+    return 'This host has an older split Auto Quality state. Turn it on here to keep profile selection and live bitrate recovery together.'
+  }
+  return 'Manual tuning is active. Polaris will keep the selected bitrate and profile controls under Advanced Tuning.'
+})
+const autoQualityRows = computed(() => [
+  {
+    label: 'Profile',
+    value: config.value.ai_enabled === 'enabled' ? 'Auto' : 'Manual',
+    note: config.value.ai_enabled === 'enabled' ? 'Per game and device' : 'No launch tuning',
+  },
+  {
+    label: 'Bitrate',
+    value: config.value.adaptive_bitrate_enabled === 'enabled' ? 'Adaptive' : 'Fixed',
+    note: config.value.adaptive_bitrate_enabled === 'enabled'
+      ? `${Number(config.value.adaptive_bitrate_min || 0) / 1000}-${Number(config.value.adaptive_bitrate_max || 0) / 1000} Mbps`
+      : `${Number(config.value.max_bitrate || 0) / 1000} Mbps cap`,
+  },
+  {
+    label: 'Runtime',
+    value: selectedStreamDisplayMode.value.title,
+    note: selectedStreamDisplayMode.value.badge,
+  },
+  {
+    label: 'Nova',
+    value: clientSettingsSyncBadge.value,
+    note: clientSettingsSync.value.relaunchRequired ? 'Relaunch to sync' : 'Push/pull ready',
+  },
 ])
 
 function setEnabledConfig(key, enabled) {
   config.value[key] = enabled ? 'enabled' : 'disabled'
+}
+
+function setAutoQuality(enabled) {
+  setEnabledConfig('adaptive_bitrate_enabled', enabled)
+  setEnabledConfig('ai_enabled', enabled)
 }
 
 function setStreamDisplayMode(mode) {
@@ -347,6 +403,44 @@ const validateFallbackMode = (event) => {
       </div>
     </section>
 
+    <section class="settings-section">
+      <div class="settings-section-header">
+        <div class="section-kicker">Auto Quality</div>
+        <h3 class="settings-section-title">Performance and quality balance</h3>
+        <div class="settings-summary-copy">One primary mode for bitrate, launch profile, and recovery behavior. Advanced controls stay available below.</div>
+      </div>
+
+      <div class="settings-subtle-surface space-y-4">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2">
+              <div class="text-base font-semibold text-silver">
+                {{ autoQualityEnabled ? 'Auto Quality is balancing this host' : autoQualityPartial ? 'Auto Quality is partially enabled' : 'Manual stream tuning' }}
+              </div>
+              <span class="meta-pill" :class="autoQualityTone">{{ autoQualityBadge }}</span>
+            </div>
+            <div class="mt-2 max-w-3xl text-sm leading-relaxed text-storm">{{ autoQualityCopy }}</div>
+          </div>
+          <button
+            type="button"
+            class="focus-ring dashboard-action-button"
+            :class="autoQualityEnabled ? 'dashboard-action-button-secondary' : 'dashboard-action-button-primary'"
+            @click="setAutoQuality(!autoQualityEnabled)"
+          >
+            {{ autoQualityEnabled ? 'Use Manual Tuning' : 'Enable Auto Quality' }}
+          </button>
+        </div>
+
+        <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+          <div v-for="row in autoQualityRows" :key="row.label" class="rounded-lg border border-storm/20 bg-void/25 px-3 py-2">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.16em] text-storm">{{ row.label }}</div>
+            <div class="mt-1 text-sm font-medium text-silver">{{ row.value }}</div>
+            <div class="mt-1 text-[11px] text-storm">{{ row.note }}</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <details class="settings-section settings-disclosure" open>
       <summary class="settings-disclosure-summary">
         <div>
@@ -497,9 +591,9 @@ pactl info | grep Source</pre>
     <details class="settings-section settings-disclosure">
       <summary class="settings-disclosure-summary">
         <div>
-          <div class="section-kicker">Delivery</div>
-          <h3 class="settings-section-title mt-2">Bitrate and pacing</h3>
-          <div class="settings-summary-copy">Set the bitrate ceiling, pacing floor, and how the host reacts to network changes.</div>
+          <div class="section-kicker">Advanced Tuning</div>
+          <h3 class="settings-section-title mt-2">Manual bitrate and pacing</h3>
+          <div class="settings-summary-copy">Direct controls for bitrate ceilings, pacing floors, and Auto Quality bitrate range.</div>
         </div>
         <svg class="settings-disclosure-chevron h-4 w-4 text-storm" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 9-7 7-7-7" /></svg>
       </summary>
@@ -522,21 +616,13 @@ pactl info | grep Source</pre>
         <div class="settings-subtle-surface space-y-3">
           <div class="flex items-start justify-between gap-4">
             <div class="min-w-0">
-              <div class="text-sm font-medium text-silver">Adaptive Bitrate</div>
-              <div class="mt-1 text-sm text-storm">Reduce bitrate on loss or RTT spikes, then recover gradually.</div>
+              <div class="text-sm font-medium text-silver">AI Auto Quality bitrate range</div>
+              <div class="mt-1 text-sm text-storm">Used by Auto Quality when it needs to lower bitrate, then recover gradually.</div>
             </div>
-            <label class="relative inline-flex shrink-0 items-center cursor-pointer">
-              <input
-                type="checkbox"
-                class="sr-only peer"
-                :checked="config.adaptive_bitrate_enabled === 'enabled'"
-                @change="config.adaptive_bitrate_enabled = $event.target.checked ? 'enabled' : 'disabled'"
-              />
-              <div class="h-5 w-9 rounded-full bg-storm/40 transition-colors peer peer-checked:bg-accent after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full"></div>
-            </label>
+            <div class="control-chip whitespace-nowrap" :class="autoQualityTone">{{ autoQualityBadge }}</div>
           </div>
 
-          <div v-if="config.adaptive_bitrate_enabled === 'enabled'" class="settings-form-grid">
+          <div v-if="autoQualityEnabled" class="settings-form-grid">
             <div>
               <label class="block text-sm font-medium text-storm mb-1">Min Bitrate (kbps)</label>
               <input
@@ -561,8 +647,11 @@ pactl info | grep Source</pre>
             </div>
           </div>
 
-          <div v-if="config.adaptive_bitrate_enabled === 'enabled'" class="text-sm text-storm">
+          <div v-if="autoQualityEnabled" class="text-sm text-storm">
             Floor: {{ config.adaptive_bitrate_min / 1000 }} Mbps. Ceiling: {{ config.adaptive_bitrate_max / 1000 }} Mbps.
+          </div>
+          <div v-else class="text-sm text-storm">
+            Enable AI Auto Quality above to use adaptive live bitrate recovery.
           </div>
         </div>
       </div>

--- a/src_assets/common/assets/web/configs/tabs/Inputs.vue
+++ b/src_assets/common/assets/web/configs/tabs/Inputs.vue
@@ -184,14 +184,25 @@ const config = ref(props.config)
       ></Checkbox>
 
       <div v-if="config.mouse === 'enabled'" class="settings-toggle-row mb-3">
-        <Checkbox
-          id="mouse_cursor_visible"
-          locale-prefix="config"
-          v-model="config.mouse_cursor_visible"
-          :true-value="'enabled'"
-          :false-value="'disabled'"
-          default="disabled"
-        />
+      <div class="min-w-0">
+        <div>
+          <div class="settings-field-head !mb-0">
+            <div class="text-sm font-medium text-silver">Show host cursor</div>
+            <InfoHint size="sm" label="Show host cursor">
+              Controls whether Polaris draws the host cursor into the video stream. You can still toggle it at runtime with Ctrl+Alt+Shift+N.
+            </InfoHint>
+          </div>
+        </div>
+        <label class="relative inline-flex items-center cursor-pointer shrink-0">
+          <input
+            type="checkbox"
+            class="sr-only peer"
+            :checked="config.mouse_cursor_visible === 'enabled'"
+            @change="config.mouse_cursor_visible = $event.target.checked ? 'enabled' : 'disabled'"
+          />
+          <div class="w-9 h-5 bg-storm/40 peer-focus:outline-none rounded-full peer peer-checked:bg-accent transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full"></div>
+        </label>
+      </div>
       </div>
 
       <Checkbox v-if="config.mouse === 'enabled'"

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -143,18 +143,18 @@
     "address_family_both": "IPv4+IPv6",
     "address_family_desc": "Set the address family used by Polaris",
     "address_family_ipv4": "IPv4 only",
-    "adaptive_bitrate_enabled": "Adaptive Bitrate",
-    "adaptive_bitrate_enabled_desc": "Automatically adjust stream bitrate in response to changing network conditions.",
-    "adaptive_bitrate_max": "Adaptive Bitrate Ceiling",
-    "adaptive_bitrate_max_desc": "Maximum bitrate in Kbps when adaptive bitrate is enabled.",
-    "adaptive_bitrate_min": "Adaptive Bitrate Floor",
-    "adaptive_bitrate_min_desc": "Minimum bitrate in Kbps when adaptive bitrate is enabled.",
+    "adaptive_bitrate_enabled": "AI Auto Quality Bitrate Recovery",
+    "adaptive_bitrate_enabled_desc": "Live bitrate recovery is controlled by AI Auto Quality.",
+    "adaptive_bitrate_max": "Auto Quality Bitrate Ceiling",
+    "adaptive_bitrate_max_desc": "Maximum bitrate in Kbps when AI Auto Quality recovers stream quality.",
+    "adaptive_bitrate_min": "Auto Quality Bitrate Floor",
+    "adaptive_bitrate_min_desc": "Minimum bitrate in Kbps when AI Auto Quality lowers bitrate for recovery.",
     "ai_api_key": "AI Provider API Key",
     "ai_api_key_desc": "Provider API key used when AI optimization runs in direct API mode.",
     "ai_cache_ttl_hours": "AI Cache Duration",
     "ai_cache_ttl_hours_desc": "How long to cache AI optimization results before re-querying.",
-    "ai_enabled": "AI Optimization",
-    "ai_enabled_desc": "Enable AI-powered optimization recommendations for stream settings.",
+    "ai_enabled": "AI Auto Quality",
+    "ai_enabled_desc": "Let Polaris balance launch profile, bitrate recovery, and stream smoothness automatically.",
     "ai_provider": "AI Provider",
     "ai_provider_desc": "Choose the provider used for AI optimization: anthropic, openai, gemini, or local.",
     "ai_model": "AI Model",
@@ -702,7 +702,7 @@
     "sync_ready_badge": "Nova sync ready",
     "sync_pending_badge": "Sync pending",
     "sync_unavailable_badge": "Sync unavailable",
-    "sync_ready_desc": "Nova can update live bitrate, Adaptive Bitrate, and AI Optimizer settings here; display mode changes apply on the next stream.",
+    "sync_ready_desc": "Nova can update live bitrate, AI Auto Quality, and next-stream display choices here.",
     "sync_pending_desc": "Polaris saved the requested display mode and will apply it after the active stream relaunches.",
     "sync_unavailable_desc": "This host has not advertised the Nova client-settings endpoint yet.",
     "restart_badge": "Restart",
@@ -712,12 +712,12 @@
         "desc": "Start sessions on a hidden stream-only display."
       },
       "adaptive_bitrate_enabled": {
-        "label": "Adaptive Bitrate",
-        "desc": "Adjust bitrate when network quality changes."
+        "label": "AI Auto Quality Bitrate Recovery",
+        "desc": "Controlled by the AI Auto Quality toggle."
       },
       "ai_enabled": {
-        "label": "AI Optimizer",
-        "desc": "Use AI recommendations for per-game tuning."
+        "label": "AI Auto Quality",
+        "desc": "Balance FPS, bitrate, and per-game tuning automatically."
       },
       "stream_audio": {
         "label": "Stream Audio",
@@ -830,9 +830,7 @@
     "preview_capturing": "Capturing the live display…",
     "preview_retry": "Retry Preview",
     "preview_error": "Display preview is unavailable right now. The active stream may still be healthy.",
-    "preview_paused": "Display preview paused after repeated capture failures. The active stream may still be healthy.",
     "preview_unavailable_status": "Preview refresh is backing off after a failed capture.",
-    "preview_paused_status": "Preview refresh is paused until you retry it.",
     "preview_status": "Preview refreshes against the active streaming output every few seconds.",
     "preview_hidden_title": "Display preview is hidden.",
     "preview_hidden_desc": "Keep Mission Control compact until you need visual confirmation from the live output, then bring the display back inline.",

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -55,6 +55,23 @@
           </div>
         </div>
 
+        <section class="rounded-xl border p-4" :class="autoQuality.panelClass">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div class="min-w-0">
+              <div class="section-kicker">Auto Quality</div>
+              <div class="mt-2 flex flex-wrap items-center gap-2">
+                <h3 class="text-xl font-semibold leading-tight text-silver">{{ autoQuality.label }}</h3>
+                <span class="meta-pill" :class="autoQuality.toneClass">{{ autoQuality.compactLabel }}</span>
+              </div>
+              <p class="mt-2 max-w-3xl text-sm leading-relaxed text-storm">{{ autoQuality.detail }}</p>
+            </div>
+            <div class="flex shrink-0 flex-wrap gap-2 lg:max-w-sm lg:justify-end">
+              <span v-if="autoQuality.targetSummary" class="data-pill">{{ autoQuality.targetSummary }}</span>
+              <span v-for="badge in autoQuality.badges" :key="badge" class="data-pill">{{ badge }}</span>
+            </div>
+          </div>
+        </section>
+
         <div v-if="streamPathNotices.length" class="grid gap-2 md:grid-cols-2">
           <div
             v-for="notice in streamPathNotices"
@@ -111,7 +128,7 @@
                     <span>{{ $t('dashboard.preview_capturing') }}</span>
                   </div>
                   <div v-if="previewError" class="dashboard-preview-overlay dashboard-preview-overlay-error">
-                    <div class="text-sm font-medium text-silver">{{ previewErrorText }}</div>
+                    <div class="text-sm font-medium text-silver">{{ $t('dashboard.preview_error') }}</div>
                     <button @click="retryPreviewNow" class="focus-ring dashboard-action-button dashboard-action-button-secondary">
                       {{ $t('dashboard.preview_retry') }}
                     </button>
@@ -605,11 +622,7 @@ import GaugeArc from '../components/GaugeArc.vue'
 import QuickControls from '../components/QuickControls.vue'
 import { useI18n } from 'vue-i18n'
 import { resolveClientSettingsSync } from '../client-settings-sync'
-import {
-  PREVIEW_REFRESH_MS,
-  nextPreviewBackoffMs,
-  shouldPausePreviewPolling,
-} from '../display-preview-state'
+import { AUTO_QUALITY_STATES, resolveAutoQualityState } from '../auto-quality-state'
 
 const { stats } = useStreamStats(1000)
 const { gpu, displays, audio, sessionType } = useSystemStats(3000)
@@ -629,6 +642,8 @@ const discoveryEnabled = ref(false)
 const pairingEnabled = ref(false)
 const clientSettingsSync = ref(resolveClientSettingsSync({}))
 const { t } = useI18n()
+
+const autoQuality = computed(() => resolveAutoQualityState(stats.value || {}, clientSettingsSync.value || {}))
 
 const actionSummary = computed(() => {
   if (!statsLoaded.value) return t('dashboard.loading_summary')
@@ -779,7 +794,7 @@ const clientSettingsSyncCopy = computed(() => {
   if (clientSettingsSync.value.relaunchRequired) {
     return 'A requested display mode is saved and will become active after the stream relaunches.'
   }
-  return 'Nova-facing controls are available for live bitrate, Adaptive Bitrate, AI Optimizer, and next-stream display choices.'
+  return 'Nova-facing controls are available for live bitrate, AI Auto Quality, and next-stream display choices.'
 })
 
 const connectedClients = computed(() => {
@@ -1131,6 +1146,9 @@ function formatSessionDate(ts) {
 }
 
 // Display preview (polling screenshot endpoint)
+const PREVIEW_REFRESH_MS = 2000
+const PREVIEW_FAILURE_BACKOFF_MS = 15000
+const PREVIEW_MAX_BACKOFF_MS = 60000
 const streamingOutput = ref('')
 const showPreview = ref(false)
 const previewExpanded = ref(false)
@@ -1138,16 +1156,12 @@ const previewLoaded = ref(false)
 const previewError = ref(false)
 const previewUrl = ref('')
 const previewBackoffMs = ref(PREVIEW_REFRESH_MS)
-const previewFailureCount = ref(0)
 let previewTimer = null
-
-const previewPollingPaused = computed(() => shouldPausePreviewPolling(previewFailureCount.value))
 
 function startPreview() {
   previewLoaded.value = false
   previewError.value = false
   previewBackoffMs.value = PREVIEW_REFRESH_MS
-  previewFailureCount.value = 0
   showPreview.value = true
   refreshPreview()
 }
@@ -1166,7 +1180,6 @@ function refreshPreview() {
     clearTimeout(previewTimer)
     previewTimer = null
   }
-  if (previewPollingPaused.value) return
   previewError.value = false
   // When streaming, crop to the streaming output; otherwise show full display
   const output = streamingOutput.value ? `&output=${encodeURIComponent(streamingOutput.value)}` : ''
@@ -1177,22 +1190,21 @@ function handlePreviewLoad() {
   previewLoaded.value = true
   previewError.value = false
   previewBackoffMs.value = PREVIEW_REFRESH_MS
-  previewFailureCount.value = 0
   schedulePreviewRefresh(PREVIEW_REFRESH_MS)
 }
 
 function handlePreviewError() {
   previewLoaded.value = false
   previewError.value = true
-  previewFailureCount.value += 1
-  if (previewPollingPaused.value) return
-  previewBackoffMs.value = nextPreviewBackoffMs(previewBackoffMs.value)
+  previewBackoffMs.value = Math.min(
+    Math.max(PREVIEW_FAILURE_BACKOFF_MS, previewBackoffMs.value * 2),
+    PREVIEW_MAX_BACKOFF_MS,
+  )
   schedulePreviewRefresh(previewBackoffMs.value)
 }
 
 function retryPreviewNow() {
   previewBackoffMs.value = PREVIEW_REFRESH_MS
-  previewFailureCount.value = 0
   refreshPreview()
 }
 
@@ -1209,7 +1221,6 @@ function stopPreview() {
   previewLoaded.value = false
   previewError.value = false
   previewBackoffMs.value = PREVIEW_REFRESH_MS
-  previewFailureCount.value = 0
   if (previewTimer) { clearTimeout(previewTimer); previewTimer = null }
 }
 
@@ -1285,17 +1296,10 @@ const previewSupportCopy = computed(() => (
 ))
 
 const previewStatusText = computed(() => {
-  if (previewPollingPaused.value) return t('dashboard.preview_paused_status')
   if (previewError.value) return t('dashboard.preview_unavailable_status')
   if (!previewLoaded.value) return t('dashboard.preview_capturing')
   return t('dashboard.preview_status')
 })
-
-const previewErrorText = computed(() => (
-  previewPollingPaused.value
-    ? t('dashboard.preview_paused')
-    : t('dashboard.preview_error')
-))
 
 const aiOptimizationSummary = computed(() => {
   const reasoning = aiOptimization.value?.reasoning
@@ -1369,13 +1373,11 @@ const recommendations = computed(() => {
   if (s.capture_cpu_copy)
     recs.push({ color: 'text-orange-300', message: captureReasonLabel.value })
 
-  // AI optimizer recommendations
-  if (!s.ai_enabled && s.streaming)
-    recs.push({ color: 'text-accent', message: `Enable AI Optimizer in settings for per-game encoding tuning — auto-adjusts resolution, bitrate, and codec.` })
-
-  // Adaptive bitrate recommendation
-  if (s.adaptive_target_bitrate_kbps === 0 && s.packet_loss > 0 && s.streaming)
-    recs.push({ color: 'text-accent', message: `Enable Adaptive Bitrate in Audio/Video settings — auto-adjusts bitrate when network quality drops.` })
+  if (!autoQuality.value.enabled && s.streaming) {
+    recs.push({ color: 'text-accent', message: 'Enable Auto Quality in Audio/Video settings so Polaris can balance bitrate, profile choice, and recovery behavior automatically.' })
+  } else if (autoQuality.value.state === AUTO_QUALITY_STATES.RECOVERING && autoQuality.value.detail) {
+    recs.push({ color: 'text-amber-300', message: autoQuality.value.detail })
+  }
 
   return recs
 })

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,6 +134,8 @@ set(TEST_AUDIO_SOURCES
 )
 
 set(TEST_STREAM_SOURCES
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_adaptive_bitrate.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_ai_optimizer.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_stream.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_stream_stats.cpp
 )

--- a/tests/unit/test_adaptive_bitrate.cpp
+++ b/tests/unit/test_adaptive_bitrate.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file tests/unit/test_adaptive_bitrate.cpp
+ * @brief Unit tests for adaptive bitrate controller behavior.
+ */
+
+#include "src/adaptive_bitrate.h"
+#include "src/config.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace {
+  void enable_controller(int base_bitrate_kbps = 20000) {
+    config::video.adaptive_bitrate.enabled = true;
+    config::video.adaptive_bitrate.min_bitrate_kbps = 2000;
+    config::video.adaptive_bitrate.max_bitrate_kbps = 50000;
+    adaptive_bitrate::load_config();
+    adaptive_bitrate::reset();
+    adaptive_bitrate::set_base_bitrate(base_bitrate_kbps);
+  }
+}
+
+TEST(AdaptiveBitrateController, ReducesTargetOnNetworkPressure) {
+  enable_controller();
+
+  adaptive_bitrate::update_network_stats(0.0, 8.0);
+  std::this_thread::sleep_for(1100ms);
+  adaptive_bitrate::update_network_stats(8.0, 8.0);
+
+  const auto state = adaptive_bitrate::get_state();
+  EXPECT_TRUE(state.enabled);
+  EXPECT_LT(state.target_bitrate_kbps, state.base_bitrate_kbps);
+  EXPECT_EQ("network_pressure", state.state);
+}
+
+TEST(AdaptiveBitrateController, ReportsFramePacingWithoutLoweringBitrate) {
+  enable_controller();
+
+  adaptive_bitrate::update_network_stats(0.0, 8.0);
+  std::this_thread::sleep_for(1100ms);
+  adaptive_bitrate::update_stream_health(0.75, 0.05, 0.02, 3.0, 4.0, 28.0);
+
+  const auto state = adaptive_bitrate::get_state();
+  EXPECT_TRUE(state.enabled);
+  EXPECT_EQ(state.base_bitrate_kbps, state.target_bitrate_kbps);
+  EXPECT_EQ("frame_pacing_observed", state.state);
+}
+
+TEST(AdaptiveBitrateController, ReducesTargetOnEncoderPressure) {
+  enable_controller();
+
+  adaptive_bitrate::update_network_stats(0.0, 8.0);
+  std::this_thread::sleep_for(1100ms);
+  adaptive_bitrate::update_stream_health(0.96, 0.0, 0.0, 1.0, 12.0, 20.0);
+
+  const auto state = adaptive_bitrate::get_state();
+  EXPECT_TRUE(state.enabled);
+  EXPECT_LT(state.target_bitrate_kbps, state.base_bitrate_kbps);
+  EXPECT_EQ("encoder_pressure", state.state);
+}
+
+TEST(AdaptiveBitrateController, ClampsBaseToConfiguredBounds) {
+  enable_controller(100000);
+
+  const auto state = adaptive_bitrate::get_state();
+  EXPECT_EQ(50000, state.base_bitrate_kbps);
+  EXPECT_EQ(50000, state.target_bitrate_kbps);
+}

--- a/tests/unit/test_ai_optimizer.cpp
+++ b/tests/unit/test_ai_optimizer.cpp
@@ -1,0 +1,517 @@
+/**
+ * @file tests/unit/test_ai_optimizer.cpp
+ * @brief Unit tests for AI optimizer session feedback classification.
+ */
+
+#include "src/ai_optimizer.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+namespace {
+  ai_optimizer::session_history_t make_session(const std::string &grade,
+                                               const std::string &end_reason,
+                                               int duration_s,
+                                               int samples) {
+    ai_optimizer::session_history_t session;
+    session.avg_fps = grade == "F" ? 24.0 : 58.0;
+    session.last_fps = session.avg_fps;
+    session.last_target_fps = 60.0;
+    session.quality_grade = grade;
+    session.last_quality_grade = grade;
+    session.last_end_reason = end_reason;
+    session.last_duration_s = duration_s;
+    session.last_sample_count = samples;
+    return session;
+  }
+}
+
+TEST(AiOptimizerSessionFeedback, DisconnectIsAcceptedButCannotInvalidateCache) {
+  auto policy = ai_optimizer::classify_session_feedback(
+    "Black Myth: Wukong",
+    make_session("F", "disconnect", 120, 120)
+  );
+
+  EXPECT_TRUE(policy.accepted);
+  EXPECT_EQ("low", policy.confidence);
+  EXPECT_FALSE(policy.counts_poor_outcome);
+  EXPECT_FALSE(policy.can_invalidate_cache);
+}
+
+TEST(AiOptimizerSessionFeedback, ExplicitEndRequiresEnoughSamplesForHighConfidence) {
+  auto low_policy = ai_optimizer::classify_session_feedback(
+    "Black Myth: Wukong",
+    make_session("F", "end", 12, 4)
+  );
+  auto high_policy = ai_optimizer::classify_session_feedback(
+    "Black Myth: Wukong",
+    make_session("F", "end", 60, 60)
+  );
+
+  EXPECT_TRUE(low_policy.accepted);
+  EXPECT_EQ("low", low_policy.confidence);
+  EXPECT_FALSE(low_policy.counts_poor_outcome);
+
+  EXPECT_TRUE(high_policy.accepted);
+  EXPECT_EQ("high", high_policy.confidence);
+  EXPECT_TRUE(high_policy.counts_poor_outcome);
+  EXPECT_TRUE(high_policy.can_invalidate_cache);
+}
+
+TEST(AiOptimizerSessionFeedback, MissingMetricsAreIgnored) {
+  auto session = make_session("F", "end", 60, 60);
+  session.avg_fps = 0.0;
+  session.last_fps = 0.0;
+
+  auto policy = ai_optimizer::classify_session_feedback("Black Myth: Wukong", session);
+
+  EXPECT_FALSE(policy.accepted);
+  EXPECT_EQ("ignored", policy.confidence);
+  EXPECT_EQ("missing_quality_metrics", policy.ignored_reason);
+}
+
+TEST(AiOptimizerSessionGrading, TreatsIsolatedMinDipAsMildWhenSustainedPacingIsHealthy) {
+  auto session = make_session("D", "disconnect", 362, 358);
+  session.avg_fps = 56.4689;
+  session.last_fps = session.avg_fps;
+  session.last_target_fps = 60.0;
+  session.avg_latency_ms = 3.41;
+  session.packet_loss_pct = 0.0;
+  session.last_low_1_percent_fps = 52.0;
+  session.last_min_fps = 13.07;
+  session.last_frame_pacing_bad_pct = 1.4;
+
+  EXPECT_EQ("B", ai_optimizer::grade_session_quality(session));
+}
+
+TEST(AiOptimizerSessionGrading, KeepsCorroboratedPacingCollapsePoor) {
+  auto session = make_session("D", "disconnect", 180, 120);
+  session.avg_fps = 53.0;
+  session.last_fps = session.avg_fps;
+  session.last_target_fps = 60.0;
+  session.avg_latency_ms = 5.0;
+  session.packet_loss_pct = 0.0;
+  session.last_low_1_percent_fps = 35.0;
+  session.last_min_fps = 12.0;
+  session.last_frame_pacing_bad_pct = 8.0;
+
+  EXPECT_EQ("D", ai_optimizer::grade_session_quality(session));
+}
+
+TEST(AiOptimizerHistorySanitization, ResetsCorruptedCounters) {
+  auto session = make_session("B", "end", 60, 60);
+  session.session_count = 651167748;
+  session.poor_outcome_count = 382205952;
+  session.consecutive_poor_outcomes = 221184;
+
+  auto sanitized = ai_optimizer::sanitize_session_history(session);
+
+  EXPECT_EQ(1, sanitized.session_count);
+  EXPECT_EQ(0, sanitized.poor_outcome_count);
+  EXPECT_EQ(0, sanitized.consecutive_poor_outcomes);
+  EXPECT_EQ("B", sanitized.last_quality_grade);
+}
+
+TEST(AiOptimizerHistorySanitization, ClearsLowConfidenceSoftEndRecoveryBias) {
+  auto session = make_session("C", "host_pause", 20, 8);
+  session.session_count = 3;
+  session.last_sample_confidence = "low";
+  session.last_health_grade = "degraded";
+  session.last_primary_issue = "host_render_limited";
+  session.last_safe_target_fps = 30.0;
+  session.last_relaunch_recommended = true;
+  session.poor_outcome_count = 0;
+  session.consecutive_poor_outcomes = 0;
+
+  auto sanitized = ai_optimizer::sanitize_session_history(session);
+
+  EXPECT_EQ(3, sanitized.session_count);
+  EXPECT_DOUBLE_EQ(0.0, sanitized.last_safe_target_fps);
+  EXPECT_FALSE(sanitized.last_relaunch_recommended);
+  EXPECT_EQ("watch", sanitized.last_health_grade);
+  EXPECT_EQ("host_render_limited", sanitized.last_primary_issue);
+}
+
+TEST(AiOptimizerHistorySanitization, KeepsSampledSoftEndRecoveryBias) {
+  auto session = make_session("C", "disconnect", 180, 180);
+  session.session_count = 3;
+  session.last_sample_confidence = "low";
+  session.last_health_grade = "watch";
+  session.last_primary_issue = "host_render_limited";
+  session.last_issues = {"host_render_limited"};
+  session.last_safe_target_fps = 60.0;
+  session.last_relaunch_recommended = true;
+  session.poor_outcome_count = 0;
+  session.consecutive_poor_outcomes = 0;
+
+  auto sanitized = ai_optimizer::sanitize_session_history(session);
+
+  EXPECT_EQ(3, sanitized.session_count);
+  EXPECT_DOUBLE_EQ(60.0, sanitized.last_safe_target_fps);
+  EXPECT_TRUE(sanitized.last_relaunch_recommended);
+  EXPECT_EQ("watch", sanitized.last_health_grade);
+  EXPECT_EQ("host_render_limited", sanitized.last_primary_issue);
+}
+
+TEST(AiOptimizerHistorySanitization, KeepsHighConfidenceRecoveryBias) {
+  auto session = make_session("C", "end", 180, 180);
+  session.session_count = 3;
+  session.last_sample_confidence = "high";
+  session.last_primary_issue = "host_render_limited";
+  session.last_safe_target_fps = 30.0;
+  session.last_relaunch_recommended = true;
+  session.poor_outcome_count = 1;
+  session.consecutive_poor_outcomes = 1;
+
+  auto sanitized = ai_optimizer::sanitize_session_history(session);
+
+  EXPECT_EQ(3, sanitized.session_count);
+  EXPECT_EQ(1, sanitized.poor_outcome_count);
+  EXPECT_EQ(1, sanitized.consecutive_poor_outcomes);
+  EXPECT_DOUBLE_EQ(30.0, sanitized.last_safe_target_fps);
+  EXPECT_TRUE(sanitized.last_relaunch_recommended);
+}
+
+TEST(AiOptimizerHistorySafe, RelaxesCompletedThirtyFpsTrial) {
+  auto session = make_session("B", "host_pause", 180, 180);
+  session.last_target_fps = 30.0;
+  session.last_fps = 28.5;
+  session.last_safe_target_fps = 30.0;
+  session.last_optimization_source = "ai_cached+history_safe";
+
+  EXPECT_TRUE(ai_optimizer::should_relax_history_safe_target_fps(session));
+}
+
+TEST(AiOptimizerHistorySafe, KeepsCapAfterSevereSafeTargetMiss) {
+  auto session = make_session("F", "host_pause", 180, 180);
+  session.last_target_fps = 30.0;
+  session.last_fps = 12.0;
+  session.last_safe_target_fps = 30.0;
+  session.last_optimization_source = "ai_cached+history_safe";
+
+  EXPECT_FALSE(ai_optimizer::should_relax_history_safe_target_fps(session));
+}
+
+TEST(AiOptimizerHistorySafe, KeepsCapAfterShortLowConfidenceSafeTrial) {
+  auto session = make_session("A", "host_pause", 50, 20);
+  session.last_target_fps = 30.0;
+  session.last_fps = 30.0;
+  session.last_safe_target_fps = 30.0;
+  session.last_sample_confidence = "low";
+  session.last_optimization_source = "ai_cached+history_safe";
+
+  EXPECT_FALSE(ai_optimizer::should_relax_history_safe_target_fps(session));
+}
+
+TEST(AiOptimizerHistorySafe, IgnoresLowConfidenceInterruptedRetry) {
+  auto session = make_session("B", "host_pause", 20, 8);
+  session.last_target_fps = 60.0;
+  session.last_fps = 58.0;
+  session.last_safe_target_fps = 30.0;
+  session.last_sample_confidence = "low";
+  session.last_optimization_source = "ai_cached";
+
+  EXPECT_FALSE(ai_optimizer::should_relax_history_safe_target_fps(session));
+}
+
+TEST(AiOptimizerHistorySafe, KeepsCapAfterLowConfidenceFramePacingMiss) {
+  auto session = make_session("F", "host_pause", 0, 0);
+  session.last_target_fps = 40.0;
+  session.last_fps = 10.0;
+  session.last_safe_target_fps = 30.0;
+  session.last_sample_confidence = "low";
+  session.last_primary_issue = "frame_pacing";
+  session.last_optimization_source = "ai_cached";
+
+  EXPECT_FALSE(ai_optimizer::should_relax_history_safe_target_fps(session));
+}
+
+TEST(AiOptimizerHistorySafe, KeepsCapAfterLowConfidenceHostRenderMiss) {
+  auto session = make_session("F", "host_pause", 0, 0);
+  session.last_target_fps = 40.0;
+  session.last_fps = 10.0;
+  session.last_safe_target_fps = 30.0;
+  session.last_sample_confidence = "low";
+  session.last_primary_issue = "host_render_limited";
+  session.last_optimization_source = "ai_cached";
+
+  EXPECT_FALSE(ai_optimizer::should_relax_history_safe_target_fps(session));
+}
+
+TEST(AiOptimizerHistorySafe, IgnoresUnconfirmedPoorSoftEndForRecoveryFallback) {
+  auto session = make_session("F", "host_pause", 0, 0);
+  session.session_count = 3;
+  session.last_target_fps = 60.0;
+  session.last_fps = 9.9;
+  session.avg_fps = 58.0;
+  session.last_safe_bitrate_kbps = 3900;
+  session.last_safe_codec = "hevc";
+  session.last_safe_display_mode = "headless";
+  session.last_safe_target_fps = 24.0;
+  session.last_sample_confidence = "low";
+  session.last_primary_issue = "host_render_limited";
+  session.last_issues = {"frame_pacing", "host_render_limited"};
+  session.last_relaunch_recommended = true;
+  session.poor_outcome_count = 0;
+  session.consecutive_poor_outcomes = 0;
+
+  EXPECT_DOUBLE_EQ(
+    0.0,
+    ai_optimizer::effective_history_safe_target_fps("RetroidPocket6", session)
+  );
+  EXPECT_FALSE(
+    ai_optimizer::get_history_safe_fallback(
+      "RetroidPocket6",
+      "Superposition Baseline",
+      std::optional<ai_optimizer::session_history_t> {session}
+    ).has_value()
+  );
+}
+
+TEST(AiOptimizerHistorySafe, UsesSampledSoftEndForRecoveryFallback) {
+  auto session = make_session("F", "host_pause", 180, 180);
+  session.session_count = 3;
+  session.last_target_fps = 120.0;
+  session.last_fps = 38.0;
+  session.avg_fps = 38.0;
+  session.last_safe_bitrate_kbps = 13387;
+  session.last_safe_codec = "hevc";
+  session.last_safe_display_mode = "headless";
+  session.last_safe_target_fps = 30.0;
+  session.last_sample_confidence = "low";
+  session.last_primary_issue = "host_render_limited";
+  session.last_issues = {"host_render_limited"};
+  session.last_relaunch_recommended = true;
+  session.poor_outcome_count = 0;
+  session.consecutive_poor_outcomes = 0;
+
+  EXPECT_DOUBLE_EQ(
+    30.0,
+    ai_optimizer::effective_history_safe_target_fps("RetroidPocket6", session)
+  );
+  EXPECT_TRUE(
+    ai_optimizer::get_history_safe_fallback(
+      "RetroidPocket6",
+      "Superposition Quality 120",
+      std::optional<ai_optimizer::session_history_t> {session}
+    ).has_value()
+  );
+}
+
+TEST(AiOptimizerHistorySafe, UsesSampledHostRenderWatchForRecoveryFallback) {
+  auto session = make_session("C", "host_pause", 180, 180);
+  session.session_count = 3;
+  session.last_target_fps = 120.0;
+  session.last_fps = 94.0;
+  session.avg_fps = 94.0;
+  session.last_safe_bitrate_kbps = 16000;
+  session.last_safe_codec = "hevc";
+  session.last_safe_display_mode = "headless";
+  session.last_safe_target_fps = 60.0;
+  session.last_sample_confidence = "low";
+  session.last_health_grade = "watch";
+  session.last_primary_issue = "host_render_limited";
+  session.last_issues = {"host_render_limited"};
+  session.last_relaunch_recommended = true;
+  session.poor_outcome_count = 0;
+  session.consecutive_poor_outcomes = 0;
+
+  EXPECT_TRUE(
+    ai_optimizer::get_history_safe_fallback(
+      "RetroidPocket6",
+      "Superposition Quality 120",
+      std::optional<ai_optimizer::session_history_t> {session}
+    ).has_value()
+  );
+}
+
+TEST(AiOptimizerHistorySafe, UsesHighConfidenceHostRenderRecoveryFallback) {
+  auto session = make_session("C", "end", 180, 180);
+  session.session_count = 3;
+  session.last_target_fps = 120.0;
+  session.last_fps = 94.0;
+  session.avg_fps = 94.0;
+  session.last_safe_bitrate_kbps = 16000;
+  session.last_safe_codec = "hevc";
+  session.last_safe_display_mode = "headless";
+  session.last_safe_target_fps = 60.0;
+  session.last_sample_confidence = "high";
+  session.last_health_grade = "watch";
+  session.last_primary_issue = "host_render_limited";
+  session.last_issues = {"host_render_limited"};
+  session.last_relaunch_recommended = true;
+  session.poor_outcome_count = 0;
+  session.consecutive_poor_outcomes = 0;
+
+  EXPECT_TRUE(
+    ai_optimizer::get_history_safe_fallback(
+      "RetroidPocket6",
+      "Superposition Quality 120",
+      std::optional<ai_optimizer::session_history_t> {session}
+    ).has_value()
+  );
+}
+
+TEST(AiOptimizerHistorySafe, KeepsCapAfterLongSampledDisconnect) {
+  auto session = make_session("D", "disconnect", 180, 180);
+  session.last_target_fps = 60.0;
+  session.last_fps = 53.0;
+  session.last_safe_target_fps = 30.0;
+  session.last_sample_confidence = "low";
+  session.last_optimization_source = "ai_cached";
+
+  EXPECT_FALSE(ai_optimizer::should_relax_history_safe_target_fps(session));
+}
+
+TEST(AiOptimizerHistorySafe, GraduatesStaleCapAfterSuccessfulHighFpsRetry) {
+  auto session = make_session("D", "disconnect", 180, 180);
+  session.avg_fps = 118.0;
+  session.last_fps = 118.0;
+  session.last_target_fps = 120.0;
+  session.last_latency_ms = 3.5;
+  session.last_packet_loss_pct = 0.0;
+  session.last_low_1_percent_fps = 92.0;
+  session.last_min_fps = 72.0;
+  session.last_frame_pacing_bad_pct = 6.0;
+  session.last_capture_path = "headless";
+  session.last_network_risk = "normal";
+  session.last_decoder_risk = "normal";
+  session.last_hdr_risk = "normal";
+
+  EXPECT_TRUE(
+    ai_optimizer::should_graduate_history_safe_target_fps(session, 30.0)
+  );
+}
+
+TEST(AiOptimizerHistorySafe, KeepsStaleCapWhenHighFpsRetryStillMissesTarget) {
+  auto session = make_session("D", "disconnect", 180, 180);
+  session.avg_fps = 82.0;
+  session.last_fps = 82.0;
+  session.last_target_fps = 120.0;
+  session.last_latency_ms = 3.5;
+  session.last_packet_loss_pct = 0.0;
+  session.last_capture_path = "headless";
+
+  EXPECT_FALSE(
+    ai_optimizer::should_graduate_history_safe_target_fps(session, 30.0)
+  );
+}
+
+TEST(AiOptimizerHistorySafe, RefreshesStaleRecoveryCacheAfterStableThirtyFpsTrial) {
+  auto session = make_session("A", "disconnect", 414, 404);
+  session.last_target_fps = 30.0;
+  session.last_fps = 29.7;
+  session.last_low_1_percent_fps = 29.0;
+  session.last_min_fps = 29.1;
+  session.last_latency_ms = 3.7;
+  session.last_sample_confidence = "low";
+  session.last_primary_issue = "nvenc_cuda_disabled";
+  session.last_issues = {"headless_shm_fallback", "nvenc_cuda_disabled"};
+
+  device_db::optimization_t optimization;
+  optimization.display_mode = "1920x1080x30";
+  optimization.confidence = "low";
+  optimization.normalization_reason = "Lowered stream FPS from session pacing feedback.";
+
+  EXPECT_TRUE(
+    ai_optimizer::should_refresh_recovery_cache_after_stable_trial(session, optimization)
+  );
+}
+
+TEST(AiOptimizerHistorySafe, KeepsIntentionalThirtyFpsQualityCache) {
+  auto session = make_session("A", "disconnect", 414, 404);
+  session.last_target_fps = 30.0;
+  session.last_fps = 29.7;
+  session.last_low_1_percent_fps = 29.0;
+  session.last_min_fps = 29.1;
+  session.last_latency_ms = 3.7;
+
+  device_db::optimization_t optimization;
+  optimization.display_mode = "1920x1080x30";
+  optimization.confidence = "medium";
+  optimization.reasoning = "Latest session earned A at 30 FPS, so keep the proven 1080p30 stream.";
+
+  EXPECT_FALSE(
+    ai_optimizer::should_refresh_recovery_cache_after_stable_trial(session, optimization)
+  );
+}
+
+TEST(AiOptimizerSafeTargetFps, UsesStableFortyForModerateMobilePacingMiss) {
+  EXPECT_DOUBLE_EQ(
+    40.0,
+    ai_optimizer::derive_safe_target_fps(
+      60.0,
+      52.0,
+      0.0,
+      0.0,
+      8.0,
+      true,
+      false,
+      true
+    )
+  );
+}
+
+TEST(AiOptimizerSafeTargetFps, KeepsThirtyForSevereMobilePacingMiss) {
+  EXPECT_DOUBLE_EQ(
+    30.0,
+    ai_optimizer::derive_safe_target_fps(
+      60.0,
+      43.0,
+      0.0,
+      0.0,
+      18.0,
+      true,
+      false,
+      true
+    )
+  );
+}
+
+TEST(AiOptimizerSafeTargetFps, UsesSixtyForRecoverableHighRefreshMiss) {
+  EXPECT_DOUBLE_EQ(
+    60.0,
+    ai_optimizer::derive_safe_target_fps(
+      120.0,
+      94.0,
+      0.0,
+      0.0,
+      8.0,
+      true,
+      false,
+      true
+    )
+  );
+}
+
+TEST(AiOptimizerSafeTargetFps, UsesThirtyForSevereHighRefreshMiss) {
+  EXPECT_DOUBLE_EQ(
+    30.0,
+    ai_optimizer::derive_safe_target_fps(
+      120.0,
+      42.0,
+      0.0,
+      0.0,
+      18.0,
+      true,
+      false,
+      true
+    )
+  );
+}
+
+TEST(AiOptimizerSafeTargetFps, UpgradesLegacyThirtyCapWhenModerateMissCanHoldForty) {
+  auto session = make_session("B", "end", 180, 180);
+  session.avg_fps = 52.0;
+  session.last_fps = 52.0;
+  session.last_target_fps = 60.0;
+  session.last_safe_target_fps = 30.0;
+  session.last_frame_pacing_bad_pct = 8.0;
+  session.last_primary_issue = "host_render_limited";
+
+  EXPECT_DOUBLE_EQ(
+    40.0,
+    ai_optimizer::effective_history_safe_target_fps("RetroidPocket6", session)
+  );
+}

--- a/tests/unit/test_confighttp_validation.cpp
+++ b/tests/unit/test_confighttp_validation.cpp
@@ -60,9 +60,6 @@ TEST(AppValidationTests, AcceptsAWellFormedAppPayload) {
     {"prep-cmd", {{{"do", "echo start"}, {"undo", "echo stop"}, {"elevated", false}}}},
     {"detached", {"mangohud --dlsym"}},
     {"game-category", "fast_action"},
-    {"lutris-runner", "wine"},
-    {"platform", "windows"},
-    {"runtime", "wine"},
     {"source", "manual"}
   };
 
@@ -101,26 +98,4 @@ TEST(AppValidationTests, RejectsUnexpectedCommandShapes) {
   std::string error;
   EXPECT_FALSE(confighttp::validation::validate_app_payload(payload, error));
   EXPECT_NE(error.find("unsupported field"), std::string::npos);
-}
-
-TEST(AppValidationTests, RejectsUnknownPlatformMetadata) {
-  nlohmann::json payload = {
-    {"name", "Broken App"},
-    {"platform", "solaris"}
-  };
-
-  std::string error;
-  EXPECT_FALSE(confighttp::validation::validate_app_payload(payload, error));
-  EXPECT_NE(error.find("platform must be one of"), std::string::npos);
-}
-
-TEST(AppValidationTests, RejectsUnknownRuntimeMetadata) {
-  nlohmann::json payload = {
-    {"name", "Broken App"},
-    {"runtime", "dosbox"}
-  };
-
-  std::string error;
-  EXPECT_FALSE(confighttp::validation::validate_app_payload(payload, error));
-  EXPECT_NE(error.find("runtime must be one of"), std::string::npos);
 }

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -99,7 +99,7 @@ TEST(LutrisLibraryScannerTests, ScansMultipleXdgDirectories) {
     "slug: data-game\n"
     "runner: wine\n");
 
-  const auto games = game_library::scan_lutris_games(std::vector<std::filesystem::path> {config_dir, data_dir});
+  const auto games = game_library::scan_lutris_games({config_dir, data_dir});
   ASSERT_EQ(games.size(), 2);
   EXPECT_EQ(games[0].slug, "config-game");
   EXPECT_EQ(games[1].slug, "data-game");

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -133,11 +133,7 @@ TEST(ProcessMigrationTests, ParseNormalizesSteamBigPictureLaunchAndAddsCleanupUn
 
   ASSERT_NE(steam_ctx, parsed_apps.end());
   ASSERT_EQ(steam_ctx->detached.size(), 1);
-#ifdef __linux__
   EXPECT_EQ(steam_ctx->detached.front(), "setsid steam -gamepadui");
-#else
-  EXPECT_EQ(steam_ctx->detached.front(), "setsid steam steam://open/bigpicture");
-#endif
   EXPECT_TRUE(steam_ctx->cmd.empty());
   ASSERT_FALSE(steam_ctx->prep_cmds.empty());
   EXPECT_EQ(steam_ctx->prep_cmds.back().undo_cmd, "setsid steam -shutdown");
@@ -339,8 +335,6 @@ TEST(ProcessMigrationTests, ParsePreservesLutrisImportMetadataAndSource) {
       {"source", "lutris"},
       {"lutris-slug", "lutris-game"},
       {"lutris-runner", "wine"},
-      {"platform", "windows"},
-      {"runtime", "wine"},
       {"detached", {"setsid lutris lutris:rungame/lutris-game"}},
       {"gamepad", "ds5"},
       {"game-category", "cinematic"},
@@ -370,9 +364,6 @@ TEST(ProcessMigrationTests, ParsePreservesLutrisImportMetadataAndSource) {
 
   ASSERT_NE(lutris_ctx, parsed_apps.end());
   EXPECT_EQ(lutris_ctx->source, "lutris");
-  EXPECT_EQ(lutris_ctx->lutris_runner, "wine");
-  EXPECT_EQ(lutris_ctx->platform, "windows");
-  EXPECT_EQ(lutris_ctx->runtime, "wine");
   EXPECT_EQ(lutris_ctx->gamepad, "ds5");
   EXPECT_EQ(lutris_ctx->game_category, "cinematic");
   ASSERT_EQ(lutris_ctx->detached.size(), 1);

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -103,7 +103,11 @@ TEST(StreamStatsCapturePathTests, LabelsHeadlessExtcopyDmabufPath) {
   stats.encode_target_residency = platf::frame_residency_e::gpu;
 
   EXPECT_EQ(stream_stats::capture_path_summary(stats), "gpu_native");
+#ifdef __linux__
   EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_extcopy_dmabuf");
+#else
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "gpu_native");
+#endif
   EXPECT_FALSE(stream_stats::capture_path_uses_cpu_copy(stats));
   EXPECT_TRUE(stream_stats::capture_path_is_gpu_native(stats));
 }
@@ -119,7 +123,11 @@ TEST(StreamStatsCapturePathTests, LabelsWindowedDmabufOverridePath) {
   stats.encode_target_residency = platf::frame_residency_e::gpu;
 
   EXPECT_EQ(stream_stats::capture_path_summary(stats), "gpu_native");
+#ifdef __linux__
   EXPECT_EQ(stream_stats::capture_path_reason(stats), "windowed_dmabuf_override");
+#else
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "gpu_native");
+#endif
   EXPECT_FALSE(stream_stats::capture_path_uses_cpu_copy(stats));
   EXPECT_TRUE(stream_stats::capture_path_is_gpu_native(stats));
 }


### PR DESCRIPTION
## Summary

- Bump Polaris to v1.0.13 and add release notes for the Auto Quality / Nova sync release.
- Merge adaptive bitrate into the AI optimizer path with stream-health-aware recovery, FPS fallback, and safer cached recommendation handling.
- Expose richer Polaris/Nova sync and stream status surfaces through HTTP APIs and the web UI.
- Improve Linux headless/runtime diagnostics around capture path, frame residency, and GPU-native fallback behavior.
- Add focused coverage for adaptive bitrate, AI optimizer behavior, stream stats, and related process/runtime handling.

## Validation

- `npm ci --no-audit --fund=false`
- `npm run lint`
- `npm test`
- `bash scripts/check-public-surface.sh`
- `npm run build-clean`
- `git diff --check`

Note: local macOS validation covered the web/public-surface side. The Linux/C++/CUDA build should be validated by GitHub/Linux CI before tagging `v1.0.13`.