### PR TITLE
fix(web): polish accessibility and mobile affordances

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ starts at `v1.0.0`.
 ## Unreleased
 
 - Added a guided AI Auto Quality optimizer setup checklist with clearer provider/auth/runtime cards and actionable draft test feedback
+- Polished v1.1.1 accessibility/mobile readiness with named icon controls, live status regions, trapped confirmation-dialog focus, and non-sticky handheld review bars
 - Polished Mission Control live-session hierarchy with a stronger top summary for stream quality, latency, FPS, loss, bitrate, capture path, and runtime mode plus collapsible secondary live panels
 - Added a sticky Library import staging summary and review drawer with source counts, per-game removal, clear-all staging, and already-imported confirmation
 - Reduced idle web console polling pressure by deduplicating overlapping system/stream stats fetches and backing off transient fallback failures

--- a/src_assets/common/assets/web/App.vue
+++ b/src_assets/common/assets/web/App.vue
@@ -39,12 +39,13 @@
             v-for="item in section.items"
             :key="item.to"
             :to="item.to"
+            :aria-label="item.label"
             class="sidebar-link group"
             active-class="active"
             :title="sidebarCollapsed ? item.label : ''"
             @click="sidebarOpen = false"
           >
-            <div v-html="item.icon" class="w-5 h-5 shrink-0"></div>
+            <div aria-hidden="true" v-html="item.icon" class="w-5 h-5 shrink-0"></div>
             <span v-if="!sidebarCollapsed">{{ item.label }}</span>
             <kbd v-if="!sidebarCollapsed" class="ml-auto hidden text-[11px] text-storm/40 transition-opacity duration-150 lg:inline group-hover:opacity-70 group-focus-within:opacity-70" :class="$route.path === item.to ? 'opacity-70' : 'opacity-0'">
               {{ item.shortcut }}
@@ -56,6 +57,7 @@
         <button
           type="button"
           @click="cycleAppTheme"
+          :aria-label="`Switch theme to ${nextThemeLabel}`"
           class="focus-ring flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-[background-color,color,border-color] duration-200"
           :class="currentTheme !== 'polaris' ? 'text-ice bg-ice/10' : 'text-storm hover:text-silver hover:bg-twilight/50'"
           :title="'Switch to ' + nextThemeLabel"
@@ -70,6 +72,7 @@
           type="button"
           class="focus-ring flex w-full items-center gap-2 rounded-lg border border-storm/20 bg-deep/30 px-3 py-2 text-left text-sm text-silver transition-[background-color,border-color,color] duration-200 hover:border-ice/25 hover:bg-twilight/35 hover:text-ice"
           :title="paletteShortcut"
+          :aria-label="`Open command palette (${paletteShortcut})`"
           @click="commandPaletteOpen = true"
         >
           <svg class="h-4 w-4 shrink-0 text-storm" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m21 21-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z"/></svg>
@@ -92,6 +95,7 @@
         class="focus-ring mx-3 mb-2 flex items-center justify-center rounded-lg p-2 text-storm transition-[background-color,color] duration-200 hover:bg-twilight/50 hover:text-silver"
         @click="toggleCollapse"
         :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+        :aria-label="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
       >
         <svg class="w-4 h-4 transition-transform" :class="{ 'rotate-180': sidebarCollapsed }" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7"/></svg>
       </button>

--- a/src_assets/common/assets/web/accessibility-mobile-polish.test.js
+++ b/src_assets/common/assets/web/accessibility-mobile-polish.test.js
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function webSource(relativePath) {
+  return readFileSync(join(process.cwd(), 'src_assets/common/assets/web', relativePath), 'utf8')
+}
+
+describe('cross-cutting accessibility and mobile polish', () => {
+  it('gives icon-only app chrome controls explicit accessible names', () => {
+    const app = webSource('App.vue')
+
+    expect(app).toContain(':aria-label="`Switch theme to ${nextThemeLabel}`"')
+    expect(app).toContain(':aria-label="`Open command palette (${paletteShortcut})`"')
+    expect(app).toContain(':aria-label="sidebarCollapsed ? \'Expand sidebar\' : \'Collapse sidebar\'"')
+    expect(app).toContain('aria-hidden="true" v-html="item.icon"')
+  })
+
+  it('marks live status and progress surfaces for assistive technology updates', () => {
+    const dashboard = webSource('views/DashboardView.vue')
+    const apps = webSource('views/AppsView.vue')
+    const config = webSource('views/ConfigView.vue')
+
+    expect(dashboard).toContain('role="status"')
+    expect(dashboard).toContain('aria-live="polite"')
+    expect(dashboard).toContain('aria-label="Live stream telemetry summary"')
+    expect(apps).toContain('role="status"')
+    expect(config).toContain('role="status"')
+  })
+
+  it('keeps sticky review bars from covering content on handheld widths', () => {
+    const css = webSource('app.css')
+
+    expect(css).toContain('@media (max-width: 47.99rem)')
+    expect(css).toContain('.operator-console .library-import-staged-summary')
+    expect(css).toContain('position: static')
+    expect(css).toContain('.settings-command-bar.sticky')
+    expect(css).toContain('top: auto')
+  })
+})

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -437,7 +437,15 @@ textarea {
     right: 0.75rem !important;
     bottom: 1rem;
     top: auto !important;
+    width: auto;
     max-width: none;
+  }
+
+  .operator-console .library-import-staged-summary,
+  .settings-command-bar.sticky {
+    position: static;
+    top: auto;
+    z-index: auto;
   }
 }
 

