### PR TITLE
Fix headless extcopy fallback validation

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -489,6 +489,13 @@ namespace cage_display_router {
     headless_extcopy_dmabuf_probe_result.store(supported ? 2 : 1);
   }
 
+  bool headless_extcopy_dmabuf_probe_succeeded(
+    bool capture_initialized,
+    bool live_gpu_frame_converted
+  ) {
+    return capture_initialized && live_gpu_frame_converted;
+  }
+
   bool should_report_headless_ram_capture_fallback(const platf::runtime_state_t &runtime_state) {
     return runtime_state.effective_headless ||
            (runtime_state.requested_headless && !runtime_state.gpu_native_override_active);

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -158,6 +158,15 @@ namespace cage_display_router {
   void update_headless_extcopy_dmabuf_probe_result(bool supported);
 
   /**
+   * @brief Returns whether the headless extcopy DMA-BUF probe has validated
+   *        enough of the path to be selected for a real stream.
+   */
+  bool headless_extcopy_dmabuf_probe_succeeded(
+    bool capture_initialized,
+    bool live_gpu_frame_converted
+  );
+
+  /**
    * @brief Returns whether RAM-capture fallback logging should describe the
    *        current labwc runtime as headless.
    */

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -60,11 +60,15 @@ namespace gl {
     return std::filesystem::path {POLARIS_SHADERS_DIR} / std::string {shader_name};
   }
 
-  void drain_errors(const std::string_view &prefix) {
+  bool drain_errors(const std::string_view &prefix) {
     GLenum err;
+    bool drained = false;
     while ((err = ctx.GetError()) != GL_NO_ERROR) {
+      drained = true;
       BOOST_LOG(error) << "GL: "sv << prefix << ": ["sv << util::hex(err).to_string_view() << ']';
     }
+
+    return drained;
   }
 
   tex_t::~tex_t() {
@@ -586,7 +590,9 @@ namespace egl {
 
     gl::ctx.BindTexture(GL_TEXTURE_2D, 0);
 
-    gl_drain_errors;
+    if (gl_drain_errors) {
+      return std::nullopt;
+    }
 
     return rgb;
   }

--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -36,7 +36,7 @@ using frame_t = util::safe_ptr<AVFrame, free_frame>;
 
 namespace gl {
   extern GladGLContext ctx;
-  void drain_errors(const std::string_view &prefix);
+  bool drain_errors(const std::string_view &prefix);
 
   class tex_t: public util::buffer_t<GLuint> {
     using util::buffer_t<GLuint>::buffer_t;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2908,9 +2908,18 @@ namespace proc {
         return false;
       }
 
-      if (cage_display_router::cached_headless_extcopy_dmabuf_probe_result() != std::optional<bool> {true}) {
+      const bool extcopy_initialized =
+        cage_display_router::cached_headless_extcopy_dmabuf_probe_result() == std::optional<bool> {true};
+      const bool live_gpu_frame_converted =
+        extcopy_initialized && video::active_encoder_runtime_supports_live_gpu_capture(gpu_native_probe_config);
+
+      if (!cage_display_router::headless_extcopy_dmabuf_probe_succeeded(extcopy_initialized, live_gpu_frame_converted)) {
         cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
-        BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not initialize DMA-BUF capture"sv;
+        if (!extcopy_initialized) {
+          BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not initialize DMA-BUF capture"sv;
+        } else {
+          BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not validate live GPU frame conversion"sv;
+        }
         return false;
       }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -4626,9 +4626,28 @@ namespace video {
           << "Live GPU capture probe fell back to transport="sv << platf::from_frame_transport(metadata.transport)
           << " residency="sv << platf::from_frame_residency(metadata.residency)
           << " format="sv << platf::from_frame_format(metadata.format);
+        return false;
       }
 
-      return gpu_native;
+      auto frame = make_frame(std::move(captured_img));
+      auto encode_device = make_encode_device(*disp, *chosen_encoder, config);
+      if (!encode_device) {
+        BOOST_LOG(debug) << "Live GPU capture probe could not create an encode device for conversion validation"sv;
+        return false;
+      }
+
+      auto session = make_encode_session(disp.get(), *chosen_encoder, config, frame.width, frame.height, std::move(encode_device));
+      if (!session) {
+        BOOST_LOG(debug) << "Live GPU capture probe could not create an encode session for conversion validation"sv;
+        return false;
+      }
+
+      if (session->convert(frame)) {
+        BOOST_LOG(debug) << "Live GPU capture probe received a DMA-BUF frame but conversion failed"sv;
+        return false;
+      }
+
+      return true;
     }
 
     return false;

--- a/src/video.h
+++ b/src/video.h
@@ -521,10 +521,11 @@ namespace video {
   bool active_encoder_runtime_supports_config(const config_t &config);
 
   /**
-   * @brief Validate that the active encoder can capture at least one live GPU-native frame right now.
+   * @brief Validate that the active encoder can capture and convert at least one live GPU-native frame right now.
    * @details This is intended for runtime probes where a dummy encode session is not enough and we need
-   *          to confirm that the current display path is actually delivering DMA-BUF resident frames.
-   * @return True when a live frame arrives with DMA-BUF transport and GPU residency.
+   *          to confirm that the current display path is actually delivering DMA-BUF resident frames
+   *          that survive the active encoder conversion path.
+   * @return True when a live frame arrives with DMA-BUF transport/GPU residency and converts successfully.
    */
   bool active_encoder_runtime_supports_live_gpu_capture(const config_t &config);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ set(TEST_PLATFORM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_common.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_cage_display_router.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_cuda_gl_encode_device.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_graphics.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_session_manager.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_virtual_display.cpp
 )

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -180,6 +180,12 @@ TEST(CageDisplayRouterPolicyTests, HeadlessExtcopyDmabufProbeResultCachesSuccess
   EXPECT_EQ(cage_display_router::cached_headless_extcopy_dmabuf_probe_result(), std::optional<bool> {true});
 }
 
+TEST(CageDisplayRouterPolicyTests, HeadlessExtcopyDmabufProbeRequiresLiveFrameConversion) {
+  EXPECT_FALSE(cage_display_router::headless_extcopy_dmabuf_probe_succeeded(false, false));
+  EXPECT_FALSE(cage_display_router::headless_extcopy_dmabuf_probe_succeeded(true, false));
+  EXPECT_TRUE(cage_display_router::headless_extcopy_dmabuf_probe_succeeded(true, true));
+}
+
 TEST(CageDisplayRouterPolicyTests, MangoHudPrefixIsSuppressedForSteamBigPicture) {
   EXPECT_TRUE(cage_display_router::mangohud_prefix_for_command_for_tests(
     "steam -gamepadui",

--- a/tests/unit/platform/test_graphics.cpp
+++ b/tests/unit/platform/test_graphics.cpp
@@ -1,0 +1,37 @@
+/**
+ * @file tests/unit/platform/test_graphics.cpp
+ * @brief Test Linux OpenGL helper behavior used by DMA-BUF capture.
+ */
+#include "../../tests_common.h"
+
+#ifdef __linux__
+  #include <glad/gl.h>
+  #include <src/platform/linux/graphics.h>
+
+namespace {
+  GLenum fake_gl_error_once() {
+    static int calls = 0;
+    return calls++ == 0 ? GL_INVALID_OPERATION : GL_NO_ERROR;
+  }
+
+  GLenum fake_gl_no_error() {
+    return GL_NO_ERROR;
+  }
+}  // namespace
+
+TEST(GraphicsTests, DrainErrorsReportsWhetherAnyErrorWasDrained) {
+  const auto original_get_error = gl::ctx.GetError;
+
+  gl::ctx.GetError = fake_gl_no_error;
+  EXPECT_FALSE(gl::drain_errors("test"));
+
+  gl::ctx.GetError = fake_gl_error_once;
+  EXPECT_TRUE(gl::drain_errors("test"));
+
+  gl::ctx.GetError = original_get_error;
+}
+#else
+TEST(GraphicsTests, LinuxOnly) {
+  GTEST_SKIP() << "Linux-only test";
+}
+#endif


### PR DESCRIPTION
## Summary
- Require the headless extcopy DMA-BUF probe to validate live GPU frame conversion before selecting the true-headless path.
- Treat GL errors during DMA-BUF source import as import failure instead of returning a bad texture.
- Add platform coverage for the stricter probe policy and GL error draining behavior.

## Root Cause
Discussion #78 showed a Headless Stream session on NVIDIA where H.264/SDR still black-screened while Desktop Display worked. The runtime selected `headless_extcopy_dmabuf` after the capture path initialized, but the later DMA-BUF GL import/conversion path hit GL `00000502`, leaving the client with black video instead of falling back.

## Test Plan
- `git diff --check`
- `cmake --build build --target test_polaris_platform -j2`
- `./build/tests/test_polaris_platform`
- `cmake --build build --target test_polaris_video -j2`
- `./build/tests/test_polaris_video`
- `cmake --build build --target polaris -j2`