### PR TITLE
fix(stream): harden RTSP handoff and PulseAudio lifecycle

### DIFF
--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -20,6 +20,7 @@
 #include <pulse/error.h>
 #include <pulse/pulseaudio.h>
 #include <pulse/simple.h>
+#include <pulse/thread-mainloop.h>
 
 #ifdef POLARIS_BUILD_PIPEWIRE
   #include <filesystem>
@@ -634,10 +635,36 @@ namespace platf {
       pa_xfree(p);
     }
 
+    void threaded_mainloop_free(pa_threaded_mainloop *loop) {
+      pa_threaded_mainloop_free(loop);
+    }
+
     using ctx_t = util::safe_ptr<pa_context, pa_context_unref>;
-    using loop_t = util::safe_ptr<pa_mainloop, pa_mainloop_free>;
+    using loop_t = util::safe_ptr<pa_threaded_mainloop, threaded_mainloop_free>;
     using op_t = util::safe_ptr<pa_operation, pa_operation_unref>;
     using string_t = util::safe_ptr<char, pa_free<char>>;
+
+    class mainloop_lock_t {
+    public:
+      explicit mainloop_lock_t(loop_t::pointer loop):
+          loop {loop} {
+        pa_threaded_mainloop_lock(loop);
+      }
+
+      mainloop_lock_t(const mainloop_lock_t &) = delete;
+      mainloop_lock_t &operator=(const mainloop_lock_t &) = delete;
+
+      ~mainloop_lock_t() {
+        pa_threaded_mainloop_unlock(loop);
+      }
+
+    private:
+      loop_t::pointer loop;
+    };
+
+    void operation_state_cb(pa_operation *, void *userdata) {
+      pa_threaded_mainloop_signal(static_cast<pa_threaded_mainloop *>(userdata), 0);
+    }
 
     template<class T>
     using cb_simple_t = std::function<void(ctx_t::pointer, add_const_t<T> i)>;
