### PR TITLE
fix(video): harden VAAPI DMA-BUF surface lifetime

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -638,6 +638,15 @@ namespace cage_display_router {
            source_metadata.residency == platf::frame_residency_e::gpu;
   }
 
+  bool should_disable_windowed_gpu_native_after_conversion_failure(
+    const platf::runtime_state_t &runtime_state,
+    const platf::frame_metadata_t &source_metadata
+  ) {
+    return runtime_state.gpu_native_override_active &&
+           source_metadata.transport == platf::frame_transport_e::dmabuf &&
+           source_metadata.residency == platf::frame_residency_e::gpu;
+  }
+
   std::optional<bool> cached_windowed_gpu_native_probe_result() {
     return windowed_gpu_native_probe.get();
   }

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -611,11 +611,21 @@ namespace cage_display_router {
     return gpu_native_dmabuf_is_safe(hwdevice_type);
   }
 
-  bool should_attempt_gpu_native_cage_capture(
-    const platf::runtime_state_t &runtime_state,
-    platf::mem_type_e hwdevice_type
-  ) {
-    return runtime_state.gpu_native_override_active && gpu_native_dmabuf_is_safe(hwdevice_type);
+  bool should_attempt_gpu_native_cage_capture(const platf::runtime_state_t &runtime_state) {
+    if (!runtime_state.gpu_native_override_active) {
+      return false;
+    }
+
+    // A conversion that already failed once in this process is not retried.
+    // This is adaptive containment rather than a blanket refusal: it keeps the
+    // GPU-native path available to encoders that can actually use it, and
+    // retires it for the ones that cannot, per process.
+    if (auto cached_result = cached_windowed_gpu_native_probe_result();
+        cached_result && !*cached_result) {
+      return false;
+    }
+
+    return true;
   }
 
   bool should_disable_headless_extcopy_after_conversion_failure(

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -113,11 +113,9 @@ namespace cage_display_router {
    * @brief Returns whether an encoder memory type has a known-safe GPU-native
    *        DMA-BUF import/convert path.
    *
-   * This is the stability policy behind every GPU-native capture route, and it
-   * belongs in one place: it used to be applied only to the true-headless
-   * extcopy path, so a VAAPI host that took the windowed GPU-native override
-   * reached the same conversion boundary the headless path was refusing, and
-   * segfaulted at stream start.
+   * Applies to the true-headless ext-image-copy-capture route only. The
+   * windowed override deliberately does not use it: that path contains failure
+   * adaptively instead, so a fixed conversion path stays reachable there.
    */
   bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type);
 
@@ -138,14 +136,12 @@ namespace cage_display_router {
    * @brief Returns whether a windowed GPU-native override should actually take
    *        the DMA-BUF capture path.
    *
-   * The override exists to keep GPU-native capture when true-headless cannot
-   * provide it, so it is worth nothing to an encoder whose GPU-native path is
-   * unsafe: the session gives up true headless and then crashes anyway.
+   * Containment here is adaptive rather than a blanket refusal by encoder type:
+   * a conversion that failed once in this process retires the path, and the
+   * surface-lifetime fix in vaapi.cpp is what makes it viable in the first
+   * place. Refusing VAAPI outright would keep that fix from ever running.
    */
-  bool should_attempt_gpu_native_cage_capture(
-    const platf::runtime_state_t &runtime_state,
-    platf::mem_type_e hwdevice_type
-  );
+  bool should_attempt_gpu_native_cage_capture(const platf::runtime_state_t &runtime_state);
 
   /**
    * @brief Returns whether a live frame conversion failure should disable the

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -153,6 +153,15 @@ namespace cage_display_router {
   );
 
   /**
+   * @brief Returns whether a live frame conversion failure should disable the
+   *        windowed GPU-native override and retry capture through SHM.
+   */
+  bool should_disable_windowed_gpu_native_after_conversion_failure(
+    const platf::runtime_state_t &runtime_state,
+    const platf::frame_metadata_t &source_metadata
+  );
+
+  /**
    * @brief Returns the cached result of the windowed GPU-native probe for the
    *        current Polaris process, if one exists.
    */

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -97,6 +97,10 @@ namespace stream_runtime {
       const platf::runtime_state_t &runtime_state,
       const platf::frame_metadata_t &source_metadata
     );
+    bool should_disable_windowed_gpu_native_after_conversion_failure(
+      const platf::runtime_state_t &runtime_state,
+      const platf::frame_metadata_t &source_metadata
+    );
     std::optional<bool> cached_windowed_gpu_native_probe_result();
     std::optional<bool> cached_headless_extcopy_dmabuf_probe_result();
     void update_windowed_gpu_native_probe_result(bool supported);

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -88,10 +88,7 @@ namespace stream_runtime {
       bool encoder_requires_gpu_native_capture
     );
     bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type);
-    bool should_attempt_gpu_native_cage_capture(
-      const platf::runtime_state_t &runtime_state,
-      platf::mem_type_e hwdevice_type
-    );
+    bool should_attempt_gpu_native_cage_capture(const platf::runtime_state_t &runtime_state);
     bool should_attempt_headless_extcopy_dmabuf(
       const platf::runtime_state_t &runtime_state,
       platf::mem_type_e hwdevice_type

--- a/src/platform/linux/stream_runtime_labwc.cpp
+++ b/src/platform/linux/stream_runtime_labwc.cpp
@@ -108,6 +108,16 @@ namespace stream_runtime {
       );
     }
 
+    bool should_disable_windowed_gpu_native_after_conversion_failure(
+      const platf::runtime_state_t &runtime_state,
+      const platf::frame_metadata_t &source_metadata
+    ) {
+      return cage_display_router::should_disable_windowed_gpu_native_after_conversion_failure(
+        runtime_state,
+        source_metadata
+      );
+    }
+
     std::optional<bool> cached_windowed_gpu_native_probe_result() {
       return cage_display_router::cached_windowed_gpu_native_probe_result();
     }

--- a/src/platform/linux/stream_runtime_labwc.cpp
+++ b/src/platform/linux/stream_runtime_labwc.cpp
@@ -87,11 +87,8 @@ namespace stream_runtime {
       return cage_display_router::gpu_native_dmabuf_is_safe(hwdevice_type);
     }
 
-    bool should_attempt_gpu_native_cage_capture(
-      const platf::runtime_state_t &runtime_state,
-      platf::mem_type_e hwdevice_type
-    ) {
-      return cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state, hwdevice_type);
+    bool should_attempt_gpu_native_cage_capture(const platf::runtime_state_t &runtime_state) {
+      return cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state);
     }
 
     bool should_attempt_headless_extcopy_dmabuf(

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -29,6 +29,7 @@ extern "C" {
 // local includes
 #include "graphics.h"
 #include "misc.h"
+#include "vaapi.h"
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
@@ -412,28 +413,71 @@ namespace va {
   public:
     int convert(platf::img_t &img) override {
       auto &descriptor = (egl::img_descriptor_t &) img;
-
-      if (descriptor.sequence == 0) {
-        // For dummy images, use a blank RGB texture instead of importing a DMA-BUF
-        rgb = egl::create_blank(img);
-      } else if (descriptor.sequence > sequence) {
-        sequence = descriptor.sequence;
-
-        rgb = egl::rgb_t {};
-
-        auto rgb_opt = egl::import_source(display.get(), descriptor.sd);
-
-        if (!rgb_opt) {
-          return -1;
-        }
-
-        rgb = std::move(*rgb_opt);
+      std::array<bool, dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+      for (std::size_t slot = 0; slot < rgb_cache.size(); ++slot) {
+        valid_slots[slot] = rgb_cache[slot]->tex.size() > 0 &&
+                            rgb_cache[slot]->tex[0] != 0 &&
+                            rgb_cache[slot].el.xrgb8 != EGL_NO_IMAGE;
       }
 
-      sws.load_vram(descriptor, offset_x, offset_y, rgb->tex[0]);
+      auto decision = cache_policy.plan(
+        descriptor.sequence,
+        descriptor.dmabuf_buffer_key,
+        valid_slots
+      );
+      egl::rgb_t *active_rgb = nullptr;
 
-      sws.convert(nv12->buf);
-      return 0;
+      switch (decision.action) {
+        case dmabuf_surface_action_e::blank:
+          if (blank_rgb->tex.size() == 0 || blank_rgb->tex[0] == 0) {
+            blank_rgb = egl::create_blank(img);
+          }
+          cache_policy.commit_blank();
+          active_rgb = &blank_rgb;
+          break;
+
+        case dmabuf_surface_action_e::reuse:
+          active_rgb = &rgb_cache[*decision.slot];
+          cache_policy.commit_live(
+            descriptor.sequence,
+            descriptor.dmabuf_buffer_key,
+            *decision.slot
+          );
+          descriptor.reset();
+          break;
+
+        case dmabuf_surface_action_e::import: {
+          auto rgb_opt = egl::import_source(display.get(), descriptor.sd);
+          if (!rgb_opt) {
+            return -1;
+          }
+
+          auto &slot = rgb_cache[*decision.slot];
+          slot = std::move(*rgb_opt);
+          active_rgb = &slot;
+          cache_policy.commit_live(
+            descriptor.sequence,
+            descriptor.dmabuf_buffer_key,
+            *decision.slot
+          );
+          descriptor.reset();
+          break;
+        }
+
+        case dmabuf_surface_action_e::unavailable:
+          BOOST_LOG(error)
+            << "VAAPI DMA-BUF conversion has no valid active RGB surface for frame sequence "sv
+            << descriptor.sequence;
+          return -1;
+      }
+
+      if (!active_rgb || (*active_rgb)->tex.size() == 0 || (*active_rgb)->tex[0] == 0) {
+        BOOST_LOG(error) << "VAAPI DMA-BUF conversion selected an invalid RGB texture"sv;
+        return -1;
+      }
+
+      sws.load_vram(descriptor, offset_x, offset_y, (*active_rgb)->tex[0]);
+      return sws.convert(nv12->buf);
     }
 
     int init(int in_width, int in_height, file_t &&render_device, int offset_x, int offset_y) {
@@ -441,16 +485,15 @@ namespace va {
         return -1;
       }
 
-      sequence = 0;
-
       this->offset_x = offset_x;
       this->offset_y = offset_y;
 
       return 0;
     }
 
-    std::uint64_t sequence;
-    egl::rgb_t rgb;
+    dmabuf_surface_cache_policy_t cache_policy;
+    egl::rgb_t blank_rgb;
+    std::array<egl::rgb_t, dmabuf_surface_cache_policy_t::capacity> rgb_cache;
 
     int offset_x, offset_y;
   };

--- a/src/platform/linux/vaapi.h
+++ b/src/platform/linux/vaapi.h
@@ -4,6 +4,12 @@
  */
 #pragma once
 
+// standard includes
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
 // local includes
 #include "misc.h"
 #include "src/platform/common.h"
@@ -13,6 +19,76 @@ namespace egl {
 }
 
 namespace va {
+  enum class dmabuf_surface_action_e {
+    blank,
+    reuse,
+    import,
+    unavailable,
+  };
+
+  struct dmabuf_surface_decision_t {
+    dmabuf_surface_action_e action;
+    std::optional<std::size_t> slot;
+  };
+
+  /**
+   * @brief Tracks which imported DMA-BUF surface may be reused without
+   *        destroying the surface currently referenced by the GL pipeline.
+   *
+   * Planning is side-effect free so a failed EGL import leaves the previous
+   * active surface and next import slot unchanged.
+   */
+  class dmabuf_surface_cache_policy_t {
+  public:
+    static constexpr std::size_t capacity = 2;
+
+    dmabuf_surface_decision_t plan(
+      std::uint64_t frame_sequence,
+      std::uint64_t buffer_key,
+      const std::array<bool, capacity> &valid_slots
+    ) const {
+      if (frame_sequence == 0) {
+        return {dmabuf_surface_action_e::blank, std::nullopt};
+      }
+
+      if (frame_sequence <= sequence_) {
+        if (active_slot_ && valid_slots[*active_slot_]) {
+          return {dmabuf_surface_action_e::reuse, active_slot_};
+        }
+        return {dmabuf_surface_action_e::unavailable, std::nullopt};
+      }
+
+      if (buffer_key != 0) {
+        for (std::size_t slot = 0; slot < capacity; ++slot) {
+          if (valid_slots[slot] && buffer_keys_[slot] == buffer_key) {
+            return {dmabuf_surface_action_e::reuse, slot};
+          }
+        }
+      }
+
+      return {dmabuf_surface_action_e::import, next_import_slot_};
+    }
+
+    void commit_blank() {
+      active_slot_.reset();
+    }
+
+    void commit_live(std::uint64_t frame_sequence, std::uint64_t buffer_key, std::size_t slot) {
+      sequence_ = frame_sequence;
+      buffer_keys_[slot] = buffer_key;
+      active_slot_ = slot;
+      if (next_import_slot_ == slot) {
+        next_import_slot_ = (next_import_slot_ + 1) % capacity;
+      }
+    }
+
+  private:
+    std::uint64_t sequence_ {0};
+    std::array<std::uint64_t, capacity> buffer_keys_ {};
+    std::optional<std::size_t> active_slot_;
+    std::size_t next_import_slot_ {0};
+  };
+
   /**
    * Width --> Width of the image
    * Height --> Height of the image

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -685,7 +685,7 @@ namespace platf {
         config::video.linux_display.use_cage_compositor &&
         stream_runtime::labwc::is_running()) {
       auto runtime_state = stream_runtime::labwc::runtime_state();
-      if (stream_runtime::labwc::should_attempt_gpu_native_cage_capture(runtime_state, hwdevice_type)) {
+      if (stream_runtime::labwc::should_attempt_gpu_native_cage_capture(runtime_state)) {
         static bool logged_windowed_gpu_native_attempt = false;
         if (!logged_windowed_gpu_native_attempt) {
           BOOST_LOG(info)
@@ -693,19 +693,6 @@ namespace platf {
           logged_windowed_gpu_native_attempt = true;
         }
         prefer_linear_dmabuf = true;
-      } else if (runtime_state.gpu_native_override_active) {
-        // The override is active but this encoder's GPU-native path is not one
-        // Polaris will import from. Falling back to RAM capture here is the
-        // difference between a slower stream and a SIGSEGV at stream start.
-        prefer_ram_capture = true;
-        stream_stats::update_gpu_native_probe_attempt("windowed", "ineligible", "policy", "vaapi_gpu_native_dmabuf_disabled_for_stability");
-        stream_stats::update_gpu_native_probe_selection("windowed_shm", "windowed_shm");
-        static bool logged_windowed_gpu_native_refusal = false;
-        if (!logged_windowed_gpu_native_refusal) {
-          BOOST_LOG(warning)
-            << "wlr: Using RAM capture path for the windowed labwc override because GPU-native DMA-BUF is disabled for VAAPI stability"sv;
-          logged_windowed_gpu_native_refusal = true;
-        }
       } else if (stream_runtime::labwc::should_report_headless_ram_capture_fallback(runtime_state)) {
         prefer_ram_capture = true;
         using_headless_ram_capture = true;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6209,26 +6209,6 @@ namespace proc {
     };
 
     auto resolve_windowed_gpu_native_fallback = [&]() -> bool {
-      // The override trades true headless away to keep GPU-native capture, so
-      // it is worth nothing to an encoder Polaris will not import GPU frames
-      // from: the session would give up headless and then fall back to RAM
-      // anyway. Probing it is worse than pointless — the probe drives the same
-      // conversion path that crashes these stacks, in this process.
-      //
-      // An unresolved encoder reports `unknown` rather than a safe answer, and
-      // refusing on that would take the override away from stacks that are
-      // fine, so only a known-unsafe type is refused here. The capture-time
-      // gate covers the rest, by which point the encoder is always chosen.
-      const auto encoder_mem_type = video::active_encoder_mem_type();
-      if (encoder_mem_type != platf::mem_type_e::unknown &&
-          !stream_runtime::labwc::gpu_native_dmabuf_is_safe(encoder_mem_type)) {
-        stream_stats::update_gpu_native_probe_attempt("windowed", "ineligible", "policy", "vaapi_gpu_native_dmabuf_disabled_for_stability");
-        BOOST_LOG(info) << "session_manager: Skipping the windowed GPU-native fallback for encoder ["
-                        << (video::active_encoder_name().empty() ? "unknown" : video::active_encoder_name())
-                        << "] because its GPU-native DMA-BUF path is disabled for stability; staying headless"sv;
-        return false;
-      }
-
       if (cached_windowed_gpu_native_probe_result == std::optional<bool> {true}) {
         stream_stats::update_gpu_native_probe_attempt("windowed", "succeeded", {}, {}, true);
         BOOST_LOG(info) << "session_manager: Reusing cached windowed_dmabuf_override probe result"sv;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -459,13 +459,34 @@ namespace video {
       }
     }
 
-    bool handle_headless_extcopy_conversion_failure(const frame_t &frame) {
+    /**
+     * @brief Retire whichever GPU-native route produced a failed live conversion.
+     *
+     * Covers both the windowed override and the headless ext-image-copy
+     * transport, so the name is deliberately broader than either one.
+     */
+    bool handle_linux_gpu_native_conversion_failure(const frame_t &frame) {
       if (!::config::video.linux_display.use_cage_compositor) {
         return false;
       }
       const auto labwc = snapshot_labwc();
       if (!labwc.running) {
         return false;
+      }
+
+      // The windowed override is checked first: it is the path that lets an
+      // encoder attempt GPU-native conversion at all, so a live failure there
+      // has to retire it before the headless transport is considered.
+      if (stream_runtime::labwc::should_disable_windowed_gpu_native_after_conversion_failure(
+            labwc.state,
+            frame.source_metadata
+          )) {
+        stream_runtime::labwc::update_windowed_gpu_native_probe_result(false);
+        stream_stats::update_gpu_native_probe_attempt("windowed", "failed", "frame_conversion", "live_gpu_frame_conversion_failed");
+        stream_stats::update_gpu_native_probe_selection("windowed_shm", "windowed_shm");
+        BOOST_LOG(warning)
+          << "Windowed GPU-native DMA-BUF frame conversion failed; disabling the GPU-native override and reinitializing with SHM/system-memory fallback"sv;
+        return true;
       }
 
       if (!stream_runtime::labwc::should_disable_headless_extcopy_after_conversion_failure(
@@ -3196,7 +3217,7 @@ namespace video {
           if (session->convert(frame)) {
             BOOST_LOG(error) << "Could not convert image"sv;
 #ifdef __linux__
-            if (handle_headless_extcopy_conversion_failure(frame)) {
+            if (handle_linux_gpu_native_conversion_failure(frame)) {
               reinit_request_event.raise(true);
             }
 #endif
@@ -3613,7 +3634,7 @@ namespace video {
           if (frame_captured && frame.valid() && pos->session->convert(frame)) {
             BOOST_LOG(error) << "Could not convert image"sv;
 #ifdef __linux__
-            if (handle_headless_extcopy_conversion_failure(frame)) {
+            if (handle_linux_gpu_native_conversion_failure(frame)) {
               ec = platf::capture_e::reinit;
               return false;
             }

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -175,6 +175,59 @@ TEST(CageDisplayRouterPolicyTests, NonHeadlessDmabufConversionFailureDoesNotDisa
   ));
 }
 
+TEST(CageDisplayRouterPolicyTests, WindowedDmabufGpuConversionFailureDisablesGpuNativeOverride) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+  const platf::frame_metadata_t metadata {
+    .transport = platf::frame_transport_e::dmabuf,
+    .residency = platf::frame_residency_e::gpu,
+    .format = platf::frame_format_e::bgra8,
+  };
+
+  EXPECT_TRUE(cage_display_router::should_disable_windowed_gpu_native_after_conversion_failure(
+    runtime_state,
+    metadata
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, CpuFrameDoesNotDisableWindowedGpuNativeOverride) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+  const platf::frame_metadata_t metadata {
+    .transport = platf::frame_transport_e::shm,
+    .residency = platf::frame_residency_e::cpu,
+    .format = platf::frame_format_e::bgra8,
+  };
+
+  EXPECT_FALSE(cage_display_router::should_disable_windowed_gpu_native_after_conversion_failure(
+    runtime_state,
+    metadata
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, CachedWindowedProbeFailureSuppressesGpuNativeCapture) {
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+
+  EXPECT_TRUE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state));
+  cage_display_router::update_windowed_gpu_native_probe_result(false);
+  EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state));
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+}
+
 TEST(CageDisplayRouterPolicyTests, CpuFrameConversionFailureDoesNotDisableExtcopyFallback) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -95,38 +95,7 @@ TEST(CageDisplayRouterPolicyTests, WindowedOverrideDoesNotAttemptHeadlessExtcopy
   ));
 }
 
-TEST(CageDisplayRouterPolicyTests, WindowedOverrideRefusesGpuNativeCaptureForVaapi) {
-  // The crash in #212 and #279: the override put VAAPI on the DMA-BUF path the
-  // headless branch was already refusing for the same encoder, and the
-  // conversion segfaulted at stream start.
-  const platf::runtime_state_t runtime_state {
-    .requested_headless = true,
-    .effective_headless = false,
-    .gpu_native_override_active = true,
-    .backend_name = "labwc",
-  };
-
-  EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(
-    runtime_state,
-    platf::mem_type_e::vaapi
-  ));
-}
-
-TEST(CageDisplayRouterPolicyTests, WindowedOverrideAttemptsGpuNativeCaptureForCuda) {
-  const platf::runtime_state_t runtime_state {
-    .requested_headless = true,
-    .effective_headless = false,
-    .gpu_native_override_active = true,
-    .backend_name = "labwc",
-  };
-
-  EXPECT_TRUE(cage_display_router::should_attempt_gpu_native_cage_capture(
-    runtime_state,
-    platf::mem_type_e::cuda
-  ));
-}
-
-TEST(CageDisplayRouterPolicyTests, GpuNativeCaptureNeedsTheOverrideRegardlessOfEncoder) {
+TEST(CageDisplayRouterPolicyTests, GpuNativeCaptureNeedsTheOverride) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,
     .effective_headless = true,
@@ -134,40 +103,30 @@ TEST(CageDisplayRouterPolicyTests, GpuNativeCaptureNeedsTheOverrideRegardlessOfE
     .backend_name = "labwc",
   };
 
-  EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(
-    runtime_state,
-    platf::mem_type_e::cuda
-  ));
+  EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state));
 }
 
-TEST(CageDisplayRouterPolicyTests, BothGpuNativeRoutesShareOneStabilityPolicy) {
-  // Keeping the two routes' policies independent is what let a VAAPI host
-  // crash through one while the other was refusing the same buffers, so this
-  // pins them to the same answer rather than to a literal.
-  for (const auto hwdevice_type : {
-         platf::mem_type_e::cuda,
-         platf::mem_type_e::vaapi,
-         platf::mem_type_e::system,
-         platf::mem_type_e::unknown,
-       }) {
-    const platf::runtime_state_t headless {
-      .requested_headless = true,
-      .effective_headless = true,
-      .gpu_native_override_active = false,
-      .backend_name = "labwc",
-    };
-    const platf::runtime_state_t overridden {
-      .requested_headless = true,
-      .effective_headless = false,
-      .gpu_native_override_active = true,
-      .backend_name = "labwc",
-    };
+TEST(CageDisplayRouterPolicyTests, TheTwoGpuNativeRoutesContainFailureDifferently) {
+  // Deliberately asymmetric, and the asymmetry is the point. The headless
+  // ext-image-copy route refuses VAAPI by encoder type up front; the windowed
+  // override lets it run and retires the path only after a real conversion
+  // failure, because the surface-lifetime fix is what makes it viable and a
+  // blanket refusal would keep that fix from ever executing.
+  const platf::runtime_state_t headless {
+    .requested_headless = true,
+    .effective_headless = true,
+    .gpu_native_override_active = false,
+    .backend_name = "labwc",
+  };
+  const platf::runtime_state_t overridden {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
 
-    EXPECT_EQ(
-      cage_display_router::should_attempt_headless_extcopy_dmabuf(headless, hwdevice_type),
-      cage_display_router::should_attempt_gpu_native_cage_capture(overridden, hwdevice_type)
-    ) << "hwdevice_type=" << static_cast<int>(hwdevice_type);
-  }
+  EXPECT_FALSE(cage_display_router::should_attempt_headless_extcopy_dmabuf(headless, platf::mem_type_e::vaapi));
+  EXPECT_TRUE(cage_display_router::should_attempt_gpu_native_cage_capture(overridden));
 }
 
 TEST(CageDisplayRouterPolicyTests, OnlyCudaHasASafeGpuNativeDmabufPath) {

--- a/tests/unit/platform/test_graphics.cpp
+++ b/tests/unit/platform/test_graphics.cpp
@@ -7,6 +7,12 @@
 #ifdef __linux__
   #include <glad/gl.h>
   #include <src/platform/linux/graphics.h>
+  #include <src/platform/linux/vaapi.h>
+
+  #include <filesystem>
+  #include <fstream>
+  #include <sstream>
+  #include <string>
 
 namespace {
   GLenum fake_gl_error_once() {
@@ -16,6 +22,26 @@ namespace {
 
   GLenum fake_gl_no_error() {
     return GL_NO_ERROR;
+  }
+
+  std::string read_source_for_contract(const char *relative_path) {
+    const auto path = std::filesystem::path(POLARIS_SOURCE_DIR) / relative_path;
+    std::ifstream in(path);
+    if (!in) {
+      return {};
+    }
+
+    std::ostringstream out;
+    out << in.rdbuf();
+    return out.str();
+  }
+
+  std::size_t count_occurrences(const std::string &haystack, const std::string &needle) {
+    std::size_t count = 0;
+    for (std::size_t offset = 0; (offset = haystack.find(needle, offset)) != std::string::npos; offset += needle.size()) {
+      ++count;
+    }
+    return count;
   }
 }  // namespace
 
@@ -29,6 +55,130 @@ TEST(GraphicsTests, DrainErrorsReportsWhetherAnyErrorWasDrained) {
   EXPECT_TRUE(gl::drain_errors("test"));
 
   gl::ctx.GetError = original_get_error;
+}
+
+TEST(VaapiSourceContractTests, ConverterRetainsSurfacesAndPropagatesConversionFailure) {
+  const auto source = read_source_for_contract("src/platform/linux/vaapi.cpp");
+  ASSERT_FALSE(source.empty());
+
+  EXPECT_NE(source.find("egl::rgb_t blank_rgb;"), std::string::npos);
+  EXPECT_NE(
+    source.find("std::array<egl::rgb_t, dmabuf_surface_cache_policy_t::capacity> rgb_cache;"),
+    std::string::npos
+  );
+  EXPECT_EQ(count_occurrences(source, "cache_policy.plan("), 1u);
+  EXPECT_EQ(count_occurrences(source, "cache_policy.commit_live("), 2u);
+  EXPECT_EQ(count_occurrences(source, "descriptor.reset();"), 2u);
+  EXPECT_NE(source.find("slot = std::move(*rgb_opt);"), std::string::npos);
+  EXPECT_NE(source.find("return sws.convert(nv12->buf);"), std::string::npos);
+}
+
+TEST(VaapiSourceContractTests, ConversionFailuresRemainWiredToLinuxFallbackHandler) {
+  const auto source = read_source_for_contract("src/video.cpp");
+  ASSERT_FALSE(source.empty());
+
+  EXPECT_EQ(count_occurrences(source, "handle_linux_gpu_native_conversion_failure("), 3u);
+
+  EXPECT_NE(source.find("update_windowed_gpu_native_probe_result(false);"), std::string::npos);
+  EXPECT_NE(
+    source.find("if (handle_linux_gpu_native_conversion_failure(frame)) {\n              reinit_request_event.raise(true);"),
+    std::string::npos
+  );
+  EXPECT_NE(
+    source.find("if (handle_linux_gpu_native_conversion_failure(frame)) {\n              ec = platf::capture_e::reinit;"),
+    std::string::npos
+  );
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, PreservesBlankSurfaceAcrossDummyFrames) {
+  va::dmabuf_surface_cache_policy_t policy;
+  const std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto first = policy.plan(0, 0, valid_slots);
+  EXPECT_EQ(first.action, va::dmabuf_surface_action_e::blank);
+  policy.commit_blank();
+
+  auto repeated = policy.plan(0, 0, valid_slots);
+  EXPECT_EQ(repeated.action, va::dmabuf_surface_action_e::blank);
+  EXPECT_FALSE(repeated.slot.has_value());
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, ReusesImportedSurfaceByBufferKey) {
+  va::dmabuf_surface_cache_policy_t policy;
+  std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto first = policy.plan(1, 41, valid_slots);
+  ASSERT_EQ(first.action, va::dmabuf_surface_action_e::import);
+  ASSERT_EQ(first.slot, 0);
+  policy.commit_live(1, 41, *first.slot);
+  valid_slots[0] = true;
+
+  auto reused = policy.plan(2, 41, valid_slots);
+  EXPECT_EQ(reused.action, va::dmabuf_surface_action_e::reuse);
+  EXPECT_EQ(reused.slot, 0);
+  policy.commit_live(2, 41, *reused.slot);
+
+  auto repeated = policy.plan(2, 41, valid_slots);
+  EXPECT_EQ(repeated.action, va::dmabuf_surface_action_e::reuse);
+  EXPECT_EQ(repeated.slot, 0);
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, RotatesImportsWithoutDestroyingActiveSurfaceImmediately) {
+  va::dmabuf_surface_cache_policy_t policy;
+  std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto first = policy.plan(1, 10, valid_slots);
+  ASSERT_EQ(first.slot, 0);
+  policy.commit_live(1, 10, *first.slot);
+  valid_slots[0] = true;
+
+  auto second = policy.plan(2, 20, valid_slots);
+  ASSERT_EQ(second.action, va::dmabuf_surface_action_e::import);
+  ASSERT_EQ(second.slot, 1);
+  policy.commit_live(2, 20, *second.slot);
+  valid_slots[1] = true;
+
+  auto third = policy.plan(3, 30, valid_slots);
+  EXPECT_EQ(third.action, va::dmabuf_surface_action_e::import);
+  EXPECT_EQ(third.slot, 0);
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, ZeroBufferKeyNeverAliasesANewerFrame) {
+  va::dmabuf_surface_cache_policy_t policy;
+  std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto first = policy.plan(1, 0, valid_slots);
+  ASSERT_EQ(first.action, va::dmabuf_surface_action_e::import);
+  policy.commit_live(1, 0, *first.slot);
+  valid_slots[*first.slot] = true;
+
+  auto second = policy.plan(2, 0, valid_slots);
+  EXPECT_EQ(second.action, va::dmabuf_surface_action_e::import);
+  EXPECT_EQ(second.slot, 1);
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, FailedImportDoesNotMutateSelectionState) {
+  va::dmabuf_surface_cache_policy_t policy;
+  const std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  const auto first = policy.plan(1, 55, valid_slots);
+  const auto retry = policy.plan(1, 55, valid_slots);
+
+  EXPECT_EQ(first.action, va::dmabuf_surface_action_e::import);
+  EXPECT_EQ(retry.action, va::dmabuf_surface_action_e::import);
+  EXPECT_EQ(first.slot, retry.slot);
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, MissingActiveSurfaceFailsClosed) {
+  va::dmabuf_surface_cache_policy_t policy;
+  std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto imported = policy.plan(1, 77, valid_slots);
+  policy.commit_live(1, 77, *imported.slot);
+
+  auto repeated = policy.plan(1, 77, valid_slots);
+  EXPECT_EQ(repeated.action, va::dmabuf_surface_action_e::unavailable);
+  EXPECT_FALSE(repeated.slot.has_value());
 }
 #else
 TEST(GraphicsTests, LinuxOnly) {


### PR DESCRIPTION
## Summary

- retain the synthetic blank EGL surface across VAAPI conversion instead of destroying it before `gl::sws_t` consumes the texture
- retain/reuse nested-Wayland DMA-BUF EGL imports in a two-slot buffer-keyed cache so a newly captured frame cannot immediately destroy the active imported surface
- close duplicated DMA-BUF file descriptors after successful import/reuse ownership transfer
- fail closed on invalid surface/texture selection and propagate GL conversion failures
- cache a failed windowed GPU-native conversion probe and reinitialize capture through SHM/system-memory fallback
- add policy, fallback, global-state-cleanup, and production source-contract tests

Refs #212 and Discussion #167.

## Defect boundary

The existing VAAPI GPU-native converter created both the dummy blank RGB surface and live DMA-BUF-imported RGB surface as local temporaries inside `convert()`. Their destructors could destroy the EGLImage/texture before `gl::sws_t::convert()` consumed the selected texture, matching the reported startup-time DMA-BUF → VAAPI crash boundary. The converter also returned success even when `gl::sws_t::convert()` reported failure.

This change fixes that concrete lifetime/error-propagation defect without claiming maintainer-side RDNA4 hardware reproduction. Any remaining import/conversion failure is contained as a normal error and forces the windowed GPU-native probe off for the reinitialized capture path.

## Historical verification on pre-refresh candidate bytes

- candidate commit: `b861077b1f1588eb86bcfb387e3da7d9044f7447`
- independently reviewed patch SHA-256: `3c5523a555bae1d6a88ebb7f5e3df8825f0180c894c3aabc3ddd31e4de1cce1d`
- CUDA-enabled binary SHA-256: `66cd8e28ca9df6cf88d2d8d33a6f1197be20068a86291b84240df18c53464bb4`
- CPU/VAAPI binary SHA-256: `0697fb9613e5a3cababf91bd626a50b0ee1efb6dee0cb5c9ed9b1da205bdfd0e`
- CPU/VAAPI complete build: pass
- CPU/VAAPI CTest: **12/12**
- CUDA 13.2 + g++-15 complete production build: pass
- CUDA CTest: **12/12**
- focused lifecycle/fallback/source-contract tests: pass
- compiling mutants rejected: **8/8**
  - zero-key alias
  - disabled ring rotation
  - invalid active-slot reuse
  - ignored cached probe failure
  - inverted windowed failure policy
  - fresh cache policy per frame
  - disabled reinit callsite
  - swallowed GL conversion error
- added-line security scan: no findings
- changed-file compiler warnings: 0

Local ASan/UBSan execution is unavailable because this Fedora host is missing both GCC and Clang sanitizer runtime libraries. CI sanitizer jobs remain a required gate; no system packages were installed or changed for this branch.

## Rebase onto current master — 2026-08-06

This branch was `CONFLICTING/DIRTY` against master. Polaris #289 landed a blanket refusal
of the windowed GPU-native override for every encoder except CUDA, which collided with this
PR both textually and in design: refusing VAAPI up front means the corrected conversion path
in `vaapi.cpp` never executes, so the defect this PR fixes would stay masked rather than
fixed. That containment is reverted in the first commit here so the reasoning is reviewable
separately from the fix.

- `c7952ff` — `revert(linux): drop the VAAPI GPU-native refusal so the lifetime fix can run`
- `e6d1f80` — this PR's original commit, rebased, authorship preserved

The two GPU-native routes are now deliberately asymmetric, and a test asserts that with the
reasoning inline. The headless ext-image-copy route still refuses VAAPI by encoder type
because nothing here touches that transport. The windowed override lets the encoder run and
retires the path only after a real conversion failure — containment that adapts rather than
containment that forecloses.

`video.cpp` needed genuine merging rather than conflict-picking: master had renamed the
handler and routed it through `snapshot_labwc()` / `stream_runtime::labwc::`, while this PR
called `cage_display_router::` directly. Master's structure was kept and this PR's
windowed-failure branch grafted in ahead of the headless check, since the windowed override
has to be retired first — it is what permits the attempt at all. That required a
`should_disable_windowed_gpu_native_after_conversion_failure` delegate on `stream_runtime`,
and the handler took this PR's broader name because it now retires both routes.

### Verification of the rebased head

Built and run on pc-papi (Fedora, RTX 4090) at `e6d1f80`:

- full `ninja`, exit 0, no failed targets and no new warnings
- `ctest` — **17/17** targets pass
- `CageDisplayRouterPolicyTests` — **32/32**, including this PR's windowed-failure tests
- mutation probe: forcing `should_disable_windowed_gpu_native_after_conversion_failure` to
  return false fails exactly `WindowedDmabufGpuConversionFailureDisablesGpuNativeOverride`
  and nothing else; restoring returns 32/32. The containment is reachable through the merged
  `video.cpp`, not merely compiling.

The SHAs, artifact hashes and CI links recorded further down predate this rebase and refer to
commits that no longer exist on the branch. They are kept as the historical review record for
the fix itself, which is unchanged in intent; they are **not** a statement about the current
head.

## Current-master refresh — exact combined head

- current `master`: `462b6fe5768eb1f933ad695a602ec34f4023070d`
- exact candidate commit: `523a3b2edd7631a68060bac6965b5d508e475819`
- PR delta SHA-256: `3c5523a555bae1d6a88ebb7f5e3df8825f0180c894c3aabc3ddd31e4de1cce1d` (**identical to the independently reviewed patch bytes**)
- touched-file overlap across the base update: none
- CPU/VAAPI complete build + serial CTest: pass, **12/12**
- CUDA 13.2 complete production build + serial CTest: pass, **12/12**
- focused lifecycle/fallback/source-contract tests: **44/44** on CPU/VAAPI and **44/44** on CUDA
- compiling mutants rejected on the combined head: **8/8**; restored baseline passed
- `git diff --check` and added-line security scan: clean
- changed-file compiler warnings: 0
- PR merge-ref CI: https://github.com/papi-ux/polaris/actions/runs/29427835991 (tree `d66b9a442ec9526906a2112e7be9320cca485446`, identical to the branch-head tree; **success**)
- true exact-commit branch CI: https://github.com/papi-ux/polaris/actions/runs/29428567601 (**success**, exact artifact commit verified)
- RDNA4 field matrix: pending

The first all-core CUDA rebuild was interrupted by an abrupt pc-papi reboot with no compiler diagnostic, OOM, or kernel panic recorded. Worktree/repository integrity remained clean; a bounded four-job rebuild completed successfully with persistent logs. This is recorded as host-infrastructure noise, not counted as a code pass or failure.

## Field-test gate — do not merge yet

This PR must remain draft until an RDNA4/VAAPI tester validates the exact PR commit with:

1. `linux_prefer_gpu_native_capture = enabled`: at least **5 launches**
2. `linux_prefer_gpu_native_capture = disabled`: at least **5 launches**
3. exact Polaris commit/version captured in every evidence bundle
4. whether each launch reached first frame
5. requested versus effective capture path and FPS
6. one privacy-safe journal excerpt per mode
7. `coredumpctl` result showing **zero new Polaris coredumps**
8. confirmation that a normal GPU-native conversion failure falls back/reinitializes without crashing

Do not include credentials, tokens, certificates, or private host identifiers in field evidence.

## Release status

- no tag or release is created by this PR
- not approved for merge until exact-commit CI, independent review, and RDNA4 field evidence are green

## Release gate — authoritative status

**Still gated on RDNA4/RDNA3 field evidence. Do not merge on the strength of the rebase.**

The v1.3.2 exclusion below is historical; that release has shipped. The gate itself is
unchanged and unmet: no AMD hardware exists on the maintainer side, so neither the original
crash nor its absence has been reproduced here.

Scope note added 2026-08-06: #279 reproduced this on **RDNA3** (navi31, Mesa 26.1.5), so the
field matrix should not be treated as RDNA4-only.

The strict gate record is [issue #212 comment 4999635102](https://github.com/papi-ux/polaris/issues/212#issuecomment-4999635102). Against current PR head `aa7973b8c2dfaf3369d8e652d3647ec9a1ec047e`:

- RDNA4 GPU-native evidence: **FAIL, 0/5 countable**
- RDNA4 conservative evidence: **FAIL, 0/5 countable**
- zero new coredumps: **unknown / not proven**
- truthful requested/effective paths: **unknown / not proven**
- healthy teardown: **unknown / not proven**
- fresh combined-head CI: **PASS** — [Build Polaris](https://github.com/papi-ux/polaris/actions/runs/29524728133/attempts/2), [CodeQL](https://github.com/papi-ux/polaris/actions/runs/29524727995/attempts/2), [Public Hygiene](https://github.com/papi-ux/polaris/actions/runs/29524728159/attempts/2)

This is all-or-nothing. Passing CI does not override failed or unknown field gates. The older `523a3b2` candidate named above is stale for field-evidence purposes; reconsideration requires all conditions to pass against the then-current exact PR head.

