### PR TITLE
fix(linux): soften KMS probe capability guidance

### DIFF
--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -287,12 +287,16 @@ the client stream itself fails to connect.
 CPU BGR0 frame without a valid row pitch. Use a release newer than `v1.0.4`, where
 the headless CPU fallback path was fixed.
 
-`Failed to gain CAP_SYS_ADMIN` or `You must run [sudo setcap ...] for KMS display
-capture to work` means the KMS capability was not applied to the binary that the
-user service is running. On Bazzite, copy the current packaged binary to
-`/usr/local/bin/polaris-kms`, apply `setcap` there, and make sure the
-`~/.config/systemd/user/polaris.service.d/10-bazzite-kms.conf` override points
-`ExecStart` at that file.
+`Failed to gain CAP_SYS_ADMIN` with `KMS probe could not access DRM framebuffer
+handles; continuing with non-KMS capture backends when available` is only a
+startup probe warning for portal/compositor users. Do not apply `setcap` for the
+normal portal path.
+
+`KMS display capture requires CAP_SYS_ADMIN` is actionable only when you
+intentionally selected explicit KMS capture. On Bazzite, copy the current
+packaged binary to `/usr/local/bin/polaris-kms`, apply `setcap` there, and make
+sure the `~/.config/systemd/user/polaris.service.d/10-bazzite-kms.conf` override
+points `ExecStart` at that file.
 
 `Virtual display: failed to open EVDI device` usually means the EVDI kernel
 module is loaded without a pre-created DRM card. Load EVDI with

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -151,11 +151,14 @@ nvidia_drm.modeset=1
 ```
 
 If you do not need DRM/KMS capture, keep using the default compositor and portal paths instead.
+A startup warning that says `KMS probe could not access DRM framebuffer handles; continuing with
+non-KMS capture backends when available` is informational for portal/compositor users; do not apply
+`setcap` unless you intentionally selected KMS capture.
 
-If a manually copied test binary still logs `Failed to gain CAP_SYS_ADMIN` after `setcap`, check the
-mount options for the binary path. File capabilities are ignored on `nosuid` mounts, so `/tmp`
-builds can be misleading; copy the test binary to a normal path such as `/usr/local/bin` before
-applying `setcap`.
+If a manually copied explicit-KMS test binary still logs `Failed to gain CAP_SYS_ADMIN` after
+`setcap`, check the mount options for the binary path. File capabilities are ignored on `nosuid`
+mounts, so `/tmp` builds can be misleading; copy the test binary to a normal path such as
+`/usr/local/bin` before applying `setcap`.
 
 For low-FPS NVIDIA headless reports, check `Build features: cuda=...` first. If the log says
 `cuda=disabled` and later shows `Attempting to use NVENC without CUDA support. Reverting back to

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1639,8 +1639,10 @@ namespace platf {
 
         if (!fb->handles[0]) {
           BOOST_LOG(error) << "Couldn't get handle for DRM Framebuffer ["sv << plane->fb_id << "]: Probably not permitted"sv;
-          BOOST_LOG((window_system != window_system_e::X11 || config::video.capture == "kms") ? fatal : error)
-            << "You must run [sudo setcap cap_sys_admin+ep $(readlink -f $(which polaris))] for KMS display capture to work!\n"sv
+          BOOST_LOG(config::video.capture == "kms" ? fatal : warning)
+            << "KMS display capture requires CAP_SYS_ADMIN. "sv
+            << "Run [sudo setcap cap_sys_admin+ep $(readlink -f $(which polaris))] only when explicitly using KMS capture.\n"sv
+            << "KMS probe could not access DRM framebuffer handles; continuing with non-KMS capture backends when available.\n"sv
             << "Refer to the Polaris Linux build and troubleshooting docs for the supported setup path:\n"sv
             << "https://github.com/papi-ux/polaris/blob/master/docs/troubleshooting.md"sv;
           break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_cursor_visibility.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_file_handler.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_game_library_scanner.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_kmsgrab_logging_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_prepared_ffmpeg.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_rswrapper.cpp

--- a/tests/unit/test_kmsgrab_logging_source.cpp
+++ b/tests/unit/test_kmsgrab_logging_source.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+std::string read_kmsgrab_source() {
+  const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / "src/platform/linux/kmsgrab.cpp";
+  std::ifstream file {path};
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+}  // namespace
+
+TEST(KmsgrabLoggingSource, AutoProbeSetcapGuidanceIsNotFatalOnWayland) {
+  const auto source = read_kmsgrab_source();
+
+  EXPECT_NE(source.find("config::video.capture == \"kms\" ? fatal"), std::string::npos);
+  EXPECT_EQ(source.find("window_system != window_system_e::X11 || config::video.capture == \"kms\""), std::string::npos);
+  EXPECT_NE(source.find("KMS display capture requires CAP_SYS_ADMIN"), std::string::npos);
+  EXPECT_NE(source.find("KMS probe could not access DRM framebuffer handles; continuing with non-KMS capture backends"), std::string::npos);
+}


### PR DESCRIPTION
## Summary
- downgrades the non-explicit KMS framebuffer-handle probe from fatal/error-style setcap guidance to a warning
- keeps explicit `video.capture = kms` guidance fatal/actionable
- updates Linux/Bazzite docs so users do not apply `setcap` for normal portal/compositor capture
- adds a regression test that checks the KMS log severity/message contract

## User-facing impact
Users on normal portal/private-compositor paths should no longer get pushed toward `sudo setcap` just because the startup KMS probe cannot read DRM framebuffer handles. Explicit KMS users still get the capability guidance they need.

## Test plan
- `ctest --test-dir build --output-on-failure -R '^test_polaris$'`
- `ctest --test-dir build --output-on-failure -R 'test_polaris_(audit|platform|video)$'`
- `git diff --check`
- `cmake --build build -j"$(nproc)"`

Closes #98
