### PR TITLE
Integrate headless VAAPI capture reinit for issues 111/124

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -492,8 +492,15 @@ namespace cage_display_router {
     return runtime_state.gpu_native_override_active;
   }
 
-  bool should_attempt_headless_extcopy_dmabuf(const platf::runtime_state_t &runtime_state) {
-    return runtime_state.effective_headless && !runtime_state.gpu_native_override_active;
+  bool should_attempt_headless_extcopy_dmabuf(
+    const platf::runtime_state_t &runtime_state,
+    platf::mem_type_e hwdevice_type
+  ) {
+    if (!runtime_state.effective_headless || runtime_state.gpu_native_override_active) {
+      return false;
+    }
+
+    return hwdevice_type == platf::mem_type_e::cuda;
   }
 
   std::optional<bool> cached_windowed_gpu_native_probe_result() {

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -130,8 +130,15 @@ namespace cage_display_router {
   /**
    * @brief Returns whether a headless labwc runtime should try the
    *        ext-image-copy-capture DMA-BUF path before falling back to SHM.
+   *
+   * The true-headless extcopy DMA-BUF path is only enabled for encoder memory
+   * types with a known-safe import/convert path. VAAPI stacks have proven
+   * crash-prone here, so they stay on the conservative SHM path.
    */
-  bool should_attempt_headless_extcopy_dmabuf(const platf::runtime_state_t &runtime_state);
+  bool should_attempt_headless_extcopy_dmabuf(
+    const platf::runtime_state_t &runtime_state,
+    platf::mem_type_e hwdevice_type
+  );
 
   /**
    * @brief Returns the cached result of the windowed GPU-native probe for the

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -544,23 +544,23 @@ namespace wl {
       return;
     }
 
-    const auto original_monitor_count = monitors.size();
-    monitors.erase(
-      std::remove_if(
-        monitors.begin(),
-        monitors.end(),
-        [id](const std::unique_ptr<monitor_t> &monitor) {
-          return monitor && monitor->registry_id == id;
-        }
-      ),
-      monitors.end()
-    );
-
+    const auto monitor_count = monitors.size();
     BOOST_LOG(info) << "Wayland output topology changed: removed output global "sv
                     << id
-                    << "; monitors="sv << original_monitor_count
-                    << "->"sv << monitors.size();
+                    << "; keeping "sv << monitor_count
+                    << " monitor handle(s) alive until capture reinit"sv;
   }
+
+#ifdef POLARIS_TESTS
+  void interface_t::add_monitor_for_tests(std::uint32_t id) {
+    output_registry_state.add_output(id);
+    monitors.emplace_back(std::make_unique<monitor_t>(nullptr, id));
+  }
+
+  void interface_t::remove_global_for_tests(std::uint32_t id) {
+    del_interface(nullptr, id);
+  }
+#endif
 
   // Initialize GBM
   bool dmabuf_t::init_gbm() {

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -214,8 +214,9 @@ namespace wl {
     return wl_display_get_registry(display_internal.get());
   }
 
-  inline monitor_t::monitor_t(wl_output *output):
+  inline monitor_t::monitor_t(wl_output *output, std::uint32_t registry_id):
       output {output},
+      registry_id {registry_id},
       wl_listener {
         &CLASS_CALL(monitor_t, wl_geometry),
         &CLASS_CALL(monitor_t, wl_mode),
@@ -493,9 +494,11 @@ namespace wl {
 
     if (!std::strcmp(interface, wl_output_interface.name)) {
       BOOST_LOG(info) << "Found interface: "sv << interface << '(' << id << ") version "sv << version;
+      output_registry_state.add_output(id);
       monitors.emplace_back(
         std::make_unique<monitor_t>(
-          (wl_output *) wl_registry_bind(registry, id, &wl_output_interface, 2)
+          (wl_output *) wl_registry_bind(registry, id, &wl_output_interface, 2),
+          id
         )
       );
     } else if (!std::strcmp(interface, zxdg_output_manager_v1_interface.name)) {
@@ -536,7 +539,27 @@ namespace wl {
   }
 
   void interface_t::del_interface(wl_registry *registry, uint32_t id) {
-    BOOST_LOG(info) << "Delete: "sv << id;
+    if (!output_registry_state.remove_global(id)) {
+      BOOST_LOG(info) << "Delete: "sv << id;
+      return;
+    }
+
+    const auto original_monitor_count = monitors.size();
+    monitors.erase(
+      std::remove_if(
+        monitors.begin(),
+        monitors.end(),
+        [id](const std::unique_ptr<monitor_t> &monitor) {
+          return monitor && monitor->registry_id == id;
+        }
+      ),
+      monitors.end()
+    );
+
+    BOOST_LOG(info) << "Wayland output topology changed: removed output global "sv
+                    << id
+                    << "; monitors="sv << original_monitor_count
+                    << "->"sv << monitors.size();
   }
 
   // Initialize GBM

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -385,6 +385,11 @@ namespace wl {
       return true;
     }
 
+#ifdef POLARIS_TESTS
+    void add_monitor_for_tests(std::uint32_t id);
+    void remove_global_for_tests(std::uint32_t id);
+#endif
+
     std::vector<std::unique_ptr<monitor_t>> monitors;
     zwlr_screencopy_manager_v1 *screencopy_manager {nullptr};
     zwp_linux_dmabuf_v1 *dmabuf_interface {nullptr};

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -5,10 +5,13 @@
 #pragma once
 
 // standard includes
+#include <algorithm>
 #include <bitset>
+#include <cstdint>
 #include <sys/types.h>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #ifdef POLARIS_BUILD_WAYLAND
   #include <ext-image-capture-source-v1.h>
@@ -23,6 +26,45 @@ struct gbm_device;
 
 // local includes
 #include "graphics.h"
+
+namespace wl {
+  class output_registry_state_t {
+  public:
+    void add_output(std::uint32_t id) {
+      if (std::find(output_ids.begin(), output_ids.end(), id) == output_ids.end()) {
+        output_ids.emplace_back(id);
+      }
+      topology_dirty = true;
+    }
+
+    bool remove_global(std::uint32_t id) {
+      auto it = std::find(output_ids.begin(), output_ids.end(), id);
+      if (it == output_ids.end()) {
+        return false;
+      }
+
+      output_ids.erase(it);
+      topology_dirty = true;
+      return true;
+    }
+
+    bool has_output(std::uint32_t id) const {
+      return std::find(output_ids.begin(), output_ids.end(), id) != output_ids.end();
+    }
+
+    bool output_topology_dirty() const {
+      return topology_dirty;
+    }
+
+    void clear_output_topology_dirty() {
+      topology_dirty = false;
+    }
+
+  private:
+    std::vector<std::uint32_t> output_ids;
+    bool topology_dirty {false};
+  };
+}  // namespace wl
 
 /**
  * The classes defined in this macro block should only be used by
@@ -268,7 +310,7 @@ namespace wl {
 
   class monitor_t {
   public:
-    explicit monitor_t(wl_output *output);
+    explicit monitor_t(wl_output *output, std::uint32_t registry_id = 0);
 
     monitor_t(monitor_t &&) = delete;
     monitor_t(const monitor_t &) = delete;
@@ -292,6 +334,7 @@ namespace wl {
     void wl_scale(wl_output *wl_output, std::int32_t factor) {}
 
     wl_output *output;
+    std::uint32_t registry_id;
     std::string name;
     std::string description;
     platf::touch_port_t viewport;
@@ -329,6 +372,19 @@ namespace wl {
       return interface[bit];
     }
 
+    bool output_topology_dirty() const {
+      return output_registry_state.output_topology_dirty();
+    }
+
+    bool consume_output_topology_dirty() {
+      if (!output_registry_state.output_topology_dirty()) {
+        return false;
+      }
+
+      output_registry_state.clear_output_topology_dirty();
+      return true;
+    }
+
     std::vector<std::unique_ptr<monitor_t>> monitors;
     zwlr_screencopy_manager_v1 *screencopy_manager {nullptr};
     zwp_linux_dmabuf_v1 *dmabuf_interface {nullptr};
@@ -350,6 +406,7 @@ namespace wl {
     void add_interface(wl_registry *registry, std::uint32_t id, const char *interface, std::uint32_t version);
     void del_interface(wl_registry *registry, uint32_t id);
 
+    output_registry_state_t output_registry_state;
     std::bitset<MAX_INTERFACES> interface;
     wl_registry_listener listener;
     zwp_linux_dmabuf_feedback_v1 *dmabuf_feedback_object {nullptr};
@@ -400,7 +457,7 @@ struct zxdg_output_manager_v1;
 namespace wl {
   class monitor_t {
   public:
-    monitor_t(wl_output *output);
+    monitor_t(wl_output *output, std::uint32_t registry_id = 0);
 
     monitor_t(monitor_t &&) = delete;
     monitor_t(const monitor_t &) = delete;
@@ -410,6 +467,7 @@ namespace wl {
     void listen(zxdg_output_manager_v1 *output_manager);
 
     wl_output *output;
+    std::uint32_t registry_id;
     std::string name;
     std::string description;
     platf::touch_port_t viewport;

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -741,7 +741,13 @@ namespace platf {
         prefer_ram_capture = true;
         using_headless_ram_capture = true;
         try_headless_extcopy_dmabuf =
-          cage_display_router::should_attempt_headless_extcopy_dmabuf(runtime_state);
+          cage_display_router::should_attempt_headless_extcopy_dmabuf(runtime_state, hwdevice_type);
+        if (!try_headless_extcopy_dmabuf &&
+            hwdevice_type == platf::mem_type_e::vaapi &&
+            cage_display_router::should_log_headless_ram_capture_warning()) {
+          BOOST_LOG(info)
+            << "wlr: Using RAM capture path for headless labwc because true-headless ext-image-copy-capture DMA-BUF is disabled for VAAPI stability"sv;
+        }
       } else {
         prefer_ram_capture = true;
 

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -126,9 +126,8 @@ namespace wl {
       monitor->listen(interface.output_manager);
 
       display.roundtrip();
-
+      interface.consume_output_topology_dirty();
       output = monitor->output;
-
       offset_x = monitor->viewport.offset_x;
       offset_y = monitor->viewport.offset_y;
       width = monitor->viewport.width;
@@ -161,6 +160,10 @@ namespace wl {
         auto remaining_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(to - std::chrono::steady_clock::now());
         if (remaining_time_ms.count() < 0 || !display.dispatch(remaining_time_ms)) {
           return platf::capture_e::timeout;
+        }
+        if (interface.consume_output_topology_dirty()) {
+          BOOST_LOG(warning) << "wlr: Wayland output topology changed during capture; reinitializing display capture"sv;
+          return platf::capture_e::reinit;
         }
       } while (dmabuf.status == dmabuf_t::WAITING);
 
@@ -608,6 +611,10 @@ namespace wl {
         capture_ready = true;
       } else {
         extcopy.capture(display);
+        if (interface.consume_output_topology_dirty()) {
+          BOOST_LOG(warning) << "wlr: Wayland output topology changed during ext-image-copy capture; reinitializing display capture"sv;
+          return platf::capture_e::reinit;
+        }
         if (extcopy.status == wl::extcopy_t::WAITING) {
           return platf::capture_e::timeout;
         }

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -6,6 +6,33 @@
 
 #ifdef __linux__
   #include <src/platform/linux/cage_display_router.h>
+  #include <src/platform/linux/wayland.h>
+
+TEST(WaylandOutputRegistryStateTests, OutputHotplugMarksTopologyDirtyUntilCleared) {
+  wl::output_registry_state_t state;
+
+  state.add_output(10);
+  EXPECT_TRUE(state.output_topology_dirty());
+
+  state.clear_output_topology_dirty();
+  EXPECT_FALSE(state.output_topology_dirty());
+
+  state.remove_global(10);
+  EXPECT_TRUE(state.output_topology_dirty());
+  EXPECT_FALSE(state.has_output(10));
+}
+
+TEST(WaylandOutputRegistryStateTests, RemovingNonOutputGlobalDoesNotDirtyOutputTopology) {
+  wl::output_registry_state_t state;
+
+  state.add_output(10);
+  state.clear_output_topology_dirty();
+
+  state.remove_global(99);
+
+  EXPECT_FALSE(state.output_topology_dirty());
+  EXPECT_TRUE(state.has_output(10));
+}
 
 TEST(CageDisplayRouterPolicyTests, HeadlessNvencRequestsWindowedGpuNativeProbeWhenAllConditionsMatch) {
   EXPECT_TRUE(cage_display_router::should_attempt_windowed_gpu_native_probe(

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -55,7 +55,7 @@ TEST(CageDisplayRouterPolicyTests, HeadlessRuntimeDoesNotAttemptGpuNativeCapture
   EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state));
 }
 
-TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessAttemptsExtcopyDmabufBeforeShmFallback) {
+TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiSkipsExtcopyDmabufForShmFallback) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,
     .effective_headless = true,
@@ -63,7 +63,24 @@ TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessAttemptsExtcopyDmabufBeforeS
     .backend_name = "labwc",
   };
 
-  EXPECT_TRUE(cage_display_router::should_attempt_headless_extcopy_dmabuf(runtime_state));
+  EXPECT_FALSE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
+    runtime_state,
+    platf::mem_type_e::vaapi
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessCudaCanAttemptExtcopyDmabuf) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = true,
+    .gpu_native_override_active = false,
+    .backend_name = "labwc",
+  };
+
+  EXPECT_TRUE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
+    runtime_state,
+    platf::mem_type_e::cuda
+  ));
 }
 
 TEST(CageDisplayRouterPolicyTests, WindowedOverrideDoesNotAttemptHeadlessExtcopyDmabuf) {
@@ -74,7 +91,10 @@ TEST(CageDisplayRouterPolicyTests, WindowedOverrideDoesNotAttemptHeadlessExtcopy
     .backend_name = "labwc",
   };
 
-  EXPECT_FALSE(cage_display_router::should_attempt_headless_extcopy_dmabuf(runtime_state));
+  EXPECT_FALSE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
+    runtime_state,
+    platf::mem_type_e::cuda
+  ));
 }
 
 TEST(CageDisplayRouterPolicyTests, RequestedHeadlessWithoutOverrideStillReportsHeadlessFallback) {

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -34,6 +34,21 @@ TEST(WaylandOutputRegistryStateTests, RemovingNonOutputGlobalDoesNotDirtyOutputT
   EXPECT_TRUE(state.has_output(10));
 }
 
+#ifdef POLARIS_TESTS
+TEST(WaylandInterfaceTests, RemovedOutputMarksDirtyButKeepsMonitorStorageUntilReinit) {
+  wl::interface_t interface;
+
+  interface.add_monitor_for_tests(57);
+  EXPECT_TRUE(interface.consume_output_topology_dirty());
+  ASSERT_EQ(interface.monitors.size(), 1u);
+
+  interface.remove_global_for_tests(57);
+
+  EXPECT_TRUE(interface.consume_output_topology_dirty());
+  EXPECT_EQ(interface.monitors.size(), 1u);
+}
+#endif
+
 TEST(CageDisplayRouterPolicyTests, HeadlessNvencRequestsWindowedGpuNativeProbeWhenAllConditionsMatch) {
   EXPECT_TRUE(cage_display_router::should_attempt_windowed_gpu_native_probe(
     true,


### PR DESCRIPTION
Summary:
- Merges polaris/issue-111-headless-dmabuf-fallback into current master.
- Keeps Wayland outputs alive across capture reinit and disables headless extcopy DMA-BUF for VAAPI.

Validation:
- git diff --check polaris/master..HEAD
- cmake --build build --parallel
- ctest --test-dir build --output-on-failure passed 12/12
- npm run test passed 134/134
- npm run lint
- npm run build:budget
- npm run smoke:web passed unauthenticated route smoke with authenticated checks skipped.

Refs #111 and #124.

No deploy and no merge performed.
