### PR TITLE
fix(web): show config save error details

### DIFF
--- a/src_assets/common/assets/web/config-pending-changes.test.js
+++ b/src_assets/common/assets/web/config-pending-changes.test.js
@@ -4,6 +4,12 @@ import { nextTick } from 'vue'
 
 import ConfigView from './views/ConfigView.vue'
 
+const mockToast = vi.fn()
+
+vi.mock('./composables/useToast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
 vi.mock('./restart-host.js', () => ({
   requestHostRestart: vi.fn(() => Promise.resolve()),
 }))
@@ -95,6 +101,7 @@ function mountConfigView(config = {}) {
 describe('ConfigView pending changes review', () => {
   afterEach(() => {
     document.body.innerHTML = ''
+    mockToast.mockClear()
     vi.restoreAllMocks()
     delete global.fetch
   })
@@ -138,5 +145,44 @@ describe('ConfigView pending changes review', () => {
     expect(wrapper.vm.config.sunshine_name).toBe('Old Host')
     expect(wrapper.text()).not.toContain('Polaris Name')
     expect(wrapper.text()).toContain('Maximum Bitrate')
+  })
+
+  it('shows backend validation details when saving configuration fails', async () => {
+    const wrapper = mountConfigView()
+    await flushConfigLoad()
+
+    wrapper.vm.config.sunshine_name = 'Broken Host'
+    await nextTick()
+
+    global.fetch.mockResolvedValueOnce({
+      status: 400,
+      text: () => Promise.resolve('Unsupported config key: container_encoders'),
+    })
+
+    const result = await wrapper.vm.save()
+
+    expect(result).toBe(false)
+    expect(mockToast).toHaveBeenCalledWith(
+      'Failed to save configuration: Unsupported config key: container_encoders',
+      'error'
+    )
+  })
+
+  it('uses the generic save failure when the backend response body is empty', async () => {
+    const wrapper = mountConfigView()
+    await flushConfigLoad()
+
+    wrapper.vm.config.sunshine_name = 'Broken Host'
+    await nextTick()
+
+    global.fetch.mockResolvedValueOnce({
+      status: 500,
+      text: () => Promise.resolve('   '),
+    })
+
+    const result = await wrapper.vm.save()
+
+    expect(result).toBe(false)
+    expect(mockToast).toHaveBeenCalledWith('Failed to save configuration', 'error')
   })
 })

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -867,6 +867,18 @@ async function focusSectionTarget(sectionId) {
   target.scrollIntoView?.({ behavior: 'smooth', block: 'start', inline: 'nearest' })
 }
 
+async function configSaveFailureMessage(response) {
+  const fallbackMessage = 'Failed to save configuration'
+  if (!response || typeof response.text !== 'function') return fallbackMessage
+
+  try {
+    const detail = (await response.text()).trim()
+    return detail ? `${fallbackMessage}: ${detail}` : fallbackMessage
+  } catch {
+    return fallbackMessage
+  }
+}
+
 function serialize() {
   // Validate fallback mode
   if (config.value.fallback_mode && !config.value.fallback_mode.match(/^\d+x\d+x\d+$/)) {
@@ -915,7 +927,7 @@ function save() {
     headers: { 'Content-Type': 'application/json' },
     method: 'POST',
     body: JSON.stringify(configCopy),
-  }).then((r) => {
+  }).then(async (r) => {
     if (r.status === 200) {
       saved.value = true
       initialSerialized.value = JSON.stringify(serialize())
@@ -931,7 +943,7 @@ function save() {
       return saved.value
     }
     else {
-      toast('Failed to save configuration', 'error')
+      toast(await configSaveFailureMessage(r), 'error')
       return false
     }
   }).finally(() => {


### PR DESCRIPTION
## Summary
- Show the `/api/config` response body in the failed-save toast when Polaris rejects a config update.
- Keep the previous generic `Failed to save configuration` toast when the backend response body is empty or unreadable.
- Add focused ConfigView regression coverage for both detailed and fallback error toasts.

## Test Plan
- [x] `npm test -- src_assets/common/assets/web/config-pending-changes.test.js`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
