### PR TITLE
docs: clarify GPU-native guidance for NVIDIA and AMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ what the host is actually doing.
 | AI Auto Quality | Optional | Provider-configured tuning and recovery guidance; core streaming does not require AI or cloud services |
 | Browser Stream | Experimental | Chromium-oriented WebTransport/WebCodecs streaming path for browser testing |
 | HDR / Main10 | Conditional | Main10 SDR can work when requested; true HDR requires real HDR metadata from the active capture path |
-| VAAPI / software encode | Supported, less validated | Useful fallback paths, but NVIDIA/NVENC is still the most exercised release target |
+| AMD / VAAPI and software encode | Supported, expanding validation | AMD/Intel VAAPI and software fallback are supported; NVIDIA/NVENC remains the most exercised release target while AMD coverage grows |
 
 ## Privacy and Local-First Defaults
 
@@ -80,7 +80,7 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 ### First stream checklist
 
 1. Open the first-run setup at **https://localhost:47990/#/welcome**.
-2. Confirm the recommended Linux path: `headless_mode = enabled`, `linux_use_cage_compositor = enabled`, and `linux_prefer_gpu_native_capture = disabled`.
+2. Confirm the recommended Linux path: `headless_mode = enabled`, `linux_use_cage_compositor = enabled`, and `linux_prefer_gpu_native_capture = enabled`.
 3. Pair with Trusted Pair on a trusted LAN, QR pairing for Nova, or manual PIN for standard Moonlight clients.
 4. Start a game from the Polaris library, Nova, or a Moonlight client.
 5. Watch the live session dashboard to confirm the active runtime and encoder path.
@@ -134,7 +134,8 @@ Detailed source builds, local Arch package builds, distro dependency lists, open
 | Debian-family distros | Source-build oriented | Ubuntu 24.04 is the only direct DEB asset today |
 | Other Linux distros | Source-build/community validation | Bring distro, GPU, driver, compositor, and package details when reporting success or breakage |
 | NVIDIA / NVENC | Best-tested | Main fast path and most validated encoder/runtime combination |
-| VAAPI / software encode | Supported | Works, but is less battle-tested than NVENC |
+| AMD / VAAPI | Supported, expanding validation | Mesa VAAPI is the Linux AMD baseline; GPU-native DMA-BUF is preferred when available and reported truthfully when it falls back |
+| Software encode | Supported fallback | Useful for diagnostics and unsupported hardware, but not the performance target |
 | Nova for Android | Best experience | Full launch contract, watch mode, tuning, and richer live state |
 | Standard Moonlight clients | Compatible | Core streaming works without Nova-specific UX |
 | Browser Stream | Experimental | Browser-based streaming path using WebTransport and WebCodecs; best tested on Chromium-family browsers |
@@ -144,19 +145,19 @@ Detailed source builds, local Arch package builds, distro dependency lists, open
 If you want the smoothest first run, start here:
 
 - **Host distro**: Fedora 44 or Arch Linux / CachyOS.
-- **GPU path**: NVIDIA with NVENC.
+- **GPU path**: NVIDIA/NVENC is the most validated path; AMD/Mesa VAAPI is supported and should use the same Headless Stream flow with capture-path truth in Mission Control.
 - **Desktop**: KDE Plasma Wayland is the most exercised daily-driver setup, but Headless Stream launches its own compositor and is not KDE-only.
-- **Config**: `headless_mode = enabled`, `linux_use_cage_compositor = enabled`, `linux_prefer_gpu_native_capture = disabled`.
+- **Config**: `headless_mode = enabled`, `linux_use_cage_compositor = enabled`, `linux_prefer_gpu_native_capture = enabled`.
 - **Client**: Nova on an ARM64 Android handheld / Android TV device, or a standard Moonlight client for the core stream path.
 
 ## Known Limitations
 
 - Polaris is not a Windows host today. Linux is the supported platform.
 - Fedora and Arch are the most validated package paths; CachyOS should use the Arch path first, but derivative-specific issues still need reports.
