### PR TITLE
Honor paired client bitrate in optimize

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -143,6 +143,21 @@ namespace nvhttp {
       return value;
     }
 
+    std::optional<int> select_paired_client_launch_bitrate(
+        const std::optional<int> &target_bitrate_kbps,
+        int paired_bitrate_kbps,
+        bool applied_history_safe) {
+      if (paired_bitrate_kbps <= 0) {
+        return target_bitrate_kbps;
+      }
+
+      if (applied_history_safe && target_bitrate_kbps) {
+        return std::min(*target_bitrate_kbps, paired_bitrate_kbps);
+      }
+
+      return paired_bitrate_kbps;
+    }
+
     bool ai_auto_quality_enabled() {
       return ai_optimizer::is_enabled();
     }
@@ -1991,6 +2006,19 @@ namespace nvhttp {
       return health;
     }
   }  // namespace
+
+#ifdef POLARIS_TESTS
+  std::optional<int> select_paired_client_launch_bitrate_for_tests(
+      const std::optional<int> &target_bitrate_kbps,
+      int paired_bitrate_kbps,
+      bool applied_history_safe) {
+    return select_paired_client_launch_bitrate(
+      target_bitrate_kbps,
+      paired_bitrate_kbps,
+      applied_history_safe
+    );
+  }
+#endif
 
 #ifdef __linux__
   namespace {
@@ -5827,18 +5855,15 @@ namespace nvhttp {
 
       if (named_cert_p->target_bitrate_kbps > 0) {
         const int paired_bitrate = named_cert_p->target_bitrate_kbps;
-        const auto optimization_confidence = lower_copy(output.value("confidence", std::string {}));
-        const auto optimization_source = lower_copy(output.value("source", std::string {}));
-        const bool optimizer_can_raise_bitrate =
-          optimization_confidence == "high" &&
-          optimization_source.find("history_safe") == std::string::npos;
-        const int selected_bitrate = target_bitrate_kbps ?
-          (optimizer_can_raise_bitrate ? *target_bitrate_kbps : std::min(*target_bitrate_kbps, paired_bitrate)) :
-          paired_bitrate;
-        if (!target_bitrate_kbps || *target_bitrate_kbps != selected_bitrate) {
+        const auto selected_bitrate = select_paired_client_launch_bitrate(
+          target_bitrate_kbps,
+          paired_bitrate,
+          applied_history_safe
+        );
+        if (selected_bitrate && (!target_bitrate_kbps || *target_bitrate_kbps != *selected_bitrate)) {
           target_bitrate_kbps = selected_bitrate;
-          effective_optimization.target_bitrate_kbps = selected_bitrate;
-          output["target_bitrate_kbps"] = selected_bitrate;
+          effective_optimization.target_bitrate_kbps = *selected_bitrate;
+          output["target_bitrate_kbps"] = *selected_bitrate;
           append_normalization_reason(
             "Aligned launch optimization bitrate to the paired client profile."
           );

--- a/tests/unit/test_stream.cpp
+++ b/tests/unit/test_stream.cpp
@@ -5,11 +5,20 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace stream {
   void concat_and_insert_into(std::vector<uint8_t> &result, uint64_t insert_size, uint64_t slice_size, const std::string_view &data1, const std::string_view &data2);
+}
+
+namespace nvhttp {
+  std::optional<int> select_paired_client_launch_bitrate_for_tests(
+    const std::optional<int> &target_bitrate_kbps,
+    int paired_bitrate_kbps,
+    bool applied_history_safe
+  );
 }
 
 namespace {
@@ -44,4 +53,26 @@ TEST(ConcatAndInsertTests, ConcatSmallStrideTest) {
   auto res = concat_and_insert(1, 1, std::string_view {b1, sizeof(b1)}, std::string_view {b2, sizeof(b2)});
   auto expected = std::vector<uint8_t> {0, 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e'};
   ASSERT_EQ(res, expected);
+}
+
+TEST(NvhttpOptimizerTests, PairedClientLaunchBitrateOverridesCachedLowerOptimizerTarget) {
+  const auto selected = nvhttp::select_paired_client_launch_bitrate_for_tests(
+    25000,
+    80000,
+    false
+  );
+
+  ASSERT_TRUE(selected.has_value());
+  EXPECT_EQ(*selected, 80000);
+}
+
+TEST(NvhttpOptimizerTests, PairedClientLaunchBitrateKeepsHistorySafeRecoveryCap) {
+  const auto selected = nvhttp::select_paired_client_launch_bitrate_for_tests(
+    25000,
+    80000,
+    true
+  );
+
+  ASSERT_TRUE(selected.has_value());
+  EXPECT_EQ(*selected, 25000);
 }


### PR DESCRIPTION
## Summary
- Make paired-client bitrate overrides authoritative in `/polaris/v1/optimize` for launch profile selection.
- Preserve history-safe recovery caps when Polaris is explicitly applying a recovery fallback.
- Add regression coverage for cached 25 Mbps optimizer output plus an 80 Mbps paired client target.

## Validation
- `./build-tests/tests/test_polaris_stream --gtest_color=no`
- `cmake --build build-cuda --target polaris -j$(nproc)`
- Retroid 6 smoke with SFE=2: SDP advertised `2560x1440@120` and `configuredBitrateKbps:80000`; Nova decoder configured/output at `2560x1440`, `frame-rate=120`; `nvidia-smi encodersessions` showed H.265 `2560x1440`.