### PR TITLE
chore(release): prepare Polaris v1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.2.1
+project(Polaris VERSION 1.3.0
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/README.md
+++ b/README.md
@@ -88,15 +88,16 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at `https://localhost:<port + 1>`. If you want background autostart, enable the user service with `systemctl --user enable --now polaris`.
 
-## What is New in v1.2.1
+## What is New in v1.3.0
 
-Polaris v1.2.1 is a reliability patch for Linux hosts and Moonlight-compatible newcomers: fewer Settings save goblins, clearer capture/audio diagnostics, and better Arch/CachyOS support breadcrumbs.
+Polaris v1.3.0 turns the web console into a stronger self-service streaming cockpit: diagnose the host and live path, plan display modes before launch, see updates without spelunking GitHub, and recover more cleanly from Linux capture-environment drift.
 
-- **Portable Chrome is the new visual baseline**: Mission Control now uses a smoked graphite / dim Moonlight-grey skin with restrained green status accents.
-- **Private streams are safer by default**: Polaris and Nova coordinate launch intent so handheld launches do not silently reuse desktop Steam or expose games on the physical monitor.
-- **Mission Control tells the truth**: stream quality, latency, FPS, packet loss, bitrate, capture path, runtime mode, and host-affecting actions are easier to scan and act on.
-- **Trusted Nova clients get the right permissions**: Game Control pairing can grant browse, launch, and input without broad clipboard, file-transfer, or server-command access.
-- **Linux capture diagnostics improved**: CUDA/GPU-native, DMA-BUF fallback, virtual-display preservation, VAAPI/headless behavior, and downgrade reasons are surfaced more clearly.
+- **Polaris Doctor and support reports**: deterministic host, stream, and post-session findings now drive privacy-safe support bundles, self-tests, and issue drafts; optional AI explanations translate the evidence without replacing it.
+- **Network and controller truth**: native probes surface route, reachability, latency, packet loss, controller isolation, and haptics evidence so support can stop blaming the nearest random subsystem.
+- **Display planning before launch**: the resolution planner compares client requests, host capabilities, capture constraints, and output modes before a stream starts.
+- **Update Center**: Mission Control can check release metadata and expose package-aware update guidance without silently mutating the host.
+- **More resilient Linux capture**: stale desktop environment values self-heal, while headless DMA-BUF conversion failures fall back instead of stranding the session.
+- **Clearer GPU guidance**: public docs now explain NVIDIA, AMD/VAAPI, GPU-native, and fallback behavior with less vendor-specific fog.
 See the [changelog](docs/changelog.md) for the full release history.
 
 ## Install

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,21 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+## v1.3.0 - 2026-07-11
+
+Feature release focused on self-service stream diagnostics, safer release visibility, display planning, and more resilient Linux capture startup.
+
+- Added a manual Update Center with release metadata, package guidance, and a visible update call to action in the web console
+- Added deterministic Polaris Doctor diagnostics and privacy-safe support reports for host readiness, active streams, and post-session troubleshooting
+- Added optional AI Doctor explanations that translate deterministic findings without replacing the local-first diagnostic source of truth
+- Added native network-path probes for route, latency, packet-loss, and reachability evidence in support workflows
+- Added native controller, isolation, and haptics diagnostics so input-path failures can be separated from client or game behavior
+- Added a display resolution planner that explains requested, host, capture, and output-mode compatibility before launch
+- Expanded Mission Control and Troubleshooting self-tests, support bundles, and issue-draft generation with clearer remediation steps
+- Improved Linux desktop capture startup by self-healing stale Wayland, display, and session-bus environment values
+- Hardened headless DMA-BUF capture so conversion failures fall back cleanly instead of leaving private streams stranded
+- Clarified NVIDIA, AMD/VAAPI, GPU-native, and fallback guidance across the public setup and troubleshooting docs
+
 ## v1.2.1 - 2026-07-10
 
 Patch release focused on CachyOS/Arch Settings reliability, Linux audio/capture diagnostics, and safer Moonlight-compatible host troubleshooting.


### PR DESCRIPTION
## Summary
- bump Polaris to v1.3.0
- promote the diagnostics, Update Center, display planner, and Linux capture resilience work into the public changelog
- refresh the README release headline

## Test plan
- [x] npm run lint
- [x] npm run test (182 tests)
- [x] npm run build-clean
- [x] npm run budget:web
- [x] cmake native test_polaris (CPU-only verification configuration)
- [x] scripts/check-public-docs.sh
- [x] git diff --check