### PR TITLE
feat(web): add manual Update Center

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -126,6 +126,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/confighttp.h"
         "${CMAKE_SOURCE_DIR}/src/confighttp_validation.cpp"
         "${CMAKE_SOURCE_DIR}/src/confighttp_validation.h"
+        "${CMAKE_SOURCE_DIR}/src/update_status.h"
+        "${CMAKE_SOURCE_DIR}/src/update_status.cpp"
         "${CMAKE_SOURCE_DIR}/src/rtsp.cpp"
         "${CMAKE_SOURCE_DIR}/src/rtsp.h"
         "${CMAKE_SOURCE_DIR}/src/stream.cpp"

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -52,6 +52,7 @@
 #include "session_event_queue.h"
 #include "stream_recorder.h"
 #include "stream_stats.h"
+#include "update_status.h"
 #include "utility.h"
 #include "video.h"
 #include "uuid.h"
@@ -2578,6 +2579,22 @@ namespace confighttp {
   }
 
   /**
+   * @brief Get update awareness metadata for the web Update Center.
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   *
+   * @api_examples{/api/update-status| GET| null}
+   */
+  void getUpdateStatus(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+
+    print_req(request);
+    send_response(response, update_status::host_update_status());
+  }
+
+  /**
    * @brief Get the configuration settings.
    * @param response The HTTP response object.
    * @param request The HTTP request object.
@@ -5025,6 +5042,7 @@ namespace confighttp {
     server.resource["^/api/logs$"]["GET"] = getLogs;
     server.resource["^/api/logs/clear$"]["POST"] = withCsrf(clearLogs);
     server.resource["^/api/config$"]["GET"] = getConfig;
+    server.resource["^/api/update-status$"]["GET"] = getUpdateStatus;
     server.resource["^/api/config$"]["POST"] = withCsrf(saveConfig);
     server.resource["^/api/configLocale$"]["GET"] = getLocale;
     server.resource["^/api/restart$"]["POST"] = withCsrf(restart);

--- a/src/update_status.cpp
+++ b/src/update_status.cpp
@@ -1,0 +1,174 @@
+/**
+ * @file src/update_status.cpp
+ * @brief Host update awareness helpers for the web Update Center.
+ */
+#include "update_status.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace update_status {
+  namespace {
+    std::string trim(std::string value) {
+      const auto not_space = [](unsigned char ch) {
+        return !std::isspace(ch);
+      };
+      value.erase(value.begin(), std::find_if(value.begin(), value.end(), not_space));
+      value.erase(std::find_if(value.rbegin(), value.rend(), not_space).base(), value.end());
+      return value;
+    }
+
+    std::string unquote(std::string value) {
+      value = trim(std::move(value));
+      if (value.size() >= 2 &&
+          ((value.front() == '"' && value.back() == '"') || (value.front() == '\'' && value.back() == '\''))) {
+        value = value.substr(1, value.size() - 2);
+      }
+      return value;
+    }
+
+    std::string lower_copy(std::string value) {
+      std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+      });
+      return value;
+    }
+
+    std::vector<std::string> distro_tokens(const distro_info_t &distro) {
+      std::vector<std::string> tokens;
+      if (!distro.id.empty()) {
+        tokens.push_back(lower_copy(distro.id));
+      }
+
+      std::istringstream input(distro.id_like);
+      std::string token;
+      while (input >> token) {
+        tokens.push_back(lower_copy(token));
+      }
+      return tokens;
+    }
+
+    bool has_token(const std::vector<std::string> &tokens, std::string_view value) {
+      return std::find(tokens.begin(), tokens.end(), value) != tokens.end();
+    }
+  }  // namespace
+
+  distro_info_t parse_os_release(std::string_view content) {
+    distro_info_t distro;
+    std::istringstream input {std::string(content)};
+    std::string line;
+
+    while (std::getline(input, line)) {
+      line = trim(std::move(line));
+      if (line.empty() || line.front() == '#') {
+        continue;
+      }
+
+      const auto sep = line.find('=');
+      if (sep == std::string::npos) {
+        continue;
+      }
+
+      auto key = lower_copy(trim(line.substr(0, sep)));
+      auto value = unquote(line.substr(sep + 1));
+
+      if (key == "id") {
+        distro.id = lower_copy(std::move(value));
+      } else if (key == "id_like") {
+        distro.id_like = lower_copy(std::move(value));
+      } else if (key == "version_id") {
+        distro.version_id = std::move(value);
+      } else if (key == "pretty_name") {
+        distro.pretty_name = std::move(value);
+      } else if (key == "name" && distro.pretty_name.empty()) {
+        distro.pretty_name = std::move(value);
+      }
+    }
+
+    return distro;
+  }
+
+  distro_info_t detect_host_distro() {
+#ifdef __linux__
+    std::ifstream os_release {"/etc/os-release"};
+    if (!os_release) {
+      return {};
+    }
+
+    std::ostringstream buffer;
+    buffer << os_release.rdbuf();
+    return parse_os_release(buffer.str());
+#else
+    return {};
+#endif
+  }
+
+  std::string package_family(const distro_info_t &distro) {
+    const auto tokens = distro_tokens(distro);
+    if (has_token(tokens, "arch") || has_token(tokens, "cachyos") ||
+        has_token(tokens, "manjaro") || has_token(tokens, "endeavouros")) {
+      return "arch";
+    }
+
+    if (has_token(tokens, "fedora") || has_token(tokens, "bazzite") ||
+        has_token(tokens, "rhel") || has_token(tokens, "centos")) {
+      return "fedora";
+    }
+
+    if (has_token(tokens, "ubuntu")) {
+      return "ubuntu";
+    }
+
+    return {};
+  }
+
+  std::string recommended_release_asset(const distro_info_t &distro) {
+    const auto family = package_family(distro);
+    if (family == "arch") {
+      return "Polaris-arch-x86_64.pkg.tar.zst";
+    }
+
+    if (family == "fedora") {
+      if (distro.version_id.empty()) {
+        return {};
+      }
+      return "Polaris-fedora" + distro.version_id + "-x86_64.rpm";
+    }
+
+    if (family == "ubuntu" && distro.version_id.rfind("24.04", 0) == 0) {
+      return "Polaris-ubuntu24.04-x86_64.deb";
+    }
+
+    return {};
+  }
+
+  nlohmann::json distro_json(const distro_info_t &distro) {
+    return {
+      {"id", distro.id},
+      {"id_like", distro.id_like},
+      {"version_id", distro.version_id},
+      {"pretty_name", distro.pretty_name},
+    };
+  }
+
+  nlohmann::json host_update_status() {
+    const auto distro = detect_host_distro();
+    return {
+      {"status", true},
+      {"platform", POLARIS_PLATFORM},
+      {"version", PROJECT_VERSION},
+      {"manual_install_only", true},
+      {"auto_install_supported", false},
+      {"auto_install_enabled", false},
+      {"distro", distro_json(distro)},
+      {"package_family", package_family(distro)},
+      {"recommended_asset_name", recommended_release_asset(distro)},
+    };
+  }
+
+}  // namespace update_status

