### PR TITLE
docs: clarify v1.3.1 wording and Linux-only scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="docs/screenshots/logo-polaris.svg" width="72" alt="Polaris" />
 
 # Polaris
-**Self-hosted game streaming for Linux.**
+**Linux-only, self-hosted game streaming. Free, open source, and community-driven.**
 
 Stream PC games to Nova and Moonlight clients without letting the stream take
 over your desktop. Polaris combines an isolated Linux compositor runtime,
@@ -27,7 +27,11 @@ what the host is actually doing.
 </div>
 
 > [!IMPORTANT]
-> Polaris is a Linux host today. Fedora 42/43/44 and Arch Linux are the recommended package paths. CachyOS generally follows the Arch package path; Bazzite and Ubuntu 24.04 are tester package paths; openSUSE Tumbleweed builds from source with a dedicated guide.
+> **Polaris is Linux-only by design and will remain that way.** Windows and macOS host ports are not on the roadmap. Linux is not a secondary build target here; it is the reason the project exists.
+>
+> Polaris is and will remain free and open source under GPLv3. It is maintainer-led and community-driven: development happens in public, contributions are welcome, and real Linux hardware testing and user feedback shape the roadmap.
+>
+> Fedora 42/43/44 and Arch Linux are the recommended package paths. CachyOS generally follows the Arch package path; Bazzite and Ubuntu 24.04 are tester package paths; openSUSE Tumbleweed builds from source with a dedicated guide.
 
 > [!NOTE]
 > Start with **Headless Stream** if you want games to launch into a stream-only runtime without changing your KDE, GNOME, or wlroots desktop layout.
@@ -124,7 +128,7 @@ Detailed source builds, local Arch package builds, distro dependency lists, open
 
 | Area | Status | Notes |
 |---|---|---|
-| Linux host OS | Supported | Polaris is Linux-first today |
+| Linux host OS | Supported | Polaris is Linux-only by design; Linux is the product focus, not a secondary target |
 | Fedora 42/43/44 | Recommended | Official RPM assets and most validated release path |
 | Arch Linux | Recommended | Official package asset |
 | CachyOS / Arch derivatives | Expected via Arch package | Pacman-compatible derivatives should start here; report derivative-specific dependency/runtime gaps |
@@ -152,7 +156,7 @@ If you want the smoothest first run, start here:
 
 ## Known Limitations
 
-- Polaris is not a Windows host today. Linux is the supported platform.
+- Polaris is a Linux-only host. Windows and macOS host ports are not planned.
 - Fedora and Arch are the most validated package paths; CachyOS should use the Arch path first, but derivative-specific issues still need reports.
 - Bazzite support is experimental. Desktop Mode has Headless Stream validation on NVIDIA and growing AMD/Mesa VAAPI coverage; real Steam/Game Mode and Steam Deck client flows need more hardware reports.
 - Ubuntu 24.04 DEB packaging is experimental; other Debian-family distros are still source-build oriented.
@@ -462,7 +466,7 @@ trust boundaries, and release quality.
 
 ## Contributing
 
-Contributions are welcome, especially focused fixes, docs, translations, packaging improvements, and careful feature work. Polaris is still a small maintainer-led project, so the easiest pull requests to review are the ones that explain the problem clearly and keep the change scoped.
+Contributions are welcome, especially focused fixes, docs, translations, packaging improvements, real-hardware testing, and careful feature work. Polaris is still a small maintainer-led project, so the easiest pull requests to review are the ones that explain the problem clearly, keep the change scoped, and say what was tested on Linux.
 
 1. Fork the repo and branch from `master`.
 2. Make your changes and test them locally.
@@ -473,7 +477,7 @@ Contributions are welcome, especially focused fixes, docs, translations, packagi
 > [!NOTE]
 > The web UI lives in `src_assets/common/assets/web/` and uses Vue 3 with Tailwind CSS v4. The backend lives in `src/`. CMake builds both together.
 
-Polaris is a spare-time project built to make Linux game streaming safer, clearer, and easier to trust. If it becomes part of your setup, that alone makes my day. Bug reports, testing notes, and thoughtful feedback help too.
+Polaris is a spare-time project and my way of giving something back to Linux gaming and open source. The best donation anyone can give is time: test Polaris on your hardware, write a clear bug report, improve docs or translations, review an issue, contribute a focused fix, or help another open source project that matters to you. No pressure, no guilt; if all you do is use Polaris and enjoy it, that already means a lot.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Polaris v1.3.1 is a focused security and pairing-state patch: current Browser St
 - **Browser Stream security refresh**: current Go cryptography and supporting modules clear the dependency alerts previously attached to the helper dependency graph.
 - **Added and Last seen timestamps**: newly paired and authenticated clients expose localized history while legacy records remain honestly labeled as not recorded.
 - **Fail-closed client authorization**: canonical certificate identity, revocation, duplicate-state validation, and request-time authorization snapshots are hardened.
-- **Safer state persistence**: paired-client records use private atomic replacement across processes on supported POSIX and Windows hosts.
+- **Safer state persistence**: paired-client records use private, cross-process atomic state replacement.
 - **Truthful client controls**: failed paired-client mutations remain visible instead of being presented as successful in the web console.
 See the [changelog](docs/changelog.md) for the full release history.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,7 @@ Security and pairing-state patch focused on current cryptography dependencies, d
 - Updated the Browser Stream helper's Go cryptography and supporting modules, clearing the associated Dependabot alerts
 - Added localized Added and Last seen values for paired clients while keeping unknown timestamps truthful for legacy records
 - Hardened canonical X.509 client identity, revocation, duplicate-state validation, and authenticated request-time authorization snapshots
-- Hardened paired-client persistence across processes with private atomic state replacement on supported POSIX and Windows hosts
+- Hardened paired-client persistence with private, cross-process atomic state replacement
 - Improved paired-client controls so failed mutations remain visible instead of reporting false success in the web console
 
 ## v1.3.0 - 2026-07-11


### PR DESCRIPTION
## Summary
- remove wording that could imply Polaris supports Windows hosts
- declare Polaris Linux-only by design, with no Windows or macOS host ports planned
- state prominently that Polaris will remain free and open source under GPLv3
- reinforce its maintainer-led, community-driven development model
- preserve cross-platform Moonlight client compatibility while keeping the host Linux-only

## Community
Polaris is a spare-time Linux gaming project developed in public. Contributions, real-hardware testing, bug reports, docs, translations, and helping other open-source projects are emphasized over donation pressure.

## Verification
- `git diff --check`
- exact changed-file scope: `README.md`, `docs/changelog.md`
- temporary platform wording such as “Linux host today” is absent
- Linux-only, GPLv3, and community-driven declarations are present
- web contribution commands remain intact
- no donation headings, payment links, or fundraising badges were added
- v1.3.1 tag remains immutable