### PR TITLE
fix(linux): harden strict gamepad isolation sysfs masking

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -179,6 +179,26 @@ namespace cage_display_router {
     return !path.empty() && access(path.c_str(), X_OK) == 0;
   }
 
+  static std::string shell_quote(std::string_view value) {
+    const auto quote = std::string(1, static_cast<char>(39));
+    const auto slash = std::string(1, static_cast<char>(92));
+    std::string result = quote;
+
+    for (char ch : value) {
+      if (ch == static_cast<char>(39)) {
+        result += quote;
+        result += slash;
+        result += quote;
+        result += quote;
+      } else {
+        result += ch;
+      }
+    }
+
+    result += quote;
+    return result;
+  }
+
   static std::string resolve_executable(const std::string &name) {
     if (name.find('/') != std::string::npos) {
       return executable_accessible(name) ? name : "";
@@ -763,9 +783,10 @@ namespace cage_display_router {
       }
 
       // labwc -C: config dir for rc.xml, -s: startup command (game)
+      const auto startup_shell = std::string("bash -c " ) + shell_quote(startup_cmd);
       execl(labwc_path.c_str(), "labwc",
         "-C", config_dir.c_str(),
-        "-s", ("bash -c '" + startup_cmd + "'").c_str(),
+        "-s", startup_shell.c_str(),
         nullptr);
       _exit(errno == ENOENT ? 127 : 126);
     } else if (pid > 0) {

--- a/src/platform/linux/input/inputtino_gamepad.cpp
+++ b/src/platform/linux/input/inputtino_gamepad.cpp
@@ -10,6 +10,7 @@
 // local includes
 #include "inputtino_common.h"
 #include "inputtino_gamepad.h"
+#include "inputtino_gamepad_isolation.h"
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
@@ -25,6 +26,16 @@ namespace platf::gamepad {
     XINPUT_NOT_AVAILABLE,  ///< XINPUT is not available
     GAMEPAD_STATUS  ///< Helper to indicate the number of status
   };
+
+  std::vector<std::string> joypad_nodes(const joypads_t &joypad) {
+    return std::visit([](const auto &device) {
+      return device.get_nodes();
+    }, joypad);
+  }
+
+  void register_created_joypad_nodes(int globalIndex, const joypads_t &joypad) {
+    isolation::register_virtual_gamepad_nodes(globalIndex, joypad_nodes(joypad));
+  }
 
   auto create_xbox_one(int globalIndex) {
     std::string device_id = "";
@@ -42,12 +53,20 @@ namespace platf::gamepad {
                                              .device_uniq = device_id});
   }
 
-  auto create_switch() {
+  auto create_switch(int globalIndex) {
+    std::string device_id = "";
+
+    if (globalIndex >= 0 && globalIndex <= 255) {
+      device_id = std::format("02:00:00:00:20:{:02x}", globalIndex);
+    }
+
     return inputtino::SwitchJoypad::create({.name = "Sunshine Nintendo (virtual) pad",
                                             // https://github.com/torvalds/linux/blob/master/drivers/hid/hid-ids.h#L981
                                             .vendor_id = 0x057e,
                                             .product_id = 0x2009,
-                                            .version = 0x8111});
+                                            .version = 0x8111,
+                                            .device_phys = device_id,
+                                            .device_uniq = device_id});
   }
 
   auto create_ds5(int globalIndex) {
@@ -131,6 +150,7 @@ namespace platf::gamepad {
           if (xOne) {
             (*xOne).set_on_rumble(on_rumble_fn);
             gamepad->joypad = std::make_unique<joypads_t>(std::move(*xOne));
+            register_created_joypad_nodes(id.globalIndex, *gamepad->joypad);
             raw->gamepads[id.globalIndex] = std::move(gamepad);
             return 0;
           } else {
@@ -140,10 +160,11 @@ namespace platf::gamepad {
         }
       case SwitchProWired:
         {
-          auto switchPro = create_switch();
+          auto switchPro = create_switch(id.globalIndex);
           if (switchPro) {
             (*switchPro).set_on_rumble(on_rumble_fn);
             gamepad->joypad = std::make_unique<joypads_t>(std::move(*switchPro));
+            register_created_joypad_nodes(id.globalIndex, *gamepad->joypad);
             raw->gamepads[id.globalIndex] = std::move(gamepad);
             return 0;
           } else {
@@ -176,6 +197,7 @@ namespace platf::gamepad {
             feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_GYRO, 100));
 
             gamepad->joypad = std::make_unique<joypads_t>(std::move(*ds5));
+            register_created_joypad_nodes(id.globalIndex, *gamepad->joypad);
             raw->gamepads[id.globalIndex] = std::move(gamepad);
             return 0;
           } else {
@@ -188,6 +210,7 @@ namespace platf::gamepad {
   }
 
   void free(input_raw_t *raw, int nr) {
+    isolation::unregister_virtual_gamepad_nodes(nr);
     // This will call the destructor which in turn will stop the background threads for rumble and LED (and ultimately remove the joypad device)
     raw->gamepads[nr]->joypad.reset();
     raw->gamepads[nr].reset();
@@ -283,7 +306,7 @@ namespace platf::gamepad {
     }
 
     auto ds5 = create_ds5(-1);  // Index -1 will result in a random MAC virtual device, which is fine for probing
-    auto switchPro = create_switch();
+    auto switchPro = create_switch(-1);
     auto xOne = create_xbox_one(0);
 
     static std::vector gps {

--- a/src/platform/linux/input/inputtino_gamepad_isolation.cpp
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.cpp
@@ -1,0 +1,332 @@
+/**
+ * @file src/platform/linux/input/inputtino_gamepad_isolation.cpp
+ * @brief Linux gamepad visibility classification for headless labwc launch diagnostics.
+ */
+#include "inputtino_gamepad_isolation.h"
+#include "src/logging.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <dirent.h>
+#include <fcntl.h>
+#include <iomanip>
+#include <libevdev/libevdev.h>
+#include <set>
+#include <sstream>
+#include <string_view>
+#include <unistd.h>
+#include <utility>
+
+namespace platf::gamepad::isolation {
+namespace {
+  using vid_pid_pair_t = std::pair<uint16_t, uint16_t>;
+
+  constexpr std::string_view xbox_virtual_name = "Sunshine X-Box One (virtual) pad";
+  constexpr std::string_view switch_virtual_name = "Sunshine Nintendo (virtual) pad";
+  constexpr std::string_view ps5_virtual_name = "Sunshine PS5 (virtual) pad";
+  constexpr std::string_view xbox_private_prefix = "02:00:00:00:10:";
+  constexpr std::string_view ds5_private_prefix = "02:00:00:00:00:";
+
+  std::string safe_string(const char *value) {
+    return value ? std::string(value) : std::string {};
+  }
+
+  std::string lowercase(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+      return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+  }
+
+  bool starts_with(std::string_view value, std::string_view prefix) {
+    return value.size() >= prefix.size() && value.substr(0, prefix.size()) == prefix;
+  }
+
+  bool has_private_virtual_prefix(const device_snapshot_t &device) {
+    const auto phys = lowercase(device.phys);
+    const auto uniq = lowercase(device.uniq);
+
+    return starts_with(phys, xbox_private_prefix) ||
+           starts_with(uniq, xbox_private_prefix) ||
+           starts_with(phys, ds5_private_prefix) ||
+           starts_with(uniq, ds5_private_prefix);
+  }
+
+  bool has_known_virtual_name(std::string_view name) {
+    return name == xbox_virtual_name ||
+           name == switch_virtual_name ||
+           name == ps5_virtual_name;
+  }
+
+  std::optional<vid_pid_pair_t> vid_pid(const device_snapshot_t &device) {
+    if (!device.vendor_id || !device.product_id) {
+      return std::nullopt;
+    }
+
+    return vid_pid_pair_t {*device.vendor_id, *device.product_id};
+  }
+
+  std::string format_vid_pid(const vid_pid_pair_t &pair) {
+    std::ostringstream out;
+    out << std::hex << std::nouppercase << std::setfill(static_cast<char>(48));
+    out << "0x" << std::setw(4) << pair.first << "/0x" << std::setw(4) << pair.second;
+    return out.str();
+  }
+
+  std::string join_vid_pid_pairs(const std::set<vid_pid_pair_t> &pairs) {
+    std::string joined;
+    for (const auto &pair : pairs) {
+      if (!joined.empty()) {
+        joined += ",";
+      }
+      joined += format_vid_pid(pair);
+    }
+    return joined;
+  }
+
+  std::string shell_quote(std::string_view value) {
+    const auto quote = std::string(1, static_cast<char>(39));
+    const auto slash = std::string(1, static_cast<char>(92));
+    std::string result = quote;
+
+    for (char ch : value) {
+      if (ch == static_cast<char>(39)) {
+        result += quote;
+        result += slash;
+        result += quote;
+        result += quote;
+      } else {
+        result += ch;
+      }
+    }
+
+    result += quote;
+    return result;
+  }
+
+  bool libevdev_has_any_key(const libevdev *device, const std::array<int, 12> &codes) {
+    return std::any_of(codes.begin(), codes.end(), [device](int code) {
+      return libevdev_has_event_code(device, EV_KEY, code) != 0;
+    });
+  }
+
+  bool libevdev_has_any_abs(const libevdev *device, const std::array<int, 8> &codes) {
+    return std::any_of(codes.begin(), codes.end(), [device](int code) {
+      return libevdev_has_event_code(device, EV_ABS, code) != 0;
+    });
+  }
+
+  bool libevdev_looks_like_gamepad(const libevdev *device) {
+    static constexpr std::array<int, 12> gamepad_keys {
+      BTN_GAMEPAD,
+      BTN_SOUTH,
+      BTN_EAST,
+      BTN_NORTH,
+      BTN_WEST,
+      BTN_A,
+      BTN_B,
+      BTN_X,
+      BTN_Y,
+      BTN_TL,
+      BTN_TR,
+      BTN_START,
+    };
+
+    static constexpr std::array<int, 8> gamepad_axes {
+      ABS_X,
+      ABS_Y,
+      ABS_RX,
+      ABS_RY,
+      ABS_Z,
+      ABS_RZ,
+      ABS_HAT0X,
+      ABS_HAT0Y,
+    };
+
+    return libevdev_has_any_key(device, gamepad_keys) &&
+           libevdev_has_any_abs(device, gamepad_axes);
+  }
+
+  std::optional<uint16_t> positive_id(int value) {
+    if (value <= 0) {
+      return std::nullopt;
+    }
+    return static_cast<uint16_t>(value);
+  }
+}  // namespace
+
+device_classification_e classify_device(const device_snapshot_t &device) {
+  if (!device.gamepad_class) {
+    return device_classification_e::ignored;
+  }
+
+  if (has_known_virtual_name(device.name) || has_private_virtual_prefix(device)) {
+    return device_classification_e::polaris_virtual;
+  }
+
+  return device_classification_e::host_visible;
+}
+
+std::vector<classified_device_t> classify_devices(const std::vector<device_snapshot_t> &devices) {
+  std::vector<classified_device_t> classified;
+  classified.reserve(devices.size());
+
+  for (const auto &device : devices) {
+    classified.push_back(classified_device_t {device, classify_device(device)});
+  }
+
+  return classified;
+}
+
+sdl_hint_plan_t build_sdl_hint_plan(const std::vector<classified_device_t> &devices) {
+  std::vector<device_snapshot_t> polaris_virtual;
+  std::vector<device_snapshot_t> host_visible;
+
+  for (const auto &classified : devices) {
+    if (classified.classification == device_classification_e::polaris_virtual) {
+      polaris_virtual.push_back(classified.device);
+    } else if (classified.classification == device_classification_e::host_visible) {
+      host_visible.push_back(classified.device);
+    }
+  }
+
+  sdl_hint_plan_t plan;
+
+  if (host_visible.empty()) {
+    plan.reason = "gamepad_isolation: no host physical controllers visible; SDL hints not needed";
+    return plan;
+  }
+
+  if (polaris_virtual.empty()) {
+    plan.reason = "gamepad_isolation: host physical controllers are visible, but no Polaris virtual gamepad was identified; SDL hints skipped";
+    return plan;
+  }
+
+  std::set<vid_pid_pair_t> virtual_pairs;
+  std::set<vid_pid_pair_t> host_pairs;
+
+  for (const auto &device : polaris_virtual) {
+    const auto pair = vid_pid(device);
+    if (!pair) {
+      plan.reason = "gamepad_isolation: Polaris virtual gamepad is missing VID/PID; SDL hints skipped";
+      return plan;
+    }
+    virtual_pairs.insert(*pair);
+  }
+
+  for (const auto &device : host_visible) {
+    const auto pair = vid_pid(device);
+    if (!pair) {
+      plan.reason = "gamepad_isolation: host-visible controller is missing VID/PID; SDL hints skipped";
+      return plan;
+    }
+    host_pairs.insert(*pair);
+  }
+
+  for (const auto &pair : host_pairs) {
+    if (virtual_pairs.contains(pair)) {
+      plan.reason = "gamepad_isolation: host-visible controller VID/PID overlaps Polaris virtual gamepad; SDL hints skipped";
+      return plan;
+    }
+  }
+
+  plan.env["SDL_GAMECONTROLLER_IGNORE_DEVICES"] = join_vid_pid_pairs(host_pairs);
+  plan.env["SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT"] = join_vid_pid_pairs(virtual_pairs);
+  plan.reason = "gamepad_isolation: exporting best-effort SDL controller privacy hints; strict /dev/input and hidraw isolation is not active";
+  return plan;
+}
+
+std::string command_with_sdl_env_prefix(const std::string &command, const sdl_hint_plan_t &plan) {
+  if (!plan.applied() || command.empty()) {
+    return command;
+  }
+
+  std::string prefixed = "env ";
+  for (const auto &[key, value] : plan.env) {
+    prefixed += key;
+    prefixed += "=";
+    prefixed += shell_quote(value);
+    prefixed += " ";
+  }
+
+  prefixed += command;
+  return prefixed;
+}
+
+sdl_hint_plan_t prepare_headless_labwc_launch() {
+  const auto devices = classify_devices(enumerate_visible_gamepads());
+
+  std::size_t polaris_virtual_count = 0;
+  std::size_t host_visible_count = 0;
+  for (const auto &device : devices) {
+    if (device.classification == device_classification_e::polaris_virtual) {
+      ++polaris_virtual_count;
+    } else if (device.classification == device_classification_e::host_visible) {
+      ++host_visible_count;
+    }
+  }
+
+  BOOST_LOG(info) << "gamepad_isolation: headless labwc visible controllers: polaris_virtual="
+                  << polaris_virtual_count
+                  << " host_visible="
+                  << host_visible_count;
+
+  auto plan = build_sdl_hint_plan(devices);
+  if (host_visible_count > 0 && !plan.applied()) {
+    BOOST_LOG(warning) << plan.reason;
+  } else {
+    BOOST_LOG(info) << plan.reason;
+  }
+  BOOST_LOG(info) << "gamepad_isolation: diagnostics and SDL hints are best-effort only; strict /dev/input and hidraw hiding is not active";
+  return plan;
+}
+
+std::vector<device_snapshot_t> enumerate_visible_gamepads() {
+  std::vector<device_snapshot_t> devices;
+
+  auto *dir = opendir("/dev/input");
+  if (!dir) {
+    return devices;
+  }
+
+  while (auto *entry = readdir(dir)) {
+    const std::string name = safe_string(entry->d_name);
+    if (!starts_with(name, "event")) {
+      continue;
+    }
+
+    const auto event_node = std::string("/dev/input/") + name;
+    const int fd = open(event_node.c_str(), O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    if (fd < 0) {
+      continue;
+    }
+
+    libevdev *evdev = nullptr;
+    if (libevdev_new_from_fd(fd, &evdev) < 0 || !evdev) {
+      close(fd);
+      continue;
+    }
+
+    device_snapshot_t snapshot;
+    snapshot.event_node = event_node;
+    snapshot.name = safe_string(libevdev_get_name(evdev));
+    snapshot.vendor_id = positive_id(libevdev_get_id_vendor(evdev));
+    snapshot.product_id = positive_id(libevdev_get_id_product(evdev));
+    snapshot.version = positive_id(libevdev_get_id_version(evdev));
+    snapshot.phys = safe_string(libevdev_get_phys(evdev));
+    snapshot.uniq = safe_string(libevdev_get_uniq(evdev));
+    snapshot.gamepad_class = libevdev_looks_like_gamepad(evdev);
+
+    if (snapshot.gamepad_class) {
+      devices.push_back(std::move(snapshot));
+    }
+
+    libevdev_free(evdev);
+    close(fd);
+  }
+
+  closedir(dir);
+  return devices;
+}
+}  // namespace platf::gamepad::isolation

--- a/src/platform/linux/input/inputtino_gamepad_isolation.cpp
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.cpp
@@ -8,10 +8,12 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstdlib>
 #include <dirent.h>
 #include <fcntl.h>
 #include <iomanip>
 #include <libevdev/libevdev.h>
+#include <mutex>
 #include <set>
 #include <sstream>
 #include <string_view>
@@ -25,8 +27,15 @@ namespace {
   constexpr std::string_view xbox_virtual_name = "Sunshine X-Box One (virtual) pad";
   constexpr std::string_view switch_virtual_name = "Sunshine Nintendo (virtual) pad";
   constexpr std::string_view ps5_virtual_name = "Sunshine PS5 (virtual) pad";
+  constexpr std::string_view polaris_xbox_virtual_name = "Polaris X-Box One (virtual) pad";
+  constexpr std::string_view polaris_switch_virtual_name = "Polaris Nintendo (virtual) pad";
+  constexpr std::string_view polaris_ps5_virtual_name = "Polaris PS5 (virtual) pad";
   constexpr std::string_view xbox_private_prefix = "02:00:00:00:10:";
+  constexpr std::string_view switch_private_prefix = "02:00:00:00:20:";
   constexpr std::string_view ds5_private_prefix = "02:00:00:00:00:";
+
+  std::mutex virtual_nodes_mutex;
+  std::map<int, std::vector<std::string>> virtual_nodes_by_gamepad;
 
   std::string safe_string(const char *value) {
     return value ? std::string(value) : std::string {};
@@ -49,6 +58,8 @@ namespace {
 
     return starts_with(phys, xbox_private_prefix) ||
            starts_with(uniq, xbox_private_prefix) ||
+           starts_with(phys, switch_private_prefix) ||
+           starts_with(uniq, switch_private_prefix) ||
            starts_with(phys, ds5_private_prefix) ||
            starts_with(uniq, ds5_private_prefix);
   }
@@ -56,7 +67,10 @@ namespace {
   bool has_known_virtual_name(std::string_view name) {
     return name == xbox_virtual_name ||
            name == switch_virtual_name ||
-           name == ps5_virtual_name;
+           name == ps5_virtual_name ||
+           name == polaris_xbox_virtual_name ||
+           name == polaris_switch_virtual_name ||
+           name == polaris_ps5_virtual_name;
   }
 
   std::optional<vid_pid_pair_t> vid_pid(const device_snapshot_t &device) {
@@ -85,6 +99,71 @@ namespace {
     return joined;
   }
 
+  bool has_numeric_suffix(std::string_view value, std::string_view prefix) {
+    if (!starts_with(value, prefix) || value.size() == prefix.size()) {
+      return false;
+    }
+
+    return std::all_of(value.begin() + static_cast<std::ptrdiff_t>(prefix.size()), value.end(), [](unsigned char ch) {
+      return std::isdigit(ch) != 0;
+    });
+  }
+
+  bool is_virtual_gamepad_node(std::string_view node) {
+    return has_numeric_suffix(node, "/dev/input/event") ||
+           has_numeric_suffix(node, "/dev/input/js") ||
+           has_numeric_suffix(node, "/dev/hidraw");
+  }
+
+  bool is_hidraw_node(std::string_view node) {
+    return starts_with(node, "/dev/hidraw");
+  }
+
+  std::vector<std::string> sanitized_virtual_nodes(const std::vector<std::string> &nodes) {
+    std::set<std::string> unique;
+    for (const auto &node : nodes) {
+      if (is_virtual_gamepad_node(node)) {
+        unique.insert(node);
+      }
+    }
+
+    return std::vector<std::string>(unique.begin(), unique.end());
+  }
+
+  std::string find_executable(std::string_view name) {
+    if (name.empty()) {
+      return {};
+    }
+
+    const auto requested = std::string(name);
+    if (requested.find("/") != std::string::npos) {
+      return access(requested.c_str(), X_OK) == 0 ? requested : std::string {};
+    }
+
+    const char *path_env = std::getenv("PATH");
+    const std::string path = path_env && *path_env ? path_env : "/usr/local/bin:/usr/bin:/bin";
+    std::size_t start = 0;
+    while (start <= path.size()) {
+      const auto end = path.find(static_cast<char>(58), start);
+      auto dir = path.substr(start, end == std::string::npos ? std::string::npos : end - start);
+      if (dir.empty()) {
+        dir = ".";
+      }
+
+      const auto candidate = dir + "/" + requested;
+      if (access(candidate.c_str(), X_OK) == 0) {
+        return candidate;
+      }
+
+      if (end == std::string::npos) {
+        break;
+      }
+      start = end + 1;
+    }
+
+    return {};
+  }
+
   std::string shell_quote(std::string_view value) {
     const auto quote = std::string(1, static_cast<char>(39));
     const auto slash = std::string(1, static_cast<char>(92));
@@ -103,6 +182,26 @@ namespace {
 
     result += quote;
     return result;
+  }
+
+  bool probe_bubblewrap_usable(std::string_view bubblewrap_path) {
+    if (bubblewrap_path.empty()) {
+      return false;
+    }
+
+    std::string command = shell_quote(bubblewrap_path);
+    command += " --bind / /";
+    command += " --dev /dev";
+    command += " --proc /proc";
+    command += " --ro-bind /sys /sys";
+    command += " --tmpfs /dev/input";
+    command += " --dir /dev/input/by-id";
+    command += " --dir /dev/input/by-path";
+    command += " --tmpfs /run/udev";
+    command += " --tmpfs /sys/class/input";
+    command += " --tmpfs /sys/class/hidraw";
+    command += " -- /usr/bin/true >/dev/null 2>&1";
+    return std::system(command.c_str()) == 0;
   }
 
   bool libevdev_has_any_key(const libevdev *device, const std::array<int, 12> &codes) {
@@ -237,6 +336,42 @@ sdl_hint_plan_t build_sdl_hint_plan(const std::vector<classified_device_t> &devi
   return plan;
 }
 
+
+strict_gamepad_isolation_plan_t build_strict_gamepad_isolation_plan(
+  const std::vector<classified_device_t> &devices,
+  const std::vector<std::string> &registered_virtual_nodes,
+  const strict_isolation_options_t &options
+) {
+  strict_gamepad_isolation_plan_t plan;
+  plan.bubblewrap_path = options.bubblewrap_path.empty() ? "bwrap" : options.bubblewrap_path;
+  plan.fallback_sdl = build_sdl_hint_plan(devices);
+  plan.allowed_nodes = sanitized_virtual_nodes(registered_virtual_nodes);
+
+  if (!options.bubblewrap_available || !options.bubblewrap_usable) {
+    const auto unavailable_reason = options.bubblewrap_available ?
+                                      std::string("bubblewrap probe failed") :
+                                      std::string("bubblewrap is unavailable");
+    if (plan.fallback_sdl.applied()) {
+      plan.mode = isolation_mode_e::best_effort_sdl;
+      plan.reason = "gamepad_isolation: strict device isolation is not active because " + unavailable_reason + "; using best-effort SDL hints";
+    } else {
+      plan.mode = isolation_mode_e::unavailable;
+      plan.reason = "gamepad_isolation: strict device isolation is not active because " + unavailable_reason;
+    }
+    return plan;
+  }
+
+  plan.mode = isolation_mode_e::strict_bwrap;
+  if (plan.allowed_nodes.empty()) {
+    plan.reason = "gamepad_isolation: strict bubblewrap device isolation active; no registered Polaris virtual gamepad nodes are exposed";
+  } else {
+    plan.reason = "gamepad_isolation: strict bubblewrap device isolation active; binding " +
+                  std::to_string(plan.allowed_nodes.size()) +
+                  " registered Polaris virtual gamepad node(s)";
+  }
+  return plan;
+}
+
 std::string command_with_sdl_env_prefix(const std::string &command, const sdl_hint_plan_t &plan) {
   if (!plan.applied() || command.empty()) {
     return command;
@@ -254,7 +389,97 @@ std::string command_with_sdl_env_prefix(const std::string &command, const sdl_hi
   return prefixed;
 }
 
-sdl_hint_plan_t prepare_headless_labwc_launch() {
+std::string command_with_headless_gamepad_isolation(const std::string &command, const strict_gamepad_isolation_plan_t &plan) {
+  if (command.empty()) {
+    return command;
+  }
+
+  if (!plan.strict_applied()) {
+    return command_with_sdl_env_prefix(command, plan.fallback_sdl);
+  }
+
+  std::string wrapped = shell_quote(plan.bubblewrap_path.empty() ? "bwrap" : plan.bubblewrap_path);
+  wrapped += " --bind / /";
+  wrapped += " --dev /dev";
+  wrapped += " --proc /proc";
+  wrapped += " --ro-bind /sys /sys";
+  wrapped += " --tmpfs /dev/input";
+  wrapped += " --dir /dev/input/by-id";
+  wrapped += " --dir /dev/input/by-path";
+  wrapped += " --tmpfs /run/udev";
+  wrapped += " --tmpfs /sys/class/input";
+  wrapped += " --tmpfs /sys/class/hidraw";
+
+  static constexpr std::array<std::string_view, 12> runtime_device_roots {
+    "/dev/dri",
+    "/dev/snd",
+    "/dev/kfd",
+    "/dev/nvidiactl",
+    "/dev/nvidia0",
+    "/dev/nvidia-uvm",
+    "/dev/nvidia-uvm-tools",
+    "/dev/nvidia-modeset",
+    "/dev/nvidia-caps",
+    "/dev/shm",
+    "/dev/fd",
+    "/dev/pts",
+  };
+
+  for (const auto node : runtime_device_roots) {
+    wrapped += " --dev-bind-try ";
+    wrapped += node;
+    wrapped += " ";
+    wrapped += node;
+  }
+
+  for (const auto &node : plan.allowed_nodes) {
+    wrapped += is_hidraw_node(node) ? " --dev-bind-try " : " --dev-bind ";
+    wrapped += node;
+    wrapped += " ";
+    wrapped += node;
+  }
+
+  wrapped += " -- /bin/sh -lc ";
+  wrapped += shell_quote(command);
+  return wrapped;
+}
+
+void register_virtual_gamepad_nodes(int gamepad_index, const std::vector<std::string> &nodes) {
+  auto sanitized = sanitized_virtual_nodes(nodes);
+  std::lock_guard lock(virtual_nodes_mutex);
+  if (sanitized.empty()) {
+    virtual_nodes_by_gamepad.erase(gamepad_index);
+    return;
+  }
+  virtual_nodes_by_gamepad[gamepad_index] = std::move(sanitized);
+}
+
+void unregister_virtual_gamepad_nodes(int gamepad_index) {
+  std::lock_guard lock(virtual_nodes_mutex);
+  virtual_nodes_by_gamepad.erase(gamepad_index);
+}
+
+std::vector<std::string> registered_virtual_gamepad_nodes() {
+  std::vector<std::string> nodes;
+  std::lock_guard lock(virtual_nodes_mutex);
+  for (const auto &[_, device_nodes] : virtual_nodes_by_gamepad) {
+    nodes.insert(nodes.end(), device_nodes.begin(), device_nodes.end());
+  }
+  return sanitized_virtual_nodes(nodes);
+}
+
+strict_isolation_options_t detect_strict_isolation_options() {
+  strict_isolation_options_t options;
+  options.bubblewrap_path = find_executable("bwrap");
+  options.bubblewrap_available = !options.bubblewrap_path.empty();
+  if (options.bubblewrap_path.empty()) {
+    options.bubblewrap_path = "bwrap";
+  }
+  options.bubblewrap_usable = options.bubblewrap_available && probe_bubblewrap_usable(options.bubblewrap_path);
+  return options;
+}
+
+strict_gamepad_isolation_plan_t prepare_headless_labwc_launch() {
   const auto devices = classify_devices(enumerate_visible_gamepads());
 
   std::size_t polaris_virtual_count = 0;
@@ -272,13 +497,20 @@ sdl_hint_plan_t prepare_headless_labwc_launch() {
                   << " host_visible="
                   << host_visible_count;
 
-  auto plan = build_sdl_hint_plan(devices);
-  if (host_visible_count > 0 && !plan.applied()) {
-    BOOST_LOG(warning) << plan.reason;
-  } else {
+  const auto registered_nodes = registered_virtual_gamepad_nodes();
+  auto plan = build_strict_gamepad_isolation_plan(devices, registered_nodes, detect_strict_isolation_options());
+  BOOST_LOG(info) << "gamepad_isolation: registered Polaris virtual nodes="
+                  << registered_nodes.size();
+
+  if (plan.strict_applied()) {
     BOOST_LOG(info) << plan.reason;
+  } else {
+    BOOST_LOG(warning) << plan.reason;
+    if (!plan.fallback_sdl.reason.empty()) {
+      BOOST_LOG(info) << plan.fallback_sdl.reason;
+    }
+    BOOST_LOG(info) << "gamepad_isolation: fallback is best-effort only; strict /dev/input and hidraw hiding is not active";
   }
-  BOOST_LOG(info) << "gamepad_isolation: diagnostics and SDL hints are best-effort only; strict /dev/input and hidraw hiding is not active";
   return plan;
 }
 

--- a/src/platform/linux/input/inputtino_gamepad_isolation.cpp
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.cpp
@@ -12,6 +12,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <iomanip>
+#include <limits.h>
 #include <libevdev/libevdev.h>
 #include <mutex>
 #include <set>
@@ -130,6 +131,77 @@ namespace {
     return std::vector<std::string>(unique.begin(), unique.end());
   }
 
+  bool is_safe_sysfs_path(std::string_view path) {
+    if (!starts_with(path, "/sys/devices/")) {
+      return false;
+    }
+
+    return std::all_of(path.begin(), path.end(), [](unsigned char ch) {
+      return std::isalnum(ch) != 0 ||
+             ch == 47 ||
+             ch == 45 ||
+             ch == 95 ||
+             ch == 46 ||
+             ch == 58;
+    });
+  }
+
+  std::optional<std::string> host_input_sysfs_root(std::string_view sysfs_path) {
+    if (!is_safe_sysfs_path(sysfs_path)) {
+      return std::nullopt;
+    }
+
+    constexpr std::string_view input_dir_marker = "/input/";
+    const auto input_dir_pos = sysfs_path.find(input_dir_marker);
+    if (input_dir_pos == std::string_view::npos) {
+      return std::nullopt;
+    }
+
+    const auto input_device_start = input_dir_pos + input_dir_marker.size();
+    if (!starts_with(sysfs_path.substr(input_device_start), "input")) {
+      return std::nullopt;
+    }
+
+    auto input_device_end = sysfs_path.find("/", input_device_start);
+    if (input_device_end == std::string_view::npos) {
+      input_device_end = sysfs_path.size();
+    }
+
+    const auto root = std::string(sysfs_path.substr(0, input_device_end));
+    if (root.find("/sys/devices/virtual/input/") == 0) {
+      return std::nullopt;
+    }
+    return root;
+  }
+
+  std::vector<std::string> host_input_sysfs_mask_paths(const std::vector<classified_device_t> &devices) {
+    std::set<std::string> paths;
+    for (const auto &classified : devices) {
+      if (classified.classification != device_classification_e::host_visible) {
+        continue;
+      }
+      auto root = host_input_sysfs_root(classified.device.sysfs_path);
+      if (root) {
+        paths.insert(*root);
+      }
+    }
+    return std::vector<std::string>(paths.begin(), paths.end());
+  }
+
+  std::string event_sysfs_path(std::string_view event_node) {
+    constexpr std::string_view input_prefix = "/dev/input/";
+    if (!starts_with(event_node, input_prefix)) {
+      return {};
+    }
+
+    const auto sysfs = std::string("/sys/class/input/") + std::string(event_node.substr(input_prefix.size()));
+    char resolved[PATH_MAX];
+    if (realpath(sysfs.c_str(), resolved) == nullptr) {
+      return {};
+    }
+    return std::string(resolved);
+  }
+
   std::string find_executable(std::string_view name) {
     if (name.empty()) {
       return {};
@@ -200,6 +272,7 @@ namespace {
     command += " --tmpfs /run/udev";
     command += " --tmpfs /sys/class/input";
     command += " --tmpfs /sys/class/hidraw";
+    command += " --tmpfs /sys/bus/hid/devices";
     command += " -- /usr/bin/true >/dev/null 2>&1";
     return std::system(command.c_str()) == 0;
   }
@@ -346,6 +419,7 @@ strict_gamepad_isolation_plan_t build_strict_gamepad_isolation_plan(
   plan.bubblewrap_path = options.bubblewrap_path.empty() ? "bwrap" : options.bubblewrap_path;
   plan.fallback_sdl = build_sdl_hint_plan(devices);
   plan.allowed_nodes = sanitized_virtual_nodes(registered_virtual_nodes);
+  plan.masked_sysfs_paths = host_input_sysfs_mask_paths(devices);
 
   if (!options.bubblewrap_available || !options.bubblewrap_usable) {
     const auto unavailable_reason = options.bubblewrap_available ?
@@ -409,6 +483,12 @@ std::string command_with_headless_gamepad_isolation(const std::string &command, 
   wrapped += " --tmpfs /run/udev";
   wrapped += " --tmpfs /sys/class/input";
   wrapped += " --tmpfs /sys/class/hidraw";
+  wrapped += " --tmpfs /sys/bus/hid/devices";
+
+  for (const auto &path : plan.masked_sysfs_paths) {
+    wrapped += " --tmpfs ";
+    wrapped += path;
+  }
 
   static constexpr std::array<std::string_view, 12> runtime_device_roots {
     "/dev/dri",
@@ -542,6 +622,7 @@ std::vector<device_snapshot_t> enumerate_visible_gamepads() {
 
     device_snapshot_t snapshot;
     snapshot.event_node = event_node;
+    snapshot.sysfs_path = event_sysfs_path(event_node);
     snapshot.name = safe_string(libevdev_get_name(evdev));
     snapshot.vendor_id = positive_id(libevdev_get_id_vendor(evdev));
     snapshot.product_id = positive_id(libevdev_get_id_product(evdev));

--- a/src/platform/linux/input/inputtino_gamepad_isolation.h
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.h
@@ -1,0 +1,52 @@
+/**
+ * @file src/platform/linux/input/inputtino_gamepad_isolation.h
+ * @brief Linux gamepad visibility classification for headless labwc launch diagnostics.
+ */
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace platf::gamepad::isolation {
+  enum class device_classification_e {
+    ignored,
+    polaris_virtual,
+    host_visible,
+  };
+
+  struct device_snapshot_t {
+    std::string event_node;
+    std::string name;
+    std::optional<uint16_t> vendor_id;
+    std::optional<uint16_t> product_id;
+    std::optional<uint16_t> version;
+    std::string phys;
+    std::string uniq;
+    bool gamepad_class = false;
+  };
+
+  struct classified_device_t {
+    device_snapshot_t device;
+    device_classification_e classification = device_classification_e::ignored;
+  };
+
+  struct sdl_hint_plan_t {
+    std::map<std::string, std::string> env;
+    std::string reason;
+
+    bool applied() const {
+      return !env.empty();
+    }
+  };
+
+  device_classification_e classify_device(const device_snapshot_t &device);
+  std::vector<classified_device_t> classify_devices(const std::vector<device_snapshot_t> &devices);
+  sdl_hint_plan_t build_sdl_hint_plan(const std::vector<classified_device_t> &devices);
+  std::string command_with_sdl_env_prefix(const std::string &command, const sdl_hint_plan_t &plan);
+
+  sdl_hint_plan_t prepare_headless_labwc_launch();
+  std::vector<device_snapshot_t> enumerate_visible_gamepads();
+}  // namespace platf::gamepad::isolation

--- a/src/platform/linux/input/inputtino_gamepad_isolation.h
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.h
@@ -42,11 +42,51 @@ namespace platf::gamepad::isolation {
     }
   };
 
+  enum class isolation_mode_e {
+    disabled,
+    strict_bwrap,
+    best_effort_sdl,
+    unavailable,
+  };
+
+  struct strict_isolation_options_t {
+    bool bubblewrap_available = false;
+    bool bubblewrap_usable = true;
+    std::string bubblewrap_path = "bwrap";
+  };
+
+  struct strict_gamepad_isolation_plan_t {
+    isolation_mode_e mode = isolation_mode_e::disabled;
+    std::string bubblewrap_path = "bwrap";
+    std::vector<std::string> allowed_nodes;
+    sdl_hint_plan_t fallback_sdl;
+    std::string reason;
+
+    bool strict_applied() const {
+      return mode == isolation_mode_e::strict_bwrap;
+    }
+
+    bool fallback_applied() const {
+      return mode == isolation_mode_e::best_effort_sdl && fallback_sdl.applied();
+    }
+  };
+
   device_classification_e classify_device(const device_snapshot_t &device);
   std::vector<classified_device_t> classify_devices(const std::vector<device_snapshot_t> &devices);
   sdl_hint_plan_t build_sdl_hint_plan(const std::vector<classified_device_t> &devices);
+  strict_gamepad_isolation_plan_t build_strict_gamepad_isolation_plan(
+    const std::vector<classified_device_t> &devices,
+    const std::vector<std::string> &registered_virtual_nodes,
+    const strict_isolation_options_t &options
+  );
   std::string command_with_sdl_env_prefix(const std::string &command, const sdl_hint_plan_t &plan);
+  std::string command_with_headless_gamepad_isolation(const std::string &command, const strict_gamepad_isolation_plan_t &plan);
 
-  sdl_hint_plan_t prepare_headless_labwc_launch();
+  void register_virtual_gamepad_nodes(int gamepad_index, const std::vector<std::string> &nodes);
+  void unregister_virtual_gamepad_nodes(int gamepad_index);
+  std::vector<std::string> registered_virtual_gamepad_nodes();
+
+  strict_isolation_options_t detect_strict_isolation_options();
+  strict_gamepad_isolation_plan_t prepare_headless_labwc_launch();
   std::vector<device_snapshot_t> enumerate_visible_gamepads();
 }  // namespace platf::gamepad::isolation

--- a/src/platform/linux/input/inputtino_gamepad_isolation.h
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.h
@@ -19,6 +19,7 @@ namespace platf::gamepad::isolation {
 
   struct device_snapshot_t {
     std::string event_node;
+    std::string sysfs_path;
     std::string name;
     std::optional<uint16_t> vendor_id;
     std::optional<uint16_t> product_id;
@@ -59,6 +60,7 @@ namespace platf::gamepad::isolation {
     isolation_mode_e mode = isolation_mode_e::disabled;
     std::string bubblewrap_path = "bwrap";
     std::vector<std::string> allowed_nodes;
+    std::vector<std::string> masked_sysfs_paths;
     sdl_hint_plan_t fallback_sdl;
     std::string reason;
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -68,6 +68,7 @@
   #include "platform/linux/session_manager.h"
   #include "platform/linux/cage_display_router.h"
   #include "platform/linux/stream_display_policy.h"
+  #include "platform/linux/input/inputtino_gamepad_isolation.h"
   #include <dirent.h>
   #include <signal.h>
   #include <unistd.h>
@@ -3011,6 +3012,36 @@ namespace proc {
                          << "] can use a GPU-native capture path"sv;
     }
 
+    const bool has_launch_commands = !_app.detached.empty() || !_app.cmd.empty();
+    platf::gamepad::isolation::sdl_hint_plan_t gamepad_sdl_hint_plan;
+    bool gamepad_isolation_prepared = false;
+
+    auto should_apply_headless_gamepad_isolation = [&]() {
+      return has_launch_commands &&
+             config::video.linux_display.use_cage_compositor &&
+             config::video.linux_display.headless_mode &&
+             !force_windowed_cage_for_gpu_native;
+    };
+
+    auto prepare_headless_gamepad_isolation = [&]() {
+      if (gamepad_isolation_prepared || !should_apply_headless_gamepad_isolation()) {
+        return;
+      }
+      gamepad_isolation_prepared = true;
+      gamepad_sdl_hint_plan = platf::gamepad::isolation::prepare_headless_labwc_launch();
+    };
+
+    auto apply_gamepad_sdl_env = [&](auto &env) {
+      prepare_headless_gamepad_isolation();
+      for (const auto &[key, value] : gamepad_sdl_hint_plan.env) {
+        env[key] = value;
+      }
+    };
+
+    auto command_with_gamepad_sdl_env = [&](const std::string &command) {
+      prepare_headless_gamepad_isolation();
+      return platf::gamepad::isolation::command_with_sdl_env_prefix(command, gamepad_sdl_hint_plan);
+    };
     auto start_cage_with_runtime_fallback = [&](const std::string &startup_cmd) -> bool {
       confighttp::set_session_state(confighttp::session_state_e::cage_starting);
       confighttp::emit_session_event("cage_starting", "Starting compositor");
@@ -3025,10 +3056,10 @@ namespace proc {
         force_windowed_cage_for_gpu_native = false;
       }
 
-      return start_cage_session(startup_cmd, false);
+      return start_cage_session(command_with_gamepad_sdl_env(startup_cmd), false);
     };
 
-    if (!_app.detached.empty() || !_app.cmd.empty()) {
+    if (has_launch_commands) {
       input::preallocate_gamepad();
     }
 
@@ -3052,6 +3083,7 @@ namespace proc {
         if (!allow_cage_mangohud) {
           strip_mangohud_env(cmd_env);
         }
+        apply_gamepad_sdl_env(cmd_env);
         auto cage_socket = cage_display_router::get_wayland_socket();
         if (!cage_socket.empty()) {
           cmd_env["WAYLAND_DISPLAY"] = cage_socket;
@@ -3107,6 +3139,7 @@ namespace proc {
       if (!allow_cage_mangohud) {
         strip_mangohud_env(launch_env);
       }
+      apply_gamepad_sdl_env(launch_env);
       auto cage_socket = cage_display_router::get_wayland_socket();
       if (!cage_socket.empty()) {
         launch_env["WAYLAND_DISPLAY"] = cage_socket;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3013,7 +3013,7 @@ namespace proc {
     }
 
     const bool has_launch_commands = !_app.detached.empty() || !_app.cmd.empty();
-    platf::gamepad::isolation::sdl_hint_plan_t gamepad_sdl_hint_plan;
+    platf::gamepad::isolation::strict_gamepad_isolation_plan_t gamepad_isolation_plan;
     bool gamepad_isolation_prepared = false;
 
     auto should_apply_headless_gamepad_isolation = [&]() {
@@ -3028,19 +3028,22 @@ namespace proc {
         return;
       }
       gamepad_isolation_prepared = true;
-      gamepad_sdl_hint_plan = platf::gamepad::isolation::prepare_headless_labwc_launch();
+      gamepad_isolation_plan = platf::gamepad::isolation::prepare_headless_labwc_launch();
     };
 
     auto apply_gamepad_sdl_env = [&](auto &env) {
       prepare_headless_gamepad_isolation();
-      for (const auto &[key, value] : gamepad_sdl_hint_plan.env) {
+      if (!gamepad_isolation_plan.fallback_applied()) {
+        return;
+      }
+      for (const auto &[key, value] : gamepad_isolation_plan.fallback_sdl.env) {
         env[key] = value;
       }
     };
 
-    auto command_with_gamepad_sdl_env = [&](const std::string &command) {
+    auto command_with_gamepad_isolation = [&](const std::string &command) {
       prepare_headless_gamepad_isolation();
-      return platf::gamepad::isolation::command_with_sdl_env_prefix(command, gamepad_sdl_hint_plan);
+      return platf::gamepad::isolation::command_with_headless_gamepad_isolation(command, gamepad_isolation_plan);
     };
     auto start_cage_with_runtime_fallback = [&](const std::string &startup_cmd) -> bool {
       confighttp::set_session_state(confighttp::session_state_e::cage_starting);
@@ -3056,7 +3059,7 @@ namespace proc {
         force_windowed_cage_for_gpu_native = false;
       }
 
-      return start_cage_session(command_with_gamepad_sdl_env(startup_cmd), false);
+      return start_cage_session(command_with_gamepad_isolation(startup_cmd), false);
     };
 
     if (has_launch_commands) {
@@ -3095,11 +3098,12 @@ namespace proc {
             cmd_env.erase("DISPLAY");
           }
         }
+        const auto launch_cmd = command_with_gamepad_isolation(cmd);
         boost::filesystem::path working_dir = _app.working_dir.empty() ?
                                                 find_working_directory(cmd, cmd_env) :
                                                 boost::filesystem::path(_app.working_dir);
-        BOOST_LOG(info) << "Spawning ["sv << cmd << "] in ["sv << working_dir << ']';
-        auto child = platf::run_command(_app.elevated, true, cmd, working_dir, cmd_env, _pipe.get(), ec, &_process_group);
+        BOOST_LOG(info) << "Spawning ["sv << launch_cmd << "] in ["sv << working_dir << ']';
+        auto child = platf::run_command(_app.elevated, true, launch_cmd, working_dir, cmd_env, _pipe.get(), ec, &_process_group);
         if (ec) {
           BOOST_LOG(warning) << "Couldn't spawn ["sv << cmd << "]: System: "sv << ec.message();
         } else {
@@ -3133,9 +3137,13 @@ namespace proc {
 #ifdef __linux__
     // Set cage environment for the app command (if cage is running and app has a cmd)
     std::string effective_cmd = _app.cmd;
+    std::string working_dir_cmd = effective_cmd;
     auto launch_env = _env;
+    bool app_command_uses_cage_runtime = false;
     if (config::video.linux_display.use_cage_compositor && cage_display_router::is_running() && !_app.cmd.empty()) {
       effective_cmd = cage_runtime_command(_app.cmd);
+      working_dir_cmd = effective_cmd;
+      app_command_uses_cage_runtime = true;
       if (!allow_cage_mangohud) {
         strip_mangohud_env(launch_env);
       }
@@ -3156,8 +3164,12 @@ namespace proc {
         }
       }
     }
+    if (app_command_uses_cage_runtime) {
+      effective_cmd = command_with_gamepad_isolation(effective_cmd);
+    }
 #else
     const std::string &effective_cmd = _app.cmd;
+    const std::string &working_dir_cmd = effective_cmd;
     auto &launch_env = _env;
 #endif
 
@@ -3173,7 +3185,7 @@ namespace proc {
       placebo = true;
     } else {
       boost::filesystem::path working_dir = _app.working_dir.empty() ?
-                                              find_working_directory(effective_cmd, launch_env) :
+                                              find_working_directory(working_dir_cmd, launch_env) :
                                               boost::filesystem::path(_app.working_dir);
       BOOST_LOG(info) << "Executing: ["sv << effective_cmd << "] in ["sv << working_dir << ']';
       _process = platf::run_command(_app.elevated, true, effective_cmd, working_dir, launch_env, _pipe.get(), ec, &_process_group);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,7 @@ set(TEST_PLATFORM_SOURCES
 
 if (NOT WIN32 AND NOT APPLE)
     list(APPEND TEST_PLATFORM_SOURCES
+        ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamepad_isolation.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_wayland_virtual_input.cpp
     )
 endif()

--- a/tests/unit/platform/test_gamepad_isolation.cpp
+++ b/tests/unit/platform/test_gamepad_isolation.cpp
@@ -408,4 +408,35 @@ TEST(GamepadIsolationTests, StrictWrapperHidesHostUdevAndInputSysfsMetadata) {
   EXPECT_TRUE(text_lacks(command, "--ro-bind /run/udev /run/udev"));
 }
 
+
+TEST(GamepadIsolationTests, StrictWrapperMasksHostSysfsInputDeviceRoots) {
+  auto host = gamepad("Microsoft X-Box One pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  host.event_node = "/dev/input/event4";
+  host.sysfs_path = "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1:1.0/input/input41/event4";
+  auto virtual_pad = gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  virtual_pad.event_node = "/dev/input/event99";
+  virtual_pad.sysfs_path = "/sys/devices/virtual/input/input99/event99";
+
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({host, virtual_pad}),
+    {"/dev/input/event99", "/dev/input/js99"},
+    strict_options()
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam", plan);
+
+  EXPECT_TRUE(text_contains(command, "--tmpfs /sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1:1.0/input/input41"));
+  EXPECT_TRUE(text_lacks(command, "/sys/devices/virtual/input/input99"));
+}
+
+TEST(GamepadIsolationTests, StrictWrapperMasksHostHidBusMetadata) {
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
+    {"/dev/input/event9"},
+    strict_options()
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam", plan);
+
+  EXPECT_TRUE(text_contains(command, "--tmpfs /sys/bus/hid/devices"));
+}
+
 #endif

--- a/tests/unit/platform/test_gamepad_isolation.cpp
+++ b/tests/unit/platform/test_gamepad_isolation.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file tests/unit/platform/test_gamepad_isolation.cpp
+ * @brief Test Linux headless gamepad isolation classification and SDL hint helpers.
+ */
+#include "../../tests_common.h"
+
+#ifdef __linux__
+  #include "src/platform/linux/input/inputtino_gamepad_isolation.h"
+
+  #include <cstdint>
+  #include <optional>
+  #include <string>
+  #include <string_view>
+
+namespace {
+  using platf::gamepad::isolation::build_sdl_hint_plan;
+  using platf::gamepad::isolation::classify_device;
+  using platf::gamepad::isolation::classify_devices;
+  using platf::gamepad::isolation::command_with_sdl_env_prefix;
+  using platf::gamepad::isolation::device_classification_e;
+  using platf::gamepad::isolation::device_snapshot_t;
+  using platf::gamepad::isolation::sdl_hint_plan_t;
+
+  device_snapshot_t gamepad(std::string name,
+                            std::optional<uint16_t> vendor_id,
+                            std::optional<uint16_t> product_id,
+                            std::string phys = {},
+                            std::string uniq = {}) {
+    return device_snapshot_t {
+      .event_node = "/dev/input/event9",
+      .name = std::move(name),
+      .vendor_id = vendor_id,
+      .product_id = product_id,
+      .version = std::optional<uint16_t> {0x0001},
+      .phys = std::move(phys),
+      .uniq = std::move(uniq),
+      .gamepad_class = true,
+    };
+  }
+
+  bool reason_contains(const sdl_hint_plan_t &plan, std::string_view needle) {
+    return plan.reason.find(needle) != std::string::npos;
+  }
+}  // namespace
+
+TEST(GamepadIsolationTests, SunshineVirtualNamesClassifyAsPolarisVirtual) {
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "Sunshine X-Box One (virtual) pad",
+              std::optional<uint16_t> {0x045e},
+              std::optional<uint16_t> {0x02ea}
+            )));
+
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "Sunshine Nintendo (virtual) pad",
+              std::optional<uint16_t> {0x057e},
+              std::optional<uint16_t> {0x2009}
+            )));
+
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "Sunshine PS5 (virtual) pad",
+              std::optional<uint16_t> {0x054c},
+              std::optional<uint16_t> {0x0ce6}
+            )));
+}
+
+TEST(GamepadIsolationTests, PrivateInputtinoPhysOrUniqClassifiesAsPolarisVirtual) {
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "inputtino xbox compatible",
+              std::optional<uint16_t> {0x045e},
+              std::optional<uint16_t> {0x02ea},
+              "02:00:00:00:10:00",
+              ""
+            )));
+
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "inputtino dualsense compatible",
+              std::optional<uint16_t> {0x054c},
+              std::optional<uint16_t> {0x0ce6},
+              "",
+              "02:00:00:00:00:7f"
+            )));
+}
+
+TEST(GamepadIsolationTests, PhysicalControllerWithVirtualVidPidRemainsHostVisible) {
+  const auto physical_xbox = gamepad(
+    "Microsoft X-Box One pad",
+    std::optional<uint16_t> {0x045e},
+    std::optional<uint16_t> {0x02ea},
+    "usb-0000:07:00.3-1/input0",
+    ""
+  );
+
+  EXPECT_EQ(device_classification_e::host_visible, classify_device(physical_xbox));
+}
+
+TEST(GamepadIsolationTests, NonGamepadClassDeviceIsIgnored) {
+  auto keyboard = gamepad(
+    "OwLab SUIT80 Keyboard",
+    std::optional<uint16_t> {0x4f53},
+    std::optional<uint16_t> {0x5355}
+  );
+  keyboard.gamepad_class = false;
+
+  EXPECT_EQ(device_classification_e::ignored, classify_device(keyboard));
+}
+
+TEST(GamepadIsolationTests, DisjointHostAndVirtualControllersGenerateSdlHints) {
+  const auto devices = classify_devices({
+    gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea}),
+    gamepad("Logitech Gamepad F310", std::optional<uint16_t> {0x046d}, std::optional<uint16_t> {0xc216}),
+  });
+
+  const auto plan = build_sdl_hint_plan(devices);
+
+  ASSERT_TRUE(plan.applied());
+  EXPECT_EQ("0x046d/0xc216", plan.env.at("SDL_GAMECONTROLLER_IGNORE_DEVICES"));
+  EXPECT_EQ("0x045e/0x02ea", plan.env.at("SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT"));
+  EXPECT_TRUE(reason_contains(plan, "best-effort"));
+}
+
+TEST(GamepadIsolationTests, MissingHostVidPidSkipsSdlHints) {
+  const auto devices = classify_devices({
+    gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea}),
+    gamepad("Mystery Controller", std::nullopt, std::nullopt),
+  });
+
+  const auto plan = build_sdl_hint_plan(devices);
+
+  EXPECT_FALSE(plan.applied());
+  EXPECT_TRUE(reason_contains(plan, "missing VID/PID"));
+}
+
+TEST(GamepadIsolationTests, OverlappingHostAndVirtualVidPidSkipsSdlHints) {
+  const auto devices = classify_devices({
+    gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea}),
+    gamepad("Microsoft X-Box One pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea}),
+  });
+
+  const auto plan = build_sdl_hint_plan(devices);
+
+  EXPECT_FALSE(plan.applied());
+  EXPECT_TRUE(reason_contains(plan, "overlaps"));
+}
+
+TEST(GamepadIsolationTests, SdlEnvPrefixUsesShellSafeQuoting) {
+  const auto quote = std::string(1, static_cast<char>(39));
+  const auto escaped_quote = std::string(1, static_cast<char>(92)) + quote;
+
+  sdl_hint_plan_t plan;
+  plan.env["SDL_GAMECONTROLLER_IGNORE_DEVICES"] = "0x1234/0xab" + quote + "cd";
+
+  const auto expected = "env SDL_GAMECONTROLLER_IGNORE_DEVICES=" + quote +
+                        "0x1234/0xab" + quote + escaped_quote + quote + "cd" + quote +
+                        " steam --gamepadui";
+
+  EXPECT_EQ(expected, command_with_sdl_env_prefix("steam --gamepadui", plan));
+}
+#endif

--- a/tests/unit/platform/test_gamepad_isolation.cpp
+++ b/tests/unit/platform/test_gamepad_isolation.cpp
@@ -7,19 +7,25 @@
 #ifdef __linux__
   #include "src/platform/linux/input/inputtino_gamepad_isolation.h"
 
+  #include <algorithm>
   #include <cstdint>
   #include <optional>
   #include <string>
   #include <string_view>
+  #include <vector>
 
 namespace {
   using platf::gamepad::isolation::build_sdl_hint_plan;
+  using platf::gamepad::isolation::build_strict_gamepad_isolation_plan;
   using platf::gamepad::isolation::classify_device;
   using platf::gamepad::isolation::classify_devices;
+  using platf::gamepad::isolation::command_with_headless_gamepad_isolation;
   using platf::gamepad::isolation::command_with_sdl_env_prefix;
   using platf::gamepad::isolation::device_classification_e;
   using platf::gamepad::isolation::device_snapshot_t;
+  using platf::gamepad::isolation::isolation_mode_e;
   using platf::gamepad::isolation::sdl_hint_plan_t;
+  using platf::gamepad::isolation::strict_isolation_options_t;
 
   device_snapshot_t gamepad(std::string name,
                             std::optional<uint16_t> vendor_id,
@@ -41,6 +47,21 @@ namespace {
   bool reason_contains(const sdl_hint_plan_t &plan, std::string_view needle) {
     return plan.reason.find(needle) != std::string::npos;
   }
+
+  bool text_contains(std::string_view haystack, std::string_view needle) {
+    return haystack.find(needle) != std::string_view::npos;
+  }
+
+  bool text_lacks(std::string_view haystack, std::string_view needle) {
+    return haystack.find(needle) == std::string_view::npos;
+  }
+
+  strict_isolation_options_t strict_options(bool bubblewrap_available = true) {
+    strict_isolation_options_t options;
+    options.bubblewrap_available = bubblewrap_available;
+    options.bubblewrap_path = "/usr/bin/bwrap";
+    return options;
+  }
 }  // namespace
 
 TEST(GamepadIsolationTests, SunshineVirtualNamesClassifyAsPolarisVirtual) {
@@ -61,6 +82,29 @@ TEST(GamepadIsolationTests, SunshineVirtualNamesClassifyAsPolarisVirtual) {
   EXPECT_EQ(device_classification_e::polaris_virtual,
             classify_device(gamepad(
               "Sunshine PS5 (virtual) pad",
+              std::optional<uint16_t> {0x054c},
+              std::optional<uint16_t> {0x0ce6}
+            )));
+}
+
+TEST(GamepadIsolationTests, PolarisReporterVirtualNamesClassifyAsPolarisVirtual) {
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "Polaris X-Box One (virtual) pad",
+              std::optional<uint16_t> {0x045e},
+              std::optional<uint16_t> {0x02ea}
+            )));
+
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "Polaris Nintendo (virtual) pad",
+              std::optional<uint16_t> {0x057e},
+              std::optional<uint16_t> {0x2009}
+            )));
+
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "Polaris PS5 (virtual) pad",
               std::optional<uint16_t> {0x054c},
               std::optional<uint16_t> {0x0ce6}
             )));
@@ -160,4 +204,208 @@ TEST(GamepadIsolationTests, SdlEnvPrefixUsesShellSafeQuoting) {
 
   EXPECT_EQ(expected, command_with_sdl_env_prefix("steam --gamepadui", plan));
 }
+
+TEST(GamepadIsolationTests, StrictPlanAppliesEvenWhenNoHostControllersCurrentlyVisible) {
+  const auto devices = classify_devices({
+    gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea}),
+  });
+
+  const auto plan = build_strict_gamepad_isolation_plan(
+    devices,
+    {"/dev/input/event42", "/dev/input/js42"},
+    strict_options()
+  );
+
+  EXPECT_EQ(isolation_mode_e::strict_bwrap, plan.mode);
+  EXPECT_TRUE(plan.strict_applied());
+  EXPECT_TRUE(text_contains(plan.reason, "strict"));
+}
+
+TEST(GamepadIsolationTests, StrictPlanWithNoRegisteredNodesStillHidesHostDevices) {
+  auto host = gamepad("Microsoft X-Box One pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  host.event_node = "/dev/input/event3";
+
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({host}),
+    {},
+    strict_options()
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam --gamepadui", plan);
+
+  EXPECT_EQ(isolation_mode_e::strict_bwrap, plan.mode);
+  EXPECT_TRUE(plan.strict_applied());
+  EXPECT_TRUE(plan.allowed_nodes.empty());
+  EXPECT_TRUE(text_contains(command, "--tmpfs /dev/input"));
+  EXPECT_TRUE(text_contains(command, "--tmpfs /sys/class/input"));
+  EXPECT_TRUE(text_contains(command, "--tmpfs /sys/class/hidraw"));
+  EXPECT_TRUE(text_lacks(command, "/dev/input/event3"));
+  EXPECT_TRUE(text_contains(plan.reason, "no registered Polaris virtual gamepad nodes"));
+}
+
+TEST(GamepadIsolationTests, StrictWrapperBindsOnlyRegisteredVirtualEventJsAndHidrawNodes) {
+  auto host = gamepad("Microsoft X-Box One pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  host.event_node = "/dev/input/event3";
+  auto virtual_pad = gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  virtual_pad.event_node = "/dev/input/event9";
+
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({host, virtual_pad}),
+    {"/dev/input/event9", "/dev/input/js9", "/dev/hidraw9"},
+    strict_options()
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam --gamepadui", plan);
+
+  EXPECT_TRUE(plan.strict_applied());
+  EXPECT_TRUE(text_contains(command, "--dev-bind /dev/input/event9 /dev/input/event9"));
+  EXPECT_TRUE(text_contains(command, "--dev-bind /dev/input/js9 /dev/input/js9"));
+  EXPECT_TRUE(text_contains(command, "--dev-bind-try /dev/hidraw9 /dev/hidraw9"));
+  EXPECT_TRUE(text_lacks(command, "/dev/input/event3"));
+  EXPECT_TRUE(text_lacks(command, "/dev/input/js3"));
+  EXPECT_TRUE(text_lacks(command, "/dev/hidraw3"));
+}
+
+TEST(GamepadIsolationTests, SameVidPidHostAndVirtualAllowsOnlyRegisteredVirtualNode) {
+  auto host = gamepad("Microsoft X-Box One pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  host.event_node = "/dev/input/event4";
+  auto virtual_pad = gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  virtual_pad.event_node = "/dev/input/event12";
+
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({host, virtual_pad}),
+    {"/dev/input/event12"},
+    strict_options()
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam", plan);
+
+  EXPECT_EQ(isolation_mode_e::strict_bwrap, plan.mode);
+  EXPECT_TRUE(text_contains(command, "/dev/input/event12"));
+  EXPECT_TRUE(text_lacks(command, "/dev/input/event4"));
+}
+
+TEST(GamepadIsolationTests, VirtualNameAloneDoesNotCreateStrictBindWhenRegistryDisagrees) {
+  auto virtual_pad = gamepad("Polaris X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  virtual_pad.event_node = "/dev/input/event20";
+
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({virtual_pad}),
+    {"/dev/input/event21"},
+    strict_options()
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam", plan);
+
+  EXPECT_TRUE(plan.strict_applied());
+  EXPECT_TRUE(text_contains(command, "/dev/input/event21"));
+  EXPECT_TRUE(text_lacks(command, "/dev/input/event20"));
+}
+
+TEST(GamepadIsolationTests, UnavailableBubblewrapFallsBackHonestlyToSdlHints) {
+  const auto devices = classify_devices({
+    gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea}),
+    gamepad("Logitech Gamepad F310", std::optional<uint16_t> {0x046d}, std::optional<uint16_t> {0xc216}),
+  });
+
+  const auto plan = build_strict_gamepad_isolation_plan(
+    devices,
+    {"/dev/input/event9"},
+    strict_options(false)
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam --gamepadui", plan);
+
+  EXPECT_EQ(isolation_mode_e::best_effort_sdl, plan.mode);
+  EXPECT_FALSE(plan.strict_applied());
+  EXPECT_TRUE(plan.fallback_sdl.applied());
+  EXPECT_TRUE(text_contains(plan.reason, "strict"));
+  EXPECT_TRUE(text_contains(plan.reason, "not active"));
+  EXPECT_TRUE(text_contains(command, "SDL_GAMECONTROLLER_IGNORE_DEVICES="));
+  EXPECT_TRUE(text_lacks(command, "bwrap"));
+}
+
+
+TEST(GamepadIsolationTests, FailedBubblewrapProbeFallsBackHonestlyToSdlHints) {
+  const auto devices = classify_devices({
+    gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea}),
+    gamepad("Logitech Gamepad F310", std::optional<uint16_t> {0x046d}, std::optional<uint16_t> {0xc216}),
+  });
+
+  auto options = strict_options();
+  options.bubblewrap_usable = false;
+  const auto plan = build_strict_gamepad_isolation_plan(
+    devices,
+    {"/dev/input/event9"},
+    options
+  );
+
+  EXPECT_EQ(isolation_mode_e::best_effort_sdl, plan.mode);
+  EXPECT_FALSE(plan.strict_applied());
+  EXPECT_TRUE(plan.fallback_sdl.applied());
+  EXPECT_TRUE(text_contains(plan.reason, "probe"));
+  EXPECT_TRUE(text_contains(plan.reason, "not active"));
+}
+
+TEST(GamepadIsolationTests, StrictWrapperRejectsMalformedVirtualNodesAndQuotesBwrapPath) {
+  auto options = strict_options();
+  options.bubblewrap_path = "/tmp/bwrap helper";
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
+    {"/dev/input/event9;touch /tmp/polaris-pwned", "/dev/input/js9", "/dev/hidraw9;echo nope", "/dev/hidraw9"},
+    options
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam", plan);
+  const auto expected_bwrap = std::string(1, static_cast<char>(39)) + "/tmp/bwrap helper" + std::string(1, static_cast<char>(39));
+
+  EXPECT_TRUE(plan.strict_applied());
+  EXPECT_TRUE(text_contains(command, expected_bwrap));
+  EXPECT_TRUE(text_contains(command, "--dev-bind /dev/input/js9 /dev/input/js9"));
+  EXPECT_TRUE(text_contains(command, "--dev-bind-try /dev/hidraw9 /dev/hidraw9"));
+  EXPECT_TRUE(text_lacks(command, "touch /tmp/polaris-pwned"));
+  EXPECT_TRUE(text_lacks(command, "echo nope"));
+  EXPECT_TRUE(text_lacks(command, "/dev/input/event9;"));
+  EXPECT_TRUE(text_lacks(command, "/dev/hidraw9;"));
+  EXPECT_TRUE(text_lacks(command, "/tmp/bwrap helper --bind"));
+}
+
+TEST(GamepadIsolationTests, StrictWrapperQuotesOriginalCommandSafely) {
+  const auto quote = std::string(1, static_cast<char>(39));
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
+    {"/dev/input/event9"},
+    strict_options()
+  );
+
+  const auto command = command_with_headless_gamepad_isolation("steam -silent " + quote + "quoted game" + quote, plan);
+
+  EXPECT_TRUE(text_contains(command, "/bin/sh -lc"));
+  EXPECT_TRUE(text_contains(command, "steam -silent"));
+  EXPECT_TRUE(text_contains(command, "quoted game"));
+}
+
+TEST(GamepadIsolationTests, StrictWrapperDoesNotExposeBroadInputOrHidrawPaths) {
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
+    {"/dev/input/event9"},
+    strict_options()
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam", plan);
+
+  EXPECT_TRUE(text_lacks(command, "--dev-bind /dev/input /dev/input"));
+  EXPECT_TRUE(text_lacks(command, "--dev-bind /dev/hidraw"));
+  EXPECT_TRUE(text_lacks(command, "--bind /dev/input/by-id /dev/input/by-id"));
+  EXPECT_TRUE(text_lacks(command, "--bind /dev/input/by-path /dev/input/by-path"));
+}
+
+TEST(GamepadIsolationTests, StrictWrapperHidesHostUdevAndInputSysfsMetadata) {
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
+    {"/dev/input/event9"},
+    strict_options()
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam", plan);
+
+  EXPECT_TRUE(text_contains(command, "--tmpfs /run/udev"));
+  EXPECT_TRUE(text_contains(command, "--tmpfs /sys/class/input"));
+  EXPECT_TRUE(text_contains(command, "--tmpfs /sys/class/hidraw"));
+  EXPECT_TRUE(text_lacks(command, "--bind /run/udev /run/udev"));
+  EXPECT_TRUE(text_lacks(command, "--ro-bind /run/udev /run/udev"));
+}
+
 #endif


### PR DESCRIPTION
## Summary
- Rebases the approved issue 115 strict gamepad isolation work onto current master.
- Adds sysfs metadata masking for host controller input roots plus the HID bus device list inside the bubblewrap launch namespace.
- Keeps the existing virtual event/js/hidraw allowlist model so only registered Polaris virtual nodes are bound back into the app namespace.

## Root cause
The previous strict wrapper hid /dev/input, /run/udev, /sys/class/input, and /sys/class/hidraw, but host controller metadata still remained visible through /sys/devices/.../input/inputN and /sys/bus/hid/devices. Steam and HID stacks can use those sysfs paths as another enumeration route, so host controllers could still leak as metadata even when the device nodes were hidden.

## Test plan
- RED: new GamepadIsolationTests.StrictWrapperMasksHostSysfsInputDeviceRoots failed to compile before device snapshots carried sysfs paths.
- cmake --build build --target test_polaris_platform -j 8
- ./build/tests/test_polaris_platform --gtest_filter=GamepadIsolationTests.*
- ctest --test-dir build --output-on-failure -R test_polaris_platform
- cmake --build build --target polaris -j 4
- git diff --check polaris/master...HEAD
- privacy scan over changed files: no matches

## Notes
- No deploy, no merge, no GitHub issue comments.
- Manual lab validation is still required before any public fixed claim for issue 115.