--- a/src/update_status.h
+++ b/src/update_status.h
@@ -1,0 +1,42 @@
+/**
+ * @file src/update_status.h
+ * @brief Host update awareness helpers for the web Update Center.
+ */
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <string_view>
+
+namespace update_status {
+
+  struct distro_info_t {
+    std::string id;
+    std::string id_like;
+    std::string version_id;
+    std::string pretty_name;
+  };
+
+  distro_info_t parse_os_release(std::string_view content);
+  distro_info_t detect_host_distro();
+  std::string package_family(const distro_info_t &distro);
+  std::string recommended_release_asset(const distro_info_t &distro);
+  nlohmann::json distro_json(const distro_info_t &distro);
+  nlohmann::json host_update_status();
+
+#ifdef POLARIS_TESTS
+  inline distro_info_t parse_os_release_for_tests(std::string_view content) {
+    return parse_os_release(content);
+  }
+
+  inline std::string package_family_for_tests(const distro_info_t &distro) {
+    return package_family(distro);
+  }
+
+  inline std::string recommended_release_asset_for_tests(const distro_info_t &distro) {
+    return recommended_release_asset(distro);
+  }
+#endif
+
+}  // namespace update_status

--- a/src_assets/common/assets/web/update-center.js
+++ b/src_assets/common/assets/web/update-center.js
@@ -1,0 +1,189 @@
+import PolarisVersion from './polaris_version'
+
+const PACKAGE_LABELS = {
+  arch: 'Arch/CachyOS package',
+  fedora: 'Fedora RPM package',
+  ubuntu: 'Ubuntu 24.04 DEB package',
+}
+
+function normalizeToken(value) {
+  return String(value || '').trim().toLowerCase()
+}
+
+function distroTokens(host = {}) {
+  const distro = host.distro || {}
+  const tokens = []
+  const id = normalizeToken(distro.id)
+  if (id) tokens.push(id)
+  String(distro.id_like || '')
+    .split(/\s+/)
+    .map(normalizeToken)
+    .filter(Boolean)
+    .forEach((token) => tokens.push(token))
+  return tokens
+}
+
+function hasToken(tokens, value) {
+  return tokens.includes(value)
+}
+
+export function inferPackageFamily(host = {}) {
+  if (normalizeToken(host.platform) !== 'linux') return ''
+  if (host.package_family) return normalizeToken(host.package_family)
+
+  const tokens = distroTokens(host)
+  if (hasToken(tokens, 'arch') || hasToken(tokens, 'cachyos') || hasToken(tokens, 'manjaro') || hasToken(tokens, 'endeavouros')) {
+    return 'arch'
+  }
+  if (hasToken(tokens, 'fedora') || hasToken(tokens, 'bazzite') || hasToken(tokens, 'rhel') || hasToken(tokens, 'centos')) {
+    return 'fedora'
+  }
+  if (hasToken(tokens, 'ubuntu')) {
+    return 'ubuntu'
+  }
+  return ''
+}
+
+function preferredAssetName(host = {}) {
+  if (host.recommended_asset_name) return host.recommended_asset_name
+
+  const family = inferPackageFamily(host)
+  const versionId = String(host.distro?.version_id || '').trim()
+  if (family === 'arch') return 'Polaris-arch-x86_64.pkg.tar.zst'
+  if (family === 'fedora' && versionId) return `Polaris-fedora${versionId}-x86_64.rpm`
+  if (family === 'ubuntu' && versionId.startsWith('24.04')) return 'Polaris-ubuntu24.04-x86_64.deb'
+  return ''
+}
+
+export function selectReleaseAsset(release, host = {}) {
+  const assets = Array.isArray(release?.assets) ? release.assets : []
+  const preferredName = preferredAssetName(host)
+  if (preferredName) {
+    const exact = assets.find((asset) => asset.name === preferredName)
+    if (exact) return { ...exact, packageFamily: inferPackageFamily(host) }
+  }
+
+  const family = inferPackageFamily(host)
+  const fallback = assets.find((asset) => {
+    if (family === 'arch') return /Polaris-arch-x86_64\.pkg\.tar\.zst$/.test(asset.name)
+    if (family === 'fedora') return /Polaris-fedora\d+-x86_64\.rpm$/.test(asset.name)
+    if (family === 'ubuntu') return /Polaris-ubuntu24\.04-x86_64\.deb$/.test(asset.name)
+    return false
+  })
+  return fallback ? { ...fallback, packageFamily: family } : null
+}
+
+export function buildManualInstallCommand(asset, host = {}) {
+  if (!asset?.name || !asset?.browser_download_url) return ''
+
+  const family = normalizeToken(asset.packageFamily || host.packageFamily || inferPackageFamily(host))
+  const fileName = asset.name
+  const lines = [`wget ${asset.browser_download_url}`]
+
+  if (family === 'arch') {
+    lines.push(`sudo pacman -U ./${fileName}`)
+  } else if (family === 'fedora') {
+    lines.push(`sudo dnf install "./${fileName}"`)
+  } else if (family === 'ubuntu') {
+    lines.push(`sudo apt install ./${fileName}`)
+  } else {
+    return ''
+  }
+
+  lines.push('sudo polaris --setup-host')
+  lines.push('systemctl --user restart polaris')
+  return lines.join('\n')
+}
+
+function versionFromRelease(release) {
+  return release?.tag_name || release?.name || ''
+}
+
+function isReleaseGreater(release, version, includeIncremental = false) {
+  if (!release || !version) return false
+  try {
+    return new PolarisVersion(release, null).isGreater(new PolarisVersion(null, version), includeIncremental)
+  } catch {
+    return false
+  }
+}
+
+function isVersionGreater(version, release) {
+  if (!release || !version) return false
+  try {
+    return new PolarisVersion(null, version).isGreater(new PolarisVersion(release, null))
+  } catch {
+    return false
+  }
+}
+
+export function chooseCandidateRelease({ latestRelease, prereleaseRelease, includePrereleases = false, currentVersion = '' } = {}) {
+  if (includePrereleases && prereleaseRelease && isReleaseGreater(prereleaseRelease, latestRelease ? versionFromRelease(latestRelease) : currentVersion, true)) {
+    return prereleaseRelease
+  }
+  return latestRelease || null
+}
+
+export function buildUpdateCenterState({ currentVersion = '', latestRelease = null, prereleaseRelease = null, includePrereleases = false, host = {}, disabled = false } = {}) {
+  if (disabled) {
+    return {
+      status: 'disabled',
+      statusLabel: 'Update checks disabled',
+      summary: 'Update awareness is disabled for this host.',
+      latestVersion: '',
+      releaseUrl: '',
+      asset: null,
+      packageLabel: '',
+      installCommand: '',
+      canCopyInstallCommand: false,
+    }
+  }
+
+  const candidateRelease = chooseCandidateRelease({ latestRelease, prereleaseRelease, includePrereleases, currentVersion })
+  if (!currentVersion || !candidateRelease) {
+    return {
+      status: 'unavailable',
+      statusLabel: 'Update status unavailable',
+      summary: 'Polaris could not check GitHub releases from this browser session.',
+      latestVersion: versionFromRelease(candidateRelease),
+      releaseUrl: candidateRelease?.html_url || '',
+      asset: null,
+      packageLabel: '',
+      installCommand: '',
+      canCopyInstallCommand: false,
+    }
+  }
+
+  let status = 'current'
+  let statusLabel = 'Current release'
+  let summary = 'This host is on the latest public release.'
+  if (isReleaseGreater(candidateRelease, currentVersion, includePrereleases)) {
+    status = 'update_available'
+    statusLabel = candidateRelease.prerelease ? 'Prerelease available' : 'Update available'
+    summary = 'A newer Polaris package is available. Copy the manual install command when you are ready.'
+  } else if (isVersionGreater(currentVersion, candidateRelease)) {
+    status = 'ahead'
+    statusLabel = 'Ahead of latest release'
+    summary = 'This host is running a build newer than the selected release channel.'
+  }
+
+  const asset = selectReleaseAsset(candidateRelease, host)
+  const packageFamily = normalizeToken(asset?.packageFamily || inferPackageFamily(host))
+  const installCommand = asset ? buildManualInstallCommand(asset, { ...host, packageFamily }) : ''
+
+  return {
+    status,
+    statusLabel,
+    summary,
+    currentVersion,
+    latestVersion: versionFromRelease(candidateRelease),
+    releaseUrl: candidateRelease.html_url || '',
+    asset,
+    assetDigest: asset?.digest || '',
+    packageFamily,
+    packageLabel: PACKAGE_LABELS[packageFamily] || '',
+    installCommand,
+    canCopyInstallCommand: Boolean(installCommand),
+    manualInstallOnly: true,
+  }
+}

