### PR TITLE
feat(linux): add headless gamepad isolation toggle

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,7 @@ Stream when you want a stream-only runtime that leaves the host desktop layout a
 | `linux_use_cage_compositor` | `enabled` | Enable Polaris' private stream runtime |
 | `linux_prefer_gpu_native_capture` | `disabled` | Keep Headless Stream as the first validation path; enable only after testing GPU-native capture on your stack |
 | `trusted_subnets` | CIDR list | Enable Trusted Pair on known local networks |
+| `headless_gamepad_isolation` | `enabled` | Hide host-connected gamepads from private headless streams; disable only when you intentionally want a wired host controller visible inside the stream |
 | `encoder` | `nvenc` / `vaapi` / `software` | Primary encoder backend |
 | `nvenc_split_encode_mode` | `disabled` | Experimental Linux/FFmpeg NVENC split-frame encoding for HEVC/AV1 |
 | `adaptive_bitrate_enabled` | `enabled` | Allow mid-stream bitrate adjustment |

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -665,6 +665,7 @@ namespace config {
     true,  // client gamepads with motion events are emulated as DS4
     true,  // client gamepads with touchpads are emulated as DS4
     true,  // ds5_inputtino_randomize_mac
+    true,  // headless_gamepad_isolation
 
     true,  // keyboard enabled
     true,  // mouse enabled
@@ -1441,6 +1442,7 @@ namespace config {
     bool_f(vars, "motion_as_ds4", input.motion_as_ds4);
     bool_f(vars, "touchpad_as_ds4", input.touchpad_as_ds4);
     bool_f(vars, "ds5_inputtino_randomize_mac", input.ds5_inputtino_randomize_mac);
+    bool_f(vars, "headless_gamepad_isolation", input.headless_gamepad_isolation);
 
     bool_f(vars, "mouse", input.mouse);
     bool_f(vars, "mouse_cursor_visible", input.mouse_cursor_visible);

--- a/src/config.h
+++ b/src/config.h
@@ -244,6 +244,7 @@ namespace config {
     bool motion_as_ds4;
     bool touchpad_as_ds4;
     bool ds5_inputtino_randomize_mac;
+    bool headless_gamepad_isolation;
 
     bool keyboard;
     bool mouse;

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -132,6 +132,7 @@ namespace confighttp::validation {
       "file_state"sv,
       "forward_rumble"sv,
       "gamepad"sv,
+      "headless_gamepad_isolation"sv,
       "global_prep_cmd"sv,
       "global_state_cmd"sv,
       "hdr_mode"sv,

--- a/src/platform/linux/input/inputtino_gamepad_isolation.cpp
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.cpp
@@ -3,6 +3,7 @@
  * @brief Linux gamepad visibility classification for headless labwc launch diagnostics.
  */
 #include "inputtino_gamepad_isolation.h"
+#include "src/config.h"
 #include "src/logging.h"
 
 #include <algorithm>
@@ -497,6 +498,13 @@ strict_gamepad_isolation_plan_t build_strict_gamepad_isolation_plan(
 
   plan.allowed_sysfs_paths = virtual_gamepad_sysfs_bind_paths(devices, plan.allowed_nodes);
 
+  if (!options.enabled) {
+    plan.mode = isolation_mode_e::disabled;
+    plan.reason = "gamepad_isolation: strict headless host controller isolation disabled by config; leaving host controllers visible to the launched app";
+    plan.fallback_sdl = {};
+    return plan;
+  }
+
   const bool has_host_visible_controller = std::any_of(devices.begin(), devices.end(), [](const auto &device) {
     return device.classification == device_classification_e::host_visible;
   });
@@ -641,6 +649,7 @@ std::vector<std::string> registered_virtual_gamepad_nodes() {
 
 strict_isolation_options_t detect_strict_isolation_options() {
   strict_isolation_options_t options;
+  options.enabled = config::input.headless_gamepad_isolation;
   options.bubblewrap_path = find_executable("bwrap");
   options.bubblewrap_available = !options.bubblewrap_path.empty();
   if (options.bubblewrap_path.empty()) {

--- a/src/platform/linux/input/inputtino_gamepad_isolation.h
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.h
@@ -51,6 +51,7 @@ namespace platf::gamepad::isolation {
   };
 
   struct strict_isolation_options_t {
+    bool enabled = true;
     bool bubblewrap_available = false;
     bool bubblewrap_usable = true;
     std::string bubblewrap_path = "bwrap";

--- a/src_assets/common/assets/web/configs/tabs/Inputs.vue
+++ b/src_assets/common/assets/web/configs/tabs/Inputs.vue
@@ -100,6 +100,13 @@ const config = ref(props.config)
           </div>
         </details>
       </template>
+        <Checkbox class="mb-3"
+                  v-if="platform === 'linux'"
+                  id="headless_gamepad_isolation"
+                  locale-prefix="config"
+                  v-model="config.headless_gamepad_isolation"
+                  default="true"
+        ></Checkbox>
       </template>
 
       <div class="mb-3" v-if="config.controller === 'enabled'">

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -363,6 +363,8 @@
     "gamepad_manual": "Manual DS4 options",
     "gamepad_x360": "X360 (Xbox 360)",
     "gamepad_xone": "XOne (Xbox One)",
+    "headless_gamepad_isolation": "Isolate Host Gamepads in Headless Streams",
+    "headless_gamepad_isolation_desc": "Prevents controllers physically connected to the host from appearing inside private headless streams. Disable only when you intentionally use a host-wired controller, such as a DualSense for haptics or adaptive triggers.",
     "global_prep_cmd": "Command Preparations",
     "global_prep_cmd_desc": "Configure a list of commands to be executed before or after running any application. If any of the specified preparation commands fail, the application launch process will be aborted.",
     "global_state_cmd": "Resume/Pause Commands",

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -338,6 +338,7 @@ const tabs = ref([
       "motion_as_ds4": "enabled",
       "touchpad_as_ds4": "enabled",
       "ds5_inputtino_randomize_mac": "enabled",
+      "headless_gamepad_isolation": "enabled",
       "back_button_timeout": -1,
       "keyboard": "enabled",
       "key_repeat_delay": 500,

--- a/tests/unit/platform/test_gamepad_isolation.cpp
+++ b/tests/unit/platform/test_gamepad_isolation.cpp
@@ -227,6 +227,29 @@ TEST(GamepadIsolationTests, NoHostPhysicalControllersLeaveLaunchUnwrappedEvenWhe
   EXPECT_TRUE(text_contains(plan.reason, "no host physical controllers visible"));
 }
 
+TEST(GamepadIsolationTests, DisabledHeadlessHostControllerIsolationLeavesLaunchUnwrapped) {
+  auto host = gamepad("Sony DualSense Wireless Controller", std::optional<uint16_t> {0x054c}, std::optional<uint16_t> {0x0ce6});
+  host.event_node = "/dev/input/event7";
+
+  auto options = strict_options();
+  options.enabled = false;
+
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({host}),
+    {},
+    options
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam --gamepadui", plan);
+
+  EXPECT_EQ(isolation_mode_e::disabled, plan.mode);
+  EXPECT_FALSE(plan.strict_applied());
+  EXPECT_FALSE(plan.fallback_applied());
+  EXPECT_EQ("steam --gamepadui", command);
+  EXPECT_TRUE(text_lacks(command, "bwrap"));
+  EXPECT_TRUE(text_lacks(command, "SDL_GAMECONTROLLER_IGNORE_DEVICES"));
+  EXPECT_TRUE(text_contains(plan.reason, "disabled by config"));
+}
+
 TEST(GamepadIsolationTests, StrictPlanWithNoRegisteredNodesStillHidesHostDevices) {
   auto host = gamepad("Microsoft X-Box One pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
   host.event_node = "/dev/input/event3";


### PR DESCRIPTION
## Summary
- Adds an advanced Linux input setting, `headless_gamepad_isolation`, enabled by default.
- Keeps strict host-controller isolation as the default for private/headless streams.
- Lets users intentionally opt out when they want host-wired controllers visible inside Steam, e.g. DualSense haptics/adaptive triggers.
- Surfaces the setting in Mission Control Inputs and documents the config key.

## Test plan
- RED: `GamepadIsolationTests.DisabledHeadlessHostControllerIsolationLeavesLaunchUnwrapped` failed before the option existed.
- `cmake --build build --target test_polaris_platform -j8`
- `build/tests/test_polaris_platform --gtest_filter=GamepadIsolationTests.*` — 23 passed
- `cmake --build build --target test_polaris_config -j8`
- `build/tests/test_polaris_config` — 198 passed
- `cmake --build build --target test_polaris_audit -j8`
- `build/tests/test_polaris_audit` — 14 passed
- `npm test` — 135 passed
- `npm run lint`
- `npm run build`
- `cmake --build build --target polaris -j8`
- `git diff --check`

Refs #115