-- Bazzite support is experimental. Desktop Mode has NVIDIA validation with the recommended Headless Stream settings, while real Steam/Game Mode, AMD, and Steam Deck client flows need more hardware coverage.
+- Bazzite support is experimental. Desktop Mode has Headless Stream validation on NVIDIA and growing AMD/Mesa VAAPI coverage; real Steam/Game Mode and Steam Deck client flows need more hardware reports.
 - Ubuntu 24.04 DEB packaging is experimental; other Debian-family distros are still source-build oriented.
 - openSUSE Tumbleweed has source-build guidance and CI coverage, but no published release package asset yet; Leap and other RPM distros should start from source.
-- NVIDIA/NVENC is the most heavily validated hardware path. Other encode backends work, but they are not equally battle-tested.
+- NVIDIA/NVENC is the most heavily validated hardware path. AMD/Mesa VAAPI is supported and should stay visible in docs/UI, but it still needs broader real-hardware coverage before claiming parity.
 - Some UX surfaced in Nova, such as explicit launch recommendations, watch mode polish, and live tuning, depends on the Nova Android client.
 - MangoHud can still be risky on Steam Big Picture and some Steam/Proton launches.
 
@@ -306,12 +307,12 @@ Config file: `~/.config/polaris/polaris.conf`
 # Headless Stream path
 headless_mode = enabled
 linux_use_cage_compositor = enabled
-linux_prefer_gpu_native_capture = disabled
+linux_prefer_gpu_native_capture = enabled
 
 # Pairing on your trusted LAN
 trusted_subnets = ["10.0.0.0/24"]
 
-# Encoding
+# Encoding (choose for your GPU: nvenc on NVIDIA, vaapi on AMD/Intel)
 encoder = nvenc
 
 # Optional
@@ -342,7 +343,7 @@ Full config tables, AI provider examples, HDR notes, and credential recovery ste
 <details>
 <summary><b>Do I need an NVIDIA GPU?</b></summary>
 
-No, but NVENC is the most heavily tested path today. VAAPI and software encode paths are supported, but current Linux compositor and DMA-BUF work has been tuned most heavily around NVIDIA.
+No. NVIDIA/NVENC is the most heavily tested path today, but AMD/Mesa VAAPI and software encode paths are supported. GPU-native/DMA-BUF capture is an optimization request on both NVIDIA and AMD-capable stacks; Polaris reports the actual path when a host falls back to SHM/system memory.
 
 </details>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Polaris is public and usable today, but it is still early. This roadmap is meant
 - CachyOS generally follows the Arch package path, but derivative-specific gaps still need reports.
 - Bazzite and Ubuntu 24.04 are tester package paths.
 - openSUSE Tumbleweed is source-build supported; other distros are source-build/community-validation oriented.
-- NVIDIA/NVENC is the most heavily validated encoder path.
+- NVIDIA/NVENC is the most heavily validated encoder path; AMD/Mesa VAAPI is supported and should stay visible while broader validation catches up.
 - Browser Stream is experimental.
 - Some richer live-session behavior depends on Nova.
 

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -121,19 +121,21 @@ Use Headless Stream for the first stream:
 ```ini
 headless_mode = enabled
 linux_use_cage_compositor = enabled
-linux_prefer_gpu_native_capture = disabled
+linux_prefer_gpu_native_capture = enabled
 ```
 
-This is the validated Bazzite optimization for the current NVIDIA Desktop Mode
-path. It creates an isolated headless `labwc` runtime for the stream, routes
-launched apps and virtual input into that socket, and avoids targeting the
-physical KDE desktop.
+This is the recommended Bazzite Desktop Mode optimization for NVIDIA/NVENC and
+AMD/Mesa VAAPI hosts. It creates an isolated headless `labwc` runtime for the
+stream, routes launched apps and virtual input into that socket, and avoids
+targeting the physical KDE desktop.
 
