### PR TITLE
feat(web): add Portable Chrome theme

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Added the Portable Chrome web theme with a silver retro handheld-inspired skin and generic theme-toggle cycling across every registered skin
 - Improved `npm run smoke:web` so release smoke gates can target live Polaris or built static web assets, check hashed JS/CSS assets plus the unauthenticated login page, and report a clear preflight when the live HTTPS server is not running
 - Added a guided AI Auto Quality optimizer setup checklist with clearer provider/auth/runtime cards and actionable draft test feedback
 - Polished v1.1.1 accessibility/mobile readiness with named icon controls, live status regions, trapped confirmation-dialog focus, and non-sticky handheld review bars

--- a/src_assets/common/assets/web/ThemeToggle.vue
+++ b/src_assets/common/assets/web/ThemeToggle.vue
@@ -1,20 +1,26 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { getTheme, toggleTheme } from './theme.js'
+import { getNextTheme, getTheme, getThemeMeta, toggleTheme } from './theme.js'
 
 const props = defineProps({
   collapsed: { type: Boolean, default: false }
 })
 
-const isOled = ref(false)
+const activeTheme = ref(getThemeMeta(getTheme()))
+const nextTheme = ref(getThemeMeta(getNextTheme(activeTheme.value.id)))
+
+function syncTheme(theme = getTheme()) {
+  activeTheme.value = getThemeMeta(theme)
+  nextTheme.value = getThemeMeta(getNextTheme(activeTheme.value.id))
+}
 
 onMounted(() => {
-  isOled.value = getTheme() === 'oled'
+  syncTheme()
 })
 
 function toggle() {
   const next = toggleTheme()
-  isOled.value = next === 'oled'
+  syncTheme(next)
 }
 </script>
 
@@ -22,11 +28,10 @@ function toggle() {
   <button
     @click="toggle"
     class="flex items-center gap-2 w-full px-3 py-2 rounded-lg text-sm transition-colors"
-    :class="isOled ? 'text-ice bg-ice/10' : 'text-storm hover:text-silver hover:bg-twilight/50'"
-    :title="isOled ? 'Switch to Space Whale theme' : 'Switch to OLED Dark Galaxy'"
+    :class="activeTheme.id !== 'polaris' ? 'text-ice bg-ice/10' : 'text-storm hover:text-silver hover:bg-twilight/50'"
+    :title="`Switch to ${nextTheme.label} theme`"
   >
-    <svg v-if="isOled" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
-    <svg v-else class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
-    <span v-if="!props.collapsed">{{ isOled ? 'OLED Galaxy' : 'Space Whale' }}</span>
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+    <span v-if="!props.collapsed">{{ activeTheme.shortLabel }}</span>
   </button>
 </template>

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -1374,3 +1374,74 @@ textarea {
   background: #ff5cab;
   box-shadow: 0 0 18px rgba(255, 92, 171, 0.45);
 }
+
+/* ── Portable Chrome Skin ── */
+[data-theme="portable-chrome"] {
+  --color-ice: #eaf7ff;
+  --color-silver: #d9e0e5;
+  --color-storm: #65707a;
+  --color-twilight: #2e343a;
+  --color-deep: #11171d;
+  --color-void: #05080b;
+  --color-accent: #7bd7ff;
+  --color-surface: #20262c;
+  --color-background: #0b1015;
+  --color-foreground: #d9e0e5;
+  --color-muted: #8f9aa3;
+  --color-border: #6f7a83;
+}
+
+[data-theme="portable-chrome"] body {
+  background:
+    radial-gradient(circle at 18% 12%, rgba(123, 215, 255, 0.18), transparent 28rem),
+    radial-gradient(circle at 82% 18%, rgba(192, 202, 210, 0.20), transparent 24rem),
+    linear-gradient(135deg, #070a0d 0%, #141a20 48%, #070a0d 100%);
+}
+
+[data-theme="portable-chrome"] .glass,
+[data-theme="portable-chrome"] .card,
+[data-theme="portable-chrome"] .section-card,
+[data-theme="portable-chrome"] .config-page .settings-section {
+  background:
+    linear-gradient(145deg, rgba(246, 250, 252, 0.18), rgba(96, 107, 116, 0.14) 36%, rgba(5, 8, 11, 0.78) 37%, rgba(13, 18, 23, 0.92)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.02));
+  border-color: rgba(218, 228, 235, 0.24);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.28),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.62),
+    0 18px 42px rgba(0, 0, 0, 0.34),
+    0 0 0 1px rgba(123, 215, 255, 0.06);
+}
+
+[data-theme="portable-chrome"] .surface-subtle,
+[data-theme="portable-chrome"] .action-tile,
+[data-theme="portable-chrome"] .meta-pill,
+[data-theme="portable-chrome"] .control-chip {
+  background:
+    linear-gradient(160deg, rgba(232, 239, 244, 0.16), rgba(70, 80, 88, 0.18) 34%, rgba(5, 8, 11, 0.74) 35%, rgba(11, 16, 21, 0.86));
+  border-color: rgba(218, 228, 235, 0.20);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), inset 0 -1px 0 rgba(0, 0, 0, 0.52);
+}
+
+[data-theme="portable-chrome"] .action-tile:hover {
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.22), rgba(92, 104, 113, 0.22) 34%, rgba(7, 13, 18, 0.78) 35%, rgba(15, 23, 30, 0.9));
+  border-color: rgba(123, 215, 255, 0.34);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24), 0 0 22px rgba(123, 215, 255, 0.10);
+}
+
+[data-theme="portable-chrome"] .sidebar-link.active {
+  color: #eaf7ff;
+  background: linear-gradient(90deg, rgba(123, 215, 255, 0.18), rgba(123, 215, 255, 0.06));
+  box-shadow: inset 2px 0 0 rgba(123, 215, 255, 0.94), inset 0 1px 0 rgba(255,255,255,0.18);
+}
+
+[data-theme="portable-chrome"] .pulse-dot {
+  background: #59ff8f;
+  box-shadow: 0 0 16px rgba(89, 255, 143, 0.68), 0 0 28px rgba(123, 215, 255, 0.24);
+}
+
+[data-theme="portable-chrome"] .skeleton-shimmer {
+  background: linear-gradient(90deg, rgba(12, 18, 24, 0.9) 25%, rgba(123, 215, 255, 0.12) 50%, rgba(12, 18, 24, 0.9) 75%);
+  background-size: 200% 100%;
+}

