### PR TITLE
fix: tolerate near-target stream FPS

### DIFF
--- a/src/ai_optimizer.cpp
+++ b/src/ai_optimizer.cpp
@@ -8,6 +8,7 @@
 #include "game_classifier.h"
 #include "logging.h"
 #include "platform/common.h"
+#include "stream_stats.h"
 
 #include <algorithm>
 #include <cctype>
@@ -497,6 +498,37 @@ namespace ai_optimizer {
       session.last_safe_target_fps = 0.0;
     }
 
+    const double reported_target_fps = session.last_target_fps;
+    const double reported_fps = session.last_fps > 0.0 ? session.last_fps : session.avg_fps;
+    const bool detailed_near_target_evidence =
+      grade_session_quality(session) == "A" &&
+      reported_target_fps >= 24.0 &&
+      reported_fps > 0.0 &&
+      reported_fps / reported_target_fps >= 0.95 &&
+      session.last_low_1_percent_fps > 0.0 &&
+      session.last_low_1_percent_fps / reported_target_fps >= 0.85 &&
+      session.last_min_fps > 0.0 &&
+      session.last_min_fps / reported_target_fps >= 0.60 &&
+      session.last_frame_pacing_bad_pct < 5.0 &&
+      session.poor_outcome_count <= 0 &&
+      session.consecutive_poor_outcomes <= 0 &&
+      to_lower_copy(session.last_network_risk) != "elevated" &&
+      to_lower_copy(session.last_decoder_risk) != "elevated" &&
+      to_lower_copy(session.last_hdr_risk) != "elevated";
+    const bool primary_issue_is_frame_or_host =
+      is_frame_or_host_pacing_issue(session.last_primary_issue);
+    if (primary_issue_is_frame_or_host && detailed_near_target_evidence) {
+      std::erase_if(session.last_issues, [](const std::string &issue) {
+        return is_frame_or_host_pacing_issue(issue);
+      });
+      session.last_primary_issue = session.last_issues.empty() ? "steady" : session.last_issues.front();
+      if (session.last_issues.empty()) {
+        session.last_health_grade = "good";
+        session.last_safe_target_fps = 0.0;
+        session.last_relaunch_recommended = false;
+      }
+    }
+
     if (is_low_confidence_soft_end_without_confirming_signal(session)) {
       session.last_safe_target_fps = 0.0;
       session.last_relaunch_recommended = false;
@@ -515,7 +547,9 @@ namespace ai_optimizer {
       before.consecutive_poor_outcomes != after.consecutive_poor_outcomes ||
       before.last_safe_target_fps != after.last_safe_target_fps ||
       before.last_relaunch_recommended != after.last_relaunch_recommended ||
-      before.last_health_grade != after.last_health_grade;
+      before.last_health_grade != after.last_health_grade ||
+      before.last_primary_issue != after.last_primary_issue ||
+      before.last_issues != after.last_issues;
   }
 
   static bool is_control_shell_app(const std::string &app_name) {
@@ -756,7 +790,6 @@ namespace ai_optimizer {
       history_fps > 0.0 && session.last_fps > 0.0 ? std::min(session.last_fps, history_fps) :
       history_fps > 0.0 ? history_fps :
       session.last_fps;
-    const double fps_gap = target_fps > 0.0 ? std::max(0.0, target_fps - session.last_fps) : 0.0;
     const double fps_ratio =
       (target_fps > 0.0 && session.last_fps > 0.0) ? std::clamp(session.last_fps / target_fps, 0.0, 1.5) : 0.0;
     const bool prior_frame_pacing = has_frame_or_host_pacing_issue(session);
@@ -767,7 +800,7 @@ namespace ai_optimizer {
        session.last_min_fps < target_fps * 0.60) ||
       session.last_frame_pacing_bad_pct >= 8.0;
     const bool pacing_risk =
-      fps_gap >= 4.0 ||
+      stream_stats::is_meaningful_fps_shortfall(target_fps, session.last_fps) ||
       (target_fps > 0.0 && fps_ratio < 0.88) ||
       client_pacing_risk ||
       prior_frame_pacing ||
@@ -826,7 +859,7 @@ namespace ai_optimizer {
        session.last_min_fps < target_fps * 0.60) ||
       session.last_frame_pacing_bad_pct >= 8.0;
     const bool pacing_risk =
-      fps_gap >= 4.0 ||
+      stream_stats::is_meaningful_fps_shortfall(target_fps, session.last_fps) ||
       (target_fps > 0.0 && fps_ratio < 0.88) ||
       client_pacing_risk ||
       prior_frame_pacing ||
@@ -835,7 +868,7 @@ namespace ai_optimizer {
     const auto active_codec_family = codec_family(latest_codec(session));
     const bool decoder_risk =
       ((active_codec_family == "av1") || (mobile_client && active_codec_family == "hevc" && fps_gap >= 8.0)) &&
-      (pacing_risk || fps_gap >= 4.0) &&
+      pacing_risk &&
       !network_risk;
 
     bool capture_fallback = false;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2048,13 +2048,15 @@ namespace nvhttp {
         stats.requested_client_fps > 0 ? stats.requested_client_fps :
         stats.fps;
       const double fps_gap = target_fps > 0 ? std::max(0.0, target_fps - stats.fps) : 0.0;
+      const bool meaningful_fps_shortfall =
+        stream_stats::is_meaningful_fps_shortfall(target_fps, stats.fps);
 
       const bool network_risk = stats.packet_loss >= 0.35 || stats.latency_ms >= 28.0;
       const bool pacing_risk =
         stats.frame_jitter_ms >= 2.2 ||
         stats.duplicate_frame_ratio >= 0.10 ||
         stats.dropped_frame_ratio >= 0.04 ||
-        fps_gap >= 4.0;
+        meaningful_fps_shortfall;
       const bool capture_fallback =
         stream_stats::capture_path_uses_cpu_copy(stats);
       const auto capture_path = stream_stats::capture_path_summary(stats);
@@ -2072,15 +2074,12 @@ namespace nvhttp {
       const bool hdr_risk = stats.stream_hdr_enabled && (pacing_risk || encoder_risk);
       const bool decoder_risk =
         (active_codec_family == "av1" || stats.encode_target_format == platf::frame_format_e::p010) &&
-        (pacing_risk || fps_gap >= 4.0) &&
+        pacing_risk &&
         !network_risk;
       const bool virtual_display_risk =
         current_virtual_display &&
         (pacing_risk || capture_fallback || hdr_risk);
-      const bool sustained_target_miss =
-        target_fps >= 24.0 &&
-        stats.fps > 0.0 &&
-        fps_gap >= std::max(2.0, target_fps * 0.06);
+      const bool sustained_target_miss = meaningful_fps_shortfall;
       const bool host_render_limited =
         pacing_risk &&
         !network_risk &&

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -352,6 +352,95 @@ namespace proc {
              session_state == "paused"sv;
     }
 
+    struct host_pause_session_classification_t {
+      bool network_risk = false;
+      bool pacing_risk = false;
+      bool capture_fallback = false;
+      bool encoder_risk = false;
+      bool hdr_risk = false;
+      bool decoder_risk = false;
+      bool virtual_display_risk = false;
+      bool host_render_limited = false;
+      bool av1_codec = false;
+      std::string capture_path;
+      std::string codec_lower;
+      std::string primary_issue = "steady";
+      std::vector<std::string> issues;
+      std::string health_grade = "good";
+    };
+
+    host_pause_session_classification_t classify_host_pause_session(
+        const stream_stats::stats_t &stats,
+        double target_fps,
+        bool current_virtual_display) {
+      host_pause_session_classification_t classification;
+      const bool meaningful_fps_shortfall =
+        stream_stats::is_meaningful_fps_shortfall(target_fps, stats.fps);
+      classification.network_risk = stats.packet_loss >= 0.35 || stats.latency_ms >= 28.0;
+      classification.pacing_risk =
+        stats.frame_jitter_ms >= 2.2 ||
+        stats.duplicate_frame_ratio >= 0.10 ||
+        stats.dropped_frame_ratio >= 0.04 ||
+        meaningful_fps_shortfall;
+      classification.capture_fallback = stream_stats::capture_path_uses_cpu_copy(stats);
+      classification.capture_path = stream_stats::capture_path_summary(stats);
+      classification.encoder_risk = stats.encode_time_ms >= 11.0 || stats.avg_frame_age_ms >= 18.0;
+      classification.hdr_risk = stats.dynamic_range > 0 &&
+                                (classification.pacing_risk || classification.encoder_risk);
+      classification.codec_lower = boost::algorithm::to_lower_copy(stats.codec);
+      classification.av1_codec = classification.codec_lower.find("av1") != std::string::npos;
+      classification.decoder_risk = classification.av1_codec &&
+                                    classification.pacing_risk &&
+                                    !classification.network_risk;
+      classification.virtual_display_risk = current_virtual_display &&
+                                            (classification.pacing_risk ||
+                                             classification.capture_fallback ||
+                                             classification.hdr_risk);
+      classification.host_render_limited =
+        classification.pacing_risk &&
+        !classification.network_risk &&
+        !classification.capture_fallback &&
+        !classification.encoder_risk &&
+        !classification.hdr_risk &&
+        !classification.decoder_risk &&
+        !classification.virtual_display_risk &&
+        (meaningful_fps_shortfall ||
+         stats.duplicate_frame_ratio >= 0.08 ||
+         stats.dropped_frame_ratio >= 0.03);
+
+      if (classification.network_risk) classification.primary_issue = "network_jitter";
+      else if (classification.hdr_risk) classification.primary_issue = "hdr_path";
+      else if (classification.virtual_display_risk) classification.primary_issue = "virtual_display_path";
+      else if (classification.decoder_risk) classification.primary_issue = "decoder_path";
+      else if (classification.capture_fallback) classification.primary_issue = "capture_fallback";
+      else if (classification.host_render_limited) classification.primary_issue = "host_render_limited";
+      else if (classification.pacing_risk) classification.primary_issue = "frame_pacing";
+      else if (classification.encoder_risk) classification.primary_issue = "encoder_load";
+
+      if (classification.network_risk) classification.issues.push_back("network_jitter");
+      if (classification.host_render_limited) classification.issues.push_back("host_render_limited");
+      else if (classification.pacing_risk) classification.issues.push_back("frame_pacing");
+      if (classification.capture_fallback) classification.issues.push_back("capture_fallback");
+      if (classification.encoder_risk) classification.issues.push_back("encoder_load");
+      if (classification.hdr_risk) classification.issues.push_back("hdr_path");
+      if (classification.decoder_risk) classification.issues.push_back("decoder_path");
+      if (classification.virtual_display_risk) classification.issues.push_back("virtual_display_path");
+
+      const int concern_count =
+        static_cast<int>(classification.network_risk) +
+        static_cast<int>(classification.pacing_risk) +
+        static_cast<int>(classification.capture_fallback) +
+        static_cast<int>(classification.encoder_risk) +
+        static_cast<int>(classification.hdr_risk) +
+        static_cast<int>(classification.decoder_risk) +
+        static_cast<int>(classification.virtual_display_risk);
+      classification.health_grade =
+        concern_count >= 2 || classification.hdr_risk || classification.decoder_risk ? "degraded" :
+        concern_count == 1 ? "watch" :
+        "good";
+      return classification;
+    }
+
     void publish_stream_ended_after_terminate_if_needed(bool had_running_app) {
       if (!should_publish_stream_ended_after_terminate(had_running_app, stream::session::active_count(), confighttp::get_session_state())) {
         return;
@@ -2066,6 +2155,22 @@ namespace proc {
 #if defined(POLARIS_TESTS)
   bool should_publish_stream_ended_after_terminate_for_tests(bool had_running_app, int active_sessions, std::string_view session_state) {
     return should_publish_stream_ended_after_terminate(had_running_app, active_sessions, session_state);
+  }
+
+  nlohmann::json classify_host_pause_session_for_tests(
+      const stream_stats::stats_t &stats,
+      double target_fps,
+      bool current_virtual_display) {
+    const auto classification = classify_host_pause_session(
+      stats,
+      target_fps,
+      current_virtual_display
+    );
+    return {
+      {"health_grade", classification.health_grade},
+      {"primary_issue", classification.primary_issue},
+      {"host_render_limited", classification.host_render_limited}
+    };
   }
 
   std::optional<int> resolve_device_db_launch_bitrate_for_tests(
@@ -4076,40 +4181,21 @@ namespace proc {
           device_profile &&
           (device_profile->type == "handheld" || device_profile->type == "phone");
 
-        const double fps_gap =
-          session.last_target_fps > 0.0 ? std::max(0.0, session.last_target_fps - session.last_fps) : 0.0;
-        const bool network_risk = stats.packet_loss >= 0.35 || stats.latency_ms >= 28.0;
-        const bool pacing_risk =
-          stats.frame_jitter_ms >= 2.2 ||
-          stats.duplicate_frame_ratio >= 0.10 ||
-          stats.dropped_frame_ratio >= 0.04 ||
-          fps_gap >= 4.0;
-        const bool capture_fallback =
-          stream_stats::capture_path_uses_cpu_copy(stats);
-        const auto capture_path = stream_stats::capture_path_summary(stats);
-        const bool encoder_risk = stats.encode_time_ms >= 11.0 || stats.avg_frame_age_ms >= 18.0;
-        const bool hdr_risk = stats.dynamic_range > 0 && (pacing_risk || encoder_risk);
-        const std::string codec_lower = boost::algorithm::to_lower_copy(session.last_codec);
-        const bool av1_codec = codec_lower.find("av1") != std::string::npos;
-        const bool decoder_risk = av1_codec && (pacing_risk || fps_gap >= 4.0) && !network_risk;
-        const bool virtual_display_risk = _launch_session->virtual_display && (pacing_risk || capture_fallback || hdr_risk);
-        const double target_gap_threshold =
-          session.last_target_fps > 0.0 ? std::max(2.0, session.last_target_fps * 0.06) : 2.0;
-        const bool sustained_target_miss =
-          session.last_target_fps >= 24.0 &&
-          session.last_fps > 0.0 &&
-          fps_gap >= target_gap_threshold;
-        const bool host_render_limited =
-          pacing_risk &&
-          !network_risk &&
-          !capture_fallback &&
-          !encoder_risk &&
-          !hdr_risk &&
-          !decoder_risk &&
-          !virtual_display_risk &&
-          (sustained_target_miss ||
-           stats.duplicate_frame_ratio >= 0.08 ||
-           stats.dropped_frame_ratio >= 0.03);
+        const auto classification = classify_host_pause_session(
+          stats,
+          session.last_target_fps,
+          _launch_session->virtual_display
+        );
+        const bool network_risk = classification.network_risk;
+        const bool pacing_risk = classification.pacing_risk;
+        const bool capture_fallback = classification.capture_fallback;
+        const auto &capture_path = classification.capture_path;
+        const bool hdr_risk = classification.hdr_risk;
+        const auto &codec_lower = classification.codec_lower;
+        const bool av1_codec = classification.av1_codec;
+        const bool decoder_risk = classification.decoder_risk;
+        const bool virtual_display_risk = classification.virtual_display_risk;
+        const bool host_render_limited = classification.host_render_limited;
 
         session.last_network_risk = network_risk ? "elevated" : "normal";
         session.last_decoder_risk = decoder_risk ? "elevated" : "normal";
@@ -4123,35 +4209,9 @@ namespace proc {
         } else {
           session.last_capture_path = capture_path == "gpu_native" ? "gpu_native" : "desktop";
         }
-        if (network_risk) session.last_primary_issue = "network_jitter";
-        else if (hdr_risk) session.last_primary_issue = "hdr_path";
-        else if (virtual_display_risk) session.last_primary_issue = "virtual_display_path";
-        else if (decoder_risk) session.last_primary_issue = "decoder_path";
-        else if (capture_fallback) session.last_primary_issue = "capture_fallback";
-        else if (host_render_limited) session.last_primary_issue = "host_render_limited";
-        else if (pacing_risk) session.last_primary_issue = "frame_pacing";
-        else if (encoder_risk) session.last_primary_issue = "encoder_load";
-        else session.last_primary_issue = "steady";
-        if (network_risk) session.last_issues.push_back("network_jitter");
-        if (host_render_limited) session.last_issues.push_back("host_render_limited");
-        else if (pacing_risk) session.last_issues.push_back("frame_pacing");
-        if (capture_fallback) session.last_issues.push_back("capture_fallback");
-        if (encoder_risk) session.last_issues.push_back("encoder_load");
-        if (hdr_risk) session.last_issues.push_back("hdr_path");
-        if (decoder_risk) session.last_issues.push_back("decoder_path");
-        if (virtual_display_risk) session.last_issues.push_back("virtual_display_path");
-        const int concern_count =
-          static_cast<int>(network_risk) +
-          static_cast<int>(pacing_risk) +
-          static_cast<int>(capture_fallback) +
-          static_cast<int>(encoder_risk) +
-          static_cast<int>(hdr_risk) +
-          static_cast<int>(decoder_risk) +
-          static_cast<int>(virtual_display_risk);
-        session.last_health_grade =
-          concern_count >= 2 || hdr_risk || decoder_risk ? "degraded" :
-          concern_count == 1 ? "watch" :
-          "good";
+        session.last_primary_issue = classification.primary_issue;
+        session.last_issues = classification.issues;
+        session.last_health_grade = classification.health_grade;
         session.last_safe_bitrate_kbps =
           stats.adaptive_target_bitrate_kbps > 0 ? stats.adaptive_target_bitrate_kbps :
           stats.bitrate_kbps > 0 ? static_cast<int>(std::lround(static_cast<double>(stats.bitrate_kbps) * (session.last_health_grade == "good" ? 1.0 : 0.75))) :

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -8,6 +8,7 @@
 // standard includes
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <filesystem>
 #include <mutex>
 #include <vector>
@@ -26,6 +27,17 @@
 #endif
 
 namespace stream_stats {
+
+  bool is_meaningful_fps_shortfall(double target_fps, double delivered_fps) {
+    if (!std::isfinite(target_fps) || !std::isfinite(delivered_fps) ||
+        target_fps < 24.0 || delivered_fps <= 0.0 || delivered_fps >= target_fps) {
+      return false;
+    }
+
+    const double fps_gap = target_fps - delivered_fps;
+    const double fps_ratio = delivered_fps / target_fps;
+    return fps_gap >= 2.0 && fps_ratio < 0.95;
+  }
 
   static std::mutex stats_mutex;
   static stats_t current_stats;
@@ -670,12 +682,16 @@ namespace stream_stats {
     const bool capture_gpu_native = capture_path_is_gpu_native(stats);
     const bool capture_known = doctor_has_capture_metadata(stats);
     const double target_fps = doctor_target_fps(stats);
-    const double fps_gap = target_fps > 0.0 ? std::max(0.0, target_fps - stats.fps) : 0.0;
+    const bool meaningful_fps_shortfall = is_meaningful_fps_shortfall(target_fps, stats.fps);
     const bool network_fail = stats.packet_loss > 2.0 || stats.latency_ms >= 45.0;
     const bool network_watch = !network_fail && (stats.packet_loss > 0.5 || stats.latency_ms >= 28.0);
     const bool encoder_fail = stats.encode_time_ms >= 12.0 || stats.avg_frame_age_ms >= 22.0;
     const bool encoder_watch = !encoder_fail && (stats.encode_time_ms >= 8.0 || stats.avg_frame_age_ms >= 18.0);
-    const bool pacing_watch = stats.frame_jitter_ms >= 2.2 || stats.duplicate_frame_ratio >= 0.10 || stats.dropped_frame_ratio >= 0.04 || fps_gap >= 4.0;
+    const bool pacing_watch =
+      stats.frame_jitter_ms >= 2.2 ||
+      stats.duplicate_frame_ratio >= 0.10 ||
+      stats.dropped_frame_ratio >= 0.04 ||
+      meaningful_fps_shortfall;
 
     std::string primary_issue = health.value("primary_issue", std::string {});
     if (primary_issue == "steady") primary_issue = "none";

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -24,6 +24,15 @@
 namespace stream_stats {
 
   /**
+   * @brief Return true when delivered FPS is materially below target.
+   *
+   * Uses the same 95% healthy boundary as session grading while requiring at
+   * least a 2 FPS absolute gap so low-rate telemetry noise does not trigger
+   * recovery.
+   */
+  bool is_meaningful_fps_shortfall(double target_fps, double delivered_fps);
+
+  /**
    * @brief Per-client statistics for multi-session tracking.
    */
   struct client_stats_t {

--- a/tests/unit/test_ai_optimizer.cpp
+++ b/tests/unit/test_ai_optimizer.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "src/ai_optimizer.h"
+#include "src/stream_stats.h"
 
 #include <gtest/gtest.h>
 
@@ -92,6 +93,16 @@ TEST(AiOptimizerSessionFeedback, MissingMetricsAreIgnored) {
   EXPECT_EQ("missing_quality_metrics", policy.ignored_reason);
 }
 
+TEST(AiOptimizerSessionGrading, UsesRelativeToleranceForMeaningfulFpsShortfall) {
+  EXPECT_FALSE(stream_stats::is_meaningful_fps_shortfall(120.0, 115.6));
+  EXPECT_FALSE(stream_stats::is_meaningful_fps_shortfall(120.0, 114.0));
+  EXPECT_TRUE(stream_stats::is_meaningful_fps_shortfall(120.0, 113.9));
+  EXPECT_TRUE(stream_stats::is_meaningful_fps_shortfall(60.0, 54.0));
+  EXPECT_TRUE(stream_stats::is_meaningful_fps_shortfall(30.0, 28.0));
+  EXPECT_FALSE(stream_stats::is_meaningful_fps_shortfall(0.0, 115.6));
+  EXPECT_FALSE(stream_stats::is_meaningful_fps_shortfall(120.0, 0.0));
+}
+
 TEST(AiOptimizerSessionGrading, TreatsIsolatedMinDipAsMildWhenSustainedPacingIsHealthy) {
   auto session = make_session("D", "disconnect", 362, 358);
   session.avg_fps = 56.4689;
@@ -132,6 +143,107 @@ TEST(AiOptimizerHistorySanitization, ResetsCorruptedCounters) {
   EXPECT_EQ(0, sanitized.poor_outcome_count);
   EXPECT_EQ(0, sanitized.consecutive_poor_outcomes);
   EXPECT_EQ("B", sanitized.last_quality_grade);
+}
+
+TEST(AiOptimizerHistorySanitization, RepairsHealthyNearTargetHostLimit) {
+  auto session = make_session("A", "disconnect", 130, 11);
+  session.avg_fps = 115.6;
+  session.last_fps = session.avg_fps;
+  session.last_target_fps = 120.0;
+  session.avg_latency_ms = 0.0;
+  session.packet_loss_pct = 0.0;
+  session.last_low_1_percent_fps = 110.78;
+  session.last_min_fps = 110.78;
+  session.last_frame_pacing_bad_pct = 0.0;
+  session.last_health_grade = "watch";
+  session.last_primary_issue = "host_render_limited";
+  session.last_issues = {"host_render_limited", "frame_pacing"};
+  session.last_safe_target_fps = 60.0;
+  session.last_relaunch_recommended = true;
+
+  auto sanitized = ai_optimizer::sanitize_session_history(session);
+
+  EXPECT_EQ("A", ai_optimizer::grade_session_quality(sanitized));
+  EXPECT_EQ("good", sanitized.last_health_grade);
+  EXPECT_EQ("steady", sanitized.last_primary_issue);
+  EXPECT_TRUE(sanitized.last_issues.empty());
+  EXPECT_DOUBLE_EQ(0.0, sanitized.last_safe_target_fps);
+  EXPECT_FALSE(sanitized.last_relaunch_recommended);
+  EXPECT_DOUBLE_EQ(
+    0.0,
+    ai_optimizer::effective_history_safe_target_fps("RetroidPocket6", sanitized)
+  );
+}
+
+TEST(AiOptimizerHistorySanitization, KeepsHostLimitWhenTargetTelemetryIsMissing) {
+  auto session = make_session("A", "end", 130, 11);
+  session.avg_fps = 115.6;
+  session.last_fps = 115.6;
+  session.last_target_fps = 0.0;
+  session.last_low_1_percent_fps = 110.8;
+  session.last_min_fps = 110.8;
+  session.last_frame_pacing_bad_pct = 0.0;
+  session.last_health_grade = "watch";
+  session.last_primary_issue = "host_render_limited";
+  session.last_issues = {"frame_pacing", "host_render_limited"};
+  session.last_safe_target_fps = 60.0;
+  session.last_relaunch_recommended = true;
+
+  const auto sanitized = ai_optimizer::sanitize_session_history(session);
+
+  EXPECT_EQ("host_render_limited", sanitized.last_primary_issue);
+  EXPECT_DOUBLE_EQ(60.0, sanitized.last_safe_target_fps);
+  EXPECT_TRUE(sanitized.last_relaunch_recommended);
+}
+
+TEST(AiOptimizerHistorySanitization, KeepsCorroboratedPacingFailureAtHighRefresh) {
+  auto session = make_session("C", "disconnect", 130, 100);
+  session.avg_fps = 115.6;
+  session.last_fps = session.avg_fps;
+  session.last_target_fps = 120.0;
+  session.avg_latency_ms = 8.0;
+  session.packet_loss_pct = 0.0;
+  session.last_low_1_percent_fps = 72.0;
+  session.last_min_fps = 45.0;
+  session.last_frame_pacing_bad_pct = 10.0;
+  session.last_health_grade = "watch";
+  session.last_primary_issue = "frame_pacing";
+  session.last_issues = {"frame_pacing"};
+  session.last_safe_target_fps = 60.0;
+  session.last_relaunch_recommended = true;
+
+  auto sanitized = ai_optimizer::sanitize_session_history(session);
+
+  EXPECT_EQ("D", ai_optimizer::grade_session_quality(sanitized));
+  EXPECT_EQ("watch", sanitized.last_health_grade);
+  EXPECT_EQ("frame_pacing", sanitized.last_primary_issue);
+  EXPECT_EQ(std::vector<std::string>({"frame_pacing"}), sanitized.last_issues);
+  EXPECT_DOUBLE_EQ(60.0, sanitized.last_safe_target_fps);
+  EXPECT_TRUE(sanitized.last_relaunch_recommended);
+}
+
+TEST(AiOptimizerSafeTargetFps, KeepsMeaningfulSixtyFpsShortfallRecoverable) {
+  auto session = make_session("B", "disconnect", 130, 100);
+  session.avg_fps = 54.0;
+  session.last_fps = session.avg_fps;
+  session.last_target_fps = 60.0;
+  session.last_low_1_percent_fps = 45.0;
+  session.last_min_fps = 42.0;
+  session.last_frame_pacing_bad_pct = 5.0;
+
+  EXPECT_DOUBLE_EQ(
+    40.0,
+    ai_optimizer::derive_safe_target_fps(
+      session.last_target_fps,
+      session.last_fps,
+      session.last_low_1_percent_fps,
+      session.last_min_fps,
+      session.last_frame_pacing_bad_pct,
+      true,
+      false,
+      true
+    )
+  );
 }
 
 TEST(AiOptimizerHistorySanitization, ClearsLowConfidenceSoftEndRecoveryBias) {

--- a/tests/unit/test_stream.cpp
+++ b/tests/unit/test_stream.cpp
@@ -5,7 +5,9 @@
 
 #include <cstdint>
 #include <functional>
+#include <nlohmann/json.hpp>
 #include <optional>
+#include <src/stream_stats.h>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -20,10 +22,23 @@ namespace nvhttp {
     int paired_bitrate_kbps,
     bool applied_history_safe
   );
+
+  nlohmann::json build_session_health_json_for_tests(
+    const stream_stats::stats_t &stats,
+    bool current_virtual_display,
+    const std::string &device_name,
+    const std::string &app_name
+  );
 }
 
 namespace proc {
   bool should_publish_stream_ended_after_terminate_for_tests(bool had_running_app, int active_sessions, std::string_view session_state);
+
+  nlohmann::json classify_host_pause_session_for_tests(
+    const stream_stats::stats_t &stats,
+    double target_fps,
+    bool current_virtual_display
+  );
 }
 
 namespace {
@@ -31,6 +46,19 @@ namespace {
     std::vector<uint8_t> result;
     stream::concat_and_insert_into(result, insert_size, slice_size, data1, data2);
     return result;
+  }
+
+  stream_stats::stats_t stable_gpu_native_stats(double delivered_fps, double target_fps) {
+    stream_stats::stats_t stats;
+    stats.streaming = true;
+    stats.runtime_effective_headless = true;
+    stats.capture_transport = platf::frame_transport_e::dmabuf;
+    stats.capture_residency = platf::frame_residency_e::gpu;
+    stats.encode_target_residency = platf::frame_residency_e::gpu;
+    stats.fps = delivered_fps;
+    stats.encode_target_fps = target_fps;
+    stats.codec = "hevc";
+    return stats;
   }
 }
 
@@ -80,6 +108,58 @@ TEST(NvhttpOptimizerTests, PairedClientLaunchBitrateKeepsHistorySafeRecoveryCap)
 
   ASSERT_TRUE(selected.has_value());
   EXPECT_EQ(*selected, 25000);
+}
+
+TEST(NvhttpSessionHealthTests, HighRefreshNearTargetDeliveryRemainsSteady) {
+  const auto health = nvhttp::build_session_health_json_for_tests(
+    stable_gpu_native_stats(115.6, 120.0),
+    false,
+    "Nova Client",
+    "Mouse"
+  );
+
+  EXPECT_EQ(health.at("grade"), "good");
+  EXPECT_EQ(health.at("primary_issue"), "steady");
+  EXPECT_EQ(health.at("limiting_factor"), "none");
+  EXPECT_FALSE(health.at("host_render_limited").get<bool>());
+}
+
+TEST(NvhttpSessionHealthTests, MeaningfulTargetMissRemainsHostRenderLimited) {
+  const auto health = nvhttp::build_session_health_json_for_tests(
+    stable_gpu_native_stats(54.0, 60.0),
+    false,
+    "Nova Client",
+    "Mouse"
+  );
+
+  EXPECT_EQ(health.at("grade"), "watch");
+  EXPECT_EQ(health.at("primary_issue"), "host_render_limited");
+  EXPECT_EQ(health.at("limiting_factor"), "host_render");
+  EXPECT_TRUE(health.at("host_render_limited").get<bool>());
+}
+
+TEST(ProcHostPauseClassificationTests, HighRefreshNearTargetDeliveryRemainsSteady) {
+  const auto classification = proc::classify_host_pause_session_for_tests(
+    stable_gpu_native_stats(115.6, 120.0),
+    120.0,
+    false
+  );
+
+  EXPECT_EQ(classification.at("health_grade"), "good");
+  EXPECT_EQ(classification.at("primary_issue"), "steady");
+  EXPECT_FALSE(classification.at("host_render_limited").get<bool>());
+}
+
+TEST(ProcHostPauseClassificationTests, MeaningfulTargetMissRemainsHostRenderLimited) {
+  const auto classification = proc::classify_host_pause_session_for_tests(
+    stable_gpu_native_stats(54.0, 60.0),
+    60.0,
+    false
+  );
+
+  EXPECT_EQ(classification.at("health_grade"), "watch");
+  EXPECT_EQ(classification.at("primary_issue"), "host_render_limited");
+  EXPECT_TRUE(classification.at("host_render_limited").get<bool>());
 }
 
 TEST(ProcSessionLifecycleTests, TerminatedPausedAppPublishesStreamEndedWhenNoSessionsRemain) {

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -581,6 +581,27 @@ TEST(StreamStatsDoctorTests, ClassifiesGpuNativeStreamAsReady) {
   EXPECT_FALSE(doctor.at("safe_recovery_action").at("destructive"));
 }
 
+TEST(StreamStatsDoctorTests, KeepsNearTargetHighRefreshPacingGreen) {
+  stream_stats::stats_t stats {};
+  stats.streaming = true;
+  stats.fps = 115.6;
+  stats.encode_target_fps = 120;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+  stats.encode_time_ms = 4.0;
+  stats.packet_loss = 0.0;
+
+  const auto doctor = stream_stats::build_doctor_json(
+    stats,
+    {{"primary_issue", "steady"}, {"grade", "good"}}
+  );
+
+  EXPECT_EQ(doctor.at("traffic_light"), "green");
+  EXPECT_EQ(doctor.at("status"), "ok");
+  EXPECT_EQ(doctor.at("primary_issue"), "none");
+}
+
 TEST(StreamStatsDoctorTests, ClassifiesVaapiShmFallbackAsAdvancedIssue) {
   LinuxDisplayConfigGuard guard;
   config::video.adapter_name = "/dev/dri/renderD128";


### PR DESCRIPTION
## Summary
- centralize the meaningful FPS shortfall contract at a 95% relative boundary with a 2 FPS absolute noise floor
- apply the contract consistently to live session health, host-pause feedback, Polaris Doctor, optimizer history, and safe-target recovery
- sanitize stale persisted near-target host-render classifications instead of preserving false recovery/downshift state
- add direct NvHTTP session-health and host-pause classification coverage for near-target and meaningful-miss controls

## Evidence boundary
The historical `115.6 / 120 FPS` Mouse row is valid optimizer history, but it is not uniquely attributable to one smoke because multiple launches and another Hermes inspection overlapped. It is reproduction context, not causal proof. The deterministic contract tests and compiling mutant are the authoritative regression evidence.

## Verification
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure -j2` — 12/12 targets passed
- direct NvHTTP/process classifier tests — 4/4 passed
- compiled old-behavior mutant — exactly both `115.6 / 120` near-target tests failed; both meaningful-miss controls remained green
- restored `src/stream_stats.cpp` to its exact pre-mutant SHA-256 and reran the direct tests green
- `git diff --check`
- added-line security/debug-residue scan
- independent fail-closed review of the exact final diff

## Safety
- no service deployment or runtime restart
- no game/Steam process changes
- no credential material in code, tests, logs, or PR content
