### PR TITLE
feat(support): add native network path probes

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -4775,6 +4775,73 @@ namespace confighttp {
     response->write(output.dump(), headers);
   }
 
+  nlohmann::json build_network_path_port_probe(const net::network_path_probe_port_t &port) {
+    nlohmann::json item;
+    item["key"] = port.key;
+    item["label"] = port.label;
+    item["port"] = port.port;
+    item["transport"] = port.transport;
+
+    if (port.transport == "tcp") {
+      try {
+        boost::asio::io_context io;
+        boost::asio::ip::tcp::socket socket {io};
+        socket.connect({boost::asio::ip::make_address("127.0.0.1"), port.port});
+        item["status"] = "open";
+        item["detail"] = "Local Polaris host accepted a TCP connection on the mapped port.";
+      } catch (const std::exception &e) {
+        item["status"] = "closed";
+        item["detail"] = "Local Polaris host did not accept a TCP connection on this mapped port.";
+        item["error"] = e.what();
+      }
+    } else {
+      item["status"] = "hint";
+      item["detail"] = "UDP stream reachability cannot be proven from the Web UI server without sending test media; verify firewall/NAT allows this mapped port.";
+    }
+
+    return item;
+  }
+
+  void getNetworkPathProbe(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+
+    print_req(request);
+
+    const auto remote_address = net::addr_to_normalized_string(request->remote_endpoint().address());
+    const auto host_header = request->header.find("host");
+    const auto request_host = host_header == request->header.end() ? std::string {} : host_header->second;
+    const auto configured_ports = net::network_path_probe_ports(static_cast<std::uint16_t>(config::sunshine.port));
+
+    nlohmann::json ports = nlohmann::json::array();
+    for (const auto &port : configured_ports) {
+      ports.push_back(build_network_path_port_probe(port));
+    }
+
+    nlohmann::json output;
+    output["status"] = true;
+    output["kind"] = "network-path-probe";
+    output["targetHost"] = remote_address;
+    output["requestHost"] = request_host;
+    output["classification"] = net::network_path_probe_classification(remote_address);
+    output["hostReachable"] = true;
+    output["mdnsAvailable"] = request_host.find(".local") != std::string::npos;
+    output["ports"] = ports;
+    output["samples"] = {
+      {"latencyMs", nlohmann::json::array()},
+      {"jitterMs", nullptr},
+      {"packetLossPercent", nullptr},
+      {"source", "stream telemetry when active; no synthetic packets sent"},
+    };
+    output["notes"] = nlohmann::json::array({
+      "Server-side probe is read-only: it checks the requesting client address, local mapped TCP listeners, and UDP port contract hints.",
+      "WAN/NAT UDP reachability still needs a client-side stream attempt or external port test."
+    });
+
+    send_response(response, output);
+  }
+
   void getStreamStats(resp_https_t response, req_https_t request) {
     if (!authenticate(response, request))
       return;
@@ -5107,6 +5174,7 @@ namespace confighttp {
     server.resource["^/api/stats/system$"]["GET"] = getSystemStats;
     server.resource["^/api/stats/stream$"]["GET"] = getStreamStats;
     server.resource["^/api/stats/stream-sse$"]["GET"] = getStreamStatsSSE;
+    server.resource["^/api/support/network-path-probe$"]["GET"] = getNetworkPathProbe;
     server.resource["^/api/recording/start$"]["POST"] = withCsrf(startRecording);
     server.resource["^/api/recording/stop$"]["POST"] = withCsrf(stopRecording);
     server.resource["^/api/recording/save-replay$"]["POST"] = withCsrf(saveReplay);

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -4,6 +4,7 @@
  */
 // standard includes
 #include <algorithm>
+#include <cctype>
 #include <sstream>
 
 // local includes
@@ -222,5 +223,48 @@ namespace net {
     }
 
     return !instancename.empty() ? instancename : "Apollo";
+  }
+
+  std::string network_path_probe_classification(const std::string_view &host) {
+    std::string value {host.data(), host.size()};
+    const auto bracketed_v6_end = value.find(']');
+    if (!value.empty() && value.front() == '[' && bracketed_v6_end != std::string::npos) {
+      value = value.substr(1, bracketed_v6_end - 1);
+    } else if (const auto scheme = value.find("://"); scheme != std::string::npos) {
+      value = value.substr(scheme + 3);
+    }
+    if (const auto slash = value.find('/'); slash != std::string::npos) {
+      value = value.substr(0, slash);
+    }
+    if (const auto colon = value.find(':'); colon != std::string::npos && value.find(':', colon + 1) == std::string::npos) {
+      value = value.substr(0, colon);
+    }
+
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+
+    if (value.ends_with(".local") || value == "localhost") {
+      return "lan";
+    }
+    if (value.ends_with(".ts.net") || value.find("tailscale") != std::string::npos || value.find("zerotier") != std::string::npos) {
+      return "vpn";
+    }
+
+    try {
+      return std::string {to_enum_string(from_address(value))};
+    } catch (const std::exception &) {
+      return "wan";
+    }
+  }
+
+  std::vector<network_path_probe_port_t> network_path_probe_ports(std::uint16_t base_port) {
+    return {
+      {"control_https", "Web/control HTTPS", static_cast<std::uint16_t>(base_port + 1), "tcp"},
+      {"rtsp_setup", "RTSP setup", static_cast<std::uint16_t>(base_port + 21), "tcp"},
+      {"control_udp", "Input/control stream", static_cast<std::uint16_t>(base_port + 10), "udp"},
+      {"video_udp", "Video stream", static_cast<std::uint16_t>(base_port + 9), "udp"},
+      {"audio_udp", "Audio stream", static_cast<std::uint16_t>(base_port + 11), "udp"},
+    };
   }
 }  // namespace net

