### PR TITLE
docs: document headless fallback diagnostics

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -59,6 +59,26 @@ Important runtime fields:
 
 Deferred headless encoder capabilities are primed before first launch negotiation so Main10 support is advertised correctly on the first real launch. On Linux, Polaris uses RealtimeKit when available so thread-priority elevation can still succeed when the user service inherits conservative limits.
 
+## Linux LTS Headless Fallback Matrix
+
+The 1.1.x validation target is the existing labwc Headless Stream architecture, not an Xvfb or gamescope replacement. Use Xvfb/gamescope only as investigation tools if this matrix exposes a real target environment that the current path cannot cover.
+
+| Environment | Expected runtime | Expected capture decision | Required packages / caveats |
+|---|---|---|---|
+| Ubuntu 24.04 LTS | `labwc` private Wayland session, `HEADLESS-1`, `requested_headless=true`, `effective_headless=true` | Prefer `headless_extcopy_dmabuf` when wlroots/ext-image-copy and the encoder import path expose DMA-BUF; otherwise `headless_shm_fallback` is supported | Install Polaris runtime dependencies plus `labwc`, `xwayland`, `wayland-protocols`, Mesa/Vulkan drivers, PipeWire/WirePlumber, and `grim` for dashboard previews. NVIDIA high-FPS tests should use a CUDA-enabled package. |
+| Debian 12 Stable | Same headless labwc session and `HEADLESS-1` routing | `headless_shm_fallback` is the conservative baseline; DMA-BUF may be unavailable on older wlroots/protocol combinations | Ensure backported/new-enough `labwc`/wlroots where possible, `xwayland`, GPU userspace drivers, PipeWire/WirePlumber, and user access to render/input devices. Treat SHM as a compatibility path, not a startup failure. |
+| Ubuntu 22.04 LTS | Headless labwc can run when dependencies are available, but distro packages are older | Expect SHM/RAM fallback unless the compositor/protocol/driver stack has been updated | Older wlroots/labwc packages may miss headless-output or ext-image-copy behavior needed for DMA-BUF. Validate with logs before filing a runtime replacement issue. |
+| Parent Wayland desktop with GPU-native override | Windowed private compositor under the existing desktop, not true headless | `windowed_dmabuf_override` when `linux_prefer_gpu_native_capture`/override is active and frames stay GPU-resident | Requires a working parent `WAYLAND_DISPLAY`. Use only after normal Headless Stream has been validated. |
+
+Capture decision meanings:
+
+- `headless_extcopy_dmabuf`: true-headless labwc capture selected DMA-BUF and frames remain GPU-resident through encoder conversion.
+- `headless_shm_fallback`: true-headless labwc capture fell back to SHM/system memory. This is a supported RAM-capture fallback and can still be healthy, especially for compatibility validation.
+- `gpu_native_requested_shm_fallback`: a GPU-native path was requested, but Wayland capture still produced SHM frames.
+- `windowed_dmabuf_override`: Polaris intentionally used a windowed private compositor under a parent Wayland session to keep capture GPU-native.
+
+Check `/polaris/v1/session/status`, `/polaris/v1/stream-policy`, or a support bundle for `capture.path`, `capture.reason`, `capture.reason_message`, `capture.cpu_copy`, `capture.gpu_native`, and the nested `capture.decision` / `capture_decision` object. The nested decision repeats transport, residency, frame format, selected reason, runtime backend, requested/effective headless state, and GPU-native override state so a bundle shows both what path was selected and why.
+
 ## Session Lifecycle
 
 Polaris tracks owner and viewer roles explicitly. The owner controls the active session. Viewers can join in watch mode without taking over the running stream, and passive watch mode uses the active owner profile instead of silently renegotiating a different stream.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -177,12 +177,19 @@ stream capture path. Repeated failures are rate-limited in the log, and the dash
 preview refreshes after failed captures. If the preview is missing, confirm `grim` is installed with
 `command -v grim`.
 