--- a/src_assets/common/assets/web/update-center.test.js
+++ b/src_assets/common/assets/web/update-center.test.js
@@ -1,0 +1,100 @@
+import {
+  buildManualInstallCommand,
+  buildUpdateCenterState,
+  selectReleaseAsset,
+} from './update-center.js'
+
+const release = {
+  tag_name: 'v1.2.2',
+  name: 'Polaris v1.2.2',
+  html_url: 'https://github.com/papi-ux/polaris/releases/tag/v1.2.2',
+  prerelease: false,
+  assets: [
+    {
+      name: 'Polaris-arch-x86_64.pkg.tar.zst',
+      browser_download_url: 'https://example.test/Polaris-arch-x86_64.pkg.tar.zst',
+      digest: 'sha256:archdigest',
+    },
+    {
+      name: 'Polaris-fedora44-x86_64.rpm',
+      browser_download_url: 'https://example.test/Polaris-fedora44-x86_64.rpm',
+      digest: 'sha256:fedoradigest',
+    },
+    {
+      name: 'Polaris-ubuntu24.04-x86_64.deb',
+      browser_download_url: 'https://example.test/Polaris-ubuntu24.04-x86_64.deb',
+      digest: 'sha256:ubuntudigest',
+    },
+  ],
+}
+
+describe('Update Center release awareness', () => {
+  it('detects a stable update and selects the Arch/CachyOS package', () => {
+    const state = buildUpdateCenterState({
+      currentVersion: '1.2.1',
+      latestRelease: release,
+      host: {
+        platform: 'linux',
+        distro: { id: 'cachyos', id_like: 'arch', version_id: '2026' },
+      },
+    })
+
+    expect(state.status).toBe('update_available')
+    expect(state.latestVersion).toBe('v1.2.2')
+    expect(state.asset.name).toBe('Polaris-arch-x86_64.pkg.tar.zst')
+    expect(state.packageLabel).toBe('Arch/CachyOS package')
+    expect(state.installCommand).toContain('wget https://example.test/Polaris-arch-x86_64.pkg.tar.zst')
+    expect(state.installCommand).toContain('sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst')
+    expect(state.installCommand).toContain('sudo polaris --setup-host')
+    expect(state.installCommand).toContain('systemctl --user restart polaris')
+    expect(state.installCommand).not.toMatch(/curl\s+[^\n|]+\|\s*sudo/i)
+  })
+
+  it('selects the matching Fedora package by host version', () => {
+    const asset = selectReleaseAsset(release, {
+      platform: 'linux',
+      distro: { id: 'bazzite', id_like: 'fedora', version_id: '44' },
+    })
+
+    expect(asset.name).toBe('Polaris-fedora44-x86_64.rpm')
+    expect(buildManualInstallCommand(asset, { packageFamily: 'fedora' })).toContain(
+      'sudo dnf install "./Polaris-fedora44-x86_64.rpm"',
+    )
+  })
+
+  it('selects the Ubuntu 24.04 package for Debian-family tester hosts', () => {
+    const state = buildUpdateCenterState({
+      currentVersion: '1.2.1',
+      latestRelease: release,
+      host: {
+        platform: 'linux',
+        distro: { id: 'ubuntu', id_like: 'debian', version_id: '24.04' },
+      },
+    })
+
+    expect(state.asset.name).toBe('Polaris-ubuntu24.04-x86_64.deb')
+    expect(state.installCommand).toContain('sudo apt install ./Polaris-ubuntu24.04-x86_64.deb')
+  })
+
+  it('does not offer a prerelease unless the user opted into prerelease notifications', () => {
+    const prerelease = { ...release, tag_name: 'v1.3.0-beta.1', prerelease: true }
+
+    expect(buildUpdateCenterState({ currentVersion: '1.2.2', latestRelease: release, prereleaseRelease: prerelease }).status)
+      .toBe('current')
+    expect(buildUpdateCenterState({ currentVersion: '1.2.2', latestRelease: release, prereleaseRelease: prerelease, includePrereleases: true }).status)
+      .toBe('update_available')
+  })
+
+  it('stays informational on unsupported platforms instead of attempting auto-install', () => {
+    const state = buildUpdateCenterState({
+      currentVersion: '1.2.1',
+      latestRelease: release,
+      host: { platform: 'windows', distro: {} },
+    })
+
+    expect(state.status).toBe('update_available')
+    expect(state.asset).toBeNull()
+    expect(state.installCommand).toBe('')
+    expect(state.canCopyInstallCommand).toBe(false)
+  })
+})

