### PR TITLE
feat(web): add staged library import review

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Added a sticky Library import staging summary and review drawer with source counts, per-game removal, clear-all staging, and already-imported confirmation
 - Reduced idle web console polling pressure by deduplicating overlapping system/stream stats fetches and backing off transient fallback failures
 - Added a Settings pending-changes review drawer with safe before/after values, save/apply impact labels, jump links, and per-setting reset controls
 - Added confirmation dialogs and async toast feedback for host-affecting web actions such as disconnecting clients, recovery controls, stale display cleanup, and restart-sensitive quick toggles

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -626,6 +626,39 @@ textarea {
   @apply text-base font-semibold text-silver;
 }
 
+.operator-console .library-import-staged-summary {
+  @apply sticky top-4 z-20 flex flex-col gap-4 rounded-xl border border-ice/25 bg-deep/95 px-4 py-4 shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur lg:flex-row lg:items-center lg:justify-between;
+}
+
+.operator-console .library-import-staged-title {
+  @apply mt-1 text-lg font-semibold text-silver;
+}
+
+.operator-console .library-import-staged-copy {
+  @apply mt-1 max-w-2xl text-sm leading-relaxed text-storm;
+}
+
+.operator-console .library-import-staged-sources,
+.operator-console .library-import-staged-actions {
+  @apply mt-3 flex flex-wrap items-center gap-2;
+}
+
+.operator-console .library-import-staged-actions {
+  @apply lg:mt-0 lg:justify-end;
+}
+
+.operator-console .library-import-review-drawer {
+  @apply rounded-xl border border-storm/20 bg-deep/45 p-4;
+}
+
+.operator-console .library-import-review-list {
+  @apply mt-4 grid gap-2;
+}
+
+.operator-console .library-import-review-row {
+  @apply flex min-w-0 flex-col gap-3 rounded-lg border border-storm/15 bg-void/35 px-3 py-3 sm:flex-row sm:items-center sm:justify-between;
+}
+
 .operator-console .library-import-alert {
   @apply flex flex-col gap-3 rounded-lg border border-amber-300/25 bg-amber-300/8 px-4 py-3 sm:flex-row sm:items-center sm:justify-between;
 }

