### PR TITLE
chore: ignore Hermes agent files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 .vscode/
 .codex
 .claude/
+.hermes/
 .superpowers/
 .private/
 AGENTS.md


### PR DESCRIPTION
## Summary
- Ignore the local `.hermes/` agent workspace directory alongside other local editor/agent files

## Test Plan
- `git check-ignore -v .hermes .hermes/`
- `git diff --check`
