### PR TITLE
feat(support): surface native controller diagnostics

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include "input.h"
 #include "logging.h"
 #include "platform/common.h"
+#include "stream_stats.h"
 #include "thread_pool.h"
 #include "utility.h"
 
@@ -119,6 +120,21 @@ namespace input {
   static int preallocated_gamepad_id {-1};
   static safe::mail_t preallocated_gamepad_mail;
   static platf::feedback_queue_t preallocated_gamepad_feedback_queue;
+
+  void update_controller_diagnostics(bool created,
+                                     int controller_number,
+                                     const std::string &error = {}) {
+    stream_stats::update_controller_input_state(
+      created,
+      created ? controller_number + 1 : 0,
+      config::input.gamepad,
+      error,
+      "unknown",
+      {},
+      config::input.forward_rumble,
+      config::input.forward_rumble ? "Rumble feedback forwarding is enabled for native virtual gamepads." : "Rumble feedback forwarding is disabled in input settings."
+    );
+  }
 
   void free_gamepad(platf::input_t &platf_input, int id) {
     platf::gamepad_update(platf_input, id, platf::gamepad_state_t {});
@@ -222,10 +238,12 @@ namespace input {
 
     if (platf::alloc_gamepad(platf_input, {id, static_cast<std::uint8_t>(controller_number)}, arrival, input->feedback_queue)) {
       free_id(gamepadMask, id);
+      update_controller_diagnostics(false, controller_number, "Native virtual controller allocation failed.");
       return false;
     }
 
     gamepad.id = id;
+    update_controller_diagnostics(true, controller_number);
     if (reason && *reason) {
       BOOST_LOG(info) << "ControllerNumber ["sv << controller_number << "] allocated for "sv << reason;
     }
@@ -255,12 +273,14 @@ namespace input {
     constexpr int controller_number = 0;
     if (platf::alloc_gamepad(platf_input, {id, static_cast<std::uint8_t>(controller_number)}, {}, preallocated_gamepad_feedback_queue)) {
       free_id(gamepadMask, id);
+      update_controller_diagnostics(false, controller_number, "ControllerNumber [0] could not be preallocated before app launch.");
       BOOST_LOG(warning) << "ControllerNumber [0] could not be preallocated before app launch"sv;
       return;
     }
 
     preallocated_controller_number = controller_number;
     preallocated_gamepad_id = id;
+    update_controller_diagnostics(true, controller_number);
     platf::gamepad_update(platf_input, id, {});
     BOOST_LOG(info) << "ControllerNumber [0] preallocated before app launch"sv;
   }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3344,6 +3344,32 @@ namespace proc {
       }
       gamepad_isolation_prepared = true;
       gamepad_isolation_plan = platf::gamepad::isolation::prepare_headless_labwc_launch();
+      auto stats = stream_stats::get_current();
+      std::string isolation_mode = "unknown";
+      switch (gamepad_isolation_plan.mode) {
+        case platf::gamepad::isolation::isolation_mode_e::disabled:
+          isolation_mode = "disabled";
+          break;
+        case platf::gamepad::isolation::isolation_mode_e::strict_bwrap:
+          isolation_mode = "strict_bwrap";
+          break;
+        case platf::gamepad::isolation::isolation_mode_e::best_effort_sdl:
+          isolation_mode = "best_effort_sdl";
+          break;
+        case platf::gamepad::isolation::isolation_mode_e::unavailable:
+          isolation_mode = "unavailable";
+          break;
+      }
+      stream_stats::update_controller_input_state(
+        stats.input_virtual_controller_created,
+        stats.input_virtual_controller_number,
+        stats.input_virtual_controller_kind,
+        stats.input_virtual_controller_error,
+        isolation_mode,
+        gamepad_isolation_plan.reason,
+        stats.input_haptics_supported,
+        stats.input_haptics_detail
+      );
     };
 
     auto apply_gamepad_sdl_env = [&](auto &env) {

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -174,6 +174,16 @@ namespace stream_stats {
     j["adaptive_target_bitrate_kbps"] = adaptive_target_bitrate_kbps;
     j["headless_mode"] = config::video.linux_display.headless_mode;
     j["ai_enabled"] = config::video.ai_optimizer.enabled;
+    j["controller_input"] = {
+      {"virtual_controller_created", input_virtual_controller_created},
+      {"virtual_controller_number", input_virtual_controller_number},
+      {"virtual_controller_kind", input_virtual_controller_kind},
+      {"virtual_controller_error", input_virtual_controller_error},
+      {"host_controller_isolation", input_host_controller_isolation},
+      {"host_controller_isolation_detail", input_host_controller_isolation_detail},
+      {"haptics_supported", input_haptics_supported},
+      {"haptics_detail", input_haptics_detail}
+    };
 
     // Multi-client data
     nlohmann::json clients_json = nlohmann::json::array();
@@ -907,6 +917,25 @@ namespace stream_stats {
     current_stats.hdr_metadata_available = hdr_metadata_available;
     current_stats.stream_hdr_enabled = stream_hdr_enabled;
     current_stats.color_coding = color_coding;
+  }
+
+  void update_controller_input_state(bool virtual_controller_created,
+                                     int virtual_controller_number,
+                                     const std::string &virtual_controller_kind,
+                                     const std::string &virtual_controller_error,
+                                     const std::string &host_controller_isolation,
+                                     const std::string &host_controller_isolation_detail,
+                                     bool haptics_supported,
+                                     const std::string &haptics_detail) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.input_virtual_controller_created = virtual_controller_created;
+    current_stats.input_virtual_controller_number = virtual_controller_number;
+    current_stats.input_virtual_controller_kind = virtual_controller_kind;
+    current_stats.input_virtual_controller_error = virtual_controller_error;
+    current_stats.input_host_controller_isolation = host_controller_isolation.empty() ? "unknown" : host_controller_isolation;
+    current_stats.input_host_controller_isolation_detail = host_controller_isolation_detail;
+    current_stats.input_haptics_supported = haptics_supported;
+    current_stats.input_haptics_detail = haptics_detail;
   }
 
   void update_capture_profile(const capture_profile_sample_t &sample) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -108,6 +108,16 @@ namespace stream_stats {
     // System
     double gpu_usage = 0;
 
+    // Controller/input runtime evidence
+    bool input_virtual_controller_created = false;
+    int input_virtual_controller_number = 0;
+    std::string input_virtual_controller_kind;
+    std::string input_virtual_controller_error;
+    std::string input_host_controller_isolation = "unknown";
+    std::string input_host_controller_isolation_detail;
+    bool input_haptics_supported = false;
+    std::string input_haptics_detail;
+
     // Multi-client
     std::vector<client_stats_t> clients;
 
@@ -321,6 +331,18 @@ namespace stream_stats {
                         bool hdr_metadata_available,
                         bool stream_hdr_enabled,
                         const std::string &color_coding);
+
+  /**
+   * @brief Update native controller/input diagnostics exposed to support self-tests.
+   */
+  void update_controller_input_state(bool virtual_controller_created,
+                                     int virtual_controller_number,
+                                     const std::string &virtual_controller_kind,
+                                     const std::string &virtual_controller_error,
+                                     const std::string &host_controller_isolation,
+                                     const std::string &host_controller_isolation_detail,
+                                     bool haptics_supported,
+                                     const std::string &haptics_detail);
 
   /**
    * @brief Record a single capture timing sample into the shared telemetry sink.

--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -508,24 +508,42 @@ export function buildNetworkPathTestReport(input = {}) {
 export function buildControllerInputTestReport(input = {}) {
   const events = Array.isArray(input.events) ? input.events : []
   const gamepads = Array.isArray(input.gamepads) ? input.gamepads : []
-  const virtual = input.virtualController || {}
-  const hostIsolation = lower(input.hostPhysicalControllerIsolation)
+  const native = input.native || input.controllerInput || input.controller_input || {}
+  const virtual = input.virtualController || {
+    created: native.virtualControllerCreated ?? native.virtual_controller_created,
+    number: native.virtualControllerNumber ?? native.virtual_controller_number,
+    kind: native.virtualControllerKind ?? native.virtual_controller_kind,
+    error: native.virtualControllerError ?? native.virtual_controller_error,
+  }
+  const hostIsolationRaw = native.hostControllerIsolation ?? native.host_controller_isolation ?? input.hostPhysicalControllerIsolation
+  const hostIsolation = lower(hostIsolationRaw)
+  const hostIsolationDetail = native.hostControllerIsolationDetail ?? native.host_controller_isolation_detail
+  const hapticsSupported = native.hapticsSupported ?? native.haptics_supported ?? input.rumbleSupported
+  const hapticsDetail = native.hapticsDetail ?? native.haptics_detail
   const pads = new Set(events.map((event) => event.pad ?? event.gamepadIndex ?? 1))
+  const visiblePadCount = Math.max(pads.size, gamepads.length)
+  const virtualPadLabel = virtual.created
+    ? `Native virtual controller${virtual.number ? ` #${virtual.number}` : ''}${virtual.kind ? ` (${virtual.kind})` : ''} is reported created.`
+    : virtual.error
+      ? redactSensitiveText(virtual.error)
+      : 'Host virtual controller creation has not been confirmed yet.'
+  const isolationPass = ['isolated', 'strict_bwrap', 'best_effort_sdl'].includes(hostIsolation)
+  const isolationFail = ['shared', 'leaking', 'unavailable'].includes(hostIsolation)
   const checks = [
     checklistItem('client-events', 'Client button events', events.length ? 'pass' : 'warning', events.length ? `${events.length} client control event${events.length === 1 ? '' : 's'} detected.` : 'No client button or axis events detected yet.', events.length ? 'Input is reaching the browser/client layer.' : 'Press buttons/sticks on the client controller while this panel is open.'),
-    checklistItem('virtual-controller', 'Virtual controller', virtual.created ? 'pass' : virtual.error ? 'fail' : 'warning', virtual.created ? `Virtual controller${virtual.number ? ` #${virtual.number}` : ''} is reported created.` : virtual.error ? redactSensitiveText(virtual.error) : 'Host virtual controller creation has not been confirmed yet.', virtual.created ? 'Launch a game and verify the same controller number is selected.' : 'If games see no pad, check virtual gamepad permissions/driver state.'),
-    checklistItem('multi-pad', 'Controller number / multi-pad', pads.size > 1 || gamepads.length > 1 ? 'pass' : 'warning', `${Math.max(pads.size, gamepads.length)} client pad${Math.max(pads.size, gamepads.length) === 1 ? '' : 's'} visible.`, 'Keep controller order stable before starting split-screen or multi-pad games.'),
-    checklistItem('rumble', 'Rumble / haptics', input.rumbleSupported === true ? 'pass' : input.rumbleSupported === false ? 'warning' : 'warning', input.rumbleSupported === true ? 'Rumble actuator test is available.' : 'Rumble/haptics support is not available or not exposed by this browser/client.', input.rumbleSupported === true ? 'Use the optional rumble pulse only after input is mapped correctly.' : 'Treat missing rumble as non-blocking unless the game requires it.'),
-    checklistItem('host-isolation', 'Host physical controller isolation', hostIsolation === 'isolated' ? 'pass' : hostIsolation === 'shared' || hostIsolation === 'leaking' ? 'fail' : 'warning', hostIsolation === 'isolated' ? 'Host physical controllers are reported isolated from client virtual pads.' : hostIsolation ? `Isolation state: ${input.hostPhysicalControllerIsolation}.` : 'Host physical controller isolation has not been reported yet.', hostIsolation === 'isolated' ? 'No host-side controller conflict stands out.' : 'If inputs double-fire, unplug/disable the host physical controller or isolate it before retesting.'),
+    checklistItem('virtual-controller', 'Native virtual controller', virtual.created ? 'pass' : virtual.error ? 'fail' : 'warning', virtualPadLabel, virtual.created ? 'Launch a game and verify the same controller number is selected.' : 'If games see no pad, check virtual gamepad permissions/driver state.'),
+    checklistItem('multi-pad', 'Controller number / multi-pad', visiblePadCount > 1 ? 'pass' : 'warning', `${visiblePadCount} client pad${visiblePadCount === 1 ? '' : 's'} visible${virtual.number ? `; native virtual pad #${virtual.number}` : ''}.`, 'Keep controller order stable before starting split-screen or multi-pad games.'),
+    checklistItem('rumble', 'Rumble / haptics', hapticsSupported === true ? 'pass' : 'warning', hapticsSupported === true ? (hapticsDetail || 'Rumble/haptics feedback is available for the native virtual controller.') : 'Rumble/haptics support is not available or not exposed by this browser/client.', hapticsSupported === true ? 'Use the optional rumble pulse only after input is mapped correctly.' : 'Treat missing rumble as non-blocking unless the game requires it.'),
+    checklistItem('host-isolation', 'Host physical controller isolation', isolationPass ? 'pass' : isolationFail ? 'fail' : 'warning', isolationPass ? `Isolation state: ${hostIsolationRaw}${hostIsolationDetail ? ` — ${hostIsolationDetail}` : ''}.` : hostIsolation ? `Isolation state: ${hostIsolationRaw}${hostIsolationDetail ? ` — ${hostIsolationDetail}` : ''}.` : 'Host physical controller isolation has not been reported yet.', isolationPass ? 'No host-side controller conflict stands out.' : 'If inputs double-fire, unplug/disable the host physical controller or isolate it before retesting.'),
   ]
   const status = worstStatus(checks.filter((check) => check.key !== 'rumble'))
   return {
     kind: 'controller-input-test',
     status,
     classification: status === 'pass' ? 'clean' : 'client',
-    summary: events.length ? `${events.length} client control event${events.length === 1 ? '' : 's'} captured; virtual pad ${virtual.created ? 'created' : 'not confirmed'}.` : 'Waiting for client controller input.',
+    summary: events.length ? `${events.length} client control event${events.length === 1 ? '' : 's'} captured; native virtual pad ${virtual.created ? `#${virtual.number || '?'}` : 'not confirmed'}.` : 'Waiting for client controller input.',
     checks,
-    advancedEvidence: sanitizeDiagnosticsValue({ events: events.slice(-12), gamepads, virtualController: virtual, hostPhysicalControllerIsolation: input.hostPhysicalControllerIsolation }),
+    advancedEvidence: sanitizeDiagnosticsValue({ events: events.slice(-12), gamepads, native, virtualController: virtual, hostPhysicalControllerIsolation: hostIsolationRaw }),
   }
 }
 

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -370,23 +370,32 @@ describe('support self-service reports', () => {
     expect(copy).not.toContain('abc123')
   })
 
-  it('summarizes controller input events without requiring hardware-level host evidence', () => {
+  it('summarizes controller input events with native virtual pad, isolation, and haptics evidence', () => {
     const report = buildControllerInputTestReport({
       events: [
         { pad: 1, control: 'A', type: 'buttondown' },
         { pad: 2, control: 'Left Stick', type: 'axis', value: 0.74 },
       ],
       gamepads: [{ index: 0, id: 'Xbox Wireless Controller' }, { index: 1, id: 'DualSense' }],
-      virtualController: { created: true, number: 2 },
-      rumbleSupported: false,
-      hostPhysicalControllerIsolation: 'isolated',
+      native: {
+        virtualControllerCreated: true,
+        virtualControllerNumber: 2,
+        virtualControllerKind: 'xone',
+        hostControllerIsolation: 'strict_bwrap',
+        hostControllerIsolationDetail: '2 virtual nodes allowed; host pads masked',
+        hapticsSupported: true,
+        hapticsDetail: 'rumble callbacks registered for client pad 2',
+      },
     })
 
     expect(report.status).toBe('pass')
     expect(report.summary).toContain('2 client control events')
+    expect(report.summary).toContain('native virtual pad #2')
     expect(report.checks.find((check) => check.key === 'multi-pad').detail).toContain('2 client pads')
-    expect(report.checks.find((check) => check.key === 'rumble').status).toBe('warning')
+    expect(report.checks.find((check) => check.key === 'rumble').status).toBe('pass')
     expect(report.checks.find((check) => check.key === 'host-isolation').status).toBe('pass')
+    expect(report.checks.find((check) => check.key === 'host-isolation').detail).toContain('strict_bwrap')
+    expect(report.advancedEvidence.native.virtualControllerKind).toBe('xone')
   })
 
   it('builds a post-session report with issue owner and next launch profile', () => {

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -129,6 +129,7 @@
           <div class="mt-3 flex flex-wrap gap-2">
             <button class="focus-ring troubleshooting-action-button troubleshooting-action-button-secondary" @click="refreshControllerSnapshot">Detect controller</button>
             <button class="focus-ring troubleshooting-action-button troubleshooting-action-button-secondary" @click="recordControllerEvent('A / primary button', 1)">Log A press</button>
+            <button class="focus-ring troubleshooting-action-button troubleshooting-action-button-secondary" :disabled="controllerRumbleSupported !== true" @click="pulseControllerHaptics">Test rumble</button>
           </div>
           <details class="mt-3 text-xs text-storm">
             <summary class="cursor-pointer text-ice">Advanced evidence</summary>
@@ -468,8 +469,6 @@ const pendingConfirmedAction = ref(null)
 const requestedConfirmAction = ref(null)
 const controllerEvents = ref([])
 const controllerRumbleSupported = ref(null)
-const hostPhysicalControllerIsolation = ref('unknown')
-const virtualControllerStatus = ref({ created: false })
 const nativeNetworkPathProbe = ref(null)
 const lastCompletedStreamStats = ref(null)
 const lastDisconnectReason = ref('')
@@ -738,12 +737,13 @@ const browserGamepads = computed(() => {
   }))
 })
 
+const controllerNativeEvidence = computed(() => streamStats.value?.controller_input || {})
+
 const controllerInputReport = computed(() => buildControllerInputTestReport({
   events: controllerEvents.value,
   gamepads: browserGamepads.value,
-  virtualController: virtualControllerStatus.value,
+  native: controllerNativeEvidence.value,
   rumbleSupported: controllerRumbleSupported.value,
-  hostPhysicalControllerIsolation: hostPhysicalControllerIsolation.value,
 }))
 
 const postSessionReport = computed(() => buildPostSessionStreamReport({
@@ -781,18 +781,28 @@ function recordControllerEvent(label, pad = 1) {
     ...controllerEvents.value.slice(-15),
     { pad, control: label, type: 'manual', at: new Date().toISOString() },
   ]
-  virtualControllerStatus.value = { created: true, number: pad }
 }
 
 function refreshControllerSnapshot() {
   const pads = browserGamepads.value
   if (pads.length) {
-    virtualControllerStatus.value = { created: true, number: pads[0].index + 1 }
     controllerRumbleSupported.value = Boolean(navigator.getGamepads?.()[pads[0].index]?.vibrationActuator)
     recordControllerEvent('Browser gamepad visible', pads[0].index + 1)
   } else {
     recordControllerEvent('Manual button sample', 1)
   }
+}
+
+async function pulseControllerHaptics() {
+  const pad = navigator.getGamepads?.().find((candidate) => candidate?.vibrationActuator)
+  if (!pad?.vibrationActuator?.playEffect) return
+  await pad.vibrationActuator.playEffect('dual-rumble', {
+    duration: 180,
+    strongMagnitude: 0.35,
+    weakMagnitude: 0.25,
+  })
+  controllerRumbleSupported.value = true
+  recordControllerEvent('Optional rumble pulse', pad.index + 1)
 }
 
 function copySupportSelfTests() {

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -131,6 +131,29 @@ TEST(StreamStatsLinuxGpuProfileTests, WarnsWhenNvidiaTrueHeadlessDisablesGpuNati
   );
 }
 
+TEST(StreamStatsControllerInputTests, SerializesNativeControllerDiagnostics) {
+  stream_stats::stats_t stats {};
+  stats.input_virtual_controller_created = true;
+  stats.input_virtual_controller_number = 2;
+  stats.input_virtual_controller_kind = "xone";
+  stats.input_virtual_controller_error = "";
+  stats.input_host_controller_isolation = "strict_bwrap";
+  stats.input_host_controller_isolation_detail = "2 virtual nodes allowed; host pads masked";
+  stats.input_haptics_supported = true;
+  stats.input_haptics_detail = "rumble callbacks registered for client pad 2";
+
+  const auto json = nlohmann::json::parse(stats.to_json());
+
+  ASSERT_TRUE(json.contains("controller_input"));
+  const auto &input = json.at("controller_input");
+  EXPECT_TRUE(input.at("virtual_controller_created"));
+  EXPECT_EQ(input.at("virtual_controller_number"), 2);
+  EXPECT_EQ(input.at("virtual_controller_kind"), "xone");
+  EXPECT_EQ(input.at("host_controller_isolation"), "strict_bwrap");
+  EXPECT_EQ(input.at("host_controller_isolation_detail"), "2 virtual nodes allowed; host pads masked");
+  EXPECT_TRUE(input.at("haptics_supported"));
+  EXPECT_EQ(input.at("haptics_detail"), "rumble callbacks registered for client pad 2");
+}
 
 TEST(StreamStatsHdrStateTests, LabelsRequestedHdrWithoutSourceAsTenBitSdr) {
   stream_stats::stats_t stats {};


### PR DESCRIPTION
## Summary
- Surfaces native/runtime controller diagnostics for the Controller/Input Tester.
- Adds virtual controller creation evidence, host controller isolation state, multi-pad clarity, and haptics capability detail.
- Keeps UI normal-user first with advanced evidence expandable and no destructive host actions.

## Test Plan
- npm run test -- src_assets/common/assets/web/diagnostics-export.test.js
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_FULL_TESTS=ON -DPOLARIS_ENABLE_CUDA=OFF -DCUDA_FAIL_ON_MISSING=OFF -DPOLARIS_ALLOW_CUDA_DISABLED_ON_NVIDIA=ON
- cmake --build build --target test_polaris_stream -j$(nproc)
- ./build/tests/test_polaris_stream
- npm run lint
- npm run build
- git diff --check

## Guardrails
- No deploy, public issue comments, secrets, destructive recovery, desktop Steam kill, or gamescope install.