-For capture performance, check `/polaris/v1/session/status` or `/polaris/v1/stream-policy` and look
-at `capture.path`, `capture.reason`, `capture.reason_message`, `capture.cpu_copy`, and
-`capture.gpu_native`. A reason such as `headless_shm_fallback` means Headless Stream is healthy
-enough to run but still using the conservative SHM/system-memory path. `headless_extcopy_dmabuf`
-is the true-headless DMA-BUF path, and `gpu_native_requested_shm_fallback` means GPU-native capture
-was requested but the Wayland capture path still fell back to SHM.
+For capture performance, check `/polaris/v1/session/status`; its `capture` object includes
+`path`, `reason`, `reason_message`, `cpu_copy`, `gpu_native`, and nested `decision` fields.
+`/polaris/v1/stream-policy` exposes the same data as `capture_path`, `capture_path_reason`,
+`capture_path_reason_message`, `capture_cpu_copy`, `capture_gpu_native`, and `capture_decision`.
+A reason such as `headless_shm_fallback` means Headless Stream is healthy enough to run but still
+using the conservative SHM/system-memory path. `headless_extcopy_dmabuf` is the true-headless
+DMA-BUF path, and `gpu_native_requested_shm_fallback` means GPU-native capture was requested but
+the Wayland capture path still fell back to SHM. Support bundles include the same normalized
+decision data under `capture.decision` and stream stats `capture_decision` so a report captures
+the selected path, reason message, transport, residency, runtime backend, effective headless
+state, and GPU-native override state.
+
+For LTS distro expectations and package caveats, see the [Linux LTS Headless Fallback Matrix](runtime.md#linux-lts-headless-fallback-matrix). Xvfb or gamescope should be treated as investigation-only unless this supported labwc path cannot cover a confirmed target environment.
 
 ## VAAPI or software encode fallback
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1273,43 +1273,6 @@ namespace nvhttp {
       });
     }
 
