### PR TITLE
fix(linux): expose GPU probe topology diagnostics

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1684,9 +1684,11 @@ namespace nvhttp {
       policy["capture_residency"] = platf::from_frame_residency(stats.capture_residency);
       policy["capture_format"] = platf::from_frame_format(stats.capture_format);
       policy["capture_device"] = stats.capture_device;
+      policy["capture_wayland_main_device"] = stats.wayland_main_device;
       policy["capture_encoder_adapter"] = config::video.adapter_name;
       policy["capture_cross_gpu_dmabuf_risk"] = stream_stats::capture_path_has_cross_gpu_dmabuf_risk(stats);
       policy["linux_gpu_profile"] = stream_stats::linux_gpu_profile_json(stats);
+      policy["gpu_native_probe"] = stream_stats::gpu_native_probe_json(stats);
       policy["capture_decision"] = {
         {"path", capture_path},
         {"reason", capture_reason},
@@ -1695,6 +1697,7 @@ namespace nvhttp {
         {"residency", policy["capture_residency"]},
         {"format", policy["capture_format"]},
         {"capture_device", policy["capture_device"]},
+        {"wayland_main_device", policy["capture_wayland_main_device"]},
         {"encoder_adapter", policy["capture_encoder_adapter"]},
         {"cross_gpu_dmabuf_risk", policy["capture_cross_gpu_dmabuf_risk"]},
         {"cpu_copy", capture_cpu_copy},

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -78,6 +78,26 @@ namespace wl {
       return resolved;
     }
 
+    std::string render_node_from_drm_device(dev_t device) {
+      if (device == dev_t {}) {
+        return {};
+      }
+
+      drmDevicePtr drm_device = nullptr;
+      if (drmGetDeviceFromDevId(device, 0, &drm_device) != 0 || !drm_device) {
+        return {};
+      }
+
+      std::string node;
+      if (drm_device->available_nodes & (1 << DRM_NODE_RENDER)) {
+        node = drm_device->nodes[DRM_NODE_RENDER];
+      } else if (drm_device->available_nodes & (1 << DRM_NODE_PRIMARY)) {
+        node = drm_device->nodes[DRM_NODE_PRIMARY];
+      }
+      drmFreeDevice(&drm_device);
+      return node;
+    }
+
     bool decode_dev_id(const wl_array *device_array, dev_t &device_id) {
       if (!device_array || device_array->size != sizeof(device_id) || !device_array->data) {
         return false;
@@ -344,9 +364,14 @@ namespace wl {
     dmabuf_feedback = std::move(pending_dmabuf_feedback);
     pending_dmabuf_feedback = {};
     dmabuf_feedback_update_in_progress = false;
+    if (dmabuf_feedback.main_device_valid) {
+      dmabuf_feedback.main_device_path = render_node_from_drm_device(dmabuf_feedback.main_device);
+    }
 
     BOOST_LOG(info) << "Wayland DMA-BUF feedback ready: main_device_valid="sv
                     << dmabuf_feedback.main_device_valid
+                    << " main_device="sv
+                    << (dmabuf_feedback.main_device_path.empty() ? "unresolved" : dmabuf_feedback.main_device_path)
                     << " tranches="sv << dmabuf_feedback.tranches.size()
                     << " format_table_entries="sv << dmabuf_feedback_table.size();
   }
@@ -1225,27 +1250,13 @@ namespace wl {
 
     cleanup_gbm();
 
-    drmDevicePtr drm_device = nullptr;
-    if (drmGetDeviceFromDevId(device, 0, &drm_device) != 0 || !drm_device) {
-      BOOST_LOG(error) << "Extcopy DMA-BUF capture could not resolve DRM device for dev_t ["sv << device << ']';
+    const auto node = render_node_from_drm_device(device);
+    if (node.empty()) {
+      BOOST_LOG(error) << "Extcopy DMA-BUF capture could not resolve a renderable DRM node for dev_t ["sv << device << ']';
       return false;
     }
 
-    const char *node = nullptr;
-    if (drm_device->available_nodes & (1 << DRM_NODE_RENDER)) {
-      node = drm_device->nodes[DRM_NODE_RENDER];
-    } else if (drm_device->available_nodes & (1 << DRM_NODE_PRIMARY)) {
-      node = drm_device->nodes[DRM_NODE_PRIMARY];
-    }
-
-    if (!node) {
-      BOOST_LOG(error) << "Extcopy DMA-BUF capture could not find a renderable DRM node"sv;
-      drmFreeDevice(&drm_device);
-      return false;
-    }
-
-    auto drm_fd = open(node, O_RDWR | O_CLOEXEC);
-    drmFreeDevice(&drm_device);
+    auto drm_fd = open(node.c_str(), O_RDWR | O_CLOEXEC);
     if (drm_fd < 0) {
       BOOST_LOG(error) << "Extcopy DMA-BUF capture failed to open DRM node ["sv << node << ']';
       return false;
@@ -1848,6 +1859,12 @@ namespace wl {
     // File descriptors aren't open
     std::fill_n(sd.fds, 4, -1);
   };
+
+#ifdef POLARIS_TESTS
+  std::string render_node_from_drm_device_for_tests(dev_t device) {
+    return render_node_from_drm_device(device);
+  }
+#endif
 
   std::vector<std::unique_ptr<monitor_t>> monitors(const char *display_name) {
     display_t display;

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -89,6 +89,7 @@ namespace wl {
     bool available {false};
     bool main_device_valid {false};
     dev_t main_device {};
+    std::string main_device_path;
     std::vector<dmabuf_feedback_tranche_t> tranches;
   };
 
@@ -452,6 +453,9 @@ namespace wl {
   };
 
   std::vector<std::unique_ptr<monitor_t>> monitors(const char *display_name = nullptr);
+#ifdef POLARIS_TESTS
+  std::string render_node_from_drm_device_for_tests(dev_t device);
+#endif
   int init();
 }  // namespace wl
 #else

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -87,6 +87,7 @@ namespace wl {
       }
 #endif
 
+      stream_stats::update_wayland_main_device({});
       if (display.init(wayland_target)) {
         return -1;
       }
@@ -126,6 +127,7 @@ namespace wl {
       monitor->listen(interface.output_manager);
 
       display.roundtrip();
+      stream_stats::update_wayland_main_device(interface.dmabuf_feedback.main_device_path);
       interface.consume_output_topology_dirty();
       output = monitor->output;
       offset_x = monitor->viewport.offset_x;
@@ -749,11 +751,13 @@ namespace platf {
         using_headless_ram_capture = true;
         try_headless_extcopy_dmabuf =
           cage_display_router::should_attempt_headless_extcopy_dmabuf(runtime_state, hwdevice_type);
-        if (!try_headless_extcopy_dmabuf &&
-            hwdevice_type == platf::mem_type_e::vaapi &&
-            cage_display_router::should_log_headless_ram_capture_warning()) {
-          BOOST_LOG(info)
-            << "wlr: Using RAM capture path for headless labwc because true-headless ext-image-copy-capture DMA-BUF is disabled for VAAPI stability"sv;
+        if (!try_headless_extcopy_dmabuf && hwdevice_type == platf::mem_type_e::vaapi) {
+          stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "ineligible", "policy", "vaapi_headless_dmabuf_disabled_for_stability");
+          stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");
+          if (cage_display_router::should_log_headless_ram_capture_warning()) {
+            BOOST_LOG(info)
+              << "wlr: Using RAM capture path for headless labwc because true-headless ext-image-copy-capture DMA-BUF is disabled for VAAPI stability"sv;
+          }
         }
       } else {
         prefer_ram_capture = true;
@@ -785,12 +789,14 @@ namespace platf {
     }
 
     if (try_headless_extcopy_dmabuf && gpu_native_capture_supported) {
+      bool adapter_mismatch = false;
       auto wlr = std::make_shared<wl::wlr_extcopy_vram_t>();
       if (!wlr->init(hwdevice_type, display_name, config)) {
         const auto capture_render_node = wlr->extcopy.capture_render_node();
         if (!config::video.adapter_name.empty() &&
             !capture_render_node.empty() &&
             config::video.adapter_name != capture_render_node) {
+          adapter_mismatch = true;
           BOOST_LOG(warning)
             << "wlr: Disabling true-headless ext-image-copy-capture DMA-BUF because capture render_node=["sv
             << capture_render_node
@@ -799,10 +805,13 @@ namespace platf {
 #ifdef __linux__
           cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
 #endif
+          stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "device_pairing", "cross_gpu_adapter_mismatch");
         } else {
 #ifdef __linux__
           cage_display_router::update_headless_extcopy_dmabuf_probe_result(true);
 #endif
+          stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "succeeded");
+          stream_stats::update_gpu_native_probe_selection("headless_extcopy_dmabuf");
           BOOST_LOG(info) << "wlr: Using ext-image-copy-capture DMA-BUF for headless labwc"sv;
           return wlr;
         }
@@ -811,6 +820,10 @@ namespace platf {
 #ifdef __linux__
       cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
 #endif
+      if (!adapter_mismatch) {
+        stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "capture_init", "dmabuf_capture_not_initialized");
+      }
+      stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");
       BOOST_LOG(info) << "wlr: Headless ext-image-copy-capture DMA-BUF unavailable or unsafe; using SHM fallback"sv;
     }
 

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -127,7 +127,8 @@ namespace wl {
       monitor->listen(interface.output_manager);
 
       display.roundtrip();
-      stream_stats::update_wayland_main_device(interface.dmabuf_feedback.main_device_path);
+      reported_wayland_main_device = interface.dmabuf_feedback.main_device_path;
+      stream_stats::update_wayland_main_device(reported_wayland_main_device);
       interface.consume_output_topology_dirty();
       output = monitor->output;
       offset_x = monitor->viewport.offset_x;
@@ -169,6 +170,11 @@ namespace wl {
         }
       } while (dmabuf.status == dmabuf_t::WAITING);
 
+      if (reported_wayland_main_device != interface.dmabuf_feedback.main_device_path) {
+        reported_wayland_main_device = interface.dmabuf_feedback.main_device_path;
+        stream_stats::update_wayland_main_device(reported_wayland_main_device);
+      }
+
       auto current_frame = dmabuf.current_frame;
       const bool shm_frame_ready = dmabuf.shm_frame_ready && dmabuf.shm_data;
       const auto captured_width = shm_frame_ready ? static_cast<int>(dmabuf.shm_info.width) : static_cast<int>(current_frame->sd.width);
@@ -190,6 +196,7 @@ namespace wl {
     platf::mem_type_e mem_type;
     bool capture_transport_logged = false;
     bool prefer_shm_screencopy = false;
+    std::string reported_wayland_main_device;
     std::chrono::microseconds last_dispatch_time {};
 
     std::chrono::nanoseconds delay;
@@ -789,23 +796,31 @@ namespace platf {
     }
 
     if (try_headless_extcopy_dmabuf && gpu_native_capture_supported) {
-      bool adapter_mismatch = false;
+      bool device_pairing_failed = false;
       auto wlr = std::make_shared<wl::wlr_extcopy_vram_t>();
       if (!wlr->init(hwdevice_type, display_name, config)) {
         const auto capture_render_node = wlr->extcopy.capture_render_node();
+        const auto adapter_pairing = stream_stats::device_nodes_match(capture_render_node, config::video.adapter_name);
         if (!config::video.adapter_name.empty() &&
             !capture_render_node.empty() &&
-            config::video.adapter_name != capture_render_node) {
-          adapter_mismatch = true;
+            (!adapter_pairing.has_value() || !*adapter_pairing)) {
+          device_pairing_failed = true;
+          const bool identity_resolved = adapter_pairing.has_value();
           BOOST_LOG(warning)
             << "wlr: Disabling true-headless ext-image-copy-capture DMA-BUF because capture render_node=["sv
             << capture_render_node
-            << "] differs from encoder adapter=["sv << config::video.adapter_name
-            << "]; using SHM/system-memory fallback to avoid known cross-GPU black video"sv;
+            << (identity_resolved ? "] differs from encoder adapter=["sv : "] could not be identity-matched to encoder adapter=["sv)
+            << config::video.adapter_name
+            << "]; using SHM/system-memory fallback to avoid unsafe cross-GPU import"sv;
 #ifdef __linux__
           cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
 #endif
-          stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "device_pairing", "cross_gpu_adapter_mismatch");
+          stream_stats::update_gpu_native_probe_attempt(
+            "headless_extcopy",
+            "failed",
+            "device_pairing",
+            identity_resolved ? "cross_gpu_adapter_mismatch" : "device_identity_unresolved"
+          );
         } else {
 #ifdef __linux__
           cage_display_router::update_headless_extcopy_dmabuf_probe_result(true);
@@ -820,7 +835,7 @@ namespace platf {
 #ifdef __linux__
       cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
 #endif
-      if (!adapter_mismatch) {
+      if (!device_pairing_failed) {
         stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "capture_init", "dmabuf_capture_not_initialized");
       }
       stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3143,7 +3143,7 @@ namespace proc {
         prefer_gpu_native_capture,
         should_try_gpu_native_cage_probe
       );
-    stream_stats::reset_gpu_native_probe(should_probe_windowed_cage_for_gpu_native);
+    stream_stats::reset_gpu_native_probe(should_probe_windowed_cage_for_gpu_native, rtsp_stream::session_count() == 0);
     const auto cached_windowed_gpu_native_probe_result =
       should_probe_windowed_cage_for_gpu_native ?
         cage_display_router::cached_windowed_gpu_native_probe_result() :

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3143,6 +3143,7 @@ namespace proc {
         prefer_gpu_native_capture,
         should_try_gpu_native_cage_probe
       );
+    stream_stats::reset_gpu_native_probe(should_probe_windowed_cage_for_gpu_native);
     const auto cached_windowed_gpu_native_probe_result =
       should_probe_windowed_cage_for_gpu_native ?
         cage_display_router::cached_windowed_gpu_native_probe_result() :
@@ -3152,6 +3153,7 @@ namespace proc {
         cage_display_router::cached_headless_extcopy_dmabuf_probe_result() :
         std::optional<bool> {};
     bool force_windowed_cage_for_gpu_native = false;
+    bool headless_extcopy_dmabuf_selected = false;
     const int cage_refresh_hz = std::max(pacing_target_fps, 1);
 
     const int gpu_native_probe_fps = std::max(pacing_target_fps, 1);
@@ -3210,6 +3212,7 @@ namespace proc {
 
       auto encoder_name = video::active_encoder_name();
       auto encoder_label = encoder_name.empty() ? "unknown" : encoder_name;
+      stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "running");
       BOOST_LOG(info) << "session_manager: Probing headless_extcopy_dmabuf with encoder ["
                       << encoder_label << ']';
 
@@ -3221,6 +3224,7 @@ namespace proc {
 
       if (!start_cage_session("", false, true, false)) {
         cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+        stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "compositor_encoder_init", "compositor_or_encoder_init_failed");
         BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe could not initialize the compositor/encoder path"sv;
         return false;
       }
@@ -3228,12 +3232,14 @@ namespace proc {
       const auto runtime_state = cage_display_router::runtime_state();
       if (!runtime_state.effective_headless) {
         cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+        stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "runtime_validation", "not_effective_headless");
         BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not start an effective headless runtime"sv;
         return false;
       }
 
       if (!video::active_encoder_runtime_supports_config(gpu_native_probe_config)) {
         cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+        stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "ineligible", "encoder_validation", "encoder_config_not_supported");
         BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not validate the active encoder configuration"sv;
         return false;
       }
@@ -3246,14 +3252,24 @@ namespace proc {
       if (!cage_display_router::headless_extcopy_dmabuf_probe_succeeded(extcopy_initialized, live_gpu_frame_converted)) {
         cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
         if (!extcopy_initialized) {
+          const auto gpu_profile = stream_stats::linux_gpu_profile_json(stream_stats::get_current());
+          if (encoder_label.find("vaapi") != std::string::npos) {
+            stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "ineligible", "policy", "vaapi_headless_dmabuf_disabled_for_stability");
+          } else if (gpu_profile.value("adapter_pairing_status", std::string {}) == "mismatched") {
+            stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "device_pairing", "cross_gpu_adapter_mismatch");
+          } else {
+            stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "capture_init", "dmabuf_capture_not_initialized");
+          }
           BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not initialize DMA-BUF capture"sv;
         } else {
+          stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "frame_conversion", "live_gpu_frame_conversion_failed");
           BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not validate live GPU frame conversion"sv;
         }
         return false;
       }
 
       cage_display_router::update_headless_extcopy_dmabuf_probe_result(true);
+      stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "succeeded");
       BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe succeeded with encoder ["
                       << video::active_encoder_name() << ']';
       return true;
@@ -3266,6 +3282,7 @@ namespace proc {
 
       auto encoder_name = video::active_encoder_name();
       auto encoder_label = encoder_name.empty() ? "unknown" : encoder_name;
+      stream_stats::update_gpu_native_probe_attempt("windowed", "running");
       BOOST_LOG(info) << "session_manager: Probing windowed labwc for GPU-native capture with encoder ["
                       << encoder_label << ']';
 
@@ -3277,17 +3294,20 @@ namespace proc {
 
       if (!start_cage_session("", true, true, false)) {
         cage_display_router::update_windowed_gpu_native_probe_result(false);
+        stream_stats::update_gpu_native_probe_attempt("windowed", "failed", "compositor_encoder_init", "compositor_or_encoder_init_failed");
         BOOST_LOG(info) << "session_manager: Windowed GPU-native cage probe could not initialize the compositor/encoder path; staying headless"sv;
         return false;
       }
 
       if (!video::active_encoder_runtime_supports_live_gpu_capture(gpu_native_probe_config)) {
         cage_display_router::update_windowed_gpu_native_probe_result(false);
+        stream_stats::update_gpu_native_probe_attempt("windowed", "failed", "first_frame", "no_live_dmabuf_frame");
         BOOST_LOG(info) << "session_manager: Windowed GPU-native cage probe did not deliver a live DMA-BUF frame; staying headless"sv;
         return false;
       }
 
       cage_display_router::update_windowed_gpu_native_probe_result(true);
+      stream_stats::update_gpu_native_probe_attempt("windowed", "succeeded");
       BOOST_LOG(info) << "session_manager: Windowed GPU-native cage probe succeeded with encoder ["
                       << video::active_encoder_name() << ']';
       return true;
@@ -3295,11 +3315,13 @@ namespace proc {
 
     auto resolve_windowed_gpu_native_fallback = [&]() -> bool {
       if (cached_windowed_gpu_native_probe_result == std::optional<bool> {true}) {
+        stream_stats::update_gpu_native_probe_attempt("windowed", "succeeded", {}, {}, true);
         BOOST_LOG(info) << "session_manager: Reusing cached windowed_dmabuf_override probe result"sv;
         return true;
       }
 
       if (cached_windowed_gpu_native_probe_result == std::optional<bool> {false}) {
+        stream_stats::update_gpu_native_probe_attempt("windowed", "ineligible", "cache", "cached_unsupported", true);
         BOOST_LOG(info) << "session_manager: Cached windowed_dmabuf_override probe result indicates nested DMA-BUF capture is unavailable on this runtime"sv;
         return false;
       }
@@ -3308,15 +3330,27 @@ namespace proc {
     };
 
     if (cached_headless_extcopy_dmabuf_probe_result == std::optional<bool> {true}) {
+      headless_extcopy_dmabuf_selected = true;
+      stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "succeeded", {}, {}, true);
       BOOST_LOG(info) << "session_manager: Reusing cached headless_extcopy_dmabuf probe result; keeping true headless runtime"sv;
     } else if (cached_headless_extcopy_dmabuf_probe_result == std::optional<bool> {false}) {
+      stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "ineligible", "cache", "cached_unsupported", true);
       BOOST_LOG(info) << "session_manager: Cached headless_extcopy_dmabuf probe result indicates headless DMA-BUF capture is unavailable; evaluating windowed fallback"sv;
       force_windowed_cage_for_gpu_native = resolve_windowed_gpu_native_fallback();
     } else if (probe_headless_extcopy_dmabuf_cage()) {
+      headless_extcopy_dmabuf_selected = true;
       BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf selected; keeping true headless runtime"sv;
     } else if (should_probe_windowed_cage_for_gpu_native) {
       BOOST_LOG(info) << "session_manager: headless_shm_fallback would be used for true headless; evaluating windowed GPU-native fallback"sv;
       force_windowed_cage_for_gpu_native = resolve_windowed_gpu_native_fallback();
+    }
+
+    if (headless_extcopy_dmabuf_selected) {
+      stream_stats::update_gpu_native_probe_selection("headless_extcopy_dmabuf");
+    } else if (force_windowed_cage_for_gpu_native) {
+      stream_stats::update_gpu_native_probe_selection("windowed_dmabuf_override");
+    } else if (should_probe_windowed_cage_for_gpu_native) {
+      stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");
     }
 
     auto encoder_name = video::active_encoder_name();
@@ -3396,6 +3430,8 @@ namespace proc {
 
       if (force_windowed_cage_for_gpu_native) {
         cage_display_router::update_windowed_gpu_native_probe_result(false);
+        stream_stats::update_gpu_native_probe_attempt("windowed", "failed", "session_start", "windowed_override_start_failed");
+        stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");
         BOOST_LOG(warning) << "session_manager: windowed_dmabuf_override start failed; falling back to headless_shm_fallback if headless DMA-BUF remains unavailable"sv;
         force_windowed_cage_for_gpu_native = false;
       }

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -8,6 +8,7 @@
 // standard includes
 #include <algorithm>
 #include <array>
+#include <filesystem>
 #include <mutex>
 #include <vector>
 
@@ -41,6 +42,18 @@ namespace stream_stats {
     };
 
     std::array<capture_profile_bucket_t, CAPTURE_PROFILE_BUCKET_COUNT> capture_profile_buckets;
+
+    bool device_nodes_match(const std::string &lhs, const std::string &rhs) {
+      if (lhs.empty() || rhs.empty()) {
+        return false;
+      }
+      if (lhs == rhs) {
+        return true;
+      }
+
+      std::error_code ec;
+      return std::filesystem::equivalent(lhs, rhs, ec) && !ec;
+    }
 
     capture_profile_bucket_t &capture_profile_bucket(platf::frame_transport_e transport) {
       auto index = static_cast<std::size_t>(transport);
@@ -108,6 +121,8 @@ namespace stream_stats {
     j["capture_residency"] = platf::from_frame_residency(capture_residency);
     j["capture_format"] = platf::from_frame_format(capture_format);
     j["capture_device"] = capture_device;
+    j["wayland_main_device"] = wayland_main_device;
+    j["gpu_native_probe"] = gpu_native_probe_json(*this);
     const auto capture_path = capture_path_summary(*this);
     const auto capture_reason = capture_path_reason(*this);
     const auto capture_reason_message = capture_path_reason_message(capture_reason);
@@ -126,6 +141,7 @@ namespace stream_stats {
       {"residency", platf::from_frame_residency(capture_residency)},
       {"format", platf::from_frame_format(capture_format)},
       {"capture_device", capture_device},
+      {"wayland_main_device", wayland_main_device},
       {"encoder_adapter", config::video.adapter_name},
       {"cross_gpu_dmabuf_risk", capture_path_has_cross_gpu_dmabuf_risk(*this)},
       {"cpu_copy", capture_cpu_copy},
@@ -233,7 +249,7 @@ namespace stream_stats {
       stats.capture_residency == platf::frame_residency_e::gpu &&
       !stats.capture_device.empty() &&
       !config::video.adapter_name.empty() &&
-      stats.capture_device != config::video.adapter_name;
+      !device_nodes_match(stats.capture_device, config::video.adapter_name);
 #else
     return false;
 #endif
@@ -242,12 +258,32 @@ namespace stream_stats {
   nlohmann::json linux_gpu_profile_json(const stats_t &stats) {
     const auto &linux_display = config::video.linux_display;
     const bool gpu_native_requested =
+      stats.gpu_native_probe.requested ||
       stats.runtime_gpu_native_override_active ||
       linux_display.prefer_gpu_native_capture;
-    const bool adapter_matches_capture_device =
-      stats.capture_device.empty() ||
-      config::video.adapter_name.empty() ||
-      stats.capture_device == config::video.adapter_name;
+    nlohmann::json adapter_matches_capture_device = nullptr;
+    nlohmann::json adapter_matches_wayland_main_device = nullptr;
+    if (!stats.capture_device.empty() && !config::video.adapter_name.empty()) {
+      adapter_matches_capture_device = device_nodes_match(stats.capture_device, config::video.adapter_name);
+    }
+    if (!stats.wayland_main_device.empty() && !config::video.adapter_name.empty()) {
+      adapter_matches_wayland_main_device = device_nodes_match(stats.wayland_main_device, config::video.adapter_name);
+    }
+
+    std::string adapter_pairing_device;
+    std::string adapter_pairing_device_source = "none";
+    if (!stats.capture_device.empty()) {
+      adapter_pairing_device = stats.capture_device;
+      adapter_pairing_device_source = "capture_device";
+    } else if (!stats.wayland_main_device.empty()) {
+      adapter_pairing_device = stats.wayland_main_device;
+      adapter_pairing_device_source = "wayland_main_device";
+    }
+
+    std::string adapter_pairing_status = "unknown";
+    if (!adapter_pairing_device.empty() && !config::video.adapter_name.empty()) {
+      adapter_pairing_status = device_nodes_match(adapter_pairing_device, config::video.adapter_name) ? "matched" : "mismatched";
+    }
     const bool capture_metadata_reported =
       stats.capture_transport != platf::frame_transport_e::unknown ||
       stats.capture_residency != platf::frame_residency_e::unknown ||
@@ -269,15 +305,28 @@ namespace stream_stats {
       });
     }
 #endif
+    if (adapter_pairing_status == "mismatched") {
+      configuration_warnings.push_back({
+        {"id", "linux_gpu_adapter_mismatch"},
+        {"severity", "warning"},
+        {"message", "The configured encoder adapter " + config::video.adapter_name + " differs from the " + adapter_pairing_device_source + " render node " + adapter_pairing_device + "; cross-GPU DMA-BUF import can fail or fall back to system memory."},
+        {"action", "Verify the render-node mapping under /dev/dri/by-path, then select the adapter used by the compositor or keep the conservative SHM fallback."}
+      });
+    }
 
     nlohmann::json profile = {
       {"encoder_api", stats.encode_target_device},
       {"encoder_adapter", config::video.adapter_name},
       {"capture_device", stats.capture_device},
+      {"wayland_main_device", stats.wayland_main_device},
       {"adapter_matches_capture_device", adapter_matches_capture_device},
+      {"adapter_matches_wayland_main_device", adapter_matches_wayland_main_device},
+      {"adapter_pairing_status", adapter_pairing_status},
+      {"adapter_pairing_device", adapter_pairing_device},
+      {"adapter_pairing_device_source", adapter_pairing_device_source},
       {"cross_gpu_dmabuf_risk", capture_path_has_cross_gpu_dmabuf_risk(stats)},
       {"gpu_native_requested", gpu_native_requested},
-      {"gpu_native_attempted", gpu_native_requested && capture_metadata_reported},
+      {"gpu_native_attempted", stats.gpu_native_probe.headless_extcopy.attempted || stats.gpu_native_probe.windowed.attempted || (gpu_native_requested && capture_metadata_reported)},
       {"gpu_native_succeeded", capture_path_is_gpu_native(stats)},
       {"configuration_warnings", std::move(configuration_warnings)}
     };
@@ -366,6 +415,27 @@ namespace stream_stats {
     }
 
     return "mixed_or_unknown";
+  }
+
+  nlohmann::json gpu_native_probe_json(const stats_t &stats) {
+    auto attempt_json = [](const gpu_native_probe_attempt_t &attempt) {
+      return nlohmann::json {
+        {"attempted", attempt.attempted},
+        {"cached", attempt.cached},
+        {"result", attempt.result},
+        {"failure_stage", attempt.failure_stage},
+        {"failure_reason", attempt.failure_reason}
+      };
+    };
+
+    return {
+      {"requested", stats.gpu_native_probe.requested},
+      {"attempted", stats.gpu_native_probe.headless_extcopy.attempted || stats.gpu_native_probe.windowed.attempted},
+      {"headless_extcopy", attempt_json(stats.gpu_native_probe.headless_extcopy)},
+      {"windowed", attempt_json(stats.gpu_native_probe.windowed)},
+      {"selected_strategy", stats.gpu_native_probe.selected_strategy},
+      {"fallback", stats.gpu_native_probe.fallback}
+    };
   }
 
   std::string capture_path_reason_message(const std::string &reason) {
@@ -663,12 +733,14 @@ namespace stream_stats {
       {"residency", platf::from_frame_residency(stats.capture_residency)},
       {"format", platf::from_frame_format(stats.capture_format)},
       {"capture_device", stats.capture_device},
+      {"wayland_main_device", stats.wayland_main_device},
       {"encoder_adapter", config::video.adapter_name},
       {"cross_gpu_dmabuf_risk", capture_path_has_cross_gpu_dmabuf_risk(stats)},
       {"cpu_copy", capture_cpu_copy},
       {"gpu_native", capture_gpu_native}
     };
     advanced["linux_gpu_profile"] = linux_gpu_profile_json(stats);
+    advanced["gpu_native_probe"] = gpu_native_probe_json(stats);
     advanced["health"] = health;
     advanced["recent_issue_codes"] = nlohmann::json::array();
     advanced["raw_fields_redacted"] = true;
@@ -892,6 +964,49 @@ namespace stream_stats {
     current_stats.capture_residency = metadata.residency;
     current_stats.capture_format = metadata.format;
     current_stats.capture_device = metadata.device;
+  }
+
+  void update_wayland_main_device(const std::string &device) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.wayland_main_device = device;
+  }
+
+  void reset_gpu_native_probe(bool requested) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.gpu_native_probe = gpu_native_probe_t {};
+    current_stats.gpu_native_probe.requested = requested;
+  }
+
+  void update_gpu_native_probe_attempt(const std::string &strategy,
+                                       const std::string &result,
+                                       const std::string &failure_stage,
+                                       const std::string &failure_reason,
+                                       bool cached) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    if (!current_stats.gpu_native_probe.requested) {
+      return;
+    }
+    auto *attempt = strategy == "headless_extcopy" ?
+      &current_stats.gpu_native_probe.headless_extcopy :
+      strategy == "windowed" ? &current_stats.gpu_native_probe.windowed : nullptr;
+    if (!attempt) {
+      return;
+    }
+    attempt->attempted = !cached && result != "ineligible" && result != "not_attempted";
+    attempt->cached = cached;
+    attempt->result = result;
+    attempt->failure_stage = failure_stage;
+    attempt->failure_reason = failure_reason;
+  }
+
+  void update_gpu_native_probe_selection(const std::string &selected_strategy,
+                                         const std::string &fallback) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    if (!current_stats.gpu_native_probe.requested) {
+      return;
+    }
+    current_stats.gpu_native_probe.selected_strategy = selected_strategy;
+    current_stats.gpu_native_probe.fallback = fallback;
   }
 
   void update_encode_path_metadata(const std::string &target_device,

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -30,6 +30,22 @@ namespace stream_stats {
   static std::mutex stats_mutex;
   static stats_t current_stats;
 
+  std::optional<bool> device_nodes_match(const std::string &lhs, const std::string &rhs) {
+    if (lhs.empty() || rhs.empty()) {
+      return std::nullopt;
+    }
+    if (lhs == rhs) {
+      return true;
+    }
+
+    std::error_code ec;
+    const bool equivalent = std::filesystem::equivalent(lhs, rhs, ec);
+    if (ec) {
+      return std::nullopt;
+    }
+    return equivalent;
+  }
+
   namespace {
     constexpr std::size_t CAPTURE_PROFILE_SUMMARY_FRAMES = 600;
     constexpr std::size_t CAPTURE_PROFILE_BUCKET_COUNT =
@@ -42,18 +58,6 @@ namespace stream_stats {
     };
 
     std::array<capture_profile_bucket_t, CAPTURE_PROFILE_BUCKET_COUNT> capture_profile_buckets;
-
-    bool device_nodes_match(const std::string &lhs, const std::string &rhs) {
-      if (lhs.empty() || rhs.empty()) {
-        return false;
-      }
-      if (lhs == rhs) {
-        return true;
-      }
-
-      std::error_code ec;
-      return std::filesystem::equivalent(lhs, rhs, ec) && !ec;
-    }
 
     capture_profile_bucket_t &capture_profile_bucket(platf::frame_transport_e transport) {
       auto index = static_cast<std::size_t>(transport);
@@ -242,14 +246,14 @@ namespace stream_stats {
 
   bool capture_path_has_cross_gpu_dmabuf_risk(const stats_t &stats) {
 #ifdef __linux__
-    return
-      stats.runtime_effective_headless &&
-      config::video.linux_display.use_cage_compositor &&
-      stats.capture_transport == platf::frame_transport_e::dmabuf &&
-      stats.capture_residency == platf::frame_residency_e::gpu &&
-      !stats.capture_device.empty() &&
-      !config::video.adapter_name.empty() &&
-      !device_nodes_match(stats.capture_device, config::video.adapter_name);
+    if (!stats.runtime_effective_headless ||
+        !config::video.linux_display.use_cage_compositor ||
+        stats.capture_transport != platf::frame_transport_e::dmabuf ||
+        stats.capture_residency != platf::frame_residency_e::gpu) {
+      return false;
+    }
+    const auto pairing = device_nodes_match(stats.capture_device, config::video.adapter_name);
+    return pairing.has_value() && !*pairing;
 #else
     return false;
 #endif
@@ -261,28 +265,33 @@ namespace stream_stats {
       stats.gpu_native_probe.requested ||
       stats.runtime_gpu_native_override_active ||
       linux_display.prefer_gpu_native_capture;
+    const auto capture_device_pairing = device_nodes_match(stats.capture_device, config::video.adapter_name);
+    const auto wayland_device_pairing = device_nodes_match(stats.wayland_main_device, config::video.adapter_name);
     nlohmann::json adapter_matches_capture_device = nullptr;
     nlohmann::json adapter_matches_wayland_main_device = nullptr;
-    if (!stats.capture_device.empty() && !config::video.adapter_name.empty()) {
-      adapter_matches_capture_device = device_nodes_match(stats.capture_device, config::video.adapter_name);
+    if (capture_device_pairing.has_value()) {
+      adapter_matches_capture_device = *capture_device_pairing;
     }
-    if (!stats.wayland_main_device.empty() && !config::video.adapter_name.empty()) {
-      adapter_matches_wayland_main_device = device_nodes_match(stats.wayland_main_device, config::video.adapter_name);
+    if (wayland_device_pairing.has_value()) {
+      adapter_matches_wayland_main_device = *wayland_device_pairing;
     }
 
     std::string adapter_pairing_device;
     std::string adapter_pairing_device_source = "none";
+    std::optional<bool> adapter_pairing;
     if (!stats.capture_device.empty()) {
       adapter_pairing_device = stats.capture_device;
       adapter_pairing_device_source = "capture_device";
+      adapter_pairing = capture_device_pairing;
     } else if (!stats.wayland_main_device.empty()) {
       adapter_pairing_device = stats.wayland_main_device;
       adapter_pairing_device_source = "wayland_main_device";
+      adapter_pairing = wayland_device_pairing;
     }
 
     std::string adapter_pairing_status = "unknown";
-    if (!adapter_pairing_device.empty() && !config::video.adapter_name.empty()) {
-      adapter_pairing_status = device_nodes_match(adapter_pairing_device, config::video.adapter_name) ? "matched" : "mismatched";
+    if (adapter_pairing.has_value()) {
+      adapter_pairing_status = *adapter_pairing ? "matched" : "mismatched";
     }
     const bool capture_metadata_reported =
       stats.capture_transport != platf::frame_transport_e::unknown ||
@@ -971,8 +980,12 @@ namespace stream_stats {
     current_stats.wayland_main_device = device;
   }
 
-  void reset_gpu_native_probe(bool requested) {
+  void reset_gpu_native_probe(bool requested, bool reset_capture_identity) {
     std::lock_guard<std::mutex> lock(stats_mutex);
+    if (reset_capture_identity) {
+      current_stats.capture_device.clear();
+      current_stats.wayland_main_device.clear();
+    }
     current_stats.gpu_native_probe = gpu_native_probe_t {};
     current_stats.gpu_native_probe.requested = requested;
   }

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -34,10 +34,6 @@ namespace stream_stats {
     if (lhs.empty() || rhs.empty()) {
       return std::nullopt;
     }
-    if (lhs == rhs) {
-      return true;
-    }
-
     std::error_code ec;
     const bool equivalent = std::filesystem::equivalent(lhs, rhs, ec);
     if (ec) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -53,6 +53,22 @@ namespace stream_stats {
     std::chrono::microseconds total_time {};
   };
 
+  struct gpu_native_probe_attempt_t {
+    bool attempted = false;
+    bool cached = false;
+    std::string result = "not_attempted";
+    std::string failure_stage;
+    std::string failure_reason;
+  };
+
+  struct gpu_native_probe_t {
+    bool requested = false;
+    gpu_native_probe_attempt_t headless_extcopy;
+    gpu_native_probe_attempt_t windowed;
+    std::string selected_strategy = "none";
+    std::string fallback = "none";
+  };
+
   struct stats_t {
     // Stream state
     bool streaming = false;
@@ -66,6 +82,8 @@ namespace stream_stats {
     platf::frame_residency_e capture_residency = platf::frame_residency_e::unknown;
     platf::frame_format_e capture_format = platf::frame_format_e::unknown;
     std::string capture_device;
+    std::string wayland_main_device;
+    gpu_native_probe_t gpu_native_probe;
     std::string encode_target_device;
     platf::frame_residency_e encode_target_residency = platf::frame_residency_e::unknown;
     platf::frame_format_e encode_target_format = platf::frame_format_e::unknown;
@@ -163,6 +181,9 @@ namespace stream_stats {
    * @param stats Current stream statistics snapshot.
    */
   nlohmann::json linux_gpu_profile_json(const stats_t &stats);
+
+  /** @brief Structured result of GPU-native capture probes for diagnostics. */
+  nlohmann::json gpu_native_probe_json(const stats_t &stats);
 
   /**
    * @brief Human-readable explanation for a capture path reason.
@@ -303,6 +324,26 @@ namespace stream_stats {
    * @param metadata Current frame transport/residency/format metadata.
    */
   void update_capture_metadata(const platf::frame_metadata_t &metadata);
+
+  /**
+   * @brief Update the DRM render node advertised as Wayland DMA-BUF main_device.
+   * @param device Render-node path, or empty when the compositor did not advertise one.
+   */
+  void update_wayland_main_device(const std::string &device);
+
+  /** @brief Reset GPU-native probe telemetry for a new cage launch decision. */
+  void reset_gpu_native_probe(bool requested);
+
+  /** @brief Record one GPU-native probe strategy result. */
+  void update_gpu_native_probe_attempt(const std::string &strategy,
+                                       const std::string &result,
+                                       const std::string &failure_stage = {},
+                                       const std::string &failure_reason = {},
+                                       bool cached = false);
+
+  /** @brief Record the final capture strategy selected after probing. */
+  void update_gpu_native_probe_selection(const std::string &selected_strategy,
+                                         const std::string &fallback = "none");
 
   /**
    * @brief Update the encode conversion path metadata exposed to the dashboard.

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <cstdint>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -145,6 +146,12 @@ namespace stream_stats {
      */
     std::string to_json() const;
   };
+
+  /**
+   * @brief Compare two device-node paths by filesystem identity.
+   * @return true/false when both identities resolve, or nullopt when unknown.
+   */
+  std::optional<bool> device_nodes_match(const std::string &lhs, const std::string &rhs);
 
   /**
    * @brief Whether the current capture/encode path requires a CPU-side copy.
@@ -332,7 +339,7 @@ namespace stream_stats {
   void update_wayland_main_device(const std::string &device);
 
   /** @brief Reset GPU-native probe telemetry for a new cage launch decision. */
-  void reset_gpu_native_probe(bool requested);
+  void reset_gpu_native_probe(bool requested, bool reset_capture_identity = false);
 
   /** @brief Record one GPU-native probe strategy result. */
   void update_gpu_native_probe_attempt(const std::string &strategy,

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -446,6 +446,8 @@ namespace video {
       }
 
       cage_display_router::update_headless_extcopy_dmabuf_probe_result(false);
+      stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "frame_conversion", "live_gpu_frame_conversion_failed");
+      stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");
       BOOST_LOG(warning)
         << "Headless ext-image-copy-capture DMA-BUF frame conversion failed; disabling headless DMA-BUF capture and reinitializing with SHM/system-memory fallback"sv;
       return true;

--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -107,6 +107,13 @@ export function describeLinuxGpuProfile(stats = {}) {
     stats?.capture?.gpu_native
   )
   const adapterMatchesCaptureDevice = profile.adapter_matches_capture_device ?? profile.adapterMatchesCaptureDevice
+  const adapterPairingStatus = lower(profile.adapter_pairing_status || profile.adapterPairingStatus)
+  const adapterPairingSource = lower(profile.adapter_pairing_device_source || profile.adapterPairingDeviceSource)
+  const encoderAdapter = profile.encoder_adapter || profile.encoderAdapter || 'unreported encoder adapter'
+  const waylandMainDevice = profile.wayland_main_device || profile.waylandMainDevice || 'unreported Wayland device'
+  const pairingMismatch = adapterPairingStatus
+    ? adapterPairingStatus === 'mismatched'
+    : adapterMatchesCaptureDevice === false
   const cpuCopy = Boolean(
     stats?.capture_cpu_copy ||
     stats?.capture?.cpu_copy ||
@@ -116,7 +123,10 @@ export function describeLinuxGpuProfile(stats = {}) {
 
   if (encoderApi !== 'vaapi') return ''
 
-  if (adapterMatchesCaptureDevice === false) {
+  if (pairingMismatch) {
+    if (adapterPairingSource === 'wayland_main_device') {
+      return `AMD/VAAPI is active, but encoder adapter ${encoderAdapter} does not match the Wayland compositor device ${waylandMainDevice}. Verify the /dev/dri/renderD* mapping before blaming the client.`
+    }
     return 'AMD/VAAPI is active, but the capture render node does not match the encoder adapter. Review the /dev/dri/renderD* selection before blaming the client.'
   }
 
@@ -286,6 +296,25 @@ export function buildGithubIssueDraft(input = {}) {
   const clientType = firstNonEmpty(client.type, stats.client_type, stats.client_name, 'unknown')
   const clientName = firstNonEmpty(client.name, stats.client_name)
   const capture = `${formatIssueValue(stats.capture_path || stats.capture_transport, 'unknown')} — ${formatIssueValue(stats.capture_path_reason, 'unknown')}`
+  const gpuProfile = linuxGpuProfile(stats)
+  const gpuNativeProbe = stats.gpu_native_probe || stats.gpuNativeProbe || {}
+  const probeReason = firstNonEmpty(
+    gpuNativeProbe?.windowed?.failure_reason,
+    gpuNativeProbe?.windowed?.failureReason,
+    gpuNativeProbe?.headless_extcopy?.failure_reason,
+    gpuNativeProbe?.headlessExtcopy?.failureReason
+  )
+  const probeSummary = `${formatIssueValue(probeReason, 'not reported')} — selected ${formatIssueValue(gpuNativeProbe.selected_strategy || gpuNativeProbe.selectedStrategy, 'unknown')}, fallback ${formatIssueValue(gpuNativeProbe.fallback, 'none')}`
+  const gpuDiagnosticLines = []
+  const encoderAdapter = firstNonEmpty(gpuProfile.encoder_adapter, gpuProfile.encoderAdapter)
+  const captureDevice = firstNonEmpty(gpuProfile.capture_device, gpuProfile.captureDevice)
+  const waylandMainDevice = firstNonEmpty(gpuProfile.wayland_main_device, gpuProfile.waylandMainDevice)
+  const adapterPairing = firstNonEmpty(gpuProfile.adapter_pairing_status, gpuProfile.adapterPairingStatus)
+  if (encoderAdapter) gpuDiagnosticLines.push(issueDraftLine('Encoder adapter', encoderAdapter))
+  if (captureDevice) gpuDiagnosticLines.push(issueDraftLine('Capture device', captureDevice))
+  if (waylandMainDevice) gpuDiagnosticLines.push(issueDraftLine('Wayland main device', waylandMainDevice))
+  if (adapterPairing) gpuDiagnosticLines.push(issueDraftLine('Adapter pairing', adapterPairing))
+  if (Object.keys(gpuNativeProbe).length > 0) gpuDiagnosticLines.push(issueDraftLine('GPU-native probe', probeSummary))
   const doctorSummary = firstNonEmpty(doctor.simple_state, doctor.summary, doctor.diagnosis, doctor.primary_issue, 'Polaris did not include a Doctor diagnosis yet.')
 
   return redactSensitiveText([
@@ -305,6 +334,7 @@ export function buildGithubIssueDraft(input = {}) {
     issueDraftLine('Launch mode', firstNonEmpty(stats.launch_mode, stats.stream_display_mode, stats.runtime_backend)),
     issueDraftLine('Encoder', firstNonEmpty(stats.encoder, stats.encode_target_device, config.encoder)),
     issueDraftLine('Capture', capture),
+    ...gpuDiagnosticLines,
     issueDraftLine('Active stream', summarizeActiveStream(stats)),
     '',
     '## What Polaris thinks happened',

--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -109,11 +109,14 @@ export function describeLinuxGpuProfile(stats = {}) {
   const adapterMatchesCaptureDevice = profile.adapter_matches_capture_device ?? profile.adapterMatchesCaptureDevice
   const adapterPairingStatus = lower(profile.adapter_pairing_status || profile.adapterPairingStatus)
   const adapterPairingSource = lower(profile.adapter_pairing_device_source || profile.adapterPairingDeviceSource)
-  const encoderAdapter = profile.encoder_adapter || profile.encoderAdapter || 'unreported encoder adapter'
-  const waylandMainDevice = profile.wayland_main_device || profile.waylandMainDevice || 'unreported Wayland device'
-  const pairingMismatch = adapterPairingStatus
-    ? adapterPairingStatus === 'mismatched'
-    : adapterMatchesCaptureDevice === false
+  const encoderAdapter = profile.encoder_adapter || profile.encoderAdapter || ''
+  const captureDevice = profile.capture_device || profile.captureDevice || ''
+  const waylandMainDevice = profile.wayland_main_device || profile.waylandMainDevice || ''
+  const pairingDevice = profile.adapter_pairing_device || profile.adapterPairingDevice ||
+    (adapterPairingSource === 'capture_device' ? captureDevice : adapterPairingSource === 'wayland_main_device' ? waylandMainDevice : captureDevice || waylandMainDevice)
+  const pairingMismatch = Boolean(encoderAdapter && pairingDevice && (
+    adapterPairingStatus ? adapterPairingStatus === 'mismatched' : adapterMatchesCaptureDevice === false
+  ))
   const cpuCopy = Boolean(
     stats?.capture_cpu_copy ||
     stats?.capture?.cpu_copy ||
@@ -226,6 +229,29 @@ function formatIssueValue(value, fallback = 'unknown') {
   return String(safe)
 }
 
+function formatGpuNativeProbeAttempt(label, attempt) {
+  if (!attempt || typeof attempt !== 'object' || Object.keys(attempt).length === 0) return ''
+  const result = firstNonEmpty(attempt.result, 'unknown')
+  const stage = firstNonEmpty(attempt.failure_stage, attempt.failureStage)
+  const reason = firstNonEmpty(attempt.failure_reason, attempt.failureReason)
+  const parts = [`result=${formatIssueValue(result)}`]
+  const hasOwn = (key) => Object.prototype.hasOwnProperty.call(attempt, key)
+  if (hasOwn('attempted')) parts.push(`attempted=${attempt.attempted ? 'yes' : 'no'}`)
+  if (hasOwn('cached')) parts.push(`cached=${attempt.cached ? 'yes' : 'no'}`)
+  if (stage) parts.push(`stage=${formatIssueValue(stage)}`)
+  if (reason) parts.push(`reason=${formatIssueValue(reason)}`)
+  return `${label}[${parts.join(', ')}]`
+}
+
+function formatGpuNativeProbe(probe = {}) {
+  const attempts = [
+    formatGpuNativeProbeAttempt('headless_extcopy', probe.headless_extcopy || probe.headlessExtcopy),
+    formatGpuNativeProbeAttempt('windowed', probe.windowed),
+  ].filter(Boolean)
+  const outcomes = attempts.length > 0 ? attempts.join('; ') : 'outcomes unavailable'
+  return `${outcomes} — selected ${formatIssueValue(probe.selected_strategy || probe.selectedStrategy, 'unknown')}, fallback ${formatIssueValue(probe.fallback, 'none')}`
+}
+
 function formatIssueNumber(value, digits = 1, fallback = 'unknown') {
   const numeric = Number(value)
   return Number.isFinite(numeric) ? numeric.toFixed(digits) : fallback
@@ -298,22 +324,25 @@ export function buildGithubIssueDraft(input = {}) {
   const capture = `${formatIssueValue(stats.capture_path || stats.capture_transport, 'unknown')} — ${formatIssueValue(stats.capture_path_reason, 'unknown')}`
   const gpuProfile = linuxGpuProfile(stats)
   const gpuNativeProbe = stats.gpu_native_probe || stats.gpuNativeProbe || {}
-  const probeReason = firstNonEmpty(
-    gpuNativeProbe?.windowed?.failure_reason,
-    gpuNativeProbe?.windowed?.failureReason,
-    gpuNativeProbe?.headless_extcopy?.failure_reason,
-    gpuNativeProbe?.headlessExtcopy?.failureReason
-  )
-  const probeSummary = `${formatIssueValue(probeReason, 'not reported')} — selected ${formatIssueValue(gpuNativeProbe.selected_strategy || gpuNativeProbe.selectedStrategy, 'unknown')}, fallback ${formatIssueValue(gpuNativeProbe.fallback, 'none')}`
+  const probeSummary = formatGpuNativeProbe(gpuNativeProbe)
   const gpuDiagnosticLines = []
   const encoderAdapter = firstNonEmpty(gpuProfile.encoder_adapter, gpuProfile.encoderAdapter)
   const captureDevice = firstNonEmpty(gpuProfile.capture_device, gpuProfile.captureDevice)
   const waylandMainDevice = firstNonEmpty(gpuProfile.wayland_main_device, gpuProfile.waylandMainDevice)
   const adapterPairing = firstNonEmpty(gpuProfile.adapter_pairing_status, gpuProfile.adapterPairingStatus)
+  const adapterPairingSource = lower(gpuProfile.adapter_pairing_device_source || gpuProfile.adapterPairingDeviceSource)
+  const adapterPairingDevice = firstNonEmpty(
+    gpuProfile.adapter_pairing_device,
+    gpuProfile.adapterPairingDevice,
+    adapterPairingSource === 'capture_device' ? captureDevice : '',
+    adapterPairingSource === 'wayland_main_device' ? waylandMainDevice : '',
+    captureDevice,
+    waylandMainDevice
+  )
   if (encoderAdapter) gpuDiagnosticLines.push(issueDraftLine('Encoder adapter', encoderAdapter))
   if (captureDevice) gpuDiagnosticLines.push(issueDraftLine('Capture device', captureDevice))
   if (waylandMainDevice) gpuDiagnosticLines.push(issueDraftLine('Wayland main device', waylandMainDevice))
-  if (adapterPairing) gpuDiagnosticLines.push(issueDraftLine('Adapter pairing', adapterPairing))
+  if (encoderAdapter && adapterPairingDevice && adapterPairing) gpuDiagnosticLines.push(issueDraftLine('Adapter pairing', adapterPairing))
   if (Object.keys(gpuNativeProbe).length > 0) gpuDiagnosticLines.push(issueDraftLine('GPU-native probe', probeSummary))
   const doctorSummary = firstNonEmpty(doctor.simple_state, doctor.summary, doctor.diagnosis, doctor.primary_issue, 'Polaris did not include a Doctor diagnosis yet.')
 

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -131,7 +131,7 @@ describe('GitHub issue draft support flow', () => {
           adapter_pairing_status: 'mismatched',
         },
         gpu_native_probe: {
-          windowed: { failure_reason: 'no_live_dmabuf_frame' },
+          windowed: { attempted: true, cached: false, result: 'failed', failure_stage: 'first_frame', failure_reason: 'no_live_dmabuf_frame' },
           selected_strategy: 'headless_shm',
           fallback: 'headless_shm',
         },
@@ -164,7 +164,7 @@ describe('GitHub issue draft support flow', () => {
     expect(draft).toContain('- Encoder adapter: /dev/dri/renderD129')
     expect(draft).toContain('- Wayland main device: /dev/dri/renderD128')
     expect(draft).toContain('- Adapter pairing: mismatched')
-    expect(draft).toContain('- GPU-native probe: no_live_dmabuf_frame — selected headless_shm, fallback headless_shm')
+    expect(draft).toContain('- GPU-native probe: windowed[result=failed, attempted=yes, cached=no, stage=first_frame, reason=no_live_dmabuf_frame] — selected headless_shm, fallback headless_shm')
     expect(draft).toContain('- Active stream: yes, 118.5 FPS / 120.0 target, 45000 kbps, 2.40% loss, 9.8 ms encode')
     expect(draft).toContain('## What Polaris thinks happened')
     expect(draft).toContain('Stream is playable, but capture fell back to system memory.')
@@ -178,10 +178,57 @@ describe('GitHub issue draft support flow', () => {
     expect(draft).not.toContain('abc123')
   })
 
+  it('reports successful GPU-native probe outcomes without calling them unreported', () => {
+    const draft = buildGithubIssueDraft({ session_snapshot: { gpu_native_probe: {
+      headless_extcopy: { attempted: true, cached: false, result: 'succeeded', failure_stage: '', failure_reason: '' },
+      selected_strategy: 'headless_extcopy_dmabuf', fallback: 'none',
+    } } })
+    expect(draft).toContain('headless_extcopy[result=succeeded, attempted=yes, cached=no]')
+    expect(draft).not.toContain('GPU-native probe: not reported')
+  })
+
+  it('reports cached probe outcomes as cached rather than live attempts', () => {
+    const draft = buildGithubIssueDraft({ session_snapshot: { gpu_native_probe: {
+      windowed: { attempted: false, cached: true, result: 'succeeded', failure_stage: '', failure_reason: '' },
+      selected_strategy: 'windowed_dmabuf_override', fallback: 'none',
+    } } })
+    expect(draft).toContain('windowed[result=succeeded, attempted=no, cached=yes]')
+  })
+
+  it('preserves explicit not-attempted probe outcomes', () => {
+    const draft = buildGithubIssueDraft({ session_snapshot: { gpu_native_probe: {
+      headless_extcopy: { attempted: false, cached: false, result: 'not_attempted', failure_stage: '', failure_reason: '' },
+      windowed: { attempted: false, cached: false, result: 'not_attempted', failure_stage: '', failure_reason: '' },
+      selected_strategy: 'none', fallback: 'none',
+    } } })
+    expect(draft).toContain('headless_extcopy[result=not_attempted, attempted=no, cached=no]')
+    expect(draft).toContain('windowed[result=not_attempted, attempted=no, cached=no]')
+  })
+
+  it('reports both strategy failures instead of discarding one reason', () => {
+    const draft = buildGithubIssueDraft({ session_snapshot: { gpu_native_probe: {
+      headless_extcopy: { attempted: true, cached: false, result: 'failed', failure_stage: 'capture_init', failure_reason: 'dmabuf_capture_not_initialized' },
+      windowed: { attempted: true, cached: false, result: 'failed', failure_stage: 'first_frame', failure_reason: 'no_live_dmabuf_frame' },
+      selected_strategy: 'headless_shm', fallback: 'headless_shm',
+    } } })
+    expect(draft).toContain('headless_extcopy[result=failed, attempted=yes, cached=no, stage=capture_init, reason=dmabuf_capture_not_initialized]')
+    expect(draft).toContain('windowed[result=failed, attempted=yes, cached=no, stage=first_frame, reason=no_live_dmabuf_frame]')
+  })
+
   it('omits unavailable GPU topology and probe rows instead of fabricating unknown evidence', () => {
     const draft = buildGithubIssueDraft({
       version: '1.2.3-dev',
-      session_snapshot: { capture_path: 'unknown' },
+      session_snapshot: {
+        capture_path: 'unknown',
+        linux_gpu_profile: {
+          encoder_adapter: '/dev/dri/renderD129',
+          capture_device: '',
+          wayland_main_device: '',
+          adapter_pairing_status: 'unknown',
+          adapter_pairing_device: '',
+          adapter_pairing_device_source: 'none',
+        },
+      },
     })
 
     expect(draft).not.toContain('- Encoder adapter: unknown')

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -124,6 +124,17 @@ describe('GitHub issue draft support flow', () => {
         bitrate_kbps: 45000,
         packet_loss: 2.4,
         encode_time_ms: 9.8,
+        linux_gpu_profile: {
+          encoder_adapter: '/dev/dri/renderD129',
+          capture_device: '',
+          wayland_main_device: '/dev/dri/renderD128',
+          adapter_pairing_status: 'mismatched',
+        },
+        gpu_native_probe: {
+          windowed: { failure_reason: 'no_live_dmabuf_frame' },
+          selected_strategy: 'headless_shm',
+          fallback: 'headless_shm',
+        },
         doctor: {
           simple_state: 'Stream is playable, but capture fell back to system memory.',
           primary_issue: 'gpu_native_requested_shm_fallback',
@@ -150,6 +161,10 @@ describe('GitHub issue draft support flow', () => {
     expect(draft).toContain('- Launch mode: Private Stream')
     expect(draft).toContain('- Encoder: vaapi')
     expect(draft).toContain('- Capture: shm_cpu_capture — gpu_native_requested_shm_fallback')
+    expect(draft).toContain('- Encoder adapter: /dev/dri/renderD129')
+    expect(draft).toContain('- Wayland main device: /dev/dri/renderD128')
+    expect(draft).toContain('- Adapter pairing: mismatched')
+    expect(draft).toContain('- GPU-native probe: no_live_dmabuf_frame — selected headless_shm, fallback headless_shm')
     expect(draft).toContain('- Active stream: yes, 118.5 FPS / 120.0 target, 45000 kbps, 2.40% loss, 9.8 ms encode')
     expect(draft).toContain('## What Polaris thinks happened')
     expect(draft).toContain('Stream is playable, but capture fell back to system memory.')
@@ -161,6 +176,19 @@ describe('GitHub issue draft support flow', () => {
     expect(draft).toContain('This report was generated locally from a redacted Polaris support bundle. Nothing was submitted automatically.')
     expect(draft).not.toContain('hunter2')
     expect(draft).not.toContain('abc123')
+  })
+
+  it('omits unavailable GPU topology and probe rows instead of fabricating unknown evidence', () => {
+    const draft = buildGithubIssueDraft({
+      version: '1.2.3-dev',
+      session_snapshot: { capture_path: 'unknown' },
+    })
+
+    expect(draft).not.toContain('- Encoder adapter: unknown')
+    expect(draft).not.toContain('- Capture device: unknown')
+    expect(draft).not.toContain('- Wayland main device: unknown')
+    expect(draft).not.toContain('- Adapter pairing: unknown')
+    expect(draft).not.toContain('- GPU-native probe: not reported')
   })
 })
 
@@ -267,6 +295,45 @@ describe('Fix My Stream checklist', () => {
     expect(capture.action).toContain('conservative Private Stream baseline')
     expect(`${capture.detail} ${capture.action}`).not.toContain('CUDA')
     expect(`${capture.detail} ${capture.action}`).not.toContain('NVIDIA')
+  })
+
+  it('reports a Wayland-to-encoder adapter mismatch before generic SHM fallback guidance', () => {
+    const stats = {
+      capture_path: 'shm_cpu_capture',
+      capture_path_reason: 'gpu_native_requested_shm_fallback',
+      capture_cpu_copy: true,
+      capture_gpu_native: false,
+      encode_target_device: 'vaapi',
+      linux_gpu_profile: {
+        encoder_api: 'vaapi',
+        encoder_adapter: '/dev/dri/renderD129',
+        capture_device: '',
+        wayland_main_device: '/dev/dri/renderD128',
+        adapter_matches_capture_device: null,
+        adapter_matches_wayland_main_device: false,
+        adapter_pairing_status: 'mismatched',
+        adapter_pairing_device_source: 'wayland_main_device',
+        gpu_native_requested: true,
+        gpu_native_succeeded: false,
+      },
+      gpu_native_probe: {
+        requested: true,
+        attempted: true,
+        windowed: {
+          result: 'failed',
+          failure_stage: 'first_frame',
+          failure_reason: 'no_live_dmabuf_frame',
+        },
+        selected_strategy: 'headless_shm',
+        fallback: 'headless_shm',
+      },
+    }
+
+    const description = describeLinuxGpuProfile(stats)
+    expect(description).toContain('/dev/dri/renderD129')
+    expect(description).toContain('/dev/dri/renderD128')
+    expect(description).toContain('Wayland compositor')
+    expect(description).not.toContain('NVIDIA')
   })
 
   it('surfaces NVIDIA true-headless GPU-native configuration warnings before capture tuning', () => {

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -241,6 +241,10 @@ TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessDoesNotReportWindowedFallbac
 }
 
 #ifdef POLARIS_TESTS
+TEST(WaylandDrmDeviceTests, InvalidDeviceDoesNotFabricateRenderNode) {
+  EXPECT_TRUE(wl::render_node_from_drm_device_for_tests(dev_t {}).empty());
+}
+
 TEST(CageDisplayRouterPolicyTests, WindowedRamCaptureFallbackWarningLogsOnlyOnce) {
   cage_display_router::reset_windowed_ram_capture_warning_for_tests();
 

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -155,6 +155,20 @@ TEST(StreamStatsLinuxGpuProfileTests, DoesNotCallMissingCaptureDeviceAnAdapterMa
   EXPECT_EQ(profile.at("adapter_pairing_device_source"), "none");
 }
 
+TEST(StreamStatsLinuxGpuProfileTests, KeepsIdenticalUnresolvableDevicePairingUnknown) {
+  LinuxDisplayConfigGuard guard;
+  config::video.adapter_name = "/dev/dri/polaris-missing-shared-node";
+
+  stream_stats::stats_t stats {};
+  stats.wayland_main_device = "/dev/dri/polaris-missing-shared-node";
+
+  const auto profile = stream_stats::linux_gpu_profile_json(stats);
+
+  EXPECT_TRUE(profile.at("adapter_matches_wayland_main_device").is_null());
+  EXPECT_EQ(profile.at("adapter_pairing_status"), "unknown");
+  EXPECT_TRUE(profile.at("configuration_warnings").empty());
+}
+
 TEST(StreamStatsLinuxGpuProfileTests, KeepsUnresolvableDevicePairingUnknown) {
   LinuxDisplayConfigGuard guard;
   config::video.adapter_name = "/dev/dri/polaris-missing-encoder-node";

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -9,7 +9,12 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
+#include <filesystem>
 #include <string>
+#ifdef __linux__
+  #include <unistd.h>
+#endif
 
 namespace {
   struct LinuxDisplayConfigGuard {
@@ -131,6 +136,76 @@ TEST(StreamStatsLinuxGpuProfileTests, WarnsWhenNvidiaTrueHeadlessDisablesGpuNati
   );
 }
 
+TEST(StreamStatsLinuxGpuProfileTests, DoesNotCallMissingCaptureDeviceAnAdapterMatch) {
+  LinuxDisplayConfigGuard guard;
+  config::video.adapter_name = "/dev/dri/renderD129";
+
+  stream_stats::stats_t stats {};
+  stats.capture_transport = platf::frame_transport_e::shm;
+  stats.capture_residency = platf::frame_residency_e::cpu;
+  stats.encode_target_device = "vaapi";
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+
+  const auto profile = stream_stats::linux_gpu_profile_json(stats);
+
+  EXPECT_TRUE(profile.at("adapter_matches_capture_device").is_null());
+  ASSERT_TRUE(profile.contains("adapter_pairing_status"));
+  EXPECT_EQ(profile.at("adapter_pairing_status"), "unknown");
+  ASSERT_TRUE(profile.contains("adapter_pairing_device_source"));
+  EXPECT_EQ(profile.at("adapter_pairing_device_source"), "none");
+}
+
+TEST(StreamStatsLinuxGpuProfileTests, UsesWaylandMainDeviceWhenCaptureFrameDeviceIsUnavailable) {
+  LinuxDisplayConfigGuard guard;
+  config::video.adapter_name = "/dev/dri/renderD129";
+
+  stream_stats::stats_t stats {};
+  stats.capture_transport = platf::frame_transport_e::shm;
+  stats.capture_residency = platf::frame_residency_e::cpu;
+  stats.wayland_main_device = "/dev/dri/renderD128";
+  stats.encode_target_device = "vaapi";
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+
+  const auto profile = stream_stats::linux_gpu_profile_json(stats);
+
+  EXPECT_TRUE(profile.at("adapter_matches_capture_device").is_null());
+  EXPECT_FALSE(profile.at("adapter_matches_wayland_main_device"));
+  EXPECT_EQ(profile.at("adapter_pairing_status"), "mismatched");
+  EXPECT_EQ(profile.at("adapter_pairing_device"), "/dev/dri/renderD128");
+  EXPECT_EQ(profile.at("adapter_pairing_device_source"), "wayland_main_device");
+
+  const auto &warnings = profile.at("configuration_warnings");
+  const auto mismatch = std::find_if(warnings.begin(), warnings.end(), [](const auto &warning) {
+    return warning.value("id", std::string {}) == "linux_gpu_adapter_mismatch";
+  });
+  ASSERT_NE(mismatch, warnings.end());
+  EXPECT_NE(mismatch->at("message").get<std::string>().find("renderD129"), std::string::npos);
+  EXPECT_NE(mismatch->at("message").get<std::string>().find("renderD128"), std::string::npos);
+}
+
+#ifdef __linux__
+TEST(StreamStatsLinuxGpuProfileTests, TreatsSymlinkedAdapterAsTheSameDeviceNode) {
+  LinuxDisplayConfigGuard guard;
+  const auto link_path = std::filesystem::temp_directory_path() /
+    ("polaris-stream-stats-device-link-" + std::to_string(::getpid()));
+  std::error_code ec;
+  std::filesystem::remove(link_path, ec);
+  ec.clear();
+  std::filesystem::create_symlink("/dev/null", link_path, ec);
+  ASSERT_FALSE(ec);
+
+  config::video.adapter_name = "/dev/null";
+  stream_stats::stats_t stats {};
+  stats.wayland_main_device = link_path.string();
+
+  const auto profile = stream_stats::linux_gpu_profile_json(stats);
+  EXPECT_EQ(profile.at("adapter_pairing_status"), "matched");
+  EXPECT_TRUE(profile.at("adapter_matches_wayland_main_device"));
+
+  std::filesystem::remove(link_path, ec);
+}
+#endif
+
 TEST(StreamStatsControllerInputTests, SerializesNativeControllerDiagnostics) {
   stream_stats::stats_t stats {};
   stats.input_virtual_controller_created = true;
@@ -247,6 +322,75 @@ TEST(StreamStatsCapturePathTests, ExplainsGpuNativeShmFallback) {
   EXPECT_TRUE(profile.at("adapter_matches_capture_device"));
   EXPECT_TRUE(profile.at("gpu_native_requested"));
   EXPECT_FALSE(profile.at("gpu_native_succeeded"));
+}
+
+TEST(StreamStatsCapturePathTests, SerializesStructuredGpuNativeProbeFailures) {
+  stream_stats::stats_t stats {};
+  stats.gpu_native_probe.requested = true;
+  stats.gpu_native_probe.headless_extcopy.attempted = true;
+  stats.gpu_native_probe.headless_extcopy.result = "failed";
+  stats.gpu_native_probe.headless_extcopy.failure_stage = "capture_init";
+  stats.gpu_native_probe.headless_extcopy.failure_reason = "dmabuf_capture_not_initialized";
+  stats.gpu_native_probe.windowed.attempted = true;
+  stats.gpu_native_probe.windowed.result = "failed";
+  stats.gpu_native_probe.windowed.failure_stage = "first_frame";
+  stats.gpu_native_probe.windowed.failure_reason = "no_live_dmabuf_frame";
+  stats.gpu_native_probe.selected_strategy = "headless_shm";
+  stats.gpu_native_probe.fallback = "headless_shm";
+
+  const auto json = nlohmann::json::parse(stats.to_json());
+  const auto &probe = json.at("gpu_native_probe");
+
+  EXPECT_TRUE(probe.at("requested"));
+  EXPECT_TRUE(probe.at("attempted"));
+  EXPECT_EQ(probe.at("headless_extcopy").at("failure_reason"), "dmabuf_capture_not_initialized");
+  EXPECT_EQ(probe.at("windowed").at("failure_stage"), "first_frame");
+  EXPECT_EQ(probe.at("windowed").at("failure_reason"), "no_live_dmabuf_frame");
+  EXPECT_EQ(probe.at("selected_strategy"), "headless_shm");
+  EXPECT_EQ(probe.at("fallback"), "headless_shm");
+
+  const auto profile = stream_stats::linux_gpu_profile_json(stats);
+  EXPECT_TRUE(profile.at("gpu_native_requested"));
+  EXPECT_TRUE(profile.at("gpu_native_attempted"));
+  EXPECT_FALSE(profile.at("gpu_native_succeeded"));
+}
+
+TEST(StreamStatsGpuNativeProbeTests, RecordsCachedFailuresAndResetsForNextDecision) {
+  stream_stats::update_wayland_main_device("/dev/dri/renderD128");
+  stream_stats::reset_gpu_native_probe(true);
+  EXPECT_EQ(stream_stats::get_current().wayland_main_device, "/dev/dri/renderD128");
+  stream_stats::update_gpu_native_probe_attempt(
+    "headless_extcopy",
+    "failed",
+    "capture_init",
+    "dmabuf_capture_not_initialized"
+  );
+  stream_stats::update_gpu_native_probe_attempt(
+    "windowed",
+    "failed",
+    "cache",
+    "cached_unsupported",
+    true
+  );
+  stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");
+
+  auto stats = stream_stats::get_current();
+  EXPECT_TRUE(stats.gpu_native_probe.requested);
+  EXPECT_EQ(stats.gpu_native_probe.headless_extcopy.failure_reason, "dmabuf_capture_not_initialized");
+  EXPECT_TRUE(stats.gpu_native_probe.windowed.cached);
+  EXPECT_FALSE(stats.gpu_native_probe.windowed.attempted);
+  EXPECT_EQ(stats.gpu_native_probe.selected_strategy, "headless_shm");
+
+  stream_stats::reset_gpu_native_probe(false);
+  stats = stream_stats::get_current();
+  EXPECT_FALSE(stats.gpu_native_probe.requested);
+  EXPECT_FALSE(stats.gpu_native_probe.headless_extcopy.attempted);
+  EXPECT_EQ(stats.gpu_native_probe.windowed.result, "not_attempted");
+  EXPECT_EQ(stats.gpu_native_probe.selected_strategy, "none");
+
+  stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "policy", "not_requested");
+  EXPECT_FALSE(stream_stats::get_current().gpu_native_probe.headless_extcopy.attempted);
+  stream_stats::update_wayland_main_device({});
 }
 
 TEST(StreamStatsCapturePathTests, DetectsCpuEncodeUpload) {

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -155,14 +155,28 @@ TEST(StreamStatsLinuxGpuProfileTests, DoesNotCallMissingCaptureDeviceAnAdapterMa
   EXPECT_EQ(profile.at("adapter_pairing_device_source"), "none");
 }
 
+TEST(StreamStatsLinuxGpuProfileTests, KeepsUnresolvableDevicePairingUnknown) {
+  LinuxDisplayConfigGuard guard;
+  config::video.adapter_name = "/dev/dri/polaris-missing-encoder-node";
+
+  stream_stats::stats_t stats {};
+  stats.wayland_main_device = "/dev/dri/polaris-missing-wayland-node";
+
+  const auto profile = stream_stats::linux_gpu_profile_json(stats);
+
+  EXPECT_TRUE(profile.at("adapter_matches_wayland_main_device").is_null());
+  EXPECT_EQ(profile.at("adapter_pairing_status"), "unknown");
+  EXPECT_TRUE(profile.at("configuration_warnings").empty());
+}
+
 TEST(StreamStatsLinuxGpuProfileTests, UsesWaylandMainDeviceWhenCaptureFrameDeviceIsUnavailable) {
   LinuxDisplayConfigGuard guard;
-  config::video.adapter_name = "/dev/dri/renderD129";
+  config::video.adapter_name = "/dev/null";
 
   stream_stats::stats_t stats {};
   stats.capture_transport = platf::frame_transport_e::shm;
   stats.capture_residency = platf::frame_residency_e::cpu;
-  stats.wayland_main_device = "/dev/dri/renderD128";
+  stats.wayland_main_device = "/dev/zero";
   stats.encode_target_device = "vaapi";
   stats.encode_target_residency = platf::frame_residency_e::gpu;
 
@@ -171,7 +185,7 @@ TEST(StreamStatsLinuxGpuProfileTests, UsesWaylandMainDeviceWhenCaptureFrameDevic
   EXPECT_TRUE(profile.at("adapter_matches_capture_device").is_null());
   EXPECT_FALSE(profile.at("adapter_matches_wayland_main_device"));
   EXPECT_EQ(profile.at("adapter_pairing_status"), "mismatched");
-  EXPECT_EQ(profile.at("adapter_pairing_device"), "/dev/dri/renderD128");
+  EXPECT_EQ(profile.at("adapter_pairing_device"), "/dev/zero");
   EXPECT_EQ(profile.at("adapter_pairing_device_source"), "wayland_main_device");
 
   const auto &warnings = profile.at("configuration_warnings");
@@ -179,8 +193,8 @@ TEST(StreamStatsLinuxGpuProfileTests, UsesWaylandMainDeviceWhenCaptureFrameDevic
     return warning.value("id", std::string {}) == "linux_gpu_adapter_mismatch";
   });
   ASSERT_NE(mismatch, warnings.end());
-  EXPECT_NE(mismatch->at("message").get<std::string>().find("renderD129"), std::string::npos);
-  EXPECT_NE(mismatch->at("message").get<std::string>().find("renderD128"), std::string::npos);
+  EXPECT_NE(mismatch->at("message").get<std::string>().find("/dev/null"), std::string::npos);
+  EXPECT_NE(mismatch->at("message").get<std::string>().find("/dev/zero"), std::string::npos);
 }
 
 #ifdef __linux__
@@ -355,6 +369,19 @@ TEST(StreamStatsCapturePathTests, SerializesStructuredGpuNativeProbeFailures) {
   EXPECT_FALSE(profile.at("gpu_native_succeeded"));
 }
 
+TEST(StreamStatsGpuNativeProbeTests, ClearsStaleDeviceIdentityForNewCaptureGeneration) {
+  stream_stats::update_capture_metadata(platf::frame_metadata_t {
+    .device = "/dev/dri/renderD130",
+  });
+  stream_stats::update_wayland_main_device("/dev/dri/renderD131");
+
+  stream_stats::reset_gpu_native_probe(true, true);
+  const auto stats = stream_stats::get_current();
+
+  EXPECT_TRUE(stats.capture_device.empty());
+  EXPECT_TRUE(stats.wayland_main_device.empty());
+}
+
 TEST(StreamStatsGpuNativeProbeTests, RecordsCachedFailuresAndResetsForNextDecision) {
   stream_stats::update_wayland_main_device("/dev/dri/renderD128");
   stream_stats::reset_gpu_native_probe(true);
@@ -443,7 +470,7 @@ TEST(StreamStatsCapturePathTests, LabelsHeadlessExtcopyDmabufPath) {
 
 TEST(StreamStatsCapturePathTests, FlagsHeadlessCrossGpuDmabufRisk) {
   LinuxDisplayConfigGuard guard;
-  config::video.adapter_name = "/dev/dri/renderD128";
+  config::video.adapter_name = "/dev/null";
   config::video.linux_display.use_cage_compositor = true;
 
   stream_stats::stats_t stats {};
@@ -453,7 +480,7 @@ TEST(StreamStatsCapturePathTests, FlagsHeadlessCrossGpuDmabufRisk) {
   stats.capture_transport = platf::frame_transport_e::dmabuf;
   stats.capture_residency = platf::frame_residency_e::gpu;
   stats.capture_format = platf::frame_format_e::bgra8;
-  stats.capture_device = "/dev/dri/renderD129";
+  stats.capture_device = "/dev/zero";
   stats.encode_target_residency = platf::frame_residency_e::gpu;
 
 #ifdef __linux__
@@ -464,11 +491,11 @@ TEST(StreamStatsCapturePathTests, FlagsHeadlessCrossGpuDmabufRisk) {
 #endif
 
   const auto json = nlohmann::json::parse(stats.to_json());
-  EXPECT_EQ(json.at("capture_device"), "/dev/dri/renderD129");
+  EXPECT_EQ(json.at("capture_device"), "/dev/zero");
   ASSERT_TRUE(json.contains("capture_decision"));
   const auto &decision = json.at("capture_decision");
-  EXPECT_EQ(decision.at("capture_device"), "/dev/dri/renderD129");
-  EXPECT_EQ(decision.at("encoder_adapter"), "/dev/dri/renderD128");
+  EXPECT_EQ(decision.at("capture_device"), "/dev/zero");
+  EXPECT_EQ(decision.at("encoder_adapter"), "/dev/null");
 #ifdef __linux__
   EXPECT_TRUE(decision.at("cross_gpu_dmabuf_risk"));
   EXPECT_EQ(decision.at("reason"), "headless_extcopy_dmabuf_cross_gpu_risk");


### PR DESCRIPTION
## Summary
- resolve Wayland DMA-BUF `main_device` feedback to a DRM render node for diagnostics
- replace unknown-as-matched adapter reporting with nullable match fields and explicit `matched` / `mismatched` / `unknown` pairing status
- compare device-node aliases by filesystem identity and keep unresolved identities unknown while preserving safe SHM fallback
- export structured headless and windowed GPU-native probe outcomes through stream stats, Doctor evidence, `/stream-policy`, support bundles, and generated issue drafts
- generation-scope capture-device telemetry and refresh late Wayland feedback to prevent stale topology reports

## Safety
- preserves the existing true-headless VAAPI DMA-BUF stability gate
- preserves conservative SHM/system-memory fallback
- does not rewrite the configured encoder adapter automatically
- defers topology-keyed probe-cache invalidation to a separate tested change

## Verification
- full GCC 15 / CUDA-disabled Polaris build passed
- serial CTest: 12/12 suites passed
- ESLint passed
- Vitest: 40/40 files, 198/198 tests passed
- production Vite build passed
- `git diff --check` passed

## Context
Improves the mixed-GPU AMD/VAAPI evidence needed to diagnose the capture fallback reported in Discussion #167 without weakening the current stability policy.