### PR TITLE
release: Polaris v1.3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.3.1
+project(Polaris VERSION 1.3.2
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/README.md
+++ b/README.md
@@ -92,15 +92,14 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at `https://localhost:<port + 1>`. If you want background autostart, enable the user service with `systemctl --user enable --now polaris`.
 
-## What is New in v1.3.1
+## What is New in v1.3.2
 
-Polaris v1.3.1 is a focused security and pairing-state patch: current Browser Stream cryptography dependencies, stronger client authorization persistence, and clearer paired-device history without changing the streaming workflow.
+Polaris v1.3.2 is a focused reliability patch for stream lifecycle, Linux private sessions, reconnect recovery, and truthful diagnostics.
 
-- **Browser Stream security refresh**: current Go cryptography and supporting modules clear the dependency alerts previously attached to the helper dependency graph.
-- **Added and Last seen timestamps**: newly paired and authenticated clients expose localized history while legacy records remain honestly labeled as not recorded.
-- **Fail-closed client authorization**: canonical certificate identity, revocation, duplicate-state validation, and request-time authorization snapshots are hardened.
-- **Safer state persistence**: paired-client records use private, cross-process atomic state replacement.
-- **Truthful client controls**: failed paired-client mutations remain visible instead of being presented as successful in the web console.
+- **More reliable stream handoff**: RTSP follow-up control connections and started commands stay bound to the live session while PulseAudio operations remain serialized.
+- **Safer session cleanup**: lifecycle teardown, private Steam ownership, interrupted process waits, and Big Picture input isolation are hardened without broadly touching desktop Steam.
+- **Resilient web recovery**: the web console survives transient host outages and preserves authenticated sessions across host restarts.
+- **Truthful stream health**: near-target FPS no longer produces misleading degraded-state noise, and Linux GPU probe topology is easier to diagnose.
 See the [changelog](docs/changelog.md) for the full release history.
 
 ## Install

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,9 +5,7 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
-## Unreleased
-
-## v1.3.2 - 2026-07-17
+## v1.3.2 - Unreleased
 
 Reliability patch focused on stream lifecycle, Linux private-session isolation, reconnect recovery, and truthful host diagnostics.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,18 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+## v1.3.2 - 2026-07-17
+
+Reliability patch focused on stream lifecycle, Linux private-session isolation, reconnect recovery, and truthful host diagnostics.
+
+- Hardened RTSP follow-up control admission, live-session command ownership, session teardown, and serialized PulseAudio operations
+- Prevented private-stream controller input from also navigating host Steam Big Picture while preserving normal game input
+- Hardened private Steam teardown ownership and bounded interrupted process waits without broadly terminating desktop Steam
+- Preserved authenticated web sessions across host restarts and improved recovery from transient host outages
+- Tolerated near-target stream FPS so healthy sessions are not mislabeled as degraded
+- Exposed clearer Linux GPU probe topology diagnostics for capture-path troubleshooting
+- Hardened Dashboard smoke navigation so release checks do not issue duplicate route requests
+
 ## v1.3.1 - 2026-07-12
 
 Security and pairing-state patch focused on current cryptography dependencies, durable client authorization, and clearer paired-device history.

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -67,6 +67,12 @@ namespace bp = boost::process::v1;
 
 window_system_e window_system;
 
+#ifdef POLARIS_BUILD_PORTAL
+namespace portal {
+  void shutdown();
+}
+#endif
+
 namespace {
   std::atomic_bool thread_priority_permission_denied {false};
   std::atomic_bool thread_priority_permission_warning_logged {false};
@@ -1244,6 +1250,19 @@ std::string get_local_ip_for_gateway() {
     return nullptr;
   }
 
+  class linux_deinit_t final: public deinit_t {
+  public:
+    ~linux_deinit_t() override {
+#ifdef POLARIS_BUILD_PORTAL
+      ::portal::shutdown();
+#endif
+    }
+  };
+
+  static std::unique_ptr<deinit_t> make_linux_deinit_guard() {
+    return std::make_unique<linux_deinit_t>();
+  }
+
   std::unique_ptr<deinit_t> init() {
     // enable low latency mode for AMD
     // https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30039
@@ -1340,8 +1359,14 @@ std::string get_local_ip_for_gateway() {
       BOOST_LOG(warning) << "Couldn't load EGL library"sv;
     }
 
-    return std::make_unique<deinit_t>();
+    return make_linux_deinit_guard();
   }
+
+#ifdef POLARIS_TESTS
+  std::unique_ptr<deinit_t> linux_deinit_guard_for_tests() {
+    return make_linux_deinit_guard();
+  }
+#endif
 
   class linux_high_precision_timer: public high_precision_timer {
   public:

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <future>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -433,6 +434,20 @@ namespace portal {
   // PipeWire frame capture
   // -----------------------------------------------------------------------
 
+#ifdef POLARIS_TESTS
+  static bool g_shutdown_probe_active = false;
+  static bool g_capture_running_when_loop_stopped = false;
+  static unsigned g_teardown_state_callback_count = 0;
+  static std::vector<std::string> g_shutdown_events;
+  static bool g_throw_state_callback_log = false;
+  static bool g_throw_process_callback = false;
+  static bool g_process_callback_probe_active = false;
+  static unsigned g_process_callback_requeue_count = 0;
+#endif
+
+  static void on_state_changed(void *userdata, enum pw_stream_state old,
+    enum pw_stream_state state, const char *errmsg) noexcept;
+
   struct pw_capture_t {
     struct pw_thread_loop *pw_loop = nullptr;
     struct pw_stream *pw_stream_handle = nullptr;
@@ -448,39 +463,89 @@ namespace portal {
 
     std::atomic<bool> running{false};
     std::atomic<bool> negotiated{false};
+    std::atomic<bool> shutting_down{false};
 
     ~pw_capture_t() {
+      shutting_down.store(true, std::memory_order_release);
+      running.store(false, std::memory_order_release);
+      frame_cv.notify_all();
+
+#ifdef POLARIS_TESTS
+      if (g_shutdown_probe_active) {
+        if (pw_loop) {
+          g_capture_running_when_loop_stopped = running.load();
+          g_shutdown_events.emplace_back("loop_stop");
+        }
+        if (pw_stream_handle) {
+          g_shutdown_events.emplace_back("stream_destroy");
+          on_state_changed(this, PW_STREAM_STATE_STREAMING, PW_STREAM_STATE_UNCONNECTED, nullptr);
+        }
+        if (pw_loop) {
+          g_shutdown_events.emplace_back("loop_destroy");
+        }
+        return;
+      }
+#endif
       if (pw_loop) pw_thread_loop_stop(pw_loop);
       if (pw_stream_handle) pw_stream_destroy(pw_stream_handle);
       if (pw_loop) pw_thread_loop_destroy(pw_loop);
     }
   };
 
-  static void on_process(void *userdata) {
-    auto *cap = static_cast<pw_capture_t *>(userdata);
-    struct pw_buffer *b = pw_stream_dequeue_buffer(cap->pw_stream_handle);
-    if (!b) return;
-
-    struct spa_buffer *buf = b->buffer;
-    if (!buf->datas[0].data || buf->datas[0].chunk->size == 0) {
-      pw_stream_queue_buffer(cap->pw_stream_handle, b);
+  static void queue_process_buffer(pw_capture_t *cap, struct pw_buffer *buffer) noexcept {
+#ifdef POLARIS_TESTS
+    if (g_process_callback_probe_active) {
+      ++g_process_callback_requeue_count;
       return;
     }
-
-    uint32_t size = buf->datas[0].chunk->size;
-    {
-      std::lock_guard lk(cap->frame_mtx);
-      cap->frame_data.resize(size);
-      std::memcpy(cap->frame_data.data(), buf->datas[0].data, size);
-      cap->frame_available = true;
-      cap->frame_cv.notify_one();
-    }
-
-    pw_stream_queue_buffer(cap->pw_stream_handle, b);
+#endif
+    pw_stream_queue_buffer(cap->pw_stream_handle, buffer);
   }
 
-  static void on_param_changed(void *userdata, uint32_t id, const struct spa_pod *param) {
+  static void on_process(void *userdata) noexcept {
     auto *cap = static_cast<pw_capture_t *>(userdata);
+    if (!cap || cap->shutting_down.load(std::memory_order_acquire)) return;
+
+    struct pw_buffer *b = nullptr;
+    try {
+#ifdef POLARIS_TESTS
+      if (g_throw_process_callback) {
+        b = reinterpret_cast<pw_buffer *>(1);
+        throw std::runtime_error("injected process callback failure");
+      }
+#endif
+
+      b = pw_stream_dequeue_buffer(cap->pw_stream_handle);
+      if (!b) return;
+
+      struct spa_buffer *buf = b->buffer;
+      if (!buf->datas[0].data || buf->datas[0].chunk->size == 0) {
+        queue_process_buffer(cap, b);
+        b = nullptr;
+        return;
+      }
+
+      uint32_t size = buf->datas[0].chunk->size;
+      {
+        std::lock_guard lk(cap->frame_mtx);
+        cap->frame_data.resize(size);
+        std::memcpy(cap->frame_data.data(), buf->datas[0].data, size);
+        cap->frame_available = true;
+        cap->frame_cv.notify_one();
+      }
+
+      queue_process_buffer(cap, b);
+      b = nullptr;
+    } catch (...) {
+      if (b) {
+        queue_process_buffer(cap, b);
+      }
+    }
+  }
+
+  static void on_param_changed(void *userdata, uint32_t id, const struct spa_pod *param) noexcept {
+    auto *cap = static_cast<pw_capture_t *>(userdata);
+    if (!cap || cap->shutting_down.load(std::memory_order_acquire)) return;
     if (!param || id != SPA_PARAM_Format) return;
 
     uint32_t media_type, media_subtype;
@@ -495,8 +560,12 @@ namespace portal {
     cap->frame_stride = cap->frame_width * 4;
     cap->negotiated = true;
 
-    BOOST_LOG(info) << "portal: PipeWire format negotiated: "sv
-                    << cap->frame_width << "x"sv << cap->frame_height;
+    try {
+      BOOST_LOG(info) << "portal: PipeWire format negotiated: "sv
+                      << cap->frame_width << "x"sv << cap->frame_height;
+    } catch (...) {
+      // PipeWire callbacks must not propagate logging failures across the C ABI.
+    }
 
     // Set buffer parameters
     uint8_t params_buffer[1024];
@@ -511,14 +580,64 @@ namespace portal {
   }
 
   static void on_state_changed(void *userdata, enum pw_stream_state old,
-    enum pw_stream_state state, const char *errmsg) {
-    BOOST_LOG(info) << "portal: PipeWire state: "sv
-                    << pw_stream_state_as_string(old) << " -> "sv
-                    << pw_stream_state_as_string(state);
-    if (state == PW_STREAM_STATE_ERROR && errmsg) {
-      BOOST_LOG(warning) << "portal: PipeWire error: "sv << errmsg;
+    enum pw_stream_state state, const char *errmsg) noexcept {
+    auto *cap = static_cast<pw_capture_t *>(userdata);
+    if (!cap || cap->shutting_down.load(std::memory_order_acquire)) return;
+
+#ifdef POLARIS_TESTS
+    if (g_shutdown_probe_active) {
+      ++g_teardown_state_callback_count;
+    }
+#endif
+    try {
+#ifdef POLARIS_TESTS
+      if (g_throw_state_callback_log) {
+        throw std::runtime_error("injected state callback log failure");
+      }
+#endif
+      BOOST_LOG(info) << "portal: PipeWire state: "sv
+                      << pw_stream_state_as_string(old) << " -> "sv
+                      << pw_stream_state_as_string(state);
+      if (state == PW_STREAM_STATE_ERROR && errmsg) {
+        BOOST_LOG(warning) << "portal: PipeWire error: "sv << errmsg;
+      }
+    } catch (...) {
+      // PipeWire callbacks must not propagate logging failures across the C ABI.
     }
   }
+
+#ifdef POLARIS_TESTS
+  void exercise_state_callback_log_failure_for_tests() {
+    pw_capture_t capture;
+    g_throw_state_callback_log = true;
+    try {
+      on_state_changed(&capture, PW_STREAM_STATE_STREAMING, PW_STREAM_STATE_UNCONNECTED, nullptr);
+    } catch (...) {
+      g_throw_state_callback_log = false;
+      throw;
+    }
+    g_throw_state_callback_log = false;
+  }
+
+  void exercise_process_callback_failure_for_tests() {
+    pw_capture_t capture;
+    g_process_callback_probe_active = true;
+    g_process_callback_requeue_count = 0;
+    g_throw_process_callback = true;
+    try {
+      on_process(&capture);
+    } catch (...) {
+      g_throw_process_callback = false;
+      g_process_callback_probe_active = false;
+      throw;
+    }
+    g_throw_process_callback = false;
+    g_process_callback_probe_active = false;
+    if (g_process_callback_requeue_count != 1) {
+      throw std::runtime_error("process callback did not requeue its dequeued buffer");
+    }
+  }
+#endif
 
   static const struct pw_stream_events pw_events = {
     .version = PW_VERSION_STREAM_EVENTS,
@@ -925,6 +1044,56 @@ namespace portal {
   static std::unique_ptr<portal_session_t> g_portal;
   static std::unique_ptr<pw_capture_t> g_capture;
   static uint32_t g_node_id = 0;
+
+  void shutdown() {
+    g_screencopy_stop = true;
+    g_capture.reset();
+    g_portal.reset();
+    g_node_id = 0;
+  }
+
+#ifdef POLARIS_TESTS
+  void install_shutdown_probe_for_tests() {
+    g_shutdown_probe_active = true;
+    g_capture_running_when_loop_stopped = false;
+    g_teardown_state_callback_count = 0;
+    g_shutdown_events.clear();
+
+    g_portal = std::make_unique<portal_session_t>();
+    g_capture = std::make_unique<pw_capture_t>();
+    g_capture->pw_loop = reinterpret_cast<pw_thread_loop *>(1);
+    g_capture->pw_stream_handle = reinterpret_cast<pw_stream *>(1);
+    g_capture->running = true;
+    g_node_id = 1;
+  }
+
+  void cleanup_shutdown_probe_for_tests() {
+    g_capture.reset();
+    g_portal.reset();
+    g_node_id = 0;
+    g_shutdown_probe_active = false;
+  }
+
+  bool global_capture_present_for_tests() {
+    return static_cast<bool>(g_capture);
+  }
+
+  bool global_session_present_for_tests() {
+    return static_cast<bool>(g_portal);
+  }
+
+  bool capture_running_when_loop_stopped_for_tests() {
+    return g_capture_running_when_loop_stopped;
+  }
+
+  unsigned teardown_state_callback_count_for_tests() {
+    return g_teardown_state_callback_count;
+  }
+
+  std::vector<std::string> shutdown_events_for_tests() {
+    return g_shutdown_events;
+  }
+#endif
 
   static bool ensure_global_session() {
     // Create the portal D-Bus session once (shows picker on first use)

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1016,6 +1016,8 @@ namespace proc {
 #ifdef POLARIS_TESTS
     thread_local pid_t forced_pidfd_open_failure_pid = -1;
     thread_local std::atomic<bool> *pidfd_wait_entered_for_tests = nullptr;
+    thread_local bool forced_steam_ownership_descendants_only = false;
+    thread_local std::set<pid_t> forced_steam_ownership_test_pids;
 #endif
 
     std::optional<pidfd_handle_t> open_process_pidfd(pid_t pid, int &open_error) {
@@ -1254,6 +1256,26 @@ namespace proc {
       const auto effective_argv0 = argv0_path.empty() ? proc_argv0_from_cmdline(cmdline) : std::string {argv0_path};
       return is_desktop_steam_client_process(comm, effective_argv0) &&
              !proc_status_is_zombie(status);
+    }
+
+    enum class steam_client_process_role_e {
+      native_root,
+      launcher_root,
+      helper,
+    };
+
+    steam_client_process_role_e steam_client_process_role(std::string_view comm, std::string_view argv0_path) {
+      const auto argv0 = basename_from_path(argv0_path);
+      if (path_has_suffix(argv0_path, "/ubuntu12_32/steam")) {
+        return steam_client_process_role_e::native_root;
+      }
+      if (comm == "steam" ||
+          argv0 == "steam" ||
+          argv0 == "steam.sh" ||
+          path_has_suffix(argv0_path, "/steam.sh")) {
+        return steam_client_process_role_e::launcher_root;
+      }
+      return steam_client_process_role_e::helper;
     }
 
 #ifdef POLARIS_TESTS
@@ -1509,10 +1531,89 @@ namespace proc {
     }
 
     struct steam_client_ownership_snapshot_t {
-      std::vector<pidfd_handle_t> owned;
+      std::vector<pidfd_handle_t> roots;
+      std::vector<pidfd_handle_t> launcher_roots;
+      std::vector<pidfd_handle_t> helpers;
       std::vector<pidfd_handle_t> unowned;
       bool capture_complete = true;
+
+      std::size_t owned_count() const {
+        return roots.size() + launcher_roots.size() + helpers.size();
+      }
     };
+
+    std::optional<std::size_t> unique_top_level_steam_launcher(
+      const std::vector<pidfd_handle_t> &launchers
+    ) {
+      std::optional<std::size_t> selected;
+      for (std::size_t candidate_index = 0; candidate_index < launchers.size(); ++candidate_index) {
+        bool descends_from_another_launcher = false;
+        for (std::size_t ancestor_index = 0; ancestor_index < launchers.size(); ++ancestor_index) {
+          if (candidate_index == ancestor_index) {
+            continue;
+          }
+          const auto descends = proc_pid_descends_from(
+            launchers[candidate_index].pid,
+            launchers[ancestor_index].pid
+          );
+          if (!descends) {
+            return std::nullopt;
+          }
+          if (*descends) {
+            descends_from_another_launcher = true;
+            break;
+          }
+        }
+        if (!descends_from_another_launcher) {
+          if (selected) {
+            return std::nullopt;
+          }
+          selected = candidate_index;
+        }
+      }
+      return selected;
+    }
+
+    void select_ordered_steam_root(steam_client_ownership_snapshot_t &snapshot) {
+      if (snapshot.roots.size() == 1) {
+        for (auto &launcher : snapshot.launcher_roots) {
+          snapshot.helpers.emplace_back(std::move(launcher));
+        }
+        snapshot.launcher_roots.clear();
+        return;
+      }
+      if (!snapshot.roots.empty()) {
+        return;
+      }
+
+      const auto launcher_index = unique_top_level_steam_launcher(snapshot.launcher_roots);
+      if (!launcher_index) {
+        return;
+      }
+      for (std::size_t index = 0; index < snapshot.launcher_roots.size(); ++index) {
+        if (index == *launcher_index) {
+          snapshot.roots.emplace_back(std::move(snapshot.launcher_roots[index]));
+        } else {
+          snapshot.helpers.emplace_back(std::move(snapshot.launcher_roots[index]));
+        }
+      }
+      snapshot.launcher_roots.clear();
+    }
+
+    std::vector<pidfd_handle_t> take_owned_steam_handles(steam_client_ownership_snapshot_t &snapshot) {
+      std::vector<pidfd_handle_t> handles;
+      handles.reserve(snapshot.owned_count());
+      for (auto &handle : snapshot.roots) {
+        handles.emplace_back(std::move(handle));
+      }
+      for (auto &handle : snapshot.launcher_roots) {
+        handles.emplace_back(std::move(handle));
+      }
+      for (auto &handle : snapshot.helpers) {
+        handles.emplace_back(std::move(handle));
+      }
+      return handles;
+    }
 
     steam_client_ownership_snapshot_t steam_client_ownership_snapshot(std::string_view session_instance_id) {
       steam_client_ownership_snapshot_t snapshot;
@@ -1538,7 +1639,6 @@ namespace proc {
         if (pid <= 1 || pid == getpid()) {
           continue;
         }
-
         const auto identity_before = proc_start_time_ticks(pid);
         const auto comm_before = read_proc_status_file_result(pid, "comm");
         const auto cmdline_before = read_proc_status_file_result(pid, "cmdline");
@@ -1609,6 +1709,17 @@ namespace proc {
         if (!is_active_steam_shutdown_ownership_process(comm, argv0, cmdline, status)) {
           continue;
         }
+#ifdef POLARIS_TESTS
+        if (forced_steam_ownership_descendants_only) {
+          if (!forced_steam_ownership_test_pids.contains(pid)) {
+            const auto descends_from_test = proc_pid_descends_from(pid, getpid());
+            if (!descends_from_test || !*descends_from_test) {
+              continue;
+            }
+            forced_steam_ownership_test_pids.emplace(pid);
+          }
+        }
+#endif
         auto identity_after = proc_start_time_ticks(pid);
 #ifdef POLARIS_TESTS
         if (pid == forced_reused_exact_generation_pid && identity_after) {
@@ -1636,7 +1747,17 @@ namespace proc {
           continue;
         }
         if (proc_environ_matches_isolated_session(environ.bytes, session_instance_id)) {
-          snapshot.owned.emplace_back(std::move(*handle));
+          switch (steam_client_process_role(comm, argv0)) {
+            case steam_client_process_role_e::native_root:
+              snapshot.roots.emplace_back(std::move(*handle));
+              break;
+            case steam_client_process_role_e::launcher_root:
+              snapshot.launcher_roots.emplace_back(std::move(*handle));
+              break;
+            case steam_client_process_role_e::helper:
+              snapshot.helpers.emplace_back(std::move(*handle));
+              break;
+          }
         } else {
           snapshot.unowned.emplace_back(std::move(*handle));
         }
@@ -1648,6 +1769,7 @@ namespace proc {
       }
 
       closedir(dir);
+      select_ordered_steam_root(snapshot);
       return snapshot;
     }
 
@@ -1666,7 +1788,7 @@ namespace proc {
             app,
             session_owned_cage,
             !session_instance_id.empty(),
-            !ownership.owned.empty(),
+            ownership.owned_count() > 0,
             !ownership.unowned.empty(),
             ownership.capture_complete
           )) {
@@ -1675,20 +1797,62 @@ namespace proc {
         } else if (!ownership.unowned.empty()) {
           BOOST_LOG(warning) << "process: skipping pre-cage private Steam termination because "sv
                              << ownership.unowned.size() << " active Steam client process(es) are not session-owned"sv;
-        } else if (ownership.owned.empty()) {
+        } else if (ownership.owned_count() == 0) {
           BOOST_LOG(info) << "process: skipping pre-cage private Steam termination because no session-owned Steam client is active"sv;
         }
         return false;
       }
 
-      BOOST_LOG(info) << "process: terminating "sv << ownership.owned.size()
-                      << " session-owned Steam process(es) through pidfd before isolated cage stop"sv;
-      if (terminate_pidfds(ownership.owned, 5s, 1s, "private Steam"sv)) {
+      if (ownership.roots.size() != 1) {
+        BOOST_LOG(warning) << "process: skipping ordered pre-cage private Steam termination because ownership capture found "sv
+                           << ownership.roots.size() << " selected root process(es) and "sv
+                           << ownership.launcher_roots.size() << " unresolved launcher root candidate(s)"sv;
+        return false;
+      }
+
+      BOOST_LOG(info) << "process: terminating the session-owned Steam client root through pidfd before "sv
+                      << ownership.helpers.size() << " helper process(es)"sv;
+      if (!terminate_pidfds(ownership.roots, 5s, 1s, "private Steam client root"sv)) {
+        BOOST_LOG(warning) << "process: session-owned Steam client root remained after bounded pidfd termination; "sv
+                           << "continuing with isolated cage fallback cleanup"sv;
+        return false;
+      }
+
+      if (!ownership.helpers.empty()) {
+        BOOST_LOG(info) << "process: allowing "sv << ownership.helpers.size()
+                        << " session-owned Steam helper process(es) to drain after client-root exit"sv;
+        if (wait_for_pidfds_exit(ownership.helpers, 2s)) {
+          BOOST_LOG(info) << "process: session-owned Steam helpers drained without direct signaling"sv;
+        } else {
+          BOOST_LOG(info) << "process: session-owned Steam helper drain grace elapsed; capturing exact survivors"sv;
+        }
+      }
+
+      auto survivors = steam_client_ownership_snapshot(session_instance_id);
+      if (!survivors.capture_complete) {
+        BOOST_LOG(warning) << "process: skipping private Steam survivor cleanup because post-root ownership capture was incomplete"sv;
+        return false;
+      }
+      if (!survivors.unowned.empty()) {
+        BOOST_LOG(warning) << "process: skipping private Steam survivor cleanup because "sv
+                           << survivors.unowned.size() << " active Steam client process(es) are not session-owned"sv;
+        return false;
+      }
+      if (survivors.owned_count() == 0) {
+        BOOST_LOG(info) << "process: session-owned Steam client root drained all helpers before isolated cage stop"sv;
+        return true;
+      }
+
+      auto survivor_handles = take_owned_steam_handles(survivors);
+      BOOST_LOG(info) << "process: terminating "sv << survivor_handles.size()
+                      << " session-owned Steam survivor process(es) after client-root drain"sv;
+      if (terminate_pidfds(survivor_handles, 2s, 1s, "private Steam survivor"sv)) {
         BOOST_LOG(info) << "process: session-owned Steam exited before isolated cage stop"sv;
         return true;
       }
 
-      BOOST_LOG(warning) << "process: session-owned Steam remained after bounded pidfd termination; continuing with isolated cage fallback cleanup"sv;
+      BOOST_LOG(warning) << "process: session-owned Steam survivors remained after bounded pidfd termination; "sv
+                         << "continuing with isolated cage fallback cleanup"sv;
       return false;
     }
 
@@ -3620,18 +3784,26 @@ namespace proc {
     const auto previous_app = _app;
     const auto previous_used_cage = _session_used_cage_compositor;
     const auto previous_instance_id = _session_instance_id;
+    const auto previous_descendants_only = forced_steam_ownership_descendants_only;
+    const auto previous_test_pids = forced_steam_ownership_test_pids;
     _app = app;
     _session_used_cage_compositor = session_owned_cage;
     _session_instance_id = session_instance_id;
+    forced_steam_ownership_descendants_only = true;
+    forced_steam_ownership_test_pids.clear();
     auto restore_state = util::fail_guard([
       this,
       previous_app,
       previous_used_cage,
-      previous_instance_id
+      previous_instance_id,
+      previous_descendants_only,
+      previous_test_pids
     ]() {
       _app = previous_app;
       _session_used_cage_compositor = previous_used_cage;
       _session_instance_id = previous_instance_id;
+      forced_steam_ownership_descendants_only = previous_descendants_only;
+      forced_steam_ownership_test_pids = previous_test_pids;
     });
     return terminate_session_owned_steam_before_cage_stop();
   }

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -4,11 +4,29 @@
  */
 
 #include "../../tests_common.h"
+#include "src/platform/common.h"
 
 #include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
+#ifdef POLARIS_BUILD_PORTAL
 namespace portal {
   std::uint32_t capture_type_for_stream_display_for_tests(bool headless_mode, bool use_cage_compositor);
+  void install_shutdown_probe_for_tests();
+  void cleanup_shutdown_probe_for_tests();
+  bool global_capture_present_for_tests();
+  bool global_session_present_for_tests();
+  bool capture_running_when_loop_stopped_for_tests();
+  unsigned teardown_state_callback_count_for_tests();
+  std::vector<std::string> shutdown_events_for_tests();
+  void exercise_state_callback_log_failure_for_tests();
+  void exercise_process_callback_failure_for_tests();
+}
+
+namespace platf {
+  std::unique_ptr<deinit_t> linux_deinit_guard_for_tests();
 }
 
 TEST(PortalGrabPolicyTests, DesktopDisplayRequestsMonitorSource) {
@@ -19,3 +37,33 @@ TEST(PortalGrabPolicyTests, PrivateAndWindowedCagePathsRequestWindowSource) {
   EXPECT_EQ(portal::capture_type_for_stream_display_for_tests(true, true), 2u);
   EXPECT_EQ(portal::capture_type_for_stream_display_for_tests(false, true), 2u);
 }
+
+TEST(PortalPipeWireShutdownTests, ActiveGlobalCaptureQuiescesCallbacksBeforeLoggingLifetimeEnds) {
+  portal::install_shutdown_probe_for_tests();
+
+  auto deinit_guard = platf::linux_deinit_guard_for_tests();
+  deinit_guard.reset();
+
+  EXPECT_FALSE(portal::global_capture_present_for_tests());
+  EXPECT_FALSE(portal::global_session_present_for_tests());
+  EXPECT_EQ(portal::shutdown_events_for_tests(),
+    (std::vector<std::string> {"loop_stop", "stream_destroy", "loop_destroy"}));
+  EXPECT_FALSE(portal::capture_running_when_loop_stopped_for_tests());
+  EXPECT_EQ(portal::teardown_state_callback_count_for_tests(), 0u);
+
+  auto second_deinit_guard = platf::linux_deinit_guard_for_tests();
+  second_deinit_guard.reset();
+  EXPECT_EQ(portal::shutdown_events_for_tests(),
+    (std::vector<std::string> {"loop_stop", "stream_destroy", "loop_destroy"}));
+
+  portal::cleanup_shutdown_probe_for_tests();
+}
+
+TEST(PortalPipeWireShutdownTests, StateCallbackContainsLoggingFailure) {
+  EXPECT_NO_THROW(portal::exercise_state_callback_log_failure_for_tests());
+}
+
+TEST(PortalPipeWireShutdownTests, ProcessCallbackRequeuesBufferAfterPostDequeueFailure) {
+  EXPECT_NO_THROW(portal::exercise_process_callback_failure_for_tests());
+}
+#endif

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1389,7 +1389,7 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownUsesImmutableExact
   steam_app.name = "Steam Big Picture";
   steam_app.cmd = "steam -gamepadui";
 
-  auto spawn_steam_like = [&](bool marked) {
+  auto spawn_steam_like = [&](bool marked, const char *argv0 = "steam") {
     const auto child = fork();
     EXPECT_GE(child, 0);
     if (child == 0) {
@@ -1398,7 +1398,7 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownUsesImmutableExact
       } else {
         unsetenv("POLARIS_SESSION_INSTANCE_ID");
       }
-      execl("/bin/sleep", "steam", "60", nullptr);
+      execl("/bin/sleep", argv0, "60", nullptr);
       _exit(127);
     }
     return child;
@@ -1433,7 +1433,7 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownUsesImmutableExact
 
   auto faulted_owned = spawn_steam_like(true);
   linux_child_guard_t faulted_guard {faulted_owned};
-  auto faulted_control = spawn_steam_like(true);
+  auto faulted_control = spawn_steam_like(true, "steamwebhelper");
   linux_child_guard_t faulted_control_guard {faulted_control};
   ASSERT_GT(faulted_owned, 0);
   ASSERT_GT(faulted_control, 0);
@@ -1493,6 +1493,327 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownUsesImmutableExact
   EXPECT_EQ(mirror_guard.wait(&status, WNOHANG), 0);
 #else
   GTEST_SKIP() << "Linux-only immutable private Steam teardown wiring";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownDrainsHelpersBeforeFallbackSignals) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t config_guard;
+  const std::string token = "steam-root-first-generation";
+  proc::ctx_t steam_app {};
+  steam_app.name = "MOUSE: P.I. For Hire";
+  steam_app.source = "steam";
+  steam_app.steam_appid = "2416450";
+
+  int ready_pipe[2] {-1, -1};
+  int event_pipe[2] {-1, -1};
+  int helper_pid_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  ASSERT_EQ(pipe(event_pipe), 0);
+  ASSERT_EQ(pipe(helper_pid_pipe), 0);
+
+  const auto root = fork();
+  ASSERT_NE(root, -1);
+  if (root == 0) {
+    close(ready_pipe[0]);
+    close(event_pipe[0]);
+    close(helper_pid_pipe[0]);
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+
+    const auto helper_script =
+      "import os, signal, time\n"
+      "event_fd = " + std::to_string(event_pipe[1]) + "\n"
+      "ready_fd = " + std::to_string(ready_pipe[1]) + "\n"
+      "def on_term(signum, frame):\n"
+      "    os.write(event_fd, b'H')\n"
+      "def on_drain(signum, frame):\n"
+      "    time.sleep(1.0)\n"
+      "    os.write(event_fd, b'G')\n"
+      "    raise SystemExit(0)\n"
+      "signal.signal(signal.SIGTERM, on_term)\n"
+      "signal.signal(signal.SIGUSR1, on_drain)\n"
+      "os.write(ready_fd, b'H')\n"
+      "while True:\n"
+      "    signal.pause()\n";
+    setenv("POLARIS_TEST_STEAM_HELPER_SCRIPT", helper_script.c_str(), 1);
+    const auto root_script =
+      std::string {"exec -a steamwebhelper python3 -c \"$POLARIS_TEST_STEAM_HELPER_SCRIPT\" & "} +
+      "helper=$!; printf '%s\\n' \"$helper\" >&" + std::to_string(helper_pid_pipe[1]) + "; " +
+      "trap 'printf R >&" + std::to_string(event_pipe[1]) +
+      "; kill -USR1 \"$helper\"; exit 0' TERM; " +
+      "printf R >&" + std::to_string(ready_pipe[1]) + "; " +
+      "wait \"$helper\"";
+    execl("/bin/bash", "/tmp/ubuntu12_32/steam", "-c", root_script.c_str(), nullptr);
+    _exit(120);
+  }
+  linux_child_guard_t root_guard {root};
+
+  close(ready_pipe[1]);
+  close(event_pipe[1]);
+  close(helper_pid_pipe[1]);
+  std::string helper_pid_text;
+  for (;;) {
+    char digit = 0;
+    ASSERT_EQ(read(helper_pid_pipe[0], &digit, 1), 1);
+    if (digit == '\n') {
+      break;
+    }
+    helper_pid_text.push_back(digit);
+  }
+  close(helper_pid_pipe[0]);
+  const auto helper = static_cast<pid_t>(std::stol(helper_pid_text));
+  ASSERT_GT(helper, 0);
+
+  std::string ready_events;
+  while (ready_events.size() < 2) {
+    char event = 0;
+    ASSERT_EQ(read(ready_pipe[0], &event, 1), 1);
+    ready_events.push_back(event);
+  }
+  close(ready_pipe[0]);
+  EXPECT_NE(ready_events.find('R'), std::string::npos);
+  EXPECT_NE(ready_events.find('H'), std::string::npos);
+
+  config::video.linux_display.use_cage_compositor = false;
+  const bool terminated = proc::terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, token
+  );
+  if (!terminated) {
+    (void) kill(root, SIGKILL);
+    (void) kill(helper, SIGKILL);
+    int ignored_status = 0;
+    (void) root_guard.wait(&ignored_status, 0);
+    close(event_pipe[0]);
+    FAIL() << "production pre-cage Steam ownership capture unexpectedly refused the test graph";
+    return;
+  }
+
+  int root_status = 0;
+  ASSERT_EQ(root_guard.wait(&root_status, 0), root);
+  ASSERT_TRUE(WIFEXITED(root_status));
+  EXPECT_EQ(WEXITSTATUS(root_status), 0);
+
+  std::string shutdown_events;
+  for (;;) {
+    char buffer[16];
+    const auto bytes = read(event_pipe[0], buffer, sizeof(buffer));
+    if (bytes > 0) {
+      shutdown_events.append(buffer, static_cast<std::size_t>(bytes));
+      continue;
+    }
+    ASSERT_EQ(bytes, 0);
+    break;
+  }
+  close(event_pipe[0]);
+
+  EXPECT_NE(shutdown_events.find('R'), std::string::npos)
+    << "the Steam client root must receive the initial graceful signal";
+  EXPECT_NE(shutdown_events.find('G'), std::string::npos)
+    << "the Steam helper must drain through the client root";
+  EXPECT_EQ(shutdown_events.find('H'), std::string::npos)
+    << "Steam helpers must not receive fallback SIGTERM before the client root can drain them";
+#else
+  GTEST_SKIP() << "Linux-only private Steam process-graph teardown ordering";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownTreatsSteamScriptAsClientRoot) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t config_guard;
+  const std::string token = "steam-script-root-generation";
+  proc::ctx_t steam_app {};
+  steam_app.name = "Steam Big Picture";
+  steam_app.source = "steam";
+
+  const auto root = fork();
+  ASSERT_NE(root, -1);
+  if (root == 0) {
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    execl("/bin/sleep", "/tmp/steam.sh", "60", nullptr);
+    _exit(127);
+  }
+  linux_child_guard_t root_guard {root};
+
+  const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
+  bool ready = false;
+  for (int attempt = 0; attempt < 40; ++attempt) {
+    std::ifstream environ("/proc/" + std::to_string(root) + "/environ", std::ios::binary);
+    std::ostringstream bytes;
+    bytes << environ.rdbuf();
+    if (bytes.str().find(expected) != std::string::npos) {
+      ready = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  }
+  ASSERT_TRUE(ready);
+
+  config::video.linux_display.use_cage_compositor = false;
+  EXPECT_TRUE(proc::terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, token
+  ));
+
+  int status = 0;
+  const auto waited = root_guard.wait(&status, WNOHANG);
+  EXPECT_EQ(waited, root);
+  if (waited == 0) {
+    EXPECT_EQ(root_guard.terminate_and_reap(&status), root);
+  }
+#else
+  GTEST_SKIP() << "Linux-only private Steam script root classification";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownPrefersNativeClientOverSteamLauncher) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t config_guard;
+  const std::string token = "native-steam-root-priority-generation";
+  proc::ctx_t steam_app {};
+  steam_app.name = "MOUSE: P.I. For Hire";
+  steam_app.source = "steam";
+  steam_app.steam_appid = "2416450";
+
+  auto spawn_owned = [&](const char *argv0) {
+    const auto child = fork();
+    EXPECT_NE(child, -1);
+    if (child == 0) {
+      setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+      execl("/bin/sleep", argv0, "60", nullptr);
+      _exit(127);
+    }
+    return child;
+  };
+
+  const auto native_root = spawn_owned("/tmp/ubuntu12_32/steam");
+  linux_child_guard_t native_guard {native_root};
+  const auto launcher = spawn_owned("steam");
+  linux_child_guard_t launcher_guard {launcher};
+  ASSERT_GT(native_root, 0);
+  ASSERT_GT(launcher, 0);
+
+  const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
+  auto wait_for_token = [&](pid_t pid) {
+    for (int attempt = 0; attempt < 40; ++attempt) {
+      std::ifstream environ("/proc/" + std::to_string(pid) + "/environ", std::ios::binary);
+      std::ostringstream bytes;
+      bytes << environ.rdbuf();
+      if (bytes.str().find(expected) != std::string::npos) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    return false;
+  };
+  ASSERT_TRUE(wait_for_token(native_root));
+  ASSERT_TRUE(wait_for_token(launcher));
+
+  config::video.linux_display.use_cage_compositor = false;
+  EXPECT_TRUE(proc::terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, token
+  ));
+
+  int status = 0;
+  const auto native_wait = native_guard.wait(&status, WNOHANG);
+  EXPECT_EQ(native_wait, native_root);
+  if (native_wait == 0) {
+    EXPECT_EQ(native_guard.terminate_and_reap(&status), native_root);
+  }
+  const auto launcher_wait = launcher_guard.wait(&status, WNOHANG);
+  EXPECT_EQ(launcher_wait, launcher);
+  if (launcher_wait == 0) {
+    EXPECT_EQ(launcher_guard.terminate_and_reap(&status), launcher);
+  }
+#else
+  GTEST_SKIP() << "Linux-only native Steam root priority";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownSelectsTopLevelLauncherFromLauncherTree) {
+#ifdef __linux__
+  linux_cage_compositor_guard_t config_guard;
+  const std::string token = "steam-launcher-tree-generation";
+  proc::ctx_t steam_app {};
+  steam_app.name = "Steam Big Picture";
+  steam_app.source = "steam";
+
+  int child_pid_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(child_pid_pipe), 0);
+  const auto launcher_root = fork();
+  ASSERT_NE(launcher_root, -1);
+  if (launcher_root == 0) {
+    close(child_pid_pipe[0]);
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    const auto launcher_child = fork();
+    if (launcher_child < 0) {
+      _exit(120);
+    }
+    if (launcher_child == 0) {
+      close(child_pid_pipe[1]);
+      execl("/bin/sleep", "steam", "60", nullptr);
+      _exit(121);
+    }
+    (void) write(child_pid_pipe[1], &launcher_child, sizeof(launcher_child));
+    close(child_pid_pipe[1]);
+    execl("/bin/sleep", "steam", "60", nullptr);
+    _exit(122);
+  }
+  linux_child_guard_t root_guard {launcher_root};
+
+  close(child_pid_pipe[1]);
+  pid_t launcher_child = -1;
+  ASSERT_EQ(read(child_pid_pipe[0], &launcher_child, sizeof(launcher_child)), sizeof(launcher_child));
+  close(child_pid_pipe[0]);
+  ASSERT_GT(launcher_child, 0);
+
+  const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
+  auto wait_for_token = [&](pid_t pid) {
+    for (int attempt = 0; attempt < 40; ++attempt) {
+      std::ifstream environ("/proc/" + std::to_string(pid) + "/environ", std::ios::binary);
+      std::ostringstream bytes;
+      bytes << environ.rdbuf();
+      if (bytes.str().find(expected) != std::string::npos) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    return false;
+  };
+  ASSERT_TRUE(wait_for_token(launcher_root));
+  ASSERT_TRUE(wait_for_token(launcher_child));
+
+  config::video.linux_display.use_cage_compositor = false;
+  const bool terminated = proc::terminate_session_owned_steam_before_cage_stop_for_tests(
+    steam_app, true, token
+  );
+  if (!terminated) {
+    (void) kill(launcher_child, SIGKILL);
+  }
+  EXPECT_TRUE(terminated);
+
+  int status = 0;
+  const auto root_wait = root_guard.wait(&status, WNOHANG);
+  EXPECT_EQ(root_wait, launcher_root);
+  if (root_wait == 0) {
+    EXPECT_EQ(root_guard.terminate_and_reap(&status), launcher_root);
+  }
+
+  bool child_exited = false;
+  for (int attempt = 0; attempt < 40; ++attempt) {
+    std::ifstream status_file("/proc/" + std::to_string(launcher_child) + "/status");
+    std::ostringstream status_bytes;
+    status_bytes << status_file.rdbuf();
+    if (!status_file || status_bytes.str().find("State:\tZ") != std::string::npos) {
+      child_exited = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  }
+  if (!child_exited) {
+    (void) kill(launcher_child, SIGKILL);
+  }
+  EXPECT_TRUE(child_exited);
+#else
+  GTEST_SKIP() << "Linux-only Steam launcher tree root selection";
 #endif
 }
 


### PR DESCRIPTION
## Summary

This pull request prepares the exact reviewed Polaris v1.3.2 candidate. It contains four commits that:

- prepare the v1.3.2 source and release metadata,
- drain the private Steam root before helper teardown,
- tear down portal capture before logging, and
- keep the changelog entry marked unreleased until the later merge/tag/release gates.

## Exact candidate

- Base (`master`): `7fc4e3270d31d0f2a2d08f716d87445afef9a683`
- Head: `d6c3bead135a26ef28ef1a4bbef2764ef7515911`
- Tree: `5bdf0d380ffa9540304d9c6c5f87af8cc239a01e`
- Branch: `release/exact-polaris-v1.3.2-t_a1a05193`
- Delta: 4 commits, 0 behind / 4 ahead of the refreshed public base

The candidate worktree was clean before publication. The public `master` SHA, head SHA, tree SHA, ancestry, changed paths, and `git diff --check` were revalidated immediately before the push.

## Verification

Sealed exact-candidate evidence was checksum-verified again on both the source host and the release-control host before publication (36/36 bundle entries):

- Web dependency install: PASS
- Web lint: PASS
- Web tests: 45 files, 239/239 tests PASS
- Web production build: PASS
- Native Fedora 44 Release build, including all default targets and all CTest commands: PASS
- Native serial CTest: 12/12 PASS
- Recursive-submodule/source checks: PASS
- Fresh high-confidence credential/private-path scan of the exact source delta: PASS (0 findings)
- Sealed RPM/evidence privacy scan: PASS (0 forbidden identity/path findings; 0 high-confidence credential findings)

Frozen reviewed RPM (not published by this PR gate):

- Asset: `Polaris-fedora44-x86_64.rpm`
- SHA-256: `03335b179bddaa02f06eb9d221ba9cc03df8af8c71ae5a0fd2794b4e6b00ad94`
- Size: `11033927` bytes
- Package: unsigned Fedora 44 x86_64 staging artifact

## Known integration limitation and release-policy decision

The accepted limitation is preserved verbatim:

> End-to-end candidate Polaris + published Nova + Control gameplay/stream/audio/controller validation was not completed because the final harness remained generic-incompatible; candidate Polaris was never activated and is not implicated. Do not claim smoke PASS.

The attempted generic-handheld smoke stopped before product activation at a harness boundary. A corrected static successor then blocked because the sealed live-operator cleanup identity allowed only `rp6`/`thor`, while producer tests had masked `generic-handheld` by patching the profile. The candidate Polaris build was never activated and is not implicated by either harness result.

By explicit release-policy decision, this missing end-to-end emulator validation is disclosed and non-blocking for the v1.3.2 release train. **This PR does not claim that Control streaming, audio, controller, gameplay, or integration smoke passed.** No additional harness/preflight successor is authorized for this release line. RP6, Thor, TV, and phone/tablet validation remain non-blocking follow-ups.

All remaining source/tree/privacy/CI/rebuild/tag/asset gates remain fail-closed.

## Scope of this gate

This action opens the exact PR only. It does **not** merge the PR, create or push `v1.3.2`, publish a GitHub release, upload the RPM, deploy/install/activate Polaris, run gameplay or input, restart services, or announce the release.