-Keep `linux_prefer_gpu_native_capture = disabled` until the stream is healthy on
-your hardware. On this path, logs may report SHM/RAM capture, CPU frame
-residency, or an extra CPU-side copy/conversion path. Treat those as performance
-notes, not startup failures, when the client receives a stable stream from
-`HEADLESS-1`.
+With `linux_prefer_gpu_native_capture = enabled`, logs may still report SHM/RAM
+capture, CPU frame residency, or an extra CPU-side copy/conversion path when the
+current compositor, driver, or encoder import path cannot stay GPU-native. Treat
+those as performance notes, not startup failures, when the client receives a
+stable stream from `HEADLESS-1`. If the setting prevents launch on a specific
+AMD/NVIDIA stack, temporarily switch it to `disabled` and report the capture
+decision JSON/logs.
 
 Do not manually export `WAYLAND_DISPLAY`; Polaris starts `labwc` with its own
 Wayland socket and routes launched apps into that socket. Do not add EVDI or

--- a/docs/building.md
+++ b/docs/building.md
@@ -55,7 +55,7 @@ those less-turnkey paths.
 | Fedora 42/43/44 | Published RPM assets | Most validated package path. |
 | Arch Linux | Published `pkg.tar.zst` asset | Recommended rolling-release path. |
 | CachyOS / Arch derivatives | Start with the Arch package | Pacman-compatible derivatives should work from the Arch asset first; use source/local package fallback if dependency names or runtime helpers drift. |
-| Bazzite 44 | Fedora 44 RPM layered with `rpm-ostree` | Experimental; Desktop Mode has NVIDIA Headless Stream coverage, Steam/Game Mode needs more reports. |
+| Bazzite 44 | Fedora 44 RPM layered with `rpm-ostree` | Experimental; Desktop Mode has NVIDIA Headless Stream coverage and growing AMD/Mesa VAAPI validation, Steam/Game Mode needs more reports. |
 | Ubuntu 24.04 | Published DEB asset | Experimental tester package; broader desktop/GPU coverage needed. |
 | openSUSE Tumbleweed | Source build | Dedicated guide and CI build coverage; no published release asset yet. |
 | Debian-family other than Ubuntu 24.04 | Source build | No general Debian package asset yet. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ If you change `port` in `polaris.conf`, the web UI moves to `https://localhost:<
 ```ini
 headless_mode = enabled
 linux_use_cage_compositor = enabled
-linux_prefer_gpu_native_capture = disabled
+linux_prefer_gpu_native_capture = enabled
 trusted_subnets = ["10.0.0.0/24"]
 encoder = nvenc
 nvenc_split_encode_mode = disabled