--- a/src/network.h
+++ b/src/network.h
@@ -5,8 +5,12 @@
 #pragma once
 
 // standard includes
+#include <cstdint>
+#include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 // lib includes
 #include <boost/asio.hpp>
@@ -102,4 +106,24 @@ namespace net {
    * @return Hostname-based instance name or "Sunshine" if hostname is invalid.
    */
   std::string mdns_instance_name(const std::string_view &hostname);
+
+  struct network_path_probe_port_t {
+    std::string key;
+    std::string label;
+    std::uint16_t port;
+    std::string transport;
+  };
+
+  /**
+   * @brief Classify a host/address for safe network-path self-test copy.
+   * @details This is intentionally side-effect free; callers may combine it with
+   * bounded probes, but classification itself never opens sockets.
+   */
+  std::string network_path_probe_classification(const std::string_view &host);
+
+  /**
+   * @brief Build the normal-user-safe Polaris/Moonlight port contract.
+   * @param base_port Configured Sunshine/Polaris base port, normally config::sunshine.port.
+   */
+  std::vector<network_path_probe_port_t> network_path_probe_ports(std::uint16_t base_port);
 }  // namespace net

--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -366,13 +366,72 @@ function reportLine(label, value) {
   return `${label}: ${value || '(unknown)'}`
 }
 