--- a/src_assets/common/assets/web/theme.js
+++ b/src_assets/common/assets/web/theme.js
@@ -1,4 +1,4 @@
-// Polaris Theme System — Space Whale (default), OLED Dark Galaxy, and Miami Nebula
+// Polaris Theme System — Space Whale (default), OLED Dark Galaxy, Miami Nebula, and Portable Chrome
 
 const STORAGE_KEY = 'polaris-theme'
 
@@ -6,6 +6,7 @@ export const THEMES = [
   { id: 'polaris', label: 'Space Whale', shortLabel: 'Polaris' },
   { id: 'oled', label: 'OLED Dark Galaxy', shortLabel: 'OLED' },
   { id: 'miami', label: 'Miami Nebula', shortLabel: 'Miami' },
+  { id: 'portable-chrome', label: 'Portable Chrome', shortLabel: 'Portable Chrome' },
 ]
 
 const DEFAULT_THEME = THEMES[0].id

--- a/src_assets/common/assets/web/theme.test.js
+++ b/src_assets/common/assets/web/theme.test.js
@@ -1,7 +1,10 @@
+import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
+import ThemeToggle from './ThemeToggle.vue'
 import {
   applyTheme,
   cycleTheme,
+  getThemeMeta,
   getNextTheme,
   getTheme,
   setTheme,
@@ -15,27 +18,41 @@ describe('theme skin registry', () => {
     document.documentElement.removeAttribute('data-theme')
   })
 
-  it('registers Miami Nebula alongside the existing skins', () => {
-    expect(THEMES.map((theme) => theme.id)).toEqual(['polaris', 'oled', 'miami'])
+  it('registers Portable Chrome after Miami Nebula alongside the existing skins', () => {
+    expect(THEMES.map((theme) => theme.id)).toEqual(['polaris', 'oled', 'miami', 'portable-chrome'])
     expect(THEMES.find((theme) => theme.id === 'miami')).toMatchObject({
       label: 'Miami Nebula',
       shortLabel: 'Miami',
     })
+    expect(THEMES.find((theme) => theme.id === 'portable-chrome')).toMatchObject({
+      label: 'Portable Chrome',
+      shortLabel: 'Portable Chrome',
+    })
   })
 
   it('applies non-default skins through the data-theme attribute', () => {
-    setTheme('miami')
+    setTheme('portable-chrome')
 
-    expect(getTheme()).toBe('miami')
-    expect(localStorage.getItem('polaris-theme')).toBe('miami')
-    expect(document.documentElement.getAttribute('data-theme')).toBe('miami')
+    expect(getTheme()).toBe('portable-chrome')
+    expect(localStorage.getItem('polaris-theme')).toBe('portable-chrome')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('portable-chrome')
+  })
+
+  it('resolves metadata for registered skins and falls back for unknown skins', () => {
+    expect(getThemeMeta('portable-chrome')).toMatchObject({
+      id: 'portable-chrome',
+      label: 'Portable Chrome',
+      shortLabel: 'Portable Chrome',
+    })
+    expect(getThemeMeta('mystery-meat')).toMatchObject({ id: 'polaris', label: 'Space Whale' })
   })
 
   it('resolves the next registered skin from any current skin', () => {
     expect(getNextTheme()).toBe('oled')
     expect(getNextTheme('polaris')).toBe('oled')
     expect(getNextTheme('oled')).toBe('miami')
-    expect(getNextTheme('miami')).toBe('polaris')
+    expect(getNextTheme('miami')).toBe('portable-chrome')
+    expect(getNextTheme('portable-chrome')).toBe('polaris')
     expect(getNextTheme('mystery-meat')).toBe('polaris')
   })
 
@@ -44,6 +61,8 @@ describe('theme skin registry', () => {
     expect(document.documentElement.getAttribute('data-theme')).toBe('oled')
     expect(cycleTheme()).toBe('miami')
     expect(document.documentElement.getAttribute('data-theme')).toBe('miami')
+    expect(cycleTheme()).toBe('portable-chrome')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('portable-chrome')
     expect(cycleTheme()).toBe('polaris')
     expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
   })
@@ -53,6 +72,8 @@ describe('theme skin registry', () => {
 
     expect(toggleTheme()).toBe('miami')
     expect(getTheme()).toBe('miami')
+    expect(toggleTheme()).toBe('portable-chrome')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('portable-chrome')
     expect(toggleTheme()).toBe('polaris')
     expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
   })
@@ -63,5 +84,27 @@ describe('theme skin registry', () => {
     expect(getTheme()).toBe('polaris')
     applyTheme(getTheme())
     expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+  })
+
+  it('renders toggle copy from the active and next registered skins', async () => {
+    setTheme('miami')
+    const wrapper = mount(ThemeToggle)
+
+    expect(wrapper.text()).toBe('Miami')
+    expect(wrapper.attributes('title')).toBe('Switch to Portable Chrome theme')
+
+    await wrapper.trigger('click')
+
+    expect(getTheme()).toBe('portable-chrome')
+    expect(wrapper.text()).toBe('Portable Chrome')
+    expect(wrapper.attributes('title')).toBe('Switch to Space Whale theme')
+  })
+
+  it('keeps registered skin titles accurate when collapsed', () => {
+    setTheme('portable-chrome')
+    const wrapper = mount(ThemeToggle, { props: { collapsed: true } })
+
+    expect(wrapper.text()).toBe('')
+    expect(wrapper.attributes('title')).toBe('Switch to Space Whale theme')
   })
 })


### PR DESCRIPTION
## Summary
- Add the Portable Chrome registered web theme and preserve the polaris → oled → miami → portable-chrome → polaris cycle
- Refactor ThemeToggle to render active/next labels from theme metadata instead of hardcoding OLED/default states
- Add the silver chrome handheld CSS skin and changelog entry

## Test Plan
- npm audit
- npm run test -- src_assets/common/assets/web/theme.test.js
- npm run test
- npm run lint
- npm run build
- npm run smoke:web -- --static-dir build/assets/web
- npm run smoke:web (live no-login; local Polaris service was active)

Closes t_b24efbf4