@@ -26,7 +26,7 @@ adaptive_bitrate_enabled = enabled
 max_sessions = 2
 ```
 
-These are the settings behind the recommended Headless Stream mode on a Linux host.
+These are the settings behind the recommended Headless Stream mode on a Linux host. Use `encoder = nvenc` on NVIDIA, `encoder = vaapi` on AMD/Intel Mesa VAAPI hosts, and `encoder = software` only as a fallback or diagnostic path.
 
 ## Linux display modes
 
@@ -43,7 +43,7 @@ Stream when you want a stream-only runtime that leaves the host desktop layout a
 | --- | --- | --- |
 | `headless_mode` | `enabled` | Request a stream-only session instead of the visible desktop |
 | `linux_use_cage_compositor` | `enabled` | Enable Polaris' private stream runtime |
-| `linux_prefer_gpu_native_capture` | `disabled` | Keep Headless Stream as the first validation path; enable only after testing GPU-native capture on your stack |
+| `linux_prefer_gpu_native_capture` | `enabled` | Prefer DMA-BUF/GPU-resident capture on NVIDIA and AMD-capable stacks; Polaris reports SHM/system-memory fallback truthfully when the compositor or driver cannot provide it |
 | `trusted_subnets` | CIDR list | Enable Trusted Pair on known local networks |
 | `headless_gamepad_isolation` | `enabled` | Hide host-connected gamepads from private headless streams; disable only when you intentionally want a wired host controller visible inside the stream |
 | `encoder` | `nvenc` / `vaapi` / `software` | Primary encoder backend |

--- a/docs/research/kde-wayland-virtual-display.md
+++ b/docs/research/kde-wayland-virtual-display.md
@@ -1,0 +1,95 @@
+# KDE Wayland Host Virtual Display Research
+
+This document captures public research for a future Polaris **Host Virtual Display** backend on KDE Wayland. It is intentionally generalized: do not add private hostnames, LAN addresses, pairing secrets, screenshots, or support-bundle contents.
+
+## Source
+
+- Reddit / r/MoonlightStreaming: <https://www.reddit.com/r/MoonlightStreaming/comments/1tg1dnc/guide_sunshine_on_kde_wayland_virtual_display/>
+
+The guide describes Sunshine on KDE Wayland using KWin capture plus `krfb-virtualmonitor` so Moonlight clients receive a temporary virtual display at the client resolution/aspect ratio without HDMI dummy plugs, EDID kernel injection, or permanent physical-port state.
+
+## What It Proves
+
+- KDE/KWin can create a temporary virtual monitor through `krfb-virtualmonitor`.
+- `kscreen-doctor` can add/select a custom resolution and refresh rate for that virtual output.
+- KWin/portal-style capture can see the virtual monitor because it exists in the compositor, even though it is not a real DRM connector.
+- Fedora 44 KDE, Bazzite, CachyOS, and Arch users reported success in the thread.
+- HDR is not solved by this path: KWin virtual outputs do not expose the DRM/KMS HDR metadata Polaris needs to truthfully advertise true HDR.
+
+## Product Position
+
+This should not replace Polaris' default **Private Stream** path. The default player-facing recommendation remains:
+
+```ini
+headless_mode = enabled
+linux_use_cage_compositor = enabled
+linux_prefer_gpu_native_capture = enabled
+```
+
+Private Stream remains the safest default for NVIDIA/NVENC and AMD/Mesa VAAPI hosts because it avoids physical desktop layout changes and reports whether capture stayed GPU-native or fell back to SHM/system memory.
+
+The useful Polaris lane is a KDE-only **Host Virtual Display** backend that is advertised only when available, with a clear unavailable reason when KDE/krfb/kscreen prerequisites are missing.
+
+## Backend Sketch
+
+A Polaris-owned backend should do the work directly instead of asking users to paste Sunshine prep scripts:
+
+1. Detect KDE Wayland:
+   - `XDG_CURRENT_DESKTOP` contains `KDE`
+   - `XDG_SESSION_TYPE=wayland`
+   - `WAYLAND_DISPLAY` and `DBUS_SESSION_BUS_ADDRESS` are available from the user manager
+2. Detect helpers:
+   - `krfb-virtualmonitor`
+   - `kscreen-doctor`
+3. Import the graphical session environment for helper processes:
+   - `WAYLAND_DISPLAY`
+   - `DISPLAY`
+   - `XDG_CURRENT_DESKTOP`
+   - `XDG_SESSION_TYPE`
+   - `XDG_RUNTIME_DIR`
+   - `DBUS_SESSION_BUS_ADDRESS`
+   - `QT_QPA_PLATFORM=wayland`
+4. Create a session-scoped output name, for example `polaris-vmon-<session-id>`.
+5. Launch `krfb-virtualmonitor --resolution <WIDTH>x<HEIGHT> --name <name> --password <random> --port <ephemeral-or-reserved>`.
+6. Wait for KWin to register `Virtual-<name>`.
+7. Use `kscreen-doctor` to add/select the requested mode:
+   - refresh rate is expressed in mHz for `addCustomMode`, e.g. `120000` for 120 Hz.
+8. Route capture to that virtual output when Host Virtual Display is selected.
+9. Persist enough state for stale cleanup if Polaris exits mid-session.
+10. Destroy the virtual monitor and clear state during normal session stop, process deinit, and explicit stale-cleanup API calls.
+
+## Polaris/Nova Contract
+
+- `/polaris/v1/client-settings` should advertise `host_virtual_display` only when the backend is available and configured enough to launch.
+- If unavailable, Nova should show Host Virtual Display disabled with the host-provided reason rather than pretending the client can force it.
+- `/polaris/v1/session/status` and Mission Control should report the actual mode, backend, output name, capture transport, frame residency, and encoder.
+- Nova labels should stay vendor-inclusive where technically true: NVIDIA/NVENC and AMD/Mesa VAAPI users should both see Host Virtual Display and GPU-native copy as host capability/fallback facts, not NVIDIA-only branding.
+
+## Do Not Copy Blindly
+
+- Do not use `sed -i` to rewrite config files.
+- Do not hard-code `DP-1` or any physical connector name.
+- Do not disable all physical monitors as the default Polaris behavior.
+- Do not depend on Sunshine-specific environment variables such as `SUNSHINE_CLIENT_WIDTH`; Polaris should use its own launch/stream policy.
+- Do not recommend broad `KWIN_WAYLAND_NO_PERMISSION_CHECKS=1` as normal setup. Treat it as a last-resort diagnostic for KWin permission rejection.
+- Do not claim true HDR support until the capture path exposes real HDR metadata.
+
+## Open Questions
+
+- Can `krfb-virtualmonitor` be used only for monitor creation without exposing a VNC listener, or must Polaris randomize/isolate the VNC password and port every session?
+- Which KDE/Plasma versions require the portal desktop-file/app-id fix mentioned in community reports?
+- Can KWin virtual monitor creation be controlled through a more direct D-Bus or portal API than shelling out to `krfb-virtualmonitor`?
+- How should Polaris choose between EVDI, wlroots headless outputs, kscreen existing-output management, and KDE `krfb-virtualmonitor` when more than one backend exists?
+- Should Host Virtual Display preserve physical outputs by default, or offer an explicit advanced option to temporarily disable them for game focus/window-placement reliability?
+
+## Validation Checklist
+
+For the first implementation spike, verify on KDE Wayland with both NVIDIA/NVENC and AMD/Mesa VAAPI where possible:
+
+- `krfb-virtualmonitor --version` succeeds when Polaris imports the graphical session environment.
+- The virtual output appears as `Virtual-polaris-vmon-*` in `kscreen-doctor`.
+- Requested width/height/FPS match the Nova/Moonlight launch policy.
+- Host Virtual Display appears in Nova only when available.
+- A stream reaches active state and reports actual capture transport/residency.
+- Stop/cleanup removes the virtual output even after a failed launch.
+- True HDR remains disabled unless real HDR metadata is present.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -11,12 +11,12 @@ Headless Stream is controlled by these settings:
 ```ini
 headless_mode = enabled
 linux_use_cage_compositor = enabled
