### PR TITLE
feat(web): add support self-test reports

### DIFF
--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -328,6 +328,201 @@ Suggested safe action: ${formatIssueValue(doctor.safe_recovery_action.id)}${doct
   ].filter((line) => line !== '').join('\n'))
 }
 
+function statusRank(status) {
+  if (status === 'fail') return 2
+  if (status === 'warning') return 1
+  return 0
+}
+
+function worstStatus(items = []) {
+  return items.reduce((worst, item) => statusRank(item.status) > statusRank(worst) ? item.status : worst, 'pass')
+}
+
+function average(values = []) {
+  const numeric = values.map(Number).filter(Number.isFinite)
+  if (!numeric.length) return null
+  return numeric.reduce((sum, value) => sum + value, 0) / numeric.length
+}
+
+function jitter(values = []) {
+  const numeric = values.map(Number).filter(Number.isFinite)
+  if (numeric.length < 2) return null
+  const deltas = numeric.slice(1).map((value, index) => Math.abs(value - numeric[index]))
+  return average(deltas)
+}
+
+function isPrivateHost(host = '') {
+  const value = String(host || '').toLowerCase()
+  return value === 'localhost' ||
+    value.endsWith('.local') ||
+    value.startsWith('192.168.') ||
+    value.startsWith('10.') ||
+    /^172\.(1[6-9]|2\d|3[0-1])\./.test(value) ||
+    value.startsWith('fd') ||
+    value.startsWith('fe80:')
+}
+
+function reportLine(label, value) {
+  return `${label}: ${value || '(unknown)'}`
+}
+
+export function buildNetworkPathTestReport(input = {}) {
+  const samples = Array.isArray(input.pingSamplesMs) ? input.pingSamplesMs.map(Number).filter(Number.isFinite) : []
+  const latency = average(samples)
+  const sampleJitter = jitter(samples)
+  const loss = Number(input.packetLossPercent ?? input.packet_loss ?? input.lossPercent)
+  const host = input.host || input.originHostname || input.hostname || ''
+  const lanLike = isPrivateHost(host) || input.lan === true
+  const currentBitrate = Number(input.currentBitrateKbps ?? input.bitrateKbps ?? input.bitrate_kbps)
+  const latencyPenalty = Number.isFinite(latency) && latency > 60 ? 0.55 : Number.isFinite(latency) && latency > 30 ? 0.75 : 1
+  const jitterPenalty = Number.isFinite(sampleJitter) && sampleJitter > 15 ? 0.7 : 1
+  const lossPenalty = Number.isFinite(loss) && loss > 2 ? 0.45 : Number.isFinite(loss) && loss > 0.5 ? 0.7 : 1
+  const fallbackBitrate = lanLike ? 50000 : 30000
+  const bitrateBase = Number.isFinite(currentBitrate) && currentBitrate > 0 ? currentBitrate : fallbackBitrate
+  const recommendedBitrateKbps = Math.max(8000, Math.min(bitrateBase, Math.round(bitrateBase * latencyPenalty * jitterPenalty * lossPenalty / 1000) * 1000))
+
+  const checks = [
+    checklistItem(
+      'host-reachable',
+      'Host reachable',
+      input.hostReachable === false ? 'fail' : samples.length || input.hostReachable === true ? 'pass' : 'warning',
+      samples.length ? `${samples.length} latency sample${samples.length === 1 ? '' : 's'} collected.` : 'Browser-side reachability is inferred from the Web UI session.',
+      samples.length ? 'Keep this host address for the client test.' : 'Open this page from the same client/network you plan to stream from.'
+    ),
+    checklistItem(
+      'control-port',
+      'Control port',
+      input.controlPortOpen === false ? 'fail' : input.controlPortOpen === true ? 'pass' : 'warning',
+      input.controlPortOpen === true ? 'Control/pairing path is reachable.' : input.controlPortOpen === false ? 'Control/pairing port did not respond.' : 'Control port was not directly tested by this browser.',
+      input.controlPortOpen === false ? 'Check host firewall/NAT before pairing.' : 'If pairing fails, verify the HTTPS/control port from the client network.'
+    ),
+    checklistItem(
+      'stream-port',
+      'Stream ports',
+      input.streamPortOpen === false ? 'fail' : input.streamPortOpen === true ? 'pass' : 'warning',
+      input.streamPortOpen === true ? 'Stream ports look reachable.' : input.streamPortOpen === false ? 'One or more stream ports did not respond.' : 'Stream ports were not directly tested by this browser.',
+      input.streamPortOpen === false ? 'Fix firewall/NAT before tuning bitrate.' : 'If video starts then freezes, retest UDP reachability from the client.'
+    ),
+    checklistItem(
+      'discovery-mdns',
+      'Discovery / mDNS',
+      input.mdnsAvailable === false ? 'warning' : input.mdnsAvailable === true || String(input.originHostname || '').endsWith('.local') ? 'pass' : 'warning',
+      input.mdnsAvailable === false ? 'mDNS discovery was not confirmed; manual host add may be needed.' : 'Discovery hints are present or not required.',
+      input.mdnsAvailable === false ? 'Use the host IP directly in Moonlight/Nova if auto-discovery misses it.' : 'Discovery is not the loudest signal right now.'
+    ),
+    checklistItem(
+      'lan-vpn-clue',
+      'LAN / VPN clue',
+      lanLike ? 'pass' : 'warning',
+      lanLike ? 'Host address looks LAN/local.' : 'Host address looks remote/VPN or public.',
+      lanLike ? 'Start with normal LAN bitrate, then tune up.' : 'Expect lower bitrate and higher jitter until VPN/NAT path is proven stable.'
+    ),
+    checklistItem(
+      'latency-jitter-loss',
+      'Latency / jitter / loss',
+      (Number.isFinite(loss) && loss > 2) || (Number.isFinite(sampleJitter) && sampleJitter > 20) ? 'fail' : (Number.isFinite(loss) && loss > 0.5) || (Number.isFinite(latency) && latency > 40) ? 'warning' : 'pass',
+      `${Number.isFinite(latency) ? latency.toFixed(1) : 'unknown'} ms avg / ${Number.isFinite(sampleJitter) ? sampleJitter.toFixed(1) : 'unknown'} ms jitter / ${Number.isFinite(loss) ? loss.toFixed(1) : 'unknown'}% loss.`,
+      (Number.isFinite(loss) && loss > 0.5) ? 'Lower bitrate one step and prefer wired/5 GHz before changing encoder settings.' : 'Network quality is not the loudest signal right now.'
+    ),
+    checklistItem(
+      'bitrate-ceiling',
+      'Recommended bitrate ceiling',
+      recommendedBitrateKbps < bitrateBase ? 'warning' : 'pass',
+      `Recommended ceiling: ${recommendedBitrateKbps} kbps.`,
+      recommendedBitrateKbps < bitrateBase ? 'Use this as the next launch ceiling, then raise only after a clean session.' : 'Current bitrate target is reasonable for the sampled path.'
+    ),
+  ]
+
+  const status = worstStatus(checks)
+  return {
+    kind: 'network-path-test',
+    status,
+    classification: status === 'pass' ? 'clean' : 'network',
+    summary: `${lanLike ? 'LAN/local' : 'remote/VPN'} path: ${status === 'fail' ? 'fix reachability/loss first' : status === 'warning' ? 'usable with caution' : 'ready'}.`,
+    recommendedBitrateKbps,
+    checks,
+    advancedEvidence: sanitizeDiagnosticsValue({ host, samples, latency, jitter: sampleJitter, packetLossPercent: Number.isFinite(loss) ? loss : null }),
+  }
+}
+
+export function buildControllerInputTestReport(input = {}) {
+  const events = Array.isArray(input.events) ? input.events : []
+  const gamepads = Array.isArray(input.gamepads) ? input.gamepads : []
+  const virtual = input.virtualController || {}
+  const hostIsolation = lower(input.hostPhysicalControllerIsolation)
+  const pads = new Set(events.map((event) => event.pad ?? event.gamepadIndex ?? 1))
+  const checks = [
+    checklistItem('client-events', 'Client button events', events.length ? 'pass' : 'warning', events.length ? `${events.length} client control event${events.length === 1 ? '' : 's'} detected.` : 'No client button or axis events detected yet.', events.length ? 'Input is reaching the browser/client layer.' : 'Press buttons/sticks on the client controller while this panel is open.'),
+    checklistItem('virtual-controller', 'Virtual controller', virtual.created ? 'pass' : virtual.error ? 'fail' : 'warning', virtual.created ? `Virtual controller${virtual.number ? ` #${virtual.number}` : ''} is reported created.` : virtual.error ? redactSensitiveText(virtual.error) : 'Host virtual controller creation has not been confirmed yet.', virtual.created ? 'Launch a game and verify the same controller number is selected.' : 'If games see no pad, check virtual gamepad permissions/driver state.'),
+    checklistItem('multi-pad', 'Controller number / multi-pad', pads.size > 1 || gamepads.length > 1 ? 'pass' : 'warning', `${Math.max(pads.size, gamepads.length)} client pad${Math.max(pads.size, gamepads.length) === 1 ? '' : 's'} visible.`, 'Keep controller order stable before starting split-screen or multi-pad games.'),
+    checklistItem('rumble', 'Rumble / haptics', input.rumbleSupported === true ? 'pass' : input.rumbleSupported === false ? 'warning' : 'warning', input.rumbleSupported === true ? 'Rumble actuator test is available.' : 'Rumble/haptics support is not available or not exposed by this browser/client.', input.rumbleSupported === true ? 'Use the optional rumble pulse only after input is mapped correctly.' : 'Treat missing rumble as non-blocking unless the game requires it.'),
+    checklistItem('host-isolation', 'Host physical controller isolation', hostIsolation === 'isolated' ? 'pass' : hostIsolation === 'shared' || hostIsolation === 'leaking' ? 'fail' : 'warning', hostIsolation === 'isolated' ? 'Host physical controllers are reported isolated from client virtual pads.' : hostIsolation ? `Isolation state: ${input.hostPhysicalControllerIsolation}.` : 'Host physical controller isolation has not been reported yet.', hostIsolation === 'isolated' ? 'No host-side controller conflict stands out.' : 'If inputs double-fire, unplug/disable the host physical controller or isolate it before retesting.'),
+  ]
+  const status = worstStatus(checks.filter((check) => check.key !== 'rumble'))
+  return {
+    kind: 'controller-input-test',
+    status,
+    classification: status === 'pass' ? 'clean' : 'client',
+    summary: events.length ? `${events.length} client control event${events.length === 1 ? '' : 's'} captured; virtual pad ${virtual.created ? 'created' : 'not confirmed'}.` : 'Waiting for client controller input.',
+    checks,
+    advancedEvidence: sanitizeDiagnosticsValue({ events: events.slice(-12), gamepads, virtualController: virtual, hostPhysicalControllerIsolation: input.hostPhysicalControllerIsolation }),
+  }
+}
+
+export function buildPostSessionStreamReport({ stats = {}, logs = '', disconnectReason = '' } = {}) {
+  const loss = Number(stats.packet_loss)
+  const latency = Number(stats.latency_ms)
+  const encodeTime = Number(stats.encode_time_ms)
+  const dropped = Number(stats.dropped_frame_ratio)
+  const safeLogs = redactSensitiveText(logs)
+  let issueOwner = 'client'
+  let mainIssue = 'Client disconnected or ended the session before Polaris saw a louder host/network signal.'
+  let suggestedNextLaunchProfile = 'Retry the same launch profile once, then collect a support bundle if it repeats.'
+
+  if ((Number.isFinite(loss) && loss > 1) || (Number.isFinite(latency) && latency > 45) || /packet loss|network|udp|timeout/i.test(safeLogs)) {
+    issueOwner = 'network'
+    mainIssue = Number.isFinite(loss) && loss > 1 ? `Network packet loss was ${loss.toFixed(1)}%.` : 'Network latency/transport warnings stood out.'
+    suggestedNextLaunchProfile = 'Lower bitrate one step, prefer wired/5 GHz, then retry the same game.'
+  }
+
+  if ((Number.isFinite(encodeTime) && encodeTime > 12) || stats.capture_cpu_copy || /encoder|capture|shm|dmabuf|vaapi|nvenc/i.test(safeLogs)) {
+    issueOwner = 'host'
+    mainIssue = Number.isFinite(encodeTime) && encodeTime > 12 ? `Host encoder time was ${encodeTime.toFixed(1)} ms.` : 'Host capture/encoder path was the loudest signal.'
+    suggestedNextLaunchProfile = stats.capture_cpu_copy
+      ? 'Try Private Stream (GPU-native) or lower resolution/FPS before changing network settings.'
+      : 'Try the low-latency hardware encoder profile or lower resolution/FPS.'
+  }
+
+  const qualitySummary = `${Number.isFinite(latency) ? latency.toFixed(1) : 'unknown'} ms latency / ${Number.isFinite(loss) ? loss.toFixed(1) : 'unknown'}% loss / ${Number.isFinite(encodeTime) ? encodeTime.toFixed(1) : 'unknown'} ms encode / ${Number.isFinite(dropped) ? (dropped * 100).toFixed(2) : 'unknown'}% dropped.`
+  const report = {
+    kind: 'post-session-stream-report',
+    status: issueOwner === 'client' ? 'warning' : 'fail',
+    issueOwner,
+    mainIssue,
+    qualitySummary,
+    suggestedNextLaunchProfile,
+    disconnectReason: redactSensitiveText(disconnectReason),
+  }
+  report.copyText = [
+    'Post-session Stream Report',
+    reportLine('Issue owner', issueOwner),
+    reportLine('Main issue', mainIssue),
+    reportLine('Quality', qualitySummary),
+    reportLine('Disconnect reason', report.disconnectReason),
+    reportLine('Suggested next launch', suggestedNextLaunchProfile),
+    ...(safeLogs.trim() ? [reportLine('Recent evidence', safeLogs.trim().split('\n').slice(-3).join(' | '))] : []),
+  ].join('\n')
+  return report
+}
+
+export function buildSupportSelfTestCopy({ network, controller, postSession } = {}) {
+  const sections = []
+  if (network) sections.push(['Network Path Tester', network.summary, `Status: ${network.status}`, `Recommended bitrate: ${network.recommendedBitrateKbps || 'unknown'} kbps`].join('\n'))
+  if (controller) sections.push(['Controller/Input Tester', controller.summary, `Status: ${controller.status}`].join('\n'))
+  if (postSession) sections.push(postSession.copyText || ['Post-session Stream Report', postSession.mainIssue].join('\n'))
+  return redactSensitiveText(sections.join('\n\n'))
+}
+
 export function buildAnonymizedDiagnosticsBundle(input = {}) {
   const streamEvidence = input.stream_evidence || buildStreamEvidence(input)
   const issueDraft = input.issue_draft || buildGithubIssueDraft({ ...input, stream_evidence: streamEvidence })

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -2,8 +2,12 @@ import { describe, expect, it } from 'vitest'
 import {
   REDACTED_VALUE,
   buildAnonymizedDiagnosticsBundle,
+  buildControllerInputTestReport,
   buildFixMyStreamChecklist,
   buildGithubIssueDraft,
+  buildNetworkPathTestReport,
+  buildPostSessionStreamReport,
+  buildSupportSelfTestCopy,
   describeLinuxGpuProfile,
   redactSensitiveText,
   sanitizeDiagnosticsValue,
@@ -290,5 +294,92 @@ describe('Fix My Stream checklist', () => {
     expect(hostConfig.detail).toContain('cold-cache 503')
     expect(hostConfig.action).toContain('linux_prefer_gpu_native_capture = enabled')
     expect(checklist.map((item) => item.key)[1]).toBe('host-config')
+  })
+})
+
+
+describe('support self-service reports', () => {
+  it('classifies a lossy remote network path and recommends a safer bitrate ceiling', () => {
+    const report = buildNetworkPathTestReport({
+      host: '203.0.113.40',
+      originHostname: 'polaris-host.local',
+      controlPortOpen: true,
+      streamPortOpen: false,
+      mdnsAvailable: false,
+      pingSamplesMs: [38, 55, 92, 44],
+      packetLossPercent: 4.5,
+      currentBitrateKbps: 60000,
+    })
+
+    expect(report.status).toBe('fail')
+    expect(report.classification).toBe('network')
+    expect(report.summary).toContain('remote/VPN')
+    expect(report.recommendedBitrateKbps).toBeLessThanOrEqual(30000)
+    expect(report.checks.map((check) => check.key)).toEqual([
+      'host-reachable',
+      'control-port',
+      'stream-port',
+      'discovery-mdns',
+      'lan-vpn-clue',
+      'latency-jitter-loss',
+      'bitrate-ceiling',
+    ])
+    expect(report.checks.find((check) => check.key === 'stream-port').status).toBe('fail')
+  })
+
+  it('summarizes controller input events without requiring hardware-level host evidence', () => {
+    const report = buildControllerInputTestReport({
+      events: [
+        { pad: 1, control: 'A', type: 'buttondown' },
+        { pad: 2, control: 'Left Stick', type: 'axis', value: 0.74 },
+      ],
+      gamepads: [{ index: 0, id: 'Xbox Wireless Controller' }, { index: 1, id: 'DualSense' }],
+      virtualController: { created: true, number: 2 },
+      rumbleSupported: false,
+      hostPhysicalControllerIsolation: 'isolated',
+    })
+
+    expect(report.status).toBe('pass')
+    expect(report.summary).toContain('2 client control events')
+    expect(report.checks.find((check) => check.key === 'multi-pad').detail).toContain('2 client pads')
+    expect(report.checks.find((check) => check.key === 'rumble').status).toBe('warning')
+    expect(report.checks.find((check) => check.key === 'host-isolation').status).toBe('pass')
+  })
+
+  it('builds a post-session report with issue owner and next launch profile', () => {
+    const report = buildPostSessionStreamReport({
+      stats: {
+        streaming: false,
+        packet_loss: 0.1,
+        latency_ms: 6.4,
+        encode_time_ms: 15.2,
+        dropped_frame_ratio: 0.02,
+        capture_cpu_copy: true,
+        capture_gpu_native: false,
+        stream_display_mode: 'headless_stream',
+      },
+      logs: 'Warning: encoder queue saturated after capture fell back to SHM',
+      disconnectReason: 'client disconnected',
+    })
+
+    expect(report.issueOwner).toBe('host')
+    expect(report.mainIssue).toContain('encoder')
+    expect(report.suggestedNextLaunchProfile).toContain('Private Stream')
+    expect(report.copyText).toContain('Issue owner: host')
+    expect(report.copyText).not.toContain('token=')
+  })
+
+  it('generates support-copy text for network, controller, and post-session reports', () => {
+    const copy = buildSupportSelfTestCopy({
+      network: buildNetworkPathTestReport({ controlPortOpen: true, streamPortOpen: true, pingSamplesMs: [4, 5], packetLossPercent: 0 }),
+      controller: buildControllerInputTestReport({ events: [{ pad: 1, control: 'A' }], virtualController: { created: true } }),
+      postSession: buildPostSessionStreamReport({ stats: { packet_loss: 3.4, latency_ms: 70 }, logs: 'Warning: packet loss spike token=abc123' }),
+    })
+
+    expect(copy).toContain('Network Path Tester')
+    expect(copy).toContain('Controller/Input Tester')
+    expect(copy).toContain('Post-session Stream Report')
+    expect(copy).toContain(`token=${REDACTED_VALUE}`)
+    expect(copy).not.toContain('abc123')
   })
 })

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -87,6 +87,75 @@
       </div>
     </section>
 
+    <section class="section-card space-y-4" data-support-self-tests>
+      <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div class="section-kicker">Built-in self tests</div>
+          <h2 class="section-title">Network, controller, and post-session report</h2>
+          <p class="section-copy">Quick normal-user checks first; expandable evidence keeps the nerd-sniping below the fold where it belongs.</p>
+        </div>
+        <button class="focus-ring troubleshooting-action-button troubleshooting-action-button-secondary" @click="copySupportSelfTests">
+          Copy self-test summary
+        </button>
+      </div>
+
+      <div class="grid gap-3 xl:grid-cols-3">
+        <div class="surface-subtle border p-4" :class="selfTestCardClass(networkPathReport.status)">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-sm font-semibold text-silver">Network Path Tester</div>
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]" :class="selfTestBadgeClass(networkPathReport.status)">{{ selfTestStatusLabel(networkPathReport.status) }}</span>
+          </div>
+          <p class="mt-2 text-sm leading-relaxed text-storm">{{ networkPathReport.summary }}</p>
+          <p class="mt-3 text-xs leading-relaxed text-ice">Recommended ceiling: {{ networkPathReport.recommendedBitrateKbps }} kbps.</p>
+          <details class="mt-3 text-xs text-storm">
+            <summary class="cursor-pointer text-ice">Advanced evidence</summary>
+            <div class="mt-2 space-y-2">
+              <div v-for="check in networkPathReport.checks" :key="check.key" class="rounded-lg border border-storm/15 bg-void/40 px-3 py-2">
+                <div class="font-medium text-silver">{{ check.label }} · {{ selfTestStatusLabel(check.status) }}</div>
+                <div>{{ check.detail }}</div>
+                <div class="mt-1 text-ice">{{ check.action }}</div>
+              </div>
+            </div>
+          </details>
+        </div>
+
+        <div class="surface-subtle border p-4" :class="selfTestCardClass(controllerInputReport.status)">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-sm font-semibold text-silver">Controller/Input Tester</div>
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]" :class="selfTestBadgeClass(controllerInputReport.status)">{{ selfTestStatusLabel(controllerInputReport.status) }}</span>
+          </div>
+          <p class="mt-2 text-sm leading-relaxed text-storm">{{ controllerInputReport.summary }}</p>
+          <div class="mt-3 flex flex-wrap gap-2">
+            <button class="focus-ring troubleshooting-action-button troubleshooting-action-button-secondary" @click="refreshControllerSnapshot">Detect controller</button>
+            <button class="focus-ring troubleshooting-action-button troubleshooting-action-button-secondary" @click="recordControllerEvent('A / primary button', 1)">Log A press</button>
+          </div>
+          <details class="mt-3 text-xs text-storm">
+            <summary class="cursor-pointer text-ice">Advanced evidence</summary>
+            <div class="mt-2 space-y-2">
+              <div v-for="check in controllerInputReport.checks" :key="check.key" class="rounded-lg border border-storm/15 bg-void/40 px-3 py-2">
+                <div class="font-medium text-silver">{{ check.label }} · {{ selfTestStatusLabel(check.status) }}</div>
+                <div>{{ check.detail }}</div>
+                <div class="mt-1 text-ice">{{ check.action }}</div>
+              </div>
+            </div>
+          </details>
+        </div>
+
+        <div class="surface-subtle border p-4" :class="selfTestCardClass(postSessionReport.status)">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-sm font-semibold text-silver">Post-session Stream Report</div>
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]" :class="selfTestBadgeClass(postSessionReport.status)">{{ postSessionReport.issueOwner }}</span>
+          </div>
+          <p class="mt-2 text-sm leading-relaxed text-storm">{{ postSessionReport.mainIssue }}</p>
+          <p class="mt-3 text-xs leading-relaxed text-ice">Next launch: {{ postSessionReport.suggestedNextLaunchProfile }}</p>
+          <details class="mt-3 text-xs text-storm">
+            <summary class="cursor-pointer text-ice">Advanced evidence</summary>
+            <pre class="mt-2 whitespace-pre-wrap rounded-lg border border-storm/15 bg-void/50 p-3">{{ postSessionReport.copyText }}</pre>
+          </details>
+        </div>
+      </div>
+    </section>
+
     <section class="section-card space-y-4">
       <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