--- a/src_assets/common/assets/web/components/ConfirmActionDialog.test.js
+++ b/src_assets/common/assets/web/components/ConfirmActionDialog.test.js
@@ -80,4 +80,22 @@ describe('ConfirmActionDialog', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.emitted('cancel')).toHaveLength(1)
   })
+
+  it('traps Tab focus inside the dialog controls', async () => {
+    const wrapper = mountDialog()
+    await wrapper.vm.$nextTick()
+
+    const cancel = bodyGet('[data-confirm-cancel]')
+    const confirm = bodyGet('[data-confirm-confirm]')
+
+    cancel.focus()
+    bodyGet('[role="dialog"]').dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, shiftKey: true }))
+    await wrapper.vm.$nextTick()
+    expect(document.activeElement).toBe(confirm)
+
+    confirm.focus()
+    bodyGet('[role="dialog"]').dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
+    await wrapper.vm.$nextTick()
+    expect(document.activeElement).toBe(cancel)
+  })
 })

--- a/src_assets/common/assets/web/components/ConfirmActionDialog.vue
+++ b/src_assets/common/assets/web/components/ConfirmActionDialog.vue
@@ -93,6 +93,10 @@ function focusCancel() {
   dialogEl.value?.querySelector('[data-confirm-cancel]')?.focus()
 }
 
