### PR TITLE
fix(linux): fall back to loginctl when D-Bus unlock leaves session locked

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Hardened Linux lock-screen dismissal so a failed `loginctl unlock-session` attempt continues through other graphical user sessions before falling back to `loginctl unlock-sessions`
+
 ## v1.1.0
 
 Feature release focused on the Polaris web console, Library workflows, safer pairing defaults, and NVENC split-frame hardening.

--- a/src/platform/linux/session_manager.cpp
+++ b/src/platform/linux/session_manager.cpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 using namespace std::literals;
 
@@ -136,7 +137,21 @@ namespace session_manager {
     return session;
   }
 
-  static std::string select_loginctl_session_for_unlock() {
+  static void append_unique_session_id(std::vector<std::string> &session_ids, const std::string &session_id) {
+    if (session_id.empty()) {
+      return;
+    }
+
+    for (const auto &candidate : session_ids) {
+      if (candidate == session_id) {
+        return;
+      }
+    }
+
+    session_ids.push_back(session_id);
+  }
+
+  static std::vector<std::string> select_loginctl_sessions_for_unlock() {
     const char *env_session_id = std::getenv("XDG_SESSION_ID");
     const std::string xdg_session_id =
       (env_session_id && env_session_id[0] != '\0') ? env_session_id : "";
@@ -146,7 +161,7 @@ namespace session_manager {
     auto sessions = exec("loginctl list-sessions --no-legend 2>/dev/null");
     std::istringstream lines {sessions};
     std::string line;
-    std::string graphical_session_id;
+    std::vector<std::string> graphical_session_ids;
     bool xdg_session_is_graphical = false;
 
     while (std::getline(lines, line)) {
@@ -154,40 +169,50 @@ namespace session_manager {
       if (!session.is_graphical_user_session(current_user)) {
         continue;
       }
-      if (graphical_session_id.empty()) {
-        graphical_session_id = session.id;
-      }
+
+      append_unique_session_id(graphical_session_ids, session.id);
       if (!xdg_session_id.empty() && session.id == xdg_session_id) {
         xdg_session_is_graphical = true;
       }
     }
 
+    std::vector<std::string> candidates;
     if (xdg_session_is_graphical) {
-      return xdg_session_id;
+      append_unique_session_id(candidates, xdg_session_id);
     }
-    if (!graphical_session_id.empty()) {
-      return graphical_session_id;
+    for (const auto &session_id : graphical_session_ids) {
+      append_unique_session_id(candidates, session_id);
     }
-    return xdg_session_id;
+    if (candidates.empty()) {
+      append_unique_session_id(candidates, xdg_session_id);
+    }
+
+    return candidates;
   }
 
-  static bool unlock_with_loginctl() {
-    const std::string session_id = select_loginctl_session_for_unlock();
-    std::string cmd;
-    if (!session_id.empty()) {
-      BOOST_LOG(info) << "session_manager: Attempting loginctl unlock for session "sv << session_id;
-      cmd = "loginctl unlock-session " + shell_quote(session_id) + " 2>/dev/null";
-    } else {
-      BOOST_LOG(info) << "session_manager: XDG_SESSION_ID is not set; attempting loginctl unlock-sessions"sv;
-      cmd = "loginctl unlock-sessions 2>/dev/null";
-    }
-
+  static bool run_loginctl_unlock_command(const std::string &cmd, std::string_view failure_message) {
     if (!run(cmd)) {
-      BOOST_LOG(warning) << "session_manager: loginctl unlock command failed"sv;
+      BOOST_LOG(warning) << failure_message;
       return false;
     }
 
     return wait_for_unlock(2s);
+  }
+
+  static bool unlock_with_loginctl() {
+    for (const auto &session_id : select_loginctl_sessions_for_unlock()) {
+      BOOST_LOG(info) << "session_manager: Attempting loginctl unlock for session "sv << session_id;
+      const std::string cmd = "loginctl unlock-session " + shell_quote(session_id) + " 2>/dev/null";
+      if (run_loginctl_unlock_command(cmd, "session_manager: loginctl unlock command failed"sv)) {
+        return true;
+      }
+    }
+
+    BOOST_LOG(info) << "session_manager: Attempting loginctl unlock-sessions"sv;
+    return run_loginctl_unlock_command(
+      "loginctl unlock-sessions 2>/dev/null",
+      "session_manager: loginctl unlock-sessions command failed"sv
+    );
   }
 
   // -----------------------------------------------------------------------

--- a/tests/unit/platform/test_session_manager.cpp
+++ b/tests/unit/platform/test_session_manager.cpp
@@ -125,6 +125,26 @@ TEST(SessionManagerUnlockTests, ManagerSessionIdFallsBackToGraphicalLoginctlSess
   EXPECT_FALSE(harness.ran("loginctl unlock-session '2'"));
 }
 
+TEST(SessionManagerUnlockTests, FailedGraphicalUnlockTriesNextGraphicalSession) {
+  SessionManagerCommandHarness harness;
+  harness.loginctl_clears_lock = true;
+  harness.loginctl_command_that_clears = "loginctl unlock-session '3'";
+  const char *user = std::getenv("USER");
+  ASSERT_NE(nullptr, user);
+  harness.loginctl_list_sessions_output =
+    "1 1000 " + std::string {user} + " seat0 2134 user tty1 no -\n"
+    "2 1000 " + std::string {user} + " - 2197 manager - no -\n"
+    "3 1000 " + std::string {user} + " seat0 2244 user tty2 no -";
+  setenv("XDG_SESSION_ID", "2", 1);
+
+  EXPECT_TRUE(session_manager::unlock_screen());
+
+  EXPECT_FALSE(harness.locked);
+  EXPECT_TRUE(harness.ran("loginctl unlock-session '1'"));
+  EXPECT_TRUE(harness.ran("loginctl unlock-session '3'"));
+  EXPECT_FALSE(harness.ran("loginctl unlock-session '2'"));
+}
+
 TEST(SessionManagerUnlockTests, MissingSessionIdUsesAllSessionsLoginctlFallback) {
   SessionManagerCommandHarness harness;
   harness.loginctl_clears_lock = true;


### PR DESCRIPTION
## Summary
- continue past a successful ScreenSaver D-Bus unlock when the session still reports locked
- discover the real graphical user session before calling `loginctl unlock-session`
- add coverage for the D-Bus-still-locked fallback and missing session ID behavior

Fixes #110.

## Validation
- `cmake -S . -B build-test/issue-110 -G Ninja -DBUILD_TESTS=ON -DBUILD_FULL_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DPOLARIS_ENABLE_CUDA=OFF -DPOLARIS_ENABLE_BROWSER_STREAM=OFF -DCUDA_FAIL_ON_MISSING=OFF`
- `cmake --build build-test/issue-110 --target test_polaris_platform -j$(nproc)`
- `ctest --test-dir build-test/issue-110/tests --output-on-failure -R '^test_polaris_platform$'`

## Manual smoke
- Verified on pc-papi KDE/Wayland with a locked graphical logind session.
- Simulated ScreenSaver D-Bus `SetActive(false)` returning success without clearing the lock.
- Confirmed Polaris fell back to `loginctl unlock-session <graphical-session>` instead of targeting the manager session.
