### PR TITLE
ci: add sanitizer unit test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,57 @@ jobs:
           path: web-ui-build.tar.gz
           if-no-files-found: error
 
+  cpp-sanitizer-tests:
+    name: C++ sanitizer tests
+    runs-on: ubuntu-24.04
+    env:
+      ASAN_OPTIONS: detect_leaks=0:halt_on_error=1:strict_string_checks=1
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake ninja-build \
+            libboost-all-dev libssl-dev libevdev-dev \
+            libpulse-dev libopus-dev libcurl4-openssl-dev \
+            libdrm-dev libgbm-dev libcap-dev libwayland-dev \
+            libpipewire-0.3-dev libx11-dev libxrandr-dev \
+            libxfixes-dev libxi-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev \
+            libva-dev libminiupnpc-dev libnotify-dev nlohmann-json3-dev \
+            libappindicator3-dev libgtk-3-dev \
+            libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
+            nodejs npm wayland-protocols
+
+      - name: Configure sanitizer build
+        run: |
+          cmake -B build-sanitize -G Ninja \
+            -DBUILD_TESTS=ON \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all' \
+            -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all' \
+            -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address,undefined' \
+            -DPOLARIS_ENABLE_CUDA=OFF \
+            -DPOLARIS_ENABLE_BROWSER_STREAM=OFF \
+            -DCUDA_FAIL_ON_MISSING=OFF
+
+      - name: Build sanitizer unit tests
+        run: cmake --build build-sanitize --target test_polaris -j"$(nproc)"
+
+      - name: Run sanitizer unit tests
+        run: ctest --test-dir build-sanitize/tests --output-on-failure -R '^test_polaris$'
+
   arch-build:
     name: Arch build
     needs: web-checks
@@ -820,6 +871,7 @@ jobs:
       - arch-build
       - ubuntu-build
       - fedora-rpm-build
+      - cpp-sanitizer-tests
     if: ${{ startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '' }}
     runs-on: ubuntu-24.04
     permissions:

--- a/docs/building.md
+++ b/docs/building.md
@@ -152,6 +152,27 @@ checkout yourself.
 - Use `scripts/dev-clean.sh git-prune --apply` after deleting branches, stashes, or worktrees to prune stale remote refs, worktree metadata, and unreachable Git objects.
 - Use `scripts/dev-clean.sh nuke-local-builds --apply` when you intentionally want to reset generated build outputs plus `node_modules/`.
 
+### C++ sanitizer check
+
+The `C++ sanitizer tests` CI job runs the fast C++ unit-test target under AddressSanitizer and
+UndefinedBehaviorSanitizer. To mirror it locally, use a throwaway Debug build tree:
+
+```bash
+cmake -B build-sanitize -G Ninja \
+  -DBUILD_TESTS=ON \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all' \
+  -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all' \
+  -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address,undefined' \
+  -DPOLARIS_ENABLE_CUDA=OFF \
+  -DPOLARIS_ENABLE_BROWSER_STREAM=OFF \
+  -DCUDA_FAIL_ON_MISSING=OFF
+cmake --build build-sanitize --target test_polaris -j"$(nproc)"
+ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:strict_string_checks=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+  ctest --test-dir build-sanitize/tests --output-on-failure -R '^test_polaris$'
+```
+
 ## Packaging
 
 The public release assets are currently:


### PR DESCRIPTION
## Summary
- Add a targeted `C++ sanitizer tests` GitHub Actions job for the fast Linux C++ unit test target
- Run the job with ASan/UBSan, frame pointers, and non-recovering sanitizer failures
- Document the matching local `build-sanitize` command in `docs/building.md`

## Test Plan
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` to validate workflow YAML and inspect jobs
- `git diff --check`
- Attempted local sanitizer configure; blocked on this Fedora host because `libasan`/`libubsan` runtime packages are not installed locally. The CI job uses Ubuntu 24.04 `build-essential`, which should provide the matching sanitizer runtimes.

Closes #85
