### PR TITLE
fix(linux): reclaim orphan gamescope sockets and keep idle alive on teardown

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -100,7 +100,9 @@ in
       Service = {
         Type = "simple";
         ExecStart = session.portalFrontendExec;
-        Restart = "on-failure";
+        # always: frontend can be cleanly stopped while polaris stays up; stream
+        # needs org.freedesktop.portal.Desktop on the private bus.
+        Restart = "always";
         RestartSec = "1s";
         Environment = session.envToList session.portalEnvironment;
       };

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -28,7 +28,10 @@ polaris_process_fields() {
 
 polaris_read_marker() {
   local marker="$1" extra executable_name
-  read -r POLARIS_MARKER_PID POLARIS_MARKER_START_TIME POLARIS_MARKER_ROLE POLARIS_MARKER_EXECUTABLE extra <"$marker" 2>/dev/null || return 1
+  # Check readability first — bash still prints "No such file" for <"$missing"
+  # even when the whole command redirects stderr.
+  [ -r "$marker" ] || return 1
+  read -r POLARIS_MARKER_PID POLARIS_MARKER_START_TIME POLARIS_MARKER_ROLE POLARIS_MARKER_EXECUTABLE extra <"$marker" || return 1
   [ -z "${extra:-}" ] || return 1
   case "$POLARIS_MARKER_PID:$POLARIS_MARKER_START_TIME" in
     *[!0-9:]*|0:*|:*|*:) return 1 ;;
@@ -48,7 +51,7 @@ polaris_read_marker() {
 }
 
 polaris_headless_gamescope_pid() {
-  local pid="$1" arg first=1 executable= backend=0 previous=
+  local pid="$1" arg first=1 executable="" backend=0 previous=""
   local exe_path exe_name
   exe_path="$(readlink "$(polaris_proc_root)/$pid/exe" 2>/dev/null)" || return 1
   exe_name="${exe_path##*/}"
@@ -94,11 +97,11 @@ polaris_process_has_argument() {
 }
 
 polaris_write_marker_for_pid() (
-  local marker="$1" pid="$2" role="$3" attempt tmp lock_bin="${POLARIS_FLOCK_BIN:-flock}"
+  local marker="$1" pid="$2" role="$3" tmp lock_bin="${POLARIS_FLOCK_BIN:-flock}"
   umask 077
   exec 9>>"${marker%/*}/polaris-gamescope.lock" || return 1
   "$lock_bin" -x 9 || return 1
-  for attempt in $(seq 1 100); do
+  for _ in $(seq 1 100); do
     if polaris_process_fields "$pid" && polaris_headless_gamescope_pid "$pid"; then
       local start_time="$POLARIS_PROCESS_START_TIME" executable_path="$POLARIS_GAMESCOPE_EXECUTABLE"
       if polaris_validate_marker "$marker"; then
@@ -130,8 +133,9 @@ polaris_pid_is_descendant() {
 }
 
 polaris_socket_inode() {
-  local wanted="$1" num ref protocol flags type state inode path rest found=""
-  while read -r num ref protocol flags type state inode path rest; do
+  local wanted="$1" inode path found=""
+  # /proc/net/unix columns: num ref protocol flags type state inode path …
+  while read -r _ _ _ _ _ _ inode path _; do
     [ "$path" = "$wanted" ] || continue
     case "$inode" in ''|*[!0-9]*) return 1 ;; esac
     # Duplicate pathname rows are ambiguous: an unlinked old listener may
@@ -172,6 +176,70 @@ polaris_marker_owns_socket() {
   polaris_process_tree_holds_inode "$POLARIS_MARKER_PID" "$inode"
 }
 
+polaris_any_process_holds_inode() {
+  local inode="$1" process pid
+  for process in "$(polaris_proc_root)"/[0-9]*; do
+    [ -d "$process" ] || continue
+    pid="${process##*/}"
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    if polaris_pid_holds_inode "$pid" "$inode"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# True (0) when $1 is missing or has no live holder — safe to unlink.
+# False (1) when a live process holds the socket or the pathname is ambiguous.
+polaris_socket_is_orphan() {
+  local socket="$1" inode path found="" count=0
+  [ -e "$socket" ] || return 0
+  while read -r _ _ _ _ _ _ inode path _; do
+    [ "$path" = "$socket" ] || continue
+    case "$inode" in ''|*[!0-9]*) continue ;; esac
+    count=$((count + 1))
+    found="$inode"
+  done <"$(polaris_proc_net_unix)" 2>/dev/null
+  # Duplicate pathname rows are ambiguous (unlink/rebind); refuse reclaim.
+  [ "$count" -le 1 ] || return 1
+  # Filesystem residue with no /proc/net/unix listener is safe to remove.
+  [ "$count" -eq 1 ] || return 0
+  if polaris_any_process_holds_inode "$found"; then
+    return 1
+  fi
+  return 0
+}
+
+# Remove one socket path if orphaned. 0 = missing/removed, 1 = live holder.
+polaris_remove_orphan_socket() {
+  local socket="$1"
+  if [ ! -e "$socket" ]; then
+    rm -f "$socket.lock" 2>/dev/null || true
+    return 0
+  fi
+  polaris_socket_is_orphan "$socket" || return 1
+  echo "polaris: reclaiming orphan socket $socket" >&2
+  rm -f "$socket" "$socket.lock" 2>/dev/null || true
+  return 0
+}
+
+# Reclaim dead gamescope-* residue after crash. Fails closed on live holders.
+polaris_reclaim_orphan_gamescope_sockets() {
+  local runtime_dir="$1" name socket
+  for name in gamescope-0 gamescope-1 gamescope-0-ei gamescope-1-ei; do
+    socket="$runtime_dir/$name"
+    if [ -e "$socket" ] || [ -S "$socket" ]; then
+      if ! polaris_remove_orphan_socket "$socket"; then
+        echo "polaris: refusing destructive cleanup of live unowned $socket" >&2
+        return 1
+      fi
+    else
+      rm -f "$socket.lock" 2>/dev/null || true
+    fi
+  done
+  return 0
+}
+
 polaris_xwayland_pid() {
   local pid="$1" executable exe_path
   exe_path="$(readlink "$(polaris_proc_root)/$pid/exe" 2>/dev/null)" || return 1
@@ -180,8 +248,24 @@ polaris_xwayland_pid() {
   [ "${executable##*/}" = Xwayland ]
 }
 
+# gamescope may reparent Xwayland under the user manager while keeping the
+# service cgroup; treat same-cgroup as related when ancestry is gone.
+polaris_pid_same_cgroup() {
+  local a="$1" b="$2" ca cb
+  ca="$(cat "$(polaris_proc_root)/$a/cgroup" 2>/dev/null)" || return 1
+  cb="$(cat "$(polaris_proc_root)/$b/cgroup" 2>/dev/null)" || return 1
+  [ -n "$ca" ] && [ "$ca" = "$cb" ]
+}
+
+polaris_pid_related_to_root() {
+  local pid="$1" root="$2"
+  [ "$pid" = "$root" ] && return 0
+  polaris_pid_is_descendant "$pid" "$root" && return 0
+  polaris_pid_same_cgroup "$pid" "$root"
+}
+
 polaris_discover_xwayland_display() {
-  local marker="$1" expected_role="${2:-}" xdir socket name display inode process pid best=
+  local marker="$1" expected_role="${2:-}" xdir socket name display inode path process pid best=
   polaris_validate_marker "$marker" "$expected_role" || return 1
   local root_pid="$POLARIS_MARKER_PID"
   xdir="$(polaris_x11_socket_dir)"
@@ -190,18 +274,24 @@ polaris_discover_xwayland_display() {
     name="${socket##*/}"
     display="${name#X}"
     case "$display" in ''|*[!0-9]*) continue ;; esac
-    inode="$(polaris_socket_inode "$socket")" || continue
-    for process in "$(polaris_proc_root)"/[0-9]*; do
-      [ -d "$process" ] || continue
-      pid="${process##*/}"
-      [ "$pid" != "$root_pid" ] || continue
-      if polaris_pid_is_descendant "$pid" "$root_pid" && polaris_xwayland_pid "$pid" \
-          && polaris_pid_holds_inode "$pid" "$inode"; then
-        if [ -z "$best" ] || [ "$display" -lt "$best" ]; then
-          best="$display"
+    # Walk every /proc/net/unix row for this path. Ambiguous unlink/rebind
+    # residue is ok if a related Xwayland still holds one of the inodes.
+    while read -r _ _ _ _ _ _ inode path _; do
+      [ "$path" = "$socket" ] || continue
+      case "$inode" in ''|*[!0-9]*) continue ;; esac
+      for process in "$(polaris_proc_root)"/[0-9]*; do
+        [ -d "$process" ] || continue
+        pid="${process##*/}"
+        case "$pid" in ''|*[!0-9]*) continue ;; esac
+        [ "$pid" != "$root_pid" ] || continue
+        if polaris_xwayland_pid "$pid" && polaris_pid_related_to_root "$pid" "$root_pid" \
+            && polaris_pid_holds_inode "$pid" "$inode"; then
+          if [ -z "$best" ] || [ "$display" -lt "$best" ]; then
+            best="$display"
+          fi
         fi
-      fi
-    done
+      done
+    done <"$(polaris_proc_net_unix)" 2>/dev/null
   done
   [ -n "$best" ] || return 1
   printf ':%s\n' "$best"
@@ -230,7 +320,7 @@ polaris_write_runtime_env() (
 polaris_stop_marked_gamescope() (
   local marker="$1" expected_role="$2" runtime_dir="$3" kill_bin="${POLARIS_KILL_BIN:-kill}"
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}"
-  local marker_line pid start_time executable_path socket inode entry current_inode attempt
+  local marker_line pid start_time executable_path socket inode entry current_inode
   local owned_sockets=() term_steps="${POLARIS_STOP_WAIT_STEPS:-30}" kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}"
   umask 077
   exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
@@ -252,7 +342,7 @@ polaris_stop_marked_gamescope() (
   polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
   [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
   "$kill_bin" -TERM "-$pid" 2>/dev/null || "$kill_bin" -TERM "$pid" 2>/dev/null || return 1
-  for attempt in $(seq 1 "$term_steps"); do
+  for _ in $(seq 1 "$term_steps"); do
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
     if ! polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
       break
@@ -262,7 +352,7 @@ polaris_stop_marked_gamescope() (
   if polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
     "$kill_bin" -KILL "-$pid" 2>/dev/null || "$kill_bin" -KILL "$pid" 2>/dev/null || return 1
-    for attempt in $(seq 1 "$kill_steps"); do
+    for _ in $(seq 1 "$kill_steps"); do
       [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
       polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || break
       sleep 0.1

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -317,6 +317,37 @@ polaris_write_runtime_env() (
   mv -f "$tmp" "$runtime_dir/polaris-gamescope.env"
 )
 
+# Hjem / NixOS install polaris units under ~/.config/systemd/user, which has
+# higher search priority than $XDG_RUNTIME_DIR/systemd/user. Plain
+# `systemctl --user mask --runtime` therefore does NOT mask those units, and
+# polaris-portal-gamescope Wants= / polaris Wants= keep restarting idle under
+# nested WSI (yield loop). Mask via user.control (first path) instead.
+polaris_idle_unit_control_dir() {
+  printf '%s\n' "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/systemd/user.control"
+}
+
+polaris_mask_idle_unit_runtime() {
+  local unit="${1:-polaris-gamescope-idle.service}"
+  local control
+  control="$(polaris_idle_unit_control_dir)"
+  mkdir -p "$control"
+  ln -sfn /dev/null "$control/$unit"
+  # Drop legacy ineffective mask --runtime symlink if present.
+  rm -f "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/systemd/user/$unit"
+  systemctl --user daemon-reload 2>/dev/null || true
+  systemctl --user stop "$unit" 2>/dev/null || true
+}
+
+polaris_unmask_idle_unit_runtime() {
+  local unit="${1:-polaris-gamescope-idle.service}"
+  local control
+  control="$(polaris_idle_unit_control_dir)"
+  rm -f "$control/$unit"
+  rm -f "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/systemd/user/$unit"
+  systemctl --user daemon-reload 2>/dev/null || true
+  systemctl --user unmask --runtime "$unit" 2>/dev/null || true
+}
+
 polaris_stop_marked_gamescope() (
   local marker="$1" expected_role="$2" runtime_dir="$3" kill_bin="${POLARIS_KILL_BIN:-kill}"
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}"

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -192,10 +192,10 @@ case "${1:-}" in
     if [ "$want_wsi" = 1 ]; then
       # --- Nested WSI path (games as gamescope child) ---
       echo "polaris-gamescope-session: WSI nested mode — Steam is ${POLARIS_GAMESCOPE_BIN:-gamescope} primary child" >&2
-      # Runtime-mask so polaris Wants= / on-failure cannot respawn idle
-      # while nested needs exclusive gamescope-0 (portal is hard-wired).
-      systemctl --user mask --runtime polaris-gamescope-idle.service 2>/dev/null || true
-      systemctl --user stop polaris-gamescope-idle.service 2>/dev/null || true
+      # Runtime-mask so polaris Wants= / portal-gamescope Wants= cannot respawn
+      # idle while nested needs exclusive gamescope-0 (portal is hard-wired).
+      # Use user.control — plain mask --runtime loses to Hjem ~/.config units.
+      polaris_mask_idle_unit_runtime
       # Stop only the exact marked owner of gamescope-0. Unknown sockets fail
       # closed instead of risking another user's compositor.
       if polaris_validate_marker "$marker"; then
@@ -378,7 +378,7 @@ case "${1:-}" in
           exit 1
         fi
         rm -f "$rt/polaris-gamescope-wsi-nested"
-        systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null || true
+        polaris_unmask_idle_unit_runtime
         systemctl --user start polaris-gamescope-idle.service || true
       elif ! systemctl --user is-active --quiet polaris-gamescope-idle.service 2>/dev/null; then
         systemctl --user start polaris-gamescope-idle.service || true
@@ -508,7 +508,7 @@ case "${1:-}" in
       # Ordered handoff: idle must own gamescope-0 before portal capture can
       # reconnect. Otherwise portal-gamescope hits "failed to connect to wayland
       # socket" (Response code 2) during the gap.
-      systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null || true
+      polaris_unmask_idle_unit_runtime
       systemctl --user reset-failed polaris-gamescope-idle.service 2>/dev/null || true
       systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true
       idle_ready=0

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -211,7 +211,7 @@ case "${1:-}" in
             exit 1
             ;;
         esac
-      elif [ -e "$rt/gamescope-0" ] || [ -e "$rt/gamescope-1" ]; then
+      elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
         echo "polaris-gamescope-session: refusing unowned gamescope socket cleanup" >&2
         exit 1
       fi
@@ -334,7 +334,7 @@ case "${1:-}" in
             echo "polaris-gamescope-session: nested owner did not stop" >&2
             exit 1
           }
-        elif [ -e "$rt/gamescope-0" ] || [ -e "$rt/gamescope-1" ]; then
+        elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
           echo "polaris-gamescope-session: refusing to clean unowned nested sockets" >&2
           exit 1
         fi
@@ -461,8 +461,8 @@ case "${1:-}" in
       if polaris_validate_marker "$marker" nested; then
         polaris_stop_marked_gamescope "$marker" nested "$rt" ||
           echo "polaris-gamescope-session: nested owner did not reach terminal state" >&2
-      elif [ -e "$rt/gamescope-0" ] || [ -e "$rt/gamescope-1" ]; then
-        echo "polaris-gamescope-session: leaving unowned gamescope sockets untouched" >&2
+      elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+        echo "polaris-gamescope-session: leaving live unowned gamescope sockets untouched" >&2
       fi
       rm -f "$rt/polaris-gamescope-wsi-nested"
       printf '0\n' >"$rt/polaris-gamescope-force"

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -283,10 +283,29 @@ case "${1:-}" in
         >"$steam_log" 2>&1 &
       nested_pid=$!
 
+      # Resolve the real headless gamescope PID. setsid/env/wrapProgram may leave
+      # $! as a short-lived parent; marker must pin the compositor generation.
+      resolve_nested_gamescope_pid() {
+        local root="$1" p
+        if polaris_headless_gamescope_pid "$root" 2>/dev/null; then
+          printf '%s\n' "$root"
+          return 0
+        fi
+        for p in $(pgrep -P "$root" 2>/dev/null || true); do
+          if polaris_headless_gamescope_pid "$p" 2>/dev/null; then
+            printf '%s\n' "$p"
+            return 0
+          fi
+        done
+        return 1
+      }
+
       nested_marked=0
-      for _ in $(seq 1 100); do
-        if polaris_write_marker_for_pid "$marker" "$nested_pid" nested; then
+      for _ in $(seq 1 150); do
+        gs_pid="$(resolve_nested_gamescope_pid "$nested_pid" 2>/dev/null || true)"
+        if [ -n "${gs_pid:-}" ] && polaris_write_marker_for_pid "$marker" "$gs_pid" nested; then
           nested_marked=1
+          nested_pid="$gs_pid"
           break
         fi
         kill -0 "$nested_pid" 2>/dev/null || break
@@ -319,11 +338,31 @@ case "${1:-}" in
         echo "polaris-gamescope-session: nested bound gamescope-1 (portal captures gamescope-0) — see $steam_log" >&2
         exit 1
       fi
-      # Do NOT systemctl-restart portal here: it races Steam's udev/controller
-      # hotplug (pad is created only after prep returns) and left the virtual
-      # Xbox pad unopened — no controller after 2026-07-27 deploy.
-      # Portal already tracks gamescope-0; capture rebinds on stream start.
-      sleep 2
+      # Rebind private portal backend to this gamescope generation. Without this,
+      # xdg-desktop-portal-gamescope keeps the prior (idle) wayland connection and
+      # Start fails with "gamescope stream not available: failed to connect to
+      # wayland socket" when the compositor was replaced under it.
+      # Restart only the gamescope impl — not the full portal frontend — so we
+      # avoid the udev/controller race that killing xdg-desktop-portal caused.
+      systemctl --user restart polaris-portal-gamescope.service 2>/dev/null || true
+      portal_bus="unix:path=$rt/polaris-portal/bus"
+      portal_ready=0
+      for _ in $(seq 1 80); do
+        if busctl --address="$portal_bus" --no-pager \
+            status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1; then
+          portal_ready=1
+          break
+        fi
+        sleep 0.1
+      done
+      if [ "$portal_ready" != 1 ]; then
+        echo "polaris-gamescope-session: portal-gamescope did not rebind after nested start" >&2
+        # Non-fatal: stream may still gamescopegrab the PW node.
+      else
+        echo "polaris-gamescope-session: portal-gamescope rebound to nested gamescope-0" >&2
+      fi
+      # Brief settle so Steam's first controller udev events land after portal is up.
+      sleep 1
       echo "polaris-gamescope-session: nested ${POLARIS_GAMESCOPE_BIN:-gamescope} ready; WSI logs → $steam_log and ~/.local/share/Steam/logs/console-linux.txt" >&2
       echo "polaris-gamescope-session: pass = 'Creating Gamescope surface' + 'hdr formats exposed: true'" >&2
     else
@@ -466,8 +505,35 @@ case "${1:-}" in
       fi
       rm -f "$rt/polaris-gamescope-wsi-nested"
       printf '0\n' >"$rt/polaris-gamescope-force"
+      # Ordered handoff: idle must own gamescope-0 before portal capture can
+      # reconnect. Otherwise portal-gamescope hits "failed to connect to wayland
+      # socket" (Response code 2) during the gap.
       systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null || true
+      systemctl --user reset-failed polaris-gamescope-idle.service 2>/dev/null || true
       systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true
+      idle_ready=0
+      for _ in $(seq 1 100); do
+        if polaris_validate_marker "$marker" idle &&
+           polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle; then
+          polaris_write_runtime_env "$marker" gamescope-0 idle "$rt" 2>/dev/null || true
+          idle_ready=1
+          break
+        fi
+        sleep 0.1
+      done
+      if [ "$idle_ready" != 1 ]; then
+        echo "polaris-gamescope-session: idle gamescope-0 not ready after nested stop" >&2
+      else
+        echo "polaris-gamescope-session: idle gamescope restored after nested stop" >&2
+      fi
+      # Rebind portal backend to idle generation for the next stream.
+      systemctl --user restart polaris-portal-gamescope.service 2>/dev/null || true
+      portal_bus="unix:path=$rt/polaris-portal/bus"
+      for _ in $(seq 1 50); do
+        busctl --address="$portal_bus" --no-pager \
+          status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1 && break
+        sleep 0.1
+      done
     elif [ -f "$rt/polaris-gamescope-force" ] && [ "$(tr -d '[:space:]' <"$rt/polaris-gamescope-force")" = "1" ]; then
       printf '0\n' >"$rt/polaris-gamescope-force"
       systemctl --user restart polaris-gamescope-idle.service || true

--- a/nix/modules/session-lib.nix
+++ b/nix/modules/session-lib.nix
@@ -77,8 +77,13 @@ let
 
   idleApp = pkgs.writeShellApplication {
     name = "polaris-gamescope-idle";
-    runtimeInputs = with pkgs; [
-      bash coreutils gnugrep gnused util-linux gamescope
+    runtimeInputs = [
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.util-linux
+      gamescope # cfg.packageGamescope (gamescope-polaris), not stock pkgs.gamescope
     ];
     text = ''
       export POLARIS_HDR_WIDTH="''${POLARIS_HDR_WIDTH:-${toString cfg.width}}"
@@ -93,16 +98,16 @@ let
 
   sessionBin = pkgs.writeShellApplication {
     name = "polaris-gamescope-session";
-    runtimeInputs = with pkgs; [
-      coreutils
-      gamescope
-      gnugrep
-      gnused
-      procps
-      pulseaudio
-      systemd
-      util-linux
-      wireplumber
+    runtimeInputs = [
+      pkgs.coreutils
+      gamescope # cfg.packageGamescope
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.procps
+      pkgs.pulseaudio
+      pkgs.systemd
+      pkgs.util-linux
+      pkgs.wireplumber
     ];
     text = ''
       export POLARIS_GAMESCOPE_BIN=${lib.getExe gamescope}
@@ -243,8 +248,10 @@ let
       serviceConfig = ''
         Type=simple
         ExecStart=${lib.getExe idleApp}
-        # on-abnormal: stop/mask for nested WSI must not look like a crash restart.
-        Restart=on-abnormal
+        # on-failure: gamescope ABRT ends the wrapper with exit 134; on-abnormal
+        # ignores that and leaves idle permanently failed (orphan sockets stick).
+        # Nested WSI uses runtime mask so stop/mask still will not respawn idle.
+        Restart=on-failure
         RestartSec=5s
         TimeoutStopSec=10s
         ${envToUnitLines baseEnvironment}
@@ -291,7 +298,9 @@ let
       serviceConfig = ''
         Type=simple
         ExecStart=${portalFrontendExec}
-        Restart=on-failure
+        # always: frontend can be cleanly stopped while polaris stays up; stream
+        # needs org.freedesktop.portal.Desktop on the private bus.
+        Restart=always
         RestartSec=1s
         ${envToUnitLines portalEnvironment}
       '';

--- a/nix/modules/session-lib.nix
+++ b/nix/modules/session-lib.nix
@@ -162,7 +162,7 @@ let
       fi
       rm -f "$rt/polaris-gamescope-wsi-nested" "$rt/polaris-gamescope-appid" \
         "$rt/polaris-gamescope-audio-sink" || true
-      ${pkgs.systemd}/bin/systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null || true
+      polaris_unmask_idle_unit_runtime
       if [ ! -S "$rt/gamescope-0" ]; then
         ${pkgs.systemd}/bin/systemctl --user restart polaris-gamescope-idle.service 2>/dev/null \
           || ${pkgs.systemd}/bin/systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true
@@ -250,7 +250,8 @@ let
         ExecStart=${lib.getExe idleApp}
         # on-failure: gamescope ABRT ends the wrapper with exit 134; on-abnormal
         # ignores that and leaves idle permanently failed (orphan sockets stick).
-        # Nested WSI uses runtime mask so stop/mask still will not respawn idle.
+        # Nested WSI masks via user.control (not plain mask --runtime) so
+        # portal-gamescope Wants= cannot respawn idle under ~/.config units.
         Restart=on-failure
         RestartSec=5s
         TimeoutStopSec=10s

--- a/scripts/install/lib/polaris-gamescope-idle.sh
+++ b/scripts/install/lib/polaris-gamescope-idle.sh
@@ -45,16 +45,16 @@ if polaris_validate_marker "$marker"; then
     exit 1
   fi
 else
-  # Invalid marker metadata is safe to discard; unknown sockets are not.
+  # Invalid marker is safe to discard. Crash residue sockets are reclaimed only
+  # when no live process holds them; live unowned holders still fail closed.
   rm -f "$marker"
+  rm -f "$rt/polaris-gamescope.env"
 fi
 
-for socket in gamescope-0 gamescope-1; do
-  if [ -e "$rt/$socket" ]; then
-    echo "polaris-gamescope-idle: refusing destructive cleanup of unowned $rt/$socket" >&2
-    exit 1
-  fi
-done
+if ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+  echo "polaris-gamescope-idle: cannot start while live unowned gamescope sockets remain" >&2
+  exit 1
+fi
 
 prefer_vk=()
 if [ -n "${POLARIS_GAMESCOPE_PREFER_VK:-}" ]; then

--- a/scripts/install/lib/polaris-gamescope-idle.sh
+++ b/scripts/install/lib/polaris-gamescope-idle.sh
@@ -35,25 +35,42 @@ trap cleanup EXIT
 trap 'exit 143' TERM INT
 
 if polaris_validate_marker "$marker"; then
-  if [ "$POLARIS_MARKER_ROLE" = idle ]; then
-    polaris_stop_marked_gamescope "$marker" idle "$rt" || {
-      echo "polaris-gamescope-idle: existing idle owner did not stop" >&2
+  case "$POLARIS_MARKER_ROLE" in
+    idle)
+      polaris_stop_marked_gamescope "$marker" idle "$rt" || {
+        echo "polaris-gamescope-idle: existing idle owner did not stop" >&2
+        exit 1
+      }
+      ;;
+    nested|runtime)
+      # Nested WSI / owned spawn holds gamescope-0. Exit 0 so Restart=on-failure
+      # does not fight polaris-gamescope-session (mask can race with restart).
+      echo "polaris-gamescope-idle: yielding to active $POLARIS_MARKER_ROLE owner pid=$POLARIS_MARKER_PID" >&2
+      exit 0
+      ;;
+    *)
+      echo "polaris-gamescope-idle: refusing to replace active $POLARIS_MARKER_ROLE owner pid=$POLARIS_MARKER_PID" >&2
       exit 1
-    }
-  else
-    echo "polaris-gamescope-idle: refusing to replace active $POLARIS_MARKER_ROLE owner pid=$POLARIS_MARKER_PID" >&2
-    exit 1
-  fi
+      ;;
+  esac
 else
-  # Invalid marker is safe to discard. Crash residue sockets are reclaimed only
-  # when no live process holds them; live unowned holders still fail closed.
+  # No valid marker. If gamescope-0 is still live (nested race, or marker write
+  # lag), yield cleanly — do NOT delete someone else's state or restart-loop.
+  if [ -e "$rt/gamescope-0" ] || [ -S "$rt/gamescope-0" ]; then
+    if ! polaris_socket_is_orphan "$rt/gamescope-0"; then
+      echo "polaris-gamescope-idle: yielding to live gamescope-0 holder (not idle-owned)" >&2
+      exit 0
+    fi
+  fi
+  # Invalid marker + orphan sockets only: safe to discard and reclaim residue.
   rm -f "$marker"
   rm -f "$rt/polaris-gamescope.env"
 fi
 
 if ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
-  echo "polaris-gamescope-idle: cannot start while live unowned gamescope sockets remain" >&2
-  exit 1
+  # Live holder appeared between checks (nested start race): yield, don't loop.
+  echo "polaris-gamescope-idle: yielding; live gamescope sockets remain" >&2
+  exit 0
 fi
 
 prefer_vk=()

--- a/scripts/install/lib/polaris-wait-gamescope.sh
+++ b/scripts/install/lib/polaris-wait-gamescope.sh
@@ -41,7 +41,7 @@ if [ -f "$rt/polaris-gamescope-wsi-nested" ] || [ ! -S "$rt/gamescope-0" ]; then
   fi
   rm -f "$rt/polaris-gamescope-wsi-nested" "$rt/polaris-gamescope-appid" \
     "$rt/polaris-gamescope-audio-sink" || true
-  systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null || true
+  polaris_unmask_idle_unit_runtime
   if [ ! -S "$rt/gamescope-0" ] && [ "$marker_role" != runtime ]; then
     systemctl --user restart polaris-gamescope-idle.service 2>/dev/null \
       || systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true

--- a/scripts/install/lib/polaris-wait-gamescope.sh
+++ b/scripts/install/lib/polaris-wait-gamescope.sh
@@ -12,6 +12,19 @@ fi
 rt="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 marker="$rt/polaris-gamescope.pid"
 
+# Crash residue: a gamescope-0 path without a live holder looks "ready" to -S
+# but cannot accept clients. Reclaim orphans before treating the socket as up.
+if ! polaris_validate_marker "$marker"; then
+  rm -f "$marker"
+  if ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+    echo "polaris: live unowned gamescope sockets block startup" >&2
+    exit 1
+  fi
+elif ! polaris_marker_owns_socket "$marker" "$rt/gamescope-0" 2>/dev/null; then
+  # Valid marker but not holding gamescope-0 — still drop dead residue only.
+  polaris_reclaim_orphan_gamescope_sockets "$rt" || true
+fi
+
 # Nested stop can leave runtime-masked idle / no gamescope-0.
 if [ -f "$rt/polaris-gamescope-wsi-nested" ] || [ ! -S "$rt/gamescope-0" ]; then
   echo "polaris: recover idle gamescope-0 (nested leftover or missing socket)" >&2

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -266,6 +266,42 @@ namespace stream_runtime::gamescope_process {
       return false;
     }
 
+    std::optional<std::string> read_cgroup(const lookup_paths_t &paths, int pid) {
+      std::ifstream input(paths.proc_root / std::to_string(pid) / "cgroup");
+      std::string line;
+      std::string last;
+      while (std::getline(input, line)) {
+        if (!line.empty()) {
+          last = line;
+        }
+      }
+      if (last.empty()) {
+        return std::nullopt;
+      }
+      return last;
+    }
+
+    bool same_cgroup(const lookup_paths_t &paths, int a, int b) {
+      const auto ca = read_cgroup(paths, a);
+      const auto cb = read_cgroup(paths, b);
+      return ca && cb && *ca == *cb;
+    }
+
+    bool related_to_root(
+      int pid,
+      int root,
+      const std::map<int, process_t> &processes,
+      const lookup_paths_t &paths
+    ) {
+      if (pid == root) {
+        return true;
+      }
+      if (is_descendant_of(pid, root, processes)) {
+        return true;
+      }
+      return same_cgroup(paths, pid, root);
+    }
+
     std::optional<std::uint64_t> inode_for_path(
       const socket_inode_map_t &inodes,
       const fs::path &path
@@ -275,6 +311,39 @@ namespace stream_runtime::gamescope_process {
         return std::nullopt;
       }
       return *found->second;
+    }
+
+    // All inode numbers listed for pathname (including ambiguous multi-row sets).
+    std::vector<std::uint64_t> all_inodes_for_path(
+      const fs::path &proc_net_unix,
+      const fs::path &path
+    ) {
+      std::vector<std::uint64_t> out;
+      std::ifstream input(proc_net_unix);
+      std::string line;
+      std::getline(input, line);  // header
+      while (std::getline(input, line)) {
+        std::istringstream row(line);
+        std::string num;
+        std::string ref_count;
+        std::string protocol;
+        std::string flags;
+        std::string type;
+        std::string state;
+        std::string inode_text;
+        if (!(row >> num >> ref_count >> protocol >> flags >> type >> state >> inode_text)) {
+          continue;
+        }
+        std::string sock_path;
+        std::getline(row >> std::ws, sock_path);
+        if (sock_path != path.string()) {
+          continue;
+        }
+        if (const auto inode = parse_integer<std::uint64_t>(inode_text)) {
+          out.push_back(*inode);
+        }
+      }
+      return out;
     }
   }  // namespace
 
@@ -408,6 +477,51 @@ namespace stream_runtime::gamescope_process {
     return false;
   }
 
+  bool socket_has_live_holder(
+    const fs::path &socket_path,
+    const lookup_paths_t &paths
+  ) {
+    std::error_code ec;
+    if (!fs::exists(socket_path, ec) || ec) {
+      return false;
+    }
+    const auto inodes = read_unix_socket_inodes(paths.proc_net_unix);
+    const auto found = inodes.find(socket_path.string());
+    // No /proc/net/unix row → filesystem residue only.
+    if (found == inodes.end()) {
+      return false;
+    }
+    // Ambiguous duplicate pathname rows: treat as live so callers fail closed.
+    if (!found->second) {
+      return true;
+    }
+    const auto processes = read_processes(paths.proc_root);
+    for (const auto &[pid, process] : processes) {
+      (void) process;
+      if (process_holds_inode(paths, pid, *found->second)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool remove_orphan_socket(
+    const fs::path &socket_path,
+    const lookup_paths_t &paths
+  ) {
+    std::error_code ec;
+    if (!fs::exists(socket_path, ec) || ec) {
+      fs::remove(fs::path(socket_path.string() + ".lock"), ec);
+      return true;
+    }
+    if (socket_has_live_holder(socket_path, paths)) {
+      return false;
+    }
+    fs::remove(socket_path, ec);
+    fs::remove(fs::path(socket_path.string() + ".lock"), ec);
+    return !fs::exists(socket_path, ec);
+  }
+
   std::optional<std::string> discover_owned_x11_display(
     const marker_t &marker,
     const lookup_paths_t &paths
@@ -415,41 +529,41 @@ namespace stream_runtime::gamescope_process {
     if (!validate_process(marker, paths)) {
       return std::nullopt;
     }
-    const auto inodes = read_unix_socket_inodes(paths.proc_net_unix);
     const auto processes = read_processes(paths.proc_root);
-    std::vector<std::pair<int, std::uint64_t>> candidates;
-    for (const auto &[path, inode] : inodes) {
-      if (!inode) {
-        continue;
+    std::optional<int> best;
+
+    std::error_code ec;
+    for (const auto &entry : fs::directory_iterator(paths.x11_socket_dir, ec)) {
+      if (ec) {
+        break;
       }
-      const fs::path socket_path(path);
-      if (socket_path.parent_path() != paths.x11_socket_dir) {
-        continue;
-      }
-      const auto name = socket_path.filename().string();
+      const auto name = entry.path().filename().string();
       if (name.size() < 2 || name.front() != 'X') {
         continue;
       }
       const auto display = parse_integer<int>(std::string_view {name}.substr(1));
-      std::error_code ec;
-      if (display && *display >= 0 && fs::exists(socket_path, ec) && !ec) {
-        candidates.emplace_back(*display, *inode);
+      if (!display || *display < 0 || !entry.exists(ec)) {
+        continue;
+      }
+      // Include every inode row for this path so unlink/rebind residue does not
+      // hide a live Xwayland still related to the marker generation.
+      for (const auto inode : all_inodes_for_path(paths.proc_net_unix, entry.path())) {
+        for (const auto &[pid, process] : processes) {
+          if (pid == marker.pid || !executable_named(process, "Xwayland") ||
+              !related_to_root(pid, marker.pid, processes, paths) ||
+              !process_holds_inode(paths, pid, inode)) {
+            continue;
+          }
+          if (!best || *display < *best) {
+            best = *display;
+          }
+        }
       }
     }
-    std::sort(candidates.begin(), candidates.end());
-
-    for (const auto &[display, inode] : candidates) {
-      for (const auto &[pid, process] : processes) {
-        if (pid == marker.pid || !is_descendant_of(pid, marker.pid, processes) ||
-            !executable_named(process, "Xwayland")) {
-          continue;
-        }
-        if (process_holds_inode(paths, pid, inode)) {
-          return ":" + std::to_string(display);
-        }
-      }
+    if (!best) {
+      return std::nullopt;
     }
-    return std::nullopt;
+    return ":" + std::to_string(*best);
   }
 
 }  // namespace stream_runtime::gamescope_process

--- a/src/platform/linux/gamescope_process.h
+++ b/src/platform/linux/gamescope_process.h
@@ -64,6 +64,26 @@ namespace stream_runtime::gamescope_process {
     const lookup_paths_t &paths = {}
   );
 
+  /**
+   * True when any process holds the unique /proc/net/unix inode for socket_path.
+   * False when missing, filesystem-only residue, or no live holder.
+   * Ambiguous duplicate pathname rows fail closed as "live" (not safe to unlink).
+   */
+  bool socket_has_live_holder(
+    const std::filesystem::path &socket_path,
+    const lookup_paths_t &paths = {}
+  );
+
+  /**
+   * Unlink a crash-orphaned Wayland socket (and .lock) when no live holder exists.
+   * Returns true when the path is gone afterward; false if a live holder (or
+   * ambiguous pathname) still owns it.
+   */
+  bool remove_orphan_socket(
+    const std::filesystem::path &socket_path,
+    const lookup_paths_t &paths = {}
+  );
+
   /** Lowest numbered X socket held by an Xwayland descendant of marker.pid. */
   std::optional<std::string> discover_owned_x11_display(
     const marker_t &marker,

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -257,10 +257,27 @@ namespace portal {
   static bool ensure_session_unlocked() {
     if (!g_media.portal || !g_media.portal->ready || g_media.portal->pw_node_id == 0) {
       g_media.portal.reset();
-      g_media.portal = create_portal_session(capture_type_for_stream_display(
-        config::video.linux_display.headless_mode,
-        config::video.linux_display.use_cage_compositor,
-        config::video.linux_display.stream_mode));
+      auto try_create = []() {
+        return create_portal_session(capture_type_for_stream_display(
+          config::video.linux_display.headless_mode,
+          config::video.linux_display.use_cage_compositor,
+          config::video.linux_display.stream_mode));
+      };
+      g_media.portal = try_create();
+      // Nested↔idle gamescope handoff: portal-gamescope may briefly fail Start with
+      // "failed to connect to wayland socket" until the new generation owns
+      // gamescope-0. Retry a few times rather than fail the whole stream.
+      for (int attempt = 1;
+           attempt <= 4 &&
+           (!g_media.portal || g_media.portal->failed || !g_media.portal->ready ||
+            g_media.portal->pw_node_id == 0);
+           ++attempt) {
+        BOOST_LOG(warning) << "portal: create session attempt "sv << attempt
+                           << " failed; waiting for gamescope-0 before retry"sv;
+        g_media.portal.reset();
+        std::this_thread::sleep_for(std::chrono::milliseconds(400 * attempt));
+        g_media.portal = try_create();
+      }
       if (!g_media.portal || g_media.portal->failed || !g_media.portal->ready ||
           g_media.portal->pw_node_id == 0) {
         BOOST_LOG(warning) << "portal: Failed to create global session"sv;

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -701,6 +701,11 @@ namespace portal {
         // Bad/stale restore token often hangs Start with no Response; drop it so
         // the next connect can re-bootstrap with a visible picker.
         clear_restore_token();
+        // Nested↔idle gamescope handoff leaves a short window where
+        // xdg-desktop-portal-gamescope cannot open WAYLAND_DISPLAY=gamescope-0
+        // ("failed to connect to wayland socket" → Response code 2). One delayed
+        // retry on a *fresh* session is owned by the caller; here we only clear
+        // the token so the next CreateSession is clean.
         BOOST_LOG(warning) << "portal: Start timeout/failure — cleared restore_token (no Start retry; session is single-use)"sv;
         session->failed = true;
         return session;

--- a/src/platform/linux/session_manager.cpp
+++ b/src/platform/linux/session_manager.cpp
@@ -326,15 +326,28 @@ namespace session_manager {
     const bool private_headless_runtime =
       config::video.linux_display.headless_mode &&
       config::video.linux_display.use_cage_compositor;
+    // gamescope_stream / unit hosts intentionally unset host WAYLAND_DISPLAY so
+    // probes do not bind KWin; capture uses GAMESCOPE_WAYLAND_DISPLAY=gamescope-0.
+    const char *gamescope_wl = getenv("GAMESCOPE_WAYLAND_DISPLAY");
+    const bool gamescope_stream_host =
+      config::video.linux_display.stream_mode == "gamescope_stream" ||
+      (gamescope_wl && gamescope_wl[0] != '\0');
+    const bool wayland_optional = private_headless_runtime || gamescope_stream_host;
 
     const char *vars[] = {"WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "XDG_RUNTIME_DIR"};
     for (auto var : vars) {
       const char *val = getenv(var);
       if (!val || val[0] == '\0') {
-        if (std::string_view {var} == "WAYLAND_DISPLAY"sv && private_headless_runtime) {
-          BOOST_LOG(info) << "session_manager: WAYLAND_DISPLAY is not set; continuing because Private Stream "
-                          << "will start a private labwc socket. Desktop preview and portal capture may be "
-                          << "unavailable until Polaris is launched from a desktop session."sv;
+        if (std::string_view {var} == "WAYLAND_DISPLAY"sv && wayland_optional) {
+          if (gamescope_stream_host) {
+            BOOST_LOG(info) << "session_manager: WAYLAND_DISPLAY unset (expected for gamescope_stream); "
+                            << "using GAMESCOPE_WAYLAND_DISPLAY="sv
+                            << (gamescope_wl && gamescope_wl[0] ? gamescope_wl : "gamescope-0") << ""sv;
+          } else {
+            BOOST_LOG(info) << "session_manager: WAYLAND_DISPLAY is not set; continuing because Private Stream "
+                            << "will start a private labwc socket. Desktop preview and portal capture may be "
+                            << "unavailable until Polaris is launched from a desktop session."sv;
+          }
           continue;
         }
 
@@ -445,7 +458,9 @@ namespace session_manager {
       } catch (...) {}
     }
 
-    BOOST_LOG(warning) << "session_manager: Failed to inhibit lock screen via D-Bus"sv;
+    // D-Bus ScreenSaver is often missing under pure gamescope/headless user units;
+    // systemd-inhibit is the normal path there — do not warn as if streaming is broken.
+    BOOST_LOG(info) << "session_manager: ScreenSaver.Inhibit unavailable; using systemd-inhibit fallback"sv;
 
     // Fallback: use systemd-inhibit style via loginctl
     run("systemd-inhibit --what=idle:sleep --who=polaris "

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -126,16 +126,20 @@ namespace stream_runtime {
       bool start(const start_params_t &params) override {
         std::lock_guard lock(mu_);
         if (is_running_unlocked()) {
-          refresh_runtime_state(params);
-          if (!write_env_file()) {
-            return false;
+          // Crash/teardown can leave in-memory attach state while gamescope is dead.
+          // Re-validate exact generation + socket ownership before reuse.
+          if (revalidate_running_unlocked(params)) {
+            BOOST_LOG(info) << "gamescope_runtime: already "sv
+                            << (owned_ ? "owned"sv : "attached"sv)
+                            << " "sv << (socket_name_.empty() ? "gamescope-0" : socket_name_)
+                            << "; reusing"sv;
+            return true;
           }
-          BOOST_LOG(info) << "gamescope_runtime: already "sv
-                          << (owned_ ? "owned"sv : "attached"sv)
-                          << " "sv << (socket_name_.empty() ? "gamescope-0" : socket_name_)
-                          << "; reusing"sv;
-          return true;
+          BOOST_LOG(warning) << "gamescope_runtime: dropping stale in-memory gamescope state"sv;
+          clear_runtime_state_unlocked();
         }
+
+        ensure_portal_stack();
 
         // 1) Prefer attach to idle gamescope-0 (portal + polaris-gamescope.env contract).
         if (try_attach_gamescope0(params)) {
@@ -154,8 +158,14 @@ namespace stream_runtime {
 
         // 3) Spawn owned headless gamescope — only if gamescope-0 is still free.
         // Never attach/spawn onto gamescope-1 (portal is hard-wired to gamescope-0).
+        // Crash residue with no live holder is reclaimed; live unowned holders fail closed.
+        reclaim_orphan_gamescope_sockets();
         if (socket_exists("gamescope-0") && wait_for_stable_socket("gamescope-0", 1500)) {
-          return try_attach_gamescope0(params);
+          if (try_attach_gamescope0(params)) {
+            return true;
+          }
+          BOOST_LOG(error) << "gamescope_runtime: gamescope-0 exists but is not a validated owner; refusing destructive cleanup"sv;
+          return false;
         }
         if (socket_exists("gamescope-1") && !socket_exists("gamescope-0")) {
           BOOST_LOG(error) << "gamescope_runtime: gamescope-1 exists without a validated gamescope-0 owner; refusing destructive cleanup"sv;
@@ -499,6 +509,55 @@ namespace stream_runtime {
         (void) params;
       }
 
+      void clear_runtime_state_unlocked() {
+        marker_.reset();
+        owned_ = false;
+        pid_ = 0;
+        socket_name_.clear();
+        x11_display_.clear();
+        state_ = {};
+      }
+
+      bool revalidate_running_unlocked(const start_params_t &params) {
+        if (!marker_ || socket_name_.empty() || x11_display_.empty()) {
+          return false;
+        }
+        const auto current = validated_marker_for_socket(socket_name_, marker_->role);
+        if (!current || *current != *marker_) {
+          return false;
+        }
+        const auto display = gp::discover_owned_x11_display(*marker_);
+        if (!display || *display != x11_display_) {
+          return false;
+        }
+        refresh_runtime_state(params);
+        return write_env_file();
+      }
+
+      static void ensure_portal_stack() {
+        // Best-effort: private portal frontend can be TERM'd while polaris stays up.
+        // Idle recovery alone is not enough — CreateSession needs org.freedesktop.portal.Desktop.
+        (void) std::system(
+          "systemctl --user start polaris-portal-dbus.service "
+          "polaris-portal-gamescope.service polaris-portal.service 2>/dev/null"
+        );
+      }
+
+      // Best-effort: drop crash residue only. Live holders are left for attach / fail-closed.
+      static void reclaim_orphan_gamescope_sockets() {
+        const auto rt = fs::path(xdg_runtime_dir());
+        for (const char *name : {"gamescope-0", "gamescope-1", "gamescope-0-ei", "gamescope-1-ei"}) {
+          const auto path = rt / name;
+          std::error_code ec;
+          if (!fs::exists(path, ec) || ec) {
+            continue;
+          }
+          if (gp::remove_orphan_socket(path)) {
+            BOOST_LOG(info) << "gamescope_runtime: reclaimed orphan socket "sv << path.string();
+          }
+        }
+      }
+
       bool try_attach_gamescope0(const start_params_t &params) {
         if (!wait_for_stable_socket("gamescope-0", 2000)) {
           return false;
@@ -546,6 +605,7 @@ namespace stream_runtime {
       }
 
       static bool restart_or_start_idle_unit() {
+        ensure_portal_stack();
         const int rc = std::system(
           "systemctl --user restart polaris-gamescope-idle.service 2>/dev/null || "
           "systemctl --user start polaris-gamescope-idle.service 2>/dev/null");
@@ -554,6 +614,8 @@ namespace stream_runtime {
 
       bool try_start_idle_unit_and_attach(const start_params_t &params) {
         // Best-effort: host may ship polaris-gamescope-idle.service that owns gamescope-0.
+        // Clear crash residue so idle can bind gamescope-0 again.
+        reclaim_orphan_gamescope_sockets();
         const bool active =
           std::system("systemctl --user is-active --quiet polaris-gamescope-idle.service 2>/dev/null") == 0;
         const bool activating =

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -71,6 +71,7 @@
   #include "platform/linux/stream_runtime.h"
   #include "platform/linux/session_launch_linux.h"
   #include "platform/linux/display_topology.h"
+  #include "platform/linux/gamescope_process.h"
   #include "platform/linux/input/inputtino_gamepad_isolation.h"
   #include <dirent.h>
   #include <fcntl.h>
@@ -995,15 +996,83 @@ namespace proc {
       return false;
     }
 
+    // True when environ looks like a Polaris session / Steam / Proton game client
+    // rather than a host helper that merely inherited gamescope attach keys.
+    bool proc_environ_is_session_game_client(std::string_view environ) {
+      std::size_t start = 0;
+      while (start < environ.size()) {
+        const auto end = environ.find('\0', start);
+        if (end == std::string_view::npos) {
+          break;
+        }
+        const auto entry = environ.substr(start, end - start);
+        if (entry.starts_with("POLARIS_SESSION_INSTANCE_ID="sv) && entry.size() > 28) {
+          return true;
+        }
+        if (entry.starts_with("STEAM_COMPAT_APP_ID="sv) ||
+            entry.starts_with("SteamAppId="sv) ||
+            entry.starts_with("SteamGameId="sv) ||
+            entry.starts_with("STEAM_COMPAT_DATA_PATH="sv) ||
+            entry.starts_with("PRESSURE_VESSEL_"sv) ||
+            entry.starts_with("WINEPREFIX="sv) ||
+            entry.starts_with("PROTON_"sv)) {
+          return true;
+        }
+        start = end + 1;
+      }
+      return false;
+    }
+
+    bool is_steam_or_game_client_process(
+      std::string_view comm,
+      std::string_view cmdline,
+      std::string_view environ,
+      const std::string &steam_appid
+    ) {
+      if (proc_environ_is_session_game_client(environ)) {
+        return true;
+      }
+      if (!steam_appid.empty()) {
+        const std::string appid_marker = "AppId=" + steam_appid;
+        if (cmdline.find(appid_marker) != std::string_view::npos ||
+            cmdline.find("steam://rungameid/" + steam_appid) != std::string_view::npos ||
+            cmdline.find("rungameid/" + steam_appid) != std::string_view::npos) {
+          return true;
+        }
+      }
+      if (comm.find("steam") != std::string_view::npos ||
+          comm == "reaper" ||
+          comm.find("pressure-vessel") != std::string_view::npos ||
+          comm.find("proton") != std::string_view::npos ||
+          comm.find("wine") != std::string_view::npos ||
+          comm.find("wineserver") != std::string_view::npos) {
+        return true;
+      }
+      if (cmdline.find("SteamLaunch") != std::string_view::npos ||
+          cmdline.find("steam://rungameid/") != std::string_view::npos ||
+          cmdline.find("pressure-vessel") != std::string_view::npos ||
+          cmdline.find("/proton") != std::string_view::npos ||
+          cmdline.find("steam-runtime") != std::string_view::npos ||
+          cmdline.find("steamapps/common/") != std::string_view::npos ||
+          cmdline.find("steamapps\\common\\") != std::string_view::npos) {
+        return true;
+      }
+      return false;
+    }
+
     bool is_gamescope_infrastructure_process(std::string_view comm, std::string_view cmdline) {
       if (comm == "gamescope" || comm == "gamescope-wl" || comm == "gamescopereaper" ||
-          comm == "Xwayland" || comm == "Xwayland.bin") {
+          comm == ".gamescope-wrapped" || comm == "Xwayland" || comm == "Xwayland.bin") {
         return true;
       }
       if (comm.find("portal-gamescope") != std::string_view::npos) {
         return true;
       }
       if (cmdline.find("xdg-desktop-portal-gamescope") != std::string_view::npos) {
+        return true;
+      }
+      // Idle unit primary child: setsid gamescope … -- sleep infinity
+      if (comm == "sleep" && cmdline.find("infinity") != std::string_view::npos) {
         return true;
       }
       if (cmdline.find("gamescope --backend") != std::string_view::npos ||
@@ -1015,6 +1084,40 @@ namespace proc {
         }
       }
       return false;
+    }
+
+    // After attach-path client cleanup, gamescope may ABRT on X11 I/O when Steam
+    // disconnects. Idle must stay up for portal capture on the next session.
+    void ensure_idle_gamescope_alive_for_portal() {
+      namespace fs = std::filesystem;
+      namespace gp = stream_runtime::gamescope_process;
+
+      const char *xdg = std::getenv("XDG_RUNTIME_DIR");
+      const fs::path rt = (xdg && *xdg) ? fs::path(xdg) : fs::path("/run/user") / std::to_string(getuid());
+      const auto marker_path = rt / "polaris-gamescope.pid";
+      const auto socket_path = rt / "gamescope-0";
+
+      if (const auto marker = gp::validated_marker(marker_path)) {
+        if (marker->role == "nested" || marker->role == "runtime") {
+          // Owned session compositor — not the idle portal path.
+          return;
+        }
+        if (marker->role == "idle" && gp::process_tree_owns_socket(*marker, socket_path)) {
+          return;
+        }
+      }
+
+      BOOST_LOG(info) << "process: idle gamescope not healthy after session client cleanup; restarting unit"sv;
+      (void) std::system(
+        "systemctl --user start polaris-portal-dbus.service "
+        "polaris-portal-gamescope.service polaris-portal.service 2>/dev/null"
+      );
+      (void) std::system(
+        "systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null; "
+        "systemctl --user reset-failed polaris-gamescope-idle.service 2>/dev/null; "
+        "systemctl --user restart polaris-gamescope-idle.service 2>/dev/null || "
+        "systemctl --user start polaris-gamescope-idle.service 2>/dev/null"
+      );
     }
 
     struct pidfd_handle_t {
@@ -1900,9 +2003,13 @@ namespace proc {
     }
 
     /**
-     * Kill gamescope-attached clients (games reaper, game binary, leftover Steam)
-     * that pressure-vessel stripped of POLARIS_SESSION_INSTANCE_ID. Does not touch
-     * the gamescope compositor or desktop processes without gamescope attach env.
+     * Kill gamescope-attached Steam/game clients that pressure-vessel stripped of
+     * POLARIS_SESSION_INSTANCE_ID. Does not touch the idle gamescope compositor,
+     * Xwayland, reaper, or host helpers that only inherited attach env keys.
+     *
+     * Attach-env alone is not enough: hard-killing arbitrary X11 clients on the
+     * idle compositor causes gamescope xwm "X11 I/O error" ABRT and takes down
+     * the portal capture target.
      */
     bool terminate_gamescope_attached_session_clients(const std::string &steam_appid) {
       std::vector<pidfd_handle_t> targets;
@@ -1915,7 +2022,6 @@ namespace proc {
       });
 
       const auto this_pid = getpid();
-      const std::string appid_marker = steam_appid.empty() ? std::string {} : ("AppId=" + steam_appid);
 
       for (;;) {
         auto *entry = read_next_proc_entry(dir);
@@ -1954,14 +2060,21 @@ namespace proc {
         }
 
         const bool gamescope_attached = proc_environ_is_gamescope_stream_attached(environ_r.bytes);
+        const bool game_client = is_steam_or_game_client_process(
+          comm,
+          cmdline,
+          environ_r.bytes,
+          steam_appid
+        );
         const bool steam_launch_for_app =
-          !appid_marker.empty() && cmdline.find(appid_marker) != std::string::npos &&
+          game_client && !steam_appid.empty() &&
           (cmdline.find("SteamLaunch") != std::string::npos ||
            cmdline.find("steam://rungameid/") != std::string::npos ||
            cmdline.find("rungameid/") != std::string::npos);
 
-        // Gamescope-attached Steam/game, or reaper for this appid (may lose attach env).
-        if (!gamescope_attached && !steam_launch_for_app) {
+        // Require attach env + steam/game identity, or an explicit app launch line.
+        // Bare attach-env matches are too broad and can crash idle gamescope.
+        if (!(gamescope_attached && game_client) && !steam_launch_for_app) {
           continue;
         }
 
@@ -1970,17 +2083,23 @@ namespace proc {
         if (!handle) {
           continue;
         }
+        BOOST_LOG(debug) << "process: gamescope session client candidate pid="sv << pid
+                         << " comm="sv << comm;
         targets.emplace_back(std::move(*handle));
       }
 
       if (targets.empty()) {
         BOOST_LOG(info) << "process: no gamescope-attached session clients to terminate"sv;
+        ensure_idle_gamescope_alive_for_portal();
         return true;
       }
 
       BOOST_LOG(info) << "process: terminating "sv << targets.size()
                       << " gamescope-attached session client(s) (game/reaper/steam)"sv;
-      return terminate_pidfds(targets, 3s, 2s, "gamescope session client"sv);
+      const bool ok = terminate_pidfds(targets, 3s, 2s, "gamescope session client"sv);
+      // Steam disconnect often ABRTs idle gamescope (xwm X11 I/O). Restore portal target.
+      ensure_idle_gamescope_alive_for_portal();
+      return ok;
     }
 
     bool is_active_desktop_steam_client_process(
@@ -6432,7 +6551,8 @@ namespace proc {
 
     // Gamescope Steam/pressure-vessel often strips POLARIS_SESSION_INSTANCE_ID, so
     // exact-generation + session-owned Steam paths find nothing and webui close
-    // leaves the game running. Always sweep gamescope-attached clients by attach env.
+    // leaves the game running. Sweep attach-env Steam/game clients only (not bare
+    // infrastructure), then ensure idle gamescope survives for portal capture.
     if (_session_used_cage_compositor && !immediate) {
       const bool gamescope_session =
         config::video.linux_display.stream_mode == "gamescope_stream" ||

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1112,7 +1112,13 @@ namespace proc {
         "systemctl --user start polaris-portal-dbus.service "
         "polaris-portal-gamescope.service polaris-portal.service 2>/dev/null"
       );
+      // Hjem units live under ~/.config/systemd/user (higher priority than
+      // mask --runtime). Clear user.control mask so start can succeed.
       (void) std::system(
+        "rt=\"${XDG_RUNTIME_DIR:-/run/user/$(id -u)}\"; "
+        "rm -f \"$rt/systemd/user.control/polaris-gamescope-idle.service\" "
+        "\"$rt/systemd/user/polaris-gamescope-idle.service\"; "
+        "systemctl --user daemon-reload 2>/dev/null; "
         "systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null; "
         "systemctl --user reset-failed polaris-gamescope-idle.service 2>/dev/null; "
         "systemctl --user restart polaris-gamescope-idle.service 2>/dev/null || "

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -599,7 +599,13 @@ namespace rtsp_stream {
 
     void handle_accept(const boost::system::error_code &ec) {
       if (ec) {
-        BOOST_LOG(error) << "Couldn't accept incoming connections: "sv << ec.message();
+        // Service stop/restart cancels the acceptor — expected, not a fault.
+        if (ec == boost::asio::error::operation_aborted ||
+            ec == boost::system::errc::operation_canceled) {
+          BOOST_LOG(info) << "RTSP acceptor stopped: "sv << ec.message();
+        } else {
+          BOOST_LOG(error) << "Couldn't accept incoming connections: "sv << ec.message();
+        }
 
         // Stop server
         clear();

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -204,7 +204,12 @@ namespace system_tray {
   #endif
 
     if (tray_init(&tray) < 0) {
-      BOOST_LOG(warning) << "Failed to create system tray"sv;
+      // Headless / gamescope user services often have no tray host — not a fault.
+      static bool logged_once = false;
+      if (!logged_once) {
+        logged_once = true;
+        BOOST_LOG(info) << "System tray unavailable (no tray host / headless session); continuing without it"sv;
+      }
       return 1;
     }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3385,9 +3385,20 @@ namespace video {
       // full SDR — bit_depth=8 alone still attaches Rec.2020+PQ metadata and the
       // client shows dark/red "HDR garbage" over SDR pixels.
       if (result && result->prefer_8bit_encode && colorspace_is_hdr(colorspace)) {
-        BOOST_LOG(warning)
-          << "Forcing SDR colorspace: capture path cannot produce 10-bit HDR frames "
-             "(host portal SHM/MemFd is 8-bit BGRx). Use gamescope_stream for real HDR."sv;
+        // Probe / host-portal SHM paths demote often; gamescope_stream still gets real
+        // 10-bit later via dmabuf — keep that path at info to avoid session spam.
+        const bool gamescope_stream =
+          config::video.linux_display.stream_mode == "gamescope_stream";
+        if (gamescope_stream) {
+          BOOST_LOG(info)
+            << "Forcing SDR colorspace for this encode device: capture path reported "
+               "8-bit-only frames (common during portal probe); gamescope_stream HDR "
+               "may still negotiate 10-bit on the live capture path."sv;
+        } else {
+          BOOST_LOG(warning)
+            << "Forcing SDR colorspace: capture path cannot produce 10-bit HDR frames "
+               "(host portal SHM/MemFd is 8-bit BGRx). Use gamescope_stream for real HDR."sv;
+        }
         colorspace = colorspace_from_client_config(config, /*hdr_metadata_available=*/false);
         colorspace.bit_depth = 8;
         if (auto pix8 = select_encoder_output_pix_fmt(encoder, config, colorspace)) {

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -228,8 +228,11 @@ TEST(GamescopeProcessOwnershipTests, FailsClosedOnDuplicateSocketPathRows) {
   const gp::marker_t marker {
     .pid = 410, .start_time = 9001, .role = "runtime", .executable = "/usr/bin/gamescope"
   };
+  // Pathname is ambiguous → cannot claim exclusive ownership of gamescope-0.
   EXPECT_FALSE(gp::process_tree_owns_socket(marker, gamescope_socket, paths_for(tree)));
-  EXPECT_FALSE(gp::discover_owned_x11_display(marker, paths_for(tree)).has_value());
+  // X11 discovery still finds related Xwayland across multi-row residue (the
+  // process holds a concrete inode; display routing must not go blind).
+  EXPECT_EQ(gp::discover_owned_x11_display(marker, paths_for(tree)), std::optional<std::string> {":4"});
   // Ambiguous pathnames are not safe to reclaim.
   EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
   EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -232,7 +232,7 @@ TEST(GamescopeProcessOwnershipTests, FailsClosedOnDuplicateSocketPathRows) {
   EXPECT_FALSE(gp::discover_owned_x11_display(marker, paths_for(tree)).has_value());
   // Ambiguous pathnames are not safe to reclaim.
   EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
-  EXPECT_FALSE(gp::remove_orphan_socket(gamecope_socket, paths_for(tree)));
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
   EXPECT_TRUE(fs::exists(gamescope_socket));
 }
 
@@ -242,9 +242,9 @@ TEST(GamescopeProcessOwnershipTests, ReclaimsFilesystemResidueWithoutListener) {
   std::ofstream(gamescope_socket).put('\n');
   tree.flush_unix_sockets();  // header only — no listener row
 
-  EXPECT_FALSE(gp::socket_has_live_holder(gamecope_socket, paths_for(tree)));
-  EXPECT_TRUE(gp::remove_orphan_socket(gamecope_socket, paths_for(tree)));
-  EXPECT_FALSE(fs::exists(gamecope_socket));
+  EXPECT_FALSE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_FALSE(fs::exists(gamescope_socket));
 }
 
 TEST(GamescopeProcessOwnershipTests, ReclaimsDeadListenerWithoutHolder) {
@@ -254,9 +254,9 @@ TEST(GamescopeProcessOwnershipTests, ReclaimsDeadListenerWithoutHolder) {
   tree.flush_unix_sockets();
   // No process holds inode 700.
 
-  EXPECT_FALSE(gp::socket_has_live_holder(gamecope_socket, paths_for(tree)));
-  EXPECT_TRUE(gp::remove_orphan_socket(gamecope_socket, paths_for(tree)));
-  EXPECT_FALSE(fs::exists(gamecope_socket));
+  EXPECT_FALSE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_FALSE(fs::exists(gamescope_socket));
 }
 
 TEST(GamescopeProcessOwnershipTests, RefusesLiveUnownedSocketReclaim) {
@@ -266,8 +266,8 @@ TEST(GamescopeProcessOwnershipTests, RefusesLiveUnownedSocketReclaim) {
   tree.flush_unix_sockets();
   tree.add_process(440, 1, 9400, {"/usr/bin/gamescope", "--backend=headless"}, {701});
 
-  EXPECT_TRUE(gp::socket_has_live_holder(gamecope_socket, paths_for(tree)));
-  EXPECT_FALSE(gp::remove_orphan_socket(gamecope_socket, paths_for(tree)));
-  EXPECT_TRUE(fs::exists(gamecope_socket));
+  EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
 }
 #endif

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -230,5 +230,44 @@ TEST(GamescopeProcessOwnershipTests, FailsClosedOnDuplicateSocketPathRows) {
   };
   EXPECT_FALSE(gp::process_tree_owns_socket(marker, gamescope_socket, paths_for(tree)));
   EXPECT_FALSE(gp::discover_owned_x11_display(marker, paths_for(tree)).has_value());
+  // Ambiguous pathnames are not safe to reclaim.
+  EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
+  EXPECT_FALSE(gp::remove_orphan_socket(gamecope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
+}
+
+TEST(GamescopeProcessOwnershipTests, ReclaimsFilesystemResidueWithoutListener) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  std::ofstream(gamescope_socket).put('\n');
+  tree.flush_unix_sockets();  // header only — no listener row
+
+  EXPECT_FALSE(gp::socket_has_live_holder(gamecope_socket, paths_for(tree)));
+  EXPECT_TRUE(gp::remove_orphan_socket(gamecope_socket, paths_for(tree)));
+  EXPECT_FALSE(fs::exists(gamecope_socket));
+}
+
+TEST(GamescopeProcessOwnershipTests, ReclaimsDeadListenerWithoutHolder) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  tree.add_unix_socket(700, gamescope_socket);
+  tree.flush_unix_sockets();
+  // No process holds inode 700.
+
+  EXPECT_FALSE(gp::socket_has_live_holder(gamecope_socket, paths_for(tree)));
+  EXPECT_TRUE(gp::remove_orphan_socket(gamecope_socket, paths_for(tree)));
+  EXPECT_FALSE(fs::exists(gamecope_socket));
+}
+
+TEST(GamescopeProcessOwnershipTests, RefusesLiveUnownedSocketReclaim) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  tree.add_unix_socket(701, gamescope_socket);
+  tree.flush_unix_sockets();
+  tree.add_process(440, 1, 9400, {"/usr/bin/gamescope", "--backend=headless"}, {701});
+
+  EXPECT_TRUE(gp::socket_has_live_holder(gamecope_socket, paths_for(tree)));
+  EXPECT_FALSE(gp::remove_orphan_socket(gamecope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamecope_socket));
 }
 #endif

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -185,6 +185,51 @@ fi
 [ -e "$work/run/polaris-gamescope.env" ] || fail "missing marker allowed runtime env cleanup"
 [ -e "$work/run/gamescope-0" ] || fail "missing marker allowed socket cleanup"
 
+# Crash residue: filesystem socket with no /proc/net/unix listener is reclaimable.
+: >"$work/run/gamescope-0"
+: >"$work/run/gamescope-0.lock"
+: >"$work/run/gamescope-0-ei"
+write_unix_header
+polaris_socket_is_orphan "$work/run/gamescope-0" || fail "filesystem residue not treated as orphan"
+polaris_reclaim_orphan_gamescope_sockets "$work/run" || fail "orphan reclaim failed"
+[ ! -e "$work/run/gamescope-0" ] || fail "orphan gamescope-0 survived reclaim"
+[ ! -e "$work/run/gamescope-0-ei" ] || fail "orphan gamescope-0-ei survived reclaim"
+[ ! -e "$work/run/gamescope-0.lock" ] || fail "orphan lock survived reclaim"
+
+# Dead listener inode with no process holder is reclaimable.
+: >"$work/run/gamescope-0"
+write_unix_header
+printf '0000000000000000: 00000002 00000000 00010000 0001 01 901 %s\n' \
+  "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+polaris_socket_is_orphan "$work/run/gamescope-0" || fail "dead listener not treated as orphan"
+polaris_remove_orphan_socket "$work/run/gamescope-0" || fail "dead listener not removed"
+[ ! -e "$work/run/gamescope-0" ] || fail "dead listener socket survived"
+
+# Live unowned holder must fail closed (do not unlink).
+write_process 430 1 9300 /usr/bin/gamescope --backend headless
+: >"$work/run/gamescope-0"
+ln -s 'socket:[902]' "$POLARIS_PROC_ROOT/430/fd/3"
+write_unix_header
+printf '0000000000000000: 00000002 00000000 00010000 0001 01 902 %s\n' \
+  "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+if polaris_socket_is_orphan "$work/run/gamescope-0"; then
+  fail "live unowned holder treated as orphan"
+fi
+if polaris_reclaim_orphan_gamescope_sockets "$work/run"; then
+  fail "live unowned reclaim was allowed"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "live unowned socket was removed"
+
+# Ambiguous duplicate pathname rows fail closed.
+write_unix_header
+printf '0000000000000000: 00000002 00000000 00010000 0001 01 903 %s\n' \
+  "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+printf '0000000000000001: 00000002 00000000 00010000 0001 01 904 %s\n' \
+  "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+if polaris_socket_is_orphan "$work/run/gamescope-0"; then
+  fail "ambiguous socket pathname treated as orphan"
+fi
+
 # Production call sites must use exact markers, never process-name-wide pkill/pgrep.
 for source in \
   "$repo_root/src/platform/linux/stream_runtime_gamescope.cpp" \
@@ -202,6 +247,9 @@ grep -q 'polaris_stop_marked_gamescope' "$repo_root/nix/modules/polaris-gamescop
   fail "session lifecycle does not stop the marked generation"
 grep -q 'polaris_stop_marked_gamescope' "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh" ||
   fail "non-Nix readiness helper does not stop nested ownership exactly"
+grep -q 'polaris_reclaim_orphan_gamescope_sockets' \
+  "$repo_root/scripts/install/lib/polaris-gamescope-idle.sh" ||
+  fail "idle unit does not reclaim orphan gamescope sockets"
 if grep -Eq 'rm .*polaris-gamescope\.pid|rm -f .*polaris-gamescope\.pid' \
     "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh"; then
   fail "non-Nix readiness helper still removes ownership markers unconditionally"

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -254,5 +254,16 @@ if grep -Eq 'rm .*polaris-gamescope\.pid|rm -f .*polaris-gamescope\.pid' \
     "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh"; then
   fail "non-Nix readiness helper still removes ownership markers unconditionally"
 fi
+# Nested mask must use user.control (Hjem ~/.config units beat mask --runtime).
+grep -q 'polaris_mask_idle_unit_runtime' \
+  "$repo_root/nix/modules/polaris-gamescope-session.sh" ||
+  fail "nested session does not mask idle via polaris_mask_idle_unit_runtime"
+grep -q 'user.control' \
+  "$repo_root/nix/modules/polaris-gamescope-runtime-lib.sh" ||
+  fail "runtime lib mask helpers do not target user.control"
+if grep -E 'systemctl --user mask --runtime polaris-gamescope-idle' \
+    "$repo_root/nix/modules/polaris-gamescope-session.sh"; then
+  fail "session still uses ineffective mask --runtime for idle"
+fi
 
 printf 'PASS: gamescope shell ownership and display routing\n'


### PR DESCRIPTION
## Summary

Follow-up to the linux stream runtime ownership work. After gamescope ABRT / session teardown, fail-closed ownership left the portal stack stuck (orphan `gamescope-0`, idle failed permanently, dead attach targets).

- **Orphan reclaim**: remove gamescope sockets only when there is no live holder (still refuse live unowned / ambiguous paths). Wired into idle, session, wait-gamescope, and C++ spawn/attach.
- **Shellcheck**: fix `writeShellApplication` check-phase failures so idle/session packages build.
- **Idle unit**: `Restart=on-failure` (exit 134 after ABRT was ignored by `on-abnormal`); pin idle/session to `packageGamescope`.
- **Xwayland discovery**: same-cgroup match when Xwayland reparents under the user manager; tolerate multi-inode X paths.
- **Teardown survival**: only kill Steam/Proton/game-like clients (not bare attach-env matches); restart idle+portal if the idle generation is unhealthy after client cleanup.
- **Portal**: `Restart=always` on private frontend; best-effort start portal stack on stream start.

## Test plan

- [x] `tests/unit/platform/test_gamescope_runtime_shell.sh`
- [x] `writeShellApplication` build for polaris-gamescope-idle / session
- [x] C++ unit tests added for orphan reclaim / ambiguous pathname
- [ ] Deploy on lea; stream attach-path game; stop session; confirm idle stays/respawns and next stream captures without manual socket cleanup
- [ ] Nested WSI path still masks idle and does not fight restart policy

## Follow-ups (expected)

More issues likely under real stream/teardown pressure — keep this draft open and land extras on the same branch or stacked follow-ups (e.g. gentler X client teardown, C++ test coverage for process filters, deploy of rebuilt polaris-stream).