### PR TITLE
fix: clarify GPU-native stream relaunch notice

### DIFF
--- a/src_assets/common/assets/web/client-settings-sync.js
+++ b/src_assets/common/assets/web/client-settings-sync.js
@@ -69,6 +69,38 @@ export function labelForStreamDisplayMode(mode) {
   return 'Desktop Display'
 }
 
+export function resolveStreamDisplayRuntimeNotice(sync = {}, selectedMode = '') {
+  const selectedLabel = labelForStreamDisplayMode(selectedMode) || sync.desiredModeLabel || 'Stream display mode'
+  const desiredLabel = sync.desiredModeLabel || selectedLabel
+  const effectiveLabel = sync.effectiveModeLabel || desiredLabel
+
+  if (sync.available && selectedMode && sync.desiredMode && selectedMode !== sync.desiredMode) {
+    return {
+      state: 'unsaved',
+      copy: `${selectedLabel} selected. Save this display choice; new launches use it after Polaris reloads the host settings.`,
+    }
+  }
+
+  if (sync.available && sync.relaunchRequired) {
+    return {
+      state: 'pending_relaunch',
+      copy: `Pending relaunch. The active stream is still using ${effectiveLabel}; relaunch to apply ${desiredLabel}.`,
+    }
+  }
+
+  if (sync.available) {
+    return {
+      state: 'synced',
+      copy: `${desiredLabel} saved. Effective runtime is ${effectiveLabel}; no pending relaunch is reported.`,
+    }
+  }
+
+  return {
+    state: 'info',
+    copy: `${selectedLabel} selected. Save this display choice; it applies when the next stream starts.`,
+  }
+}
+
 export function normalizeFieldList(value) {
   if (Array.isArray(value)) return value
   if (typeof value === 'string') {

--- a/src_assets/common/assets/web/client-settings-sync.js
+++ b/src_assets/common/assets/web/client-settings-sync.js
@@ -66,13 +66,15 @@ export function labelForStreamDisplayMode(mode) {
   if (mode === 'headless_stream') return 'Headless Stream'
   if (mode === 'host_virtual_display') return 'Host Virtual Display'
   if (mode === 'windowed_stream') return 'GPU-Native Stream'
-  return 'Desktop Display'
+  if (mode === 'desktop_display') return 'Desktop Display'
+  return ''
 }
 
 export function resolveStreamDisplayRuntimeNotice(sync = {}, selectedMode = '') {
   const selectedLabel = labelForStreamDisplayMode(selectedMode) || sync.desiredModeLabel || 'Stream display mode'
-  const desiredLabel = sync.desiredModeLabel || selectedLabel
-  const effectiveLabel = sync.effectiveModeLabel || desiredLabel
+  const desiredLabel = sync.desiredModeLabel || labelForStreamDisplayMode(sync.desiredMode) || selectedLabel
+  const effectiveLabel = sync.effectiveModeLabel || labelForStreamDisplayMode(sync.effectiveMode) || desiredLabel
+  const modesDiffer = sync.desiredMode && sync.effectiveMode ? sync.desiredMode !== sync.effectiveMode : sync.relaunchRequired
 
   if (sync.available && selectedMode && sync.desiredMode && selectedMode !== sync.desiredMode) {
     return {
@@ -81,7 +83,7 @@ export function resolveStreamDisplayRuntimeNotice(sync = {}, selectedMode = '') 
     }
   }
 
-  if (sync.available && sync.relaunchRequired) {
+  if (sync.available && sync.relaunchRequired && modesDiffer) {
     return {
       state: 'pending_relaunch',
       copy: `Pending relaunch. The active stream is still using ${effectiveLabel}; relaunch to apply ${desiredLabel}.`,

--- a/src_assets/common/assets/web/client-settings-sync.test.js
+++ b/src_assets/common/assets/web/client-settings-sync.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   resolveClientSettingsSync,
   resolveStreamDisplayMode,
+  resolveStreamDisplayRuntimeNotice,
   stripClientSettingsResponseOnly,
 } from './client-settings-sync'
 
@@ -55,6 +56,57 @@ describe('client settings sync helpers', () => {
     expect(sync.relaunchRequired).toBe(true)
     expect(sync.desiredModeLabel).toBe('Headless Stream')
     expect(sync.effectiveModeLabel).toBe('Desktop Display')
+  })
+
+  it('uses pending relaunch copy only when desired and effective stream display modes differ', () => {
+    const pending = resolveStreamDisplayRuntimeNotice(
+      resolveClientSettingsSync({
+        client_settings_available: true,
+        client_settings_relaunch_required: true,
+        client_settings_stream_display_mode: 'windowed_stream',
+        client_settings_effective_stream_display_mode: 'headless_stream',
+      }),
+      'windowed_stream'
+    )
+
+    expect(pending.state).toBe('pending_relaunch')
+    expect(pending.copy).toContain('Pending relaunch')
+    expect(pending.copy).toContain('Headless Stream')
+    expect(pending.copy).toContain('GPU-Native Stream')
+  })
+
+  it('shows saved active-mode copy after GPU-native stream is synced', () => {
+    const notice = resolveStreamDisplayRuntimeNotice(
+      resolveClientSettingsSync({
+        client_settings_available: true,
+        client_settings_relaunch_required: false,
+        client_settings_stream_display_mode: 'windowed_stream',
+        client_settings_effective_stream_display_mode: 'windowed_stream',
+      }),
+      'windowed_stream'
+    )
+
+    expect(notice.state).toBe('synced')
+    expect(notice.copy).toContain('GPU-Native Stream saved')
+    expect(notice.copy).toContain('no pending relaunch')
+    expect(notice.copy).not.toContain('Requires restart')
+  })
+
+  it('calls out unsaved local display-mode changes before relaunch guidance', () => {
+    const notice = resolveStreamDisplayRuntimeNotice(
+      resolveClientSettingsSync({
+        client_settings_available: true,
+        client_settings_relaunch_required: false,
+        client_settings_stream_display_mode: 'headless_stream',
+        client_settings_effective_stream_display_mode: 'headless_stream',
+      }),
+      'windowed_stream'
+    )
+
+    expect(notice.state).toBe('unsaved')
+    expect(notice.copy).toContain('GPU-Native Stream selected')
+    expect(notice.copy).toContain('Save')
+    expect(notice.copy).not.toContain('Requires restart')
   })
 
   it('strips server-only client-settings fields before config save', () => {

--- a/src_assets/common/assets/web/client-settings-sync.test.js
+++ b/src_assets/common/assets/web/client-settings-sync.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  labelForStreamDisplayMode,
   resolveClientSettingsSync,
   resolveStreamDisplayMode,
   resolveStreamDisplayRuntimeNotice,
@@ -73,6 +74,37 @@ describe('client settings sync helpers', () => {
     expect(pending.copy).toContain('Pending relaunch')
     expect(pending.copy).toContain('Headless Stream')
     expect(pending.copy).toContain('GPU-Native Stream')
+  })
+
+  it('does not show pending relaunch when backend restart flag is stale but modes match', () => {
+    const notice = resolveStreamDisplayRuntimeNotice(
+      resolveClientSettingsSync({
+        client_settings_available: true,
+        client_settings_relaunch_required: true,
+        client_settings_stream_display_mode: 'windowed_stream',
+        client_settings_effective_stream_display_mode: 'windowed_stream',
+      }),
+      'windowed_stream'
+    )
+
+    expect(notice.state).toBe('synced')
+    expect(notice.copy).not.toContain('Pending relaunch')
+  })
+
+  it('keeps unknown stream display modes unlabeled so server labels can win', () => {
+    expect(labelForStreamDisplayMode('future_stream_mode')).toBe('')
+
+    const notice = resolveStreamDisplayRuntimeNotice(
+      resolveClientSettingsSync({
+        client_settings_available: true,
+        client_settings_stream_display_mode: 'future_stream_mode',
+        client_settings_stream_display_mode_label: 'Future Stream',
+      }),
+      'future_stream_mode'
+    )
+
+    expect(notice.copy).toContain('Future Stream saved')
+    expect(notice.copy).not.toContain('Desktop Display saved')
   })
 
   it('shows saved active-mode copy after GPU-native stream is synced', () => {

--- a/src_assets/common/assets/web/config-defaults.test.js
+++ b/src_assets/common/assets/web/config-defaults.test.js
@@ -14,6 +14,15 @@ describe('config defaults', () => {
     expect(source).not.toContain('DMA-BUF/CUDA/NVENC hosts')
   })
 
+  it('uses dynamic stream-display runtime notices instead of static restart warnings', () => {
+    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/configs/tabs/AudioVideo.vue'), 'utf8')
+
+    expect(source).toContain('resolveStreamDisplayRuntimeNotice')
+    expect(source).toContain('streamDisplayRuntimeNotice.copy')
+    expect(source).not.toContain('restartCopy')
+    expect(source).not.toContain('Requires restart.')
+  })
+
   it('uses Browser Stream as the primary browser streaming config key', () => {
     const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/ConfigView.vue'), 'utf8')
 

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -7,7 +7,7 @@ import DisplayOutputSelector from './audiovideo/DisplayOutputSelector.vue'
 import DisplayDeviceOptions from "./audiovideo/DisplayDeviceOptions.vue";
 import VirtualDisplayStatus from "./audiovideo/VirtualDisplayStatus.vue";
 import Checkbox from "../../Checkbox.vue";
-import { resolveClientSettingsSync } from '../../client-settings-sync'
+import { resolveClientSettingsSync, resolveStreamDisplayRuntimeNotice } from '../../client-settings-sync'
 
 const $t = inject('i18n').t;
 
@@ -38,7 +38,6 @@ const streamDisplayModes = [
     badge: 'Recommended',
     copy: 'Recommended. Starts apps inside a private hidden compositor. Capable GPU-native hosts can stay on DMA-BUF frames; AMD/VAAPI and other unsupported paths honestly report SHM/system-memory fallback instead of pretending.',
     note: 'Best isolation path. Hosts that cannot produce GPU-resident frames may still fall back to Headless Stream with SHM/RAM capture; Polaris reports that instead of pretending.',
-    restartCopy: 'Requires restart. Polaris will stream an isolated hidden runtime, not the existing KDE or GNOME session.',
   },
   {
     id: 'host_virtual_display',
@@ -46,7 +45,6 @@ const streamDisplayModes = [
     badge: 'Compatibility',
     copy: 'Compatibility mode. Creates a display the operating system can see. Your desktop may rearrange or remember it.',
     note: 'Use this when the hidden compositor path is not available or the desktop needs to own the virtual output.',
-    restartCopy: 'Requires restart. KDE, GNOME, or display tools may see this as a monitor.',
   },
   {
     id: 'desktop_display',
@@ -54,7 +52,6 @@ const streamDisplayModes = [
     badge: 'Visible desktop',
     copy: 'Streams from your current desktop session when you want the visible KDE, GNOME, or wlroots desktop.',
     note: 'Useful for quick validation, but it is not isolated from the host desktop.',
-    restartCopy: 'Requires restart. Polaris will stream from the current desktop session.',
   },
   {
     id: 'windowed_stream',
@@ -62,7 +59,6 @@ const streamDisplayModes = [
     badge: 'Performance',
     copy: 'Requests the GPU-native fallback path: private stream runtime with windowed labwc allowed when hidden headless cannot stay GPU-resident.',
     note: 'Use when diagnostics say hidden headless fell back to SHM/system-memory. Hosts that cannot produce GPU-resident frames may still fall back to Headless Stream with SHM/RAM capture.',
-    restartCopy: 'Requires restart. GPU-Native Stream may use a windowed labwc runtime when the runtime proves it can avoid SHM/system-memory fallback.',
   },
 ]
 
@@ -82,6 +78,18 @@ const selectedStreamDisplayMode = computed(() => (
 ))
 
 const clientSettingsSync = computed(() => resolveClientSettingsSync(config.value))
+const streamDisplayRuntimeNotice = computed(() => (
+  resolveStreamDisplayRuntimeNotice(clientSettingsSync.value, streamDisplayMode.value)
+))
+const streamDisplayRuntimeNoticeTone = computed(() => {
+  if (streamDisplayRuntimeNotice.value.state === 'synced') {
+    return 'border-green-400/25 bg-green-400/10 text-green-200'
+  }
+  if (streamDisplayRuntimeNotice.value.state === 'pending_relaunch' || streamDisplayRuntimeNotice.value.state === 'unsaved') {
+    return 'border-amber-300/25 bg-amber-300/10 text-amber-100'
+  }
+  return 'border-storm/30 bg-deep/40 text-storm'
+})
 const clientSettingsSyncBadge = computed(() => {
   if (!clientSettingsSync.value.available) return 'Unavailable'
   if (clientSettingsSync.value.relaunchRequired) return 'Pending relaunch'
@@ -288,8 +296,12 @@ const validateFallbackMode = (event) => {
             </button>
           </div>
 
-          <div class="settings-warning-surface">
-            {{ selectedStreamDisplayMode.restartCopy }}
+          <div
+            class="rounded-2xl border p-4 text-sm leading-relaxed"
+            :class="streamDisplayRuntimeNoticeTone"
+            data-stream-display-runtime-notice
+          >
+            {{ streamDisplayRuntimeNotice.copy }}
           </div>
 
           <div class="settings-subtle-surface" data-linux-streaming-setup>


### PR DESCRIPTION
## Summary
- Replace the static GPU-Native/stream-display “Requires restart” warning with dynamic runtime notice copy.
- Show Pending relaunch only when Polaris reports desired/effective mode mismatch.
- Show saved/active runtime copy when GPU-Native Stream is synced, plus unsaved local-selection copy before save.

## Test Plan
- `npm test` — 34 files / 145 tests passed
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`

## Notes
Reddit user report: GPU-Native mode still displayed “Requires restart” after restart because the web UI was using static mode copy instead of Polaris client-settings runtime truth.
