### PR TITLE
chore(release): prepare Polaris v1.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.2.0
+project(Polaris VERSION 1.2.1
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at `https://localhost:<port + 1>`. If you want background autostart, enable the user service with `systemctl --user enable --now polaris`.
 
-## What is New in v1.2.0
+## What is New in v1.2.1
 
-Polaris v1.2.0 is about making Linux streaming feel less like ritual sacrifice and more like a controllable cockpit.
+Polaris v1.2.1 is a reliability patch for Linux hosts and Moonlight-compatible newcomers: fewer Settings save goblins, clearer capture/audio diagnostics, and better Arch/CachyOS support breadcrumbs.
 
 - **Portable Chrome is the new visual baseline**: Mission Control now uses a smoked graphite / dim Moonlight-grey skin with restrained green status accents.
 - **Private streams are safer by default**: Polaris and Nova coordinate launch intent so handheld launches do not silently reuse desktop Steam or expose games on the physical monitor.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,18 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+## v1.2.1 - 2026-07-10
+
+Patch release focused on CachyOS/Arch Settings reliability, Linux audio/capture diagnostics, and safer Moonlight-compatible host troubleshooting.
+
+- Fixed Settings saves being blocked by an internal SteamGridDB clear-key flag, allowing unrelated Network and trusted-subnet changes to save normally
+- Improved Settings pending-change handling so cancelled SteamGridDB key clears no longer reappear as phantom unsaved edits
+- Added clearer backend error details for failed Settings saves so support can identify rejected config keys instead of treating every failure like a filesystem permission issue
+- Improved PipeWire audio overrun diagnostics so stream support bundles and logs better explain audio-path failures during launch/connect attempts
+- Clarified GPU-native Stream relaunch/fallback reporting for Linux hosts, including AMD/VAAPI SHM fallback messaging and vendor-neutral capture diagnostics
+- Hardened Linux private/windowed compositor capture policy so cage/labwc runtime probes happen against the intended streaming runtime instead of a missing display context
+- Refreshed public docs, screenshots, and install guidance for Moonlight-compatible users arriving through Fedora, Arch/CachyOS, Ubuntu, and Bazzite paths
+
 ## v1.2.0 - 2026-07-03
 
 Feature release focused on Nova-ready private/headless streaming, Portable Chrome cockpit polish, safer launch contracts, Linux input/capture hardening, and broader package coverage.


### PR DESCRIPTION
## Summary
- Bump Polaris to `1.2.1`
- Promote the v1.2.1 changelog section for the CachyOS/Arch Settings save hotfix and Linux diagnostics work
- Refresh the README latest-release summary for Moonlight-compatible newcomers and CachyOS/Arch support

## Test Plan
- [x] `bash scripts/check-public-docs.sh`
- [x] `bash scripts/check-public-surface.sh`
- [x] `npm ci`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`

## Release Plan
After this lands on `master`, tag `v1.2.1` at the merge commit and verify the tag-triggered release workflow publishes the Arch, Fedora 42/43/44, and Ubuntu 24.04 assets.
