### PR TITLE
feat(web): surface Update Center CTA

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -612,7 +612,7 @@ namespace confighttp {
       headers.emplace("Referrer-Policy", "no-referrer");
       headers.emplace("Permissions-Policy", "camera=(), microphone=(), geolocation=(), usb=(), payment=()");
       headers.emplace("Strict-Transport-Security", "max-age=31536000");
-      headers.emplace("Content-Security-Policy", std::format("default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*:{} https://*:{}; font-src 'self'; frame-ancestors 'none';", browser_stream::default_webtransport_port, client_settings_endpoint_https_port()));
+      headers.emplace("Content-Security-Policy", std::format("default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.github.com https://*:{} https://*:{}; font-src 'self'; frame-ancestors 'none';", browser_stream::default_webtransport_port, client_settings_endpoint_https_port()));
     }
 
     void append_json_security_headers(SimpleWeb::CaseInsensitiveMultimap &headers) {

--- a/src_assets/common/assets/web/update-center.js
+++ b/src_assets/common/assets/web/update-center.js
@@ -95,6 +95,67 @@ export function buildManualInstallCommand(asset, host = {}) {
   return lines.join('\n')
 }
 
+
+function buildActionMetadata(status, asset, installCommand, releaseUrl) {
+  if (status === 'update_available') {
+    if (installCommand) {
+      return {
+        statusTone: 'update',
+        statusLightLabel: 'Update available',
+        primaryActionLabel: 'Update',
+        primaryActionKind: 'copy_install_command',
+        primaryActionSummary: 'Copy the safe local install command and jump to the package details.',
+      }
+    }
+
+    return {
+      statusTone: 'update',
+      statusLightLabel: 'Update available',
+      primaryActionLabel: releaseUrl ? 'Open release' : 'Update details',
+      primaryActionKind: releaseUrl ? 'open_release' : 'scroll_to_update_center',
+      primaryActionSummary: 'A newer release is available, but Polaris could not match a local package for this host.',
+    }
+  }
+
+  if (status === 'ahead') {
+    return {
+      statusTone: 'ahead',
+      statusLightLabel: 'Build is newer than selected release channel',
+      primaryActionLabel: 'Details',
+      primaryActionKind: 'scroll_to_update_center',
+      primaryActionSummary: 'This host is ahead of the selected release channel.',
+    }
+  }
+
+  if (status === 'unavailable') {
+    return {
+      statusTone: 'warning',
+      statusLightLabel: 'Update check unavailable',
+      primaryActionLabel: 'Check again',
+      primaryActionKind: 'refresh_update_status',
+      primaryActionSummary: 'Release metadata could not be loaded from this browser session.',
+    }
+  }
+
+  if (status === 'disabled') {
+    return {
+      statusTone: 'disabled',
+      statusLightLabel: 'Update checks disabled',
+      primaryActionLabel: 'Disabled',
+      primaryActionKind: 'none',
+      primaryActionSummary: 'Update checks are disabled for this host.',
+    }
+  }
+
+  return {
+    statusTone: 'current',
+    statusLightLabel: 'Current release installed',
+    primaryActionLabel: asset ? 'Package' : 'Current',
+    primaryActionKind: asset ? 'scroll_to_update_center' : 'none',
+    primaryActionSummary: 'This host is on the latest public release.',
+  }
+}
+
 function versionFromRelease(release) {
   return release?.tag_name || release?.name || ''
 }
@@ -126,6 +187,7 @@ export function chooseCandidateRelease({ latestRelease, prereleaseRelease, inclu
 
 export function buildUpdateCenterState({ currentVersion = '', latestRelease = null, prereleaseRelease = null, includePrereleases = false, host = {}, disabled = false } = {}) {
   if (disabled) {
+    const action = buildActionMetadata('disabled', null, '', '')
     return {
       status: 'disabled',
       statusLabel: 'Update checks disabled',
@@ -136,21 +198,25 @@ export function buildUpdateCenterState({ currentVersion = '', latestRelease = nu
       packageLabel: '',
       installCommand: '',
       canCopyInstallCommand: false,
+      ...action,
     }
   }
 
   const candidateRelease = chooseCandidateRelease({ latestRelease, prereleaseRelease, includePrereleases, currentVersion })
   if (!currentVersion || !candidateRelease) {
+    const releaseUrl = candidateRelease?.html_url || ''
+    const action = buildActionMetadata('unavailable', null, '', releaseUrl)
     return {
       status: 'unavailable',
       statusLabel: 'Update status unavailable',
       summary: 'Polaris could not check GitHub releases from this browser session.',
       latestVersion: versionFromRelease(candidateRelease),
-      releaseUrl: candidateRelease?.html_url || '',
+      releaseUrl,
       asset: null,
       packageLabel: '',
       installCommand: '',
       canCopyInstallCommand: false,
+      ...action,
     }
   }
 
@@ -170,6 +236,8 @@ export function buildUpdateCenterState({ currentVersion = '', latestRelease = nu
   const asset = selectReleaseAsset(candidateRelease, host)
   const packageFamily = normalizeToken(asset?.packageFamily || inferPackageFamily(host))
   const installCommand = asset ? buildManualInstallCommand(asset, { ...host, packageFamily }) : ''
+  const releaseUrl = candidateRelease.html_url || ''
+  const action = buildActionMetadata(status, asset, installCommand, releaseUrl)
 
   return {
     status,
@@ -177,7 +245,7 @@ export function buildUpdateCenterState({ currentVersion = '', latestRelease = nu
     summary,
     currentVersion,
     latestVersion: versionFromRelease(candidateRelease),
-    releaseUrl: candidateRelease.html_url || '',
+    releaseUrl,
     asset,
     assetDigest: asset?.digest || '',
     packageFamily,
@@ -185,5 +253,6 @@ export function buildUpdateCenterState({ currentVersion = '', latestRelease = nu
     installCommand,
     canCopyInstallCommand: Boolean(installCommand),
     manualInstallOnly: true,
+    ...action,
   }
 }

--- a/src_assets/common/assets/web/update-center.test.js
+++ b/src_assets/common/assets/web/update-center.test.js
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   buildManualInstallCommand,
   buildUpdateCenterState,
@@ -83,6 +85,35 @@ describe('Update Center release awareness', () => {
       .toBe('current')
     expect(buildUpdateCenterState({ currentVersion: '1.2.2', latestRelease: release, prereleaseRelease: prerelease, includePrereleases: true }).status)
       .toBe('update_available')
+  })
+
+
+
+  it('surfaces a front-page update CTA and status light metadata', () => {
+    const state = buildUpdateCenterState({
+      currentVersion: '1.2.1',
+      latestRelease: release,
+      host: {
+        platform: 'linux',
+        distro: { id: 'cachyos', id_like: 'arch', version_id: '2026' },
+      },
+    })
+
+    expect(state.primaryActionLabel).toBe('Update')
+    expect(state.primaryActionKind).toBe('copy_install_command')
+    expect(state.statusTone).toBe('update')
+    expect(state.statusLightLabel).toBe('Update available')
+  })
+
+  it('keeps the front-page Update button copy-only and wires refresh affordances', () => {
+    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/HomeView.vue'), 'utf8')
+
+    expect(source).toContain('data-update-center-cta')
+    expect(source).toContain('data-update-status-light')
+    expect(source).toContain('@click="handlePrimaryUpdateAction"')
+    expect(source).toContain('@click="refreshUpdateStatus"')
+    expect(source).toContain('scrollIntoView')
+    expect(source).not.toMatch(/POST['"]\s*,\s*['"].*update/i)
   })
 
   it('stays informational on unsupported platforms instead of attempting auto-install', () => {

--- a/src_assets/common/assets/web/update-center.test.js
+++ b/src_assets/common/assets/web/update-center.test.js
@@ -117,6 +117,14 @@ describe('Update Center release awareness', () => {
     expect(source).not.toMatch(/POST['"]\s*,\s*['"].*update/i)
   })
 
+
+
+  it('allows the browser release check through the web UI content security policy', () => {
+    const source = readFileSync(join(process.cwd(), 'src/confighttp.cpp'), 'utf8')
+
+    expect(source).toContain('https://api.github.com')
+  })
+
   it('stays informational on unsupported platforms instead of attempting auto-install', () => {
     const state = buildUpdateCenterState({
       currentVersion: '1.2.1',

--- a/src_assets/common/assets/web/update-center.test.js
+++ b/src_assets/common/assets/web/update-center.test.js
@@ -106,13 +106,14 @@ describe('Update Center release awareness', () => {
   })
 
   it('keeps the front-page Update button copy-only and wires refresh affordances', () => {
-    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/HomeView.vue'), 'utf8')
+    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/DashboardView.vue'), 'utf8')
 
     expect(source).toContain('data-update-center-cta')
     expect(source).toContain('data-update-status-light')
     expect(source).toContain('@click="handlePrimaryUpdateAction"')
     expect(source).toContain('@click="refreshUpdateStatus"')
     expect(source).toContain('scrollIntoView')
+    expect(source).toContain('buildUpdateCenterState')
     expect(source).not.toMatch(/POST['"]\s*,\s*['"].*update/i)
   })
 

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -36,6 +36,56 @@
       <div class="mission-control-copy">{{ secondScreenOverlayRecommendation.detail }}</div>
     </section>
 
+    <section ref="updateCenterSection" class="section-card border-ice/15 bg-gradient-to-br from-deep/70 via-deep/40 to-ice/5" aria-label="Update Center">
+      <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div class="min-w-0">
+          <div class="section-kicker">Update Center</div>
+          <div class="mt-2 flex flex-wrap items-center gap-3">
+            <span
+              data-update-status-light
+              class="h-2.5 w-2.5 rounded-full"
+              :class="updateCenterStatusLightClass"
+              :aria-label="updateCenterState.statusLightLabel"
+              role="status"
+            ></span>
+            <h2 class="section-title">{{ updateCenterState.statusLabel }}</h2>
+            <span class="meta-pill" :class="updateCenterBadgeClass">{{ updateCenterState.latestVersion || 'Release check' }}</span>
+          </div>
+          <p class="section-copy mt-2">{{ updateCheckError || updateCenterState.summary }}</p>
+          <div v-if="updateCenterState.asset?.name" class="mt-2 break-all text-xs text-storm">
+            {{ updateCenterState.packageLabel }} · {{ updateCenterState.asset.name }}
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2 lg:justify-end">
+          <button
+            data-update-center-cta
+            type="button"
+            class="focus-ring inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium transition-[background-color,border-color,color,box-shadow] duration-200 disabled:opacity-50"
+            :class="updateCenterCtaClass"
+            :disabled="updateCenterState.primaryActionKind === 'none'"
+            @click="handlePrimaryUpdateAction"
+          >
+            {{ copiedInstallCommand ? 'Copied' : updateCenterState.primaryActionLabel }}
+          </button>
+          <button
+            data-update-center-refresh
+            type="button"
+            class="focus-ring inline-flex h-10 items-center justify-center rounded-lg border border-storm px-4 text-sm font-medium text-silver transition-colors hover:border-ice hover:text-ice disabled:opacity-50"
+            :disabled="checkingUpdates"
+            @click="refreshUpdateStatus"
+          >
+            {{ checkingUpdates ? 'Checking…' : 'Refresh' }}
+          </button>
+          <router-link
+            to="/info"
+            class="focus-ring inline-flex h-10 items-center justify-center rounded-lg border border-ice/30 px-4 text-sm font-medium text-ice no-underline transition-colors hover:bg-ice/10"
+          >
+            Details
+          </router-link>
+        </div>
+      </div>
+    </section>
+
     <div v-if="statsLoaded && !stats?.streaming" class="grid grid-cols-1 gap-3 lg:grid-cols-3">
       <div class="surface-subtle p-4">
         <div class="section-title-row">
@@ -803,6 +853,7 @@ import { useI18n } from 'vue-i18n'
 import { resolveClientSettingsSync } from '../client-settings-sync'
 import { resolveAutoQualityState } from '../auto-quality-state'
 import { buildReadyCheckDisplay } from '../dashboard-ready-checks'
+import { buildUpdateCenterState } from '../update-center.js'
 import {
   buildFpsTargetGap,
   buildLiveSummary,
@@ -829,11 +880,125 @@ const version = ref('')
 const headlessEnabled = ref(false)
 const discoveryEnabled = ref(false)
 const pairingEnabled = ref(false)
+const updateHost = ref({ platform: '', distro: {} })
+const latestRelease = ref(null)
+const prereleaseRelease = ref(null)
+const notifyPreReleases = ref(false)
+const checkingUpdates = ref(false)
+const updateCheckError = ref('')
+const copiedInstallCommand = ref(false)
+const updateCenterSection = ref(null)
 const clientSettingsSync = ref(resolveClientSettingsSync({}))
 const { t } = useI18n()
 const { toast: showToast } = useToast()
 
 const autoQuality = computed(() => resolveAutoQualityState(stats.value || {}, clientSettingsSync.value || {}))
+
+const updateCenterState = computed(() => buildUpdateCenterState({
+  currentVersion: version.value || '',
+  latestRelease: latestRelease.value,
+  prereleaseRelease: prereleaseRelease.value,
+  includePrereleases: notifyPreReleases.value,
+  host: updateHost.value,
+}))
+
+const updateCenterBadgeClass = computed(() => {
+  switch (updateCenterState.value.status) {
+    case 'update_available':
+      return 'border-ice/30 bg-ice/10 text-ice'
+    case 'ahead':
+      return 'border-purple-300/30 bg-purple-500/10 text-purple-200'
+    case 'unavailable':
+      return 'border-amber-300/30 bg-amber-300/10 text-amber-200'
+    case 'disabled':
+      return 'border-storm/30 bg-deep/60 text-storm'
+    default:
+      return 'border-green-500/30 bg-green-500/10 text-green-200'
+  }
+})
+
+const updateCenterStatusLightClass = computed(() => {
+  switch (updateCenterState.value.statusTone) {
+    case 'update':
+      return 'bg-ice shadow-[0_0_18px_rgba(200,214,229,0.75)] animate-pulse'
+    case 'ahead':
+      return 'bg-purple-300 shadow-[0_0_14px_rgba(216,180,254,0.55)]'
+    case 'warning':
+      return 'bg-amber-300 shadow-[0_0_14px_rgba(252,211,77,0.55)]'
+    case 'disabled':
+      return 'bg-storm/60'
+    default:
+      return 'bg-green-400 shadow-[0_0_14px_rgba(74,222,128,0.55)]'
+  }
+})
+
+const updateCenterCtaClass = computed(() => {
+  if (updateCenterState.value.status === 'update_available') {
+    return 'bg-ice text-void hover:bg-ice/90 hover:shadow-[0_0_24px_rgba(200,214,229,0.22)]'
+  }
+  if (updateCenterState.value.primaryActionKind === 'none') {
+    return 'border border-storm bg-deep/50 text-storm'
+  }
+  return 'border border-ice/30 text-ice hover:bg-ice/10'
+})
+
+function scrollToUpdateCenter() {
+  updateCenterSection.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+async function copyInstallCommand() {
+  if (!updateCenterState.value.installCommand || !navigator.clipboard) return false
+  await navigator.clipboard.writeText(updateCenterState.value.installCommand)
+  copiedInstallCommand.value = true
+  window.setTimeout(() => {
+    copiedInstallCommand.value = false
+  }, 1800)
+  return true
+}
+
+async function handlePrimaryUpdateAction() {
+  const action = updateCenterState.value.primaryActionKind
+  if (action === 'refresh_update_status') {
+    await refreshUpdateStatus()
+    return
+  }
+  if (action === 'open_release' && updateCenterState.value.releaseUrl) {
+    window.open(updateCenterState.value.releaseUrl, '_blank', 'noopener')
+    return
+  }
+  scrollToUpdateCenter()
+  if (action === 'copy_install_command') {
+    await copyInstallCommand()
+  }
+}
+
+async function refreshUpdateStatus() {
+  checkingUpdates.value = true
+  updateCheckError.value = ''
+  try {
+    const config = await fetch('./api/config', { credentials: 'include' }).then((r) => r.json())
+    const hostStatus = await fetch('./api/update-status', { credentials: 'include' }).then((r) => r.json()).catch(() => null)
+    updateHost.value = hostStatus || { platform: config.platform || '', distro: {} }
+    notifyPreReleases.value = config.notify_pre_releases === true || config.notify_pre_releases === 'enabled'
+    version.value = hostStatus?.version || config.version || version.value
+
+    try {
+      latestRelease.value = await fetch('https://api.github.com/repos/papi-ux/polaris/releases/latest').then((r) => r.json())
+      const releases = await fetch('https://api.github.com/repos/papi-ux/polaris/releases').then((r) => r.json())
+      prereleaseRelease.value = Array.isArray(releases) ? releases.find((release) => release.prerelease) || null : null
+    } catch (error) {
+      latestRelease.value = null
+      prereleaseRelease.value = null
+      updateCheckError.value = 'Release check unavailable'
+      console.error(error)
+    }
+  } catch (error) {
+    updateCheckError.value = 'Host update status unavailable'
+    console.error(error)
+  } finally {
+    checkingUpdates.value = false
+  }
+}
 
 const actionSummary = computed(() => {
   if (!statsLoaded.value) return t('dashboard.loading_summary')
@@ -1909,6 +2074,7 @@ onMounted(async () => {
   }
 
   fetchSystemInfo()
+  refreshUpdateStatus()
   fetchAiStatus()
   fetchAiDevices()
 

--- a/src_assets/common/assets/web/views/HomeView.vue
+++ b/src_assets/common/assets/web/views/HomeView.vue
@@ -54,6 +54,42 @@
         </article>
 
         <article class="header-support-card">
+          <div class="header-support-title-row">
+            <div class="section-kicker !mb-0">Update</div>
+            <span
+              data-update-status-light
+              class="h-2.5 w-2.5 rounded-full"
+              :class="updateCenterStatusLightClass"
+              :aria-label="updateCenterState.statusLightLabel"
+              role="status"
+            ></span>
+          </div>
+          <div class="header-support-value">{{ updateCenterState.statusLabel }}</div>
+          <div class="header-support-copy">{{ updateCheckError || updateCenterState.primaryActionSummary }}</div>
+          <div class="mt-3 flex flex-wrap gap-2">
+            <button
+              data-update-center-cta
+              type="button"
+              class="focus-ring inline-flex h-8 items-center justify-center rounded-lg px-3 text-sm font-medium transition-[background-color,border-color,color,box-shadow] duration-200"
+              :class="updateCenterCtaClass"
+              :disabled="updateCenterState.primaryActionKind === 'none'"
+              @click="handlePrimaryUpdateAction"
+            >
+              {{ copiedInstallCommand ? 'Copied' : updateCenterState.primaryActionLabel }}
+            </button>
+            <button
+              data-update-center-refresh
+              type="button"
+              class="focus-ring inline-flex h-8 items-center justify-center rounded-lg border border-storm px-3 text-sm font-medium text-silver transition-colors hover:border-ice hover:text-ice disabled:opacity-50"
+              :disabled="checkingUpdates"
+              @click="refreshUpdateStatus"
+            >
+              {{ checkingUpdates ? 'Checking…' : 'Refresh' }}
+            </button>
+          </div>
+        </article>
+
+        <article class="header-support-card">
           <div class="section-kicker">Issues</div>
           <div class="header-support-value">{{ recentIssues.length }}</div>
           <div class="header-support-copy">
@@ -63,7 +99,7 @@
       </div>
     </section>
 
-    <section class="section-card border-ice/15 bg-gradient-to-br from-deep/70 via-deep/40 to-ice/5">
+    <section ref="updateCenterSection" class="section-card border-ice/15 bg-gradient-to-br from-deep/70 via-deep/40 to-ice/5">
       <div class="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
         <div class="max-w-3xl">
           <div class="section-kicker">Update Center</div>
@@ -75,7 +111,17 @@
           </div>
           <p class="section-copy mt-2">{{ updateCenterState.summary }}</p>
         </div>
-        <span class="meta-pill self-start" :class="updateCenterBadgeClass">{{ updateCenterState.statusLabel }}</span>
+        <div class="flex flex-wrap items-center gap-2 self-start">
+          <span class="meta-pill" :class="updateCenterBadgeClass">{{ updateCenterState.statusLabel }}</span>
+          <button
+            type="button"
+            class="focus-ring inline-flex h-8 items-center justify-center rounded-lg border border-storm px-3 text-sm font-medium text-silver transition-colors hover:border-ice hover:text-ice disabled:opacity-50"
+            :disabled="checkingUpdates"
+            @click="refreshUpdateStatus"
+          >
+            {{ checkingUpdates ? 'Checking…' : 'Check again' }}
+          </button>
+        </div>
       </div>
 
       <div class="mt-5 grid gap-3 lg:grid-cols-3">
@@ -309,6 +355,9 @@ const logs = ref(null)
 const copiedVersion = ref(false)
 const copiedInstallCommand = ref(false)
 const updateHost = ref({ platform: '', distro: {} })
+const checkingUpdates = ref(false)
+const updateCheckError = ref('')
+const updateCenterSection = ref(null)
 
 const compatibilityClients = [
   { platform: 'Android', name: 'Nova', status: 'Supported', link: 'https://github.com/papi-ux/nova' },
@@ -479,6 +528,32 @@ const updateCenterBadgeClass = computed(() => {
   }
 })
 
+
+const updateCenterStatusLightClass = computed(() => {
+  switch (updateCenterState.value.statusTone) {
+    case 'update':
+      return 'bg-ice shadow-[0_0_18px_rgba(200,214,229,0.75)] animate-pulse'
+    case 'ahead':
+      return 'bg-purple-300 shadow-[0_0_14px_rgba(216,180,254,0.55)]'
+    case 'warning':
+      return 'bg-amber-300 shadow-[0_0_14px_rgba(252,211,77,0.55)]'
+    case 'disabled':
+      return 'bg-storm/60'
+    default:
+      return 'bg-green-400 shadow-[0_0_14px_rgba(74,222,128,0.55)]'
+  }
+})
+
+const updateCenterCtaClass = computed(() => {
+  if (updateCenterState.value.status === 'update_available') {
+    return 'bg-ice text-void hover:bg-ice/90 hover:shadow-[0_0_24px_rgba(200,214,229,0.22)]'
+  }
+  if (updateCenterState.value.primaryActionKind === 'none') {
+    return 'border border-storm bg-deep/50 text-storm'
+  }
+  return 'border border-ice/30 text-ice hover:bg-ice/10'
+})
+
 function buildIssueCounter(count, label, tone) {
   if (count === 0) {
     return {
@@ -562,32 +637,66 @@ async function copyVersion() {
 }
 
 async function copyInstallCommand() {
-  if (!updateCenterState.value.installCommand || !navigator.clipboard) return
+  if (!updateCenterState.value.installCommand || !navigator.clipboard) return false
   await navigator.clipboard.writeText(updateCenterState.value.installCommand)
   copiedInstallCommand.value = true
   window.setTimeout(() => {
     copiedInstallCommand.value = false
   }, 1800)
+  return true
 }
 
-;(async () => {
+function scrollToUpdateCenter() {
+  updateCenterSection.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+async function handlePrimaryUpdateAction() {
+  const action = updateCenterState.value.primaryActionKind
+  if (action === 'refresh_update_status') {
+    await refreshUpdateStatus()
+    return
+  }
+  if (action === 'open_release' && updateCenterState.value.releaseUrl) {
+    window.open(updateCenterState.value.releaseUrl, '_blank', 'noopener')
+    return
+  }
+  scrollToUpdateCenter()
+  if (action === 'copy_install_command') {
+    await copyInstallCommand()
+  }
+}
+
+async function refreshUpdateStatus() {
+  checkingUpdates.value = true
+  updateCheckError.value = ''
   try {
     const config = await fetch('./api/config', { credentials: 'include' }).then((r) => r.json())
     const hostStatus = await fetch('./api/update-status', { credentials: 'include' }).then((r) => r.json()).catch(() => null)
     updateHost.value = hostStatus || { platform: config.platform || '', distro: {} }
     notifyPreReleases.value = config.notify_pre_releases
     version.value = new PolarisVersion(null, hostStatus?.version || config.version)
-    githubVersion.value = new PolarisVersion(await fetch('https://api.github.com/repos/papi-ux/polaris/releases/latest').then((r) => r.json()), null)
-    if (githubVersion.value) {
+
+    try {
+      githubVersion.value = new PolarisVersion(await fetch('https://api.github.com/repos/papi-ux/polaris/releases/latest').then((r) => r.json()), null)
       const releases = await fetch('https://api.github.com/repos/papi-ux/polaris/releases').then((r) => r.json())
       const preRelease = releases.find((release) => release.prerelease)
-      if (preRelease) {
-        preReleaseVersion.value = new PolarisVersion(preRelease, null)
-      }
+      preReleaseVersion.value = preRelease ? new PolarisVersion(preRelease, null) : null
+    } catch (error) {
+      githubVersion.value = null
+      preReleaseVersion.value = null
+      updateCheckError.value = 'Release check unavailable'
+      console.error(error)
     }
-  } catch {
-    // GitHub API may be blocked by CSP — version check is non-critical
+  } catch (error) {
+    updateCheckError.value = 'Host update status unavailable'
+    console.error(error)
+  } finally {
+    checkingUpdates.value = false
   }
+}
+
+;(async () => {
+  await refreshUpdateStatus()
   try {
     logs.value = await fetch('./api/logs', { credentials: 'include' }).then((r) => r.text())
   } catch (error) {


### PR DESCRIPTION
## Summary
- Keeps the upcoming updater release as `v1.2.2` scope: small Update Center UX polish, not a larger feature train
- Adds a header/front-page Update card with a small status light so users see update state immediately
- Adds a primary `Update` CTA that scrolls users to the Update Center details and copies the safe local install command when a matching package is available
- Adds a `Refresh`/`Check again` affordance to re-query host/release metadata from the page
- Preserves the security boundary: no package manager execution, no privileged install, no web-triggered auto-update

## Test Plan
- [x] `npm test -- src_assets/common/assets/web/update-center.test.js`
- [x] `bash scripts/check-public-docs.sh`
- [x] `bash scripts/check-public-surface.sh`
- [x] `npm test` — 35 files / 158 tests
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