-linux_prefer_gpu_native_capture = disabled
+linux_prefer_gpu_native_capture = enabled
 ```
 
 - `headless_mode` requests a stream-only session instead of the visible desktop.
 - `linux_use_cage_compositor` routes launched apps into Polaris' private Wayland compositor.
-- `linux_prefer_gpu_native_capture = disabled` keeps the conservative Headless Stream path as the first validation path. Enable it only when testing a stack where you intentionally want to prefer DMA-BUF or another GPU-native capture path.
+- `linux_prefer_gpu_native_capture = enabled` asks Polaris to prefer DMA-BUF/GPU-resident capture on capable NVIDIA and AMD/Mesa stacks. If a compositor or driver cannot provide it, Polaris should report the real SHM/system-memory fallback instead of pretending the stream is GPU-native.
 
 The private runtime is intentionally isolated. Steam, Wine, XWayland clients, and game launches should stay inside the stream compositor instead of bouncing back to the host desktop.
 
@@ -68,7 +68,7 @@ The 1.1.x validation target is the existing labwc Headless Stream architecture, 
 | Ubuntu 24.04 LTS | `labwc` private Wayland session, `HEADLESS-1`, `requested_headless=true`, `effective_headless=true` | Prefer `headless_extcopy_dmabuf` when wlroots/ext-image-copy and the encoder import path expose DMA-BUF; otherwise `headless_shm_fallback` is supported | Install Polaris runtime dependencies plus `labwc`, `xwayland`, `wayland-protocols`, Mesa/Vulkan drivers, PipeWire/WirePlumber, and `grim` for dashboard previews. NVIDIA high-FPS tests should use a CUDA-enabled package. |
 | Debian 12 Stable | Same headless labwc session and `HEADLESS-1` routing | `headless_shm_fallback` is the conservative baseline; DMA-BUF may be unavailable on older wlroots/protocol combinations | Ensure backported/new-enough `labwc`/wlroots where possible, `xwayland`, GPU userspace drivers, PipeWire/WirePlumber, and user access to render/input devices. Treat SHM as a compatibility path, not a startup failure. |
 | Ubuntu 22.04 LTS | Headless labwc can run when dependencies are available, but distro packages are older | Expect SHM/RAM fallback unless the compositor/protocol/driver stack has been updated | Older wlroots/labwc packages may miss headless-output or ext-image-copy behavior needed for DMA-BUF. Validate with logs before filing a runtime replacement issue. |
-| Parent Wayland desktop with GPU-native override | Windowed private compositor under the existing desktop, not true headless | `windowed_dmabuf_override` when `linux_prefer_gpu_native_capture`/override is active and frames stay GPU-resident | Requires a working parent `WAYLAND_DISPLAY`. Use only after normal Headless Stream has been validated. |
+| Parent Wayland desktop with GPU-native override | Windowed private compositor under the existing desktop, not true headless | `windowed_dmabuf_override` when `linux_prefer_gpu_native_capture`/override is active and frames stay GPU-resident on the selected NVIDIA/AMD render path | Requires a working parent `WAYLAND_DISPLAY`. Use only after normal Headless Stream has been validated. |
 
 Capture decision meanings:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,14 +55,15 @@ Confirm these settings first:
 ```ini
 headless_mode = enabled
 linux_use_cage_compositor = enabled
