### PR TITLE
fix(webui): persist auth sessions across process restart

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -194,8 +194,10 @@ namespace confighttp {
 
   namespace {
     struct web_session_t {
+      // Wall clock: persisted and used for absolute SESSION_EXPIRE_DURATION.
       std::chrono::system_clock::time_point created_at;
-      std::chrono::system_clock::time_point last_seen_at;
+      // Monotonic: idle timeout only; not persisted (reset on restart).
+      std::chrono::steady_clock::time_point last_seen_at;
     };
 
     constexpr auto SESSION_IDLE_TIMEOUT = 12h;
@@ -631,8 +633,12 @@ namespace confighttp {
       return util::hex(crypto::hash(std::string {raw_cookie} + config::sunshine.salt)).to_string();
     }
 
-    bool session_expired(const web_session_t &session, const std::chrono::system_clock::time_point now) {
-      return (now - session.created_at) > SESSION_EXPIRE_DURATION || (now - session.last_seen_at) > SESSION_IDLE_TIMEOUT;
+    bool session_expired(
+      const web_session_t &session,
+      const std::chrono::system_clock::time_point wall_now,
+      const std::chrono::steady_clock::time_point mono_now
+    ) {
+      return (wall_now - session.created_at) > SESSION_EXPIRE_DURATION || (mono_now - session.last_seen_at) > SESSION_IDLE_TIMEOUT;
     }
 
     void save_web_sessions_locked() {
@@ -645,14 +651,33 @@ namespace confighttp {
       }
 
       const auto path = web_sessions_path();
-      if (file_handler::write_file(path.string().c_str(), root.dump()) != 0) {
-        BOOST_LOG(warning) << "Failed to persist web UI sessions to "sv << path.string();
+      std::error_code ec;
+      fs::create_directories(path.parent_path(), ec);
+      if (ec) {
+        BOOST_LOG(warning) << "Failed to create directory for web UI sessions "sv << path.parent_path().string() << ": "sv << ec.message();
+        return;
+      }
+
+      // Write to a temp file then rename so a crash mid-write cannot leave a truncated sessions file.
+      const auto tmp_path = fs::path {path.string() + ".tmp"};
+      if (file_handler::write_file(tmp_path.string().c_str(), root.dump()) != 0) {
+        BOOST_LOG(warning) << "Failed to persist web UI sessions to "sv << tmp_path.string();
         return;
       }
 #ifndef _WIN32
-      std::error_code ec;
-      fs::permissions(path, fs::perms::owner_read | fs::perms::owner_write, fs::perm_options::replace, ec);
+      fs::permissions(tmp_path, fs::perms::owner_read | fs::perms::owner_write, fs::perm_options::replace, ec);
 #endif
+      fs::rename(tmp_path, path, ec);
+      if (ec) {
+        // Windows (and some platforms) refuse to rename over an existing file.
+        std::error_code remove_ec;
+        fs::remove(path, remove_ec);
+        fs::rename(tmp_path, path, ec);
+      }
+      if (ec) {
+        BOOST_LOG(warning) << "Failed to replace web UI sessions file "sv << path.string() << ": "sv << ec.message();
+        fs::remove(tmp_path, ec);
+      }
     }
 
     void load_web_sessions() {
@@ -669,7 +694,8 @@ namespace confighttp {
           return;
         }
 
-        const auto now = std::chrono::system_clock::now();
+        const auto wall_now = std::chrono::system_clock::now();
+        const auto mono_now = std::chrono::steady_clock::now();
         std::size_t loaded = 0;
         std::size_t skipped = 0;
         std::lock_guard lock(s_web_sessions_mutex);
@@ -684,19 +710,26 @@ namespace confighttp {
             continue;
           }
 
-          std::chrono::system_clock::time_point created_at = now;
+          // Missing created_at: treat as created now so absolute expiry still starts from restore.
+          std::chrono::system_clock::time_point created_at = wall_now;
           if (entry.contains("created_at") && entry["created_at"].is_number_integer()) {
             created_at = std::chrono::system_clock::time_point {
               std::chrono::seconds {entry["created_at"].get<std::int64_t>()}
             };
           }
 
+          // Reject future timestamps (clock skew / tampering) so absolute lifetime cannot be extended.
+          if (created_at > wall_now) {
+            ++skipped;
+            continue;
+          }
+
           web_session_t session {
             .created_at = created_at,
             // Reset idle clock on restart so restart itself does not expire an otherwise-valid cookie.
-            .last_seen_at = now,
+            .last_seen_at = mono_now,
           };
-          if (session_expired(session, now)) {
+          if (session_expired(session, wall_now, mono_now)) {
             ++skipped;
             continue;
           }
@@ -720,12 +753,13 @@ namespace confighttp {
 
     std::string create_web_session() {
       const auto raw_cookie = crypto::rand_alphabet(64);
-      const auto now = std::chrono::system_clock::now();
+      const auto wall_now = std::chrono::system_clock::now();
+      const auto mono_now = std::chrono::steady_clock::now();
       {
         std::lock_guard lock(s_web_sessions_mutex);
         s_web_sessions[session_cookie_hash(raw_cookie)] = web_session_t {
-          .created_at = now,
-          .last_seen_at = now,
+          .created_at = wall_now,
+          .last_seen_at = mono_now,
         };
         save_web_sessions_locked();
       }
@@ -738,12 +772,13 @@ namespace confighttp {
       }
 
       const auto session_id = session_cookie_hash(raw_cookie);
-      const auto now = std::chrono::system_clock::now();
+      const auto wall_now = std::chrono::system_clock::now();
+      const auto mono_now = std::chrono::steady_clock::now();
       std::lock_guard lock(s_web_sessions_mutex);
 
       bool pruned = false;
       for (auto it = s_web_sessions.begin(); it != s_web_sessions.end();) {
-        if (session_expired(it->second, now)) {
+        if (session_expired(it->second, wall_now, mono_now)) {
           it = s_web_sessions.erase(it);
           pruned = true;
         } else {
@@ -759,7 +794,7 @@ namespace confighttp {
         return false;
       }
 
-      it->second.last_seen_at = now;
+      it->second.last_seen_at = mono_now;
       return true;
     }
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -194,8 +194,8 @@ namespace confighttp {
 
   namespace {
     struct web_session_t {
-      std::chrono::steady_clock::time_point created_at;
-      std::chrono::steady_clock::time_point last_seen_at;
+      std::chrono::system_clock::time_point created_at;
+      std::chrono::system_clock::time_point last_seen_at;
     };
 
     constexpr auto SESSION_IDLE_TIMEOUT = 12h;
@@ -621,23 +621,113 @@ namespace confighttp {
       append_common_security_headers(headers);
     }
 
+    // Persist hashed sessions under appdata so the auth cookie survives process restart.
+    // Cookie Max-Age is already 30d; without this the in-memory map is empty after every restart.
+    fs::path web_sessions_path() {
+      return platf::appdata() / "web_sessions.json";
+    }
+
     std::string session_cookie_hash(const std::string_view raw_cookie) {
       return util::hex(crypto::hash(std::string {raw_cookie} + config::sunshine.salt)).to_string();
     }
 
-    bool session_expired(const web_session_t &session, const std::chrono::steady_clock::time_point now) {
+    bool session_expired(const web_session_t &session, const std::chrono::system_clock::time_point now) {
       return (now - session.created_at) > SESSION_EXPIRE_DURATION || (now - session.last_seen_at) > SESSION_IDLE_TIMEOUT;
+    }
+
+    void save_web_sessions_locked() {
+      nlohmann::json root = nlohmann::json::array();
+      for (const auto &[id, session] : s_web_sessions) {
+        root.push_back({
+          {"id", id},
+          {"created_at", std::chrono::duration_cast<std::chrono::seconds>(session.created_at.time_since_epoch()).count()},
+        });
+      }
+
+      const auto path = web_sessions_path();
+      if (file_handler::write_file(path.string().c_str(), root.dump()) != 0) {
+        BOOST_LOG(warning) << "Failed to persist web UI sessions to "sv << path.string();
+        return;
+      }
+#ifndef _WIN32
+      std::error_code ec;
+      fs::permissions(path, fs::perms::owner_read | fs::perms::owner_write, fs::perm_options::replace, ec);
+#endif
+    }
+
+    void load_web_sessions() {
+      const auto path = web_sessions_path();
+      const auto content = file_handler::read_file(path.string().c_str());
+      if (content.empty()) {
+        return;
+      }
+
+      try {
+        const auto root = nlohmann::json::parse(content);
+        if (!root.is_array()) {
+          BOOST_LOG(warning) << "Ignoring malformed web UI sessions file "sv << path.string();
+          return;
+        }
+
+        const auto now = std::chrono::system_clock::now();
+        std::size_t loaded = 0;
+        std::size_t skipped = 0;
+        std::lock_guard lock(s_web_sessions_mutex);
+        for (const auto &entry : root) {
+          if (!entry.is_object() || !entry.contains("id") || !entry["id"].is_string()) {
+            ++skipped;
+            continue;
+          }
+          const auto id = entry["id"].get<std::string>();
+          if (id.empty()) {
+            ++skipped;
+            continue;
+          }
+
+          std::chrono::system_clock::time_point created_at = now;
+          if (entry.contains("created_at") && entry["created_at"].is_number_integer()) {
+            created_at = std::chrono::system_clock::time_point {
+              std::chrono::seconds {entry["created_at"].get<std::int64_t>()}
+            };
+          }
+
+          web_session_t session {
+            .created_at = created_at,
+            // Reset idle clock on restart so restart itself does not expire an otherwise-valid cookie.
+            .last_seen_at = now,
+          };
+          if (session_expired(session, now)) {
+            ++skipped;
+            continue;
+          }
+
+          s_web_sessions[id] = session;
+          ++loaded;
+        }
+
+        // Drop expired / invalid entries from disk so the file does not grow forever.
+        if (skipped > 0) {
+          save_web_sessions_locked();
+        }
+
+        if (loaded > 0) {
+          BOOST_LOG(info) << "Restored "sv << loaded << " web UI session(s) from "sv << path.string();
+        }
+      } catch (const std::exception &e) {
+        BOOST_LOG(warning) << "Failed to load web UI sessions from "sv << path.string() << ": "sv << e.what();
+      }
     }
 
     std::string create_web_session() {
       const auto raw_cookie = crypto::rand_alphabet(64);
-      const auto now = std::chrono::steady_clock::now();
+      const auto now = std::chrono::system_clock::now();
       {
         std::lock_guard lock(s_web_sessions_mutex);
         s_web_sessions[session_cookie_hash(raw_cookie)] = web_session_t {
           .created_at = now,
           .last_seen_at = now,
         };
+        save_web_sessions_locked();
       }
       return raw_cookie;
     }
@@ -648,15 +738,20 @@ namespace confighttp {
       }
 
       const auto session_id = session_cookie_hash(raw_cookie);
-      const auto now = std::chrono::steady_clock::now();
+      const auto now = std::chrono::system_clock::now();
       std::lock_guard lock(s_web_sessions_mutex);
 
+      bool pruned = false;
       for (auto it = s_web_sessions.begin(); it != s_web_sessions.end();) {
         if (session_expired(it->second, now)) {
           it = s_web_sessions.erase(it);
+          pruned = true;
         } else {
           ++it;
         }
+      }
+      if (pruned) {
+        save_web_sessions_locked();
       }
 
       const auto it = s_web_sessions.find(session_id);
@@ -675,11 +770,13 @@ namespace confighttp {
 
       std::lock_guard lock(s_web_sessions_mutex);
       s_web_sessions.erase(session_cookie_hash(raw_cookie));
+      save_web_sessions_locked();
     }
 
     void invalidate_all_web_sessions() {
       std::lock_guard lock(s_web_sessions_mutex);
       s_web_sessions.clear();
+      save_web_sessions_locked();
     }
 
     SimpleWeb::CaseInsensitiveMultimap make_auth_cookie_headers(std::string_view raw_cookie) {
@@ -4982,6 +5079,8 @@ namespace confighttp {
     csrfToken = crypto::rand_alphabet(48,
       std::string_view {"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"});
     BOOST_LOG(info) << "CSRF token generated for web UI session";
+
+    load_web_sessions();
 
     // Initialize AI optimizer with config
     {


### PR DESCRIPTION
## Summary

The Web UI already sets a long-lived `auth` cookie (`Max-Age=30d`), but session validity lived only in an in-memory map. Any polaris process restart wiped that map, so the browser still held a cookie that the host no longer recognized → forced re-login.

This PR persists hashed session ids under appdata (`web_sessions.json`), reloads them when `confighttp` starts, and rewrites the file on create / prune / logout / password change.

## Design question for maintainers

**Was logout-on-restart intentional?**

If yes (e.g. “restart = revoke all web sessions” as a security property), we should document that and possibly drop the long cookie `Max-Age` so the UI matches reality. If no, this patch is the missing half of the existing cookie design.

Happy to adjust (e.g. opt-in config, shorter absolute TTL, or “remember me” only) based on preferred posture.

## Behavior

| Event | Result |
|--------|--------|
| Login | Create session, set cookie, save hash + `created_at` to disk |
| Restart | Load non-expired sessions; reset idle clock so restart alone does not expire a still-valid cookie |
| Idle (`SESSION_IDLE_TIMEOUT`) | Still enforced in-process; pruned from disk when detected |
| Absolute expiry (`SESSION_EXPIRE_DURATION`) | Still enforced across restarts via wall clock |
| Logout / password change | Invalidate (all) sessions and rewrite file |

Session file stores **hashes only** (same as the in-memory map keys: `hash(cookie + salt)`), mode `0600` on non-Windows.

## Related

- Frontend race that *looks* like logout during restart (valid cookie, bad auth probe / `?polarisReload=…`): #206 — separate from this server-side gap.
- Locally verified: synthetic cookie → restart → `/api/apps` still 200; real browser stays authenticated after clean reload once the host is up.

## Test plan

- [ ] Log in to Web UI
- [ ] Confirm `web_sessions.json` appears under appdata
- [ ] Restart polaris process
- [ ] Log shows `Restored N web UI session(s)`
- [ ] Reload Web UI without re-entering password
- [ ] Logout clears session from file
- [ ] Password change invalidates other sessions