### PR TITLE
Fix Linux lock session unlock fallback

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ Feature release focused on the Polaris web console, Library workflows, safer pai
 - Added a server-authoritative `Game Control` pairing access preset for QR/OTP and manual PIN pairing, granting list/view/launch plus input permissions without clipboard, file transfer, or server-command access
 - Labeled paired clients with the exact Game Control permission mask as `Game Control` instead of `Custom Access`
 - Hardened NVENC split-frame defaults by explicitly passing FFmpeg's disabled split-frame value when split-frame encoding is disabled
+- Improved Linux lock-screen dismissal so Polaris falls back from a systemd manager session to the graphical login session before running `loginctl unlock-session`
 - Added web, pairing, and video regression coverage for the new access preset and split-frame default behavior
 
 ## v1.0.18

--- a/src/platform/linux/session_manager.cpp
+++ b/src/platform/linux/session_manager.cpp
@@ -26,6 +26,7 @@
 #ifdef POLARIS_TESTS
   #include <functional>
 #endif
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -108,10 +109,72 @@ namespace session_manager {
     return !is_screen_locked();
   }
 
+  struct loginctl_session_t {
+    std::string id;
+    std::string user;
+    std::string seat;
+    std::string session_class;
+    bool valid = false;
+
+    bool is_graphical_user_session(std::string_view current_user) const {
+      return valid &&
+             session_class == "user" &&
+             !seat.empty() &&
+             seat != "-" &&
+             (current_user.empty() || user == current_user);
+    }
+  };
+
+  static loginctl_session_t parse_loginctl_session_line(const std::string &line) {
+    loginctl_session_t session;
+    std::string uid;
+    std::string leader;
+    std::istringstream input {line};
+    if (input >> session.id >> uid >> session.user >> session.seat >> leader >> session.session_class) {
+      session.valid = true;
+    }
+    return session;
+  }
+
+  static std::string select_loginctl_session_for_unlock() {
+    const char *env_session_id = std::getenv("XDG_SESSION_ID");
+    const std::string xdg_session_id =
+      (env_session_id && env_session_id[0] != '\0') ? env_session_id : "";
+    const char *env_user = std::getenv("USER");
+    const std::string current_user = (env_user && env_user[0] != '\0') ? env_user : "";
+
+    auto sessions = exec("loginctl list-sessions --no-legend 2>/dev/null");
+    std::istringstream lines {sessions};
+    std::string line;
+    std::string graphical_session_id;
+    bool xdg_session_is_graphical = false;
+
+    while (std::getline(lines, line)) {
+      const auto session = parse_loginctl_session_line(line);
+      if (!session.is_graphical_user_session(current_user)) {
+        continue;
+      }
+      if (graphical_session_id.empty()) {
+        graphical_session_id = session.id;
+      }
+      if (!xdg_session_id.empty() && session.id == xdg_session_id) {
+        xdg_session_is_graphical = true;
+      }
+    }
+
+    if (xdg_session_is_graphical) {
+      return xdg_session_id;
+    }
+    if (!graphical_session_id.empty()) {
+      return graphical_session_id;
+    }
+    return xdg_session_id;
+  }
+
   static bool unlock_with_loginctl() {
-    const char *session_id = std::getenv("XDG_SESSION_ID");
+    const std::string session_id = select_loginctl_session_for_unlock();
     std::string cmd;
-    if (session_id && session_id[0] != '\0') {
+    if (!session_id.empty()) {
       BOOST_LOG(info) << "session_manager: Attempting loginctl unlock for session "sv << session_id;
       cmd = "loginctl unlock-session " + shell_quote(session_id) + " 2>/dev/null";
     } else {

--- a/tests/unit/platform/test_session_manager.cpp
+++ b/tests/unit/platform/test_session_manager.cpp
@@ -20,6 +20,8 @@ namespace {
     bool dbus_clears_lock = false;
     bool loginctl_run_ok = true;
     bool loginctl_clears_lock = false;
+    std::string loginctl_command_that_clears;
+    std::string loginctl_list_sessions_output;
     std::vector<std::string> run_commands;
 
     SessionManagerCommandHarness() {
@@ -27,6 +29,9 @@ namespace {
         [this](const std::string &cmd) {
           if (cmd.find("org.freedesktop.ScreenSaver.GetActive") != std::string::npos) {
             return locked ? std::string {"true"} : std::string {"false"};
+          }
+          if (cmd.find("loginctl list-sessions") != std::string::npos) {
+            return loginctl_list_sessions_output;
           }
           return std::string {};
         },
@@ -41,7 +46,10 @@ namespace {
 
           if (cmd.find("loginctl unlock-session") != std::string::npos ||
               cmd.find("loginctl unlock-sessions") != std::string::npos) {
-            if (loginctl_run_ok && loginctl_clears_lock) {
+            const bool clears_expected_session =
+              loginctl_command_that_clears.empty() ||
+              cmd.find(loginctl_command_that_clears) != std::string::npos;
+            if (loginctl_run_ok && loginctl_clears_lock && clears_expected_session) {
               locked = false;
             }
             return loginctl_run_ok;
@@ -97,6 +105,24 @@ TEST(SessionManagerUnlockTests, DbusSuccessStillLockedUsesSessionLoginctlFallbac
   EXPECT_FALSE(harness.locked);
   EXPECT_TRUE(harness.ran("org.freedesktop.ScreenSaver.SetActive"));
   EXPECT_TRUE(harness.ran("loginctl unlock-session 'alpha'\\''beta'"));
+}
+
+TEST(SessionManagerUnlockTests, ManagerSessionIdFallsBackToGraphicalLoginctlSession) {
+  SessionManagerCommandHarness harness;
+  harness.loginctl_clears_lock = true;
+  harness.loginctl_command_that_clears = "loginctl unlock-session '1'";
+  const char *user = std::getenv("USER");
+  ASSERT_NE(nullptr, user);
+  harness.loginctl_list_sessions_output =
+    "1 1000 " + std::string {user} + " seat0 2134 user tty1 no -\n"
+    "2 1000 " + std::string {user} + " - 2197 manager - no -";
+  setenv("XDG_SESSION_ID", "2", 1);
+
+  EXPECT_TRUE(session_manager::unlock_screen());
+
+  EXPECT_FALSE(harness.locked);
+  EXPECT_TRUE(harness.ran("loginctl unlock-session '1'"));
+  EXPECT_FALSE(harness.ran("loginctl unlock-session '2'"));
 }
 
 TEST(SessionManagerUnlockTests, MissingSessionIdUsesAllSessionsLoginctlFallback) {


### PR DESCRIPTION
## Summary
- Select a graphical user session for `loginctl unlock-session` instead of blindly using `XDG_SESSION_ID`.
- Cover the systemd user-manager session case where `XDG_SESSION_ID` points at a non-graphical manager session.
- Update the 1.1.0 changelog with the Linux lock-screen fallback fix.

## Validation
- `cmake --build build --target polaris test_polaris_platform -j2 && ./build/tests/test_polaris_platform --gtest_filter='SessionManagerUnlockTests.*'`
- Rebased on current `polaris/master`; the rebuilt `build/polaris` hash matches the deployed `/usr/bin/polaris-1.1.0.session-unlock` binary.
- Local live unlock smoke with Nova's paired client cert: `loginctl lock-session 1` made `GetActive` return `b true`; `POST https://127.0.0.1:47990/api/polaris/unlock` returned `{\"success\":true,\"was_locked\":true}`; `GetActive` returned `b false` afterward.
- `journalctl --user -u polaris.service` confirmed D-Bus unlock stayed locked, then Polaris selected `loginctl unlock-session 1` and dismissed the lock screen.