### PR TITLE
fix(linux): preserve virtual display output names

### DIFF
--- a/src/display_device.cpp
+++ b/src/display_device.cpp
@@ -766,7 +766,11 @@ namespace display_device {
   std::string map_display_name(const std::string &display_name) {
     std::lock_guard lock { DD_DATA.mutex };
     if (!DD_DATA.sm_instance) {
-      return {};
+      // Fallback to the display name itself when the platform display-device
+      // settings manager is unavailable. Linux capture backends already use
+      // connector names such as HDMI-A-1 directly, so clearing the name here
+      // causes host virtual display capture to fall back to the wrong output.
+      return display_name;
     }
 
     const auto available_devices { DD_DATA.sm_instance->execute([](auto &settings_iface) { return settings_iface.enumAvailableDevices(); }) };

--- a/tests/unit/test_display_device.cpp
+++ b/tests/unit/test_display_device.cpp
@@ -46,6 +46,10 @@ namespace {
   struct DisplayDeviceConfigTest: testing::TestWithParam<T> {};
 }  // namespace
 
+TEST(DisplayDeviceNameMappingTests, MapDisplayNameFallsBackToProvidedNameWhenNoSettingsManagerAvailable) {
+  EXPECT_EQ(display_device::map_display_name("HDMI-A-1"), "HDMI-A-1");
+}
+
 using ParseDeviceId = DisplayDeviceConfigTest<std::pair<std::string, std::string>>;
 INSTANTIATE_TEST_SUITE_P(
   DisplayDeviceConfigTest,


### PR DESCRIPTION
## Summary
- Preserve Linux connector/display names when no display-device settings manager is available.
- Prevent Host Virtual Display outputs like `HDMI-A-1` from being mapped to an empty `config::video.output_name` after creation.
- Add a regression test covering the no-settings-manager fallback path.

## Root cause
Linux Host Virtual Display creation sets the capture target from `display_device::map_display_name(this->display_name)`. On Linux, the display-device settings manager can be unavailable, and `map_display_name()` returned an empty string in that case. That cleared connector names such as `HDMI-A-1`, so the subsequent capture/encoder probe could target the wrong output or no explicit output at all.

## Test plan
- RED: `./build/tests/test_polaris_config --gtest_filter=DisplayDeviceNameMappingTests.MapDisplayNameFallsBackToProvidedNameWhenNoSettingsManagerAvailable` failed before the fix because `map_display_name("HDMI-A-1")` returned `""`.
- GREEN: same focused regression test passes after the fix.
- `cmake --build build --target polaris test_polaris_full test_polaris -j 4`
- `ctest --test-dir build --output-on-failure` → 100% tests passed, 0 failed out of 12.

Fixes #118
