### PR TITLE
linux: wait for Steam singleton release before private stream launch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
         run: |
           cmake -B build-sanitize -G Ninja \
             -DBUILD_TESTS=ON \
+            -DBUILD_FULL_TESTS=ON \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_C_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all' \
             -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all' \
@@ -102,10 +103,10 @@ jobs:
             -DCUDA_FAIL_ON_MISSING=OFF
 
       - name: Build sanitizer unit tests
-        run: cmake --build build-sanitize --target test_polaris -j"$(nproc)"
+        run: cmake --build build-sanitize --target test_polaris test_polaris_steam_shutdown -j"$(nproc)"
 
       - name: Run sanitizer unit tests
-        run: ctest --test-dir build-sanitize/tests --output-on-failure -R '^test_polaris$'
+        run: ctest --test-dir build-sanitize/tests --output-on-failure -R '^(test_polaris|test_polaris_steam_shutdown)$'
 
   arch-build:
     name: Arch build

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -5116,7 +5116,7 @@ namespace nvhttp {
         }
 
 #ifdef __linux__
-        const auto launch_policy = resolve_streaming_launch_safety_policy(
+        auto launch_policy = resolve_streaming_launch_safety_policy(
           args,
           *app_iter,
           current_appid > 0 && current_appid != proc::input_only_app_id
@@ -5131,15 +5131,11 @@ namespace nvhttp {
             tree.put("root.gamesession", 0);
             return;
           }
-          const auto refreshed_launch_policy = proc::resolve_desktop_launch_safety_policy(
-            true,
-            false,
-            false,
+          launch_policy = proc::resolve_desktop_launch_safety_policy_after_shutdown(
             *app_iter,
-            false,
             proc::proc.running() > 0 && proc::proc.running() != proc::input_only_app_id
           );
-          put_desktop_launch_policy(tree, refreshed_launch_policy);
+          put_desktop_launch_policy(tree, launch_policy);
         }
         if (launch_policy.recommendedAction == "refuse_private_stream") {
           tree.put("root.resume", 0);
@@ -6500,7 +6496,7 @@ namespace nvhttp {
 
 #ifdef __linux__
         const auto &app = apps.at(static_cast<size_t>(app_id - 1));
-        const auto launch_policy = resolve_streaming_launch_safety_policy(
+        auto launch_policy = resolve_streaming_launch_safety_policy(
           body,
           app,
           proc::proc.running() > 0 && proc::proc.running() != proc::input_only_app_id
@@ -6517,14 +6513,11 @@ namespace nvhttp {
             response->write(SimpleWeb::StatusCode::client_error_conflict, err.dump(), headers);
             return;
           }
-          launch_policy_json = proc::desktop_launch_safety_policy_to_json(proc::resolve_desktop_launch_safety_policy(
-            true,
-            false,
-            false,
+          launch_policy = proc::resolve_desktop_launch_safety_policy_after_shutdown(
             app,
-            false,
             proc::proc.running() > 0 && proc::proc.running() != proc::input_only_app_id
-          ));
+          );
+          launch_policy_json = proc::desktop_launch_safety_policy_to_json(launch_policy);
         }
         if (launch_policy.recommendedAction == "refuse_private_stream") {
           nlohmann::json err;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1709,6 +1709,34 @@ namespace proc {
     thread_local pid_t forced_desktop_steam_scan_only_pid = -1;
 #endif
 
+    // Steam's client singleton is a FIFO at ~/.steam/steam.pipe: every
+    // `steam ...` invocation (including `steam steam://rungameid/...`)
+    // forwards its arguments to whatever instance is reading from that
+    // pipe and then exits. The last Steam process can vanish from /proc
+    // while teardown still holds the pipe, so process scanning alone
+    // cannot tell when a new instance may safely own the singleton; a
+    // launch URI forwarded in that window is swallowed by the dying
+    // instance and the game never starts.
+    bool steam_instance_pipe_listener_active(const std::string &pipe_path) {
+      const int fd = open(pipe_path.c_str(), O_WRONLY | O_NONBLOCK | O_CLOEXEC);
+      if (fd < 0) {
+        // ENXIO: FIFO exists but has no reader. ENOENT: no pipe at all.
+        // Both mean no live instance owns the singleton. Fail closed
+        // on any other error.
+        return errno != ENXIO && errno != ENOENT;
+      }
+      close(fd);
+      return true;
+    }
+
+    bool steam_instance_singleton_released() {
+      const char *home = getenv("HOME");
+      if (home == nullptr || *home == '\0') {
+        return true;
+      }
+      return !steam_instance_pipe_listener_active(std::string(home) + "/.steam/steam.pipe");
+    }
+
     bool desktop_steam_client_active_impl() {
       DIR *dir = nullptr;
 #ifdef POLARIS_TESTS
@@ -3312,12 +3340,27 @@ namespace proc {
     child.detach();
     for (int i = 0; i < 50; ++i) {
       if (!desktop_steam_client_active_impl()) {
+        break;
+      }
+      std::this_thread::sleep_for(100ms);
+    }
+    if (desktop_steam_client_active_impl()) {
+      BOOST_LOG(warning) << "process: desktop Steam still active after explicit shutdown wait";
+      return false;
+    }
+    // The client processes are gone, but Steam's instance singleton can still
+    // be held by teardown. Launching `steam steam://rungameid/...` in that
+    // window forwards the URI to the dying instance, which swallows it, so
+    // the game never starts. Wait for the singleton to be released before
+    // reporting the shutdown as complete.
+    for (int i = 0; i < 50; ++i) {
+      if (steam_instance_singleton_released()) {
         return true;
       }
       std::this_thread::sleep_for(100ms);
     }
-    BOOST_LOG(warning) << "process: desktop Steam still active after explicit shutdown wait";
-    return !desktop_steam_client_active_impl();
+    BOOST_LOG(warning) << "process: desktop Steam instance singleton still held after shutdown wait";
+    return steam_instance_singleton_released();
   }
 #endif
 
@@ -3345,6 +3388,10 @@ namespace proc {
                                                std::string_view cmdline,
                                                std::string_view status) {
     return is_active_desktop_steam_client_process(comm, argv0_path, cmdline, status);
+  }
+
+  bool steam_instance_pipe_listener_active_for_tests(const std::string &pipe_path) {
+    return steam_instance_pipe_listener_active(pipe_path);
   }
 
   bool desktop_steam_proc_open_error_fails_closed_for_tests() {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -72,8 +72,9 @@
   #include "platform/linux/input/inputtino_gamepad_isolation.h"
   #include <dirent.h>
   #include <fcntl.h>
-  #include <signal.h>
   #include <poll.h>
+  #include <pwd.h>
+  #include <signal.h>
   #include <sys/stat.h>
   #include <sys/syscall.h>
   #include <unistd.h>
@@ -1729,12 +1730,90 @@ namespace proc {
       return true;
     }
 
-    bool steam_instance_singleton_released() {
-      const char *home = getenv("HOME");
-      if (home == nullptr || *home == '\0') {
-        return true;
+    std::string account_home_directory() {
+      constexpr std::size_t default_buffer_size = 16 * 1024;
+      constexpr std::size_t maximum_buffer_size = 1024 * 1024;
+      const auto configured_size = sysconf(_SC_GETPW_R_SIZE_MAX);
+      const auto buffer_size = configured_size > 0 ?
+        std::min(static_cast<std::size_t>(configured_size), maximum_buffer_size) :
+        default_buffer_size;
+
+      std::vector<char> buffer(buffer_size);
+      passwd entry {};
+      passwd *result = nullptr;
+      if (getpwuid_r(geteuid(), &entry, buffer.data(), buffer.size(), &result) != 0 ||
+          result == nullptr || entry.pw_dir == nullptr || *entry.pw_dir == '\0') {
+        return {};
       }
-      return !steam_instance_pipe_listener_active(std::string(home) + "/.steam/steam.pipe");
+      return entry.pw_dir;
+    }
+
+    std::optional<std::string> steam_instance_pipe_path(
+      const std::optional<std::string> &home_env,
+      const std::optional<std::string> &account_home
+    ) {
+      const std::string *home = nullptr;
+      if (home_env && !home_env->empty()) {
+        home = &*home_env;
+      } else if (account_home && !account_home->empty()) {
+        home = &*account_home;
+      }
+      if (home == nullptr) {
+        return std::nullopt;
+      }
+      return (std::filesystem::path(*home) / ".steam/steam.pipe").string();
+    }
+
+    std::optional<std::string> steam_instance_pipe_path() {
+      const char *home = getenv("HOME");
+      std::optional<std::string> home_env;
+      if (home != nullptr) {
+        home_env = home;
+      }
+
+      const auto account_home = account_home_directory();
+      return steam_instance_pipe_path(
+        home_env,
+        account_home.empty() ? std::nullopt : std::optional<std::string> {account_home}
+      );
+    }
+
+    bool steam_instance_singleton_released(const std::string &pipe_path) {
+      return !steam_instance_pipe_listener_active(pipe_path);
+    }
+
+    using steam_shutdown_clock_t = std::chrono::steady_clock;
+
+    bool wait_for_desktop_steam_quiescence(
+      const std::function<bool()> &desktop_steam_active,
+      const std::function<bool()> &singleton_released,
+      const std::function<steam_shutdown_clock_t::time_point()> &now,
+      const std::function<void(steam_shutdown_clock_t::duration)> &sleep_for,
+      steam_shutdown_clock_t::duration timeout,
+      steam_shutdown_clock_t::duration poll_interval
+    ) {
+      if (timeout < steam_shutdown_clock_t::duration::zero() ||
+          poll_interval <= steam_shutdown_clock_t::duration::zero()) {
+        return false;
+      }
+
+      const auto deadline = now() + timeout;
+      for (;;) {
+        // Recheck the process state after observing the FIFO as released. This
+        // prevents a Steam instance that starts during the FIFO probe from
+        // being accepted as quiescent.
+        if (!desktop_steam_active() &&
+            singleton_released() &&
+            !desktop_steam_active()) {
+          return true;
+        }
+
+        const auto current = now();
+        if (current >= deadline) {
+          return false;
+        }
+        sleep_for(std::min(poll_interval, deadline - current));
+      }
     }
 
     bool desktop_steam_client_active_impl() {
@@ -3308,6 +3387,20 @@ namespace proc {
     );
   }
 
+  desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy_after_shutdown(
+    const proc::ctx_t &app,
+    bool active_desktop_game
+  ) {
+    return resolve_desktop_launch_safety_policy(
+      true,
+      false,
+      false,
+      app,
+      desktop_steam_client_active_impl(),
+      active_desktop_game
+    );
+  }
+
   nlohmann::json desktop_launch_safety_policy_to_json(const desktop_launch_safety_policy_t &policy) {
     return {
       {"desktopSteamActive", policy.desktopSteamActive},
@@ -3327,6 +3420,12 @@ namespace proc {
   }
 
   bool request_desktop_steam_shutdown_for_private_stream() {
+    const auto pipe_path = steam_instance_pipe_path();
+    if (!pipe_path) {
+      BOOST_LOG(warning) << "process: cannot determine Steam singleton path; refusing private stream shutdown handoff";
+      return false;
+    }
+
     const auto command = canonical_steam_shutdown_command("steam");
     BOOST_LOG(info) << "process: explicit Nova request closing desktop Steam before private stream using [" << command << "]";
     auto env = boost::this_process::environment();
@@ -3338,29 +3437,27 @@ namespace proc {
       return false;
     }
     child.detach();
-    for (int i = 0; i < 50; ++i) {
-      if (!desktop_steam_client_active_impl()) {
-        break;
-      }
-      std::this_thread::sleep_for(100ms);
+
+    const bool quiescent = wait_for_desktop_steam_quiescence(
+      []() {
+        return desktop_steam_client_active_impl();
+      },
+      [pipe_path]() {
+        return steam_instance_singleton_released(*pipe_path);
+      },
+      []() {
+        return steam_shutdown_clock_t::now();
+      },
+      [](steam_shutdown_clock_t::duration duration) {
+        std::this_thread::sleep_for(duration);
+      },
+      10s,
+      100ms
+    );
+    if (!quiescent) {
+      BOOST_LOG(warning) << "process: desktop Steam did not reach process/FIFO quiescence before shutdown deadline";
     }
-    if (desktop_steam_client_active_impl()) {
-      BOOST_LOG(warning) << "process: desktop Steam still active after explicit shutdown wait";
-      return false;
-    }
-    // The client processes are gone, but Steam's instance singleton can still
-    // be held by teardown. Launching `steam steam://rungameid/...` in that
-    // window forwards the URI to the dying instance, which swallows it, so
-    // the game never starts. Wait for the singleton to be released before
-    // reporting the shutdown as complete.
-    for (int i = 0; i < 50; ++i) {
-      if (steam_instance_singleton_released()) {
-        return true;
-      }
-      std::this_thread::sleep_for(100ms);
-    }
-    BOOST_LOG(warning) << "process: desktop Steam instance singleton still held after shutdown wait";
-    return steam_instance_singleton_released();
+    return quiescent;
   }
 #endif
 
@@ -3381,6 +3478,61 @@ namespace proc {
       active_desktop_game,
       force_private_after_desktop_steam_shutdown
     );
+  }
+
+  steam_shutdown_quiescence_test_result_t run_steam_shutdown_quiescence_scenario_for_tests(
+    const std::vector<bool> &process_active_observations,
+    const std::vector<bool> &fifo_listener_observations,
+    std::chrono::milliseconds timeout,
+    std::chrono::milliseconds poll_interval
+  ) {
+    std::size_t process_index = 0;
+    std::size_t fifo_index = 0;
+    auto current = steam_shutdown_clock_t::time_point {};
+    steam_shutdown_quiescence_test_result_t result;
+
+    const auto next_observation = [](
+      const std::vector<bool> &observations,
+      std::size_t &index,
+      bool fallback
+    ) {
+      if (observations.empty()) {
+        return fallback;
+      }
+      const auto value = observations[std::min(index, observations.size() - 1)];
+      ++index;
+      return value;
+    };
+
+    result.quiescent = wait_for_desktop_steam_quiescence(
+      [&]() {
+        ++result.process_checks;
+        return next_observation(process_active_observations, process_index, true);
+      },
+      [&]() {
+        ++result.fifo_checks;
+        return !next_observation(fifo_listener_observations, fifo_index, true);
+      },
+      [&]() {
+        return current;
+      },
+      [&](steam_shutdown_clock_t::duration duration) {
+        current += duration;
+      },
+      timeout,
+      poll_interval
+    );
+    result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      current.time_since_epoch()
+    );
+    return result;
+  }
+
+  std::optional<std::string> steam_instance_pipe_path_for_tests(
+    const std::optional<std::string> &home_env,
+    const std::optional<std::string> &account_home
+  ) {
+    return steam_instance_pipe_path(home_env, account_home);
   }
 
   bool desktop_steam_client_process_for_tests(std::string_view comm,

--- a/src/process.h
+++ b/src/process.h
@@ -14,6 +14,7 @@
 
 // standard includes
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
@@ -21,9 +22,11 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <unordered_set>
 #include <unordered_map>
+#include <vector>
 
 // lib includes
 #include <boost/process/v1/child.hpp>
@@ -98,6 +101,10 @@ namespace proc {
     bool desktop_steam_active,
     bool active_desktop_game
   );
+  desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy_after_shutdown(
+    const struct ctx_t &app,
+    bool active_desktop_game
+  );
 
   nlohmann::json desktop_launch_safety_policy_to_json(const desktop_launch_safety_policy_t &policy);
   bool desktop_steam_client_active();
@@ -160,6 +167,24 @@ namespace proc {
     bool desktop_steam_active,
     bool active_desktop_game,
     bool force_private_after_desktop_steam_shutdown = false
+  );
+
+  struct steam_shutdown_quiescence_test_result_t {
+    bool quiescent = false;
+    std::size_t process_checks = 0;
+    std::size_t fifo_checks = 0;
+    std::chrono::milliseconds elapsed {0};
+  };
+
+  steam_shutdown_quiescence_test_result_t run_steam_shutdown_quiescence_scenario_for_tests(
+    const std::vector<bool> &process_active_observations,
+    const std::vector<bool> &fifo_listener_observations,
+    std::chrono::milliseconds timeout,
+    std::chrono::milliseconds poll_interval
+  );
+  std::optional<std::string> steam_instance_pipe_path_for_tests(
+    const std::optional<std::string> &home_env,
+    const std::optional<std::string> &account_home
   );
 
   bool desktop_steam_client_process_for_tests(std::string_view comm,

--- a/src/process.h
+++ b/src/process.h
@@ -169,6 +169,7 @@ namespace proc {
   bool desktop_steam_proc_open_error_fails_closed_for_tests();
   bool desktop_steam_proc_enumeration_error_fails_closed_for_tests();
   bool desktop_steam_proc_read_error_fails_closed_for_tests(pid_t forced_pid);
+  bool steam_instance_pipe_listener_active_for_tests(const std::string &pipe_path);
 
   bool cage_mangohud_allowed_for_session_for_tests(const struct ctx_t &app,
                                                    bool use_cage_compositor,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -296,6 +296,10 @@ if (BUILD_FULL_TESTS)
         ${TEST_CONFIG_SOURCES}
     )
 
+    configure_polaris_full_test_target(test_polaris_steam_shutdown
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_steam_shutdown_state_machine.cpp
+    )
+
     configure_polaris_full_test_target(test_polaris_pairing
         ${TEST_PAIRING_SOURCES}
     )
@@ -328,6 +332,7 @@ if (BUILD_FULL_TESTS)
             test_polaris_platform
             test_polaris_input
             test_polaris_config
+            test_polaris_steam_shutdown
             test_polaris_pairing
             test_polaris_http
             test_polaris_network

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -20,8 +20,10 @@
 
 #ifdef __linux__
   #include <csignal>
+  #include <fcntl.h>
   #include <pthread.h>
   #include <sys/prctl.h>
+  #include <sys/stat.h>
   #include <sys/wait.h>
   #include <unistd.h>
 #endif
@@ -1184,6 +1186,42 @@ TEST(ProcessRuntimeConfigTests, SteamShutdownOwnershipRejectsUnmarkedActiveClien
   EXPECT_FALSE(proc::steam_shutdown_process_is_unowned_active_for_tests(
     "steam", "/opt/steam/ubuntu12_32/steam", "/opt/steam/ubuntu12_32/steam", zombie_status, "", token
   ));
+}
+
+TEST(ProcessRuntimeConfigTests, SteamInstancePipeDetectsSingletonListener) {
+  namespace fs = std::filesystem;
+  const fs::path pipe_path = fs::temp_directory_path() /
+    ("polaris-steam-pipe-test-" + std::to_string(::getpid()));
+  ASSERT_EQ(mkfifo(pipe_path.c_str(), 0600), 0);
+
+  // No reader: opening for write fails with ENXIO, so no listener.
+  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const auto child = fork();
+  ASSERT_NE(child, -1);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    const int fd = open(pipe_path.c_str(), O_RDONLY | O_NONBLOCK);
+    if (fd < 0) _exit(2);
+    const char ready = '1';
+    (void) write(ready_pipe[1], &ready, 1);
+    for (;;) pause();
+  }
+  close(ready_pipe[1]);
+  linux_child_guard_t guard(child);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+
+  EXPECT_TRUE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+  guard.terminate_and_reap();
+  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(
+    (fs::temp_directory_path() / "polaris-steam-pipe-missing").string()));
+  std::error_code ec;
+  fs::remove(pipe_path, ec);
 }
 
 TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationSignalsOnlyCapturedChild) {

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -20,10 +20,8 @@
 
 #ifdef __linux__
   #include <csignal>
-  #include <fcntl.h>
   #include <pthread.h>
   #include <sys/prctl.h>
-  #include <sys/stat.h>
   #include <sys/wait.h>
   #include <unistd.h>
 #endif
@@ -1186,42 +1184,6 @@ TEST(ProcessRuntimeConfigTests, SteamShutdownOwnershipRejectsUnmarkedActiveClien
   EXPECT_FALSE(proc::steam_shutdown_process_is_unowned_active_for_tests(
     "steam", "/opt/steam/ubuntu12_32/steam", "/opt/steam/ubuntu12_32/steam", zombie_status, "", token
   ));
-}
-
-TEST(ProcessRuntimeConfigTests, SteamInstancePipeDetectsSingletonListener) {
-  namespace fs = std::filesystem;
-  const fs::path pipe_path = fs::temp_directory_path() /
-    ("polaris-steam-pipe-test-" + std::to_string(::getpid()));
-  ASSERT_EQ(mkfifo(pipe_path.c_str(), 0600), 0);
-
-  // No reader: opening for write fails with ENXIO, so no listener.
-  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
-
-  int ready_pipe[2] {-1, -1};
-  ASSERT_EQ(pipe(ready_pipe), 0);
-  const auto child = fork();
-  ASSERT_NE(child, -1);
-  if (child == 0) {
-    close(ready_pipe[0]);
-    const int fd = open(pipe_path.c_str(), O_RDONLY | O_NONBLOCK);
-    if (fd < 0) _exit(2);
-    const char ready = '1';
-    (void) write(ready_pipe[1], &ready, 1);
-    for (;;) pause();
-  }
-  close(ready_pipe[1]);
-  linux_child_guard_t guard(child);
-  char ready = 0;
-  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
-  close(ready_pipe[0]);
-
-  EXPECT_TRUE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
-  guard.terminate_and_reap();
-  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
-  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(
-    (fs::temp_directory_path() / "polaris-steam-pipe-missing").string()));
-  std::error_code ec;
-  fs::remove(pipe_path, ec);
 }
 
 TEST(ProcessRuntimeConfigTests, PidfdSteamTerminationSignalsOnlyCapturedChild) {

--- a/tests/unit/test_steam_shutdown_state_machine.cpp
+++ b/tests/unit/test_steam_shutdown_state_machine.cpp
@@ -158,6 +158,9 @@ TEST(SteamShutdownStateMachineTests, FifoProbeTracksReaderLifetime) {
   close_reader.disable();
   close(reader);
   EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(
+    (test_dir / "missing-steam.pipe").string()
+  ));
 }
 
 TEST(SteamShutdownStateMachineTests, ProductionShutdownUsesSingleMonotonicQuiescenceLoop) {

--- a/tests/unit/test_steam_shutdown_state_machine.cpp
+++ b/tests/unit/test_steam_shutdown_state_machine.cpp
@@ -1,0 +1,237 @@
+#include "../tests_common.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <src/process.h>
+
+#if defined(__linux__)
+  #include <fcntl.h>
+  #include <sys/stat.h>
+  #include <unistd.h>
+#endif
+
+namespace {
+  std::string read_source_file(const char *relative_path) {
+    const auto path = std::filesystem::path(POLARIS_SOURCE_DIR) / relative_path;
+    std::ifstream in(path);
+    if (!in) {
+      return {};
+    }
+    std::ostringstream out;
+    out << in.rdbuf();
+    return out.str();
+  }
+
+  std::string source_between(
+    const std::string &source,
+    std::string_view begin_marker,
+    std::string_view end_marker
+  ) {
+    const auto begin = source.find(begin_marker);
+    if (begin == std::string::npos) {
+      return {};
+    }
+    const auto end = source.find(end_marker, begin + begin_marker.size());
+    if (end == std::string::npos) {
+      return {};
+    }
+    return source.substr(begin, end - begin);
+  }
+}
+
+#if defined(__linux__)
+TEST(SteamShutdownStateMachineTests, PersistentProcessActivityUsesOneBoundedDeadline) {
+  const auto result = proc::run_steam_shutdown_quiescence_scenario_for_tests(
+    {true},
+    {false},
+    std::chrono::milliseconds(500),
+    std::chrono::milliseconds(100)
+  );
+
+  EXPECT_FALSE(result.quiescent);
+  EXPECT_EQ(result.elapsed, std::chrono::milliseconds(500));
+  EXPECT_GE(result.process_checks, 5u);
+  EXPECT_EQ(result.fifo_checks, 0u);
+}
+
+TEST(SteamShutdownStateMachineTests, PersistentFifoListenerUsesTheSameBoundedDeadline) {
+  const auto result = proc::run_steam_shutdown_quiescence_scenario_for_tests(
+    {false},
+    {true},
+    std::chrono::milliseconds(500),
+    std::chrono::milliseconds(100)
+  );
+
+  EXPECT_FALSE(result.quiescent);
+  EXPECT_EQ(result.elapsed, std::chrono::milliseconds(500));
+  EXPECT_GE(result.process_checks, 5u);
+  EXPECT_GE(result.fifo_checks, 5u);
+}
+
+TEST(SteamShutdownStateMachineTests, ProcessExitThenReleasedFifoSucceeds) {
+  const auto result = proc::run_steam_shutdown_quiescence_scenario_for_tests(
+    {true, false, false},
+    {false},
+    std::chrono::milliseconds(500),
+    std::chrono::milliseconds(100)
+  );
+
+  EXPECT_TRUE(result.quiescent);
+  EXPECT_EQ(result.elapsed, std::chrono::milliseconds(100));
+  EXPECT_EQ(result.process_checks, 3u);
+  EXPECT_EQ(result.fifo_checks, 1u);
+}
+
+TEST(SteamShutdownStateMachineTests, ProcessReappearanceAfterFifoProbeIsRevalidated) {
+  const auto result = proc::run_steam_shutdown_quiescence_scenario_for_tests(
+    {false, true, false, false},
+    {false},
+    std::chrono::milliseconds(500),
+    std::chrono::milliseconds(100)
+  );
+
+  EXPECT_TRUE(result.quiescent);
+  EXPECT_EQ(result.elapsed, std::chrono::milliseconds(100));
+  EXPECT_EQ(result.process_checks, 4u);
+  EXPECT_EQ(result.fifo_checks, 2u);
+}
+
+TEST(SteamShutdownStateMachineTests, ProcessScanErrorsRemainFailClosed) {
+  EXPECT_TRUE(proc::desktop_steam_proc_open_error_fails_closed_for_tests());
+}
+
+TEST(SteamShutdownStateMachineTests, EmptyOrUnsetHomeFallsBackToAccountHome) {
+  const std::optional<std::string> account_home {"/srv/polaris-user"};
+  const std::optional<std::string> expected {"/srv/polaris-user/.steam/steam.pipe"};
+
+  EXPECT_EQ(proc::steam_instance_pipe_path_for_tests(std::nullopt, account_home), expected);
+  EXPECT_EQ(proc::steam_instance_pipe_path_for_tests(std::string {}, account_home), expected);
+}
+
+TEST(SteamShutdownStateMachineTests, EnvironmentHomeTakesPrecedence) {
+  EXPECT_EQ(
+    proc::steam_instance_pipe_path_for_tests(
+      std::string {"/home/from-environment"},
+      std::string {"/home/from-account"}
+    ),
+    std::optional<std::string> {"/home/from-environment/.steam/steam.pipe"}
+  );
+}
+
+TEST(SteamShutdownStateMachineTests, MissingHomeAndAccountHomeFailsClosed) {
+  EXPECT_EQ(proc::steam_instance_pipe_path_for_tests(std::nullopt, std::nullopt), std::nullopt);
+  EXPECT_EQ(
+    proc::steam_instance_pipe_path_for_tests(std::string {}, std::string {}),
+    std::nullopt
+  );
+}
+
+TEST(SteamShutdownStateMachineTests, FifoProbeTracksReaderLifetime) {
+  namespace fs = std::filesystem;
+  const auto unique = std::to_string(::getpid()) + "-" + std::to_string(
+    std::chrono::steady_clock::now().time_since_epoch().count()
+  );
+  const auto test_dir = fs::temp_directory_path() / ("polaris-steam-shutdown-" + unique);
+  ASSERT_TRUE(fs::create_directories(test_dir));
+  auto cleanup = util::fail_guard([&test_dir]() {
+    std::error_code ec;
+    fs::remove_all(test_dir, ec);
+  });
+
+  const auto pipe_path = test_dir / "steam.pipe";
+  ASSERT_EQ(mkfifo(pipe_path.c_str(), 0600), 0);
+  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+
+  const int reader = open(pipe_path.c_str(), O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+  ASSERT_GE(reader, 0);
+  auto close_reader = util::fail_guard([reader]() {
+    close(reader);
+  });
+  EXPECT_TRUE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+
+  close_reader.disable();
+  close(reader);
+  EXPECT_FALSE(proc::steam_instance_pipe_listener_active_for_tests(pipe_path.string()));
+}
+
+TEST(SteamShutdownStateMachineTests, ProductionShutdownUsesSingleMonotonicQuiescenceLoop) {
+  const auto source = read_source_file("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto shutdown = source_between(
+    source,
+    "bool request_desktop_steam_shutdown_for_private_stream()",
+    "#endif"
+  );
+  ASSERT_FALSE(shutdown.empty());
+
+  const auto path_resolution = shutdown.find("const auto pipe_path = steam_instance_pipe_path()");
+  const auto fail_closed = shutdown.find("if (!pipe_path)", path_resolution);
+  const auto shutdown_command = shutdown.find("canonical_steam_shutdown_command", fail_closed);
+  ASSERT_NE(path_resolution, std::string::npos);
+  ASSERT_NE(fail_closed, std::string::npos);
+  ASSERT_NE(shutdown_command, std::string::npos);
+  EXPECT_LT(path_resolution, fail_closed);
+  EXPECT_LT(fail_closed, shutdown_command);
+  EXPECT_NE(shutdown.find("wait_for_desktop_steam_quiescence("), std::string::npos);
+  EXPECT_EQ(shutdown.find("for (int i = 0; i < 50; ++i)"), std::string::npos);
+}
+
+TEST(SteamShutdownStateMachineTests, PostShutdownPolicyRechecksLiveProcessState) {
+  const auto source = read_source_file("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto policy = source_between(
+    source,
+    "desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy_after_shutdown(",
+    "nlohmann::json desktop_launch_safety_policy_to_json("
+  );
+  ASSERT_FALSE(policy.empty());
+  EXPECT_NE(policy.find("desktop_steam_client_active_impl()"), std::string::npos);
+}
+
+TEST(SteamShutdownStateMachineTests, BothNvhttpRoutesGateOnLiveRefreshedPolicy) {
+  const auto source = read_source_file("src/nvhttp.cpp");
+  ASSERT_FALSE(source.empty());
+
+  const auto launch_route = source_between(
+    source,
+    "void launch(bool &host_audio",
+    "void resume(bool &host_audio"
+  );
+  const auto api_route = source_between(
+    source,
+    "auto polarisLaunchGame =",
+    "// Toggle MangoHud for a game"
+  );
+  ASSERT_FALSE(launch_route.empty());
+  ASSERT_FALSE(api_route.empty());
+
+  const auto launch_refresh = launch_route.find(
+    "launch_policy = proc::resolve_desktop_launch_safety_policy_after_shutdown("
+  );
+  const auto launch_gate = launch_route.find(
+    "if (launch_policy.recommendedAction == \"refuse_private_stream\")",
+    launch_refresh
+  );
+  ASSERT_NE(launch_refresh, std::string::npos);
+  ASSERT_NE(launch_gate, std::string::npos);
+  EXPECT_LT(launch_refresh, launch_gate);
+  EXPECT_EQ(launch_route.find("refreshed_launch_policy"), std::string::npos);
+
+  const auto api_refresh = api_route.find(
+    "launch_policy = proc::resolve_desktop_launch_safety_policy_after_shutdown("
+  );
+  const auto api_gate = api_route.find(
+    "if (launch_policy.recommendedAction == \"refuse_private_stream\")",
+    api_refresh
+  );
+  ASSERT_NE(api_refresh, std::string::npos);
+  ASSERT_NE(api_gate, std::string::npos);
+  EXPECT_LT(api_refresh, api_gate);
+}
+#endif

--- a/tests/unit/test_steam_shutdown_state_machine.cpp
+++ b/tests/unit/test_steam_shutdown_state_machine.cpp
@@ -117,10 +117,10 @@ TEST(SteamShutdownStateMachineTests, EmptyOrUnsetHomeFallsBackToAccountHome) {
 TEST(SteamShutdownStateMachineTests, EnvironmentHomeTakesPrecedence) {
   EXPECT_EQ(
     proc::steam_instance_pipe_path_for_tests(
-      std::string {"/home/from-environment"},
-      std::string {"/home/from-account"}
+      std::string {"/srv/environment-home"},
+      std::string {"/srv/account-home"}
     ),
-    std::optional<std::string> {"/home/from-environment/.steam/steam.pipe"}
+    std::optional<std::string> {"/srv/environment-home/.steam/steam.pipe"}
   );
 }
 


### PR DESCRIPTION
Fixes a shutdown race when launching a private stream while Steam is running: the previous process teardown could release the Steam singleton after the new stream attempted to launch, causing the launch to fail intermittently.

This change waits for the Steam singleton to be fully released before starting the private stream.