### PR TITLE
feat: expose AMD Linux capture truth in diagnostics

### DIFF
--- a/docs/research/amd-linux-streaming-optimization.md
+++ b/docs/research/amd-linux-streaming-optimization.md
@@ -1,0 +1,143 @@
+# AMD Linux Streaming Optimization Research
+
+This document captures the public research and repo seams for improving Polaris and Nova on AMD/Linux hosts. It intentionally records generalized technical patterns only; do not add private support-bundle contents, IPs, hostnames, pairing identities, screenshots, or private community thread details here.
+
+## Baseline
+
+- AMD/Linux baseline support should assume **Mesa VA-API** first.
+- Conservative Headless Stream can legitimately use **SHM/system-memory capture** and still be a valid, stable baseline.
+- GPU-native DMA-BUF capture is an optimization path, not a promise. Treat `linux_prefer_gpu_native_capture = enabled` as a request that may still fall back.
+- KMS/DRM capture can reduce compositor-copy overhead on some AMD hosts, but it changes the privilege/safety posture and must remain an advanced opt-in path.
+- Nova should consume Polaris host truth and explain host-side capture facts separately from Android decoder/network facts.
+
+## Public Sources
+
+- Sunshine docs: <https://docs.lizardbyte.dev/projects/sunshine/latest/>
+  - Sunshine publicly lists Linux VAAPI support for AMD/Intel, while AMF is not the normal Linux baseline in the public compatibility table.
+- Sunshine Linux platform overview: <https://deepwiki.com/LizardByte/Sunshine/8.2-linux-platform-implementation>
+  - Linux capture implementations choose among KMS/DRM, Wayland/PipeWire-style capture, and hardware acceleration paths such as VA-API/CUDA/Vulkan interop.
+  - KMS requires privileged DRM framebuffer access; do not recommend it as blind first-line troubleshooting.
+- Foundation/Sunshine Linux capture notes: <https://deepwiki.com/qiin2333/foundation-sunshine/4.1.2-linux-capture-methods>
+  - Linux capture can produce frames in system RAM or GPU VRAM depending on capture method and encoder requirements.
+  - Wayland capture depends on compositor protocol support and DMA-BUF surface descriptors.
+- Arch Wiki hardware video acceleration: <https://wiki.archlinux.org/title/Hardware_video_acceleration>
+  - AMD open drivers support VA-API through Mesa, Vulkan Video through RADV, and AMF as a separate framework/runtime path.
+- Wayland DMA-BUF protocol: <https://wayland.app/protocols/linux-dmabuf-unstable-v1>
+  - DMA-BUF import depends on device/modifier compatibility and can fail even when the protocol exists.
+- CachyOS AMD Sunshine field writeup: <https://thenets.org/posts/game-streaming-cachyos-amd-sunshine/>
+  - AMD community setups commonly converge on Mesa VAAPI, explicit `/dev/dri/renderD*` adapter selection, `vainfo` profile checks, and KMS only after baseline validation.
+- Mesa RADV docs: <https://docs.mesa3d.org/drivers/radv.html>
+  - RADV is the Mesa Vulkan driver for modern AMD GPUs and Steam Deck-class systems.
+- AMD AMF SDK: <https://github.com/GPUOpen-LibrariesAndSDKs/AMF>
+  - Linux AMF exists, but runtime packaging/driver coupling makes it a future spike rather than the default AMD/Linux support path.
+
+## Product Principles
+
+1. **Mesa VAAPI first.** Optimize the common open-driver path before proprietary or exotic alternatives.
+2. **Capture truth beats optimistic labels.** Surface requested GPU-native, actual DMA-BUF GPU capture, SHM fallback, encoder upload, render-node mismatch, and cross-GPU risk distinctly.
+3. **KMS is advanced opt-in.** It may help performance, but evidence and safety explanation come first.
+4. **Render-node selection is first-class.** Mixed-GPU systems need explicit capture device vs encoder adapter reporting.
+5. **HEVC is the safe AMD default.** AV1 should require capability and stability evidence, especially for handheld clients.
+6. **Nova must stay host-aware.** Host VAAPI/SHM warnings are different from Android MediaCodec decoder warnings and network warnings.
+7. **Experimental capture paths must be measurable and reversible.** Probe results, fallback reasons, and support-bundle data should explain what happened without requiring a crash archaeology degree.
+
+## Polaris Seams
+
+- `src/platform/linux/wlgrab.cpp`
+  - Chooses RAM/SHM capture, wlroots DMA-BUF capture, and experimental `ext-image-copy-capture` paths.
+  - Good home for probe/fallback logging and render-node safety decisions.
+- `src/platform/linux/vaapi.cpp` / `src/platform/linux/vaapi.h`
+  - Own VAAPI vendor/profile/entrypoint/rate-control decisions.
+  - Good home for structured capability summaries such as H.264, HEVC Main, HEVC Main10, and AV1 encode availability.
+- `src/stream_stats.cpp` / `src/stream_stats.h`
+  - Already exports capture transport, capture residency, encode target residency, reason strings, and capture decisions.
+  - Good home for a nested `linux_gpu_profile` object shared by diagnostics and APIs.
+- `src/nvhttp.cpp` / `src/nvhttp.h`
+  - Own `/polaris/v1/session/status`, `/polaris/v1/stream-policy`, optimizer, and launch-policy payloads.
+  - Good home for API-level host truth consumed by Nova.
+- Web UI:
+  - `src_assets/common/assets/web/views/DashboardView.vue`
+  - `src_assets/common/assets/web/views/TroubleshootingView.vue`
+  - `src_assets/common/assets/web/configs/tabs/AudioVideo.vue`
+  - `src_assets/common/assets/web/diagnostics-export.js`
+  - `src_assets/common/assets/web/public/assets/locale/en.json`
+
+## Nova Seams
+
+- `app/src/main/java/com/papi/nova/api/PolarisApiClient.kt`
+  - Parse new Polaris host-profile fields.
+- `app/src/main/java/com/papi/nova/api/PolarisSessionStatus.kt`
+  - Model host capture/encoder truth.
+- `app/src/main/java/com/papi/nova/api/PolarisClientSettings.kt`
+  - Carry effective policy truth when Polaris includes it in client settings.
+- `app/src/main/java/com/papi/nova/ui/NovaHudUiState.kt`
+  - Command Center/HUD labels such as `VAAPI + SHM fallback`, `VAAPI + GPU-native`, and `render-node mismatch`.
+- `app/src/main/java/com/papi/nova/ui/StreamPolicyUiState.kt`
+  - Human-readable launch/policy summaries.
+- `app/src/main/java/com/papi/nova/manager/ClientRuntimeSnapshot.kt`
+  - Keep client decoder/display telemetry separate from host GPU/capture telemetry.
+
+## Proposed `linux_gpu_profile` Shape
+
+The exact API shape should be locked by tests before implementation, but the useful fields are:
+
+```json
+{
+  "encoder_api": "vaapi",
+  "encoder_adapter": "/dev/dri/renderD128",
+  "capture_device": "/dev/dri/renderD128",
+  "adapter_matches_capture_device": true,
+  "gpu_native_requested": false,
+  "gpu_native_attempted": false,
+  "gpu_native_succeeded": false,
+  "vaapi_vendor": "Mesa Gallium",
+  "vaapi_profiles": {
+    "h264_encode": true,
+    "hevc_encode": true,
+    "hevc_main10_encode": true,
+    "av1_encode": false
+  }
+}
+```
+
+Start with facts Polaris already knows (`encoder_api`, adapter paths, requested/succeeded booleans) before adding live VAAPI profile probing.
+
+## Evidence Checklist for AMD Reports
+
+Ask for one fresh stream attempt and either a support bundle or equivalent host-side evidence:
+
+```bash
+polaris --version
+vainfo
+grep -E 'headless_mode|linux_use_cage_compositor|linux_prefer_gpu_native_capture|encoder|adapter_name' ~/.config/polaris/polaris.conf
+journalctl --user -u polaris --since '15 minutes ago' --no-pager
+curl -skS https://127.0.0.1:47984/polaris/v1/session/status
+curl -skS https://127.0.0.1:47984/polaris/v1/stream-policy
+```
+
+Interpretation rules:
+
+- `SHM/system-memory` is not automatically a bug on conservative Headless Stream.
+- If GPU-native was requested but capture remains SHM, report that as “requested but unavailable/fell back,” not as user error.
+- If capture device and encoder adapter differ, suspect render-node mismatch before blaming the client.
+- If FPS target is 120 but delivery lands around 60, split negotiation/target facts from actual delivery facts.
+- If AV1 appears during pacing instability, recommend HEVC until capability and stability are proven.
+
+## Open Questions
+
+- Should Polaris serialize `linux_gpu_profile` from `stream_stats::stats_t`, from `nvhttp` policy builders, or from a shared helper used by both?
+- Can VAAPI profile probing be deterministic enough for unit tests, or should CI rely on source guards and live smoke evidence?
+- Which VAAPI vendor strings need stricter AMD-specific rate-control behavior?
+- Should ext-image-copy DMA-BUF probe results be cached per compositor socket and render node?
+- Should Nova recommend a conservative AMD profile directly, or show the host truth and let Polaris optimizer own policy changes?
+- Which hardware lane validates first: Steam Deck/Bazzite APU, RDNA2 dGPU, RDNA3 dGPU with AV1, or mixed render-node host?
+
+## Release Lane Recommendation
+
+1. Add this research artifact.
+2. Add Polaris `linux_gpu_profile` truth in stream stats and v1 APIs.
+3. Add AMD-aware Polaris web/support-bundle guidance.
+4. Add Nova parser/model support and concise HUD/Command Center labels.
+5. Spike VAAPI profile/rate-control policy only after truth surfaces are available.
+6. Spike experimental AMD GPU-native capture probing only after fallback reasons are visible.
+7. Update public docs/community reply kit with conservative baseline, `vainfo`, render-node selection, SHM meaning, and KMS caveats.

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1669,6 +1669,7 @@ namespace nvhttp {
       policy["capture_device"] = stats.capture_device;
       policy["capture_encoder_adapter"] = config::video.adapter_name;
       policy["capture_cross_gpu_dmabuf_risk"] = stream_stats::capture_path_has_cross_gpu_dmabuf_risk(stats);
+      policy["linux_gpu_profile"] = stream_stats::linux_gpu_profile_json(stats);
       policy["capture_decision"] = {
         {"path", capture_path},
         {"reason", capture_reason},

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -135,6 +135,7 @@ namespace stream_stats {
       {"effective_headless", runtime_effective_headless},
       {"gpu_native_override_active", runtime_gpu_native_override_active}
     };
+    j["linux_gpu_profile"] = linux_gpu_profile_json(*this);
     j["encode_target_device"] = encode_target_device;
     j["encode_target_residency"] = platf::from_frame_residency(encode_target_residency);
     j["encode_target_format"] = platf::from_frame_format(encode_target_format);
@@ -227,6 +228,32 @@ namespace stream_stats {
 #endif
   }
 
+  nlohmann::json linux_gpu_profile_json(const stats_t &stats) {
+    const auto &linux_display = config::video.linux_display;
+    const bool gpu_native_requested =
+      stats.runtime_gpu_native_override_active ||
+      linux_display.prefer_gpu_native_capture;
+    const bool adapter_matches_capture_device =
+      stats.capture_device.empty() ||
+      config::video.adapter_name.empty() ||
+      stats.capture_device == config::video.adapter_name;
+    const bool capture_metadata_reported =
+      stats.capture_transport != platf::frame_transport_e::unknown ||
+      stats.capture_residency != platf::frame_residency_e::unknown ||
+      stats.encode_target_residency != platf::frame_residency_e::unknown;
+
+    return {
+      {"encoder_api", stats.encode_target_device},
+      {"encoder_adapter", config::video.adapter_name},
+      {"capture_device", stats.capture_device},
+      {"adapter_matches_capture_device", adapter_matches_capture_device},
+      {"cross_gpu_dmabuf_risk", capture_path_has_cross_gpu_dmabuf_risk(stats)},
+      {"gpu_native_requested", gpu_native_requested},
+      {"gpu_native_attempted", gpu_native_requested && capture_metadata_reported},
+      {"gpu_native_succeeded", capture_path_is_gpu_native(stats)}
+    };
+  }
+
   std::string capture_path_summary(const stats_t &stats) {
     const bool capture_unknown =
       stats.capture_transport == platf::frame_transport_e::unknown &&
@@ -285,11 +312,11 @@ namespace stream_stats {
       linux_display.prefer_gpu_native_capture;
 
     if (stats.capture_transport == platf::frame_transport_e::shm) {
-      if (stats.runtime_effective_headless && linux_display.use_cage_compositor) {
-        return "headless_shm_fallback";
-      }
       if (gpu_native_requested) {
         return "gpu_native_requested_shm_fallback";
+      }
+      if (stats.runtime_effective_headless && linux_display.use_cage_compositor) {
+        return "headless_shm_fallback";
       }
       return "shm_capture";
     }

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -14,6 +14,9 @@
 #include <string>
 #include <vector>
 
+// lib includes
+#include <nlohmann/json_fwd.hpp>
+
 // local includes
 #include "platform/common.h"
 
@@ -144,6 +147,12 @@ namespace stream_stats {
    * @param stats Current stream statistics snapshot.
    */
   bool capture_path_has_cross_gpu_dmabuf_risk(const stats_t &stats);
+
+  /**
+   * @brief Structured Linux GPU/capture truth for diagnostics and v1 APIs.
+   * @param stats Current stream statistics snapshot.
+   */
+  nlohmann::json linux_gpu_profile_json(const stats_t &stats);
 
   /**
    * @brief Human-readable explanation for a capture path reason.

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -36,8 +36,8 @@ const streamDisplayModes = [
     id: 'headless_stream',
     title: 'Headless Stream',
     badge: 'Recommended',
-    copy: 'Recommended. Starts apps inside a private hidden compositor. On capable NVIDIA/Wayland hosts this is the default GPU-native DMA-BUF/CUDA path and does not mirror your desktop.',
-    note: 'Best isolation path. If a host cannot provide DMA-BUF, Polaris reports the SHM/RAM fallback instead of pretending.',
+    copy: 'Recommended. Starts apps inside a private hidden compositor. It does not mirror your current desktop.',
+    note: 'Best isolation path. On some wlroots headless outputs this can fall back to SHM/system-memory capture instead of DMA-BUF.',
     restartCopy: 'Requires restart. Polaris will stream an isolated hidden runtime, not the existing KDE or GNOME session.',
   },
   {
@@ -60,9 +60,9 @@ const streamDisplayModes = [
     id: 'windowed_stream',
     title: 'GPU-Native Stream',
     badge: 'Performance',
-    copy: 'Forces the GPU-native fallback path: private stream runtime with windowed labwc allowed when hidden headless cannot stay on DMA-BUF/CUDA.',
-    note: 'Use when diagnostics say hidden headless fell back to SHM/RAM; capable hosts may not need it because Headless Stream can already be GPU-native.',
-    restartCopy: 'Requires restart. GPU-Native Stream can force a windowed labwc runtime to avoid the SHM/RAM copy path when hidden headless cannot stay GPU-resident.',
+    copy: 'Requests a private stream runtime and allows Polaris to run it windowed when that is needed to preserve DMA-BUF/GPU-resident capture.',
+    note: 'Use when diagnostics say hidden headless fell back to SHM/system-memory; capable hosts may not need it because Headless Stream can already be GPU-resident.',
+    restartCopy: 'Requires restart. GPU-Native Stream may override hidden headless into a windowed labwc runtime to avoid SHM/system-memory fallback.',
   },
 ]
 
@@ -173,7 +173,7 @@ const linuxStreamingSetupChecklist = computed(() => [
     id: 'runtime',
     title: 'Choose the Linux runtime path',
     status: selectedStreamDisplayMode.value.title,
-    copy: 'Headless Stream is the isolated compatibility path. GPU-Native Stream is the primary performance path for capable DMA-BUF/CUDA/NVENC hosts.',
+    copy: 'Headless Stream is the safe default. GPU-Native Stream is for validating DMA-BUF/VAAPI residency when hidden Wayland capture falls back to SHM/system-memory frames.',
   },
   {
     id: 'quality',
@@ -184,12 +184,12 @@ const linuxStreamingSetupChecklist = computed(() => [
       : 'Enable Auto Quality when you want Polaris to balance bitrate, profile choice, and recovery instead of hand-tuning every stream.',
   },
   {
-    id: 'wayland-nvidia',
-    title: 'Check Wayland / NVIDIA copy risk',
-    status: config.value.linux_prefer_gpu_native_capture === 'enabled' ? 'GPU-native fallback forced' : 'GPU-native auto',
+    id: 'wayland-vaapi',
+    title: 'Check Wayland / VAAPI capture truth',
+    status: config.value.linux_prefer_gpu_native_capture === 'enabled' ? 'GPU-native requested' : 'Safe default',
     copy: config.value.linux_prefer_gpu_native_capture === 'enabled'
-      ? 'Polaris may force labwc windowed to avoid the SHM/RAM copy path and preserve GPU-resident capture.'
-      : 'Headless Stream will use DMA-BUF/CUDA automatically on capable hosts; force GPU-Native Stream only when diagnostics report SHM/RAM fallback.',
+      ? 'Polaris may keep labwc windowed to avoid SHM/system-memory fallback and preserve GPU-resident DMA-BUF capture.'
+      : 'VAAPI / Mesa is the AMD Linux baseline. Leave GPU-native off for normal headless streaming; turn it on only when telemetry shows SHM/system-memory fallback and you are collecting support evidence. KMS/DRM is advanced.',
   },
 ])
 
@@ -298,7 +298,7 @@ const validateFallbackMode = (event) => {
                 <div class="section-kicker">Linux Streaming Setup</div>
                 <h4 class="mt-2 text-sm font-semibold text-silver">Guided checklist for desktop Linux hosts</h4>
                 <div class="mt-1 text-sm leading-relaxed text-storm">
-                  Use this before the first Moonlight run: discover the display pair, pick the runtime path, decide Auto Quality, then only enable GPU-native capture when Wayland/NVIDIA telemetry shows a copy problem.
+                  Use this before the first Moonlight run: discover the display pair, pick the runtime path, decide Auto Quality, then only enable GPU-native capture when Wayland/VAAPI telemetry shows SHM/system-memory fallback.
                 </div>
               </div>
               <span class="meta-pill shrink-0">{{ selectedStreamDisplayMode.title }}</span>
@@ -339,7 +339,7 @@ const validateFallbackMode = (event) => {
             </div>
             <div class="surface-muted p-3">
               <div class="text-xs font-semibold uppercase tracking-[0.16em] text-green-300">GPU path</div>
-              <div class="mt-2 text-sm leading-relaxed text-storm">GPU-Native Stream favors DMA-BUF and CUDA/NVENC residency, even if that means a visible labwc window.</div>
+              <div class="mt-2 text-sm leading-relaxed text-storm">GPU-Native Stream favors DMA-BUF and hardware-encoder residency, even if that means a visible labwc window.</div>
             </div>
             <div class="surface-muted p-3">
               <div class="text-xs font-semibold uppercase tracking-[0.16em] text-amber-200">FPS target</div>

--- a/src_assets/common/assets/web/dashboard-summary.js
+++ b/src_assets/common/assets/web/dashboard-summary.js
@@ -95,7 +95,7 @@ export function buildTelemetryGuidance({ stats = {}, gpu = null, fpsTargetGap = 
   }
 
   if (stats.capture_cpu_copy) {
-    concerns.push({ key: 'cpu-copy-path', label: 'CPU copy path', tone: 'text-orange-300', detail: captureReason || 'Frames are crossing system memory. Prefer the DMA-BUF/GPU-native capture path for high-FPS Linux streaming.' })
+    concerns.push({ key: 'cpu-copy-path', label: 'CPU copy path', tone: 'text-orange-300', detail: captureReason || 'Frames are crossing SHM/system-memory. For AMD/VAAPI, this can be the conservative Headless Stream baseline; compare DMA-BUF/GPU-native capture truth before changing advanced flags.' })
   }
 
   if (fpsTargetGap) {

--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -61,12 +61,61 @@ function checklistItem(key, label, status, detail, action) {
   return { key, label, status, detail, action }
 }
 
+function lower(value) {
+  return String(value || '').toLowerCase()
+}
+
+function linuxGpuProfile(stats = {}) {
+  return stats?.linux_gpu_profile || stats?.linuxGpuProfile || {}
+}
+
+export function describeLinuxGpuProfile(stats = {}) {
+  const profile = linuxGpuProfile(stats)
+  const encoderApi = lower(profile.encoder_api || profile.encoderApi || stats?.encode_target_device)
+  const captureReason = lower(stats?.capture_path_reason || stats?.capture?.reason)
+  const capturePath = lower(stats?.capture_path || stats?.capture?.path || stats?.capture_transport)
+  const gpuNativeRequested = Boolean(profile.gpu_native_requested ?? profile.gpuNativeRequested)
+  const gpuNativeSucceeded = Boolean(
+    profile.gpu_native_succeeded ??
+    profile.gpuNativeSucceeded ??
+    stats?.capture_gpu_native ??
+    stats?.capture?.gpu_native
+  )
+  const adapterMatchesCaptureDevice = profile.adapter_matches_capture_device ?? profile.adapterMatchesCaptureDevice
+  const cpuCopy = Boolean(
+    stats?.capture_cpu_copy ||
+    stats?.capture?.cpu_copy ||
+    capturePath.includes('shm') ||
+    captureReason.includes('shm')
+  )
+
+  if (encoderApi !== 'vaapi') return ''
+
+  if (adapterMatchesCaptureDevice === false) {
+    return 'AMD/VAAPI is active, but the capture render node does not match the encoder adapter. Review the /dev/dri/renderD* selection before blaming the client.'
+  }
+
+  if (cpuCopy) {
+    if (gpuNativeRequested && !gpuNativeSucceeded) {
+      return 'AMD/VAAPI is active, but GPU-native capture fell back to SHM/system-memory frames. This can be a safe conservative Headless Stream baseline.'
+    }
+    return 'AMD/VAAPI is active with SHM/system-memory capture. This can be a safe conservative Headless Stream baseline.'
+  }
+
+  if (gpuNativeSucceeded || stats?.capture_gpu_native || stats?.capture?.gpu_native) {
+    return 'AMD/VAAPI is using GPU-native capture; capture and encode are staying on the GPU path.'
+  }
+
+  return 'AMD/VAAPI is active. Compare the reported capture path, render node, and encoder adapter before changing advanced capture flags.'
+}
+
 export function buildFixMyStreamChecklist({ stats = {}, statsConnected = false, logs = '', recentIssues = [] } = {}) {
   const streaming = Boolean(stats?.streaming)
   const packetLoss = Number(stats?.packet_loss)
   const encodeTime = Number(stats?.encode_time_ms)
   const captureKnown = Boolean(stats?.capture_path || stats?.capture_transport || stats?.capture_path_reason)
   const captureCpuCopy = Boolean(stats?.capture_cpu_copy)
+  const gpuProfileDescription = describeLinuxGpuProfile(stats)
   const authPairingIssue = latestIssueMatching(logs, ['auth', 'pair', 'pin', 'credential', 'unauthorized', 'forbidden'])
   const recentIssueCount = Array.isArray(recentIssues) ? recentIssues.length : 0
 
@@ -85,11 +134,19 @@ export function buildFixMyStreamChecklist({ stats = {}, statsConnected = false, 
     : checklistItem('packet-loss', 'Packet loss', 'warning', 'Packet loss has not been reported yet.', 'Start a live stream and wait for session telemetry.')
 
   const capture = captureCpuCopy
-    ? checklistItem('capture-path', 'Capture path', 'fail', 'The active capture path is crossing system memory/CPU copy.', 'On Linux, prefer DMA-BUF/GPU-native capture for high-FPS streams; check Audio/Video display pairing and capture settings.')
+    ? checklistItem(
+      'capture-path',
+      'Capture path',
+      'fail',
+      gpuProfileDescription || 'The active capture path is crossing SHM/system-memory frames.',
+      gpuProfileDescription
+        ? 'Treat the conservative Headless Stream baseline as valid, then review render-node pairing and support evidence before testing GPU-native or KMS/DRM capture.'
+        : 'On Linux, compare DMA-BUF/GPU-native capture telemetry with the selected display and encoder adapter before changing advanced capture settings.'
+    )
     : stats?.capture_gpu_native
-      ? checklistItem('capture-path', 'Capture path', 'pass', 'Capture is reported as GPU-native.', 'Keep display pairing as-is unless the stream feels wrong.')
+      ? checklistItem('capture-path', 'Capture path', 'pass', gpuProfileDescription || 'Capture is reported as GPU-native.', 'Keep display pairing as-is unless the stream feels wrong.')
       : captureKnown
-        ? checklistItem('capture-path', 'Capture path', 'warning', `Capture path is ${stats.capture_path || stats.capture_transport || 'mixed/unknown'}.`, 'Check whether the chosen display and encoder are paired to the intended GPU path.')
+        ? checklistItem('capture-path', 'Capture path', 'warning', gpuProfileDescription || `Capture path is ${stats.capture_path || stats.capture_transport || 'mixed/unknown'}.`, 'Check whether the chosen display and encoder are paired to the intended GPU path.')
         : checklistItem('capture-path', 'Capture path', 'warning', 'No capture metadata has been reported yet.', 'Start a stream, then confirm capture path and display pairing.')
 
   const encoder = Number.isFinite(encodeTime)

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -3,6 +3,7 @@ import {
   REDACTED_VALUE,
   buildAnonymizedDiagnosticsBundle,
   buildFixMyStreamChecklist,
+  describeLinuxGpuProfile,
   redactSensitiveText,
   sanitizeDiagnosticsValue,
 } from './diagnostics-export.js'
@@ -125,5 +126,38 @@ describe('Fix My Stream checklist', () => {
     })
 
     expect(checklist.every((item) => item.status === 'pass')).toBe(true)
+  })
+
+  it('explains AMD VAAPI SHM fallback without vendor-biased copy', () => {
+    const stats = {
+      streaming: true,
+      packet_loss: 0,
+      capture_path: 'shm_cpu_capture',
+      capture_path_reason: 'gpu_native_requested_shm_fallback',
+      capture_cpu_copy: true,
+      capture_gpu_native: false,
+      encode_target_device: 'vaapi',
+      encode_time_ms: 5.2,
+      linux_gpu_profile: {
+        encoder_api: 'vaapi',
+        encoder_adapter: '/dev/dri/renderD128',
+        capture_device: '/dev/dri/renderD128',
+        adapter_matches_capture_device: true,
+        gpu_native_requested: true,
+        gpu_native_succeeded: false,
+      },
+    }
+
+    expect(describeLinuxGpuProfile(stats)).toContain('AMD/VAAPI')
+    expect(describeLinuxGpuProfile(stats)).toContain('SHM/system-memory')
+
+    const checklist = buildFixMyStreamChecklist({ statsConnected: true, stats })
+    const capture = checklist.find((item) => item.key === 'capture-path')
+
+    expect(capture.detail).toContain('AMD/VAAPI')
+    expect(capture.detail).toContain('SHM/system-memory')
+    expect(capture.action).toContain('conservative Headless Stream baseline')
+    expect(`${capture.detail} ${capture.action}`).not.toContain('CUDA')
+    expect(`${capture.detail} ${capture.action}`).not.toContain('NVIDIA')
   })
 })

--- a/src_assets/common/assets/web/linux-streaming-setup.test.js
+++ b/src_assets/common/assets/web/linux-streaming-setup.test.js
@@ -50,7 +50,7 @@ function mountAudioVideo(config = linuxConfig()) {
 }
 
 describe('Linux Streaming Setup checklist', () => {
-  it('guides desktop Linux operators through display pairing, Auto Quality, and Wayland/NVIDIA copy checks', () => {
+  it('guides desktop Linux operators through display pairing, Auto Quality, and AMD/VAAPI capture checks', () => {
     const wrapper = mountAudioVideo()
     const checklist = wrapper.find('[data-linux-streaming-setup]')
 
@@ -60,8 +60,10 @@ describe('Linux Streaming Setup checklist', () => {
     expect(checklist.text()).toContain('Discover first')
     expect(checklist.text()).toContain('Decide Auto Quality')
     expect(checklist.text()).toContain('Manual')
-    expect(checklist.text()).toContain('Check Wayland / NVIDIA copy risk')
-    expect(checklist.text()).toContain('GPU-native auto')
+    expect(checklist.text()).toContain('Check Wayland / VAAPI capture truth')
+    expect(checklist.text()).toContain('VAAPI / Mesa')
+    expect(checklist.text()).toContain('KMS/DRM is advanced')
+    expect(checklist.text()).toContain('Safe default')
   })
 
   it('reflects selected display pairing and GPU-native copy intent', () => {
@@ -75,8 +77,10 @@ describe('Linux Streaming Setup checklist', () => {
     const text = wrapper.find('[data-linux-streaming-setup]').text()
 
     expect(text).toContain('Selected')
-    expect(text).toContain('GPU-native fallback forced')
+    expect(text).toContain('GPU-native requested')
     expect(text).toContain('Enabled')
-    expect(text).toContain('avoid the SHM/RAM copy path')
+    expect(text).toContain('SHM/system-memory')
+    expect(text).not.toContain('CUDA')
+    expect(text).not.toContain('NVIDIA')
   })
 })

--- a/src_assets/common/assets/web/settings-search.test.js
+++ b/src_assets/common/assets/web/settings-search.test.js
@@ -46,7 +46,7 @@ function optionFactory(key) {
   const descriptions = {
     adapter_name: 'Pick the encoder GPU that owns the display path.',
     output_name: 'Pair Polaris with the monitor or virtual output to capture.',
-    linux_prefer_gpu_native_capture: 'Wayland NVIDIA copy avoidance; keep frames GPU resident.',
+    linux_prefer_gpu_native_capture: 'Wayland VAAPI DMA-BUF capture truth; distinguish SHM/system-memory fallback from GPU-native capture.',
     ai_enabled: 'Let Auto Quality choose per-game profiles.',
     adaptive_bitrate_enabled: 'Let Auto Quality adjust bitrate for headless streams.',
   }
@@ -69,13 +69,13 @@ describe('ranked settings search helper', () => {
     expect(results[0].firstOptionKey).toBeTruthy()
   })
 
-  it('scores Wayland NVIDIA copy queries against the GPU-native capture setting', () => {
+  it('scores AMD VAAPI SHM fallback queries against the GPU-native capture setting', () => {
     expect(scoreSettingsOption({
       key: 'linux_prefer_gpu_native_capture',
       label: 'GPU-native capture preference',
-      description: 'Wayland NVIDIA copy avoidance and DMA-BUF/CUDA capture residency.',
-      aliases: ['nvidia wayland copy', 'headless gpu native'],
-    }, 'wayland nvidia copy')).toBeGreaterThan(0)
+      description: 'Wayland VAAPI DMA-BUF capture truth and SHM/system-memory fallback guidance for AMD hosts.',
+      aliases: ['amd vaapi shm fallback', 'headless gpu native'],
+    }, 'amd vaapi shm fallback')).toBeGreaterThan(0)
   })
 
   it('keeps Auto Quality discoverable from both AI and bitrate language', () => {

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -1048,9 +1048,9 @@ function captureReasonMessage(reason) {
   const messages = {
     gpu_native: 'Capture and encoder conversion are GPU-resident.',
     headless_extcopy_dmabuf: 'True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.',
-    windowed_dmabuf_override: 'Windowed private compositor is preserving the DMA-BUF/CUDA capture path.',
-    headless_shm_fallback: 'Headless Stream is using SHM/system-memory capture. The stream can be healthy, but capable high-FPS hosts should use a GPU-native path when available.',
-    headless_shm_default: 'Headless Stream is using SHM/system-memory capture. The stream can be healthy, but capable high-FPS hosts should use a GPU-native path when available.',
+    windowed_dmabuf_override: 'Windowed private compositor is preserving the DMA-BUF/GPU-resident capture path.',
+    headless_shm_fallback: 'Headless Stream is using SHM/system-memory capture. The stream can be healthy, including AMD/VAAPI conservative baselines.',
+    headless_shm_default: 'Headless Stream is using SHM/system-memory capture. The stream can be healthy, including AMD/VAAPI conservative baselines.',
     gpu_native_requested_shm_fallback: 'GPU-native capture was requested, but Wayland capture fell back to SHM/system-memory frames.',
     gpu_native_requested_cpu_capture: 'GPU-native capture was requested, but capture frames are CPU-resident.',
     gpu_native_requested_cpu_encode_upload: 'GPU-native capture was requested, but encoder upload/conversion is CPU-resident.',
@@ -1248,7 +1248,7 @@ const streamPathNotices = computed(() => {
     notices.push({
       key: 'gpu-native-override',
       title: 'GPU-native override',
-      message: 'Polaris requested headless, but is running windowed labwc so DMA-BUF/CUDA capture can stay GPU-resident.',
+      message: 'Polaris requested headless, but is running windowed labwc so DMA-BUF/GPU-resident capture can stay on the fast path.',
       surfaceClass: 'border-amber-300/25 bg-amber-300/10',
       titleClass: 'text-amber-200',
     })

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -440,9 +440,9 @@ function captureReasonDescription(reason) {
   const messages = {
     gpu_native: 'Capture and encoder conversion are GPU-resident.',
     headless_extcopy_dmabuf: 'True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.',
-    windowed_dmabuf_override: 'Windowed private compositor is preserving the DMA-BUF/CUDA capture path.',
-    headless_shm_fallback: 'Headless Stream is using SHM/system-memory capture; healthy streams can still show this, but capable high-FPS hosts should use a GPU-native path when available.',
-    headless_shm_default: 'Headless Stream is using SHM/system-memory capture; healthy streams can still show this, but capable high-FPS hosts should use a GPU-native path when available.',
+    windowed_dmabuf_override: 'Windowed private compositor is preserving the DMA-BUF/GPU-resident capture path.',
+    headless_shm_fallback: 'Headless Stream is using SHM/system-memory capture; healthy streams can still show this, including AMD/VAAPI conservative baselines.',
+    headless_shm_default: 'Headless Stream is using SHM/system-memory capture; healthy streams can still show this, including AMD/VAAPI conservative baselines.',
     gpu_native_requested_shm_fallback: 'GPU-native capture was requested, but Wayland capture fell back to SHM/system-memory frames.',
     gpu_native_requested_cpu_capture: 'GPU-native capture was requested, but capture frames are CPU-resident.',
     gpu_native_requested_cpu_encode_upload: 'GPU-native capture was requested, but encoder upload/conversion is CPU-resident.',

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -17,16 +17,22 @@ namespace {
 #ifdef __linux__
   struct linux_cage_compositor_guard_t {
     linux_cage_compositor_guard_t():
+        adapter_name(config::video.adapter_name),
         auto_manage_displays(config::video.linux_display.auto_manage_displays),
-        use_cage_compositor(config::video.linux_display.use_cage_compositor) {}
+        use_cage_compositor(config::video.linux_display.use_cage_compositor),
+        prefer_gpu_native_capture(config::video.linux_display.prefer_gpu_native_capture) {}
 
     ~linux_cage_compositor_guard_t() {
+      config::video.adapter_name = adapter_name;
       config::video.linux_display.auto_manage_displays = auto_manage_displays;
       config::video.linux_display.use_cage_compositor = use_cage_compositor;
+      config::video.linux_display.prefer_gpu_native_capture = prefer_gpu_native_capture;
     }
 
+    std::string adapter_name;
     bool auto_manage_displays;
     bool use_cage_compositor;
+    bool prefer_gpu_native_capture;
   };
 #endif
 
@@ -224,6 +230,44 @@ TEST(ProcessRuntimeConfigTests, SessionHealthFlagsHeadlessHdrUnavailableSeparate
   EXPECT_NE(health.dump().find("Private Headless Stream"), std::string::npos);
   EXPECT_NE(health.dump().find("physical or virtual HDR-capable display path"), std::string::npos);
 }
+
+#ifdef __linux__
+TEST(ProcessRuntimeConfigTests, MissionControlPolicyIncludesLinuxGpuProfileForVaapiCaptureTruth) {
+  linux_cage_compositor_guard_t linux_guard;
+  config::video.adapter_name = "/dev/dri/renderD128";
+  config::video.linux_display.use_cage_compositor = true;
+  config::video.linux_display.prefer_gpu_native_capture = true;
+
+  crypto::named_cert_t client {};
+  client.name = "Steam Deck OLED";
+  client.uuid = "amd-vaapi-client";
+
+  stream_stats::stats_t stats {};
+  stats.runtime_effective_headless = true;
+  stats.capture_transport = platf::frame_transport_e::shm;
+  stats.capture_residency = platf::frame_residency_e::cpu;
+  stats.capture_format = platf::frame_format_e::bgra8;
+  stats.capture_device = "/dev/dri/renderD128";
+  stats.encode_target_device = "vaapi";
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_format = platf::frame_format_e::nv12;
+
+  const auto policy = nvhttp::build_stream_policy_json_for_tests(
+    client,
+    stats,
+    nlohmann::json::object()
+  );
+
+  ASSERT_TRUE(policy.contains("linux_gpu_profile"));
+  const auto &profile = policy.at("linux_gpu_profile");
+  EXPECT_EQ(profile.at("encoder_api"), "vaapi");
+  EXPECT_EQ(profile.at("encoder_adapter"), "/dev/dri/renderD128");
+  EXPECT_EQ(profile.at("capture_device"), "/dev/dri/renderD128");
+  EXPECT_TRUE(profile.at("adapter_matches_capture_device"));
+  EXPECT_TRUE(profile.at("gpu_native_requested"));
+  EXPECT_FALSE(profile.at("gpu_native_succeeded"));
+}
+#endif
 
 TEST(ProcessRuntimeConfigTests, InitialTerminateDoesNotResetAdaptiveBitrateMax) {
 #ifdef __linux__

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -160,6 +160,7 @@ TEST(StreamStatsHdrStateTests, LabelsTrueHdrAndPlainSdrWithoutDowngrade) {
 
 TEST(StreamStatsCapturePathTests, ExplainsGpuNativeShmFallback) {
   LinuxDisplayConfigGuard guard;
+  config::video.adapter_name = "/dev/dri/renderD128";
   config::video.linux_display.use_cage_compositor = true;
   config::video.linux_display.prefer_gpu_native_capture = true;
 
@@ -167,12 +168,26 @@ TEST(StreamStatsCapturePathTests, ExplainsGpuNativeShmFallback) {
   stats.runtime_effective_headless = true;
   stats.capture_transport = platf::frame_transport_e::shm;
   stats.capture_residency = platf::frame_residency_e::cpu;
-  stats.encode_target_residency = platf::frame_residency_e::cpu;
+  stats.capture_format = platf::frame_format_e::bgra8;
+  stats.capture_device = "/dev/dri/renderD128";
+  stats.encode_target_device = "vaapi";
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_format = platf::frame_format_e::nv12;
 
   EXPECT_EQ(stream_stats::capture_path_summary(stats), "shm_cpu_capture");
-  EXPECT_EQ(stream_stats::capture_path_reason(stats), "headless_shm_fallback");
+  EXPECT_EQ(stream_stats::capture_path_reason(stats), "gpu_native_requested_shm_fallback");
   EXPECT_TRUE(stream_stats::capture_path_uses_cpu_copy(stats));
   EXPECT_FALSE(stream_stats::capture_path_is_gpu_native(stats));
+
+  const auto json = nlohmann::json::parse(stats.to_json());
+  ASSERT_TRUE(json.contains("linux_gpu_profile"));
+  const auto &profile = json.at("linux_gpu_profile");
+  EXPECT_EQ(profile.at("encoder_api"), "vaapi");
+  EXPECT_EQ(profile.at("encoder_adapter"), "/dev/dri/renderD128");
+  EXPECT_EQ(profile.at("capture_device"), "/dev/dri/renderD128");
+  EXPECT_TRUE(profile.at("adapter_matches_capture_device"));
+  EXPECT_TRUE(profile.at("gpu_native_requested"));
+  EXPECT_FALSE(profile.at("gpu_native_succeeded"));
 }
 
 TEST(StreamStatsCapturePathTests, DetectsCpuEncodeUpload) {


### PR DESCRIPTION
## Summary
- Add a documented AMD/Linux streaming optimization map for VAAPI, SHM fallback, GPU-native, and KMS/DRM paths.
- Expose `linux_gpu_profile` in stream stats / stream policy so clients can distinguish GPU-native success from SHM fallback.
- Update Mission Control diagnostics, setup guidance, dashboard, troubleshooting, and settings search copy to describe AMD/VAAPI/Mesa truth without NVIDIA/CUDA bias.
- Rebased onto current `master` and preserved the newer HDR downgrade diagnostics/tests while resolving copy conflicts.

## Test Plan
- [x] `git diff --check`
- [x] `cmake --build build --parallel 32`
- [x] `ctest --test-dir build --output-on-failure` — 12/12 passed
- [x] `npm run test` — 34 files / 141 tests passed
- [x] `npm run lint`
- [x] `npm run build:budget`
- [x] `npm run smoke:web -- --static --static-dir build/assets/web`

## Artifacts
- Built binary: `build/polaris-1.2.0.29da9231`
- Binary sha256: `f35d30f62ac1cca59a3dcddce3f83af8889b2c639963097742d38fceecf28ca0`
- Built web index sha256: `397a364ae39fff895a33e74638e9ca4b4f38984d0aec2098b9417e5786d4e873`
