### PR TITLE
fix(linux): preserve virtual gamepad metadata without host pads

### DIFF
--- a/src/platform/linux/input/inputtino_gamepad_isolation.cpp
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.cpp
@@ -500,9 +500,9 @@ strict_gamepad_isolation_plan_t build_strict_gamepad_isolation_plan(
   const bool has_host_visible_controller = std::any_of(devices.begin(), devices.end(), [](const auto &device) {
     return device.classification == device_classification_e::host_visible;
   });
-  if (!has_host_visible_controller && plan.allowed_nodes.empty()) {
+  if (!has_host_visible_controller) {
     plan.mode = isolation_mode_e::disabled;
-    plan.reason = "gamepad_isolation: no host physical controllers or registered Polaris virtual nodes visible; leaving launch unwrapped";
+    plan.reason = "gamepad_isolation: no host physical controllers visible; leaving launch unwrapped so Polaris virtual gamepads keep native input and udev metadata";
     return plan;
   }
 

--- a/tests/unit/platform/test_gamepad_isolation.cpp
+++ b/tests/unit/platform/test_gamepad_isolation.cpp
@@ -205,7 +205,7 @@ TEST(GamepadIsolationTests, SdlEnvPrefixUsesShellSafeQuoting) {
   EXPECT_EQ(expected, command_with_sdl_env_prefix("steam --gamepadui", plan));
 }
 
-TEST(GamepadIsolationTests, RegisteredVirtualNodesKeepStrictWrapperActiveWhenNoHostPadIsVisibleYet) {
+TEST(GamepadIsolationTests, NoHostPhysicalControllersLeaveLaunchUnwrappedEvenWhenVirtualNodesAreRegistered) {
   const auto devices = classify_devices({
     gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea}),
   });
@@ -217,13 +217,14 @@ TEST(GamepadIsolationTests, RegisteredVirtualNodesKeepStrictWrapperActiveWhenNoH
   );
   const auto command = command_with_headless_gamepad_isolation("steam --gamepadui", plan);
 
-  EXPECT_EQ(isolation_mode_e::strict_bwrap, plan.mode);
-  EXPECT_TRUE(plan.strict_applied());
-  EXPECT_TRUE(text_contains(command, "--tmpfs /run/udev"));
-  EXPECT_TRUE(text_contains(command, "--tmpfs /sys/class/input"));
-  EXPECT_TRUE(text_contains(command, "--dev-bind /dev/input/event42 /dev/input/event42"));
-  EXPECT_TRUE(text_contains(command, "--dev-bind /dev/input/js42 /dev/input/js42"));
-  EXPECT_TRUE(text_contains(plan.reason, "binding 2 registered Polaris virtual gamepad node"));
+  EXPECT_EQ(isolation_mode_e::disabled, plan.mode);
+  EXPECT_FALSE(plan.strict_applied());
+  EXPECT_EQ("steam --gamepadui", command);
+  EXPECT_TRUE(text_lacks(command, "--tmpfs /run/udev"));
+  EXPECT_TRUE(text_lacks(command, "--tmpfs /sys/class/input"));
+  EXPECT_TRUE(text_lacks(command, "--dev-bind /dev/input/event42 /dev/input/event42"));
+  EXPECT_TRUE(text_lacks(command, "--dev-bind /dev/input/js42 /dev/input/js42"));
+  EXPECT_TRUE(text_contains(plan.reason, "no host physical controllers visible"));
 }
 
 TEST(GamepadIsolationTests, StrictPlanWithNoRegisteredNodesStillHidesHostDevices) {


### PR DESCRIPTION
## Summary\n- leave headless launches unwrapped when no host physical controller is visible\n- keep strict bwrap isolation for cases with actual host controllers to hide\n- update regression coverage for registered Polaris virtual nodes without host pads\n\n## Verification\n- cmake --build build-cuda --target test_polaris_platform -j$(nproc)\n- ctest --test-dir build-cuda -R test_polaris_platform --output-on-failure\n- ctest --test-dir build-cuda --output-on-failure\n- live Retroid MOUSE smoke: Nova launch returned 200, input stream started, MOUSE advanced from Press Any Key to menu via Retroid A button