### PR TITLE
fix(pairing): grant Nova trusted clients game control

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3354,6 +3354,9 @@ namespace nvhttp {
       named_cert_p->client_family = client.family_hint;
       if (sess.pairing_perm) {
         named_cert_p->perm = *sess.pairing_perm;
+      } else if (boost::iequals(client.family_hint, "nova")) {
+        // Nova trusted-pair clients are game stream controllers, not passive viewers.
+        named_cert_p->perm = PERM::_game_control;
       }
       // If the device is the first one paired with the server, assign full permission.
       else if (client_root.named_devices.empty()) {

--- a/tests/unit/test_http_pairing.cpp
+++ b/tests/unit/test_http_pairing.cpp
@@ -401,6 +401,21 @@ TEST_F(PairingAccessPresetTest, StoredAccessPresetOverridesFirstPairFullDefault)
   EXPECT_EQ(clients[0]["perm"].get<uint32_t>(), static_cast<uint32_t>(crypto::PERM::_game_control));
 }
 
+TEST_F(PairingAccessPresetTest, NovaTrustedPairGetsGameControlForAdditionalClient) {
+  auto first = successful_pairing_session("legacy-first");
+  complete_successful_pairing(first);
+
+  auto nova = successful_pairing_session("nova-retroid");
+  nova.client.family_hint = "nova";
+  complete_successful_pairing(nova);
+
+  auto clients = get_all_clients();
+  ASSERT_EQ(clients.size(), 2);
+  EXPECT_EQ(clients[0]["perm"].get<uint32_t>(), static_cast<uint32_t>(crypto::PERM::_all));
+  EXPECT_EQ(clients[1]["client_family"].get<std::string>(), "nova");
+  EXPECT_EQ(clients[1]["perm"].get<uint32_t>(), static_cast<uint32_t>(crypto::PERM::_game_control));
+  EXPECT_NE(static_cast<uint32_t>(crypto::PERM::_game_control & crypto::PERM::launch), 0U);
+}
 TEST_F(PairingAccessPresetTest, LegacyPairingKeepsFirstFullThenStandardBehavior) {
   auto first = successful_pairing_session("legacy-first");
   complete_successful_pairing(first);


### PR DESCRIPTION
## Summary
- default trusted Nova client pairings to the game_control preset instead of passive view/list permissions
- preserve first-client full-permission and explicit access-preset overrides
- add regression coverage for an additional Nova/Retroid pair getting Launch Apps/input permissions

## Test Plan
- RED: PairingAccessPresetTest.NovaTrustedPairGetsGameControlForAdditionalClient failed with perm 50331648 instead of 117448448 after reverting production code
- GREEN: ./build-gcc15/tests/test_polaris_pairing --gtest_filter=PairingAccessPresetTest.NovaTrustedPairGetsGameControlForAdditionalClient
- ./build-gcc15/tests/test_polaris_pairing
- ./build-gcc15/tests/test_polaris_http
- git diff --check

No deploy/merge in this lane.