--- a/src_assets/common/assets/web/views/HomeView.vue
+++ b/src_assets/common/assets/web/views/HomeView.vue
@@ -63,6 +63,60 @@
       </div>
     </section>
 
+    <section class="section-card border-ice/15 bg-gradient-to-br from-deep/70 via-deep/40 to-ice/5">
+      <div class="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+        <div class="max-w-3xl">
+          <div class="section-kicker">Update Center</div>
+          <div class="section-title-row">
+            <h2 class="section-title">Package updates</h2>
+            <InfoHint size="sm" label="Update Center details">
+              Polaris only checks and prepares manual install commands here. It never auto-installs packages or runs privileged commands from the web UI.
+            </InfoHint>
+          </div>
+          <p class="section-copy mt-2">{{ updateCenterState.summary }}</p>
+        </div>
+        <span class="meta-pill self-start" :class="updateCenterBadgeClass">{{ updateCenterState.statusLabel }}</span>
+      </div>
+
+      <div class="mt-5 grid gap-3 lg:grid-cols-3">
+        <article class="surface-subtle p-4">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-storm">Installed</div>
+          <div class="mt-2 text-2xl font-semibold text-silver">{{ updateCenterState.currentVersion || version?.version || '—' }}</div>
+          <div class="mt-1 text-xs text-storm">Running on this host</div>
+        </article>
+        <article class="surface-subtle p-4">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-storm">Latest</div>
+          <div class="mt-2 text-2xl font-semibold text-ice">{{ updateCenterState.latestVersion || '—' }}</div>
+          <a v-if="updateCenterState.releaseUrl" class="mt-2 inline-flex text-sm font-medium text-ice no-underline hover:text-ice/80" :href="updateCenterState.releaseUrl" target="_blank">View release notes</a>
+        </article>
+        <article class="surface-subtle p-4">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-storm">Package</div>
+          <div class="mt-2 text-sm font-medium text-silver">{{ updateCenterState.packageLabel || 'Manual release page' }}</div>
+          <div class="mt-1 break-all text-xs text-storm">{{ updateCenterState.asset?.name || 'No matching package detected for this host yet.' }}</div>
+          <div v-if="updateCenterState.assetDigest" class="mt-2 break-all text-[11px] text-storm">{{ updateCenterState.assetDigest }}</div>
+        </article>
+      </div>
+
+      <div v-if="updateCenterState.asset || updateCenterState.releaseUrl" class="mt-5 flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+        <div v-if="updateCenterState.canCopyInstallCommand" class="min-w-0 flex-1 rounded-2xl border border-storm/20 bg-void/40 p-4">
+          <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div class="text-sm font-medium text-silver">Manual install command</div>
+              <div class="mt-1 text-xs text-storm">Copy, inspect, and run locally when you are ready. No auto-install from the web UI.</div>
+            </div>
+            <button type="button" class="focus-ring inline-flex h-9 items-center justify-center rounded-lg border border-ice/30 px-3 text-sm font-medium text-ice transition-colors hover:bg-ice/10" @click="copyInstallCommand">
+              {{ copiedInstallCommand ? 'Copied' : 'Copy command' }}
+            </button>
+          </div>
+          <pre class="mt-3 overflow-x-auto rounded-xl border border-storm/20 bg-black/30 p-3 text-xs text-ice"><code>{{ updateCenterState.installCommand }}</code></pre>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <a v-if="updateCenterState.asset" class="focus-ring inline-flex h-9 items-center justify-center rounded-lg bg-ice px-4 text-sm font-medium text-void no-underline transition-colors hover:bg-ice/90" :href="updateCenterState.asset.browser_download_url" target="_blank">Download package</a>
+          <a v-if="updateCenterState.releaseUrl" class="focus-ring inline-flex h-9 items-center justify-center rounded-lg border border-storm px-4 text-sm font-medium text-silver no-underline transition-colors hover:border-ice hover:text-ice" :href="updateCenterState.releaseUrl" target="_blank">Open release</a>
+        </div>
+      </div>
+    </section>
+
     <section class="section-card">
       <div class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div>
