### PR TITLE
fix(webui): recover safely from transient host outages

### DIFF
--- a/src_assets/common/assets/web/App.vue
+++ b/src_assets/common/assets/web/App.vue
@@ -180,6 +180,8 @@ import Toast from './components/Toast.vue'
 import SpaceParticles from './components/SpaceParticles.vue'
 import { cycleTheme, getNextTheme, getTheme, getThemeMeta, initTheme } from './theme.js'
 import { getCachedConfig } from './config-cache.js'
+import { webUiAuthenticated } from './auth-state.js'
+import { isPublicRoute } from './router-helpers.js'
 import { createNavSections, flattenNavItems, getNavItemByPath } from './nav-metadata.js'
 import { buildUpdateCenterState } from './update-center.js'
 
@@ -257,10 +259,8 @@ const sidebarUpdateStatusLightClass = computed(() => {
       return 'bg-green-400 shadow-[0_0_14px_rgba(74,222,128,0.55)]'
   }
 })
-const authRoutes = new Set(['/login', '/welcome', '/recover'])
-
 const showNav = computed(() => {
-  return !authRoutes.has(route.path)
+  return webUiAuthenticated.value && !isPublicRoute(route.path)
 })
 
 async function loadAppVersion() {
@@ -364,8 +364,8 @@ watch(() => route.path, () => { sidebarOpen.value = false })
 onMounted(() => {
   initTheme()
   window.addEventListener('keydown', handleKeydown)
-  void loadAppVersion()
   if (showNav.value) {
+    void loadAppVersion()
     void refreshSidebarUpdateStatus()
   }
 })

--- a/src_assets/common/assets/web/auth-probe-coordinator.js
+++ b/src_assets/common/assets/web/auth-probe-coordinator.js
@@ -1,0 +1,49 @@
+let currentGeneration = 0
+let activeController = null
+
+export function beginWebUiAuthProbeGeneration() {
+  currentGeneration += 1
+  activeController?.abort()
+  activeController = null
+  return currentGeneration
+}
+
+export function isCurrentWebUiAuthProbeGeneration(generation) {
+  return generation === currentGeneration
+}
+
+export async function runWebUiAuthProbeForGeneration(generation, probe) {
+  if (generation !== currentGeneration) {
+    return { current: false }
+  }
+
+  activeController?.abort()
+  const controller = new AbortController()
+  activeController = controller
+
+  try {
+    const result = await probe(controller.signal)
+    if (
+      generation !== currentGeneration
+      || activeController !== controller
+      || controller.signal.aborted
+    ) {
+      return { current: false }
+    }
+
+    return { current: true, result }
+  } catch (error) {
+    if (
+      generation !== currentGeneration
+      || activeController !== controller
+      || controller.signal.aborted
+    ) {
+      return { current: false }
+    }
+    throw error
+  } finally {
+    if (activeController === controller) {
+      activeController = null
+    }
+  }
+}

--- a/src_assets/common/assets/web/auth-state.js
+++ b/src_assets/common/assets/web/auth-state.js
@@ -1,0 +1,34 @@
+import { readonly, ref } from 'vue'
+import { clearCachedConfig, primeCachedConfig } from './config-cache.js'
+
+const authenticated = ref(false)
+
+export const webUiAuthenticated = readonly(authenticated)
+
+function publishAuthenticationState(value) {
+  if (typeof window !== 'undefined') {
+    window.__POLARIS_AUTHENTICATED__ = value
+  }
+}
+
+export function initializeWebUiAuthState() {
+  authenticated.value = false
+  publishAuthenticationState(false)
+  clearCachedConfig()
+}
+
+export function isWebUiAuthenticated() {
+  return authenticated.value
+}
+
+export function markWebUiAuthenticated(config) {
+  primeCachedConfig(config)
+  authenticated.value = true
+  publishAuthenticationState(true)
+}
+
+export function markWebUiUnauthenticated() {
+  authenticated.value = false
+  publishAuthenticationState(false)
+  clearCachedConfig()
+}

--- a/src_assets/common/assets/web/auth-state.test.js
+++ b/src_assets/common/assets/web/auth-state.test.js
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const cache = vi.hoisted(() => ({
+  clearCachedConfig: vi.fn(),
+  primeCachedConfig: vi.fn(),
+}))
+
+vi.mock('./config-cache.js', () => cache)
+
+import {
+  initializeWebUiAuthState,
+  isWebUiAuthenticated,
+  markWebUiAuthenticated,
+  markWebUiUnauthenticated,
+  webUiAuthenticated,
+} from './auth-state.js'
+
+describe('web UI auth state', () => {
+  beforeEach(() => {
+    cache.clearCachedConfig.mockReset()
+    cache.primeCachedConfig.mockReset()
+    initializeWebUiAuthState()
+  })
+
+  it('initializes fail-closed and clears any cached config', () => {
+    expect(isWebUiAuthenticated()).toBe(false)
+    expect(webUiAuthenticated.value).toBe(false)
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
+    expect(cache.clearCachedConfig).toHaveBeenCalledOnce()
+  })
+
+  it('primes config before publishing authenticated state', () => {
+    const config = { status: true, platform: 'linux' }
+
+    markWebUiAuthenticated(config)
+
+    expect(cache.primeCachedConfig).toHaveBeenCalledWith(config)
+    expect(isWebUiAuthenticated()).toBe(true)
+    expect(webUiAuthenticated.value).toBe(true)
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(true)
+  })
+
+  it('clears cached and published state on authoritative rejection', () => {
+    markWebUiAuthenticated({ status: true })
+    cache.clearCachedConfig.mockClear()
+
+    markWebUiUnauthenticated()
+
+    expect(cache.clearCachedConfig).toHaveBeenCalledOnce()
+    expect(isWebUiAuthenticated()).toBe(false)
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
+  })
+})

--- a/src_assets/common/assets/web/main.js
+++ b/src_assets/common/assets/web/main.js
@@ -2,16 +2,16 @@ import './app.css'
 import { createApp } from 'vue'
 import App from './App.vue'
 import DashboardView from './views/DashboardView.vue'
+import ReconnectingView from './views/ReconnectingView.vue'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import i18n from './locale'
 import {
-  getAuthRedirectPath,
   isDynamicImportError,
-  isPublicRoute,
   redirectToIpv4Loopback,
   wrapFetchWithCsrfToken,
 } from './router-helpers.js'
-import { clearCachedConfig, primeCachedConfig } from './config-cache.js'
+import { initializeWebUiAuthState } from './auth-state.js'
+import { createWebUiAuthGuard } from './router-auth.js'
 
 // CSRF token from server-injected meta tag
 const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content || ''
@@ -45,6 +45,7 @@ const routes = [
   { path: '/welcome', component: () => import(/* webpackChunkName: "welcome" */ './views/WelcomeView.vue') },
   { path: '/login', component: () => import(/* webpackChunkName: "login" */ './views/LoginView.vue') },
   { path: '/recover', component: () => import(/* webpackChunkName: "recover" */ './views/RecoveryView.vue') },
+  { path: '/reconnecting', component: ReconnectingView },
 ]
 
 const router = createRouter({
@@ -58,20 +59,10 @@ const router = createRouter({
   },
 })
 
-// Auth guard - redirect to login if not authenticated
-// Uses a cached auth flag to avoid making a fetch on every navigation,
-// which exhausts server connections when response bodies aren't consumed.
-let authed = false
-window.__POLARIS_AUTHENTICATED__ = false
-
-function redirectToLoginWithReturnTarget(to) {
-  return {
-    path: '/login',
-    query: {
-      redirect: to.fullPath || to.path || '/',
-    },
-  }
-}
+// Auth guard - distinguish confirmed logout from temporary host unavailability.
+// Shared state lets the reconnect view hand a successful probe back to the guard
+// without issuing a second request during route recovery.
+initializeWebUiAuthState()
 
 function dynamicImportReloadKey(to) {
   return `polaris:dynamic-import-reload:${to.fullPath || to.path || '/'}`
@@ -92,60 +83,7 @@ function reloadDynamicImportTarget(to) {
   return true
 }
 
-router.beforeEach(async (to, _from) => {
-  if (isPublicRoute(to.path) && to.path !== '/welcome') {
-    try {
-      const res = await fetch('./api/config', { credentials: 'include' })
-      if (getAuthRedirectPath(res) === '/welcome') {
-        window.__POLARIS_AUTHENTICATED__ = false
-        clearCachedConfig()
-        return '/welcome'
-      }
-    } catch {
-      // Keep public routes reachable if the first-run probe cannot complete.
-    }
-  }
-
-  if (!isPublicRoute(to.path)) {
-    if (authed) return
-    try {
-      const res = await fetch('./api/config', { credentials: 'include' })
-      const authRedirectPath = getAuthRedirectPath(res)
-      if (authRedirectPath === '/welcome') {
-        window.__POLARIS_AUTHENTICATED__ = false
-        clearCachedConfig()
-        return '/welcome'
-      }
-      if (authRedirectPath === '/login') {
-        window.__POLARIS_AUTHENTICATED__ = false
-        clearCachedConfig()
-        return redirectToLoginWithReturnTarget(to)
-      }
-      if (res.status === 401) {
-        window.__POLARIS_AUTHENTICATED__ = false
-        clearCachedConfig()
-        return redirectToLoginWithReturnTarget(to)
-      }
-      if (!res.ok) {
-        window.__POLARIS_AUTHENTICATED__ = false
-        clearCachedConfig()
-        return redirectToLoginWithReturnTarget(to)
-      }
-      const contentType = res.headers.get('content-type') || ''
-      if (contentType.includes('application/json')) {
-        primeCachedConfig(await res.json())
-      } else {
-        await res.text()
-      }
-      authed = true
-      window.__POLARIS_AUTHENTICATED__ = true
-    } catch (e) {
-      window.__POLARIS_AUTHENTICATED__ = false
-      clearCachedConfig()
-      return redirectToLoginWithReturnTarget(to)
-    }
-  }
-})
+router.beforeEach(createWebUiAuthGuard())
 
 router.afterEach((to) => {
   sessionStorage.removeItem(dynamicImportReloadKey(to))

--- a/src_assets/common/assets/web/router-auth-guard.test.js
+++ b/src_assets/common/assets/web/router-auth-guard.test.js
@@ -56,6 +56,14 @@ function response(status, body = { status: true }, overrides = {}) {
   }
 }
 
+function deferred() {
+  let resolve
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 async function loadGuard(fetchImpl) {
   vi.resetModules()
   harness.beforeEach.mockClear()
@@ -70,6 +78,75 @@ describe('router authentication guard', () => {
     document.head.innerHTML = '<meta name="csrf-token" content="csrf-test">'
     window.history.replaceState(null, '', '/#/')
     window.__POLARIS_AUTHENTICATED__ = false
+  })
+
+  it('ignores an older authenticated completion after a newer explicit rejection', async () => {
+    vi.resetModules()
+    const older = deferred()
+    const newer = deferred()
+    const probeAuth = vi.fn()
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise)
+    const { createWebUiAuthGuard } = await import('./router-auth.js')
+    const guard = createWebUiAuthGuard(probeAuth)
+
+    const olderDecision = guard({ path: '/apps', fullPath: '/apps' }, {})
+    const newerDecision = guard({ path: '/login', fullPath: '/login', query: {} }, {})
+
+    newer.resolve({ state: 'login' })
+    await expect(newerDecision).resolves.toBeUndefined()
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
+
+    older.resolve({ state: 'authenticated', config: { status: true, platform: 'linux' } })
+    await expect(olderDecision).resolves.toBe(false)
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
+  })
+
+  it.each(['login', 'welcome'])(
+    'ignores an older %s completion after a newer authenticated success',
+    async (olderState) => {
+      vi.resetModules()
+      const older = deferred()
+      const newer = deferred()
+      const probeAuth = vi.fn()
+        .mockReturnValueOnce(older.promise)
+        .mockReturnValueOnce(newer.promise)
+      const { createWebUiAuthGuard } = await import('./router-auth.js')
+      const guard = createWebUiAuthGuard(probeAuth)
+
+      const olderDecision = guard({ path: '/login', fullPath: '/login', query: {} }, {})
+      const newerDecision = guard({ path: '/apps', fullPath: '/apps' }, {})
+
+      newer.resolve({ state: 'authenticated', config: { status: true, platform: 'linux' } })
+      await expect(newerDecision).resolves.toBeUndefined()
+      expect(window.__POLARIS_AUTHENTICATED__).toBe(true)
+
+      older.resolve({ state: olderState })
+      await expect(olderDecision).resolves.toBe(false)
+      expect(window.__POLARIS_AUTHENTICATED__).toBe(true)
+    }
+  )
+
+  it('rechecks freshness after the coordinator resolves but before the guard resumes', async () => {
+    vi.resetModules()
+    const older = deferred()
+    const newer = deferred()
+    const probeAuth = vi.fn()
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise)
+    const { createWebUiAuthGuard } = await import('./router-auth.js')
+    const guard = createWebUiAuthGuard(probeAuth)
+
+    const olderDecision = guard({ path: '/apps', fullPath: '/apps' }, {})
+    older.resolve({ state: 'authenticated', config: { status: true, platform: 'linux' } })
+    await Promise.resolve()
+
+    const newerDecision = guard({ path: '/login', fullPath: '/login', query: {} }, {})
+    newer.resolve({ state: 'login' })
+
+    await expect(newerDecision).resolves.toBeUndefined()
+    await expect(olderDecision).resolves.toBe(false)
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
   })
 
   it('keeps a transient network failure out of the login flow', async () => {

--- a/src_assets/common/assets/web/router-auth-guard.test.js
+++ b/src_assets/common/assets/web/router-auth-guard.test.js
@@ -1,0 +1,241 @@
+import { readFileSync } from 'node:fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const harness = vi.hoisted(() => {
+  const app = {
+    config: {},
+    mount: vi.fn(),
+    provide: vi.fn(),
+    use: vi.fn(),
+  }
+  app.use.mockReturnValue(app)
+
+  return {
+    afterEach: vi.fn(),
+    app,
+    beforeEach: vi.fn(),
+    onError: vi.fn(),
+  }
+})
+
+vi.mock('vue', () => ({
+  createApp: vi.fn(() => harness.app),
+  readonly: vi.fn((value) => value),
+  ref: vi.fn((value) => ({ value })),
+}))
+
+vi.mock('vue-router', () => ({
+  createRouter: vi.fn(() => ({
+    afterEach: harness.afterEach,
+    beforeEach: harness.beforeEach,
+    onError: harness.onError,
+  })),
+  createWebHashHistory: vi.fn(() => ({})),
+}))
+
+vi.mock('./App.vue', () => ({ default: {} }))
+vi.mock('./views/DashboardView.vue', () => ({ default: {} }))
+vi.mock('./locale', () => ({
+  default: vi.fn(async () => ({ global: {} })),
+}))
+vi.mock('./config-cache.js', () => ({
+  clearCachedConfig: vi.fn(),
+  primeCachedConfig: vi.fn(),
+}))
+
+function response(status, body = { status: true }, overrides = {}) {
+  return {
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: vi.fn(async () => body),
+    ok: status >= 200 && status < 300,
+    redirected: false,
+    status,
+    text: vi.fn(async () => JSON.stringify(body)),
+    url: 'https://polaris.test/api/config',
+    ...overrides,
+  }
+}
+
+async function loadGuard(fetchImpl) {
+  vi.resetModules()
+  harness.beforeEach.mockClear()
+  window.fetch = fetchImpl
+  await import('./main.js')
+  expect(harness.beforeEach).toHaveBeenCalledOnce()
+  return harness.beforeEach.mock.calls[0][0]
+}
+
+describe('router authentication guard', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '<meta name="csrf-token" content="csrf-test">'
+    window.history.replaceState(null, '', '/#/')
+    window.__POLARIS_AUTHENTICATED__ = false
+  })
+
+  it('keeps a transient network failure out of the login flow', async () => {
+    const guard = await loadGuard(vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+
+    await expect(guard({ path: '/apps', fullPath: '/apps' }, {})).resolves.toEqual({
+      path: '/reconnecting',
+      query: { redirect: '/apps' },
+    })
+  })
+
+  it('keeps a temporary server failure out of the login flow', async () => {
+    const guard = await loadGuard(vi.fn().mockResolvedValue(response(503)))
+
+    await expect(guard({ path: '/config', fullPath: '/config' }, {})).resolves.toEqual({
+      path: '/reconnecting',
+      query: { redirect: '/config' },
+    })
+  })
+
+  it('fails closed to reconnecting for an unknown future probe state', async () => {
+    vi.resetModules()
+    const { createWebUiAuthGuard } = await import('./router-auth.js')
+    const guard = createWebUiAuthGuard(vi.fn().mockResolvedValue({ state: 'future-state' }))
+
+    await expect(guard({ path: '/apps', fullPath: '/apps' }, {})).resolves.toEqual({
+      path: '/reconnecting',
+      query: { redirect: '/apps' },
+    })
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
+  })
+
+  it('returns an authenticated login route to its internal target', async () => {
+    const guard = await loadGuard(vi.fn().mockResolvedValue(response(200, { status: true, platform: 'linux' })))
+
+    await expect(guard({
+      path: '/login',
+      fullPath: '/login?redirect=/apps',
+      query: { redirect: '/apps' },
+    }, {})).resolves.toBe('/apps')
+  })
+
+  it('removes the dynamic-import reload marker after authentication succeeds', async () => {
+    window.history.replaceState(null, '', '/?polarisReload=123#/apps')
+    const guard = await loadGuard(vi.fn().mockResolvedValue(response(200, { status: true, platform: 'linux' })))
+
+    await guard({ path: '/apps', fullPath: '/apps' }, {})
+
+    expect(window.location.search).toBe('')
+    expect(window.location.hash).toBe('#/apps')
+  })
+
+  it('keeps authenticated cockpit chrome hidden on the reconnect route', () => {
+    const appSource = readFileSync('src_assets/common/assets/web/App.vue', 'utf8')
+
+    expect(appSource).toContain("return webUiAuthenticated.value && !isPublicRoute(route.path)")
+  })
+
+
+  it('uses login for an explicit 401 response', async () => {
+    const guard = await loadGuard(vi.fn().mockResolvedValue(response(401)))
+
+    await expect(guard({ path: '/apps', fullPath: '/apps' }, {})).resolves.toEqual({
+      path: '/login',
+      query: { redirect: '/apps' },
+    })
+  })
+
+  it('uses login for a confirmed server redirect to login', async () => {
+    const guard = await loadGuard(vi.fn().mockResolvedValue(response(200, {}, {
+      headers: new Headers({ 'content-type': 'text/html' }),
+      redirected: true,
+      url: 'https://polaris.test/login',
+    })))
+
+    await expect(guard({ path: '/config', fullPath: '/config' }, {})).resolves.toEqual({
+      path: '/login',
+      query: { redirect: '/config' },
+    })
+  })
+
+  it('preserves first-run routing after a confirmed welcome redirect', async () => {
+    const guard = await loadGuard(vi.fn().mockResolvedValue(response(200, {}, {
+      headers: new Headers({ 'content-type': 'text/html' }),
+      redirected: true,
+      url: 'https://polaris.test/welcome',
+    })))
+
+    await expect(guard({ path: '/apps', fullPath: '/apps' }, {})).resolves.toBe('/welcome')
+  })
+
+  it('treats an unexpected successful HTML response as unavailable', async () => {
+    const guard = await loadGuard(vi.fn().mockResolvedValue(response(200, {}, {
+      headers: new Headers({ 'content-type': 'text/html' }),
+    })))
+
+    await expect(guard({ path: '/apps', fullPath: '/apps' }, {})).resolves.toEqual({
+      path: '/reconnecting',
+      query: { redirect: '/apps' },
+    })
+  })
+
+
+  it('times out a hung initial auth probe and enters reconnecting', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi.fn((_url, options) => new Promise((_resolve, reject) => {
+      options.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+    }))
+
+    try {
+      const guard = await loadGuard(fetchImpl)
+      const decision = guard({ path: '/apps', fullPath: '/apps' }, {})
+      await Promise.resolve()
+
+      expect(fetchImpl.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+      await vi.advanceTimersByTimeAsync(5000)
+      await expect(decision).resolves.toEqual({
+        path: '/reconnecting',
+        query: { redirect: '/apps' },
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not clear authenticated state when a public-route probe returns 403', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response(200, { status: true, platform: 'linux' }))
+      .mockResolvedValueOnce(response(403))
+    const guard = await loadGuard(fetchImpl)
+
+    await guard({ path: '/apps', fullPath: '/apps' }, {})
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(true)
+
+    await expect(guard({ path: '/login', fullPath: '/login', query: {} }, {})).resolves.toBeUndefined()
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears stale authenticated state after an explicit rejection on login', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response(200, { status: true, platform: 'linux' }))
+      .mockResolvedValueOnce(response(401))
+      .mockResolvedValueOnce(response(401))
+    const guard = await loadGuard(fetchImpl)
+
+    await guard({ path: '/apps', fullPath: '/apps' }, {})
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(true)
+
+    await guard({ path: '/login', fullPath: '/login', query: {} }, {})
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
+
+    await expect(guard({ path: '/config', fullPath: '/config' }, {})).resolves.toEqual({
+      path: '/login',
+      query: { redirect: '/config' },
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+  })
+
+
+  it('does not start App config requests while auth or reconnect routes are mounted', () => {
+    const appSource = readFileSync('src_assets/common/assets/web/App.vue', 'utf8')
+    const mountedBlock = appSource.match(/onMounted\(\(\) => \{([\s\S]*?)\n\}\)/)?.[1] || ''
+
+    expect(mountedBlock).not.toMatch(/loadAppVersion\(\)[\s\S]*if \(showNav\.value\)/)
+    expect(mountedBlock).toMatch(/if \(showNav\.value\) \{[\s\S]*loadAppVersion\(\)[\s\S]*refreshSidebarUpdateStatus\(\)/)
+  })
+
+})

--- a/src_assets/common/assets/web/router-auth-integration.test.js
+++ b/src_assets/common/assets/web/router-auth-integration.test.js
@@ -1,0 +1,97 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { createMemoryHistory, createRouter, RouterView } from 'vue-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { initializeWebUiAuthState, isWebUiAuthenticated } from './auth-state.js'
+import { createWebUiAuthGuard } from './router-auth.js'
+import ReconnectingView from './views/ReconnectingView.vue'
+
+const EmptyView = defineComponent({ render: () => h('div') })
+const RouterHarness = defineComponent({ render: () => h(RouterView) })
+
+function response(status, body = { status: true }, overrides = {}) {
+  return {
+    body: { cancel: vi.fn(async () => {}) },
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: vi.fn(async () => body),
+    ok: status >= 200 && status < 300,
+    redirected: false,
+    status,
+    url: 'https://polaris.test/api/config',
+    ...overrides,
+  }
+}
+
+function makeRouter() {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: EmptyView },
+      { path: '/apps', component: EmptyView },
+      { path: '/login', component: EmptyView },
+      { path: '/welcome', component: EmptyView },
+      { path: '/recover', component: EmptyView },
+      { path: '/reconnecting', component: ReconnectingView },
+    ],
+  })
+  router.beforeEach(createWebUiAuthGuard())
+  return router
+}
+
+async function mountRoute(router, path) {
+  await router.push(path)
+  await router.isReady()
+  const wrapper = mount(RouterHarness, { global: { plugins: [router] } })
+  await flushPromises()
+  return wrapper
+}
+
+describe('real router auth recovery', () => {
+  beforeEach(() => {
+    initializeWebUiAuthState()
+    vi.stubGlobal('fetch', vi.fn())
+    window.history.replaceState(null, '', '/#/')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('hands reconnect success to the protected target without a second probe', async () => {
+    fetch
+      .mockResolvedValueOnce(response(200, { status: true, platform: 'linux' }))
+      .mockResolvedValueOnce(response(503))
+    const router = makeRouter()
+
+    const wrapper = await mountRoute(router, '/reconnecting?redirect=/apps')
+
+    expect(router.currentRoute.value.fullPath).toBe('/apps')
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(isWebUiAuthenticated()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('clears shared auth state before routing explicit rejection to login', async () => {
+    fetch.mockResolvedValue(response(401))
+    const router = makeRouter()
+
+    const wrapper = await mountRoute(router, '/reconnecting?redirect=/apps')
+
+    expect(router.currentRoute.value.path).toBe('/login')
+    expect(isWebUiAuthenticated()).toBe(false)
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('escapes a case-variant stale login route to its safe target', async () => {
+    fetch.mockResolvedValue(response(200, { status: true, platform: 'linux' }))
+    const router = makeRouter()
+
+    const wrapper = await mountRoute(router, '/LOGIN/?redirect=/apps')
+
+    expect(router.currentRoute.value.fullPath).toBe('/apps')
+    expect(fetch).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+})

--- a/src_assets/common/assets/web/router-auth-integration.test.js
+++ b/src_assets/common/assets/web/router-auth-integration.test.js
@@ -23,12 +23,21 @@ function response(status, body = { status: true }, overrides = {}) {
   }
 }
 
+function deferred() {
+  let resolve
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 function makeRouter() {
   const router = createRouter({
     history: createMemoryHistory(),
     routes: [
       { path: '/', component: EmptyView },
       { path: '/apps', component: EmptyView },
+      { path: '/config', component: EmptyView },
       { path: '/login', component: EmptyView },
       { path: '/welcome', component: EmptyView },
       { path: '/recover', component: EmptyView },
@@ -56,6 +65,64 @@ describe('real router auth recovery', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('restarts a reused reconnect view and only navigates to the latest query target', async () => {
+    const older = deferred()
+    const newer = deferred()
+    fetch
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise)
+    const router = makeRouter()
+    const wrapper = await mountRoute(router, '/reconnecting?redirect=/apps')
+
+    try {
+      await router.push('/reconnecting?redirect=/config')
+      await flushPromises()
+      expect(fetch).toHaveBeenCalledTimes(2)
+
+      newer.resolve(response(200, { status: true, platform: 'linux' }))
+      await flushPromises()
+      expect(router.currentRoute.value.fullPath).toBe('/config')
+
+      older.resolve(response(200, { status: true, platform: 'linux' }))
+      await flushPromises()
+      expect(router.currentRoute.value.fullPath).toBe('/config')
+    } finally {
+      older.resolve(response(503))
+      newer.resolve(response(503))
+      wrapper.unmount()
+    }
+  })
+
+  it('restarts a reused reconnect view when a query change keeps the same safe target', async () => {
+    const older = deferred()
+    const newer = deferred()
+    fetch
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise)
+    const router = makeRouter()
+    const wrapper = await mountRoute(router, '/reconnecting')
+
+    try {
+      await router.push('/reconnecting?redirect=/')
+      await flushPromises()
+      expect(fetch).toHaveBeenCalledTimes(2)
+
+      newer.resolve(response(200, { status: true, platform: 'linux' }))
+      await flushPromises()
+      expect(router.currentRoute.value.fullPath).toBe('/')
+      expect(isWebUiAuthenticated()).toBe(true)
+
+      older.resolve(response(401))
+      await flushPromises()
+      expect(router.currentRoute.value.fullPath).toBe('/')
+      expect(isWebUiAuthenticated()).toBe(true)
+    } finally {
+      older.resolve(response(503))
+      newer.resolve(response(503))
+      wrapper.unmount()
+    }
   })
 
   it('hands reconnect success to the protected target without a second probe', async () => {

--- a/src_assets/common/assets/web/router-auth.js
+++ b/src_assets/common/assets/web/router-auth.js
@@ -11,6 +11,11 @@ import {
   markWebUiAuthenticated,
   markWebUiUnauthenticated,
 } from './auth-state.js'
+import {
+  beginWebUiAuthProbeGeneration,
+  isCurrentWebUiAuthProbeGeneration,
+  runWebUiAuthProbeForGeneration,
+} from './auth-probe-coordinator.js'
 
 function redirectToLoginWithReturnTarget(to) {
   return {
@@ -23,13 +28,22 @@ function redirectToLoginWithReturnTarget(to) {
 
 export function createWebUiAuthGuard(probeAuth = probeWebUiAuth) {
   return async function webUiAuthGuard(to) {
+    const generation = beginWebUiAuthProbeGeneration()
     const routePath = normalizeRoutePath(to.path)
     if (routePath === '/reconnecting') {
       return
     }
 
+    const runCurrentProbe = () => runWebUiAuthProbeForGeneration(
+      generation,
+      (signal) => probeAuth(window.fetch, window.location.href, signal)
+    )
+
     if (isPublicRoute(routePath) && routePath !== '/welcome') {
-      const result = await probeAuth()
+      const outcome = await runCurrentProbe()
+      if (!outcome.current || !isCurrentWebUiAuthProbeGeneration(generation)) return false
+      const result = outcome.result
+
       if (result.state === AUTH_PROBE_STATE.welcome) {
         markWebUiUnauthenticated()
         return '/welcome'
@@ -49,7 +63,10 @@ export function createWebUiAuthGuard(probeAuth = probeWebUiAuth) {
     if (!isPublicRoute(routePath)) {
       if (isWebUiAuthenticated()) return
 
-      const result = await probeAuth()
+      const outcome = await runCurrentProbe()
+      if (!outcome.current || !isCurrentWebUiAuthProbeGeneration(generation)) return false
+      const result = outcome.result
+
       if (result.state === AUTH_PROBE_STATE.welcome) {
         markWebUiUnauthenticated()
         return '/welcome'

--- a/src_assets/common/assets/web/router-auth.js
+++ b/src_assets/common/assets/web/router-auth.js
@@ -1,0 +1,74 @@
+import {
+  AUTH_PROBE_STATE,
+  clearPolarisReloadParam,
+  getSafeAuthReturnTarget,
+  isPublicRoute,
+  normalizeRoutePath,
+  probeWebUiAuth,
+} from './router-helpers.js'
+import {
+  isWebUiAuthenticated,
+  markWebUiAuthenticated,
+  markWebUiUnauthenticated,
+} from './auth-state.js'
+
+function redirectToLoginWithReturnTarget(to) {
+  return {
+    path: '/login',
+    query: {
+      redirect: to.fullPath || to.path || '/',
+    },
+  }
+}
+
+export function createWebUiAuthGuard(probeAuth = probeWebUiAuth) {
+  return async function webUiAuthGuard(to) {
+    const routePath = normalizeRoutePath(to.path)
+    if (routePath === '/reconnecting') {
+      return
+    }
+
+    if (isPublicRoute(routePath) && routePath !== '/welcome') {
+      const result = await probeAuth()
+      if (result.state === AUTH_PROBE_STATE.welcome) {
+        markWebUiUnauthenticated()
+        return '/welcome'
+      }
+      if (result.state === AUTH_PROBE_STATE.login) {
+        markWebUiUnauthenticated()
+      }
+      if (result.state === AUTH_PROBE_STATE.authenticated) {
+        markWebUiAuthenticated(result.config)
+        clearPolarisReloadParam()
+        if (routePath === '/login') {
+          return getSafeAuthReturnTarget(to.query?.redirect)
+        }
+      }
+    }
+
+    if (!isPublicRoute(routePath)) {
+      if (isWebUiAuthenticated()) return
+
+      const result = await probeAuth()
+      if (result.state === AUTH_PROBE_STATE.welcome) {
+        markWebUiUnauthenticated()
+        return '/welcome'
+      }
+      if (result.state === AUTH_PROBE_STATE.login) {
+        markWebUiUnauthenticated()
+        return redirectToLoginWithReturnTarget(to)
+      }
+      if (result.state !== AUTH_PROBE_STATE.authenticated) {
+        return {
+          path: '/reconnecting',
+          query: {
+            redirect: to.fullPath || to.path || '/',
+          },
+        }
+      }
+
+      markWebUiAuthenticated(result.config)
+      clearPolarisReloadParam()
+    }
+  }
+}

--- a/src_assets/common/assets/web/router-helpers.js
+++ b/src_assets/common/assets/web/router-helpers.js
@@ -1,4 +1,4 @@
-const PUBLIC_ROUTES = new Set(['/login', '/welcome', '/recover'])
+const PUBLIC_ROUTES = new Set(['/login', '/welcome', '/recover', '/reconnecting'])
 
 function isMutatingMethod(method) {
   return method !== 'GET' && method !== 'HEAD'
@@ -52,8 +52,15 @@ export function isDynamicImportError(error) {
     || message.includes('Importing a module script failed')
 }
 
+export function normalizeRoutePath(path) {
+  if (typeof path !== 'string') return ''
+  const withoutQueryOrHash = path.split(/[?#]/, 1)[0]
+  const withoutTrailingSlash = withoutQueryOrHash.replace(/\/+$/, '')
+  return (withoutTrailingSlash || '/').toLowerCase()
+}
+
 export function isPublicRoute(path) {
-  return PUBLIC_ROUTES.has(path)
+  return PUBLIC_ROUTES.has(normalizeRoutePath(path))
 }
 
 export function getAuthRedirectPath(response, baseUrl = window.location.href) {
@@ -62,7 +69,7 @@ export function getAuthRedirectPath(response, baseUrl = window.location.href) {
   }
 
   try {
-    const finalPath = new URL(response.url, baseUrl).pathname
+    const finalPath = normalizeRoutePath(new URL(response.url, baseUrl).pathname)
     if (finalPath.endsWith('/welcome')) {
       return '/welcome'
     }
@@ -74,6 +81,106 @@ export function getAuthRedirectPath(response, baseUrl = window.location.href) {
   }
 
   return ''
+}
+
+export const AUTH_PROBE_STATE = Object.freeze({
+  authenticated: 'authenticated',
+  login: 'login',
+  unavailable: 'unavailable',
+  welcome: 'welcome',
+})
+
+const AUTH_PROBE_TIMEOUT_MS = 5000
+
+async function discardResponseBody(response) {
+  try {
+    await response?.body?.cancel()
+  } catch {
+    // The classification result matters more than cleanup of an already-failed response.
+  }
+}
+
+export async function probeWebUiAuth(fetchImpl = window.fetch, baseUrl = window.location.href, externalSignal) {
+  const controller = new AbortController()
+  const abortProbe = () => controller.abort()
+  const timeout = globalThis.setTimeout(abortProbe, AUTH_PROBE_TIMEOUT_MS)
+
+  if (externalSignal?.aborted) {
+    abortProbe()
+  } else {
+    externalSignal?.addEventListener('abort', abortProbe, { once: true })
+  }
+
+  try {
+    const response = await fetchImpl('./api/config', {
+      credentials: 'include',
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+    const redirectPath = getAuthRedirectPath(response, baseUrl)
+    if (redirectPath === '/welcome') {
+      await discardResponseBody(response)
+      return { state: AUTH_PROBE_STATE.welcome }
+    }
+    if (redirectPath === '/login' || response.status === 401) {
+      await discardResponseBody(response)
+      return { state: AUTH_PROBE_STATE.login }
+    }
+    if (!response.ok) {
+      await discardResponseBody(response)
+      return { state: AUTH_PROBE_STATE.unavailable }
+    }
+
+    const contentType = response.headers.get('content-type') || ''
+    const mediaType = contentType.split(';', 1)[0].trim().toLowerCase()
+    if (mediaType !== 'application/json') {
+      await discardResponseBody(response)
+      return { state: AUTH_PROBE_STATE.unavailable }
+    }
+
+    const config = await response.json()
+    if (!config || Array.isArray(config) || typeof config !== 'object' || config.status !== true) {
+      return { state: AUTH_PROBE_STATE.unavailable }
+    }
+
+    return {
+      state: AUTH_PROBE_STATE.authenticated,
+      config,
+    }
+  } catch {
+    return { state: AUTH_PROBE_STATE.unavailable }
+  } finally {
+    globalThis.clearTimeout(timeout)
+    externalSignal?.removeEventListener('abort', abortProbe)
+  }
+}
+
+export function clearPolarisReloadParam(
+  locationLike = window.location,
+  replaceState = window.history.replaceState.bind(window.history),
+  historyState = window.history.state
+) {
+  const url = new URL(locationLike.href)
+  if (!url.searchParams.has('polarisReload')) {
+    return false
+  }
+
+  url.searchParams.delete('polarisReload')
+  replaceState(historyState, '', `${url.pathname}${url.search}${url.hash}`)
+  return true
+}
+
+export function getSafeAuthReturnTarget(value, fallback = '/') {
+  const candidate = Array.isArray(value) ? value[0] : value
+  if (typeof candidate !== 'string' || !candidate.startsWith('/') || candidate.startsWith('//')) {
+    return fallback
+  }
+
+  if (isPublicRoute(candidate)) {
+    return fallback
+  }
+
+  return candidate
 }
 
 export function wrapFetchWithCsrfToken(originalFetch, initialCsrfToken, getRefreshUrl = () => window.location.pathname || '/') {

--- a/src_assets/common/assets/web/router-helpers.test.js
+++ b/src_assets/common/assets/web/router-helpers.test.js
@@ -1,8 +1,12 @@
 import {
+  AUTH_PROBE_STATE,
+  clearPolarisReloadParam,
   getAuthRedirectPath,
   getIpv4LoopbackUrl,
+  getSafeAuthReturnTarget,
   isDynamicImportError,
   isPublicRoute,
+  probeWebUiAuth,
   redirectToIpv4Loopback,
   wrapFetchWithCsrfToken,
 } from './router-helpers.js'
@@ -70,6 +74,7 @@ describe('router helpers', () => {
     expect(isPublicRoute('/login')).toBe(true)
     expect(isPublicRoute('/welcome')).toBe(true)
     expect(isPublicRoute('/recover')).toBe(true)
+    expect(isPublicRoute('/reconnecting')).toBe(true)
     expect(isPublicRoute('/config')).toBe(false)
   })
 
@@ -81,6 +86,14 @@ describe('router helpers', () => {
     expect(getAuthRedirectPath({
       redirected: true,
       url: 'https://127.0.0.1:47990/login',
+    })).toBe('/login')
+    expect(getAuthRedirectPath({
+      redirected: true,
+      url: 'https://127.0.0.1:47990/WELCOME/',
+    })).toBe('/welcome')
+    expect(getAuthRedirectPath({
+      redirected: true,
+      url: 'https://127.0.0.1:47990/LOGIN/',
     })).toBe('/login')
   })
 
@@ -143,4 +156,95 @@ describe('router helpers', () => {
     expect(calls[2].options.headers['X-CSRF-Token']).toBe('csrf-456')
     expect(document.querySelector('meta[name="csrf-token"]').content).toBe('csrf-456')
   })
+
+  it('cancels an indeterminate response body before retrying later', async () => {
+    const cancel = vi.fn(async () => {})
+    const result = await probeWebUiAuth(async () => ({
+      body: { cancel },
+      headers: new Headers({ 'content-type': 'text/plain' }),
+      ok: false,
+      redirected: false,
+      status: 503,
+      url: 'https://127.0.0.1:47990/api/config',
+    }))
+
+    expect(result).toEqual({ state: AUTH_PROBE_STATE.unavailable })
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+
+  it('requires the authenticated config response contract', async () => {
+    const response = (body) => ({
+      body: { cancel: vi.fn(async () => {}) },
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: vi.fn(async () => body),
+      ok: true,
+      redirected: false,
+      status: 200,
+      url: 'https://127.0.0.1:47990/api/config',
+    })
+
+    for (const body of [null, [], {}, { status: false }, { status: 'true' }]) {
+      await expect(probeWebUiAuth(async () => response(body))).resolves.toEqual({
+        state: AUTH_PROBE_STATE.unavailable,
+      })
+    }
+
+    await expect(probeWebUiAuth(async () => ({
+      ...response({ status: true }),
+      json: vi.fn(async () => { throw new SyntaxError('malformed JSON') }),
+    }))).resolves.toEqual({ state: AUTH_PROBE_STATE.unavailable })
+
+    const config = { status: true, platform: 'linux' }
+    await expect(probeWebUiAuth(async () => response(config))).resolves.toEqual({
+      state: AUTH_PROBE_STATE.authenticated,
+      config,
+    })
+  })
+
+  it('accepts only the application/json media type for authenticated config', async () => {
+    const response = (contentType) => ({
+      body: { cancel: vi.fn(async () => {}) },
+      headers: new Headers({ 'content-type': contentType }),
+      json: vi.fn(async () => ({ status: true, platform: 'linux' })),
+      ok: true,
+      redirected: false,
+      status: 200,
+      url: 'https://127.0.0.1:47990/api/config',
+    })
+
+    for (const contentType of ['application/json', 'Application/JSON ; charset=UTF-8']) {
+      await expect(probeWebUiAuth(async () => response(contentType))).resolves.toMatchObject({
+        state: AUTH_PROBE_STATE.authenticated,
+      })
+    }
+
+    for (const contentType of ['application/jsonp', 'application/json-patch+json', 'text/application/json']) {
+      await expect(probeWebUiAuth(async () => response(contentType))).resolves.toEqual({
+        state: AUTH_PROBE_STATE.unavailable,
+      })
+    }
+  })
+
+  it('rejects case and trailing-slash variants of public return targets', () => {
+    for (const target of ['/LOGIN', '/login/', '/Reconnecting', '/reconnecting/', '/WELCOME/', '/Recover/']) {
+      expect(getSafeAuthReturnTarget(target)).toBe('/')
+    }
+    expect(getSafeAuthReturnTarget('//attacker.example')).toBe('/')
+    expect(getSafeAuthReturnTarget('/apps?filter=recent')).toBe('/apps?filter=recent')
+  })
+
+  it('preserves Vue Router history state while removing polarisReload', () => {
+    const replaceState = vi.fn()
+    const routerState = { back: '/login', current: '/apps', forward: null, position: 4 }
+
+    expect(clearPolarisReloadParam(
+      { href: 'https://polaris.test/?foo=1&polarisReload=123#/apps' },
+      replaceState,
+      routerState
+    )).toBe(true)
+
+    expect(replaceState).toHaveBeenCalledWith(routerState, '', '/?foo=1#/apps')
+  })
+
 })

--- a/src_assets/common/assets/web/views/ReconnectingView.test.js
+++ b/src_assets/common/assets/web/views/ReconnectingView.test.js
@@ -1,7 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { initializeWebUiAuthState } from '../auth-state.js'
+import { initializeWebUiAuthState, isWebUiAuthenticated } from '../auth-state.js'
 import ReconnectingView from './ReconnectingView.vue'
 
 const routerHarness = vi.hoisted(() => ({
@@ -164,6 +164,30 @@ describe('ReconnectingView', () => {
 
     expect(signal).toBeInstanceOf(AbortSignal)
     expect(signal.aborted).toBe(true)
+    expect(routerHarness.replace).not.toHaveBeenCalled()
+  })
+
+  it('ignores a late authenticated response after unmount when fetch ignores abort', async () => {
+    let resolveFetch
+    let signal
+    fetch.mockImplementationOnce((_url, options) => {
+      signal = options.signal
+      return new Promise((resolve) => {
+        resolveFetch = resolve
+      })
+    })
+
+    const wrapper = mount(ReconnectingView)
+    await flushPromises()
+    wrapper.unmount()
+
+    expect(signal.aborted).toBe(true)
+    resolveFetch(response(200, { status: true, platform: 'linux' }))
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(8000)
+
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(isWebUiAuthenticated()).toBe(false)
     expect(routerHarness.replace).not.toHaveBeenCalled()
   })
 

--- a/src_assets/common/assets/web/views/ReconnectingView.test.js
+++ b/src_assets/common/assets/web/views/ReconnectingView.test.js
@@ -1,0 +1,170 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { initializeWebUiAuthState } from '../auth-state.js'
+import ReconnectingView from './ReconnectingView.vue'
+
+const routerHarness = vi.hoisted(() => ({
+  query: { redirect: '/apps' },
+  replace: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: routerHarness.query }),
+  useRouter: () => ({ replace: routerHarness.replace }),
+}))
+
+function response(status, body = { status: true }) {
+  return {
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: vi.fn(async () => body),
+    ok: status >= 200 && status < 300,
+    redirected: false,
+    status,
+    url: 'https://polaris.test/api/config',
+  }
+}
+
+describe('ReconnectingView', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn())
+    routerHarness.query = { redirect: '/apps' }
+    routerHarness.replace.mockReset()
+    initializeWebUiAuthState()
+    window.history.replaceState(null, '', '/?polarisReload=123#/reconnecting')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('retries a transient failure and returns to the requested route', async () => {
+    fetch
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(response(200, { status: true, platform: 'linux' }))
+
+    const wrapper = mount(ReconnectingView)
+    await flushPromises()
+
+    expect(wrapper.get('[role="status"]').text()).toContain('Your session has not been cleared')
+    expect(routerHarness.replace).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(500)
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(routerHarness.replace).toHaveBeenCalledWith('/apps')
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(true)
+    expect(window.location.search).toBe('')
+    wrapper.unmount()
+  })
+
+  it('uses login only when the server explicitly rejects the session', async () => {
+    routerHarness.query = { redirect: '/config' }
+    window.__POLARIS_AUTHENTICATED__ = true
+    fetch.mockResolvedValueOnce(response(401))
+
+    const wrapper = mount(ReconnectingView)
+    await flushPromises()
+
+    expect(routerHarness.replace).toHaveBeenCalledWith({
+      path: '/login',
+      query: { redirect: '/config' },
+    })
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('clears stale authenticated state before entering first-run setup', async () => {
+    window.__POLARIS_AUTHENTICATED__ = true
+    fetch.mockResolvedValueOnce({
+      ...response(200),
+      headers: new Headers({ 'content-type': 'text/html' }),
+      redirected: true,
+      url: 'https://polaris.test/welcome',
+    })
+
+    const wrapper = mount(ReconnectingView)
+    await flushPromises()
+
+    expect(routerHarness.replace).toHaveBeenCalledWith('/welcome')
+    expect(window.__POLARIS_AUTHENTICATED__).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('does not navigate to an unsafe return target', async () => {
+    routerHarness.query = { redirect: '//example.com/steal' }
+    fetch.mockResolvedValueOnce(response(200, { status: true, platform: 'linux' }))
+
+    const wrapper = mount(ReconnectingView)
+    await flushPromises()
+
+    expect(routerHarness.replace).toHaveBeenCalledWith('/')
+    wrapper.unmount()
+  })
+
+  it('times out a hung probe before retrying', async () => {
+    fetch
+      .mockImplementationOnce((_url, options) => new Promise((_resolve, reject) => {
+        options.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+      }))
+      .mockResolvedValueOnce(response(200, { status: true, platform: 'linux' }))
+
+    const wrapper = mount(ReconnectingView)
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(5500)
+    await flushPromises()
+
+    const requestCount = fetch.mock.calls.length
+    wrapper.unmount()
+
+    expect(requestCount).toBe(2)
+  })
+
+
+  it('caps retry backoff at eight seconds', async () => {
+    fetch.mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const wrapper = mount(ReconnectingView)
+    await flushPromises()
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    for (const [index, delay] of [500, 1000, 2000, 4000, 8000, 8000].entries()) {
+      await vi.advanceTimersByTimeAsync(delay)
+      await flushPromises()
+      expect(fetch).toHaveBeenCalledTimes(index + 2)
+    }
+
+    wrapper.unmount()
+  })
+
+  it('cancels a scheduled retry when the view unmounts', async () => {
+    fetch.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const wrapper = mount(ReconnectingView)
+    await flushPromises()
+    wrapper.unmount()
+    await vi.advanceTimersByTimeAsync(8000)
+
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it('aborts an in-flight probe when the view unmounts', async () => {
+    let signal
+    fetch.mockImplementationOnce((_url, options) => {
+      signal = options.signal
+      return new Promise(() => {})
+    })
+
+    const wrapper = mount(ReconnectingView)
+    await flushPromises()
+    wrapper.unmount()
+
+    expect(signal).toBeInstanceOf(AbortSignal)
+    expect(signal.aborted).toBe(true)
+    expect(routerHarness.replace).not.toHaveBeenCalled()
+  })
+
+})

--- a/src_assets/common/assets/web/views/ReconnectingView.vue
+++ b/src_assets/common/assets/web/views/ReconnectingView.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
   markWebUiAuthenticated,
@@ -42,6 +42,11 @@ import {
   getSafeAuthReturnTarget,
   probeWebUiAuth,
 } from '../router-helpers.js'
+import {
+  beginWebUiAuthProbeGeneration,
+  isCurrentWebUiAuthProbeGeneration,
+  runWebUiAuthProbeForGeneration,
+} from '../auth-probe-coordinator.js'
 
 const RETRY_DELAYS_MS = [500, 1000, 2000, 4000, 8000]
 
@@ -49,9 +54,9 @@ const route = useRoute()
 const router = useRouter()
 const attempts = ref(0)
 const checking = ref(false)
-const returnTarget = getSafeAuthReturnTarget(route.query.redirect)
+const returnTarget = computed(() => getSafeAuthReturnTarget(route.query.redirect))
 
-let activeProbeController = null
+let viewProbeGeneration = 0
 let retryTimer = null
 let stopped = false
 
@@ -69,30 +74,40 @@ function scheduleRetry() {
 }
 
 async function checkHost() {
-  if (checking.value || stopped) return
+  if (stopped) return
 
   clearRetryTimer()
+  const viewGeneration = ++viewProbeGeneration
+  const target = returnTarget.value
   checking.value = true
   attempts.value += 1
   let retry = false
 
-  const controller = new AbortController()
-  activeProbeController = controller
+  const probeGeneration = beginWebUiAuthProbeGeneration()
   try {
-    const result = await probeWebUiAuth(window.fetch, window.location.href, controller.signal)
-    if (stopped) return
+    const outcome = await runWebUiAuthProbeForGeneration(
+      probeGeneration,
+      (signal) => probeWebUiAuth(window.fetch, window.location.href, signal)
+    )
+    if (
+      stopped
+      || viewGeneration !== viewProbeGeneration
+      || !outcome.current
+      || !isCurrentWebUiAuthProbeGeneration(probeGeneration)
+    ) return
 
+    const result = outcome.result
     if (result.state === AUTH_PROBE_STATE.authenticated) {
       markWebUiAuthenticated(result.config)
       clearPolarisReloadParam()
-      await router.replace(returnTarget)
+      await router.replace(target)
       return
     }
     if (result.state === AUTH_PROBE_STATE.login) {
       markWebUiUnauthenticated()
       await router.replace({
         path: '/login',
-        query: { redirect: returnTarget },
+        query: { redirect: target },
       })
       return
     }
@@ -106,18 +121,28 @@ async function checkHost() {
   } catch {
     retry = true
   } finally {
-    if (activeProbeController === controller) {
-      activeProbeController = null
-    }
+    if (viewGeneration !== viewProbeGeneration) return
     checking.value = false
     if (retry) scheduleRetry()
   }
 }
 
 function retryNow() {
+  if (checking.value) return
   clearRetryTimer()
   void checkHost()
 }
+
+watch(() => route.fullPath, () => {
+  if (stopped) return
+
+  clearRetryTimer()
+  viewProbeGeneration += 1
+  checking.value = false
+  attempts.value = 0
+  beginWebUiAuthProbeGeneration()
+  void checkHost()
+})
 
 onMounted(() => {
   void checkHost()
@@ -125,8 +150,8 @@ onMounted(() => {
 
 onUnmounted(() => {
   stopped = true
-  activeProbeController?.abort()
-  activeProbeController = null
+  viewProbeGeneration += 1
+  beginWebUiAuthProbeGeneration()
   clearRetryTimer()
 })
 </script>

--- a/src_assets/common/assets/web/views/ReconnectingView.vue
+++ b/src_assets/common/assets/web/views/ReconnectingView.vue
@@ -1,0 +1,132 @@
+<template>
+  <main class="relative flex min-h-screen items-center justify-center overflow-hidden bg-background p-6">
+    <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(124,115,255,0.16),transparent_38%),radial-gradient(circle_at_bottom_right,rgba(200,214,229,0.08),transparent_30%)]"></div>
+    <section
+      role="status"
+      aria-live="polite"
+      :aria-busy="checking"
+      class="glass relative w-full max-w-lg rounded-[28px] border border-storm/30 p-8 text-center shadow-2xl"
+    >
+      <img :src="'/images/logo-polaris.svg'" class="mx-auto h-12" alt="Polaris">
+      <div class="mt-5 text-[10px] font-semibold uppercase tracking-[0.24em] text-storm/85">Host connection</div>
+      <h1 class="mt-3 text-3xl font-bold text-silver">Host reconnecting…</h1>
+      <p class="mt-4 text-sm leading-relaxed text-storm">
+        Polaris is temporarily unavailable. Your session has not been cleared.
+      </p>
+      <div class="mx-auto mt-6 flex w-fit items-center gap-3 rounded-full border border-storm/20 bg-void/45 px-4 py-2 text-xs text-storm">
+        <span class="h-2.5 w-2.5 animate-pulse rounded-full bg-amber-300 shadow-[0_0_14px_rgba(252,211,77,0.55)]"></span>
+        {{ checking ? 'Checking host…' : `Retrying connection · attempt ${attempts + 1}` }}
+      </div>
+      <button
+        type="button"
+        class="mt-6 inline-flex h-10 items-center justify-center rounded-xl border border-storm/30 bg-deep/55 px-4 text-sm font-semibold text-silver transition-colors hover:border-ice/40 hover:bg-deep/75 disabled:cursor-not-allowed disabled:opacity-50"
+        :disabled="checking"
+        @click="retryNow"
+      >
+        {{ checking ? 'Checking…' : 'Retry now' }}
+      </button>
+    </section>
+  </main>
+</template>
+
+<script setup>
+import { onMounted, onUnmounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  markWebUiAuthenticated,
+  markWebUiUnauthenticated,
+} from '../auth-state.js'
+import {
+  AUTH_PROBE_STATE,
+  clearPolarisReloadParam,
+  getSafeAuthReturnTarget,
+  probeWebUiAuth,
+} from '../router-helpers.js'
+
+const RETRY_DELAYS_MS = [500, 1000, 2000, 4000, 8000]
+
+const route = useRoute()
+const router = useRouter()
+const attempts = ref(0)
+const checking = ref(false)
+const returnTarget = getSafeAuthReturnTarget(route.query.redirect)
+
+let activeProbeController = null
+let retryTimer = null
+let stopped = false
+
+function clearRetryTimer() {
+  if (retryTimer !== null) {
+    window.clearTimeout(retryTimer)
+    retryTimer = null
+  }
+}
+
+function scheduleRetry() {
+  if (stopped) return
+  const delayIndex = Math.min(Math.max(attempts.value - 1, 0), RETRY_DELAYS_MS.length - 1)
+  retryTimer = window.setTimeout(checkHost, RETRY_DELAYS_MS[delayIndex])
+}
+
+async function checkHost() {
+  if (checking.value || stopped) return
+
+  clearRetryTimer()
+  checking.value = true
+  attempts.value += 1
+  let retry = false
+
+  const controller = new AbortController()
+  activeProbeController = controller
+  try {
+    const result = await probeWebUiAuth(window.fetch, window.location.href, controller.signal)
+    if (stopped) return
+
+    if (result.state === AUTH_PROBE_STATE.authenticated) {
+      markWebUiAuthenticated(result.config)
+      clearPolarisReloadParam()
+      await router.replace(returnTarget)
+      return
+    }
+    if (result.state === AUTH_PROBE_STATE.login) {
+      markWebUiUnauthenticated()
+      await router.replace({
+        path: '/login',
+        query: { redirect: returnTarget },
+      })
+      return
+    }
+    if (result.state === AUTH_PROBE_STATE.welcome) {
+      markWebUiUnauthenticated()
+      await router.replace('/welcome')
+      return
+    }
+
+    retry = true
+  } catch {
+    retry = true
+  } finally {
+    if (activeProbeController === controller) {
+      activeProbeController = null
+    }
+    checking.value = false
+    if (retry) scheduleRetry()
+  }
+}
+
+function retryNow() {
+  clearRetryTimer()
+  void checkHost()
+}
+
+onMounted(() => {
+  void checkHost()
+})
+
+onUnmounted(() => {
+  stopped = true
+  activeProbeController?.abort()
+  activeProbeController = null
+  clearRetryTimer()
+})
+</script>


### PR DESCRIPTION
## Summary

- distinguish trustworthy unauthentication from transient host/API unavailability
- route network failures, 5xx responses, malformed JSON, timeouts, and aborts through a bounded reconnect view without clearing the session
- preserve explicit 401/login redirects as the only logout signal
- harden reconnect cancellation, retry backoff, auth-state handoff, and safe return targets

## Validation

- Vitest: 231/231 passed
- ESLint, clean production build, and Web budget passed
- 7/7 meaningful auth/reconnect mutants rejected
- exact built asset tree: `9cf287ca3216e7b77a9578dd191ee9b854205420b61223e2e6ee4b550a040583`
- real Chromium: abort, 503, and malformed responses preserved the cookie and recovered to the protected route; explicit 401 routed to login
- combined isolated stop/start with the durable-session backend retained the same Chromium context/cookie and returned protected HTTP 200

## Scope

Draft pending CI and final exact-head review. This does not deploy, merge, or publish a release.