### PR TITLE
Add openSUSE Tumbleweed build support (docs + optional CI)

### DIFF
--- a/.github/workflows/opensuse-build.yml
+++ b/.github/workflows/opensuse-build.yml
@@ -55,6 +55,9 @@ jobs:
           #   * BOOST_USE_STATIC=OFF        - matches Arch; required on openSUSE (shared-only Boost)
           #   * CUDA=OFF, FAIL_ON_MISSING=OFF - matches Arch on a host without the CUDA toolkit
           #                                    (NVENC is NVIDIA-only; harmless on AMD/Intel)
+          #   * POLARIS_DESKTOP_ICON=polaris - upstream bug: the .desktop template references
+          #                                    @POLARIS_DESKTOP_ICON@ but never set()s it, so the
+          #                                    Icon= line ships empty and no launcher icon shows.
           cmake -B build -G Ninja \
             -DBUILD_DOCS=OFF \
             -DCMAKE_BUILD_TYPE=Release \
@@ -62,6 +65,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DPOLARIS_ASSETS_DIR=/usr/share/polaris \
             -DPOLARIS_EXECUTABLE_PATH=/usr/bin/polaris \
+            -DPOLARIS_DESKTOP_ICON=polaris \
             -DPOLARIS_ENABLE_WAYLAND=ON \
             -DPOLARIS_ENABLE_X11=ON \
             -DPOLARIS_ENABLE_DRM=ON \

--- a/.github/workflows/opensuse-build.yml
+++ b/.github/workflows/opensuse-build.yml
@@ -43,6 +43,11 @@ jobs:
 
       - name: Build
         run: |
+          # The Browser Stream helper is built with Go; Go 1.18+ stamps VCS info and the
+          # container checkout trips git's "dubious ownership" guard (exit 128). Mark the
+          # repo safe and disable VCS stamping so the Go helper builds.
+          git config --global --add safe.directory '*'
+          export GOFLAGS=-buildvcs=false
           # Flag set mirrors the upstream Fedora spec / Arch PKGBUILD feature set, so an
           # openSUSE build is the "whole thing", not a stripped-down variant:
           #   * BROWSER_STREAM=ON           - both Fedora and Arch enable it (needs Go, installed above)

