### PR TITLE
fix(linux): fall back after headless DMA-BUF conversion failure

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -520,7 +520,22 @@ namespace cage_display_router {
       return false;
     }
 
+    if (auto cached_result = cached_headless_extcopy_dmabuf_probe_result();
+        cached_result && !*cached_result) {
+      return false;
+    }
+
     return hwdevice_type == platf::mem_type_e::cuda;
+  }
+
+  bool should_disable_headless_extcopy_after_conversion_failure(
+    const platf::runtime_state_t &runtime_state,
+    const platf::frame_metadata_t &source_metadata
+  ) {
+    return runtime_state.effective_headless &&
+           !runtime_state.gpu_native_override_active &&
+           source_metadata.transport == platf::frame_transport_e::dmabuf &&
+           source_metadata.residency == platf::frame_residency_e::gpu;
   }
 
   std::optional<bool> cached_windowed_gpu_native_probe_result() {

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -141,6 +141,15 @@ namespace cage_display_router {
   );
 
   /**
+   * @brief Returns whether a live frame conversion failure should disable the
+   *        true-headless ext-image-copy-capture DMA-BUF path and retry with SHM.
+   */
+  bool should_disable_headless_extcopy_after_conversion_failure(
+    const platf::runtime_state_t &runtime_state,
+    const platf::frame_metadata_t &source_metadata
+  );
+
+  /**
    * @brief Returns the cached result of the windowed GPU-native probe for the
    *        current Polaris process, if one exists.
    */

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -431,6 +431,25 @@ namespace video {
           return {};
       }
     }
