### PR TITLE
fix(web): move Update Center status to sidebar

### DIFF
--- a/src_assets/common/assets/web/App.vue
+++ b/src_assets/common/assets/web/App.vue
@@ -55,6 +55,30 @@
           </router-link>
         </div>
       </nav>
+
+      <router-link
+        data-sidebar-update-status
+        :to="{ path: '/info', hash: '#update-center' }"
+        class="focus-ring mx-3 mb-2 flex items-center gap-2 rounded-lg border border-storm/20 bg-deep/35 px-3 py-2 text-left text-sm text-silver no-underline transition-[background-color,border-color,color,box-shadow] duration-200 hover:border-ice/25 hover:bg-twilight/40 hover:text-ice"
+        :class="{ 'justify-center px-2': sidebarCollapsed }"
+        :title="sidebarUpdateTitle"
+        :aria-label="sidebarUpdateTitle"
+        @click="sidebarOpen = false"
+      >
+        <span
+          data-sidebar-update-status-light
+          class="h-2.5 w-2.5 shrink-0 rounded-full"
+          :class="sidebarUpdateStatusLightClass"
+          aria-hidden="true"
+        ></span>
+        <template v-if="!sidebarCollapsed">
+          <span class="min-w-0 flex-1">
+            <span class="block text-[10px] font-semibold uppercase tracking-[0.2em] text-storm/70">Update</span>
+            <span class="block truncate text-sm font-medium text-silver">{{ sidebarUpdateLabel }}</span>
+            <span class="block truncate text-[11px] text-storm">{{ sidebarUpdateDetail }}</span>
+          </span>
+        </template>
+      </router-link>
       <div class="px-3 mb-1">
         <button
           type="button"
@@ -157,6 +181,7 @@ import SpaceParticles from './components/SpaceParticles.vue'
 import { cycleTheme, getNextTheme, getTheme, getThemeMeta, initTheme } from './theme.js'
 import { getCachedConfig } from './config-cache.js'
 import { createNavSections, flattenNavItems, getNavItemByPath } from './nav-metadata.js'
+import { buildUpdateCenterState } from './update-center.js'
 
 const route = useRoute()
 const currentTheme = ref(getTheme())
@@ -170,6 +195,12 @@ const sidebarOpen = ref(false)
 const sidebarCollapsed = ref(localStorage.getItem('sidebarCollapsed') === 'true')
 const appVersion = ref('')
 const appVersionLoading = ref(false)
+const sidebarUpdateHost = ref({ platform: '', distro: {} })
+const sidebarLatestRelease = ref(null)
+const sidebarPrereleaseRelease = ref(null)
+const sidebarNotifyPreReleases = ref(false)
+const sidebarUpdateError = ref('')
+const sidebarUpdateLoading = ref(false)
 const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
 
 let i18nReady = false