--- a/.github/workflows/opensuse-build.yml
+++ b/.github/workflows/opensuse-build.yml
@@ -1,0 +1,82 @@
+name: Build (openSUSE Tumbleweed)
+
+# Manual-trigger only by default so it doesn't impose container builds on every
+# push. Maintainers can add `push:` / `pull_request:` triggers if desired.
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: opensuse/tumbleweed:latest
+    steps:
+      - name: Bootstrap container (node + git for actions)
+        run: |
+          zypper --non-interactive --gpg-auto-import-keys refresh
+          zypper --non-interactive install nodejs24 git tar gzip
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          # The opensuse/tumbleweed base image ships busybox-gawk, which blocks the
+          # real gawk that desktop-file-utils and rpm-build require. Swap it in first.
+          zypper --non-interactive install --force-resolution gawk
+          zypper --non-interactive install \
+            gcc-c++ make cmake ninja python3 which wget rpm-build \
+            nodejs24 npm24 go \
+            libboost_headers-devel libboost_filesystem-devel libboost_log-devel \
+            libboost_locale-devel libboost_program_options-devel libboost_thread-devel \
+            libcap-devel libcurl-devel libdrm-devel libevdev-devel libgudev-1_0-devel \
+            libnotify-devel libva-devel libopenssl-devel systemd-devel \
+            libX11-devel libxcb-devel libXcursor-devel libXfixes-devel libXi-devel \
+            libXinerama-devel libXrandr-devel libXtst-devel \
+            Mesa-libGL-devel libgbm-devel \
+            libminiupnpc-devel nlohmann_json-devel libnuma-devel libpulse-devel \
+            libopus-devel libopusenc-devel \
+            wayland-devel wayland-protocols-devel pipewire-devel \
+            libayatana-appindicator3-devel desktop-file-utils appstream-glib
+
+      - name: Build
+        run: |
+          # BOOST_USE_STATIC=OFF: openSUSE ships only shared Boost; the static lookup
+          # otherwise fails the component check and the FetchContent fallback collides
+          # with the partially-detected system targets.
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBOOST_USE_STATIC=OFF \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DPOLARIS_ASSETS_DIR=/usr/share/polaris \
+            -DPOLARIS_ENABLE_CUDA=OFF \
+            -DPOLARIS_ENABLE_VAAPI=ON \
+            -DPOLARIS_ENABLE_DRM=ON \
+            -DPOLARIS_ENABLE_WAYLAND=ON \
+            -DPOLARIS_ENABLE_X11=ON \
+            -DPOLARIS_ENABLE_PIPEWIRE=ON
+          cmake --build build --parallel "$(nproc)"
+
+      - name: Package (tarball)
+        run: |
+          mkdir -p dist stage
+          DESTDIR="$PWD/stage" cmake --install build
+          tar -C stage -czf "dist/polaris-opensuse-tumbleweed-x86_64.tar.gz" .
+
+      - name: Package (RPM)
+        continue-on-error: true
+        run: |
+          # The project's CPACK_RPM_PACKAGE_REQUIRES uses Fedora package names; override
+          # with openSUSE names. Shared-library deps are still auto-detected (autoreq).
+          ( cd build && cpack -G RPM \
+              -D CPACK_RPM_PACKAGE_REQUIRES="grim, labwc, wlr-randr, xdpyinfo, xwayland, which" )
+          find build -name '*.rpm' -exec cp {} dist/ \; || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: polaris-opensuse-tumbleweed
+          path: dist/
+          if-no-files-found: error

--- a/.github/workflows/opensuse-build.yml
+++ b/.github/workflows/opensuse-build.yml
@@ -43,20 +43,29 @@ jobs:
 
       - name: Build
         run: |
-          # BOOST_USE_STATIC=OFF: openSUSE ships only shared Boost; the static lookup
-          # otherwise fails the component check and the FetchContent fallback collides
-          # with the partially-detected system targets.
+          # Flag set mirrors the upstream Fedora spec / Arch PKGBUILD feature set, so an
+          # openSUSE build is the "whole thing", not a stripped-down variant:
+          #   * BROWSER_STREAM=ON           - both Fedora and Arch enable it (needs Go, installed above)
+          #   * WAYLAND/X11/DRM=ON          - all capture backends (also defaults)
+          #   * BOOST_USE_STATIC=OFF        - matches Arch; required on openSUSE (shared-only Boost)
+          #   * CUDA=OFF, FAIL_ON_MISSING=OFF - matches Arch on a host without the CUDA toolkit
+          #                                    (NVENC is NVIDIA-only; harmless on AMD/Intel)
           cmake -B build -G Ninja \
+            -DBUILD_DOCS=OFF \
             -DCMAKE_BUILD_TYPE=Release \
             -DBOOST_USE_STATIC=OFF \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DPOLARIS_ASSETS_DIR=/usr/share/polaris \
-            -DPOLARIS_ENABLE_CUDA=OFF \
-            -DPOLARIS_ENABLE_VAAPI=ON \
-            -DPOLARIS_ENABLE_DRM=ON \
+            -DPOLARIS_EXECUTABLE_PATH=/usr/bin/polaris \
             -DPOLARIS_ENABLE_WAYLAND=ON \
             -DPOLARIS_ENABLE_X11=ON \
-            -DPOLARIS_ENABLE_PIPEWIRE=ON
+            -DPOLARIS_ENABLE_DRM=ON \
+            -DPOLARIS_ENABLE_BROWSER_STREAM=ON \
+            -DPOLARIS_ENABLE_CUDA=OFF \
+            -DCUDA_FAIL_ON_MISSING=OFF \
+            -DPOLARIS_PUBLISHER_NAME='Polaris Project' \
+            -DPOLARIS_PUBLISHER_WEBSITE='https://github.com/papi-ux/polaris' \
+            -DPOLARIS_PUBLISHER_ISSUE_URL='https://github.com/papi-ux/polaris/issues'
           cmake --build build --parallel "$(nproc)"
 
       - name: Package (tarball)

