### PR TITLE
fix: force LC_ALL=C when calling pactl to parse audio sink info

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -4311,7 +4311,7 @@ namespace confighttp {
     // Query audio via pactl (PipeWire/PulseAudio)
     {
       nlohmann::json audio;
-      FILE *apipe = popen("pactl info 2>/dev/null", "r");
+      FILE *apipe = popen("LC_ALL=C pactl info 2>/dev/null", "r");
       if (apipe) {
         char buf[512];
         while (fgets(buf, sizeof(buf), apipe)) {


### PR DESCRIPTION
## Summary
Dashboard "No host audio sink" false warning

The system-stats endpoint in `confighttp.cpp` runs `pactl info` and parses the output by matching English key names ("Default Sink", "Default Source", "Server Name"). On systems with a non-English locale the keys are translated (e.g. "Destination par défaut" in French), causing all three fields to silently go unmatched and `audio.sink` to remain empty — which the dashboard interprets as no audio device present.

Prepending `LC_ALL=C` to the `popen` call forces `pactl` to output in the invariant C locale regardless of the user's system locale, making the key matching reliable on all systems.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [x] I included screenshots or recordings for visible UI changes, when practical.
- [x] I updated docs or release notes when user-facing behavior changed.

## Notes

Before
<img width="788" height="323" alt="image" src="https://github.com/user-attachments/assets/7e8a7efb-3068-43a7-b47c-867991c8ff2a" />

After
<img width="770" height="314" alt="image" src="https://github.com/user-attachments/assets/025047f3-755f-49cc-8771-77e72af45d94" />

