### PR TITLE
fix(linux): defer windowed cage encoder probe

### DIFF
--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -31,8 +31,28 @@ namespace stream_display_policy {
     const auto &linux_display = config::video.linux_display;
     const bool requested_headless = linux_display.headless_mode;
     const bool use_cage_runtime = linux_display.use_cage_compositor;
+    const bool gpu_native_test =
+      linux_display.prefer_gpu_native_capture ||
+      input.active_encoder_requires_gpu_native_capture ||
+      input.runtime_gpu_native_override_active;
 
     if (!requested_headless) {
+      if (use_cage_runtime) {
+        resolved_t result;
+        result.mode = gpu_native_test ? mode_e::GPU_NATIVE_STREAM : mode_e::WINDOWED_STREAM;
+        result.selection = "windowed_stream";
+        result.label = gpu_native_test ? "GPU-Native Stream" : "Windowed Stream";
+        result.reason = gpu_native_test ?
+          "Polaris is running the private compositor windowed so capture can stay GPU-native." :
+          "Polaris streams from a private compositor window on the current desktop.";
+        result.requested_headless = false;
+        result.effective_headless = false;
+        result.use_cage_runtime = true;
+        result.should_defer_encoder_probe = true;
+        result.should_probe_against_runtime = true;
+        return result;
+      }
+
       return desktop_policy();
     }
 
@@ -55,11 +75,6 @@ namespace stream_display_policy {
       result.should_probe_against_runtime = false;
       return result;
     }
-
-    const bool gpu_native_test =
-      linux_display.prefer_gpu_native_capture ||
-      input.active_encoder_requires_gpu_native_capture ||
-      input.runtime_gpu_native_override_active;
 
     if (gpu_native_test) {
       result.mode = mode_e::GPU_NATIVE_STREAM;

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -12,6 +12,7 @@ namespace stream_display_policy {
     DESKTOP,
     HEADLESS,
     HOST_VIRTUAL_DISPLAY,
+    WINDOWED_STREAM,
     GPU_NATIVE_STREAM,
   };
 

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -61,3 +61,21 @@ TEST(StreamDisplayPolicyTests, EncoderGpuNativeRequirementPromotesCapableHostPat
   EXPECT_EQ(resolved.label, "GPU-Native Stream");
   EXPECT_EQ(resolved.reason, "Polaris can force a windowed private compositor when hidden headless capture cannot stay GPU-native.");
 }
+
+TEST(StreamDisplayPolicyTests, WindowedCageDefersEncoderProbeUntilRuntimeExists) {
+  LinuxDisplayPolicyGuard guard;
+  config::video.linux_display.headless_mode = false;
+  config::video.linux_display.use_cage_compositor = true;
+  config::video.linux_display.prefer_gpu_native_capture = false;
+
+  const auto resolved = stream_display_policy::resolve(stream_display_policy::input_t {});
+
+  EXPECT_EQ(resolved.selection, "windowed_stream");
+  EXPECT_EQ(resolved.label, "Windowed Stream");
+  EXPECT_EQ(resolved.mode, stream_display_policy::mode_e::WINDOWED_STREAM);
+  EXPECT_FALSE(resolved.requested_headless);
+  EXPECT_FALSE(resolved.effective_headless);
+  EXPECT_TRUE(resolved.use_cage_runtime);
+  EXPECT_TRUE(resolved.should_defer_encoder_probe);
+  EXPECT_TRUE(resolved.should_probe_against_runtime);
+}


### PR DESCRIPTION
## Summary
- Treat non-headless labwc/cage sessions as a private windowed stream runtime instead of plain desktop capture.
- Defer encoder probing until the windowed compositor runtime exists, so VAAPI/software probes run against the cage socket instead of failing early on the desktop context.
- Add a regression test covering the Bazzite-style windowed cage policy path.

## Test Plan
- RED: `./build/tests/test_polaris_stream --gtest_filter='StreamDisplayPolicyTests.WindowedCageDefersEncoderProbeUntilRuntimeExists'` failed before the policy fix.
- `cmake -S . -B build -G Ninja -DBUILD_TESTS=ON -DBUILD_FULL_TESTS=ON -DPOLARIS_ENABLE_CUDA=OFF -DPOLARIS_ALLOW_CUDA_DISABLED_ON_NVIDIA=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/bin/g++-15`
- `cmake --build build --target test_polaris_stream`
- `./build/tests/test_polaris_stream --gtest_filter='StreamDisplayPolicyTests.*:StreamStatsCapturePathTests.*'`
- `./build/tests/test_polaris_stream`
