### PR TITLE
fix: gate private launch when desktop Steam is active

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -976,6 +976,13 @@ namespace confighttp {
     response->write(code, tree.dump(), headers);
   }
 
+  void conflict_response(resp_https_t response, const nlohmann::json &tree) {
+    constexpr SimpleWeb::StatusCode code = SimpleWeb::StatusCode::client_error_conflict;
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    append_json_security_headers(headers);
+    response->write(code, tree.dump(), headers);
+  }
+
 
   /**
    * @brief Validate the request content type and send bad request when mismatch.
@@ -3487,6 +3494,12 @@ namespace confighttp {
         return;
       }
       std::string uuid = input_tree["uuid"].get<std::string>();
+      bool mirror_desktop_explicit = input_tree.value("mirrorDesktop", false) ||
+                                     input_tree.value("mirror_desktop", false);
+      if (!mirror_desktop_explicit) {
+        const auto launch_mode = boost::to_lower_copy(input_tree.value("launchMode", std::string {}));
+        mirror_desktop_explicit = launch_mode == "mirror_desktop" || launch_mode == "mirrordesktop";
+      }
 
       nlohmann::json output_tree;
       const auto &apps = proc::proc.get_apps();
@@ -3498,14 +3511,51 @@ namespace confighttp {
             .perm = crypto::PERM::_all,
           };
           BOOST_LOG(info) << "Launching app ["sv << app.name << "] from web UI"sv;
+#ifdef __linux__
+          const bool private_stream_requested =
+            config::video.linux_display.headless_mode &&
+            config::video.linux_display.use_cage_compositor;
+          const int running_app = proc::proc.running();
+          const auto launch_policy = proc::resolve_desktop_launch_safety_policy(
+            private_stream_requested,
+            mirror_desktop_explicit,
+            false,
+            app,
+            proc::desktop_steam_client_active(),
+            running_app > 0 && running_app != proc::input_only_app_id
+          );
+          const auto launch_policy_json = proc::desktop_launch_safety_policy_to_json(launch_policy);
+          if (launch_policy.recommendedAction == "refuse_private_stream") {
+            nlohmann::json error_tree;
+            error_tree["status_code"] = static_cast<int>(SimpleWeb::StatusCode::client_error_conflict);
+            error_tree["status"] = false;
+            error_tree["error"] = "Unsafe private stream launch refused because desktop Steam or a desktop game is active. Quit the desktop session or retry with explicit desktop mirroring.";
+            error_tree["error_code"] = "desktop_active_private_stream_refused";
+            error_tree["launchPolicy"] = launch_policy_json;
+            conflict_response(response, error_tree);
+            return;
+          }
+#endif
           auto launch_session = nvhttp::make_launch_session(true, false, request->parse_query_string(), &named_cert);
           auto err = proc::proc.execute(app, launch_session);
           if (err) {
-            bad_request(response, request, err == 503 ?
-                        "Failed to initialize video capture/encoding. Is a display connected and turned on?" :
-                        "Failed to start the specified application");
+            nlohmann::json error_tree;
+            error_tree["status_code"] = static_cast<int>(SimpleWeb::StatusCode::client_error_bad_request);
+            error_tree["status"] = false;
+            error_tree["error"] = err == 503 ?
+              "Failed to initialize video capture/encoding. Is a display connected and turned on?" :
+              "Failed to start the specified application";
+#ifdef __linux__
+            error_tree["launchPolicy"] = launch_policy_json;
+#endif
+            SimpleWeb::CaseInsensitiveMultimap headers;
+            append_json_security_headers(headers);
+            response->write(SimpleWeb::StatusCode::client_error_bad_request, error_tree.dump(), headers);
           } else {
             output_tree["status"] = true;
+#ifdef __linux__
+            output_tree["launchPolicy"] = launch_policy_json;
+#endif
             send_response(response, output_tree);
           }
           return;

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3494,11 +3494,30 @@ namespace confighttp {
         return;
       }
       std::string uuid = input_tree["uuid"].get<std::string>();
+      auto launch_args = request->parse_query_string();
+      const auto launch_mode = boost::to_lower_copy(input_tree.value("launchMode", std::string {}));
       bool mirror_desktop_explicit = input_tree.value("mirrorDesktop", false) ||
-                                     input_tree.value("mirror_desktop", false);
-      if (!mirror_desktop_explicit) {
-        const auto launch_mode = boost::to_lower_copy(input_tree.value("launchMode", std::string {}));
-        mirror_desktop_explicit = launch_mode == "mirror_desktop" || launch_mode == "mirrordesktop";
+                                     input_tree.value("mirror_desktop", false) ||
+                                     launch_mode == "mirror_desktop" ||
+                                     launch_mode == "mirrordesktop";
+      const bool force_private_after_desktop_steam_shutdown =
+        input_tree.value("closeDesktopSteamForPrivate", false) ||
+        input_tree.value("forcePrivateAfterSteamClose", false) ||
+        launch_mode == "force_private_stream" ||
+        launch_mode == "forceprivate";
+      if (mirror_desktop_explicit || force_private_after_desktop_steam_shutdown) {
+        launch_args.erase("mirrorDesktop");
+        launch_args.erase("mirror_desktop");
+        launch_args.erase("closeDesktopSteamForPrivate");
+        launch_args.erase("forcePrivateAfterSteamClose");
+        launch_args.erase("launchMode");
+      }
+      if (mirror_desktop_explicit) {
+        launch_args.emplace("mirrorDesktop", "1");
+        launch_args.emplace("launchMode", "mirror_desktop");
+      } else if (force_private_after_desktop_steam_shutdown) {
+        launch_args.emplace("closeDesktopSteamForPrivate", "1");
+        launch_args.emplace("launchMode", "force_private_stream");
       }
 
       nlohmann::json output_tree;
@@ -3519,7 +3538,7 @@ namespace confighttp {
           const auto launch_policy = proc::resolve_desktop_launch_safety_policy(
             private_stream_requested,
             mirror_desktop_explicit,
-            false,
+            force_private_after_desktop_steam_shutdown,
             app,
             proc::desktop_steam_client_active(),
             running_app > 0 && running_app != proc::input_only_app_id
@@ -3536,7 +3555,7 @@ namespace confighttp {
             return;
           }
 #endif
-          auto launch_session = nvhttp::make_launch_session(true, false, request->parse_query_string(), &named_cert);
+          auto launch_session = nvhttp::make_launch_session(true, false, launch_args, &named_cert);
           auto err = proc::proc.execute(app, launch_session);
           if (err) {
             nlohmann::json error_tree;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -143,6 +143,165 @@ namespace nvhttp {
       return value;
     }
 
+#if defined(__linux__)
+    bool truthy_query_value(std::string value) {
+      value = lower_copy(std::move(value));
+      return value == "1" || value == "true" || value == "yes" || value == "on";
+    }
+
+    bool explicit_mirror_desktop_requested(const args_t &args) {
+      for (const auto &key : {"mirrorDesktop", "mirror_desktop"}) {
+        const auto it = args.find(key);
+        if (it != args.end() && truthy_query_value(it->second)) {
+          return true;
+        }
+      }
+
+      const auto launch_mode_it = args.find("launchMode");
+      if (launch_mode_it == args.end()) {
+        return false;
+      }
+
+      const auto launch_mode = lower_copy(launch_mode_it->second);
+      return launch_mode == "mirror_desktop" || launch_mode == "mirrordesktop";
+    }
+
+    bool explicit_mirror_desktop_requested(const nlohmann::json &body) {
+      if (body.value("mirrorDesktop", false) || body.value("mirror_desktop", false)) {
+        return true;
+      }
+
+      const auto launch_mode = lower_copy(body.value("launchMode", std::string {}));
+      return launch_mode == "mirror_desktop" || launch_mode == "mirrordesktop";
+    }
+
+    bool force_private_after_desktop_steam_shutdown_requested(const args_t &args) {
+      for (const auto &key : {"closeDesktopSteamForPrivate", "forcePrivateAfterSteamClose"}) {
+        const auto it = args.find(key);
+        if (it != args.end() && truthy_query_value(it->second)) {
+          return true;
+        }
+      }
+
+      const auto launch_mode_it = args.find("launchMode");
+      if (launch_mode_it == args.end()) {
+        return false;
+      }
+      const auto launch_mode = lower_copy(launch_mode_it->second);
+      return launch_mode == "force_private_stream" || launch_mode == "forceprivate";
+    }
+
+    bool force_private_after_desktop_steam_shutdown_requested(const nlohmann::json &body) {
+      if (body.value("closeDesktopSteamForPrivate", false) || body.value("forcePrivateAfterSteamClose", false)) {
+        return true;
+      }
+      const auto launch_mode = lower_copy(body.value("launchMode", std::string {}));
+      return launch_mode == "force_private_stream" || launch_mode == "forceprivate";
+    }
+
+#if defined(POLARIS_TESTS)
+    proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy(
+      const args_t &args,
+      bool app_uses_steam,
+      bool private_stream_requested,
+      bool desktop_steam_active,
+      bool active_desktop_game,
+      bool force_private_after_desktop_steam_shutdown = false
+    ) {
+      return proc::resolve_desktop_launch_safety_policy_for_tests(
+        private_stream_requested,
+        explicit_mirror_desktop_requested(args),
+        app_uses_steam,
+        desktop_steam_active,
+        active_desktop_game,
+        force_private_after_desktop_steam_shutdown
+      );
+    }
+#endif
+
+    proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy(
+      const args_t &args,
+      const proc::ctx_t &app,
+      bool active_desktop_game
+    ) {
+      const bool private_stream_requested =
+        config::video.linux_display.headless_mode &&
+        config::video.linux_display.use_cage_compositor;
+      return proc::resolve_desktop_launch_safety_policy(
+        private_stream_requested,
+        explicit_mirror_desktop_requested(args),
+        force_private_after_desktop_steam_shutdown_requested(args),
+        app,
+        proc::desktop_steam_client_active(),
+        active_desktop_game
+      );
+    }
+
+    proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy(
+      const nlohmann::json &body,
+      const proc::ctx_t &app,
+      bool active_desktop_game
+    ) {
+      const bool private_stream_requested =
+        config::video.linux_display.headless_mode &&
+        config::video.linux_display.use_cage_compositor;
+      return proc::resolve_desktop_launch_safety_policy(
+        private_stream_requested,
+        explicit_mirror_desktop_requested(body),
+        force_private_after_desktop_steam_shutdown_requested(body),
+        app,
+        proc::desktop_steam_client_active(),
+        active_desktop_game
+      );
+    }
+
+    void put_desktop_launch_policy(pt::ptree &tree, const proc::desktop_launch_safety_policy_t &policy) {
+      const auto json = proc::desktop_launch_safety_policy_to_json(policy);
+      for (const auto &[key, value] : json.items()) {
+        const auto path = "root.launchPolicy."s + key;
+        if (value.is_boolean()) {
+          tree.put(path, value.get<bool>() ? 1 : 0);
+        } else if (value.is_string()) {
+          tree.put(path, value.get<std::string>());
+        }
+      }
+    }
+
+    std::optional<proc::ctx_t> find_app_for_optimization_game(const std::string &game) {
+      if (game.empty()) {
+        return std::nullopt;
+      }
+
+      const auto apps = proc::proc.get_apps();
+      const auto app_iter = std::find_if(apps.begin(), apps.end(), [&game](const proc::ctx_t &app) {
+        return boost::iequals(app.name, game) ||
+               boost::iequals(app.uuid, game) ||
+               boost::iequals(app.id, game);
+      });
+
+      if (app_iter == apps.end()) {
+        return std::nullopt;
+      }
+      return *app_iter;
+    }
+
+    void put_optimization_launch_policy(nlohmann::json &output,
+                                        const args_t &args,
+                                        const std::string &game) {
+      const auto app = find_app_for_optimization_game(game);
+      if (!app) {
+        return;
+      }
+
+      const auto launch_policy = resolve_streaming_launch_safety_policy(
+        args,
+        *app,
+        proc::proc.running() > 0 && proc::proc.running() != proc::input_only_app_id
+      );
+      output["launchPolicy"] = proc::desktop_launch_safety_policy_to_json(launch_policy);
+    }
+#endif
+
     std::optional<int> select_paired_client_launch_bitrate(
         const std::optional<int> &target_bitrate_kbps,
         int paired_bitrate_kbps,
@@ -2037,6 +2196,26 @@ namespace nvhttp {
                                                     const nlohmann::json &health) {
     return build_stream_policy_json(client, stats, health);
   }
+
+#if defined(__linux__)
+  proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy_for_tests(
+    const args_t &args,
+    bool app_uses_steam,
+    bool private_stream_requested,
+    bool desktop_steam_active,
+    bool active_desktop_game,
+    bool force_private_after_desktop_steam_shutdown
+  ) {
+    return resolve_streaming_launch_safety_policy(
+      args,
+      app_uses_steam,
+      private_stream_requested,
+      desktop_steam_active,
+      active_desktop_game,
+      force_private_after_desktop_steam_shutdown
+    );
+  }
+#endif
 #endif
 
 #ifdef __linux__
@@ -2919,7 +3098,9 @@ namespace nvhttp {
     launch_session->enable_hdr = util::from_view(get_arg(args, "hdrMode", "0"));
     const bool client_display_mode_explicit = util::from_view(get_arg(args, "displayModeExplicit", "0"));
     const bool client_requested_virtual_display = util::from_view(get_arg(args, "virtualDisplay", "0"));
-    launch_session->virtual_display = client_requested_virtual_display || named_cert_p->always_use_virtual_display;
+    launch_session->mirror_desktop = explicit_mirror_desktop_requested(args);
+    launch_session->force_private_after_desktop_steam_shutdown = force_private_after_desktop_steam_shutdown_requested(args);
+    launch_session->virtual_display = !launch_session->mirror_desktop && (client_requested_virtual_display || named_cert_p->always_use_virtual_display);
     launch_session->user_locked_display_mode = !named_cert_p->display_mode.empty();
     launch_session->user_locked_virtual_display = client_display_mode_explicit || named_cert_p->always_use_virtual_display;
     launch_session->scale_factor = util::from_view(get_arg(args, "scaleFactor", "100"));
@@ -4005,6 +4186,33 @@ namespace nvhttp {
           launch_session->client_do_cmds.clear();
           launch_session->client_undo_cmds.clear();
         }
+
+#ifdef __linux__
+        const auto launch_policy = resolve_streaming_launch_safety_policy(
+          args,
+          *app_iter,
+          current_appid > 0 && current_appid != proc::input_only_app_id
+        );
+        put_desktop_launch_policy(tree, launch_policy);
+        if (launch_policy.recommendedAction == "force_private_stream_after_desktop_steam_shutdown") {
+          if (!proc::request_desktop_steam_shutdown_for_private_stream()) {
+            tree.put("root.resume", 0);
+            tree.put("root.<xmlattr>.status_code", 409);
+            tree.put("root.<xmlattr>.status_message", "Desktop Steam did not exit, so Nova did not start a private stream. Quit Steam on the desktop or choose Mirror Desktop.");
+            tree.put("root.error_code", "desktop_steam_shutdown_failed");
+            tree.put("root.gamesession", 0);
+            return;
+          }
+        }
+        if (launch_policy.recommendedAction == "refuse_private_stream") {
+          tree.put("root.resume", 0);
+          tree.put("root.<xmlattr>.status_code", 409);
+          tree.put("root.<xmlattr>.status_message", "Unsafe private stream launch refused because desktop Steam or a desktop game is active. Quit the desktop session or retry with explicit desktop mirroring.");
+          tree.put("root.error_code", "desktop_active_private_stream_refused");
+          tree.put("root.gamesession", 0);
+          return;
+        }
+#endif
 
         // Update last_launched timestamp
         try {
@@ -5280,6 +5488,46 @@ namespace nvhttp {
           return;
         }
 
+#ifdef __linux__
+        const auto &app = apps.at(static_cast<size_t>(app_id - 1));
+        const auto launch_policy = resolve_streaming_launch_safety_policy(
+          body,
+          app,
+          proc::proc.running() > 0 && proc::proc.running() != proc::input_only_app_id
+        );
+        auto launch_policy_json = proc::desktop_launch_safety_policy_to_json(launch_policy);
+        if (launch_policy.recommendedAction == "force_private_stream_after_desktop_steam_shutdown") {
+          if (!proc::request_desktop_steam_shutdown_for_private_stream()) {
+            nlohmann::json err;
+            err["error"] = "Desktop Steam did not exit, so Nova did not start a private stream. Quit Steam on the desktop or choose Mirror Desktop.";
+            err["error_code"] = "desktop_steam_shutdown_failed";
+            err["launchPolicy"] = launch_policy_json;
+            SimpleWeb::CaseInsensitiveMultimap headers;
+            headers.emplace("Content-Type", "application/json");
+            response->write(SimpleWeb::StatusCode::client_error_conflict, err.dump(), headers);
+            return;
+          }
+          launch_policy_json = proc::desktop_launch_safety_policy_to_json(proc::resolve_desktop_launch_safety_policy(
+            true,
+            false,
+            false,
+            app,
+            false,
+            proc::proc.running() > 0 && proc::proc.running() != proc::input_only_app_id
+          ));
+        }
+        if (launch_policy.recommendedAction == "refuse_private_stream") {
+          nlohmann::json err;
+          err["error"] = "Unsafe private stream launch refused because desktop Steam or a desktop game is active. Quit the desktop session or retry with explicit desktop mirroring.";
+          err["error_code"] = "desktop_active_private_stream_refused";
+          err["launchPolicy"] = launch_policy_json;
+          SimpleWeb::CaseInsensitiveMultimap headers;
+          headers.emplace("Content-Type", "application/json");
+          response->write(SimpleWeb::StatusCode::client_error_conflict, err.dump(), headers);
+          return;
+        }
+#endif
+
         // Update last_launched timestamp in apps.json
         try {
           std::string content = file_handler::read_file(config::stream.file_apps.c_str());
@@ -5302,6 +5550,9 @@ namespace nvhttp {
         output["status"] = "launching";
         output["game"] = app_name;
         output["game_id"] = game_id;
+#ifdef __linux__
+        output["launchPolicy"] = launch_policy_json;
+#endif
         if (client_width > 0 && client_height > 0) {
           output["smart_launch"] = {
             {"client_width", client_width},
@@ -6147,6 +6398,10 @@ namespace nvhttp {
         output.value("recovery_policy", nlohmann::json::object()),
         applied_history_safe
       );
+
+#ifdef __linux__
+      put_optimization_launch_policy(output, args, game);
+#endif
 
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "application/json");

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3098,8 +3098,13 @@ namespace nvhttp {
     launch_session->enable_hdr = util::from_view(get_arg(args, "hdrMode", "0"));
     const bool client_display_mode_explicit = util::from_view(get_arg(args, "displayModeExplicit", "0"));
     const bool client_requested_virtual_display = util::from_view(get_arg(args, "virtualDisplay", "0"));
+    #if defined(__linux__)
     launch_session->mirror_desktop = explicit_mirror_desktop_requested(args);
     launch_session->force_private_after_desktop_steam_shutdown = force_private_after_desktop_steam_shutdown_requested(args);
+    #else
+    launch_session->mirror_desktop = false;
+    launch_session->force_private_after_desktop_steam_shutdown = false;
+    #endif
     launch_session->virtual_display = !launch_session->mirror_desktop && (client_requested_virtual_display || named_cert_p->always_use_virtual_display);
     launch_session->user_locked_display_mode = !named_cert_p->display_mode.empty();
     launch_session->user_locked_virtual_display = client_display_mode_explicit || named_cert_p->always_use_virtual_display;
@@ -4203,6 +4208,15 @@ namespace nvhttp {
             tree.put("root.gamesession", 0);
             return;
           }
+          const auto refreshed_launch_policy = proc::resolve_desktop_launch_safety_policy(
+            true,
+            false,
+            false,
+            *app_iter,
+            false,
+            proc::proc.running() > 0 && proc::proc.running() != proc::input_only_app_id
+          );
+          put_desktop_launch_policy(tree, refreshed_launch_policy);
         }
         if (launch_policy.recommendedAction == "refuse_private_stream") {
           tree.put("root.resume", 0);

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -31,6 +31,12 @@ namespace stream_stats {
 }
 #endif
 
+#if defined(__linux__)
+namespace proc {
+  struct desktop_launch_safety_policy_t;
+}
+#endif
+
 /**
  * @brief Contains all the functions and variables related to the nvhttp (GameStream) server.
  */
