### PR TITLE
fix(input): guard touchport clamp bounds

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -520,6 +520,39 @@ namespace input {
     platf::move_mouse(platf_input, util::endian::big(packet->deltaX), util::endian::big(packet->deltaY));
   }
 
+  std::optional<std::pair<float, float>> map_client_to_touchport(
+    const touch_port_t &touch_port,
+    const std::pair<float, float> &val,
+    const std::pair<float, float> &size
+  ) {
+    if (!touch_port || size.first <= 0.0f || size.second <= 0.0f || touch_port.scalar_inv <= 0.0f) {
+      return std::nullopt;
+    }
+
+    const auto scalarX = touch_port.width / size.first;
+    const auto scalarY = touch_port.height / size.second;
+    if (!std::isfinite(scalarX) || !std::isfinite(scalarY) || scalarX <= 0.0f || scalarY <= 0.0f) {
+      return std::nullopt;
+    }
+
+    const auto offsetX = touch_port.client_offsetX;
+    const auto offsetY = touch_port.client_offsetY;
+    const auto upperX = touch_port.width - offsetX;
+    const auto upperY = touch_port.height - offsetY;
+    if (!std::isfinite(offsetX) || !std::isfinite(offsetY) || !std::isfinite(upperX) || !std::isfinite(upperY) ||
+        offsetX < 0.0f || offsetY < 0.0f || offsetX > upperX || offsetY > upperY) {
+      return std::nullopt;
+    }
+
+    float x = std::clamp(val.first, 0.0f, size.first) * scalarX;
+    float y = std::clamp(val.second, 0.0f, size.second) * scalarY;
+
+    x = std::clamp(x, offsetX, upperX);
+    y = std::clamp(y, offsetY, upperY);
+
+    return std::pair {(x - offsetX) * touch_port.scalar_inv, (y - offsetY) * touch_port.scalar_inv};
+  }
+
   /**
    * @brief Converts client coordinates on the specified surface into screen coordinates.
    * @param input The input context.
@@ -538,19 +571,11 @@ namespace input {
       return std::nullopt;
     }
 
-    auto scalarX = touch_port.width / size.first;
-    auto scalarY = touch_port.height / size.second;
-
-    float x = std::clamp(val.first, 0.0f, size.first) * scalarX;
-    float y = std::clamp(val.second, 0.0f, size.second) * scalarY;
-
-    auto offsetX = touch_port.client_offsetX;
-    auto offsetY = touch_port.client_offsetY;
-
-    x = std::clamp(x, offsetX, (size.first * scalarX) - offsetX);
-    y = std::clamp(y, offsetY, (size.second * scalarY) - offsetY);
-
-    return std::pair {(x - offsetX) * touch_port.scalar_inv, (y - offsetY) * touch_port.scalar_inv};
+    auto mapped = map_client_to_touchport(touch_port, val, size);
+    if (!mapped) {
+      BOOST_LOG(warning) << "Ignoring absolute input with invalid touch port bounds"sv;
+    }
+    return mapped;
   }
 
   /**

--- a/src/input.h
+++ b/src/input.h
@@ -6,6 +6,7 @@
 
 // standard includes
 #include <functional>
+#include <optional>
 
 // local includes
 #include "platform/common.h"
@@ -38,6 +39,19 @@ namespace input {
       return width != 0 && height != 0 && env_width != 0 && env_height != 0;
     }
   };
+
+  /**
+   * @brief Convert client coordinates on the specified surface into touchport coordinates.
+   * @param touch_port The active touchport mapping.
+   * @param val The cartesian coordinate pair to convert.
+   * @param size The size of the client's surface containing the value.
+   * @return The host-relative coordinate pair if the mapping bounds are valid.
+   */
+  std::optional<std::pair<float, float>> map_client_to_touchport(
+    const touch_port_t &touch_port,
+    const std::pair<float, float> &val,
+    const std::pair<float, float> &size
+  );
 
   /**
    * @brief Scale the ellipse axes according to the provided size.

--- a/tests/unit/test_mouse.cpp
+++ b/tests/unit/test_mouse.cpp
@@ -4,7 +4,36 @@
  */
 #include "../tests_common.h"
 
+#include <optional>
+
 #include <src/input.h>
+
+TEST(InputTouchPortMapping, RejectsNonPositiveClientSurfaceDimensions) {
+  input::touch_port_t touch_port {
+    {0, 0, 1920, 1080},
+    1920,
+    1080,
+    0.0f,
+    0.0f,
+    1.0f
+  };
+
+  EXPECT_EQ(std::nullopt, input::map_client_to_touchport(touch_port, {50.0f, 50.0f}, {0.0f, 100.0f}));
+  EXPECT_EQ(std::nullopt, input::map_client_to_touchport(touch_port, {50.0f, 50.0f}, {100.0f, -1.0f}));
+}
+
+TEST(InputTouchPortMapping, RejectsInvertedLetterboxBounds) {
+  input::touch_port_t touch_port {
+    {0, 0, 100, 100},
+    100,
+    100,
+    80.0f,
+    0.0f,
+    1.0f
+  };
+
+  EXPECT_EQ(std::nullopt, input::map_client_to_touchport(touch_port, {50.0f, 50.0f}, {100.0f, 100.0f}));
+}
 
 struct MouseHIDTest: PlatformTestSuite, testing::WithParamInterface<util::point_t> {
   void SetUp() override {


### PR DESCRIPTION
## Summary
- audits `std::clamp` call sites for runtime/config/client-derived inverted bounds
- extracts touchport coordinate mapping behind a small guard helper
- rejects invalid client surface dimensions or inverted letterbox/touchport bounds before clamping, with warning logging from the input path
- adds focused input unit coverage for the invalid-bound cases

## Audit notes
- Adaptive bitrate dynamic min/max clamps are already normalized by `adaptive_bitrate::load_config()` and covered by existing stream tests.
- Browser Stream pointer dimensions are guarded before clamping; AI/session bitrate clamps use fixed bounds or `std::max()`-normalized upper bounds.
- Linux Wayland virtual input absolute movement guards non-positive touchport dimensions before clamping.
- The realistic remaining Linux runtime/client path with invertible clamp bounds was touchport coordinate mapping in `src/input.cpp` when surface dimensions or letterbox offsets are invalid.

## Test plan
- `cmake --build build --target test_polaris_input -j"$(nproc)"`
- `ctest --test-dir build --output-on-failure -R test_polaris_input`
- `ctest --test-dir build --output-on-failure -R 'test_polaris_(input|stream)'`

Fixes #84
