### PR TITLE
Per-app isolated sessions (Family Mode) for Linux

### DIFF
--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -384,6 +384,7 @@ namespace confighttp::validation {
       "elevated"sv,
       "exclude-global-prep-cmd"sv,
       "exclude-global-state-cmd"sv,
+      "isolated-session"sv,
       "launching"sv,
       "per-client-app-identity"sv,
       "terminate-on-pause"sv,

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -5278,6 +5278,14 @@ namespace nvhttp {
     if (no_active_sessions && args.find("localAudioPlayMode"s) != std::end(args)) {
       host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     }
+#ifdef __linux__
+    // A resumed isolated session (family mode) must keep stream-only audio: the
+    // client's localAudioPlayMode would otherwise re-enable host audio and leak
+    // the desktop's sound into the stream.
+    if (proc::proc.isolated_session_active()) {
+      host_audio = false;
+    }
+#endif
     auto launch_session = make_launch_session(host_audio, false, args, named_cert_p.get());
     const bool watch_only = launch_session->watch_only;
 

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -7,9 +7,9 @@
  * switching, no HDMI-A-1, no kscreen-doctor, no KWin routing scripts.
  *
  * Key environment variables set for cage:
- *   WLR_BACKENDS=wayland    — run as a Wayland client window (not DRM)
- *   WLR_RENDERER=vulkan     — best NVIDIA support
- *   WAYLAND_DISPLAY=<sock>  — cage's own socket name for its children
+ *   WLR_BACKENDS=wayland|headless — windowed on desktop, or off-screen (family mode)
+ *   WLR_RENDERER=vulkan|gles2     — per-GPU: Vulkan on AMD/Intel, GLES2 on NVIDIA
+ *   WAYLAND_DISPLAY=<sock>        — cage's own socket name for its children
  *
  * Resolution is set via wlr-randr after cage starts (--custom-mode).
  */
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <cstdio>
 #include <dirent.h>
+#include <filesystem>
 #include <functional>
 #include <fstream>
 #include <cstdlib>
@@ -138,6 +139,42 @@ namespace cage_display_router {
     return prefix;
   }
 
+  /**
+   * @brief Pick the wlroots renderer for a headless labwc compositor.
+   *
+   * The headless GLES2 renderer leaves GPU-accelerated clients — Steam's CEF UI
+   * and Proton games — as a black frame off-screen (the "Family Mode black
+   * screen"). The Vulkan renderer GPU-accelerates the compositor and paints
+   * those clients correctly while still running fully off-screen. On AMD/Intel
+   * we therefore use Vulkan for headless. NVIDIA is the exception: headless +
+   * Vulkan is unstable on the nvidia driver / wlroots 0.19, so NVIDIA keeps
+   * GLES2 (and relies on the windowed GPU-native fallback). The choice is made
+   * by inspecting the DRM driver — no user configuration required. Cached
+   * because the GPU set does not change within a process lifetime.
+   */
+  static const std::string &headless_wlr_renderer() {
+    static const std::string cached = [] {
+      namespace fs = std::filesystem;
+      std::error_code ec;
+      for (const auto &entry : fs::directory_iterator("/sys/class/drm", ec)) {
+        const auto card = entry.path().filename().string();
+        // Match render-capable primary nodes (card0, card1, ...), not the
+        // per-connector entries (card0-HDMI-A-1) which have no device/driver.
+        if (card.rfind("card", 0) != 0 || card.find('-') != std::string::npos) {
+          continue;
+        }
+        const auto driver = fs::read_symlink(entry.path() / "device" / "driver", ec);
+        if (!ec && driver.filename().string() == "nvidia") {
+          BOOST_LOG(info) << "cage: NVIDIA DRM driver detected — using GLES2 renderer for headless labwc (Vulkan headless is unstable on NVIDIA)"sv;
+          return std::string {"gles2"};
+        }
+      }
+      BOOST_LOG(info) << "cage: using Vulkan renderer for headless labwc (GPU-accelerated off-screen; required for Steam CEF / Proton to paint)"sv;
+      return std::string {"vulkan"};
+    }();
+    return cached;
+  }
+
   static std::string labwc_process_environment_value(bool headless, std::string_view key) {
     if (key == "WLR_NO_HARDWARE_CURSORS") {
       // Polaris captures the private labwc compositor, not the host desktop. On
@@ -151,7 +188,7 @@ namespace cage_display_router {
     }
 
     if (key == "WLR_RENDERER") {
-      return headless ? "gles2" : "vulkan";
+      return headless ? headless_wlr_renderer() : "vulkan";
     }
 
     if (headless && key == "WLR_HEADLESS_OUTPUTS") {
@@ -773,14 +810,14 @@ namespace cage_display_router {
         // Headless mode: no visible window on desktop, no parent display needed.
         // labwc creates virtual outputs that still support wlr-screencopy.
         //
-        // Known limitations on NVIDIA + wlroots 0.19:
-        // - Vulkan renderer crashes (vulkan_instance_destroy SEGV)
-        // - GLES2/pixman renderers work but screencopy returns SHM/ARGB frames
-        //   which CUDA/NVENC can't consume directly (needs NV12)
-        // - Requires SHM→NV12 conversion in the capture pipeline (future work)
+        // Renderer is chosen per-GPU in headless_wlr_renderer():
+        // - AMD/Intel: Vulkan renderer, so GPU-accelerated clients (Steam's CEF,
+        //   Proton games) actually paint off-screen instead of rendering black.
+        // - NVIDIA + wlroots 0.19: Vulkan headless crashes
+        //   (vulkan_instance_destroy SEGV), so NVIDIA keeps the GLES2/pixman path;
+        //   screencopy returns SHM/ARGB there and wlgrab converts via software
+        //   scaler (slower but functional). Windowed GPU-native is the fallback.
         //
-        // For now: use headless with GLES2, the SHM capture path in wlgrab
-        // handles the conversion via software scaler (slower but functional).
         // Clear inherited display vars so children ONLY talk to labwc.
         // labwc will set its own WAYLAND_DISPLAY and start XWayland (new DISPLAY).
         // Without this, Steam connects to KDE's :0 instead of labwc's XWayland.

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -754,12 +754,32 @@ namespace cage_display_router {
         mangohud_prefix = mangohud_prefix_for_command(game_cmd, allow_mangohud, mh, mhc ? mhc : "");
       }
     }
+    // Optional splash backdrop: paint the output while the game cold-starts so
+    // the stream shows a deliberate backdrop instead of a black void. Uses
+    // swaybg when installed (no hard dependency); a user-supplied image at
+    // ~/.config/polaris/splash.png wins over the solid fallback color. swaybg
+    // is backgrounded inside the session and exits on its own when the
+    // compositor goes away, so no teardown is needed.
+    std::string splash_cmd;
+    if (!resolve_executable("swaybg").empty()) {
+      const std::string user_splash = std::string(getenv("HOME") ? getenv("HOME") : "/tmp") + "/.config/polaris/splash.png";
+      if (access(user_splash.c_str(), R_OK) == 0) {
+        splash_cmd = "swaybg -m fill -i " + shell_quote(user_splash) + " >/dev/null 2>&1 & ";
+        BOOST_LOG(info) << "labwc: splash backdrop enabled (image ["sv << user_splash << "])"sv;
+      } else {
+        splash_cmd = "swaybg -c '#101418' >/dev/null 2>&1 & ";
+        BOOST_LOG(info) << "labwc: splash backdrop enabled (solid color; drop an image at ~/.config/polaris/splash.png to customize)"sv;
+      }
+    } else {
+      BOOST_LOG(info) << "labwc: swaybg not found; startup shows a black backdrop until the game paints (install swaybg for a splash)"sv;
+    }
+
     if (!game_cmd.empty()) {
       auto mode_retry_cmd =
         "for i in $(seq 1 50); do "
         "wlr-randr --output " + output_name + " --custom-mode " + mode + " >/dev/null 2>&1 && break; "
         "sleep 0.1; "
-        "done; ";
+        "done; " + splash_cmd;
       if (headless) {
         // In headless mode: set resolution, ensure XWayland is ready, then launch game.
         // labwc with xwaylandPersistence=yes starts XWayland eagerly, but we still
@@ -775,7 +795,7 @@ namespace cage_display_router {
         "for i in $(seq 1 50); do "
         "wlr-randr --output " + output_name + " --custom-mode " + mode + " >/dev/null 2>&1 && break; "
         "sleep 0.1; "
-        "done; "
+        "done; " + splash_cmd +
         "exec sleep infinity";
     }
 

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1049,6 +1049,18 @@ namespace platf {
         plane_t plane = drmModeGetPlane(card.fd.el, plane_id);
         frame_timestamp = std::chrono::steady_clock::now();
 
+        // A display-topology change (e.g. a monitor powering off and the compositor
+        // moving the desktop to a dummy plug on another CRTC/GPU) retires the plane we
+        // pinned at init(). drmModeGetPlane() then returns NULL, and a plane that still
+        // exists but stopped scanning out reports fb_id == 0. Either way the captured
+        // CRTC is dead: ask the pipeline to re-resolve onto the now-active output instead
+        // of dereferencing a null plane (crash) or spinning on capture_e::timeout forever
+        // (freeze). Mirrors the HDR-metadata and resolution reinit paths in this function.
+        if (!plane || !plane->fb_id) {
+          BOOST_LOG(info) << "Reinitializing capture after the captured plane was retired (display topology change)"sv;
+          return capture_e::reinit;
+        }
+
         auto fb = card.fb(plane.get());
         if (!fb) {
           // This can happen if the display is being reconfigured while streaming

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -45,6 +45,7 @@
 #endif
 
 // local includes
+#include "cage_display_router.h"
 #include "graphics.h"
 #include "misc.h"
 #include "src/config.h"
@@ -1171,6 +1172,13 @@ std::string get_local_ip_for_gateway() {
 #endif
 
   std::vector<std::string> display_names(mem_type_e hwdevice_type) {
+#ifdef POLARIS_BUILD_WAYLAND
+    // Match display(): while the cage runtime is live, enumeration must come from
+    // the nested compositor, not whichever source the startup bitset selected.
+    if (config::video.linux_display.use_cage_compositor && cage_display_router::is_running()) {
+      return wl_display_names();
+    }
+#endif
 #ifdef POLARIS_BUILD_CUDA
     // display using NvFBC only supports mem_type_e::cuda
     if (sources[source::NVFBC] && hwdevice_type == mem_type_e::cuda) {
@@ -1210,6 +1218,17 @@ std::string get_local_ip_for_gateway() {
   }
 
   std::shared_ptr<display_t> display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config) {
+#ifdef POLARIS_BUILD_WAYLAND
+    // The capture-source set is computed once at startup, but a per-app isolated
+    // session (family mode) can start the cage runtime afterwards. When the cage is
+    // live, capture must target the nested compositor (wlgrab connects to its
+    // socket) — never the physical desktop via KMS/X11, which the startup bitset
+    // may otherwise select (e.g. KDE hosts where KMS is the desktop capture path).
+    if (config::video.linux_display.use_cage_compositor && cage_display_router::is_running()) {
+      BOOST_LOG(info) << "Screencasting with Wayland's protocol (cage runtime)"sv;
+      return wl_display(hwdevice_type, display_name, config);
+    }
+#endif
 #ifdef POLARIS_BUILD_CUDA
     if (sources[source::NVFBC] && hwdevice_type == mem_type_e::cuda) {
       BOOST_LOG(info) << "Screencasting with NvFBC"sv;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -4168,6 +4168,41 @@ namespace proc {
     allow_client_commands = app.allow_client_commands;
 
 #ifdef __linux__
+    // Session-scoped override for per-app isolated sessions (family mode).
+    // Forcing the globals makes every downstream read — the session snapshot
+    // below, display policy, cage lifecycle, gamepad isolation, encoder-probe
+    // deferral, audio capture — behave as a headless+cage session without
+    // touching those call sites. Saved ONLY when the app opts in, so mid-session
+    // config changes made during normal sessions are never clobbered.
+    // restore_isolated_session_overrides() undoes this from terminate() (which
+    // runs on both the success path and, via the fail_guard, the failure path).
+    if (_app.isolated_session && !(launch_session && launch_session->mirror_desktop)) {
+      initial_headless_mode = config::video.linux_display.headless_mode;
+      initial_use_cage_compositor = config::video.linux_display.use_cage_compositor;
+      initial_prefer_gpu_native_capture = config::video.linux_display.prefer_gpu_native_capture;
+      initial_audio_sink = config::audio.sink;
+      initial_linux_display_saved = true;
+      config::video.linux_display.headless_mode = true;
+      config::video.linux_display.use_cage_compositor = true;
+      // Keep the compositor truly off-screen: a GPU-native windowed fallback
+      // would make the session visible on the host desktop, defeating isolation.
+      config::video.linux_display.prefer_gpu_native_capture = false;
+      // Audio isolation must hold in the CAPTURE pipeline too (rtsp copies
+      // host_audio into the session flags), so force it at the source — and
+      // clear any explicit sink so the virtual-sink env-tag routing path is
+      // taken instead of switching the desktop user's default sink.
+      launch_session->host_audio = false;
+      config::audio.sink.clear();
+      BOOST_LOG(info) << "process: app ["sv << _app.name
+                      << "] opted into isolated off-screen session; forcing headless+cage and stream-only audio for this session"sv;
+    }
+
+    // If a throw unwinds before the main fail_guard below is armed, still restore
+    // the forced globals; disabled once fg takes over (fg's terminate_impl restores).
+    auto isolated_override_guard = util::fail_guard([this]() {
+      restore_isolated_session_overrides();
+    });
+
     const bool use_cage_compositor_for_session =
       config::video.linux_display.use_cage_compositor &&
       !(launch_session && launch_session->mirror_desktop);
@@ -4575,6 +4610,9 @@ namespace proc {
       session_manager::restore_state(session_state);
 #endif
     });
+
+    // fg's terminate_impl now owns restoring the isolated-session override.
+    isolated_override_guard.disable();
 
     if (!app.gamepad.empty() && app_gamepad_override_is_supported(app.gamepad)) {
       _saved_input_config = std::make_shared<config::input_t>(config::input);
@@ -5887,6 +5925,20 @@ namespace proc {
 #endif
   }
 
+  void proc_t::restore_isolated_session_overrides() {
+#ifdef __linux__
+    if (!initial_linux_display_saved) {
+      return;
+    }
+    config::video.linux_display.headless_mode = initial_headless_mode;
+    config::video.linux_display.use_cage_compositor = initial_use_cage_compositor;
+    config::video.linux_display.prefer_gpu_native_capture = initial_prefer_gpu_native_capture;
+    config::audio.sink = initial_audio_sink;
+    initial_audio_sink.clear();
+    initial_linux_display_saved = false;
+#endif
+  }
+
   void proc_t::terminate(bool immediate, bool needs_refresh) {
     if (!_session_lifecycle_gate->begin_stop()) {
       return;
@@ -6134,6 +6186,10 @@ namespace proc {
       config::video.max_bitrate = initial_max_bitrate;
       config::video.adaptive_bitrate.max_bitrate_kbps = initial_adaptive_max_bitrate;
     }
+
+    // Undo the per-app isolated-session override (family mode). Runs after any
+    // disable_streaming_display() above so display teardown sees session config.
+    restore_isolated_session_overrides();
 
     _app_id = -1;
     _app_name.clear();
@@ -7187,6 +7243,7 @@ namespace proc {
           ctx.wait_all = app_node.value("wait-all", true);
           ctx.exit_timeout = std::chrono::seconds { app_node.value("exit-timeout", 5) };
           ctx.virtual_display = app_node.value("virtual-display", false);
+          ctx.isolated_session = app_node.value("isolated-session", false);
           ctx.scale_factor = app_node.value("scale-factor", 100);
           ctx.use_app_identity = app_node.value("use-app-identity", false);
           ctx.per_client_app_identity = app_node.value("per-client-app-identity", false);

--- a/src/process.h
+++ b/src/process.h
@@ -345,6 +345,7 @@ namespace proc {
     bool auto_detach;
     bool wait_all;
     bool virtual_display;
+    bool isolated_session;  // family mode: force headless+cage for THIS app only
     bool virtual_display_primary;
     bool use_app_identity;
     bool per_client_app_identity;
@@ -482,6 +483,28 @@ namespace proc {
     int initial_max_bitrate = 0;
     int initial_adaptive_max_bitrate = 0;
     bool initial_video_config_saved = false;
+    // Saved config for the per-app isolated-session override (family mode);
+    // populated only when the launched app opted in (initial_linux_display_saved
+    // is the guard).
+    bool initial_headless_mode = false;
+    bool initial_use_cage_compositor = false;
+    bool initial_prefer_gpu_native_capture = false;
+    std::string initial_audio_sink;
+    bool initial_linux_display_saved = false;
+
+    /**
+     * @brief Whether the currently running app opted into an isolated session.
+     * Used by the resume path to keep audio isolation across reconnects.
+     */
+    bool isolated_session_active() const {
+      return _app_id != -1 && _app.isolated_session;
+    }
+
+    /**
+     * @brief Restore the config globals forced by the isolated-session override.
+     * Idempotent; a no-op unless the override is active.
+     */
+    void restore_isolated_session_overrides();
 
     proc_t(
       boost::process::v1::environment &&env,

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -119,6 +119,8 @@
     "use_app_identity_desc": "Use the app's own identity while creating virtual displays instead of client's. This is useful when you want display configuration for each APP separately.",
     "virtual_display": "Always create Virtual Display",
     "virtual_display_desc": "Always create a virtual display when starting this app, overriding client request. Please make sure the SudoVDA driver is installed and enabled.",
+    "isolated_session": "Isolated session (Family Mode)",
+    "isolated_session_desc": "Run this app inside Polaris's hidden headless compositor so it streams alongside your live desktop. The streamed player controls only the game; your physical keyboard and mouse keep controlling the desktop, and game audio goes to a separate sink so it will not play on the host speakers. Linux only.",
     "virtual_display_primary": "Enforce Virtual Display Primary",
     "virtual_display_primary_desc": "Automatically set the virtual display as primary display when the app starts. Virtual display will always be set to primary when client requests to use virtual display. (Recommended to keep on) [Broken on Windows 11 24H2]",
     "wait_all": "Continue streaming until all app processes exit",

--- a/src_assets/common/assets/web/views/AppsView.vue
+++ b/src_assets/common/assets/web/views/AppsView.vue
@@ -979,6 +979,7 @@
               <Checkbox class="app-editor-toggle-card" id="waitAll" label="apps.wait_all" desc="apps.wait_all_desc" desc-as-hint v-model="editForm['wait-all']" default="true"></Checkbox>
               <Checkbox class="app-editor-toggle-card" id="terminateOnPause" label="apps.terminate_on_pause" desc="apps.terminate_on_pause_desc" desc-as-hint v-model="editForm['terminate-on-pause']" default="false"></Checkbox>
               <Checkbox class="app-editor-toggle-card" id="virtualDisplay" label="apps.virtual_display" desc="apps.virtual_display_desc" desc-as-hint v-model="editForm['virtual-display']" default="false"></Checkbox>
+              <Checkbox v-if="platform === 'linux'" class="app-editor-toggle-card" id="isolatedSession" label="apps.isolated_session" desc="apps.isolated_session_desc" desc-as-hint v-model="editForm['isolated-session']" default="false"></Checkbox>
               <Checkbox class="app-editor-toggle-card" id="useAppIdentity" label="apps.use_app_identity" desc="apps.use_app_identity_desc" desc-as-hint v-model="editForm['use-app-identity']" default="false"></Checkbox>
               <Checkbox class="app-editor-toggle-card" v-if="editForm['use-app-identity']" id="perClientAppIdentity" label="apps.per_client_app_identity" desc="apps.per_client_app_identity_desc" desc-as-hint v-model="editForm['per-client-app-identity']" default="false"></Checkbox>
               <div class="app-editor-field">
@@ -1157,6 +1158,7 @@ const newAppTemplate = {
   "per-client-app-identity": false,
   "allow-client-commands": true,
   "virtual-display": false,
+  "isolated-session": false,
   "terminate-on-pause": false,
   "gamepad": "",
   "game-category": ""


### PR DESCRIPTION
## Summary

Adds a per-app **Isolated Session (Family Mode)** to Polaris on Linux: mark an app and it launches inside Polaris's hidden headless labwc compositor, concurrently with the live desktop. A second person streams a game to another device while the primary user keeps using the PC — the streamed player controls only the game, the desktop user's physical keyboard/mouse keep controlling the desktop, and game audio is routed to a private virtual sink so it never plays on the host speakers.

This is the focused follow-up to #223, which I closed to split the solid isolated-session work out from more experimental EVDI/display-source changes that need more hardware testing.

## Commits (reviewable independently)

- **feat(linux): per-app isolated sessions (Family Mode)** — the feature.
- **fix(family-mode): Vulkan renderer for headless labwc on AMD/Intel** — headless GLES2 leaves GPU-accelerated clients (Steam's CEF, Proton/native games) black off-screen; select Vulkan on AMD/Intel (auto-detected from the DRM driver under /sys/class/drm), keep GLES2 on NVIDIA where headless Vulkan is unstable on wlroots 0.19.
- **feat(family-mode): swaybg splash backdrop** — optional dark backdrop during the game's cold-start instead of a black void (no hard dependency; solid-color fallback).

## Design

Implemented as a **session-scoped override of the linux_display globals** at the top of `execute_impl()`: when the launched app opted in, `headless_mode` and `use_cage_compositor` are forced true and `prefer_gpu_native_capture` false (keeping the compositor genuinely off-screen). Every downstream read — the session snapshot, display policy, cage lifecycle, gamepad isolation, encoder-probe deferral, audio capture — then behaves as a headless+cage session with **no edits at those ~dozen call sites**.

Saved values are restored from `terminate_impl()` on both the success and `fail_guard` paths, plus a scope guard covering the window before the main `fail_guard` is armed — and only when the app opted in, so normal sessions are never touched. Audio isolation is forced at the source (`launch_session->host_audio` + cleared explicit sink), and `/resume` preserves it against the client's `localAudioPlayMode` so a reconnect can't leak desktop audio.

## Testing

Field-tested end-to-end on openSUSE Tumbleweed, KDE Plasma 6 Wayland, AMD RX 9070 XT, Moonlight client: Family Mode with Steam Big Picture launching native-Linux and Proton titles, concurrent desktop use (desktop stays usable, no focus/edit-mode disruption), audio split verified via `pactl` (game on the virtual sink, desktop audio on the real default), input isolation (streamed input to the game only; host kbd/mouse to the desktop), and single-session refusal. Built green against current master via the openSUSE Tumbleweed workflow.

Co-authored with @Beary-Handsome, who did all the hardware validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)