### PR TITLE
test(web): avoid duplicate Dashboard smoke navigation

### DIFF
--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -259,12 +259,10 @@ async function verifyAuthenticatedRoutes(page, baseURL, options) {
     throw new Error(`Login failed with ${loginResponse.status()}: ${await loginResponse.text().catch(() => '')}`)
   }
 
-  await page.goto(`${baseURL}/#/`)
-  await expect(page.getByRole('navigation')).toBeVisible({ timeout: 15000 })
-
   for (const [index, route] of routes.entries()) {
     if (index === 0) {
       await page.goto(`${baseURL}/?smoke=${Date.now()}-${index}${route.hash}`)
+      await expect(page.getByRole('navigation')).toBeVisible({ timeout: 15000 })
     } else {
       await page.evaluate((hash) => {
         window.location.hash = hash

--- a/src_assets/common/assets/web/smoke-web-routes-navigation.test.js
+++ b/src_assets/common/assets/web/smoke-web-routes-navigation.test.js
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const smokeHarness = vi.hoisted(() => {
+  const gotoURLs = []
+  const locator = {
+    count: async () => 0,
+    first: () => locator,
+    innerText: async () => 'Polaris smoke route content '.repeat(5),
+  }
+  const apiResponse = {
+    ok: () => true,
+    status: () => 200,
+    text: async () => [
+      '<!doctype html>',
+      '<script type="module" crossorigin src="./assets/index-AbC123.js"></script>',
+      '<link rel="stylesheet" crossorigin href="./assets/index-ZxY987.css">',
+    ].join('\n'),
+  }
+  const apiRequest = {
+    dispose: async () => {},
+    get: async () => apiResponse,
+    post: async () => apiResponse,
+  }
+  const context = {
+    clearCookies: async () => {},
+    request: apiRequest,
+  }
+  const page = {
+    context: () => context,
+    evaluate: async () => {},
+    getByLabel: () => locator,
+    getByRole: () => locator,
+    getByText: () => locator,
+    goto: async (url) => {
+      gotoURLs.push(url)
+    },
+    locator: () => locator,
+    on: () => {},
+    screenshot: async () => {},
+    waitForTimeout: async () => {},
+  }
+  const browser = {
+    close: async () => {},
+    newContext: async () => ({
+      ...context,
+      newPage: async () => page,
+    }),
+  }
+
+  return { apiRequest, browser, gotoURLs }
+})
+
+vi.mock('@playwright/test', () => ({
+  chromium: {
+    launch: async () => smokeHarness.browser,
+  },
+  expect: () => ({
+    toBeVisible: async () => {},
+  }),
+  request: {
+    newContext: async () => smokeHarness.apiRequest,
+  },
+}))
+
+import { runSmoke } from '../../../../scripts/smoke-web-routes.mjs'
+
+describe('authenticated smoke route navigation', () => {
+  beforeEach(() => {
+    smokeHarness.gotoURLs.length = 0
+  })
+
+  it('loads Dashboard once after login instead of immediately reloading it', async () => {
+    const baseURL = 'https://127.0.0.1:58490'
+
+    await runSmoke({
+      baseURL,
+      mode: 'live',
+      noLogin: false,
+      password: 'test-password',
+      screenshotDir: '/tmp',
+      username: 'test-user',
+      writeScreenshots: false,
+    })
+
+    expect(smokeHarness.gotoURLs).toHaveLength(2)
+    expect(smokeHarness.gotoURLs[0]).toMatch(/^https:\/\/127\.0\.0\.1:58490\/\?smoke=\d+#\/login$/)
+    expect(smokeHarness.gotoURLs[1]).toMatch(/^https:\/\/127\.0\.0\.1:58490\/\?smoke=\d+-0#\/$/)
+  })
+})


### PR DESCRIPTION
## Summary
- remove the redundant authenticated Dashboard page load from the web route smoke harness
- keep the cache-busted first-route navigation as the single post-login app-shell load
- add a `runSmoke` regression test that requires exactly the login and Dashboard full-page navigations

## Root cause
The smoke hardening refactor dropped the earlier app-shell load guard and performed two consecutive Dashboard `page.goto()` calls. The second load aborted in-flight API/SSE requests and produced false console failures during the release smoke.

## Verification
- [x] focused smoke harness tests: 5/5
- [x] full Vitest suite: 45 files / 239 tests
- [x] ESLint
- [x] production build and web performance budget
- [x] static no-login web smoke
- [x] isolated authenticated route smoke: 3 consecutive passes
- [x] authenticated viewport matrix: 48/48
- [x] `npm audit`: 0 vulnerabilities
- [x] independent read-only review: no findings

No live deploy or service restart was performed.
