### PR TITLE
ci: bump GitHub Actions to latest Node 24 majors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ env.POLARIS_CHECKOUT_REF }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm
@@ -64,12 +64,12 @@ jobs:
       UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm
@@ -121,7 +121,7 @@ jobs:
       - name: Bootstrap Arch container
         run: pacman -Syu --noconfirm --needed archlinux-keyring git
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ env.POLARIS_CHECKOUT_REF }}
 
@@ -141,7 +141,7 @@ jobs:
           exit 1
 
       - name: Cache C++ compiler outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /github/home/.cache/ccache
           key: polaris-arch-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'src/**/*', 'tests/**/*') }}
@@ -149,7 +149,7 @@ jobs:
             polaris-arch-ccache-
 
       - name: Cache npm downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /github/home/.npm
           key: polaris-arch-npm-${{ hashFiles('package-lock.json') }}
@@ -407,7 +407,7 @@ jobs:
       CCACHE_COMPILERCHECK: content
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ env.POLARIS_CHECKOUT_REF }}
 
@@ -426,13 +426,13 @@ jobs:
           exit 1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm
 
       - name: Cache C++ compiler outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ccache
           key: polaris-ubuntu-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'src/**/*', 'tests/**/*') }}
@@ -600,7 +600,7 @@ jobs:
           done
           exit 1
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ env.POLARIS_CHECKOUT_REF }}
 
@@ -619,7 +619,7 @@ jobs:
           exit 1
 
       - name: Cache C++ compiler outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /github/home/.cache/ccache
           key: polaris-fedora-${{ matrix.fedora }}-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'src/**/*', 'tests/**/*') }}
@@ -627,7 +627,7 @@ jobs:
             polaris-fedora-${{ matrix.fedora }}-ccache-
 
       - name: Cache npm downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /github/home/.npm
           key: polaris-fedora-${{ matrix.fedora }}-npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
             build-mode: none
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set up Node.js
         if: matrix.language == 'cpp' && steps.code-scanning.outputs.enabled == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm

--- a/.github/workflows/opensuse-build.yml
+++ b/.github/workflows/opensuse-build.yml
@@ -17,7 +17,7 @@ jobs:
           zypper --non-interactive install nodejs24 git tar gzip
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -93,7 +93,7 @@ jobs:
           find build -name '*.rpm' -exec cp {} dist/ \; || true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: polaris-opensuse-tumbleweed
           path: dist/

--- a/.github/workflows/public-hygiene.yml
+++ b/.github/workflows/public-hygiene.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check public repo surface
         run: bash scripts/check-public-surface.sh


### PR DESCRIPTION
## Summary

- Bump workflow actions to current majors that run on **Node.js 24**, clearing GitHub’s Node 20 deprecation spam.
- Pins: `checkout@v7`, `setup-node@v7`, `cache@v6`, `upload-artifact@v7`; leave `download-artifact@v8` and `codeql-action@v4` (already latest majors).
- Web UI `node-version` stays **22** (app runtime; separate from action runner).

## Test plan

- [ ] CI green on this PR (web checks + at least one Linux build job)
- [ ] Confirm Actions log no longer lists Node.js 20 deprecation for cache/checkout/upload