--- a/src_assets/common/assets/web/library-staged-import-review.test.js
+++ b/src_assets/common/assets/web/library-staged-import-review.test.js
@@ -1,0 +1,138 @@
+import { shallowMount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+import AppsView from './views/AppsView.vue'
+
+const scannerState = {
+  scanning: ref(false),
+  importing: ref(false),
+  steamGames: ref([]),
+  lutrisGames: ref([]),
+  heroicGames: ref([]),
+  error: ref(null),
+  scan: vi.fn(),
+  importSelected: vi.fn(() => Promise.resolve(0)),
+  toggleAll: vi.fn((value, source) => {
+    const lists = {
+      steam: scannerState.steamGames,
+      lutris: scannerState.lutrisGames,
+      heroic: scannerState.heroicGames,
+    }
+    const targets = source ? [lists[source].value] : Object.values(lists).map((list) => list.value)
+    targets.forEach((games) => games.forEach((game) => {
+      if (!game.already_imported) game.selected = value
+    }))
+  }),
+}
+
+vi.mock('./composables/useGameScanner', () => ({
+  useGameScanner: () => scannerState,
+}))
+
+const i18n = {
+  t(key) { return key },
+}
+
+function flushAppsViewLoad() {
+  return Promise.resolve().then(() => Promise.resolve()).then(() => nextTick())
+}
+
+function mountAppsView() {
+  global.fetch = vi.fn((url) => {
+    if (String(url).includes('./api/apps')) {
+      return Promise.resolve({
+        json: () => Promise.resolve({ apps: [], current_app: '', host_name: 'Test Host', host_uuid: 'host-1' }),
+      })
+    }
+
+    if (String(url).includes('./api/config')) {
+      return Promise.resolve({
+        json: () => Promise.resolve({ platform: 'linux' }),
+      })
+    }
+
+    return Promise.resolve({ json: () => Promise.resolve({ status: true }) })
+  })
+
+  return shallowMount(AppsView, {
+    global: {
+      provide: { i18n },
+      mocks: { $t: i18n.t.bind(i18n) },
+      stubs: {
+        Button: { props: ['disabled'], emits: ['click'], template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>' },
+        InfoHint: { template: '<span><slot /></span>' },
+        Checkbox: { template: '<label />' },
+      },
+    },
+  })
+}
+
+function resetScannerState() {
+  scannerState.scanning.value = false
+  scannerState.importing.value = false
+  scannerState.error.value = null
+  scannerState.steamGames.value = [
+    { name: 'ARC Raiders', source: 'steam', appid: '1808500', selected: true, already_imported: false },
+    { name: 'Hades', source: 'steam', appid: '1145360', selected: false, already_imported: true },
+  ]
+  scannerState.lutrisGames.value = []
+  scannerState.heroicGames.value = [
+    { name: 'Alan Wake 2', source: 'heroic', slug: 'alan-wake-2', runner: 'legendary', selected: true, already_imported: false },
+  ]
+  scannerState.scan.mockClear()
+  scannerState.importSelected.mockClear()
+  scannerState.toggleAll.mockClear()
+}
+
+describe('AppsView staged import review', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete global.fetch
+    document.body.innerHTML = ''
+  })
+
+  it('keeps a sticky staged summary with source counts and primary import action', async () => {
+    resetScannerState()
+    const wrapper = mountAppsView()
+    await flushAppsViewLoad()
+
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+
+    const summary = wrapper.find('.library-import-staged-summary')
+    expect(summary.exists()).toBe(true)
+    expect(summary.text()).toContain('2 games staged')
+    expect(summary.text()).toContain('Steam 1')
+    expect(summary.text()).toContain('Heroic 1')
+    expect(summary.text()).toContain('Import 2 staged games')
+  })
+
+  it('reviews staged games and can remove one item or clear all staged entries', async () => {
+    resetScannerState()
+    const wrapper = mountAppsView()
+    await flushAppsViewLoad()
+
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+    await wrapper.find('[data-import-review-open]').trigger('click')
+    await nextTick()
+
+    const drawer = wrapper.find('.library-import-review-drawer')
+    expect(drawer.exists()).toBe(true)
+    expect(drawer.text()).toContain('ARC Raiders')
+    expect(drawer.text()).toContain('Alan Wake 2')
+    expect(drawer.text()).toContain('Hades')
+    expect(drawer.text()).toContain('Already imported')
+
+    await wrapper.find('[data-import-stage-remove="1808500"]').trigger('click')
+    await nextTick()
+    expect(scannerState.steamGames.value[0].selected).toBe(false)
+    expect(wrapper.find('.library-import-staged-summary').text()).toContain('1 game staged')
+
+    await wrapper.find('[data-import-stage-clear-all]').trigger('click')
+    await nextTick()
+    expect(scannerState.heroicGames.value[0].selected).toBe(false)
+    expect(wrapper.find('.library-import-staged-summary').text()).toContain('No games staged')
+  })
+})

--- a/src_assets/common/assets/web/views/AppsView.vue
+++ b/src_assets/common/assets/web/views/AppsView.vue
@@ -112,6 +112,62 @@
         </div>
       </div>
 
