### PR TITLE
fix(linux): force software cursors for private labwc runtime

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -138,6 +138,43 @@ namespace cage_display_router {
     return prefix;
   }
 
+  static std::string labwc_process_environment_value(bool headless, std::string_view key) {
+    if (key == "WLR_NO_HARDWARE_CURSORS") {
+      // Polaris captures the private labwc compositor, not the host desktop. On
+      // some wlroots/labwc stacks hardware cursors remain interactive but never
+      // appear in captured frames, so force wlroots to paint software cursors.
+      return "1";
+    }
+
+    if (key == "WLR_BACKENDS") {
+      return headless ? "headless" : "wayland";
+    }
+
+    if (key == "WLR_RENDERER") {
+      return headless ? "gles2" : "vulkan";
+    }
+
+    if (headless && key == "WLR_HEADLESS_OUTPUTS") {
+      return "1";
+    }
+
+    return {};
+  }
+
+  static void set_labwc_process_environment(bool headless) {
+    for (std::string_view key : {
+           "WLR_NO_HARDWARE_CURSORS"sv,
+           "WLR_BACKENDS"sv,
+           "WLR_RENDERER"sv,
+           "WLR_HEADLESS_OUTPUTS"sv,
+         }) {
+      const auto value = labwc_process_environment_value(headless, key);
+      if (!value.empty()) {
+        setenv(std::string {key}.c_str(), value.c_str(), 1);
+      }
+    }
+  }
+
   static bool executable_accessible(const std::string &path) {
     return !path.empty() && access(path.c_str(), X_OK) == 0;
   }
@@ -547,6 +584,10 @@ namespace cage_display_router {
   ) {
     return mangohud_prefix_for_command(game_cmd, allow_mangohud, mangohud_value, mangohud_config);
   }
+
+  std::string labwc_process_environment_value_for_tests(bool headless, std::string_view key) {
+    return labwc_process_environment_value(headless, key);
+  }
 #endif
 
   // -----------------------------------------------------------------------
@@ -672,6 +713,7 @@ namespace cage_display_router {
     pid_t pid = fork();
     if (pid == 0) {
       // Child: set wlroots environment, detach, exec labwc
+      set_labwc_process_environment(headless);
       if (headless) {
         // Headless mode: no visible window on desktop, no parent display needed.
         // labwc creates virtual outputs that still support wlr-screencopy.
@@ -684,9 +726,6 @@ namespace cage_display_router {
         //
         // For now: use headless with GLES2, the SHM capture path in wlgrab
         // handles the conversion via software scaler (slower but functional).
-        setenv("WLR_BACKENDS", "headless", 1);
-        setenv("WLR_HEADLESS_OUTPUTS", "1", 1);
-        setenv("WLR_RENDERER", "gles2", 1);
         // Clear inherited display vars so children ONLY talk to labwc.
         // labwc will set its own WAYLAND_DISPLAY and start XWayland (new DISPLAY).
         // Without this, Steam connects to KDE's :0 instead of labwc's XWayland.
@@ -694,8 +733,6 @@ namespace cage_display_router {
         unsetenv("WAYLAND_DISPLAY");
       } else {
         // Windowed mode: labwc runs as a Wayland window on the desktop
-        setenv("WLR_BACKENDS", "wayland", 1);
-        setenv("WLR_RENDERER", "vulkan", 1);
       }
       // Clear DISPLAY in ALL modes so games connect to labwc's XWayland,
       // not KDE's :0. labwc will set its own DISPLAY via XWayland.

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -227,6 +227,14 @@ namespace cage_display_router {
     std::string_view mangohud_value,
     std::string_view mangohud_config
   );
+
+  /**
+   * @brief Test helper for labwc process environment policy.
+   */
+  std::string labwc_process_environment_value_for_tests(
+    bool headless,
+    std::string_view key
+  );
 #endif
 
 }  // namespace cage_display_router

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -214,6 +214,23 @@ TEST(CageDisplayRouterPolicyTests, MangoHudPrefixStillAppliesToRegularGames) {
   );
 }
 
+TEST(CageDisplayRouterPolicyTests, LabwcProcessEnvironmentDisablesHardwareCursors) {
+  EXPECT_EQ(
+    cage_display_router::labwc_process_environment_value_for_tests(
+      true,
+      "WLR_NO_HARDWARE_CURSORS"
+    ),
+    "1"
+  );
+  EXPECT_EQ(
+    cage_display_router::labwc_process_environment_value_for_tests(
+      false,
+      "WLR_NO_HARDWARE_CURSORS"
+    ),
+    "1"
+  );
+}
+
 TEST(CageDisplayRouterPolicyTests, OutputModeParserRecognizesRequestedCurrentMode) {
   constexpr std::string_view output = R"(HEADLESS-1 "Headless output 1"
   Enabled: yes


### PR DESCRIPTION
## Bug Description

The pointer could still interact with the private labwc session, but the cursor itself was not drawn in the captured/streamed output.

A reporter confirmed that adding `WLR_NO_HARDWARE_CURSORS=1` to the labwc-polaris environment makes the cursor visible again.

## Root Cause

The private labwc/wlroots runtime could use hardware cursors, which are not reliably painted into the captured output path. That leaves input functional but the cursor visually invisible to the remote client.

## Fix

- Force `WLR_NO_HARDWARE_CURSORS=1` when Polaris spawns the private labwc process.
- Preserve the existing wlroots backend/renderer policy for headless and windowed labwc modes.
- Centralize the labwc environment policy so it is covered by unit tests.
- Add a regression test for the cursor environment setting.

## How to Verify

1. Launch a private labwc session through Polaris.
2. Connect from a streaming client.
3. Confirm the pointer is drawn/visible while moving over the streamed session.

## Test Plan

- [x] Added regression test for this bug: `CageDisplayRouterPolicyTests.LabwcProcessEnvironmentDisablesHardwareCursors`
- [x] `git diff --check`
- [x] `cmake --build build --target polaris test_polaris_platform test_polaris -j$(nproc)`
- [x] `ctest --test-dir build -R "^(test_polaris|test_polaris_platform)$" --output-on-failure`

## Risk Assessment

Low — this only changes the environment used when spawning the private labwc compositor. It forces software cursor drawing while preserving the existing backend/renderer settings for headless and windowed modes.
