### PR TITLE
fix(linux): isolate private Steam teardown ownership

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -636,7 +636,15 @@ namespace cage_display_router {
   // Public API
   // -----------------------------------------------------------------------
 
-  bool start(int width, int height, int refresh_hz, const std::string &game_cmd, bool force_windowed, bool allow_mangohud) {
+  bool start(
+    int width,
+    int height,
+    int refresh_hz,
+    const std::string &game_cmd,
+    bool force_windowed,
+    bool allow_mangohud,
+    const std::string &session_instance_id
+  ) {
     const auto startup_begin = std::chrono::steady_clock::now();
 
     if (cage_pid > 0 && is_running()) {
@@ -755,6 +763,11 @@ namespace cage_display_router {
     pid_t pid = fork();
     if (pid == 0) {
       // Child: set wlroots environment, detach, exec labwc
+      if (!session_instance_id.empty()) {
+        setenv("POLARIS_SESSION_INSTANCE_ID", session_instance_id.c_str(), 1);
+      } else {
+        unsetenv("POLARIS_SESSION_INSTANCE_ID");
+      }
       set_labwc_process_environment(headless);
       if (headless) {
         // Headless mode: no visible window on desktop, no parent display needed.
@@ -919,6 +932,29 @@ namespace cage_display_router {
       .backend_name = "labwc",
     };
   }
+
+  void reset_after_external_stop() {
+    if (cage_pid > 0) {
+      (void) waitpid(cage_pid, nullptr, WNOHANG);
+    }
+    BOOST_LOG(info) << "labwc: Cleared router state after exact-generation pidfd cleanup"sv;
+    cage_pid = 0;
+    cage_wayland_socket.clear();
+    cage_x11_display.clear();
+    cage_runtime_state = {
+      .requested_headless = false,
+      .effective_headless = false,
+      .gpu_native_override_active = false,
+      .backend_name = "labwc",
+    };
+  }
+
+#if defined(POLARIS_TESTS)
+  void reset_after_external_stop_for_tests(pid_t pid) {
+    cage_pid = pid;
+    reset_after_external_stop();
+  }
+#endif
 
   bool is_running() {
     if (cage_pid <= 0) return false;

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -18,7 +18,9 @@
  * The caller (process.cpp) should:
  *   1. Call start() with the client's requested resolution
  *   2. Use wrap_cmd(original_cmd) for the app command
- *   3. Call stop() in the cleanup/fail_guard
+ *   3. For an owned streaming session, terminate exact-generation processes
+ *      through pidfds and call reset_after_external_stop(); stop() remains for
+ *      pre-session probes and startup failures before ownership is committed.
  */
 #pragma once
 
@@ -50,6 +52,8 @@ namespace cage_display_router {
    * @param force_windowed Force the compositor to run windowed even if headless
    *                       mode is configured. Used when GPU-native capture must
    *                       take priority over invisibility.
+   * @param session_instance_id Immutable generation inherited only by the cage
+   *                            child and its descendants; never by Polaris itself.
    * @return true if cage started successfully and wayland socket is available
    */
   bool start(
@@ -58,7 +62,8 @@ namespace cage_display_router {
     int refresh_hz = 60,
     const std::string &game_cmd = "",
     bool force_windowed = false,
-    bool allow_mangohud = true
+    bool allow_mangohud = true,
+    const std::string &session_instance_id = ""
   );
 
   /**
@@ -77,6 +82,18 @@ namespace cage_display_router {
    * Sends SIGTERM, waits up to 3s, then SIGKILL if needed.
    */
   void stop();
+
+  /**
+   * @brief Clear router state after the session owner has pidfd-terminated cage.
+   *
+   * This function never signals cage_pid or its process group. It only performs
+   * a non-blocking reap of the original child and clears cached router state.
+   */
+  void reset_after_external_stop();
+
+#if defined(POLARIS_TESTS)
+  void reset_after_external_stop_for_tests(pid_t pid);
+#endif
 
   /**
    * @brief Returns true if cage is running and its wayland socket exists.

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1013,7 +1013,18 @@ namespace proc {
       }
     };
 
+#ifdef POLARIS_TESTS
+    thread_local pid_t forced_pidfd_open_failure_pid = -1;
+    thread_local std::atomic<bool> *pidfd_wait_entered_for_tests = nullptr;
+#endif
+
     std::optional<pidfd_handle_t> open_process_pidfd(pid_t pid, int &open_error) {
+#ifdef POLARIS_TESTS
+      if (pid == forced_pidfd_open_failure_pid) {
+        open_error = EACCES;
+        return std::nullopt;
+      }
+#endif
       const auto fd = static_cast<int>(syscall(SYS_pidfd_open, pid, 0));
       if (fd < 0) {
         open_error = errno;
@@ -1023,12 +1034,26 @@ namespace proc {
       return pidfd_handle_t {pid, fd};
     }
 
+#ifdef POLARIS_TESTS
+    thread_local int forced_pidfd_zero_poll_interruptions = 0;
+    thread_local std::chrono::milliseconds forced_pidfd_zero_poll_interruption_delay {0};
+#endif
+
+    int poll_pidfd_now(pollfd &descriptor) {
+#ifdef POLARIS_TESTS
+      if (forced_pidfd_zero_poll_interruptions > 0) {
+        --forced_pidfd_zero_poll_interruptions;
+        std::this_thread::sleep_for(forced_pidfd_zero_poll_interruption_delay);
+        errno = EINTR;
+        return -1;
+      }
+#endif
+      return poll(&descriptor, 1, 0);
+    }
+
     bool pidfd_has_exited(const pidfd_handle_t &handle) {
       pollfd descriptor {handle.fd, POLLIN, 0};
-      int result;
-      do {
-        result = poll(&descriptor, 1, 0);
-      } while (result < 0 && errno == EINTR);
+      const int result = poll_pidfd_now(descriptor);
       return result == 1 && (descriptor.revents & POLLIN) != 0;
     }
 
@@ -1054,6 +1079,11 @@ namespace proc {
         }
         const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
         const auto timeout_ms = static_cast<int>(std::max<std::int64_t>(1, remaining.count()));
+#ifdef POLARIS_TESTS
+        if (pidfd_wait_entered_for_tests != nullptr) {
+          pidfd_wait_entered_for_tests->store(true, std::memory_order_release);
+        }
+#endif
         const int result = poll(pending.data(), pending.size(), timeout_ms);
         if (result < 0) {
           if (errno == EINTR) {
@@ -1110,15 +1140,50 @@ namespace proc {
       });
     }
 
-    std::string read_proc_status_file(pid_t pid, std::string_view name) {
-      std::ifstream file("/proc/" + std::to_string(pid) + "/" + std::string {name}, std::ios::binary);
-      if (!file) {
-        return {};
-      }
+    struct proc_file_read_result_t {
+      std::string bytes;
+      int error = 0;
 
-      std::ostringstream buffer;
-      buffer << file.rdbuf();
-      return buffer.str();
+      bool ok() const {
+        return error == 0;
+      }
+    };
+
+    proc_file_read_result_t read_proc_status_file_result(pid_t pid, std::string_view name) {
+      const auto path = "/proc/" + std::to_string(pid) + "/" + std::string {name};
+      const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+      if (fd < 0) {
+        return {{}, errno};
+      }
+      auto close_fd = util::fail_guard([fd]() {
+        close(fd);
+      });
+
+      std::string bytes;
+      char chunk[4096];
+      for (;;) {
+        const auto bytes_read = read(fd, chunk, sizeof(chunk));
+        if (bytes_read > 0) {
+          bytes.append(chunk, static_cast<std::size_t>(bytes_read));
+          continue;
+        }
+        if (bytes_read == 0) {
+          return {std::move(bytes), 0};
+        }
+        const int error = errno;
+        if (error == EINTR) {
+          continue;
+        }
+        return {{}, error};
+      }
+    }
+
+    std::string read_proc_status_file(pid_t pid, std::string_view name) {
+      return read_proc_status_file_result(pid, name).bytes;
+    }
+
+    bool process_vanished_during_proc_read(int error) {
+      return error == ENOENT || error == ESRCH;
     }
 
     std::string proc_argv0_from_cmdline(std::string_view cmdline) {
@@ -1232,6 +1297,48 @@ namespace proc {
       return proc_start_time_from_stat(read_proc_status_file(pid, "stat"));
     }
 
+    std::optional<pid_t> proc_parent_pid_from_stat(std::string_view stat) {
+      const auto comm_end = stat.rfind(')');
+      if (comm_end == std::string_view::npos || comm_end + 1 >= stat.size()) {
+        return std::nullopt;
+      }
+      std::istringstream fields(std::string {stat.substr(comm_end + 1)});
+      std::string state;
+      pid_t parent_pid = -1;
+      if (!(fields >> state >> parent_pid) || parent_pid < 0) {
+        return std::nullopt;
+      }
+      return parent_pid;
+    }
+
+#ifdef POLARIS_TESTS
+    thread_local pid_t forced_proc_ancestry_unknown_pid = -1;
+#endif
+
+    std::optional<bool> proc_pid_descends_from(pid_t pid, pid_t ancestor_pid) {
+      std::set<pid_t> visited;
+      auto current = pid;
+      while (current > 1) {
+        if (!visited.insert(current).second) {
+          return std::nullopt;
+        }
+#ifdef POLARIS_TESTS
+        if (current == forced_proc_ancestry_unknown_pid) {
+          return std::nullopt;
+        }
+#endif
+        const auto parent = proc_parent_pid_from_stat(read_proc_status_file(current, "stat"));
+        if (!parent) {
+          return std::nullopt;
+        }
+        if (*parent == ancestor_pid) {
+          return true;
+        }
+        current = *parent;
+      }
+      return false;
+    }
+
     bool steam_pidfd_capture_identity_matches(
       const std::optional<std::uint64_t> &before,
       const std::optional<std::uint64_t> &after
@@ -1246,7 +1353,23 @@ namespace proc {
 
 #ifdef POLARIS_TESTS
     thread_local pid_t forced_isolated_session_capture_failure_pid = -1;
+    thread_local bool forced_proc_directory_enumeration_error = false;
+    thread_local pid_t forced_proc_directory_error_after_capture_pid = -1;
+    thread_local pid_t forced_reused_exact_generation_pid = -1;
+    thread_local pid_t forced_steam_ownership_capture_failure_pid = -1;
 #endif
+
+    dirent *read_next_proc_entry(DIR *directory) {
+      errno = 0;
+#ifdef POLARIS_TESTS
+      if (forced_proc_directory_enumeration_error) {
+        forced_proc_directory_enumeration_error = false;
+        errno = EIO;
+        return nullptr;
+      }
+#endif
+      return readdir(directory);
+    }
 
     isolated_session_process_snapshot_t isolated_session_process_snapshot(
       std::string_view session_instance_id
@@ -1263,7 +1386,14 @@ namespace proc {
         return snapshot;
       }
 
-      while (auto *entry = readdir(dir)) {
+      for (;;) {
+        auto *entry = read_next_proc_entry(dir);
+        if (entry == nullptr) {
+          if (errno != 0) {
+            snapshot.capture_complete = false;
+          }
+          break;
+        }
         const std::string name = entry->d_name;
         if (!proc_pid_dir_name(name)) {
           continue;
@@ -1273,8 +1403,19 @@ namespace proc {
           continue;
         }
 
-        const auto environ_before = read_proc_status_file(pid, "environ");
-        if (!proc_environ_matches_isolated_session(environ_before, session_instance_id)) {
+        const auto environ_before = read_proc_status_file_result(pid, "environ");
+        if (!environ_before.ok()) {
+          if (process_vanished_during_proc_read(environ_before.error) ||
+              proc_status_is_zombie(read_proc_status_file(pid, "status"))) {
+            continue;
+          }
+          const auto descends_from_polaris = proc_pid_descends_from(pid, getpid());
+          if (!descends_from_polaris || *descends_from_polaris) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+        if (!proc_environ_matches_isolated_session(environ_before.bytes, session_instance_id)) {
           continue;
         }
 #ifdef POLARIS_TESTS
@@ -1298,16 +1439,39 @@ namespace proc {
           continue;
         }
 
-        const auto environ_after = read_proc_status_file(pid, "environ");
-        const auto identity_after = proc_start_time_ticks(pid);
-        if (!steam_pidfd_capture_identity_matches(identity_before, identity_after) ||
-            !proc_environ_matches_isolated_session(environ_after, session_instance_id)) {
-          if (!pidfd_has_exited(*handle)) {
+        const auto environ_after = read_proc_status_file_result(pid, "environ");
+        auto identity_after = proc_start_time_ticks(pid);
+#ifdef POLARIS_TESTS
+        if (pid == forced_reused_exact_generation_pid && identity_after) {
+          ++*identity_after;
+        }
+#endif
+        const bool identity_matches = steam_pidfd_capture_identity_matches(identity_before, identity_after);
+        const bool environment_matches = environ_after.ok() &&
+                                         proc_environ_matches_isolated_session(
+                                           environ_after.bytes,
+                                           session_instance_id
+                                         );
+        if (!identity_matches || !environment_matches) {
+          bool captured_process_exited = pidfd_has_exited(*handle);
+#ifdef POLARIS_TESTS
+          if (pid == forced_reused_exact_generation_pid) {
+            captured_process_exited = true;
+          }
+#endif
+          const bool replacement_may_be_exact_generation =
+            !identity_matches && identity_after && (!environ_after.ok() || environment_matches);
+          if (!captured_process_exited || replacement_may_be_exact_generation) {
             snapshot.capture_complete = false;
           }
           continue;
         }
         snapshot.owned.emplace_back(std::move(*handle));
+#ifdef POLARIS_TESTS
+        if (pid == forced_proc_directory_error_after_capture_pid) {
+          forced_proc_directory_enumeration_error = true;
+        }
+#endif
       }
 
       closedir(dir);
@@ -1326,9 +1490,10 @@ namespace proc {
         auto snapshot = isolated_session_process_snapshot(session_instance_id);
         if (!snapshot.capture_complete) {
           BOOST_LOG(warning) << "process: exact-generation isolated process capture was incomplete "sv << reason;
+          return false;
         }
         if (snapshot.owned.empty()) {
-          return snapshot.capture_complete;
+          return true;
         }
 
         BOOST_LOG(info) << "process: terminating "sv << snapshot.owned.size()
@@ -1357,7 +1522,14 @@ namespace proc {
         return snapshot;
       }
 
-      while (auto *entry = readdir(dir)) {
+      for (;;) {
+        auto *entry = read_next_proc_entry(dir);
+        if (entry == nullptr) {
+          if (errno != 0) {
+            snapshot.capture_complete = false;
+          }
+          break;
+        }
         const std::string name = entry->d_name;
         if (!proc_pid_dir_name(name)) {
           continue;
@@ -1368,14 +1540,41 @@ namespace proc {
         }
 
         const auto identity_before = proc_start_time_ticks(pid);
-        auto comm = boost::to_lower_copy(read_proc_status_file(pid, "comm"));
+        const auto comm_before = read_proc_status_file_result(pid, "comm");
+        const auto cmdline_before = read_proc_status_file_result(pid, "cmdline");
+        const auto status_before = read_proc_status_file_result(pid, "status");
+        auto comm = boost::to_lower_copy(comm_before.bytes);
         boost::trim(comm);
-        auto cmdline = read_proc_status_file(pid, "cmdline");
+        auto cmdline = cmdline_before.bytes;
         auto argv0 = proc_argv0_from_cmdline(cmdline);
-        auto status = read_proc_status_file(pid, "status");
+        auto status = status_before.bytes;
+        const bool before_reads_complete = comm_before.ok() && cmdline_before.ok() && status_before.ok();
+        if (!before_reads_complete) {
+          const auto read_is_ok_or_vanished = [](const proc_file_read_result_t &result) {
+            return result.ok() || process_vanished_during_proc_read(result.error);
+          };
+          const bool all_failures_are_vanished =
+            read_is_ok_or_vanished(comm_before) &&
+            read_is_ok_or_vanished(cmdline_before) &&
+            read_is_ok_or_vanished(status_before);
+          if (!all_failures_are_vanished) {
+            const auto descends_from_polaris = proc_pid_descends_from(pid, getpid());
+            if (is_desktop_steam_client_process(comm, argv0) ||
+                !descends_from_polaris || *descends_from_polaris) {
+              snapshot.capture_complete = false;
+            }
+          }
+          continue;
+        }
         if (!is_active_steam_shutdown_ownership_process(comm, argv0, cmdline, status)) {
           continue;
         }
+#ifdef POLARIS_TESTS
+        if (pid == forced_steam_ownership_capture_failure_pid) {
+          snapshot.capture_complete = false;
+          continue;
+        }
+#endif
         if (!identity_before) {
           snapshot.capture_complete = false;
           continue;
@@ -1390,32 +1589,62 @@ namespace proc {
           continue;
         }
 
-        comm = boost::to_lower_copy(read_proc_status_file(pid, "comm"));
+        const auto comm_after = read_proc_status_file_result(pid, "comm");
+        const auto cmdline_after = read_proc_status_file_result(pid, "cmdline");
+        const auto status_after = read_proc_status_file_result(pid, "status");
+        comm = boost::to_lower_copy(comm_after.bytes);
         boost::trim(comm);
-        cmdline = read_proc_status_file(pid, "cmdline");
+        cmdline = cmdline_after.bytes;
         argv0 = proc_argv0_from_cmdline(cmdline);
-        status = read_proc_status_file(pid, "status");
-        const auto identity_after = proc_start_time_ticks(pid);
+        status = status_after.bytes;
+        const bool after_reads_complete = comm_after.ok() && cmdline_after.ok() && status_after.ok();
+        if (!after_reads_complete) {
+          const auto current_identity = proc_start_time_ticks(pid);
+          if (!pidfd_has_exited(*handle) ||
+              (current_identity && !steam_pidfd_capture_identity_matches(identity_before, current_identity))) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
         if (!is_active_steam_shutdown_ownership_process(comm, argv0, cmdline, status)) {
           continue;
         }
+        auto identity_after = proc_start_time_ticks(pid);
+#ifdef POLARIS_TESTS
+        if (pid == forced_reused_exact_generation_pid && identity_after) {
+          ++*identity_after;
+        }
+#endif
         if (!steam_pidfd_capture_identity_matches(identity_before, identity_after)) {
-          if (!pidfd_has_exited(*handle)) {
+          bool captured_process_exited = pidfd_has_exited(*handle);
+#ifdef POLARIS_TESTS
+          if (pid == forced_reused_exact_generation_pid) {
+            captured_process_exited = true;
+          }
+#endif
+          if (!captured_process_exited || identity_after) {
             snapshot.capture_complete = false;
           }
           continue;
         }
 
-        const auto environ = read_proc_status_file(pid, "environ");
-        if (environ.empty() && !pidfd_has_exited(*handle)) {
-          snapshot.capture_complete = false;
+        const auto environ = read_proc_status_file_result(pid, "environ");
+        if (!environ.ok() || environ.bytes.empty()) {
+          if (!pidfd_has_exited(*handle)) {
+            snapshot.capture_complete = false;
+          }
           continue;
         }
-        if (proc_environ_matches_isolated_session(environ, session_instance_id)) {
+        if (proc_environ_matches_isolated_session(environ.bytes, session_instance_id)) {
           snapshot.owned.emplace_back(std::move(*handle));
         } else {
           snapshot.unowned.emplace_back(std::move(*handle));
         }
+#ifdef POLARIS_TESTS
+        if (pid == forced_proc_directory_error_after_capture_pid) {
+          forced_proc_directory_enumeration_error = true;
+        }
+#endif
       }
 
       closedir(dir);
@@ -1474,14 +1703,36 @@ namespace proc {
              !is_transient_steam_client_cmdline(cmdline);
     }
 
+#ifdef POLARIS_TESTS
+    thread_local bool forced_desktop_steam_proc_open_error = false;
+    thread_local pid_t forced_desktop_steam_proc_read_error_pid = -1;
+    thread_local pid_t forced_desktop_steam_scan_only_pid = -1;
+#endif
+
     bool desktop_steam_client_active_impl() {
-      DIR *dir = opendir("/proc");
-      if (!dir) {
-        return false;
+      DIR *dir = nullptr;
+#ifdef POLARIS_TESTS
+      if (forced_desktop_steam_proc_open_error) {
+        errno = EACCES;
+      } else {
+        dir = opendir("/proc");
       }
+#else
+      dir = opendir("/proc");
+#endif
+      if (!dir) {
+        return true;
+      }
+      auto close_dir = util::fail_guard([dir]() {
+        closedir(dir);
+      });
 
       const auto this_pid = getpid();
-      while (auto *entry = readdir(dir)) {
+      for (;;) {
+        auto *entry = read_next_proc_entry(dir);
+        if (entry == nullptr) {
+          return errno != 0;
+        }
         const std::string name = entry->d_name;
         if (!proc_pid_dir_name(name)) {
           continue;
@@ -1491,23 +1742,44 @@ namespace proc {
         if (pid <= 1 || pid == this_pid) {
           continue;
         }
-
-        auto comm = boost::to_lower_copy(read_proc_status_file(pid, "comm"));
-        while (!comm.empty() && (comm.back() == '\n' || comm.back() == '\r')) {
-          comm.pop_back();
+#ifdef POLARIS_TESTS
+        if (forced_desktop_steam_scan_only_pid > 0 && pid != forced_desktop_steam_scan_only_pid) {
+          continue;
         }
+#endif
 
-        const auto cmdline = read_proc_status_file(pid, "cmdline");
+        auto comm_result = read_proc_status_file_result(pid, "comm");
+        auto cmdline_result = read_proc_status_file_result(pid, "cmdline");
+        auto status_result = read_proc_status_file_result(pid, "status");
+#ifdef POLARIS_TESTS
+        if (pid == forced_desktop_steam_proc_read_error_pid) {
+          comm_result = {{}, EACCES};
+        }
+#endif
+        auto comm = boost::to_lower_copy(comm_result.bytes);
+        boost::trim(comm);
+        const auto cmdline = cmdline_result.bytes;
         const auto argv0 = proc_argv0_from_cmdline(cmdline);
-        const auto status = read_proc_status_file(pid, "status");
+        const auto status = status_result.bytes;
+        const bool reads_complete = comm_result.ok() && cmdline_result.ok() && status_result.ok();
+        if (!reads_complete) {
+          if (is_active_desktop_steam_client_process(comm, argv0, cmdline, status)) {
+            return true;
+          }
+          const auto read_is_ok_or_vanished = [](const proc_file_read_result_t &result) {
+            return result.ok() || process_vanished_during_proc_read(result.error);
+          };
+          if (!read_is_ok_or_vanished(comm_result) ||
+              !read_is_ok_or_vanished(cmdline_result) ||
+              !read_is_ok_or_vanished(status_result)) {
+            return true;
+          }
+          continue;
+        }
         if (is_active_desktop_steam_client_process(comm, argv0, cmdline, status)) {
-          closedir(dir);
           return true;
         }
       }
-
-      closedir(dir);
-      return false;
     }
 
     proc::desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy_impl(
@@ -3075,6 +3347,36 @@ namespace proc {
     return is_active_desktop_steam_client_process(comm, argv0_path, cmdline, status);
   }
 
+  bool desktop_steam_proc_open_error_fails_closed_for_tests() {
+    const auto previous = forced_desktop_steam_proc_open_error;
+    auto restore = util::fail_guard([previous]() {
+      forced_desktop_steam_proc_open_error = previous;
+    });
+    forced_desktop_steam_proc_open_error = true;
+    return desktop_steam_client_active_impl();
+  }
+
+  bool desktop_steam_proc_enumeration_error_fails_closed_for_tests() {
+    const auto previous = forced_proc_directory_enumeration_error;
+    auto restore = util::fail_guard([previous]() {
+      forced_proc_directory_enumeration_error = previous;
+    });
+    forced_proc_directory_enumeration_error = true;
+    return desktop_steam_client_active_impl();
+  }
+
+  bool desktop_steam_proc_read_error_fails_closed_for_tests(pid_t forced_pid) {
+    const auto previous_error_pid = forced_desktop_steam_proc_read_error_pid;
+    const auto previous_only_pid = forced_desktop_steam_scan_only_pid;
+    auto restore = util::fail_guard([previous_error_pid, previous_only_pid]() {
+      forced_desktop_steam_proc_read_error_pid = previous_error_pid;
+      forced_desktop_steam_scan_only_pid = previous_only_pid;
+    });
+    forced_desktop_steam_proc_read_error_pid = forced_pid;
+    forced_desktop_steam_scan_only_pid = forced_pid;
+    return desktop_steam_client_active_impl();
+  }
+
   bool cage_mangohud_allowed_for_session_for_tests(const proc::ctx_t &app,
                                                    bool use_cage_compositor,
                                                    bool requested_headless) {
@@ -3174,27 +3476,175 @@ namespace proc {
     return terminate_pidfds(handles, graceful_timeout, kill_timeout, "test process"sv);
   }
 
+  bool terminate_pid_with_pidfd_after_wait_entry_for_tests(
+    pid_t pid,
+    std::chrono::milliseconds graceful_timeout,
+    std::chrono::milliseconds kill_timeout,
+    std::atomic<bool> &wait_entered
+  ) {
+    const auto previous = pidfd_wait_entered_for_tests;
+    auto restore = util::fail_guard([previous]() {
+      pidfd_wait_entered_for_tests = previous;
+    });
+    pidfd_wait_entered_for_tests = &wait_entered;
+    return terminate_pid_with_pidfd_for_tests(pid, graceful_timeout, kill_timeout);
+  }
+
+  bool terminate_pid_with_forced_zero_poll_eintr_for_tests(
+    pid_t pid,
+    std::chrono::milliseconds graceful_timeout,
+    std::chrono::milliseconds kill_timeout,
+    int forced_interruptions,
+    std::chrono::milliseconds interruption_delay
+  ) {
+    const auto previous_interruptions = forced_pidfd_zero_poll_interruptions;
+    const auto previous_delay = forced_pidfd_zero_poll_interruption_delay;
+    forced_pidfd_zero_poll_interruptions = forced_interruptions;
+    forced_pidfd_zero_poll_interruption_delay = interruption_delay;
+    auto restore_fault = util::fail_guard([previous_interruptions, previous_delay]() {
+      forced_pidfd_zero_poll_interruptions = previous_interruptions;
+      forced_pidfd_zero_poll_interruption_delay = previous_delay;
+    });
+    return terminate_pid_with_pidfd_for_tests(pid, graceful_timeout, kill_timeout);
+  }
+
   bool terminate_exact_generation_processes_for_tests(std::string_view session_instance_id) {
     return terminate_isolated_session_processes(session_instance_id, "during exact-generation test"sv);
+  }
+
+  bool exact_generation_proc_enumeration_error_fails_closed_for_tests(
+    std::string_view session_instance_id
+  ) {
+    const auto previous = forced_proc_directory_enumeration_error;
+    auto restore = util::fail_guard([previous]() {
+      forced_proc_directory_enumeration_error = previous;
+    });
+    forced_proc_directory_enumeration_error = true;
+    return !terminate_isolated_session_processes(session_instance_id, "during enumeration-error test"sv);
+  }
+
+  bool exact_generation_unknown_ancestry_fails_closed_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_unknown_pid
+  ) {
+    const auto previous = forced_proc_ancestry_unknown_pid;
+    auto restore = util::fail_guard([previous]() {
+      forced_proc_ancestry_unknown_pid = previous;
+    });
+    forced_proc_ancestry_unknown_pid = forced_unknown_pid;
+    return !terminate_isolated_session_processes(session_instance_id, "during unknown-ancestry test"sv);
+  }
+
+  bool exact_generation_post_capture_enumeration_error_fails_closed_for_tests(
+    std::string_view session_instance_id,
+    pid_t captured_pid
+  ) {
+    const auto previous_after_pid = forced_proc_directory_error_after_capture_pid;
+    const auto previous_error = forced_proc_directory_enumeration_error;
+    auto restore = util::fail_guard([previous_after_pid, previous_error]() {
+      forced_proc_directory_error_after_capture_pid = previous_after_pid;
+      forced_proc_directory_enumeration_error = previous_error;
+    });
+    forced_proc_directory_error_after_capture_pid = captured_pid;
+    return !terminate_isolated_session_processes(
+      session_instance_id,
+      "during post-capture enumeration-error test"sv
+    );
+  }
+
+  bool exact_generation_reused_pid_fails_closed_for_tests(
+    std::string_view session_instance_id,
+    pid_t reused_pid
+  ) {
+    const auto previous = forced_reused_exact_generation_pid;
+    auto restore = util::fail_guard([previous]() {
+      forced_reused_exact_generation_pid = previous;
+    });
+    forced_reused_exact_generation_pid = reused_pid;
+    return !terminate_isolated_session_processes(session_instance_id, "during reused-pid test"sv);
+  }
+
+  bool exact_generation_pidfd_open_error_fails_closed_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_pid
+  ) {
+    const auto previous = forced_pidfd_open_failure_pid;
+    auto restore = util::fail_guard([previous]() {
+      forced_pidfd_open_failure_pid = previous;
+    });
+    forced_pidfd_open_failure_pid = forced_pid;
+    return !terminate_isolated_session_processes(session_instance_id, "during pidfd-open-error test"sv);
+  }
+
+  bool proc_t::isolated_session_capture_failure_retains_generation_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_capture_failure_pid
+  ) {
+    const auto previous_failure_pid = forced_isolated_session_capture_failure_pid;
+    const auto previous_instance_id = _session_instance_id;
+    const auto previous_used_cage = _session_used_cage_compositor;
+    const auto previous_cleanup_complete = _exact_generation_cleanup_complete;
+    forced_isolated_session_capture_failure_pid = forced_capture_failure_pid;
+    _session_instance_id = session_instance_id;
+    _session_used_cage_compositor = true;
+    _exact_generation_cleanup_complete = true;
+    auto restore_state = util::fail_guard([
+      this,
+      previous_failure_pid,
+      previous_instance_id,
+      previous_used_cage,
+      previous_cleanup_complete
+    ]() {
+      forced_isolated_session_capture_failure_pid = previous_failure_pid;
+      _session_instance_id = previous_instance_id;
+      _session_used_cage_compositor = previous_used_cage;
+      _exact_generation_cleanup_complete = previous_cleanup_complete;
+    });
+
+    terminate_isolated_session_generation();
+    finish_isolated_session_generation_cleanup();
+    return !_exact_generation_cleanup_complete &&
+           _session_used_cage_compositor &&
+           _session_instance_id == session_instance_id &&
+           isolated_session_generation_blocks_launch(
+             _session_used_cage_compositor,
+             !_session_instance_id.empty()
+           );
+  }
+
+  bool proc_t::terminate_session_owned_steam_before_cage_stop_for_tests(
+    const ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id
+  ) {
+    const auto previous_app = _app;
+    const auto previous_used_cage = _session_used_cage_compositor;
+    const auto previous_instance_id = _session_instance_id;
+    _app = app;
+    _session_used_cage_compositor = session_owned_cage;
+    _session_instance_id = session_instance_id;
+    auto restore_state = util::fail_guard([
+      this,
+      previous_app,
+      previous_used_cage,
+      previous_instance_id
+    ]() {
+      _app = previous_app;
+      _session_used_cage_compositor = previous_used_cage;
+      _session_instance_id = previous_instance_id;
+    });
+    return terminate_session_owned_steam_before_cage_stop();
   }
 
   bool isolated_session_capture_failure_retains_generation_for_tests(
     std::string_view session_instance_id,
     pid_t forced_capture_failure_pid
   ) {
-    const auto previous_failure_pid = forced_isolated_session_capture_failure_pid;
-    forced_isolated_session_capture_failure_pid = forced_capture_failure_pid;
-    auto restore_failure_pid = util::fail_guard([previous_failure_pid]() {
-      forced_isolated_session_capture_failure_pid = previous_failure_pid;
-    });
-    const auto exact_cleanup_complete = terminate_isolated_session_processes(
+    boost::process::v1::environment env = boost::this_process::environment();
+    proc_t test_process {std::move(env), {}};
+    return test_process.isolated_session_capture_failure_retains_generation_for_tests(
       session_instance_id,
-      "during forced incomplete-capture test"sv
-    );
-    return !isolated_session_cleanup_clears_state(
-      true,
-      !session_instance_id.empty(),
-      exact_cleanup_complete
+      forced_capture_failure_pid
     );
   }
 
@@ -3203,7 +3653,83 @@ namespace proc {
     bool session_owned_cage,
     std::string_view session_instance_id
   ) {
-    return terminate_session_owned_steam_before_cage_stop_impl(
+    boost::process::v1::environment env = boost::this_process::environment();
+    proc_t test_process {std::move(env), {}};
+    return test_process.terminate_session_owned_steam_before_cage_stop_for_tests(
+      app,
+      session_owned_cage,
+      session_instance_id
+    );
+  }
+
+  bool terminate_session_owned_steam_with_forced_capture_failure_for_tests(
+    const ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id,
+    pid_t forced_pid
+  ) {
+    const auto previous = forced_steam_ownership_capture_failure_pid;
+    auto restore = util::fail_guard([previous]() {
+      forced_steam_ownership_capture_failure_pid = previous;
+    });
+    forced_steam_ownership_capture_failure_pid = forced_pid;
+    return terminate_session_owned_steam_before_cage_stop_for_tests(
+      app,
+      session_owned_cage,
+      session_instance_id
+    );
+  }
+
+  bool terminate_session_owned_steam_with_pidfd_open_error_for_tests(
+    const ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id,
+    pid_t forced_pid
+  ) {
+    const auto previous = forced_pidfd_open_failure_pid;
+    auto restore = util::fail_guard([previous]() {
+      forced_pidfd_open_failure_pid = previous;
+    });
+    forced_pidfd_open_failure_pid = forced_pid;
+    return terminate_session_owned_steam_before_cage_stop_for_tests(
+      app,
+      session_owned_cage,
+      session_instance_id
+    );
+  }
+
+  bool terminate_session_owned_steam_with_post_capture_enumeration_error_for_tests(
+    const ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id,
+    pid_t captured_pid
+  ) {
+    const auto previous_after_pid = forced_proc_directory_error_after_capture_pid;
+    const auto previous_error = forced_proc_directory_enumeration_error;
+    auto restore = util::fail_guard([previous_after_pid, previous_error]() {
+      forced_proc_directory_error_after_capture_pid = previous_after_pid;
+      forced_proc_directory_enumeration_error = previous_error;
+    });
+    forced_proc_directory_error_after_capture_pid = captured_pid;
+    return terminate_session_owned_steam_before_cage_stop_for_tests(
+      app,
+      session_owned_cage,
+      session_instance_id
+    );
+  }
+
+  bool terminate_session_owned_steam_with_reused_pid_for_tests(
+    const ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id,
+    pid_t reused_pid
+  ) {
+    const auto previous = forced_reused_exact_generation_pid;
+    auto restore = util::fail_guard([previous]() {
+      forced_reused_exact_generation_pid = previous;
+    });
+    forced_reused_exact_generation_pid = reused_pid;
+    return terminate_session_owned_steam_before_cage_stop_for_tests(
       app,
       session_owned_cage,
       session_instance_id
@@ -5382,12 +5908,44 @@ namespace proc {
   }
 
 #ifdef __linux__
-  void proc_t::terminate_session_owned_steam_before_cage_stop() {
-    (void) terminate_session_owned_steam_before_cage_stop_impl(
+  bool proc_t::terminate_session_owned_steam_before_cage_stop() {
+    return terminate_session_owned_steam_before_cage_stop_impl(
       _app,
       _session_used_cage_compositor,
       _session_instance_id
     );
+  }
+
+  void proc_t::terminate_isolated_session_generation() {
+    _exact_generation_cleanup_complete = true;
+    if (!_session_used_cage_compositor) {
+      return;
+    }
+
+    _exact_generation_cleanup_complete = terminate_isolated_session_processes(
+      _session_instance_id,
+      "after private Steam pre-cage termination"sv
+    );
+    if (isolated_session_cleanup_resets_router(
+          _session_used_cage_compositor,
+          !_session_instance_id.empty(),
+          _exact_generation_cleanup_complete
+        )) {
+      cage_display_router::reset_after_external_stop();
+    } else {
+      BOOST_LOG(error) << "process: retaining immutable cage generation because exact-generation cleanup was incomplete"sv;
+    }
+  }
+
+  void proc_t::finish_isolated_session_generation_cleanup() {
+    if (isolated_session_cleanup_clears_state(
+          _session_used_cage_compositor,
+          !_session_instance_id.empty(),
+          _exact_generation_cleanup_complete
+        )) {
+      _session_instance_id.clear();
+      _session_used_cage_compositor = false;
+    }
   }
 
 #endif
@@ -5399,7 +5957,6 @@ namespace proc {
     placebo = false;
 
 #ifdef __linux__
-    bool exact_generation_cleanup_complete = true;
     stop_steam_big_picture_input_guard();
     if (!immediate) {
       terminate_session_owned_steam_before_cage_stop();
@@ -5408,21 +5965,7 @@ namespace proc {
     // The immutable launch generation, not mutable config, owns this cleanup.
     // Capture and terminate every exact-generation process through pidfds before
     // any legacy child/group handle can signal or be destroyed.
-    if (_session_used_cage_compositor) {
-      exact_generation_cleanup_complete = terminate_isolated_session_processes(
-        _session_instance_id,
-        "after private Steam pre-cage termination"sv
-      );
-      if (isolated_session_cleanup_resets_router(
-            _session_used_cage_compositor,
-            !_session_instance_id.empty(),
-            exact_generation_cleanup_complete
-          )) {
-        cage_display_router::reset_after_external_stop();
-      } else {
-        BOOST_LOG(error) << "process: retaining immutable cage generation because exact-generation cleanup was incomplete"sv;
-      }
-    }
+    terminate_isolated_session_generation();
 #endif
 
 #ifdef __linux__
@@ -5509,14 +6052,7 @@ namespace proc {
     }
 
 #ifdef __linux__
-    if (isolated_session_cleanup_clears_state(
-          _session_used_cage_compositor,
-          !_session_instance_id.empty(),
-          exact_generation_cleanup_complete
-        )) {
-      _session_instance_id.clear();
-      _session_used_cage_compositor = false;
-    }
+    finish_isolated_session_generation_cleanup();
 
     // Disable streaming display after undo commands have run.
     // Skip if a virtual display was created (it will be destroyed below).

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1054,11 +1054,14 @@ namespace proc {
         }
         const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
         const auto timeout_ms = static_cast<int>(std::max<std::int64_t>(1, remaining.count()));
-        int result;
-        do {
-          result = poll(pending.data(), pending.size(), timeout_ms);
-        } while (result < 0 && errno == EINTR);
-        if (result <= 0) {
+        const int result = poll(pending.data(), pending.size(), timeout_ms);
+        if (result < 0) {
+          if (errno == EINTR) {
+            continue;
+          }
+          return false;
+        }
+        if (result == 0) {
           return false;
         }
       }
@@ -1241,6 +1244,10 @@ namespace proc {
       bool capture_complete = true;
     };
 
+#ifdef POLARIS_TESTS
+    thread_local pid_t forced_isolated_session_capture_failure_pid = -1;
+#endif
+
     isolated_session_process_snapshot_t isolated_session_process_snapshot(
       std::string_view session_instance_id
     ) {
@@ -1270,6 +1277,12 @@ namespace proc {
         if (!proc_environ_matches_isolated_session(environ_before, session_instance_id)) {
           continue;
         }
+#ifdef POLARIS_TESTS
+        if (pid == forced_isolated_session_capture_failure_pid) {
+          snapshot.capture_complete = false;
+          continue;
+        }
+#endif
         const auto identity_before = proc_start_time_ticks(pid);
         if (!identity_before) {
           snapshot.capture_complete = false;
@@ -3163,6 +3176,26 @@ namespace proc {
 
   bool terminate_exact_generation_processes_for_tests(std::string_view session_instance_id) {
     return terminate_isolated_session_processes(session_instance_id, "during exact-generation test"sv);
+  }
+
+  bool isolated_session_capture_failure_retains_generation_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_capture_failure_pid
+  ) {
+    const auto previous_failure_pid = forced_isolated_session_capture_failure_pid;
+    forced_isolated_session_capture_failure_pid = forced_capture_failure_pid;
+    auto restore_failure_pid = util::fail_guard([previous_failure_pid]() {
+      forced_isolated_session_capture_failure_pid = previous_failure_pid;
+    });
+    const auto exact_cleanup_complete = terminate_isolated_session_processes(
+      session_instance_id,
+      "during forced incomplete-capture test"sv
+    );
+    return !isolated_session_cleanup_clears_state(
+      true,
+      !session_instance_id.empty(),
+      exact_cleanup_complete
+    );
   }
 
   bool terminate_session_owned_steam_before_cage_stop_for_tests(

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -73,7 +73,9 @@
   #include <dirent.h>
   #include <fcntl.h>
   #include <signal.h>
+  #include <poll.h>
   #include <sys/stat.h>
+  #include <sys/syscall.h>
   #include <unistd.h>
 #elif __APPLE__
   #include <mach-o/dyld.h>
@@ -824,363 +826,38 @@ namespace proc {
       return sanitized;
     }
 
-    bool is_proc_pid_dir(std::string_view name) {
-      return !name.empty() && std::all_of(name.begin(), name.end(), [](char ch) {
-        return std::isdigit(static_cast<unsigned char>(ch));
-      });
-    }
-
-    std::string read_proc_text(pid_t pid, std::string_view file_name) {
-      std::ifstream file("/proc/" + std::to_string(pid) + "/" + std::string(file_name), std::ios::binary);
-      if (!file) {
-        return {};
+    bool proc_environ_contains_exact_entry(
+      std::string_view environ,
+      std::string_view key,
+      std::string_view value
+    ) {
+      if (key.empty() || value.empty()) {
+        return false;
       }
-
-      std::ostringstream buffer;
-      buffer << file.rdbuf();
-      return buffer.str();
-    }
-
-    std::string proc_text_summary(std::string text, std::size_t limit = 180) {
-      std::replace(text.begin(), text.end(), '\0', ' ');
-      boost::trim(text);
-      if (text.size() > limit) {
-        text.resize(limit);
-        text += "...";
-      }
-      return text;
-    }
-
-    std::string proc_debug_summary(pid_t pid) {
-      auto comm = proc_text_summary(read_proc_text(pid, "comm"), 80);
-      auto cmdline = proc_text_summary(read_proc_text(pid, "cmdline"));
-      if (cmdline.empty()) {
-        cmdline = comm.empty() ? "(unknown)" : comm;
-      }
-
-      std::ostringstream summary;
-      summary << "pid=" << pid;
-      if (const auto pgid = getpgid(pid); pgid > 0) {
-        summary << " pgid=" << pgid;
-      }
-      if (!comm.empty()) {
-        summary << " comm=" << comm;
-      }
-      summary << " cmd=[" << cmdline << ']';
-      return summary.str();
-    }
-
-    std::string proc_debug_summaries(const std::vector<pid_t> &pids, std::size_t limit = 8) {
-      std::ostringstream summaries;
-      for (std::size_t i = 0; i < pids.size() && i < limit; ++i) {
-        if (i > 0) {
-          summaries << "; ";
-        }
-        summaries << proc_debug_summary(pids[i]);
-      }
-      if (pids.size() > limit) {
-        summaries << "; +" << (pids.size() - limit) << " more";
-      }
-      return summaries.str();
-    }
-
-    std::mutex isolated_browser_stream_steam_cleanup_mutex;
-    std::chrono::steady_clock::time_point isolated_browser_stream_steam_settle_until {};
-
-    std::string ascii_lower_copy(std::string_view value) {
-      std::string lowered {value};
-      std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char ch) {
-        return static_cast<char>(std::tolower(ch));
-      });
-      return lowered;
-    }
-
-    std::string proc_argv0_lower(const std::string &cmdline) {
-      const auto end = cmdline.find('\0');
-      return ascii_lower_copy(std::string_view {cmdline.data(), end == std::string::npos ? cmdline.size() : end});
-    }
-
-    std::string proc_argv0_basename(std::string_view argv0_path) {
-      auto argv0 = std::string {argv0_path};
-      if (const auto slash = argv0.find_last_of('/'); slash != std::string::npos) {
-        argv0 = argv0.substr(slash + 1);
-      }
-      return argv0;
-    }
-
-    bool path_ends_with(std::string_view value, std::string_view suffix) {
-      return value.size() >= suffix.size() &&
-             value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
-    }
-
-    bool process_is_steam_client(std::string_view comm, std::string_view argv0_path) {
-      const auto argv0 = proc_argv0_basename(argv0_path);
-      return comm == "steam" ||
-             argv0 == "steam" ||
-             argv0 == "steam.sh" ||
-             path_ends_with(argv0_path, "/steam.sh") ||
-             path_ends_with(argv0_path, "/ubuntu12_32/steam");
-    }
-
-    std::vector<pid_t> scan_proc_pids(const std::function<bool(pid_t)> &predicate) {
-      std::vector<pid_t> pids;
-      DIR *dir = opendir("/proc");
-      if (!dir) {
-        return pids;
-      }
-
-      while (auto *entry = readdir(dir)) {
-        const std::string name = entry->d_name;
-        if (!is_proc_pid_dir(name)) {
-          continue;
-        }
-
-        const auto pid = static_cast<pid_t>(std::strtol(name.c_str(), nullptr, 10));
-        if (pid <= 1 || pid == getpid()) {
-          continue;
-        }
-
-        if (predicate(pid)) {
-          pids.emplace_back(pid);
-        }
-      }
-
-      closedir(dir);
-      return pids;
-    }
-
-    std::vector<pid_t> transient_steam_client_pids() {
-      return scan_proc_pids([](pid_t pid) {
-        auto comm = ascii_lower_copy(read_proc_text(pid, "comm"));
-        boost::trim(comm);
-
-        const auto cmdline = read_proc_text(pid, "cmdline");
-        const auto argv0 = proc_argv0_lower(cmdline);
-        if (!process_is_steam_client(comm, argv0)) {
+      const auto expected = std::string {key} + "=" + std::string {value};
+      std::size_t start = 0;
+      while (start < environ.size()) {
+        const auto end = environ.find('\0', start);
+        if (end == std::string_view::npos) {
           return false;
         }
-
-        const auto lower_cmdline = ascii_lower_copy(cmdline);
-        return lower_cmdline.find("-shutdown") != std::string::npos ||
-               lower_cmdline.find("-child-update-ui") != std::string::npos ||
-               lower_cmdline.find("-srt-logger-opened") != std::string::npos;
-      });
-    }
-
-    std::vector<pid_t> steam_runtime_probe_pids() {
-      return scan_proc_pids([](pid_t pid) {
-        const auto lower_cmdline = ascii_lower_copy(read_proc_text(pid, "cmdline"));
-        const auto lower_environ = ascii_lower_copy(read_proc_text(pid, "environ"));
-        return lower_cmdline.find("d3ddriverquery") != std::string::npos ||
-               lower_environ.find("d3ddriverquery") != std::string::npos;
-      });
-    }
-
-    bool pid_exists(pid_t pid) {
-      return std::filesystem::exists(std::filesystem::path("/proc") / std::to_string(pid));
-    }
-
-    bool any_pid_exists(const std::vector<pid_t> &pids) {
-      return std::any_of(pids.begin(), pids.end(), pid_exists);
-    }
-
-    void signal_processes_and_groups(const std::vector<pid_t> &pids, int signal) {
-      std::set<pid_t> groups;
-      for (auto pid : pids) {
-        const auto pgid = getpgid(pid);
-        if (pgid > 1 && pgid != getpgrp()) {
-          groups.insert(pgid);
-        }
-      }
-
-      for (auto pgid : groups) {
-        kill(-pgid, signal);
-      }
-      for (auto pid : pids) {
-        kill(pid, signal);
-      }
-    }
-
-    void terminate_steam_runtime_probes(std::string_view reason) {
-      auto pids = steam_runtime_probe_pids();
-      if (pids.empty()) {
-        return;
-      }
-
-      BOOST_LOG(info) << "process: terminating "sv << pids.size()
-                      << " Steam runtime probe process(es) "sv << reason;
-      signal_processes_and_groups(pids, SIGTERM);
-
-      for (int i = 0; i < 10; ++i) {
-        if (!any_pid_exists(pids)) {
-          return;
-        }
-        std::this_thread::sleep_for(100ms);
-      }
-
-      pids = steam_runtime_probe_pids();
-      if (!pids.empty()) {
-        BOOST_LOG(warning) << "process: Steam runtime probe process(es) did not exit after SIGTERM; sending SIGKILL"sv;
-        signal_processes_and_groups(pids, SIGKILL);
-      }
-    }
-
-    bool wait_for_transient_steam_clients(std::chrono::milliseconds timeout, std::string_view reason) {
-      const auto deadline = std::chrono::steady_clock::now() + timeout;
-      bool logged = false;
-
-      while (std::chrono::steady_clock::now() < deadline) {
-        auto pids = transient_steam_client_pids();
-        if (pids.empty()) {
+        if (environ.substr(start, end - start) == expected) {
           return true;
         }
-
-        if (!logged) {
-          BOOST_LOG(info) << "process: waiting for "sv << pids.size()
-                          << " transient Steam client process(es) "sv << reason;
-          logged = true;
-        }
-        std::this_thread::sleep_for(250ms);
+        start = end + 1;
       }
-
-      auto pids = transient_steam_client_pids();
-      if (!pids.empty()) {
-        BOOST_LOG(warning) << "process: "sv << pids.size()
-                           << " transient Steam client process(es) still running after settle window"sv;
-        return false;
-      }
-      return true;
+      return false;
     }
 
-    bool proc_text_contains_steam_appid(const std::string &text, const std::string &appid) {
-      if (appid.empty() || text.empty()) {
-        return false;
-      }
-
-      return text.find("SteamLaunch AppId=" + appid) != std::string::npos ||
-             text.find("SteamAppId=" + appid) != std::string::npos ||
-             text.find("SteamGameId=" + appid) != std::string::npos ||
-             text.find("steam://rungameid/" + appid) != std::string::npos ||
-             (text.find("-applaunch") != std::string::npos && text.find(appid) != std::string::npos);
-    }
-
-    std::vector<pid_t> steam_app_pids(const std::string &appid) {
-      std::vector<pid_t> pids;
-      DIR *dir = opendir("/proc");
-      if (!dir) {
-        return pids;
-      }
-
-      while (auto *entry = readdir(dir)) {
-        const std::string name = entry->d_name;
-        if (!is_proc_pid_dir(name)) {
-          continue;
-        }
-
-        const auto pid = static_cast<pid_t>(std::strtol(name.c_str(), nullptr, 10));
-        if (pid <= 1 || pid == getpid()) {
-          continue;
-        }
-
-        if (proc_text_contains_steam_appid(read_proc_text(pid, "cmdline"), appid) ||
-            proc_text_contains_steam_appid(read_proc_text(pid, "environ"), appid)) {
-          pids.emplace_back(pid);
-        }
-      }
-
-      closedir(dir);
-      return pids;
-    }
-
-    bool proc_environ_contains_isolated_session_marker(const std::string &environ) {
-      return environ.find("POLARIS_SESSION_AUDIO_SINK=") != std::string::npos ||
-             environ.find("POLARIS_SESSION_TARGET_FPS=") != std::string::npos ||
-             environ.find("POLARIS_SESSION_REQUESTED_FPS=") != std::string::npos;
-    }
-
-    std::vector<pid_t> isolated_session_pids() {
-      std::vector<pid_t> pids;
-      DIR *dir = opendir("/proc");
-      if (!dir) {
-        return pids;
-      }
-
-      while (auto *entry = readdir(dir)) {
-        const std::string name = entry->d_name;
-        if (!is_proc_pid_dir(name)) {
-          continue;
-        }
-
-        const auto pid = static_cast<pid_t>(std::strtol(name.c_str(), nullptr, 10));
-        if (pid <= 1 || pid == getpid()) {
-          continue;
-        }
-
-        if (proc_environ_contains_isolated_session_marker(read_proc_text(pid, "environ"))) {
-          pids.emplace_back(pid);
-        }
-      }
-
-      closedir(dir);
-      return pids;
-    }
-
-    void terminate_isolated_session_processes(std::string_view reason) {
-      auto pids = isolated_session_pids();
-      if (pids.empty()) {
-        return;
-      }
-
-      std::set<pid_t> groups;
-      for (auto pid : pids) {
-        const auto pgid = getpgid(pid);
-        if (pgid > 1 && pgid != getpgrp()) {
-          groups.insert(pgid);
-        }
-      }
-
-      BOOST_LOG(info) << "process: terminating "sv << pids.size()
-                      << " isolated session process(es) "sv << reason
-                      << " process_groups="sv << groups.size();
-
-      for (auto pgid : groups) {
-        kill(-pgid, SIGTERM);
-      }
-      for (auto pid : pids) {
-        kill(pid, SIGTERM);
-      }
-
-      for (int i = 0; i < 20; ++i) {
-        if (isolated_session_pids().empty()) {
-          return;
-        }
-        std::this_thread::sleep_for(100ms);
-      }
-
-      pids = isolated_session_pids();
-      if (pids.empty()) {
-        return;
-      }
-
-      BOOST_LOG(warning) << "process: "sv << pids.size()
-                         << " isolated session process(es) still running "sv
-                         << reason << "; sending SIGKILL survivors=["sv
-                         << proc_debug_summaries(pids) << ']';
-
-      groups.clear();
-      for (auto pid : pids) {
-        const auto pgid = getpgid(pid);
-        if (pgid > 1 && pgid != getpgrp()) {
-          groups.insert(pgid);
-        }
-      }
-
-      for (auto pgid : groups) {
-        kill(-pgid, SIGKILL);
-      }
-      for (auto pid : pids) {
-        kill(pid, SIGKILL);
-      }
+    bool proc_environ_matches_isolated_session(
+      std::string_view environ,
+      std::string_view session_instance_id
+    ) {
+      return proc_environ_contains_exact_entry(
+        environ,
+        "POLARIS_SESSION_INSTANCE_ID"sv,
+        session_instance_id
+      );
     }
 
     std::string steam_appid_for_context(const proc::ctx_t &ctx) {
@@ -1201,65 +878,6 @@ namespace proc {
       return {};
     }
 
-    void terminate_steam_app_processes(const proc::ctx_t &ctx) {
-      const auto appid = steam_appid_for_context(ctx);
-      if (appid.empty()) {
-        return;
-      }
-
-      auto pids = steam_app_pids(appid);
-      if (pids.empty()) {
-        return;
-      }
-
-      std::set<pid_t> groups;
-      for (auto pid : pids) {
-        const auto pgid = getpgid(pid);
-        if (pgid > 1 && pgid != getpgrp()) {
-          groups.insert(pgid);
-        }
-      }
-
-      BOOST_LOG(info) << "process: terminating Steam app ["sv << appid
-                      << "] process groups="sv << groups.size()
-                      << " matched_pids="sv << pids.size();
-
-      for (auto pgid : groups) {
-        kill(-pgid, SIGTERM);
-      }
-      for (auto pid : pids) {
-        kill(pid, SIGTERM);
-      }
-
-      for (int i = 0; i < 20; ++i) {
-        if (steam_app_pids(appid).empty()) {
-          return;
-        }
-        std::this_thread::sleep_for(100ms);
-      }
-
-      pids = steam_app_pids(appid);
-      if (!pids.empty()) {
-        BOOST_LOG(warning) << "process: Steam app ["sv << appid
-                           << "] did not exit after SIGTERM; sending SIGKILL survivors=["sv
-                           << proc_debug_summaries(pids) << ']';
-      }
-
-      groups.clear();
-      for (auto pid : pids) {
-        const auto pgid = getpgid(pid);
-        if (pgid > 1 && pgid != getpgrp()) {
-          groups.insert(pgid);
-        }
-      }
-
-      for (auto pgid : groups) {
-        kill(-pgid, SIGKILL);
-      }
-      for (auto pid : pids) {
-        kill(pid, SIGKILL);
-      }
-    }
 #endif
 
     bool prep_cmd_undo_stops_steam(const proc::cmd_t &cmd) {
@@ -1312,6 +930,175 @@ namespace proc {
       return is_steam_big_picture_app(ctx) ||
              is_steam_library_app(ctx) ||
              !steam_appid_for_context(ctx).empty();
+    }
+
+    bool isolated_session_generation_blocks_launch(
+      bool session_owned_cage,
+      bool generation_available
+    ) {
+      return session_owned_cage || generation_available;
+    }
+
+    bool isolated_session_cleanup_resets_router(
+      bool session_owned_cage,
+      bool generation_available,
+      bool exact_cleanup_complete
+    ) {
+      return session_owned_cage && generation_available && exact_cleanup_complete;
+    }
+
+    bool isolated_session_cleanup_clears_state(
+      bool session_owned_cage,
+      bool generation_available,
+      bool exact_cleanup_complete
+    ) {
+      return !session_owned_cage || (generation_available && exact_cleanup_complete);
+    }
+
+    bool isolated_session_uses_legacy_group_termination(
+      bool session_owned_cage,
+      bool immediate
+    ) {
+      return !session_owned_cage && !immediate;
+    }
+
+    bool isolated_session_detaches_legacy_handles(bool session_owned_cage) {
+      return session_owned_cage;
+    }
+
+    bool should_terminate_session_owned_steam_before_cage_stop(
+      const proc::ctx_t &ctx,
+      bool session_owned_cage,
+      bool session_generation_available,
+      bool session_owned_steam_client_active,
+      bool unowned_steam_client_active,
+      bool ownership_capture_complete
+    ) {
+      return session_owned_cage &&
+             session_generation_available &&
+             context_uses_steam(ctx) &&
+             session_owned_steam_client_active &&
+             !unowned_steam_client_active &&
+             ownership_capture_complete;
+    }
+
+    struct pidfd_handle_t {
+      pid_t pid = -1;
+      int fd = -1;
+
+      pidfd_handle_t() = default;
+      pidfd_handle_t(pid_t process_id, int descriptor): pid(process_id), fd(descriptor) {}
+      pidfd_handle_t(const pidfd_handle_t &) = delete;
+      pidfd_handle_t &operator=(const pidfd_handle_t &) = delete;
+      pidfd_handle_t(pidfd_handle_t &&other) noexcept: pid(other.pid), fd(other.fd) {
+        other.pid = -1;
+        other.fd = -1;
+      }
+      pidfd_handle_t &operator=(pidfd_handle_t &&other) noexcept {
+        if (this != &other) {
+          if (fd >= 0) {
+            close(fd);
+          }
+          pid = other.pid;
+          fd = other.fd;
+          other.pid = -1;
+          other.fd = -1;
+        }
+        return *this;
+      }
+      ~pidfd_handle_t() {
+        if (fd >= 0) {
+          close(fd);
+        }
+      }
+    };
+
+    std::optional<pidfd_handle_t> open_process_pidfd(pid_t pid, int &open_error) {
+      const auto fd = static_cast<int>(syscall(SYS_pidfd_open, pid, 0));
+      if (fd < 0) {
+        open_error = errno;
+        return std::nullopt;
+      }
+      open_error = 0;
+      return pidfd_handle_t {pid, fd};
+    }
+
+    bool pidfd_has_exited(const pidfd_handle_t &handle) {
+      pollfd descriptor {handle.fd, POLLIN, 0};
+      int result;
+      do {
+        result = poll(&descriptor, 1, 0);
+      } while (result < 0 && errno == EINTR);
+      return result == 1 && (descriptor.revents & POLLIN) != 0;
+    }
+
+    bool wait_for_pidfds_exit(
+      const std::vector<pidfd_handle_t> &handles,
+      std::chrono::milliseconds timeout
+    ) {
+      const auto deadline = std::chrono::steady_clock::now() + timeout;
+      for (;;) {
+        std::vector<pollfd> pending;
+        for (const auto &handle : handles) {
+          if (!pidfd_has_exited(handle)) {
+            pending.emplace_back(pollfd {handle.fd, POLLIN, 0});
+          }
+        }
+        if (pending.empty()) {
+          return true;
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
+          return false;
+        }
+        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+        const auto timeout_ms = static_cast<int>(std::max<std::int64_t>(1, remaining.count()));
+        int result;
+        do {
+          result = poll(pending.data(), pending.size(), timeout_ms);
+        } while (result < 0 && errno == EINTR);
+        if (result <= 0) {
+          return false;
+        }
+      }
+    }
+
+    bool send_pidfd_signal(const pidfd_handle_t &handle, int signal_number) {
+      if (pidfd_has_exited(handle)) {
+        return true;
+      }
+      if (syscall(SYS_pidfd_send_signal, handle.fd, signal_number, nullptr, 0) == 0) {
+        return true;
+      }
+      return errno == ESRCH;
+    }
+
+    bool terminate_pidfds(
+      std::vector<pidfd_handle_t> &handles,
+      std::chrono::milliseconds graceful_timeout,
+      std::chrono::milliseconds kill_timeout,
+      std::string_view label
+    ) {
+      for (const auto &handle : handles) {
+        if (!send_pidfd_signal(handle, SIGTERM)) {
+          BOOST_LOG(warning) << "process: pidfd SIGTERM failed for "sv << label
+                             << " pid="sv << handle.pid << " error="sv << std::strerror(errno);
+        }
+      }
+      if (wait_for_pidfds_exit(handles, graceful_timeout)) {
+        return true;
+      }
+
+      BOOST_LOG(warning) << "process: "sv << label
+                         << " did not exit after pidfd SIGTERM; sending PID-bound SIGKILL"sv;
+      for (const auto &handle : handles) {
+        if (!send_pidfd_signal(handle, SIGKILL)) {
+          BOOST_LOG(warning) << "process: pidfd SIGKILL failed for "sv << label
+                             << " pid="sv << handle.pid << " error="sv << std::strerror(errno);
+        }
+      }
+      return wait_for_pidfds_exit(handles, kill_timeout);
     }
 
     bool proc_pid_dir_name(std::string_view name) {
@@ -1387,6 +1174,279 @@ namespace proc {
         return value_pos < status.size() && status[value_pos] == static_cast<char>(90);
       }
 
+      return false;
+    }
+
+    bool is_active_steam_shutdown_ownership_process(
+      std::string_view comm,
+      std::string_view argv0_path,
+      std::string_view cmdline,
+      std::string_view status
+    ) {
+      const auto effective_argv0 = argv0_path.empty() ? proc_argv0_from_cmdline(cmdline) : std::string {argv0_path};
+      return is_desktop_steam_client_process(comm, effective_argv0) &&
+             !proc_status_is_zombie(status);
+    }
+
+#ifdef POLARIS_TESTS
+    bool steam_shutdown_process_is_unowned_active(
+      std::string_view comm,
+      std::string_view argv0_path,
+      std::string_view cmdline,
+      std::string_view status,
+      std::string_view environ,
+      std::string_view session_instance_id
+    ) {
+      return is_active_steam_shutdown_ownership_process(comm, argv0_path, cmdline, status) &&
+             !proc_environ_matches_isolated_session(environ, session_instance_id);
+    }
+#endif
+
+    std::optional<std::uint64_t> proc_start_time_from_stat(std::string_view stat) {
+      const auto comm_end = stat.rfind(')');
+      if (comm_end == std::string_view::npos || comm_end + 1 >= stat.size()) {
+        return std::nullopt;
+      }
+
+      std::istringstream fields(std::string {stat.substr(comm_end + 1)});
+      std::string token;
+      if (!(fields >> token)) {
+        return std::nullopt;
+      }
+      for (int field = 4; field <= 21; ++field) {
+        if (!(fields >> token)) {
+          return std::nullopt;
+        }
+      }
+      std::uint64_t start_time = 0;
+      if (!(fields >> start_time)) {
+        return std::nullopt;
+      }
+      return start_time;
+    }
+
+    std::optional<std::uint64_t> proc_start_time_ticks(pid_t pid) {
+      return proc_start_time_from_stat(read_proc_status_file(pid, "stat"));
+    }
+
+    bool steam_pidfd_capture_identity_matches(
+      const std::optional<std::uint64_t> &before,
+      const std::optional<std::uint64_t> &after
+    ) {
+      return before && after && *before == *after;
+    }
+
+    struct isolated_session_process_snapshot_t {
+      std::vector<pidfd_handle_t> owned;
+      bool capture_complete = true;
+    };
+
+    isolated_session_process_snapshot_t isolated_session_process_snapshot(
+      std::string_view session_instance_id
+    ) {
+      isolated_session_process_snapshot_t snapshot;
+      if (session_instance_id.empty()) {
+        snapshot.capture_complete = false;
+        return snapshot;
+      }
+
+      DIR *dir = opendir("/proc");
+      if (!dir) {
+        snapshot.capture_complete = false;
+        return snapshot;
+      }
+
+      while (auto *entry = readdir(dir)) {
+        const std::string name = entry->d_name;
+        if (!proc_pid_dir_name(name)) {
+          continue;
+        }
+        const auto pid = static_cast<pid_t>(std::strtol(name.c_str(), nullptr, 10));
+        if (pid <= 1 || pid == getpid()) {
+          continue;
+        }
+
+        const auto environ_before = read_proc_status_file(pid, "environ");
+        if (!proc_environ_matches_isolated_session(environ_before, session_instance_id)) {
+          continue;
+        }
+        const auto identity_before = proc_start_time_ticks(pid);
+        if (!identity_before) {
+          snapshot.capture_complete = false;
+          continue;
+        }
+
+        int open_error = 0;
+        auto handle = open_process_pidfd(pid, open_error);
+        if (!handle) {
+          if (open_error != ESRCH) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+
+        const auto environ_after = read_proc_status_file(pid, "environ");
+        const auto identity_after = proc_start_time_ticks(pid);
+        if (!steam_pidfd_capture_identity_matches(identity_before, identity_after) ||
+            !proc_environ_matches_isolated_session(environ_after, session_instance_id)) {
+          if (!pidfd_has_exited(*handle)) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+        snapshot.owned.emplace_back(std::move(*handle));
+      }
+
+      closedir(dir);
+      return snapshot;
+    }
+
+    bool terminate_isolated_session_processes(
+      std::string_view session_instance_id,
+      std::string_view reason
+    ) {
+      if (session_instance_id.empty()) {
+        return false;
+      }
+
+      for (int pass = 0; pass < 2; ++pass) {
+        auto snapshot = isolated_session_process_snapshot(session_instance_id);
+        if (!snapshot.capture_complete) {
+          BOOST_LOG(warning) << "process: exact-generation isolated process capture was incomplete "sv << reason;
+        }
+        if (snapshot.owned.empty()) {
+          return snapshot.capture_complete;
+        }
+
+        BOOST_LOG(info) << "process: terminating "sv << snapshot.owned.size()
+                        << " exact-generation isolated process(es) "sv << reason;
+        if (!terminate_pidfds(snapshot.owned, 2s, 1s, "isolated session process"sv)) {
+          BOOST_LOG(warning) << "process: exact-generation isolated processes remained after bounded pidfd cleanup "sv
+                             << reason;
+        }
+      }
+
+      const auto final_snapshot = isolated_session_process_snapshot(session_instance_id);
+      return final_snapshot.capture_complete && final_snapshot.owned.empty();
+    }
+
+    struct steam_client_ownership_snapshot_t {
+      std::vector<pidfd_handle_t> owned;
+      std::vector<pidfd_handle_t> unowned;
+      bool capture_complete = true;
+    };
+
+    steam_client_ownership_snapshot_t steam_client_ownership_snapshot(std::string_view session_instance_id) {
+      steam_client_ownership_snapshot_t snapshot;
+      DIR *dir = opendir("/proc");
+      if (!dir) {
+        snapshot.capture_complete = false;
+        return snapshot;
+      }
+
+      while (auto *entry = readdir(dir)) {
+        const std::string name = entry->d_name;
+        if (!proc_pid_dir_name(name)) {
+          continue;
+        }
+        const auto pid = static_cast<pid_t>(std::strtol(name.c_str(), nullptr, 10));
+        if (pid <= 1 || pid == getpid()) {
+          continue;
+        }
+
+        const auto identity_before = proc_start_time_ticks(pid);
+        auto comm = boost::to_lower_copy(read_proc_status_file(pid, "comm"));
+        boost::trim(comm);
+        auto cmdline = read_proc_status_file(pid, "cmdline");
+        auto argv0 = proc_argv0_from_cmdline(cmdline);
+        auto status = read_proc_status_file(pid, "status");
+        if (!is_active_steam_shutdown_ownership_process(comm, argv0, cmdline, status)) {
+          continue;
+        }
+        if (!identity_before) {
+          snapshot.capture_complete = false;
+          continue;
+        }
+
+        int open_error = 0;
+        auto handle = open_process_pidfd(pid, open_error);
+        if (!handle) {
+          if (open_error != ESRCH) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+
+        comm = boost::to_lower_copy(read_proc_status_file(pid, "comm"));
+        boost::trim(comm);
+        cmdline = read_proc_status_file(pid, "cmdline");
+        argv0 = proc_argv0_from_cmdline(cmdline);
+        status = read_proc_status_file(pid, "status");
+        const auto identity_after = proc_start_time_ticks(pid);
+        if (!is_active_steam_shutdown_ownership_process(comm, argv0, cmdline, status)) {
+          continue;
+        }
+        if (!steam_pidfd_capture_identity_matches(identity_before, identity_after)) {
+          if (!pidfd_has_exited(*handle)) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+
+        const auto environ = read_proc_status_file(pid, "environ");
+        if (environ.empty() && !pidfd_has_exited(*handle)) {
+          snapshot.capture_complete = false;
+          continue;
+        }
+        if (proc_environ_matches_isolated_session(environ, session_instance_id)) {
+          snapshot.owned.emplace_back(std::move(*handle));
+        } else {
+          snapshot.unowned.emplace_back(std::move(*handle));
+        }
+      }
+
+      closedir(dir);
+      return snapshot;
+    }
+
+    bool terminate_session_owned_steam_before_cage_stop_impl(
+      const proc::ctx_t &app,
+      bool session_owned_cage,
+      std::string_view session_instance_id
+    ) {
+      const bool steam_context = context_uses_steam(app);
+      if (!session_owned_cage || session_instance_id.empty() || !steam_context) {
+        return false;
+      }
+
+      auto ownership = steam_client_ownership_snapshot(session_instance_id);
+      if (!should_terminate_session_owned_steam_before_cage_stop(
+            app,
+            session_owned_cage,
+            !session_instance_id.empty(),
+            !ownership.owned.empty(),
+            !ownership.unowned.empty(),
+            ownership.capture_complete
+          )) {
+        if (!ownership.capture_complete) {
+          BOOST_LOG(warning) << "process: skipping pre-cage private Steam termination because pidfd ownership capture was incomplete"sv;
+        } else if (!ownership.unowned.empty()) {
+          BOOST_LOG(warning) << "process: skipping pre-cage private Steam termination because "sv
+                             << ownership.unowned.size() << " active Steam client process(es) are not session-owned"sv;
+        } else if (ownership.owned.empty()) {
+          BOOST_LOG(info) << "process: skipping pre-cage private Steam termination because no session-owned Steam client is active"sv;
+        }
+        return false;
+      }
+
+      BOOST_LOG(info) << "process: terminating "sv << ownership.owned.size()
+                      << " session-owned Steam process(es) through pidfd before isolated cage stop"sv;
+      if (terminate_pidfds(ownership.owned, 5s, 1s, "private Steam"sv)) {
+        BOOST_LOG(info) << "process: session-owned Steam exited before isolated cage stop"sv;
+        return true;
+      }
+
+      BOOST_LOG(warning) << "process: session-owned Steam remained after bounded pidfd termination; continuing with isolated cage fallback cleanup"sv;
       return false;
     }
 
@@ -1481,51 +1541,13 @@ namespace proc {
       return policy;
     }
 
-    bool should_skip_steam_shutdown_undo_after_cage_cleanup(const proc::ctx_t &ctx,
+    bool should_skip_steam_shutdown_undo_after_cage_cleanup(const proc::ctx_t &,
                                                             const proc::cmd_t &cmd,
-                                                            bool use_cage_compositor) {
-      return use_cage_compositor &&
-             context_uses_steam(ctx) &&
+                                                            bool session_owned_cage) {
+      return session_owned_cage &&
              command_requests_steam_shutdown(cmd.undo_cmd);
     }
 
-    bool is_browser_stream_session(const std::shared_ptr<rtsp_stream::launch_session_t> &launch_session) {
-      return launch_session && launch_session->device_name == "Browser Stream";
-    }
-
-    void settle_isolated_browser_stream_steam_cleanup(const proc::ctx_t &ctx) {
-      if (!context_uses_steam(ctx)) {
-        return;
-      }
-
-      terminate_steam_runtime_probes("after Browser Stream cleanup"sv);
-      wait_for_transient_steam_clients(4s, "after Browser Stream cleanup"sv);
-
-      std::lock_guard lock(isolated_browser_stream_steam_cleanup_mutex);
-      isolated_browser_stream_steam_settle_until = std::chrono::steady_clock::now() + 30s;
-    }
-
-    void settle_recent_browser_stream_steam_cleanup_before_launch(const proc::ctx_t &next_app) {
-      if (!context_uses_steam(next_app)) {
-        return;
-      }
-
-      {
-        std::lock_guard lock(isolated_browser_stream_steam_cleanup_mutex);
-        if (std::chrono::steady_clock::now() >= isolated_browser_stream_steam_settle_until) {
-          return;
-        }
-      }
-
-      BOOST_LOG(info) << "process: settling previous Browser Stream Steam cleanup before launching ["sv
-                      << next_app.name << ']';
-      terminate_steam_runtime_probes("before next Steam launch"sv);
-      wait_for_transient_steam_clients(8s, "before next Steam launch"sv);
-      std::this_thread::sleep_for(500ms);
-
-      std::lock_guard lock(isolated_browser_stream_steam_cleanup_mutex);
-      isolated_browser_stream_steam_settle_until = {};
-    }
 #endif
 
     void normalize_steam_big_picture_app(proc::ctx_t &ctx) {
@@ -2028,6 +2050,14 @@ namespace proc {
                              const std::string &value) {
       env[key] = value;
       platf::set_env(key, value);
+      tracked_keys.insert(key);
+    }
+
+    void set_child_only_session_env_var(boost::process::v1::environment &env,
+                                        std::unordered_set<std::string> &tracked_keys,
+                                        const std::string &key,
+                                        const std::string &value) {
+      env[key] = value;
       tracked_keys.insert(key);
     }
 
@@ -3043,6 +3073,152 @@ namespace proc {
                                                                    bool use_cage_compositor) {
     return should_skip_steam_shutdown_undo_after_cage_cleanup(app, cmd, use_cage_compositor);
   }
+
+  bool should_terminate_session_owned_steam_before_cage_stop_for_tests(
+    const proc::ctx_t &app,
+    bool session_owned_cage,
+    bool session_generation_available,
+    bool session_owned_steam_client_active,
+    bool unowned_steam_client_active,
+    bool ownership_capture_complete
+  ) {
+    return should_terminate_session_owned_steam_before_cage_stop(
+      app,
+      session_owned_cage,
+      session_generation_available,
+      session_owned_steam_client_active,
+      unowned_steam_client_active,
+      ownership_capture_complete
+    );
+  }
+
+  bool steam_shutdown_process_is_unowned_active_for_tests(
+    std::string_view comm,
+    std::string_view argv0_path,
+    std::string_view cmdline,
+    std::string_view status,
+    std::string_view environ,
+    std::string_view session_instance_id
+  ) {
+    return steam_shutdown_process_is_unowned_active(
+      comm, argv0_path, cmdline, status, environ, session_instance_id
+    );
+  }
+
+  bool isolated_session_environ_matches_for_tests(
+    std::string_view environ,
+    std::string_view session_instance_id
+  ) {
+    return proc_environ_matches_isolated_session(environ, session_instance_id);
+  }
+
+  bool session_instance_environment_is_child_only_for_tests(
+    std::string_view session_instance_id
+  ) {
+    constexpr auto key = "POLARIS_SESSION_INSTANCE_ID";
+    const auto original = copy_env_var(key);
+    platf::unset_env(key);
+
+    boost::process::v1::environment env = boost::this_process::environment();
+    std::unordered_set<std::string> tracked_keys;
+    set_child_only_session_env_var(
+      env,
+      tracked_keys,
+      key,
+      std::string {session_instance_id}
+    );
+
+    const bool child_has_exact_value = env[key].to_string() == session_instance_id;
+    const bool parent_is_untouched = std::getenv(key) == nullptr;
+    const bool key_is_tracked = tracked_keys.contains(key);
+    restore_env_var(key, original);
+    return child_has_exact_value && parent_is_untouched && key_is_tracked;
+  }
+
+  std::optional<std::uint64_t> proc_start_time_from_stat_for_tests(std::string_view stat) {
+    return proc_start_time_from_stat(stat);
+  }
+
+  bool steam_pidfd_capture_identity_matches_for_tests(
+    std::optional<std::uint64_t> before,
+    std::optional<std::uint64_t> after
+  ) {
+    return steam_pidfd_capture_identity_matches(before, after);
+  }
+
+  bool terminate_pid_with_pidfd_for_tests(
+    pid_t pid,
+    std::chrono::milliseconds graceful_timeout,
+    std::chrono::milliseconds kill_timeout
+  ) {
+    int open_error = 0;
+    auto handle = open_process_pidfd(pid, open_error);
+    if (!handle) {
+      return false;
+    }
+    std::vector<pidfd_handle_t> handles;
+    handles.emplace_back(std::move(*handle));
+    return terminate_pidfds(handles, graceful_timeout, kill_timeout, "test process"sv);
+  }
+
+  bool terminate_exact_generation_processes_for_tests(std::string_view session_instance_id) {
+    return terminate_isolated_session_processes(session_instance_id, "during exact-generation test"sv);
+  }
+
+  bool terminate_session_owned_steam_before_cage_stop_for_tests(
+    const ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id
+  ) {
+    return terminate_session_owned_steam_before_cage_stop_impl(
+      app,
+      session_owned_cage,
+      session_instance_id
+    );
+  }
+
+  bool isolated_session_generation_blocks_launch_for_tests(
+    bool session_owned_cage,
+    bool generation_available
+  ) {
+    return isolated_session_generation_blocks_launch(session_owned_cage, generation_available);
+  }
+
+  bool isolated_session_cleanup_resets_router_for_tests(
+    bool session_owned_cage,
+    bool generation_available,
+    bool exact_cleanup_complete
+  ) {
+    return isolated_session_cleanup_resets_router(
+      session_owned_cage,
+      generation_available,
+      exact_cleanup_complete
+    );
+  }
+
+  bool isolated_session_cleanup_clears_state_for_tests(
+    bool session_owned_cage,
+    bool generation_available,
+    bool exact_cleanup_complete
+  ) {
+    return isolated_session_cleanup_clears_state(
+      session_owned_cage,
+      generation_available,
+      exact_cleanup_complete
+    );
+  }
+
+  bool isolated_session_uses_legacy_group_termination_for_tests(
+    bool session_owned_cage,
+    bool immediate
+  ) {
+    return isolated_session_uses_legacy_group_termination(session_owned_cage, immediate);
+  }
+
+  bool isolated_session_detaches_legacy_handles_for_tests(bool session_owned_cage) {
+    return isolated_session_detaches_legacy_handles(session_owned_cage);
+  }
+
 #endif
 
 #ifdef _WIN32
@@ -3405,7 +3581,21 @@ namespace proc {
       terminate_impl(false, false);
     }
 
+#ifdef __linux__
+    if (isolated_session_generation_blocks_launch(
+          _session_used_cage_compositor,
+          !_session_instance_id.empty()
+        )) {
+      BOOST_LOG(error) << "process: refusing launch while an incompletely cleaned isolated session generation remains"sv;
+      return 503;
+    }
+#endif
+
     ++_session_generation;
+#ifdef __linux__
+    _session_instance_id = generate_session_token();
+    _session_used_cage_compositor = false;
+#endif
     _app = app;
     _app_id = util::from_view(app.id);
     _app_name = app.name;
@@ -3425,10 +3615,6 @@ namespace proc {
     const bool requested_headless_for_session =
       config::video.linux_display.headless_mode &&
       !(launch_session && launch_session->mirror_desktop);
-    settle_recent_browser_stream_steam_cleanup_before_launch(_app);
-    if (use_cage_compositor_for_session) {
-      terminate_isolated_session_processes("before launching isolated cage session"sv);
-    }
     const auto steam_guard_snapshot = snapshot_steam_big_picture_input_guard(
       use_cage_compositor_for_session,
       launch_session && launch_session->mirror_desktop
@@ -3825,10 +4011,8 @@ namespace proc {
 #ifdef __linux__
       confighttp::set_session_state(confighttp::session_state_e::tearing_down);
       confighttp::emit_session_event("session_ending", "Cleaning up");
-      // Stop cage compositor (kills the game running inside it)
-      if (config::video.linux_display.use_cage_compositor) {
-        cage_display_router::stop();
-      }
+      // terminate_impl() owns exact-generation cage cleanup. Do not follow it
+      // with raw PID/group signaling from cage_display_router::stop().
       session_manager::restore_state(session_state);
 #endif
     });
@@ -4211,6 +4395,12 @@ namespace proc {
     _session_env_keys.clear();
 
 #ifdef __linux__
+    set_child_only_session_env_var(
+      _env,
+      _session_env_keys,
+      "POLARIS_SESSION_INSTANCE_ID",
+      _session_instance_id
+    );
     _audio_context = {};
     if (config::audio.stream) {
       _audio_context = audio::get_audio_ctx_ref();
@@ -4410,7 +4600,15 @@ namespace proc {
         cage_display_router::stop();
       }
 
-      if (!cage_display_router::start(render_width, render_height, cage_refresh_hz, startup_cmd, force_windowed, allow_cage_mangohud)) {
+      if (!cage_display_router::start(
+            render_width,
+            render_height,
+            cage_refresh_hz,
+            startup_cmd,
+            force_windowed,
+            allow_cage_mangohud,
+            _session_instance_id
+          )) {
         return false;
       }
 
@@ -4680,6 +4878,7 @@ namespace proc {
         confighttp::emit_session_event("error", "Failed to start cage compositor");
         return 503;
       } else {
+        _session_used_cage_compositor = true;
         cage_started_with_detached_client = true;
         confighttp::set_session_state(confighttp::session_state_e::game_launching);
         confighttp::emit_session_event("game_launching", "Launching " + _app.name);
@@ -4721,6 +4920,7 @@ namespace proc {
         BOOST_LOG(error) << "session_manager: Failed to start cage compositor"sv;
         return 503;
       }
+      _session_used_cage_compositor = true;
     } else
 #endif
     {
@@ -5148,6 +5348,17 @@ namespace proc {
     terminate_impl(false, true);
   }
 
+#ifdef __linux__
+  void proc_t::terminate_session_owned_steam_before_cage_stop() {
+    (void) terminate_session_owned_steam_before_cage_stop_impl(
+      _app,
+      _session_used_cage_compositor,
+      _session_instance_id
+    );
+  }
+
+#endif
+
   void proc_t::terminate_impl(bool immediate, bool needs_refresh) {
     auto &sync = session_lifecycle_sync();
     std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
@@ -5155,13 +5366,56 @@ namespace proc {
     placebo = false;
 
 #ifdef __linux__
+    bool exact_generation_cleanup_complete = true;
     stop_steam_big_picture_input_guard();
+    if (!immediate) {
+      terminate_session_owned_steam_before_cage_stop();
+    }
+
+    // The immutable launch generation, not mutable config, owns this cleanup.
+    // Capture and terminate every exact-generation process through pidfds before
+    // any legacy child/group handle can signal or be destroyed.
+    if (_session_used_cage_compositor) {
+      exact_generation_cleanup_complete = terminate_isolated_session_processes(
+        _session_instance_id,
+        "after private Steam pre-cage termination"sv
+      );
+      if (isolated_session_cleanup_resets_router(
+            _session_used_cage_compositor,
+            !_session_instance_id.empty(),
+            exact_generation_cleanup_complete
+          )) {
+        cage_display_router::reset_after_external_stop();
+      } else {
+        BOOST_LOG(error) << "process: retaining immutable cage generation because exact-generation cleanup was incomplete"sv;
+      }
+    }
 #endif
 
-    if (!immediate) {
+#ifdef __linux__
+    if (isolated_session_uses_legacy_group_termination(
+          _session_used_cage_compositor,
+          immediate
+        )) {
       terminate_process_group(_process, _process_group, _app.exit_timeout);
     }
 
+    if (isolated_session_detaches_legacy_handles(_session_used_cage_compositor)) {
+      // Boost.Process child/group destructors signal attached processes. The
+      // exact pidfd path above is the only signaling authority for cage-owned
+      // sessions, so detach legacy bookkeeping before resetting its handles.
+      if (_process.joinable()) {
+        _process.detach();
+      }
+      if (_process_group.joinable()) {
+        _process_group.detach();
+      }
+    }
+#else
+    if (!immediate) {
+      terminate_process_group(_process, _process_group, _app.exit_timeout);
+    }
+#endif
     _process = boost::process::v1::child();
     _process_group = boost::process::v1::group();
 
@@ -5177,25 +5431,6 @@ namespace proc {
     }
     _session_env_keys.clear();
     _audio_context = {};
-
-#ifdef __linux__
-    const bool should_settle_browser_stream_steam =
-      is_browser_stream_session(_launch_session) &&
-      config::video.linux_display.use_cage_compositor &&
-      context_uses_steam(_app);
-
-    // Stop labwc compositor — this kills all games running inside it.
-    // Without this, games launched with setsid escape the process group
-    // and keep running after the stream ends.
-    if (config::video.linux_display.use_cage_compositor) {
-      cage_display_router::stop();
-      terminate_isolated_session_processes("after isolated cage stop"sv);
-      terminate_steam_app_processes(_app);
-      if (should_settle_browser_stream_steam) {
-        settle_isolated_browser_stream_steam_cleanup(_app);
-      }
-    }
-#endif
 
     for (; _app_prep_it != _app_prep_begin; --_app_prep_it) {
       auto &cmd = *(_app_prep_it - 1);
@@ -5214,7 +5449,7 @@ namespace proc {
       if (should_skip_steam_shutdown_undo_after_cage_cleanup(
             _app,
             cmd,
-            config::video.linux_display.use_cage_compositor
+            _session_used_cage_compositor
           )) {
         BOOST_LOG(info) << "Skipping Steam shutdown undo after isolated cage Steam cleanup ["sv
                         << cmd.undo_cmd << ']';
@@ -5241,6 +5476,15 @@ namespace proc {
     }
 
 #ifdef __linux__
+    if (isolated_session_cleanup_clears_state(
+          _session_used_cage_compositor,
+          !_session_instance_id.empty(),
+          exact_generation_cleanup_complete
+        )) {
+      _session_instance_id.clear();
+      _session_used_cage_compositor = false;
+    }
+
     // Disable streaming display after undo commands have run.
     // Skip if a virtual display was created (it will be destroyed below).
     if (!linux_vdisplay.has_value() || !linux_vdisplay->active) {

--- a/src/process.h
+++ b/src/process.h
@@ -173,6 +173,61 @@ namespace proc {
   bool should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(const struct ctx_t &app,
                                                                    const config::prep_cmd_t &cmd,
                                                                    bool use_cage_compositor);
+  bool should_terminate_session_owned_steam_before_cage_stop_for_tests(
+    const struct ctx_t &app,
+    bool use_cage_compositor,
+    bool cage_running,
+    bool session_owned_steam_client_active,
+    bool unowned_steam_client_active,
+    bool ownership_capture_complete
+  );
+  bool steam_shutdown_process_is_unowned_active_for_tests(
+    std::string_view comm,
+    std::string_view argv0_path,
+    std::string_view cmdline,
+    std::string_view status,
+    std::string_view environ,
+    std::string_view session_instance_id
+  );
+  bool isolated_session_environ_matches_for_tests(
+    std::string_view environ,
+    std::string_view session_instance_id
+  );
+  bool session_instance_environment_is_child_only_for_tests(
+    std::string_view session_instance_id
+  );
+  std::optional<std::uint64_t> proc_start_time_from_stat_for_tests(std::string_view stat);
+  bool steam_pidfd_capture_identity_matches_for_tests(
+    std::optional<std::uint64_t> before,
+    std::optional<std::uint64_t> after
+  );
+  bool terminate_pid_with_pidfd_for_tests(
+    pid_t pid,
+    std::chrono::milliseconds graceful_timeout,
+    std::chrono::milliseconds kill_timeout
+  );
+  bool terminate_exact_generation_processes_for_tests(std::string_view session_instance_id);
+  bool terminate_session_owned_steam_before_cage_stop_for_tests(
+    const struct ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id
+  );
+  bool isolated_session_generation_blocks_launch_for_tests(bool session_owned_cage, bool generation_available);
+  bool isolated_session_cleanup_resets_router_for_tests(
+    bool session_owned_cage,
+    bool generation_available,
+    bool exact_cleanup_complete
+  );
+  bool isolated_session_cleanup_clears_state_for_tests(
+    bool session_owned_cage,
+    bool generation_available,
+    bool exact_cleanup_complete
+  );
+  bool isolated_session_uses_legacy_group_termination_for_tests(
+    bool session_owned_cage,
+    bool immediate
+  );
+  bool isolated_session_detaches_legacy_handles_for_tests(bool session_owned_cage);
 #endif
 
   typedef config::prep_cmd_t cmd_t;
@@ -442,6 +497,7 @@ namespace proc {
     );
     void terminate_impl(bool immediate, bool needs_refresh);
 #ifdef __linux__
+    void terminate_session_owned_steam_before_cage_stop();
     std::shared_ptr<const steam_big_picture_guard_snapshot_t> snapshot_steam_big_picture_input_guard(
       bool use_cage_compositor,
       bool mirror_desktop
@@ -485,6 +541,8 @@ namespace proc {
     std::unordered_set<std::string> _session_env_keys;
 #ifdef __linux__
     std::shared_ptr<steam_big_picture_guard_runtime_t> _steam_big_picture_guard;
+    std::string _session_instance_id;
+    bool _session_used_cage_compositor = false;
 #endif
     std::vector<cmd_t>::const_iterator _app_prep_it;
     std::vector<cmd_t>::const_iterator _app_prep_begin;

--- a/src/process.h
+++ b/src/process.h
@@ -166,6 +166,9 @@ namespace proc {
                                                std::string_view argv0_path,
                                                std::string_view cmdline,
                                                std::string_view status = {});
+  bool desktop_steam_proc_open_error_fails_closed_for_tests();
+  bool desktop_steam_proc_enumeration_error_fails_closed_for_tests();
+  bool desktop_steam_proc_read_error_fails_closed_for_tests(pid_t forced_pid);
 
   bool cage_mangohud_allowed_for_session_for_tests(const struct ctx_t &app,
                                                    bool use_cage_compositor,
@@ -206,7 +209,39 @@ namespace proc {
     std::chrono::milliseconds graceful_timeout,
     std::chrono::milliseconds kill_timeout
   );
+  bool terminate_pid_with_pidfd_after_wait_entry_for_tests(
+    pid_t pid,
+    std::chrono::milliseconds graceful_timeout,
+    std::chrono::milliseconds kill_timeout,
+    std::atomic<bool> &wait_entered
+  );
+  bool terminate_pid_with_forced_zero_poll_eintr_for_tests(
+    pid_t pid,
+    std::chrono::milliseconds graceful_timeout,
+    std::chrono::milliseconds kill_timeout,
+    int forced_interruptions,
+    std::chrono::milliseconds interruption_delay
+  );
   bool terminate_exact_generation_processes_for_tests(std::string_view session_instance_id);
+  bool exact_generation_proc_enumeration_error_fails_closed_for_tests(
+    std::string_view session_instance_id
+  );
+  bool exact_generation_unknown_ancestry_fails_closed_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_unknown_pid
+  );
+  bool exact_generation_post_capture_enumeration_error_fails_closed_for_tests(
+    std::string_view session_instance_id,
+    pid_t captured_pid
+  );
+  bool exact_generation_reused_pid_fails_closed_for_tests(
+    std::string_view session_instance_id,
+    pid_t reused_pid
+  );
+  bool exact_generation_pidfd_open_error_fails_closed_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_pid
+  );
   bool isolated_session_capture_failure_retains_generation_for_tests(
     std::string_view session_instance_id,
     pid_t forced_capture_failure_pid
@@ -215,6 +250,30 @@ namespace proc {
     const struct ctx_t &app,
     bool session_owned_cage,
     std::string_view session_instance_id
+  );
+  bool terminate_session_owned_steam_with_forced_capture_failure_for_tests(
+    const struct ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id,
+    pid_t forced_pid
+  );
+  bool terminate_session_owned_steam_with_pidfd_open_error_for_tests(
+    const struct ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id,
+    pid_t forced_pid
+  );
+  bool terminate_session_owned_steam_with_post_capture_enumeration_error_for_tests(
+    const struct ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id,
+    pid_t captured_pid
+  );
+  bool terminate_session_owned_steam_with_reused_pid_for_tests(
+    const struct ctx_t &app,
+    bool session_owned_cage,
+    std::string_view session_instance_id,
+    pid_t reused_pid
   );
   bool isolated_session_generation_blocks_launch_for_tests(bool session_owned_cage, bool generation_available);
   bool isolated_session_cleanup_resets_router_for_tests(
@@ -481,6 +540,17 @@ namespace proc {
     void terminate_from_admitted_launch();
     bool reload_configuration_from_file(const std::string &file_name);
     void reload_configuration(proc_t &&parsed);
+#if defined(POLARIS_TESTS) && defined(__linux__)
+    bool isolated_session_capture_failure_retains_generation_for_tests(
+      std::string_view session_instance_id,
+      pid_t forced_capture_failure_pid
+    );
+    bool terminate_session_owned_steam_before_cage_stop_for_tests(
+      const ctx_t &app,
+      bool session_owned_cage,
+      std::string_view session_instance_id
+    );
+#endif
 #if defined(POLARIS_TESTS)
     std::pair<const void *, const void *> session_lifecycle_identity_for_tests() const;
     void with_session_lifecycle_lock_for_tests(const std::function<void()> &callback);
@@ -501,7 +571,9 @@ namespace proc {
     );
     void terminate_impl(bool immediate, bool needs_refresh);
 #ifdef __linux__
-    void terminate_session_owned_steam_before_cage_stop();
+    bool terminate_session_owned_steam_before_cage_stop();
+    void terminate_isolated_session_generation();
+    void finish_isolated_session_generation_cleanup();
     std::shared_ptr<const steam_big_picture_guard_snapshot_t> snapshot_steam_big_picture_input_guard(
       bool use_cage_compositor,
       bool mirror_desktop
@@ -547,6 +619,7 @@ namespace proc {
     std::shared_ptr<steam_big_picture_guard_runtime_t> _steam_big_picture_guard;
     std::string _session_instance_id;
     bool _session_used_cage_compositor = false;
+    bool _exact_generation_cleanup_complete = true;
 #endif
     std::vector<cmd_t>::const_iterator _app_prep_it;
     std::vector<cmd_t>::const_iterator _app_prep_begin;

--- a/src/process.h
+++ b/src/process.h
@@ -207,6 +207,10 @@ namespace proc {
     std::chrono::milliseconds kill_timeout
   );
   bool terminate_exact_generation_processes_for_tests(std::string_view session_instance_id);
+  bool isolated_session_capture_failure_retains_generation_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_capture_failure_pid
+  );
   bool terminate_session_owned_steam_before_cage_stop_for_tests(
     const struct ctx_t &app,
     bool session_owned_cage,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -2,6 +2,7 @@
 #include "../tests_paths.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -18,6 +19,7 @@
 
 #ifdef __linux__
   #include <csignal>
+  #include <pthread.h>
   #include <sys/wait.h>
   #include <unistd.h>
 #endif
@@ -1134,6 +1136,65 @@ TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationBoundsGracefulWaitAndKillsS
   EXPECT_EQ(WTERMSIG(status), SIGKILL);
 }
 
+TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationDeadlineSurvivesRepeatedEintr) {
+#ifdef __linux__
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const auto child = fork();
+  ASSERT_NE(child, -1);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    std::signal(SIGTERM, SIG_IGN);
+    const char ready = '1';
+    (void) write(ready_pipe[1], &ready, 1);
+    for (;;) pause();
+  }
+
+  close(ready_pipe[1]);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+
+  struct sigaction interrupt_action {};
+  struct sigaction previous_action {};
+  interrupt_action.sa_handler = [](int) {};
+  sigemptyset(&interrupt_action.sa_mask);
+  interrupt_action.sa_flags = 0;
+  ASSERT_EQ(sigaction(SIGUSR1, &interrupt_action, &previous_action), 0);
+
+  const auto test_thread = pthread_self();
+  std::atomic<bool> stop_interrupting {false};
+  std::thread interrupter([&] {
+    const auto stop_at = std::chrono::steady_clock::now() + std::chrono::milliseconds(350);
+    while (!stop_interrupting.load() && std::chrono::steady_clock::now() < stop_at) {
+      (void) pthread_kill(test_thread, SIGUSR1);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  });
+
+  const auto started = std::chrono::steady_clock::now();
+  const bool terminated = proc::terminate_pid_with_pidfd_for_tests(
+    child, std::chrono::milliseconds(100), std::chrono::milliseconds(500)
+  );
+  const auto elapsed = std::chrono::steady_clock::now() - started;
+  stop_interrupting.store(true);
+  interrupter.join();
+  EXPECT_EQ(sigaction(SIGUSR1, &previous_action, nullptr), 0);
+
+  if (!terminated) {
+    kill(child, SIGKILL);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_TRUE(terminated);
+  EXPECT_LT(elapsed, std::chrono::milliseconds(250));
+  ASSERT_TRUE(WIFSIGNALED(status));
+  EXPECT_EQ(WTERMSIG(status), SIGKILL);
+#else
+  GTEST_SKIP() << "Linux-only pidfd interruption deadline";
+#endif
+}
+
 TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownUsesImmutableExactGeneration) {
 #ifdef __linux__
   linux_cage_compositor_guard_t config_guard;
@@ -1197,6 +1258,85 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownUsesImmutableExact
   cleanup(mirror_owned);
 #else
   GTEST_SKIP() << "Linux-only immutable private Steam teardown wiring";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownRejectsMixedOwnedAndUnownedSteam) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t config_guard;
+  const std::string token = "mixed-production-wiring-generation";
+  proc::ctx_t steam_app {};
+  steam_app.name = "Steam Big Picture";
+  steam_app.cmd = "steam -gamepadui";
+
+  auto spawn_steam_like = [&](bool marked) {
+    const auto child = fork();
+    EXPECT_GE(child, 0);
+    if (child == 0) {
+      if (marked) {
+        setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+      } else {
+        unsetenv("POLARIS_SESSION_INSTANCE_ID");
+      }
+      execl("/bin/sleep", "steam", "60", nullptr);
+      _exit(127);
+    }
+    return child;
+  };
+  auto wait_for_steam_like = [&](pid_t pid, bool marked) {
+    const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
+    for (int attempt = 0; attempt < 40; ++attempt) {
+      std::ifstream cmdline_file("/proc/" + std::to_string(pid) + "/cmdline", std::ios::binary);
+      const std::string cmdline(
+        (std::istreambuf_iterator<char>(cmdline_file)),
+        std::istreambuf_iterator<char>()
+      );
+      std::ifstream environ_file("/proc/" + std::to_string(pid) + "/environ", std::ios::binary);
+      const std::string environ(
+        (std::istreambuf_iterator<char>(environ_file)),
+        std::istreambuf_iterator<char>()
+      );
+      const bool marker_matches = environ.find(expected) != std::string::npos;
+      if (cmdline.starts_with(std::string("steam\0", 6)) && marker_matches == marked) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    return false;
+  };
+  auto cleanup = [](pid_t pid) {
+    if (pid > 0) {
+      kill(pid, SIGKILL);
+      int status = 0;
+      waitpid(pid, &status, 0);
+    }
+  };
+
+  const auto owned = spawn_steam_like(true);
+  const auto unowned = spawn_steam_like(false);
+  ASSERT_TRUE(wait_for_steam_like(owned, true));
+  ASSERT_TRUE(wait_for_steam_like(unowned, false));
+
+  EXPECT_FALSE(proc::terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, token
+  ));
+  int owned_status = 0;
+  const auto owned_wait = waitpid(owned, &owned_status, WNOHANG);
+  EXPECT_EQ(owned_wait, 0)
+    << "mixed ownership must preserve the exact-generation Steam process";
+  int unowned_status = 0;
+  const auto unowned_wait = waitpid(unowned, &unowned_status, WNOHANG);
+  EXPECT_EQ(unowned_wait, 0)
+    << "mixed ownership must preserve the unowned Steam process";
+
+  if (owned_wait == 0) {
+    cleanup(owned);
+  }
+  if (unowned_wait == 0) {
+    cleanup(unowned);
+  }
+#else
+  GTEST_SKIP() << "Linux-only mixed private/desktop Steam ownership";
 #endif
 }
 
@@ -1310,6 +1450,45 @@ TEST(ProcessRuntimeConfigTests, ExactGenerationCleanupLeavesUnownedControlProces
     << "unowned control process must remain alive";
   kill(control, SIGKILL);
   EXPECT_EQ(waitpid(control, &control_status, 0), control);
+}
+
+TEST(ProcessRuntimeConfigTests, ExactGenerationCaptureFailureRetainsGenerationAndLeavesChildUnsignaled) {
+#ifdef __linux__
+  const std::string token = "forced-incomplete-generation-capture";
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    execl("/bin/sleep", "sleep", "60", nullptr);
+    _exit(127);
+  }
+
+  const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
+  bool token_visible = false;
+  for (int attempt = 0; attempt < 40 && !token_visible; ++attempt) {
+    std::ifstream environ_file("/proc/" + std::to_string(child) + "/environ", std::ios::binary);
+    const std::string environ(
+      (std::istreambuf_iterator<char>(environ_file)),
+      std::istreambuf_iterator<char>()
+    );
+    token_visible = environ.find(expected) != std::string::npos;
+    if (!token_visible) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+  }
+  ASSERT_TRUE(token_visible);
+
+  EXPECT_TRUE(proc::isolated_session_capture_failure_retains_generation_for_tests(token, child));
+  int status = 0;
+  EXPECT_EQ(waitpid(child, &status, WNOHANG), 0)
+    << "an incompletely captured exact-generation child must not be signaled";
+
+  EXPECT_TRUE(proc::terminate_exact_generation_processes_for_tests(token));
+  EXPECT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_TRUE(WIFSIGNALED(status));
+#else
+  GTEST_SKIP() << "Linux-only exact-generation capture fault propagation";
+#endif
 }
 
 TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBeforeImmutableCageCleanup) {

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -11,7 +11,16 @@
 #include <src/file_handler.h>
 #include <src/nvhttp.h>
 #include <src/process.h>
+#ifdef __linux__
+  #include <src/platform/linux/cage_display_router.h>
+#endif
 #include <src/stream_stats.h>
+
+#ifdef __linux__
+  #include <csignal>
+  #include <sys/wait.h>
+  #include <unistd.h>
+#endif
 
 namespace {
 #ifdef __linux__
@@ -961,6 +970,521 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardDisablesIfLogChangesBef
   EXPECT_TRUE(actions.empty());
 }
 
+TEST(ProcessRuntimeConfigTests, PreCageSteamTerminationRequiresImmutableCageAndExactSessionOwnership) {
+  proc::ctx_t steam_app {};
+  steam_app.source = "steam";
+  steam_app.steam_appid = "2416450";
+  steam_app.detached = {"setsid steam steam://rungameid/2416450"};
+
+  EXPECT_TRUE(proc::should_terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, true, true, false, true
+  ));
+  EXPECT_FALSE(proc::should_terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, true, true, true, true
+  ));
+  EXPECT_FALSE(proc::should_terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, true, true, false, false
+  ));
+  EXPECT_FALSE(proc::should_terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, false, true, true, false, true
+  ));
+  EXPECT_FALSE(proc::should_terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, false, true, false, true
+  ));
+  EXPECT_FALSE(proc::should_terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, true, false, false, true
+  ));
+
+  proc::ctx_t non_steam_app {};
+  non_steam_app.name = "Native Game";
+  non_steam_app.cmd = "/usr/bin/native-game";
+  EXPECT_FALSE(proc::should_terminate_session_owned_steam_before_cage_stop_for_tests(
+    non_steam_app, true, true, true, false, true
+  ));
+}
+
+TEST(ProcessRuntimeConfigTests, IsolatedSessionOwnershipRequiresExactNulDelimitedGeneration) {
+  const std::string token = "private-generation-42";
+  const std::string exact = std::string("HOME=/tmp") + char(0) +
+                            "POLARIS_SESSION_INSTANCE_ID=" + token + char(0) +
+                            "DISPLAY=:9" + char(0);
+  EXPECT_TRUE(proc::isolated_session_environ_matches_for_tests(exact, token));
+  EXPECT_FALSE(proc::isolated_session_environ_matches_for_tests(exact, "other-generation"));
+  EXPECT_FALSE(proc::isolated_session_environ_matches_for_tests(
+    "POLARIS_SESSION_INSTANCE_ID=" + token + "-suffix" + char(0), token
+  ));
+  EXPECT_FALSE(proc::isolated_session_environ_matches_for_tests(
+    "NOT_POLARIS_SESSION_INSTANCE_ID=" + token + char(0), token
+  ));
+  EXPECT_FALSE(proc::isolated_session_environ_matches_for_tests(
+    "PAYLOAD=POLARIS_SESSION_INSTANCE_ID=" + token + char(0), token
+  ));
+  EXPECT_FALSE(proc::isolated_session_environ_matches_for_tests(
+    "POLARIS_SESSION_INSTANCE_ID=" + token, token
+  ));
+  EXPECT_FALSE(proc::isolated_session_environ_matches_for_tests("", token));
+  EXPECT_FALSE(proc::isolated_session_environ_matches_for_tests(exact, ""));
+  EXPECT_FALSE(proc::isolated_session_environ_matches_for_tests(
+    std::string("POLARIS_SESSION_INSTANCE_ID=") + char(0), ""
+  ));
+  EXPECT_TRUE(proc::session_instance_environment_is_child_only_for_tests(token));
+}
+
+TEST(ProcessRuntimeConfigTests, ProcStartTimeParserHandlesParenthesizedNames) {
+  std::ostringstream stat;
+  stat << "123 (steam helper (private)) S";
+  for (int field = 4; field <= 21; ++field) {
+    stat << " 0";
+  }
+  stat << " 4242";
+  EXPECT_EQ(proc::proc_start_time_from_stat_for_tests(stat.str()), std::optional<std::uint64_t> {4242});
+  EXPECT_EQ(proc::proc_start_time_from_stat_for_tests("malformed"), std::nullopt);
+}
+
+TEST(ProcessRuntimeConfigTests, SteamPidfdCaptureRejectsStartTimeMismatch) {
+  EXPECT_TRUE(proc::steam_pidfd_capture_identity_matches_for_tests(4242, 4242));
+  EXPECT_FALSE(proc::steam_pidfd_capture_identity_matches_for_tests(4242, 4243));
+  EXPECT_FALSE(proc::steam_pidfd_capture_identity_matches_for_tests(std::nullopt, 4242));
+  EXPECT_FALSE(proc::steam_pidfd_capture_identity_matches_for_tests(4242, std::nullopt));
+}
+
+TEST(ProcessRuntimeConfigTests, SteamShutdownOwnershipRejectsUnmarkedActiveClients) {
+  const std::string running_status = "Name:\tsteam\nState:\tS (sleeping)\n";
+  const std::string zombie_status = "Name:\tsteam\nState:\tZ (zombie)\n";
+  const std::string token = "private-generation-42";
+  const std::string marker = "POLARIS_SESSION_INSTANCE_ID=" + token + char(0);
+
+  EXPECT_TRUE(proc::steam_shutdown_process_is_unowned_active_for_tests(
+    "steamwebhelper", "/opt/steam/steamwebhelper", "/opt/steam/steamwebhelper", running_status, "", token
+  ));
+  EXPECT_FALSE(proc::steam_shutdown_process_is_unowned_active_for_tests(
+    "steam", "/opt/steam/ubuntu12_32/steam", "/opt/steam/ubuntu12_32/steam", running_status, marker, token
+  ));
+  EXPECT_TRUE(proc::steam_shutdown_process_is_unowned_active_for_tests(
+    "steam", "/opt/steam/ubuntu12_32/steam", "/opt/steam/ubuntu12_32/steam", running_status,
+    "POLARIS_SESSION_INSTANCE_ID=" + token + "-stale" + char(0), token
+  ));
+  EXPECT_FALSE(proc::steam_shutdown_process_is_unowned_active_for_tests(
+    "steam", "/opt/steam/ubuntu12_32/steam", "/opt/steam/ubuntu12_32/steam", zombie_status, "", token
+  ));
+}
+
+TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationSignalsOnlyCapturedChild) {
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const auto child = fork();
+  ASSERT_NE(child, -1);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    std::signal(SIGTERM, SIG_DFL);
+    const char ready = '1';
+    (void) write(ready_pipe[1], &ready, 1);
+    for (;;) pause();
+  }
+  ASSERT_GT(child, 0);
+
+  close(ready_pipe[1]);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+  const bool terminated = proc::terminate_pid_with_pidfd_for_tests(
+    child, std::chrono::milliseconds(500), std::chrono::milliseconds(500)
+  );
+  if (!terminated) {
+    kill(child, SIGKILL);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_TRUE(terminated);
+  ASSERT_TRUE(WIFSIGNALED(status));
+  EXPECT_EQ(WTERMSIG(status), SIGTERM);
+}
+
+TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationBoundsGracefulWaitAndKillsSurvivor) {
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const auto child = fork();
+  ASSERT_NE(child, -1);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    std::signal(SIGTERM, SIG_IGN);
+    const char ready = '1';
+    (void) write(ready_pipe[1], &ready, 1);
+    for (;;) pause();
+  }
+  ASSERT_GT(child, 0);
+
+  close(ready_pipe[1]);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+  const auto started = std::chrono::steady_clock::now();
+  const bool terminated = proc::terminate_pid_with_pidfd_for_tests(
+    child, std::chrono::milliseconds(100), std::chrono::milliseconds(500)
+  );
+  const auto elapsed = std::chrono::steady_clock::now() - started;
+  if (!terminated) {
+    kill(child, SIGKILL);
+  }
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_TRUE(terminated);
+  EXPECT_LT(elapsed, std::chrono::seconds(2));
+  ASSERT_TRUE(WIFSIGNALED(status));
+  EXPECT_EQ(WTERMSIG(status), SIGKILL);
+}
+
+TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownUsesImmutableExactGeneration) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t config_guard;
+  const std::string token = "production-wiring-generation";
+  proc::ctx_t steam_app {};
+  steam_app.name = "Steam Big Picture";
+  steam_app.cmd = "steam -gamepadui";
+
+  auto spawn_steam_like = [&](bool marked) {
+    const auto child = fork();
+    EXPECT_GE(child, 0);
+    if (child == 0) {
+      if (marked) {
+        setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+      } else {
+        unsetenv("POLARIS_SESSION_INSTANCE_ID");
+      }
+      execl("/bin/sleep", "steam", "60", nullptr);
+      _exit(127);
+    }
+    return child;
+  };
+  auto wait_for_token = [&](pid_t pid) {
+    const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
+    for (int attempt = 0; attempt < 40; ++attempt) {
+      std::ifstream environ("/proc/" + std::to_string(pid) + "/environ", std::ios::binary);
+      std::ostringstream bytes;
+      bytes << environ.rdbuf();
+      if (bytes.str().find(expected) != std::string::npos) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    return false;
+  };
+  auto cleanup = [](pid_t pid) {
+    if (pid > 0) {
+      kill(pid, SIGKILL);
+      int status = 0;
+      waitpid(pid, &status, 0);
+    }
+  };
+
+  auto owned = spawn_steam_like(true);
+  ASSERT_TRUE(wait_for_token(owned));
+  config::video.linux_display.use_cage_compositor = false;
+  EXPECT_TRUE(proc::terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, token
+  ));
+  int status = 0;
+  EXPECT_EQ(waitpid(owned, &status, 0), owned);
+
+  auto mirror_owned = spawn_steam_like(true);
+  ASSERT_TRUE(wait_for_token(mirror_owned));
+  config::video.linux_display.use_cage_compositor = true;
+  EXPECT_FALSE(proc::terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, false, token
+  ));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_EQ(waitpid(mirror_owned, &status, WNOHANG), 0);
+  cleanup(mirror_owned);
+#else
+  GTEST_SKIP() << "Linux-only immutable private Steam teardown wiring";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, IsolatedSessionCleanupPolicyRetainsIncompleteCageGeneration) {
+#ifdef __linux__
+  EXPECT_TRUE(proc::isolated_session_generation_blocks_launch_for_tests(true, true));
+  EXPECT_TRUE(proc::isolated_session_generation_blocks_launch_for_tests(true, false));
+  EXPECT_TRUE(proc::isolated_session_generation_blocks_launch_for_tests(false, true));
+  EXPECT_FALSE(proc::isolated_session_generation_blocks_launch_for_tests(false, false));
+
+  EXPECT_FALSE(proc::isolated_session_cleanup_resets_router_for_tests(true, true, false));
+  EXPECT_FALSE(proc::isolated_session_cleanup_clears_state_for_tests(true, true, false));
+  EXPECT_FALSE(proc::isolated_session_cleanup_resets_router_for_tests(true, false, true));
+  EXPECT_FALSE(proc::isolated_session_cleanup_clears_state_for_tests(true, false, true));
+
+  EXPECT_TRUE(proc::isolated_session_cleanup_resets_router_for_tests(true, true, true));
+  EXPECT_TRUE(proc::isolated_session_cleanup_clears_state_for_tests(true, true, true));
+
+  // Mirror/non-cage launches still receive a generation token, but no cage state
+  // is owned; teardown must clear that token without touching the cage router.
+  EXPECT_FALSE(proc::isolated_session_cleanup_resets_router_for_tests(false, true, true));
+  EXPECT_TRUE(proc::isolated_session_cleanup_clears_state_for_tests(false, true, true));
+
+  EXPECT_FALSE(proc::isolated_session_uses_legacy_group_termination_for_tests(true, false));
+  EXPECT_TRUE(proc::isolated_session_uses_legacy_group_termination_for_tests(false, false));
+  EXPECT_FALSE(proc::isolated_session_uses_legacy_group_termination_for_tests(false, true));
+  EXPECT_TRUE(proc::isolated_session_detaches_legacy_handles_for_tests(true));
+  EXPECT_FALSE(proc::isolated_session_detaches_legacy_handles_for_tests(false));
+#else
+  GTEST_SKIP() << "Linux-only isolated session generation policy";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, ExternalCageRouterResetDoesNotSignalLiveProcess) {
+#ifdef __linux__
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    execl("/bin/sleep", "sleep", "60", nullptr);
+    _exit(127);
+  }
+
+  cage_display_router::reset_after_external_stop_for_tests(child);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  int status = 0;
+  EXPECT_EQ(waitpid(child, &status, WNOHANG), 0)
+    << "router reset must not signal or reap a live externally-owned process";
+  kill(child, SIGKILL);
+  waitpid(child, &status, 0);
+#else
+  GTEST_SKIP() << "Linux-only cage router signal safety";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, ExactGenerationCleanupLeavesUnownedControlProcessAlive) {
+  const std::string token = "test-private-generation-4242";
+  const auto spawn_sleep = [&](bool owned) {
+    const auto child = fork();
+    if (child == 0) {
+      if (owned) {
+        setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+      } else {
+        unsetenv("POLARIS_SESSION_INSTANCE_ID");
+      }
+      execl("/bin/sleep", "sleep", "60", static_cast<char *>(nullptr));
+      _exit(127);
+    }
+    return child;
+  };
+
+  const auto owned = spawn_sleep(true);
+  const auto control = spawn_sleep(false);
+  auto cleanup_child = [](pid_t pid) {
+    if (pid > 0) {
+      kill(pid, SIGKILL);
+      (void) waitpid(pid, nullptr, 0);
+    }
+  };
+  if (owned <= 0 || control <= 0) {
+    cleanup_child(owned);
+    cleanup_child(control);
+    FAIL() << "failed to spawn exact-generation cleanup test children";
+    return;
+  }
+
+  const auto owned_environ = "/proc/" + std::to_string(owned) + "/environ";
+  bool token_visible = false;
+  for (int i = 0; i < 40 && !token_visible; ++i) {
+    std::ifstream in(owned_environ, std::ios::binary);
+    const std::string environ((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    token_visible = environ.find("POLARIS_SESSION_INSTANCE_ID=" + token) != std::string::npos;
+    if (!token_visible) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+  }
+  if (!token_visible) {
+    cleanup_child(owned);
+    cleanup_child(control);
+    FAIL() << "exact generation token did not become visible in child environ";
+    return;
+  }
+
+  EXPECT_TRUE(proc::terminate_exact_generation_processes_for_tests(token));
+
+  int owned_status = 0;
+  EXPECT_EQ(waitpid(owned, &owned_status, 0), owned);
+  EXPECT_TRUE(WIFSIGNALED(owned_status));
+
+  int control_status = 0;
+  EXPECT_EQ(waitpid(control, &control_status, WNOHANG), 0)
+    << "unowned control process must remain alive";
+  kill(control, SIGKILL);
+  EXPECT_EQ(waitpid(control, &control_status, 0), control);
+}
+
+TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBeforeImmutableCageCleanup) {
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  const auto cage_source = read_source_file_for_contract("src/platform/linux/cage_display_router.cpp");
+  ASSERT_FALSE(source.empty());
+  ASSERT_FALSE(cage_source.empty());
+
+  const auto implementation_start = source.find("bool terminate_session_owned_steam_before_cage_stop_impl(");
+  const auto implementation_end = source.find("bool is_active_desktop_steam_client_process(", implementation_start);
+  const auto helper_start = source.find("void proc_t::terminate_session_owned_steam_before_cage_stop(");
+  const auto terminate_start = source.find("void proc_t::terminate_impl(");
+  const auto terminate_end = source.find("bool proc_t::reload_configuration_from_file", terminate_start);
+  const auto execute_start = source.find("int proc_t::execute_impl(");
+  const auto execute_end = source.find("int proc_t::running()", execute_start);
+  ASSERT_NE(implementation_start, std::string::npos);
+  ASSERT_NE(implementation_end, std::string::npos);
+  ASSERT_NE(helper_start, std::string::npos);
+  ASSERT_NE(terminate_start, std::string::npos);
+  ASSERT_NE(terminate_end, std::string::npos);
+  ASSERT_NE(execute_start, std::string::npos);
+  ASSERT_NE(execute_end, std::string::npos);
+  ASSERT_LT(helper_start, terminate_start);
+
+  const auto implementation = source.substr(
+    implementation_start, implementation_end - implementation_start
+  );
+  const auto helper = source.substr(helper_start, terminate_start - helper_start);
+  EXPECT_NE(helper.find("terminate_session_owned_steam_before_cage_stop_impl("), std::string::npos);
+  EXPECT_NE(helper.find("_app"), std::string::npos);
+  EXPECT_NE(helper.find("_session_used_cage_compositor"), std::string::npos);
+  EXPECT_NE(helper.find("_session_instance_id"), std::string::npos);
+  const auto ownership_scan = implementation.find("steam_client_ownership_snapshot(session_instance_id)");
+  const auto immutable_cage_gate = implementation.find("session_owned_cage");
+  const auto generation_gate = implementation.find("session_instance_id.empty()");
+  const auto capture_gate = implementation.find("ownership.capture_complete");
+  const auto mixed_ownership_gate = implementation.find("ownership.unowned.empty()");
+  const auto pidfd_termination = implementation.find("terminate_pidfds(");
+  ASSERT_NE(ownership_scan, std::string::npos);
+  ASSERT_NE(immutable_cage_gate, std::string::npos);
+  ASSERT_NE(generation_gate, std::string::npos);
+  ASSERT_NE(capture_gate, std::string::npos);
+  ASSERT_NE(mixed_ownership_gate, std::string::npos);
+  ASSERT_NE(pidfd_termination, std::string::npos);
+  EXPECT_LT(ownership_scan, capture_gate);
+  EXPECT_LT(capture_gate, pidfd_termination);
+  EXPECT_LT(mixed_ownership_gate, pidfd_termination);
+  EXPECT_EQ(implementation.find("config::video.linux_display.use_cage_compositor"), std::string::npos);
+  EXPECT_EQ(implementation.find("cage_display_router::is_running()"), std::string::npos);
+  EXPECT_EQ(implementation.find("platf::run_command("), std::string::npos);
+  EXPECT_EQ(implementation.find("_env"), std::string::npos);
+  EXPECT_EQ(implementation.find("child.wait"), std::string::npos);
+  EXPECT_EQ(implementation.find("steam -shutdown"), std::string::npos);
+
+  EXPECT_NE(source.find("SYS_pidfd_open"), std::string::npos);
+  EXPECT_NE(source.find("SYS_pidfd_send_signal"), std::string::npos);
+  EXPECT_NE(source.find("poll("), std::string::npos);
+  EXPECT_NE(source.find("proc_environ_contains_exact_entry("), std::string::npos);
+  EXPECT_NE(
+    source.find("return final_snapshot.capture_complete && final_snapshot.owned.empty();"),
+    std::string::npos
+  );
+  EXPECT_EQ(source.find("proc_environ_contains_isolated_session_marker("), std::string::npos);
+
+  const auto execute = source.substr(execute_start, execute_end - execute_start);
+  const auto refuse_stale_generation = execute.find(
+    "refusing launch while an incompletely cleaned isolated session generation remains"
+  );
+  const auto generate_instance = execute.find("_session_instance_id = generate_session_token()");
+  const auto inject_instance = execute.find("set_child_only_session_env_var(");
+  const auto start_cage = execute.find("start_cage_with_runtime_fallback(");
+  const auto remember_cage = execute.find("_session_used_cage_compositor = true", start_cage);
+  ASSERT_NE(refuse_stale_generation, std::string::npos);
+  EXPECT_NE(
+    execute.find("isolated_session_generation_blocks_launch("),
+    std::string::npos
+  );
+  ASSERT_NE(generate_instance, std::string::npos);
+  ASSERT_NE(inject_instance, std::string::npos);
+  ASSERT_NE(start_cage, std::string::npos);
+  ASSERT_NE(remember_cage, std::string::npos);
+  EXPECT_LT(refuse_stale_generation, generate_instance);
+  EXPECT_LT(generate_instance, inject_instance);
+  EXPECT_LT(inject_instance, start_cage);
+  EXPECT_LT(start_cage, remember_cage);
+  EXPECT_EQ(execute.find("terminate_isolated_session_processes(\"before launching"), std::string::npos);
+  const auto cage_child_start = cage_source.find("if (pid == 0)");
+  const auto cage_child_end = cage_source.find("set_labwc_process_environment(headless)", cage_child_start);
+  ASSERT_NE(cage_child_start, std::string::npos);
+  ASSERT_NE(cage_child_end, std::string::npos);
+  const auto cage_child = cage_source.substr(cage_child_start, cage_child_end - cage_child_start);
+  EXPECT_NE(
+    cage_child.find("\n        setenv(\"POLARIS_SESSION_INSTANCE_ID\""),
+    std::string::npos
+  );
+  const auto fail_guard_start = execute.find("auto fg = util::fail_guard(");
+  const auto fail_guard_end = execute.find("if (!app.gamepad.empty()", fail_guard_start);
+  ASSERT_NE(fail_guard_start, std::string::npos);
+  ASSERT_NE(fail_guard_end, std::string::npos);
+  const auto fail_guard = execute.substr(fail_guard_start, fail_guard_end - fail_guard_start);
+  EXPECT_EQ(fail_guard.find("cage_display_router::stop();"), std::string::npos)
+    << "execute failure cleanup must not bypass exact-generation pidfd cleanup";
+
+  const auto terminate = source.substr(terminate_start, terminate_end - terminate_start);
+  const auto terminate_private_steam = terminate.find("terminate_session_owned_steam_before_cage_stop(");
+  const auto terminate_main = terminate.find("terminate_process_group(");
+  const auto terminate_isolated = terminate.find("terminate_isolated_session_processes(");
+  const auto cleanup_result = terminate.find(
+    "exact_generation_cleanup_complete = terminate_isolated_session_processes("
+  );
+  const auto reset_cage = terminate.find("cage_display_router::reset_after_external_stop()");
+  const auto retain_generation = terminate.find(
+    "retaining immutable cage generation because exact-generation cleanup was incomplete"
+  );
+  const auto immutable_undo_guard = terminate.find("_session_used_cage_compositor", reset_cage);
+  ASSERT_NE(terminate_private_steam, std::string::npos);
+  ASSERT_NE(terminate_main, std::string::npos);
+  ASSERT_NE(terminate_isolated, std::string::npos);
+  ASSERT_NE(cleanup_result, std::string::npos);
+  ASSERT_NE(reset_cage, std::string::npos);
+  const auto cleanup_success_gate = terminate.rfind(
+    "isolated_session_cleanup_resets_router(", reset_cage
+  );
+  const auto cleanup_clear_gate = terminate.find(
+    "isolated_session_cleanup_clears_state(", reset_cage
+  );
+  ASSERT_NE(cleanup_success_gate, std::string::npos);
+  ASSERT_NE(cleanup_clear_gate, std::string::npos);
+  EXPECT_LT(cleanup_success_gate, reset_cage);
+  EXPECT_LT(reset_cage, cleanup_clear_gate);
+  ASSERT_NE(retain_generation, std::string::npos);
+  ASSERT_NE(immutable_undo_guard, std::string::npos);
+  const auto legacy_group_gate = terminate.find(
+    "isolated_session_uses_legacy_group_termination("
+  );
+  const auto legacy_detach_gate = terminate.find(
+    "isolated_session_detaches_legacy_handles("
+  );
+  const auto detach_legacy_child = terminate.find("_process.detach();");
+  const auto detach_legacy_group = terminate.find("_process_group.detach();");
+  const auto clear_legacy_child = terminate.find("_process = boost::process::v1::child();");
+  ASSERT_NE(legacy_group_gate, std::string::npos);
+  ASSERT_NE(legacy_detach_gate, std::string::npos);
+  ASSERT_NE(detach_legacy_child, std::string::npos);
+  ASSERT_NE(detach_legacy_group, std::string::npos);
+  ASSERT_NE(clear_legacy_child, std::string::npos);
+  EXPECT_LT(terminate_private_steam, terminate_isolated);
+  EXPECT_LT(cleanup_result, terminate_isolated);
+  EXPECT_LT(terminate_isolated, terminate_main);
+  EXPECT_LT(terminate_isolated, legacy_group_gate);
+  EXPECT_LT(legacy_group_gate, legacy_detach_gate);
+  EXPECT_LT(legacy_detach_gate, detach_legacy_child);
+  EXPECT_LT(detach_legacy_child, detach_legacy_group);
+  EXPECT_LT(detach_legacy_group, clear_legacy_child);
+  EXPECT_LT(terminate_isolated, reset_cage);
+  EXPECT_LT(reset_cage, retain_generation);
+  EXPECT_LT(reset_cage, immutable_undo_guard);
+  EXPECT_EQ(terminate.find("config::video.linux_display.use_cage_compositor"), std::string::npos);
+  EXPECT_EQ(terminate.find("cage_display_router::stop()"), std::string::npos);
+  EXPECT_EQ(terminate.find("terminate_steam_app_processes("), std::string::npos);
+  EXPECT_EQ(terminate.find("settle_isolated_browser_stream_steam_cleanup("), std::string::npos);
+
+  const auto reset_start = cage_source.find("void reset_after_external_stop()");
+  const auto reset_end = cage_source.find("bool is_running()", reset_start);
+  ASSERT_NE(reset_start, std::string::npos);
+  ASSERT_NE(reset_end, std::string::npos);
+  const auto reset = cage_source.substr(reset_start, reset_end - reset_start);
+  EXPECT_NE(reset.find("waitpid("), std::string::npos);
+  EXPECT_NE(reset.find("WNOHANG"), std::string::npos);
+  EXPECT_EQ(reset.find("kill("), std::string::npos);
+  EXPECT_EQ(reset.find("SIGTERM"), std::string::npos);
+  EXPECT_EQ(reset.find("SIGKILL"), std::string::npos);
+}
+
+
 TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsStartedAndStoppedInsideProcessLifetime) {
   const auto source = read_source_file_for_contract("src/process.cpp");
   ASSERT_FALSE(source.empty());
@@ -1000,10 +1524,13 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsStartedAndStoppedInsi
   EXPECT_LT(start_guard, first_main_launch);
   EXPECT_LT(first_main_launch, launch_committed);
   const auto stop_guard = terminate.find("stop_steam_big_picture_input_guard()");
-  const auto stop_cage = terminate.find("cage_display_router::stop()");
+  const auto cleanup_generation = terminate.find("terminate_isolated_session_processes(");
+  const auto reset_cage = terminate.find("cage_display_router::reset_after_external_stop()");
   ASSERT_NE(stop_guard, std::string::npos);
-  ASSERT_NE(stop_cage, std::string::npos);
-  EXPECT_LT(stop_guard, stop_cage);
+  ASSERT_NE(cleanup_generation, std::string::npos);
+  ASSERT_NE(reset_cage, std::string::npos);
+  EXPECT_LT(stop_guard, cleanup_generation);
+  EXPECT_LT(cleanup_generation, reset_cage);
 }
 
 TEST(ProcessRuntimeConfigTests, HeadlessCageSteamBigPictureSkipsHostShutdownUndo) {
@@ -1019,6 +1546,13 @@ TEST(ProcessRuntimeConfigTests, HeadlessCageSteamBigPictureSkipsHostShutdownUndo
 
   EXPECT_TRUE(proc::should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(app, shutdown_undo, true));
   EXPECT_FALSE(proc::should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(app, shutdown_undo, false));
+
+  proc::ctx_t unclassified_app {};
+  unclassified_app.name = "Custom Cage App";
+  unclassified_app.cmd = "/usr/bin/custom-launcher";
+  EXPECT_TRUE(proc::should_skip_steam_shutdown_undo_after_cage_cleanup_for_tests(
+    unclassified_app, shutdown_undo, true
+  )) << "immutable cage ownership plus an explicit Steam shutdown undo must fail closed";
 }
 
 

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -20,12 +21,126 @@
 #ifdef __linux__
   #include <csignal>
   #include <pthread.h>
+  #include <sys/prctl.h>
   #include <sys/wait.h>
   #include <unistd.h>
 #endif
 
 namespace {
 #ifdef __linux__
+  volatile std::sig_atomic_t sigusr1_interruptions = 0;
+
+  void record_sigusr1_interrupt(int) {
+    sigusr1_interruptions = sigusr1_interruptions + 1;
+  }
+
+  struct linux_child_guard_t {
+    explicit linux_child_guard_t(pid_t child_pid): pid(child_pid) {}
+    linux_child_guard_t(const linux_child_guard_t &) = delete;
+    linux_child_guard_t &operator=(const linux_child_guard_t &) = delete;
+
+    ~linux_child_guard_t() {
+      terminate_and_reap();
+    }
+
+    pid_t wait(int *status, int options) {
+      if (pid <= 0 || reaped) {
+        errno = ECHILD;
+        return -1;
+      }
+      pid_t result;
+      do {
+        result = waitpid(pid, status, options);
+      } while (result < 0 && errno == EINTR);
+      if (result == pid || (result < 0 && errno == ECHILD)) {
+        reaped = true;
+      }
+      return result;
+    }
+
+    pid_t terminate_and_reap(int *status_out = nullptr) {
+      if (pid <= 0 || reaped) {
+        errno = ECHILD;
+        return -1;
+      }
+      int local_status = 0;
+      int *status = status_out != nullptr ? status_out : &local_status;
+      auto observed = wait(status, WNOHANG);
+      if (observed == 0) {
+        (void) kill(pid, SIGKILL);
+        observed = wait(status, 0);
+      }
+      return observed;
+    }
+
+    pid_t pid = -1;
+    bool reaped = false;
+  };
+
+  struct sigusr1_interrupt_guard_t {
+    sigusr1_interrupt_guard_t() {
+      struct sigaction action {};
+      action.sa_handler = record_sigusr1_interrupt;
+      sigemptyset(&action.sa_mask);
+      action.sa_flags = 0;
+      if (sigaction(SIGUSR1, &action, &previous_action) != 0) {
+        return;
+      }
+
+      sigemptyset(&signal_set);
+      sigaddset(&signal_set, SIGUSR1);
+      if (pthread_sigmask(SIG_UNBLOCK, &signal_set, &previous_mask) != 0) {
+        (void) sigaction(SIGUSR1, &previous_action, nullptr);
+        return;
+      }
+      installed = true;
+    }
+
+    ~sigusr1_interrupt_guard_t() {
+      (void) restore();
+    }
+
+    bool restore() {
+      if (!installed) {
+        return true;
+      }
+      if (pthread_sigmask(SIG_BLOCK, &signal_set, nullptr) != 0) {
+        return false;
+      }
+      const timespec no_wait {};
+      for (;;) {
+        int result = -1;
+        if (forced_drain_interruptions > 0) {
+          --forced_drain_interruptions;
+          errno = EINTR;
+        } else {
+          result = sigtimedwait(&signal_set, nullptr, &no_wait);
+        }
+        if (result == SIGUSR1 || (result < 0 && errno == EINTR)) {
+          continue;
+        }
+        if (result < 0 && errno == EAGAIN) {
+          break;
+        }
+        return false;
+      }
+      if (sigaction(SIGUSR1, &previous_action, nullptr) != 0) {
+        return false;
+      }
+      if (pthread_sigmask(SIG_SETMASK, &previous_mask, nullptr) != 0) {
+        return false;
+      }
+      installed = false;
+      return true;
+    }
+
+    bool installed = false;
+    int forced_drain_interruptions = 1;
+    sigset_t signal_set {};
+    sigset_t previous_mask {};
+    struct sigaction previous_action {};
+  };
+
   struct linux_cage_compositor_guard_t {
     linux_cage_compositor_guard_t():
         adapter_name(config::video.adapter_name),
@@ -1083,7 +1198,7 @@ TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationSignalsOnlyCapturedChild) {
     (void) write(ready_pipe[1], &ready, 1);
     for (;;) pause();
   }
-  ASSERT_GT(child, 0);
+  linux_child_guard_t child_guard {child};
 
   close(ready_pipe[1]);
   char ready = 0;
@@ -1093,10 +1208,10 @@ TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationSignalsOnlyCapturedChild) {
     child, std::chrono::milliseconds(500), std::chrono::milliseconds(500)
   );
   if (!terminated) {
-    kill(child, SIGKILL);
+    child_guard.terminate_and_reap();
   }
   int status = 0;
-  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_EQ(child_guard.wait(&status, 0), child);
   EXPECT_TRUE(terminated);
   ASSERT_TRUE(WIFSIGNALED(status));
   EXPECT_EQ(WTERMSIG(status), SIGTERM);
@@ -1114,7 +1229,7 @@ TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationBoundsGracefulWaitAndKillsS
     (void) write(ready_pipe[1], &ready, 1);
     for (;;) pause();
   }
-  ASSERT_GT(child, 0);
+  linux_child_guard_t child_guard {child};
 
   close(ready_pipe[1]);
   char ready = 0;
@@ -1126,10 +1241,10 @@ TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationBoundsGracefulWaitAndKillsS
   );
   const auto elapsed = std::chrono::steady_clock::now() - started;
   if (!terminated) {
-    kill(child, SIGKILL);
+    child_guard.terminate_and_reap();
   }
   int status = 0;
-  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_EQ(child_guard.wait(&status, 0), child);
   EXPECT_TRUE(terminated);
   EXPECT_LT(elapsed, std::chrono::seconds(2));
   ASSERT_TRUE(WIFSIGNALED(status));
@@ -1149,49 +1264,120 @@ TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationDeadlineSurvivesRepeatedEin
     (void) write(ready_pipe[1], &ready, 1);
     for (;;) pause();
   }
+  linux_child_guard_t child_guard {child};
 
   close(ready_pipe[1]);
   char ready = 0;
   ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
   close(ready_pipe[0]);
 
-  struct sigaction interrupt_action {};
-  struct sigaction previous_action {};
-  interrupt_action.sa_handler = [](int) {};
-  sigemptyset(&interrupt_action.sa_mask);
-  interrupt_action.sa_flags = 0;
-  ASSERT_EQ(sigaction(SIGUSR1, &interrupt_action, &previous_action), 0);
-
+  sigusr1_interruptions = 0;
+  sigusr1_interrupt_guard_t signal_guard;
+  ASSERT_TRUE(signal_guard.installed);
   const auto test_thread = pthread_self();
-  std::atomic<bool> stop_interrupting {false};
-  std::thread interrupter([&] {
+  std::atomic<bool> sender_ready {false};
+  std::atomic<bool> call_active {false};
+  std::atomic<bool> production_wait_entered {false};
+  std::atomic<int> signals_sent_while_call_active {0};
+  std::jthread interrupter([
+    test_thread,
+    &sender_ready,
+    &call_active,
+    &production_wait_entered,
+    &signals_sent_while_call_active
+  ](std::stop_token stop_token) {
+    sender_ready.store(true, std::memory_order_release);
+    while (!stop_token.stop_requested() && !production_wait_entered.load(std::memory_order_acquire)) {
+      std::this_thread::yield();
+    }
     const auto stop_at = std::chrono::steady_clock::now() + std::chrono::milliseconds(350);
-    while (!stop_interrupting.load() && std::chrono::steady_clock::now() < stop_at) {
-      (void) pthread_kill(test_thread, SIGUSR1);
+    while (!stop_token.stop_requested() &&
+           call_active.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < stop_at) {
+      if (pthread_kill(test_thread, SIGUSR1) == 0 && call_active.load(std::memory_order_acquire)) {
+        signals_sent_while_call_active.fetch_add(1, std::memory_order_relaxed);
+      }
       std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
   });
+  while (!sender_ready.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
 
+  const auto handled_before_call = sigusr1_interruptions;
+  call_active.store(true, std::memory_order_release);
   const auto started = std::chrono::steady_clock::now();
-  const bool terminated = proc::terminate_pid_with_pidfd_for_tests(
-    child, std::chrono::milliseconds(100), std::chrono::milliseconds(500)
+  const bool terminated = proc::terminate_pid_with_pidfd_after_wait_entry_for_tests(
+    child,
+    std::chrono::milliseconds(100),
+    std::chrono::milliseconds(500),
+    production_wait_entered
   );
   const auto elapsed = std::chrono::steady_clock::now() - started;
-  stop_interrupting.store(true);
+  const auto handled_at_return = sigusr1_interruptions;
+  call_active.store(false, std::memory_order_release);
+  interrupter.request_stop();
   interrupter.join();
-  EXPECT_EQ(sigaction(SIGUSR1, &previous_action, nullptr), 0);
+  EXPECT_TRUE(production_wait_entered.load(std::memory_order_acquire));
+  EXPECT_GT(signals_sent_while_call_active.load(std::memory_order_relaxed), 0);
+  EXPECT_GT(handled_at_return, handled_before_call)
+    << "SIGUSR1 must be handled after production enters pidfd wait and before it returns";
+  EXPECT_TRUE(signal_guard.restore())
+    << "signal disposition, mask, and pending state must restore explicitly";
 
   if (!terminated) {
-    kill(child, SIGKILL);
+    child_guard.terminate_and_reap();
   }
   int status = 0;
-  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_EQ(child_guard.wait(&status, 0), child);
   EXPECT_TRUE(terminated);
   EXPECT_LT(elapsed, std::chrono::milliseconds(250));
   ASSERT_TRUE(WIFSIGNALED(status));
   EXPECT_EQ(WTERMSIG(status), SIGKILL);
 #else
   GTEST_SKIP() << "Linux-only pidfd interruption deadline";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationDeadlineSurvivesZeroPollEintr) {
+#ifdef __linux__
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const auto child = fork();
+  ASSERT_NE(child, -1);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    std::signal(SIGTERM, SIG_IGN);
+    const char ready = '1';
+    (void) write(ready_pipe[1], &ready, 1);
+    for (;;) pause();
+  }
+  linux_child_guard_t child_guard {child};
+
+  close(ready_pipe[1]);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+
+  const auto started = std::chrono::steady_clock::now();
+  const bool terminated = proc::terminate_pid_with_forced_zero_poll_eintr_for_tests(
+    child,
+    std::chrono::milliseconds(50),
+    std::chrono::milliseconds(50),
+    80,
+    std::chrono::milliseconds(5)
+  );
+  const auto elapsed = std::chrono::steady_clock::now() - started;
+
+  int status = 0;
+  const auto reaped = terminated ? child_guard.wait(&status, 0) : child_guard.terminate_and_reap(&status);
+  ASSERT_EQ(reaped, child);
+  EXPECT_FALSE(terminated);
+  EXPECT_LT(elapsed, std::chrono::milliseconds(200));
+  ASSERT_TRUE(WIFSIGNALED(status));
+  EXPECT_EQ(WTERMSIG(status), SIGKILL);
+#else
+  GTEST_SKIP() << "Linux-only pidfd zero-poll interruption deadline";
 #endif
 }
 
@@ -1230,32 +1416,81 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownUsesImmutableExact
     }
     return false;
   };
-  auto cleanup = [](pid_t pid) {
-    if (pid > 0) {
-      kill(pid, SIGKILL);
-      int status = 0;
-      waitpid(pid, &status, 0);
-    }
-  };
-
   auto owned = spawn_steam_like(true);
+  linux_child_guard_t owned_guard {owned};
+  ASSERT_GT(owned, 0);
   ASSERT_TRUE(wait_for_token(owned));
   config::video.linux_display.use_cage_compositor = false;
   EXPECT_TRUE(proc::terminate_session_owned_steam_before_cage_stop_for_tests(
     steam_app, true, token
   ));
   int status = 0;
-  EXPECT_EQ(waitpid(owned, &status, 0), owned);
+  const auto owned_wait = owned_guard.wait(&status, WNOHANG);
+  EXPECT_EQ(owned_wait, owned);
+  if (owned_wait == 0) {
+    EXPECT_EQ(owned_guard.terminate_and_reap(&status), owned);
+  }
+
+  auto faulted_owned = spawn_steam_like(true);
+  linux_child_guard_t faulted_guard {faulted_owned};
+  auto faulted_control = spawn_steam_like(true);
+  linux_child_guard_t faulted_control_guard {faulted_control};
+  ASSERT_GT(faulted_owned, 0);
+  ASSERT_GT(faulted_control, 0);
+  ASSERT_TRUE(wait_for_token(faulted_owned));
+  ASSERT_TRUE(wait_for_token(faulted_control));
+  EXPECT_FALSE(proc::terminate_session_owned_steam_with_forced_capture_failure_for_tests(
+    steam_app, true, token, faulted_owned
+  ));
+  EXPECT_EQ(faulted_guard.wait(&status, WNOHANG), 0)
+    << "pre-cage ownership capture failure must preserve the faulted Steam process";
+  EXPECT_EQ(faulted_control_guard.wait(&status, WNOHANG), 0)
+    << "incomplete ownership capture must preserve other captured Steam processes";
+  EXPECT_FALSE(proc::terminate_session_owned_steam_with_pidfd_open_error_for_tests(
+    steam_app, true, token, faulted_owned
+  ));
+  EXPECT_EQ(faulted_guard.wait(&status, WNOHANG), 0)
+    << "non-ESRCH pidfd_open failure must preserve the target Steam process";
+  EXPECT_EQ(faulted_control_guard.wait(&status, WNOHANG), 0)
+    << "non-ESRCH pidfd_open failure must preserve every captured Steam process";
+  EXPECT_FALSE(proc::terminate_session_owned_steam_with_post_capture_enumeration_error_for_tests(
+    steam_app, true, token, faulted_owned
+  ));
+  EXPECT_EQ(faulted_guard.wait(&status, WNOHANG), 0)
+    << "post-capture proc enumeration failure must not authorize pre-cage signaling";
+  EXPECT_EQ(faulted_control_guard.wait(&status, WNOHANG), 0)
+    << "partial enumeration must preserve every captured Steam process";
+  EXPECT_FALSE(proc::terminate_session_owned_steam_with_reused_pid_for_tests(
+    steam_app, true, token, faulted_owned
+  ));
+  EXPECT_EQ(faulted_guard.wait(&status, WNOHANG), 0)
+    << "an active Steam replacement at a reused PID must keep ownership capture incomplete";
+  EXPECT_EQ(faulted_control_guard.wait(&status, WNOHANG), 0)
+    << "reused-PID ambiguity must preserve other captured Steam processes";
+  EXPECT_TRUE(proc::terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, token
+  ));
+  const auto faulted_wait = faulted_guard.wait(&status, WNOHANG);
+  EXPECT_EQ(faulted_wait, faulted_owned);
+  if (faulted_wait == 0) {
+    EXPECT_EQ(faulted_guard.terminate_and_reap(&status), faulted_owned);
+  }
+  const auto control_wait = faulted_control_guard.wait(&status, WNOHANG);
+  EXPECT_EQ(control_wait, faulted_control);
+  if (control_wait == 0) {
+    EXPECT_EQ(faulted_control_guard.terminate_and_reap(&status), faulted_control);
+  }
 
   auto mirror_owned = spawn_steam_like(true);
+  linux_child_guard_t mirror_guard {mirror_owned};
+  ASSERT_GT(mirror_owned, 0);
   ASSERT_TRUE(wait_for_token(mirror_owned));
   config::video.linux_display.use_cage_compositor = true;
   EXPECT_FALSE(proc::terminate_session_owned_steam_before_cage_stop_for_tests(
     steam_app, false, token
   ));
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  EXPECT_EQ(waitpid(mirror_owned, &status, WNOHANG), 0);
-  cleanup(mirror_owned);
+  EXPECT_EQ(mirror_guard.wait(&status, WNOHANG), 0);
 #else
   GTEST_SKIP() << "Linux-only immutable private Steam teardown wiring";
 #endif
@@ -1304,16 +1539,12 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownRejectsMixedOwnedA
     }
     return false;
   };
-  auto cleanup = [](pid_t pid) {
-    if (pid > 0) {
-      kill(pid, SIGKILL);
-      int status = 0;
-      waitpid(pid, &status, 0);
-    }
-  };
-
   const auto owned = spawn_steam_like(true);
+  linux_child_guard_t owned_guard {owned};
   const auto unowned = spawn_steam_like(false);
+  linux_child_guard_t unowned_guard {unowned};
+  ASSERT_GT(owned, 0);
+  ASSERT_GT(unowned, 0);
   ASSERT_TRUE(wait_for_steam_like(owned, true));
   ASSERT_TRUE(wait_for_steam_like(unowned, false));
 
@@ -1321,20 +1552,14 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownRejectsMixedOwnedA
     steam_app, true, token
   ));
   int owned_status = 0;
-  const auto owned_wait = waitpid(owned, &owned_status, WNOHANG);
+  const auto owned_wait = owned_guard.wait(&owned_status, WNOHANG);
   EXPECT_EQ(owned_wait, 0)
     << "mixed ownership must preserve the exact-generation Steam process";
   int unowned_status = 0;
-  const auto unowned_wait = waitpid(unowned, &unowned_status, WNOHANG);
+  const auto unowned_wait = unowned_guard.wait(&unowned_status, WNOHANG);
   EXPECT_EQ(unowned_wait, 0)
     << "mixed ownership must preserve the unowned Steam process";
 
-  if (owned_wait == 0) {
-    cleanup(owned);
-  }
-  if (unowned_wait == 0) {
-    cleanup(unowned);
-  }
 #else
   GTEST_SKIP() << "Linux-only mixed private/desktop Steam ownership";
 #endif
@@ -1378,14 +1603,13 @@ TEST(ProcessRuntimeConfigTests, ExternalCageRouterResetDoesNotSignalLiveProcess)
     execl("/bin/sleep", "sleep", "60", nullptr);
     _exit(127);
   }
+  linux_child_guard_t child_guard {child};
 
   cage_display_router::reset_after_external_stop_for_tests(child);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   int status = 0;
-  EXPECT_EQ(waitpid(child, &status, WNOHANG), 0)
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), 0)
     << "router reset must not signal or reap a live externally-owned process";
-  kill(child, SIGKILL);
-  waitpid(child, &status, 0);
 #else
   GTEST_SKIP() << "Linux-only cage router signal safety";
 #endif
@@ -1408,16 +1632,10 @@ TEST(ProcessRuntimeConfigTests, ExactGenerationCleanupLeavesUnownedControlProces
   };
 
   const auto owned = spawn_sleep(true);
+  linux_child_guard_t owned_guard {owned};
   const auto control = spawn_sleep(false);
-  auto cleanup_child = [](pid_t pid) {
-    if (pid > 0) {
-      kill(pid, SIGKILL);
-      (void) waitpid(pid, nullptr, 0);
-    }
-  };
+  linux_child_guard_t control_guard {control};
   if (owned <= 0 || control <= 0) {
-    cleanup_child(owned);
-    cleanup_child(control);
     FAIL() << "failed to spawn exact-generation cleanup test children";
     return;
   }
@@ -1433,8 +1651,6 @@ TEST(ProcessRuntimeConfigTests, ExactGenerationCleanupLeavesUnownedControlProces
     }
   }
   if (!token_visible) {
-    cleanup_child(owned);
-    cleanup_child(control);
     FAIL() << "exact generation token did not become visible in child environ";
     return;
   }
@@ -1442,14 +1658,13 @@ TEST(ProcessRuntimeConfigTests, ExactGenerationCleanupLeavesUnownedControlProces
   EXPECT_TRUE(proc::terminate_exact_generation_processes_for_tests(token));
 
   int owned_status = 0;
-  EXPECT_EQ(waitpid(owned, &owned_status, 0), owned);
+  EXPECT_EQ(owned_guard.wait(&owned_status, 0), owned);
   EXPECT_TRUE(WIFSIGNALED(owned_status));
 
   int control_status = 0;
-  EXPECT_EQ(waitpid(control, &control_status, WNOHANG), 0)
+  EXPECT_EQ(control_guard.wait(&control_status, WNOHANG), 0)
     << "unowned control process must remain alive";
-  kill(control, SIGKILL);
-  EXPECT_EQ(waitpid(control, &control_status, 0), control);
+  EXPECT_EQ(control_guard.terminate_and_reap(&control_status), control);
 }
 
 TEST(ProcessRuntimeConfigTests, ExactGenerationCaptureFailureRetainsGenerationAndLeavesChildUnsignaled) {
@@ -1462,6 +1677,7 @@ TEST(ProcessRuntimeConfigTests, ExactGenerationCaptureFailureRetainsGenerationAn
     execl("/bin/sleep", "sleep", "60", nullptr);
     _exit(127);
   }
+  linux_child_guard_t child_guard {child};
 
   const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
   bool token_visible = false;
@@ -1480,14 +1696,92 @@ TEST(ProcessRuntimeConfigTests, ExactGenerationCaptureFailureRetainsGenerationAn
 
   EXPECT_TRUE(proc::isolated_session_capture_failure_retains_generation_for_tests(token, child));
   int status = 0;
-  EXPECT_EQ(waitpid(child, &status, WNOHANG), 0)
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), 0)
     << "an incompletely captured exact-generation child must not be signaled";
 
+  EXPECT_TRUE(proc::exact_generation_pidfd_open_error_fails_closed_for_tests(token, child));
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), 0)
+    << "non-ESRCH pidfd_open failure must not authorize exact-generation signaling";
+
+  EXPECT_TRUE(proc::exact_generation_post_capture_enumeration_error_fails_closed_for_tests(token, child));
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), 0)
+    << "a post-capture proc enumeration error must fail before signaling captured children";
+
+  EXPECT_TRUE(proc::exact_generation_reused_pid_fails_closed_for_tests(token, child));
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), 0)
+    << "a reused exact-generation PID must keep capture incomplete without signaling the replacement";
+
   EXPECT_TRUE(proc::terminate_exact_generation_processes_for_tests(token));
-  EXPECT_EQ(waitpid(child, &status, 0), child);
+  EXPECT_EQ(child_guard.wait(&status, 0), child);
   EXPECT_TRUE(WIFSIGNALED(status));
 #else
   GTEST_SKIP() << "Linux-only exact-generation capture fault propagation";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, ExactGenerationUnreadableEnvironFailsClosedAndLeavesChildUnsignaled) {
+#ifdef __linux__
+  const std::string token = "unreadable-exact-generation-environ";
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    if (prctl(PR_SET_DUMPABLE, 0) != 0) {
+      _exit(126);
+    }
+    const char ready = '1';
+    (void) write(ready_pipe[1], &ready, 1);
+    close(ready_pipe[1]);
+    for (;;) pause();
+  }
+  linux_child_guard_t child_guard {child};
+
+  close(ready_pipe[1]);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+
+  EXPECT_FALSE(proc::terminate_exact_generation_processes_for_tests(token));
+  EXPECT_TRUE(proc::exact_generation_unknown_ancestry_fails_closed_for_tests(token, child));
+  int status = 0;
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), 0)
+    << "an unreadable same-UID process must not be silently excluded or signaled";
+#else
+  GTEST_SKIP() << "Linux-only unreadable exact-generation environ handling";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, ExactGenerationProcEnumerationErrorFailsClosedAndLeavesChildUnsignaled) {
+#ifdef __linux__
+  const std::string token = "private-steam-enumeration-error-test";
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const auto child = fork();
+  ASSERT_NE(child, -1);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    const char ready = '1';
+    (void) write(ready_pipe[1], &ready, 1);
+    close(ready_pipe[1]);
+    for (;;) pause();
+  }
+  linux_child_guard_t child_guard {child};
+
+  close(ready_pipe[1]);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+
+  EXPECT_TRUE(proc::exact_generation_proc_enumeration_error_fails_closed_for_tests(token));
+  int status = 0;
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), 0)
+    << "enumeration failure must never authorize signals";
+#else
+  GTEST_SKIP() << "Linux-only exact-generation /proc enumeration handling";
 #endif
 }
 
@@ -1499,7 +1793,7 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
 
   const auto implementation_start = source.find("bool terminate_session_owned_steam_before_cage_stop_impl(");
   const auto implementation_end = source.find("bool is_active_desktop_steam_client_process(", implementation_start);
-  const auto helper_start = source.find("void proc_t::terminate_session_owned_steam_before_cage_stop(");
+  const auto helper_start = source.find("bool proc_t::terminate_session_owned_steam_before_cage_stop(");
   const auto terminate_start = source.find("void proc_t::terminate_impl(");
   const auto terminate_end = source.find("bool proc_t::reload_configuration_from_file", terminate_start);
   const auto execute_start = source.find("int proc_t::execute_impl(");
@@ -1594,33 +1888,8 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
 
   const auto terminate = source.substr(terminate_start, terminate_end - terminate_start);
   const auto terminate_private_steam = terminate.find("terminate_session_owned_steam_before_cage_stop(");
+  const auto terminate_generation = terminate.find("terminate_isolated_session_generation();");
   const auto terminate_main = terminate.find("terminate_process_group(");
-  const auto terminate_isolated = terminate.find("terminate_isolated_session_processes(");
-  const auto cleanup_result = terminate.find(
-    "exact_generation_cleanup_complete = terminate_isolated_session_processes("
-  );
-  const auto reset_cage = terminate.find("cage_display_router::reset_after_external_stop()");
-  const auto retain_generation = terminate.find(
-    "retaining immutable cage generation because exact-generation cleanup was incomplete"
-  );
-  const auto immutable_undo_guard = terminate.find("_session_used_cage_compositor", reset_cage);
-  ASSERT_NE(terminate_private_steam, std::string::npos);
-  ASSERT_NE(terminate_main, std::string::npos);
-  ASSERT_NE(terminate_isolated, std::string::npos);
-  ASSERT_NE(cleanup_result, std::string::npos);
-  ASSERT_NE(reset_cage, std::string::npos);
-  const auto cleanup_success_gate = terminate.rfind(
-    "isolated_session_cleanup_resets_router(", reset_cage
-  );
-  const auto cleanup_clear_gate = terminate.find(
-    "isolated_session_cleanup_clears_state(", reset_cage
-  );
-  ASSERT_NE(cleanup_success_gate, std::string::npos);
-  ASSERT_NE(cleanup_clear_gate, std::string::npos);
-  EXPECT_LT(cleanup_success_gate, reset_cage);
-  EXPECT_LT(reset_cage, cleanup_clear_gate);
-  ASSERT_NE(retain_generation, std::string::npos);
-  ASSERT_NE(immutable_undo_guard, std::string::npos);
   const auto legacy_group_gate = terminate.find(
     "isolated_session_uses_legacy_group_termination("
   );
@@ -1630,22 +1899,64 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   const auto detach_legacy_child = terminate.find("_process.detach();");
   const auto detach_legacy_group = terminate.find("_process_group.detach();");
   const auto clear_legacy_child = terminate.find("_process = boost::process::v1::child();");
+  const auto immutable_undo_guard = terminate.find("_session_used_cage_compositor", clear_legacy_child);
+  const auto finish_generation = terminate.find("finish_isolated_session_generation_cleanup();");
+  ASSERT_NE(terminate_private_steam, std::string::npos);
+  ASSERT_NE(terminate_generation, std::string::npos);
+  ASSERT_NE(terminate_main, std::string::npos);
   ASSERT_NE(legacy_group_gate, std::string::npos);
   ASSERT_NE(legacy_detach_gate, std::string::npos);
   ASSERT_NE(detach_legacy_child, std::string::npos);
   ASSERT_NE(detach_legacy_group, std::string::npos);
   ASSERT_NE(clear_legacy_child, std::string::npos);
-  EXPECT_LT(terminate_private_steam, terminate_isolated);
-  EXPECT_LT(cleanup_result, terminate_isolated);
-  EXPECT_LT(terminate_isolated, terminate_main);
-  EXPECT_LT(terminate_isolated, legacy_group_gate);
+  ASSERT_NE(immutable_undo_guard, std::string::npos);
+  ASSERT_NE(finish_generation, std::string::npos);
+  EXPECT_LT(terminate_private_steam, terminate_generation);
+  EXPECT_LT(terminate_generation, terminate_main);
+  EXPECT_LT(terminate_generation, legacy_group_gate);
   EXPECT_LT(legacy_group_gate, legacy_detach_gate);
   EXPECT_LT(legacy_detach_gate, detach_legacy_child);
   EXPECT_LT(detach_legacy_child, detach_legacy_group);
   EXPECT_LT(detach_legacy_group, clear_legacy_child);
-  EXPECT_LT(terminate_isolated, reset_cage);
+  EXPECT_LT(clear_legacy_child, immutable_undo_guard);
+  EXPECT_LT(immutable_undo_guard, finish_generation);
+  EXPECT_EQ(terminate.find("exact_generation_cleanup_complete"), std::string::npos)
+    << "terminate_impl must not be able to replace captured completeness with a literal";
+
+  const auto generation_cleanup_start = source.find("void proc_t::terminate_isolated_session_generation()");
+  const auto generation_finish_start = source.find("void proc_t::finish_isolated_session_generation_cleanup()");
+  const auto generation_finish_end = source.find("#endif", generation_finish_start);
+  ASSERT_NE(generation_cleanup_start, std::string::npos);
+  ASSERT_NE(generation_finish_start, std::string::npos);
+  ASSERT_NE(generation_finish_end, std::string::npos);
+  const auto generation_cleanup = source.substr(
+    generation_cleanup_start,
+    generation_finish_start - generation_cleanup_start
+  );
+  const auto generation_finish = source.substr(
+    generation_finish_start,
+    generation_finish_end - generation_finish_start
+  );
+  const auto cleanup_result = generation_cleanup.find(
+    "_exact_generation_cleanup_complete = terminate_isolated_session_processes("
+  );
+  const auto cleanup_success_gate = generation_cleanup.find("isolated_session_cleanup_resets_router(");
+  const auto reset_cage = generation_cleanup.find("cage_display_router::reset_after_external_stop()");
+  const auto retain_generation = generation_cleanup.find(
+    "retaining immutable cage generation because exact-generation cleanup was incomplete"
+  );
+  const auto cleanup_clear_gate = generation_finish.find("isolated_session_cleanup_clears_state(");
+  const auto clear_generation = generation_finish.find("_session_instance_id.clear()");
+  ASSERT_NE(cleanup_result, std::string::npos);
+  ASSERT_NE(cleanup_success_gate, std::string::npos);
+  ASSERT_NE(reset_cage, std::string::npos);
+  ASSERT_NE(retain_generation, std::string::npos);
+  ASSERT_NE(cleanup_clear_gate, std::string::npos);
+  ASSERT_NE(clear_generation, std::string::npos);
+  EXPECT_LT(cleanup_result, cleanup_success_gate);
+  EXPECT_LT(cleanup_success_gate, reset_cage);
   EXPECT_LT(reset_cage, retain_generation);
-  EXPECT_LT(reset_cage, immutable_undo_guard);
+  EXPECT_LT(cleanup_clear_gate, clear_generation);
   EXPECT_EQ(terminate.find("config::video.linux_display.use_cage_compositor"), std::string::npos);
   EXPECT_EQ(terminate.find("cage_display_router::stop()"), std::string::npos);
   EXPECT_EQ(terminate.find("terminate_steam_app_processes("), std::string::npos);
@@ -1703,13 +2014,13 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsStartedAndStoppedInsi
   EXPECT_LT(start_guard, first_main_launch);
   EXPECT_LT(first_main_launch, launch_committed);
   const auto stop_guard = terminate.find("stop_steam_big_picture_input_guard()");
-  const auto cleanup_generation = terminate.find("terminate_isolated_session_processes(");
-  const auto reset_cage = terminate.find("cage_display_router::reset_after_external_stop()");
+  const auto cleanup_generation = terminate.find("terminate_isolated_session_generation();");
+  const auto finish_generation = terminate.find("finish_isolated_session_generation_cleanup();");
   ASSERT_NE(stop_guard, std::string::npos);
   ASSERT_NE(cleanup_generation, std::string::npos);
-  ASSERT_NE(reset_cage, std::string::npos);
+  ASSERT_NE(finish_generation, std::string::npos);
   EXPECT_LT(stop_guard, cleanup_generation);
-  EXPECT_LT(cleanup_generation, reset_cage);
+  EXPECT_LT(cleanup_generation, finish_generation);
 }
 
 TEST(ProcessRuntimeConfigTests, HeadlessCageSteamBigPictureSkipsHostShutdownUndo) {
@@ -1758,6 +2069,44 @@ TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorIgnoresZombieShutdownRemnant
     "",
     "Name:\tsteam\nState:\tZ (zombie)\nPPid:\t275560\n"
   ));
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorFailsClosedOnProcOpenError) {
+#ifdef __linux__
+  EXPECT_TRUE(proc::desktop_steam_proc_open_error_fails_closed_for_tests());
+#else
+  GTEST_SKIP() << "Linux-only desktop Steam proc scanner";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorFailsClosedOnProcEnumerationError) {
+#ifdef __linux__
+  EXPECT_TRUE(proc::desktop_steam_proc_enumeration_error_fails_closed_for_tests());
+#else
+  GTEST_SKIP() << "Linux-only desktop Steam proc scanner";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorFailsClosedOnProcReadError) {
+#ifdef __linux__
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    execl("/bin/sleep", "sleep", "60", nullptr);
+    _exit(127);
+  }
+  linux_child_guard_t child_guard {child};
+  for (int attempt = 0; attempt < 40; ++attempt) {
+    std::ifstream status("/proc/" + std::to_string(child) + "/status");
+    if (status.good()) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  }
+  EXPECT_TRUE(proc::desktop_steam_proc_read_error_fails_closed_for_tests(child));
+#else
+  GTEST_SKIP() << "Linux-only desktop Steam proc scanner";
+#endif
 }
 
 TEST(ProcessRuntimeConfigTests, DesktopSteamActiveOffersExplicitForcePrivateShutdown) {


### PR DESCRIPTION
## Summary

- bind Linux cage/private-Steam teardown to a fresh immutable per-launch generation instead of process names, app IDs, displays, or environment substrings
- capture exact-generation descendants with pidfds plus `/proc/<pid>/stat` start-time validation, then use bounded pidfd `SIGTERM` → `SIGKILL` cleanup before compositor removal or legacy Boost process/group teardown
- preserve absolute pidfd wait deadlines across repeated and zero-timeout `EINTR`
- propagate the generation only through child launch environments and the forked labwc child; do not contaminate the Polaris daemon environment
- fail closed by retaining unresolved generation state and refusing relaunch when `/proc` enumeration/read, ancestry, identity, ownership, pidfd capture/signaling, or cleanup is incomplete
- fail closed when desktop-Steam detection cannot open or completely enumerate `/proc`, or cannot read a non-vanished process identity
- clear cage-router bookkeeping without raw-PID signaling and suppress legacy Steam shutdown undo from immutable launch state

## Safety properties

- exact NUL-delimited `KEY=value` ownership matching
- pidfd plus start-time identity binding; no bare-PID signaling fallback
- bounded absolute `SIGTERM` → `SIGKILL` deadlines under `EINTR`
- no host-wide `steam -shutdown` from normal cage-owned teardown
- unowned, stale-generation, PID-reused, and indeterminate processes are not signaled
- exact-generation cleanup runs before cage removal and before legacy child/group destructor paths
- incomplete cleanup retains generation authority and blocks relaunch
- desktop Steam uncertainty blocks private launch/shutdown completion
- desktop Xwayland remains outside the isolated generation

## Frozen artifact

- Base commit: `b1e8dd11c0926ece25e3730d1a825107658e7d27`
- Commit: `737d950d2656b04693712665e78404e010782996`
- Commit tree: `22ded51f7ab37b607a7416e2087e7d6f2f56d350`
- Binary diff SHA-256: `a747c7d1ea68ded422fb88c2153d447373abd4b2b27abf5222d0aa3520eaf627`
- Mutation runner SHA-256: `a555b07bf7d5b439c1d865e3af4788fb921e8dc19ef13364155a9dbf7d54865f`

## Verification

- CPU production/full build: PASS
- CPU configuration tests: 236/236
- CPU CTest: 12/12
- CUDA production/full build with GCC/G++ 15 and CUDA 13.2.78: PASS
- CUDA configuration tests: 236/236
- CUDA CTest: 12/12
- Gamepad isolation: 24/24
- CUDA-enabled platform contracts: 3/3; CPU-only build reports the expected Linux/CUDA-only skip
- Compiling mutation matrix: 44/44 killed; 0 survivors, noncompiling mutants, invalid anchors, or harness errors
- Mutation restoration build and focused baseline: PASS
- Post-commit CPU and CUDA configuration tests: 236/236 each
- Production test-seam symbol scan: 0 in CPU and CUDA binaries
- Test-process residue after gate: 0
- `git diff --check`: clean
- Added-line credential scan: clean
- Independent exact-tree Linux lifecycle/security review: PASS, no findings

## Fresh combined-head CI

- Synthetic merge commit: `7dfcb6ce28be7450f25496550cd04abbfe58f633`
- Merge parents: base `462b6fe5768eb1f933ad695a602ec34f4023070d` + reviewed head `737d950d2656b04693712665e78404e010782996`
- Synthetic merge tree: `22ded51f7ab37b607a7416e2087e7d6f2f56d350` (identical to the reviewed tree)
- [Public Hygiene](https://github.com/papi-ux/polaris/actions/runs/29506343749): PASS
- [CodeQL](https://github.com/papi-ux/polaris/actions/runs/29506343705): PASS
- [Build Polaris](https://github.com/papi-ux/polaris/actions/runs/29506343814): PASS
  - Web checks, C++ sanitizers, Arch, Ubuntu, Fedora 42/43/44: PASS
  - Release assets: expected skip for pull requests

## Exact-candidate Retroid field validation

The earlier Retroid smoke evidence belonged to the superseded candidate at old PR head `b1e8dd11c0926ece25e3730d1a825107658e7d27` and is **not** claimed for this replacement artifact.

With explicit deployment approval, one serialized Steam Big Picture Private Stream → Nova **End session** cycle passed on Retroid `498c8ae8` using the exact reviewed candidate:

- Deployed path: `/usr/bin/polaris-1.3.1.737d950d.private-steam-22ded51f`
- Deployed/live SHA-256: `8149e157f45195e25917296a7ce0f3c09242f24562de37bbdf41303c230de8ed`
- Rollback retained: `/usr/bin/polaris-1.3.1.462b6fe5.private-steam-b4f88bd3` (`fc1558b53c45c35785ac18696b5c21debdadb0ba4f933423719b4f2eb3a8986d`)
- Retroid visibly rendered coherent Steam Big Picture; first video packet 0 ms, first audio packet 300 ms, fatal transport errors 0
- Polaris daemon generation marker absent
- One exact non-empty generation across 11 Steam processes, one labwc compositor, and one isolated Xwayland
- Desktop Xwayland PID/start identity preserved and unmarked
- End-session journal showed private-Steam pre-cage termination, four remaining exact-generation processes terminated, then router state cleared after pidfd cleanup
- After End: Steam 0, labwc/cage 0, Wine 0, generation-marker processes 0, authenticated running apps 0, streaming false, active sessions 0
- Retained/incomplete-generation logs 0; legacy-cleanup logs 0
- New `.dmp` files 0; new Polaris coredumps 0; actual assertion/SIGABRT/XIO/minidump-write signatures 0
- Nova returned to idle Library with no Resume card and displayed “Successfully quit Steam Big Picture”
- Evidence bundle: 44 files with a locally verified SHA-256 manifest

Automated ADB evidence proves transport/UI lifecycle only; physical-controller and human-audio confirmation were not requested and are not claimed.
