### PR TITLE
fix(linux): self-heal desktop display environment

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <format>
 #include <fstream>
@@ -3820,6 +3821,8 @@ namespace confighttp {
     if (!authenticate(response, request)) return;
     print_req(request);
 
+    session_manager::repair_desktop_session_environment();
+
     auto tid = std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id()));
     std::string tmpfile = "/tmp/polaris_preview_" + tid + ".png";
     std::string outfile = tmpfile;
@@ -3893,6 +3896,8 @@ namespace confighttp {
   void getDisplayStream(resp_https_t response, req_https_t request) {
     if (!authenticate(response, request)) return;
     print_req(request);
+
+    session_manager::repair_desktop_session_environment();
 
     // Parse params
     int target_fps = 5;
@@ -4575,6 +4580,28 @@ namespace confighttp {
     output["gpu"] = nullptr;
     output["video"]["active_encoder"] = video::active_encoder_name();
 #ifdef __linux__
+    const bool display_environment_repaired =
+      session_manager::repair_desktop_session_environment() ||
+      session_manager::desktop_session_environment_was_repaired();
+    const char *wayland_display = std::getenv("WAYLAND_DISPLAY");
+    const char *x11_display = std::getenv("DISPLAY");
+    const char *desktop_name = std::getenv("XDG_CURRENT_DESKTOP");
+    const char *session_type = std::getenv("XDG_SESSION_TYPE");
+    const bool has_wayland_display = wayland_display && wayland_display[0] != '\0';
+    const bool has_x11_display = x11_display && x11_display[0] != '\0';
+    output["display_session"]["status"] = has_wayland_display || has_x11_display ? "healthy" : "missing_display_environment";
+    output["display_session"]["summary"] = has_wayland_display ?
+      "Wayland desktop environment is available to Polaris." :
+      (has_x11_display ? "X11 desktop environment is available to Polaris." :
+                         "Polaris could not find WAYLAND_DISPLAY or DISPLAY for desktop previews.");
+    output["display_session"]["action"] = has_wayland_display || has_x11_display ?
+      "No action needed." :
+      "Restart Polaris from the desktop session or run the user service so it inherits the graphical environment.";
+    output["display_session"]["environment_repaired"] = display_environment_repaired;
+    output["display_session"]["session_type"] = session_type && session_type[0] ? std::string(session_type) : "unknown";
+    output["display_session"]["desktop"] = desktop_name && desktop_name[0] ? std::string(desktop_name) : "unknown";
+    output["display_session"]["wayland_available"] = has_wayland_display;
+    output["display_session"]["x11_available"] = has_x11_display;
     {
       auto runtime_state = cage_display_router::runtime_state();
       output["runtime"]["backend"] = runtime_state.backend_name;
@@ -4635,7 +4662,7 @@ namespace confighttp {
         }
       }
 
-      if (wayland_monitors.empty()) {
+      if (wayland_monitors.empty() && has_wayland_display) {
         wayland_monitors = wl::monitors();
       }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
   #include "platform/windows/misc.h"
   #include "platform/windows/virtual_display.h"
 #elif __linux__
+  #include "platform/linux/session_manager.h"
   #include "platform/linux/stream_display_policy.h"
 #endif
 
@@ -231,6 +232,11 @@ int main(int argc, char *argv[]) {
 
     return fn->second(argv[0], config::sunshine.cmd.argc, config::sunshine.cmd.argv);
   }
+
+#ifdef __linux__
+  // Repair manual/SSH launches from the user manager before display, tray, or preview paths touch Wayland.
+  session_manager::repair_desktop_session_environment();
+#endif
 
   // Adding guard here first as it also performs recovery after crash,
   // otherwise people could theoretically end up without display output.

--- a/src/platform/linux/session_manager.cpp
+++ b/src/platform/linux/session_manager.cpp
@@ -19,6 +19,8 @@
 #include "../../config.h"
 #include "../../logging.h"
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdio>
@@ -41,6 +43,7 @@ namespace session_manager {
 
   // Edit mode watchdog
   static std::atomic<bool> g_watchdog_running{false};
+  static std::atomic<bool> g_desktop_environment_repaired{false};
   static std::thread g_watchdog_thread;
 
 #ifdef POLARIS_TESTS
@@ -215,11 +218,110 @@ namespace session_manager {
     );
   }
 
+  static constexpr std::array<std::string_view, 8> DESKTOP_SESSION_ENV_VARS {
+    "WAYLAND_DISPLAY"sv,
+    "DISPLAY"sv,
+    "XDG_CURRENT_DESKTOP"sv,
+    "XDG_SESSION_TYPE"sv,
+    "XDG_SESSION_ID"sv,
+    "XAUTHORITY"sv,
+    "XDG_RUNTIME_DIR"sv,
+    "DBUS_SESSION_BUS_ADDRESS"sv,
+  };
+
+  static bool is_desktop_session_env_var(std::string_view key) {
+    return std::any_of(DESKTOP_SESSION_ENV_VARS.begin(), DESKTOP_SESSION_ENV_VARS.end(), [key](std::string_view allowed) {
+      return key == allowed;
+    });
+  }
+
+  static bool env_value_is_empty(const char *value) {
+    return !value || value[0] == '\0';
+  }
+
+  static bool should_import_desktop_session_env(std::string_view key, std::string_view manager_value) {
+    if (manager_value.empty()) {
+      return false;
+    }
+
+    const std::string key_string {key};
+    const char *current_value = std::getenv(key_string.c_str());
+    if (env_value_is_empty(current_value)) {
+      return true;
+    }
+
+    if (key == "XDG_SESSION_TYPE"sv) {
+      const std::string_view current {current_value};
+      return (current == "tty"sv || current == "unspecified"sv) &&
+             (manager_value == "wayland"sv || manager_value == "x11"sv);
+    }
+
+    return false;
+  }
+
+  static std::string join_imported_env_names(const std::vector<std::string> &names) {
+    std::string joined;
+    for (const auto &name : names) {
+      if (!joined.empty()) {
+        joined += ", ";
+      }
+      joined += name;
+    }
+    return joined;
+  }
+
   // -----------------------------------------------------------------------
   // Public API
   // -----------------------------------------------------------------------
 
+  bool repair_desktop_session_environment() {
+    const auto manager_environment = exec("systemctl --user show-environment 2>/dev/null");
+    if (manager_environment.empty()) {
+      BOOST_LOG(debug) << "session_manager: user systemd environment was unavailable for desktop env repair"sv;
+      return false;
+    }
+
+    std::vector<std::string> imported;
+    std::istringstream lines {manager_environment};
+    std::string line;
+    while (std::getline(lines, line)) {
+      if (!line.empty() && line.back() == '\r') {
+        line.pop_back();
+      }
+
+      const auto separator = line.find('=');
+      if (separator == std::string::npos || separator == 0) {
+        continue;
+      }
+
+      const std::string key = line.substr(0, separator);
+      const std::string value = line.substr(separator + 1);
+      if (!is_desktop_session_env_var(key) || !should_import_desktop_session_env(key, value)) {
+        continue;
+      }
+
+      if (setenv(key.c_str(), value.c_str(), 1) == 0) {
+        imported.push_back(key);
+      }
+    }
+
+    if (!imported.empty()) {
+      g_desktop_environment_repaired = true;
+      BOOST_LOG(info) << "session_manager: repaired desktop session environment from user systemd manager ["sv
+                      << join_imported_env_names(imported) << ']';
+      return true;
+    }
+
+    return false;
+  }
+
+  bool desktop_session_environment_was_repaired() {
+    return g_desktop_environment_repaired.load();
+  }
+
   bool validate_environment() {
+    repair_desktop_session_environment();
+
     bool ok = true;
     const bool private_headless_runtime =
       config::video.linux_display.headless_mode &&

--- a/src/platform/linux/session_manager.h
+++ b/src/platform/linux/session_manager.h
@@ -46,6 +46,20 @@ namespace session_manager {
   bool validate_environment();
 
   /**
+   * @brief Import missing desktop session variables from the user systemd manager.
+   *
+   * This recovers source/manual launches started from SSH or a tty while the
+   * graphical user manager already knows the active Wayland/X11 session.
+   * @return true when at least one environment variable was repaired
+   */
+  bool repair_desktop_session_environment();
+
+  /**
+   * @brief Whether Polaris repaired desktop session variables during this process lifetime.
+   */
+  bool desktop_session_environment_was_repaired();
+
+  /**
    * @brief Save minimal desktop state before streaming session.
    */
   desktop_state_t save_state();

--- a/src_assets/common/assets/web/composables/useSystemStats.js
+++ b/src_assets/common/assets/web/composables/useSystemStats.js
@@ -8,13 +8,14 @@ import { ref, onMounted, onUnmounted, watch } from 'vue'
  *
  * @param {number} intervalMs - Poll interval in ms (default: 3000)
  * @param {{ shouldPoll?: (() => boolean) | { value: boolean }, pauseWhenHidden?: boolean, maxBackoffMs?: number }} options
- * @returns {{ gpu: Ref, displays: Ref, audio: Ref, sessionType: Ref, loading: Ref<boolean> }}
+ * @returns {{ gpu: Ref, displays: Ref, audio: Ref, sessionType: Ref, displaySession: Ref, loading: Ref<boolean> }}
  */
 export function useSystemStats(intervalMs = 3000, options = {}) {
   const gpu = ref(null)
   const displays = ref([])
   const audio = ref(null)
   const sessionType = ref(null)
+  const displaySession = ref(null)
   const loading = ref(true)
 
   const maxBackoffMs = Math.max(intervalMs, options.maxBackoffMs ?? intervalMs * 8)
@@ -82,6 +83,7 @@ export function useSystemStats(intervalMs = 3000, options = {}) {
           displays.value = data.displays || []
           audio.value = data.audio || null
           sessionType.value = data.session_type || null
+          displaySession.value = data.display_session || null
           ok = true
         }
       } catch {
@@ -147,5 +149,5 @@ export function useSystemStats(intervalMs = 3000, options = {}) {
     }
   })
 
-  return { gpu, displays, audio, sessionType, loading }
+  return { gpu, displays, audio, sessionType, displaySession, loading }
 }

--- a/src_assets/common/assets/web/system-telemetry.test.js
+++ b/src_assets/common/assets/web/system-telemetry.test.js
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('System telemetry display-session guidance', () => {
+  it('surfaces automatic display environment repair and recovery guidance in the app shell', () => {
+    const home = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/HomeView.vue'), 'utf8')
+    const composable = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/composables/useSystemStats.js'), 'utf8')
+
+    expect(composable).toContain('displaySession')
+    expect(composable).toContain('data.display_session')
+    expect(home).toContain('data-display-session-health')
+    expect(home).toContain('environment_repaired')
+    expect(home).toContain('missing_display_environment')
+    expect(home).toContain('Restart Polaris from the desktop session')
+  })
+})

--- a/src_assets/common/assets/web/views/HomeView.vue
+++ b/src_assets/common/assets/web/views/HomeView.vue
@@ -225,6 +225,20 @@
           <div class="mt-3 text-xs text-storm">
             {{ sessionType ? sessionModeDescription : $t('index.session_mode_idle_desc') }}
           </div>
+          <div
+            v-if="displaySession?.environment_repaired"
+            data-display-session-health
+            class="mt-3 rounded-lg border border-green-400/30 bg-green-400/10 px-3 py-2 text-xs text-green-200"
+          >
+            Desktop session environment was repaired automatically from the user service.
+          </div>
+          <div
+            v-else-if="displaySession?.status === 'missing_display_environment'"
+            data-display-session-health
+            class="mt-3 rounded-lg border border-amber-300/30 bg-amber-300/10 px-3 py-2 text-xs text-amber-100"
+          >
+            Desktop preview environment is missing. Restart Polaris from the desktop session or run the user service so it inherits Wayland/X11.
+          </div>
         </article>
       </div>
     </section>
@@ -344,7 +358,7 @@ import PolarisVersion from '../polaris_version'
 import { buildUpdateCenterState } from '../update-center.js'
 import InfoHint from '../components/InfoHint.vue'
 
-const { gpu, displays, audio, sessionType, loading: systemLoading } = useSystemStats(3000)
+const { gpu, displays, audio, sessionType, displaySession, loading: systemLoading } = useSystemStats(3000)
 
 const version = ref(null)
 const githubVersion = ref(null)

--- a/tests/unit/platform/test_session_manager.cpp
+++ b/tests/unit/platform/test_session_manager.cpp
@@ -22,6 +22,7 @@ namespace {
     bool loginctl_clears_lock = false;
     std::string loginctl_command_that_clears;
     std::string loginctl_list_sessions_output;
+    std::string systemd_environment_output;
     std::vector<std::string> run_commands;
 
     SessionManagerCommandHarness() {
@@ -32,6 +33,9 @@ namespace {
           }
           if (cmd.find("loginctl list-sessions") != std::string::npos) {
             return loginctl_list_sessions_output;
+          }
+          if (cmd.find("systemctl --user show-environment") != std::string::npos) {
+            return systemd_environment_output;
           }
           return std::string {};
         },
@@ -63,6 +67,13 @@ namespace {
     ~SessionManagerCommandHarness() {
       session_manager::reset_command_hooks_for_tests();
       unsetenv("XDG_SESSION_ID");
+      unsetenv("WAYLAND_DISPLAY");
+      unsetenv("DISPLAY");
+      unsetenv("XDG_CURRENT_DESKTOP");
+      unsetenv("XDG_SESSION_TYPE");
+      unsetenv("DBUS_SESSION_BUS_ADDRESS");
+      unsetenv("XDG_RUNTIME_DIR");
+      unsetenv("POLARIS_TEST_SENTINEL");
     }
 
     bool ran(std::string_view needle) const {
@@ -71,6 +82,33 @@ namespace {
       });
     }
   };
+}
+
+TEST(SessionManagerEnvironmentRepairTests, ImportsMissingDesktopSessionVariablesFromUserSystemdEnvironment) {
+  SessionManagerCommandHarness harness;
+  unsetenv("WAYLAND_DISPLAY");
+  unsetenv("DISPLAY");
+  unsetenv("XDG_CURRENT_DESKTOP");
+  setenv("XDG_SESSION_TYPE", "tty", 1);
+  setenv("XDG_RUNTIME_DIR", "/run/user/1000", 1);
+  setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/1000/bus", 1);
+  harness.systemd_environment_output =
+    "XDG_RUNTIME_DIR=/run/user/1000\n"
+    "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus\n"
+    "DISPLAY=:0\n"
+    "WAYLAND_DISPLAY=wayland-0\n"
+    "XDG_CURRENT_DESKTOP=KDE\n"
+    "XDG_SESSION_TYPE=wayland\n"
+    "POLARIS_TEST_SENTINEL=must-not-import";
+
+  EXPECT_TRUE(session_manager::repair_desktop_session_environment());
+
+  EXPECT_STREQ("wayland-0", getenv("WAYLAND_DISPLAY"));
+  EXPECT_STREQ(":0", getenv("DISPLAY"));
+  EXPECT_STREQ("KDE", getenv("XDG_CURRENT_DESKTOP"));
+  EXPECT_STREQ("wayland", getenv("XDG_SESSION_TYPE"));
+  EXPECT_EQ(nullptr, getenv("POLARIS_TEST_SENTINEL"));
+  EXPECT_TRUE(session_manager::desktop_session_environment_was_repaired());
 }
 
 TEST(SessionManagerUnlockTests, AlreadyUnlockedSkipsUnlockCommands) {


### PR DESCRIPTION
## Summary
- import missing Wayland/X11 desktop session variables from the user systemd manager when Polaris is launched from SSH/tty/source dogfood
- expose display-session health in `/api/stats/system` and System → Telemetry so users get a clear repaired/missing state plus recovery guidance
- retry desktop preview/screenshot paths after the environment repair instead of spamming `WAYLAND_DISPLAY` errors

## Test Plan
- [x] `./build-wayland-env-tdd/tests/test_polaris_platform --gtest_filter='SessionManagerEnvironmentRepairTests.*:SessionManagerUnlockTests.*'`
- [x] `npm test -- src_assets/common/assets/web/system-telemetry.test.js`
- [x] `npm audit`
- [x] `npm test` — 36 files / 160 tests passed
- [x] `npm run lint`
- [x] `npm run build`
- [x] `bash scripts/check-public-docs.sh`
- [x] `bash scripts/check-public-surface.sh`
- [x] `ctest --test-dir build-wayland-env-tdd/tests --output-on-failure -R '^test_polaris_platform$'`
- [x] `git diff --check`
- [x] isolated source preview launched with `WAYLAND_DISPLAY`/`DISPLAY` removed; `/api/stats/system` reported `display_session.environment_repaired=true` and `/api/display/screenshot` returned `200 image/png`