+function normalizeProbeStatus(status) {
+  const value = lower(status)
+  if (['open', 'reachable', 'pass', 'ok'].includes(value)) return 'pass'
+  if (['closed', 'blocked', 'timeout', 'fail', 'failed', 'unreachable'].includes(value)) return 'fail'
+  return 'warning'
+}
+
+function nativeProbePort(nativeProbe = {}, keyPattern) {
+  const ports = Array.isArray(nativeProbe.ports) ? nativeProbe.ports : []
+  return ports.find((port) => keyPattern.test(String(port.key || port.label || '')))
+}
+
+function nativeProbePortDetail(port) {
+  if (!port) return ''
+  const endpoint = [port.port, port.transport].filter(Boolean).join('/')
+  const status = port.status || 'hint'
+  const detail = port.detail || port.error || ''
+  return `${port.label || port.key || 'Port'}${endpoint ? ` ${endpoint}` : ''}: ${status}${detail ? ` (${detail})` : ''}`
+}
+
+function nativeProbeSamples(nativeProbe = {}) {
+  const samples = nativeProbe.samples || nativeProbe.latency || {}
+  const latencySamples = Array.isArray(samples.latencyMs)
+    ? samples.latencyMs
+    : Array.isArray(samples.pingSamplesMs)
+      ? samples.pingSamplesMs
+      : Array.isArray(nativeProbe.pingSamplesMs)
+        ? nativeProbe.pingSamplesMs
+        : []
+  return {
+    latencySamples,
+    jitterMs: samples.jitterMs ?? nativeProbe.jitterMs,
+    packetLossPercent: samples.packetLossPercent ?? nativeProbe.packetLossPercent,
+  }
+}
+
+function formatNativeProbeEvidence(nativeProbe = {}) {
+  const ports = Array.isArray(nativeProbe.ports) ? nativeProbe.ports : []
+  const lines = [
+    `Native evidence: ${nativeProbe.classification || 'unknown'}${nativeProbe.targetHost ? ` path to ${nativeProbe.targetHost}` : ''}`,
+    ...ports.map(nativeProbePortDetail),
+    ...(Array.isArray(nativeProbe.notes) ? nativeProbe.notes : []),
+  ].filter(Boolean)
+  return redactSensitiveText(lines.join('\n'))
+}
+
 export function buildNetworkPathTestReport(input = {}) {
-  const samples = Array.isArray(input.pingSamplesMs) ? input.pingSamplesMs.map(Number).filter(Number.isFinite) : []
+  const nativeProbe = input.nativeProbe && typeof input.nativeProbe === 'object' ? input.nativeProbe : null
+  const nativeSamples = nativeProbe ? nativeProbeSamples(nativeProbe) : {}
+  const samples = Array.isArray(nativeSamples.latencySamples) && nativeSamples.latencySamples.length
+    ? nativeSamples.latencySamples.map(Number).filter(Number.isFinite)
+    : Array.isArray(input.pingSamplesMs)
+      ? input.pingSamplesMs.map(Number).filter(Number.isFinite)
+      : []
   const latency = average(samples)
-  const sampleJitter = jitter(samples)
-  const loss = Number(input.packetLossPercent ?? input.packet_loss ?? input.lossPercent)
-  const host = input.host || input.originHostname || input.hostname || ''
-  const lanLike = isPrivateHost(host) || input.lan === true
+  const sampleJitter = Number.isFinite(Number(nativeSamples.jitterMs)) ? Number(nativeSamples.jitterMs) : jitter(samples)
+  const loss = Number(nativeSamples.packetLossPercent ?? input.packetLossPercent ?? input.packet_loss ?? input.lossPercent)
+  const host = nativeProbe?.targetHost || input.host || input.originHostname || input.hostname || ''
+  const nativeClassification = lower(nativeProbe?.classification)
+  const lanLike = nativeClassification ? ['pc', 'lan', 'local'].includes(nativeClassification) : isPrivateHost(host) || input.lan === true
+  const vpnLike = nativeClassification === 'vpn'
+  const pathLabel = lanLike ? 'LAN/local' : vpnLike ? 'VPN' : 'remote/VPN'
+  const controlPort = nativeProbePort(nativeProbe || {}, /(control|https)/i)
+  const streamPorts = Array.isArray(nativeProbe?.ports) ? nativeProbe.ports.filter((port) => /(stream|video|audio|rtsp|udp)/i.test(String(port.key || port.label || ''))) : []
+  const streamPortFailed = streamPorts.some((port) => normalizeProbeStatus(port.status) === 'fail')
+  const streamPortPassed = streamPorts.length > 0 && streamPorts.every((port) => normalizeProbeStatus(port.status) !== 'fail') && streamPorts.some((port) => normalizeProbeStatus(port.status) === 'pass')
   const currentBitrate = Number(input.currentBitrateKbps ?? input.bitrateKbps ?? input.bitrate_kbps)
   const latencyPenalty = Number.isFinite(latency) && latency > 60 ? 0.55 : Number.isFinite(latency) && latency > 30 ? 0.75 : 1
   const jitterPenalty = Number.isFinite(sampleJitter) && sampleJitter > 15 ? 0.7 : 1
@@ -385,36 +444,36 @@ export function buildNetworkPathTestReport(input = {}) {
     checklistItem(
       'host-reachable',
       'Host reachable',
-      input.hostReachable === false ? 'fail' : samples.length || input.hostReachable === true ? 'pass' : 'warning',
-      samples.length ? `${samples.length} latency sample${samples.length === 1 ? '' : 's'} collected.` : 'Browser-side reachability is inferred from the Web UI session.',
-      samples.length ? 'Keep this host address for the client test.' : 'Open this page from the same client/network you plan to stream from.'
+      nativeProbe?.hostReachable === false ? 'fail' : nativeProbe?.hostReachable === true ? 'pass' : input.hostReachable === false ? 'fail' : samples.length || input.hostReachable === true ? 'pass' : 'warning',
+      samples.length ? `${samples.length} latency sample${samples.length === 1 ? '' : 's'} collected.` : nativeProbe ? 'Polaris server returned native reachability evidence for this Web UI request.' : 'Browser-side reachability is inferred from the Web UI session.',
+      samples.length || nativeProbe ? 'Keep this host address for the client test.' : 'Open this page from the same client/network you plan to stream from.'
     ),
     checklistItem(
       'control-port',
       'Control port',
-      input.controlPortOpen === false ? 'fail' : input.controlPortOpen === true ? 'pass' : 'warning',
-      input.controlPortOpen === true ? 'Control/pairing path is reachable.' : input.controlPortOpen === false ? 'Control/pairing port did not respond.' : 'Control port was not directly tested by this browser.',
-      input.controlPortOpen === false ? 'Check host firewall/NAT before pairing.' : 'If pairing fails, verify the HTTPS/control port from the client network.'
+      controlPort ? normalizeProbeStatus(controlPort.status) : input.controlPortOpen === false ? 'fail' : input.controlPortOpen === true ? 'pass' : 'warning',
+      controlPort ? nativeProbePortDetail(controlPort) : input.controlPortOpen === true ? 'Control/pairing path is reachable.' : input.controlPortOpen === false ? 'Control/pairing port did not respond.' : 'Control port was not directly tested by this browser.',
+      (controlPort && normalizeProbeStatus(controlPort.status) === 'fail') || input.controlPortOpen === false ? 'Check host firewall/NAT before pairing.' : 'If pairing fails, verify the HTTPS/control port from the client network.'
     ),
     checklistItem(
       'stream-port',
       'Stream ports',
-      input.streamPortOpen === false ? 'fail' : input.streamPortOpen === true ? 'pass' : 'warning',
-      input.streamPortOpen === true ? 'Stream ports look reachable.' : input.streamPortOpen === false ? 'One or more stream ports did not respond.' : 'Stream ports were not directly tested by this browser.',
-      input.streamPortOpen === false ? 'Fix firewall/NAT before tuning bitrate.' : 'If video starts then freezes, retest UDP reachability from the client.'
+      streamPortFailed ? 'fail' : streamPortPassed ? 'pass' : input.streamPortOpen === false ? 'fail' : input.streamPortOpen === true ? 'pass' : 'warning',
+      streamPorts.length ? streamPorts.map(nativeProbePortDetail).join(' · ') : input.streamPortOpen === true ? 'Stream ports look reachable.' : input.streamPortOpen === false ? 'One or more stream ports did not respond.' : 'Stream ports were not directly tested by this browser.',
+      streamPortFailed || input.streamPortOpen === false ? 'Fix firewall/NAT before tuning bitrate.' : 'If video starts then freezes, retest UDP reachability from the client.'
     ),
     checklistItem(
       'discovery-mdns',
       'Discovery / mDNS',
-      input.mdnsAvailable === false ? 'warning' : input.mdnsAvailable === true || String(input.originHostname || '').endsWith('.local') ? 'pass' : 'warning',
-      input.mdnsAvailable === false ? 'mDNS discovery was not confirmed; manual host add may be needed.' : 'Discovery hints are present or not required.',
-      input.mdnsAvailable === false ? 'Use the host IP directly in Moonlight/Nova if auto-discovery misses it.' : 'Discovery is not the loudest signal right now.'
+      nativeProbe?.mdnsAvailable === false ? 'warning' : input.mdnsAvailable === false ? 'warning' : nativeProbe?.mdnsAvailable === true || input.mdnsAvailable === true || String(input.originHostname || '').endsWith('.local') ? 'pass' : 'warning',
+      nativeProbe?.mdnsAvailable === false || input.mdnsAvailable === false ? 'mDNS discovery was not confirmed; manual host add may be needed.' : 'Discovery hints are present or not required.',
+      nativeProbe?.mdnsAvailable === false || input.mdnsAvailable === false ? 'Use the host IP directly in Moonlight/Nova if auto-discovery misses it.' : 'Discovery is not the loudest signal right now.'
     ),
     checklistItem(
       'lan-vpn-clue',
       'LAN / VPN clue',
-      lanLike ? 'pass' : 'warning',
-      lanLike ? 'Host address looks LAN/local.' : 'Host address looks remote/VPN or public.',
+      lanLike || vpnLike ? 'pass' : 'warning',
+      lanLike ? 'Host address looks LAN/local.' : vpnLike ? 'Host address looks VPN/overlay.' : 'Host address looks remote/VPN or public.',
       lanLike ? 'Start with normal LAN bitrate, then tune up.' : 'Expect lower bitrate and higher jitter until VPN/NAT path is proven stable.'
     ),
     checklistItem(
@@ -438,10 +497,11 @@ export function buildNetworkPathTestReport(input = {}) {
     kind: 'network-path-test',
     status,
     classification: status === 'pass' ? 'clean' : 'network',
-    summary: `${lanLike ? 'LAN/local' : 'remote/VPN'} path: ${status === 'fail' ? 'fix reachability/loss first' : status === 'warning' ? 'usable with caution' : 'ready'}.`,
+    summary: `${pathLabel} path: ${status === 'fail' ? 'fix reachability/loss first' : status === 'warning' ? 'usable with caution' : 'ready'}.`,
     recommendedBitrateKbps,
     checks,
-    advancedEvidence: sanitizeDiagnosticsValue({ host, samples, latency, jitter: sampleJitter, packetLossPercent: Number.isFinite(loss) ? loss : null }),
+    advancedEvidence: sanitizeDiagnosticsValue({ host, samples, latency, jitter: sampleJitter, packetLossPercent: Number.isFinite(loss) ? loss : null, nativeProbe }),
+    nativeEvidenceText: nativeProbe ? formatNativeProbeEvidence(nativeProbe) : '',
   }
 }
 
@@ -517,7 +577,7 @@ export function buildPostSessionStreamReport({ stats = {}, logs = '', disconnect
 
 export function buildSupportSelfTestCopy({ network, controller, postSession } = {}) {
   const sections = []
-  if (network) sections.push(['Network Path Tester', network.summary, `Status: ${network.status}`, `Recommended bitrate: ${network.recommendedBitrateKbps || 'unknown'} kbps`].join('\n'))
+  if (network) sections.push(['Network Path Tester', network.summary, `Status: ${network.status}`, `Recommended bitrate: ${network.recommendedBitrateKbps || 'unknown'} kbps`, network.nativeEvidenceText].filter(Boolean).join('\n'))
   if (controller) sections.push(['Controller/Input Tester', controller.summary, `Status: ${controller.status}`].join('\n'))
   if (postSession) sections.push(postSession.copyText || ['Post-session Stream Report', postSession.mainIssue].join('\n'))
   return redactSensitiveText(sections.join('\n\n'))

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -327,6 +327,49 @@ describe('support self-service reports', () => {
     expect(report.checks.find((check) => check.key === 'stream-port').status).toBe('fail')
   })
 
+  it('prefers native server-side network probe evidence when available', () => {
+    const report = buildNetworkPathTestReport({
+      nativeProbe: {
+        targetHost: '100.72.10.4',
+        classification: 'vpn',
+        mdnsAvailable: false,
+        hostReachable: true,
+        samples: { latencyMs: [16, 19, 18], jitterMs: 2, packetLossPercent: 0 },
+        ports: [
+          { key: 'control_https', label: 'Web/control HTTPS', port: 47990, transport: 'tcp', status: 'open' },
+          { key: 'rtsp_setup', label: 'RTSP setup', port: 48010, transport: 'tcp', status: 'closed' },
+          { key: 'video_udp', label: 'Video stream', port: 47998, transport: 'udp', status: 'hint' },
+        ],
+      },
+      currentBitrateKbps: 60000,
+    })
+
+    expect(report.summary).toContain('VPN')
+    expect(report.checks.find((check) => check.key === 'host-reachable').status).toBe('pass')
+    expect(report.checks.find((check) => check.key === 'control-port').detail).toContain('47990/tcp')
+    expect(report.checks.find((check) => check.key === 'stream-port').status).toBe('fail')
+    expect(report.advancedEvidence.nativeProbe).toEqual(expect.objectContaining({ classification: 'vpn' }))
+  })
+
+  it('includes redacted native network evidence in support-copy text', () => {
+    const report = buildNetworkPathTestReport({
+      nativeProbe: {
+        targetHost: '192.168.1.44',
+        classification: 'lan',
+        hostReachable: true,
+        ports: [{ key: 'control_https', label: 'Web/control HTTPS', port: 47990, transport: 'tcp', status: 'open' }],
+        notes: ['token=abc123 should never survive copy'],
+      },
+    })
+
+    const copy = buildSupportSelfTestCopy({ network: report })
+
+    expect(copy).toContain('Native evidence')
+    expect(copy).toContain('Web/control HTTPS 47990/tcp: open')
+    expect(copy).toContain(`token=${REDACTED_VALUE}`)
+    expect(copy).not.toContain('abc123')
+  })
+
   it('summarizes controller input events without requiring hardware-level host evidence', () => {
     const report = buildControllerInputTestReport({
       events: [

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -115,6 +115,7 @@
                 <div>{{ check.detail }}</div>
                 <div class="mt-1 text-ice">{{ check.action }}</div>
               </div>
+              <pre v-if="networkPathReport.nativeEvidenceText" class="whitespace-pre-wrap rounded-lg border border-storm/15 bg-void/50 p-3">{{ networkPathReport.nativeEvidenceText }}</pre>
             </div>
           </details>
         </div>
@@ -469,6 +470,7 @@ const controllerEvents = ref([])
 const controllerRumbleSupported = ref(null)
 const hostPhysicalControllerIsolation = ref('unknown')
 const virtualControllerStatus = ref({ created: false })
+const nativeNetworkPathProbe = ref(null)
 const lastCompletedStreamStats = ref(null)
 const lastDisconnectReason = ref('')
 
@@ -714,6 +716,7 @@ const doctorAdvancedItems = computed(() => {
 })
 
 const networkPathReport = computed(() => buildNetworkPathTestReport({
+  nativeProbe: nativeNetworkPathProbe.value,
   host: streamStats.value?.client_ip || window.location.hostname,
   originHostname: window.location.hostname,
   hostReachable: streamStatsConnected.value,
@@ -907,6 +910,21 @@ function refreshLogs() {
     .catch(error => console.error("Error fetching logs:", error))
 }
 
+function refreshNetworkPathProbe() {
+  fetch("./api/support/network-path-probe", { credentials: 'include' })
+    .then((response) => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      return response.json()
+    })
+    .then((probe) => {
+      nativeNetworkPathProbe.value = probe?.status === false ? null : probe
+    })
+    .catch((error) => {
+      console.error("Error fetching network path probe:", error)
+      nativeNetworkPathProbe.value = null
+    })
+}
+
 function closeApp() {
   closeAppPressed.value = true
   return fetch("./api/apps/close", {
@@ -1081,6 +1099,7 @@ async function collectSupportContext() {
     version: version.value || config.version || 'unknown',
     browser_user_agent: navigator.userAgent,
     stream_stats_connected: streamStatsConnected.value,
+    network_path_probe: nativeNetworkPathProbe.value,
     fix_my_stream_checklist: fixMyStreamChecklist.value,
     session_snapshot: streamStats.value,
     client: {
@@ -1243,6 +1262,7 @@ fetch("/api/config")
 
 logInterval = setInterval(() => { refreshLogs() }, 5000)
 refreshLogs()
+refreshNetworkPathProbe()
 
 onBeforeUnmount(() => {
   clearInterval(logInterval)

--- a/tests/unit/test_network.cpp
+++ b/tests/unit/test_network.cpp
@@ -26,3 +26,30 @@ INSTANTIATE_TEST_SUITE_P(
     std::make_tuple(std::string(128, 'a'), std::string(63, 'a'))
   )
 );
+
+TEST(NetworkPathProbe, ClassifiesNativeProbeHostsWithoutTouchingTheNetwork) {
+  EXPECT_EQ(net::network_path_probe_classification("127.0.0.1"), "pc");
+  EXPECT_EQ(net::network_path_probe_classification("192.168.50.25"), "lan");
+  EXPECT_EQ(net::network_path_probe_classification("fd7a:115c:a1e0::1"), "lan");
+  EXPECT_EQ(net::network_path_probe_classification("203.0.113.40"), "wan");
+  EXPECT_EQ(net::network_path_probe_classification("polaris-host.local"), "lan");
+  EXPECT_EQ(net::network_path_probe_classification("tailscale-host.ts.net"), "vpn");
+}
+
+TEST(NetworkPathProbe, BuildsSafeNormalUserPortContracts) {
+  const auto ports = net::network_path_probe_ports(47989);
+
+  ASSERT_EQ(ports.size(), 5);
+  EXPECT_EQ(ports[0].key, "control_https");
+  EXPECT_EQ(ports[0].transport, "tcp");
+  EXPECT_EQ(ports[0].port, 47990);
+  EXPECT_EQ(ports[1].key, "rtsp_setup");
+  EXPECT_EQ(ports[1].port, 48010);
+  EXPECT_EQ(ports[2].key, "control_udp");
+  EXPECT_EQ(ports[2].transport, "udp");
+  EXPECT_EQ(ports[2].port, 47999);
+  EXPECT_EQ(ports[3].key, "video_udp");
+  EXPECT_EQ(ports[3].port, 47998);
+  EXPECT_EQ(ports[4].key, "audio_udp");
+  EXPECT_EQ(ports[4].port, 48000);
+}


### PR DESCRIPTION
## Summary
- Adds native/server-side network path probe evidence behind the Troubleshooting Network Path Tester.
- Exposes read-only host classification, port contract, local listener checks, and discovery/VPN hints for support reports.
- Keeps probes side-effect-free: no synthetic media, no destructive recovery, no deploy.

## Test Plan
- npm run test -- src_assets/common/assets/web/diagnostics-export.test.js
- npm run test -- src_assets/common/assets/web/diagnostics-export.test.js src_assets/common/assets/web/restart-host.test.js src_assets/common/assets/web/dangerous-action-workflows.test.js
- cmake --build build --target test_polaris_network -j$(nproc) && ctest --test-dir build --output-on-failure -R '^test_polaris_network$'\n- npm run lint\n- npm run build\n- git diff --check\n\n## Guardrails\n- No deploy, public issue comments, secrets, destructive recovery, Steam kill, or gamescope install.