+      <section v-if="hasImportSources" class="library-import-staged-summary" aria-live="polite">
+        <div class="min-w-0">
+          <div class="section-kicker">Staged import</div>
+          <div class="library-import-staged-title">{{ stagedImportSummaryTitle }}</div>
+          <div class="library-import-staged-copy">{{ stagedImportSummaryCopy }}</div>
+          <div v-if="stagedImportSources.length" class="library-import-staged-sources">
+            <span v-for="source in stagedImportSources" :key="source.key" class="meta-pill">
+              {{ source.label }} {{ source.selected }}
+            </span>
+          </div>
+        </div>
+        <div class="library-import-staged-actions">
+          <Button variant="outline" :disabled="allImportGames.length === 0" data-import-review-open @click="showImportReview = !showImportReview">
+            {{ showImportReview ? 'Hide review' : 'Review staged' }}
+          </Button>
+          <Button variant="outline" :disabled="selectedImportCount === 0" data-import-stage-clear-all @click="clearAllImportStaging">
+            Clear all
+          </Button>
+          <Button variant="primary" :disabled="gameImporting || selectedImportCount === 0" :loading="gameImporting" @click="doImport">
+            {{ importSelectedButtonLabel }}
+          </Button>
+        </div>
+      </section>
+
+      <section v-if="hasImportSources && showImportReview" class="library-import-review-drawer">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div class="section-kicker">Review queue</div>
+            <h3 class="text-base font-semibold text-silver">Confirm staged and already imported games</h3>
+            <p class="mt-1 text-sm text-storm">Remove individual staged entries before importing, or use already-imported rows as a sanity check.</p>
+          </div>
+          <span class="meta-pill">{{ reviewImportGames.length }} discovered</span>
+        </div>
+        <div class="library-import-review-list">
+          <article v-for="game in reviewImportGames" :key="importGameKey(game)" class="library-import-review-row">
+            <div class="min-w-0">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="truncate text-sm font-semibold text-silver">{{ game.name }}</span>
+                <span class="control-chip">{{ sourceLabel(game.source) }}</span>
+                <span class="control-chip">{{ importGameStateLabel(game) }}</span>
+              </div>
+              <div class="mt-1 text-xs text-storm">{{ importGameStateCopy(game) }}</div>
+            </div>
+            <Button
+              v-if="game.selected && !game.already_imported"
+              variant="ghost"
+              size="sm"
+              :data-import-stage-remove="importGameKey(game)"
+              @click="unstageImportGame(game)"
+            >
+              Remove
+            </Button>
+          </article>
+        </div>
+      </section>
+
       <div v-if="gameScanError" class="library-import-alert">
         <div class="min-w-0">
           <div class="text-sm font-semibold text-amber-100">Import scanner needs attention</div>
@@ -125,7 +181,7 @@
           <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z"/></svg>
         </div>
         <div class="mt-4 flex items-center justify-center gap-2">
-          <h3 class="text-lg font-semibold text-silver">Ready to scan</h3>
+          <h3 class="text-lg font-semibold text-silver">Ready to scan installed libraries</h3>
           <InfoHint size="sm" label="Game library scan">
             Start a scan to discover install candidates from Steam, Lutris, and Heroic. Already-imported entries stay visible so you can spot what is new.
           </InfoHint>
@@ -141,6 +197,7 @@
       <div v-else-if="gameScanning" class="mt-5 rounded-lg border border-storm/20 bg-deep/35 px-5 py-10 text-center">
         <svg class="mx-auto h-7 w-7 animate-spin text-ice" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" /><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4Zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647Z" /></svg>
         <h3 class="mt-4 text-lg font-semibold text-silver">Scanning installed libraries</h3>
+        <p class="mt-2 text-sm text-storm">Checking Steam, Lutris, and Heroic for new, staged, and already-imported entries.</p>
       </div>
 
       <div v-else class="library-import-workspace">
@@ -985,6 +1042,7 @@ const {
   scan: scanGames, importSelected, toggleAll: gameToggleAll
 } = useGameScanner()
 const showImport = ref(false)
+const showImportReview = ref(false)
 const importTab = ref('steam')
 const importSearch = ref('')
 const importStatus = ref('new')
@@ -992,6 +1050,7 @@ async function doImport() {
   const count = await importSelected()
   if (count > 0) {
     showToast(`Imported ${count} game${count > 1 ? 's' : ''}`, 'success')
+    showImportReview.value = true
     loadApps()
   }
 }