@@ -720,12 +747,6 @@ namespace platf {
     }
 
     class server_t: public audio_control_t {
-      enum ctx_event_e : int {
-        ready,
-        terminated,
-        failed
-      };
-
     public:
       loop_t loop;
       ctx_t ctx;
@@ -737,18 +758,15 @@ namespace platf {
         std::uint32_t surround71 = PA_INVALID_INDEX;
       } index;
 
-      std::unique_ptr<safe::event_t<ctx_event_e>> events;
-      std::unique_ptr<std::function<void(ctx_t::pointer)>> events_cb;
-
-      std::thread worker;
+      std::unique_ptr<std::function<void(ctx_t::pointer)>> state_cb;
+      bool mainloop_started = false;
+      bool context_connected = false;
 
 #ifdef POLARIS_BUILD_PIPEWIRE
       bool use_pipewire = false;
 #endif
 
       int init() {
-        events = std::make_unique<safe::event_t<ctx_event_e>>();
-
 #ifdef POLARIS_BUILD_PIPEWIRE
         // Attempt to detect and configure PipeWire environment before
         // connecting to PulseAudio. This fixes the most common failure
@@ -760,21 +778,27 @@ namespace platf {
         }
 #endif
 
-        loop.reset(pa_mainloop_new());
-        ctx.reset(pa_context_new(pa_mainloop_get_api(loop.get()), "sunshine"));
+        loop.reset(pa_threaded_mainloop_new());
+        if (!loop) {
+          BOOST_LOG(error) << "Couldn't create pulseaudio threaded main loop"sv;
+          return -1;
+        }
 
-        events_cb = std::make_unique<std::function<void(ctx_t::pointer)>>([this](ctx_t::pointer ctx) {
+        ctx.reset(pa_context_new(pa_threaded_mainloop_get_api(loop.get()), "sunshine"));
+        if (!ctx) {
+          BOOST_LOG(error) << "Couldn't create pulseaudio context"sv;
+          return -1;
+        }
+
+        state_cb = std::make_unique<std::function<void(ctx_t::pointer)>>([this](ctx_t::pointer ctx) {
           switch (pa_context_get_state(ctx)) {
             case PA_CONTEXT_READY:
-              events->raise(ready);
               break;
             case PA_CONTEXT_TERMINATED:
-              BOOST_LOG(debug) << "Pulseadio context terminated"sv;
-              events->raise(terminated);
+              BOOST_LOG(debug) << "PulseAudio context terminated"sv;
               break;
             case PA_CONTEXT_FAILED:
-              BOOST_LOG(debug) << "Pulseadio context failed"sv;
-              events->raise(failed);
+              BOOST_LOG(debug) << "PulseAudio context failed"sv;
               break;
             case PA_CONTEXT_CONNECTING:
               BOOST_LOG(debug) << "Connecting to pulseaudio"sv;
@@ -783,39 +807,63 @@ namespace platf {
             case PA_CONTEXT_SETTING_NAME:
               break;
           }
+
+          pa_threaded_mainloop_signal(loop.get(), 0);
         });
 
-        pa_context_set_state_callback(ctx.get(), ctx_state_cb, events_cb.get());
+        pa_context_set_state_callback(ctx.get(), ctx_state_cb, state_cb.get());
 
-        auto status = pa_context_connect(ctx.get(), nullptr, PA_CONTEXT_NOFLAGS, nullptr);
+        if (pa_threaded_mainloop_start(loop.get()) < 0) {
+          BOOST_LOG(error) << "Couldn't start pulseaudio threaded main loop"sv;
+          return -1;
+        }
+        mainloop_started = true;
+
+        mainloop_lock_t lock {loop.get()};
+        const auto status = pa_context_connect(ctx.get(), nullptr, PA_CONTEXT_NOFLAGS, nullptr);
         if (status) {
-          BOOST_LOG(error) << "Couldn't connect to pulseaudio: "sv << pa_strerror(status);
+          BOOST_LOG(error) << "Couldn't connect to pulseaudio: "sv << pa_strerror(pa_context_errno(ctx.get()));
           return -1;
         }
+        context_connected = true;
 
-        worker = std::thread {
-          [](loop_t::pointer loop) {
-            int retval;
-            auto status = pa_mainloop_run(loop, &retval);
+        while (true) {
+          const auto state = pa_context_get_state(ctx.get());
+          if (state == PA_CONTEXT_READY) {
+            return 0;
+          }
+          if (!PA_CONTEXT_IS_GOOD(state)) {
+            BOOST_LOG(error) << "Pulseaudio context failed while connecting: "sv
+                             << pa_strerror(pa_context_errno(ctx.get()));
+            return -1;
+          }
 
-            if (status < 0) {
-              BOOST_LOG(error) << "Couldn't run pulseaudio main loop"sv;
-              return;
-            }
-          },
-          loop.get()
-        };
-
-        auto event = events->pop();
-        if (event == failed) {
-          return -1;
+          pa_threaded_mainloop_wait(loop.get());
         }
+      }
 
-        return 0;
+      // The caller must hold mainloop_lock_t. pa_threaded_mainloop_wait()
+      // atomically releases and reacquires that lock around callback dispatch.
+      bool wait_for_operation(op_t &op) {
+        pa_operation_set_state_callback(op.get(), operation_state_cb, loop.get());
+        while (pa_operation_get_state(op.get()) == PA_OPERATION_RUNNING) {
+          if (!PA_CONTEXT_IS_GOOD(pa_context_get_state(ctx.get()))) {
+            pa_operation_cancel(op.get());
+            return false;
+          }
+          pa_threaded_mainloop_wait(loop.get());
+        }
+        return pa_operation_get_state(op.get()) == PA_OPERATION_DONE;
+      }
+
+      int context_errno() {
+        mainloop_lock_t lock {loop.get()};
+        return pa_context_errno(ctx.get());
       }
 
       int load_null(const char *name, const std::uint8_t *channel_mapping, int channels) {
         auto alarm = safe::make_alarm<int>();
+        mainloop_lock_t lock {loop.get()};
 
         op_t op {
           pa_context_load_module(
@@ -827,7 +875,16 @@ namespace platf {
           ),
         };
 
-        alarm->wait();
+        if (!op) {
+          BOOST_LOG(error) << "Couldn't create null-sink load operation: "sv
+                           << pa_strerror(pa_context_errno(ctx.get()));
+          return -1;
+        }
+
+        if (!wait_for_operation(op) || !alarm->status()) {
+          BOOST_LOG(error) << "Null-sink load operation was cancelled"sv;
+          return -1;
+        }
         return *alarm->status();
       }
 
@@ -837,12 +894,22 @@ namespace platf {
         }
 
         auto alarm = safe::make_alarm<int>();
+        mainloop_lock_t lock {loop.get()};
 
         op_t op {
           pa_context_unload_module(ctx.get(), i, success_cb, alarm.get())
         };
 
-        alarm->wait();
+        if (!op) {
+          BOOST_LOG(error) << "Couldn't create null-sink unload operation: "sv
+                           << pa_strerror(pa_context_errno(ctx.get()));
+          return -1;
+        }
+
+        if (!wait_for_operation(op) || !alarm->status()) {
+          BOOST_LOG(error) << "Null-sink unload operation was cancelled for index ["sv << i << ']';
+          return -1;
+        }
 
         if (*alarm->status()) {
           BOOST_LOG(error) << "Couldn't unload null-sink with index ["sv << i << "]: "sv << pa_strerror(pa_context_errno(ctx.get()));
@@ -892,17 +959,20 @@ namespace platf {
           }
         };
 
-        op_t op {pa_context_get_sink_info_list(ctx.get(), cb<pa_sink_info *>, &f)};
+        bool sink_list_completed = false;
+        {
+          mainloop_lock_t lock {loop.get()};
+          op_t op {pa_context_get_sink_info_list(ctx.get(), cb<pa_sink_info *>, &f)};
 
-        if (!op) {
-          BOOST_LOG(error) << "Couldn't create card info operation: "sv << pa_strerror(pa_context_errno(ctx.get()));
+          if (!op) {
+            BOOST_LOG(error) << "Couldn't create card info operation: "sv << pa_strerror(pa_context_errno(ctx.get()));
+            return std::nullopt;
+          }
 
-          return std::nullopt;
+          sink_list_completed = wait_for_operation(op);
         }
 
-        alarm->wait();
-
-        if (*alarm->status()) {
+        if (!sink_list_completed || !alarm->status() || *alarm->status()) {
           return std::nullopt;
         }
 
@@ -912,7 +982,7 @@ namespace platf {
         if (index.stereo == PA_INVALID_INDEX) {
           index.stereo = load_null(stereo, speaker::map_stereo, sizeof(speaker::map_stereo));
           if (index.stereo == PA_INVALID_INDEX) {
-            BOOST_LOG(warning) << "Couldn't create virtual sink for stereo: "sv << pa_strerror(pa_context_errno(ctx.get()));
+            BOOST_LOG(warning) << "Couldn't create virtual sink for stereo: "sv << pa_strerror(context_errno());
           } else {
             ++nullcount;
           }
@@ -921,7 +991,7 @@ namespace platf {
         if (index.surround51 == PA_INVALID_INDEX) {
           index.surround51 = load_null(surround51, speaker::map_surround51, sizeof(speaker::map_surround51));
           if (index.surround51 == PA_INVALID_INDEX) {
-            BOOST_LOG(warning) << "Couldn't create virtual sink for surround-51: "sv << pa_strerror(pa_context_errno(ctx.get()));
+            BOOST_LOG(warning) << "Couldn't create virtual sink for surround-51: "sv << pa_strerror(context_errno());
           } else {
             ++nullcount;
           }
@@ -930,7 +1000,7 @@ namespace platf {
         if (index.surround71 == PA_INVALID_INDEX) {
           index.surround71 = load_null(surround71, speaker::map_surround71, sizeof(speaker::map_surround71));
           if (index.surround71 == PA_INVALID_INDEX) {
-            BOOST_LOG(warning) << "Couldn't create virtual sink for surround-71: "sv << pa_strerror(pa_context_errno(ctx.get()));
+            BOOST_LOG(warning) << "Couldn't create virtual sink for surround-71: "sv << pa_strerror(context_errno());
           } else {
             ++nullcount;
           }
@@ -970,6 +1040,7 @@ namespace platf {
           if (!server_info) {
             BOOST_LOG(error) << "Couldn't get pulseaudio server info: "sv << pa_strerror(pa_context_errno(ctx));
             alarm->ring(-1);
+            return;
           }
 
           if (server_info->default_sink_name) {
@@ -978,8 +1049,14 @@ namespace platf {
           alarm->ring(0);
         };
 
+        mainloop_lock_t lock {loop.get()};
         op_t server_op {pa_context_get_server_info(ctx.get(), cb<pa_server_info *>, &server_f)};
-        alarm->wait();
+        if (!server_op) {
+          BOOST_LOG(error) << "Couldn't create pulseaudio server info operation: "sv
+                           << pa_strerror(pa_context_errno(ctx.get()));
+          return sink_name;
+        }
+        wait_for_operation(server_op);
         // No need to check status. If it failed just return default name.
         return sink_name;
       }
@@ -1007,9 +1084,15 @@ namespace platf {
           monitor_name = sink_info->monitor_source_name;
         };
 
+        mainloop_lock_t lock {loop.get()};
         op_t sink_op {pa_context_get_sink_info_by_name(ctx.get(), sink_name.c_str(), cb<pa_sink_info *>, &sink_f)};
+        if (!sink_op) {
+          BOOST_LOG(error) << "Couldn't create monitor lookup operation for ["sv << sink_name
+                           << "]: "sv << pa_strerror(pa_context_errno(ctx.get()));
+          return monitor_name;
+        }
 
-        alarm->wait();
+        wait_for_operation(sink_op);
         // No need to check status. If it failed just return default name.
         BOOST_LOG(info) << "Found default monitor by name: "sv << monitor_name;
         return monitor_name;
@@ -1038,6 +1121,7 @@ namespace platf {
           sink_index = sink_info->index;
         };
 
+        mainloop_lock_t lock {loop.get()};
         op_t sink_op {pa_context_get_sink_info_by_name(ctx.get(), sink_name.c_str(), cb<pa_sink_info *>, &sink_f)};
 
         if (!sink_op) {
@@ -1046,8 +1130,7 @@ namespace platf {
           return std::nullopt;
         }
 
-        alarm->wait();
-        if (*alarm->status()) {
+        if (!wait_for_operation(sink_op) || !alarm->status() || *alarm->status()) {
           return std::nullopt;
         }
 
@@ -1110,14 +1193,18 @@ namespace platf {
           });
         };
 
-        op_t list_op {pa_context_get_sink_input_info_list(ctx.get(), cb<pa_sink_input_info *>, &input_f)};
-        if (!list_op) {
-          BOOST_LOG(error) << "Couldn't create sink input list operation: "sv << pa_strerror(pa_context_errno(ctx.get()));
-          return;
-        }
+        bool sink_inputs_completed = false;
+        {
+          mainloop_lock_t lock {loop.get()};
+          op_t list_op {pa_context_get_sink_input_info_list(ctx.get(), cb<pa_sink_input_info *>, &input_f)};
+          if (!list_op) {
+            BOOST_LOG(error) << "Couldn't create sink input list operation: "sv << pa_strerror(pa_context_errno(ctx.get()));
+            return;
+          }
 
-        alarm->wait();
-        if (*alarm->status()) {
+          sink_inputs_completed = wait_for_operation(list_op);
+        }
+        if (!sink_inputs_completed || !alarm->status() || *alarm->status()) {
           return;
         }
 
@@ -1129,6 +1216,7 @@ namespace platf {
                           << " to ["sv << sink << ']';
 
           auto move_alarm = safe::make_alarm<int>();
+          mainloop_lock_t lock {loop.get()};
           op_t move_op {
             pa_context_move_sink_input_by_name(
               ctx.get(),
@@ -1145,8 +1233,8 @@ namespace platf {
             continue;
           }
 
-          move_alarm->wait();
-          if (*move_alarm->status()) {
+          const bool move_completed = wait_for_operation(move_op);
+          if (!move_completed || !move_alarm->status() || *move_alarm->status()) {
             BOOST_LOG(warning) << "Linux audio isolation: failed to move session audio stream ["sv
                                << route.app_name << "] pid="sv << route.pid
                                << " to ["sv << sink << "]: "sv << pa_strerror(pa_context_errno(ctx.get()));
@@ -1199,6 +1287,7 @@ namespace platf {
 
       int set_sink(const std::string &sink) override {
         auto alarm = safe::make_alarm<int>();
+        mainloop_lock_t lock {loop.get()};
 
         BOOST_LOG(info) << "Setting default sink to: ["sv << sink << "]"sv;
         op_t op {
@@ -1215,7 +1304,10 @@ namespace platf {
           return -1;
         }
 
-        alarm->wait();
+        if (!wait_for_operation(op) || !alarm->status()) {
+          BOOST_LOG(error) << "Set default-sink operation was cancelled for ["sv << sink << ']';
+          return -1;
+        }
         if (*alarm->status()) {
           BOOST_LOG(error) << "Couldn't set default-sink ["sv << sink << "]: "sv << pa_strerror(pa_context_errno(ctx.get()));
 
@@ -1228,19 +1320,19 @@ namespace platf {
       }
 
       ~server_t() override {
-        unload_null(index.stereo);
-        unload_null(index.surround51);
-        unload_null(index.surround71);
+        if (mainloop_started) {
+          unload_null(index.stereo);
+          unload_null(index.surround51);
+          unload_null(index.surround71);
 
-        if (worker.joinable()) {
-          pa_context_disconnect(ctx.get());
+          if (context_connected) {
+            mainloop_lock_t lock {loop.get()};
+            pa_context_disconnect(ctx.get());
+            context_connected = false;
+          }
 
-          KITTY_WHILE_LOOP(auto event = events->pop(), event != terminated && event != failed, {
-            event = events->pop();
-          })
-
-          pa_mainloop_quit(loop.get(), 0);
-          worker.join();
+          pa_threaded_mainloop_stop(loop.get());
+          mainloop_started = false;
         }
       }
     };

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -556,19 +556,39 @@ namespace rtsp_stream {
       });
     }
 
-    void handle_msg(tcp::socket &sock, launch_session_t &session, msg_t &&req) {
+    template<class Dispatch, class Reject>
+    bool dispatch_control_command(
+      launch_session_t &session,
+      Dispatch &&on_dispatch,
+      Reject &&on_reject
+    ) {
       if (!control_command_admissible(session)) {
-        BOOST_LOG(debug) << "Rejecting RTSP command for an inadmissible launch session"sv;
-        boost::system::error_code ec;
-        sock.close(ec);
-        return;
+        std::forward<Reject>(on_reject)();
+        return false;
       }
 
-      auto func = _map_cmd_cb.find(req->message.request.command);
-      if (func != std::end(_map_cmd_cb)) {
-        func->second(this, sock, session, std::move(req));
-      } else {
-        cmd_not_found(sock, session, std::move(req));
+      std::forward<Dispatch>(on_dispatch)();
+      return true;
+    }
+
+    void handle_msg(tcp::socket &sock, launch_session_t &session, msg_t &&req) {
+      if (!dispatch_control_command(
+            session,
+            [&]() {
+              auto func = _map_cmd_cb.find(req->message.request.command);
+              if (func != std::end(_map_cmd_cb)) {
+                func->second(this, sock, session, std::move(req));
+              } else {
+                cmd_not_found(sock, session, std::move(req));
+              }
+            },
+            [&sock]() {
+              BOOST_LOG(debug) << "Rejecting RTSP command for an inadmissible launch session"sv;
+              boost::system::error_code ec;
+              sock.close(ec);
+            }
+          )) {
+        return;
       }
 
       boost::system::error_code ec;
@@ -983,6 +1003,18 @@ namespace rtsp_stream {
 
   bool control_command_admissible_for_tests(const launch_session_t &launch_session) {
     return server.control_command_admissible(launch_session);
+  }
+
+  bool dispatch_control_command_for_tests(
+    launch_session_t &launch_session,
+    std::function<void()> on_dispatch,
+    std::function<void()> on_reject
+  ) {
+    return server.dispatch_control_command(
+      launch_session,
+      std::move(on_dispatch),
+      std::move(on_reject)
+    );
   }
 
   void reset_cleanup_call_count_for_tests() {

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -537,6 +537,13 @@ namespace rtsp_stream {
     }
 
     void handle_msg(tcp::socket &sock, launch_session_t &session, msg_t &&req) {
+      if (!session.accepts_control_connection()) {
+        BOOST_LOG(debug) << "Rejecting RTSP command for cancelled launch session"sv;
+        boost::system::error_code ec;
+        sock.close(ec);
+        return;
+      }
+
       auto func = _map_cmd_cb.find(req->message.request.command);
       if (func != std::end(_map_cmd_cb)) {
         func->second(this, sock, session, std::move(req));
@@ -560,15 +567,15 @@ namespace rtsp_stream {
       auto socket = std::move(next_socket);
 
       auto launch_session {launch_event.view(0s)};
-      if (launch_session && launch_session->is_pending()) {
+      if (launch_session && launch_session->accepts_control_connection()) {
         // Associate the current RTSP session with this socket and start reading
         socket->session = launch_session;
         socket->read();
       } else {
         // This can happen due to normal things like port scanning, so let's not make these visible by default
-        BOOST_LOG(debug) << "No pending session for incoming RTSP connection"sv;
+        BOOST_LOG(debug) << "No admissible launch session for incoming RTSP connection"sv;
 
-        // If there is no session pending, close the connection immediately
+        // If there is no admissible launch session, close the connection immediately
         boost::system::error_code ec;
         socket->sock.close(ec);
       }

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -536,9 +536,29 @@ namespace rtsp_stream {
       return 0;
     }
 
-    void handle_msg(tcp::socket &sock, launch_session_t &session, msg_t &&req) {
+    bool control_command_admissible(const launch_session_t &session) {
       if (!session.accepts_control_connection()) {
-        BOOST_LOG(debug) << "Rejecting RTSP command for cancelled launch session"sv;
+        return false;
+      }
+      if (session.is_pending_or_handoff()) {
+        return true;
+      }
+      if (session.session_token.empty()) {
+        return false;
+      }
+
+      auto lg = _session_slots.lock();
+      return std::any_of(_session_slots->begin(), _session_slots->end(), [&session](const auto &slot) {
+        return slot &&
+               stream::session::state(*slot) != stream::session::state_e::STOPPING &&
+               stream::session::launch_session_id(*slot) == session.id &&
+               stream::session::session_token(*slot) == session.session_token;
+      });
+    }
+
+    void handle_msg(tcp::socket &sock, launch_session_t &session, msg_t &&req) {
+      if (!control_command_admissible(session)) {
+        BOOST_LOG(debug) << "Rejecting RTSP command for an inadmissible launch session"sv;
         boost::system::error_code ec;
         sock.close(ec);
         return;
@@ -567,7 +587,7 @@ namespace rtsp_stream {
       auto socket = std::move(next_socket);
 
       auto launch_session {launch_event.view(0s)};
-      if (launch_session && launch_session->accepts_control_connection()) {
+      if (launch_session && control_command_admissible(*launch_session)) {
         // Associate the current RTSP session with this socket and start reading
         socket->session = launch_session;
         socket->read();
@@ -959,6 +979,10 @@ namespace rtsp_stream {
 
   bool expire_pending_launch_for_tests(uint32_t launch_session_id, std::uint64_t timer_generation) {
     return server.expire_pending_launch(launch_session_id, timer_generation);
+  }
+
+  bool control_command_admissible_for_tests(const launch_session_t &launch_session) {
+    return server.control_command_admissible(launch_session);
   }
 
   void reset_cleanup_call_count_for_tests() {

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -179,6 +179,11 @@ namespace rtsp_stream {
   std::uint64_t launch_timer_generation_for_tests();
   bool expire_pending_launch_for_tests(uint32_t launch_session_id, std::uint64_t timer_generation);
   bool control_command_admissible_for_tests(const launch_session_t &launch_session);
+  bool dispatch_control_command_for_tests(
+    launch_session_t &launch_session,
+    std::function<void()> on_dispatch,
+    std::function<void()> on_reject
+  );
   void reset_cleanup_call_count_for_tests();
   unsigned cleanup_call_count_for_tests();
   void set_cleanup_unlocked_probe_for_tests(std::function<void()> probe);

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -178,6 +178,7 @@ namespace rtsp_stream {
   );
   std::uint64_t launch_timer_generation_for_tests();
   bool expire_pending_launch_for_tests(uint32_t launch_session_id, std::uint64_t timer_generation);
+  bool control_command_admissible_for_tests(const launch_session_t &launch_session);
   void reset_cleanup_call_count_for_tests();
   unsigned cleanup_call_count_for_tests();
   void set_cleanup_unlocked_probe_for_tests(std::function<void()> probe);

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -100,6 +100,11 @@ namespace rtsp_stream {
       return setup_state.load() == setup_state_e::cancelled;
     }
 
+    // Moonlight sends SETUP and PLAY over separate TCP connections, so started sessions remain admissible.
+    bool accepts_control_connection() const {
+      return setup_state.load() != setup_state_e::cancelled;
+    }
+
     bool input_only;
     bool host_audio;
     int requested_width;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2106,6 +2106,10 @@ namespace stream {
       return session.session_token;
     }
 
+    std::uint32_t launch_session_id(const session_t& session) {
+      return session.launch_session_id;
+    }
+
     bool uuid_match(const session_t &session, const std::string_view& uuid) {
       return session.device_uuid == uuid;
     }

--- a/src/stream.h
+++ b/src/stream.h
@@ -63,6 +63,7 @@ namespace stream {
     session_profile_t profile(const session_t& session);
     std::string uuid(const session_t& session);
     std::string session_token(const session_t& session);
+    std::uint32_t launch_session_id(const session_t& session);
     bool uuid_match(const session_t& session, const std::string_view& uuid);
     bool is_watch_only(const session_t& session);
     bool update_device_info(session_t& session, const std::string& name, const crypto::PERM& newPerm);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_kmsgrab_logging_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_prepared_ffmpeg.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_pulse_mainloop_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_rswrapper.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_session_event_queue.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_update_status.cpp

--- a/tests/unit/test_pulse_mainloop_contract.cpp
+++ b/tests/unit/test_pulse_mainloop_contract.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file tests/unit/test_pulse_mainloop_contract.cpp
+ * @brief Contract tests for synchronized PulseAudio async-operation ownership.
+ */
+
+#include "../tests_common.h"
+
+#include <filesystem>
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <string>
+
+namespace {
+  std::string read_linux_audio_source() {
+    const auto path = std::filesystem::path(POLARIS_SOURCE_DIR) / "src/platform/linux/audio.cpp";
+    std::ifstream in(path);
+    if (!in) {
+      return {};
+    }
+
+    std::ostringstream out;
+    out << in.rdbuf();
+    return out.str();
+  }
+
+  std::size_t count_occurrences(const std::string &text, const std::string &needle) {
+    std::size_t count = 0;
+    std::size_t pos = 0;
+    while ((pos = text.find(needle, pos)) != std::string::npos) {
+      ++count;
+      pos += needle.size();
+    }
+    return count;
+  }
+}
+
+TEST(PulseAudioMainloopContractTest, SerializesContextAndOperationAccessWithThreadedMainloop) {
+  const auto source = read_linux_audio_source();
+  ASSERT_FALSE(source.empty());
+
+  EXPECT_NE(source.find("pa_threaded_mainloop_new"), std::string::npos);
+  EXPECT_NE(source.find("pa_threaded_mainloop_get_api"), std::string::npos);
+  EXPECT_NE(source.find("pa_threaded_mainloop_lock"), std::string::npos);
+  EXPECT_NE(source.find("pa_threaded_mainloop_unlock"), std::string::npos);
+  EXPECT_NE(source.find("pa_threaded_mainloop_wait"), std::string::npos);
+  EXPECT_NE(source.find("pa_threaded_mainloop_signal"), std::string::npos);
+  EXPECT_NE(source.find("pa_operation_get_state"), std::string::npos);
+  EXPECT_NE(source.find("PA_OPERATION_RUNNING"), std::string::npos);
+
+  EXPECT_EQ(source.find("pa_mainloop_run"), std::string::npos);
+  EXPECT_EQ(source.find("std::thread worker"), std::string::npos);
+
+  const auto pa_namespace = source.find("namespace pa {");
+  ASSERT_NE(pa_namespace, std::string::npos);
+  const auto server_source = source.substr(pa_namespace);
+  EXPECT_EQ(server_source.find("alarm->wait()"), std::string::npos);
+  EXPECT_EQ(server_source.find("move_alarm->wait()"), std::string::npos);
+
+  const std::regex operation_local {R"(\bop_t\s+[A-Za-z_][A-Za-z0-9_]*\s*\{)"};
+  const auto operation_locals = std::distance(
+    std::sregex_iterator(server_source.begin(), server_source.end(), operation_local),
+    std::sregex_iterator()
+  );
+  const auto operation_waits = count_occurrences(server_source, "wait_for_operation(") - 1;
+  EXPECT_EQ(operation_locals, operation_waits);
+}

--- a/tests/unit/test_pulse_mainloop_contract.cpp
+++ b/tests/unit/test_pulse_mainloop_contract.cpp
@@ -10,6 +10,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace {
   std::string read_linux_audio_source() {
@@ -24,14 +25,105 @@ namespace {
     return out.str();
   }
 
-  std::size_t count_occurrences(const std::string &text, const std::string &needle) {
-    std::size_t count = 0;
-    std::size_t pos = 0;
-    while ((pos = text.find(needle, pos)) != std::string::npos) {
-      ++count;
-      pos += needle.size();
+  std::size_t leading_spaces(const std::string &line) {
+    return line.find_first_not_of(' ');
+  }
+
+  std::vector<std::string> operation_contract_violations(const std::string &source) {
+    std::vector<std::string> lines;
+    std::istringstream input {source};
+    for (std::string line; std::getline(input, line);) {
+      lines.emplace_back(std::move(line));
     }
-    return count;
+
+    std::vector<std::string> violations;
+    const std::regex operation_declaration {R"(^([ ]*)op_t[ ]+([A-Za-z_][A-Za-z0-9_]*)[ ]*\{)"};
+    std::size_t operation_count = 0;
+
+    for (std::size_t line_index = 0; line_index < lines.size(); ++line_index) {
+      std::smatch match;
+      if (!std::regex_search(lines[line_index], match, operation_declaration)) {
+        continue;
+      }
+
+      ++operation_count;
+      const auto indentation = match[1].str().size();
+      const auto variable = match[2].str();
+
+      std::size_t scope_begin = 0;
+      for (auto previous = line_index; previous > 0; --previous) {
+        const auto &line = lines[previous - 1];
+        const auto previous_indentation = leading_spaces(line);
+        if (previous_indentation != std::string::npos &&
+            previous_indentation < indentation &&
+            line.find('{') != std::string::npos) {
+          scope_begin = previous;
+          break;
+        }
+      }
+
+      std::size_t scope_end = lines.size();
+      for (auto following = line_index + 1; following < lines.size(); ++following) {
+        const auto following_indentation = leading_spaces(lines[following]);
+        if (following_indentation != std::string::npos && following_indentation < indentation) {
+          scope_end = following;
+          break;
+        }
+      }
+
+      std::size_t lock_count = 0;
+      for (auto candidate = scope_begin; candidate < line_index; ++candidate) {
+        if (leading_spaces(lines[candidate]) == indentation &&
+            lines[candidate].find("mainloop_lock_t ") != std::string::npos) {
+          ++lock_count;
+        }
+      }
+      if (lock_count != 1) {
+        violations.emplace_back(
+          "operation '" + variable + "' on line " + std::to_string(line_index + 1) +
+          " must have exactly one preceding same-scope mainloop lock"
+        );
+      }
+
+      const std::regex matching_wait {
+        "wait_for_operation[ ]*\\([ ]*" + variable + "[ ]*\\)"
+      };
+      std::size_t wait_count = 0;
+      for (auto candidate = line_index + 1; candidate < scope_end; ++candidate) {
+        wait_count += std::distance(
+          std::sregex_iterator(lines[candidate].begin(), lines[candidate].end(), matching_wait),
+          std::sregex_iterator()
+        );
+      }
+      if (wait_count != 1) {
+        violations.emplace_back(
+          "operation '" + variable + "' on line " + std::to_string(line_index + 1) +
+          " must have exactly one matching same-scope wait"
+        );
+      }
+    }
+
+    if (operation_count == 0) {
+      violations.emplace_back("no PulseAudio operations found");
+    }
+
+    const std::regex wait_recheck_loop {
+      R"(while[ ]*\([ ]*pa_operation_get_state[ ]*\([ ]*op\.get\(\)[ ]*\)[ ]*==[ ]*PA_OPERATION_RUNNING[ ]*\))"
+    };
+    if (!std::regex_search(source, wait_recheck_loop)) {
+      violations.emplace_back("wait_for_operation must recheck PA_OPERATION_RUNNING in a while loop");
+    }
+
+    return violations;
+  }
+
+  std::string replace_once(std::string source, const std::string &needle, const std::string &replacement) {
+    const auto position = source.find(needle);
+    if (position == std::string::npos || source.find(needle, position + needle.size()) != std::string::npos) {
+      return {};
+    }
+    source.replace(position, needle.size(), replacement);
+    return source;
   }
 }
 
@@ -57,11 +149,60 @@ TEST(PulseAudioMainloopContractTest, SerializesContextAndOperationAccessWithThre
   EXPECT_EQ(server_source.find("alarm->wait()"), std::string::npos);
   EXPECT_EQ(server_source.find("move_alarm->wait()"), std::string::npos);
 
-  const std::regex operation_local {R"(\bop_t\s+[A-Za-z_][A-Za-z0-9_]*\s*\{)"};
-  const auto operation_locals = std::distance(
-    std::sregex_iterator(server_source.begin(), server_source.end(), operation_local),
-    std::sregex_iterator()
+  const auto violations = operation_contract_violations(server_source);
+  EXPECT_TRUE(violations.empty()) << (violations.empty() ? "" : violations.front());
+}
+
+TEST(PulseAudioMainloopContractTest, RejectsOperationWithoutSameScopeLock) {
+  const auto source = read_linux_audio_source();
+  ASSERT_FALSE(source.empty());
+
+  const auto mutant = replace_once(
+    source,
+    "      int load_null(const char *name, const std::uint8_t *channel_mapping, int channels) {\n"
+    "        auto alarm = safe::make_alarm<int>();\n"
+    "        mainloop_lock_t lock {loop.get()};\n\n"
+    "        op_t op {",
+    "      int load_null(const char *name, const std::uint8_t *channel_mapping, int channels) {\n"
+    "        auto alarm = safe::make_alarm<int>();\n\n"
+    "        op_t op {"
   );
-  const auto operation_waits = count_occurrences(server_source, "wait_for_operation(") - 1;
-  EXPECT_EQ(operation_locals, operation_waits);
+  ASSERT_FALSE(mutant.empty());
+  EXPECT_FALSE(operation_contract_violations(mutant).empty());
+}
+
+TEST(PulseAudioMainloopContractTest, RejectsOneShotOperationWait) {
+  const auto source = read_linux_audio_source();
+  ASSERT_FALSE(source.empty());
+
+  const auto mutant = replace_once(
+    source,
+    "while (pa_operation_get_state(op.get()) == PA_OPERATION_RUNNING) {",
+    "if (pa_operation_get_state(op.get()) == PA_OPERATION_RUNNING) {"
+  );
+  ASSERT_FALSE(mutant.empty());
+  EXPECT_FALSE(operation_contract_violations(mutant).empty());
+}
+
+TEST(PulseAudioMainloopContractTest, RejectsDuplicateAndMissingOperationWaits) {
+  const auto source = read_linux_audio_source();
+  ASSERT_FALSE(source.empty());
+
+  auto mutant = replace_once(
+    source,
+    "if (!wait_for_operation(op) || !alarm->status()) {\n"
+    "          BOOST_LOG(error) << \"Null-sink load operation was cancelled\"sv;",
+    "if (!wait_for_operation(op) || !wait_for_operation(op) || !alarm->status()) {\n"
+    "          BOOST_LOG(error) << \"Null-sink load operation was cancelled\"sv;"
+  );
+  ASSERT_FALSE(mutant.empty());
+  mutant = replace_once(
+    std::move(mutant),
+    "if (!wait_for_operation(op) || !alarm->status()) {\n"
+    "          BOOST_LOG(error) << \"Null-sink unload operation was cancelled for index [\"sv << i << ']';",
+    "if (!alarm->status()) {\n"
+    "          BOOST_LOG(error) << \"Null-sink unload operation was cancelled for index [\"sv << i << ']';"
+  );
+  ASSERT_FALSE(mutant.empty());
+  EXPECT_GE(operation_contract_violations(mutant).size(), 2u);
 }

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -10,7 +10,10 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <future>
+#include <sstream>
 #include <thread>
 
 namespace {
@@ -35,6 +38,14 @@ namespace {
       stop_in_progress,
       token_matches
     );
+  }
+
+  std::string read_rtsp_source_for_contract() {
+    const auto path = std::filesystem::path(POLARIS_SOURCE_DIR) / "src/rtsp.cpp";
+    std::ifstream in(path);
+    std::ostringstream out;
+    out << in.rdbuf();
+    return out.str();
   }
 }
 
@@ -333,6 +344,37 @@ TEST(RtspLaunchHandoffTests, TimeoutAndSetupHandoffHaveOneAtomicWinner) {
   EXPECT_TRUE(setup_wins.commit_setup_start());
   EXPECT_FALSE(setup_wins.cancel_for_timeout());
   EXPECT_FALSE(setup_wins.is_cancelled());
+}
+
+TEST(RtspLaunchHandoffTests, FollowupControlConnectionsRemainAdmissibleAfterSetupStarts) {
+  rtsp_stream::launch_session_t session {};
+  EXPECT_TRUE(session.accepts_control_connection());
+
+  ASSERT_TRUE(session.try_begin_setup_handoff());
+  EXPECT_TRUE(session.accepts_control_connection());
+
+  ASSERT_TRUE(session.commit_setup_start());
+  EXPECT_TRUE(session.accepts_control_connection());
+
+  session.cancel();
+  EXPECT_FALSE(session.accepts_control_connection());
+}
+
+TEST(RtspLaunchHandoffTests, CancelledAcceptedSocketsAreRejectedBeforeCommandDispatch) {
+  const auto source = read_rtsp_source_for_contract();
+  ASSERT_FALSE(source.empty());
+
+  const auto handle_start = source.find("void handle_msg(tcp::socket &sock, launch_session_t &session, msg_t &&req)");
+  const auto handle_end = source.find("void handle_accept(const boost::system::error_code &ec)", handle_start);
+  ASSERT_NE(handle_start, std::string::npos);
+  ASSERT_NE(handle_end, std::string::npos);
+
+  const auto handle_body = source.substr(handle_start, handle_end - handle_start);
+  const auto cancelled_gate = handle_body.find("if (!session.accepts_control_connection())");
+  const auto command_dispatch = handle_body.find("_map_cmd_cb.find");
+  ASSERT_NE(cancelled_gate, std::string::npos);
+  ASSERT_NE(command_dispatch, std::string::npos);
+  EXPECT_LT(cancelled_gate, command_dispatch);
 }
 
 TEST(RtspLaunchHandoffTests, SnapshotAndTeardownRetainClaimedHandoffBeforeSlotInsertion) {

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -398,6 +398,25 @@ TEST(RtspLaunchHandoffTests, StartedControlCommandsRequireMatchingLiveSessionSlo
   EXPECT_FALSE(rtsp_stream::control_command_admissible_for_tests(session));
 }
 
+TEST(RtspLaunchHandoffTests, CancelledControlCommandRejectsWithoutInvokingHandler) {
+  rtsp_stream::launch_session_t session {};
+  session.cancel();
+  bool handler_invoked = false;
+  bool rejection_invoked = false;
+
+  EXPECT_FALSE(rtsp_stream::dispatch_control_command_for_tests(
+    session,
+    [&handler_invoked]() {
+      handler_invoked = true;
+    },
+    [&rejection_invoked]() {
+      rejection_invoked = true;
+    }
+  ));
+  EXPECT_FALSE(handler_invoked);
+  EXPECT_TRUE(rejection_invoked);
+}
+
 TEST(RtspLaunchHandoffTests, AcceptAndDispatchUseSlotAwareCommandAdmission) {
   const auto source = read_rtsp_source_for_contract();
   ASSERT_FALSE(source.empty());
@@ -408,7 +427,7 @@ TEST(RtspLaunchHandoffTests, AcceptAndDispatchUseSlotAwareCommandAdmission) {
   ASSERT_NE(handle_end, std::string::npos);
 
   const auto handle_body = source.substr(handle_start, handle_end - handle_start);
-  const auto dispatch_gate = handle_body.find("if (!control_command_admissible(session))");
+  const auto dispatch_gate = handle_body.find("if (!dispatch_control_command(");
   const auto command_dispatch = handle_body.find("_map_cmd_cb.find");
   EXPECT_NE(dispatch_gate, std::string::npos);
   ASSERT_NE(command_dispatch, std::string::npos);

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -360,7 +360,45 @@ TEST(RtspLaunchHandoffTests, FollowupControlConnectionsRemainAdmissibleAfterSetu
   EXPECT_FALSE(session.accepts_control_connection());
 }
 
-TEST(RtspLaunchHandoffTests, CancelledAcceptedSocketsAreRejectedBeforeCommandDispatch) {
+TEST(RtspLaunchHandoffTests, StartedControlCommandsRequireMatchingLiveSessionSlot) {
+  rtsp_stream::terminate_sessions();
+  rtsp_stream::launch_session_t session {};
+  session.id = 5103;
+  session.unique_id = "started-command-admission";
+  session.session_token = "started-command-admission-token";
+
+  ASSERT_TRUE(session.try_begin_setup_handoff());
+  ASSERT_TRUE(session.commit_setup_start());
+  EXPECT_FALSE(rtsp_stream::control_command_admissible_for_tests(session));
+
+  rtsp_stream::launch_session_t reconnect {};
+  reconnect.id = 5104;
+  reconnect.unique_id = session.unique_id;
+  reconnect.session_token = session.session_token;
+  ASSERT_TRUE(reconnect.try_begin_setup_handoff());
+  ASSERT_TRUE(reconnect.commit_setup_start());
+  rtsp_stream::add_session_for_tests(reconnect, false);
+  EXPECT_FALSE(rtsp_stream::control_command_admissible_for_tests(session));
+  rtsp_stream::set_cleanup_session_probe_for_tests([]() {});
+  rtsp_stream::terminate_sessions();
+  rtsp_stream::set_cleanup_session_probe_for_tests({});
+
+  rtsp_stream::add_session_for_tests(session, true);
+  EXPECT_FALSE(rtsp_stream::control_command_admissible_for_tests(session));
+  rtsp_stream::set_cleanup_session_probe_for_tests([]() {});
+  rtsp_stream::terminate_sessions();
+  rtsp_stream::set_cleanup_session_probe_for_tests({});
+
+  rtsp_stream::add_session_for_tests(session, false);
+  EXPECT_TRUE(rtsp_stream::control_command_admissible_for_tests(session));
+
+  rtsp_stream::set_cleanup_session_probe_for_tests([]() {});
+  rtsp_stream::terminate_sessions();
+  rtsp_stream::set_cleanup_session_probe_for_tests({});
+  EXPECT_FALSE(rtsp_stream::control_command_admissible_for_tests(session));
+}
+
+TEST(RtspLaunchHandoffTests, AcceptAndDispatchUseSlotAwareCommandAdmission) {
   const auto source = read_rtsp_source_for_contract();
   ASSERT_FALSE(source.empty());
 
@@ -370,11 +408,22 @@ TEST(RtspLaunchHandoffTests, CancelledAcceptedSocketsAreRejectedBeforeCommandDis
   ASSERT_NE(handle_end, std::string::npos);
 
   const auto handle_body = source.substr(handle_start, handle_end - handle_start);
-  const auto cancelled_gate = handle_body.find("if (!session.accepts_control_connection())");
+  const auto dispatch_gate = handle_body.find("if (!control_command_admissible(session))");
   const auto command_dispatch = handle_body.find("_map_cmd_cb.find");
-  ASSERT_NE(cancelled_gate, std::string::npos);
+  EXPECT_NE(dispatch_gate, std::string::npos);
   ASSERT_NE(command_dispatch, std::string::npos);
-  EXPECT_LT(cancelled_gate, command_dispatch);
+  if (dispatch_gate != std::string::npos) {
+    EXPECT_LT(dispatch_gate, command_dispatch);
+  }
+
+  const auto accept_start = handle_end;
+  const auto accept_end = source.find("void map(const std::string_view &type, cmd_func_t cb)", accept_start);
+  ASSERT_NE(accept_end, std::string::npos);
+  const auto accept_body = source.substr(accept_start, accept_end - accept_start);
+  EXPECT_NE(
+    accept_body.find("if (launch_session && control_command_admissible(*launch_session))"),
+    std::string::npos
+  );
 }
 
 TEST(RtspLaunchHandoffTests, SnapshotAndTeardownRetainClaimedHandoffBeforeSlotInsertion) {


### PR DESCRIPTION
## Summary

- Serialize PulseAudio threaded-mainloop operations and teardown so callbacks and lifecycle changes cannot race the native audio path.
- Admit legitimate follow-up RTSP control connections after setup while keeping stale or cross-launch commands fail-closed.
- Bind started commands to the live launch and session identity, and add compiling mutation contracts for both the PulseAudio and RTSP/session lifecycle invariants.

## Root cause

Moonlight may continue the RTSP flow over a follow-up TCP connection after setup. The previous ownership state was too connection-local, so valid `PLAY` handoff traffic could be rejected even though the token and live launch were still authoritative. At the same time, PulseAudio operations could cross lifecycle boundaries without one serialized threaded-mainloop contract.

This change makes launch/session identity authoritative across RTSP connections, rejects stale-token and stale-launch mutants, and serializes PulseAudio operations under the native mainloop lock.

## Verification

### Exact candidate

- HEAD: `8f8ceea647373b591d66a8b8696bd1ec4de03171`
- Deployed executable: `/usr/bin/polaris-1.3.1.8f8ceea6`
- Binary SHA-256: `2c129d44b9f29ddc3ee36bae6a81852ce2e0be0192cb29ebff57c1fe467fb76f`
- Worktree clean and remote branch SHA verified exact

### Build and tests

- Debug build: PASS
- `ctest --test-dir build-codex-mutant-pa -j2 --output-on-failure`: 16/16 PASS
- `ctest --test-dir build-codex-mutant -j2 --output-on-failure`: 50/50 PASS
- Focused C++ lifecycle contract test: PASS
- Python contract and smoke tests: PASS
- Compiling PulseAudio lock-removal mutant: correctly rejected
- Compiling RTSP stale-token/different-launch mutants: correctly rejected
- Exact-head independent review: GO, no findings

### Retroid Pocket 6 serialized smoke

- Nova `1.3.1` (`com.papi.nova.debug`), exact APK SHA-256 `3827309b763a19a26036984d8792630ec1da1f5cd11ab2564071ca357e54d8ef`
- Initial MOUSE stream: complete RTSP handshake; first video `0 ms`; first audio `400 ms`
- Capture: GPU-native DMA-BUF; NVENC HEVC; PipeWire native 2ch/48 kHz
- Coherent 1920x1080 frame at 30/30 FPS
- Command Center Disconnect produced `stream_paused`; server remained BUSY for the delayed resume window
- Same labwc PID `2046626` and MOUSE PID `2050980` survived before, during, and after reconnect
- Library Resume completed a second RTSP handshake; first video `0 ms`; first audio `300 ms`
- No new session, cage, or game launch during resume
- Additional external close/reopen completed a third pause/resume handshake without replacing the host process or crashing
- Zero RTSP handshake timeouts, ping timeouts, connection resets, segfaults, or candidate coredumps

### Teardown

- Nova Command Center End session confirmation returned Polaris to `POLARIS_SERVER_FREE` in 3 seconds
- Final `currentgame=0`
- Zero MOUSE/labwc residue
- Nova returned to an idle Library with no stale Resume banner

## Non-blocking observations

- One isolated audio FEC recovery/drop notice appeared during the extended third connection; no reset or sustained failure followed.
- Nova labeled the resumed private GPU-native stream as Mirror Desktop in its HUD. The host process identity and headless runtime remained correct; this is a separate UI truth-surface follow-up, not an RTSP handoff failure.
- Synthetic ADB input was not forwarded into the game, so this PR does not claim automated controller-input verification.

## Merge gate

Do not merge until GitHub CI is green and the exact PR head remains `8f8ceea647373b591d66a8b8696bd1ec4de03171`.