### PR TITLE
fix(linux): keep virtual gamepads isolated in headless launches

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -518,6 +518,58 @@ namespace nvhttp {
 #endif
     }
 
+    nlohmann::json build_launch_mode_contract(bool app_prefers_virtual_display,
+                                              std::string_view app_name,
+                                              bool virtual_display_available,
+                                              bool prefers_headless) {
+      // preferred_mode reflects the per-game stored preference; recommended_mode reflects
+      // the Polaris-supported launch mode clients should choose for this host right now.
+      const std::string preferred_mode = app_prefers_virtual_display ? "host_virtual_display" : "headless_stream";
+      std::string recommended_mode = preferred_mode;
+      std::string mode_reason;
+
+      auto allowed_modes = nlohmann::json::array();
+      allowed_modes.push_back("headless_stream");
+      allowed_modes.push_back("desktop_display");
+      allowed_modes.push_back("windowed_stream");
+      if (virtual_display_available) {
+        allowed_modes.push_back("host_virtual_display");
+      }
+
+      const bool steam_big_picture = boost::iequals(boost::trim_copy(std::string {app_name}), "Steam Big Picture");
+
+      if (prefers_headless) {
+        recommended_mode = "headless_stream";
+        mode_reason = app_prefers_virtual_display ?
+          "This app prefers Host Virtual Display, but this Polaris host is already configured for Headless Stream, so Headless Stream is recommended." :
+          "Headless Stream is recommended because this Polaris host is already configured for headless streaming.";
+      } else if (app_prefers_virtual_display && virtual_display_available) {
+        recommended_mode = "host_virtual_display";
+        mode_reason = steam_big_picture ?
+          "Steam Big Picture is configured to prefer a dedicated virtual display on this host." :
+          "This app is configured to prefer a dedicated virtual display on the host.";
+      } else if (app_prefers_virtual_display && !virtual_display_available) {
+        recommended_mode = "headless_stream";
+        mode_reason =
+          "This app prefers Host Virtual Display, but Polaris does not currently have a virtual display backend available, so Headless Stream is recommended.";
+      } else if (virtual_display_available) {
+        recommended_mode = "headless_stream";
+        mode_reason =
+          "This app defaults to Headless Stream. Host Virtual Display is available when you want a dedicated display for the session.";
+      } else {
+        recommended_mode = "headless_stream";
+        mode_reason =
+          "This app defaults to Headless Stream on this host.";
+      }
+
+      nlohmann::json launch_mode;
+      launch_mode["preferred_mode"] = preferred_mode;
+      launch_mode["recommended_mode"] = recommended_mode;
+      launch_mode["allowed_modes"] = std::move(allowed_modes);
+      launch_mode["mode_reason"] = mode_reason;
+      return launch_mode;
+    }
+
     bool build_has_cuda() {
 #ifdef POLARIS_BUILD_CUDA
       return true;
@@ -2225,6 +2277,18 @@ namespace nvhttp {
     return build_session_health_json(stats, current_virtual_display, device_name, app_name);
   }
 
+  nlohmann::json build_launch_mode_contract_for_tests(bool app_prefers_virtual_display,
+                                                      const std::string &app_name,
+                                                      bool host_virtual_display_available,
+                                                      bool host_prefers_headless) {
+    return build_launch_mode_contract(
+      app_prefers_virtual_display,
+      app_name,
+      host_virtual_display_available,
+      host_prefers_headless
+    );
+  }
+
 #if defined(__linux__)
   proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy_for_tests(
     const args_t &args,
@@ -2497,50 +2561,12 @@ namespace nvhttp {
     }
 
     nlohmann::json launch_mode_contract_for_app(const proc::ctx_t &app) {
-      const bool app_prefers_virtual_display = app.virtual_display;
-      const std::string preferred_mode = app_prefers_virtual_display ? "host_virtual_display" : "headless_stream";
-      std::string recommended_mode = preferred_mode;
-      std::string mode_reason;
-
-      auto allowed_modes = nlohmann::json::array();
-      allowed_modes.push_back("headless_stream");
-      allowed_modes.push_back("desktop_display");
-      allowed_modes.push_back("windowed_stream");
-      if (host_virtual_display_available()) {
-        allowed_modes.push_back("host_virtual_display");
-      }
-
-      const bool steam_big_picture = boost::iequals(boost::trim_copy(app.name), "Steam Big Picture");
-
-      if (app_prefers_virtual_display && host_virtual_display_available()) {
-        recommended_mode = "host_virtual_display";
-        mode_reason = steam_big_picture ?
-          "Steam Big Picture is configured to prefer a dedicated virtual display on this host." :
-          "This app is configured to prefer a dedicated virtual display on the host.";
-      } else if (app_prefers_virtual_display && !host_virtual_display_available()) {
-        recommended_mode = "headless_stream";
-        mode_reason =
-          "This app prefers Host Virtual Display, but Polaris does not currently have a virtual display backend available, so Headless Stream is recommended.";
-      } else if (host_prefers_headless()) {
-        recommended_mode = "headless_stream";
-        mode_reason =
-          "Headless Stream is recommended because this Polaris host is already configured for headless streaming.";
-      } else if (host_virtual_display_available()) {
-        recommended_mode = "headless_stream";
-        mode_reason =
-          "This app defaults to Headless Stream. Host Virtual Display is available when you want a dedicated display for the session.";
-      } else {
-        recommended_mode = "headless_stream";
-        mode_reason =
-          "This app defaults to Headless Stream on this host.";
-      }
-
-      nlohmann::json launch_mode;
-      launch_mode["preferred_mode"] = preferred_mode;
-      launch_mode["recommended_mode"] = recommended_mode;
-      launch_mode["allowed_modes"] = std::move(allowed_modes);
-      launch_mode["mode_reason"] = mode_reason;
-      return launch_mode;
+      return build_launch_mode_contract(
+        app.virtual_display,
+        app.name,
+        host_virtual_display_available(),
+        host_prefers_headless()
+      );
     }
 
     nlohmann::json steam_launch_contract_for_app(const proc::ctx_t &app) {

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -333,6 +333,10 @@ namespace nvhttp {
                                                    bool current_virtual_display,
                                                    const std::string &device_name,
                                                    const std::string &app_name);
+  nlohmann::json build_launch_mode_contract_for_tests(bool app_prefers_virtual_display,
+                                                      const std::string &app_name,
+                                                      bool host_virtual_display_available,
+                                                      bool host_prefers_headless);
 #if defined(__linux__)
   proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy_for_tests(
     const args_t &args,

--- a/src/platform/linux/input/inputtino_gamepad_isolation.cpp
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.cpp
@@ -188,6 +188,80 @@ namespace {
     return std::vector<std::string>(paths.begin(), paths.end());
   }
 
+  std::optional<std::string> virtual_input_sysfs_root(std::string_view sysfs_path) {
+    if (!is_safe_sysfs_path(sysfs_path)) {
+      return std::nullopt;
+    }
+
+    constexpr std::string_view input_dir_marker = "/input/";
+    const auto input_dir_pos = sysfs_path.find(input_dir_marker);
+    if (input_dir_pos == std::string_view::npos) {
+      return std::nullopt;
+    }
+
+    const auto input_device_start = input_dir_pos + input_dir_marker.size();
+    if (!starts_with(sysfs_path.substr(input_device_start), "input")) {
+      return std::nullopt;
+    }
+
+    auto input_device_end = sysfs_path.find("/", input_device_start);
+    if (input_device_end == std::string_view::npos) {
+      input_device_end = sysfs_path.size();
+    }
+
+    return std::string(sysfs_path.substr(0, input_device_end));
+  }
+
+  std::optional<std::string> input_class_sysfs_path_for_node(std::string_view node) {
+    constexpr std::string_view input_prefix = "/dev/input/";
+    if (!starts_with(node, input_prefix)) {
+      return std::nullopt;
+    }
+    if (!has_numeric_suffix(node, "/dev/input/event") && !has_numeric_suffix(node, "/dev/input/js")) {
+      return std::nullopt;
+    }
+    return std::string("/sys/class/input/") + std::string(node.substr(input_prefix.size()));
+  }
+
+  std::optional<std::string> hidraw_class_sysfs_path_for_node(std::string_view node) {
+    constexpr std::string_view dev_prefix = "/dev/";
+    if (!starts_with(node, dev_prefix) || !has_numeric_suffix(node, "/dev/hidraw")) {
+      return std::nullopt;
+    }
+    return std::string("/sys/class/hidraw/") + std::string(node.substr(dev_prefix.size()));
+  }
+
+  std::vector<std::string> virtual_gamepad_sysfs_bind_paths(
+    const std::vector<classified_device_t> &devices,
+    const std::vector<std::string> &allowed_nodes
+  ) {
+    std::set<std::string> paths;
+    std::set<std::string> allowed(allowed_nodes.begin(), allowed_nodes.end());
+
+    for (const auto &node : allowed_nodes) {
+      if (auto path = input_class_sysfs_path_for_node(node)) {
+        paths.insert(*path);
+      }
+      if (auto path = hidraw_class_sysfs_path_for_node(node)) {
+        paths.insert(*path);
+      }
+    }
+
+    for (const auto &classified : devices) {
+      if (classified.classification != device_classification_e::polaris_virtual) {
+        continue;
+      }
+      if (classified.device.event_node.empty() || !allowed.contains(classified.device.event_node)) {
+        continue;
+      }
+      if (auto root = virtual_input_sysfs_root(classified.device.sysfs_path)) {
+        paths.insert(*root);
+      }
+    }
+
+    return std::vector<std::string>(paths.begin(), paths.end());
+  }
+
   std::string event_sysfs_path(std::string_view event_node) {
     constexpr std::string_view input_prefix = "/dev/input/";
     if (!starts_with(event_node, input_prefix)) {
@@ -421,6 +495,17 @@ strict_gamepad_isolation_plan_t build_strict_gamepad_isolation_plan(
   plan.allowed_nodes = sanitized_virtual_nodes(registered_virtual_nodes);
   plan.masked_sysfs_paths = host_input_sysfs_mask_paths(devices);
 
+  plan.allowed_sysfs_paths = virtual_gamepad_sysfs_bind_paths(devices, plan.allowed_nodes);
+
+  const bool has_host_visible_controller = std::any_of(devices.begin(), devices.end(), [](const auto &device) {
+    return device.classification == device_classification_e::host_visible;
+  });
+  if (!has_host_visible_controller && plan.allowed_nodes.empty()) {
+    plan.mode = isolation_mode_e::disabled;
+    plan.reason = "gamepad_isolation: no host physical controllers or registered Polaris virtual nodes visible; leaving launch unwrapped";
+    return plan;
+  }
+
   if (!options.bubblewrap_available || !options.bubblewrap_usable) {
     const auto unavailable_reason = options.bubblewrap_available ?
                                       std::string("bubblewrap probe failed") :
@@ -487,6 +572,13 @@ std::string command_with_headless_gamepad_isolation(const std::string &command, 
 
   for (const auto &path : plan.masked_sysfs_paths) {
     wrapped += " --tmpfs ";
+    wrapped += path;
+  }
+
+  for (const auto &path : plan.allowed_sysfs_paths) {
+    wrapped += " --ro-bind-try ";
+    wrapped += path;
+    wrapped += " ";
     wrapped += path;
   }
 
@@ -582,6 +674,8 @@ strict_gamepad_isolation_plan_t prepare_headless_labwc_launch() {
                   << registered_nodes.size();
 
   if (plan.strict_applied()) {
+    BOOST_LOG(info) << plan.reason;
+  } else if (plan.mode == isolation_mode_e::disabled) {
     BOOST_LOG(info) << plan.reason;
   } else {
     BOOST_LOG(warning) << plan.reason;

--- a/src/platform/linux/input/inputtino_gamepad_isolation.h
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.h
@@ -61,6 +61,7 @@ namespace platf::gamepad::isolation {
     std::string bubblewrap_path = "bwrap";
     std::vector<std::string> allowed_nodes;
     std::vector<std::string> masked_sysfs_paths;
+    std::vector<std::string> allowed_sysfs_paths;
     sdl_hint_plan_t fallback_sdl;
     std::string reason;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,7 @@ set(TEST_PAIRING_SOURCES
 
 set(TEST_HTTP_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_httpcommon.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_mode_contract.cpp
 )
 
 set(TEST_NETWORK_SOURCES

--- a/tests/unit/platform/test_gamepad_isolation.cpp
+++ b/tests/unit/platform/test_gamepad_isolation.cpp
@@ -205,7 +205,7 @@ TEST(GamepadIsolationTests, SdlEnvPrefixUsesShellSafeQuoting) {
   EXPECT_EQ(expected, command_with_sdl_env_prefix("steam --gamepadui", plan));
 }
 
-TEST(GamepadIsolationTests, StrictPlanAppliesEvenWhenNoHostControllersCurrentlyVisible) {
+TEST(GamepadIsolationTests, RegisteredVirtualNodesKeepStrictWrapperActiveWhenNoHostPadIsVisibleYet) {
   const auto devices = classify_devices({
     gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea}),
   });
@@ -215,10 +215,15 @@ TEST(GamepadIsolationTests, StrictPlanAppliesEvenWhenNoHostControllersCurrentlyV
     {"/dev/input/event42", "/dev/input/js42"},
     strict_options()
   );
+  const auto command = command_with_headless_gamepad_isolation("steam --gamepadui", plan);
 
   EXPECT_EQ(isolation_mode_e::strict_bwrap, plan.mode);
   EXPECT_TRUE(plan.strict_applied());
-  EXPECT_TRUE(text_contains(plan.reason, "strict"));
+  EXPECT_TRUE(text_contains(command, "--tmpfs /run/udev"));
+  EXPECT_TRUE(text_contains(command, "--tmpfs /sys/class/input"));
+  EXPECT_TRUE(text_contains(command, "--dev-bind /dev/input/event42 /dev/input/event42"));
+  EXPECT_TRUE(text_contains(command, "--dev-bind /dev/input/js42 /dev/input/js42"));
+  EXPECT_TRUE(text_contains(plan.reason, "binding 2 registered Polaris virtual gamepad node"));
 }
 
 TEST(GamepadIsolationTests, StrictPlanWithNoRegisteredNodesStillHidesHostDevices) {
@@ -287,8 +292,10 @@ TEST(GamepadIsolationTests, VirtualNameAloneDoesNotCreateStrictBindWhenRegistryD
   auto virtual_pad = gamepad("Polaris X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
   virtual_pad.event_node = "/dev/input/event20";
 
+  auto host = gamepad("Logitech Gamepad F310", std::optional<uint16_t> {0x046d}, std::optional<uint16_t> {0xc216});
+  host.event_node = "/dev/input/event3";
   const auto plan = build_strict_gamepad_isolation_plan(
-    classify_devices({virtual_pad}),
+    classify_devices({host, virtual_pad}),
     {"/dev/input/event21"},
     strict_options()
   );
@@ -346,8 +353,10 @@ TEST(GamepadIsolationTests, FailedBubblewrapProbeFallsBackHonestlyToSdlHints) {
 TEST(GamepadIsolationTests, StrictWrapperRejectsMalformedVirtualNodesAndQuotesBwrapPath) {
   auto options = strict_options();
   options.bubblewrap_path = "/tmp/bwrap helper";
+  auto host = gamepad("Logitech Gamepad F310", std::optional<uint16_t> {0x046d}, std::optional<uint16_t> {0xc216});
+  host.event_node = "/dev/input/event3";
   const auto plan = build_strict_gamepad_isolation_plan(
-    classify_devices({gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
+    classify_devices({host, gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
     {"/dev/input/event9;touch /tmp/polaris-pwned", "/dev/input/js9", "/dev/hidraw9;echo nope", "/dev/hidraw9"},
     options
   );
@@ -367,8 +376,10 @@ TEST(GamepadIsolationTests, StrictWrapperRejectsMalformedVirtualNodesAndQuotesBw
 
 TEST(GamepadIsolationTests, StrictWrapperQuotesOriginalCommandSafely) {
   const auto quote = std::string(1, static_cast<char>(39));
+  auto host = gamepad("Logitech Gamepad F310", std::optional<uint16_t> {0x046d}, std::optional<uint16_t> {0xc216});
+  host.event_node = "/dev/input/event3";
   const auto plan = build_strict_gamepad_isolation_plan(
-    classify_devices({gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
+    classify_devices({host, gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
     {"/dev/input/event9"},
     strict_options()
   );
@@ -395,8 +406,10 @@ TEST(GamepadIsolationTests, StrictWrapperDoesNotExposeBroadInputOrHidrawPaths) {
 }
 
 TEST(GamepadIsolationTests, StrictWrapperHidesHostUdevAndInputSysfsMetadata) {
+  auto host = gamepad("Logitech Gamepad F310", std::optional<uint16_t> {0x046d}, std::optional<uint16_t> {0xc216});
+  host.event_node = "/dev/input/event3";
   const auto plan = build_strict_gamepad_isolation_plan(
-    classify_devices({gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
+    classify_devices({host, gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
     {"/dev/input/event9"},
     strict_options()
   );
@@ -426,12 +439,16 @@ TEST(GamepadIsolationTests, StrictWrapperMasksHostSysfsInputDeviceRoots) {
   const auto command = command_with_headless_gamepad_isolation("steam", plan);
 
   EXPECT_TRUE(text_contains(command, "--tmpfs /sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1:1.0/input/input41"));
-  EXPECT_TRUE(text_lacks(command, "/sys/devices/virtual/input/input99"));
+  EXPECT_TRUE(text_contains(command, "--ro-bind-try /sys/devices/virtual/input/input99 /sys/devices/virtual/input/input99"));
+  EXPECT_TRUE(text_contains(command, "--ro-bind-try /sys/class/input/event99 /sys/class/input/event99"));
+  EXPECT_TRUE(text_contains(command, "--ro-bind-try /sys/class/input/js99 /sys/class/input/js99"));
 }
 
 TEST(GamepadIsolationTests, StrictWrapperMasksHostHidBusMetadata) {
+  auto host = gamepad("Logitech Gamepad F310", std::optional<uint16_t> {0x046d}, std::optional<uint16_t> {0xc216});
+  host.event_node = "/dev/input/event3";
   const auto plan = build_strict_gamepad_isolation_plan(
-    classify_devices({gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
+    classify_devices({host, gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea})}),
     {"/dev/input/event9"},
     strict_options()
   );

--- a/tests/unit/test_launch_mode_contract.cpp
+++ b/tests/unit/test_launch_mode_contract.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file tests/unit/test_launch_mode_contract.cpp
+ * @brief Tests for the Polaris v1 game launch-mode recommendation contract.
+ */
+
+#include <src/nvhttp.h>
+
+#include <gtest/gtest.h>
+
+TEST(LaunchModeContractTests, HostHeadlessConfigurationWinsOverPerGameVirtualDisplayPreference) {
+  const auto contract = nvhttp::build_launch_mode_contract_for_tests(
+    true,
+    "Indiana Jones and the Great Circle",
+    true,
+    true
+  );
+
+  EXPECT_EQ(contract.at("preferred_mode"), "host_virtual_display");
+  EXPECT_EQ(contract.at("recommended_mode"), "headless_stream");
+  bool allowed_host_virtual_display = false;
+  for (const auto &mode : contract.at("allowed_modes")) {
+    allowed_host_virtual_display = allowed_host_virtual_display || mode == "host_virtual_display";
+  }
+  EXPECT_TRUE(allowed_host_virtual_display);
+  EXPECT_NE(contract.at("mode_reason").get<std::string>().find("already configured for Headless Stream"), std::string::npos);
+}
+
+TEST(LaunchModeContractTests, PerGameVirtualDisplayPreferenceIsRecommendedWhenHostIsNotHeadless) {
+  const auto contract = nvhttp::build_launch_mode_contract_for_tests(
+    true,
+    "Indiana Jones and the Great Circle",
+    true,
+    false
+  );
+
+  EXPECT_EQ(contract.at("preferred_mode"), "host_virtual_display");
+  EXPECT_EQ(contract.at("recommended_mode"), "host_virtual_display");
+}


### PR DESCRIPTION
## Summary
- keep strict headless gamepad isolation active when Polaris virtual pad nodes are registered even if no host controller is visible at launch
- bind back only registered Polaris virtual /dev/input, hidraw, and safe sysfs class/device metadata inside bwrap
- keep host /dev/input, /dev/hidraw, udev, input class, hidraw class, and HID bus metadata masked so hot-plugged host controllers do not leak into streamed Steam sessions
- add launch-mode contract coverage for headless host recommendations

Refs #115

## Verification
- RED captured first: GamepadIsolationTests.RegisteredVirtualNodesKeepStrictWrapperActiveWhenNoHostPadIsVisibleYet failed while the planner disabled strict bwrap
- cmake configure: build-gcc15 with gcc-15/g++-15 and CUDA 13.2 nvcc host compiler g++-15
- build: cmake --build build-gcc15 --target test_polaris_platform test_polaris_http test_polaris_config polaris -j 16
- tests: build-gcc15/tests/test_polaris_platform --gtest_filter=GamepadIsolationTests.* — 22 passed
- tests: build-gcc15/tests/test_polaris_http — 11 passed, 1 skipped because external httpbin redirect dependency was unavailable
- tests: build-gcc15/tests/test_polaris_config --gtest_filter=ProcessRuntimeConfigTests.*Steam*:ProcessMigrationTests.*LaunchMode* — 12 passed
- binary: build-gcc15/polaris --version reports Build features: cuda=enabled

## Notes
- Fedora GCC 16 on pc-papi repeatedly ICEd while compiling unrelated Boost/Wayland objects. Reconfigured clean verification with gcc-15/g++-15, matching the CUDA 13.2 host compiler support window.