### PR TITLE
fix: keep headless bwrap from binding dev fd

### DIFF
--- a/src/platform/linux/input/inputtino_gamepad_isolation.cpp
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.cpp
@@ -490,7 +490,7 @@ std::string command_with_headless_gamepad_isolation(const std::string &command, 
     wrapped += path;
   }
 
-  static constexpr std::array<std::string_view, 12> runtime_device_roots {
+  static constexpr std::array<std::string_view, 11> runtime_device_roots {
     "/dev/dri",
     "/dev/snd",
     "/dev/kfd",
@@ -501,7 +501,6 @@ std::string command_with_headless_gamepad_isolation(const std::string &command, 
     "/dev/nvidia-modeset",
     "/dev/nvidia-caps",
     "/dev/shm",
-    "/dev/fd",
     "/dev/pts",
   };
 

--- a/tests/unit/platform/test_gamepad_isolation.cpp
+++ b/tests/unit/platform/test_gamepad_isolation.cpp
@@ -262,6 +262,7 @@ TEST(GamepadIsolationTests, StrictWrapperBindsOnlyRegisteredVirtualEventJsAndHid
   EXPECT_TRUE(text_lacks(command, "/dev/input/event3"));
   EXPECT_TRUE(text_lacks(command, "/dev/input/js3"));
   EXPECT_TRUE(text_lacks(command, "/dev/hidraw3"));
+  EXPECT_TRUE(text_lacks(command, "--dev-bind-try /dev/fd /dev/fd"));
 }
 
 TEST(GamepadIsolationTests, SameVidPidHostAndVirtualAllowsOnlyRegisteredVirtualNode) {


### PR DESCRIPTION
## Summary
- remove the strict headless gamepad-isolation bwrap /dev/fd bind that fails on Fedora before app launch
- keep GPU/audio/shared-memory device roots available while preserving registered virtual gamepad binds
- add a regression assertion so generated wrappers do not include /dev/fd

## Test Plan
- ./build/tests/test_polaris_platform --gtest_filter=GamepadIsolationTests.*
- cmake --build build --target polaris -j4
- live Retroid → Nova → Polaris Lutris smoke after deploying patched binary: visible Lutris UI instead of black cursor-only compositor

Refs black headless stream smoke.