### PR TITLE
fix(linux): skip host Steam shutdown after headless cage cleanup

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -992,6 +992,14 @@ namespace proc {
              !steam_appid_for_context(ctx).empty();
     }
 
+    bool should_skip_steam_shutdown_undo_after_cage_cleanup(const proc::ctx_t &ctx,
+                                                            const proc::cmd_t &cmd,
+                                                            bool use_cage_compositor) {
+      return use_cage_compositor &&
+             context_uses_steam(ctx) &&
+             command_requests_steam_shutdown(cmd.undo_cmd);
+    }
+
     bool is_browser_stream_session(const std::shared_ptr<rtsp_stream::launch_session_t> &launch_session) {
       return launch_session && launch_session->device_name == "Browser Stream";
     }
@@ -1663,6 +1671,12 @@ namespace proc {
                                                    bool use_cage_compositor,
                                                    bool requested_headless) {
     return cage_mangohud_allowed_for_session(app, use_cage_compositor, requested_headless);
+  }
+
+  bool should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(const proc::ctx_t &app,
+                                                                   const proc::cmd_t &cmd,
+                                                                   bool use_cage_compositor) {
+    return should_skip_steam_shutdown_undo_after_cage_cleanup(app, cmd, use_cage_compositor);
   }
 #endif
 
@@ -3553,10 +3567,12 @@ namespace proc {
       }
 
 #ifdef __linux__
-      if (config::video.linux_display.use_cage_compositor &&
-          !steam_appid_for_context(_app).empty() &&
-          command_requests_steam_shutdown(cmd.undo_cmd)) {
-        BOOST_LOG(info) << "Skipping Steam shutdown undo after isolated cage Steam app cleanup ["sv
+      if (should_skip_steam_shutdown_undo_after_cage_cleanup(
+            _app,
+            cmd,
+            config::video.linux_display.use_cage_compositor
+          )) {
+        BOOST_LOG(info) << "Skipping Steam shutdown undo after isolated cage Steam cleanup ["sv
                         << cmd.undo_cmd << ']';
         continue;
       }

--- a/src/process.h
+++ b/src/process.h
@@ -63,6 +63,9 @@ namespace proc {
   bool cage_mangohud_allowed_for_session_for_tests(const struct ctx_t &app,
                                                    bool use_cage_compositor,
                                                    bool requested_headless);
+  bool should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(const struct ctx_t &app,
+                                                                   const config::prep_cmd_t &cmd,
+                                                                   bool use_cage_compositor);
 #endif
 
   typedef config::prep_cmd_t cmd_t;

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -71,6 +71,21 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureNeverAllowsCageMangoHud) {
 
   EXPECT_FALSE(proc::cage_mangohud_allowed_for_session_for_tests(app, true, true));
 }
+
+TEST(ProcessRuntimeConfigTests, HeadlessCageSteamBigPictureSkipsHostShutdownUndo) {
+  proc::ctx_t app {};
+  app.name = "Steam Big Picture";
+  app.detached = {"setsid steam -gamepadui"};
+
+  proc::cmd_t shutdown_undo {
+    std::string {},
+    std::string {"setsid -f steam -shutdown"},
+    false
+  };
+
+  EXPECT_TRUE(proc::should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(app, shutdown_undo, true));
+  EXPECT_FALSE(proc::should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(app, shutdown_undo, false));
+}
 #endif
 
 TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {


### PR DESCRIPTION
## Summary
- Treat Steam Big Picture as a Steam cleanup context in the isolated Linux cage shutdown path.
- Skip `steam -shutdown` undo after private `labwc` cleanup for any Steam context, preventing Steam Gamepad UI from briefly appearing on the host display when a headless stream ends.
- Add a regression helper/test covering the no-AppID Steam Big Picture case.

Fixes #122

## Test Plan
- [x] `cmake --build build --target test_polaris_config -j$(nproc)` on pc-papi
- [x] `./build/tests/test_polaris_config --gtest_color=no` on pc-papi — 175 tests passed