### PR TITLE
fix: surface HDR downgrade truth

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1500,6 +1500,9 @@ namespace nvhttp {
       const bool capture_cpu_copy = stream_stats::capture_path_uses_cpu_copy(stats);
       const bool capture_gpu_native = stream_stats::capture_path_is_gpu_native(stats);
       const bool auto_quality_enabled = ai_auto_quality_enabled();
+      const auto hdr_effective_mode = stream_stats::hdr_effective_mode(stats);
+      const auto hdr_downgrade_reason = stream_stats::hdr_downgrade_reason(stats);
+      const auto hdr_downgrade_message = stream_stats::hdr_downgrade_message(stats);
       int target_bitrate_kbps = 0;
       std::string target_bitrate_source = "client_request";
       if (stats.adaptive_target_bitrate_kbps > 0) {
@@ -1541,7 +1544,7 @@ namespace nvhttp {
         append_stream_policy_warning(
           warnings,
           "hdr_downgraded",
-          "The client requested HDR, but the active capture path is not exposing HDR metadata; Polaris is reporting the stream as SDR."
+          hdr_downgrade_message
         );
       }
       if (device_profile && is_mobile_client_type(device_profile) &&
@@ -1599,6 +1602,9 @@ namespace nvhttp {
       policy["hdr_requested"] = stats.dynamic_range > 0;
       policy["hdr_active"] = stats.stream_hdr_enabled;
       policy["hdr_metadata_available"] = stats.hdr_metadata_available;
+      policy["hdr_effective_mode"] = hdr_effective_mode;
+      policy["hdr_downgrade_reason"] = hdr_downgrade_reason;
+      policy["hdr_downgrade_message"] = hdr_downgrade_message;
       const auto capture_reason_message = stream_stats::capture_path_reason_message(capture_reason);
       policy["capture_path"] = capture_path;
       policy["capture_path_reason"] = capture_reason;
@@ -1974,7 +1980,10 @@ namespace nvhttp {
         !build_has_cuda() &&
         capture_fallback;
       const bool encoder_risk = stats.encode_time_ms >= 11.0 || stats.avg_frame_age_ms >= 18.0;
-      const bool hdr_source_missing = stats.dynamic_range > 0 && !stats.stream_hdr_enabled;
+      const auto hdr_effective_mode = stream_stats::hdr_effective_mode(stats);
+      const auto hdr_downgrade_reason = stream_stats::hdr_downgrade_reason(stats);
+      const auto hdr_downgrade_message = stream_stats::hdr_downgrade_message(stats);
+      const bool hdr_source_missing = hdr_downgrade_reason != "none";
       const bool hdr_risk = stats.stream_hdr_enabled && (pacing_risk || encoder_risk);
       const bool decoder_risk =
         (active_codec_family == "av1" || stats.encode_target_format == platf::frame_format_e::p010) &&
@@ -2018,6 +2027,10 @@ namespace nvhttp {
         issues.push_back(capture_reason);
         recommendations.push_back(stream_stats::capture_path_reason_message(capture_reason));
       }
+      if (hdr_source_missing) {
+        issues.push_back("hdr_downgraded");
+        recommendations.push_back(hdr_downgrade_message);
+      }
       if (nvenc_cuda_disabled_path) {
         issues.push_back("nvenc_cuda_disabled");
         recommendations.push_back("Use a CUDA-enabled Polaris build/package before judging NVIDIA headless performance.");
@@ -2041,6 +2054,7 @@ namespace nvhttp {
 
       std::string primary_issue = "steady";
       if (network_risk) primary_issue = "network_jitter";
+      else if (hdr_source_missing) primary_issue = "hdr_downgraded";
       else if (hdr_risk) primary_issue = "hdr_path";
       else if (virtual_display_risk) primary_issue = "virtual_display_path";
       else if (decoder_risk) primary_issue = "decoder_path";
@@ -2052,6 +2066,7 @@ namespace nvhttp {
 
       const std::string limiting_factor =
         network_risk ? "network" :
+        hdr_source_missing ? "hdr" :
         hdr_risk ? "hdr" :
         virtual_display_risk ? "capture" :
         decoder_risk ? "decoder" :
@@ -2063,7 +2078,7 @@ namespace nvhttp {
         "none";
       const std::string auto_action =
         network_risk || encoder_risk ? "lower_bitrate" :
-        hdr_risk || virtual_display_risk || decoder_risk || nvenc_cuda_disabled_path || capture_fallback ? "suggest_recovery" :
+        hdr_source_missing || hdr_risk || virtual_display_risk || decoder_risk || nvenc_cuda_disabled_path || capture_fallback ? "suggest_recovery" :
         host_render_limited ? "lower_render_profile" :
         "none";
 
@@ -2073,6 +2088,7 @@ namespace nvhttp {
         static_cast<int>(capture_fallback) +
         static_cast<int>(nvenc_cuda_disabled_path) +
         static_cast<int>(encoder_risk) +
+        static_cast<int>(hdr_source_missing) +
         static_cast<int>(hdr_risk) +
         static_cast<int>(decoder_risk) +
         static_cast<int>(virtual_display_risk);
@@ -2132,6 +2148,7 @@ namespace nvhttp {
       health["summary"] =
         grade == "good" ? "Session looks steady." :
         network_risk ? "Network jitter is the most likely source of the hitching." :
+        hdr_source_missing ? hdr_downgrade_message :
         hdr_risk ? "The current HDR path looks unstable." :
         virtual_display_risk ? "The virtual display path is likely adding pacing overhead." :
         decoder_risk ? "The current codec path looks harder on this client than expected." :
@@ -2147,6 +2164,9 @@ namespace nvhttp {
         health["safe_target_fps"] = static_cast<int>(std::round(safe_target_fps));
       }
       health["safe_hdr"] = stats.stream_hdr_enabled && !hdr_risk;
+      health["hdr_effective_mode"] = hdr_effective_mode;
+      health["hdr_downgrade_reason"] = hdr_downgrade_reason;
+      health["hdr_downgrade_message"] = hdr_downgrade_message;
       health["decoder_risk"] = decoder_risk ? "elevated" : "normal";
       health["hdr_risk"] = hdr_risk ? "elevated" : "normal";
       health["hdr_source"] = hdr_source_missing ? "missing" : (stats.stream_hdr_enabled ? "metadata" : "sdr");
@@ -2165,7 +2185,7 @@ namespace nvhttp {
       health["capture_gpu_native"] = stream_stats::capture_path_is_gpu_native(stats);
       health["active_encoder"] = active_encoder_name.empty() ? "unknown" : active_encoder_name;
       health["cuda_build"] = build_has_cuda();
-      health["relaunch_recommended"] = hdr_risk || decoder_risk || virtual_display_risk ||
+      health["relaunch_recommended"] = hdr_source_missing || hdr_risk || decoder_risk || virtual_display_risk ||
         nvenc_cuda_disabled_path || safe_target_fps > 0.0;
       if (safe_codec) {
         health["safe_codec"] = *safe_codec;
@@ -2195,6 +2215,14 @@ namespace nvhttp {
                                                     const stream_stats::stats_t &stats,
                                                     const nlohmann::json &health) {
     return build_stream_policy_json(client, stats, health);
+  }
+
+
+  nlohmann::json build_session_health_json_for_tests(const stream_stats::stats_t &stats,
+                                                   bool current_virtual_display,
+                                                   const std::string &device_name,
+                                                   const std::string &app_name) {
+    return build_session_health_json(stats, current_virtual_display, device_name, app_name);
   }
 
 #if defined(__linux__)
@@ -4871,6 +4899,9 @@ namespace nvhttp {
       hdr["metadata_available"] = stats.hdr_metadata_available;
       hdr["stream_hdr_enabled"] = stats.stream_hdr_enabled;
       hdr["color_coding"] = stats.color_coding;
+      hdr["effective_mode"] = stream_stats::hdr_effective_mode(stats);
+      hdr["downgrade_reason"] = stream_stats::hdr_downgrade_reason(stats);
+      hdr["downgrade_message"] = stream_stats::hdr_downgrade_message(stats);
       output["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
       output["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
       output["adaptive_bitrate_state"] = adaptive_state.state;

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -329,6 +329,10 @@ namespace nvhttp {
   nlohmann::json build_stream_policy_json_for_tests(const crypto::named_cert_t &client,
                                                     const stream_stats::stats_t &stats,
                                                     const nlohmann::json &health);
+  nlohmann::json build_session_health_json_for_tests(const stream_stats::stats_t &stats,
+                                                   bool current_virtual_display,
+                                                   const std::string &device_name,
+                                                   const std::string &app_name);
 #if defined(__linux__)
   proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy_for_tests(
     const args_t &args,

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -143,6 +143,9 @@ namespace stream_stats {
     j["hdr_metadata_available"] = hdr_metadata_available;
     j["stream_hdr_enabled"] = stream_hdr_enabled;
     j["color_coding"] = color_coding;
+    j["hdr_effective_mode"] = hdr_effective_mode(*this);
+    j["hdr_downgrade_reason"] = hdr_downgrade_reason(*this);
+    j["hdr_downgrade_message"] = hdr_downgrade_message(*this);
     j["fps"] = fps;
     j["requested_client_fps"] = requested_client_fps;
     j["session_target_fps"] = session_target_fps;
@@ -343,8 +346,46 @@ namespace stream_stats {
     }
     if (reason == "no_capture_metadata") {
       return "No capture metadata has been reported yet.";
+
     }
     return "The active capture and encoder path is mixed or not fully classified.";
+  }
+
+  std::string hdr_effective_mode(const stats_t &stats) {
+    if (stats.dynamic_range > 0 && stats.stream_hdr_enabled) {
+      return "hdr10";
+    }
+    if (stats.dynamic_range > 0) {
+      return "sdr_10bit";
+    }
+    return "sdr_8bit";
+  }
+
+  std::string hdr_downgrade_reason(const stats_t &stats) {
+    if (stats.dynamic_range <= 0 || stats.stream_hdr_enabled) {
+      return "none";
+    }
+    if (!stats.display_hdr) {
+      return "display_not_hdr";
+    }
+    if (!stats.hdr_metadata_available) {
+      return "hdr_metadata_missing";
+    }
+    return "stream_hdr_disabled";
+  }
+
+  std::string hdr_downgrade_message(const stats_t &stats) {
+    const auto reason = hdr_downgrade_reason(stats);
+    if (reason == "none") {
+      return {};
+    }
+    if (reason == "display_not_hdr") {
+      return "The client requested HDR, but the active capture display is not reporting HDR. Polaris is streaming 10-bit SDR, not HDR.";
+    }
+    if (reason == "hdr_metadata_missing") {
+      return "The client requested HDR, but the active capture display did not expose HDR10 metadata. Polaris is streaming 10-bit SDR, not HDR.";
+    }
+    return "The client requested HDR, but Polaris did not advertise HDR for this stream. Polaris is streaming 10-bit SDR, not HDR.";
   }
 
   void update_stream_active(bool active, const std::string &client_name, const std::string &client_ip) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -152,6 +152,24 @@ namespace stream_stats {
   std::string capture_path_reason_message(const std::string &reason);
 
   /**
+   * @brief Effective dynamic range mode Polaris is advertising for the stream.
+   * @param stats Current stream statistics snapshot.
+   */
+  std::string hdr_effective_mode(const stats_t &stats);
+
+  /**
+   * @brief Machine-readable reason when a requested HDR stream was downgraded.
+   * @param stats Current stream statistics snapshot.
+   */
+  std::string hdr_downgrade_reason(const stats_t &stats);
+
+  /**
+   * @brief Human-readable HDR downgrade explanation for diagnostics and clients.
+   * @param stats Current stream statistics snapshot.
+   */
+  std::string hdr_downgrade_message(const stats_t &stats);
+
+  /**
    * @brief Update stream active state.
    * @param active Whether streaming is active.
    * @param client_name Name of the connected client.

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -126,6 +126,55 @@ TEST(ProcessRuntimeConfigTests, MissionControlPolicyDoesNotUseDeviceDbBitrateWhe
   EXPECT_EQ(policy.value("target_bitrate_source", std::string {}), "client_request");
 }
 
+
+TEST(ProcessRuntimeConfigTests, StreamPolicySurfacesHdrDowngradeEffectiveMode) {
+  crypto::named_cert_t client {};
+  client.name = "Nova Client";
+
+  stream_stats::stats_t stats {};
+  stats.dynamic_range = 1;
+  stats.display_hdr = false;
+  stats.hdr_metadata_available = false;
+  stats.stream_hdr_enabled = false;
+  stats.color_coding = "SDR (Rec. 709)";
+
+  const auto policy = nvhttp::build_stream_policy_json_for_tests(
+    client,
+    stats,
+    nlohmann::json::object()
+  );
+
+  EXPECT_TRUE(policy.value("hdr_requested", false));
+  EXPECT_FALSE(policy.value("hdr_active", true));
+  EXPECT_EQ(policy.value("hdr_effective_mode", std::string {}), "sdr_10bit");
+  EXPECT_EQ(policy.value("hdr_downgrade_reason", std::string {}), "display_not_hdr");
+  EXPECT_NE(policy.dump().find("10-bit SDR, not HDR"), std::string::npos);
+  EXPECT_NE(policy.dump().find("hdr_downgraded"), std::string::npos);
+}
+
+TEST(ProcessRuntimeConfigTests, SessionHealthFlagsHdrSourceMissingAsActionableIssue) {
+  stream_stats::stats_t stats {};
+  stats.dynamic_range = 1;
+  stats.display_hdr = false;
+  stats.hdr_metadata_available = false;
+  stats.stream_hdr_enabled = false;
+  stats.color_coding = "SDR (Rec. 709)";
+
+  const auto health = nvhttp::build_session_health_json_for_tests(
+    stats,
+    false,
+    "Nova Client",
+    "Steam Big Picture"
+  );
+
+  EXPECT_EQ(health.value("primary_issue", std::string {}), "hdr_downgraded");
+  EXPECT_EQ(health.value("grade", std::string {}), "watch");
+  EXPECT_EQ(health.value("limiting_factor", std::string {}), "hdr");
+  EXPECT_EQ(health.value("hdr_effective_mode", std::string {}), "sdr_10bit");
+  EXPECT_EQ(health.value("hdr_downgrade_reason", std::string {}), "display_not_hdr");
+  EXPECT_NE(health.dump().find("10-bit SDR, not HDR"), std::string::npos);
+  EXPECT_NE(health.dump().find("hdr_downgraded"), std::string::npos);
+}
 TEST(ProcessRuntimeConfigTests, InitialTerminateDoesNotResetAdaptiveBitrateMax) {
 #ifdef __linux__
   linux_cage_compositor_guard_t linux_guard;

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -95,6 +95,47 @@ TEST(StreamStatsCapturePathTests, SerializesCaptureDecisionDiagnostics) {
   EXPECT_FALSE(decision.at("gpu_native_override_active"));
 }
 
+
+TEST(StreamStatsHdrStateTests, LabelsRequestedHdrWithoutSourceAsTenBitSdr) {
+  stream_stats::stats_t stats {};
+  stats.dynamic_range = 1;
+  stats.display_hdr = false;
+  stats.hdr_metadata_available = false;
+  stats.stream_hdr_enabled = false;
+  stats.color_coding = "SDR (Rec. 709)";
+
+  EXPECT_EQ(stream_stats::hdr_effective_mode(stats), "sdr_10bit");
+  EXPECT_EQ(stream_stats::hdr_downgrade_reason(stats), "display_not_hdr");
+  EXPECT_NE(
+    stream_stats::hdr_downgrade_message(stats).find("10-bit SDR, not HDR"),
+    std::string::npos
+  );
+
+  const auto json = nlohmann::json::parse(stats.to_json());
+  EXPECT_EQ(json.at("hdr_effective_mode"), "sdr_10bit");
+  EXPECT_EQ(json.at("hdr_downgrade_reason"), "display_not_hdr");
+  EXPECT_NE(
+    json.at("hdr_downgrade_message").get<std::string>().find("10-bit SDR, not HDR"),
+    std::string::npos
+  );
+}
+
+TEST(StreamStatsHdrStateTests, LabelsTrueHdrAndPlainSdrWithoutDowngrade) {
+  stream_stats::stats_t hdr_stats {};
+  hdr_stats.dynamic_range = 1;
+  hdr_stats.display_hdr = true;
+  hdr_stats.hdr_metadata_available = true;
+  hdr_stats.stream_hdr_enabled = true;
+
+  EXPECT_EQ(stream_stats::hdr_effective_mode(hdr_stats), "hdr10");
+  EXPECT_EQ(stream_stats::hdr_downgrade_reason(hdr_stats), "none");
+  EXPECT_TRUE(stream_stats::hdr_downgrade_message(hdr_stats).empty());
+
+  stream_stats::stats_t sdr_stats {};
+  EXPECT_EQ(stream_stats::hdr_effective_mode(sdr_stats), "sdr_8bit");
+  EXPECT_EQ(stream_stats::hdr_downgrade_reason(sdr_stats), "none");
+}
+
 TEST(StreamStatsCapturePathTests, ExplainsGpuNativeShmFallback) {
   LinuxDisplayConfigGuard guard;
   config::video.linux_display.use_cage_compositor = true;


### PR DESCRIPTION
## Summary
- Adds canonical HDR effective mode/reason/message helpers to stream stats.
- Surfaces HDR downgrade truth through stream policy, session health, and session HDR JSON.
- Marks requested-HDR-but-SDR-source sessions as actionable hdr_downgraded health warnings.

## Test plan
- CC=clang CXX=clang++ cmake -S . -B build-clang -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_FULL_TESTS=ON -DPOLARIS_ENABLE_CUDA=OFF -DPOLARIS_ALLOW_CUDA_DISABLED_ON_NVIDIA=ON
- cmake --build build-clang --target test_polaris_full -- -j2
- ./build-clang/tests/test_polaris_stream
- ./build-clang/tests/test_polaris_config --gtest_filter=ProcessRuntimeConfigTests.StreamPolicySurfacesHdrDowngradeEffectiveMode:ProcessRuntimeConfigTests.SessionHealthFlagsHdrSourceMissingAsActionableIssue
- git diff --check