--- a/docs/openSUSE.md
+++ b/docs/openSUSE.md
@@ -38,11 +38,17 @@ isolated compositor / headless capture path.)
 git clone --recursive https://github.com/papi-ux/polaris.git
 cd polaris
 cmake -B build -G Ninja \
+  -DBUILD_DOCS=OFF \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
   -DPOLARIS_ASSETS_DIR=/usr/share/polaris \
+  -DPOLARIS_EXECUTABLE_PATH=/usr/bin/polaris \
   -DBOOST_USE_STATIC=OFF \
-  -DPOLARIS_ENABLE_CUDA=OFF
+  -DPOLARIS_ENABLE_WAYLAND=ON \
+  -DPOLARIS_ENABLE_X11=ON \
+  -DPOLARIS_ENABLE_DRM=ON \
+  -DPOLARIS_ENABLE_BROWSER_STREAM=ON \
+  -DPOLARIS_ENABLE_CUDA=OFF -DCUDA_FAIL_ON_MISSING=OFF
 cmake --build build --parallel "$(nproc)"
 sudo cmake --install build
 sudo polaris --setup-host

--- a/docs/openSUSE.md
+++ b/docs/openSUSE.md
@@ -1,0 +1,85 @@
+# Building Polaris on openSUSE Tumbleweed
+
+Polaris has no prebuilt openSUSE package yet, but it builds cleanly from source on
+**openSUSE Tumbleweed** (x86_64). This guide covers the dependencies, the build, and
+a few openSUSE-specific gotchas. A CI workflow that builds an installable RPM in an
+`opensuse/tumbleweed` container lives at
+[`.github/workflows/opensuse-build.yml`](../.github/workflows/opensuse-build.yml).
+
+> Tested on Tumbleweed with an AMD GPU (VAAPI encode). NVIDIA hosts should add the
+> CUDA toolkit and build with `-DPOLARIS_ENABLE_CUDA=ON`.
+
+## 1. Install build dependencies
+
+```bash
+sudo zypper install \
+  gcc-c++ make cmake ninja git python3 which wget \
+  nodejs24 npm24 go \
+  libboost_headers-devel libboost_filesystem-devel libboost_log-devel \
+  libboost_locale-devel libboost_program_options-devel libboost_thread-devel \
+  libcap-devel libcurl-devel libdrm-devel libevdev-devel libgudev-1_0-devel \
+  libnotify-devel libva-devel libopenssl-devel systemd-devel \
+  libX11-devel libxcb-devel libXcursor-devel libXfixes-devel libXi-devel \
+  libXinerama-devel libXrandr-devel libXtst-devel \
+  Mesa-libGL-devel libgbm-devel \
+  libminiupnpc-devel nlohmann_json-devel libnuma-devel libpulse-devel \
+  libopus-devel libopusenc-devel \
+  wayland-devel wayland-protocols-devel pipewire-devel \
+  libayatana-appindicator3-devel desktop-file-utils appstream-glib \
+  labwc grim wlr-randr xdpyinfo xwayland
+```
+
+(The last line — `labwc grim wlr-randr xdpyinfo xwayland` — are runtime helpers for the
+isolated compositor / headless capture path.)
+
+## 2. Build
+
+```bash
+git clone --recursive https://github.com/papi-ux/polaris.git
+cd polaris
+cmake -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DPOLARIS_ASSETS_DIR=/usr/share/polaris \
+  -DBOOST_USE_STATIC=OFF \
+  -DPOLARIS_ENABLE_CUDA=OFF
+cmake --build build --parallel "$(nproc)"
+sudo cmake --install build
+sudo polaris --setup-host
+```
+
+### openSUSE-specific notes
+
+- **`-DBOOST_USE_STATIC=OFF` is required.** openSUSE ships only *shared* Boost. With the
+  default static lookup, `find_package(Boost ...)` reports missing component targets and
+  the FetchContent fallback collides with the partially-detected system targets
+  (`add_library cannot create ALIAS target "Boost::headers" ... already exists`). Turning
+  static off makes it use the shared system Boost directly.
+- **AMD / VAAPI** is the default-friendly path (`-DPOLARIS_ENABLE_CUDA=OFF`); choose the
+  VAAPI encoder in the web UI. NVIDIA hosts: install the CUDA toolkit and use
+  `-DPOLARIS_ENABLE_CUDA=ON`.
+
+## 3. Optional: build an installable RPM
+
+`cpack -G RPM` works, but the project's explicit `CPACK_RPM_PACKAGE_REQUIRES` uses
+Fedora package names (`boost-filesystem`, `libcurl`, `xorg-x11-server-Xwayland`, …) that
+don't exist on openSUSE. Override them with openSUSE names — the shared-library
+dependencies are still auto-detected:
+
+```bash
+( cd build && cpack -G RPM \
+    -D CPACK_RPM_PACKAGE_REQUIRES="grim, labwc, wlr-randr, xdpyinfo, xwayland, which" )
+sudo zypper install --allow-unsigned-rpm ./build/cpack_artifacts/*.rpm
+```
+
+## 4. Container/CI note
+
+When building inside a minimal `opensuse/tumbleweed` container, the base image ships
+`busybox-gawk`, which blocks the real `gawk` that `desktop-file-utils`/`rpm-build`
+require. Install gawk first to swap it in:
+
+```bash
+zypper --non-interactive install --force-resolution gawk
+```
+
+This is unnecessary on a normal Tumbleweed desktop (gawk is already present).