@@ -1091,12 +1150,23 @@ const allImportGames = computed(() => [...steamGames.value, ...lutrisGames.value
 const availableImportCount = computed(() => allImportGames.value.filter((game) => !game.already_imported).length)
 const selectedImportCount = computed(() => allImportGames.value.filter((game) => game.selected && !game.already_imported).length)
 const importedImportCount = computed(() => allImportGames.value.filter((game) => game.already_imported).length)
+const stagedImportSources = computed(() => importSources.value.filter((source) => source.selected > 0))
+const reviewImportGames = computed(() => allImportGames.value.filter((game) => game.selected || game.already_imported))
+const stagedImportSummaryTitle = computed(() => {
+  if (selectedImportCount.value === 0) return 'No games staged'
+  return `${selectedImportCount.value} game${selectedImportCount.value === 1 ? '' : 's'} staged`
+})
+const stagedImportSummaryCopy = computed(() => {
+  if (selectedImportCount.value === 0 && importedImportCount.value > 0) return 'Nothing queued. Already-imported entries remain visible in review so you can confirm state.'
+  if (selectedImportCount.value === 0) return 'Select candidates from any source to build one import queue.'
+  return 'Review the cross-source queue, remove anything you do not want, then import everything in one pass.'
+})
 const activeImportSource = computed(() => importSources.value.find((source) => source.key === importTab.value) || importSources.value[0] || null)
 const activeImportSourceKey = computed(() => activeImportSource.value?.key || importTab.value)
 const activeImportGames = computed(() => importPools.value[activeImportSourceKey.value] || [])
 const activeImportSummary = computed(() => summarizeImportGames(activeImportGames.value))
 const activeImportSelectedCount = computed(() => activeImportSummary.value.selected)
-const importSelectedButtonLabel = computed(() => selectedImportCount.value > 0 ? `Import ${selectedImportCount.value} Selected` : 'Import Selected')
+const importSelectedButtonLabel = computed(() => selectedImportCount.value > 0 ? `Import ${selectedImportCount.value} staged game${selectedImportCount.value === 1 ? '' : 's'}` : 'Import staged games')
 const visibleImportGames = computed(() => filterImportGames(activeImportGames.value, {
   query: importSearch.value,
   status: importStatus.value,
@@ -1127,6 +1197,30 @@ function formatCategory(category = '') {
 function trimCommand(command = '') {
   if (command.length <= 44) return command
   return `${command.slice(0, 41)}...`
+}
+
+function sourceLabel(source = '') {
+  return {
+    steam: 'Steam',
+    lutris: 'Lutris',
+    heroic: 'Heroic',
+  }[source] || source || 'Unknown'
+}
+
+function importGameKey(game) {
+  return game.appid || game.slug || game.name
+}
+
+function importGameStateLabel(game) {
+  if (game.already_imported) return 'Already imported'
+  if (game.selected) return 'Staged'
+  return 'New'
+}
+
+function importGameStateCopy(game) {
+  if (game.already_imported) return 'Already in Polaris; it will not be imported again.'
+  if (game.selected) return 'Queued for the next import pass.'
+  return 'Available to stage from its source list.'
 }
 
 function appOrderIndex(app) {
@@ -1161,6 +1255,14 @@ function selectVisibleImportGames(selected) {
 
 function clearActiveImportSource() {
   gameToggleAll(false, activeImportSourceKey.value)
+}
+
+function clearAllImportStaging() {
+  gameToggleAll(false)
+}
+
+function unstageImportGame(game) {
+  if (!game?.already_imported) game.selected = false
 }
 
 function launchHref(app) {


### PR DESCRIPTION
## Summary
- Adds a sticky Library import staging summary with staged totals, per-source counts, clear-all, and primary import action
- Adds a review drawer to confirm staged and already-imported games, remove individual staged items, and keep imported state visible
- Improves import scan/progress copy and adds an Unreleased changelog note for v1.1.1

## Test Plan
- npm run test -- src_assets/common/assets/web/library-staged-import-review.test.js
- npm run test
- npm run lint
- npm run build