### PR TITLE
feat(web): polish live dashboard hierarchy

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Polished Mission Control live-session hierarchy with a stronger top summary for stream quality, latency, FPS, loss, bitrate, capture path, and runtime mode plus collapsible secondary live panels
 - Added a sticky Library import staging summary and review drawer with source counts, per-game removal, clear-all staging, and already-imported confirmation
 - Reduced idle web console polling pressure by deduplicating overlapping system/stream stats fetches and backing off transient fallback failures
 - Added a Settings pending-changes review drawer with safe before/after values, save/apply impact labels, jump links, and per-setting reset controls

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -1056,6 +1056,30 @@ textarea {
   @apply flex flex-wrap gap-2 xl:justify-end;
 }
 
+.dashboard-live-summary-grid {
+  @apply grid gap-3 sm:grid-cols-2 lg:grid-cols-4 2xl:grid-cols-7;
+}
+
+.dashboard-live-summary-tile {
+  @apply rounded-2xl border border-storm/20 bg-void/35 px-4 py-3;
+}
+
+.dashboard-live-summary-tile-primary {
+  @apply border-ice/25 bg-ice/10;
+}
+
+.dashboard-live-summary-label {
+  @apply text-[10px] font-semibold uppercase tracking-[0.18em] text-storm;
+}
+
+.dashboard-live-summary-value {
+  @apply mt-2 truncate text-xl font-semibold leading-tight;
+}
+
+.dashboard-live-summary-copy {
+  @apply mt-1 truncate text-[11px] text-storm;
+}
+
 .dashboard-live-stage {
   @apply grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.95fr)];
   align-items: start;
@@ -1192,6 +1216,31 @@ textarea {
 
 .dashboard-live-support-grid {
   @apply grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)];