@@ -190,6 +221,42 @@ const currentPageSection = computed(() => currentNavItem.value?.sectionLabel || 
 const paletteShortcut = computed(() => `${isMac ? '\u2318' : 'Ctrl+'}K ${i18nReady ? t('navbar.search_hint') : 'to search'}`)
 const displayVersion = computed(() => appVersion.value ? `v${appVersion.value}` : 'v...')
 const compactVersion = computed(() => appVersion.value ? appVersion.value.split('.')[0] : '...')
+const sidebarUpdateState = computed(() => buildUpdateCenterState({
+  currentVersion: appVersion.value || '',
+  latestRelease: sidebarLatestRelease.value,
+  prereleaseRelease: sidebarPrereleaseRelease.value,
+  includePrereleases: sidebarNotifyPreReleases.value,
+  host: sidebarUpdateHost.value,
+}))
+const sidebarUpdateLabel = computed(() => {
+  if (sidebarUpdateLoading.value && !sidebarLatestRelease.value) return 'Checking…'
+  if (sidebarUpdateError.value) return 'Check unavailable'
+  if (sidebarUpdateState.value.status === 'update_available' && sidebarUpdateState.value.latestVersion) {
+    return `${sidebarUpdateState.value.latestVersion} available`
+  }
+  return sidebarUpdateState.value.currentVersion ? `v${sidebarUpdateState.value.currentVersion} current` : sidebarUpdateState.value.statusLabel
+})
+const sidebarUpdateDetail = computed(() => {
+  if (sidebarUpdateError.value) return sidebarUpdateError.value
+  if (sidebarUpdateState.value.status === 'update_available') return 'Open System to copy or download'
+  if (sidebarUpdateState.value.latestVersion) return `Latest ${sidebarUpdateState.value.latestVersion}`
+  return 'System update details'
+})
+const sidebarUpdateTitle = computed(() => `Update Center: ${sidebarUpdateLabel.value}. ${sidebarUpdateDetail.value}`)
+const sidebarUpdateStatusLightClass = computed(() => {
+  switch (sidebarUpdateState.value.statusTone) {
+    case 'update':
+      return 'bg-ice shadow-[0_0_18px_rgba(200,214,229,0.75)] animate-pulse'
+    case 'ahead':
+      return 'bg-purple-300 shadow-[0_0_14px_rgba(216,180,254,0.55)]'
+    case 'warning':
+      return 'bg-amber-300 shadow-[0_0_14px_rgba(252,211,77,0.55)]'
+    case 'disabled':
+      return 'bg-storm/60'
+    default:
+      return 'bg-green-400 shadow-[0_0_14px_rgba(74,222,128,0.55)]'
+  }
+})
 const authRoutes = new Set(['/login', '/welcome', '/recover'])
 
 const showNav = computed(() => {
@@ -211,9 +278,45 @@ async function loadAppVersion() {
   }
 }
 
+async function refreshSidebarUpdateStatus() {
+  if (sidebarUpdateLoading.value) return
+  sidebarUpdateLoading.value = true
+  sidebarUpdateError.value = ''
+  try {
+    const config = await getCachedConfig().catch(() => null)
+    if (config?.version && !appVersion.value) {
+      appVersion.value = config.version
+    }
+    sidebarNotifyPreReleases.value = config?.notify_pre_releases === true || config?.notify_pre_releases === 'enabled'
+
+    const hostStatus = await fetch('./api/update-status', { credentials: 'include' }).then((r) => r.ok ? r.json() : null).catch(() => null)
+    sidebarUpdateHost.value = hostStatus || { platform: config?.platform || '', distro: {} }
+    if (hostStatus?.version) {
+      appVersion.value = hostStatus.version
+    }
+
+    const latest = await fetch('https://api.github.com/repos/papi-ux/polaris/releases/latest').then((r) => r.ok ? r.json() : null)
+    sidebarLatestRelease.value = latest
+    if (sidebarNotifyPreReleases.value) {
+      const releases = await fetch('https://api.github.com/repos/papi-ux/polaris/releases').then((r) => r.ok ? r.json() : [])
+      sidebarPrereleaseRelease.value = Array.isArray(releases) ? releases.find((release) => release.prerelease) || null : null
+    } else {
+      sidebarPrereleaseRelease.value = null
+    }
+  } catch (error) {
+    sidebarLatestRelease.value = null
+    sidebarPrereleaseRelease.value = null
+    sidebarUpdateError.value = 'Release check unavailable'
+    console.error(error)
+  } finally {
+    sidebarUpdateLoading.value = false
+  }
+}
+
 watch(showNav, (visible) => {
   if (visible) {
     void loadAppVersion()
+    void refreshSidebarUpdateStatus()
   }
 })
 
@@ -262,6 +365,9 @@ onMounted(() => {
   initTheme()
   window.addEventListener('keydown', handleKeydown)
   void loadAppVersion()
+  if (showNav.value) {
+    void refreshSidebarUpdateStatus()
+  }
 })
 
 onUnmounted(() => {

--- a/src_assets/common/assets/web/main.js
+++ b/src_assets/common/assets/web/main.js
@@ -50,6 +50,12 @@ const routes = [
 const router = createRouter({
   history: createWebHashHistory(),
   routes,
+  scrollBehavior(to) {
+    if (to.hash) {
+      return { el: to.hash, behavior: 'smooth' }
+    }
+    return { top: 0 }
+  },
 })
 
 // Auth guard - redirect to login if not authenticated

--- a/src_assets/common/assets/web/update-center.test.js
+++ b/src_assets/common/assets/web/update-center.test.js
@@ -105,16 +105,27 @@ describe('Update Center release awareness', () => {
     expect(state.statusLightLabel).toBe('Update available')
   })
 
-  it('keeps the front-page Update button copy-only and wires refresh affordances', () => {
-    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/DashboardView.vue'), 'utf8')
+  it('keeps Update Center out of Mission Control and exposes sidebar/System affordances', () => {
+    const dashboard = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/DashboardView.vue'), 'utf8')
+    const appShell = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/App.vue'), 'utf8')
+    const system = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/HomeView.vue'), 'utf8')
 
-    expect(source).toContain('data-update-center-cta')
-    expect(source).toContain('data-update-status-light')
-    expect(source).toContain('@click="handlePrimaryUpdateAction"')
-    expect(source).toContain('@click="refreshUpdateStatus"')
-    expect(source).toContain('scrollIntoView')
-    expect(source).toContain('buildUpdateCenterState')
-    expect(source).not.toMatch(/POST['"]\s*,\s*['"].*update/i)
+    expect(dashboard).not.toContain('data-update-center-cta')
+    expect(dashboard).not.toContain('data-update-status-light')
+    expect(dashboard).not.toContain('buildUpdateCenterState')
+
+    expect(appShell).toContain('data-sidebar-update-status')
+    expect(appShell).toContain('data-sidebar-update-status-light')
+    expect(appShell).toContain("path: '/info'")
+    expect(appShell).toContain("hash: '#update-center'")
+    expect(appShell).toContain('buildUpdateCenterState')
+
+    expect(system).toContain('id="update-center"')
+    expect(system).toContain('data-update-center-details')
+    expect(system).toContain('@click="handlePrimaryUpdateAction"')
+    expect(system).toContain('@click="refreshUpdateStatus"')
+    expect(system).toContain('scrollIntoView')
+    expect(system).not.toMatch(/POST['"]\s*,\s*['"].*update/i)
   })
 
 

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -36,56 +36,6 @@
       <div class="mission-control-copy">{{ secondScreenOverlayRecommendation.detail }}</div>
     </section>
 
-    <section ref="updateCenterSection" class="section-card border-ice/15 bg-gradient-to-br from-deep/70 via-deep/40 to-ice/5" aria-label="Update Center">
-      <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-        <div class="min-w-0">
-          <div class="section-kicker">Update Center</div>
-          <div class="mt-2 flex flex-wrap items-center gap-3">
-            <span
-              data-update-status-light
-              class="h-2.5 w-2.5 rounded-full"
-              :class="updateCenterStatusLightClass"
-              :aria-label="updateCenterState.statusLightLabel"
-              role="status"
-            ></span>
-            <h2 class="section-title">{{ updateCenterState.statusLabel }}</h2>
-            <span class="meta-pill" :class="updateCenterBadgeClass">{{ updateCenterState.latestVersion || 'Release check' }}</span>
-          </div>
-          <p class="section-copy mt-2">{{ updateCheckError || updateCenterState.summary }}</p>
-          <div v-if="updateCenterState.asset?.name" class="mt-2 break-all text-xs text-storm">
-            {{ updateCenterState.packageLabel }} · {{ updateCenterState.asset.name }}
-          </div>
-        </div>
-        <div class="flex flex-wrap gap-2 lg:justify-end">
-          <button
-            data-update-center-cta
-            type="button"
-            class="focus-ring inline-flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium transition-[background-color,border-color,color,box-shadow] duration-200 disabled:opacity-50"
-            :class="updateCenterCtaClass"
-            :disabled="updateCenterState.primaryActionKind === 'none'"
-            @click="handlePrimaryUpdateAction"
-          >
-            {{ copiedInstallCommand ? 'Copied' : updateCenterState.primaryActionLabel }}
-          </button>
-          <button
-            data-update-center-refresh
-            type="button"
-            class="focus-ring inline-flex h-10 items-center justify-center rounded-lg border border-storm px-4 text-sm font-medium text-silver transition-colors hover:border-ice hover:text-ice disabled:opacity-50"
-            :disabled="checkingUpdates"
-            @click="refreshUpdateStatus"
-          >
-            {{ checkingUpdates ? 'Checking…' : 'Refresh' }}
-          </button>
-          <router-link
-            to="/info"
-            class="focus-ring inline-flex h-10 items-center justify-center rounded-lg border border-ice/30 px-4 text-sm font-medium text-ice no-underline transition-colors hover:bg-ice/10"
-          >
-            Details
-          </router-link>
-        </div>
-      </div>
-    </section>
-
     <div v-if="statsLoaded && !stats?.streaming" class="grid grid-cols-1 gap-3 lg:grid-cols-3">
       <div class="surface-subtle p-4">
         <div class="section-title-row">
@@ -853,7 +803,6 @@ import { useI18n } from 'vue-i18n'
 import { resolveClientSettingsSync } from '../client-settings-sync'
 import { resolveAutoQualityState } from '../auto-quality-state'
 import { buildReadyCheckDisplay } from '../dashboard-ready-checks'
-import { buildUpdateCenterState } from '../update-center.js'
 import {
   buildFpsTargetGap,
   buildLiveSummary,
@@ -880,125 +829,11 @@ const version = ref('')
 const headlessEnabled = ref(false)
 const discoveryEnabled = ref(false)
 const pairingEnabled = ref(false)
-const updateHost = ref({ platform: '', distro: {} })
-const latestRelease = ref(null)
-const prereleaseRelease = ref(null)
-const notifyPreReleases = ref(false)
-const checkingUpdates = ref(false)
-const updateCheckError = ref('')
-const copiedInstallCommand = ref(false)
-const updateCenterSection = ref(null)
 const clientSettingsSync = ref(resolveClientSettingsSync({}))
 const { t } = useI18n()
 const { toast: showToast } = useToast()
 
 const autoQuality = computed(() => resolveAutoQualityState(stats.value || {}, clientSettingsSync.value || {}))
-
-const updateCenterState = computed(() => buildUpdateCenterState({
-  currentVersion: version.value || '',
-  latestRelease: latestRelease.value,
-  prereleaseRelease: prereleaseRelease.value,
-  includePrereleases: notifyPreReleases.value,
-  host: updateHost.value,
-}))
-
-const updateCenterBadgeClass = computed(() => {
-  switch (updateCenterState.value.status) {
-    case 'update_available':
-      return 'border-ice/30 bg-ice/10 text-ice'
-    case 'ahead':
-      return 'border-purple-300/30 bg-purple-500/10 text-purple-200'
-    case 'unavailable':
-      return 'border-amber-300/30 bg-amber-300/10 text-amber-200'
-    case 'disabled':
-      return 'border-storm/30 bg-deep/60 text-storm'
-    default:
-      return 'border-green-500/30 bg-green-500/10 text-green-200'
-  }
-})
-
-const updateCenterStatusLightClass = computed(() => {
-  switch (updateCenterState.value.statusTone) {
-    case 'update':
-      return 'bg-ice shadow-[0_0_18px_rgba(200,214,229,0.75)] animate-pulse'
-    case 'ahead':
-      return 'bg-purple-300 shadow-[0_0_14px_rgba(216,180,254,0.55)]'
-    case 'warning':
-      return 'bg-amber-300 shadow-[0_0_14px_rgba(252,211,77,0.55)]'
-    case 'disabled':
-      return 'bg-storm/60'
-    default:
-      return 'bg-green-400 shadow-[0_0_14px_rgba(74,222,128,0.55)]'
-  }
-})
-
-const updateCenterCtaClass = computed(() => {
-  if (updateCenterState.value.status === 'update_available') {
-    return 'bg-ice text-void hover:bg-ice/90 hover:shadow-[0_0_24px_rgba(200,214,229,0.22)]'
-  }
-  if (updateCenterState.value.primaryActionKind === 'none') {
-    return 'border border-storm bg-deep/50 text-storm'
-  }
-  return 'border border-ice/30 text-ice hover:bg-ice/10'
-})
-
-function scrollToUpdateCenter() {
-  updateCenterSection.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-}
-
-async function copyInstallCommand() {
-  if (!updateCenterState.value.installCommand || !navigator.clipboard) return false
-  await navigator.clipboard.writeText(updateCenterState.value.installCommand)
-  copiedInstallCommand.value = true
-  window.setTimeout(() => {
-    copiedInstallCommand.value = false
-  }, 1800)
-  return true
-}
-
-async function handlePrimaryUpdateAction() {
-  const action = updateCenterState.value.primaryActionKind
-  if (action === 'refresh_update_status') {
-    await refreshUpdateStatus()
-    return
-  }
-  if (action === 'open_release' && updateCenterState.value.releaseUrl) {
-    window.open(updateCenterState.value.releaseUrl, '_blank', 'noopener')
-    return
-  }
-  scrollToUpdateCenter()
-  if (action === 'copy_install_command') {
-    await copyInstallCommand()
-  }
-}
-
-async function refreshUpdateStatus() {
-  checkingUpdates.value = true
-  updateCheckError.value = ''
-  try {
-    const config = await fetch('./api/config', { credentials: 'include' }).then((r) => r.json())
-    const hostStatus = await fetch('./api/update-status', { credentials: 'include' }).then((r) => r.json()).catch(() => null)
-    updateHost.value = hostStatus || { platform: config.platform || '', distro: {} }
-    notifyPreReleases.value = config.notify_pre_releases === true || config.notify_pre_releases === 'enabled'
-    version.value = hostStatus?.version || config.version || version.value
-
-    try {
-      latestRelease.value = await fetch('https://api.github.com/repos/papi-ux/polaris/releases/latest').then((r) => r.json())
-      const releases = await fetch('https://api.github.com/repos/papi-ux/polaris/releases').then((r) => r.json())
-      prereleaseRelease.value = Array.isArray(releases) ? releases.find((release) => release.prerelease) || null : null
-    } catch (error) {
-      latestRelease.value = null
-      prereleaseRelease.value = null
-      updateCheckError.value = 'Release check unavailable'
-      console.error(error)
-    }
-  } catch (error) {
-    updateCheckError.value = 'Host update status unavailable'
-    console.error(error)
-  } finally {
-    checkingUpdates.value = false
-  }
-}
 
 const actionSummary = computed(() => {
   if (!statsLoaded.value) return t('dashboard.loading_summary')
@@ -2074,7 +1909,6 @@ onMounted(async () => {
   }
 
   fetchSystemInfo()
-  refreshUpdateStatus()
   fetchAiStatus()
   fetchAiDevices()
 

--- a/src_assets/common/assets/web/views/HomeView.vue
+++ b/src_assets/common/assets/web/views/HomeView.vue
@@ -99,7 +99,7 @@
       </div>
     </section>
 
-    <section ref="updateCenterSection" class="section-card border-ice/15 bg-gradient-to-br from-deep/70 via-deep/40 to-ice/5">
+    <section id="update-center" ref="updateCenterSection" data-update-center-details class="section-card border-ice/15 bg-gradient-to-br from-deep/70 via-deep/40 to-ice/5">
       <div class="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
         <div class="max-w-3xl">
           <div class="section-kicker">Update Center</div>


### PR DESCRIPTION
## Summary
- removes the full Update Center card from Mission Control to reduce cockpit clutter
- adds a compact sidebar Update status/light that links to Support → System
- keeps the full manual Update Center details, copy/download/open-release controls, and safety copy on the System page

## Verification
- npm test -- src_assets/common/assets/web/update-center.test.js
- npm test
- npm run lint
- npm run build
- bash scripts/check-public-docs.sh
- bash scripts/check-public-surface.sh
- git diff --check
- isolated pc-papi preview on https://127.0.0.1:48990 with authenticated Playwright smoke:
  - Mission Control no longer contains the Update Center card
  - sidebar update status/light is visible
  - sidebar link opens #/info#update-center
  - System Update Center details show package/manual install controls
  - no horizontal overflow

## Notes
- Manual update awareness only: no auto-install and no privileged package-manager execution from the web UI.
