### PR TITLE
fix: clarify headless Steam launch safety contract

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -540,9 +540,14 @@ namespace nvhttp {
 
       if (prefers_headless) {
         recommended_mode = "headless_stream";
-        mode_reason = app_prefers_virtual_display ?
-          "This app prefers Host Virtual Display, but this Polaris host is already configured for Headless Stream, so Headless Stream is recommended." :
-          "Headless Stream is recommended because this Polaris host is already configured for headless streaming.";
+        if (steam_big_picture) {
+          mode_reason =
+            "Steam Big Picture is safest in the private headless session because this Polaris host is already configured for Headless Stream; this avoids waking Steam/Gamepad UI on the physical desktop during launch or teardown.";
+        } else {
+          mode_reason = app_prefers_virtual_display ?
+            "This app prefers Host Virtual Display, but this Polaris host is already configured for Headless Stream, so Headless Stream is recommended." :
+            "Headless Stream is recommended because this Polaris host is already configured for headless streaming.";
+        }
       } else if (app_prefers_virtual_display && virtual_display_available) {
         recommended_mode = "host_virtual_display";
         mode_reason = steam_big_picture ?

--- a/tests/unit/platform/test_gamepad_isolation.cpp
+++ b/tests/unit/platform/test_gamepad_isolation.cpp
@@ -294,6 +294,26 @@ TEST(GamepadIsolationTests, StrictWrapperBindsOnlyRegisteredVirtualEventJsAndHid
   EXPECT_TRUE(text_lacks(command, "--dev-bind-try /dev/fd /dev/fd"));
 }
 
+TEST(GamepadIsolationTests, StrictWrapperPreservesAmdVaapiRuntimeDevices) {
+  auto host = gamepad("Microsoft X-Box One pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  host.event_node = "/dev/input/event3";
+  auto virtual_pad = gamepad("Sunshine X-Box One (virtual) pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
+  virtual_pad.event_node = "/dev/input/event9";
+
+  const auto plan = build_strict_gamepad_isolation_plan(
+    classify_devices({host, virtual_pad}),
+    {"/dev/input/event9"},
+    strict_options()
+  );
+  const auto command = command_with_headless_gamepad_isolation("steam --gamepadui", plan);
+
+  EXPECT_TRUE(plan.strict_applied());
+  EXPECT_TRUE(text_contains(command, "--dev-bind-try /dev/dri /dev/dri"));
+  EXPECT_TRUE(text_contains(command, "--dev-bind-try /dev/kfd /dev/kfd"));
+  EXPECT_TRUE(text_contains(command, "--dev-bind-try /dev/shm /dev/shm"));
+  EXPECT_TRUE(text_lacks(command, "--dev-bind /dev/input /dev/input"));
+}
+
 TEST(GamepadIsolationTests, SameVidPidHostAndVirtualAllowsOnlyRegisteredVirtualNode) {
   auto host = gamepad("Microsoft X-Box One pad", std::optional<uint16_t> {0x045e}, std::optional<uint16_t> {0x02ea});
   host.event_node = "/dev/input/event4";

--- a/tests/unit/test_launch_mode_contract.cpp
+++ b/tests/unit/test_launch_mode_contract.cpp
@@ -25,6 +25,21 @@ TEST(LaunchModeContractTests, HostHeadlessConfigurationWinsOverPerGameVirtualDis
   EXPECT_NE(contract.at("mode_reason").get<std::string>().find("already configured for Headless Stream"), std::string::npos);
 }
 
+TEST(LaunchModeContractTests, SteamBigPictureOnHeadlessHostExplainsPrivateDesktopSafety) {
+  const auto contract = nvhttp::build_launch_mode_contract_for_tests(
+    true,
+    "Steam Big Picture",
+    true,
+    true
+  );
+
+  EXPECT_EQ(contract.at("preferred_mode"), "host_virtual_display");
+  EXPECT_EQ(contract.at("recommended_mode"), "headless_stream");
+  const auto reason = contract.at("mode_reason").get<std::string>();
+  EXPECT_NE(reason.find("private headless session"), std::string::npos);
+  EXPECT_NE(reason.find("physical desktop"), std::string::npos);
+}
+
 TEST(LaunchModeContractTests, PerGameVirtualDisplayPreferenceIsRecommendedWhenHostIsNotHeadless) {
   const auto contract = nvhttp::build_launch_mode_contract_for_tests(
     true,


### PR DESCRIPTION
## Summary
- clarifies the v1 launch-mode contract for Steam Big Picture on Headless Stream hosts so clients surface the private/headless safety reason instead of implying a virtual-display preference should win
- carries forward the AMD/CachyOS Steam Big Picture lesson from #122: keep Steam/Gamepad UI inside the private headless session and avoid waking the physical desktop during launch/teardown
- adds regression coverage that strict gamepad isolation still preserves AMD/VAAPI runtime devices (`/dev/dri`, `/dev/kfd`, `/dev/shm`) while not exposing broad `/dev/input`

## Test Plan
- `cmake -S . -B build-gcc15 -G Ninja -DBUILD_TESTS=ON -DBUILD_FULL_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/bin/g++-15 -DPOLARIS_ENABLE_CUDA=OFF -DPOLARIS_ALLOW_CUDA_DISABLED_ON_NVIDIA=ON`
- `cmake --build build-gcc15 --target test_polaris_http test_polaris_platform -j$(nproc)`
- `./build-gcc15/tests/test_polaris_http --gtest_filter='LaunchModeContractTests.*'`
- `./build-gcc15/tests/test_polaris_platform --gtest_filter='GamepadIsolationTests.*'`
- `git diff --cached --check`

Refs #115
Refs #122
Refs #92
Refs #35