@@ -352,13 +421,21 @@
 </template>
 
 <script setup>
-import { ref, computed, onBeforeUnmount, inject } from 'vue'
+import { ref, computed, onBeforeUnmount, inject, watch } from 'vue'
 import { useToast } from '../composables/useToast'
 import { useStreamStats } from '../composables/useStreamStats'
 import VirtualLogViewer from '../components/VirtualLogViewer.vue'
 import ConfirmActionDialog from '../components/ConfirmActionDialog.vue'
 import { requestHostRestart } from '../restart-host.js'
-import { buildAnonymizedDiagnosticsBundle, buildFixMyStreamChecklist, buildGithubIssueDraft } from '../diagnostics-export.js'
+import {
+  buildAnonymizedDiagnosticsBundle,
+  buildControllerInputTestReport,
+  buildFixMyStreamChecklist,
+  buildGithubIssueDraft,
+  buildNetworkPathTestReport,
+  buildPostSessionStreamReport,
+  buildSupportSelfTestCopy,
+} from '../diagnostics-export.js'
 import { AI_DOCTOR_EXPLANATION_CATEGORIES, explainDoctorWithAi } from '../ai-doctor-explanation.js'
 
 const { toast: showToast } = useToast()
@@ -388,6 +465,12 @@ const version = ref("")
 const confirmActionOpen = ref(false)
 const pendingConfirmedAction = ref(null)
 const requestedConfirmAction = ref(null)