@@ -323,6 +329,16 @@ namespace nvhttp {
   nlohmann::json build_stream_policy_json_for_tests(const crypto::named_cert_t &client,
                                                     const stream_stats::stats_t &stats,
                                                     const nlohmann::json &health);
+#if defined(__linux__)
+  proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy_for_tests(
+    const args_t &args,
+    bool app_uses_steam,
+    bool private_stream_requested,
+    bool desktop_steam_active,
+    bool active_desktop_game,
+    bool force_private_after_desktop_steam_shutdown = false
+  );
+#endif
   void reset_pairing_state_for_tests();
 #endif
 }  // namespace nvhttp

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -993,6 +993,166 @@ namespace proc {
              !steam_appid_for_context(ctx).empty();
     }
 
+    bool proc_pid_dir_name(std::string_view name) {
+      return !name.empty() && std::all_of(name.begin(), name.end(), [](char ch) {
+        return std::isdigit(static_cast<unsigned char>(ch));
+      });
+    }
+
+    std::string read_proc_status_file(pid_t pid, std::string_view name) {
+      std::ifstream file("/proc/" + std::to_string(pid) + "/" + std::string {name}, std::ios::binary);
+      if (!file) {
+        return {};
+      }
+
+      std::ostringstream buffer;
+      buffer << file.rdbuf();
+      return buffer.str();
+    }
+
+    std::string proc_argv0_from_cmdline(std::string_view cmdline) {
+      const auto end = cmdline.find('\0');
+      return boost::to_lower_copy(std::string {cmdline.substr(0, end)});
+    }
+
+    std::string basename_from_path(std::string_view path) {
+      auto value = std::string {path};
+      if (const auto slash = value.find_last_of('/'); slash != std::string::npos) {
+        value = value.substr(slash + 1);
+      }
+      return value;
+    }
+
+    bool path_has_suffix(std::string_view value, std::string_view suffix) {
+      return value.size() >= suffix.size() &&
+             value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+    }
+
+    bool is_desktop_steam_client_process(std::string_view comm, std::string_view argv0_path) {
+      const auto argv0 = basename_from_path(argv0_path);
+      return comm == "steam" ||
+             comm == "steamwebhelper" ||
+             argv0 == "steam" ||
+             argv0 == "steam.sh" ||
+             argv0 == "steamwebhelper" ||
+             path_has_suffix(argv0_path, "/steam.sh") ||
+             path_has_suffix(argv0_path, "/steamwebhelper") ||
+             path_has_suffix(argv0_path, "/ubuntu12_32/steam");
+    }
+
+    bool is_transient_steam_client_cmdline(std::string_view cmdline) {
+      const auto lower_cmdline = boost::to_lower_copy(std::string {cmdline});
+      return lower_cmdline.find("-shutdown") != std::string::npos ||
+             lower_cmdline.find("-child-update-ui") != std::string::npos ||
+             lower_cmdline.find("-srt-logger-opened") != std::string::npos;
+    }
+
+    bool proc_status_is_zombie(std::string_view status) {
+      for (size_t index = 0; index + 5 < status.size(); ++index) {
+        if (static_cast<unsigned char>(status[index]) != 83 ||
+            static_cast<unsigned char>(status[index + 1]) != 116 ||
+            static_cast<unsigned char>(status[index + 2]) != 97 ||
+            static_cast<unsigned char>(status[index + 3]) != 116 ||
+            static_cast<unsigned char>(status[index + 4]) != 101 ||
+            static_cast<unsigned char>(status[index + 5]) != 58) {
+          continue;
+        }
+
+        auto value_pos = index + 6;
+        while (value_pos < status.size() && std::isspace(static_cast<unsigned char>(status[value_pos]))) {
+          ++value_pos;
+        }
+
+        return value_pos < status.size() && status[value_pos] == static_cast<char>(90);
+      }
+
+      return false;
+    }
+
+    bool is_active_desktop_steam_client_process(
+      std::string_view comm,
+      std::string_view argv0_path,
+      std::string_view cmdline,
+      std::string_view status
+    ) {
+      return is_desktop_steam_client_process(comm, argv0_path) &&
+             !proc_status_is_zombie(status) &&
+             !is_transient_steam_client_cmdline(cmdline);
+    }
+
+    bool desktop_steam_client_active_impl() {
+      DIR *dir = opendir("/proc");
+      if (!dir) {
+        return false;
+      }
+
+      const auto this_pid = getpid();
+      while (auto *entry = readdir(dir)) {
+        const std::string name = entry->d_name;
+        if (!proc_pid_dir_name(name)) {
+          continue;
+        }
+
+        const auto pid = static_cast<pid_t>(std::strtol(name.c_str(), nullptr, 10));
+        if (pid <= 1 || pid == this_pid) {
+          continue;
+        }
+
+        auto comm = boost::to_lower_copy(read_proc_status_file(pid, "comm"));
+        while (!comm.empty() && (comm.back() == '\n' || comm.back() == '\r')) {
+          comm.pop_back();
+        }
+
+        const auto cmdline = read_proc_status_file(pid, "cmdline");
+        const auto argv0 = proc_argv0_from_cmdline(cmdline);
+        const auto status = read_proc_status_file(pid, "status");
+        if (is_active_desktop_steam_client_process(comm, argv0, cmdline, status)) {
+          closedir(dir);
+          return true;
+        }
+      }
+
+      closedir(dir);
+      return false;
+    }
+
+    proc::desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy_impl(
+      bool private_stream_requested,
+      bool mirror_desktop_explicit,
+      bool app_uses_steam,
+      bool desktop_steam_active,
+      bool active_desktop_game,
+      bool force_private_after_desktop_steam_shutdown
+    ) {
+      proc::desktop_launch_safety_policy_t policy;
+      policy.desktopSteamActive = desktop_steam_active && app_uses_steam;
+      policy.physicalDisplayRisk = active_desktop_game || policy.desktopSteamActive;
+      policy.canMirrorDesktop = true;
+      policy.canForceCloseDesktopSteamForPrivateStream = policy.desktopSteamActive;
+      policy.forcePrivateStreamLabel = "Close desktop Steam and start private stream";
+      policy.privateStreamUnavailableReason = policy.desktopSteamActive ?
+        "Desktop Steam is already active. Private launch is blocked unless you close desktop Steam first." :
+        (active_desktop_game ? "A desktop game is already active on this host." : "");
+
+      if (force_private_after_desktop_steam_shutdown && policy.canForceCloseDesktopSteamForPrivateStream) {
+        policy.canLaunchPrivateStream = true;
+        policy.recommendedAction = "force_private_stream_after_desktop_steam_shutdown";
+        return policy;
+      }
+
+      policy.canLaunchPrivateStream = !policy.physicalDisplayRisk;
+      if (mirror_desktop_explicit && policy.canMirrorDesktop) {
+        policy.recommendedAction = "mirror_desktop";
+      } else if (private_stream_requested && policy.canLaunchPrivateStream) {
+        policy.recommendedAction = "launch_private_stream";
+      } else if (private_stream_requested && policy.physicalDisplayRisk) {
+        policy.recommendedAction = "refuse_private_stream";
+      } else {
+        policy.recommendedAction = "launch_desktop_stream";
+      }
+      return policy;
+    }
+
     bool should_skip_steam_shutdown_undo_after_cage_cleanup(const proc::ctx_t &ctx,
                                                             const proc::cmd_t &cmd,
                                                             bool use_cage_compositor) {
@@ -1698,7 +1858,109 @@ namespace proc {
   }
 #endif
 
+#if defined(__linux__)
+  desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy(
+    bool private_stream_requested,
+    bool mirror_desktop_explicit,
+    const proc::ctx_t &app,
+    bool desktop_steam_active,
+    bool active_desktop_game
+  ) {
+    return resolve_desktop_launch_safety_policy(
+      private_stream_requested,
+      mirror_desktop_explicit,
+      false,
+      app,
+      desktop_steam_active,
+      active_desktop_game
+    );
+  }
+
+  desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy(
+    bool private_stream_requested,
+    bool mirror_desktop_explicit,
+    bool force_private_after_desktop_steam_shutdown,
+    const proc::ctx_t &app,
+    bool desktop_steam_active,
+    bool active_desktop_game
+  ) {
+    return resolve_desktop_launch_safety_policy_impl(
+      private_stream_requested,
+      mirror_desktop_explicit,
+      context_uses_steam(app),
+      desktop_steam_active,
+      active_desktop_game,
+      force_private_after_desktop_steam_shutdown
+    );
+  }
+
+  nlohmann::json desktop_launch_safety_policy_to_json(const desktop_launch_safety_policy_t &policy) {
+    return {
+      {"desktopSteamActive", policy.desktopSteamActive},
+      {"physicalDisplayRisk", policy.physicalDisplayRisk},
+      {"canLaunchPrivateStream", policy.canLaunchPrivateStream},
+      {"canMirrorDesktop", policy.canMirrorDesktop},
+      {"canForceCloseDesktopSteamForPrivateStream", policy.canForceCloseDesktopSteamForPrivateStream},
+      {"recommendedAction", policy.recommendedAction},
+      {"privateStreamUnavailableReason", policy.privateStreamUnavailableReason},
+      {"forcePrivateStreamLabel", policy.forcePrivateStreamLabel},
+      {"desktopGameDetection", "polaris_running_app_only"},
+    };
+  }
+
+  bool desktop_steam_client_active() {
+    return desktop_steam_client_active_impl();
+  }
+
+  bool request_desktop_steam_shutdown_for_private_stream() {
+    const auto command = canonical_steam_shutdown_command("steam");
+    BOOST_LOG(info) << "process: explicit Nova request closing desktop Steam before private stream using [" << command << "]";
+    auto env = boost::this_process::environment();
+    boost::system::error_code ec;
+    boost::filesystem::path working_dir {};
+    auto child = platf::run_command(false, true, command, working_dir, env, nullptr, ec, nullptr);
+    if (ec) {
+      BOOST_LOG(warning) << "process: explicit desktop Steam shutdown command failed: " << ec.message();
+      return false;
+    }
+    child.detach();
+    for (int i = 0; i < 50; ++i) {
+      if (!desktop_steam_client_active_impl()) {
+        return true;
+      }
+      std::this_thread::sleep_for(100ms);
+    }
+    BOOST_LOG(warning) << "process: desktop Steam still active after explicit shutdown wait";
+    return !desktop_steam_client_active_impl();
+  }
+#endif
+
 #if defined(POLARIS_TESTS) && defined(__linux__)
+  desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy_for_tests(
+    bool private_stream_requested,
+    bool mirror_desktop_explicit,
+    bool app_uses_steam,
+    bool desktop_steam_active,
+    bool active_desktop_game,
+    bool force_private_after_desktop_steam_shutdown
+  ) {
+    return resolve_desktop_launch_safety_policy_impl(
+      private_stream_requested,
+      mirror_desktop_explicit,
+      app_uses_steam,
+      desktop_steam_active,
+      active_desktop_game,
+      force_private_after_desktop_steam_shutdown
+    );
+  }
+
+  bool desktop_steam_client_process_for_tests(std::string_view comm,
+                                               std::string_view argv0_path,
+                                               std::string_view cmdline,
+                                               std::string_view status) {
+    return is_active_desktop_steam_client_process(comm, argv0_path, cmdline, status);
+  }
+
   bool cage_mangohud_allowed_for_session_for_tests(const proc::ctx_t &app,
                                                    bool use_cage_compositor,
                                                    bool requested_headless) {
@@ -1931,8 +2193,14 @@ namespace proc {
     allow_client_commands = app.allow_client_commands;
 
 #ifdef __linux__
+    const bool use_cage_compositor_for_session =
+      config::video.linux_display.use_cage_compositor &&
+      !(launch_session && launch_session->mirror_desktop);
+    const bool requested_headless_for_session =
+      config::video.linux_display.headless_mode &&
+      !(launch_session && launch_session->mirror_desktop);
     settle_recent_browser_stream_steam_cleanup_before_launch(_app);
-    if (config::video.linux_display.use_cage_compositor) {
+    if (use_cage_compositor_for_session) {
       terminate_isolated_session_processes("before launching isolated cage session"sv);
     }
 #endif
@@ -2223,8 +2491,8 @@ namespace proc {
 
 #ifdef __linux__
     const bool using_headless_cage_runtime =
-      config::video.linux_display.headless_mode &&
-      config::video.linux_display.use_cage_compositor;
+      requested_headless_for_session &&
+      use_cage_compositor_for_session;
     if (using_headless_cage_runtime && launch_session->virtual_display) {
       BOOST_LOG(info) << "session_optimization: normalized virtual_display from true to false for headless cage runtime"sv;
       launch_session->virtual_display = false;
@@ -2856,13 +3124,13 @@ namespace proc {
       return false;
     };
 
-    const bool requested_headless = config::video.linux_display.headless_mode;
+    const bool requested_headless = requested_headless_for_session;
     const bool prefer_gpu_native_capture = config::video.linux_display.prefer_gpu_native_capture;
     const bool encoder_requires_gpu_native_capture = video::active_encoder_requires_gpu_native_capture();
     const bool should_try_gpu_native_cage_probe =
       prefer_gpu_native_capture || encoder_requires_gpu_native_capture;
     const bool should_probe_windowed_cage_for_gpu_native =
-      config::video.linux_display.use_cage_compositor &&
+      use_cage_compositor_for_session &&
       cage_display_router::should_attempt_windowed_gpu_native_probe(
         requested_headless,
         prefer_gpu_native_capture,
@@ -3058,8 +3326,8 @@ namespace proc {
 
     auto should_apply_headless_gamepad_isolation = [&]() {
       return has_launch_commands &&
-             config::video.linux_display.use_cage_compositor &&
-             config::video.linux_display.headless_mode &&
+             use_cage_compositor_for_session &&
+             requested_headless_for_session &&
              !force_windowed_cage_for_gpu_native;
     };
 
@@ -3108,7 +3376,7 @@ namespace proc {
 
     // Start cage with the first detached command as its primary client.
     // Cage is a kiosk compositor — it only displays its main process fullscreen.
-    if (config::video.linux_display.use_cage_compositor && !_app.detached.empty()) {
+    if (use_cage_compositor_for_session && !_app.detached.empty()) {
       std::string game_cmd = cage_runtime_command(_app.detached[0]);
       if (!start_cage_with_runtime_fallback(game_cmd)) {
         BOOST_LOG(error) << "session_manager: Failed to start cage with game"sv;
@@ -3150,7 +3418,7 @@ namespace proc {
           child.detach();
         }
       }
-    } else if (config::video.linux_display.use_cage_compositor) {
+    } else if (use_cage_compositor_for_session) {
       // No detached commands — start cage empty, game will use _app.cmd
       if (!start_cage_with_runtime_fallback("")) {
         BOOST_LOG(error) << "session_manager: Failed to start cage compositor"sv;
@@ -3180,7 +3448,7 @@ namespace proc {
     std::string working_dir_cmd = effective_cmd;
     auto launch_env = _env;
     bool app_command_uses_cage_runtime = false;
-    if (config::video.linux_display.use_cage_compositor && cage_display_router::is_running() && !_app.cmd.empty()) {
+    if (use_cage_compositor_for_session && cage_display_router::is_running() && !_app.cmd.empty()) {
       effective_cmd = cage_runtime_command(_app.cmd);
       working_dir_cmd = effective_cmd;
       app_command_uses_cage_runtime = true;
@@ -3522,6 +3790,7 @@ namespace proc {
           (codec_lower.find("h264") != std::string::npos || codec_lower.find("avc") != std::string::npos) ? "h264" :
           "";
         session.last_safe_display_mode =
+          (_launch_session && _launch_session->mirror_desktop) ? "desktop_display" :
           (virtual_display_risk || config::video.linux_display.headless_mode) ? "headless" :
           (_launch_session->virtual_display ? "virtual_display" : "headless");
         session.last_safe_target_fps = ai_optimizer::derive_safe_target_fps(

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1134,16 +1134,21 @@ namespace proc {
         "Desktop Steam is already active. Private launch is blocked unless you close desktop Steam first." :
         (active_desktop_game ? "A desktop game is already active on this host." : "");
 
-      if (force_private_after_desktop_steam_shutdown && policy.canForceCloseDesktopSteamForPrivateStream) {
+      if (mirror_desktop_explicit && policy.canMirrorDesktop) {
+        policy.recommendedAction = "mirror_desktop";
+        return policy;
+      }
+
+      if (private_stream_requested &&
+          force_private_after_desktop_steam_shutdown &&
+          policy.canForceCloseDesktopSteamForPrivateStream) {
         policy.canLaunchPrivateStream = true;
         policy.recommendedAction = "force_private_stream_after_desktop_steam_shutdown";
         return policy;
       }
 
       policy.canLaunchPrivateStream = !policy.physicalDisplayRisk;
-      if (mirror_desktop_explicit && policy.canMirrorDesktop) {
-        policy.recommendedAction = "mirror_desktop";
-      } else if (private_stream_requested && policy.canLaunchPrivateStream) {
+      if (private_stream_requested && policy.canLaunchPrivateStream) {
         policy.recommendedAction = "launch_private_stream";
       } else if (private_stream_requested && policy.physicalDisplayRisk) {
         policy.recommendedAction = "refuse_private_stream";

--- a/src/process.h
+++ b/src/process.h
@@ -69,7 +69,48 @@ namespace proc {
   );
 #endif
 
+#if defined(__linux__)
+  struct desktop_launch_safety_policy_t {
+    bool desktopSteamActive = false;
+    bool physicalDisplayRisk = false;
+    bool canLaunchPrivateStream = true;
+    bool canMirrorDesktop = false;
+    bool canForceCloseDesktopSteamForPrivateStream = false;
+    std::string recommendedAction;
+    std::string privateStreamUnavailableReason;
+    std::string forcePrivateStreamLabel;
+  };
+
+  desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy(
+    bool private_stream_requested,
+    bool mirror_desktop_explicit,
+    bool force_private_after_desktop_steam_shutdown,
+    const struct ctx_t &app,
+    bool desktop_steam_active,
+    bool active_desktop_game
+  );
+
+  nlohmann::json desktop_launch_safety_policy_to_json(const desktop_launch_safety_policy_t &policy);
+  bool desktop_steam_client_active();
+  bool request_desktop_steam_shutdown_for_private_stream();
+#endif
+
 #if defined(POLARIS_TESTS) && defined(__linux__)
+
+  desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy_for_tests(
+    bool private_stream_requested,
+    bool mirror_desktop_explicit,
+    bool app_uses_steam,
+    bool desktop_steam_active,
+    bool active_desktop_game,
+    bool force_private_after_desktop_steam_shutdown = false
+  );
+
+  bool desktop_steam_client_process_for_tests(std::string_view comm,
+                                               std::string_view argv0_path,
+                                               std::string_view cmdline,
+                                               std::string_view status = {});
+
   bool cage_mangohud_allowed_for_session_for_tests(const struct ctx_t &app,
                                                    bool use_cage_compositor,
                                                    bool requested_headless);

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -54,6 +54,8 @@ namespace rtsp_stream {
     bool enable_hdr;
     bool enable_sops;
     bool virtual_display;
+    bool mirror_desktop = false;
+    bool force_private_after_desktop_steam_shutdown = false;
     bool user_locked_display_mode;
     bool user_locked_virtual_display;
     uint32_t scale_factor;

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -179,6 +179,170 @@ TEST(ProcessRuntimeConfigTests, HeadlessCageSteamBigPictureSkipsHostShutdownUndo
   EXPECT_TRUE(proc::should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(app, shutdown_undo, true));
   EXPECT_FALSE(proc::should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(app, shutdown_undo, false));
 }
+
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorRecognizesSteamWebHelper) {
+  EXPECT_TRUE(proc::desktop_steam_client_process_for_tests(
+    "steamwebhelper",
+    "/home/papi/.local/share/Steam/ubuntu12_64/steamwebhelper",
+    std::string("/home/papi/.local/share/Steam/ubuntu12_64/steamwebhelper") + char(0) + "-type=zygote"
+  ));
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorIgnoresTransientShutdownClient) {
+  EXPECT_FALSE(proc::desktop_steam_client_process_for_tests(
+    "steam",
+    "/usr/bin/steam",
+    std::string("steam") + char(0) + "-shutdown"
+  ));
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorIgnoresZombieShutdownRemnant) {
+  EXPECT_FALSE(proc::desktop_steam_client_process_for_tests(
+    "steam",
+    "",
+    "",
+    "Name:\tsteam\nState:\tZ (zombie)\nPPid:\t275560\n"
+  ));
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamActiveOffersExplicitForcePrivateShutdown) {
+  const auto policy = proc::resolve_desktop_launch_safety_policy_for_tests(
+    true,
+    false,
+    true,
+    true,
+    true,
+    false
+  );
+
+  EXPECT_TRUE(policy.desktopSteamActive);
+  EXPECT_FALSE(policy.canLaunchPrivateStream);
+  EXPECT_TRUE(policy.canForceCloseDesktopSteamForPrivateStream);
+  EXPECT_EQ(policy.recommendedAction, "refuse_private_stream");
+}
+
+TEST(ProcessRuntimeConfigTests, ExplicitForcePrivateAfterDesktopSteamShutdownAllowsPrivateLaunch) {
+  const auto policy = proc::resolve_desktop_launch_safety_policy_for_tests(
+    true,
+    false,
+    true,
+    true,
+    false,
+    true
+  );
+
+  EXPECT_TRUE(policy.canLaunchPrivateStream);
+  EXPECT_EQ(policy.recommendedAction, "force_private_stream_after_desktop_steam_shutdown");
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamActiveRefusesUnsafePrivateSteamLaunch) {
+  const auto policy = proc::resolve_desktop_launch_safety_policy_for_tests(
+    true,
+    false,
+    true,
+    true,
+    false
+  );
+
+  EXPECT_TRUE(policy.desktopSteamActive);
+  EXPECT_TRUE(policy.physicalDisplayRisk);
+  EXPECT_FALSE(policy.canLaunchPrivateStream);
+  EXPECT_TRUE(policy.canMirrorDesktop);
+  EXPECT_EQ(policy.recommendedAction, "refuse_private_stream");
+
+  const auto contract = proc::desktop_launch_safety_policy_to_json(policy);
+  EXPECT_TRUE(contract.at("desktopSteamActive"));
+  EXPECT_TRUE(contract.at("physicalDisplayRisk"));
+  EXPECT_FALSE(contract.at("canLaunchPrivateStream"));
+  EXPECT_TRUE(contract.at("canMirrorDesktop"));
+  EXPECT_EQ(contract.at("recommendedAction"), "refuse_private_stream");
+}
+
+TEST(ProcessRuntimeConfigTests, ActiveDesktopGameRefusesUnsafePrivateLaunch) {
+  const auto policy = proc::resolve_desktop_launch_safety_policy_for_tests(
+    true,
+    false,
+    false,
+    false,
+    true
+  );
+
+  EXPECT_FALSE(policy.desktopSteamActive);
+  EXPECT_TRUE(policy.physicalDisplayRisk);
+  EXPECT_FALSE(policy.canLaunchPrivateStream);
+  EXPECT_TRUE(policy.canMirrorDesktop);
+  EXPECT_EQ(policy.recommendedAction, "refuse_private_stream");
+}
+
+TEST(ProcessRuntimeConfigTests, ExplicitMirrorDesktopReportsPhysicalDisplayRisk) {
+  const auto policy = proc::resolve_desktop_launch_safety_policy_for_tests(
+    true,
+    true,
+    true,
+    true,
+    false
+  );
+
+  EXPECT_TRUE(policy.desktopSteamActive);
+  EXPECT_TRUE(policy.physicalDisplayRisk);
+  EXPECT_FALSE(policy.canLaunchPrivateStream);
+  EXPECT_TRUE(policy.canMirrorDesktop);
+  EXPECT_EQ(policy.recommendedAction, "mirror_desktop");
+}
+
+TEST(ProcessRuntimeConfigTests, NvHttpStreamingLaunchPolicyRefusesUnsafePrivateSteamLaunch) {
+  nvhttp::args_t args;
+
+  const auto policy = nvhttp::resolve_streaming_launch_safety_policy_for_tests(
+    args,
+    true,
+    true,
+    true,
+    false
+  );
+
+  EXPECT_TRUE(policy.desktopSteamActive);
+  EXPECT_TRUE(policy.physicalDisplayRisk);
+  EXPECT_FALSE(policy.canLaunchPrivateStream);
+  EXPECT_TRUE(policy.canMirrorDesktop);
+  EXPECT_EQ(policy.recommendedAction, "refuse_private_stream");
+}
+
+TEST(ProcessRuntimeConfigTests, NvHttpStreamingLaunchPolicyAcceptsExplicitMirrorDesktopQueryParam) {
+  nvhttp::args_t args;
+  args.emplace("launchMode", "mirror_desktop");
+
+  const auto policy = nvhttp::resolve_streaming_launch_safety_policy_for_tests(
+    args,
+    true,
+    true,
+    true,
+    false
+  );
+
+  EXPECT_TRUE(policy.desktopSteamActive);
+  EXPECT_TRUE(policy.physicalDisplayRisk);
+  EXPECT_FALSE(policy.canLaunchPrivateStream);
+  EXPECT_TRUE(policy.canMirrorDesktop);
+  EXPECT_EQ(policy.recommendedAction, "mirror_desktop");
+}
+
+TEST(ProcessRuntimeConfigTests, ClearPrivateSteamLaunchIsAllowed) {
+  const auto policy = proc::resolve_desktop_launch_safety_policy_for_tests(
+    true,
+    false,
+    true,
+    false,
+    false
+  );
+
+  EXPECT_FALSE(policy.desktopSteamActive);
+  EXPECT_FALSE(policy.physicalDisplayRisk);
+  EXPECT_TRUE(policy.canLaunchPrivateStream);
+  EXPECT_TRUE(policy.canMirrorDesktop);
+  EXPECT_EQ(policy.recommendedAction, "launch_private_stream");
+}
 #endif
 
 TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -236,6 +236,35 @@ TEST(ProcessRuntimeConfigTests, ExplicitForcePrivateAfterDesktopSteamShutdownAll
   EXPECT_EQ(policy.recommendedAction, "force_private_stream_after_desktop_steam_shutdown");
 }
 
+TEST(ProcessRuntimeConfigTests, ForcePrivateFlagWithoutPrivateStreamDoesNotEscalatePolicy) {
+  const auto policy = proc::resolve_desktop_launch_safety_policy_for_tests(
+    false,
+    false,
+    true,
+    true,
+    false,
+    true
+  );
+
+  EXPECT_TRUE(policy.desktopSteamActive);
+  EXPECT_FALSE(policy.canLaunchPrivateStream);
+  EXPECT_EQ(policy.recommendedAction, "launch_desktop_stream");
+}
+
+TEST(ProcessRuntimeConfigTests, ExplicitMirrorBeatsContradictoryForcePrivateFlag) {
+  const auto policy = proc::resolve_desktop_launch_safety_policy_for_tests(
+    true,
+    true,
+    true,
+    true,
+    false,
+    true
+  );
+
+  EXPECT_TRUE(policy.desktopSteamActive);
+  EXPECT_EQ(policy.recommendedAction, "mirror_desktop");
+}
+
 TEST(ProcessRuntimeConfigTests, DesktopSteamActiveRefusesUnsafePrivateSteamLaunch) {
   const auto policy = proc::resolve_desktop_launch_safety_policy_for_tests(
     true,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -184,8 +184,8 @@ TEST(ProcessRuntimeConfigTests, HeadlessCageSteamBigPictureSkipsHostShutdownUndo
 TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorRecognizesSteamWebHelper) {
   EXPECT_TRUE(proc::desktop_steam_client_process_for_tests(
     "steamwebhelper",
-    "/home/papi/.local/share/Steam/ubuntu12_64/steamwebhelper",
-    std::string("/home/papi/.local/share/Steam/ubuntu12_64/steamwebhelper") + char(0) + "-type=zygote"
+    "/opt/steam-test/Steam/ubuntu12_64/steamwebhelper",
+    std::string("/opt/steam-test/Steam/ubuntu12_64/steamwebhelper") + char(0) + "-type=zygote"
   ));
 }
 


### PR DESCRIPTION
## Summary
- Advertise desktop Steam launch policy to clients.
- Require explicit client choice when private stream could collide with desktop Steam on the physical session.
- Add explicit force-private launch mode that closes desktop Steam before private launch.
- Ignore zombie Steam shutdown remnants when deciding desktop Steam is active.

## Verification
- build/tests/test_polaris_config --gtest_filter=ProcessRuntimeConfigTests.DesktopSteamDetectorIgnoresZombieShutdownRemnant:ProcessRuntimeConfigTests.ExplicitForcePrivateAfterDesktopSteamShutdownAllowsPrivateLaunch:ProcessRuntimeConfigTests.DesktopSteamActiveOffersExplicitForcePrivateShutdown
- cmake --build build --target polaris -j 16 with CUDA 13.2, host compiler g++-15, arch 89
- End-to-end Retroid/Nova smoke previously verified: desktop Steam active decision path, Close desktop Steam and start private stream launches stream and leaves no steam or steamwebhelper processes.

## Notes
- Persistent /usr/bin deploy from this TUI profile is blocked by the SSH fish wrapper failing before sudo can run. The PR build itself is verified.
- Remaining human-side release smoke: physical monitor confirmation for Cancel, Mirror Desktop, and Close desktop Steam paths.