@@ -241,6 +295,7 @@
 import { ref, computed } from 'vue'
 import { useSystemStats } from '../composables/useSystemStats'
 import PolarisVersion from '../polaris_version'
+import { buildUpdateCenterState } from '../update-center.js'
 import InfoHint from '../components/InfoHint.vue'
 
 const { gpu, displays, audio, sessionType, loading: systemLoading } = useSystemStats(3000)
@@ -252,6 +307,8 @@ const preReleaseVersion = ref(null)
 const loading = ref(true)
 const logs = ref(null)
 const copiedVersion = ref(false)
+const copiedInstallCommand = ref(false)
+const updateHost = ref({ platform: '', distro: {} })
 
 const compatibilityClients = [
   { platform: 'Android', name: 'Nova', status: 'Supported', link: 'https://github.com/papi-ux/nova' },
@@ -399,6 +456,29 @@ const versionHeaderSummary = computed(() => {
   return 'Current public release'
 })
 
+const updateCenterState = computed(() => buildUpdateCenterState({
+  currentVersion: version.value?.version || '',
+  latestRelease: githubVersion.value?.release || null,
+  prereleaseRelease: preReleaseVersion.value?.release || null,
+  includePrereleases: notifyPreReleases.value,
+  host: updateHost.value,
+}))
+
+const updateCenterBadgeClass = computed(() => {
+  switch (updateCenterState.value.status) {
+    case 'update_available':
+      return 'border-ice/30 bg-ice/10 text-ice'
+    case 'ahead':
+      return 'border-purple-300/30 bg-purple-500/10 text-purple-200'
+    case 'unavailable':
+      return 'border-amber-300/30 bg-amber-300/10 text-amber-200'
+    case 'disabled':
+      return 'border-storm/30 bg-deep/60 text-storm'
+    default:
+      return 'border-green-500/30 bg-green-500/10 text-green-200'
+  }
+})
+
 function buildIssueCounter(count, label, tone) {
   if (count === 0) {
     return {
@@ -481,14 +561,29 @@ async function copyVersion() {
   }, 1800)
 }
 
+async function copyInstallCommand() {
+  if (!updateCenterState.value.installCommand || !navigator.clipboard) return
+  await navigator.clipboard.writeText(updateCenterState.value.installCommand)
+  copiedInstallCommand.value = true
+  window.setTimeout(() => {
+    copiedInstallCommand.value = false
+  }, 1800)
+}
+
 ;(async () => {
   try {
     const config = await fetch('./api/config', { credentials: 'include' }).then((r) => r.json())
+    const hostStatus = await fetch('./api/update-status', { credentials: 'include' }).then((r) => r.json()).catch(() => null)
+    updateHost.value = hostStatus || { platform: config.platform || '', distro: {} }
     notifyPreReleases.value = config.notify_pre_releases
-    version.value = new PolarisVersion(null, config.version)
+    version.value = new PolarisVersion(null, hostStatus?.version || config.version)
     githubVersion.value = new PolarisVersion(await fetch('https://api.github.com/repos/papi-ux/polaris/releases/latest').then((r) => r.json()), null)
     if (githubVersion.value) {
-      preReleaseVersion.value = new PolarisVersion((await fetch('https://api.github.com/repos/papi-ux/polaris/releases').then((r) => r.json())).find((release) => release.prerelease), null)
+      const releases = await fetch('https://api.github.com/repos/papi-ux/polaris/releases').then((r) => r.json())
+      const preRelease = releases.find((release) => release.prerelease)
+      if (preRelease) {
+        preReleaseVersion.value = new PolarisVersion(preRelease, null)
+      }
     }
   } catch {
     // GitHub API may be blocked by CSP — version check is non-critical

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/game_library_scanner.cpp
     ${CMAKE_SOURCE_DIR}/src/globals.cpp
     ${CMAKE_SOURCE_DIR}/src/logging.cpp
+    ${CMAKE_SOURCE_DIR}/src/update_status.cpp
     ${CMAKE_SOURCE_DIR}/src/rswrapper.c
 )
 
@@ -95,6 +96,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_prepared_ffmpeg.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_rswrapper.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_session_event_queue.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_update_status.cpp
 )
 
 if (NOT WIN32 AND NOT APPLE)

--- a/tests/unit/test_update_status.cpp
+++ b/tests/unit/test_update_status.cpp
@@ -1,0 +1,49 @@
+#include <src/update_status.h>
+
+#include <gtest/gtest.h>
+
+TEST(UpdateStatusTests, ParsesQuotedOsReleaseFields) {
+  const auto distro = update_status::parse_os_release_for_tests(
+    "NAME=\"CachyOS Linux\"\n"
+    "ID=cachyos\n"
+    "ID_LIKE=\"arch\"\n"
+    "VERSION_ID=2026\n"
+  );
+
+  EXPECT_EQ(distro.id, "cachyos");
+  EXPECT_EQ(distro.id_like, "arch");
+  EXPECT_EQ(distro.version_id, "2026");
+  EXPECT_EQ(distro.pretty_name, "CachyOS Linux");
+}
+
+TEST(UpdateStatusTests, RecommendsArchAssetForCachyOsAndArchLikeDistros) {
+  const auto distro = update_status::parse_os_release_for_tests(
+    "ID=cachyos\n"
+    "ID_LIKE=\"arch\"\n"
+  );
+
+  EXPECT_EQ(update_status::recommended_release_asset_for_tests(distro), "Polaris-arch-x86_64.pkg.tar.zst");
+  EXPECT_EQ(update_status::package_family_for_tests(distro), "arch");
+}
+
+TEST(UpdateStatusTests, RecommendsFedoraAssetByVersionForBazzite) {
+  const auto distro = update_status::parse_os_release_for_tests(
+    "ID=bazzite\n"
+    "ID_LIKE=\"fedora\"\n"
+    "VERSION_ID=44\n"
+  );
+
+  EXPECT_EQ(update_status::recommended_release_asset_for_tests(distro), "Polaris-fedora44-x86_64.rpm");
+  EXPECT_EQ(update_status::package_family_for_tests(distro), "fedora");
+}
+
+TEST(UpdateStatusTests, RecommendsUbuntu2404DebAsset) {
+  const auto distro = update_status::parse_os_release_for_tests(
+    "ID=ubuntu\n"
+    "ID_LIKE=\"debian\"\n"
+    "VERSION_ID=\"24.04\"\n"
+  );
+
+  EXPECT_EQ(update_status::recommended_release_asset_for_tests(distro), "Polaris-ubuntu24.04-x86_64.deb");
+  EXPECT_EQ(update_status::package_family_for_tests(distro), "ubuntu");
+}


### PR DESCRIPTION
## Summary
- Adds a Mission Control/Host Update Center card that compares the installed Polaris version with GitHub release metadata
- Adds safe Linux package matching for Arch/CachyOS, Fedora/Bazzite, and Ubuntu 24.04 release assets
- Exposes copyable manual install commands and download/release links, while explicitly avoiding auto-install from the web UI
- Adds authenticated backend update metadata at `./api/update-status`, including distro/package-family/recommended-asset fields
- Adds frontend and C++ regression coverage for update awareness and asset matching

## Safety
- No privileged package install is triggered by Polaris
- Commands are copy-only and intended for local terminal review/execution
- Unsupported platforms remain informational and do not show an install command

## Test Plan
- [x] `npm test -- src_assets/common/assets/web/update-center.test.js`
- [x] `./build-update-center-red/tests/test_polaris --gtest_filter='UpdateStatusTests.*'`
- [x] `bash scripts/check-public-docs.sh`
- [x] `bash scripts/check-public-surface.sh`
- [x] `npm test` — 35 files / 156 tests
- [x] `npm run lint`
- [x] `npm run build`
- [x] `cmake --build build-update-center-red --target polaris test_polaris -j"$(nproc)"`
- [x] `ctest --test-dir build-update-center-red/tests --output-on-failure -R '^test_polaris$'`
- [x] `git diff --check`
