### PR TITLE
feat(ui): add Miami Nebula theme

### DIFF
--- a/src_assets/common/assets/web/App.vue
+++ b/src_assets/common/assets/web/App.vue
@@ -55,14 +55,14 @@
       <div class="px-3 mb-1">
         <button
           type="button"
-          @click="currentTheme = currentTheme === 'oled' ? 'polaris' : 'oled'; setTheme(currentTheme)"
+          @click="cycleAppTheme"
           class="focus-ring flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-[background-color,color,border-color] duration-200"
-          :class="currentTheme === 'oled' ? 'text-ice bg-ice/10' : 'text-storm hover:text-silver hover:bg-twilight/50'"
-          :title="currentTheme === 'oled' ? t('navbar.theme_switch_polaris') : t('navbar.theme_switch_oled')"
+          :class="currentTheme !== 'polaris' ? 'text-ice bg-ice/10' : 'text-storm hover:text-silver hover:bg-twilight/50'"
+          :title="'Switch to ' + nextThemeLabel"
         >
           <svg v-if="currentTheme === 'oled'" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
           <svg v-else class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
-          <span v-if="!sidebarCollapsed">{{ currentTheme === 'oled' ? t('navbar.theme_oled') : t('navbar.theme_polaris') }}</span>
+          <span v-if="!sidebarCollapsed">{{ currentThemeMeta.shortLabel }}</span>
         </button>
       </div>
       <div class="px-3 mb-1">
@@ -148,12 +148,15 @@ import { useI18n } from 'vue-i18n'
 import CommandPalette from './CommandPalette.vue'
 import Toast from './components/Toast.vue'
 import SpaceParticles from './components/SpaceParticles.vue'
-import { initTheme, getTheme, setTheme as setThemeFn } from './theme.js'
+import { cycleTheme, getNextTheme, getTheme, getThemeMeta, initTheme } from './theme.js'
 import { getCachedConfig } from './config-cache.js'
 
 const route = useRoute()
 const currentTheme = ref(getTheme())
-function setTheme(t) { setThemeFn(t); currentTheme.value = t }
+const currentThemeMeta = computed(() => getThemeMeta(currentTheme.value))
+const nextThemeLabel = computed(() => getThemeMeta(getNextTheme(currentTheme.value)).label)
+
+function cycleAppTheme() { currentTheme.value = cycleTheme() }
 const router = useRouter()
 const commandPaletteOpen = ref(false)
 const sidebarOpen = ref(false)

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -1239,3 +1239,48 @@ textarea {
     animation: none;
   }
 }
+
+/* ── Miami Nebula Skin ── */
+[data-theme="miami"] {
+  --color-ice: #fff1f7;
+  --color-silver: #ffd3e2;
+  --color-storm: #b785a1;
+  --color-twilight: #3f2447;
+  --color-deep: #241429;
+  --color-void: #130817;
+  --color-accent: #ff5cab;
+  --color-surface: #3f2447;
+  --color-background: #241429;
+  --color-foreground: #ffd3e2;
+  --color-muted: #b785a1;
+  --color-border: #6c3c6f;
+}
+
+[data-theme="miami"] .glass {
+  background: linear-gradient(135deg, rgba(36, 20, 41, 0.88), rgba(72, 31, 73, 0.78));
+  border-color: rgba(255, 92, 171, 0.18);
+}
+[data-theme="miami"] .card,
+[data-theme="miami"] .section-card,
+[data-theme="miami"] .config-page .settings-section {
+  background: linear-gradient(135deg, rgba(36, 20, 41, 0.92), rgba(52, 30, 58, 0.86));
+  border-color: rgba(255, 92, 171, 0.14);
+}
+[data-theme="miami"] .surface-subtle,
+[data-theme="miami"] .action-tile {
+  background: rgba(44, 23, 52, 0.76);
+  border-color: rgba(255, 211, 226, 0.10);
+}
+[data-theme="miami"] .action-tile:hover {
+  background: rgba(65, 32, 72, 0.82);
+  border-color: rgba(255, 92, 171, 0.24);
+}
+[data-theme="miami"] .sidebar-link.active {
+  color: #fff1f7;
+  background: rgba(255, 92, 171, 0.10);
+  box-shadow: inset 2px 0 0 rgba(255, 92, 171, 0.92), inset 0 1px 0 rgba(255,255,255,0.05);
+}
+[data-theme="miami"] .pulse-dot {
+  background: #ff5cab;
+  box-shadow: 0 0 18px rgba(255, 92, 171, 0.45);
+}

--- a/src_assets/common/assets/web/theme.js
+++ b/src_assets/common/assets/web/theme.js
@@ -1,30 +1,50 @@
-// Polaris Theme System — Space Whale (default) and OLED Dark Galaxy
+// Polaris Theme System — Space Whale (default), OLED Dark Galaxy, and Miami Nebula
 
 const STORAGE_KEY = 'polaris-theme'