+function getFocusableControls() {
+  return Array.from(dialogEl.value?.querySelectorAll('button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])') || [])
+}
+
 function restoreFocus() {
   if (previousFocus instanceof HTMLElement && document.contains(previousFocus)) {
     previousFocus.focus()
@@ -111,6 +115,26 @@ function handleKeydown(event) {
   if (event.key === 'Escape') {
     event.preventDefault()
     requestCancel()
+    return
+  }
+
+  if (event.key === 'Tab') {
+    const controls = getFocusableControls()
+    if (!controls.length) {
+      event.preventDefault()
+      dialogEl.value?.focus()
+      return
+    }
+
+    const first = controls[0]
+    const last = controls[controls.length - 1]
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
   }
 }
 

--- a/src_assets/common/assets/web/views/AppsView.vue
+++ b/src_assets/common/assets/web/views/AppsView.vue
@@ -112,8 +112,8 @@
         </div>
       </div>
 
-      <section v-if="hasImportSources" class="library-import-staged-summary" aria-live="polite">
-        <div class="min-w-0">
+      <section v-if="hasImportSources" class="library-import-staged-summary">
+        <div class="min-w-0" role="status" aria-live="polite" aria-atomic="true">
           <div class="section-kicker">Staged import</div>
           <div class="library-import-staged-title">{{ stagedImportSummaryTitle }}</div>
           <div class="library-import-staged-copy">{{ stagedImportSummaryCopy }}</div>
@@ -194,7 +194,7 @@
         </div>
       </div>
 
-      <div v-else-if="gameScanning" class="mt-5 rounded-lg border border-storm/20 bg-deep/35 px-5 py-10 text-center">
+      <div v-else-if="gameScanning" class="mt-5 rounded-lg border border-storm/20 bg-deep/35 px-5 py-10 text-center" role="status" aria-live="polite">
         <svg class="mx-auto h-7 w-7 animate-spin text-ice" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" /><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4Zm2 5.291A7.962 7.962 0 0 1 4 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647Z" /></svg>
         <h3 class="mt-4 text-lg font-semibold text-silver">Scanning installed libraries</h3>
         <p class="mt-2 text-sm text-storm">Checking Steam, Lutris, and Heroic for new, staged, and already-imported entries.</p>

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -5,7 +5,7 @@
         <h1 class="page-title">{{ $t('navbar.settings') }}</h1>
         <p class="page-subtitle max-w-2xl">{{ $t('config.configuration_desc') }}</p>
       </div>
-      <div v-if="config" class="page-meta">
+      <div v-if="config" class="page-meta" role="status" aria-live="polite" aria-atomic="true">
         <span class="meta-pill">{{ visibleTabCountLabel }}</span>
         <span class="meta-pill">{{ activePanelTitle }}</span>
         <span class="meta-pill">{{ activePanelGroupLabel }}</span>
@@ -16,7 +16,7 @@
       </div>
     </section>
 
-    <section class="section-card settings-command-bar sticky top-4 z-20">
+    <section class="section-card settings-command-bar sticky top-4 z-20" role="region" :aria-label="$t('config.action_center')">
       <div class="settings-command-copy">
         <div class="section-kicker">{{ $t('config.action_center') }}</div>
         <div class="settings-command-title">
@@ -56,12 +56,12 @@
       </div>
     </section>
 
-    <section v-if="config" class="section-card settings-pending-review" aria-live="polite">
+    <section v-if="config" class="section-card settings-pending-review">
       <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div class="min-w-0">
           <div class="section-kicker">{{ $t('config.pending_changes_kicker') }}</div>
           <h2 class="section-title">{{ pendingChanges.length ? $t('config.pending_changes_title') : $t('config.pending_changes_empty_title') }}</h2>
-          <p class="section-copy">
+          <p class="section-copy" role="status" aria-live="polite" aria-atomic="true">
             {{ pendingChanges.length ? $t('config.pending_changes_desc', { count: pendingChanges.length }) : $t('config.pending_changes_empty_desc') }}
           </p>
         </div>

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -11,7 +11,7 @@
         </div>
         <div class="page-subtitle">{{ actionSummary }}</div>
       </div>
-      <div class="page-meta">
+      <div class="page-meta" role="status" aria-live="polite" aria-atomic="true">
         <span v-if="stats?.streaming" class="pulse-dot"></span>
         <span class="meta-pill" :class="stats?.streaming ? 'border-green-500/30 bg-green-500/10 text-green-300' : ''">
           {{ stats?.streaming ? $t('dashboard.live') : $t('dashboard.standby') }}
@@ -68,7 +68,7 @@
           </div>
         </div>
 
-        <section class="dashboard-live-summary-grid" aria-label="Live stream summary">
+        <section class="dashboard-live-summary-grid" role="status" aria-live="polite" aria-atomic="true" aria-label="Live stream telemetry summary">
           <div class="dashboard-live-summary-tile dashboard-live-summary-tile-primary" data-live-summary-metric="Quality">
             <div class="dashboard-live-summary-label">Quality</div>
             <div class="dashboard-live-summary-value" :class="liveSummary.qualityTone">{{ liveSummary.quality }}</div>
@@ -173,14 +173,14 @@
                     @load="handlePreviewLoad"
                     @error="handlePreviewError"
                   />
-                  <div v-if="!previewLoaded && !previewError" class="dashboard-preview-overlay">
+                  <div v-if="!previewLoaded && !previewError" class="dashboard-preview-overlay" role="status" aria-live="polite">
                     <svg class="h-7 w-7 animate-spin text-storm" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                       <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                     </svg>
                     <span>{{ $t('dashboard.preview_capturing') }}</span>
                   </div>
-                  <div v-if="previewError" class="dashboard-preview-overlay dashboard-preview-overlay-error">
+                  <div v-if="previewError" class="dashboard-preview-overlay dashboard-preview-overlay-error" role="alert">
                     <div class="text-sm font-medium text-silver">{{ $t('dashboard.preview_error') }}</div>
                     <button @click="retryPreviewNow" class="focus-ring dashboard-action-button dashboard-action-button-secondary">
                       {{ $t('dashboard.preview_retry') }}


### PR DESCRIPTION
## Summary
- Adds explicit accessible names for icon-heavy app chrome controls and hides decorative nav SVGs from the accessibility tree.
- Marks live status/progress copy with polite status regions and keeps alert semantics for preview failures.
- Traps focus inside confirmation dialogs and disables sticky review/action bars on handheld widths so they do not cover content.
- Adds an Unreleased changelog note for the v1.1.1 accessibility/mobile polish pass.

## Test Plan
- [x] RED verified first: `npm run test -- src_assets/common/assets/web/accessibility-mobile-polish.test.js src_assets/common/assets/web/components/ConfirmActionDialog.test.js` failed before implementation (3 source-regression failures + focus-trap failure).
- [x] `npm run test -- src_assets/common/assets/web/accessibility-mobile-polish.test.js src_assets/common/assets/web/components/ConfirmActionDialog.test.js`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Browser dogfood on built assets via `npx serve build/assets/web --listen tcp://127.0.0.1:4173 --no-clipboard`: login page rendered cleanly, no console errors, no visible overlay/sticky regression.

Note: `npm run smoke:web` was not used as a pass/fail gate because it expects a live Polaris HTTPS server at `https://127.0.0.1:49001`; without that server it exits with `ERR_CONNECTION_REFUSED` before exercising routes.
