### PR TITLE
fix: satisfy public hygiene for Codex home examples

### DIFF
--- a/src_assets/common/assets/web/configs/tabs/AiOptimizer.vue
+++ b/src_assets/common/assets/web/configs/tabs/AiOptimizer.vue
@@ -784,7 +784,7 @@ onBeforeUnmount(() => {
                 v-model="config.ai_codex_home"
                 type="text"
                 class="w-full bg-void/50 border border-storm/50 rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm"
-                placeholder="/home/you/.codex" />
+                placeholder="~/.codex" />
               <div class="text-xs text-storm mt-1">Optional CODEX_HOME override. Use this when Polaris runs as a service or profile with a different HOME than your logged-in Codex CLI.</div>
               <div v-if="aiStatus?.codex_home_effective" class="text-xs text-storm mt-1">Live effective CODEX_HOME: <span class="font-mono text-silver/80">{{ aiStatus.codex_home_effective }}</span></div>
             </div>

--- a/tests/unit/test_ai_optimizer.cpp
+++ b/tests/unit/test_ai_optimizer.cpp
@@ -30,11 +30,11 @@ namespace {
 TEST(AiOptimizerCodexHome, UsesExplicitCodexHomeWhenConfigured) {
   auto resolved = ai_optimizer::resolve_codex_home_for_subscription(
     "/tmp/polaris-profile-home",
-    "/home/papi/.codex"
+    "/tmp/codex-home"
   );
 
   ASSERT_TRUE(resolved.has_value());
-  EXPECT_EQ("/home/papi/.codex", *resolved);
+  EXPECT_EQ("/tmp/codex-home", *resolved);
 }
 
 TEST(AiOptimizerCodexHome, FallsBackToRuntimeHomeCodexDirectory) {


### PR DESCRIPTION
## Summary
- replace the Codex home placeholder with a tilde-based example
- use a generic /tmp fixture in the AI optimizer Codex home test

## Test Plan
- bash scripts/check-public-surface.sh
- git diff --check