### PR TITLE
feat(web): add display resolution planner

### DIFF
--- a/src_assets/common/assets/web/config-defaults.test.js
+++ b/src_assets/common/assets/web/config-defaults.test.js
@@ -38,4 +38,16 @@ describe('config defaults', () => {
 
     expect(source).toContain('"nvenc_split_encode_mode": "disabled"')
   })
+
+  it('surfaces the display planner as simple recommendations with advanced scale controls tucked away', () => {
+    const source = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/configs/tabs/AudioVideo.vue'), 'utf8')
+
+    expect(source).toContain('data-display-resolution-planner')
+    expect(source).toContain('displayPlanner.recommendedTitle')
+    expect(source).toContain('Moonlight compatibility stays standard')
+    expect(source).toContain('data-display-resolution-planner-advanced')
+    expect(source).toContain('showDisplayPlannerAdvanced')
+    expect(source).toContain('Scale factors are capped to 0.5x–2x')
+    expect(source).toContain('client/game needs a specific override')
+  })
 })

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -8,6 +8,7 @@ import DisplayDeviceOptions from "./audiovideo/DisplayDeviceOptions.vue";
 import VirtualDisplayStatus from "./audiovideo/VirtualDisplayStatus.vue";
 import Checkbox from "../../Checkbox.vue";
 import { resolveClientSettingsSync, resolveStreamDisplayRuntimeNotice } from '../../client-settings-sync'
+import { buildResolutionPlanner } from '../../display-resolution-planner'
 
 const $t = inject('i18n').t;
 
@@ -30,6 +31,13 @@ const currentDriverStatus = computed(() => sudovdaStatus[props.vdisplay])
 const config = ref(props.config)
 const isLinux = computed(() => props.platform === 'linux')
 const isWindows = computed(() => props.platform === 'windows')
