### PR TITLE
test(web): harden release smoke harness

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Improved `npm run smoke:web` so release smoke gates can target live Polaris or built static web assets, check hashed JS/CSS assets plus the unauthenticated login page, and report a clear preflight when the live HTTPS server is not running
 - Added a guided AI Auto Quality optimizer setup checklist with clearer provider/auth/runtime cards and actionable draft test feedback
 - Polished v1.1.1 accessibility/mobile readiness with named icon controls, live status regions, trapped confirmation-dialog focus, and non-sticky handheld review bars
 - Polished Mission Control live-session hierarchy with a stronger top summary for stream quality, latency, FPS, loss, bitrate, capture path, and runtime mode plus collapsible secondary live panels

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -1,23 +1,11 @@
-import { chromium, expect } from '@playwright/test'
+import { chromium, expect, request as playwrightRequest } from '@playwright/test'
+import fs from 'node:fs/promises'
+import http from 'node:http'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
-const args = new Map()
-for (let i = 2; i < process.argv.length; i += 1) {
-  const arg = process.argv[i]
-  if (arg.startsWith('--') && process.argv[i + 1] && !process.argv[i + 1].startsWith('--')) {
-    args.set(arg, process.argv[i + 1])
-    i += 1
-  } else {
-    args.set(arg, true)
-  }
-}
-
-const baseURL = String(args.get('--base-url') || process.env.POLARIS_URL || 'https://127.0.0.1:49001').replace(/\/$/, '')
-const username = process.env.POLARIS_USER || ''
-const password = process.env.POLARIS_PASS || ''
-const writeScreenshots = args.has('--screenshots') || process.env.POLARIS_SMOKE_SCREENSHOTS === '1'
-const screenshotDir = args.get('--screenshot-dir') || '/tmp'
+const DEFAULT_LIVE_URL = 'https://127.0.0.1:47990'
+const DEFAULT_STATIC_DIR = 'build/assets/web'
 const scriptName = path.basename(fileURLToPath(import.meta.url))
 
 const routes = [
@@ -31,12 +19,6 @@ const routes = [
   { name: 'welcome', hash: '#/welcome', heading: /Welcome to Polaris/i },
 ]
 
-const browser = await chromium.launch()
-const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1280, height: 720 } })
-const page = await context.newPage()
-const consoleErrors = []
-const pageErrors = []
-let loadedAppShell = false
 const ignoredConsoleErrors = [
   /^AI status fetch failed:/,
   /^Device DB fetch failed:/,
@@ -51,7 +33,77 @@ const ignoredAbortedResourcePaths = [
   /\/api\/stats\/stream-sse$/,
 ]
 
-const shouldIgnoreConsoleError = (text, url) => {
+const mimeTypes = new Map([
+  ['.css', 'text/css; charset=utf-8'],
+  ['.html', 'text/html; charset=utf-8'],
+  ['.ico', 'image/x-icon'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml; charset=utf-8'],
+])
+
+export function getSmokeHelp() {
+  return `Usage: npm run smoke:web -- [options]
+
+Modes:
+  --target-url <url>        Smoke a live Polaris HTTPS server, e.g. --target-url https://127.0.0.1:47990
+  --base-url <url>          Alias for --target-url (also POLARIS_URL). Defaults to ${DEFAULT_LIVE_URL}
+  --static                  Smoke built static web assets from ${DEFAULT_STATIC_DIR}
+  --static-dir <dir>        Smoke a specific built web asset directory (implies --static)
+
+Auth and coverage:
+  POLARIS_USER/POLARIS_PASS Login before authenticated route checks when both are set
+  --no-login                Skip credential login and only verify unauthenticated login shell/assets
+
+Diagnostics:
+  --screenshots             Write route screenshots (or POLARIS_SMOKE_SCREENSHOTS=1)
+  --screenshot-dir <dir>    Screenshot directory, default /tmp
+  --help                    Show this help
+
+Notes:
+  Live mode keeps self-signed local Polaris certificate handling explicit by using Playwright's ignoreHTTPSErrors.
+  If the live HTTPS server is missing, the preflight fails with a Polaris-specific message instead of raw ERR_CONNECTION_REFUSED.`
+}
+
+function parseRawArgs(argv) {
+  const args = new Map()
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg.startsWith('--') && argv[i + 1] && !argv[i + 1].startsWith('--')) {
+      args.set(arg, argv[i + 1])
+      i += 1
+    } else {
+      args.set(arg, true)
+    }
+  }
+  return args
+}
+
+function normalizeBaseURL(url) {
+  return String(url).replace(/\/$/, '')
+}
+
+export function parseSmokeOptions(argv = process.argv.slice(2), env = process.env) {
+  const args = parseRawArgs(argv)
+  const staticDirArg = args.get('--static-dir')
+  const mode = args.has('--static') || staticDirArg ? 'static' : 'live'
+  const targetURL = args.get('--target-url') || args.get('--base-url') || env.POLARIS_URL || DEFAULT_LIVE_URL
+
+  return {
+    help: args.has('--help') || args.has('-h'),
+    mode,
+    baseURL: mode === 'live' ? normalizeBaseURL(targetURL) : null,
+    staticDir: mode === 'static' ? path.resolve(String(staticDirArg || DEFAULT_STATIC_DIR)) : null,
+    username: env.POLARIS_USER || '',
+    password: env.POLARIS_PASS || '',
+    noLogin: args.has('--no-login'),
+    writeScreenshots: args.has('--screenshots') || env.POLARIS_SMOKE_SCREENSHOTS === '1',
+    screenshotDir: String(args.get('--screenshot-dir') || '/tmp'),
+  }
+}
+
+function shouldIgnoreConsoleError(text, url) {
   if (ignoredConsoleErrors.some((pattern) => pattern.test(text))) {
     return true
   }
@@ -61,40 +113,157 @@ const shouldIgnoreConsoleError = (text, url) => {
   return false
 }
 
-page.on('console', (message) => {
-  if (message.type() === 'error') {
-    const text = message.text()
-    const location = message.location()
-    if (!shouldIgnoreConsoleError(text, location.url || '')) {
-      consoleErrors.push(location.url ? `${text} (${location.url})` : text)
-    }
-  }
-})
-page.on('pageerror', (error) => {
-  pageErrors.push(error.message)
-})
+function isHashedAsset(assetPath) {
+  const basename = path.posix.basename(assetPath)
+  return /-[A-Za-z0-9_-]{6,}\.(?:css|js)$/.test(basename)
+}
 
-try {
-  if (username && password && !args.has('--no-login')) {
-    await context.clearCookies()
-    const loginResponse = await context.request.post(`${baseURL}/api/login`, {
-      data: {
-        username,
-        password,
-      },
-    })
-    if (!loginResponse.ok()) {
-      throw new Error(`Login failed with ${loginResponse.status()}: ${await loginResponse.text().catch(() => '')}`)
+function extractAssetPaths(indexHtml) {
+  const assets = []
+  const pattern = /(?:src|href)=["'](?:\.\/)?(assets\/[A-Za-z0-9._/-]+\.(?:css|js))["']/g
+  for (const match of indexHtml.matchAll(pattern)) {
+    const assetPath = `/${match[1]}`
+    if (isHashedAsset(assetPath) && !assets.includes(assetPath)) {
+      assets.push(assetPath)
     }
-    await page.goto(`${baseURL}/#/`)
-    await expect(page.getByRole('navigation')).toBeVisible({ timeout: 15000 })
-    loadedAppShell = true
-    consoleErrors.length = 0
-    pageErrors.length = 0
   }
+  return assets
+}
+
+export async function collectCriticalHashedAssets(staticDir) {
+  const root = path.resolve(staticDir)
+  const indexPath = path.join(root, 'index.html')
+  const indexHtml = await fs.readFile(indexPath, 'utf8')
+  const assets = extractAssetPaths(indexHtml)
+
+  if (assets.length === 0) {
+    throw new Error(`${indexPath} does not reference hashed JS/CSS assets`)
+  }
+
+  for (const asset of assets) {
+    await fs.access(path.join(root, asset))
+  }
+
+  return assets
+}
+
+async function fetchCriticalHashedAssets(baseURL, apiRequest) {
+  const indexResponse = await apiRequest.get(`${baseURL}/`)
+  if (!indexResponse.ok()) {
+    throw new Error(`Index page failed with ${indexResponse.status()} at ${baseURL}/`)
+  }
+
+  const assets = extractAssetPaths(await indexResponse.text())
+  if (assets.length === 0) {
+    throw new Error(`Index page at ${baseURL}/ does not reference hashed JS/CSS assets`)
+  }
+
+  for (const asset of assets) {
+    const assetResponse = await apiRequest.get(`${baseURL}${asset}`)
+    if (!assetResponse.ok()) {
+      throw new Error(`Critical hashed asset failed with ${assetResponse.status()}: ${baseURL}${asset}`)
+    }
+    console.log(`${scriptName}: asset ok ${asset}`)
+  }
+
+  return assets
+}
+
+export async function runLivePreflight({ baseURL, request = null } = {}) {
+  const requester = request || (await playwrightRequest.newContext({ ignoreHTTPSErrors: true }))
+  const ownsRequester = !request
+  try {
+    const response = await requester.get(`${baseURL}/`, { timeout: 5000 })
+    if (!response.ok()) {
+      throw new Error(`Polaris live HTTPS server responded with ${response.status()} at ${baseURL}/`)
+    }
+    return response
+  } catch (error) {
+    const cause = error?.code || error?.message || String(error)
+    if (/ECONNREFUSED|ERR_CONNECTION_REFUSED|connect ECONNREFUSED/i.test(cause)) {
+      throw new Error(`Polaris live HTTPS server is not reachable at ${baseURL}. Start Polaris or pass --static-dir build/assets/web for static asset smoke. (${cause})`)
+    }
+    throw error
+  } finally {
+    if (ownsRequester) {
+      await requester.dispose()
+    }
+  }
+}
+
+function safeStaticPath(root, requestUrl) {
+  const parsed = new URL(requestUrl, 'http://127.0.0.1')
+  let pathname = decodeURIComponent(parsed.pathname)
+  if (pathname === '/') {
+    pathname = '/index.html'
+  }
+  const candidate = path.resolve(root, `.${pathname}`)
+  if (!candidate.startsWith(`${root}${path.sep}`) && candidate !== root) {
+    return null
+  }
+  return candidate
+}
+
+async function startStaticServer(staticDir) {
+  const root = path.resolve(staticDir)
+  await fs.access(path.join(root, 'index.html'))
+
+  const server = http.createServer(async (req, res) => {
+    const candidate = safeStaticPath(root, req.url || '/')
+    if (!candidate) {
+      res.writeHead(403)
+      res.end('Forbidden')
+      return
+    }
+
+    try {
+      const body = await fs.readFile(candidate)
+      const mimeType = mimeTypes.get(path.extname(candidate)) || 'application/octet-stream'
+      res.writeHead(200, { 'content-type': mimeType })
+      res.end(body)
+    } catch (error) {
+      res.writeHead(error?.code === 'ENOENT' ? 404 : 500)
+      res.end(error?.code === 'ENOENT' ? 'Not found' : 'Server error')
+    }
+  })
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const address = server.address()
+  return {
+    baseURL: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve())),
+  }
+}
+
+async function verifyUnauthenticatedLoginPage(page, baseURL) {
+  await page.context().clearCookies()
+  await page.goto(`${baseURL}/?smoke=${Date.now()}#/login`)
+  await expect(page.getByRole('heading', { name: /Welcome to Polaris/i }).first()).toBeVisible({ timeout: 15000 })
+  await expect(page.getByLabel(/username/i)).toBeVisible({ timeout: 10000 })
+  await expect(page.getByLabel(/^password$/i)).toBeVisible({ timeout: 10000 })
+  console.log(`${scriptName}: unauthenticated login page ok`)
+}
+
+async function verifyAuthenticatedRoutes(page, baseURL, options) {
+  const loginResponse = await page.context().request.post(`${baseURL}/api/login`, {
+    data: {
+      username: options.username,
+      password: options.password,
+    },
+  })
+  if (!loginResponse.ok()) {
+    throw new Error(`Login failed with ${loginResponse.status()}: ${await loginResponse.text().catch(() => '')}`)
+  }
+
+  await page.goto(`${baseURL}/#/`)
+  await expect(page.getByRole('navigation')).toBeVisible({ timeout: 15000 })
 
   for (const [index, route] of routes.entries()) {
-    if (index === 0 && !loadedAppShell) {
+    if (index === 0) {
       await page.goto(`${baseURL}/?smoke=${Date.now()}-${index}${route.hash}`)
     } else {
       await page.evaluate((hash) => {
@@ -118,18 +287,97 @@ try {
     if (bodyText.length < 80) {
       throw new Error(`${route.name} rendered too little content (${bodyText.length} chars)`)
     }
-    if (writeScreenshots) {
-      await page.screenshot({ path: path.join(screenshotDir, `polaris-smoke-${route.name}.png`), fullPage: false })
+    if (options.writeScreenshots) {
+      await page.screenshot({ path: path.join(options.screenshotDir, `polaris-smoke-${route.name}.png`), fullPage: false })
     }
     console.log(`${scriptName}: ${route.name} ok (${bodyText.length} chars)`)
   }
+}
 
-  if (pageErrors.length > 0) {
-    throw new Error(`Page errors:\n${pageErrors.join('\n')}`)
+async function runBrowserSmoke(baseURL, options) {
+  const browser = await chromium.launch()
+  const context = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1280, height: 720 } })
+  const page = await context.newPage()
+  const consoleErrors = []
+  const pageErrors = []
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      const text = message.text()
+      const location = message.location()
+      if (!shouldIgnoreConsoleError(text, location.url || '')) {
+        consoleErrors.push(location.url ? `${text} (${location.url})` : text)
+      }
+    }
+  })
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message)
+  })
+
+  try {
+    await verifyUnauthenticatedLoginPage(page, baseURL)
+    consoleErrors.length = 0
+    pageErrors.length = 0
+
+    if (options.username && options.password && !options.noLogin && options.mode === 'live') {
+      await verifyAuthenticatedRoutes(page, baseURL, options)
+    } else {
+      console.log(`${scriptName}: authenticated route checks skipped (set POLARIS_USER/POLARIS_PASS for live route smoke)`)
+    }
+
+    if (pageErrors.length > 0) {
+      throw new Error(`Page errors:\n${pageErrors.join('\n')}`)
+    }
+    if (consoleErrors.length > 0) {
+      throw new Error(`Console errors:\n${consoleErrors.join('\n')}`)
+    }
+  } finally {
+    await browser.close()
   }
-  if (consoleErrors.length > 0) {
-    throw new Error(`Console errors:\n${consoleErrors.join('\n')}`)
+}
+
+export async function runSmoke(options = parseSmokeOptions()) {
+  if (options.help) {
+    console.log(getSmokeHelp())
+    return
   }
-} finally {
-  await browser.close()
+
+  let staticServer = null
+  let baseURL = options.baseURL
+  let apiRequest = null
+  try {
+    if (options.mode === 'static') {
+      const assets = await collectCriticalHashedAssets(options.staticDir)
+      console.log(`${scriptName}: static assets found ${assets.join(', ')}`)
+      staticServer = await startStaticServer(options.staticDir)
+      baseURL = staticServer.baseURL
+      apiRequest = await playwrightRequest.newContext()
+      await fetchCriticalHashedAssets(baseURL, apiRequest)
+    } else {
+      console.log(`${scriptName}: live HTTPS preflight ${baseURL} (self-signed certs allowed for local Polaris)`)
+      await runLivePreflight({ baseURL })
+      apiRequest = await playwrightRequest.newContext({ ignoreHTTPSErrors: true })
+      await fetchCriticalHashedAssets(baseURL, apiRequest)
+    }
+
+    await runBrowserSmoke(baseURL, options)
+  } finally {
+    if (apiRequest) {
+      await apiRequest.dispose()
+    }
+    if (staticServer) {
+      await staticServer.close()
+    }
+  }
+}
+
+function isMainModule() {
+  return process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+}
+
+if (isMainModule()) {
+  runSmoke().catch((error) => {
+    console.error(`${scriptName}: ${error.message}`)
+    process.exitCode = 1
+  })
 }

--- a/src_assets/common/assets/web/smoke-web-routes.test.js
+++ b/src_assets/common/assets/web/smoke-web-routes.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  collectCriticalHashedAssets,
+  getSmokeHelp,
+  parseSmokeOptions,
+  runLivePreflight,
+} from '../../../../scripts/smoke-web-routes.mjs'
+
+describe('smoke web route harness options', () => {
+  it('supports explicit live targets and documents self-signed HTTPS handling', () => {
+    const options = parseSmokeOptions(['--target-url', 'https://127.0.0.1:47990/', '--no-login'])
+
+    expect(options.mode).toBe('live')
+    expect(options.baseURL).toBe('https://127.0.0.1:47990')
+    expect(options.noLogin).toBe(true)
+    expect(getSmokeHelp()).toContain('--target-url https://127.0.0.1:47990')
+    expect(getSmokeHelp()).toContain('self-signed')
+  })
+
+  it('supports static build mode for build assets', () => {
+    const options = parseSmokeOptions(['--static-dir', 'build/assets/web'])
+
+    expect(options.mode).toBe('static')
+    expect(options.staticDir).toBe(path.resolve('build/assets/web'))
+    expect(options.baseURL).toBe(null)
+  })
+})
+
+describe('smoke web route harness asset checks', () => {
+  it('discovers hashed module and stylesheet assets from a built index', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'polaris-smoke-assets-'))
+    await fs.mkdir(path.join(root, 'assets'), { recursive: true })
+    await fs.writeFile(path.join(root, 'index.html'), [
+      '<!doctype html>',
+      '<script type="module" crossorigin src="./assets/index-AbC123.js"></script>',
+      '<link rel="stylesheet" crossorigin href="./assets/index-ZxY987.css">',
+    ].join('\n'))
+    await fs.writeFile(path.join(root, 'assets/index-AbC123.js'), 'console.log("ok")')
+    await fs.writeFile(path.join(root, 'assets/index-ZxY987.css'), 'body{}')
+
+    await expect(collectCriticalHashedAssets(root)).resolves.toEqual([
+      '/assets/index-AbC123.js',
+      '/assets/index-ZxY987.css',
+    ])
+  })
+})
+
+describe('smoke web route harness live preflight', () => {
+  it('reports a clear preflight when the live HTTPS server is missing', async () => {
+    await expect(runLivePreflight({
+      baseURL: 'https://127.0.0.1:47990',
+      request: {
+        get: async () => {
+          throw Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:47990'), { code: 'ECONNREFUSED' })
+        },
+      },
+    })).rejects.toThrow('Polaris live HTTPS server is not reachable at https://127.0.0.1:47990')
+  })
+})


### PR DESCRIPTION
## Summary
- add live/static modes to `npm run smoke:web`, including `--target-url`, `--static`, and `--static-dir` help
- verify built hashed JS/CSS assets and the unauthenticated login page before optional authenticated route checks
- add a clear live HTTPS preflight for missing Polaris servers while keeping self-signed local cert handling explicit
- add Vitest coverage and an Unreleased changelog note

## Test Plan
- [x] `npm audit`
- [x] `npm run test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run smoke:web -- --static-dir build/assets/web`
- [x] `npm run smoke:web -- --no-login` against `https://127.0.0.1:47990`

Note: live authenticated route checks are still supported when `POLARIS_USER`/`POLARIS_PASS` are set; this local run intentionally verified the unauthenticated login shell/assets only.