### PR TITLE
fix: fall back for cross-GPU headless DMA-BUF

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1422,6 +1422,9 @@ namespace nvhttp {
       policy["capture_transport"] = platf::from_frame_transport(stats.capture_transport);
       policy["capture_residency"] = platf::from_frame_residency(stats.capture_residency);
       policy["capture_format"] = platf::from_frame_format(stats.capture_format);
+      policy["capture_device"] = stats.capture_device;
+      policy["capture_encoder_adapter"] = config::video.adapter_name;
+      policy["capture_cross_gpu_dmabuf_risk"] = stream_stats::capture_path_has_cross_gpu_dmabuf_risk(stats);
       policy["capture_decision"] = {
         {"path", capture_path},
         {"reason", capture_reason},
@@ -1429,6 +1432,9 @@ namespace nvhttp {
         {"transport", policy["capture_transport"]},
         {"residency", policy["capture_residency"]},
         {"format", policy["capture_format"]},
+        {"capture_device", policy["capture_device"]},
+        {"encoder_adapter", policy["capture_encoder_adapter"]},
+        {"cross_gpu_dmabuf_risk", policy["capture_cross_gpu_dmabuf_risk"]},
         {"cpu_copy", capture_cpu_copy},
         {"gpu_native", capture_gpu_native},
         {"runtime_backend", stats.runtime_backend},
@@ -4665,6 +4671,9 @@ namespace nvhttp {
       capture_info["transport"] = platf::from_frame_transport(stats.capture_transport);
       capture_info["residency"] = platf::from_frame_residency(stats.capture_residency);
       capture_info["format"] = platf::from_frame_format(stats.capture_format);
+      capture_info["device"] = stats.capture_device;
+      capture_info["encoder_adapter"] = config::video.adapter_name;
+      capture_info["cross_gpu_dmabuf_risk"] = stream_stats::capture_path_has_cross_gpu_dmabuf_risk(stats);
       capture_info["path"] = stream_stats::capture_path_summary(stats);
       const auto capture_reason = stream_stats::capture_path_reason(stats);
       capture_info["reason"] = capture_reason;
@@ -4678,6 +4687,9 @@ namespace nvhttp {
         {"transport", capture_info["transport"]},
         {"residency", capture_info["residency"]},
         {"format", capture_info["format"]},
+        {"capture_device", capture_info["device"]},
+        {"encoder_adapter", capture_info["encoder_adapter"]},
+        {"cross_gpu_dmabuf_risk", capture_info["cross_gpu_dmabuf_risk"]},
         {"cpu_copy", capture_info["cpu_copy"]},
         {"gpu_native", capture_info["gpu_native"]},
         {"runtime_backend", stats.runtime_backend.empty() ? "screencopy" : stats.runtime_backend},

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -355,6 +355,7 @@ namespace platf {
     frame_transport_e transport {frame_transport_e::unknown};
     frame_residency_e residency {frame_residency_e::unknown};
     frame_format_e format {frame_format_e::unknown};
+    std::string device;
   };
 
   struct runtime_state_t {

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -1237,10 +1237,11 @@ namespace wl {
 
     gbm_device_id = device;
     gbm_device_id_valid = true;
+    render_node = path_for_fd(gbm_device_get_fd(gbm_device));
 
     BOOST_LOG(info) << "Extcopy DMA-BUF capture using GBM backend ["sv
                     << gbm_device_get_backend_name(gbm_device)
-                    << "] render_node=["sv << path_for_fd(gbm_device_get_fd(gbm_device)) << ']';
+                    << "] render_node=["sv << render_node << ']';
     return true;
   }
 
@@ -1256,6 +1257,7 @@ namespace wl {
 
     gbm_device_id = {};
     gbm_device_id_valid = false;
+    render_node.clear();
   }
 
   void extcopy_t::destroy_capture_frame() {

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -7,6 +7,7 @@
 // standard includes
 #include <bitset>
 #include <sys/types.h>
+#include <string>
 #include <string_view>
 
 #ifdef POLARIS_BUILD_WAYLAND
@@ -198,6 +199,10 @@ namespace wl {
       return current_frame == &frames[0] ? &frames[1] : &frames[0];
     }
 
+    std::string capture_render_node() const {
+      return render_node;
+    }
+
     status_e status;
     std::array<frame_t, 2> frames;
     frame_t *current_frame;
@@ -242,6 +247,7 @@ namespace wl {
     ext_image_copy_capture_session_v1 *capture_session {nullptr};
     ext_image_copy_capture_frame_v1 *capture_frame_object {nullptr};
     ::gbm_device *gbm_device {nullptr};
+    std::string render_node;
     dev_t gbm_device_id {};
     bool gbm_device_id_valid {false};
     bool blend_cursor {false};

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -634,6 +634,7 @@ namespace wl {
         .transport = platf::frame_transport_e::dmabuf,
         .residency = platf::frame_residency_e::gpu,
         .format = platf::frame_format_e::bgra8,
+        .device = extcopy.capture_render_node(),
       };
       stream_stats::update_capture_metadata(img->frame_metadata);
       log_capture_metadata(img->frame_metadata);
@@ -773,17 +774,31 @@ namespace platf {
     if (try_headless_extcopy_dmabuf && gpu_native_capture_supported) {
       auto wlr = std::make_shared<wl::wlr_extcopy_vram_t>();
       if (!wlr->init(hwdevice_type, display_name, config)) {
+        const auto capture_render_node = wlr->extcopy.capture_render_node();
+        if (!config::video.adapter_name.empty() &&
+            !capture_render_node.empty() &&
+            config::video.adapter_name != capture_render_node) {
+          BOOST_LOG(warning)
+            << "wlr: Disabling true-headless ext-image-copy-capture DMA-BUF because capture render_node=["sv
+            << capture_render_node
+            << "] differs from encoder adapter=["sv << config::video.adapter_name
+            << "]; using SHM/system-memory fallback to avoid known cross-GPU black video"sv;
 #ifdef __linux__
-        cage_display_router::update_headless_extcopy_dmabuf_probe_result(true);
+          cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
 #endif
-        BOOST_LOG(info) << "wlr: Using ext-image-copy-capture DMA-BUF for headless labwc"sv;
-        return wlr;
+        } else {
+#ifdef __linux__
+          cage_display_router::update_headless_extcopy_dmabuf_probe_result(true);
+#endif
+          BOOST_LOG(info) << "wlr: Using ext-image-copy-capture DMA-BUF for headless labwc"sv;
+          return wlr;
+        }
       }
 
 #ifdef __linux__
       cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
 #endif
-      BOOST_LOG(info) << "wlr: Headless ext-image-copy-capture DMA-BUF unavailable; using SHM fallback"sv;
+      BOOST_LOG(info) << "wlr: Headless ext-image-copy-capture DMA-BUF unavailable or unsafe; using SHM fallback"sv;
     }
 
     auto wlr = std::make_shared<wl::wlr_ram_t>();

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -107,6 +107,7 @@ namespace stream_stats {
     j["capture_transport"] = platf::from_frame_transport(capture_transport);
     j["capture_residency"] = platf::from_frame_residency(capture_residency);
     j["capture_format"] = platf::from_frame_format(capture_format);
+    j["capture_device"] = capture_device;
     const auto capture_path = capture_path_summary(*this);
     const auto capture_reason = capture_path_reason(*this);
     const auto capture_reason_message = capture_path_reason_message(capture_reason);
@@ -124,6 +125,9 @@ namespace stream_stats {
       {"transport", platf::from_frame_transport(capture_transport)},
       {"residency", platf::from_frame_residency(capture_residency)},
       {"format", platf::from_frame_format(capture_format)},
+      {"capture_device", capture_device},
+      {"encoder_adapter", config::video.adapter_name},
+      {"cross_gpu_dmabuf_risk", capture_path_has_cross_gpu_dmabuf_risk(*this)},
       {"cpu_copy", capture_cpu_copy},
       {"gpu_native", capture_gpu_native},
       {"runtime_backend", runtime_backend},
@@ -205,6 +209,21 @@ namespace stream_stats {
       stats.encode_target_residency == platf::frame_residency_e::gpu;
   }
 
+  bool capture_path_has_cross_gpu_dmabuf_risk(const stats_t &stats) {
+#ifdef __linux__
+    return
+      stats.runtime_effective_headless &&
+      config::video.linux_display.use_cage_compositor &&
+      stats.capture_transport == platf::frame_transport_e::dmabuf &&
+      stats.capture_residency == platf::frame_residency_e::gpu &&
+      !stats.capture_device.empty() &&
+      !config::video.adapter_name.empty() &&
+      stats.capture_device != config::video.adapter_name;
+#else
+    return false;
+#endif
+  }
+
   std::string capture_path_summary(const stats_t &stats) {
     const bool capture_unknown =
       stats.capture_transport == platf::frame_transport_e::unknown &&
@@ -245,6 +264,9 @@ namespace stream_stats {
 #ifdef __linux__
       const auto &linux_display = config::video.linux_display;
       if (stats.runtime_effective_headless && linux_display.use_cage_compositor) {
+        if (capture_path_has_cross_gpu_dmabuf_risk(stats)) {
+          return "headless_extcopy_dmabuf_cross_gpu_risk";
+        }
         return "headless_extcopy_dmabuf";
       }
       if (stats.runtime_gpu_native_override_active) {
@@ -291,6 +313,9 @@ namespace stream_stats {
     }
     if (reason == "headless_extcopy_dmabuf") {
       return "True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.";
+    }
+    if (reason == "headless_extcopy_dmabuf_cross_gpu_risk") {
+      return "True-headless DMA-BUF capture is using a different DRM render node than the configured encoder adapter; Polaris should fall back to SHM/system memory to avoid known cross-GPU black video.";
     }
     if (reason == "windowed_dmabuf_override") {
       return "Polaris is using a windowed private compositor so DMA-BUF/CUDA capture can stay GPU-resident.";
@@ -502,6 +527,7 @@ namespace stream_stats {
     current_stats.capture_transport = metadata.transport;
     current_stats.capture_residency = metadata.residency;
     current_stats.capture_format = metadata.format;
+    current_stats.capture_device = metadata.device;
   }
 
   void update_encode_path_metadata(const std::string &target_device,

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -62,6 +62,7 @@ namespace stream_stats {
     platf::frame_transport_e capture_transport = platf::frame_transport_e::unknown;
     platf::frame_residency_e capture_residency = platf::frame_residency_e::unknown;
     platf::frame_format_e capture_format = platf::frame_format_e::unknown;
+    std::string capture_device;
     std::string encode_target_device;
     platf::frame_residency_e encode_target_residency = platf::frame_residency_e::unknown;
     platf::frame_format_e encode_target_format = platf::frame_format_e::unknown;
@@ -137,6 +138,12 @@ namespace stream_stats {
    * @param stats Current stream statistics snapshot.
    */
   std::string capture_path_reason(const stats_t &stats);
+
+  /**
+   * @brief Whether a true-headless DMA-BUF path is crossing DRM render nodes.
+   * @param stats Current stream statistics snapshot.
+   */
+  bool capture_path_has_cross_gpu_dmabuf_risk(const stats_t &stats);
 
   /**
    * @brief Human-readable explanation for a capture path reason.

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -9,18 +9,23 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <string>
+
 namespace {
   struct LinuxDisplayConfigGuard {
     LinuxDisplayConfigGuard():
+        adapter_name {config::video.adapter_name},
         use_cage_compositor {config::video.linux_display.use_cage_compositor},
         prefer_gpu_native_capture {config::video.linux_display.prefer_gpu_native_capture} {
     }
 
     ~LinuxDisplayConfigGuard() {
+      config::video.adapter_name = adapter_name;
       config::video.linux_display.use_cage_compositor = use_cage_compositor;
       config::video.linux_display.prefer_gpu_native_capture = prefer_gpu_native_capture;
     }
 
+    std::string adapter_name;
     bool use_cage_compositor;
     bool prefer_gpu_native_capture;
   };
@@ -133,22 +138,84 @@ TEST(StreamStatsCapturePathTests, DetectsFullyGpuNativePath) {
 
 TEST(StreamStatsCapturePathTests, LabelsHeadlessExtcopyDmabufPath) {
   LinuxDisplayConfigGuard guard;
+  config::video.adapter_name = "/dev/dri/renderD128";
   config::video.linux_display.use_cage_compositor = true;
 
   stream_stats::stats_t stats {};
   stats.runtime_effective_headless = true;
   stats.capture_transport = platf::frame_transport_e::dmabuf;
   stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.capture_format = platf::frame_format_e::bgra8;
+  stats.capture_device = "/dev/dri/renderD128";
   stats.encode_target_residency = platf::frame_residency_e::gpu;
 
   EXPECT_EQ(stream_stats::capture_path_summary(stats), "gpu_native");
 #ifdef __linux__
+  EXPECT_FALSE(stream_stats::capture_path_has_cross_gpu_dmabuf_risk(stats));
   EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_extcopy_dmabuf");
 #else
   EXPECT_EQ(stream_stats::capture_path_reason(stats), "gpu_native");
 #endif
   EXPECT_FALSE(stream_stats::capture_path_uses_cpu_copy(stats));
   EXPECT_TRUE(stream_stats::capture_path_is_gpu_native(stats));
+}
+
+TEST(StreamStatsCapturePathTests, FlagsHeadlessCrossGpuDmabufRisk) {
+  LinuxDisplayConfigGuard guard;
+  config::video.adapter_name = "/dev/dri/renderD128";
+  config::video.linux_display.use_cage_compositor = true;
+
+  stream_stats::stats_t stats {};
+  stats.runtime_backend = "labwc";
+  stats.runtime_requested_headless = true;
+  stats.runtime_effective_headless = true;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.capture_format = platf::frame_format_e::bgra8;
+  stats.capture_device = "/dev/dri/renderD129";
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+
+#ifdef __linux__
+  EXPECT_TRUE(stream_stats::capture_path_has_cross_gpu_dmabuf_risk(stats));
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_extcopy_dmabuf_cross_gpu_risk");
+#else
+  EXPECT_FALSE(stream_stats::capture_path_has_cross_gpu_dmabuf_risk(stats));
+#endif
+
+  const auto json = nlohmann::json::parse(stats.to_json());
+  EXPECT_EQ(json.at("capture_device"), "/dev/dri/renderD129");
+  ASSERT_TRUE(json.contains("capture_decision"));
+  const auto &decision = json.at("capture_decision");
+  EXPECT_EQ(decision.at("capture_device"), "/dev/dri/renderD129");
+  EXPECT_EQ(decision.at("encoder_adapter"), "/dev/dri/renderD128");
+#ifdef __linux__
+  EXPECT_TRUE(decision.at("cross_gpu_dmabuf_risk"));
+  EXPECT_EQ(decision.at("reason"), "headless_extcopy_dmabuf_cross_gpu_risk");
+#else
+  EXPECT_FALSE(decision.at("cross_gpu_dmabuf_risk"));
+#endif
+  EXPECT_FALSE(stream_stats::capture_path_uses_cpu_copy(stats));
+  EXPECT_TRUE(stream_stats::capture_path_is_gpu_native(stats));
+}
+
+TEST(StreamStatsCapturePathTests, IgnoresCrossGpuRiskWithoutExplicitEncoderAdapter) {
+  LinuxDisplayConfigGuard guard;
+  config::video.adapter_name.clear();
+  config::video.linux_display.use_cage_compositor = true;
+
+  stream_stats::stats_t stats {};
+  stats.runtime_effective_headless = true;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.capture_device = "/dev/dri/renderD129";
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+
+  EXPECT_FALSE(stream_stats::capture_path_has_cross_gpu_dmabuf_risk(stats));
+#ifdef __linux__
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_extcopy_dmabuf");
+#else
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "gpu_native");
+#endif
 }
 
 TEST(StreamStatsCapturePathTests, LabelsWindowedDmabufOverridePath) {


### PR DESCRIPTION
## Summary
- Track the DRM render node used by true-headless ext-image-copy DMA-BUF capture
- Detect true-headless cross-GPU DMA-BUF risk when capture and configured encoder adapter render nodes differ
- Fall back to the SHM/system-memory capture path instead of keeping the known black-video DMA-BUF path alive
- Expose additive capture device / encoder adapter / cross-GPU risk diagnostics in stats, session status, and stream policy JSON

## Test Plan
- `git diff --check`
- `cmake --build build --target test_polaris_stream -j2 && ./build/tests/test_polaris_stream --gtest_filter='StreamStatsCapturePathTests.*'`
- `cmake --build build --target test_polaris_platform -j2 && ./build/tests/test_polaris_platform --gtest_filter='CageDisplayRouter*'`
- `cmake --build build -j2`

Closes #91
