### PR TITLE
fix(web): add Portable Chrome panel depth

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
-- Added the Portable Chrome web theme with a slightly dimmer Moonlight-grey early-2000s retro-futurist skin and generic theme-toggle cycling across every registered skin
+- Added the Portable Chrome web theme with a slightly dimmer Moonlight-grey early-2000s retro-futurist skin, stronger chrome panel depth, and generic theme-toggle cycling across every registered skin
 - Improved `npm run smoke:web` so release smoke gates can target live Polaris or built static web assets, check hashed JS/CSS assets plus the unauthenticated login page, and report a clear preflight when the live HTTPS server is not running
 - Added a guided AI Auto Quality optimizer setup checklist with clearer provider/auth/runtime cards and actionable draft test feedback
 - Polished v1.1.1 accessibility/mobile readiness with named icon controls, live status regions, trapped confirmation-dialog focus, and non-sticky handheld review bars

--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -1425,13 +1425,14 @@ textarea {
   background:
     linear-gradient(180deg, rgba(239, 244, 248, 0.90), rgba(211, 218, 226, 0.86) 46%, rgba(183, 193, 204, 0.90)),
     linear-gradient(90deg, rgba(255, 255, 255, 0.26), rgba(148, 160, 174, 0.14) 52%, rgba(255, 255, 255, 0.18));
-  border-color: rgba(119, 132, 147, 0.52);
+  border-color: rgba(88, 101, 116, 0.58);
   color: #25313d;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.78),
-    inset 0 -1px 0 rgba(106, 119, 135, 0.34),
-    0 16px 36px rgba(72, 84, 99, 0.22),
-    0 0 0 1px rgba(255, 255, 255, 0.24);
+    inset 0 1px 0 rgba(255, 255, 255, 0.74),
+    inset 0 -1px 0 rgba(81, 94, 110, 0.36),
+    inset 0 0 0 1px rgba(74, 86, 101, 0.20),
+    0 22px 48px rgba(54, 65, 79, 0.28),
+    0 3px 10px rgba(255, 255, 255, 0.22);
 }
 
 [data-theme="portable-chrome"] .surface-subtle,
@@ -1441,17 +1442,17 @@ textarea {
   background:
     linear-gradient(180deg, rgba(231, 236, 242, 0.88), rgba(201, 209, 219, 0.80)),
     linear-gradient(90deg, rgba(255, 255, 255, 0.22), rgba(139, 151, 165, 0.12));
-  border-color: rgba(132, 145, 160, 0.50);
+  border-color: rgba(96, 111, 128, 0.56);
   color: #25313d;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72), inset 0 -1px 0 rgba(109, 122, 138, 0.26);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.66), inset 0 -1px 0 rgba(81, 94, 110, 0.30), 0 8px 20px rgba(72, 84, 99, 0.12);
 }
 
 [data-theme="portable-chrome"] .action-tile:hover {
   background:
     linear-gradient(180deg, rgba(239, 244, 248, 0.94), rgba(208, 216, 225, 0.88)),
     linear-gradient(90deg, rgba(95, 127, 167, 0.18), rgba(255, 255, 255, 0.20));
-  border-color: rgba(95, 127, 167, 0.56);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.76), 0 0 18px rgba(95, 127, 167, 0.18);
+  border-color: rgba(82, 111, 148, 0.68);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.70), inset 0 -1px 0 rgba(81, 94, 110, 0.28), 0 10px 24px rgba(72, 84, 99, 0.16), 0 0 18px rgba(95, 127, 167, 0.16);
 }
 
 [data-theme="portable-chrome"] .sidebar-link {
@@ -1465,7 +1466,7 @@ textarea {
 }
 
 [data-theme="portable-chrome"] .border-storm {
-  border-color: rgba(137, 150, 164, 0.48);
+  border-color: rgba(92, 106, 123, 0.56);
 }
 
 [data-theme="portable-chrome"] .pulse-dot {

--- a/src_assets/common/assets/web/theme.test.js
+++ b/src_assets/common/assets/web/theme.test.js
@@ -42,6 +42,17 @@ describe('theme skin registry', () => {
     expect(portableChromeCss).toContain('repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.10)')
   })
 
+  it('adds panel depth while keeping the approved Portable Chrome base palette', () => {
+    const css = readFileSync('src_assets/common/assets/web/app.css', 'utf8')
+    const portableChromeCss = css.slice(css.indexOf('/* ── Portable Chrome Skin ── */'))
+
+    expect(portableChromeCss).toContain('--color-background: #cbd1d9')
+    expect(portableChromeCss).toContain('--color-surface: #e2e6eb')
+    expect(portableChromeCss).toContain('0 22px 48px rgba(54, 65, 79, 0.28)')
+    expect(portableChromeCss).toContain('inset 0 0 0 1px rgba(74, 86, 101, 0.20)')
+    expect(portableChromeCss).toContain('box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.66), inset 0 -1px 0 rgba(81, 94, 110, 0.30), 0 8px 20px rgba(72, 84, 99, 0.12);')
+  })
+
   it('applies non-default skins through the data-theme attribute', () => {
     setTheme('portable-chrome')
 


### PR DESCRIPTION
## Summary
- Add selective Portable Chrome panel depth without globally darkening the approved Moonlight-grey palette
- Strengthen chrome borders, inset seams, and shadows on primary/secondary surfaces
- Keep base background and surface colors unchanged while adding regression coverage

## Test Plan
- RED: npm run test -- src_assets/common/assets/web/theme.test.js failed before CSS depth polish
- npm run test -- src_assets/common/assets/web/theme.test.js
- npm audit
- npm test
- npm run lint
- npm run build
- npm run smoke:web -- --static-dir build/assets/web