### PR TITLE
Fix adaptive bitrate clamp crash

### DIFF
--- a/src/adaptive_bitrate.cpp
+++ b/src/adaptive_bitrate.cpp
@@ -47,6 +47,17 @@ namespace adaptive_bitrate {
     controller_reason = reason;
   }
 
+  static void normalize_config_bounds(config_t &config) {
+    if (config.max_bitrate_kbps >= config.min_bitrate_kbps) {
+      return;
+    }
+
+    BOOST_LOG(warning) << "Adaptive bitrate: max bitrate "
+                       << config.max_bitrate_kbps << " kbps is below min bitrate "
+                       << config.min_bitrate_kbps << " kbps; using min as max";
+    config.max_bitrate_kbps = config.min_bitrate_kbps;
+  }
+
   static int clamp_target(int target, int base) {
     target = std::clamp(target, current_config.min_bitrate_kbps, current_config.max_bitrate_kbps);
     return std::min(target, base);
@@ -276,6 +287,8 @@ namespace adaptive_bitrate {
     current_config.enabled = config::video.adaptive_bitrate.enabled;
     current_config.min_bitrate_kbps = config::video.adaptive_bitrate.min_bitrate_kbps;
     current_config.max_bitrate_kbps = config::video.adaptive_bitrate.max_bitrate_kbps;
+    normalize_config_bounds(current_config);
+    config::video.adaptive_bitrate.max_bitrate_kbps = current_config.max_bitrate_kbps;
 
     enabled.store(current_config.enabled, std::memory_order_relaxed);
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1788,6 +1788,7 @@ namespace proc {
     this->initial_nvenc_tune = config::video.nvenc_tune;
     this->initial_max_bitrate = config::video.max_bitrate;
     this->initial_adaptive_max_bitrate = config::video.adaptive_bitrate.max_bitrate_kbps;
+    this->initial_video_config_saved = true;
 
     launch_session->width = launch_session->requested_width;
     launch_session->height = launch_session->requested_height;
@@ -2151,7 +2152,9 @@ namespace proc {
       config::video.color_range = this->initial_color_range;
       config::video.nvenc_tune = this->initial_nvenc_tune;
       config::video.max_bitrate = this->initial_max_bitrate;
-      config::video.adaptive_bitrate.max_bitrate_kbps = this->initial_adaptive_max_bitrate;
+      if (this->initial_video_config_saved) {
+        config::video.adaptive_bitrate.max_bitrate_kbps = this->initial_adaptive_max_bitrate;
+      }
       terminate();
       display_device::revert_configuration();
 #ifdef __linux__
@@ -3515,10 +3518,12 @@ namespace proc {
       // Restore output name to its original value
       config::video.output_name = initial_display;
     }
-    config::video.color_range = initial_color_range;
-    config::video.nvenc_tune = initial_nvenc_tune;
-    config::video.max_bitrate = initial_max_bitrate;
-    config::video.adaptive_bitrate.max_bitrate_kbps = initial_adaptive_max_bitrate;
+    if (initial_video_config_saved) {
+      config::video.color_range = initial_color_range;
+      config::video.nvenc_tune = initial_nvenc_tune;
+      config::video.max_bitrate = initial_max_bitrate;
+      config::video.adaptive_bitrate.max_bitrate_kbps = initial_adaptive_max_bitrate;
+    }
 
     _app_id = -1;
     _app_name.clear();
@@ -3529,6 +3534,7 @@ namespace proc {
     initial_nvenc_tune = 0;
     initial_max_bitrate = 0;
     initial_adaptive_max_bitrate = 0;
+    initial_video_config_saved = false;
     mode_changed_display.clear();
     _launch_session.reset();
     virtual_display = false;

--- a/src/process.h
+++ b/src/process.h
@@ -123,6 +123,7 @@ namespace proc {
     int initial_nvenc_tune = 0;
     int initial_max_bitrate = 0;
     int initial_adaptive_max_bitrate = 0;
+    bool initial_video_config_saved = false;
 
     proc_t(
       boost::process::v1::environment &&env,

--- a/tests/unit/test_adaptive_bitrate.cpp
+++ b/tests/unit/test_adaptive_bitrate.cpp
@@ -70,3 +70,18 @@ TEST(AdaptiveBitrateController, ClampsBaseToConfiguredBounds) {
   EXPECT_EQ(50000, state.base_bitrate_kbps);
   EXPECT_EQ(50000, state.target_bitrate_kbps);
 }
+
+TEST(AdaptiveBitrateController, NormalizesMaxBelowMinBeforeClampingBase) {
+  config::video.adaptive_bitrate.enabled = false;
+  config::video.adaptive_bitrate.min_bitrate_kbps = 2000;
+  config::video.adaptive_bitrate.max_bitrate_kbps = 0;
+
+  adaptive_bitrate::load_config();
+  adaptive_bitrate::reset();
+  adaptive_bitrate::set_base_bitrate(30000);
+
+  const auto state = adaptive_bitrate::get_state();
+  EXPECT_GE(state.max_bitrate_kbps, state.min_bitrate_kbps);
+  EXPECT_EQ(state.min_bitrate_kbps, state.base_bitrate_kbps);
+  EXPECT_EQ(0, state.target_bitrate_kbps);
+}

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -11,16 +11,35 @@
 namespace {
   struct linux_cage_compositor_guard_t {
     linux_cage_compositor_guard_t():
+        auto_manage_displays(config::video.linux_display.auto_manage_displays),
         use_cage_compositor(config::video.linux_display.use_cage_compositor) {}
 
     ~linux_cage_compositor_guard_t() {
+      config::video.linux_display.auto_manage_displays = auto_manage_displays;
       config::video.linux_display.use_cage_compositor = use_cage_compositor;
     }
 
+    bool auto_manage_displays;
     bool use_cage_compositor;
   };
 }  // namespace
 #endif
+
+TEST(ProcessRuntimeConfigTests, InitialTerminateDoesNotResetAdaptiveBitrateMax) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t linux_guard;
+  config::video.linux_display.auto_manage_displays = false;
+  config::video.linux_display.use_cage_compositor = false;
+#endif
+  const auto original_max = config::video.adaptive_bitrate.max_bitrate_kbps;
+  config::video.adaptive_bitrate.max_bitrate_kbps = 100000;
+
+  proc::proc_t process {boost::process::v1::environment {}, {}};
+  process.terminate(false, false);
+
+  EXPECT_EQ(100000, config::video.adaptive_bitrate.max_bitrate_kbps);
+  config::video.adaptive_bitrate.max_bitrate_kbps = original_max;
+}
 
 TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {
   const auto file_path = test_paths::root() / "legacy_apps_migration.json";


### PR DESCRIPTION
## Summary
- Prevent pre-launch process teardown from restoring unsaved session video config over the active configuration.
- Normalize adaptive bitrate bounds before using them for `std::clamp()`.
- Add regression coverage for the corrupted adaptive bitrate max path that caused issue #67.

## Root Cause
A pre-launch `proc::terminate()` call could restore `config::video.adaptive_bitrate.max_bitrate_kbps` from the default unsaved value `0`. The next streaming session initialized adaptive bitrate with the normal minimum of `2000` and the corrupted maximum of `0`, then called `std::clamp()` with invalid bounds. Newer libstdc++ assertion builds abort on that condition, matching the reported coredumps.

Fixes #67

## Test Plan
- `git diff --check`
- `build-tests/tests/test_polaris_stream`
- `build-tests/tests/test_polaris_config --gtest_filter=ProcessRuntimeConfigTests.InitialTerminateDoesNotResetAdaptiveBitrateMax`

## Notes
Full `test_polaris_config` still has unrelated existing Steam cleanup expectation failures where tests expect `setsid steam -shutdown` while current code emits `setsid -f steam -shutdown`.