-    std::string capture_path_reason_message(const std::string &reason) {
-      if (reason == "gpu_native") {
-        return "Capture and encoder conversion are GPU-resident.";
-      }
-      if (reason == "headless_extcopy_dmabuf") {
-        return "True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.";
-      }
-      if (reason == "windowed_dmabuf_override") {
-        return "Polaris is using a windowed private compositor so DMA-BUF/CUDA capture can stay GPU-resident.";
-      }
-      if (reason == "gpu_native_requested_shm_fallback") {
-        return "GPU-native capture was requested, but the active Wayland capture fell back to SHM/system-memory frames.";
-      }
-      if (reason == "gpu_native_requested_cpu_capture") {
-        return "GPU-native capture was requested, but the active capture frames are CPU-resident.";
-      }
-      if (reason == "gpu_native_requested_cpu_encode_upload") {
-        return "GPU-native capture was requested, but encoder upload/conversion is still CPU-resident.";
-      }
-      if (reason == "headless_shm_fallback" || reason == "headless_shm_default") {
-        return "Headless Stream is using the conservative SHM/system-memory path; the stream can be healthy, but high-FPS NVIDIA testing should use a CUDA-enabled GPU-native path.";
-      }
-      if (reason == "encoder_upload_cpu") {
-        return "Capture is GPU-resident, but encoder upload/conversion crosses system memory.";
-      }
-      if (reason == "cpu_capture" || reason == "shm_capture") {
-        return "The active capture path is CPU-resident.";
-      }
-      if (reason == "dmabuf_gpu_capture") {
-        return "Capture is using DMA-BUF/GPU frames, but the encoder path is not fully GPU-native.";
-      }
-      if (reason == "no_capture_metadata") {
-        return "No capture metadata has been reported yet.";
-      }
-      return "The active capture and encoder path is mixed or not fully classified.";
-    }
-
     nlohmann::json build_client_presentation_policy_json(double policy_fps) {
       const bool prefer_stable_multiple =
         policy_fps > 0.0 &&
@@ -1387,7 +1350,7 @@ namespace nvhttp {
         append_stream_policy_warning(
           warnings,
           capture_reason,
-          capture_path_reason_message(capture_reason)
+          stream_stats::capture_path_reason_message(capture_reason)
         );
       }
       if (stats.dynamic_range > 0 && !stats.stream_hdr_enabled) {
@@ -1450,14 +1413,29 @@ namespace nvhttp {
       policy["hdr_requested"] = stats.dynamic_range > 0;
       policy["hdr_active"] = stats.stream_hdr_enabled;
       policy["hdr_metadata_available"] = stats.hdr_metadata_available;
+      const auto capture_reason_message = stream_stats::capture_path_reason_message(capture_reason);
       policy["capture_path"] = capture_path;
       policy["capture_path_reason"] = capture_reason;
-      policy["capture_path_reason_message"] = capture_path_reason_message(capture_reason);
+      policy["capture_path_reason_message"] = capture_reason_message;
       policy["capture_cpu_copy"] = capture_cpu_copy;
       policy["capture_gpu_native"] = capture_gpu_native;
       policy["capture_transport"] = platf::from_frame_transport(stats.capture_transport);
       policy["capture_residency"] = platf::from_frame_residency(stats.capture_residency);
       policy["capture_format"] = platf::from_frame_format(stats.capture_format);
+      policy["capture_decision"] = {
+        {"path", capture_path},
+        {"reason", capture_reason},
+        {"reason_message", capture_reason_message},
+        {"transport", policy["capture_transport"]},
+        {"residency", policy["capture_residency"]},
+        {"format", policy["capture_format"]},
+        {"cpu_copy", capture_cpu_copy},
+        {"gpu_native", capture_gpu_native},
+        {"runtime_backend", stats.runtime_backend},
+        {"requested_headless", stats.runtime_requested_headless},
+        {"effective_headless", stats.runtime_effective_headless},
+        {"gpu_native_override_active", stats.runtime_gpu_native_override_active}
+      };
       policy["presentation_policy"] = build_client_presentation_policy_json(policy_fps);
       policy["warnings"] = std::move(warnings);
       policy["has_warnings"] = !policy["warnings"].empty();
@@ -1844,7 +1822,7 @@ namespace nvhttp {
       }
       if (capture_fallback) {
         issues.push_back(capture_reason);
-        recommendations.push_back(capture_path_reason_message(capture_reason));
+        recommendations.push_back(stream_stats::capture_path_reason_message(capture_reason));
       }
       if (nvenc_cuda_disabled_path) {
         issues.push_back("nvenc_cuda_disabled");
@@ -1964,7 +1942,7 @@ namespace nvhttp {
         virtual_display_risk ? "The virtual display path is likely adding pacing overhead." :
         decoder_risk ? "The current codec path looks harder on this client than expected." :
         nvenc_cuda_disabled_path ? "The NVIDIA path is using a CUDA-disabled CPU copy fallback." :
-        capture_fallback ? capture_path_reason_message(capture_reason) :
+        capture_fallback ? stream_stats::capture_path_reason_message(capture_reason) :
         host_render_limited ? "Host render is missing the stream FPS target; lower game render settings or stream FPS before tuning bitrate." :
         "The stream needs a safer pacing or encode path.";
       health["issues"] = std::move(issues);
@@ -1988,7 +1966,7 @@ namespace nvhttp {
       }
       health["capture_path"] = capture_path;
       health["capture_path_reason"] = capture_reason;
-      health["capture_path_reason_message"] = capture_path_reason_message(capture_reason);
+      health["capture_path_reason_message"] = stream_stats::capture_path_reason_message(capture_reason);
       health["capture_cpu_copy"] = capture_fallback;
       health["capture_gpu_native"] = stream_stats::capture_path_is_gpu_native(stats);
       health["active_encoder"] = active_encoder_name.empty() ? "unknown" : active_encoder_name;
@@ -4690,9 +4668,23 @@ namespace nvhttp {
       capture_info["path"] = stream_stats::capture_path_summary(stats);
       const auto capture_reason = stream_stats::capture_path_reason(stats);
       capture_info["reason"] = capture_reason;
-      capture_info["reason_message"] = capture_path_reason_message(capture_reason);
+      capture_info["reason_message"] = stream_stats::capture_path_reason_message(capture_reason);
       capture_info["cpu_copy"] = stream_stats::capture_path_uses_cpu_copy(stats);
       capture_info["gpu_native"] = stream_stats::capture_path_is_gpu_native(stats);
+      capture_info["decision"] = {
+        {"path", capture_info["path"]},
+        {"reason", capture_info["reason"]},
+        {"reason_message", capture_info["reason_message"]},
+        {"transport", capture_info["transport"]},
+        {"residency", capture_info["residency"]},
+        {"format", capture_info["format"]},
+        {"cpu_copy", capture_info["cpu_copy"]},
+        {"gpu_native", capture_info["gpu_native"]},
+        {"runtime_backend", stats.runtime_backend.empty() ? "screencopy" : stats.runtime_backend},
+        {"requested_headless", stats.runtime_requested_headless},
+        {"effective_headless", stats.runtime_effective_headless},
+        {"gpu_native_override_active", stats.runtime_gpu_native_override_active}
+      };
 
       // Encoder info
       auto &encoder = output["encoder"];

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -107,10 +107,30 @@ namespace stream_stats {
     j["capture_transport"] = platf::from_frame_transport(capture_transport);
     j["capture_residency"] = platf::from_frame_residency(capture_residency);
     j["capture_format"] = platf::from_frame_format(capture_format);
-    j["capture_path"] = capture_path_summary(*this);
-    j["capture_path_reason"] = capture_path_reason(*this);
-    j["capture_cpu_copy"] = capture_path_uses_cpu_copy(*this);
-    j["capture_gpu_native"] = capture_path_is_gpu_native(*this);
+    const auto capture_path = capture_path_summary(*this);
+    const auto capture_reason = capture_path_reason(*this);
+    const auto capture_reason_message = capture_path_reason_message(capture_reason);
+    const bool capture_cpu_copy = capture_path_uses_cpu_copy(*this);
+    const bool capture_gpu_native = capture_path_is_gpu_native(*this);
+    j["capture_path"] = capture_path;
+    j["capture_path_reason"] = capture_reason;
+    j["capture_path_reason_message"] = capture_reason_message;
+    j["capture_cpu_copy"] = capture_cpu_copy;
+    j["capture_gpu_native"] = capture_gpu_native;
+    j["capture_decision"] = {
+      {"path", capture_path},
+      {"reason", capture_reason},
+      {"reason_message", capture_reason_message},
+      {"transport", platf::from_frame_transport(capture_transport)},
+      {"residency", platf::from_frame_residency(capture_residency)},
+      {"format", platf::from_frame_format(capture_format)},
+      {"cpu_copy", capture_cpu_copy},
+      {"gpu_native", capture_gpu_native},
+      {"runtime_backend", runtime_backend},
+      {"requested_headless", runtime_requested_headless},
+      {"effective_headless", runtime_effective_headless},
+      {"gpu_native_override_active", runtime_gpu_native_override_active}
+    };
     j["encode_target_device"] = encode_target_device;
     j["encode_target_residency"] = platf::from_frame_residency(encode_target_residency);
     j["encode_target_format"] = platf::from_frame_format(encode_target_format);
@@ -263,6 +283,43 @@ namespace stream_stats {
     }
 
     return "mixed_or_unknown";
+  }
+
+  std::string capture_path_reason_message(const std::string &reason) {
+    if (reason == "gpu_native") {
+      return "Capture and encoder conversion are GPU-resident.";
+    }
+    if (reason == "headless_extcopy_dmabuf") {
+      return "True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.";
+    }
+    if (reason == "windowed_dmabuf_override") {
+      return "Polaris is using a windowed private compositor so DMA-BUF/CUDA capture can stay GPU-resident.";
+    }
+    if (reason == "gpu_native_requested_shm_fallback") {
+      return "GPU-native capture was requested, but the active Wayland capture fell back to SHM/system-memory frames.";
+    }
+    if (reason == "gpu_native_requested_cpu_capture") {
+      return "GPU-native capture was requested, but the active capture frames are CPU-resident.";
+    }
+    if (reason == "gpu_native_requested_cpu_encode_upload") {
+      return "GPU-native capture was requested, but encoder upload/conversion is still CPU-resident.";
+    }
+    if (reason == "headless_shm_fallback" || reason == "headless_shm_default") {
+      return "Headless Stream is using the conservative SHM/system-memory path; the stream can be healthy, but high-FPS NVIDIA testing should use a CUDA-enabled GPU-native path.";
+    }
+    if (reason == "encoder_upload_cpu") {
+      return "Capture is GPU-resident, but encoder upload/conversion crosses system memory.";
+    }
+    if (reason == "cpu_capture" || reason == "shm_capture") {
+      return "The active capture path is CPU-resident.";
+    }
+    if (reason == "dmabuf_gpu_capture") {
+      return "Capture is using DMA-BUF/GPU frames, but the encoder path is not fully GPU-native.";
+    }
+    if (reason == "no_capture_metadata") {
+      return "No capture metadata has been reported yet.";
+    }
+    return "The active capture and encoder path is mixed or not fully classified.";
   }
 
   void update_stream_active(bool active, const std::string &client_name, const std::string &client_ip) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -139,6 +139,12 @@ namespace stream_stats {
   std::string capture_path_reason(const stats_t &stats);
 
   /**
+   * @brief Human-readable explanation for a capture path reason.
+   * @param reason Machine-readable reason returned by capture_path_reason().
+   */
+  std::string capture_path_reason_message(const std::string &reason);
+
+  /**
    * @brief Update stream active state.
    * @param active Whether streaming is active.
    * @param client_name Name of the connected client.

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -7,6 +7,7 @@
 #include <src/config.h>
 
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
 namespace {
   struct LinuxDisplayConfigGuard {
@@ -49,6 +50,44 @@ TEST(StreamStatsCapturePathTests, DetectsShmCpuCapture) {
   EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_shm_fallback");
   EXPECT_TRUE(stream_stats::capture_path_uses_cpu_copy(stats));
   EXPECT_FALSE(stream_stats::capture_path_is_gpu_native(stats));
+  EXPECT_EQ(
+    stream_stats::capture_path_reason_message(stream_stats::capture_path_reason(stats)),
+    "Headless Stream is using the conservative SHM/system-memory path; the stream can be healthy, but high-FPS NVIDIA testing should use a CUDA-enabled GPU-native path."
+  );
+}
+
+TEST(StreamStatsCapturePathTests, SerializesCaptureDecisionDiagnostics) {
+  LinuxDisplayConfigGuard guard;
+  config::video.linux_display.use_cage_compositor = true;
+
+  stream_stats::stats_t stats {};
+  stats.runtime_backend = "labwc";
+  stats.runtime_requested_headless = true;
+  stats.runtime_effective_headless = true;
+  stats.capture_transport = platf::frame_transport_e::shm;
+  stats.capture_residency = platf::frame_residency_e::cpu;
+  stats.capture_format = platf::frame_format_e::bgra8;
+  stats.encode_target_residency = platf::frame_residency_e::cpu;
+
+  const auto json = nlohmann::json::parse(stats.to_json());
+
+  EXPECT_EQ(json.at("capture_path"), "shm_cpu_capture");
+  EXPECT_EQ(json.at("capture_path_reason"), "headless_shm_fallback");
+  EXPECT_FALSE(json.at("capture_path_reason_message").get<std::string>().empty());
+  ASSERT_TRUE(json.contains("capture_decision"));
+  const auto &decision = json.at("capture_decision");
+  EXPECT_EQ(decision.at("path"), json.at("capture_path"));
+  EXPECT_EQ(decision.at("reason"), json.at("capture_path_reason"));
+  EXPECT_EQ(decision.at("reason_message"), json.at("capture_path_reason_message"));
+  EXPECT_EQ(decision.at("transport"), "shm");
+  EXPECT_EQ(decision.at("residency"), "cpu");
+  EXPECT_EQ(decision.at("format"), "bgra8");
+  EXPECT_TRUE(decision.at("cpu_copy"));
+  EXPECT_FALSE(decision.at("gpu_native"));
+  EXPECT_EQ(decision.at("runtime_backend"), "labwc");
+  EXPECT_TRUE(decision.at("requested_headless"));
+  EXPECT_TRUE(decision.at("effective_headless"));
+  EXPECT_FALSE(decision.at("gpu_native_override_active"));
 }
 
 TEST(StreamStatsCapturePathTests, ExplainsGpuNativeShmFallback) {


### PR DESCRIPTION
## Summary
- Document the Linux LTS headless fallback matrix for labwc, headless DMA-BUF, SHM/RAM fallback, and windowed GPU-native override
- Add additive capture-decision diagnostics to stream stats, session status, and stream policy JSON
- Reuse one capture reason message helper across stream stats and HTTP surfaces, with focused serialization coverage

Closes #86

## Test Plan
- `git diff --check`
- `cmake --build build --target test_polaris_stream -j2`
- `./build/tests/test_polaris_stream --gtest_filter='StreamStatsCapturePathTests.*'`
- `cmake --build build --target test_polaris_platform -j2`
- `./build/tests/test_polaris_platform --gtest_filter='CageDisplayRouter*'`

## Notes
- No runtime architecture replacement here. Xvfb/gamescope stay documented as investigation-only unless the supported labwc fallback path cannot cover a confirmed target environment.
