### PR TITLE
fix(kms): follow display-topology changes instead of freezing (+ null-deref)

### DIFF
--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -1049,6 +1049,18 @@ namespace platf {
         plane_t plane = drmModeGetPlane(card.fd.el, plane_id);
         frame_timestamp = std::chrono::steady_clock::now();
 
+        // A display-topology change (e.g. a monitor powering off and the compositor
+        // moving the desktop to a dummy plug on another CRTC/GPU) retires the plane we
+        // pinned at init(). drmModeGetPlane() then returns NULL, and a plane that still
+        // exists but stopped scanning out reports fb_id == 0. Either way the captured
+        // CRTC is dead: ask the pipeline to re-resolve onto the now-active output instead
+        // of dereferencing a null plane (crash) or spinning on capture_e::timeout forever
+        // (freeze). Mirrors the HDR-metadata and resolution reinit paths in this function.
+        if (!plane || !plane->fb_id) {
+          BOOST_LOG(info) << "Reinitializing capture after the captured plane was retired (display topology change)"sv;
+          return capture_e::reinit;
+        }
+
         auto fb = card.fb(plane.get());
         if (!fb) {
           // This can happen if the display is being reconfigured while streaming


### PR DESCRIPTION
## Summary

KMS capture (`kmsgrab`) pins to one plane/CRTC at `init()`. When the display topology changes mid-stream — most commonly a physical monitor powering off while the compositor moves the desktop to a dummy plug / second output on a **different** CRTC — the pinned plane is retired. Two failure modes result, both in `kms::display_t::refresh()`:

1. **Latent null-deref crash.** `drmModeGetPlane(card.fd.el, plane_id)` returns `NULL` for a retired plane, but the result is used without a null check — `card.fb(plane.get())` and the warning log both dereference `plane->fb_id`.
2. **Permanent freeze.** If the plane survives but stops scanning out, `plane->fb_id == 0`; `card.fb()` then returns null and `refresh()` returns `capture_e::timeout`, which the capture loop replays forever. The stream freezes and never recovers for the rest of the session.

## Fix

Detect the dead plane in `refresh()` and return `capture_e::reinit`, so the existing pipeline tears the display down and re-resolves capture onto the now-active output:

```cpp
if (!plane || !plane->fb_id) {
  BOOST_LOG(info) << "Reinitializing capture after the captured plane was retired (display topology change)";
  return capture_e::reinit;
}
```

Placed right after the plane read, before any dereference. It mirrors the two `reinit` paths already in the same function (HDR-metadata change, resolution change).

## Why no `video.cpp` change is needed

The existing reinit machinery already re-resolves and survives the brief window where no output is active during a handoff:
- `refresh_displays()` never yields an empty list (it restores the previous list if re-enumeration is momentarily empty), so `captureThread`'s fatal `if (display_names.empty()) return;` is not reached during a transient.
- `reset_display()` retries with backoff until an active plane appears, then `init()` re-resolves (with an empty `output_name`, to index 0 = the first active plane — i.e. the output the desktop moved to).

The trigger is edge-like (fires once per topology change; the re-resolved plane is stable afterward), so there's no reinit storm.

## Scope / risk

- **One file, 12 lines** (`src/platform/linux/kmsgrab.cpp`); covers both the RAM and VRAM capture paths via the shared base `refresh()`.
- **Zero effect on healthy sessions** — the guard is only taken when the captured plane is already dead, a state that today either crashes or freezes.
- Not unit-testable (`refresh()` needs a live DRM fd, like the existing HDR/resolution reinit paths).

## Testing

Live hardware: openSUSE Tumbleweed, KDE Plasma 6 Wayland, AMD, a physical monitor + an HDMI dummy plug on a different connector, streaming the desktop over Moonlight with `output_name` empty.
- Power the monitor **off** → the compositor migrates the desktop to the dummy plug; capture follows and re-resolves onto it within ~1-2 s instead of freezing (log shows the re-resolution: `Found monitor: <dummy plug>`), no crash.
- Power it **back on** → capture follows back.
- The old per-frame `Couldn't get drm fb for plane [...]` warning spam is gone, and the stream never dies (`No displays were found after reenumeration` from `captureThread` never fires).

Discovered while hardening a headless-streaming setup on KDE; it's a standalone stock-kmsgrab correctness fix independent of any feature work.

Co-authored with @Beary-Handsome (hardware validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)