### PR TITLE
fix: filter session SSE events by client cursor

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -49,6 +49,7 @@
 #include "nvhttp.h"
 #include "platform/common.h"
 #include "process.h"
+#include "session_event_queue.h"
 #include "stream_recorder.h"
 #include "stream_stats.h"
 #include "utility.h"
@@ -4709,8 +4710,7 @@ namespace confighttp {
 
   // Session event bus (file-scope for access from emit_session_event and SSE handler)
   static std::mutex s_event_mtx;
-  static std::vector<std::string> s_events;
-  static std::atomic<uint64_t> s_event_seq{0};
+  static session_event_queue::event_queue s_events;
 
   /**
    * @brief Start the HTTPS server.
@@ -4778,9 +4778,21 @@ namespace confighttp {
         });
         if (header_sent.get_future().get()) return;
 
-        uint64_t last_seq = s_event_seq;
+        uint64_t last_seq;
+        {
+          std::lock_guard lk(s_event_mtx);
+          last_seq = s_events.cursor();
+        }
 
         while (!shutdown_event->peek()) {
+          std::vector<std::string> pending_events;
+          uint64_t current_seq;
+          {
+            std::lock_guard lk(s_event_mtx);
+            current_seq = s_events.cursor();
+            pending_events = s_events.events_after(last_seq);
+          }
+
           // Build current session state
           nlohmann::json state;
 #ifdef __linux__
@@ -4788,19 +4800,17 @@ namespace confighttp {
           state["cage_socket"] = cage_display_router::get_wayland_socket();
           state["screen_locked"] = session_manager::is_screen_locked();
 #endif
-          state["seq"] = s_event_seq.load();
+          state["seq"] = current_seq;
           state["session_state"] = get_session_state();
 
-          // Check for new events
-          {
-            std::lock_guard lk(s_event_mtx);
-            if (!s_events.empty() && s_event_seq > last_seq) {
-              for (auto &evt : s_events) {
-                *response << "event: session\ndata: " << evt << "\n\n";
-              }
-              s_events.clear();
-              last_seq = s_event_seq;
+          // Send only events emitted after this SSE client cursor.
+          // Older terminal events may still be retained for other clients, but
+          // they must not be replayed into a fresh Nova game activity.
+          if (!pending_events.empty()) {
+            for (const auto &evt : pending_events) {
+              *response << "event: session\ndata: " << evt << "\n\n";
             }
+            last_seq = current_seq;
           }
 
           // Always send heartbeat with state
@@ -5018,8 +5028,7 @@ namespace confighttp {
       std::chrono::system_clock::now().time_since_epoch()).count();
 
     std::lock_guard lk(s_event_mtx);
-    s_events.push_back(evt.dump());
-    s_event_seq++;
+    s_events.push(evt.dump());
 
     BOOST_LOG(info) << "session_event: "sv << event << " ["sv << get_session_state() << "] "sv << message;
   }

--- a/src/session_event_queue.h
+++ b/src/session_event_queue.h
@@ -1,0 +1,52 @@
+/**
+ * @file src/session_event_queue.h
+ * @brief Small sequence-aware backlog for Polaris session SSE events.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace session_event_queue {
+  class event_queue {
+  public:
+    explicit event_queue(std::size_t max_events = 128):
+        max_events_ {max_events == 0 ? 1 : max_events} {
+    }
+
+    std::uint64_t cursor() const {
+      return next_seq_;
+    }
+
+    std::uint64_t push(std::string payload) {
+      const auto seq = ++next_seq_;
+      events_.emplace_back(seq, std::move(payload));
+      prune();
+      return seq;
+    }
+
+    std::vector<std::string> events_after(std::uint64_t cursor) const {
+      std::vector<std::string> result;
+      for (const auto &entry : events_) {
+        if (entry.first > cursor) {
+          result.push_back(entry.second);
+        }
+      }
+      return result;
+    }
+
+  private:
+    void prune() {
+      while (events_.size() > max_events_) {
+        events_.erase(events_.begin());
+      }
+    }
+
+    std::size_t max_events_;
+    std::uint64_t next_seq_ {0};
+    std::vector<std::pair<std::uint64_t, std::string>> events_;
+  };
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_prepared_ffmpeg.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_rswrapper.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_session_event_queue.cpp
 )
 
 if (NOT WIN32 AND NOT APPLE)

--- a/tests/unit/test_session_event_queue.cpp
+++ b/tests/unit/test_session_event_queue.cpp
@@ -1,0 +1,40 @@
+/**
+ * @file tests/unit/test_session_event_queue.cpp
+ * @brief Tests for Polaris session SSE event backlog filtering.
+ */
+
+#include <src/session_event_queue.h>
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+TEST(SessionEventQueueTests, SubscriberOnlyReceivesEventsNewerThanItsCursor) {
+  session_event_queue::event_queue queue;
+
+  queue.push("stale-stream-ended");
+  const auto cursor = queue.cursor();
+  queue.push("current-stream-active");
+
+  const auto events = queue.events_after(cursor);
+
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events.front(), "current-stream-active");
+}
+
+TEST(SessionEventQueueTests, OldEventsArePrunedWithoutReplayingToNewSubscribers) {
+  session_event_queue::event_queue queue {3};
+
+  queue.push("old-1");
+  queue.push("old-2");
+  queue.push("old-3");
+  queue.push("old-4");
+
+  const auto cursor = queue.cursor();
+  queue.push("new-1");
+
+  const auto events = queue.events_after(cursor);
+
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events.front(), "new-1");
+}


### PR DESCRIPTION
## Summary
- add a sequence-aware session SSE event backlog
- initialize each SSE client with its own cursor so stale terminal events are not replayed into fresh Nova sessions
- add regression coverage for cursor filtering and backlog pruning

## Test Plan
- [x] cmake -S . -B build -DPOLARIS_ENABLE_CUDA=OFF -DBUILD_TESTS=ON -DCUDA_FAIL_ON_MISSING=OFF
- [x] cmake --build build --target test_polaris -j$(nproc)
- [x] ./build/tests/test_polaris --gtest_filter=SessionEventQueueTests.*
- [x] ctest --test-dir build/tests --output-on-failure -R ^test_polaris$
- [x] cmake --build build --target polaris -j$(nproc)

## Live smoke
- deployed equivalent fix on pc-papi
- Retroid/Nova Indiana stayed in Game at 10s/45s/90s instead of returning to Library
- Retroid/Nova Wukong stayed in Game at 15s/60s/120s
