### PR TITLE
fix: clarify private headless HDR downgrade

### DIFF
--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -366,6 +366,9 @@ namespace stream_stats {
       return "none";
     }
     if (!stats.display_hdr) {
+      if (stats.runtime_effective_headless) {
+        return "headless_hdr_unavailable";
+      }
       return "display_not_hdr";
     }
     if (!stats.hdr_metadata_available) {
@@ -378,6 +381,9 @@ namespace stream_stats {
     const auto reason = hdr_downgrade_reason(stats);
     if (reason == "none") {
       return {};
+    }
+    if (reason == "headless_hdr_unavailable") {
+      return "The client requested HDR, but Private Headless Stream is using a compositor output that does not report HDR. Polaris is streaming 10-bit SDR, not HDR; use a physical or virtual HDR-capable display path for true HDR.";
     }
     if (reason == "display_not_hdr") {
       return "The client requested HDR, but the active capture display is not reporting HDR. Polaris is streaming 10-bit SDR, not HDR.";

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -175,6 +175,30 @@ TEST(ProcessRuntimeConfigTests, SessionHealthFlagsHdrSourceMissingAsActionableIs
   EXPECT_NE(health.dump().find("10-bit SDR, not HDR"), std::string::npos);
   EXPECT_NE(health.dump().find("hdr_downgraded"), std::string::npos);
 }
+
+TEST(ProcessRuntimeConfigTests, SessionHealthFlagsHeadlessHdrUnavailableSeparately) {
+  stream_stats::stats_t stats {};
+  stats.dynamic_range = 1;
+  stats.runtime_effective_headless = true;
+  stats.display_hdr = false;
+  stats.hdr_metadata_available = false;
+  stats.stream_hdr_enabled = false;
+  stats.color_coding = "SDR (Rec. 709)";
+
+  const auto health = nvhttp::build_session_health_json_for_tests(
+    stats,
+    false,
+    "Nova Client",
+    "Steam Big Picture"
+  );
+
+  EXPECT_EQ(health.value("primary_issue", std::string {}), "hdr_downgraded");
+  EXPECT_EQ(health.value("hdr_effective_mode", std::string {}), "sdr_10bit");
+  EXPECT_EQ(health.value("hdr_downgrade_reason", std::string {}), "headless_hdr_unavailable");
+  EXPECT_NE(health.dump().find("Private Headless Stream"), std::string::npos);
+  EXPECT_NE(health.dump().find("physical or virtual HDR-capable display path"), std::string::npos);
+}
+
 TEST(ProcessRuntimeConfigTests, InitialTerminateDoesNotResetAdaptiveBitrateMax) {
 #ifdef __linux__
   linux_cage_compositor_guard_t linux_guard;

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -120,6 +120,28 @@ TEST(StreamStatsHdrStateTests, LabelsRequestedHdrWithoutSourceAsTenBitSdr) {
   );
 }
 
+TEST(StreamStatsHdrStateTests, LabelsRequestedHdrOnHeadlessAsHeadlessUnavailable) {
+  stream_stats::stats_t stats {};
+  stats.dynamic_range = 1;
+  stats.runtime_effective_headless = true;
+  stats.display_hdr = false;
+  stats.hdr_metadata_available = false;
+  stats.stream_hdr_enabled = false;
+  stats.color_coding = "SDR (Rec. 709)";
+
+  EXPECT_EQ(stream_stats::hdr_effective_mode(stats), "sdr_10bit");
+  EXPECT_EQ(stream_stats::hdr_downgrade_reason(stats), "headless_hdr_unavailable");
+  EXPECT_NE(
+    stream_stats::hdr_downgrade_message(stats).find("Private Headless Stream"),
+    std::string::npos
+  );
+
+  const auto json = nlohmann::json::parse(stats.to_json());
+  EXPECT_EQ(json.at("hdr_effective_mode"), "sdr_10bit");
+  EXPECT_EQ(json.at("hdr_downgrade_reason"), "headless_hdr_unavailable");
+  EXPECT_NE(json.dump().find("physical or virtual HDR-capable display path"), std::string::npos);
+}
+
 TEST(StreamStatsHdrStateTests, LabelsTrueHdrAndPlainSdrWithoutDowngrade) {
   stream_stats::stats_t hdr_stats {};
   hdr_stats.dynamic_range = 1;


### PR DESCRIPTION
## Summary

- Adds headless-specific hdr_downgrade_reason=headless_hdr_unavailable when HDR is requested but the effective runtime is headless and the capture display does not report HDR.
- Preserves the generic display_not_hdr reason for non-headless SDR capture displays.
- Adds stream stats and session health coverage so Nova Command Center can explain that Private Headless Stream needs a physical or virtual HDR-capable display path for true HDR.

## Spike verdict

- Current private labwc HEADLESS-1 path cannot produce true HDR just because Nova sends hdrMode=1.
- Polaris correctly gates Rec.2020/PQ HDR on display_hdr plus usable HDR10 metadata.
- Live evidence showed HEADLESS-1 reporting no HDR and no HDR metadata, so Polaris streamed 10-bit SDR.
- wayland-info on the private labwc socket showed screencopy, DMA-BUF, ext-image-copy, and gamma control, but no Wayland color-management/HDR protocol for HEADLESS-1.
- The physical KDE socket did advertise color-management protocols, making physical/KDE HDR capture the likely future experiment.

## Verification

- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPOLARIS_ENABLE_CUDA=OFF -DPOLARIS_ALLOW_CUDA_DISABLED_ON_NVIDIA=ON -DBUILD_TESTS=ON -DBUILD_FULL_TESTS=ON
- cmake --build build --target test_polaris_config test_polaris_stream -j32
- build/tests/test_polaris_stream --gtest_filter=StreamStatsHdrStateTests.* : 3 passed
- build/tests/test_polaris_config --gtest_filter=ProcessRuntimeConfigTests.SessionHealthFlags*Hdr* : 2 passed
- git diff --check

Stacked on PR #154. Do not merge before #154.

