### PR TITLE
fix(library): scan account home outside Hermes profiles

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1595,46 +1595,58 @@ namespace confighttp {
    */
   std::vector<fs::path> lutris_game_config_dirs() {
     std::vector<fs::path> dirs;
-    const char *home = std::getenv("HOME");
-    if (!home || !*home) {
-      return dirs;
-    }
+    std::set<fs::path> seen_dirs;
+    auto append_dir = [&](fs::path path) {
+      if (path.empty()) {
+        return;
+      }
+      path = path.lexically_normal();
+      if (seen_dirs.insert(path).second) {
+        dirs.push_back(std::move(path));
+      }
+    };
 
     const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
     const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
-    dirs.emplace_back(
-      xdg_config_home && *xdg_config_home ?
-        fs::path(xdg_config_home) / "lutris/games" :
-        fs::path(home) / ".config/lutris/games"
-    );
-    dirs.emplace_back(
-      xdg_data_home && *xdg_data_home ?
-        fs::path(xdg_data_home) / "lutris/games" :
-        fs::path(home) / ".local/share/lutris/games"
-    );
+    if (xdg_config_home && *xdg_config_home) {
+      append_dir(fs::path(xdg_config_home) / "lutris/games");
+    }
+    if (xdg_data_home && *xdg_data_home) {
+      append_dir(fs::path(xdg_data_home) / "lutris/games");
+    }
+    for (const auto &home : game_library::library_home_roots()) {
+      append_dir(home / ".config/lutris/games");
+      append_dir(home / ".local/share/lutris/games");
+    }
 
     return dirs;
   }
 
   std::vector<fs::path> lutris_art_roots() {
     std::vector<fs::path> roots;
-    const char *home = std::getenv("HOME");
-    if (!home || !*home) {
-      return roots;
-    }
+    std::set<fs::path> seen_roots;
+    auto append_root = [&](fs::path path) {
+      if (path.empty()) {
+        return;
+      }
+      path = path.lexically_normal();
+      if (seen_roots.insert(path).second) {
+        roots.push_back(std::move(path));
+      }
+    };
 
     const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
     const char *xdg_cache_home = std::getenv("XDG_CACHE_HOME");
-    roots.emplace_back(
-      xdg_data_home && *xdg_data_home ?
-        fs::path(xdg_data_home) / "lutris" :
-        fs::path(home) / ".local/share/lutris"
-    );
-    roots.emplace_back(
-      xdg_cache_home && *xdg_cache_home ?
-        fs::path(xdg_cache_home) / "lutris" :
-        fs::path(home) / ".cache/lutris"
-    );
+    if (xdg_data_home && *xdg_data_home) {
+      append_root(fs::path(xdg_data_home) / "lutris");
+    }
+    if (xdg_cache_home && *xdg_cache_home) {
+      append_root(fs::path(xdg_cache_home) / "lutris");
+    }
+    for (const auto &home : game_library::library_home_roots()) {
+      append_root(home / ".local/share/lutris");
+      append_root(home / ".cache/lutris");
+    }
 
     return roots;
   }
@@ -1759,24 +1771,26 @@ namespace confighttp {
 
     // Scan Steam appmanifest files
     std::vector<std::string> steam_paths;
+    std::set<std::string> seen_steam_paths;
     std::set<std::string> seen_appids;
-    const char *home = std::getenv("HOME");
-    if (home) {
-      steam_paths.push_back(std::string(home) + "/.steam/steam/steamapps");
-      steam_paths.push_back(std::string(home) + "/.local/share/Steam/steamapps");
+    auto append_steam_path = [&](const fs::path &path) {
+      const auto value = path.lexically_normal().string();
+      if (!value.empty() && seen_steam_paths.insert(value).second) {
+        steam_paths.push_back(value);
+      }
+    };
+    for (const auto &home : game_library::library_home_roots()) {
+      append_steam_path(home / ".steam/steam/steamapps");
+      append_steam_path(home / ".local/share/Steam/steamapps");
 
-      // Discover additional library locations from libraryfolders.vdf
-      std::set<std::string> seen_steam_paths(steam_paths.begin(), steam_paths.end());
       const std::vector<std::string> vdf_candidates = {
-        std::string(home) + "/.steam/steam/steamapps/libraryfolders.vdf",
-        std::string(home) + "/.local/share/Steam/steamapps/libraryfolders.vdf",
-        std::string(home) + "/.local/share/Steam/config/libraryfolders.vdf",
+        (home / ".steam/steam/steamapps/libraryfolders.vdf").string(),
+        (home / ".local/share/Steam/steamapps/libraryfolders.vdf").string(),
+        (home / ".local/share/Steam/config/libraryfolders.vdf").string(),
       };
       for (const auto &vdf : vdf_candidates) {
         for (const auto &lib_path : parse_steam_library_folders(vdf)) {
-          if (seen_steam_paths.insert(lib_path).second) {
-            steam_paths.push_back(lib_path);
-          }
+          append_steam_path(lib_path);
         }
       }
     }
@@ -1845,7 +1859,8 @@ namespace confighttp {
 
     // Scan Lutris games
     nlohmann::json lutris_games = nlohmann::json::array();
-    if (home) {
+    const auto home_roots = game_library::library_home_roots();
+    if (!home_roots.empty()) {
       auto lutris_yml_dirs = lutris_game_config_dirs();
       auto lutris_roots = lutris_art_roots();
 
@@ -1878,12 +1893,12 @@ namespace confighttp {
 
     // Scan Heroic Games Launcher (GOG + Epic via Legendary)
     nlohmann::json heroic_games = nlohmann::json::array();
-    if (home) {
-      // Heroic stores installed game info in library JSON files
-      std::vector<std::pair<std::string, std::string>> heroic_paths = {
-        {std::string(home) + "/.config/heroic/gog_store/installed.json", "gog"},
-        {std::string(home) + "/.config/heroic/legendaryConfig/legendary/installed.json", "epic"},
-      };
+    if (!home_roots.empty()) {
+      std::vector<std::pair<std::string, std::string>> heroic_paths;
+      for (const auto &home : home_roots) {
+        heroic_paths.emplace_back((home / ".config/heroic/gog_store/installed.json").string(), "gog");
+        heroic_paths.emplace_back((home / ".config/heroic/legendaryConfig/legendary/installed.json").string(), "epic");
+      }
 
       for (const auto &[path, store] : heroic_paths) {
         if (!std::filesystem::exists(path)) continue;
@@ -1929,11 +1944,12 @@ namespace confighttp {
       }
 
       // Also check Heroic library.json (a combined library cache)
-      std::string heroic_lib = std::string(home) + "/.config/heroic/store_cache/gog_library.json";
-      std::string heroic_egs = std::string(home) + "/.config/heroic/store_cache/egs_library.json";
-      for (const auto &[path, store] : std::vector<std::pair<std::string, std::string>>{
-        {heroic_lib, "gog"}, {heroic_egs, "epic"}
-      }) {
+      std::vector<std::pair<std::string, std::string>> heroic_cache_paths;
+      for (const auto &home : home_roots) {
+        heroic_cache_paths.emplace_back((home / ".config/heroic/store_cache/gog_library.json").string(), "gog");
+        heroic_cache_paths.emplace_back((home / ".config/heroic/store_cache/egs_library.json").string(), "epic");
+      }
+      for (const auto &[path, store] : heroic_cache_paths) {
         if (!std::filesystem::exists(path)) continue;
         try {
           std::ifstream f(path);

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstdlib>
 #include <cstdio>
 #include <fstream>
 #include <set>
@@ -15,8 +16,35 @@
 
 #include <nlohmann/json.hpp>
 
+#if !defined(_WIN32)
+  #include <pwd.h>
+  #include <sys/types.h>
+  #include <unistd.h>
+#endif
+
 namespace game_library {
   namespace {
+    void append_unique_path(std::vector<std::filesystem::path> &paths, std::filesystem::path path) {
+      if (path.empty()) {
+        return;
+      }
+
+      path = path.lexically_normal();
+      if (std::find(paths.begin(), paths.end(), path) == paths.end()) {
+        paths.push_back(std::move(path));
+      }
+    }
+
+    std::string account_home_dir() {
+    #if !defined(_WIN32)
+      const auto *entry = getpwuid(getuid());
+      if (entry && entry->pw_dir && *entry->pw_dir) {
+        return entry->pw_dir;
+      }
+    #endif
+      return {};
+    }
+
     std::string trim_copy(std::string_view text) {
       auto begin = text.begin();
       auto end = text.end();
@@ -187,6 +215,18 @@ namespace game_library {
     return std::all_of(slug.begin(), slug.end(), [](unsigned char ch) {
       return std::isalnum(ch) || ch == '-' || ch == '_' || ch == '.';
     });
+  }
+
+  std::vector<std::filesystem::path> library_home_roots(std::string_view runtime_home, std::string_view account_home) {
+    std::vector<std::filesystem::path> roots;
+    append_unique_path(roots, std::filesystem::path(runtime_home));
+    append_unique_path(roots, std::filesystem::path(account_home));
+    return roots;
+  }
+
+  std::vector<std::filesystem::path> library_home_roots() {
+    const char *home = std::getenv("HOME");
+    return library_home_roots(home ? std::string_view(home) : std::string_view(), account_home_dir());
   }
 
   std::string lutris_launch_command(const std::string &slug) {

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -21,6 +21,8 @@ namespace game_library {
   };
 
   bool is_lutris_slug_safe(const std::string &slug);
+  std::vector<std::filesystem::path> library_home_roots(std::string_view runtime_home, std::string_view account_home);
+  std::vector<std::filesystem::path> library_home_roots();
   std::string find_lutris_image_path(const std::string &slug, const std::vector<std::filesystem::path> &lutris_roots);
   std::string lutris_launch_command(const std::string &slug);
   std::vector<lutris_game_t> parse_lutris_list_games_json(std::string_view json_payload);

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -145,3 +145,11 @@ TEST(LutrisLibraryScannerTests, FindsLocalLutrisArtworkBySlug) {
   EXPECT_EQ(image_path, (lutris_root / "coverart" / "black-myth-wukong.jpg").string());
   EXPECT_TRUE(game_library::find_lutris_image_path("bad slug", {lutris_root}).empty());
 }
+
+TEST(GameLibraryScannerTests, IncludesAccountHomeWhenRuntimeHomeIsProfile) {
+  const auto roots = game_library::library_home_roots("/tmp/agent-profile-home", "/tmp/account-home");
+
+  ASSERT_EQ(roots.size(), 2);
+  EXPECT_EQ(roots[0], std::filesystem::path("/tmp/agent-profile-home"));
+  EXPECT_EQ(roots[1], std::filesystem::path("/tmp/account-home"));
+}


### PR DESCRIPTION
## Summary
- scan Steam, Lutris, and Heroic libraries from both runtime HOME and the real account home
- dedupe normalized launcher paths so Hermes/profile HOME fallbacks do not double-import the same location
- add regression coverage for including the account home when runtime HOME points at an agent profile

## User-facing impact
When Polaris is launched from a Hermes profile or another environment with HOME redirected, Library import can still find the user’s real Steam/Lutris/Heroic libraries under the account home instead of only scanning the profile sandbox.

## Test Plan
- [x] `cmake --build build --target test_polaris -j"$(nproc)" && ctest --test-dir build --output-on-failure -R '^test_polaris$'`
- [x] `ctest --test-dir build --output-on-failure -R 'test_polaris_(audit|platform|video)$'`
- [x] `git diff --check`
- [x] `cmake --build build -j"$(nproc)"`