+const showDisplayPlannerAdvanced = ref(false)
+const customDisplayScale = ref(1)
+const displayPlanner = computed(() => buildResolutionPlanner({
+  fallbackMode: config.value.fallback_mode,
+  customScale: customDisplayScale.value,
+  showAdvanced: showDisplayPlannerAdvanced.value,
+}))
 
 const streamDisplayModes = [
   {
@@ -245,6 +253,11 @@ function setStreamDisplayMode(mode) {
       setEnabledConfig('linux_prefer_gpu_native_capture', true)
       break
   }
+}
+
+function applyDisplayPlan(choice) {
+  if (!choice?.safe) return
+  config.value.fallback_mode = choice.targetMode
 }
 
 const validateFallbackMode = (event) => {
@@ -624,6 +637,85 @@ pactl info | grep Source</pre>
       </summary>
 
       <div class="settings-disclosure-body settings-inline-stack">
+        <div class="settings-subtle-surface space-y-4" data-display-resolution-planner>
+          <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <div class="section-kicker">Display Planner</div>
+              <h4 class="mt-2 text-sm font-semibold text-silver">{{ displayPlanner.recommendedTitle }}</h4>
+              <div class="mt-1 text-sm leading-relaxed text-storm">
+                Start from the client panel shape, keep the aspect ratio at {{ displayPlanner.sourceAspectRatio }}, and choose a plain-language target before touching raw WxHxFPS values.
+              </div>
+            </div>
+            <div class="rounded-2xl border border-green-400/25 bg-green-400/10 px-3 py-2 text-right text-sm text-green-200">
+              <div class="text-[10px] font-semibold uppercase tracking-[0.16em]">Recommended</div>
+              <div class="mt-1 font-medium">{{ displayPlanner.recommendedMode }}</div>
+            </div>
+          </div>
+
+          <div class="grid gap-3 xl:grid-cols-3">
+            <button
+              v-for="choice in displayPlanner.visibleChoices"
+              :key="choice.id"
+              type="button"
+              class="focus-ring min-h-[126px] rounded-lg border border-storm/30 bg-deep/40 p-4 text-left transition hover:border-storm/70"
+              :class="choice.id === displayPlanner.recommendedId ? 'border-green-400/45 bg-green-400/10' : ''"
+              @click="applyDisplayPlan(choice)"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <div class="text-sm font-semibold text-silver">{{ choice.title }}</div>
+                <span class="shrink-0 rounded-full border border-storm/30 bg-storm/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-storm">{{ choice.badge }}</span>
+              </div>
+              <div class="mt-3 text-sm leading-relaxed text-storm">{{ choice.reason }}</div>
+              <div class="mt-3 rounded-md border border-storm/20 bg-void/25 px-2.5 py-2 font-mono text-xs text-silver">{{ choice.targetMode }}</div>
+            </button>
+          </div>
+
+          <div class="flex flex-col gap-3 rounded-lg border border-ice/15 bg-ice/5 p-4 text-sm text-storm lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <div class="font-medium text-silver">Moonlight compatibility stays standard</div>
+              <div class="mt-1">Planner choices only write the existing fallback display mode format. Nova/per-game overrides can layer on top where client-settings support exists.</div>
+            </div>
+            <button type="button" class="focus-ring dashboard-action-button dashboard-action-button-secondary" @click="showDisplayPlannerAdvanced = !showDisplayPlannerAdvanced">
+              {{ showDisplayPlannerAdvanced ? 'Hide Advanced' : 'Show Advanced' }}
+            </button>
+          </div>
+
+          <div v-if="showDisplayPlannerAdvanced" class="settings-subtle-surface space-y-4" data-display-resolution-planner-advanced>
+            <div>
+              <div class="section-kicker">Advanced Display Planner</div>
+              <div class="mt-2 text-sm leading-relaxed text-storm">
+                Scale factors are capped to 0.5x–2x and excessive modes stay hidden. Use Custom only when a client/game needs a specific override and the normal recommendation is not right.
+              </div>
+            </div>
+            <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-6">
+              <button
+                v-for="factor in displayPlanner.advancedScaleFactors"
+                :key="factor.label"
+                type="button"
+                class="focus-ring rounded-lg border px-3 py-3 text-left"
+                :class="factor.safe ? 'border-storm/30 bg-void/25 hover:border-storm/70' : 'border-amber-300/25 bg-amber-300/10 opacity-60'"
+                :disabled="!factor.safe"
+                @click="customDisplayScale = factor.scaleFactor"
+              >
+                <div class="text-sm font-semibold text-silver">{{ factor.label }}</div>
+                <div class="mt-1 font-mono text-xs text-storm">{{ factor.targetMode }}</div>
+                <div class="mt-1 text-[11px]" :class="factor.safe ? 'text-storm' : 'text-amber-100'">{{ factor.safe ? 'Available' : 'Hidden as excessive' }}</div>
+              </button>
+            </div>
+            <label class="block text-sm font-medium text-storm">
+              Custom scale factor
+              <input
+                v-model.number="customDisplayScale"
+                type="number"
+                min="0.5"
+                max="2"
+                step="0.25"
+                class="mt-2 w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+              />
+            </label>
+          </div>
+        </div>
+
         <DisplayOutputSelector
           :platform="platform"
           :config="config"

--- a/src_assets/common/assets/web/display-resolution-planner.js
+++ b/src_assets/common/assets/web/display-resolution-planner.js
@@ -1,0 +1,172 @@
+export const DISPLAY_PLANNER_SCALE_FACTORS = [0.5, 0.75, 1, 1.25, 1.5, 2]
+
+export const DISPLAY_PLANNER_PRESETS = [
+  {
+    id: 'native',
+    title: 'Native',
+    intent: 'Match the client panel exactly.',
+    scaleFactor: 1,
+  },
+  {
+    id: 'balanced',
+    title: 'Balanced',
+    intent: 'Best for this device: preserve aspect ratio while easing encoder and network load.',
+    scaleFactor: 0.75,
+  },
+  {
+    id: 'sharp',
+    title: 'Sharp / Supersampled',
+    intent: 'Render above the client panel and downscale for extra clarity when the host has headroom.',
+    scaleFactor: 1.5,
+    advanced: true,
+  },
+  {
+    id: 'performance',
+    title: 'Performance',
+    intent: 'Favor frame pacing and bandwidth over raw pixel count.',
+    scaleFactor: 0.5,
+  },
+  {
+    id: 'custom',
+    title: 'Custom',
+    intent: 'Advanced manual scale factor using the existing fallback display mode field.',
+    custom: true,
+    advanced: true,
+  },
+]
+
+const DEFAULT_DEVICE = Object.freeze({ width: 1920, height: 1080, fps: 60 })
+const DEFAULT_LIMITS = Object.freeze({ maxWidth: 7680, maxHeight: 4320, maxPixels: 7680 * 4320 })
+
+export function parseDisplayMode(value, fallback = DEFAULT_DEVICE) {
+  const match = String(value || '').trim().match(/^(\d+)x(\d+)x(\d+(?:\.\d+)?)$/)
+  if (!match) return { ...fallback }
+
+  return {
+    width: Number(match[1]),
+    height: Number(match[2]),
+    fps: Number(match[3]),
+  }
+}
+
+export function formatDisplayMode({ width, height, fps = 60 }) {
+  return `${Math.round(width)}x${Math.round(height)}x${Number(fps)}`
+}
+
+export function clampPlannerScale(value) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return 1
+  return Math.min(2, Math.max(0.5, numeric))
+}
+
+export function buildResolutionPlanner({
+  fallbackMode = '',
+  device = null,
+  customScale = 1,
+  showAdvanced = false,
+  limits = DEFAULT_LIMITS,
+} = {}) {
+  const base = normalizeDevice(device || parseDisplayMode(fallbackMode))
+  const effectiveLimits = { ...DEFAULT_LIMITS, ...(limits || {}) }
+  const customFactor = clampPlannerScale(customScale)
+
+  const choices = DISPLAY_PLANNER_PRESETS.map((preset) => {
+    const scaleFactor = preset.custom ? customFactor : preset.scaleFactor
+    const target = resolveScaledMode(base, scaleFactor)
+    const safe = isSafeMode(target, effectiveLimits)
+    const hidden = Boolean((preset.advanced && !showAdvanced) || !safe)
+    const reason = safe
+      ? preset.intent
+      : 'Hidden because this would exceed the safe display-mode envelope for normal users.'
+
+    return {
+      ...preset,
+      scaleFactor,
+      target,
+      targetMode: formatDisplayMode(target),
+      hidden,
+      safe,
+      reason,
+      badge: resolvePresetBadge(preset.id, base, scaleFactor),
+      aspectRatio: aspectRatioLabel(base.width, base.height),
+    }
+  })
+
+  const visibleChoices = choices.filter((choice) => !choice.hidden)
+  const recommended = visibleChoices.find((choice) => choice.id === 'balanced') || visibleChoices[0] || choices[0]
+
+  return {
+    sourceMode: formatDisplayMode(base),
+    sourceAspectRatio: aspectRatioLabel(base.width, base.height),
+    sourceFps: base.fps,
+    recommendedId: recommended.id,
+    recommendedTitle: 'Best for this device',
+    recommendedMode: recommended.targetMode,
+    choices,
+    visibleChoices,
+    advancedScaleFactors: DISPLAY_PLANNER_SCALE_FACTORS.map((scaleFactor) => {
+      const target = resolveScaledMode(base, scaleFactor)
+      return {
+        scaleFactor,
+        label: `${scaleFactor}x`,
+        target,
+        targetMode: formatDisplayMode(target),
+        safe: isSafeMode(target, effectiveLimits),
+      }
+    }),
+  }
+}
+
+export function resolveScaledMode(base, scaleFactor) {
+  const scale = clampPlannerScale(scaleFactor)
+  const width = roundToEven(base.width * scale)
+  const height = roundToEven(base.height * scale)
+  return { width, height, fps: base.fps }
+}
+
+function normalizeDevice(device = {}) {
+  const width = positiveNumber(device.width, DEFAULT_DEVICE.width)
+  const height = positiveNumber(device.height, DEFAULT_DEVICE.height)
+  const fps = positiveNumber(device.fps, DEFAULT_DEVICE.fps)
+  return { width, height, fps }
+}
+
+function positiveNumber(value, fallback) {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : fallback
+}
+
+function roundToEven(value) {
+  const rounded = Math.max(2, Math.round(value))
+  return rounded % 2 === 0 ? rounded : rounded + 1
+}
+
+function isSafeMode(target, limits) {
+  return target.width <= limits.maxWidth
+    && target.height <= limits.maxHeight
+    && target.width * target.height <= limits.maxPixels
+}
+
+function resolvePresetBadge(id, base, scaleFactor) {
+  if (id === 'balanced') return 'Best for this device'
+  if (id === 'native') return `${base.width}×${base.height}`
+  if (id === 'sharp') return `${scaleFactor}x supersample`
+  if (id === 'performance') return `${scaleFactor}x downscale`
+  return 'Advanced'
+}
+
+function aspectRatioLabel(width, height) {
+  const divisor = gcd(width, height)
+  return `${width / divisor}:${height / divisor}`
+}
+
+function gcd(a, b) {
+  let x = Math.abs(Math.round(a))
+  let y = Math.abs(Math.round(b))
+  while (y) {
+    const next = x % y
+    x = y
+    y = next
+  }
+  return x || 1
+}

--- a/src_assets/common/assets/web/display-resolution-planner.test.js
+++ b/src_assets/common/assets/web/display-resolution-planner.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DISPLAY_PLANNER_SCALE_FACTORS,
+  buildResolutionPlanner,
+  clampPlannerScale,
+  formatDisplayMode,
+  parseDisplayMode,
+} from './display-resolution-planner'
+
+describe('display resolution planner', () => {
+  it('frames Balanced as the normal-user recommendation instead of dumping raw modes first', () => {
+    const planner = buildResolutionPlanner({ fallbackMode: '2560x1600x90' })
+
+    expect(planner.recommendedId).toBe('balanced')
+    expect(planner.recommendedTitle).toBe('Best for this device')
+    expect(planner.recommendedMode).toBe('1920x1200x90')
+    expect(planner.sourceAspectRatio).toBe('8:5')
+    expect(planner.visibleChoices.map((choice) => choice.title)).toEqual([
+      'Native',
+      'Balanced',
+      'Performance',
+    ])
+  })
+
+  it('keeps supersampling and custom controls behind advanced visibility', () => {
+    const simple = buildResolutionPlanner({ fallbackMode: '1920x1080x60', showAdvanced: false })
+    const advanced = buildResolutionPlanner({ fallbackMode: '1920x1080x60', showAdvanced: true, customScale: 1.25 })
+
+    expect(simple.visibleChoices.map((choice) => choice.id)).not.toContain('sharp')
+    expect(simple.visibleChoices.map((choice) => choice.id)).not.toContain('custom')
+    expect(advanced.visibleChoices.map((choice) => choice.id)).toEqual([
+      'native',
+      'balanced',
+      'sharp',
+      'performance',
+      'custom',
+    ])
+    expect(advanced.visibleChoices.find((choice) => choice.id === 'custom').targetMode).toBe('2400x1350x60')
+  })
+
+  it('hides unsafe or excessive modes even when advanced controls are open', () => {
+    const planner = buildResolutionPlanner({
+      fallbackMode: '7680x4320x60',
+      showAdvanced: true,
+      limits: { maxWidth: 7680, maxHeight: 4320, maxPixels: 7680 * 4320 },
+    })
+
+    expect(planner.visibleChoices.map((choice) => choice.id)).toEqual([
+      'native',
+      'balanced',
+      'performance',
+      'custom',
+    ])
+    expect(planner.choices.find((choice) => choice.id === 'sharp').hidden).toBe(true)
+    expect(planner.choices.find((choice) => choice.id === 'sharp').safe).toBe(false)
+  })
+
+  it('exposes only the supported scale-factor set and clamps custom values', () => {
+    expect(DISPLAY_PLANNER_SCALE_FACTORS).toEqual([0.5, 0.75, 1, 1.25, 1.5, 2])
+    expect(clampPlannerScale(0.1)).toBe(0.5)
+    expect(clampPlannerScale(3)).toBe(2)
+  })
+
+  it('parses and formats Moonlight-compatible WxHxFPS display modes', () => {
+    expect(parseDisplayMode('3840x2160x120')).toEqual({ width: 3840, height: 2160, fps: 120 })
+    expect(formatDisplayMode({ width: 1920, height: 1080, fps: 60 })).toBe('1920x1080x60')
+  })
+})


### PR DESCRIPTION
## Summary
- add a Display Resolution Planner prototype to Polaris web/config UI
- provide simple Native/Balanced/Sharp/Supersampled/Performance/Custom choices before advanced scale controls
- write existing Moonlight-compatible WxHxFPS fallback_mode values without protocol/API changes

## Verification
- npm run test -- src_assets/common/assets/web/display-resolution-planner.test.js src_assets/common/assets/web/config-defaults.test.js
- npm run lint
- npm run build
- git diff --check HEAD~1..HEAD

## Scope / follow-up
- productizes the Apollo #188 downscale/supersampling idea as a safe UI planner first
- current device shape derives from fallback_mode; real client panel metadata and API-backed per-client/per-game overrides remain future work
- Nova client-side planner mirroring remains a separate lane