### PR TITLE
Fix AMD headless DMA-BUF crash, add OnePlus 12R profile, suppress fal…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ CLAUDE.md
 # build directories
 build/
 build-local/
+build-debug/
 build-test/
 build-tests/
 cmake-*/

--- a/src/device_db.cpp
+++ b/src/device_db.cpp
@@ -151,6 +151,19 @@ namespace device_db {
       "Google Pixel 9 — 1080p, 120Hz, HEVC, WiFi 6E"
     };
 
+    devices["OnePlus 12R"] = {
+      "phone", "2780x1264x120", "av1", 35000, 2, true, true, 3,
+      "OnePlus 12R (CPH2609) — 2780x1264@120Hz, Snapdragon 8 Gen 2, AV1/HEVC, HDR10+, WiFi 6E"
+    };
+    register_canonical_alias("OnePlus 12R", "OnePlus 12R");
+    register_canonical_alias("OnePlus 12r", "OnePlus 12R");
+    register_canonical_alias("OnePlus12R", "OnePlus 12R");
+    register_canonical_alias("CPH2609", "OnePlus 12R");
+    register_friendly_alias("OnePlus 12R", "OnePlus 12R");
+    register_friendly_alias("OnePlus 12r", "OnePlus 12R");
+    register_friendly_alias("OnePlus12R", "OnePlus 12R");
+    register_friendly_alias("CPH2609", "OnePlus 12R");
+
     devices["Galaxy S24"] = {
       "phone", "2340x1080x120", "hevc", 25000, 2, true, true, 3,
       "Samsung Galaxy S24 — 1080p, 120Hz, HEVC/AV1, WiFi 6E"

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1384,11 +1384,22 @@ namespace nvhttp {
       }
       if (device_profile && is_mobile_client_type(device_profile) &&
           policy_width > 1920 && policy_height > 1080 && policy_fps >= 100.0) {
-        append_stream_policy_warning(
-          warnings,
-          "high_resolution_120_mobile",
-          "This handheld/phone policy is above 1080p at 100+ FPS; 1080p120 is the safer target for steady true-headless testing."
-        );
+        // Suppress the warning when the device_db profile itself targets this
+        // resolution — the profile is the authoritative signal that the device
+        // can handle it; emitting the warning would push the AI toward a cap.
+        int db_w = 0, db_h = 0;
+        double db_fps = 0.0;
+        const bool profile_targets_this_mode =
+          !device_profile->display_mode.empty() &&
+          parse_stream_policy_display_mode(device_profile->display_mode, db_w, db_h, db_fps) &&
+          db_w >= policy_width && db_h >= policy_height && db_fps >= policy_fps;
+        if (!profile_targets_this_mode) {
+          append_stream_policy_warning(
+            warnings,
+            "high_resolution_120_mobile",
+            "This handheld/phone policy is above 1080p at 100+ FPS; 1080p120 is the safer target for steady true-headless testing."
+          );
+        }
       }
       const auto health_primary_issue = health.value("primary_issue", std::string {"steady"});
       if (health_primary_issue != "steady" && health_primary_issue != capture_reason) {

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -1414,7 +1414,27 @@ namespace wl {
     target.destroy();
 
     bool used_implicit_modifier = false;
-    if (!chosen_format.modifiers.empty()) {
+
+    // Prefer linear modifier if the compositor advertised it. Headless compositor
+    // backends using a software renderer (e.g. wlroots pixman) can't blit into
+    // tiled DMA-BUF buffers and will return frame_failed(reason=0) for any
+    // tiling modifier, even ones they advertised.
+    auto linear_it = std::find(chosen_format.modifiers.begin(), chosen_format.modifiers.end(),
+                               (std::uint64_t)DRM_FORMAT_MOD_LINEAR);
+    if (linear_it != chosen_format.modifiers.end()) {
+      std::uint64_t linear_mod = DRM_FORMAT_MOD_LINEAR;
+      target.bo = gbm_bo_create_with_modifiers2(
+        gbm_device,
+        frame_width,
+        frame_height,
+        chosen_format.format,
+        &linear_mod,
+        1,
+        GBM_BO_USE_RENDERING
+      );
+    }
+
+    if (!target.bo && !chosen_format.modifiers.empty()) {
       target.bo = gbm_bo_create_with_modifiers2(
         gbm_device,
         frame_width,
@@ -1531,6 +1551,33 @@ namespace wl {
     }
 
     capture(display);
+
+    // reason=0 means the compositor's renderer couldn't process the buffer
+    // (e.g. wlroots pixman renderer with a tiled AMD modifier). Try again
+    // forcing a linear modifier — even if not explicitly advertised, most
+    // compositors accept DRM_FORMAT_MOD_LINEAR via zwp_linux_dmabuf_v1.
+    if (status == REINIT && probe_failed_unknown_) {
+      probe_failed_unknown_ = false;
+      BOOST_LOG(info) << "Extcopy DMA-BUF: retrying probe with linear modifier after reason=0 failure"sv;
+      for (auto &f : frames) f.destroy();
+
+      // Inject linear into the modifier list so allocate_buffer prefers it,
+      // even if the compositor did not advertise it in the session constraints.
+      bool injected_linear = false;
+      if (std::find(chosen_format.modifiers.begin(), chosen_format.modifiers.end(),
+                    (std::uint64_t)DRM_FORMAT_MOD_LINEAR) == chosen_format.modifiers.end()) {
+        chosen_format.modifiers.insert(chosen_format.modifiers.begin(), DRM_FORMAT_MOD_LINEAR);
+        injected_linear = true;
+      }
+
+      status = WAITING;
+      capture(display);
+
+      if (injected_linear) {
+        chosen_format.modifiers.erase(chosen_format.modifiers.begin());
+      }
+    }
+
     return status == READY ? 0 : -1;
   }
 
@@ -1734,6 +1781,7 @@ namespace wl {
 
   void extcopy_t::frame_failed(ext_image_copy_capture_frame_v1 *frame, std::uint32_t reason) {
     BOOST_LOG(error) << "Extcopy DMA-BUF frame capture failed: reason="sv << reason;
+    if (reason == 0) probe_failed_unknown_ = true;
     destroy_capture_frame();
     status = REINIT;
   }

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -251,6 +251,7 @@ namespace wl {
     bool chosen_format_valid {false};
     bool buffer_create_done {false};
     bool buffer_create_success {false};
+    bool probe_failed_unknown_ {false};  ///< frame_failed(reason=0) fired during init probe
     std::uint32_t frame_width {0};
     std::uint32_t frame_height {0};
     dev_t device_id {};


### PR DESCRIPTION
## Summary

Fix AMD headless DMA-BUF crash, add OnePlus 12R profile, suppress false fps warning

### wayland: fix extcopy DMA-BUF crash on AMD with tiled modifiers

On headless compositors using a software renderer (wlroots pixman), tiled DMA-BUF modifiers advertised in the session constraints cause the compositor to return frame_failed(reason=0) because it cannot blit into tiled buffers. Without a recovery path, this triggers an infinite REINIT loop that crashes the streaming session roughly 60 seconds in.

Two-part fix in the ext_image_copy_capture (extcopy) path:

1. Prefer DRM_FORMAT_MOD_LINEAR when allocating the GBM buffer if the compositor advertised it in the format constraints, before falling back to the full modifier list. This avoids the frame_failed in the first place on compositors that advertise linear alongside tiled modifiers.

2. Track a new probe_failed_unknown_ flag in extcopy_t. When frame_failed fires with reason=0 during the init probe, the flag is set and the probe loop injects DRM_FORMAT_MOD_LINEAR into the modifier list and retries. This recovers sessions where linear was not explicitly advertised but the compositor still accepts it (common on headless AMD + labwc).

Note: the existing PR #61 (76c9bb1) added the same linear-preference logic to the zwlr_screencopy path. This change applies the equivalent fix to the newer ext_image_copy_capture path used for headless labwc streaming.

### device_db: add OnePlus 12R profile

Add a curated device profile for the OnePlus 12R (model CPH2609).

### nvhttp: suppress high_resolution_120_mobile warning for profiled devices

The high_resolution_120_mobile stream-policy warning fires for any phone or handheld client streaming above 1920×1080 at ≥100 fps, and was being passed to the AI optimization prompt. The AI would interpret it as a signal to cap the stream below 120fps (the OnePlus 12R was consistently recommended at 90fps despite having a cached optimization of 2780×1264×120).

The warning is now suppressed when the device_db profile for the connected device explicitly targets a resolution and frame rate that meets or exceeds the active stream parameters. If the device has a curated profile saying it can handle the mode, the warning adds no useful signal and only pushes the AI toward a conservative cap.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [x] I included screenshots or recordings for visible UI changes, when practical.
- [x] I updated docs or release notes when user-facing behavior changed.

## Notes

