### PR TITLE
fix: harden session lifecycle teardown

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2699,7 +2699,7 @@ namespace confighttp {
     if (stats.streaming) {
       if (stats.runtime_gpu_native_override_active) {
         effective_mode = "windowed_stream";
-      } else if (proc::proc.virtual_display) {
+      } else if (proc::proc.session_uses_virtual_display()) {
         effective_mode = "host_virtual_display";
       } else if (configured_mode == "windowed_stream" && stats.runtime_effective_headless) {
         effective_mode = "windowed_stream";

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -893,24 +893,31 @@ namespace nvhttp {
       return "headless_stream";
     }
 
-	    std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats) {
-	      if (!stats.streaming) {
-	        return configured_stream_display_mode_selection();
-	      }
-	      const auto configured_mode = configured_stream_display_mode_selection();
-	      if (stats.runtime_gpu_native_override_active) {
-	        return "windowed_stream";
-	      }
-	      if (proc::proc.virtual_display) {
-	        return "host_virtual_display";
-	      }
+    std::string effective_stream_display_mode_selection(
+      const stream_stats::stats_t &stats,
+      bool session_uses_virtual_display
+    ) {
+      if (!stats.streaming) {
+        return configured_stream_display_mode_selection();
+      }
+      const auto configured_mode = configured_stream_display_mode_selection();
+      if (stats.runtime_gpu_native_override_active) {
+        return "windowed_stream";
+      }
+      if (session_uses_virtual_display) {
+        return "host_virtual_display";
+      }
       if (configured_mode == "windowed_stream" && stats.runtime_effective_headless) {
         return "windowed_stream";
       }
-	      if (stats.runtime_effective_headless) {
-	        return "headless_stream";
-	      }
+      if (stats.runtime_effective_headless) {
+        return "headless_stream";
+      }
       return "desktop_display";
+    }
+
+    std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats) {
+      return effective_stream_display_mode_selection(stats, proc::proc.session_uses_virtual_display());
     }
 
     std::string stream_display_mode_label_for_selection(const std::string &selection) {
@@ -2787,20 +2794,6 @@ namespace nvhttp {
       return session_token_matches_value(get_arg(args, "sessiontoken", ""));
     }
 
-    void request_active_session_shutdown() {
-      proc::proc.set_session_shutdown_requested(true);
-      rtsp_stream::terminate_sessions();
-
-      if (proc::proc.running() > 0) {
-        proc::proc.terminate();
-      } else {
-        proc::proc.set_session_shutdown_requested(false);
-      }
-
-      // The config needs to be reverted regardless of whether "proc::proc.terminate()" was called or not.
-      display_device::revert_configuration();
-    }
-
     void append_current_game_session_fields(pt::ptree &tree, const crypto::named_cert_t *named_cert_p) {
       const auto current_session_token = proc::proc.get_session_token();
       const auto current_session_owner = proc::proc.get_session_owner_unique_id();
@@ -2815,6 +2808,7 @@ namespace nvhttp {
       );
     }
   }  // namespace
+
 
   /**
    * @brief Check if an IP address falls within any configured trusted subnet.
@@ -4892,9 +4886,6 @@ namespace nvhttp {
     auto appid_str = get_arg(args, "appid", "0");
     auto appuuid_str = get_arg(args, "appuuid", "");
     auto appid = util::from_view(appid_str);
-    auto current_appid = proc::proc.running();
-    auto current_app_uuid = proc::proc.get_running_app_uuid();
-    bool is_input_only = config::input.enable_input_only_mode && (appid == proc::input_only_app_id || (appuuid_str == REMOTE_INPUT_UUID));
 
     auto named_cert_p = get_verified_cert(request);
     if (!named_cert_p) {
@@ -4904,6 +4895,20 @@ namespace nvhttp {
       return;
     }
 
+    const auto launch_generation = proc::proc.capture_session_launch_generation();
+    if (!launch_generation || !proc::proc.try_begin_session_launch(*launch_generation)) {
+      tree.put("root.resume", 0);
+      tree.put("root.<xmlattr>.status_code", 409);
+      tree.put("root.<xmlattr>.status_message", "The active session is stopping or changing");
+      return;
+    }
+    auto release_session_launch = util::fail_guard([]() {
+      proc::proc.finish_session_launch();
+    });
+
+    auto current_appid = proc::proc.running();
+    auto current_app_uuid = proc::proc.get_running_app_uuid();
+    bool is_input_only = config::input.enable_input_only_mode && (appid == proc::input_only_app_id || (appuuid_str == REMOTE_INPUT_UUID));
     auto perm = PERM::launch;
 
     BOOST_LOG(verbose) << "Launching app [" << appid_str << "] with UUID [" << appuuid_str << "]";
@@ -4946,7 +4951,8 @@ namespace nvhttp {
         (config::input.enable_input_only_mode && appid == proc::terminate_app_id)
         || appuuid_str == TERMINATE_APP_UUID
       ) {
-        proc::proc.terminate();
+        release_session_launch.disable();
+        proc::proc.terminate_from_admitted_launch();
 
         tree.put("root.resume", 0);
         tree.put("root.<xmlattr>.status_code", 410);
@@ -4974,6 +4980,7 @@ namespace nvhttp {
     host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     auto launch_session = make_launch_session(host_audio, is_input_only, args, named_cert_p.get());
     const bool watch_only = launch_session->watch_only;
+    bool launch_session_raised = false;
 
     auto encryption_mode = net::encryption_mode_for_address(request->remote_endpoint().address());
     if (!launch_session->rtsp_cipher && encryption_mode == config::ENCRYPTION_MODE_MANDATORY) {
@@ -5030,7 +5037,7 @@ namespace nvhttp {
 
       // Still probe encoders once, if input only session is launched first
       // But we're ignoring if it's successful or not
-      if (no_active_sessions && !proc::proc.virtual_display) {
+      if (no_active_sessions && !proc::proc.session_uses_virtual_display()) {
 #ifdef __linux__
         if (should_defer_encoder_probe_until_cage()) {
           BOOST_LOG(info) << "nvhttp: Deferring input-only encoder probe until the cage runtime is available"sv;
@@ -5040,7 +5047,7 @@ namespace nvhttp {
           video::probe_encoders();
         }
         if (current_appid == 0) {
-          proc::proc.launch_input_only(launch_session);
+          launch_session_raised = proc::proc.launch_input_only_and_raise(launch_session);
         }
       }
     } else if (appid > 0 || !appuuid_str.empty()) {
@@ -5066,7 +5073,7 @@ namespace nvhttp {
 
         launch_session->session_token = proc::proc.get_session_token();
 
-        if (watch_only || !proc::proc.allow_client_commands || !named_cert_p->allow_client_commands) {
+        if (watch_only || !proc::proc.session_allows_client_commands() || !named_cert_p->allow_client_commands) {
           launch_session->client_do_cmds.clear();
           launch_session->client_undo_cmds.clear();
         }
@@ -5075,7 +5082,7 @@ namespace nvhttp {
           launch_session->input_only = true;
         }
 
-        if (no_active_sessions && !proc::proc.virtual_display) {
+        if (no_active_sessions && !proc::proc.session_uses_virtual_display()) {
           display_device::configure_display(config::video, *launch_session);
 #ifdef __linux__
           if (should_defer_encoder_probe_until_cage()) {
@@ -5161,7 +5168,8 @@ namespace nvhttp {
           }
         } catch (...) {}
 
-        auto err = proc::proc.execute(*app_iter, launch_session);
+        auto err = proc::proc.execute_and_raise(*app_iter, launch_session);
+        launch_session_raised = err == 0;
         if (err) {
           tree.put("root.<xmlattr>.status_code", err);
           tree.put(
@@ -5180,6 +5188,13 @@ namespace nvhttp {
       tree.put("root.gamesession", 0);
     }
 
+    if (!launch_session_raised && !proc::proc.raise_session_for_admitted_launch(launch_session)) {
+      tree.put("root.resume", 0);
+      tree.put("root.<xmlattr>.status_code", 409);
+      tree.put("root.<xmlattr>.status_message", "Another launch is already pending");
+      return;
+    }
+
     tree.put("root.<xmlattr>.status_code", 200);
     tree.put(
       "root.sessionUrl0",
@@ -5193,7 +5208,6 @@ namespace nvhttp {
     tree.put("root.sessionToken", launch_session->session_token);
     tree.put("root.gamesession", 1);
 
-    rtsp_stream::launch_session_raise(launch_session);
   }
 
   void resume(bool &host_audio, resp_https_t response, req_https_t request) {
@@ -5225,6 +5239,17 @@ namespace nvhttp {
 
       return;
     }
+
+    const auto launch_generation = proc::proc.capture_session_launch_generation();
+    if (!launch_generation || !proc::proc.try_begin_session_launch(*launch_generation)) {
+      tree.put("root.resume", 0);
+      tree.put("root.<xmlattr>.status_code", 409);
+      tree.put("root.<xmlattr>.status_message", "The active session is stopping or changing");
+      return;
+    }
+    auto release_session_launch = util::fail_guard([]() {
+      proc::proc.finish_session_launch();
+    });
 
     auto current_appid = proc::proc.running();
     if (current_appid == 0) {
@@ -5289,7 +5314,7 @@ namespace nvhttp {
     }
     launch_session->session_token = proc::proc.get_session_token();
 
-    if (watch_only || !proc::proc.allow_client_commands || !named_cert_p->allow_client_commands) {
+    if (watch_only || !proc::proc.session_allows_client_commands() || !named_cert_p->allow_client_commands) {
       launch_session->client_do_cmds.clear();
       launch_session->client_undo_cmds.clear();
     }
@@ -5298,7 +5323,7 @@ namespace nvhttp {
       launch_session->input_only = true;
     }
 
-    if (no_active_sessions && !proc::proc.virtual_display) {
+    if (no_active_sessions && !proc::proc.session_uses_virtual_display()) {
       // We want to prepare display only if there are no active sessions
       // and the current session isn't virtual display at the moment.
       // This should be done before probing encoders as it could change the active displays.
@@ -5333,6 +5358,13 @@ namespace nvhttp {
       return;
     }
 
+    if (!proc::proc.raise_session_for_admitted_launch(launch_session)) {
+      tree.put("root.resume", 0);
+      tree.put("root.<xmlattr>.status_code", 409);
+      tree.put("root.<xmlattr>.status_message", "Another launch is already pending");
+      return;
+    }
+
     tree.put("root.<xmlattr>.status_code", 200);
     tree.put(
       "root.sessionUrl0",
@@ -5345,8 +5377,6 @@ namespace nvhttp {
     );
     tree.put("root.sessionToken", launch_session->session_token);
     tree.put("root.resume", 1);
-
-    rtsp_stream::launch_session_raise(launch_session);
 
 #if defined POLARIS_TRAY && POLARIS_TRAY >= 1
     system_tray::update_tray_client_connected(named_cert_p->name);
@@ -5384,25 +5414,43 @@ namespace nvhttp {
       return;
     }
 
-    if (proc::proc.running() > 0 && !proc::proc.is_session_owner(named_cert_p->uuid)) {
-      tree.put("root.cancel", 0);
-      tree.put("root.<xmlattr>.status_code", 470);
-      tree.put("root.<xmlattr>.status_message", "The current session belongs to another client");
-
-      return;
+    const auto session_token = get_arg(args, "sessiontoken", "");
+    const auto shutdown = proc::proc.request_session_shutdown(
+      named_cert_p->uuid,
+      session_token,
+      true,
+      !session_token.empty()
+    );
+    switch (shutdown.snapshot.outcome) {
+      case proc::session_stop_outcome_t::allowed:
+      case proc::session_stop_outcome_t::no_active_session:
+        tree.put("root.cancel", 1);
+        tree.put("root.<xmlattr>.status_code", 200);
+        break;
+      case proc::session_stop_outcome_t::permission_denied:
+      case proc::session_stop_outcome_t::viewer_forbidden:
+      case proc::session_stop_outcome_t::uncontrolled_stream:
+        tree.put("root.cancel", 0);
+        tree.put("root.<xmlattr>.status_code", 403);
+        tree.put("root.<xmlattr>.status_message", "This client cannot stop the active session");
+        break;
+      case proc::session_stop_outcome_t::stop_in_progress:
+      case proc::session_stop_outcome_t::session_changed:
+        tree.put("root.cancel", 0);
+        tree.put("root.<xmlattr>.status_code", 409);
+        tree.put("root.<xmlattr>.status_message", "The active session changed or is already stopping");
+        break;
+      case proc::session_stop_outcome_t::other_owner:
+        tree.put("root.cancel", 0);
+        tree.put("root.<xmlattr>.status_code", 470);
+        tree.put("root.<xmlattr>.status_message", "The current session belongs to another client");
+        break;
+      case proc::session_stop_outcome_t::token_mismatch:
+        tree.put("root.cancel", 0);
+        tree.put("root.<xmlattr>.status_code", 470);
+        tree.put("root.<xmlattr>.status_message", "The requested session token does not match the active session");
+        break;
     }
-    if (proc::proc.running() > 0 && !session_token_matches_request(args)) {
-      tree.put("root.cancel", 0);
-      tree.put("root.<xmlattr>.status_code", 470);
-      tree.put("root.<xmlattr>.status_message", "The requested session token does not match the active session");
-
-      return;
-    }
-
-    tree.put("root.cancel", 1);
-    tree.put("root.<xmlattr>.status_code", 200);
-
-    request_active_session_shutdown();
 
   }
 
@@ -5724,17 +5772,21 @@ namespace nvhttp {
 
       nlohmann::json output;
 
-      // Session state from the state machine
+      // Hold lifecycle snapshot admission while assembling all generation-bound status fields.
+      const bool can_launch = static_cast<bool>(named_cert_p->perm & PERM::launch);
+      auto status_view = proc::proc.get_session_status_view(named_cert_p->uuid, can_launch);
+      const auto &status_snapshot = status_view.snapshot;
+      const auto &stop_snapshot = status_snapshot.stop;
       auto stats = stream_stats::get_current();
       auto adaptive_state = adaptive_bitrate::get_state();
       const auto session_state = confighttp::get_session_state();
-      const auto session_token = proc::proc.get_session_token();
-      const bool owned_by_client =
-        !session_token.empty() && proc::proc.is_session_owner(named_cert_p->uuid);
-      const bool shutdown_requested = proc::proc.session_shutdown_requested();
+      const auto running_app_id = stop_snapshot.running_app_id;
+      const auto &session_token = stop_snapshot.session_token;
+      const bool owned_by_client = stop_snapshot.owned_by_client;
+      const bool stop_in_progress = stop_snapshot.stop_in_progress;
       output["state"] = session_state;
       output["streaming_active"] = stats.streaming;
-      output["shutdown_requested"] = shutdown_requested;
+      output["shutdown_requested"] = stop_in_progress;
       auto &build = output["build"];
       build["cuda"] = build_has_cuda();
 #ifdef __linux__
@@ -5743,35 +5795,34 @@ namespace nvhttp {
 #endif
       output["owned_by_client"] = owned_by_client;
       output["session_token"] = session_token;
-      output["owner_unique_id"] = proc::proc.get_session_owner_unique_id();
-      output["owner_device_name"] = proc::proc.get_session_owner_device_name();
-      output["viewer_count"] = rtsp_stream::viewer_count();
+      output["owner_unique_id"] = status_snapshot.owner_unique_id;
+      output["owner_device_name"] = status_snapshot.owner_device_name;
+      output["viewer_count"] = status_snapshot.viewer_count;
 
       std::string client_role = "none";
-      if (const auto session = rtsp_stream::find_session(named_cert_p->uuid)) {
-        client_role = stream::session::is_watch_only(*session) ? "viewer" : "owner";
+      if (stop_snapshot.requester_role == rtsp_stream::session_role_e::viewer) {
+        client_role = "viewer";
+      } else if (stop_snapshot.requester_role == rtsp_stream::session_role_e::controller) {
+        client_role = "owner";
       }
       output["client_role"] = client_role;
       const bool host_tuning_allowed =
         owned_by_client &&
-        client_role != "viewer" &&
-        !shutdown_requested &&
+        stop_snapshot.requester_role != rtsp_stream::session_role_e::viewer &&
+        !stop_in_progress &&
         stats.streaming;
       const bool session_command_allowed =
-        owned_by_client &&
-        client_role != "viewer" &&
-        !shutdown_requested &&
-        proc::proc.running() > 0;
+        stop_snapshot.outcome == proc::session_stop_outcome_t::allowed;
       const bool quit_allowed =
         session_command_allowed &&
-        proc::proc.allow_client_commands &&
+        status_snapshot.client_commands_enabled &&
         named_cert_p->allow_client_commands;
       const bool session_stop_allowed = session_command_allowed;
 
       // Game info
-      output["game_id"] = proc::proc.running();
-      output["game"] = proc::proc.get_last_run_app_name();
-      output["game_uuid"] = proc::proc.get_running_app_uuid();
+      output["game_id"] = running_app_id;
+      output["game"] = status_snapshot.game;
+      output["game_uuid"] = status_snapshot.game_uuid;
       output["cursor_visible"] = cursor::visible();
       output["dynamic_range"] = stats.dynamic_range;
       auto &hdr = output["hdr"];
@@ -5789,15 +5840,15 @@ namespace nvhttp {
       output["adaptive_bitrate_reason"] = adaptive_state.reason;
       output["ai_auto_quality_enabled"] = ai_auto_quality_enabled();
       output["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
-      output["mangohud_configured"] = proc::proc.current_app_has_mangohud();
+      output["mangohud_configured"] = status_snapshot.mangohud_configured;
 
       auto &controls = output["controls"];
       controls["host_tuning_allowed"] = host_tuning_allowed;
       controls["quit_allowed"] = quit_allowed;
       controls["stop_allowed"] = session_stop_allowed;
       controls["stop_endpoint"] = "/polaris/v1/session/stop";
-      controls["shutdown_in_progress"] = shutdown_requested;
-      controls["client_commands_enabled"] = proc::proc.allow_client_commands;
+      controls["shutdown_in_progress"] = stop_in_progress;
+      controls["client_commands_enabled"] = status_snapshot.client_commands_enabled;
       controls["device_commands_enabled"] = named_cert_p->allow_client_commands;
 
       auto &tuning = output["tuning"];
@@ -5812,21 +5863,24 @@ namespace nvhttp {
       tuning["adaptive_rtt_ewma_ms"] = adaptive_state.ewma_rtt_ms;
       tuning["ai_auto_quality_enabled"] = ai_auto_quality_enabled();
       tuning["ai_optimizer_enabled"] = ai_optimizer::is_enabled();
-      tuning["mangohud_configured"] = proc::proc.current_app_has_mangohud();
+      tuning["mangohud_configured"] = status_snapshot.mangohud_configured;
 
       auto &display_mode = output["display_mode"];
-      const auto stream_display_mode = effective_stream_display_mode_selection(stats);
-      display_mode["virtual_display"] = proc::proc.virtual_display;
+      const auto stream_display_mode = effective_stream_display_mode_selection(
+        stats,
+        status_snapshot.virtual_display
+      );
+      display_mode["virtual_display"] = status_snapshot.virtual_display;
       display_mode["requested_headless"] = stats.runtime_requested_headless;
       display_mode["effective_headless"] = stats.runtime_effective_headless;
       display_mode["gpu_native_override_active"] = stats.runtime_gpu_native_override_active;
       display_mode["selection"] = stream_display_mode;
       display_mode["stream_display_mode"] = stream_display_mode;
-      display_mode["explicit_choice"] = proc::proc.session_display_mode_is_explicit();
+      display_mode["explicit_choice"] = status_snapshot.display_mode_explicit;
       display_mode["requested"] =
         session_token.empty() ? "" :
-        proc::proc.session_display_mode_is_explicit() ?
-          (proc::proc.virtual_display ? "virtual_display" : "headless") :
+        status_snapshot.display_mode_explicit ?
+          (status_snapshot.virtual_display ? "virtual_display" : "headless") :
           "auto";
       display_mode["label"] = stream_display_mode_label_for_selection(stream_display_mode);
       display_mode["reason"] = stream_display_mode_reason_for_selection(stream_display_mode);
@@ -5890,9 +5944,9 @@ namespace nvhttp {
       encoder["recommendation_version"] = stats.recommendation_version;
       const auto health = build_session_health_json(
         stats,
-        proc::proc.virtual_display,
+        status_snapshot.virtual_display,
         named_cert_p->name,
-        proc::proc.get_last_run_app_name()
+        status_snapshot.game
       );
       output["health"] = health;
       output["doctor"] = health.value("doctor", nlohmann::json::object());
@@ -6007,7 +6061,7 @@ namespace nvhttp {
         const auto stats = stream_stats::get_current();
         const auto health = build_session_health_json(
           stats,
-          proc::proc.virtual_display,
+          proc::proc.session_uses_virtual_display(),
           response_client->name,
           app_name
         );
@@ -6221,7 +6275,7 @@ namespace nvhttp {
         const auto stats = stream_stats::get_current();
         const auto health = build_session_health_json(
           stats,
-          proc::proc.virtual_display,
+          proc::proc.session_uses_virtual_display(),
           response_client->name,
           proc::proc.get_last_run_app_name()
         );
@@ -6704,7 +6758,7 @@ namespace nvhttp {
         const auto stats = stream_stats::get_current();
         const auto health = build_session_health_json(
           stats,
-          proc::proc.virtual_display,
+          proc::proc.session_uses_virtual_display(),
           named_cert_p->name,
           proc::proc.get_last_run_app_name()
         );
@@ -6766,7 +6820,7 @@ namespace nvhttp {
         output["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
         const auto health = build_session_health_json(
           stats,
-          proc::proc.virtual_display,
+          proc::proc.session_uses_virtual_display(),
           named_cert_p->name,
           proc::proc.get_last_run_app_name()
         );
@@ -6827,7 +6881,7 @@ namespace nvhttp {
         const auto stats = stream_stats::get_current();
         const auto health = build_session_health_json(
           stats,
-          proc::proc.virtual_display,
+          proc::proc.session_uses_virtual_display(),
           named_cert_p->name,
           proc::proc.get_last_run_app_name()
         );
@@ -6897,6 +6951,12 @@ namespace nvhttp {
         return;
       }
 
+      const bool can_launch = static_cast<bool>(named_cert_p->perm & PERM::launch);
+      if (!can_launch) {
+        write_json({{"status", false}, {"error", "Permission denied"}}, SimpleWeb::StatusCode::client_error_forbidden);
+        return;
+      }
+
       std::string expected_token;
       try {
         std::string body_str(std::istreambuf_iterator<char>(request->content), {});
@@ -6909,38 +6969,81 @@ namespace nvhttp {
         return;
       }
 
-      if (!(named_cert_p->perm & PERM::launch)) {
-        write_json({{"status", false}, {"error", "Permission denied"}}, SimpleWeb::StatusCode::client_error_forbidden);
+      const auto shutdown = proc::proc.request_session_shutdown(
+        named_cert_p->uuid,
+        expected_token,
+        can_launch,
+        true
+      );
+      const auto &stop_snapshot = shutdown.snapshot;
+      const bool had_running_app = stop_snapshot.had_running_app;
+      const auto active_sessions = stop_snapshot.active_sessions;
+      const bool stopped = shutdown.stopped;
+
+      if (stop_snapshot.outcome != proc::session_stop_outcome_t::allowed &&
+          stop_snapshot.outcome != proc::session_stop_outcome_t::no_active_session) {
+        switch (stop_snapshot.outcome) {
+          case proc::session_stop_outcome_t::permission_denied:
+            write_json({{"status", false}, {"error", "Permission denied"}}, SimpleWeb::StatusCode::client_error_forbidden);
+            break;
+          case proc::session_stop_outcome_t::stop_in_progress:
+            write_json(
+              {{"status", false}, {"error", "Session shutdown is already in progress"}},
+              SimpleWeb::StatusCode::client_error_conflict
+            );
+            break;
+          case proc::session_stop_outcome_t::viewer_forbidden:
+            write_json(
+              {{"status", false}, {"error", "Viewer sessions cannot stop the active session"}},
+              SimpleWeb::StatusCode::client_error_forbidden
+            );
+            break;
+          case proc::session_stop_outcome_t::uncontrolled_stream:
+            write_json(
+              {{"status", false}, {"error", "This client does not control an active stream"}},
+              SimpleWeb::StatusCode::client_error_forbidden
+            );
+            break;
+          case proc::session_stop_outcome_t::other_owner:
+            write_json(
+              {{"status", false}, {"error", "The current session belongs to another client"}},
+              static_cast<SimpleWeb::StatusCode>(470)
+            );
+            break;
+          case proc::session_stop_outcome_t::token_mismatch:
+            write_json(
+              {{"status", false}, {"error", "The requested session token does not match the active session"}},
+              static_cast<SimpleWeb::StatusCode>(470)
+            );
+            break;
+          case proc::session_stop_outcome_t::session_changed:
+            write_json(
+              {{"status", false}, {"error", "The active session changed before shutdown could complete"}},
+              SimpleWeb::StatusCode::client_error_conflict
+            );
+            break;
+          case proc::session_stop_outcome_t::allowed:
+          case proc::session_stop_outcome_t::no_active_session:
+            break;
+        }
+        BOOST_LOG(warning) << "Rejected Polaris v1 session stop request"
+                           << " owner=" << stop_snapshot.owned_by_client
+                           << " viewer=" << (stop_snapshot.requester_role == rtsp_stream::session_role_e::viewer)
+                           << " controller=" << (stop_snapshot.requester_role == rtsp_stream::session_role_e::controller)
+                           << " shutdown_requested=" << stop_snapshot.stop_in_progress
+                           << " running_app=" << had_running_app
+                           << " active_sessions=" << active_sessions;
         return;
       }
 
-      const bool had_running_app = proc::proc.running() > 0;
-      const auto active_sessions = rtsp_stream::session_count();
-      if (had_running_app && !proc::proc.is_session_owner(named_cert_p->uuid)) {
-        write_json({{"status", false}, {"error", "The current session belongs to another client"}}, static_cast<SimpleWeb::StatusCode>(470));
-        return;
-      }
-      if (had_running_app && !session_token_matches_value(expected_token)) {
-        write_json({{"status", false}, {"error", "The requested session token does not match the active session"}}, static_cast<SimpleWeb::StatusCode>(470));
-        return;
-      }
-
-      const auto game = proc::proc.get_last_run_app_name();
-      const auto session_token = proc::proc.get_session_token();
-      const bool stopped = had_running_app || active_sessions > 0;
-      if (stopped) {
-        confighttp::set_session_state(confighttp::session_state_e::tearing_down);
-        confighttp::emit_session_event("stream_stopping", "Stopping session");
-        request_active_session_shutdown();
-      }
-
+      const auto &game = stop_snapshot.game;
       nlohmann::json output;
       output["status"] = true;
       output["stopped"] = stopped;
       output["had_running_app"] = had_running_app;
       output["terminated_streams"] = active_sessions;
       output["game"] = game;
-      output["session_token"] = session_token;
+      output["session_token"] = stop_snapshot.session_token;
       output["state"] = confighttp::get_session_state();
       write_json(output);
     };

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -94,6 +94,235 @@ namespace proc {
   int terminate_app_id = -1;
   std::string terminate_app_id_str;
 
+  session_stop_outcome_t evaluate_session_stop_request(
+    bool can_launch,
+    bool has_running_app,
+    int active_sessions,
+    bool owned_by_client,
+    rtsp_stream::session_role_e requester_role,
+    bool stop_in_progress,
+    bool token_matches
+  ) {
+    if (!can_launch) {
+      return session_stop_outcome_t::permission_denied;
+    }
+    if (stop_in_progress) {
+      return session_stop_outcome_t::stop_in_progress;
+    }
+    if (!has_running_app && active_sessions <= 0) {
+      return session_stop_outcome_t::no_active_session;
+    }
+    if (requester_role == rtsp_stream::session_role_e::viewer) {
+      return session_stop_outcome_t::viewer_forbidden;
+    }
+    if (has_running_app && !owned_by_client) {
+      return session_stop_outcome_t::other_owner;
+    }
+    if (!has_running_app && requester_role != rtsp_stream::session_role_e::controller) {
+      return session_stop_outcome_t::uncontrolled_stream;
+    }
+    if (!token_matches) {
+      return session_stop_outcome_t::token_mismatch;
+    }
+    return session_stop_outcome_t::allowed;
+  }
+
+  bool session_token_matches_active(std::string_view expected_token, std::string_view active_token) {
+    return !expected_token.empty() &&
+           !active_token.empty() &&
+           crypto::constant_time_equals(expected_token, active_token);
+  }
+
+  bool session_stop_token_matches(
+    bool require_exact_token,
+    std::string_view expected_token,
+    std::string_view active_token,
+    const std::vector<std::string> &requester_rtsp_tokens
+  ) {
+    if (!require_exact_token) {
+      return true;
+    }
+    if (session_token_matches_active(expected_token, active_token)) {
+      return true;
+    }
+    return std::any_of(
+      requester_rtsp_tokens.begin(),
+      requester_rtsp_tokens.end(),
+      [expected_token](const std::string &candidate) {
+        return session_token_matches_active(expected_token, candidate);
+      }
+    );
+  }
+
+  void session_lifecycle_gate_t::begin_launch() {
+    std::unique_lock lock(_mutex);
+    _changed.wait(lock, [this]() {
+      return _state == state_e::idle && !_stop_waiting && !_launch_to_stop_handoff;
+    });
+    _state = state_e::launching;
+  }
+
+  std::optional<std::uint64_t> session_lifecycle_gate_t::capture_launch_generation() const {
+    std::unique_lock lock(_mutex);
+    _changed.wait(lock, [this]() {
+      return _state != state_e::snapshotting && !_launch_to_stop_handoff;
+    });
+    if (_state != state_e::idle || _stop_waiting) {
+      return std::nullopt;
+    }
+    return _generation;
+  }
+
+  bool session_lifecycle_gate_t::try_begin_rtsp_launch() {
+    std::unique_lock lock(_mutex);
+    _changed.wait(lock, [this]() {
+      return _state != state_e::snapshotting && !_launch_to_stop_handoff;
+    });
+    if (_state != state_e::idle || _stop_waiting) {
+      return false;
+    }
+    _state = state_e::launching;
+    return true;
+  }
+
+  bool session_lifecycle_gate_t::try_begin_rtsp_launch(std::uint64_t expected_generation) {
+    std::unique_lock lock(_mutex);
+    _changed.wait(lock, [this]() {
+      return _state != state_e::snapshotting && !_launch_to_stop_handoff;
+    });
+    if (_state != state_e::idle || _stop_waiting || _generation != expected_generation) {
+      return false;
+    }
+    _state = state_e::launching;
+    return true;
+  }
+
+  bool session_lifecycle_gate_t::begin_stop() {
+    std::unique_lock lock(_mutex);
+    _changed.wait(lock, [this]() {
+      return _state != state_e::snapshotting && !_launch_to_stop_handoff;
+    });
+    if (_state == state_e::stopping || _stop_waiting) {
+      return false;
+    }
+    _stop_waiting = true;
+    _last_stop_committed = false;
+    ++_generation;
+    _changed.notify_all();
+    _changed.wait(lock, [this]() {
+      return _state != state_e::launching;
+    });
+    _stop_waiting = false;
+    _state = state_e::stopping;
+    return true;
+  }
+
+  bool session_lifecycle_gate_t::transition_launch_to_stop() {
+    std::unique_lock lock(_mutex);
+    if (_state != state_e::launching) {
+      return false;
+    }
+    if (_stop_waiting) {
+      _launch_to_stop_handoff = true;
+      _state = state_e::idle;
+      _changed.notify_all();
+      _changed.wait(lock, [this]() {
+        return _state == state_e::idle && !_stop_waiting;
+      });
+      if (_last_stop_committed) {
+        _launch_to_stop_handoff = false;
+        _changed.notify_all();
+        return false;
+      }
+      ++_generation;
+      _state = state_e::stopping;
+      _launch_to_stop_handoff = false;
+      _changed.notify_all();
+      return true;
+    }
+    ++_generation;
+    _state = state_e::stopping;
+    return true;
+  }
+
+  void session_lifecycle_gate_t::begin_snapshot() {
+    std::unique_lock lock(_mutex);
+    _changed.wait(lock, [this]() {
+      return _state == state_e::idle && !_stop_waiting && !_launch_to_stop_handoff;
+    });
+    _state = state_e::snapshotting;
+  }
+
+  bool session_lifecycle_gate_t::try_begin_snapshot() {
+    std::unique_lock lock(_mutex);
+    _changed.wait(lock, [this]() {
+      return _stop_waiting ||
+             _launch_to_stop_handoff ||
+             (_state != state_e::launching && _state != state_e::snapshotting);
+    });
+    if (_state != state_e::idle || _stop_waiting || _launch_to_stop_handoff) {
+      return false;
+    }
+    _state = state_e::snapshotting;
+    return true;
+  }
+
+  void session_lifecycle_gate_t::finish_snapshot() {
+    std::lock_guard lock(_mutex);
+    if (_state == state_e::snapshotting) {
+      _state = state_e::idle;
+      _changed.notify_all();
+    }
+  }
+
+  session_snapshot_guard_t::session_snapshot_guard_t(session_lifecycle_gate_t &gate):
+      _gate(&gate) {
+    _gate->begin_snapshot();
+  }
+
+  session_snapshot_guard_t session_snapshot_guard_t::try_acquire(session_lifecycle_gate_t &gate) {
+    session_snapshot_guard_t guard;
+    if (gate.try_begin_snapshot()) {
+      guard._gate = &gate;
+    }
+    return guard;
+  }
+
+  bool session_snapshot_guard_t::owns_snapshot() const {
+    return _gate != nullptr;
+  }
+
+  session_snapshot_guard_t::~session_snapshot_guard_t() {
+    if (_gate) {
+      _gate->finish_snapshot();
+    }
+  }
+
+  session_snapshot_guard_t::session_snapshot_guard_t(session_snapshot_guard_t &&other) noexcept:
+      _gate(std::exchange(other._gate, nullptr)) {}
+
+  void session_lifecycle_gate_t::finish_launch() {
+    std::lock_guard lock(_mutex);
+    if (_state == state_e::launching) {
+      _state = state_e::idle;
+      _changed.notify_all();
+    }
+  }
+
+  void session_lifecycle_gate_t::finish_stop(bool committed) {
+    std::lock_guard lock(_mutex);
+    if (_state == state_e::stopping) {
+      _last_stop_committed = committed;
+      _state = state_e::idle;
+      _changed.notify_all();
+    }
+  }
+
+  bool session_lifecycle_gate_t::stop_in_progress() const {
+    std::lock_guard lock(_mutex);
+    return _state == state_e::stopping || _stop_waiting || _launch_to_stop_handoff;
+  }
+
   std::string normalize_steam_launch_mode(std::string mode) {
     boost::trim(mode);
     boost::to_lower(mode);
@@ -2159,6 +2388,22 @@ namespace proc {
   }
 
   void proc_t::launch_input_only(std::shared_ptr<rtsp_stream::launch_session_t> launch_session) {
+    _session_lifecycle_gate->begin_launch();
+    auto release_launch = util::fail_guard([this]() {
+      _session_lifecycle_gate->finish_launch();
+    });
+    launch_input_only_impl(std::move(launch_session));
+  }
+
+  bool proc_t::launch_input_only_and_raise(std::shared_ptr<rtsp_stream::launch_session_t> launch_session) {
+    launch_input_only_impl(launch_session);
+    return rtsp_stream::launch_session_raise(std::move(launch_session));
+  }
+
+  void proc_t::launch_input_only_impl(std::shared_ptr<rtsp_stream::launch_session_t> launch_session) {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
+    ++_session_generation;
     _app_id = input_only_app_id;
     _app_name = "Remote Input";
     _app.uuid = REMOTE_INPUT_UUID;
@@ -2179,14 +2424,65 @@ namespace proc {
   }
 
   int proc_t::execute(const ctx_t& app, std::shared_ptr<rtsp_stream::launch_session_t> launch_session) {
+    _session_lifecycle_gate->begin_launch();
+    auto release_launch = util::fail_guard([this]() {
+      _session_lifecycle_gate->finish_launch();
+    });
+    const bool no_active_sessions_at_launch = rtsp_stream::session_count() == 0;
+    return execute_impl(app, std::move(launch_session), no_active_sessions_at_launch);
+  }
+
+  int proc_t::execute_and_raise(
+    const ctx_t& app,
+    std::shared_ptr<rtsp_stream::launch_session_t> launch_session
+  ) {
+    const bool no_active_sessions_at_launch = rtsp_stream::session_count() == 0;
+    const auto err = execute_impl(app, launch_session, no_active_sessions_at_launch);
+    if (!err) {
+      return rtsp_stream::launch_session_raise(std::move(launch_session)) ? 0 : 409;
+    }
+    return err;
+  }
+
+  bool proc_t::raise_session_for_admitted_launch(std::shared_ptr<rtsp_stream::launch_session_t> launch_session) {
+    return rtsp_stream::launch_session_raise(std::move(launch_session));
+  }
+
+  std::optional<std::uint64_t> proc_t::capture_session_launch_generation() const {
+    return _session_lifecycle_gate->capture_launch_generation();
+  }
+
+  bool proc_t::try_begin_session_launch(std::uint64_t expected_generation) {
+    if (!_session_lifecycle_gate->try_begin_rtsp_launch(expected_generation)) {
+      return false;
+    }
+    if (rtsp_stream::session_snapshot({}).pending_sessions > 0) {
+      _session_lifecycle_gate->finish_launch();
+      return false;
+    }
+    return true;
+  }
+
+  void proc_t::finish_session_launch() {
+    _session_lifecycle_gate->finish_launch();
+  }
+
+  int proc_t::execute_impl(
+    const ctx_t& app,
+    std::shared_ptr<rtsp_stream::launch_session_t> launch_session,
+    bool no_active_sessions_at_launch
+  ) {
+    auto &sync = session_lifecycle_sync();
+    std::unique_lock<std::recursive_mutex> lifecycle_lock(sync.mutex);
     if (_app_id == input_only_app_id) {
-      terminate(false, false);
+      terminate_impl(false, false);
       std::this_thread::sleep_for(1s);
     } else {
       // Ensure starting from a clean slate
-      terminate(false, false);
+      terminate_impl(false, false);
     }
 
+    ++_session_generation;
     _app = app;
     _app_id = util::from_view(app.id);
     _app_name = app.name;
@@ -2597,7 +2893,7 @@ namespace proc {
       if (this->initial_video_config_saved) {
         config::video.adaptive_bitrate.max_bitrate_kbps = this->initial_adaptive_max_bitrate;
       }
-      terminate();
+      terminate_impl(false, true);
       display_device::revert_configuration();
 #ifdef __linux__
       confighttp::set_session_state(confighttp::session_state_e::tearing_down);
@@ -2829,7 +3125,7 @@ namespace proc {
     constexpr bool delay_encoder_probe_until_cage = false;
 #endif
     if (!delay_encoder_probe_until_cage &&
-        rtsp_stream::session_count() == 0 &&
+        no_active_sessions_at_launch &&
         video::probe_encoders()) {
       if (config::video.ignore_encoder_probe_failure) {
         BOOST_LOG(warning) << "Encoder probe failed, but continuing due to user configuration.";
@@ -3091,7 +3387,7 @@ namespace proc {
     bool cage_started_with_detached_client = false;
 
     auto reprobe_encoders_for_cage = [&](bool strict_configured_encoder = false, bool save_successful_cache = true) -> bool {
-      if (!config::video.linux_display.use_cage_compositor || rtsp_stream::session_count() != 0) {
+      if (!config::video.linux_display.use_cage_compositor || !no_active_sessions_at_launch) {
         return true;
       }
 
@@ -3143,7 +3439,7 @@ namespace proc {
         prefer_gpu_native_capture,
         should_try_gpu_native_cage_probe
       );
-    stream_stats::reset_gpu_native_probe(should_probe_windowed_cage_for_gpu_native, rtsp_stream::session_count() == 0);
+    stream_stats::reset_gpu_native_probe(should_probe_windowed_cage_for_gpu_native, no_active_sessions_at_launch);
     const auto cached_windowed_gpu_native_probe_result =
       should_probe_windowed_cage_for_gpu_native ?
         cage_display_router::cached_windowed_gpu_native_probe_result() :
@@ -3206,7 +3502,7 @@ namespace proc {
     };
 
     auto probe_headless_extcopy_dmabuf_cage = [&]() -> bool {
-      if (!should_probe_windowed_cage_for_gpu_native || rtsp_stream::session_count() != 0) {
+      if (!should_probe_windowed_cage_for_gpu_native || !no_active_sessions_at_launch) {
         return false;
       }
 
@@ -3276,7 +3572,7 @@ namespace proc {
     };
 
     auto probe_windowed_gpu_native_cage = [&]() -> bool {
-      if (!should_probe_windowed_cage_for_gpu_native || rtsp_stream::session_count() != 0) {
+      if (!should_probe_windowed_cage_for_gpu_native || !no_active_sessions_at_launch) {
         return false;
       }
 
@@ -3640,6 +3936,8 @@ namespace proc {
   }
 
   int proc_t::running() {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
 #ifndef _WIN32
     // On POSIX OSes, we must periodically wait for our children to avoid
     // them becoming zombies. This must be synchronized carefully with
@@ -3674,13 +3972,15 @@ namespace proc {
 
     // Perform cleanup actions now if needed
     if (_process) {
-      terminate();
+      terminate_impl(false, true);
     }
 
     return 0;
   }
 
   void proc_t::resume() {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     BOOST_LOG(info) << "Session resuming for app [" << _app_name << "].";
     _client_session_report_recorded = false;
     _client_session_report_recorded_at = {};
@@ -3728,13 +4028,17 @@ namespace proc {
   }
 
   void proc_t::pause() {
-    if (!running()) {
+    auto &sync = session_lifecycle_sync();
+    std::unique_lock<std::recursive_mutex> lifecycle_lock(sync.mutex);
+    if (_app_id <= 0) {
       BOOST_LOG(info) << "Session already stopped, do not run pause commands.";
       return;
     }
 
     if (_app.terminate_on_pause) {
-      BOOST_LOG(info) << "Terminating app [" << _app_name << "] when all clients are disconnected. Pause commands are skipped.";
+      const auto app_name = _app_name;
+      lifecycle_lock.unlock();
+      BOOST_LOG(info) << "Terminating app [" << app_name << "] when all clients are disconnected. Pause commands are skipped.";
       terminate();
       return;
     }
@@ -3934,6 +4238,28 @@ namespace proc {
   }
 
   void proc_t::terminate(bool immediate, bool needs_refresh) {
+    if (!_session_lifecycle_gate->begin_stop()) {
+      return;
+    }
+    auto release_stop = util::fail_guard([this]() {
+      _session_lifecycle_gate->finish_stop();
+    });
+    terminate_impl(immediate, needs_refresh);
+  }
+
+  void proc_t::terminate_from_admitted_launch() {
+    if (!_session_lifecycle_gate->transition_launch_to_stop()) {
+      return;
+    }
+    auto release_stop = util::fail_guard([this]() {
+      _session_lifecycle_gate->finish_stop();
+    });
+    terminate_impl(false, true);
+  }
+
+  void proc_t::terminate_impl(bool immediate, bool needs_refresh) {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     std::error_code ec;
     placebo = false;
 
@@ -4114,7 +4440,6 @@ namespace proc {
     mode_changed_display.clear();
     _launch_session.reset();
     virtual_display = false;
-    _session_shutdown_requested->store(false, std::memory_order_relaxed);
     allow_client_commands = false;
 
     if (_saved_input_config) {
@@ -4127,15 +4452,49 @@ namespace proc {
     publish_stream_ended_after_terminate_if_needed(has_run);
 
     if (needs_refresh) {
-      refresh(config::stream.file_apps, false);
+      reload_configuration_from_file(config::stream.file_apps);
     }
   }
 
-  const std::vector<ctx_t> &proc_t::get_apps() const {
-    return _apps;
+  bool proc_t::reload_configuration_from_file(const std::string &file_name) {
+    auto parsed = parse(file_name);
+    if (!parsed) {
+      return false;
+    }
+    reload_configuration(std::move(*parsed));
+    return true;
   }
 
-  std::vector<ctx_t> &proc_t::get_apps() {
+  void proc_t::reload_configuration(proc_t &&parsed) {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
+    _env = std::move(parsed._env);
+    _apps = std::move(parsed._apps);
+  }
+
+#if defined(POLARIS_TESTS)
+  std::pair<const void *, const void *> proc_t::session_lifecycle_identity_for_tests() const {
+    return {_session_lifecycle_gate.get(), _session_lifecycle_sync.get()};
+  }
+
+  void proc_t::with_session_lifecycle_lock_for_tests(const std::function<void()> &callback) {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
+    callback();
+  }
+
+  bool proc_t::begin_session_stop_for_tests() {
+    return _session_lifecycle_gate->begin_stop();
+  }
+
+  void proc_t::finish_session_stop_for_tests(bool committed) {
+    _session_lifecycle_gate->finish_stop(committed);
+  }
+#endif
+
+  std::vector<ctx_t> proc_t::get_apps() const {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return _apps;
   }
 
@@ -4153,30 +4512,56 @@ namespace proc {
   }
 
   std::string proc_t::get_last_run_app_name() {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return _app_name;
   }
 
   std::string proc_t::get_running_app_uuid() {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return _app.uuid;
   }
 
   std::string proc_t::get_session_token() {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return _launch_session ? _launch_session->session_token : std::string {};
   }
 
   std::string proc_t::get_session_owner_unique_id() {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return _launch_session ? _launch_session->unique_id : std::string {};
   }
 
   std::string proc_t::get_session_owner_device_name() {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return _launch_session ? _launch_session->device_name : std::string {};
   }
 
   bool proc_t::is_session_owner(const std::string &unique_id) {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return !_launch_session || _launch_session->unique_id.empty() || _launch_session->unique_id == unique_id;
   }
 
+  bool proc_t::session_uses_virtual_display() {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
+    return virtual_display;
+  }
+
+  bool proc_t::session_allows_client_commands() {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
+    return allow_client_commands;
+  }
+
   void proc_t::mark_client_session_report_recorded(const std::string &unique_id) {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     if (!_launch_session) {
       return;
     }
@@ -4189,14 +4574,20 @@ namespace proc {
   }
 
   bool proc_t::client_session_report_recorded() const {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return _client_session_report_recorded;
   }
 
   bool proc_t::session_display_mode_is_explicit() const {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return _launch_session && _launch_session->user_locked_virtual_display;
   }
 
   bool proc_t::current_app_has_mangohud() const {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     if (_app.uuid.empty()) {
       return false;
     }
@@ -4205,6 +4596,8 @@ namespace proc {
   }
 
   void proc_t::set_app_mangohud_configured(const std::string &uuid, bool enabled) {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     auto apply = [enabled](ctx_t &app) {
       if (enabled) {
         app.env_vars["MANGOHUD"] = "1";
@@ -4225,6 +4618,8 @@ namespace proc {
   }
 
   void proc_t::set_app_steam_launch_mode_configured(const std::string &uuid, const std::string &mode) {
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     const auto normalized = normalize_steam_launch_mode(mode);
     auto apply = [&normalized](ctx_t &app) {
       app.steam_launch_mode = normalized;
@@ -4242,12 +4637,159 @@ namespace proc {
     }
   }
 
-  void proc_t::set_session_shutdown_requested(bool requested) {
-    _session_shutdown_requested->store(requested, std::memory_order_relaxed);
+  proc_t::session_lifecycle_sync_t &proc_t::session_lifecycle_sync() const {
+    return *_session_lifecycle_sync;
+  }
+
+  session_stop_snapshot_t proc_t::get_session_stop_snapshot_locked(
+    const std::string &unique_id,
+    bool can_launch,
+    std::string_view expected_token,
+    bool require_exact_token,
+    const rtsp_stream::session_snapshot_t &rtsp_snapshot,
+    bool stop_in_progress
+  ) {
+    session_stop_snapshot_t snapshot;
+    snapshot.running_app_id = running();
+    snapshot.had_running_app = snapshot.running_app_id > 0;
+    snapshot.active_sessions = rtsp_snapshot.active_sessions + rtsp_snapshot.pending_sessions;
+    snapshot.requester_role = rtsp_snapshot.requester_role;
+    snapshot.stop_in_progress = stop_in_progress;
+    snapshot.session_token = _launch_session ? _launch_session->session_token : std::string {};
+    snapshot.token_available =
+      !snapshot.session_token.empty() ||
+      std::any_of(
+        rtsp_snapshot.requester_session_tokens.begin(),
+        rtsp_snapshot.requester_session_tokens.end(),
+        [](const std::string &token) {
+          return !token.empty();
+        }
+      );
+    snapshot.owned_by_client =
+      _launch_session &&
+      !unique_id.empty() &&
+      !_launch_session->unique_id.empty() &&
+      _launch_session->unique_id == unique_id;
+    snapshot.game = _app_name;
+    const bool token_matches = session_stop_token_matches(
+      require_exact_token,
+      expected_token,
+      snapshot.session_token,
+      rtsp_snapshot.requester_session_tokens
+    );
+    snapshot.outcome = evaluate_session_stop_request(
+      can_launch,
+      snapshot.had_running_app,
+      snapshot.active_sessions,
+      snapshot.owned_by_client,
+      snapshot.requester_role,
+      snapshot.stop_in_progress,
+      token_matches
+    );
+    return snapshot;
+  }
+
+  session_status_view_t proc_t::get_session_status_view(const std::string &unique_id, bool can_launch) {
+    auto guard = session_snapshot_guard_t::try_acquire(*_session_lifecycle_gate);
+    const bool stop_observed = !guard.owns_snapshot();
+    const auto rtsp_snapshot = rtsp_stream::session_snapshot(unique_id);
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
+
+    session_status_snapshot_t snapshot;
+    snapshot.stop = get_session_stop_snapshot_locked(
+      unique_id,
+      can_launch,
+      {},
+      false,
+      rtsp_snapshot,
+      stop_observed
+    );
+    snapshot.viewer_count = rtsp_snapshot.viewer_count;
+    snapshot.owner_unique_id = _launch_session ? _launch_session->unique_id : std::string {};
+    snapshot.owner_device_name = _launch_session ? _launch_session->device_name : std::string {};
+    snapshot.game = _app_name;
+    snapshot.game_uuid = _app.uuid;
+    snapshot.client_commands_enabled = allow_client_commands;
+    snapshot.mangohud_configured = !_app.uuid.empty() && env_flag_enabled(_app, _env, "MANGOHUD");
+    snapshot.virtual_display = virtual_display;
+    snapshot.display_mode_explicit = _launch_session && _launch_session->user_locked_virtual_display;
+    return {std::move(guard), std::move(snapshot)};
+  }
+
+  session_stop_snapshot_t proc_t::get_session_stop_snapshot(const std::string &unique_id, bool can_launch) {
+    auto view = get_session_status_view(unique_id, can_launch);
+    return std::move(view.snapshot.stop);
+  }
+
+  session_stop_result_t proc_t::request_session_shutdown(
+    const std::string &unique_id,
+    std::string_view expected_token,
+    bool can_launch,
+    bool require_exact_token
+  ) {
+    session_stop_result_t result;
+    if (!can_launch) {
+      result.snapshot.outcome = session_stop_outcome_t::permission_denied;
+      return result;
+    }
+    if (!_session_lifecycle_gate->begin_stop()) {
+      result.snapshot.outcome = session_stop_outcome_t::stop_in_progress;
+      result.snapshot.stop_in_progress = true;
+      return result;
+    }
+    bool stop_committed = false;
+    auto release_stop = util::fail_guard([this, &stop_committed]() {
+      _session_lifecycle_gate->finish_stop(stop_committed);
+    });
+
+    const auto rtsp_snapshot = rtsp_stream::session_snapshot(unique_id);
+    std::uint64_t claimed_generation = 0;
+    {
+      auto &sync = session_lifecycle_sync();
+      std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
+      result.snapshot = get_session_stop_snapshot_locked(
+        unique_id,
+        can_launch,
+        expected_token,
+        require_exact_token,
+        rtsp_snapshot,
+        false
+      );
+      if (result.snapshot.outcome != session_stop_outcome_t::allowed) {
+        return result;
+      }
+      claimed_generation = _session_generation;
+    }
+
+    if (result.snapshot.had_running_app || result.snapshot.active_sessions > 0) {
+      confighttp::set_session_state(confighttp::session_state_e::tearing_down);
+      confighttp::emit_session_event("stream_stopping", "Stopping session");
+    }
+    rtsp_stream::terminate_sessions();
+
+    {
+      auto &sync = session_lifecycle_sync();
+      std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
+      if (_session_generation != claimed_generation) {
+        result.snapshot.outcome = session_stop_outcome_t::session_changed;
+        return result;
+      }
+      if (result.snapshot.had_running_app && running() > 0) {
+        terminate_impl(false, true);
+      }
+      display_device::revert_configuration();
+      result.stopped = result.snapshot.had_running_app || result.snapshot.active_sessions > 0;
+    }
+
+    stop_committed = true;
+    _session_lifecycle_gate->finish_stop(stop_committed);
+    release_stop.disable();
+    return result;
   }
 
   bool proc_t::session_shutdown_requested() const {
-    return _session_shutdown_requested->load(std::memory_order_relaxed);
+    return _session_lifecycle_gate->stop_in_progress();
   }
 
   boost::process::environment proc_t::get_env() {
@@ -5210,10 +5752,6 @@ namespace proc {
     }
   #endif
 
-    auto proc_opt = proc::parse(file_name);
-
-    if (proc_opt) {
-      proc = std::move(*proc_opt);
-    }
+    proc.reload_configuration_from_file(file_name);
   }
 }  // namespace proc

--- a/src/process.h
+++ b/src/process.h
@@ -14,8 +14,12 @@
 
 // standard includes
 #include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string_view>
 #include <unordered_set>
@@ -180,6 +184,119 @@ namespace proc {
     std::chrono::seconds exit_timeout;
   };
 
+  enum class session_stop_outcome_t {
+    allowed,
+    no_active_session,
+    permission_denied,
+    stop_in_progress,
+    viewer_forbidden,
+    uncontrolled_stream,
+    other_owner,
+    token_mismatch,
+    session_changed,
+  };
+
+  struct session_stop_snapshot_t {
+    session_stop_outcome_t outcome = session_stop_outcome_t::no_active_session;
+    int running_app_id = 0;
+    int active_sessions = 0;
+    bool had_running_app = false;
+    bool owned_by_client = false;
+    rtsp_stream::session_role_e requester_role = rtsp_stream::session_role_e::none;
+    bool stop_in_progress = false;
+    bool token_available = false;
+    std::string session_token;
+    std::string game;
+  };
+
+  struct session_stop_result_t {
+    session_stop_snapshot_t snapshot;
+    bool stopped = false;
+  };
+
+  struct session_status_snapshot_t {
+    session_stop_snapshot_t stop;
+    int viewer_count = 0;
+    std::string owner_unique_id;
+    std::string owner_device_name;
+    std::string game;
+    std::string game_uuid;
+    bool client_commands_enabled = false;
+    bool mangohud_configured = false;
+    bool virtual_display = false;
+    bool display_mode_explicit = false;
+  };
+
+  session_stop_outcome_t evaluate_session_stop_request(
+    bool can_launch,
+    bool has_running_app,
+    int active_sessions,
+    bool owned_by_client,
+    rtsp_stream::session_role_e requester_role,
+    bool stop_in_progress,
+    bool token_matches
+  );
+  bool session_token_matches_active(std::string_view expected_token, std::string_view active_token);
+  bool session_stop_token_matches(
+    bool require_exact_token,
+    std::string_view expected_token,
+    std::string_view active_token,
+    const std::vector<std::string> &requester_rtsp_tokens
+  );
+
+  class session_lifecycle_gate_t {
+  public:
+    void begin_launch();
+    std::optional<std::uint64_t> capture_launch_generation() const;
+    bool try_begin_rtsp_launch();
+    bool try_begin_rtsp_launch(std::uint64_t expected_generation);
+    bool begin_stop();
+    bool transition_launch_to_stop();
+    void begin_snapshot();
+    bool try_begin_snapshot();
+    void finish_snapshot();
+    void finish_launch();
+    void finish_stop(bool committed = true);
+    bool stop_in_progress() const;
+
+  private:
+    enum class state_e {
+      idle,
+      launching,
+      snapshotting,
+      stopping,
+    };
+
+    mutable std::mutex _mutex;
+    mutable std::condition_variable _changed;
+    state_e _state = state_e::idle;
+    bool _stop_waiting = false;
+    bool _launch_to_stop_handoff = false;
+    bool _last_stop_committed = false;
+    std::uint64_t _generation = 1;
+  };
+
+  class session_snapshot_guard_t {
+  public:
+    explicit session_snapshot_guard_t(session_lifecycle_gate_t &gate);
+    static session_snapshot_guard_t try_acquire(session_lifecycle_gate_t &gate);
+    ~session_snapshot_guard_t();
+    bool owns_snapshot() const;
+    session_snapshot_guard_t(const session_snapshot_guard_t &) = delete;
+    session_snapshot_guard_t &operator=(const session_snapshot_guard_t &) = delete;
+    session_snapshot_guard_t(session_snapshot_guard_t &&other) noexcept;
+    session_snapshot_guard_t &operator=(session_snapshot_guard_t &&) = delete;
+
+  private:
+    session_snapshot_guard_t() = default;
+    session_lifecycle_gate_t *_gate = nullptr;
+  };
+
+  struct session_status_view_t {
+    session_snapshot_guard_t guard;
+    session_status_snapshot_t snapshot;
+  };
+
   class proc_t {
   public:
     KITTY_DEFAULT_CONSTR_MOVE_THROW(proc_t)
@@ -205,8 +322,14 @@ namespace proc {
     }
 
     void launch_input_only(std::shared_ptr<rtsp_stream::launch_session_t> launch_session);
+    bool launch_input_only_and_raise(std::shared_ptr<rtsp_stream::launch_session_t> launch_session);
 
     int execute(const ctx_t& _app, std::shared_ptr<rtsp_stream::launch_session_t> launch_session);
+    int execute_and_raise(const ctx_t& _app, std::shared_ptr<rtsp_stream::launch_session_t> launch_session);
+    bool raise_session_for_admitted_launch(std::shared_ptr<rtsp_stream::launch_session_t> launch_session);
+    std::optional<std::uint64_t> capture_session_launch_generation() const;
+    bool try_begin_session_launch(std::uint64_t expected_generation);
+    void finish_session_launch();
 
     /**
      * @return `_app_id` if a process is running, otherwise returns `0`
@@ -215,8 +338,7 @@ namespace proc {
 
     ~proc_t();
 
-    const std::vector<ctx_t> &get_apps() const;
-    std::vector<ctx_t> &get_apps();
+    std::vector<ctx_t> get_apps() const;
     std::string get_app_image(int app_id);
     std::string get_last_run_app_name();
     std::string get_running_app_uuid();
@@ -224,20 +346,59 @@ namespace proc {
     std::string get_session_owner_unique_id();
     std::string get_session_owner_device_name();
     bool is_session_owner(const std::string &unique_id);
+    bool session_uses_virtual_display();
+    bool session_allows_client_commands();
     void mark_client_session_report_recorded(const std::string &unique_id);
     bool client_session_report_recorded() const;
     bool session_display_mode_is_explicit() const;
     bool current_app_has_mangohud() const;
     void set_app_mangohud_configured(const std::string &uuid, bool enabled);
     void set_app_steam_launch_mode_configured(const std::string &uuid, const std::string &mode);
-    void set_session_shutdown_requested(bool requested);
     bool session_shutdown_requested() const;
+    session_status_view_t get_session_status_view(const std::string &unique_id, bool can_launch);
+    session_stop_snapshot_t get_session_stop_snapshot(const std::string &unique_id, bool can_launch);
+    session_stop_result_t request_session_shutdown(
+      const std::string &unique_id,
+      std::string_view expected_token,
+      bool can_launch,
+      bool require_exact_token
+    );
     boost::process::v1::environment get_env();
     void resume();
     void pause();
     void terminate(bool immediate = false, bool needs_refresh = true);
+    void terminate_from_admitted_launch();
+    bool reload_configuration_from_file(const std::string &file_name);
+    void reload_configuration(proc_t &&parsed);
+#if defined(POLARIS_TESTS)
+    std::pair<const void *, const void *> session_lifecycle_identity_for_tests() const;
+    void with_session_lifecycle_lock_for_tests(const std::function<void()> &callback);
+    bool begin_session_stop_for_tests();
+    void finish_session_stop_for_tests(bool committed);
+#endif
 
   private:
+    struct session_lifecycle_sync_t {
+      std::recursive_mutex mutex;
+    };
+
+    void launch_input_only_impl(std::shared_ptr<rtsp_stream::launch_session_t> launch_session);
+    int execute_impl(
+      const ctx_t& app,
+      std::shared_ptr<rtsp_stream::launch_session_t> launch_session,
+      bool no_active_sessions_at_launch
+    );
+    void terminate_impl(bool immediate, bool needs_refresh);
+    session_lifecycle_sync_t &session_lifecycle_sync() const;
+    session_stop_snapshot_t get_session_stop_snapshot_locked(
+      const std::string &unique_id,
+      bool can_launch,
+      std::string_view expected_token,
+      bool require_exact_token,
+      const rtsp_stream::session_snapshot_t &rtsp_snapshot,
+      bool stop_in_progress
+    );
+
     int _app_id = 0;
     std::string _app_name;
 
@@ -261,7 +422,9 @@ namespace proc {
     std::unordered_set<std::string> _session_env_keys;
     std::vector<cmd_t>::const_iterator _app_prep_it;
     std::vector<cmd_t>::const_iterator _app_prep_begin;
-    std::shared_ptr<std::atomic_bool> _session_shutdown_requested {std::make_shared<std::atomic_bool>(false)};
+    std::shared_ptr<session_lifecycle_gate_t> _session_lifecycle_gate {std::make_shared<session_lifecycle_gate_t>()};
+    std::shared_ptr<session_lifecycle_sync_t> _session_lifecycle_sync {std::make_shared<session_lifecycle_sync_t>()};
+    std::uint64_t _session_generation = 0;
     bool _client_session_report_recorded = false;
     std::chrono::steady_clock::time_point _client_session_report_recorded_at {};
     std::string _client_session_report_recorded_unique_id;

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -50,6 +50,24 @@ namespace rtsp_stream {
   }
 
   namespace {
+    session_role_e merge_session_role(session_role_e current, bool watch_only) {
+      if (current == session_role_e::controller || !watch_only) {
+        return session_role_e::controller;
+      }
+      return session_role_e::viewer;
+    }
+
+    void accumulate_session_snapshot(
+      session_snapshot_t &snapshot,
+      bool requester_matches,
+      bool watch_only
+    ) {
+      snapshot.viewer_count += watch_only ? 1 : 0;
+      if (requester_matches) {
+        snapshot.requester_role = merge_session_role(snapshot.requester_role, watch_only);
+      }
+    }
+
     std::string_view codec_name_for_video_format(int video_format) {
       switch (video_format) {
         case 1:
@@ -477,6 +495,12 @@ namespace rtsp_stream {
     std::shared_ptr<launch_session_t> session;
   };
 
+#ifdef POLARIS_TESTS
+  std::atomic_uint cleanup_call_counter_for_tests {0};
+  std::function<void()> cleanup_unlocked_probe_for_tests;
+  std::function<void()> cleanup_session_probe_for_tests;
+#endif
+
   class rtsp_server_t {
   public:
     ~rtsp_server_t() {
@@ -536,7 +560,7 @@ namespace rtsp_stream {
       auto socket = std::move(next_socket);
 
       auto launch_session {launch_event.view(0s)};
-      if (launch_session) {
+      if (launch_session && launch_session->is_pending()) {
         // Associate the current RTSP session with this socket and start reading
         socket->session = launch_session;
         socket->read();
@@ -568,25 +592,47 @@ namespace rtsp_stream {
      *       the session will be discarded.
      * @param launch_session Streaming session information.
      */
-    void session_raise(std::shared_ptr<launch_session_t> launch_session) {
-      // If a launch event is still pending, don't overwrite it.
-      if (launch_event.view(0s)) {
-        return;
+    bool expire_pending_launch(uint32_t launch_session_id, std::uint64_t timer_generation) {
+      std::lock_guard timer_lock(_launch_timer_mutex);
+      if (_raised_timer_generation.load() != timer_generation) {
+        return false;
       }
 
-      // Raise the new launch session to prepare for the RTSP handshake
-      launch_event.raise(std::move(launch_session));
+      auto pending = launch_event.view(0s);
+      if (!pending || pending->id != launch_session_id) {
+        return false;
+      }
 
-      // Arm the timer to expire this launch session if the client times out
+      const bool cancelled = pending->cancel_for_timeout();
+      auto discarded = launch_event.pop_if([launch_session_id](const auto &candidate) {
+        return candidate && candidate->id == launch_session_id;
+      });
+      if (cancelled && discarded) {
+        BOOST_LOG(debug) << "Event timeout: "sv << discarded->unique_id;
+      }
+      return cancelled && static_cast<bool>(discarded);
+    }
+
+    std::uint64_t launch_timer_generation() const {
+      return _raised_timer_generation.load();
+    }
+
+    bool session_raise(std::shared_ptr<launch_session_t> launch_session) {
+      std::lock_guard timer_lock(_launch_timer_mutex);
+      const auto launch_session_id = launch_session->id;
+      if (!launch_event.raise_if_empty(std::move(launch_session))) {
+        return false;
+      }
+
+      const auto timer_generation = ++_raised_timer_generation;
+      raised_timer.cancel();
       raised_timer.expires_after(config::stream.ping_timeout);
-      raised_timer.async_wait([this](const boost::system::error_code &ec) {
+      raised_timer.async_wait([this, launch_session_id, timer_generation](const boost::system::error_code &ec) {
         if (!ec) {
-          auto discarded = launch_event.pop(0s);
-          if (discarded) {
-            BOOST_LOG(debug) << "Event timeout: "sv << discarded->unique_id;
-          }
+          expire_pending_launch(launch_session_id, timer_generation);
         }
       });
+      return true;
     }
 
     /**
@@ -594,6 +640,7 @@ namespace rtsp_stream {
      * @param launch_session_id The ID of the session to clear.
      */
     void session_clear(uint32_t launch_session_id) {
+      std::lock_guard timer_lock(_launch_timer_mutex);
       // We currently only support a single pending RTSP session,
       // so the ID should always match the one for that session.
       auto launch_session = launch_event.view(0s);
@@ -601,9 +648,20 @@ namespace rtsp_stream {
         if (launch_session->id != launch_session_id) {
           BOOST_LOG(error) << "Attempted to clear unexpected session: "sv << launch_session_id << " vs "sv << launch_session->id;
         } else {
+          ++_raised_timer_generation;
           raised_timer.cancel();
           launch_event.pop();
         }
+      }
+    }
+
+    void cancel_pending_session() {
+      std::lock_guard timer_lock(_launch_timer_mutex);
+      ++_raised_timer_generation;
+      raised_timer.cancel();
+      auto launch_session = launch_event.pop(0s);
+      if (launch_session) {
+        launch_session->cancel();
       }
     }
 
@@ -633,18 +691,36 @@ namespace rtsp_stream {
      * @examples_end
      */
     void clear(bool all = true) {
-      auto lg = _session_slots.lock();
-
-      for (auto i = _session_slots->begin(); i != _session_slots->end();) {
-        auto &slot = *(*i);
-        if (all || stream::session::state(slot) == stream::session::state_e::STOPPING) {
-          stream::session::stop(slot);
-          stream::session::join(slot);
-
-          i = _session_slots->erase(i);
-        } else {
-          i++;
+#ifdef POLARIS_TESTS
+      ++cleanup_call_counter_for_tests;
+#endif
+      std::vector<std::shared_ptr<stream::session_t>> sessions_to_join;
+      {
+        auto lg = _session_slots.lock();
+        for (auto i = _session_slots->begin(); i != _session_slots->end();) {
+          const auto &slot = *i;
+          if (slot && (all || stream::session::state(*slot) == stream::session::state_e::STOPPING)) {
+            sessions_to_join.emplace_back(slot);
+            i = _session_slots->erase(i);
+          } else {
+            ++i;
+          }
         }
+      }
+#ifdef POLARIS_TESTS
+      if (cleanup_unlocked_probe_for_tests) {
+        cleanup_unlocked_probe_for_tests();
+      }
+#endif
+      for (auto &slot : sessions_to_join) {
+#ifdef POLARIS_TESTS
+        if (cleanup_session_probe_for_tests) {
+          cleanup_session_probe_for_tests();
+          continue;
+        }
+#endif
+        stream::session::stop(*slot);
+        stream::session::join(*slot);
       }
     }
 
@@ -661,11 +737,81 @@ namespace rtsp_stream {
      * @brief Inserts the provided session into the set of sessions.
      * @param session The session to insert.
      */
-    void insert(const std::shared_ptr<stream::session_t> &session) {
+    enum class insert_start_result_e {
+      started,
+      cancelled,
+      failed,
+    };
+
+    insert_start_result_e insert_and_start_if_not_cancelled(
+      const std::shared_ptr<stream::session_t> &session,
+      launch_session_t &launch_session,
+      const std::string &remote_address
+#ifdef POLARIS_TESTS
+      , const std::function<void()> &after_insert = {}
+      , const std::function<int()> &start_override = {}
+#endif
+    ) {
+      if (!launch_session.try_begin_setup_handoff()) {
+        return insert_start_result_e::cancelled;
+      }
+
       auto lg = _session_slots.lock();
       _session_slots->emplace(session);
+#ifdef POLARIS_TESTS
+      if (after_insert) {
+        after_insert();
+      }
+#endif
+      if (!launch_session.commit_setup_start()) {
+        _session_slots->erase(session);
+        return insert_start_result_e::cancelled;
+      }
+      int start_result;
+#ifdef POLARIS_TESTS
+      if (start_override) {
+        start_result = start_override();
+      } else
+#endif
+      {
+        start_result = stream::session::start(*session, remote_address);
+      }
+      if (start_result) {
+        launch_session.cancel();
+        _session_slots->erase(session);
+        return insert_start_result_e::failed;
+      }
       BOOST_LOG(info) << "New streaming session started [active sessions: "sv << _session_slots->size() << ']';
+      return insert_start_result_e::started;
     }
+
+#ifdef POLARIS_TESTS
+    int run_setup_insert_for_tests(
+      const std::shared_ptr<stream::session_t> &session,
+      launch_session_t &launch_session,
+      bool cancel_after_insert,
+      int start_result
+    ) {
+      return static_cast<int>(insert_and_start_if_not_cancelled(
+        session,
+        launch_session,
+        "127.0.0.1",
+        [&launch_session, cancel_after_insert]() {
+          if (cancel_after_insert) {
+            launch_session.cancel();
+          }
+        },
+        [start_result]() {
+          return start_result;
+        }
+      ));
+    }
+
+    void add_session_for_tests(const std::shared_ptr<stream::session_t> &session) {
+      auto lg = _session_slots.lock();
+      _session_slots->emplace(session);
+    }
+#endif
 
     /**
      * @brief Runs an iteration of the RTSP server loop
@@ -702,6 +848,35 @@ namespace rtsp_stream {
       return nullptr;
     }
 
+    session_snapshot_t session_snapshot(const std::string_view& uuid) {
+      session_snapshot_t snapshot;
+      auto lg = _session_slots.lock();
+
+      for (auto &slot : *_session_slots) {
+        if (!slot || stream::session::state(*slot) == stream::session::state_e::STOPPING) {
+          continue;
+        }
+        ++snapshot.active_sessions;
+        const bool watch_only = stream::session::is_watch_only(*slot);
+        const bool requester_matches = stream::session::uuid_match(*slot, uuid);
+        accumulate_session_snapshot(snapshot, requester_matches, watch_only);
+        if (requester_matches) {
+          snapshot.requester_session_tokens.emplace_back(stream::session::session_token(*slot));
+        }
+      }
+
+      auto pending = launch_event.view(0s);
+      if (pending && pending->is_pending_or_handoff()) {
+        snapshot.pending_sessions = 1;
+        if (pending->unique_id == uuid) {
+          snapshot.requester_role = merge_session_role(snapshot.requester_role, pending->watch_only);
+          snapshot.requester_session_tokens.emplace_back(pending->session_token);
+        }
+      }
+
+      return snapshot;
+    }
+
     std::list<std::string>
     get_all_session_uuids() {
       std::list<std::string> uuids;
@@ -722,14 +897,16 @@ namespace rtsp_stream {
     boost::asio::io_context io_context;
     tcp::acceptor acceptor {io_context};
     boost::asio::steady_timer raised_timer {io_context};
+    std::mutex _launch_timer_mutex;
+    std::atomic<std::uint64_t> _raised_timer_generation {0};
 
     std::shared_ptr<socket_t> next_socket;
   };
 
   rtsp_server_t server {};
 
-  void launch_session_raise(std::shared_ptr<launch_session_t> launch_session) {
-    server.session_raise(std::move(launch_session));
+  bool launch_session_raise(std::shared_ptr<launch_session_t> launch_session) {
+    return server.session_raise(std::move(launch_session));
   }
 
   void launch_session_clear(uint32_t launch_session_id) {
@@ -752,11 +929,95 @@ namespace rtsp_stream {
     return server.find_session(uuid);
   }
 
+  session_snapshot_t session_snapshot(const std::string_view& uuid) {
+    return server.session_snapshot(uuid);
+  }
+
+#ifdef POLARIS_TESTS
+  session_role_e merge_session_role_for_tests(session_role_e current, bool watch_only) {
+    return merge_session_role(current, watch_only);
+  }
+
+  void accumulate_session_snapshot_for_tests(
+    session_snapshot_t &snapshot,
+    bool requester_matches,
+    bool watch_only
+  ) {
+    accumulate_session_snapshot(snapshot, requester_matches, watch_only);
+  }
+
+  std::uint64_t launch_timer_generation_for_tests() {
+    return server.launch_timer_generation();
+  }
+
+  bool expire_pending_launch_for_tests(uint32_t launch_session_id, std::uint64_t timer_generation) {
+    return server.expire_pending_launch(launch_session_id, timer_generation);
+  }
+
+  void reset_cleanup_call_count_for_tests() {
+    cleanup_call_counter_for_tests.store(0);
+  }
+
+  unsigned cleanup_call_count_for_tests() {
+    return cleanup_call_counter_for_tests.load();
+  }
+
+  void set_cleanup_unlocked_probe_for_tests(std::function<void()> probe) {
+    cleanup_unlocked_probe_for_tests = std::move(probe);
+  }
+
+  void set_cleanup_session_probe_for_tests(std::function<void()> probe) {
+    cleanup_session_probe_for_tests = std::move(probe);
+  }
+
+  void run_cleanup_for_tests() {
+    server.clear(false);
+  }
+
+  setup_insert_result_e run_setup_insert_for_tests(
+    launch_session_t &launch_session,
+    bool cancel_after_insert,
+    int start_result
+  ) {
+    if (launch_session.iv.size() < sizeof(std::uint32_t)) {
+      launch_session.iv.resize(16);
+    }
+    if (launch_session.gcm_key.empty()) {
+      launch_session.gcm_key.resize(16);
+    }
+    stream::config_t config {};
+    auto session = stream::session::alloc(config, launch_session);
+    return static_cast<setup_insert_result_e>(server.run_setup_insert_for_tests(
+      session,
+      launch_session,
+      cancel_after_insert,
+      start_result
+    ));
+  }
+
+  void add_session_for_tests(launch_session_t &launch_session, bool stopping) {
+    if (launch_session.iv.size() < sizeof(std::uint32_t)) {
+      launch_session.iv.resize(16);
+    }
+    if (launch_session.gcm_key.empty()) {
+      launch_session.gcm_key.resize(16);
+    }
+    stream::config_t config {};
+    auto session = stream::session::alloc(config, launch_session);
+    stream::session::set_state_for_tests(
+      *session,
+      stopping ? stream::session::state_e::STOPPING : stream::session::state_e::RUNNING
+    );
+    server.add_session_for_tests(session);
+  }
+#endif
+
   std::list<std::string> get_all_session_uuids() {
     return server.get_all_session_uuids();
   }
 
   void terminate_sessions() {
+    server.cancel_pending_session();
     server.clear(true);
   }
 
@@ -1294,13 +1555,22 @@ namespace rtsp_stream {
       return;
     }
 
+    if (session.is_cancelled()) {
+      BOOST_LOG(info) << "Rejecting RTSP setup for a cancelled launch session"sv;
+      respond(sock, session, &option, 409, "Conflict", req->sequenceNumber, {});
+      return;
+    }
+
     auto stream_session = stream::session::alloc(config, session);
-    server->insert(stream_session);
-
-    if (stream::session::start(*stream_session, sock.remote_endpoint().address().to_string())) {
+    const auto remote_address = sock.remote_endpoint().address().to_string();
+    const auto start_result = server->insert_and_start_if_not_cancelled(stream_session, session, remote_address);
+    if (start_result == rtsp_server_t::insert_start_result_e::cancelled) {
+      BOOST_LOG(info) << "Rejecting RTSP setup cancelled during session handoff"sv;
+      respond(sock, session, &option, 409, "Conflict", req->sequenceNumber, {});
+      return;
+    }
+    if (start_result == rtsp_server_t::insert_start_result_e::failed) {
       BOOST_LOG(error) << "Failed to start a streaming session"sv;
-
-      server->remove(stream_session);
       respond(sock, session, &option, 500, "Internal Server Error", req->sequenceNumber, {});
       return;
     }

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -6,8 +6,10 @@
 
 // standard includes
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <list>
+#include <vector>
 
 // local includes
 #include "crypto.h"
@@ -25,6 +27,20 @@ namespace stream {
 namespace rtsp_stream {
   constexpr auto RTSP_SETUP_PORT = 21;
 
+  enum class session_role_e {
+    none,
+    viewer,
+    controller,
+  };
+
+  struct session_snapshot_t {
+    int active_sessions = 0;
+    int pending_sessions = 0;
+    int viewer_count = 0;
+    session_role_e requester_role = session_role_e::none;
+    std::vector<std::string> requester_session_tokens;
+  };
+
   struct launch_session_t {
     uint32_t id;
 
@@ -39,6 +55,50 @@ namespace rtsp_stream {
     std::string session_token;
     crypto::PERM perm;
     bool watch_only;
+
+    enum class setup_state_e : std::uint8_t {
+      pending,
+      handoff,
+      started,
+      cancelled,
+    };
+
+    bool try_begin_setup_handoff() {
+      auto expected = setup_state_e::pending;
+      return setup_state.compare_exchange_strong(expected, setup_state_e::handoff);
+    }
+
+    bool commit_setup_start() {
+      auto expected = setup_state_e::handoff;
+      return setup_state.compare_exchange_strong(expected, setup_state_e::started);
+    }
+
+    bool cancel_for_timeout() {
+      auto expected = setup_state.load();
+      while (expected == setup_state_e::pending || expected == setup_state_e::handoff) {
+        if (setup_state.compare_exchange_weak(expected, setup_state_e::cancelled)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    void cancel() {
+      setup_state.store(setup_state_e::cancelled);
+    }
+
+    bool is_pending() const {
+      return setup_state.load() == setup_state_e::pending;
+    }
+
+    bool is_pending_or_handoff() const {
+      const auto state = setup_state.load();
+      return state == setup_state_e::pending || state == setup_state_e::handoff;
+    }
+
+    bool is_cancelled() const {
+      return setup_state.load() == setup_state_e::cancelled;
+    }
 
     bool input_only;
     bool host_audio;
@@ -71,6 +131,7 @@ namespace rtsp_stream {
     int optimization_recommendation_version = 0;
     std::string pacing_policy;
 
+    std::atomic<setup_state_e> setup_state {setup_state_e::pending};
     std::optional<crypto::cipher::gcm_t> rtsp_cipher;
     std::string rtsp_url_scheme;
     uint32_t rtsp_iv_counter;
@@ -83,7 +144,7 @@ namespace rtsp_stream {
   #endif
   };
 
-  void launch_session_raise(std::shared_ptr<launch_session_t> launch_session);
+  bool launch_session_raise(std::shared_ptr<launch_session_t> launch_session);
 
   /**
    * @brief Clear state for the specified launch session.
@@ -100,6 +161,35 @@ namespace rtsp_stream {
 
   std::shared_ptr<stream::session_t>
   find_session(const std::string_view& uuid);
+
+  session_snapshot_t session_snapshot(const std::string_view& uuid);
+
+#ifdef POLARIS_TESTS
+  session_role_e merge_session_role_for_tests(session_role_e current, bool watch_only);
+  void accumulate_session_snapshot_for_tests(
+    session_snapshot_t &snapshot,
+    bool requester_matches,
+    bool watch_only
+  );
+  std::uint64_t launch_timer_generation_for_tests();
+  bool expire_pending_launch_for_tests(uint32_t launch_session_id, std::uint64_t timer_generation);
+  void reset_cleanup_call_count_for_tests();
+  unsigned cleanup_call_count_for_tests();
+  void set_cleanup_unlocked_probe_for_tests(std::function<void()> probe);
+  void set_cleanup_session_probe_for_tests(std::function<void()> probe);
+  void run_cleanup_for_tests();
+  enum class setup_insert_result_e {
+    started,
+    cancelled,
+    failed,
+  };
+  setup_insert_result_e run_setup_insert_for_tests(
+    launch_session_t &launch_session,
+    bool cancel_after_insert,
+    int start_result
+  );
+  void add_session_for_tests(launch_session_t &launch_session, bool stopping);
+#endif
 
   std::list<std::string>
   get_all_session_uuids();

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -461,6 +461,7 @@ namespace stream {
     std::uint32_t launch_session_id;
     std::string device_name;
     std::string device_uuid;
+    std::string session_token;
     bool watch_only;
     int requested_fps = 0;
     int session_target_fps = 0;
@@ -2087,12 +2088,22 @@ namespace stream {
       return session.state.load(std::memory_order_relaxed);
     }
 
+#ifdef POLARIS_TESTS
+    void set_state_for_tests(session_t &session, state_e state) {
+      session.state.store(state, std::memory_order_relaxed);
+    }
+#endif
+
     inline bool send(session_t& session, const std::string_view &payload) {
       return session.broadcast_ref->control_server.send(payload, session.control.peer);
     }
 
     std::string uuid(const session_t& session) {
       return session.device_uuid;
+    }
+
+    std::string session_token(const session_t& session) {
+      return session.session_token;
     }
 
     bool uuid_match(const session_t &session, const std::string_view& uuid) {
@@ -2384,6 +2395,7 @@ namespace stream {
       session->launch_session_id = launch_session.id;
       session->device_name = launch_session.device_name;
       session->device_uuid = launch_session.unique_id;
+      session->session_token = launch_session.session_token;
       session->requested_fps = launch_session.requested_fps;
       session->session_target_fps = launch_session.fps;
       session->pacing_policy = launch_session.pacing_policy;

--- a/src/stream.h
+++ b/src/stream.h
@@ -62,6 +62,7 @@ namespace stream {
     std::shared_ptr<session_t> alloc(config_t &config, rtsp_stream::launch_session_t &launch_session);
     session_profile_t profile(const session_t& session);
     std::string uuid(const session_t& session);
+    std::string session_token(const session_t& session);
     bool uuid_match(const session_t& session, const std::string_view& uuid);
     bool is_watch_only(const session_t& session);
     bool update_device_info(session_t& session, const std::string& name, const crypto::PERM& newPerm);
@@ -70,6 +71,9 @@ namespace stream {
     void graceful_stop(session_t& session);
     void join(session_t &session);
     state_e state(session_t &session);
+#ifdef POLARIS_TESTS
+    void set_state_for_tests(session_t &session, state_e state);
+#endif
     unsigned active_count();
     inline bool send(session_t& session, const std::string_view &payload);
   }  // namespace session

--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -79,6 +79,32 @@ namespace safe {
       return val;
     }
 
+    template<class Predicate>
+    status_t pop_if(Predicate &&predicate) {
+      std::unique_lock ul {_lock};
+      if (!_continue || !_status || !std::invoke(std::forward<Predicate>(predicate), _status)) {
+        return util::false_v<status_t>;
+      }
+      auto val = std::move(_status);
+      _status = util::false_v<status_t>;
+      return val;
+    }
+
+    template<class... Args>
+    bool raise_if_empty(Args &&...args) {
+      std::lock_guard lg {_lock};
+      if (!_continue || _status) {
+        return false;
+      }
+      if constexpr (std::is_same_v<std::optional<T>, status_t>) {
+        _status = std::make_optional<T>(std::forward<Args>(args)...);
+      } else {
+        _status = status_t {std::forward<Args>(args)...};
+      }
+      _cv.notify_all();
+      return true;
+    }
+
     // pop and view should not be used interchangeably
     status_t view() {
       std::unique_lock ul {_lock};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,7 @@ set(TEST_PAIRING_SOURCES
 set(TEST_HTTP_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_httpcommon.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_mode_contract.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_session_stop_contract.cpp
 )
 
 set(TEST_NETWORK_SOURCES

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -75,12 +75,494 @@ TEST(ProcessRuntimeConfigTests, PolarisV1SessionStopContractIsAdvertisedAndRoute
   const auto source = read_source_file_for_contract("src/nvhttp.cpp");
   ASSERT_FALSE(source.empty());
 
+  const auto status_start = source.find("auto polarisSessionStatus");
+  const auto status_end = source.find("auto polarisStreamPolicy", status_start);
+  const auto stop_start = source.find("auto polarisSessionStop");
+  const auto stop_end = source.find("// Client session report", stop_start);
+  const auto cancel_start = source.find("void cancel(");
+  const auto cancel_end = source.find("void appasset(", cancel_start);
+  ASSERT_NE(status_start, std::string::npos);
+  ASSERT_NE(status_end, std::string::npos);
+  ASSERT_NE(stop_start, std::string::npos);
+  ASSERT_NE(stop_end, std::string::npos);
+  ASSERT_NE(cancel_start, std::string::npos);
+  ASSERT_NE(cancel_end, std::string::npos);
+
+  const auto status_handler = source.substr(status_start, status_end - status_start);
+  const auto stop_handler = source.substr(stop_start, stop_end - stop_start);
+  const auto cancel_handler = source.substr(cancel_start, cancel_end - cancel_start);
+
   EXPECT_NE(source.find("session_stop_v1"), std::string::npos);
-  EXPECT_NE(source.find("stop_allowed"), std::string::npos);
-  EXPECT_NE(source.find("polarisSessionStop"), std::string::npos);
   EXPECT_NE(source.find("/polaris/v1/session/stop"), std::string::npos);
-  EXPECT_NE(source.find("session_token_matches_value"), std::string::npos);
-  EXPECT_NE(source.find("request_active_session_shutdown"), std::string::npos);
+  EXPECT_NE(status_handler.find("PERM::launch"), std::string::npos);
+  EXPECT_NE(status_handler.find("get_session_status_view("), std::string::npos);
+  EXPECT_NE(status_handler.find("auto status_view = proc::proc.get_session_status_view("), std::string::npos);
+  EXPECT_NE(status_handler.find("const auto &status_snapshot = status_view.snapshot"), std::string::npos);
+  const auto status_view_claim = status_handler.find("get_session_status_view(");
+  const auto status_stats_read = status_handler.find("stream_stats::get_current()");
+  ASSERT_NE(status_view_claim, std::string::npos);
+  ASSERT_NE(status_stats_read, std::string::npos);
+  EXPECT_LT(status_view_claim, status_stats_read);
+  for (const auto loose_read : {
+         "proc::proc.get_session_owner_unique_id()",
+         "proc::proc.get_session_owner_device_name()",
+         "rtsp_stream::viewer_count()",
+         "proc::proc.session_allows_client_commands()",
+         "proc::proc.get_last_run_app_name()",
+         "proc::proc.get_running_app_uuid()",
+         "proc::proc.current_app_has_mangohud()",
+         "proc::proc.session_uses_virtual_display()",
+         "proc::proc.session_display_mode_is_explicit()"
+       }) {
+    EXPECT_EQ(status_handler.find(loose_read), std::string::npos);
+  }
+  const auto captured_display_helper_start = source.find(
+    "std::string effective_stream_display_mode_selection(\n      const stream_stats::stats_t &stats,"
+  );
+  const auto captured_display_helper_end = source.find(
+    "std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats)",
+    captured_display_helper_start
+  );
+  ASSERT_NE(captured_display_helper_start, std::string::npos);
+  ASSERT_NE(captured_display_helper_end, std::string::npos);
+  const auto captured_display_helper = source.substr(
+    captured_display_helper_start,
+    captured_display_helper_end - captured_display_helper_start
+  );
+  EXPECT_EQ(captured_display_helper.find("proc::proc.session_uses_virtual_display()"), std::string::npos);
+  const auto captured_display_call = status_handler.find("effective_stream_display_mode_selection(");
+  const auto captured_display_call_end = status_handler.find(");", captured_display_call);
+  const auto captured_virtual_display = status_handler.find(
+    "status_snapshot.virtual_display",
+    captured_display_call
+  );
+  ASSERT_NE(captured_display_call, std::string::npos);
+  ASSERT_NE(captured_display_call_end, std::string::npos);
+  ASSERT_NE(captured_virtual_display, std::string::npos);
+  EXPECT_LT(captured_display_call, captured_virtual_display);
+  EXPECT_LT(captured_virtual_display, captured_display_call_end);
+  EXPECT_NE(status_handler.find("session_stop_outcome_t::allowed"), std::string::npos);
+  EXPECT_NE(stop_handler.find("PERM::launch"), std::string::npos);
+  EXPECT_NE(stop_handler.find("request_session_shutdown("), std::string::npos);
+  EXPECT_NE(stop_handler.find("session_stop_outcome_t::no_active_session"), std::string::npos);
+  EXPECT_EQ(stop_handler.find("session_token_matches_value"), std::string::npos);
+  EXPECT_EQ(stop_handler.find("request_active_session_shutdown"), std::string::npos);
+  EXPECT_EQ(cancel_handler.find("session_token_matches_request"), std::string::npos);
+  EXPECT_EQ(cancel_handler.find("request_active_session_shutdown"), std::string::npos);
+  EXPECT_NE(
+    cancel_handler.find(
+      "request_session_shutdown(\n"
+      "      named_cert_p->uuid,\n"
+      "      session_token,\n"
+      "      true,\n"
+      "      !session_token.empty()\n"
+      "    )"
+    ),
+    std::string::npos
+  );
+  EXPECT_NE(
+    stop_handler.find(
+      "request_session_shutdown(\n"
+      "        named_cert_p->uuid,\n"
+      "        expected_token,\n"
+      "        can_launch,\n"
+      "        true\n"
+      "      )"
+    ),
+    std::string::npos
+  );
+}
+
+TEST(ProcessRuntimeConfigTests, SessionLifecycleGateOwnsLaunchRaiseAndTeardownWithoutCrossLockingRtsp) {
+  const auto header = read_source_file_for_contract("src/process.h");
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  const auto rtsp_source = read_source_file_for_contract("src/rtsp.cpp");
+  const auto rtsp_header = read_source_file_for_contract("src/rtsp.h");
+  const auto nvhttp = read_source_file_for_contract("src/nvhttp.cpp");
+  ASSERT_FALSE(header.empty());
+  ASSERT_FALSE(source.empty());
+  ASSERT_FALSE(rtsp_source.empty());
+  ASSERT_FALSE(rtsp_header.empty());
+  ASSERT_FALSE(nvhttp.empty());
+
+  EXPECT_NE(header.find("_session_lifecycle_gate"), std::string::npos);
+  EXPECT_NE(header.find("execute_and_raise"), std::string::npos);
+  EXPECT_NE(header.find("raise_session_for_admitted_launch"), std::string::npos);
+  EXPECT_NE(header.find("capture_launch_generation"), std::string::npos);
+  EXPECT_NE(source.find("session_snapshot({}).pending_sessions > 0"), std::string::npos);
+
+  const auto execute_start = source.find("int proc_t::execute_impl(");
+  const auto execute_end = source.find("int proc_t::running()", execute_start);
+  ASSERT_NE(execute_start, std::string::npos);
+  ASSERT_NE(execute_end, std::string::npos);
+  const auto execute_impl = source.substr(execute_start, execute_end - execute_start);
+  EXPECT_EQ(source.find("session_count_without_process_lock"), std::string::npos);
+  EXPECT_EQ(execute_impl.find("lifecycle_lock.unlock()"), std::string::npos);
+  EXPECT_NE(execute_impl.find("no_active_sessions_at_launch"), std::string::npos);
+  EXPECT_EQ(execute_impl.find("rtsp_stream::session_count()"), std::string::npos);
+  const auto function_source_between = [](const std::string &text, std::string_view begin, std::string_view end) {
+    const auto start = text.find(begin);
+    if (start == std::string::npos) {
+      return std::string {};
+    }
+    const auto finish = text.find(end, start + begin.size());
+    if (finish == std::string::npos) {
+      return std::string {};
+    }
+    return text.substr(start, finish - start);
+  };
+  const auto begin_stop_body = function_source_between(
+    source,
+    "bool session_lifecycle_gate_t::begin_stop()",
+    "void session_lifecycle_gate_t::finish_stop(bool"
+  );
+  const auto snapshot_wait = begin_stop_body.find("_state != state_e::snapshotting");
+  const auto stop_publish = begin_stop_body.find("_stop_waiting = true");
+  ASSERT_NE(snapshot_wait, std::string::npos);
+  ASSERT_NE(stop_publish, std::string::npos);
+  EXPECT_LT(snapshot_wait, stop_publish);
+  const auto resume_body = function_source_between(source, "void proc_t::resume()", "void proc_t::pause()");
+  const auto pause_body = function_source_between(source, "void proc_t::pause()", "void proc_t::terminate(");
+  const auto report_writer = function_source_between(source, "void proc_t::mark_client_session_report_recorded", "bool proc_t::client_session_report_recorded");
+  const auto report_reader = function_source_between(source, "bool proc_t::client_session_report_recorded", "bool proc_t::session_display_mode_is_explicit");
+  const auto display_reader = function_source_between(source, "bool proc_t::session_display_mode_is_explicit", "bool proc_t::current_app_has_mangohud");
+  const auto mangohud_reader = function_source_between(source, "bool proc_t::current_app_has_mangohud", "void proc_t::set_app_mangohud_configured");
+  EXPECT_NE(resume_body.find("session_lifecycle_sync()"), std::string::npos);
+  EXPECT_NE(pause_body.find("session_lifecycle_sync()"), std::string::npos);
+  EXPECT_NE(report_writer.find("session_lifecycle_sync()"), std::string::npos);
+  EXPECT_NE(report_reader.find("session_lifecycle_sync()"), std::string::npos);
+  EXPECT_NE(display_reader.find("session_lifecycle_sync()"), std::string::npos);
+  EXPECT_NE(mangohud_reader.find("session_lifecycle_sync()"), std::string::npos);
+  const auto guarded_reader = [&](std::string_view begin, std::string_view end) {
+    const auto body = function_source_between(source, begin, end);
+    EXPECT_FALSE(body.empty());
+    const auto sync = body.find("auto &sync = session_lifecycle_sync()");
+    const auto lock = body.find("std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex)");
+    ASSERT_NE(sync, std::string::npos);
+    ASSERT_NE(lock, std::string::npos);
+    EXPECT_LT(sync, lock);
+  };
+  guarded_reader("void proc_t::resume()", "void proc_t::pause()");
+  guarded_reader("void proc_t::mark_client_session_report_recorded", "bool proc_t::client_session_report_recorded");
+  guarded_reader("bool proc_t::client_session_report_recorded", "bool proc_t::session_display_mode_is_explicit");
+  guarded_reader("bool proc_t::session_display_mode_is_explicit", "bool proc_t::current_app_has_mangohud");
+  guarded_reader("bool proc_t::current_app_has_mangohud", "void proc_t::set_app_mangohud_configured");
+  guarded_reader("void proc_t::set_app_mangohud_configured", "void proc_t::set_app_steam_launch_mode_configured");
+  guarded_reader("void proc_t::set_app_steam_launch_mode_configured", "proc_t::session_lifecycle_sync_t &proc_t::session_lifecycle_sync");
+  guarded_reader("std::string proc_t::get_last_run_app_name", "std::string proc_t::get_running_app_uuid");
+  guarded_reader("std::string proc_t::get_running_app_uuid", "std::string proc_t::get_session_token");
+  guarded_reader("std::string proc_t::get_session_token", "std::string proc_t::get_session_owner_unique_id");
+  guarded_reader("std::string proc_t::get_session_owner_unique_id", "std::string proc_t::get_session_owner_device_name");
+  guarded_reader("std::string proc_t::get_session_owner_device_name", "bool proc_t::is_session_owner");
+  guarded_reader("bool proc_t::is_session_owner", "bool proc_t::session_uses_virtual_display");
+  guarded_reader("bool proc_t::session_uses_virtual_display", "bool proc_t::session_allows_client_commands");
+  guarded_reader("bool proc_t::session_allows_client_commands", "void proc_t::mark_client_session_report_recorded");
+  EXPECT_NE(pause_body.find("std::unique_lock<std::recursive_mutex> lifecycle_lock(sync.mutex)"), std::string::npos);
+
+  const auto status_snapshot = function_source_between(
+    source,
+    "session_status_view_t proc_t::get_session_status_view(",
+    "session_stop_snapshot_t proc_t::get_session_stop_snapshot("
+  );
+  const auto snapshot_guard = function_source_between(
+    source,
+    "session_snapshot_guard_t::session_snapshot_guard_t(session_lifecycle_gate_t &gate)",
+    "session_snapshot_guard_t::session_snapshot_guard_t(session_snapshot_guard_t &&other)"
+  );
+  const auto status_claim = status_snapshot.find("session_snapshot_guard_t::try_acquire");
+  const auto status_latch = status_snapshot.find("const bool stop_observed = !guard.owns_snapshot()");
+  const auto status_rtsp = status_snapshot.find("rtsp_stream::session_snapshot(unique_id)");
+  const auto status_sync = status_snapshot.find("session_lifecycle_sync()");
+  ASSERT_NE(status_claim, std::string::npos);
+  ASSERT_NE(status_latch, std::string::npos);
+  ASSERT_NE(status_rtsp, std::string::npos);
+  ASSERT_NE(status_sync, std::string::npos);
+  EXPECT_LT(status_claim, status_latch);
+  EXPECT_LT(status_latch, status_rtsp);
+  EXPECT_LT(status_rtsp, status_sync);
+  EXPECT_NE(status_snapshot.find("rtsp_snapshot,\n      stop_observed"), std::string::npos);
+  EXPECT_EQ(status_snapshot.find("stop_in_progress()"), std::string::npos);
+  EXPECT_NE(snapshot_guard.find("begin_snapshot()"), std::string::npos);
+  EXPECT_NE(snapshot_guard.find("finish_snapshot()"), std::string::npos);
+  EXPECT_NE(header.find("session_snapshot_guard_t guard;"), std::string::npos);
+  EXPECT_NE(status_snapshot.find("snapshot.viewer_count = rtsp_snapshot.viewer_count"), std::string::npos);
+  const auto stop_snapshot_locked = function_source_between(
+    source,
+    "session_stop_snapshot_t proc_t::get_session_stop_snapshot_locked(",
+    "session_status_view_t proc_t::get_session_status_view("
+  );
+  EXPECT_NE(stop_snapshot_locked.find("session_stop_token_matches("), std::string::npos);
+  EXPECT_NE(stop_snapshot_locked.find("snapshot.stop_in_progress = stop_in_progress"), std::string::npos);
+  EXPECT_EQ(stop_snapshot_locked.find("_session_lifecycle_gate->stop_in_progress()"), std::string::npos);
+  const auto rtsp_snapshot_body = function_source_between(
+    rtsp_source,
+    "session_snapshot_t session_snapshot(const std::string_view& uuid)",
+    "std::list<std::string>"
+  );
+  EXPECT_NE(rtsp_snapshot_body.find("accumulate_session_snapshot("), std::string::npos);
+  EXPECT_NE(rtsp_snapshot_body.find("pending->is_pending_or_handoff()"), std::string::npos);
+  EXPECT_NE(rtsp_snapshot_body.find("stream::session::state(*slot) == stream::session::state_e::STOPPING"), std::string::npos);
+  EXPECT_EQ(rtsp_snapshot_body.find("break;"), std::string::npos);
+  const auto rtsp_clear_body = function_source_between(
+    rtsp_source,
+    "void clear(bool all = true)",
+    "/**\n     * @brief Removes the provided session"
+  );
+  const auto clear_lock = rtsp_clear_body.find("_session_slots.lock()");
+  const auto clear_unlock = rtsp_clear_body.find("}\n#ifdef POLARIS_TESTS", clear_lock);
+  const auto clear_join = rtsp_clear_body.find("stream::session::join", clear_unlock);
+  ASSERT_NE(clear_lock, std::string::npos);
+  ASSERT_NE(clear_unlock, std::string::npos);
+  ASSERT_NE(clear_join, std::string::npos);
+  EXPECT_LT(clear_lock, clear_unlock);
+  EXPECT_LT(clear_unlock, clear_join);
+  const auto rtsp_server_instance = rtsp_source.find("rtsp_server_t server {}");
+  const auto public_rtsp_snapshot_start = rtsp_source.find(
+    "session_snapshot_t session_snapshot(const std::string_view& uuid)",
+    rtsp_server_instance
+  );
+  const auto public_rtsp_snapshot_end = rtsp_source.find("#ifdef POLARIS_TESTS", public_rtsp_snapshot_start);
+  ASSERT_NE(rtsp_server_instance, std::string::npos);
+  ASSERT_NE(public_rtsp_snapshot_start, std::string::npos);
+  ASSERT_NE(public_rtsp_snapshot_end, std::string::npos);
+  const auto public_rtsp_snapshot = rtsp_source.substr(
+    public_rtsp_snapshot_start,
+    public_rtsp_snapshot_end - public_rtsp_snapshot_start
+  );
+  EXPECT_EQ(public_rtsp_snapshot.find("server.clear(false)"), std::string::npos);
+  EXPECT_NE(status_snapshot.find("stop_observed"), std::string::npos);
+
+  const auto stop_snapshot_adapter = function_source_between(
+    source,
+    "session_stop_snapshot_t proc_t::get_session_stop_snapshot(",
+    "session_stop_result_t proc_t::request_session_shutdown("
+  );
+  EXPECT_NE(stop_snapshot_adapter.find("get_session_status_view(unique_id, can_launch)"), std::string::npos);
+  EXPECT_EQ(execute_impl.find("terminate();"), std::string::npos);
+
+  const auto stop_start = source.find("proc_t::request_session_shutdown(");
+  const auto stop_end = source.find("bool proc_t::session_shutdown_requested()", stop_start);
+  ASSERT_NE(stop_start, std::string::npos);
+  ASSERT_NE(stop_end, std::string::npos);
+  const auto stop_impl = source.substr(stop_start, stop_end - stop_start);
+  const auto claim = stop_impl.find("begin_stop()");
+  const auto rtsp_snapshot = stop_impl.find("rtsp_stream::session_snapshot(unique_id)");
+  const auto rtsp_terminate = stop_impl.find("rtsp_stream::terminate_sessions()");
+  const auto process_terminate = stop_impl.find("terminate_impl(");
+  const auto stop_commit = stop_impl.find("stop_committed = true");
+  const auto release = stop_impl.rfind("finish_stop(stop_committed)");
+  ASSERT_NE(claim, std::string::npos);
+  ASSERT_NE(rtsp_snapshot, std::string::npos);
+  ASSERT_NE(rtsp_terminate, std::string::npos);
+  ASSERT_NE(process_terminate, std::string::npos);
+  ASSERT_NE(stop_commit, std::string::npos);
+  ASSERT_NE(release, std::string::npos);
+  EXPECT_LT(claim, rtsp_snapshot);
+  EXPECT_LT(rtsp_snapshot, rtsp_terminate);
+  EXPECT_LT(rtsp_terminate, process_terminate);
+  EXPECT_LT(process_terminate, stop_commit);
+  EXPECT_LT(stop_commit, release);
+  EXPECT_NE(stop_impl.find("bool stop_committed = false"), std::string::npos);
+
+  const auto lifecycle_handoff = function_source_between(
+    source,
+    "bool session_lifecycle_gate_t::transition_launch_to_stop()",
+    "void session_lifecycle_gate_t::begin_snapshot()"
+  );
+  EXPECT_NE(header.find("bool _launch_to_stop_handoff = false"), std::string::npos);
+  EXPECT_NE(header.find("bool _last_stop_committed = false"), std::string::npos);
+  EXPECT_NE(header.find("void finish_stop(bool committed = true)"), std::string::npos);
+  EXPECT_NE(lifecycle_handoff.find("_launch_to_stop_handoff = true"), std::string::npos);
+  EXPECT_NE(lifecycle_handoff.find("if (_last_stop_committed)"), std::string::npos);
+  EXPECT_NE(lifecycle_handoff.find("_state = state_e::stopping"), std::string::npos);
+  EXPECT_NE(lifecycle_handoff.find("return true"), std::string::npos);
+
+  for (const auto &body : {
+         function_source_between(source, "void session_lifecycle_gate_t::begin_launch()", "std::optional<std::uint64_t> session_lifecycle_gate_t::capture_launch_generation"),
+         function_source_between(source, "std::optional<std::uint64_t> session_lifecycle_gate_t::capture_launch_generation", "bool session_lifecycle_gate_t::try_begin_rtsp_launch()"),
+         function_source_between(source, "bool session_lifecycle_gate_t::try_begin_rtsp_launch()", "bool session_lifecycle_gate_t::try_begin_rtsp_launch(std::uint64_t"),
+         function_source_between(source, "void session_lifecycle_gate_t::begin_snapshot()", "void session_lifecycle_gate_t::finish_snapshot()")
+       }) {
+    EXPECT_NE(body.find("_launch_to_stop_handoff"), std::string::npos);
+  }
+  EXPECT_NE(stop_impl.find("[this, &stop_committed]"), std::string::npos);
+
+  const auto terminate_start = source.find("void proc_t::terminate_impl(");
+  const auto terminate_end = source.find("bool proc_t::reload_configuration_from_file", terminate_start);
+  ASSERT_NE(terminate_start, std::string::npos);
+  ASSERT_NE(terminate_end, std::string::npos);
+  const auto terminate_impl = source.substr(terminate_start, terminate_end - terminate_start);
+  EXPECT_EQ(terminate_impl.find("finish_stop()"), std::string::npos);
+  EXPECT_EQ(terminate_impl.find("_session_shutdown_requested"), std::string::npos);
+
+  const auto launch_start = nvhttp.find("void launch(bool &host_audio");
+  const auto resume_start = nvhttp.find("void resume(bool &host_audio", launch_start);
+  const auto resume_end = nvhttp.find("void cancel(", resume_start);
+  ASSERT_NE(launch_start, std::string::npos);
+  ASSERT_NE(resume_start, std::string::npos);
+  ASSERT_NE(resume_end, std::string::npos);
+  const auto launch_handler = nvhttp.substr(launch_start, resume_start - launch_start);
+  const auto resume_handler = nvhttp.substr(resume_start, resume_end - resume_start);
+
+  const auto launch_generation = launch_handler.find("capture_session_launch_generation()");
+  const auto launch_admission = launch_handler.find("try_begin_session_launch(*launch_generation)");
+  const auto launch_running = launch_handler.find("proc::proc.running()");
+  ASSERT_NE(launch_generation, std::string::npos);
+  ASSERT_NE(launch_admission, std::string::npos);
+  ASSERT_NE(launch_running, std::string::npos);
+  EXPECT_LT(launch_generation, launch_admission);
+  EXPECT_LT(launch_admission, launch_running);
+  const auto launch_rejection = launch_handler.substr(launch_admission, launch_running - launch_admission);
+  EXPECT_NE(launch_rejection.find("status_code\", 409"), std::string::npos);
+  EXPECT_NE(launch_rejection.find("return;"), std::string::npos);
+
+  const auto resume_generation = resume_handler.find("capture_session_launch_generation()");
+  const auto resume_admission = resume_handler.find("try_begin_session_launch(*launch_generation)");
+  const auto resume_running = resume_handler.find("proc::proc.running()");
+  ASSERT_NE(resume_generation, std::string::npos);
+  ASSERT_NE(resume_admission, std::string::npos);
+  ASSERT_NE(resume_running, std::string::npos);
+  EXPECT_LT(resume_generation, resume_admission);
+  EXPECT_LT(resume_admission, resume_running);
+  const auto resume_rejection = resume_handler.substr(resume_admission, resume_running - resume_admission);
+  EXPECT_NE(resume_rejection.find("status_code\", 409"), std::string::npos);
+  EXPECT_NE(resume_rejection.find("return;"), std::string::npos);
+
+  const auto count_occurrences = [](const std::string &text, std::string_view needle) {
+    std::size_t count = 0;
+    for (auto pos = text.find(needle); pos != std::string::npos; pos = text.find(needle, pos + needle.size())) {
+      ++count;
+    }
+    return count;
+  };
+  EXPECT_EQ(count_occurrences(launch_handler, "finish_session_launch()"), 1);
+  EXPECT_EQ(count_occurrences(resume_handler, "finish_session_launch()"), 1);
+  EXPECT_NE(launch_handler.find("terminate_from_admitted_launch()"), std::string::npos);
+
+  EXPECT_EQ(launch_handler.find("rtsp_stream::launch_session_raise("), std::string::npos);
+  EXPECT_NE(
+    launch_handler.find("launch_input_only_and_raise(launch_session)"),
+    std::string::npos
+  );
+  EXPECT_NE(
+    launch_handler.find("execute_and_raise(*app_iter, launch_session)"),
+    std::string::npos
+  );
+  EXPECT_NE(
+    launch_handler.find("raise_session_for_admitted_launch(launch_session)"),
+    std::string::npos
+  );
+  const auto launch_gate = launch_handler.find("raise_session_for_admitted_launch(");
+  const auto launch_raise_guard = launch_handler.find("if (!launch_session_raised && !proc::proc.raise_session_for_admitted_launch(launch_session))");
+  const auto launch_success = launch_handler.rfind("tree.put(\"root.<xmlattr>.status_code\", 200)");
+  ASSERT_NE(launch_raise_guard, std::string::npos);
+  EXPECT_NE(launch_handler.substr(launch_raise_guard, launch_success - launch_raise_guard).find("status_code\", 409"), std::string::npos);
+  EXPECT_LT(launch_gate, launch_success);
+
+  EXPECT_EQ(resume_handler.find("rtsp_stream::launch_session_raise("), std::string::npos);
+  EXPECT_NE(
+    resume_handler.find("raise_session_for_admitted_launch(launch_session)"),
+    std::string::npos
+  );
+  const auto resume_gate = resume_handler.find("raise_session_for_admitted_launch(");
+  const auto resume_raise_guard = resume_handler.find("if (!proc::proc.raise_session_for_admitted_launch(launch_session))");
+  const auto resume_success = resume_handler.find("tree.put(\"root.<xmlattr>.status_code\", 200)");
+  ASSERT_NE(resume_raise_guard, std::string::npos);
+  EXPECT_NE(resume_handler.substr(resume_raise_guard, resume_success - resume_raise_guard).find("status_code\", 409"), std::string::npos);
+  EXPECT_LT(resume_gate, resume_success);
+
+  const auto rtsp = read_source_file_for_contract("src/rtsp.cpp");
+  ASSERT_FALSE(rtsp.empty());
+  EXPECT_NE(rtsp.find("snapshot.pending_sessions = 1"), std::string::npos);
+  EXPECT_NE(rtsp.find("server.cancel_pending_session()"), std::string::npos);
+  const auto handoff_start = rtsp.find("insert_start_result_e insert_and_start_if_not_cancelled(");
+  const auto handoff_end = rtsp.find("void iterate()", handoff_start);
+  ASSERT_NE(handoff_start, std::string::npos);
+  ASSERT_NE(handoff_end, std::string::npos);
+  const auto handoff = rtsp.substr(handoff_start, handoff_end - handoff_start);
+  const auto handoff_claim = handoff.find("try_begin_setup_handoff()");
+  const auto handoff_lock = handoff.find("_session_slots.lock()");
+  const auto handoff_insert = handoff.find("_session_slots->emplace(session)");
+  const auto handoff_commit = handoff.find("commit_setup_start()");
+  const auto handoff_start_stream = handoff.find("stream::session::start(*session, remote_address)");
+  ASSERT_NE(handoff_claim, std::string::npos);
+  ASSERT_NE(handoff_lock, std::string::npos);
+  ASSERT_NE(handoff_insert, std::string::npos);
+  ASSERT_NE(handoff_commit, std::string::npos);
+  ASSERT_NE(handoff_start_stream, std::string::npos);
+  EXPECT_LT(handoff_claim, handoff_lock);
+  EXPECT_LT(handoff_lock, handoff_insert);
+  EXPECT_LT(handoff_insert, handoff_commit);
+  EXPECT_LT(handoff_commit, handoff_start_stream);
+  EXPECT_EQ(handoff.find("_launch_timer_mutex"), std::string::npos);
+  EXPECT_NE(rtsp.find("insert_and_start_if_not_cancelled(stream_session, session"), std::string::npos);
+  EXPECT_NE(rtsp.find("pending->cancel_for_timeout()"), std::string::npos);
+  EXPECT_NE(rtsp_header.find("expected == setup_state_e::pending || expected == setup_state_e::handoff"), std::string::npos);
+  EXPECT_NE(rtsp.find("_raised_timer_generation"), std::string::npos);
+  EXPECT_NE(rtsp.find("std::mutex _launch_timer_mutex"), std::string::npos);
+  EXPECT_NE(rtsp.find("std::lock_guard timer_lock(_launch_timer_mutex)"), std::string::npos);
+  EXPECT_NE(rtsp.find("launch_event.pop_if("), std::string::npos);
+  const auto cancel_pending_start = rtsp.find("void cancel_pending_session()");
+  const auto cancel_pending_end = rtsp.find("/**", cancel_pending_start);
+  ASSERT_NE(cancel_pending_start, std::string::npos);
+  ASSERT_NE(cancel_pending_end, std::string::npos);
+  const auto cancel_pending = rtsp.substr(cancel_pending_start, cancel_pending_end - cancel_pending_start);
+  EXPECT_NE(cancel_pending.find("std::lock_guard timer_lock(_launch_timer_mutex)"), std::string::npos);
+  EXPECT_NE(cancel_pending.find("raised_timer.cancel()"), std::string::npos);
+  EXPECT_NE(cancel_pending.find("++_raised_timer_generation"), std::string::npos);
+  const auto timer_callback_start = rtsp.find("raised_timer.async_wait(");
+  const auto timer_callback_end = rtsp.find("return true;", timer_callback_start);
+  ASSERT_NE(timer_callback_start, std::string::npos);
+  ASSERT_NE(timer_callback_end, std::string::npos);
+  const auto timer_callback = rtsp.substr(timer_callback_start, timer_callback_end - timer_callback_start);
+  EXPECT_NE(timer_callback.find("expire_pending_launch(launch_session_id, timer_generation)"), std::string::npos);
+  const auto timer_expiry_start = rtsp.find("bool expire_pending_launch(");
+  const auto timer_expiry_end = rtsp.find("std::uint64_t launch_timer_generation()", timer_expiry_start);
+  ASSERT_NE(timer_expiry_start, std::string::npos);
+  ASSERT_NE(timer_expiry_end, std::string::npos);
+  const auto timer_expiry = rtsp.substr(timer_expiry_start, timer_expiry_end - timer_expiry_start);
+  EXPECT_NE(timer_expiry.find("std::lock_guard timer_lock(_launch_timer_mutex)"), std::string::npos);
+  EXPECT_NE(timer_expiry.find("_raised_timer_generation.load() != timer_generation"), std::string::npos);
+  EXPECT_NE(timer_expiry.find("launch_event.pop_if("), std::string::npos);
+  EXPECT_NE(source.find("rtsp_snapshot.active_sessions + rtsp_snapshot.pending_sessions"), std::string::npos);
+}
+
+TEST(ProcessRuntimeConfigTests, RefreshPreservesLifecycleSynchronizationObjects) {
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  const auto refresh_start = source.find("void refresh(const std::string &file_name, bool needs_terminate)");
+  const auto refresh_end = source.find("}  // namespace proc", refresh_start);
+  ASSERT_NE(refresh_start, std::string::npos);
+  ASSERT_NE(refresh_end, std::string::npos);
+  const auto refresh_body = source.substr(refresh_start, refresh_end - refresh_start);
+  EXPECT_NE(refresh_body.find("proc.reload_configuration_from_file(file_name)"), std::string::npos);
+  EXPECT_EQ(refresh_body.find("proc = std::move(*proc_opt)"), std::string::npos);
+
+  const auto terminate_start = source.find("void proc_t::terminate_impl(bool immediate, bool needs_refresh)");
+  const auto terminate_end = source.find("bool proc_t::reload_configuration_from_file", terminate_start);
+  ASSERT_NE(terminate_start, std::string::npos);
+  ASSERT_NE(terminate_end, std::string::npos);
+  const auto terminate_body = source.substr(terminate_start, terminate_end - terminate_start);
+  EXPECT_NE(terminate_body.find("reload_configuration_from_file(config::stream.file_apps)"), std::string::npos);
+  EXPECT_EQ(terminate_body.find("refresh(config::stream.file_apps, false)"), std::string::npos);
+
+  const auto reload_start = source.find("void proc_t::reload_configuration(proc_t &&parsed)");
+  const auto reload_end = source.find("#if defined(POLARIS_TESTS)", reload_start);
+  ASSERT_NE(reload_start, std::string::npos);
+  ASSERT_NE(reload_end, std::string::npos);
+  const auto reload_body = source.substr(reload_start, reload_end - reload_start);
+  EXPECT_NE(reload_body.find("std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex)"), std::string::npos);
+  EXPECT_NE(reload_body.find("_env = std::move(parsed._env)"), std::string::npos);
+  EXPECT_NE(reload_body.find("_apps = std::move(parsed._apps)"), std::string::npos);
+  EXPECT_EQ(reload_body.find("_session_lifecycle_gate"), std::string::npos);
+  EXPECT_EQ(reload_body.find("_session_lifecycle_sync"), std::string::npos);
+
+  const auto get_apps_start = source.find("std::vector<ctx_t> proc_t::get_apps() const");
+  const auto get_apps_end = source.find("std::string proc_t::get_app_image", get_apps_start);
+  ASSERT_NE(get_apps_start, std::string::npos);
+  ASSERT_NE(get_apps_end, std::string::npos);
+  const auto get_apps_body = source.substr(get_apps_start, get_apps_end - get_apps_start);
+  EXPECT_NE(get_apps_body.find("std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex)"), std::string::npos);
+  EXPECT_NE(get_apps_body.find("return _apps"), std::string::npos);
 }
 
 TEST(ProcessRuntimeConfigTests, DeviceDbBitrateStaysOutWhenAutoQualityOffAndMaxBitrateUnlocked) {

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -1,0 +1,768 @@
+/**
+ * @file tests/unit/test_session_stop_contract.cpp
+ * @brief Behavioral HTTP and RTSP-role contracts for the Polaris v1 session stop endpoint.
+ */
+
+#include <src/nvhttp.h>
+#include <src/process.h>
+#include <src/rtsp.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <future>
+#include <thread>
+
+namespace {
+  using proc::session_stop_outcome_t;
+  using rtsp_stream::session_role_e;
+
+  session_stop_outcome_t decide(
+    bool can_launch,
+    bool has_running_app,
+    int active_sessions,
+    bool owned_by_client,
+    session_role_e requester_role,
+    bool stop_in_progress = false,
+    bool token_matches = true
+  ) {
+    return proc::evaluate_session_stop_request(
+      can_launch,
+      has_running_app,
+      active_sessions,
+      owned_by_client,
+      requester_role,
+      stop_in_progress,
+      token_matches
+    );
+  }
+}
+
+TEST(ProcessRefreshContractTests, ParsedConfigurationPreservesLifecycleIdentityAndGeneration) {
+  auto current_env = boost::this_process::environment();
+  proc::proc_t subject {std::move(current_env), {}};
+  const auto identity_before = subject.session_lifecycle_identity_for_tests();
+  const auto generation_before = subject.capture_session_launch_generation();
+  ASSERT_TRUE(generation_before.has_value());
+
+  auto refreshed_env = boost::this_process::environment();
+  std::vector<proc::ctx_t> refreshed_apps;
+  proc::ctx_t refreshed_app;
+  refreshed_app.name = "refreshed-app";
+  refreshed_apps.emplace_back(std::move(refreshed_app));
+  proc::proc_t parsed {std::move(refreshed_env), std::move(refreshed_apps)};
+
+  subject.reload_configuration(std::move(parsed));
+
+  EXPECT_EQ(subject.session_lifecycle_identity_for_tests(), identity_before);
+  EXPECT_EQ(subject.capture_session_launch_generation(), generation_before);
+  ASSERT_EQ(subject.get_apps().size(), 1);
+  EXPECT_EQ(subject.get_apps().front().name, "refreshed-app");
+}
+
+TEST(SessionStopContractTests, ActiveOwnerCanStopRunningSession) {
+  EXPECT_EQ(decide(true, true, 1, true, session_role_e::controller), session_stop_outcome_t::allowed);
+}
+
+TEST(SessionStopContractTests, RevokedLaunchPermissionIsDeniedForStatusAndPostDecision) {
+  EXPECT_EQ(decide(false, true, 1, true, session_role_e::controller), session_stop_outcome_t::permission_denied);
+}
+
+TEST(SessionStopContractTests, ActiveControllerCanCleanUpRtspOnlySession) {
+  EXPECT_EQ(decide(true, false, 1, false, session_role_e::controller), session_stop_outcome_t::allowed);
+}
+
+TEST(SessionStopContractTests, UnrelatedPairedClientCannotStopRtspOnlySession) {
+  EXPECT_EQ(decide(true, false, 1, false, session_role_e::none), session_stop_outcome_t::uncontrolled_stream);
+}
+
+TEST(SessionStopContractTests, ViewerCannotStopRtspOnlySession) {
+  EXPECT_EQ(decide(true, false, 1, false, session_role_e::viewer), session_stop_outcome_t::viewer_forbidden);
+}
+
+TEST(SessionStopContractTests, DifferentPairedClientCannotStopOwnedSession) {
+  EXPECT_EQ(decide(true, true, 1, false, session_role_e::none), session_stop_outcome_t::other_owner);
+}
+
+TEST(SessionStopContractTests, DuplicateStopIsRejectedWhileStopIsInProgress) {
+  EXPECT_EQ(
+    decide(true, true, 1, true, session_role_e::controller, true),
+    session_stop_outcome_t::stop_in_progress
+  );
+}
+
+TEST(SessionStopContractTests, RtspOnlyDuplicateStopBeatsZeroSessionIdempotence) {
+  EXPECT_EQ(
+    decide(true, false, 0, false, session_role_e::none, true),
+    session_stop_outcome_t::stop_in_progress
+  );
+}
+
+TEST(SessionStopContractTests, LegacyCancelOwnerWithoutTokenKeepsOwnerAuthorizedSemantics) {
+  EXPECT_EQ(
+    decide(true, true, 1, true, session_role_e::controller, false, true),
+    session_stop_outcome_t::allowed
+  );
+}
+
+TEST(SessionStopContractTests, LegacyOwnerAuthorizationDoesNotRequireAnActiveToken) {
+  EXPECT_TRUE(proc::session_stop_token_matches(false, "", "", {}));
+  EXPECT_TRUE(proc::session_stop_token_matches(false, "", "active-token", {}));
+  EXPECT_FALSE(proc::session_stop_token_matches(true, "", "active-token", {}));
+  EXPECT_TRUE(proc::session_stop_token_matches(true, "active-token", "active-token", {}));
+}
+
+TEST(SessionStopContractTests, ExactTokenIsRequiredForRtspOnlyPendingSession) {
+  rtsp_stream::terminate_sessions();
+  auto pending = std::make_shared<rtsp_stream::launch_session_t>();
+  pending->id = 4242;
+  pending->unique_id = "rtsp-only-controller";
+  pending->session_token = "rtsp-only-token";
+  ASSERT_TRUE(rtsp_stream::launch_session_raise(pending));
+
+  auto env = boost::this_process::environment();
+  proc::proc_t subject {std::move(env), {}};
+
+  const auto omitted = subject.request_session_shutdown(
+    pending->unique_id,
+    "",
+    true,
+    true
+  );
+  EXPECT_EQ(omitted.snapshot.outcome, session_stop_outcome_t::token_mismatch);
+  EXPECT_FALSE(omitted.stopped);
+  EXPECT_FALSE(pending->is_cancelled());
+
+  const auto mismatched = subject.request_session_shutdown(
+    pending->unique_id,
+    "wrong-token",
+    true,
+    true
+  );
+  EXPECT_EQ(mismatched.snapshot.outcome, session_stop_outcome_t::token_mismatch);
+  EXPECT_FALSE(mismatched.stopped);
+  EXPECT_FALSE(pending->is_cancelled());
+
+  const auto matched = subject.request_session_shutdown(
+    pending->unique_id,
+    "rtsp-only-token",
+    true,
+    true
+  );
+  EXPECT_EQ(matched.snapshot.outcome, session_stop_outcome_t::allowed);
+  EXPECT_TRUE(matched.stopped);
+  EXPECT_TRUE(pending->is_cancelled());
+  rtsp_stream::terminate_sessions();
+}
+
+TEST(SessionStopContractTests, MismatchedTokenIsRejectedForRunningApp) {
+  EXPECT_EQ(
+    decide(true, true, 1, true, session_role_e::controller, false, false),
+    session_stop_outcome_t::token_mismatch
+  );
+}
+
+TEST(SessionStopContractTests, AuthorizedZeroSessionRequestIsIdempotentNoOp) {
+  EXPECT_EQ(decide(true, false, 0, false, session_role_e::none), session_stop_outcome_t::no_active_session);
+}
+
+TEST(SessionStopContractTests, ZeroSessionRequestStillRequiresLaunchPermission) {
+  EXPECT_EQ(decide(false, false, 0, false, session_role_e::none), session_stop_outcome_t::permission_denied);
+}
+
+TEST(SessionStopContractTests, OmittedTokenCannotMatchRunningSession) {
+  EXPECT_FALSE(proc::session_token_matches_active("", "active-token"));
+}
+
+TEST(SessionStopContractTests, MissingActiveTokenCannotAuthorizeRunningSession) {
+  EXPECT_FALSE(proc::session_token_matches_active("expected-token", ""));
+}
+
+TEST(SessionStopContractTests, ExactNonEmptyTokenMatchesRunningSession) {
+  EXPECT_TRUE(proc::session_token_matches_active("session-token", "session-token"));
+}
+
+TEST(SessionStopContractTests, DifferentNonEmptyTokenCannotMatchRunningSession) {
+  EXPECT_FALSE(proc::session_token_matches_active("stale-token", "active-token"));
+}
+
+TEST(SessionRoleContractTests, StoppingSlotIsExcludedAndConcurrentCleanupClaimsItOnce) {
+  rtsp_stream::terminate_sessions();
+  std::atomic_int cleaned {0};
+  rtsp_stream::set_cleanup_session_probe_for_tests([&cleaned]() {
+    ++cleaned;
+  });
+
+  rtsp_stream::launch_session_t launch {};
+  launch.id = 5201;
+  launch.unique_id = "stopping-slot";
+  launch.session_token = "stopping-token";
+  rtsp_stream::add_session_for_tests(launch, true);
+
+  const auto stopping_snapshot = rtsp_stream::session_snapshot(launch.unique_id);
+  EXPECT_EQ(stopping_snapshot.active_sessions, 0);
+  EXPECT_TRUE(stopping_snapshot.requester_session_tokens.empty());
+
+  auto first = std::async(std::launch::async, []() {
+    rtsp_stream::run_cleanup_for_tests();
+  });
+  auto second = std::async(std::launch::async, []() {
+    rtsp_stream::run_cleanup_for_tests();
+  });
+  first.get();
+  second.get();
+
+  EXPECT_EQ(cleaned.load(), 1);
+  EXPECT_EQ(rtsp_stream::session_snapshot(launch.unique_id).active_sessions, 0);
+  rtsp_stream::set_cleanup_session_probe_for_tests({});
+}
+
+TEST(SessionStopContractTests, ExactTokenIsRequiredForRtspOnlyActiveSession) {
+  rtsp_stream::terminate_sessions();
+  std::atomic_int cleaned {0};
+  rtsp_stream::set_cleanup_session_probe_for_tests([&cleaned]() {
+    ++cleaned;
+  });
+
+  rtsp_stream::launch_session_t launch {};
+  launch.id = 5202;
+  launch.unique_id = "active-rtsp-controller";
+  launch.session_token = "active-rtsp-token";
+  rtsp_stream::add_session_for_tests(launch, false);
+
+  auto env = boost::this_process::environment();
+  proc::proc_t subject {std::move(env), {}};
+  const auto omitted = subject.request_session_shutdown(launch.unique_id, "", true, true);
+  EXPECT_EQ(omitted.snapshot.outcome, session_stop_outcome_t::token_mismatch);
+  EXPECT_FALSE(omitted.stopped);
+  const auto mismatched = subject.request_session_shutdown(launch.unique_id, "wrong", true, true);
+  EXPECT_EQ(mismatched.snapshot.outcome, session_stop_outcome_t::token_mismatch);
+  EXPECT_FALSE(mismatched.stopped);
+  EXPECT_EQ(rtsp_stream::session_snapshot(launch.unique_id).active_sessions, 1);
+
+  const auto matched = subject.request_session_shutdown(
+    launch.unique_id,
+    "active-rtsp-token",
+    true,
+    true
+  );
+  EXPECT_EQ(matched.snapshot.outcome, session_stop_outcome_t::allowed);
+  EXPECT_TRUE(matched.stopped);
+  EXPECT_EQ(cleaned.load(), 1);
+  EXPECT_EQ(rtsp_stream::session_snapshot(launch.unique_id).active_sessions, 0);
+  rtsp_stream::terminate_sessions();
+  rtsp_stream::set_cleanup_session_probe_for_tests({});
+}
+
+TEST(SessionRoleContractTests, RtspCleanupReleasesSlotsBeforeJoiningSessionThreads) {
+  auto completed = std::make_shared<std::promise<void>>();
+  auto completed_future = completed->get_future();
+
+  rtsp_stream::set_cleanup_unlocked_probe_for_tests([completed, &completed_future]() {
+    std::thread([completed]() {
+      static_cast<void>(rtsp_stream::session_snapshot("cleanup-probe"));
+      completed->set_value();
+    }).detach();
+    EXPECT_EQ(completed_future.wait_for(100ms), std::future_status::ready);
+  });
+
+  rtsp_stream::run_cleanup_for_tests();
+  EXPECT_EQ(completed_future.wait_for(1s), std::future_status::ready);
+  rtsp_stream::set_cleanup_unlocked_probe_for_tests({});
+}
+
+TEST(SessionRoleContractTests, StatusSnapshotDoesNotRunRtspCleanupOrJoin) {
+  rtsp_stream::reset_cleanup_call_count_for_tests();
+  static_cast<void>(rtsp_stream::session_snapshot("snapshot-client"));
+  EXPECT_EQ(rtsp_stream::cleanup_call_count_for_tests(), 0);
+}
+
+TEST(SessionRoleContractTests, ControllerBeforeViewerStillCountsEveryViewer) {
+  rtsp_stream::session_snapshot_t snapshot;
+  rtsp_stream::accumulate_session_snapshot_for_tests(snapshot, true, false);
+  rtsp_stream::accumulate_session_snapshot_for_tests(snapshot, false, true);
+  EXPECT_EQ(snapshot.requester_role, session_role_e::controller);
+  EXPECT_EQ(snapshot.viewer_count, 1);
+}
+
+TEST(RtspLaunchHandoffTests, CancellationAfterRealSlotInsertionRollsBackBeforeCommit) {
+  rtsp_stream::terminate_sessions();
+  rtsp_stream::launch_session_t launch {};
+  launch.id = 5101;
+  launch.unique_id = "insert-cancel";
+  launch.session_token = "insert-cancel-token";
+
+  const auto result = rtsp_stream::run_setup_insert_for_tests(launch, true, 0);
+  EXPECT_EQ(result, rtsp_stream::setup_insert_result_e::cancelled);
+  EXPECT_TRUE(launch.is_cancelled());
+  EXPECT_EQ(rtsp_stream::session_snapshot(launch.unique_id).active_sessions, 0);
+  rtsp_stream::set_cleanup_session_probe_for_tests([]() {});
+  rtsp_stream::terminate_sessions();
+  rtsp_stream::set_cleanup_session_probe_for_tests({});
+}
+
+TEST(RtspLaunchHandoffTests, StartFailureAfterCommitCancelsAndRollsBackRealSlot) {
+  rtsp_stream::terminate_sessions();
+  rtsp_stream::launch_session_t launch {};
+  launch.id = 5102;
+  launch.unique_id = "insert-start-failure";
+  launch.session_token = "insert-start-failure-token";
+
+  const auto result = rtsp_stream::run_setup_insert_for_tests(launch, false, 1);
+  EXPECT_EQ(result, rtsp_stream::setup_insert_result_e::failed);
+  EXPECT_TRUE(launch.is_cancelled());
+  EXPECT_EQ(rtsp_stream::session_snapshot(launch.unique_id).active_sessions, 0);
+  rtsp_stream::set_cleanup_session_probe_for_tests([]() {});
+  rtsp_stream::terminate_sessions();
+  rtsp_stream::set_cleanup_session_probe_for_tests({});
+}
+
+TEST(RtspLaunchHandoffTests, TimeoutAndSetupHandoffHaveOneAtomicWinner) {
+  rtsp_stream::launch_session_t timeout_wins {};
+  EXPECT_TRUE(timeout_wins.cancel_for_timeout());
+  EXPECT_FALSE(timeout_wins.try_begin_setup_handoff());
+  EXPECT_TRUE(timeout_wins.is_cancelled());
+
+  rtsp_stream::launch_session_t timeout_beats_handoff {};
+  EXPECT_TRUE(timeout_beats_handoff.try_begin_setup_handoff());
+  EXPECT_TRUE(timeout_beats_handoff.cancel_for_timeout());
+  EXPECT_FALSE(timeout_beats_handoff.commit_setup_start());
+
+  rtsp_stream::launch_session_t setup_wins {};
+  EXPECT_TRUE(setup_wins.try_begin_setup_handoff());
+  EXPECT_TRUE(setup_wins.commit_setup_start());
+  EXPECT_FALSE(setup_wins.cancel_for_timeout());
+  EXPECT_FALSE(setup_wins.is_cancelled());
+}
+
+TEST(RtspLaunchHandoffTests, SnapshotAndTeardownRetainClaimedHandoffBeforeSlotInsertion) {
+  rtsp_stream::terminate_sessions();
+  auto session = std::make_shared<rtsp_stream::launch_session_t>();
+  session->id = 3131;
+  session->unique_id = "handoff-controller";
+  ASSERT_TRUE(rtsp_stream::launch_session_raise(session));
+  ASSERT_TRUE(session->try_begin_setup_handoff());
+
+  const auto during_handoff = rtsp_stream::session_snapshot(session->unique_id);
+  EXPECT_EQ(during_handoff.pending_sessions, 1);
+  EXPECT_EQ(during_handoff.requester_role, session_role_e::controller);
+
+  rtsp_stream::terminate_sessions();
+  EXPECT_TRUE(session->is_cancelled());
+  EXPECT_FALSE(session->commit_setup_start());
+}
+
+TEST(RtspLaunchHandoffTests, TimerExpiryRemovesStartedAndCancelledLaunchEvents) {
+  rtsp_stream::terminate_sessions();
+  auto started = std::make_shared<rtsp_stream::launch_session_t>();
+  started->id = 3130;
+  started->unique_id = "started-expiry";
+  ASSERT_TRUE(rtsp_stream::launch_session_raise(started));
+  const auto started_generation = rtsp_stream::launch_timer_generation_for_tests();
+  ASSERT_TRUE(started->try_begin_setup_handoff());
+  ASSERT_TRUE(started->commit_setup_start());
+  EXPECT_FALSE(rtsp_stream::expire_pending_launch_for_tests(started->id, started_generation));
+
+  auto after_started = std::make_shared<rtsp_stream::launch_session_t>();
+  after_started->id = 3129;
+  ASSERT_TRUE(rtsp_stream::launch_session_raise(after_started));
+  rtsp_stream::terminate_sessions();
+
+  auto cancelled = std::make_shared<rtsp_stream::launch_session_t>();
+  cancelled->id = 3128;
+  cancelled->unique_id = "cancelled-expiry";
+  ASSERT_TRUE(rtsp_stream::launch_session_raise(cancelled));
+  const auto cancelled_generation = rtsp_stream::launch_timer_generation_for_tests();
+  cancelled->cancel();
+  EXPECT_FALSE(rtsp_stream::expire_pending_launch_for_tests(cancelled->id, cancelled_generation));
+
+  auto after_cancelled = std::make_shared<rtsp_stream::launch_session_t>();
+  after_cancelled->id = 3127;
+  EXPECT_TRUE(rtsp_stream::launch_session_raise(after_cancelled));
+  rtsp_stream::terminate_sessions();
+}
+
+TEST(RtspLaunchHandoffTests, ExplicitCancellationCanBeatClaimedSetupBeforeStart) {
+  rtsp_stream::launch_session_t session {};
+  EXPECT_TRUE(session.try_begin_setup_handoff());
+  session.cancel();
+  EXPECT_FALSE(session.commit_setup_start());
+  EXPECT_TRUE(session.is_cancelled());
+}
+
+TEST(SessionRoleContractTests, MixedViewerThenControllerAggregatesToController) {
+  auto role = rtsp_stream::merge_session_role_for_tests(session_role_e::none, true);
+  role = rtsp_stream::merge_session_role_for_tests(role, false);
+  EXPECT_EQ(role, session_role_e::controller);
+}
+
+TEST(SessionRoleContractTests, MixedControllerThenViewerRemainsController) {
+  auto role = rtsp_stream::merge_session_role_for_tests(session_role_e::none, false);
+  role = rtsp_stream::merge_session_role_for_tests(role, true);
+  EXPECT_EQ(role, session_role_e::controller);
+}
+
+TEST(SessionRoleContractTests, ViewerOnlySessionsAggregateToViewer) {
+  auto role = rtsp_stream::merge_session_role_for_tests(session_role_e::none, true);
+  role = rtsp_stream::merge_session_role_for_tests(role, true);
+  EXPECT_EQ(role, session_role_e::viewer);
+}
+
+
+TEST(SessionLifecycleGateTests, StopWaitsForAdmittedLaunchAndBlocksPendingReplacement) {
+  using namespace std::chrono_literals;
+
+  proc::session_lifecycle_gate_t gate;
+  gate.begin_launch();
+
+  std::promise<void> stop_started;
+  auto stop_acquired = std::async(std::launch::async, [&]() {
+    stop_started.set_value();
+    return gate.begin_stop();
+  });
+  stop_started.get_future().wait();
+
+  EXPECT_EQ(stop_acquired.wait_for(20ms), std::future_status::timeout);
+  gate.finish_launch();
+  ASSERT_EQ(stop_acquired.wait_for(1s), std::future_status::ready);
+  EXPECT_TRUE(stop_acquired.get());
+
+  EXPECT_TRUE(gate.stop_in_progress());
+  EXPECT_FALSE(gate.begin_stop());
+  EXPECT_FALSE(gate.try_begin_rtsp_launch());
+
+  gate.finish_stop();
+  EXPECT_FALSE(gate.stop_in_progress());
+  EXPECT_TRUE(gate.try_begin_rtsp_launch());
+  gate.finish_launch();
+}
+
+TEST(SessionLifecycleGateTests, CompletedStopInvalidatesLaunchGenerationCapturedBeforeTeardown) {
+  proc::session_lifecycle_gate_t gate;
+  const auto stale_generation = gate.capture_launch_generation();
+  ASSERT_TRUE(stale_generation.has_value());
+
+  ASSERT_TRUE(gate.begin_stop());
+  gate.finish_stop();
+
+  EXPECT_FALSE(gate.try_begin_rtsp_launch(*stale_generation));
+
+  const auto fresh_generation = gate.capture_launch_generation();
+  ASSERT_TRUE(fresh_generation.has_value());
+  EXPECT_NE(*fresh_generation, *stale_generation);
+  EXPECT_TRUE(gate.try_begin_rtsp_launch(*fresh_generation));
+  gate.finish_launch();
+}
+
+TEST(SessionLifecycleGateTests, RequestCapturedDuringStopCannotBecomeLaunchableAfterStopCompletes) {
+  proc::session_lifecycle_gate_t gate;
+  ASSERT_TRUE(gate.begin_stop());
+
+  const auto during_stop = gate.capture_launch_generation();
+  EXPECT_FALSE(during_stop.has_value());
+
+  gate.finish_stop();
+  EXPECT_FALSE(gate.try_begin_rtsp_launch(during_stop.value_or(0)));
+}
+
+TEST(SessionLifecycleGateTests, SnapshotStateBlocksInsteadOfRejectingConcurrentLaunchCapture) {
+  proc::session_lifecycle_gate_t gate;
+  gate.begin_snapshot();
+  auto capture = std::async(std::launch::async, [&]() {
+    return gate.capture_launch_generation();
+  });
+
+  EXPECT_EQ(capture.wait_for(20ms), std::future_status::timeout);
+  EXPECT_FALSE(gate.stop_in_progress());
+  gate.finish_snapshot();
+  const auto generation = capture.get();
+  ASSERT_TRUE(generation.has_value());
+  EXPECT_TRUE(gate.try_begin_rtsp_launch(*generation));
+  gate.finish_launch();
+}
+TEST(SessionLifecycleGateTests, StatusLatchesObservedStopAcrossProcessMutexDelay) {
+  auto env = boost::this_process::environment();
+  proc::proc_t subject {std::move(env), {}};
+  std::promise<void> mutex_acquired;
+  std::promise<void> release_mutex;
+  const auto release_future = release_mutex.get_future().share();
+  auto holder = std::async(std::launch::async, [&]() {
+    subject.with_session_lifecycle_lock_for_tests([&]() {
+      mutex_acquired.set_value();
+      release_future.wait();
+    });
+  });
+  mutex_acquired.get_future().wait();
+
+  ASSERT_TRUE(subject.begin_session_stop_for_tests());
+  auto status = std::async(std::launch::async, [&]() {
+    return subject.get_session_status_view("status-client", true).snapshot.stop.stop_in_progress;
+  });
+  EXPECT_EQ(status.wait_for(20ms), std::future_status::timeout);
+
+  subject.finish_session_stop_for_tests(true);
+  release_mutex.set_value();
+  holder.get();
+
+  ASSERT_EQ(status.wait_for(1s), std::future_status::ready);
+  EXPECT_TRUE(status.get());
+}
+
+TEST(SessionLifecycleGateTests, StatusSnapshotCanObserveActiveTeardownWithoutWaiting) {
+  proc::session_lifecycle_gate_t gate;
+  ASSERT_TRUE(gate.begin_stop());
+  auto guard = proc::session_snapshot_guard_t::try_acquire(gate);
+  EXPECT_FALSE(guard.owns_snapshot());
+  EXPECT_TRUE(gate.stop_in_progress());
+  gate.finish_stop(false);
+}
+
+TEST(SessionLifecycleGateTests, StatusSnapshotObservesStopQueuedBehindAdmittedLaunch) {
+  proc::session_lifecycle_gate_t gate;
+  gate.begin_launch();
+  auto status = std::async(std::launch::async, [&]() {
+    return proc::session_snapshot_guard_t::try_acquire(gate);
+  });
+  EXPECT_EQ(status.wait_for(20ms), std::future_status::timeout);
+
+  auto stop = std::async(std::launch::async, [&]() {
+    const bool admitted = gate.begin_stop();
+    if (admitted) {
+      gate.finish_stop(false);
+    }
+    return admitted;
+  });
+  while (!gate.stop_in_progress()) {
+    std::this_thread::yield();
+  }
+
+  EXPECT_EQ(status.wait_for(20ms), std::future_status::ready);
+  if (status.wait_for(0ms) == std::future_status::ready) {
+    EXPECT_FALSE(status.get().owns_snapshot());
+  }
+
+  gate.finish_launch();
+  EXPECT_TRUE(stop.get());
+}
+
+TEST(SessionLifecycleGateTests, StopWaitsForSnapshotStateBeforeTeardown) {
+  proc::session_lifecycle_gate_t gate;
+  gate.begin_snapshot();
+  std::promise<void> stop_started;
+
+  auto stop = std::async(std::launch::async, [&]() {
+    stop_started.set_value();
+    return gate.begin_stop();
+  });
+  stop_started.get_future().wait();
+  EXPECT_EQ(stop.wait_for(20ms), std::future_status::timeout);
+  EXPECT_FALSE(gate.stop_in_progress());
+  gate.finish_snapshot();
+  EXPECT_TRUE(stop.get());
+  gate.finish_stop();
+}
+
+TEST(SessionLifecycleGateTests, ProcessStopSnapshotDoesNotReenterLifecycleGate) {
+  rtsp_stream::terminate_sessions();
+  auto snapshot = std::async(std::launch::async, []() {
+    return proc::proc.get_session_stop_snapshot("snapshot-reader", true);
+  });
+  ASSERT_EQ(snapshot.wait_for(1s), std::future_status::ready);
+  EXPECT_FALSE(snapshot.get().stop_in_progress);
+}
+
+TEST(SessionLifecycleGateTests, ReturnedStatusViewKeepsSnapshotAdmissionUntilDestroyed) {
+  rtsp_stream::terminate_sessions();
+  std::optional<proc::session_status_view_t> status_view;
+  status_view.emplace(proc::proc.get_session_status_view("status-view-client", true));
+
+  auto launch_capture = std::async(std::launch::async, []() {
+    return proc::proc.capture_session_launch_generation();
+  });
+  EXPECT_EQ(launch_capture.wait_for(20ms), std::future_status::timeout);
+
+  status_view.reset();
+  ASSERT_EQ(launch_capture.wait_for(1s), std::future_status::ready);
+  EXPECT_TRUE(launch_capture.get().has_value());
+}
+
+TEST(SessionLifecycleGateTests, AdmittedTerminateTransitionsDirectlyToStopWithoutIdleWindow) {
+  proc::session_lifecycle_gate_t gate;
+  const auto generation = gate.capture_launch_generation();
+  ASSERT_TRUE(generation.has_value());
+  ASSERT_TRUE(gate.try_begin_rtsp_launch(*generation));
+
+  EXPECT_TRUE(gate.transition_launch_to_stop());
+  EXPECT_TRUE(gate.stop_in_progress());
+  EXPECT_FALSE(gate.try_begin_rtsp_launch());
+
+  gate.finish_stop();
+  EXPECT_FALSE(gate.stop_in_progress());
+}
+
+TEST(SessionLifecycleGateTests, AdmittedTerminateDefersToAlreadyWaitingStopWithoutAnIdleAdmissionWindow) {
+  proc::session_lifecycle_gate_t gate;
+  ASSERT_TRUE(gate.try_begin_rtsp_launch());
+
+  auto stop = std::async(std::launch::async, [&]() {
+    const bool admitted = gate.begin_stop();
+    if (admitted) {
+      gate.finish_stop();
+    }
+    return admitted;
+  });
+  while (!gate.stop_in_progress()) {
+    std::this_thread::yield();
+  }
+
+  EXPECT_FALSE(gate.transition_launch_to_stop());
+  EXPECT_TRUE(stop.get());
+  EXPECT_FALSE(gate.stop_in_progress());
+  const auto next = gate.capture_launch_generation();
+  ASSERT_TRUE(next.has_value());
+  EXPECT_TRUE(gate.try_begin_rtsp_launch(*next));
+  gate.finish_launch();
+}
+
+TEST(SessionLifecycleGateTests, AdmittedTerminateTakesOverWhenWaitingStopIsRejected) {
+  proc::session_lifecycle_gate_t gate;
+  ASSERT_TRUE(gate.try_begin_rtsp_launch());
+
+  std::promise<void> stop_admitted;
+  std::promise<void> allow_rejected_stop_to_finish;
+  auto stop = std::async(std::launch::async, [&]() {
+    const bool admitted = gate.begin_stop();
+    if (admitted) {
+      stop_admitted.set_value();
+      allow_rejected_stop_to_finish.get_future().wait();
+      gate.finish_stop(false);
+    }
+    return admitted;
+  });
+  while (!gate.stop_in_progress()) {
+    std::this_thread::yield();
+  }
+
+  auto terminate_handoff = std::async(std::launch::async, [&]() {
+    return gate.transition_launch_to_stop();
+  });
+  stop_admitted.get_future().wait();
+
+  auto competing_launch = std::async(std::launch::async, [&]() {
+    gate.begin_launch();
+    return true;
+  });
+  EXPECT_EQ(competing_launch.wait_for(20ms), std::future_status::timeout);
+
+  allow_rejected_stop_to_finish.set_value();
+  EXPECT_EQ(competing_launch.wait_for(20ms), std::future_status::timeout);
+  ASSERT_EQ(terminate_handoff.wait_for(1s), std::future_status::ready);
+  EXPECT_TRUE(terminate_handoff.get());
+  EXPECT_TRUE(stop.get());
+  EXPECT_TRUE(gate.stop_in_progress());
+
+  gate.finish_stop(true);
+  ASSERT_EQ(competing_launch.wait_for(1s), std::future_status::ready);
+  EXPECT_TRUE(competing_launch.get());
+  gate.finish_launch();
+}
+
+TEST(SessionLifecycleGateTests, TeardownCountsAndClearsPendingRtspLaunch) {
+  rtsp_stream::terminate_sessions();
+
+  auto pending = std::make_shared<rtsp_stream::launch_session_t>();
+  pending->id = 3132;
+  pending->unique_id = "pending-controller";
+  pending->watch_only = false;
+  rtsp_stream::launch_session_raise(pending);
+
+  const auto before = rtsp_stream::session_snapshot(pending->unique_id);
+  EXPECT_EQ(before.active_sessions, 0);
+  EXPECT_EQ(before.pending_sessions, 1);
+  EXPECT_EQ(before.requester_role, session_role_e::controller);
+
+  rtsp_stream::terminate_sessions();
+
+  const auto after = rtsp_stream::session_snapshot(pending->unique_id);
+  EXPECT_EQ(after.active_sessions, 0);
+  EXPECT_EQ(after.pending_sessions, 0);
+  EXPECT_EQ(after.requester_role, session_role_e::none);
+}
+
+TEST(SessionLifecycleGateTests, PendingRtspLaunchBlocksReplacementAdmission) {
+  rtsp_stream::terminate_sessions();
+
+  auto pending = std::make_shared<rtsp_stream::launch_session_t>();
+  pending->id = 3133;
+  pending->unique_id = "first-pending-controller";
+  rtsp_stream::launch_session_raise(pending);
+
+  const auto generation = proc::proc.capture_session_launch_generation();
+  ASSERT_TRUE(generation.has_value());
+  EXPECT_FALSE(proc::proc.try_begin_session_launch(*generation));
+
+  rtsp_stream::terminate_sessions();
+}
+
+TEST(SessionLifecycleGateTests, ConditionalEventPopCannotConsumeReplacementLaunch) {
+  safe::event_t<std::shared_ptr<rtsp_stream::launch_session_t>> event;
+  auto original = std::make_shared<rtsp_stream::launch_session_t>();
+  original->id = 3134;
+  auto replacement = std::make_shared<rtsp_stream::launch_session_t>();
+  replacement->id = 3135;
+
+  EXPECT_TRUE(event.raise_if_empty(replacement));
+  EXPECT_FALSE(event.raise_if_empty(original));
+  EXPECT_FALSE(event.pop_if([&](const auto &pending) {
+    return pending && pending->id == original->id;
+  }));
+
+  const auto preserved = event.pop_if([&](const auto &pending) {
+    return pending && pending->id == replacement->id;
+  });
+  ASSERT_TRUE(preserved);
+  EXPECT_EQ(preserved->id, replacement->id);
+}
+
+TEST(SessionLifecycleGateTests, StaleTimerGenerationCannotCancelReplacementWithReusedId) {
+  rtsp_stream::terminate_sessions();
+
+  auto original = std::make_shared<rtsp_stream::launch_session_t>();
+  original->id = 3136;
+  original->unique_id = "stale-generation-original";
+  ASSERT_TRUE(rtsp_stream::launch_session_raise(original));
+  const auto stale_generation = rtsp_stream::launch_timer_generation_for_tests();
+
+  rtsp_stream::terminate_sessions();
+  auto replacement = std::make_shared<rtsp_stream::launch_session_t>();
+  replacement->id = original->id;
+  replacement->unique_id = "same-id-replacement";
+  ASSERT_TRUE(rtsp_stream::launch_session_raise(replacement));
+  ASSERT_NE(rtsp_stream::launch_timer_generation_for_tests(), stale_generation);
+
+  EXPECT_FALSE(rtsp_stream::expire_pending_launch_for_tests(original->id, stale_generation));
+  const auto preserved = rtsp_stream::session_snapshot(replacement->unique_id);
+  EXPECT_EQ(preserved.pending_sessions, 1);
+  EXPECT_EQ(preserved.requester_role, session_role_e::controller);
+
+  rtsp_stream::terminate_sessions();
+}
+
+TEST(SessionLifecycleGateTests, DuplicatePendingRaiseIsRejectedWithoutReplacingOriginal) {
+  rtsp_stream::terminate_sessions();
+  auto original = std::make_shared<rtsp_stream::launch_session_t>();
+  original->id = 3136;
+  original->unique_id = "original-pending";
+  auto replacement = std::make_shared<rtsp_stream::launch_session_t>();
+  replacement->id = 3137;
+  replacement->unique_id = "replacement-pending";
+
+  EXPECT_TRUE(rtsp_stream::launch_session_raise(original));
+  EXPECT_FALSE(rtsp_stream::launch_session_raise(replacement));
+  const auto original_snapshot = rtsp_stream::session_snapshot(original->unique_id);
+  const auto replacement_snapshot = rtsp_stream::session_snapshot(replacement->unique_id);
+  EXPECT_EQ(original_snapshot.pending_sessions, 1);
+  EXPECT_EQ(original_snapshot.requester_role, rtsp_stream::session_role_e::controller);
+  EXPECT_EQ(replacement_snapshot.requester_role, rtsp_stream::session_role_e::none);
+  rtsp_stream::terminate_sessions();
+}


### PR DESCRIPTION
## Summary

Hardens Polaris session launch, status, cancellation, and teardown across process and RTSP state.

- serializes launch/stop/status transitions through a persistent lifecycle gate;
- prevents rejected or stale stop waiters from suppressing an admitted teardown;
- preserves lifecycle synchronization and gate identity during configuration reloads;
- makes status snapshots coherent and nonblocking while teardown is queued or active;
- makes RTSP SETUP handoff/cancellation atomic and keeps handoff visible to teardown;
- prevents stale launch timers from consuming replacement events;
- makes RTSP snapshots read-only and moves stop/join work outside the slots lock;
- requires exact nonempty v1 tokens for process-backed, pending RTSP-only, and active RTSP-only sessions while retaining legacy owner-authorized `/cancel` behavior;
- retains active RTSP launch tokens internally for requester-bound authorization without adding them to response serialization;
- preserves complete viewer counting and captured virtual-display status semantics.

## Security and authorization

- `/polaris/v1/session/stop` requires a nonempty exact token for every active or pending session shape.
- Token comparisons use the existing constant-time helper.
- RTSP tokens are considered only for sessions or pending launches matching the authenticated requester UUID.
- Permission, owner, controller, and viewer checks remain fail-closed and precede token authorization.
- Legacy tokenless `/cancel` remains available only through its existing owner/controller path.

## Concurrency invariants

- RTSP launch state transitions atomically through `pending -> handoff -> started` or `cancelled`.
- A slot is inserted before setup commit; cancellation-before-commit and start failure both erase it.
- Pending and handoff launches remain visible to stop snapshots.
- Timer callbacks verify generation before same-ID event removal.
- Status latches observed stop intent before RTSP/process mutex acquisition.
- Public RTSP snapshots never clear, stop, or join sessions.
- Cleanup extracts and erases eligible slots under `_session_slots`, releases the lock, then stops/joins retained `shared_ptr` sessions.
- Concurrent cleanup callers claim a populated STOPPING slot at most once.

## Verification

Reviewed commit:

```text
512091d69447bfea9c20a4c58438661a48a245b9
```

Exact reviewed diff SHA-256:

```text
fed964b273d375bec205c62e90795012131368b0b2c1eba41f15b6146f8727f7
```

Base:

```text
2008458634c0d3f04f8abc39fab862bc69a47af8
```

Executed on pc-papi:

- HTTP unit tests: **64/64 passed**
- Config/process unit tests: **201/201 passed**
- Serial CTest: **12/12 passed**
- CUDA production build: **passed**
- Lifecycle/token/RTSP/timer/snapshot/cleanup/rollback mutation checks: **all RED**
- `git diff --cached --check`: passed before commit
- Post-commit binary diff SHA-256 reproduced the exact reviewed digest
- Added-production-line static security scan: 0 findings
- Two focused exact-hash reviews: passed with no security, logic, or test-gap blockers

CUDA artifact:

```text
/tmp/polaris-v132-session-teardown-cuda-build-2/polaris-1.3.1.20084586.dirty
SHA-256: 0e85f93cb42fba1d1d0b39ba074c19c9b7ea37ac614ab56fdb9c077a235a9133
```

## Mutation coverage

- exact v1 token bypass for RTSP-only pending/active sessions;
- missing requester-bound pending and active RTSP token propagation;
- cancellation moved after setup commit;
- missing slot rollback after start failure;
- duplicate cleanup claim;
- STOPPING slots counted in snapshots;
- status stop observation reread after teardown;
- cleanup or join reintroduced into status snapshots;
- cleanup callback moved back under `_session_slots`;
- stale same-ID timer callback consumes replacement;
- refresh replaces the persistent process singleton/gate/sync;
- invalid preexisting stop waiter suppresses teardown.

## Operational safety

This PR does **not** deploy or restart Polaris and does not modify Steam, desktop, display, or gamescope state.
