### PR TITLE
fix: respect client bitrate when auto quality is off

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -820,7 +820,9 @@ namespace nvhttp {
         {"live", true},
         {"requires_relaunch", false},
         {"adaptive_target_bitrate_kbps", stats.adaptive_target_bitrate_kbps},
-        {"paired_override_active", paired_bitrate_override}
+        {"paired_override_active", paired_bitrate_override},
+        {"source", policy.value("target_bitrate_source", std::string {"client_request"})},
+        {"source_label", policy.value("target_bitrate_source_label", std::string {"Client request"})}
       };
       fields["ai_auto_quality_enabled"] = {
         {"direction", "read_write"},
@@ -1246,6 +1248,15 @@ namespace nvhttp {
       if (normalized == "paired_client") {
         return "Paired client override";
       }
+      if (normalized == "client_request") {
+        return "Client request";
+      }
+      if (normalized == "manual_config") {
+        return "Manual max bitrate";
+      }
+      if (normalized == "adaptive_bitrate") {
+        return "Adaptive bitrate";
+      }
       if (normalized.find("ai_live") != std::string::npos) {
         return "Live AI recommendation";
       }
@@ -1329,14 +1340,28 @@ namespace nvhttp {
       const auto capture_reason = stream_stats::capture_path_reason(stats);
       const bool capture_cpu_copy = stream_stats::capture_path_uses_cpu_copy(stats);
       const bool capture_gpu_native = stream_stats::capture_path_is_gpu_native(stats);
-      const int target_bitrate_kbps =
-        stats.adaptive_target_bitrate_kbps > 0 ? stats.adaptive_target_bitrate_kbps :
-        stats.bitrate_kbps > 0 ? stats.bitrate_kbps :
-        paired_bitrate_override ? client.target_bitrate_kbps :
-        device_profile ? device_profile->ideal_bitrate_kbps : 0;
+      const bool auto_quality_enabled = ai_auto_quality_enabled();
+      int target_bitrate_kbps = 0;
+      std::string target_bitrate_source = "client_request";
+      if (stats.adaptive_target_bitrate_kbps > 0) {
+        target_bitrate_kbps = stats.adaptive_target_bitrate_kbps;
+        target_bitrate_source = "adaptive_bitrate";
+      } else if (stats.bitrate_kbps > 0) {
+        target_bitrate_kbps = stats.bitrate_kbps;
+        target_bitrate_source = "client_request";
+      } else if (paired_bitrate_override) {
+        target_bitrate_kbps = client.target_bitrate_kbps;
+        target_bitrate_source = "paired_client";
+      } else if (config::video.max_bitrate > 0) {
+        target_bitrate_kbps = config::video.max_bitrate;
+        target_bitrate_source = "manual_config";
+      } else if (auto_quality_enabled && device_profile && device_profile->ideal_bitrate_kbps > 0) {
+        target_bitrate_kbps = device_profile->ideal_bitrate_kbps;
+        target_bitrate_source = "device_db";
+      }
       const std::string source = (paired_display_override || paired_bitrate_override) ? "paired_client" :
         (!stats.optimization_source.empty() ? stats.optimization_source :
-          (device_profile ? "device_db" : "default"));
+          (target_bitrate_source == "device_db" || (auto_quality_enabled && device_profile) ? "device_db" : "default"));
 
       nlohmann::json warnings = nlohmann::json::array();
       if (paired_display_override) {
@@ -1409,6 +1434,8 @@ namespace nvhttp {
       policy["paired_target_bitrate_locked"] = paired_bitrate_override;
       policy["target_fps"] = policy_fps;
       policy["target_bitrate_kbps"] = target_bitrate_kbps;
+      policy["target_bitrate_source"] = target_bitrate_source;
+      policy["target_bitrate_source_label"] = stream_policy_source_label(target_bitrate_source);
       policy["preferred_codec"] = stats.codec;
       policy["hdr_requested"] = stats.dynamic_range > 0;
       policy["hdr_active"] = stats.stream_hdr_enabled;
@@ -1477,6 +1504,8 @@ namespace nvhttp {
       effective["stream_display_mode_reason"] = stream_display_mode_reason_for_selection(effective_mode);
       effective["display_mode"] = policy.value("selected_display_mode", std::string {});
       effective["target_bitrate_kbps"] = policy.value("target_bitrate_kbps", 0);
+      effective["target_bitrate_source"] = policy.value("target_bitrate_source", std::string {"client_request"});
+      effective["target_bitrate_source_label"] = policy.value("target_bitrate_source_label", std::string {"Client request"});
       effective["ai_auto_quality_enabled"] = ai_auto_quality_enabled();
       effective["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
       effective["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
@@ -2001,6 +2030,12 @@ namespace nvhttp {
       paired_bitrate_kbps,
       applied_history_safe
     );
+  }
+
+  nlohmann::json build_stream_policy_json_for_tests(const crypto::named_cert_t &client,
+                                                    const stream_stats::stats_t &stats,
+                                                    const nlohmann::json &health) {
+    return build_stream_policy_json(client, stats, health);
   }
 #endif
 

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -25,6 +25,12 @@
 
 using namespace std::chrono_literals;
 
+#ifdef POLARIS_TESTS
+namespace stream_stats {
+  struct stats_t;
+}
+#endif
+
 /**
  * @brief Contains all the functions and variables related to the nvhttp (GameStream) server.
  */
@@ -314,6 +320,9 @@ namespace nvhttp {
   );
 
 #ifdef POLARIS_TESTS
+  nlohmann::json build_stream_policy_json_for_tests(const crypto::named_cert_t &client,
+                                                    const stream_stats::stats_t &stats,
+                                                    const nlohmann::json &health);
   void reset_pairing_state_for_tests();
 #endif
 }  // namespace nvhttp

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1397,6 +1397,12 @@ namespace proc {
       resolved.normalization_reason += reason;
     }
 
+    bool launch_bitrate_is_locked(int configured_max_bitrate,
+                                   bool has_paired_target_bitrate,
+                                   bool ai_auto_quality_enabled) {
+      return configured_max_bitrate > 0 || has_paired_target_bitrate || !ai_auto_quality_enabled;
+    }
+
     void apply_optimization_layer(resolved_session_optimization_t &resolved,
                                   const optimization_locks_t &locks,
                                   const device_db::optimization_t &optimization,
@@ -1664,6 +1670,31 @@ namespace proc {
 #if defined(POLARIS_TESTS)
   bool should_publish_stream_ended_after_terminate_for_tests(bool had_running_app, int active_sessions, std::string_view session_state) {
     return should_publish_stream_ended_after_terminate(had_running_app, active_sessions, session_state);
+  }
+
+  std::optional<int> resolve_device_db_launch_bitrate_for_tests(
+      int configured_max_bitrate,
+      const std::optional<int> &paired_target_bitrate_kbps,
+      bool ai_auto_quality_enabled,
+      const std::string &device_name,
+      const std::string &app_name) {
+    optimization_locks_t locks;
+    locks.bitrate = launch_bitrate_is_locked(
+      configured_max_bitrate,
+      paired_target_bitrate_kbps.has_value(),
+      ai_auto_quality_enabled
+    );
+
+    resolved_session_optimization_t resolved;
+    if (paired_target_bitrate_kbps.has_value()) {
+      resolved.target_bitrate_kbps = *paired_target_bitrate_kbps;
+      resolved.bitrate_source = "paired_client";
+      note_layer(resolved, "paired_client");
+    }
+
+    const auto device_optimization = device_db::get_optimization(device_name, app_name);
+    apply_optimization_layer(resolved, locks, device_optimization, "device_db");
+    return resolved.target_bitrate_kbps;
   }
 #endif
 
@@ -1954,7 +1985,16 @@ namespace proc {
     optimization_locks_t optimization_locks;
     optimization_locks.display_mode = launch_session->user_locked_display_mode || !launch_session->enable_sops;
     optimization_locks.virtual_display = launch_session->user_locked_virtual_display;
-    optimization_locks.bitrate = config::video.max_bitrate > 0 || launch_session->paired_target_bitrate_kbps.has_value();
+    const bool auto_quality_enabled = ai_optimizer::is_enabled();
+    optimization_locks.bitrate = launch_bitrate_is_locked(
+      config::video.max_bitrate,
+      launch_session->paired_target_bitrate_kbps.has_value(),
+      auto_quality_enabled
+    );
+    if (!auto_quality_enabled && config::video.max_bitrate <= 0 &&
+        !launch_session->paired_target_bitrate_kbps.has_value()) {
+      BOOST_LOG(debug) << "session_optimization: AI Auto Quality disabled with max_bitrate=0; leaving bitrate to the client request"sv;
+    }
 
     resolved_session_optimization_t resolved_optimization;
     if (launch_session->paired_target_bitrate_kbps.has_value()) {
@@ -1999,7 +2039,7 @@ namespace proc {
     std::optional<ai_optimizer::session_history_t> history;
 
     // AI optimizer: cached results override device DB; unknown devices get a sync request.
-    if (ai_optimizer::is_enabled()) {
+    if (auto_quality_enabled) {
       std::string gpu_info = config::video.adapter_name.empty()
         ? "NVIDIA GPU (NVENC)"s
         : config::video.adapter_name;

--- a/src/process.h
+++ b/src/process.h
@@ -59,6 +59,16 @@ namespace proc {
   bool is_valid_steam_launch_mode(std::string_view mode);
   bool steam_launch_mode_is_big_picture(std::string_view mode);
 
+#if defined(POLARIS_TESTS)
+  std::optional<int> resolve_device_db_launch_bitrate_for_tests(
+    int configured_max_bitrate,
+    const std::optional<int> &paired_target_bitrate_kbps,
+    bool ai_auto_quality_enabled,
+    const std::string &device_name,
+    const std::string &app_name
+  );
+#endif
+
 #if defined(POLARIS_TESTS) && defined(__linux__)
   bool cage_mangohud_allowed_for_session_for_tests(const struct ctx_t &app,
                                                    bool use_cage_compositor,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -4,8 +4,12 @@
 #include <algorithm>
 #include <chrono>
 #include <filesystem>
+#include <src/adaptive_bitrate.h>
+#include <src/ai_optimizer.h>
 #include <src/file_handler.h>
+#include <src/nvhttp.h>
 #include <src/process.h>
+#include <src/stream_stats.h>
 
 namespace {
 #ifdef __linux__
@@ -24,6 +28,20 @@ namespace {
   };
 #endif
 
+  struct auto_quality_guard_t {
+    bool ai_enabled;
+    bool adaptive_enabled;
+
+    auto_quality_guard_t():
+        ai_enabled(ai_optimizer::is_enabled()),
+        adaptive_enabled(adaptive_bitrate::is_enabled()) {}
+
+    ~auto_quality_guard_t() {
+      ai_optimizer::set_enabled(ai_enabled);
+      adaptive_bitrate::set_enabled(adaptive_enabled);
+    }
+  };
+
   constexpr const char *expected_steam_shutdown_command() {
 #ifdef __linux__
     return "setsid -f steam -shutdown";
@@ -32,6 +50,81 @@ namespace {
 #endif
   }
 }  // namespace
+
+TEST(ProcessRuntimeConfigTests, DeviceDbBitrateStaysOutWhenAutoQualityOffAndMaxBitrateUnlocked) {
+  const auto resolved = proc::resolve_device_db_launch_bitrate_for_tests(
+    0,
+    std::optional<int> {},
+    false,
+    "Steam Deck OLED",
+    "Steam Big Picture"
+  );
+
+  EXPECT_FALSE(resolved.has_value());
+}
+
+TEST(ProcessRuntimeConfigTests, DeviceDbBitrateCanSeedAutoQualityWhenEnabled) {
+  const auto resolved = proc::resolve_device_db_launch_bitrate_for_tests(
+    0,
+    std::optional<int> {},
+    true,
+    "Steam Deck OLED",
+    "Steam Big Picture"
+  );
+
+  ASSERT_TRUE(resolved.has_value());
+  EXPECT_EQ(*resolved, 25000);
+}
+
+TEST(ProcessRuntimeConfigTests, PairedClientBitrateWinsEvenWhenAutoQualityOff) {
+  const auto resolved = proc::resolve_device_db_launch_bitrate_for_tests(
+    0,
+    std::optional<int> {45000},
+    false,
+    "Steam Deck OLED",
+    "Steam Big Picture"
+  );
+
+  ASSERT_TRUE(resolved.has_value());
+  EXPECT_EQ(*resolved, 45000);
+}
+
+TEST(ProcessRuntimeConfigTests, ManualMaxBitrateLocksOutDeviceDbProfile) {
+  const auto resolved = proc::resolve_device_db_launch_bitrate_for_tests(
+    50000,
+    std::optional<int> {},
+    true,
+    "Steam Deck OLED",
+    "Steam Big Picture"
+  );
+
+  EXPECT_FALSE(resolved.has_value());
+}
+
+TEST(ProcessRuntimeConfigTests, MissionControlPolicyDoesNotUseDeviceDbBitrateWhenAutoQualityOffAndClientBitrateUnknown) {
+  auto_quality_guard_t guard;
+  ai_optimizer::set_enabled(false);
+  adaptive_bitrate::set_enabled(false);
+
+  crypto::named_cert_t client {};
+  client.name = "Steam Deck OLED";
+  client.uuid = "issue-147-client";
+
+  stream_stats::stats_t stats {};
+  stats.width = 1280;
+  stats.height = 800;
+  stats.requested_client_fps = 90.0;
+  stats.codec = "hevc";
+
+  const auto policy = nvhttp::build_stream_policy_json_for_tests(
+    client,
+    stats,
+    nlohmann::json::object()
+  );
+
+  EXPECT_EQ(policy.value("target_bitrate_kbps", -1), 0);
+  EXPECT_EQ(policy.value("target_bitrate_source", std::string {}), "client_request");
+}
 
 TEST(ProcessRuntimeConfigTests, InitialTerminateDoesNotResetAdaptiveBitrateMax) {
 #ifdef __linux__


### PR DESCRIPTION
## Summary
- Keep device-db ideal bitrate from becoming a launch max bitrate when AI Auto Quality is off and max_bitrate is 0, so Moonlight/Nova client bitrate stays authoritative.
- Preserve paired-client bitrate overrides and manual max_bitrate locks ahead of device profiles.
- Add Mission Control stream-policy bitrate source fields so the UI/API can trace client request vs manual config vs Auto Quality/device profile.

## Test plan
- RED: ./build/tests/test_polaris_config --gtest_filter=ProcessRuntimeConfigTests.DeviceDbBitrateStaysOutWhenAutoQualityOffAndMaxBitrateUnlocked:ProcessRuntimeConfigTests.MissionControlPolicyDoesNotUseDeviceDbBitrateWhenAutoQualityOffAndClientBitrateUnknown
- GREEN: ./build/tests/test_polaris_config --gtest_filter=ProcessRuntimeConfigTests.DeviceDbBitrateStaysOutWhenAutoQualityOffAndMaxBitrateUnlocked:ProcessRuntimeConfigTests.DeviceDbBitrateCanSeedAutoQualityWhenEnabled:ProcessRuntimeConfigTests.PairedClientBitrateWinsEvenWhenAutoQualityOff:ProcessRuntimeConfigTests.ManualMaxBitrateLocksOutDeviceDbProfile:ProcessRuntimeConfigTests.MissionControlPolicyDoesNotUseDeviceDbBitrateWhenAutoQualityOffAndClientBitrateUnknown
- ./build/tests/test_polaris_config
- ctest --test-dir build -R test_polaris_config --output-on-failure
- cmake --build build --target polaris -j 4

Refs #147