+}
+
+.dashboard-secondary-group {
+  @apply rounded-2xl border border-storm/20 bg-deep/20;
+}
+
+.dashboard-secondary-group[open] {
+  @apply bg-deep/30;
+}
+
+.dashboard-secondary-group-summary {
+  @apply flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.16em] text-storm transition-colors duration-200 hover:text-silver;
+}
+
+.dashboard-secondary-group-summary::-webkit-details-marker {
+  display: none;
+}
+
+.dashboard-secondary-group-summary span:last-child {
+  @apply rounded-full border border-storm/20 bg-void/40 px-2 py-1 text-[10px] normal-case tracking-normal text-silver;
+}
+
+.dashboard-secondary-group > .surface-subtle,
+.dashboard-secondary-group > .dashboard-telemetry-card {
+  @apply rounded-t-none border-x-0 border-b-0;
 }
 
 .dashboard-support-card {

--- a/src_assets/common/assets/web/dashboard-live-hierarchy.test.js
+++ b/src_assets/common/assets/web/dashboard-live-hierarchy.test.js
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function webSource(relativePath) {
+  return readFileSync(join(process.cwd(), 'src_assets/common/assets/web', relativePath), 'utf8')
+}
+
+function expectBefore(source, first, second) {
+  const firstIndex = source.indexOf(first)
+  const secondIndex = source.indexOf(second)
+  expect(firstIndex, `${first} should exist`).toBeGreaterThanOrEqual(0)
+  expect(secondIndex, `${second} should exist`).toBeGreaterThanOrEqual(0)
+  expect(firstIndex, `${first} should appear before ${second}`).toBeLessThan(secondIndex)
+}
+
+describe('DashboardView live-session hierarchy', () => {
+  it('starts live mode with a summary strip covering quality, signal, path, and runtime', () => {
+    const dashboard = webSource('views/DashboardView.vue')
+
+    expectBefore(dashboard, 'dashboard-live-summary-grid', 'Auto Quality')
+    expectBefore(dashboard, 'dashboard-live-summary-grid', 'dashboard-preview-panel')
+
+    for (const label of ['Quality', 'Latency', 'FPS', 'Loss', 'Bitrate', 'Capture path', 'Runtime mode']) {
+      expect(dashboard).toContain(`data-live-summary-metric="${label}"`)
+    }
+  })
+
+  it('keeps secondary live panels in collapsible groups below the primary summary', () => {
+    const dashboard = webSource('views/DashboardView.vue')
+    const groupedPanelCount = (dashboard.match(/<details class="dashboard-secondary-group/g) || []).length
+
+    expect(groupedPanelCount).toBeGreaterThanOrEqual(3)
+    expectBefore(dashboard, 'dashboard-live-summary-grid', '<details class="dashboard-secondary-group')
+    expect(dashboard).toContain('dashboard-secondary-group-summary')
+  })
+})

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -68,6 +68,44 @@
           </div>
         </div>
 
+        <section class="dashboard-live-summary-grid" aria-label="Live stream summary">
+          <div class="dashboard-live-summary-tile dashboard-live-summary-tile-primary" data-live-summary-metric="Quality">
+            <div class="dashboard-live-summary-label">Quality</div>
+            <div class="dashboard-live-summary-value" :class="liveSummary.qualityTone">{{ liveSummary.quality }}</div>
+            <div class="dashboard-live-summary-copy">{{ liveSummary.qualityDetail }}</div>
+          </div>
+          <div class="dashboard-live-summary-tile" data-live-summary-metric="Latency">
+            <div class="dashboard-live-summary-label">Latency</div>
+            <div class="dashboard-live-summary-value" :class="liveSummary.latencyTone">{{ liveSummary.latency }}</div>
+            <div class="dashboard-live-summary-copy">Round trip</div>
+          </div>
+          <div class="dashboard-live-summary-tile" data-live-summary-metric="FPS">
+            <div class="dashboard-live-summary-label">FPS</div>
+            <div class="dashboard-live-summary-value" :class="liveSummary.fpsTone">{{ liveSummary.fps }}</div>
+            <div class="dashboard-live-summary-copy">{{ liveSummary.fpsDetail }}</div>
+          </div>
+          <div class="dashboard-live-summary-tile" data-live-summary-metric="Loss">
+            <div class="dashboard-live-summary-label">Loss</div>
+            <div class="dashboard-live-summary-value" :class="liveSummary.lossTone">{{ liveSummary.loss }}</div>
+            <div class="dashboard-live-summary-copy">Packet loss</div>
+          </div>
+          <div class="dashboard-live-summary-tile" data-live-summary-metric="Bitrate">
+            <div class="dashboard-live-summary-label">Bitrate</div>
+            <div class="dashboard-live-summary-value text-silver">{{ liveSummary.bitrate }}</div>
+            <div class="dashboard-live-summary-copy">{{ stats.codec?.toUpperCase() || '--' }}</div>
+          </div>
+          <div class="dashboard-live-summary-tile" data-live-summary-metric="Capture path">
+            <div class="dashboard-live-summary-label">Capture path</div>
+            <div class="dashboard-live-summary-value" :class="captureGpuNativeTone">{{ capturePathLabel }}</div>
+            <div class="dashboard-live-summary-copy">{{ captureTransportLabel }} · {{ captureResidencyLabel }}</div>
+          </div>
+          <div class="dashboard-live-summary-tile" data-live-summary-metric="Runtime mode">
+            <div class="dashboard-live-summary-label">Runtime mode</div>
+            <div class="dashboard-live-summary-value" :class="runtimeEffectiveTone">{{ runtimeEffectiveMode }}</div>
+            <div class="dashboard-live-summary-copy">{{ runtimeBackendLabel }}</div>
+          </div>
+        </section>
+
         <section class="rounded-xl border p-4" :class="autoQuality.panelClass">
           <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div class="min-w-0">
@@ -173,7 +211,12 @@
             </section>
 
             <div class="dashboard-live-support-grid">
-              <section class="surface-subtle p-4 dashboard-support-card">
+              <details class="dashboard-secondary-group" open>
+                <summary class="dashboard-secondary-group-summary">
+                  <span>Priority guidance</span>
+                  <span>{{ primaryRecommendations.length || 0 }} live cues</span>
+                </summary>
+                <section class="surface-subtle p-4 dashboard-support-card">
                 <div class="flex items-start justify-between gap-3">
                   <div>
                     <div class="eyebrow-label">{{ $t('dashboard.recommendations') }}</div>
@@ -213,9 +256,15 @@
                     {{ $t('dashboard.ai_optimization_empty') }}
                   </div>
                 </div>
-              </section>
+                </section>
+              </details>
 
-              <section class="surface-subtle p-4 dashboard-support-card">
+              <details class="dashboard-secondary-group" open>
+                <summary class="dashboard-secondary-group-summary">
+                  <span>Capture and replay</span>
+                  <span>{{ recording.active ? $t('dashboard.recording_active') : $t('dashboard.recording_idle') }}</span>
+                </summary>
+                <section class="surface-subtle p-4 dashboard-support-card">
                 <div class="flex items-start justify-between gap-3">
                   <div>
                     <div class="eyebrow-label">Session tools</div>
@@ -285,10 +334,16 @@
                     {{ $t('dashboard.session_history_empty') }}
                   </div>
                 </div>
-              </section>
+                </section>
+              </details>
             </div>
 
-            <section class="dashboard-telemetry-card">
+            <details class="dashboard-secondary-group" open>
+              <summary class="dashboard-secondary-group-summary">
+                <span>{{ $t('dashboard.telemetry_title') }}</span>
+                <span>{{ stats.fps?.toFixed(1) || '--' }} fps · {{ (stats.bitrate_kbps / 1000).toFixed(1) }} Mbps</span>
+              </summary>
+              <section class="dashboard-telemetry-card">
               <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
                 <div>
                   <div class="section-kicker">{{ $t('dashboard.telemetry') }}</div>
@@ -356,7 +411,8 @@
                   <div class="mt-1 text-xs text-storm">{{ gpu.vram_total_mb != null ? '/ ' + (gpu.vram_total_mb / 1024).toFixed(0) + ' GB' : '' }}</div>
                 </div>
               </div>
-            </section>
+              </section>
+            </details>
           </div>
 
           <div class="dashboard-live-side">
@@ -1222,6 +1278,39 @@ const qualitySummaryLabel = computed(() => t('dashboard.quality_summary', {
   grade: qualityGrade.value,
   score: qualityScore.value,
 }))
+
+function formatLiveNumber(value, digits = 1, suffix = '') {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return '--'
+  return `${parsed.toFixed(digits)}${suffix}`
+}
+
+const liveSummary = computed(() => {
+  const s = stats.value || {}
+  const fps = metricNumber(s.fps)
+  const targetFps = metricNumber(s.session_target_fps || s.requested_client_fps)
+  const latency = Number(s.latency_ms)
+  const loss = Number(s.packet_loss)
+  const bitrate = Number(s.bitrate_kbps)
+
+  return {
+    quality: `${qualityGrade.value} · ${qualityScore.value}`,
+    qualityDetail: 'Stream score',
+    qualityTone: gradeColor(qualityGrade.value),
+    latency: formatLiveNumber(latency, 0, ' ms'),
+    latencyTone: Number.isFinite(latency)
+      ? (latency <= 20 ? 'text-green-400' : latency <= 50 ? 'text-yellow-400' : 'text-red-400')
+      : 'text-storm',
+    fps: formatLiveNumber(fps, 1),
+    fpsTone: fps > 0 ? (fps >= 55 ? 'text-green-400' : fps >= 30 ? 'text-yellow-400' : 'text-red-400') : 'text-storm',
+    fpsDetail: targetFps > 0 ? `${targetFps.toFixed(0)} target` : 'Encoded',
+    loss: formatLiveNumber(loss, 1, '%'),
+    lossTone: Number.isFinite(loss)
+      ? (loss < 0.5 ? 'text-green-400' : loss < 2 ? 'text-yellow-400' : 'text-red-400')
+      : 'text-storm',
+    bitrate: Number.isFinite(bitrate) ? `${(bitrate / 1000).toFixed(1)} Mbps` : '--',
+  }
+})
 
 // Check if a specific client name has AI-optimized settings (for multi-viewer list)
 function isClientAiOptimized(clientName) {


### PR DESCRIPTION
## Summary
- Adds a stronger live Mission Control summary strip for quality, latency, FPS, loss, bitrate, capture path, and runtime mode
- Groups secondary live panels into collapsible disclosure sections while keeping telemetry available
- Adds a v1.1.1 changelog note and a source-order regression test for the live hierarchy

## Test Plan
- npm run test -- src_assets/common/assets/web/dashboard-live-hierarchy.test.js (RED first, then GREEN)
- npm run test
- npm run lint
- npm run build
- git diff --check
- Browser visual pass against mocked local live session at http://127.0.0.1:4177/#/
- Mobile screenshot pass with Playwright viewport 390x844