### PR TITLE
linux: wait for Steam singleton release before private stream launch

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1709,6 +1709,34 @@ namespace proc {
     thread_local pid_t forced_desktop_steam_scan_only_pid = -1;
 #endif
 
+    // Steam's client singleton is a FIFO at ~/.steam/steam.pipe: every
+    // `steam ...` invocation (including `steam steam://rungameid/...`)
+    // forwards its arguments to whatever instance is reading from that
+    // pipe and then exits. The last Steam process can vanish from /proc
+    // while teardown still holds the pipe, so process scanning alone
+    // cannot tell when a new instance may safely own the singleton; a
+    // launch URI forwarded in that window is swallowed by the dying
+    // instance and the game never starts.
+    bool steam_instance_pipe_listener_active(const std::string &pipe_path) {
+      const int fd = open(pipe_path.c_str(), O_WRONLY | O_NONBLOCK | O_CLOEXEC);
+      if (fd < 0) {
+        // ENXIO: FIFO exists but has no reader. ENOENT: no pipe at all.
+        // Both mean no live instance owns the singleton. Fail closed
+        // on any other error.
+        return errno != ENXIO && errno != ENOENT;
+      }
+      close(fd);
+      return true;
+    }
+
+    bool steam_instance_singleton_released() {
+      const char *home = getenv("HOME");
+      if (home == nullptr || *home == '\0') {
+        return true;
+      }
+      return !steam_instance_pipe_listener_active(std::string(home) + "/.steam/steam.pipe");
+    }
+
     bool desktop_steam_client_active_impl() {
       DIR *dir = nullptr;
 #ifdef POLARIS_TESTS
@@ -3312,12 +3340,27 @@ namespace proc {
     child.detach();
     for (int i = 0; i < 50; ++i) {
       if (!desktop_steam_client_active_impl()) {
+        break;
+      }
+      std::this_thread::sleep_for(100ms);
+    }
+    if (desktop_steam_client_active_impl()) {
+      BOOST_LOG(warning) << "process: desktop Steam still active after explicit shutdown wait";
+      return false;
+    }
+    // The client processes are gone, but Steam's instance singleton can still
+    // be held by teardown. Launching `steam steam://rungameid/...` in that
+    // window forwards the URI to the dying instance, which swallows it, so
+    // the game never starts. Wait for the singleton to be released before
+    // reporting the shutdown as complete.
+    for (int i = 0; i < 50; ++i) {
+      if (steam_instance_singleton_released()) {
         return true;
       }
       std::this_thread::sleep_for(100ms);
     }
-    BOOST_LOG(warning) << "process: desktop Steam still active after explicit shutdown wait";
-    return !desktop_steam_client_active_impl();
+    BOOST_LOG(warning) << "process: desktop Steam instance singleton still held after shutdown wait";
+    return steam_instance_singleton_released();
   }
 #endif
 
@@ -3345,6 +3388,10 @@ namespace proc {
                                                std::string_view cmdline,
                                                std::string_view status) {
     return is_active_desktop_steam_client_process(comm, argv0_path, cmdline, status);
+  }
+
+  bool steam_instance_pipe_listener_active_for_tests(const std::string &pipe_path) {
+    return steam_instance_pipe_listener_active(pipe_path);
   }
 
   bool desktop_steam_proc_open_error_fails_closed_for_tests() {

--- a/src/process.h
+++ b/src/process.h
@@ -169,6 +169,7 @@ namespace proc {
   bool desktop_steam_proc_open_error_fails_closed_for_tests();
   bool desktop_steam_proc_enumeration_error_fails_closed_for_tests();
   bool desktop_steam_proc_read_error_fails_closed_for_tests(pid_t forced_pid);
+  bool steam_instance_pipe_listener_active_for_tests(const std::string &pipe_path);
 
   bool cage_mangohud_allowed_for_session_for_tests(const struct ctx_t &app,
                                                    bool use_cage_compositor,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -20,8 +20,10 @@
 
 #ifdef __linux__
   #include <csignal>
+  #include <fcntl.h>
   #include <pthread.h>
   #include <sys/prctl.h>
+  #include <sys/stat.h>
   #include <sys/wait.h>
   #include <unistd.h>
 #endif
@@ -1184,6 +1186,42 @@ TEST(ProcessRuntimeConfigTests, SteamShutdownOwnershipRejectsUnmarkedActiveClien
   EXPECT_FALSE(proc::steam_shutdown_process_is_unowned_active_for_tests(
     "steam", "/opt/steam/ubuntu12_32/steam", "/opt/steam/ubuntu12_32/steam", zombie_status, "", token
   ));
+}
+
+TEST(ProcessRuntimeConfigTests, SteamInstancePipeDetectsSingletonListener) {
+  namespace fs = std::filesystem;
+  const fs::path pipe_path = fs::temp_directory_path() /
+    ("polaris-steam-pipe-test-" + std::to_string(::getpid()));
+  ASSERT_EQ(mkfifo(pipe_path.c_str(), 0600), 0);
+
+  // No reader: opening for write fails with ENXIO, so no listener.
+  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const auto child = fork();
+  ASSERT_NE(child, -1);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    const int fd = open(pipe_path.c_str(), O_RDONLY | O_NONBLOCK);
+    if (fd < 0) _exit(2);
+    const char ready = '1';
+    (void) write(ready_pipe[1], &ready, 1);
+    for (;;) pause();
+  }
+  close(ready_pipe[1]);
+  linux_child_guard_t guard(child);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+
+  EXPECT_TRUE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+  guard.terminate_and_reap();
+  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(
+    (fs::temp_directory_path() / "polaris-steam-pipe-missing").string()));
+  std::error_code ec;
+  fs::remove(pipe_path, ec);
 }
 
 TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationSignalsOnlyCapturedChild) {


### PR DESCRIPTION
## Problem

When starting a private stream while the desktop Steam client is running, Polaris closes desktop Steam first (`request_desktop_steam_shutdown_for_private_stream()`). That function reported success as soon as no `steam`/`steamwebhelper` processes remained in `/proc`.

Process exit is not the same as teardown completing. Steam's client singleton is the `~/.steam/steam.pipe` FIFO: every `steam ...` invocation — including the `steam steam://rungameid/...` used to launch the game in the private session — forwards its arguments to whatever instance is reading from that pipe and then exits. When the private launch raced ahead while the dying instance still held the pipe, the launch URI was forwarded to the dying instance and swallowed: the stream started, but the game never launched. Quitting Steam manually (and waiting) avoided the race, which is how this was reproduced/diagnosed.

## Fix

After the process scan reports Steam gone, additionally wait (up to 5 s, same polling cadence) for the `steam.pipe` FIFO to have no listener before reporting the shutdown as complete. Opening the FIFO `O_WRONLY|O_NONBLOCK` fails with `ENXIO` once no instance is reading — exactly the point where a new instance will own the singleton and process the launch URI itself. `ENOENT` (no pipe at all) is also treated as released; any other error fails closed, matching the existing style of the surrounding code.

Verified empirically against a live Steam client: while Steam runs, the pipe has a listener; the flock on `steam.pid` hypothesis was tested and ruled out (Steam does not lock that file).

## Testing

- New unit test `SteamInstancePipeDetectsSingletonListener` in `test_process_migration.cpp` covers: FIFO with no reader (released), FIFO with a reader in a forked child (held), reader killed (released), missing path (released).
- `test_polaris_config`: 236/237 pass. The single failure (`ProductionPreCageSteamTeardownUsesImmutableExactGeneration`) also fails on unmodified `master` on the same host — it is caused by a live desktop Steam client running during the test, not by this change.
- Manually verified end-to-end on Fedora 44 (CUDA + browser stream enabled): starting a private stream with desktop Steam running now launches the game reliably.
