### PR TITLE
chore(release): prepare Polaris v1.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.3.0
+project(Polaris VERSION 1.3.1
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/README.md
+++ b/README.md
@@ -88,16 +88,15 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at `https://localhost:<port + 1>`. If you want background autostart, enable the user service with `systemctl --user enable --now polaris`.
 
-## What is New in v1.3.0
+## What is New in v1.3.1
 
-Polaris v1.3.0 turns the web console into a stronger self-service streaming cockpit: diagnose the host and live path, plan display modes before launch, see updates without spelunking GitHub, and recover more cleanly from Linux capture-environment drift.
+Polaris v1.3.1 is a focused security and pairing-state patch: current Browser Stream cryptography dependencies, stronger client authorization persistence, and clearer paired-device history without changing the streaming workflow.
 
-- **Polaris Doctor and support reports**: deterministic host, stream, and post-session findings now drive privacy-safe support bundles, self-tests, and issue drafts; optional AI explanations translate the evidence without replacing it.
-- **Network and controller truth**: native probes surface route, reachability, latency, packet loss, controller isolation, and haptics evidence so support can stop blaming the nearest random subsystem.
-- **Display planning before launch**: the resolution planner compares client requests, host capabilities, capture constraints, and output modes before a stream starts.
-- **Update Center**: Mission Control can check release metadata and expose package-aware update guidance without silently mutating the host.
-- **More resilient Linux capture**: stale desktop environment values self-heal, while headless DMA-BUF conversion failures fall back instead of stranding the session.
-- **Clearer GPU guidance**: public docs now explain NVIDIA, AMD/VAAPI, GPU-native, and fallback behavior with less vendor-specific fog.
+- **Browser Stream security refresh**: current Go cryptography and supporting modules clear the dependency alerts previously attached to the helper dependency graph.
+- **Added and Last seen timestamps**: newly paired and authenticated clients expose localized history while legacy records remain honestly labeled as not recorded.
+- **Fail-closed client authorization**: canonical certificate identity, revocation, duplicate-state validation, and request-time authorization snapshots are hardened.
+- **Safer state persistence**: paired-client records use private atomic replacement across processes on supported POSIX and Windows hosts.
+- **Truthful client controls**: failed paired-client mutations remain visible instead of being presented as successful in the web console.
 See the [changelog](docs/changelog.md) for the full release history.
 
 ## Install

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,16 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+## v1.3.1 - 2026-07-12
+
+Security and pairing-state patch focused on current cryptography dependencies, durable client authorization, and clearer paired-device history.
+
+- Updated the Browser Stream helper's Go cryptography and supporting modules, clearing the associated Dependabot alerts
+- Added localized Added and Last seen values for paired clients while keeping unknown timestamps truthful for legacy records
+- Hardened canonical X.509 client identity, revocation, duplicate-state validation, and authenticated request-time authorization snapshots
+- Hardened paired-client persistence across processes with private atomic state replacement on supported POSIX and Windows hosts
+- Improved paired-client controls so failed mutations remain visible instead of reporting false success in the web console
+
 ## v1.3.0 - 2026-07-11
 
 Feature release focused on self-service stream diagnostics, safer release visibility, display planning, and more resilient Linux capture startup.


### PR DESCRIPTION
## Summary
- bump Polaris release version to `1.3.1`
- document the Browser Stream cryptography refresh and cleared dependency alerts
- document paired-client timestamp visibility plus fail-closed authorization and atomic persistence hardening

## Scope
This patch contains the two commits already merged after `v1.3.0`:
- `70243f08` — browser helper crypto module refresh (#199)
- `86a66fdd` — paired and last-seen timestamps with authorization-state hardening (#201)

It does not include planned v1.3.2 display/audio/lifecycle/updater work or v1.3.3 UI/accessibility/performance work.

## Verification
- [x] current-master Build Polaris workflow green on exact base `86a66fdd` (web, sanitizer, Fedora 42/43/44, Ubuntu, Arch)
- [x] `npm audit` — 0 vulnerabilities
- [x] web tests — 192/192 passed
- [x] ESLint passed
- [x] production Vite build passed
- [x] web performance budget passed
- [x] Browser Stream helper `go mod verify`, `go test ./...`, and linked-worktree build passed
- [x] public docs and public surface checks passed
- [x] `git diff --check`
- [x] independent fail-closed review passed exact staged diff SHA-256 `60314049fad370aa7dcb585a9e9a1a61dbd290cb3b9a93cca5f98d587257aa85`
- [x] local CPU native build plus 12/12 CTest suites
- [x] local CUDA native build plus 12/12 CTest suites
- [x] local CPack RPM metadata/payload gate
- [ ] fresh PR CI on final commit

## Release
After merge and fresh remote-tree verification, tag the exact merged commit as `v1.3.1`. The tag workflow builds Fedora 42/43/44, Ubuntu 24.04, and Arch assets. Published assets and checksums will be verified before installing the Fedora 44 RPM on pc-papi.