### PR DESCRIPTION
## What

Adds first-class **openSUSE Tumbleweed** build support:

- **`docs/openSUSE.md`** — a from-source build guide (dependencies, build flags, optional RPM packaging).
- **`.github/workflows/opensuse-build.yml`** — a manual-trigger (`workflow_dispatch`) CI job that builds an installable `.rpm` + a relocatable tarball inside an `opensuse/tumbleweed` container and uploads them as an artifact.

## Why

There's no prebuilt openSUSE package today. This documents a clean, reproducible from-source path and lets anyone produce an openSUSE build/artifact.

## openSUSE-specific gotchas captured here

- **`-DBOOST_USE_STATIC=OFF` is required.** openSUSE ships only *shared* Boost. With the default static lookup, `find_package(Boost …)` reports missing component targets and the FetchContent fallback then collides with the partially-detected system targets (`add_library cannot create ALIAS target "Boost::headers" … already exists`). Building against shared system Boost avoids it.
- **RPM `Requires`.** The project's `CPACK_RPM_PACKAGE_REQUIRES` uses Fedora package names (`boost-filesystem`, `libcurl`, `xorg-x11-server-Xwayland`, …) that don't exist on openSUSE. The workflow overrides them with openSUSE names at `cpack` time; the shared-library dependencies are still auto-detected (autoreq), so `zypper` resolves Boost/libva/libcurl/etc. on its own.
- **Container builds** need `gawk` installed first — the `opensuse/tumbleweed` base image ships `busybox-gawk`, which blocks the real `gawk` that `desktop-file-utils`/`rpm-build` require.

## Notes

- Tested on Tumbleweed with an AMD GPU (VAAPI encode, `-DPOLARIS_ENABLE_CUDA=OFF`). NVIDIA hosts: add the CUDA toolkit and `-DPOLARIS_ENABLE_CUDA=ON`.
- The workflow is **manual-trigger only** (`workflow_dispatch`) so it doesn't impose container builds on every push — maintainers can add `push:` / `pull_request:` triggers if desired.
