### PR TITLE
Warn on NVIDIA true-headless GPU-native misconfig

### DIFF
--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -242,7 +242,24 @@ namespace stream_stats {
       stats.capture_residency != platf::frame_residency_e::unknown ||
       stats.encode_target_residency != platf::frame_residency_e::unknown;
 
-    return {
+    nlohmann::json configuration_warnings = nlohmann::json::array();
+#ifdef __linux__
+    if (
+      linux_display.headless_mode &&
+      linux_display.use_cage_compositor &&
+      !linux_display.prefer_gpu_native_capture &&
+      config::video.encoder == "nvenc"
+    ) {
+      configuration_warnings.push_back({
+        {"id", "nvidia_headless_gpu_native_disabled"},
+        {"severity", "warning"},
+        {"message", "NVIDIA true-headless labwc is configured with GPU-native capture disabled; cold or missing encoder cache can fail launch with 503 encoder initialization even when NVENC is healthy."},
+        {"action", "Set linux_prefer_gpu_native_capture = enabled, restart Polaris, and retry Private Stream (GPU-native) before chasing CUDA/NVENC driver issues."}
+      });
+    }
+#endif
+
+    nlohmann::json profile = {
       {"encoder_api", stats.encode_target_device},
       {"encoder_adapter", config::video.adapter_name},
       {"capture_device", stats.capture_device},
@@ -250,8 +267,11 @@ namespace stream_stats {
       {"cross_gpu_dmabuf_risk", capture_path_has_cross_gpu_dmabuf_risk(stats)},
       {"gpu_native_requested", gpu_native_requested},
       {"gpu_native_attempted", gpu_native_requested && capture_metadata_reported},
-      {"gpu_native_succeeded", capture_path_is_gpu_native(stats)}
+      {"gpu_native_succeeded", capture_path_is_gpu_native(stats)},
+      {"configuration_warnings", std::move(configuration_warnings)}
     };
+
+    return profile;
   }
 
   std::string capture_path_summary(const stats_t &stats) {

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -168,6 +168,12 @@ const autoQualityRows = computed(() => [
     note: clientSettingsSync.value.relaunchRequired ? 'Relaunch to sync' : 'Push/pull ready',
   },
 ])
+const nvidiaTrueHeadlessGpuNativeGuard = computed(() => (
+  String(config.value.encoder || '').toLowerCase() === 'nvenc' &&
+  config.value.headless_mode === 'enabled' &&
+  config.value.linux_use_cage_compositor === 'enabled' &&
+  config.value.linux_prefer_gpu_native_capture !== 'enabled'
+))
 const linuxStreamingSetupChecklist = computed(() => [
   {
     id: 'pairing',
@@ -199,6 +205,12 @@ const linuxStreamingSetupChecklist = computed(() => [
       ? 'Polaris may use windowed labwc to avoid SHM/system-memory fallback and preserve GPU-resident DMA-BUF capture when the runtime proves it can. Session health will show GPU-native as the capture path.'
       : 'VAAPI / Mesa is the AMD Linux baseline. Leave forced GPU-native off for normal Private Stream; turn it on only when telemetry shows SHM/system-memory fallback and you are collecting support evidence. KMS/DRM is advanced.',
   },
+  ...(nvidiaTrueHeadlessGpuNativeGuard.value ? [{
+    id: 'nvidia-headless-gpu-native-guard',
+    title: 'NVIDIA true-headless guard',
+    status: 'Needs GPU-native preference',
+    copy: 'NVENC true-headless labwc hosts can hit cold-cache 503 encoder-init failures when linux_prefer_gpu_native_capture is disabled. Set linux_prefer_gpu_native_capture = enabled / Private Stream (GPU-native), restart Polaris, then retry before chasing CUDA or driver issues.',
+  }] : []),
 ])
 
 function setEnabledConfig(key, enabled) {

--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -69,6 +69,31 @@ function linuxGpuProfile(stats = {}) {
   return stats?.linux_gpu_profile || stats?.linuxGpuProfile || {}
 }
 
+function linuxConfigurationWarnings(stats = {}) {
+  const profile = linuxGpuProfile(stats)
+  if (Array.isArray(profile.configuration_warnings)) return profile.configuration_warnings
+  if (Array.isArray(profile.configurationWarnings)) return profile.configurationWarnings
+  return []
+}
+
+function hostConfigurationWarningItem(stats = {}) {
+  const warning = linuxConfigurationWarnings(stats)[0]
+  if (!warning) return null
+
+  const severity = lower(warning.severity)
+  const status = severity === 'fail' || severity === 'error' ? 'fail' : 'warning'
+  const detail = warning.message || warning.detail || 'Linux host configuration warning.'
+  const action = warning.action || 'Review Linux streaming configuration before changing capture or encoder settings.'
+
+  return checklistItem(
+    'host-config',
+    'Host configuration',
+    status,
+    redactSensitiveText(detail),
+    redactSensitiveText(action)
+  )
+}
+
 export function describeLinuxGpuProfile(stats = {}) {
   const profile = linuxGpuProfile(stats)
   const encoderApi = lower(profile.encoder_api || profile.encoderApi || stats?.encode_target_device)
@@ -124,6 +149,7 @@ export function buildFixMyStreamChecklist({ stats = {}, statsConnected = false, 
     : streaming
       ? checklistItem('connection', 'Connection', 'pass', 'Live telemetry is connected and a stream is active.', 'Keep this page open while reproducing the issue.')
       : checklistItem('connection', 'Connection', 'warning', 'Telemetry is connected, but no active stream is running.', 'Start the affected game/session before exporting diagnostics.')
+  const hostConfig = hostConfigurationWarningItem(stats)
 
   const loss = Number.isFinite(packetLoss)
     ? packetLoss > 2
@@ -165,7 +191,15 @@ export function buildFixMyStreamChecklist({ stats = {}, statsConnected = false, 
     ? checklistItem('logs', 'Logs', 'warning', `${recentIssueCount} recent warning/error group${recentIssueCount === 1 ? '' : 's'} are visible.`, 'Copy recent issues or export anonymized diagnostics for support.')
     : checklistItem('logs', 'Logs', 'pass', 'No recent warnings, fatals, or errors are standing out.', 'Keep the live log open while reproducing the issue.')
 
-  return [connection, loss, capture, encoder, authPairing, logsItem]
+  return [
+    connection,
+    ...(hostConfig ? [hostConfig] : []),
+    loss,
+    capture,
+    encoder,
+    authPairing,
+    logsItem,
+  ]
 }
 
 export function buildAnonymizedDiagnosticsBundle(input = {}) {

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -160,4 +160,31 @@ describe('Fix My Stream checklist', () => {
     expect(`${capture.detail} ${capture.action}`).not.toContain('CUDA')
     expect(`${capture.detail} ${capture.action}`).not.toContain('NVIDIA')
   })
+
+  it('surfaces NVIDIA true-headless GPU-native configuration warnings before capture tuning', () => {
+    const checklist = buildFixMyStreamChecklist({
+      statsConnected: true,
+      stats: {
+        streaming: true,
+        packet_loss: 0,
+        encode_time_ms: 4.2,
+        linux_gpu_profile: {
+          configuration_warnings: [
+            {
+              id: 'nvidia_headless_gpu_native_disabled',
+              severity: 'warning',
+              message: 'NVIDIA true-headless labwc is configured with GPU-native capture disabled, which can cause cold-cache 503 encoder-init failures.',
+              action: 'Set linux_prefer_gpu_native_capture = enabled, restart Polaris, then retry Private Stream (GPU-native).',
+            },
+          ],
+        },
+      },
+    })
+
+    const hostConfig = checklist.find((item) => item.key === 'host-config')
+    expect(hostConfig.status).toBe('warning')
+    expect(hostConfig.detail).toContain('cold-cache 503')
+    expect(hostConfig.action).toContain('linux_prefer_gpu_native_capture = enabled')
+    expect(checklist.map((item) => item.key)[1]).toBe('host-config')
+  })
 })

--- a/src_assets/common/assets/web/linux-streaming-setup.test.js
+++ b/src_assets/common/assets/web/linux-streaming-setup.test.js
@@ -83,4 +83,19 @@ describe('Linux Streaming Setup checklist', () => {
     expect(text).not.toContain('CUDA')
     expect(text).not.toContain('NVIDIA')
   })
+
+  it('warns NVIDIA true-headless hosts when GPU-native capture is disabled', () => {
+    const wrapper = mountAudioVideo(linuxConfig({
+      encoder: 'nvenc',
+      headless_mode: 'enabled',
+      linux_use_cage_compositor: 'enabled',
+      linux_prefer_gpu_native_capture: 'disabled',
+    }))
+    const text = wrapper.find('[data-linux-streaming-setup]').text()
+
+    expect(text).toContain('NVIDIA true-headless guard')
+    expect(text).toContain('linux_prefer_gpu_native_capture = enabled')
+    expect(text).toContain('503 encoder-init failures')
+    expect(text).toContain('Private Stream (GPU-native)')
+  })
 })

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -15,17 +15,23 @@ namespace {
   struct LinuxDisplayConfigGuard {
     LinuxDisplayConfigGuard():
         adapter_name {config::video.adapter_name},
+        encoder {config::video.encoder},
+        headless_mode {config::video.linux_display.headless_mode},
         use_cage_compositor {config::video.linux_display.use_cage_compositor},
         prefer_gpu_native_capture {config::video.linux_display.prefer_gpu_native_capture} {
     }
 
     ~LinuxDisplayConfigGuard() {
       config::video.adapter_name = adapter_name;
+      config::video.encoder = encoder;
+      config::video.linux_display.headless_mode = headless_mode;
       config::video.linux_display.use_cage_compositor = use_cage_compositor;
       config::video.linux_display.prefer_gpu_native_capture = prefer_gpu_native_capture;
     }
 
     std::string adapter_name;
+    std::string encoder;
+    bool headless_mode;
     bool use_cage_compositor;
     bool prefer_gpu_native_capture;
   };
@@ -93,6 +99,36 @@ TEST(StreamStatsCapturePathTests, SerializesCaptureDecisionDiagnostics) {
   EXPECT_TRUE(decision.at("requested_headless"));
   EXPECT_TRUE(decision.at("effective_headless"));
   EXPECT_FALSE(decision.at("gpu_native_override_active"));
+}
+
+TEST(StreamStatsLinuxGpuProfileTests, WarnsWhenNvidiaTrueHeadlessDisablesGpuNativeCapture) {
+  LinuxDisplayConfigGuard guard;
+  config::video.encoder = "nvenc";
+  config::video.linux_display.headless_mode = true;
+  config::video.linux_display.use_cage_compositor = true;
+  config::video.linux_display.prefer_gpu_native_capture = false;
+
+  stream_stats::stats_t stats {};
+  stats.runtime_backend = "labwc";
+  stats.runtime_requested_headless = true;
+  stats.runtime_effective_headless = true;
+
+  const auto json = nlohmann::json::parse(stats.to_json());
+  const auto &profile = json.at("linux_gpu_profile");
+
+  ASSERT_TRUE(profile.contains("configuration_warnings"));
+  const auto &warnings = profile.at("configuration_warnings");
+  ASSERT_EQ(warnings.size(), 1);
+  EXPECT_EQ(warnings.at(0).at("id"), "nvidia_headless_gpu_native_disabled");
+  EXPECT_EQ(warnings.at(0).at("severity"), "warning");
+  EXPECT_NE(
+    warnings.at(0).at("message").get<std::string>().find("503"),
+    std::string::npos
+  );
+  EXPECT_NE(
+    warnings.at(0).at("action").get<std::string>().find("linux_prefer_gpu_native_capture = enabled"),
+    std::string::npos
+  );
 }
 
 


### PR DESCRIPTION
## Summary
- add a Linux GPU profile configuration warning for NVIDIA + true-headless labwc when GPU-native capture is disabled
- surface the warning in anonymized diagnostics / Fix My Stream before generic capture tuning
- add Mission Control Audio/Video setup copy that points users to `linux_prefer_gpu_native_capture = enabled` / Private Stream (GPU-native) for this proven cold-cache 503 failure mode

## Why
During the Retroid post-merge smoke, pc-papi could fail cold-cache Private Stream launch with `503 Failed to initialize video capture/encoding` while NVENC/CUDA were healthy. The durable config fix was enabling `linux_prefer_gpu_native_capture` for NVIDIA true-headless labwc.

## Test Plan
- [x] RED: `npm run test -- src_assets/common/assets/web/linux-streaming-setup.test.js src_assets/common/assets/web/diagnostics-export.test.js` failed on missing warning paths
- [x] RED: `./build-tdd/tests/test_polaris_stream --gtest_filter='StreamStatsLinuxGpuProfileTests.*' --gtest_color=no` failed on missing `configuration_warnings`
- [x] GREEN: focused Vitest files pass: 11 tests
- [x] GREEN: `StreamStats*` gtest filter passes: 14 tests
- [x] `git diff --check`
- [x] `npm run lint`
- [x] `npm run test` — 34 files / 149 tests
- [x] `npm run build`

## Notes
- No live deploy in this PR.
- No gamescope install, no config mutation, no desktop Steam process changes.