+
+    bool handle_headless_extcopy_conversion_failure(const frame_t &frame) {
+      if (!::config::video.linux_display.use_cage_compositor || !cage_display_router::is_running()) {
+        return false;
+      }
+
+      const auto runtime_state = cage_display_router::runtime_state();
+      if (!cage_display_router::should_disable_headless_extcopy_after_conversion_failure(
+            runtime_state,
+            frame.source_metadata
+          )) {
+        return false;
+      }
+
+      cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+      BOOST_LOG(warning)
+        << "Headless ext-image-copy-capture DMA-BUF frame conversion failed; disabling headless DMA-BUF capture and reinitializing with SHM/system-memory fallback"sv;
+      return true;
+    }
 #endif
 
     std::string_view color_coding_label(const sunshine_colorspace_t &colorspace) {
@@ -1359,6 +1378,7 @@ namespace video {
     std::thread capture_thread;
 
     safe::signal_t reinit_event;
+    safe::signal_t reinit_request_event;
     const encoder_t *encoder_p;
     sync_util::sync_t<std::weak_ptr<platf::display_t>> display_wp;
   };
@@ -2046,6 +2066,7 @@ namespace video {
     std::shared_ptr<safe::queue_t<capture_ctx_t>> capture_ctx_queue,
     sync_util::sync_t<std::weak_ptr<platf::display_t>> &display_wp,
     safe::signal_t &reinit_event,
+    safe::signal_t &reinit_request_event,
     const encoder_t &encoder
   ) {
     std::vector<capture_ctx_t> capture_ctxs;
@@ -2226,6 +2247,11 @@ namespace video {
           return false;
         }
 
+        if (reinit_request_event.peek()) {
+          artificial_reinit = true;
+          return false;
+        }
+
         return true;
       };
 
@@ -2308,6 +2334,7 @@ namespace video {
 
             display_wp = disp;
 
+            reinit_request_event.reset();
             reinit_event.reset();
             continue;
           }
@@ -2944,6 +2971,7 @@ namespace video {
     std::shared_ptr<platf::display_t> disp,
     std::unique_ptr<platf::encode_device_t> encode_device,
     safe::signal_t &reinit_event,
+    safe::signal_t &reinit_request_event,
     const encoder_t &encoder,
     void *channel_data,
     packet_queue_t packets
@@ -3133,6 +3161,11 @@ namespace video {
 
           if (session->convert(frame)) {
             BOOST_LOG(error) << "Could not convert image"sv;
+#ifdef __linux__
+            if (handle_headless_extcopy_conversion_failure(frame)) {
+              reinit_request_event.raise(true);
+            }
+#endif
             break;
           }
 
@@ -3502,6 +3535,12 @@ namespace video {
 
           if (frame_captured && frame.valid() && pos->session->convert(frame)) {
             BOOST_LOG(error) << "Could not convert image"sv;
+#ifdef __linux__
+            if (handle_headless_extcopy_conversion_failure(frame)) {
+              ec = platf::capture_e::reinit;
+              return false;
+            }
+#endif
             ctx->shutdown_event->raise(true);
 
             continue;
@@ -3615,7 +3654,7 @@ namespace video {
 
     while (!shutdown_event->peek() && images->running()) {
       // Wait for the main capture event when the display is being reinitialized
-      if (ref->reinit_event.peek()) {
+      if (ref->reinit_event.peek() || ref->reinit_request_event.peek()) {
         std::this_thread::sleep_for(20ms);
         continue;
       }
@@ -3651,6 +3690,7 @@ namespace video {
         display,
         std::move(encode_device),
         ref->reinit_event,
+        ref->reinit_request_event,
         *ref->encoder_p,
         channel_data,
         packets
@@ -4440,6 +4480,7 @@ namespace video {
   int start_capture_async(capture_thread_async_ctx_t &capture_thread_ctx) {
     capture_thread_ctx.encoder_p = chosen_encoder;
     capture_thread_ctx.reinit_event.reset();
+    capture_thread_ctx.reinit_request_event.reset();
 
     capture_thread_ctx.capture_ctx_queue = std::make_shared<safe::queue_t<capture_ctx_t>>(30);
 
@@ -4448,6 +4489,7 @@ namespace video {
       capture_thread_ctx.capture_ctx_queue,
       std::ref(capture_thread_ctx.display_wp),
       std::ref(capture_thread_ctx.reinit_event),
+      std::ref(capture_thread_ctx.reinit_request_event),
       std::ref(*capture_thread_ctx.encoder_p)
     };
 

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -139,6 +139,63 @@ TEST(CageDisplayRouterPolicyTests, WindowedOverrideDoesNotAttemptHeadlessExtcopy
   ));
 }
 
+TEST(CageDisplayRouterPolicyTests, HeadlessDmabufGpuConversionFailureDisablesExtcopyFallback) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = true,
+    .gpu_native_override_active = false,
+    .backend_name = "labwc",
+  };
+  const platf::frame_metadata_t metadata {
+    .transport = platf::frame_transport_e::dmabuf,
+    .residency = platf::frame_residency_e::gpu,
+    .format = platf::frame_format_e::bgra8,
+  };
+
+  EXPECT_TRUE(cage_display_router::should_disable_headless_extcopy_after_conversion_failure(
+    runtime_state,
+    metadata
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, NonHeadlessDmabufConversionFailureDoesNotDisableExtcopyFallback) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+  const platf::frame_metadata_t metadata {
+    .transport = platf::frame_transport_e::dmabuf,
+    .residency = platf::frame_residency_e::gpu,
+    .format = platf::frame_format_e::bgra8,
+  };
+
+  EXPECT_FALSE(cage_display_router::should_disable_headless_extcopy_after_conversion_failure(
+    runtime_state,
+    metadata
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, CpuFrameConversionFailureDoesNotDisableExtcopyFallback) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = true,
+    .gpu_native_override_active = false,
+    .backend_name = "labwc",
+  };
+  const platf::frame_metadata_t metadata {
+    .transport = platf::frame_transport_e::shm,
+    .residency = platf::frame_residency_e::cpu,
+    .format = platf::frame_format_e::bgra8,
+  };
+
+  EXPECT_FALSE(cage_display_router::should_disable_headless_extcopy_after_conversion_failure(
+    runtime_state,
+    metadata
+  ));
+}
+
 TEST(CageDisplayRouterPolicyTests, RequestedHeadlessWithoutOverrideStillReportsHeadlessFallback) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,
@@ -246,6 +303,28 @@ TEST(CageDisplayRouterPolicyTests, HeadlessExtcopyDmabufProbeRequiresLiveFrameCo
   EXPECT_FALSE(cage_display_router::headless_extcopy_dmabuf_probe_succeeded(false, false));
   EXPECT_FALSE(cage_display_router::headless_extcopy_dmabuf_probe_succeeded(true, false));
   EXPECT_TRUE(cage_display_router::headless_extcopy_dmabuf_probe_succeeded(true, true));
+}
+
+TEST(CageDisplayRouterPolicyTests, HeadlessExtcopyDmabufProbeFailureSuppressesRetry) {
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = true,
+    .gpu_native_override_active = false,
+    .backend_name = "labwc",
+  };
+
+  EXPECT_TRUE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
+    runtime_state,
+    platf::mem_type_e::cuda
+  ));
+
+  cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+
+  EXPECT_FALSE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
+    runtime_state,
+    platf::mem_type_e::cuda
+  ));
 }
 
 TEST(CageDisplayRouterPolicyTests, MangoHudPrefixIsSuppressedForSteamBigPicture) {


### PR DESCRIPTION
## Summary
- Detect headless ext-image-copy DMA-BUF GPU-frame conversion failures after capture starts.
- Mark the headless DMA-BUF path unavailable and reinitialize capture so Polaris can fall back to SHM/system-memory capture instead of looping on black/no-video frames.
- Add focused policy tests so the fallback only applies to effective-headless GPU DMA-BUF frames and suppresses retrying the broken path.

Fixes #189

## Test Plan
- [x] `cmake --build build --target test_polaris_platform`
- [x] `./build/tests/test_polaris_platform --gtest_filter='*CageDisplayRouter*'`
- [x] `./build/tests/test_polaris_platform`
- [x] `./build/tests/test_polaris_video`
- [x] `cmake --build build --parallel "$(nproc)"`
- [x] `npm run test`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`