-const THEMES = ['polaris', 'oled']
+
+export const THEMES = [
+  { id: 'polaris', label: 'Space Whale', shortLabel: 'Polaris' },
+  { id: 'oled', label: 'OLED Dark Galaxy', shortLabel: 'OLED' },
+  { id: 'miami', label: 'Miami Nebula', shortLabel: 'Miami' },
+]
+
+const DEFAULT_THEME = THEMES[0].id
+const THEME_IDS = THEMES.map((theme) => theme.id)
 
 export function getTheme() {
-  return localStorage.getItem(STORAGE_KEY) || 'polaris'
+  const storedTheme = localStorage.getItem(STORAGE_KEY)
+  return THEME_IDS.includes(storedTheme) ? storedTheme : DEFAULT_THEME
+}
+
+export function getThemeMeta(theme) {
+  return THEMES.find((item) => item.id === theme) || THEMES[0]
 }
 
 export function setTheme(theme) {
-  if (!THEMES.includes(theme)) return
+  if (!THEME_IDS.includes(theme)) return
   localStorage.setItem(STORAGE_KEY, theme)
   applyTheme(theme)
 }
 
-export function toggleTheme() {
-  const current = getTheme()
-  const next = current === 'polaris' ? 'oled' : 'polaris'
+export function getNextTheme(theme = getTheme()) {
+  const currentIndex = THEME_IDS.indexOf(theme)
+  if (currentIndex === -1) return DEFAULT_THEME
+  return THEME_IDS[(currentIndex + 1) % THEME_IDS.length]
+}
+
+export function cycleTheme() {
+  const next = getNextTheme()
   setTheme(next)
   return next
 }
 
+export const toggleTheme = cycleTheme
+
 export function applyTheme(theme) {
-  if (theme === 'oled') {
-    document.documentElement.setAttribute('data-theme', 'oled')
-  } else {
+  if (theme === DEFAULT_THEME) {
     document.documentElement.removeAttribute('data-theme')
+  } else if (THEME_IDS.includes(theme)) {
+    document.documentElement.setAttribute('data-theme', theme)
   }
 }
 

--- a/src_assets/common/assets/web/theme.test.js
+++ b/src_assets/common/assets/web/theme.test.js
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  applyTheme,
+  cycleTheme,
+  getNextTheme,
+  getTheme,
+  setTheme,
+  THEMES,
+  toggleTheme,
+} from './theme.js'
+
+describe('theme skin registry', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('registers Miami Nebula alongside the existing skins', () => {
+    expect(THEMES.map((theme) => theme.id)).toEqual(['polaris', 'oled', 'miami'])
+    expect(THEMES.find((theme) => theme.id === 'miami')).toMatchObject({
+      label: 'Miami Nebula',
+      shortLabel: 'Miami',
+    })
+  })
+
+  it('applies non-default skins through the data-theme attribute', () => {
+    setTheme('miami')
+
+    expect(getTheme()).toBe('miami')
+    expect(localStorage.getItem('polaris-theme')).toBe('miami')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('miami')
+  })
+
+  it('resolves the next registered skin from any current skin', () => {
+    expect(getNextTheme()).toBe('oled')
+    expect(getNextTheme('polaris')).toBe('oled')
+    expect(getNextTheme('oled')).toBe('miami')
+    expect(getNextTheme('miami')).toBe('polaris')
+    expect(getNextTheme('mystery-meat')).toBe('polaris')
+  })
+
+  it('cycles through every registered skin and wraps back to the default', () => {
+    expect(cycleTheme()).toBe('oled')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('oled')
+    expect(cycleTheme()).toBe('miami')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('miami')
+    expect(cycleTheme()).toBe('polaris')
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+  })
+
+  it('keeps toggleTheme as the backward-compatible cycle API', () => {
+    setTheme('oled')
+
+    expect(toggleTheme()).toBe('miami')
+    expect(getTheme()).toBe('miami')
+    expect(toggleTheme()).toBe('polaris')
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+  })
+
+  it('falls back to the default when storage contains an unknown skin', () => {
+    localStorage.setItem('polaris-theme', 'mystery-meat')
+
+    expect(getTheme()).toBe('polaris')
+    applyTheme(getTheme())
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds the Miami Nebula theme palette and applies it through the existing web theme system.
- Updates the app theme selector/markup for the new theme option.
- Adds focused unit coverage for the theme palette/apply behavior.

## Motivation
Give Polaris a polished Miami-flavored UI theme without touching streaming/runtime behavior.

No linked issue; this is intentionally separate from Issue #92.

## Changes
- Modify `src_assets/common/assets/web/theme.js` for the new Miami Nebula theme definition and behavior.
- Modify `src_assets/common/assets/web/app.css` for theme variables/styles.
- Modify `src_assets/common/assets/web/App.vue` for the theme option/markup.
- Add `src_assets/common/assets/web/theme.test.js`.

## Test Plan
- git diff --check polaris/master..feat/miami-nebula-theme
- ./node_modules/.bin/eslint "src_assets/common/assets/web/**/*.{js,vue}" --max-warnings=0
- ./node_modules/.bin/vitest run src_assets/common/assets/web/theme.test.js --run
- GitHub CI / PR checks

## Notes for Reviewers
- Web-theme-only diff; no C++ runtime, streaming, codec, session, or Nova client contract changes intended.
- Please keep any Issue #92/runtime fallback work out of this PR.
