### PR TITLE
fix(web): deep link pairing network trust settings

### DIFF
--- a/src_assets/common/assets/web/configs/tabs/Network.vue
+++ b/src_assets/common/assets/web/configs/tabs/Network.vue
@@ -137,7 +137,7 @@ const effectivePort = computed(() => +config.value?.port ?? defaultMoonlightPort
       </div>
     </section>
 
-    <section class="settings-section">
+    <section id="encryption_and_trust" class="settings-section scroll-mt-28">
       <div class="settings-section-header">
         <div class="section-kicker">Transport security</div>
         <div class="section-title-row">
@@ -191,7 +191,7 @@ const effectivePort = computed(() => +config.value?.port ?? defaultMoonlightPort
       <div class="mb-3">
         <label class="block text-sm font-medium text-storm mb-1">Trusted Subnets (TOFU)</label>
         <div class="text-sm text-storm mb-2">
-          Use IPv4 or IPv6 CIDR notation, for example <code class="bg-deep px-1 rounded">10.0.0.0/24</code> or <code class="bg-deep px-1 rounded">fdeb:c779:7c30:dedf::/64</code>.
+          Use IPv4 or IPv6 CIDR notation, for example <code class="bg-deep px-1 rounded">10.0.0.0/24</code> or <code class="bg-deep px-1 rounded">fd00:1234:5678::/64</code>.
         </div>
         <div v-if="config.trusted_subnets && config.trusted_subnets.length > 0" class="space-y-2 mb-2">
           <div v-for="(subnet, index) in config.trusted_subnets" :key="index" class="flex items-center gap-2">

--- a/src_assets/common/assets/web/pairing-network-trust.test.js
+++ b/src_assets/common/assets/web/pairing-network-trust.test.js
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('pairing network trust navigation', () => {
+  it('links Configure Network Trust directly to encryption and trust settings', () => {
+    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/PinView.vue'), 'utf8')
+
+    expect(source).toContain('href="#/config#encryption_and_trust"')
+  })
+
+  it('anchors the Network encryption and trust section for deep links', () => {
+    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/configs/tabs/Network.vue'), 'utf8')
+
+    expect(source).toContain('id="encryption_and_trust"')
+  })
+
+  it('uses generic documentation-style trusted subnet examples', () => {
+    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/configs/tabs/Network.vue'), 'utf8')
+
+    expect(source).toContain('fd00:1234:5678::/64')
+    expect(source).not.toContain('fdeb:c779:7c30:dedf::/64')
+  })
+})

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -584,6 +584,9 @@ const mobileNavItems = computed(() => tabGroups.value.flatMap(group => group.ite
 const visibleTabCountLabel = computed(() => i18n.t('config.visible_tabs', { count: matchingTabs.value.length, total: tabs.value.length }))
 const searchSummary = computed(() => i18n.t('config.search_results', { query: searchQuery.value, count: matchingTabs.value.length }))
 const searchHasResults = computed(() => matchingTabs.value.length > 0)
+const sectionHashTabs = {
+  encryption_and_trust: 'network',
+}
 const hasUnsavedChanges = computed(() => {
   if (!config.value || !initialSerialized.value) return false
   return JSON.stringify(serialize()) !== initialSerialized.value
@@ -699,6 +702,11 @@ function resolveSearchTarget(optionKey) {
   return null
 }
 
+function resolveSectionTarget(sectionId) {
+  if (!settingsContentRef.value || !sectionId) return null
+  return settingsContentRef.value.querySelector(`#${escapeSelector(sectionId)}`)
+}
+
 async function focusSearchTarget(optionKey) {
   if (!searchQuery.value || !optionKey) return
   await nextTick()
@@ -723,6 +731,13 @@ function selectNavTab(tabId) {
     return
   }
   currentTab.value = tabId
+}
+
+async function focusSectionTarget(sectionId) {
+  await nextTick()
+  const target = resolveSectionTarget(sectionId)
+  if (!target) return
+  target.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' })
 }
 
 function serialize() {
@@ -946,6 +961,14 @@ function handleHash() {
 
     if (configHash) {
       let stripped_hash = configHash
+
+      if (sectionHashTabs[stripped_hash]) {
+        currentTab.value = sectionHashTabs[stripped_hash]
+        setTimeout(() => {
+          focusSectionTarget(stripped_hash)
+        }, 400)
+        return
+      }
 
       tabs.value.forEach(tab => {
         Object.keys(tab.options).forEach(key => {

--- a/src_assets/common/assets/web/views/PinView.vue
+++ b/src_assets/common/assets/web/views/PinView.vue
@@ -97,7 +97,7 @@
                 <p class="mt-2 text-sm text-storm">{{ $t('pin.trusted_network_desc') }}</p>
               </div>
               <a
-                href="#/config"
+                href="#/config#encryption_and_trust"
                 class="inline-flex h-9 items-center justify-center rounded-lg bg-ice px-4 text-sm font-medium text-void transition-all duration-200 hover:bg-ice/90 hover:shadow-[0_0_24px_rgba(200,214,229,0.2)]"
               >
                 {{ $t('pin.configure_network') }}


### PR DESCRIPTION
## Summary
- deep-links the pairing page's Configure Network Trust action to `#/config#encryption_and_trust`
- anchors the Network tab's Encryption and Trust section and switches to that tab before scrolling
- replaces the specific IPv6 trusted subnet example with a generic documentation-style example
- adds focused source regression coverage

## User-facing impact
Pairing → Configure Network Trust now lands users directly on the relevant Network settings section instead of the top of Settings.

## Test Plan
- [x] `npm run test -- pairing-network-trust.test.js`
- [x] `git diff --check master..HEAD`
- [x] `npm run lint`
- [x] `npm run build`