+const controllerEvents = ref([])
+const controllerRumbleSupported = ref(null)
+const hostPhysicalControllerIsolation = ref('unknown')
+const virtualControllerStatus = ref({ created: false })
+const lastCompletedStreamStats = ref(null)
+const lastDisconnectReason = ref('')
 
 const confirmedActions = computed(() => ({
   forceClose: {
@@ -629,6 +712,97 @@ const doctorAdvancedItems = computed(() => {
     { label: 'Active stream stats', value: summarizeStreamStats(s) },
   ]
 })
+
+const networkPathReport = computed(() => buildNetworkPathTestReport({
+  host: streamStats.value?.client_ip || window.location.hostname,
+  originHostname: window.location.hostname,
+  hostReachable: streamStatsConnected.value,
+  controlPortOpen: streamStatsConnected.value,
+  streamPortOpen: streamStats.value?.streaming ? true : undefined,
+  mdnsAvailable: window.location.hostname.endsWith('.local'),
+  pingSamplesMs: [streamStats.value?.latency_ms].filter((value) => Number.isFinite(Number(value))),
+  packetLossPercent: streamStats.value?.packet_loss,
+  currentBitrateKbps: streamStats.value?.bitrate_kbps,
+}))
+
+const browserGamepads = computed(() => {
+  if (!navigator.getGamepads) return []
+  return Array.from(navigator.getGamepads()).filter(Boolean).map((pad) => ({
+    index: pad.index,
+    id: pad.id,
+    buttons: pad.buttons?.length || 0,
+    axes: pad.axes?.length || 0,
+  }))
+})
+
+const controllerInputReport = computed(() => buildControllerInputTestReport({
+  events: controllerEvents.value,
+  gamepads: browserGamepads.value,
+  virtualController: virtualControllerStatus.value,
+  rumbleSupported: controllerRumbleSupported.value,
+  hostPhysicalControllerIsolation: hostPhysicalControllerIsolation.value,
+}))
+
+const postSessionReport = computed(() => buildPostSessionStreamReport({
+  stats: lastCompletedStreamStats.value || streamStats.value || {},
+  logs: logs.value,
+  disconnectReason: lastDisconnectReason.value,
+}))
+
+const supportSelfTestCopy = computed(() => buildSupportSelfTestCopy({
+  network: networkPathReport.value,
+  controller: controllerInputReport.value,
+  postSession: postSessionReport.value,
+}))
+
+function selfTestCardClass(status) {
+  if (status === 'pass') return 'border-green-500/20'
+  if (status === 'fail') return 'border-red-500/25'
+  return 'border-amber-300/25'
+}
+
+function selfTestBadgeClass(status) {
+  if (status === 'pass') return 'border border-green-500/30 bg-green-500/10 text-green-300'
+  if (status === 'fail') return 'border border-red-500/30 bg-red-500/10 text-red-200'
+  return 'border border-amber-300/30 bg-amber-300/10 text-amber-200'
+}
+
+function selfTestStatusLabel(status) {
+  if (status === 'pass') return 'Looks good'
+  if (status === 'fail') return 'Fix first'
+  return 'Check'
+}
+
+function recordControllerEvent(label, pad = 1) {
+  controllerEvents.value = [
+    ...controllerEvents.value.slice(-15),
+    { pad, control: label, type: 'manual', at: new Date().toISOString() },
+  ]
+  virtualControllerStatus.value = { created: true, number: pad }
+}
+
+function refreshControllerSnapshot() {
+  const pads = browserGamepads.value
+  if (pads.length) {
+    virtualControllerStatus.value = { created: true, number: pads[0].index + 1 }
+    controllerRumbleSupported.value = Boolean(navigator.getGamepads?.()[pads[0].index]?.vibrationActuator)
+    recordControllerEvent('Browser gamepad visible', pads[0].index + 1)
+  } else {
+    recordControllerEvent('Manual button sample', 1)
+  }
+}
+
+function copySupportSelfTests() {
+  navigator.clipboard.writeText(supportSelfTestCopy.value)
+  showToast('Support self-test summary copied.', 'success')
+}
+
+watch(streamStats, (next, previous) => {
+  if (previous?.streaming && next && !next.streaming) {
+    lastCompletedStreamStats.value = previous
+    lastDisconnectReason.value = 'Stream telemetry changed from active to idle.'
+  }
+}, { deep: true })
 
 function fixMyStreamStatusLabel(status) {
   if (status === 'pass') return i18n.t('troubleshooting.fix_my_stream_status_pass')


### PR DESCRIPTION
## Summary\n- add pure report builders for network path testing, controller/input testing, and post-session stream reports\n- surface a Troubleshooting self-test section with normal-user summaries and expandable advanced evidence\n- include redacted support-copy generation for support bundles / clipboard handoff\n\n## Verification\n- npm run test -- src_assets/common/assets/web/diagnostics-export.test.js\n- npm run lint\n- git diff --check\n- npm run build\n\n## Follow-up hardware/backend slices\n- native host port reachability/mDNS probes and latency/loss sampling should move server-side when we decide the exact probe contract\n- host virtual controller/isolation/rumble evidence needs native runtime hooks beyond browser Gamepad API