### PR TITLE
fix(web): keep SteamGridDB clear flag out of config saves

### DIFF
--- a/src_assets/common/assets/web/config-pending-changes.test.js
+++ b/src_assets/common/assets/web/config-pending-changes.test.js
@@ -185,4 +185,35 @@ describe('ConfigView pending changes review', () => {
     expect(result).toBe(false)
     expect(mockToast).toHaveBeenCalledWith('Failed to save configuration', 'error')
   })
+
+  it('does not treat a cancelled SteamGridDB clear as a pending settings change', async () => {
+    const wrapper = mountConfigView({ has_steamgriddb_api_key: true })
+    await flushConfigLoad()
+
+    wrapper.vm.config.clear_steamgriddb_api_key = false
+    await nextTick()
+
+    expect(wrapper.vm.hasUnsavedChanges).toBe(false)
+    expect(wrapper.vm.pendingChanges.map((change) => change.key)).not.toContain('clear_steamgriddb_api_key')
+  })
+
+  it('posts a SteamGridDB secret clear without leaking the internal clear flag', async () => {
+    const wrapper = mountConfigView({ has_steamgriddb_api_key: true })
+    await flushConfigLoad()
+
+    wrapper.vm.config.clear_steamgriddb_api_key = true
+    wrapper.vm.config.steamgriddb_api_key = ''
+    await nextTick()
+
+    global.fetch.mockResolvedValueOnce({ status: 200 })
+
+    const result = await wrapper.vm.save()
+
+    expect(result).toBe(true)
+    const saveRequest = global.fetch.mock.calls.at(-1)
+    expect(saveRequest[0]).toBe('./api/config')
+    const body = JSON.parse(saveRequest[1].body)
+    expect(body).not.toHaveProperty('clear_steamgriddb_api_key')
+    expect(body).toHaveProperty('steamgriddb_api_key', '')
+  })
 })

--- a/src_assets/common/assets/web/configs/tabs/General.vue
+++ b/src_assets/common/assets/web/configs/tabs/General.vue
@@ -47,6 +47,22 @@ function addCmd(cmdArr, template, idx) {
 function removeCmd(cmdArr, index) {
   cmdArr.splice(index,1)
 }
+
+function clearStoredSteamGridDbKey() {
+  config.value.clear_steamgriddb_api_key = true
+  config.value.steamgriddb_api_key = ''
+}
+
+function keepStoredSteamGridDbKey() {
+  delete config.value.clear_steamgriddb_api_key
+  config.value.steamgriddb_api_key = ''
+}
+
+function handleSteamGridDbKeyInput() {
+  if (config.value.steamgriddb_api_key) {
+    delete config.value.clear_steamgriddb_api_key
+  }
+}
 </script>
 
 <template>
@@ -303,7 +319,7 @@ function removeCmd(cmdArr, index) {
           <button
             type="button"
             class="rounded-full border border-emerald-300/25 px-2.5 py-1 text-[11px] font-medium text-emerald-100 transition-colors hover:border-rose-300/40 hover:text-rose-200"
-            @click="config.clear_steamgriddb_api_key = true; config.steamgriddb_api_key = ''">
+            @click="clearStoredSteamGridDbKey">
             Clear Stored Key
           </button>
         </div>
@@ -312,14 +328,14 @@ function removeCmd(cmdArr, index) {
           <button
             type="button"
             class="rounded-full border border-rose-300/30 px-2.5 py-1 text-[11px] font-medium text-rose-100 transition-colors hover:border-ice/40 hover:text-ice"
-            @click="config.clear_steamgriddb_api_key = false">
+            @click="keepStoredSteamGridDbKey">
             Keep Existing Key
           </button>
         </div>
         <input type="password" id="steamgriddb_api_key"
                class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm"
                v-model="config.steamgriddb_api_key"
-               @input="config.steamgriddb_api_key && (config.clear_steamgriddb_api_key = false)"
+               @input="handleSteamGridDbKeyInput"
                placeholder="Enter your SteamGridDB API key" />
         <div class="text-xs text-storm mt-1">Enables cover art search for non-Steam games. Get a free key at <a href="https://www.steamgriddb.com/profile/preferences/api" target="_blank" class="text-ice hover:text-ice/80">steamgriddb.com</a>.</div>
       </div>

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -887,6 +887,9 @@ function serialize() {
     fallbackDisplayModeCache = config.value.fallback_mode
   }
   let configCopy = JSON.parse(JSON.stringify(config.value))
+  if (configCopy.clear_steamgriddb_api_key !== true) {
+    delete configCopy.clear_steamgriddb_api_key
+  }
   configCopy.global_prep_cmd = global_prep_cmd.value.filter(cmd => (cmd.do && cmd.do.trim()) || (cmd.undo && cmd.undo.trim()))
   configCopy.global_state_cmd = global_state_cmd.value.filter(cmd => (cmd.do && cmd.do.trim()) || (cmd.undo && cmd.undo.trim()))
   configCopy.dd_mode_remapping = configCopy.dd_mode_remapping
@@ -909,6 +912,8 @@ function save() {
   restarted.value = false
 
   let configCopy = serialize()
+  const clearSteamGridDbApiKey = configCopy.clear_steamgriddb_api_key === true
+  delete configCopy.clear_steamgriddb_api_key
 
   tabs.value.forEach(tab => {
     Object.keys(tab.options).forEach(optionKey => {
@@ -916,7 +921,7 @@ function save() {
       if (JSON.stringify(configCopy[optionKey]) === JSON.stringify(tab.options[optionKey])) {
         delete_value = true
       }
-      if (delete_value) {
+      if (delete_value && !(optionKey === 'steamgriddb_api_key' && clearSteamGridDbApiKey)) {
         delete configCopy[optionKey]
       }
     })


### PR DESCRIPTION
## Summary
- keep the SteamGridDB clear toggle as UI-only state so `/api/config` never receives unsupported `clear_steamgriddb_api_key`
- preserve intentional key-clears by posting an empty `steamgriddb_api_key` only when the user chooses **Clear Stored Key**
- remove cancelled clear state so **Keep Existing Key** stops showing phantom pending Settings changes

## Test Plan
- [x] `npm test -- src_assets/common/assets/web/config-pending-changes.test.js`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

## Community report
A CachyOS user found Settings saves returning HTTP 400:

```json
{"error":"Unsupported config key: clear_steamgriddb_api_key","status":false,"status_code":400}
```

The repro was hitting Save from Settings after the SteamGridDB key clear state appeared in the pending changes flow.
