### PR TITLE
style(web): tune theme accent palettes

### DIFF
--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -1407,51 +1407,51 @@ textarea {
 
 /* ── Miami Nebula Skin ── */
 [data-theme="miami"] {
-  --color-ice: #fff1f7;
-  --color-silver: #ffd3e2;
-  --color-storm: #b785a1;
-  --color-twilight: #3f2447;
-  --color-deep: #241429;
-  --color-void: #130817;
-  --color-accent: #ff5cab;
-  --color-surface: #3f2447;
-  --color-background: #241429;
-  --color-foreground: #ffd3e2;
-  --color-muted: #b785a1;
-  --color-border: #6c3c6f;
+  --color-ice: #effdff;
+  --color-silver: #b9fbff;
+  --color-storm: #79d7e3;
+  --color-twilight: #243652;
+  --color-deep: #151529;
+  --color-void: #090611;
+  --color-accent: #47f3ff;
+  --color-surface: #243652;
+  --color-background: #151529;
+  --color-foreground: #dcfbff;
+  --color-muted: #85c7d4;
+  --color-border: #326477;
 }
 
 [data-theme="miami"] .glass {
-  background: linear-gradient(135deg, rgba(36, 20, 41, 0.88), rgba(72, 31, 73, 0.78));
-  border-color: rgba(255, 92, 171, 0.18);
+  background: linear-gradient(135deg, rgba(13, 16, 32, 0.90), rgba(44, 24, 62, 0.78));
+  border-color: rgba(71, 243, 255, 0.24);
 }
 [data-theme="miami"] .card,
 [data-theme="miami"] .section-card,
 [data-theme="miami"] .config-page .settings-section {
-  background: linear-gradient(135deg, rgba(36, 20, 41, 0.92), rgba(52, 30, 58, 0.86));
-  border-color: rgba(255, 92, 171, 0.14);
+  background: linear-gradient(135deg, rgba(13, 16, 32, 0.92), rgba(31, 33, 62, 0.86));
+  border-color: rgba(71, 243, 255, 0.18);
 }
 [data-theme="miami"] .surface-subtle,
 [data-theme="miami"] .action-tile {
-  background: rgba(44, 23, 52, 0.76);
-  border-color: rgba(255, 211, 226, 0.10);
+  background: rgba(17, 25, 44, 0.78);
+  border-color: rgba(71, 243, 255, 0.16);
 }
 [data-theme="miami"] .action-tile:hover {
-  background: rgba(65, 32, 72, 0.82);
-  border-color: rgba(255, 92, 171, 0.24);
+  background: rgba(24, 45, 68, 0.84);
+  border-color: rgba(71, 243, 255, 0.36);
 }
 [data-theme="miami"] .sidebar-link.active {
-  color: #fff1f7;
-  background: rgba(255, 92, 171, 0.10);
-  box-shadow: inset 2px 0 0 rgba(255, 92, 171, 0.92), inset 0 1px 0 rgba(255,255,255,0.05);
+  color: #effdff;
+  background: linear-gradient(90deg, rgba(71, 243, 255, 0.16), rgba(255, 92, 171, 0.10));
+  box-shadow: inset 2px 0 0 rgba(71, 243, 255, 0.92), inset 0 1px 0 rgba(255,92,171,0.12);
 }
 [data-theme="miami"] .pulse-dot {
-  background: #ff5cab;
-  box-shadow: 0 0 18px rgba(255, 92, 171, 0.45);
+  background: #47f3ff;
+  box-shadow: 0 0 18px rgba(71, 243, 255, 0.52), 0 0 28px rgba(255, 92, 171, 0.22);
 }
 
 /* ── Portable Chrome Skin ── */
-/* Moonlight-grey early-2000s retro-futurism: pearl silver shell, misty grey panels, soft LCD blue. */
+/* Moonlight-grey early-2000s retro-futurism: pearl silver shell, misty grey panels, subtle PlayStation-symbol glints. */
 [data-theme="portable-chrome"] {
   color-scheme: light;
   --color-ice: #17202a;
@@ -1460,7 +1460,11 @@ textarea {
   --color-twilight: #a7b2be;
   --color-deep: #b8c1cc;
   --color-void: #d6dde5;
-  --color-accent: #557395;
+  --color-accent: #2f64b3;
+  --portable-cross: #2f64b3;
+  --portable-square: #9d679d;
+  --portable-circle: #b8575f;
+  --portable-triangle: #4f9a67;
   --color-surface: #d6dde5;
   --color-background: #b8c1cc;
   --color-foreground: #25313d;
@@ -1471,7 +1475,7 @@ textarea {
 [data-theme="portable-chrome"] body {
   background:
     radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.30), transparent 18rem),
-    radial-gradient(circle at 82% 8%, rgba(85, 115, 149, 0.12), transparent 24rem),
+    radial-gradient(circle at 82% 8%, rgba(47, 100, 179, 0.14), transparent 24rem),
     linear-gradient(135deg, #d7dde5 0%, #b8c1cc 46%, #98a6b5 100%);
 }
 
@@ -1525,9 +1529,9 @@ textarea {
 [data-theme="portable-chrome"] .action-tile:hover {
   background:
     linear-gradient(180deg, rgba(224, 231, 238, 0.92), rgba(190, 201, 213, 0.88)),
-    linear-gradient(90deg, rgba(85, 115, 149, 0.16), rgba(255, 255, 255, 0.12));
-  border-color: rgba(82, 111, 148, 0.68);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.70), inset 0 -1px 0 rgba(81, 94, 110, 0.28), 0 10px 24px rgba(72, 84, 99, 0.16), 0 0 18px rgba(85, 115, 149, 0.16);
+    linear-gradient(90deg, rgba(47, 100, 179, 0.16), rgba(157, 103, 157, 0.12));
+  border-color: rgba(47, 100, 179, 0.68);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.70), inset 0 -1px 0 rgba(81, 94, 110, 0.28), 0 10px 24px rgba(72, 84, 99, 0.16), 0 0 18px rgba(157, 103, 157, 0.20);
 }
 
 [data-theme="portable-chrome"] .sidebar-link {
@@ -1536,8 +1540,8 @@ textarea {
 
 [data-theme="portable-chrome"] .sidebar-link.active {
   color: #17202a;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.42), rgba(85, 115, 149, 0.18));
-  box-shadow: inset 2px 0 0 rgba(85, 115, 149, 0.90), inset 0 1px 0 rgba(255, 255, 255, 0.62);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.42), rgba(47, 100, 179, 0.18), rgba(184, 87, 95, 0.10));
+  box-shadow: inset 2px 0 0 rgba(47, 100, 179, 0.90), inset 0 1px 0 rgba(255, 255, 255, 0.62), 0 0 18px rgba(157, 103, 157, 0.20);
 }
 
 [data-theme="portable-chrome"] .border-storm {
@@ -1546,7 +1550,7 @@ textarea {
 
 [data-theme="portable-chrome"] .pulse-dot {
   background: #4f9a67;
-  box-shadow: 0 0 8px rgba(79, 154, 103, 0.30), 0 0 18px rgba(85, 115, 149, 0.16);
+  box-shadow: 0 0 8px rgba(79, 154, 103, 0.30), 0 0 18px rgba(47, 100, 179, 0.18);
 }
 
 [data-theme="portable-chrome"] .skeleton-shimmer {

--- a/src_assets/common/assets/web/theme.test.js
+++ b/src_assets/common/assets/web/theme.test.js
@@ -55,7 +55,7 @@ describe('theme skin registry', () => {
 
     expect(portableChromeCss).toContain('Moonlight-grey early-2000s')
     expect(portableChromeCss).toContain('--color-background: #b8c1cc')
-    expect(portableChromeCss).toContain('--color-accent: #557395')
+    expect(portableChromeCss).toContain('--color-accent: #2f64b3')
     expect(portableChromeCss).toContain('linear-gradient(180deg, rgba(224, 231, 238, 0.90)')
     expect(portableChromeCss).toContain('repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.06)')
   })
@@ -95,6 +95,33 @@ describe('theme skin registry', () => {
     expect(contrastRatio(tokens.ice, tokens.surface)).toBeGreaterThanOrEqual(7)
     expect(contrastRatio('#315b45', tokens.surface)).toBeGreaterThanOrEqual(4.5)
     expect(contrastRatio(tokens.accent, tokens.surface)).toBeGreaterThanOrEqual(3)
+  })
+
+  it('makes Miami cyan/aqua the scoped hero accent without leaking into other skins', () => {
+    const css = readFileSync('src_assets/common/assets/web/app.css', 'utf8')
+    const miamiCss = css.slice(css.indexOf('/* ── Miami Nebula Skin ── */'), css.indexOf('/* ── Portable Chrome Skin ── */'))
+    const portableChromeCss = css.slice(css.indexOf('/* ── Portable Chrome Skin ── */'))
+    const dq = String.fromCharCode(34)
+
+    expect(miamiCss).toContain('--color-accent: #47f3ff')
+    expect(miamiCss).toContain('[data-theme=' + dq + 'miami' + dq + '] .sidebar-link.active')
+    expect(miamiCss).toContain('box-shadow: inset 2px 0 0 rgba(71, 243, 255, 0.92)')
+    expect(miamiCss).toContain('border-color: rgba(71, 243, 255, 0.36)')
+    expect(miamiCss).toContain('box-shadow: 0 0 18px rgba(71, 243, 255, 0.52)')
+    expect(portableChromeCss).not.toContain('--color-accent: #47f3ff')
+  })
+
+  it('moves Portable Chrome accents to subtle original PlayStation button colors', () => {
+    const css = readFileSync('src_assets/common/assets/web/app.css', 'utf8')
+    const portableChromeCss = css.slice(css.indexOf('/* ── Portable Chrome Skin ── */'))
+
+    expect(portableChromeCss).toContain('--color-accent: #2f64b3')
+    expect(portableChromeCss).toContain('--portable-cross: #2f64b3')
+    expect(portableChromeCss).toContain('--portable-square: #9d679d')
+    expect(portableChromeCss).toContain('--portable-circle: #b8575f')
+    expect(portableChromeCss).toContain('--portable-triangle: #4f9a67')
+    expect(portableChromeCss).toContain('box-shadow: inset 2px 0 0 rgba(47, 100, 179, 0.90)')
+    expect(portableChromeCss).toContain('0 0 18px rgba(157, 103, 157, 0.20)')
   })
 
   it('applies non-default skins through the data-theme attribute', () => {


### PR DESCRIPTION
## Summary
- make Miami Nebula use cyan/aqua as its scoped hero accent for hover, active sidebar, surfaces, and pulse glow
- shift Portable Chrome accent/focus styling toward subtle original PlayStation button colors while keeping the Moonlight-grey chrome base
- add regression coverage to prevent Miami cyan and Portable Chrome accents from bleeding across theme scopes

## Test Plan
- npm ci
- npm test -- src_assets/common/assets/web/theme.test.js
- git diff --check
- npm run lint
- npm test
- npm run build
- npm run smoke:web

Note: temporary Vite visual capture was blocked because the Hermes SSH background-process wrapper dropped the server handle and no port listener survived; no daemon was left running.