-linux_prefer_gpu_native_capture = disabled
+linux_prefer_gpu_native_capture = enabled
 ```
 
-That is the intended Headless Stream path. It avoids touching your normal desktop layout and reduces
-display mode churn after a session ends. On Bazzite, this is also the first NVIDIA Desktop Mode
-validation path; SHM/RAM capture warnings are performance notes if the client is receiving a stable
-`HEADLESS-1` stream. Enable GPU-native capture later only after the headless path is working on your
-driver and compositor stack.
+That is the intended Headless Stream path for NVIDIA/NVENC and AMD/Mesa VAAPI hosts that can keep
+frames GPU-resident. It avoids touching your normal desktop layout and reduces display mode churn
+after a session ends. If the stream is stable but logs report SHM/RAM capture, treat that as a
+performance/capability fallback first, not a startup failure. If enabling GPU-native capture blocks
+launch on a specific driver/compositor stack, temporarily set it to `disabled` and include the
+capture decision fields in the bug report.
 
 The built-in Desktop entry does not launch your existing KDE, GNOME, or wlroots desktop inside this
 private compositor. If the client connects but shows an empty or black desktop while app entries work,


### PR DESCRIPTION
## Summary
- Update the public first-run/recommended Headless Stream guidance to request GPU-native capture by default.
- Keep NVIDIA/NVENC marked as the best-tested path while making AMD/Mesa VAAPI support visible instead of treating it as a footnote.
- Add a KDE Wayland Host Virtual Display research note from the Moonlight/Sunshine `krfb-virtualmonitor` guide, including what to adopt and what not to copy.

## Test Plan
- `git diff --check polaris/master...HEAD`
- Verified stale wording is absent: `linux_prefer_gpu_native_capture = disabled`, `NVIDIA with NVENC`, `VAAPI / software encode`, and the old Bazzite NVIDIA-only validation sentence.
- Verified new inclusive wording is present: `AMD/Mesa VAAPI` and `KDE Wayland Host Virtual Display Research`.

## Notes
- This is docs/research only; no runtime code changes.
- NVIDIA/NVENC remains documented as the most validated path, but AMD/Mesa VAAPI stays explicitly visible with truthful fallback caveats.
