### PR TITLE
fix(linux): explain GPU-native fallback on VAAPI hosts

### DIFF
--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -90,7 +90,7 @@ namespace stream_display_policy {
     result.mode = mode_e::HEADLESS;
     result.selection = "headless_stream";
     result.label = "Headless Stream";
-    result.reason = "Polaris streams from a private headless compositor and uses DMA-BUF/CUDA GPU-native capture when the host supports it.";
+    result.reason = "Polaris streams from a private headless compositor and uses GPU-native DMA-BUF capture when the host supports it.";
     result.effective_headless = true;
     return result;
   }

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -348,7 +348,7 @@ namespace stream_stats {
       return "True-headless DMA-BUF capture is using a different DRM render node than the configured encoder adapter; Polaris should fall back to SHM/system memory to avoid known cross-GPU black video.";
     }
     if (reason == "windowed_dmabuf_override") {
-      return "Polaris is using a windowed private compositor so DMA-BUF/CUDA capture can stay GPU-resident.";
+      return "Polaris is using a windowed private compositor so GPU-native capture can stay GPU-resident.";
     }
     if (reason == "gpu_native_requested_shm_fallback") {
       return "GPU-native capture was requested, but the active Wayland capture fell back to SHM/system-memory frames.";

--- a/src_assets/common/assets/web/config-defaults.test.js
+++ b/src_assets/common/assets/web/config-defaults.test.js
@@ -2,12 +2,16 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 describe('config defaults', () => {
-  it('presents GPU-native capture as a primary stream mode, not an experimental test', () => {
+  it('presents GPU-native capture as a primary stream mode with vendor-neutral fallback copy', () => {
     const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/configs/tabs/AudioVideo.vue'), 'utf8')
 
     expect(source).toContain('GPU-Native Stream')
+    expect(source).toContain('may still fall back to Headless Stream with SHM/RAM capture')
+    expect(source).toContain('capable GPU-native hosts')
     expect(source).not.toContain('GPU-Native Test')
     expect(source).not.toContain('Experimental')
+    expect(source).not.toContain('capable NVIDIA/Wayland hosts')
+    expect(source).not.toContain('DMA-BUF/CUDA/NVENC hosts')
   })
 
   it('uses Browser Stream as the primary browser streaming config key', () => {

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -36,8 +36,8 @@ const streamDisplayModes = [
     id: 'headless_stream',
     title: 'Headless Stream',
     badge: 'Recommended',
-    copy: 'Recommended. Starts apps inside a private hidden compositor. It does not mirror your current desktop.',
-    note: 'Best isolation path. On some wlroots headless outputs this can fall back to SHM/system-memory capture instead of DMA-BUF.',
+    copy: 'Recommended. Starts apps inside a private hidden compositor. Capable GPU-native hosts can stay on DMA-BUF frames; AMD/VAAPI and other unsupported paths honestly report SHM/system-memory fallback instead of pretending.',
+    note: 'Best isolation path. Hosts that cannot produce GPU-resident frames may still fall back to Headless Stream with SHM/RAM capture; Polaris reports that instead of pretending.',
     restartCopy: 'Requires restart. Polaris will stream an isolated hidden runtime, not the existing KDE or GNOME session.',
   },
   {
@@ -60,9 +60,9 @@ const streamDisplayModes = [
     id: 'windowed_stream',
     title: 'GPU-Native Stream',
     badge: 'Performance',
-    copy: 'Requests a private stream runtime and allows Polaris to run it windowed when that is needed to preserve DMA-BUF/GPU-resident capture.',
-    note: 'Use when diagnostics say hidden headless fell back to SHM/system-memory; capable hosts may not need it because Headless Stream can already be GPU-resident.',
-    restartCopy: 'Requires restart. GPU-Native Stream may override hidden headless into a windowed labwc runtime to avoid SHM/system-memory fallback.',
+    copy: 'Requests the GPU-native fallback path: private stream runtime with windowed labwc allowed when hidden headless cannot stay GPU-resident.',
+    note: 'Use when diagnostics say hidden headless fell back to SHM/system-memory. Hosts that cannot produce GPU-resident frames may still fall back to Headless Stream with SHM/RAM capture.',
+    restartCopy: 'Requires restart. GPU-Native Stream may use a windowed labwc runtime when the runtime proves it can avoid SHM/system-memory fallback.',
   },
 ]
 
@@ -173,7 +173,7 @@ const linuxStreamingSetupChecklist = computed(() => [
     id: 'runtime',
     title: 'Choose the Linux runtime path',
     status: selectedStreamDisplayMode.value.title,
-    copy: 'Headless Stream is the safe default. GPU-Native Stream is for validating DMA-BUF/VAAPI residency when hidden Wayland capture falls back to SHM/system-memory frames.',
+    copy: 'Headless Stream is the safe default. GPU-Native Stream is for validating capable GPU-native hosts; AMD/VAAPI and other unsupported runtimes honestly fall back when frames cannot stay GPU-resident.',
   },
   {
     id: 'quality',
@@ -188,7 +188,7 @@ const linuxStreamingSetupChecklist = computed(() => [
     title: 'Check Wayland / VAAPI capture truth',
     status: config.value.linux_prefer_gpu_native_capture === 'enabled' ? 'GPU-native requested' : 'Safe default',
     copy: config.value.linux_prefer_gpu_native_capture === 'enabled'
-      ? 'Polaris may keep labwc windowed to avoid SHM/system-memory fallback and preserve GPU-resident DMA-BUF capture.'
+      ? 'Polaris may use windowed labwc to avoid SHM/system-memory fallback and preserve GPU-resident DMA-BUF capture when the runtime proves it can.'
       : 'VAAPI / Mesa is the AMD Linux baseline. Leave GPU-native off for normal headless streaming; turn it on only when telemetry shows SHM/system-memory fallback and you are collecting support evidence. KMS/DRM is advanced.',
   },
 ])
@@ -339,7 +339,7 @@ const validateFallbackMode = (event) => {
             </div>
             <div class="surface-muted p-3">
               <div class="text-xs font-semibold uppercase tracking-[0.16em] text-green-300">GPU path</div>
-              <div class="mt-2 text-sm leading-relaxed text-storm">GPU-Native Stream favors DMA-BUF and hardware-encoder residency, even if that means a visible labwc window.</div>
+              <div class="mt-2 text-sm leading-relaxed text-storm">GPU-Native Stream favors GPU-resident capture, even if that means a visible labwc window when the runtime supports it.</div>
             </div>
             <div class="surface-muted p-3">
               <div class="text-xs font-semibold uppercase tracking-[0.16em] text-amber-200">FPS target</div>

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -376,7 +376,7 @@
     "linux_use_cage_compositor": "Private Compositor Runtime",
     "linux_use_cage_compositor_desc": "Run Linux sessions inside Polaris' private labwc Wayland compositor instead of the current desktop session.",
     "linux_prefer_gpu_native_capture": "GPU-Native Stream Capture",
-    "linux_prefer_gpu_native_capture_desc": "Allows Polaris to force a windowed private runtime when hidden headless cannot keep DMA-BUF/CUDA capture GPU-native.",
+    "linux_prefer_gpu_native_capture_desc": "Allows Polaris to request a windowed private runtime when hidden headless cannot keep capture GPU-native; unsupported hosts fall back to SHM/RAM.",
     "hevc_mode": "HEVC Support",
     "hevc_mode_0": "Polaris will advertise support for HEVC based on encoder capabilities (recommended)",
     "hevc_mode_1": "Polaris will not advertise support for HEVC",

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -1048,7 +1048,7 @@ function captureReasonMessage(reason) {
   const messages = {
     gpu_native: 'Capture and encoder conversion are GPU-resident.',
     headless_extcopy_dmabuf: 'True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.',
-    windowed_dmabuf_override: 'Windowed private compositor is preserving the DMA-BUF/GPU-resident capture path.',
+    windowed_dmabuf_override: 'Windowed private compositor is preserving the GPU-native capture path.',
     headless_shm_fallback: 'Headless Stream is using SHM/system-memory capture. The stream can be healthy, including AMD/VAAPI conservative baselines.',
     headless_shm_default: 'Headless Stream is using SHM/system-memory capture. The stream can be healthy, including AMD/VAAPI conservative baselines.',
     gpu_native_requested_shm_fallback: 'GPU-native capture was requested, but Wayland capture fell back to SHM/system-memory frames.',
@@ -1248,7 +1248,7 @@ const streamPathNotices = computed(() => {
     notices.push({
       key: 'gpu-native-override',
       title: 'GPU-native override',
-      message: 'Polaris requested headless, but is running windowed labwc so DMA-BUF/GPU-resident capture can stay on the fast path.',
+      message: 'Polaris requested headless, but is running windowed labwc so GPU-native capture can stay GPU-resident.',
       surfaceClass: 'border-amber-300/25 bg-amber-300/10',
       titleClass: 'text-amber-200',
     })

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -440,7 +440,7 @@ function captureReasonDescription(reason) {
   const messages = {
     gpu_native: 'Capture and encoder conversion are GPU-resident.',
     headless_extcopy_dmabuf: 'True-headless DMA-BUF capture is active; frames stay GPU-resident through the encoder path.',
-    windowed_dmabuf_override: 'Windowed private compositor is preserving the DMA-BUF/GPU-resident capture path.',
+    windowed_dmabuf_override: 'Windowed private compositor is preserving the GPU-native capture path.',
     headless_shm_fallback: 'Headless Stream is using SHM/system-memory capture; healthy streams can still show this, including AMD/VAAPI conservative baselines.',
     headless_shm_default: 'Headless Stream is using SHM/system-memory capture; healthy streams can still show this, including AMD/VAAPI conservative baselines.',
     gpu_native_requested_shm_fallback: 'GPU-native capture was requested, but Wayland capture fell back to SHM/system-memory frames.',


### PR DESCRIPTION
## Summary
- Treat GPU-Native Stream as a request on AMD/VAAPI hosts and make the fallback copy explicit when the runtime cannot keep frames GPU-resident.
- Keep `gpu_native_requested_shm_fallback` as the user-facing support signal instead of making the saved preference look ignored.
- Replace CUDA/NVENC-only wording in Audio/Video, Dashboard, Troubleshooting, locale, and regression tests with vendor-neutral GPU-native fallback guidance that still calls out AMD/VAAPI conservative baselines.

## Test Plan
- [x] `npm test -- src_assets/common/assets/web/config-defaults.test.js src_assets/common/assets/web/linux-streaming-setup.test.js src_assets/common/assets/web/settings-search.test.js`
- [x] `cmake -S . -B build-issue172 -G Ninja -DBUILD_TESTS=ON -DBUILD_FULL_TESTS=ON -DPOLARIS_ENABLE_CUDA=OFF -DPOLARIS_ALLOW_CUDA_DISABLED_ON_NVIDIA=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/gcc-15 -DCMAKE_CXX_COMPILER=/usr/bin/g++-15`
- [x] `cmake --build build-issue172 --target test_polaris_stream -j$(nproc)`
- [x] `./build-issue172/tests/test_polaris_stream --gtest_filter='StreamStatsCapturePathTests.*:StreamDisplayPolicyTests.*'`

Fixes #172
