### PR TITLE
fix(linux): reclaim orphan gamescope and harden nested teardown

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Build sanitizer unit tests
         run: cmake --build build-sanitize --target test_polaris test_polaris_steam_shutdown -j"$(nproc)"
 
-      - name: Run sanitizer unit tests
-        run: ctest --test-dir build-sanitize/tests --output-on-failure -R '^(test_polaris|test_polaris_steam_shutdown)$'
+      - name: Run sanitizer and gamescope ownership tests
+        run: ctest --test-dir build-sanitize/tests --output-on-failure -R '^(test_polaris|test_polaris_steam_shutdown|polaris_gamescope_runtime_shell|polaris_gamescope_session_stop_shell)$'
 
   arch-build:
     name: Arch build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,10 +103,12 @@ jobs:
             -DCUDA_FAIL_ON_MISSING=OFF
 
       - name: Build sanitizer unit tests
-        run: cmake --build build-sanitize --target test_polaris test_polaris_steam_shutdown -j"$(nproc)"
+        run: cmake --build build-sanitize --target test_polaris test_polaris_config test_polaris_http test_polaris_steam_shutdown -j"$(nproc)"
 
       - name: Run sanitizer and gamescope ownership tests
-        run: ctest --test-dir build-sanitize/tests --output-on-failure -R '^(test_polaris|test_polaris_steam_shutdown|polaris_gamescope_runtime_shell|polaris_gamescope_session_stop_shell)$'
+        run: |
+          ctest --test-dir build-sanitize/tests --output-on-failure -R '^(test_polaris|test_polaris_http|test_polaris_steam_shutdown|polaris_gamescope_runtime_shell|polaris_gamescope_session_stop_shell)$'
+          build-sanitize/tests/test_polaris_config --gtest_filter='ProcessRuntimeConfigTests.GamescopeAttached*'
 
   arch-build:
     name: Arch build

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -100,7 +100,9 @@ in
       Service = {
         Type = "simple";
         ExecStart = session.portalFrontendExec;
-        Restart = "on-failure";
+        # always: frontend can be cleanly stopped while polaris stays up; stream
+        # needs org.freedesktop.portal.Desktop on the private bus.
+        Restart = "always";
         RestartSec = "1s";
         Environment = session.envToList session.portalEnvironment;
       };
@@ -118,17 +120,15 @@ in
           "polaris-portal-gamescope.service"
           "polaris-portal.service"
         ];
+        # Soft deps: nested↔idle restarts portal-gamescope; Requires would kill polaris.
+        # Hard dep: private bus only. ExecStartPre still waits for ScreenCast readiness.
         Wants = [
           "polaris-gamescope-idle.service"
           "polaris-portal-dbus.service"
           "polaris-portal-gamescope.service"
           "polaris-portal.service"
         ];
-        Requires = [
-          "polaris-portal-dbus.service"
-          "polaris-portal-gamescope.service"
-          "polaris-portal.service"
-        ];
+        Requires = [ "polaris-portal-dbus.service" ];
         PartOf = [ cfg.desktopUserTarget ];
       };
       Service = {

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -28,7 +28,10 @@ polaris_process_fields() {
 
 polaris_read_marker() {
   local marker="$1" extra executable_name
-  read -r POLARIS_MARKER_PID POLARIS_MARKER_START_TIME POLARIS_MARKER_ROLE POLARIS_MARKER_EXECUTABLE extra <"$marker" 2>/dev/null || return 1
+  # Check readability first — bash still prints "No such file" for <"$missing"
+  # even when the whole command redirects stderr.
+  [ -r "$marker" ] || return 1
+  read -r POLARIS_MARKER_PID POLARIS_MARKER_START_TIME POLARIS_MARKER_ROLE POLARIS_MARKER_EXECUTABLE extra <"$marker" || return 1
   [ -z "${extra:-}" ] || return 1
   case "$POLARIS_MARKER_PID:$POLARIS_MARKER_START_TIME" in
     *[!0-9:]*|0:*|:*|*:) return 1 ;;
@@ -48,7 +51,7 @@ polaris_read_marker() {
 }
 
 polaris_headless_gamescope_pid() {
-  local pid="$1" arg first=1 executable= backend=0 previous=
+  local pid="$1" arg first=1 executable="" backend=0 previous=""
   local exe_path exe_name
   exe_path="$(readlink "$(polaris_proc_root)/$pid/exe" 2>/dev/null)" || return 1
   exe_name="${exe_path##*/}"
@@ -94,11 +97,11 @@ polaris_process_has_argument() {
 }
 
 polaris_write_marker_for_pid() (
-  local marker="$1" pid="$2" role="$3" attempt tmp lock_bin="${POLARIS_FLOCK_BIN:-flock}"
+  local marker="$1" pid="$2" role="$3" tmp lock_bin="${POLARIS_FLOCK_BIN:-flock}"
   umask 077
   exec 9>>"${marker%/*}/polaris-gamescope.lock" || return 1
   "$lock_bin" -x 9 || return 1
-  for attempt in $(seq 1 100); do
+  for _ in $(seq 1 100); do
     if polaris_process_fields "$pid" && polaris_headless_gamescope_pid "$pid"; then
       local start_time="$POLARIS_PROCESS_START_TIME" executable_path="$POLARIS_GAMESCOPE_EXECUTABLE"
       if polaris_validate_marker "$marker"; then
@@ -130,8 +133,9 @@ polaris_pid_is_descendant() {
 }
 
 polaris_socket_inode() {
-  local wanted="$1" num ref protocol flags type state inode path rest found=""
-  while read -r num ref protocol flags type state inode path rest; do
+  local wanted="$1" inode path found=""
+  # /proc/net/unix columns: num ref protocol flags type state inode path …
+  while read -r _ _ _ _ _ _ inode path _; do
     [ "$path" = "$wanted" ] || continue
     case "$inode" in ''|*[!0-9]*) return 1 ;; esac
     # Duplicate pathname rows are ambiguous: an unlinked old listener may
@@ -172,6 +176,70 @@ polaris_marker_owns_socket() {
   polaris_process_tree_holds_inode "$POLARIS_MARKER_PID" "$inode"
 }
 
+polaris_any_process_holds_inode() {
+  local inode="$1" process pid
+  for process in "$(polaris_proc_root)"/[0-9]*; do
+    [ -d "$process" ] || continue
+    pid="${process##*/}"
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    if polaris_pid_holds_inode "$pid" "$inode"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# True (0) when $1 is missing or has no live holder — safe to unlink.
+# False (1) when a live process holds the socket or the pathname is ambiguous.
+polaris_socket_is_orphan() {
+  local socket="$1" inode path found="" count=0
+  [ -e "$socket" ] || return 0
+  while read -r _ _ _ _ _ _ inode path _; do
+    [ "$path" = "$socket" ] || continue
+    case "$inode" in ''|*[!0-9]*) continue ;; esac
+    count=$((count + 1))
+    found="$inode"
+  done <"$(polaris_proc_net_unix)" 2>/dev/null
+  # Duplicate pathname rows are ambiguous (unlink/rebind); refuse reclaim.
+  [ "$count" -le 1 ] || return 1
+  # Filesystem residue with no /proc/net/unix listener is safe to remove.
+  [ "$count" -eq 1 ] || return 0
+  if polaris_any_process_holds_inode "$found"; then
+    return 1
+  fi
+  return 0
+}
+
+# Remove one socket path if orphaned. 0 = missing/removed, 1 = live holder.
+polaris_remove_orphan_socket() {
+  local socket="$1"
+  if [ ! -e "$socket" ]; then
+    rm -f "$socket.lock" 2>/dev/null || true
+    return 0
+  fi
+  polaris_socket_is_orphan "$socket" || return 1
+  echo "polaris: reclaiming orphan socket $socket" >&2
+  rm -f "$socket" "$socket.lock" 2>/dev/null || true
+  return 0
+}
+
+# Reclaim dead gamescope-* residue after crash. Fails closed on live holders.
+polaris_reclaim_orphan_gamescope_sockets() {
+  local runtime_dir="$1" name socket
+  for name in gamescope-0 gamescope-1 gamescope-0-ei gamescope-1-ei; do
+    socket="$runtime_dir/$name"
+    if [ -e "$socket" ] || [ -S "$socket" ]; then
+      if ! polaris_remove_orphan_socket "$socket"; then
+        echo "polaris: refusing destructive cleanup of live unowned $socket" >&2
+        return 1
+      fi
+    else
+      rm -f "$socket.lock" 2>/dev/null || true
+    fi
+  done
+  return 0
+}
+
 polaris_xwayland_pid() {
   local pid="$1" executable exe_path
   exe_path="$(readlink "$(polaris_proc_root)/$pid/exe" 2>/dev/null)" || return 1
@@ -180,8 +248,24 @@ polaris_xwayland_pid() {
   [ "${executable##*/}" = Xwayland ]
 }
 
+# gamescope may reparent Xwayland under the user manager while keeping the
+# service cgroup; treat same-cgroup as related when ancestry is gone.
+polaris_pid_same_cgroup() {
+  local a="$1" b="$2" ca cb
+  ca="$(cat "$(polaris_proc_root)/$a/cgroup" 2>/dev/null)" || return 1
+  cb="$(cat "$(polaris_proc_root)/$b/cgroup" 2>/dev/null)" || return 1
+  [ -n "$ca" ] && [ "$ca" = "$cb" ]
+}
+
+polaris_pid_related_to_root() {
+  local pid="$1" root="$2"
+  [ "$pid" = "$root" ] && return 0
+  polaris_pid_is_descendant "$pid" "$root" && return 0
+  polaris_pid_same_cgroup "$pid" "$root"
+}
+
 polaris_discover_xwayland_display() {
-  local marker="$1" expected_role="${2:-}" xdir socket name display inode process pid best=
+  local marker="$1" expected_role="${2:-}" xdir socket name display inode path process pid best=
   polaris_validate_marker "$marker" "$expected_role" || return 1
   local root_pid="$POLARIS_MARKER_PID"
   xdir="$(polaris_x11_socket_dir)"
@@ -190,18 +274,24 @@ polaris_discover_xwayland_display() {
     name="${socket##*/}"
     display="${name#X}"
     case "$display" in ''|*[!0-9]*) continue ;; esac
-    inode="$(polaris_socket_inode "$socket")" || continue
-    for process in "$(polaris_proc_root)"/[0-9]*; do
-      [ -d "$process" ] || continue
-      pid="${process##*/}"
-      [ "$pid" != "$root_pid" ] || continue
-      if polaris_pid_is_descendant "$pid" "$root_pid" && polaris_xwayland_pid "$pid" \
-          && polaris_pid_holds_inode "$pid" "$inode"; then
-        if [ -z "$best" ] || [ "$display" -lt "$best" ]; then
-          best="$display"
+    # Walk every /proc/net/unix row for this path. Ambiguous unlink/rebind
+    # residue is ok if a related Xwayland still holds one of the inodes.
+    while read -r _ _ _ _ _ _ inode path _; do
+      [ "$path" = "$socket" ] || continue
+      case "$inode" in ''|*[!0-9]*) continue ;; esac
+      for process in "$(polaris_proc_root)"/[0-9]*; do
+        [ -d "$process" ] || continue
+        pid="${process##*/}"
+        case "$pid" in ''|*[!0-9]*) continue ;; esac
+        [ "$pid" != "$root_pid" ] || continue
+        if polaris_xwayland_pid "$pid" && polaris_pid_related_to_root "$pid" "$root_pid" \
+            && polaris_pid_holds_inode "$pid" "$inode"; then
+          if [ -z "$best" ] || [ "$display" -lt "$best" ]; then
+            best="$display"
+          fi
         fi
-      fi
-    done
+      done
+    done <"$(polaris_proc_net_unix)" 2>/dev/null
   done
   [ -n "$best" ] || return 1
   printf ':%s\n' "$best"
@@ -227,10 +317,30 @@ polaris_write_runtime_env() (
   mv -f "$tmp" "$runtime_dir/polaris-gamescope.env"
 )
 
+# Hjem units live under ~/.config/systemd/user (higher priority than
+# mask --runtime). Mask via $XDG_RUNTIME_DIR/systemd/user.control instead.
+polaris_mask_idle_unit_runtime() {
+  local unit="${1:-polaris-gamescope-idle.service}"
+  local rt="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+  mkdir -p "$rt/systemd/user.control"
+  ln -sfn /dev/null "$rt/systemd/user.control/$unit"
+  rm -f "$rt/systemd/user/$unit"
+  systemctl --user daemon-reload 2>/dev/null || true
+  systemctl --user stop "$unit" 2>/dev/null || true
+}
+
+polaris_unmask_idle_unit_runtime() {
+  local unit="${1:-polaris-gamescope-idle.service}"
+  local rt="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+  rm -f "$rt/systemd/user.control/$unit" "$rt/systemd/user/$unit"
+  systemctl --user daemon-reload 2>/dev/null || true
+  systemctl --user unmask --runtime "$unit" 2>/dev/null || true
+}
+
 polaris_stop_marked_gamescope() (
   local marker="$1" expected_role="$2" runtime_dir="$3" kill_bin="${POLARIS_KILL_BIN:-kill}"
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}"
-  local marker_line pid start_time executable_path socket inode entry current_inode attempt
+  local marker_line pid start_time executable_path socket inode entry current_inode
   local owned_sockets=() term_steps="${POLARIS_STOP_WAIT_STEPS:-30}" kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}"
   umask 077
   exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
@@ -252,7 +362,7 @@ polaris_stop_marked_gamescope() (
   polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
   [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
   "$kill_bin" -TERM "-$pid" 2>/dev/null || "$kill_bin" -TERM "$pid" 2>/dev/null || return 1
-  for attempt in $(seq 1 "$term_steps"); do
+  for _ in $(seq 1 "$term_steps"); do
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
     if ! polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
       break
@@ -262,7 +372,7 @@ polaris_stop_marked_gamescope() (
   if polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
     "$kill_bin" -KILL "-$pid" 2>/dev/null || "$kill_bin" -KILL "$pid" 2>/dev/null || return 1
-    for attempt in $(seq 1 "$kill_steps"); do
+    for _ in $(seq 1 "$kill_steps"); do
       [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
       polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || break
       sleep 0.1

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -232,7 +232,7 @@ polaris_wayland_lock_has_no_deleted_holder() {
 
 # Remove one socket path if orphaned. 0 = missing/removed, 1 = live holder.
 polaris_remove_orphan_socket() (
-  local socket="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}"
+  local socket="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}" socket_identity current_identity
   if [ ! -e "$socket" ]; then
     return 0
   fi
@@ -246,9 +246,13 @@ polaris_remove_orphan_socket() (
   polaris_wayland_lock_is_stable "$socket.lock" || return 1
   polaris_wayland_lock_has_no_deleted_holder "$socket.lock" || return 1
   [ -e "$socket" ] || return 0
+  [ ! -L "$socket" ] || return 1
+  socket_identity="$(stat -Lc '%d:%i:%f' "$socket" 2>/dev/null)" || return 1
   polaris_socket_is_orphan "$socket" || return 1
   polaris_wayland_lock_is_stable "$socket.lock" || return 1
   polaris_wayland_lock_has_no_deleted_holder "$socket.lock" || return 1
+  current_identity="$(stat -Lc '%d:%i:%f' "$socket" 2>/dev/null)" || return 1
+  [ "$current_identity" = "$socket_identity" ] || return 1
   echo "polaris: reclaiming orphan socket $socket" >&2
   rm -f "$socket" 2>/dev/null || return 1
   [ ! -e "$socket" ] && [ ! -S "$socket" ] || return 1
@@ -389,10 +393,12 @@ polaris_unmask_idle_unit_runtime() {
 }
 
 polaris_private_group_alive() {
-  local pgid="$1" proc_root process pid found=1
+  local pgid="$1" proc_root process pid found=1 seen=0
   proc_root="$(polaris_proc_root)"
+  [ -d "$proc_root" ] && [ -r "$proc_root" ] && [ -x "$proc_root" ] || return 2
   for process in "$proc_root"/[0-9]*; do
     [ -d "$process" ] || continue
+    seen=1
     pid="${process##*/}"
     case "$pid" in ''|*[!0-9]*) continue ;; esac
     if ! polaris_process_fields "$pid"; then
@@ -403,6 +409,7 @@ polaris_private_group_alive() {
     [ "$POLARIS_PROCESS_SESSION_ID" = "$pgid" ] || return 2
     found=0
   done
+  [ "$seen" = 1 ] || return 2
   return "$found"
 }
 

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -176,45 +176,30 @@ polaris_marker_owns_socket() {
   polaris_process_tree_holds_inode "$POLARIS_MARKER_PID" "$inode"
 }
 
-polaris_any_process_holds_inode() {
-  local inode="$1" process pid
-  for process in "$(polaris_proc_root)"/[0-9]*; do
-    [ -d "$process" ] || continue
-    pid="${process##*/}"
-    case "$pid" in ''|*[!0-9]*) continue ;; esac
-    if polaris_pid_holds_inode "$pid" "$inode"; then
-      return 0
-    fi
-  done
-  return 1
-}
-
 # True (0) when $1 is missing or has no live holder — safe to unlink.
-# False (1) when a live process holds the socket or the pathname is ambiguous.
+# False (1) when a live process holds the socket, ownership metadata is
+# unavailable, or the pathname is ambiguous.
 polaris_socket_is_orphan() {
-  local socket="$1" inode path found="" count=0
+  local socket="$1" inode path count=0 proc_net_unix
   [ -e "$socket" ] || return 0
+  proc_net_unix="$(polaris_proc_net_unix)"
+  # Unknown ownership is not evidence of an orphan. Destructive reclaim must
+  # fail closed when the kernel socket table cannot be read.
+  [ -r "$proc_net_unix" ] || return 1
   while read -r _ _ _ _ _ _ inode path _; do
     [ "$path" = "$socket" ] || continue
     case "$inode" in ''|*[!0-9]*) continue ;; esac
     count=$((count + 1))
-    found="$inode"
-  done <"$(polaris_proc_net_unix)" 2>/dev/null
-  # Duplicate pathname rows are ambiguous (unlink/rebind); refuse reclaim.
-  [ "$count" -le 1 ] || return 1
-  # Filesystem residue with no /proc/net/unix listener is safe to remove.
-  [ "$count" -eq 1 ] || return 0
-  if polaris_any_process_holds_inode "$found"; then
-    return 1
-  fi
-  return 0
+  done <"$proc_net_unix"
+  # Any kernel row means the socket is still referenced. Its fd holder may be
+  # hidden by procfs permissions, so only a path with no row is reclaimable.
+  [ "$count" -eq 0 ]
 }
 
 # Remove one socket path if orphaned. 0 = missing/removed, 1 = live holder.
 polaris_remove_orphan_socket() {
   local socket="$1"
   if [ ! -e "$socket" ]; then
-    rm -f "$socket.lock" 2>/dev/null || true
     return 0
   fi
   polaris_socket_is_orphan "$socket" || return 1

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -200,6 +200,34 @@ polaris_socket_is_orphan() {
   [ "$count" -eq 0 ]
 }
 
+polaris_wayland_lock_is_stable() {
+  local lock="$1" fd_identity path_identity
+  [ ! -L "$lock" ] || return 1
+  fd_identity="$(stat -Lc '%d:%i:%u' "/proc/$BASHPID/fd/8" 2>/dev/null)" || return 1
+  path_identity="$(stat -Lc '%d:%i:%u' "$lock" 2>/dev/null)" || return 1
+  [ "$fd_identity" = "$path_identity" ]
+}
+
+# Fail closed if an older producer still holds an unlinked lock inode with the
+# same pathname. An unlocked replacement lock cannot serialize with it.
+polaris_wayland_lock_has_no_deleted_holder() {
+  local lock="$1" owner proc_root process process_owner fd target
+  owner="$(stat -Lc '%u' "$lock" 2>/dev/null)" || return 1
+  proc_root="$(polaris_proc_root)"
+  for process in "$proc_root"/[0-9]*; do
+    [ -d "$process" ] || continue
+    process_owner="$(stat -Lc '%u' "$process" 2>/dev/null)" || return 1
+    [ "$process_owner" = "$owner" ] || continue
+    [ -d "$process/fd" ] || return 1
+    for fd in "$process"/fd/*; do
+      [ -e "$fd" ] || [ -L "$fd" ] || continue
+      target="$(readlink "$fd" 2>/dev/null)" || return 1
+      [ "$target" != "$lock (deleted)" ] || return 1
+    done
+  done
+  return 0
+}
+
 # Remove one socket path if orphaned. 0 = missing/removed, 1 = live holder.
 polaris_remove_orphan_socket() (
   local socket="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}"
@@ -209,10 +237,16 @@ polaris_remove_orphan_socket() (
   # Libwayland holds this lock across bind and display lifetime. Acquire it
   # non-blocking so reclaim cannot race a compositor between lock and bind.
   [ -f "$socket.lock" ] && [ ! -L "$socket.lock" ] || return 1
+  polaris_wayland_lock_has_no_deleted_holder "$socket.lock" || return 1
   exec 8<"$socket.lock" || return 1
+  polaris_wayland_lock_is_stable "$socket.lock" || return 1
   "$lock_bin" -n -x 8 || return 1
+  polaris_wayland_lock_is_stable "$socket.lock" || return 1
+  polaris_wayland_lock_has_no_deleted_holder "$socket.lock" || return 1
   [ -e "$socket" ] || return 0
   polaris_socket_is_orphan "$socket" || return 1
+  polaris_wayland_lock_is_stable "$socket.lock" || return 1
+  polaris_wayland_lock_has_no_deleted_holder "$socket.lock" || return 1
   echo "polaris: reclaiming orphan socket $socket" >&2
   rm -f "$socket" 2>/dev/null || return 1
   [ ! -e "$socket" ] && [ ! -S "$socket" ] || return 1

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -208,7 +208,8 @@ polaris_remove_orphan_socket() (
   fi
   # Libwayland holds this lock across bind and display lifetime. Acquire it
   # non-blocking so reclaim cannot race a compositor between lock and bind.
-  exec 8<"$socket.lock" 2>/dev/null || return 1
+  [ -f "$socket.lock" ] && [ ! -L "$socket.lock" ] || return 1
+  exec 8<"$socket.lock" || return 1
   "$lock_bin" -n -x 8 || return 1
   [ -e "$socket" ] || return 0
   polaris_socket_is_orphan "$socket" || return 1

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -234,7 +234,8 @@ polaris_wayland_lock_has_no_deleted_holder() {
 
 # Remove one socket path if orphaned. 0 = missing/removed, 1 = live holder.
 polaris_remove_orphan_socket() (
-  local socket="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}" socket_identity current_identity
+  local socket="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}" \
+    socket_identity current_identity pin_identity socket_pin
   if [ ! -e "$socket" ]; then
     return 0
   fi
@@ -249,12 +250,21 @@ polaris_remove_orphan_socket() (
   polaris_wayland_lock_has_no_deleted_holder "$socket.lock" || return 1
   [ -e "$socket" ] || return 0
   [ ! -L "$socket" ] || return 1
-  socket_identity="$(stat -Lc '%d:%i:%f' "$socket" 2>/dev/null)" || return 1
+  # Pin the original inode with a same-filesystem hard link. If the pathname is
+  # replaced during orphan validation, the original inode cannot be recycled
+  # into the replacement while this pin exists.
+  socket_pin="${socket}.polaris-pin.$$.$RANDOM"
+  [ ! -e "$socket_pin" ] && [ ! -L "$socket_pin" ] || return 1
+  ln -- "$socket" "$socket_pin" 2>/dev/null || return 1
+  trap 'rm -f -- "$socket_pin"' EXIT
+  socket_identity="$(stat -Lc '%d:%i:%f' "$socket_pin" 2>/dev/null)" || return 1
   polaris_socket_is_orphan "$socket" || return 1
   polaris_wayland_lock_is_stable "$socket.lock" || return 1
   polaris_wayland_lock_has_no_deleted_holder "$socket.lock" || return 1
   current_identity="$(stat -Lc '%d:%i:%f' "$socket" 2>/dev/null)" || return 1
-  [ "$current_identity" = "$socket_identity" ] || return 1
+  pin_identity="$(stat -Lc '%d:%i:%f' "$socket_pin" 2>/dev/null)" || return 1
+  [ "$pin_identity" = "$socket_identity" ] \
+    && [ "$current_identity" = "$socket_identity" ] || return 1
   echo "polaris: reclaiming orphan socket $socket" >&2
   rm -f "$socket" 2>/dev/null || return 1
   [ ! -e "$socket" ] && [ ! -S "$socket" ] || return 1

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -211,11 +211,13 @@ polaris_wayland_lock_is_stable() {
 # Fail closed if an older producer still holds an unlinked lock inode with the
 # same pathname. An unlocked replacement lock cannot serialize with it.
 polaris_wayland_lock_has_no_deleted_holder() {
-  local lock="$1" owner proc_root process process_owner fd target
+  local lock="$1" owner proc_root process process_owner fd target seen=0
   owner="$(stat -Lc '%u' "$lock" 2>/dev/null)" || return 1
   proc_root="$(polaris_proc_root)"
+  [ -d "$proc_root" ] && [ -r "$proc_root" ] && [ -x "$proc_root" ] || return 1
   for process in "$proc_root"/[0-9]*; do
     [ -d "$process" ] || continue
+    seen=1
     process_owner="$(stat -Lc '%u' "$process" 2>/dev/null)" || return 1
     [ "$process_owner" = "$owner" ] || continue
     [ -d "$process/fd" ] || return 1
@@ -225,7 +227,7 @@ polaris_wayland_lock_has_no_deleted_holder() {
       [ "$target" != "$lock (deleted)" ] || return 1
     done
   done
-  return 0
+  [ "$seen" = 1 ]
 }
 
 # Remove one socket path if orphaned. 0 = missing/removed, 1 = live holder.
@@ -286,9 +288,22 @@ polaris_pid_related_to_root() {
   [ "$pid" != "$root" ] && polaris_pid_is_descendant "$pid" "$root"
 }
 
+polaris_unique_unix_socket_inode() {
+  local wanted="$1" inode path count=0 selected=
+  [ -r "$(polaris_proc_net_unix)" ] || return 1
+  while read -r _ _ _ _ _ _ inode path _; do
+    [ "$path" = "$wanted" ] || continue
+    case "$inode" in ''|*[!0-9]*) return 1 ;; esac
+    count=$((count + 1))
+    selected="$inode"
+  done <"$(polaris_proc_net_unix)" || return 1
+  [ "$count" -eq 1 ] || return 1
+  printf '%s\n' "$selected"
+}
+
 polaris_discover_xwayland_display() {
-  local marker="$1" expected_role="${2:-}" xdir socket name display inode path process pid
-  local best= best_pid= best_start= best_inode= marker_line
+  local marker="$1" expected_role="${2:-}" xdir socket name display inode process pid final_inode
+  local best= best_pid= best_start= best_inode= best_socket= marker_line
   polaris_validate_marker "$marker" "$expected_role" || return 1
   local root_pid="$POLARIS_MARKER_PID" root_start="$POLARIS_MARKER_START_TIME" root_executable="$POLARIS_MARKER_EXECUTABLE"
   marker_line="$(<"$marker")"
@@ -298,28 +313,26 @@ polaris_discover_xwayland_display() {
     name="${socket##*/}"
     display="${name#X}"
     case "$display" in ''|*[!0-9]*) continue ;; esac
-    # Walk every /proc/net/unix row for this path. Ambiguous unlink/rebind
-    # residue is ok if a related Xwayland still holds one of the inodes.
-    while read -r _ _ _ _ _ _ inode path _; do
-      [ "$path" = "$socket" ] || continue
-      case "$inode" in ''|*[!0-9]*) continue ;; esac
-      for process in "$(polaris_proc_root)"/[0-9]*; do
-        [ -d "$process" ] || continue
-        pid="${process##*/}"
-        case "$pid" in ''|*[!0-9]*) continue ;; esac
-        [ "$pid" != "$root_pid" ] || continue
-        if polaris_xwayland_pid "$pid" && polaris_pid_related_to_root "$pid" "$root_pid" \
-            && polaris_pid_holds_inode "$pid" "$inode" \
-            && polaris_process_fields "$pid"; then
-          if [ -z "$best" ] || [ "$display" -lt "$best" ]; then
-            best="$display"
-            best_pid="$pid"
-            best_start="$POLARIS_PROCESS_START_TIME"
-            best_inode="$inode"
-          fi
+    # Duplicate pathname generations are ambiguous after unlink/rebind. The
+    # process may hold an old inode while clients route to an unrelated new one.
+    inode="$(polaris_unique_unix_socket_inode "$socket")" || continue
+    for process in "$(polaris_proc_root)"/[0-9]*; do
+      [ -d "$process" ] || continue
+      pid="${process##*/}"
+      case "$pid" in ''|*[!0-9]*) continue ;; esac
+      [ "$pid" != "$root_pid" ] || continue
+      if polaris_xwayland_pid "$pid" && polaris_pid_related_to_root "$pid" "$root_pid" \
+          && polaris_pid_holds_inode "$pid" "$inode" \
+          && polaris_process_fields "$pid"; then
+        if [ -z "$best" ] || [ "$display" -lt "$best" ]; then
+          best="$display"
+          best_pid="$pid"
+          best_start="$POLARIS_PROCESS_START_TIME"
+          best_inode="$inode"
+          best_socket="$socket"
         fi
-      done
-    done <"$(polaris_proc_net_unix)" 2>/dev/null
+      fi
+    done
   done
   [ -n "$best" ] || return 1
   # Revalidate both process generations and the exact socket ownership after
@@ -330,6 +343,8 @@ polaris_discover_xwayland_display() {
   polaris_xwayland_pid "$best_pid" \
     && polaris_pid_related_to_root "$best_pid" "$root_pid" \
     && polaris_pid_holds_inode "$best_pid" "$best_inode" || return 1
+  final_inode="$(polaris_unique_unix_socket_inode "$best_socket")" || return 1
+  [ "$final_inode" = "$best_inode" ] || return 1
   printf ':%s\n' "$best"
 }
 

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -103,8 +103,10 @@ polaris_process_has_argument() {
 polaris_write_marker_for_pid() (
   local marker="$1" pid="$2" role="$3" tmp lock_bin="${POLARIS_FLOCK_BIN:-flock}"
   umask 077
-  exec 9>>"${marker%/*}/polaris-gamescope.lock" || return 1
-  "$lock_bin" -x 9 || return 1
+  if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
+    exec 9>>"${marker%/*}/polaris-gamescope.lock" || return 1
+    "$lock_bin" -x 9 || return 1
+  fi
   for _ in $(seq 1 100); do
     if polaris_process_fields "$pid" && polaris_headless_gamescope_pid "$pid"; then
       local start_time="$POLARIS_PROCESS_START_TIME" executable_path="$POLARIS_GAMESCOPE_EXECUTABLE"
@@ -356,8 +358,10 @@ polaris_write_runtime_env() (
   local marker="$1" wayland="$2" expected_role="${3:-}" runtime_dir="$4" display tmp
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}" marker_line role
   umask 077
-  exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
-  "$lock_bin" -x 9 || return 1
+  if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
+    exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
+    "$lock_bin" -x 9 || return 1
+  fi
   polaris_validate_marker "$marker" "$expected_role" || return 1
   local pid="$POLARIS_MARKER_PID" start_time="$POLARIS_MARKER_START_TIME" executable_path="$POLARIS_MARKER_EXECUTABLE"
   role="$POLARIS_MARKER_ROLE"
@@ -419,8 +423,10 @@ polaris_stop_marked_gamescope() (
   local marker_line pid start_time executable_path pgid session_id socket inode entry current_inode
   local owned_sockets=() term_steps="${POLARIS_STOP_WAIT_STEPS:-30}" kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}"
   umask 077
-  exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
-  "$lock_bin" -x 9 || return 1
+  if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
+    exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
+    "$lock_bin" -x 9 || return 1
+  fi
   polaris_validate_marker "$marker" "$expected_role" || return 1
   marker_line="$(<"$marker")"
   pid="$POLARIS_MARKER_PID"

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -208,7 +208,7 @@ polaris_remove_orphan_socket() (
   fi
   # Libwayland holds this lock across bind and display lifetime. Acquire it
   # non-blocking so reclaim cannot race a compositor between lock and bind.
-  exec 8>>"$socket.lock" || return 1
+  exec 8<"$socket.lock" 2>/dev/null || return 1
   "$lock_bin" -n -x 8 || return 1
   [ -e "$socket" ] || return 0
   polaris_socket_is_orphan "$socket" || return 1

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -19,11 +19,15 @@ polaris_process_fields() {
   local fields=( $rest )
   [ "${#fields[@]}" -ge 20 ] || return 1
   POLARIS_PROCESS_PPID="${fields[1]}"
+  POLARIS_PROCESS_PGID="${fields[2]}"
+  POLARIS_PROCESS_SESSION_ID="${fields[3]}"
   POLARIS_PROCESS_START_TIME="${fields[19]}"
-  case "$POLARIS_PROCESS_PPID:$POLARIS_PROCESS_START_TIME" in
+  case "$POLARIS_PROCESS_PPID:$POLARIS_PROCESS_PGID:$POLARIS_PROCESS_SESSION_ID:$POLARIS_PROCESS_START_TIME" in
     *[!0-9:]*|:*|*:) return 1 ;;
   esac
-  [ "$POLARIS_PROCESS_START_TIME" != 0 ]
+  [ "$POLARIS_PROCESS_PGID" -gt 1 ] 2>/dev/null \
+    && [ "$POLARIS_PROCESS_SESSION_ID" -gt 1 ] 2>/dev/null \
+    && [ "$POLARIS_PROCESS_START_TIME" != 0 ]
 }
 
 polaris_read_marker() {
@@ -239,26 +243,20 @@ polaris_xwayland_pid() {
   [ "${executable##*/}" = Xwayland ]
 }
 
-# gamescope may reparent Xwayland under the user manager while keeping the
-# service cgroup; treat same-cgroup as related when ancestry is gone.
-polaris_pid_same_cgroup() {
-  local a="$1" b="$2" ca cb
-  ca="$(cat "$(polaris_proc_root)/$a/cgroup" 2>/dev/null)" || return 1
-  cb="$(cat "$(polaris_proc_root)/$b/cgroup" 2>/dev/null)" || return 1
-  [ -n "$ca" ] && [ "$ca" = "$cb" ]
-}
-
+# Xwayland ownership is exact-generation ancestry only. Service cgroups are
+# scheduling containers shared by old and new compositor generations and are
+# never authorization for DISPLAY routing.
 polaris_pid_related_to_root() {
   local pid="$1" root="$2"
-  [ "$pid" = "$root" ] && return 0
-  polaris_pid_is_descendant "$pid" "$root" && return 0
-  polaris_pid_same_cgroup "$pid" "$root"
+  [ "$pid" != "$root" ] && polaris_pid_is_descendant "$pid" "$root"
 }
 
 polaris_discover_xwayland_display() {
-  local marker="$1" expected_role="${2:-}" xdir socket name display inode path process pid best=
+  local marker="$1" expected_role="${2:-}" xdir socket name display inode path process pid
+  local best= best_pid= best_start= best_inode= marker_line
   polaris_validate_marker "$marker" "$expected_role" || return 1
-  local root_pid="$POLARIS_MARKER_PID"
+  local root_pid="$POLARIS_MARKER_PID" root_start="$POLARIS_MARKER_START_TIME" root_executable="$POLARIS_MARKER_EXECUTABLE"
+  marker_line="$(<"$marker")"
   xdir="$(polaris_x11_socket_dir)"
   for socket in "$xdir"/X*; do
     [ -e "$socket" ] || continue
@@ -276,15 +274,27 @@ polaris_discover_xwayland_display() {
         case "$pid" in ''|*[!0-9]*) continue ;; esac
         [ "$pid" != "$root_pid" ] || continue
         if polaris_xwayland_pid "$pid" && polaris_pid_related_to_root "$pid" "$root_pid" \
-            && polaris_pid_holds_inode "$pid" "$inode"; then
+            && polaris_pid_holds_inode "$pid" "$inode" \
+            && polaris_process_fields "$pid"; then
           if [ -z "$best" ] || [ "$display" -lt "$best" ]; then
             best="$display"
+            best_pid="$pid"
+            best_start="$POLARIS_PROCESS_START_TIME"
+            best_inode="$inode"
           fi
         fi
       done
     done <"$(polaris_proc_net_unix)" 2>/dev/null
   done
   [ -n "$best" ] || return 1
+  # Revalidate both process generations and the exact socket ownership after
+  # the scan. Numeric PIDs and procfs metadata are not stable authorizations.
+  polaris_validate_process_generation "$root_pid" "$root_start" "$root_executable" || return 1
+  [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
+  polaris_process_fields "$best_pid" && [ "$POLARIS_PROCESS_START_TIME" = "$best_start" ] || return 1
+  polaris_xwayland_pid "$best_pid" \
+    && polaris_pid_related_to_root "$best_pid" "$root_pid" \
+    && polaris_pid_holds_inode "$best_pid" "$best_inode" || return 1
   printf ':%s\n' "$best"
 }
 
@@ -331,7 +341,7 @@ polaris_unmask_idle_unit_runtime() {
 polaris_stop_marked_gamescope() (
   local marker="$1" expected_role="$2" runtime_dir="$3" kill_bin="${POLARIS_KILL_BIN:-kill}"
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}"
-  local marker_line pid start_time executable_path socket inode entry current_inode
+  local marker_line pid start_time executable_path pgid session_id socket inode entry current_inode
   local owned_sockets=() term_steps="${POLARIS_STOP_WAIT_STEPS:-30}" kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}"
   umask 077
   exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
@@ -351,21 +361,35 @@ polaris_stop_marked_gamescope() (
   done
 
   polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
+  pgid="$POLARIS_PROCESS_PGID"
+  session_id="$POLARIS_PROCESS_SESSION_ID"
+  [ "$pgid" -gt 1 ] 2>/dev/null && [ "$session_id" = "$pgid" ] || return 1
   [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-  "$kill_bin" -TERM "-$pid" 2>/dev/null || "$kill_bin" -TERM "$pid" 2>/dev/null || return 1
+  polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
+  [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
+    && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
+  "$kill_bin" -TERM "-$pgid" 2>/dev/null || return 1
   for _ in $(seq 1 "$term_steps"); do
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
     if ! polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
       break
     fi
+    [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
+      && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
     sleep 0.1
   done
   if polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
+    [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
+      && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-    "$kill_bin" -KILL "-$pid" 2>/dev/null || "$kill_bin" -KILL "$pid" 2>/dev/null || return 1
+    "$kill_bin" -KILL "-$pgid" 2>/dev/null || return 1
     for _ in $(seq 1 "$kill_steps"); do
       [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-      polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || break
+      if ! polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
+        break
+      fi
+      [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
+        && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
       sleep 0.1
     done
   fi
@@ -388,7 +412,7 @@ polaris_stop_marked_gamescope() (
     current_inode="$(polaris_socket_inode "$socket" 2>/dev/null || true)"
     if [ -n "$current_inode" ] && [ "$current_inode" = "$inode" ]; then
       [ "$(<"$marker")" = "$marker_line" ] || return 1
-      rm -f "$socket" "$socket.lock"
+      polaris_remove_orphan_socket "$socket" || return 1
     fi
   done
   [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -373,6 +373,24 @@ polaris_unmask_idle_unit_runtime() {
   systemctl --user unmask --runtime "$unit" 2>/dev/null || true
 }
 
+polaris_private_group_alive() {
+  local pgid="$1" proc_root process pid found=1
+  proc_root="$(polaris_proc_root)"
+  for process in "$proc_root"/[0-9]*; do
+    [ -d "$process" ] || continue
+    pid="${process##*/}"
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    if ! polaris_process_fields "$pid"; then
+      [ ! -e "$process" ] && continue
+      return 2
+    fi
+    [ "$POLARIS_PROCESS_PGID" = "$pgid" ] || continue
+    [ "$POLARIS_PROCESS_SESSION_ID" = "$pgid" ] || return 2
+    found=0
+  done
+  return "$found"
+}
+
 polaris_stop_marked_gamescope() (
   local marker="$1" expected_role="$2" runtime_dir="$3" kill_bin="${POLARIS_KILL_BIN:-kill}"
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}"
@@ -404,31 +422,44 @@ polaris_stop_marked_gamescope() (
   [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
     && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
   "$kill_bin" -TERM "-$pgid" 2>/dev/null || return 1
+  group_rc=0
   for _ in $(seq 1 "$term_steps"); do
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-    if ! polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
+    if polaris_private_group_alive "$pgid"; then
+      sleep 0.1
+      continue
+    else
+      group_rc=$?
+      [ "$group_rc" -eq 1 ] || return 1
       break
     fi
-    [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
-      && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
-    sleep 0.1
   done
-  if polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
-    [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
-      && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
+  if polaris_private_group_alive "$pgid"; then
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
+    # The private session still has exact PGID/SID members even if its marked
+    # compositor exited after TERM. Escalate the whole surviving generation.
     "$kill_bin" -KILL "-$pgid" 2>/dev/null || return 1
     for _ in $(seq 1 "$kill_steps"); do
       [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-      if ! polaris_validate_process_generation "$pid" "$start_time" "$executable_path"; then
+      if polaris_private_group_alive "$pgid"; then
+        sleep 0.1
+        continue
+      else
+        group_rc=$?
+        [ "$group_rc" -eq 1 ] || return 1
         break
       fi
-      [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
-        && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
-      sleep 0.1
     done
+  else
+    group_rc=$?
+    [ "$group_rc" -eq 1 ] || return 1
   fi
-  polaris_validate_process_generation "$pid" "$start_time" "$executable_path" && return 1
+  if polaris_private_group_alive "$pgid"; then
+    return 1
+  else
+    group_rc=$?
+    [ "$group_rc" -eq 1 ] || return 1
+  fi
 
   # Runtime state belongs to the exact marker generation, not merely the PID.
   # Missing or changed authority fails closed and leaves env/socket state alone.

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -432,7 +432,7 @@ polaris_stop_marked_gamescope() (
   local marker="$1" expected_role="$2" runtime_dir="$3" kill_bin="${POLARIS_KILL_BIN:-kill}"
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}"
   local marker_line pid start_time executable_path pgid session_id group_leader_start group_leader_executable socket inode entry current_inode
-  local owned_sockets=() term_steps="${POLARIS_STOP_WAIT_STEPS:-30}" kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}"
+  local owned_sockets=() term_steps="${POLARIS_STOP_WAIT_STEPS:-30}" kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}" leader_stopped=0
   umask 077
   if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
     exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
@@ -466,6 +466,24 @@ polaris_stop_marked_gamescope() (
   polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
   [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
     && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
+  resume_group_leader_on_failure() {
+    [ "$leader_stopped" = 1 ] || return 0
+    if polaris_process_fields "$pgid" \
+        && [ "$POLARIS_PROCESS_START_TIME" = "$group_leader_start" ] \
+        && [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
+        && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] \
+        && [ "$(readlink -f "$(polaris_proc_root)/$pgid/exe" 2>/dev/null)" = "$group_leader_executable" ]; then
+      "$kill_bin" -CONT "$pgid" 2>/dev/null || true
+    fi
+  }
+  trap resume_group_leader_on_failure EXIT
+  "$kill_bin" -STOP "$pgid" 2>/dev/null || return 1
+  leader_stopped=1
+  polaris_process_fields "$pgid" || return 1
+  [ "$POLARIS_PROCESS_START_TIME" = "$group_leader_start" ] \
+    && [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
+    && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
+  [ "$(readlink -f "$(polaris_proc_root)/$pgid/exe" 2>/dev/null)" = "$group_leader_executable" ] || return 1
   "$kill_bin" -TERM "-$pgid" 2>/dev/null || return 1
   group_rc=0
   for _ in $(seq 1 "$term_steps"); do

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -407,8 +407,8 @@ polaris_unmask_idle_unit_runtime() {
   systemctl --user unmask --runtime "$unit" 2>/dev/null || true
 }
 
-polaris_private_group_alive() {
-  local pgid="$1" proc_root process pid found=1 seen=0
+polaris_private_session_alive() {
+  local session_id="$1" proc_root process pid found=1 seen=0
   proc_root="$(polaris_proc_root)"
   [ -d "$proc_root" ] && [ -r "$proc_root" ] && [ -x "$proc_root" ] || return 2
   for process in "$proc_root"/[0-9]*; do
@@ -420,8 +420,9 @@ polaris_private_group_alive() {
       [ ! -e "$process" ] && continue
       return 2
     fi
-    [ "$POLARIS_PROCESS_PGID" = "$pgid" ] || continue
-    [ "$POLARIS_PROCESS_SESSION_ID" = "$pgid" ] || return 2
+    [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || continue
+    # Any live member of the authorized private session keeps teardown alive,
+    # including descendants that moved to a separate process group.
     found=0
   done
   [ "$seen" = 1 ] || return 2
@@ -488,7 +489,7 @@ polaris_stop_marked_gamescope() (
   group_rc=0
   for _ in $(seq 1 "$term_steps"); do
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-    if polaris_private_group_alive "$pgid"; then
+    if polaris_private_session_alive "$pgid"; then
       sleep 0.1
       continue
     else
@@ -497,7 +498,7 @@ polaris_stop_marked_gamescope() (
       break
     fi
   done
-  if polaris_private_group_alive "$pgid"; then
+  if polaris_private_session_alive "$pgid"; then
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
     # Keep the exact private-session leader allocation as an immutable PGID-reuse
     # barrier through the last negative-PGID operation. The marked compositor may
@@ -512,7 +513,7 @@ polaris_stop_marked_gamescope() (
     "$kill_bin" -KILL "-$pgid" 2>/dev/null || return 1
     for _ in $(seq 1 "$kill_steps"); do
       [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-      if polaris_private_group_alive "$pgid"; then
+      if polaris_private_session_alive "$pgid"; then
         sleep 0.1
         continue
       else
@@ -525,7 +526,7 @@ polaris_stop_marked_gamescope() (
     group_rc=$?
     [ "$group_rc" -eq 1 ] || return 1
   fi
-  if polaris_private_group_alive "$pgid"; then
+  if polaris_private_session_alive "$pgid"; then
     return 1
   else
     group_rc=$?

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -197,16 +197,24 @@ polaris_socket_is_orphan() {
 }
 
 # Remove one socket path if orphaned. 0 = missing/removed, 1 = live holder.
-polaris_remove_orphan_socket() {
-  local socket="$1"
+polaris_remove_orphan_socket() (
+  local socket="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}"
   if [ ! -e "$socket" ]; then
     return 0
   fi
+  # Libwayland holds this lock across bind and display lifetime. Acquire it
+  # non-blocking so reclaim cannot race a compositor between lock and bind.
+  exec 8>>"$socket.lock" || return 1
+  "$lock_bin" -n -x 8 || return 1
+  [ -e "$socket" ] || return 0
   polaris_socket_is_orphan "$socket" || return 1
   echo "polaris: reclaiming orphan socket $socket" >&2
-  rm -f "$socket" "$socket.lock" 2>/dev/null || true
+  rm -f "$socket" 2>/dev/null || return 1
+  [ ! -e "$socket" ] && [ ! -S "$socket" ] || return 1
+  # Never unlink the lock path: a process may hold its inode while another
+  # binder creates and acquires a replacement inode.
   return 0
-}
+)
 
 # Reclaim dead gamescope-* residue after crash. Fails closed on live holders.
 polaris_reclaim_orphan_gamescope_sockets() {
@@ -218,8 +226,6 @@ polaris_reclaim_orphan_gamescope_sockets() {
         echo "polaris: refusing destructive cleanup of live unowned $socket" >&2
         return 1
       fi
-    else
-      rm -f "$socket.lock" 2>/dev/null || true
     fi
   done
   return 0

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -355,9 +355,10 @@ polaris_discover_xwayland_display() {
 }
 
 polaris_write_runtime_env() (
-  local marker="$1" wayland="$2" expected_role="${3:-}" runtime_dir="$4" display tmp
+  local marker="$1" wayland="$2" expected_role="${3:-}" runtime_dir="$4" display final_display tmp
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}" marker_line role
   umask 077
+  trap 'rm -f "${tmp:-}"' EXIT
   if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
     exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
     "$lock_bin" -x 9 || return 1
@@ -373,6 +374,16 @@ polaris_write_runtime_env() (
   tmp="$runtime_dir/polaris-gamescope.env.tmp.$$"
   (umask 077; printf 'DISPLAY=%s\nWAYLAND_DISPLAY=%s\nGAMESCOPE_WAYLAND_DISPLAY=%s\nPOLARIS_GAMESCOPE_PID=%s\nPOLARIS_GAMESCOPE_START_TIME=%s\nPOLARIS_GAMESCOPE_ROLE=%s\nPOLARIS_GAMESCOPE_EXECUTABLE=%s\n' \
     "$display" "$wayland" "$wayland" "$pid" "$start_time" "$role" "$executable_path" >"$tmp") || return 1
+  if [ -n "${POLARIS_RUNTIME_ENV_BEFORE_COMMIT_HOOK:-}" ]; then
+    "${POLARIS_RUNTIME_ENV_BEFORE_COMMIT_HOOK}" || return 1
+  fi
+  # Joint publication boundary: neither selected pathname may have rebound
+  # while the other was being discovered or while the temporary file was built.
+  polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
+  [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
+  polaris_marker_owns_socket "$marker" "$runtime_dir/$wayland" "$expected_role" || return 1
+  final_display="$(polaris_discover_xwayland_display "$marker" "$expected_role")" || return 1
+  [ "$final_display" = "$display" ] || return 1
   mv -f "$tmp" "$runtime_dir/polaris-gamescope.env"
 )
 
@@ -420,7 +431,7 @@ polaris_private_group_alive() {
 polaris_stop_marked_gamescope() (
   local marker="$1" expected_role="$2" runtime_dir="$3" kill_bin="${POLARIS_KILL_BIN:-kill}"
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}"
-  local marker_line pid start_time executable_path pgid session_id socket inode entry current_inode
+  local marker_line pid start_time executable_path pgid session_id group_leader_start group_leader_executable socket inode entry current_inode
   local owned_sockets=() term_steps="${POLARIS_STOP_WAIT_STEPS:-30}" kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}"
   umask 077
   if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
@@ -445,6 +456,12 @@ polaris_stop_marked_gamescope() (
   pgid="$POLARIS_PROCESS_PGID"
   session_id="$POLARIS_PROCESS_SESSION_ID"
   [ "$pgid" -gt 1 ] 2>/dev/null && [ "$session_id" = "$pgid" ] || return 1
+  polaris_process_fields "$pgid" || return 1
+  [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
+    && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
+  group_leader_start="$POLARIS_PROCESS_START_TIME"
+  group_leader_executable="$(readlink -f "$(polaris_proc_root)/$pgid/exe" 2>/dev/null)" || return 1
+  [ -n "$group_leader_executable" ] || return 1
   [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
   polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
   [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
@@ -464,8 +481,16 @@ polaris_stop_marked_gamescope() (
   done
   if polaris_private_group_alive "$pgid"; then
     [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-    # The private session still has exact PGID/SID members even if its marked
-    # compositor exited after TERM. Escalate the whole surviving generation.
+    # Keep the exact private-session leader allocation as an immutable PGID-reuse
+    # barrier through the last negative-PGID operation. The marked compositor may
+    # be a launcher child and may exit after TERM; only the retained leader can
+    # authorize safe escalation.
+    polaris_process_fields "$pgid" || return 1
+    [ "$POLARIS_PROCESS_START_TIME" = "$group_leader_start" ] \
+      && [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
+      && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
+    [ "$(readlink -f "$(polaris_proc_root)/$pgid/exe" 2>/dev/null)" = "$group_leader_executable" ] || return 1
+    [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
     "$kill_bin" -KILL "-$pgid" 2>/dev/null || return 1
     for _ in $(seq 1 "$kill_steps"); do
       [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -149,15 +149,14 @@ case "${1:-}" in
       echo "polaris-gamescope-session: missing immutable session credential" >&2
       exit 1
     }
-    if [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
-      [ -s "$session_id_file" ] || {
-        echo "polaris-gamescope-session: nested recovery lacks its immutable session credential" >&2
-        exit 1
-      }
-      echo "polaris-gamescope-session: complete prior nested recovery before new launch" >&2
+    if [ -s "$session_id_file" ]; then
+      echo "polaris-gamescope-session: complete prior session recovery before new launch" >&2
       POLARIS_SESSION_INSTANCE_ID= "$0" stop || exit 1
       POLARIS_SESSION_INSTANCE_ID="$requested_session_id"
       export POLARIS_SESSION_INSTANCE_ID
+    elif [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
+      echo "polaris-gamescope-session: recovery claim lacks its immutable session credential" >&2
+      exit 1
     fi
     session_id_tmp="$session_id_file.tmp.$$"
     printf '%s\n' "$POLARIS_SESSION_INSTANCE_ID" >"$session_id_tmp"
@@ -616,8 +615,8 @@ case "${1:-}" in
               echo "polaris-gamescope-session: nested owner did not reach terminal state; retaining recovery claim" >&2
               exit 1
             fi
-          elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
-            echo "polaris-gamescope-session: live or unknown gamescope sockets block teardown; retaining recovery claim" >&2
+          else
+            echo "polaris-gamescope-session: nested launch lacks a valid exact marker; retaining recovery claim" >&2
             exit 1
           fi
           if ! kill_session_steam || ! session_steam_absent; then

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -192,10 +192,10 @@ case "${1:-}" in
     if [ "$want_wsi" = 1 ]; then
       # --- Nested WSI path (games as gamescope child) ---
       echo "polaris-gamescope-session: WSI nested mode — Steam is ${POLARIS_GAMESCOPE_BIN:-gamescope} primary child" >&2
-      # Runtime-mask so polaris Wants= / on-failure cannot respawn idle
-      # while nested needs exclusive gamescope-0 (portal is hard-wired).
-      systemctl --user mask --runtime polaris-gamescope-idle.service 2>/dev/null || true
-      systemctl --user stop polaris-gamescope-idle.service 2>/dev/null || true
+      # Runtime-mask so polaris Wants= / portal-gamescope Wants= cannot respawn
+      # idle while nested needs exclusive gamescope-0 (portal is hard-wired).
+      # Use user.control — plain mask --runtime loses to Hjem ~/.config units.
+      polaris_mask_idle_unit_runtime
       # Stop only the exact marked owner of gamescope-0. Unknown sockets fail
       # closed instead of risking another user's compositor.
       if polaris_validate_marker "$marker"; then
@@ -211,7 +211,7 @@ case "${1:-}" in
             exit 1
             ;;
         esac
-      elif [ -e "$rt/gamescope-0" ] || [ -e "$rt/gamescope-1" ]; then
+      elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
         echo "polaris-gamescope-session: refusing unowned gamescope socket cleanup" >&2
         exit 1
       fi
@@ -283,10 +283,29 @@ case "${1:-}" in
         >"$steam_log" 2>&1 &
       nested_pid=$!
 
+      # Resolve the real headless gamescope PID. setsid/env/wrapProgram may leave
+      # $! as a short-lived parent; marker must pin the compositor generation.
+      resolve_nested_gamescope_pid() {
+        local root="$1" p
+        if polaris_headless_gamescope_pid "$root" 2>/dev/null; then
+          printf '%s\n' "$root"
+          return 0
+        fi
+        for p in $(pgrep -P "$root" 2>/dev/null || true); do
+          if polaris_headless_gamescope_pid "$p" 2>/dev/null; then
+            printf '%s\n' "$p"
+            return 0
+          fi
+        done
+        return 1
+      }
+
       nested_marked=0
-      for _ in $(seq 1 100); do
-        if polaris_write_marker_for_pid "$marker" "$nested_pid" nested; then
+      for _ in $(seq 1 150); do
+        gs_pid="$(resolve_nested_gamescope_pid "$nested_pid" 2>/dev/null || true)"
+        if [ -n "${gs_pid:-}" ] && polaris_write_marker_for_pid "$marker" "$gs_pid" nested; then
           nested_marked=1
+          nested_pid="$gs_pid"
           break
         fi
         kill -0 "$nested_pid" 2>/dev/null || break
@@ -319,11 +338,32 @@ case "${1:-}" in
         echo "polaris-gamescope-session: nested bound gamescope-1 (portal captures gamescope-0) — see $steam_log" >&2
         exit 1
       fi
-      # Do NOT systemctl-restart portal here: it races Steam's udev/controller
-      # hotplug (pad is created only after prep returns) and left the virtual
-      # Xbox pad unopened — no controller after 2026-07-27 deploy.
-      # Portal already tracks gamescope-0; capture rebinds on stream start.
-      sleep 2
+      # Rebind private portal backend to this gamescope generation. Without this,
+      # xdg-desktop-portal-gamescope keeps the prior (idle) wayland connection and
+      # Start fails with "gamescope stream not available: failed to connect to
+      # wayland socket" when the compositor was replaced under it.
+      # Restart only the gamescope impl — not the full portal frontend — so we
+      # avoid the udev/controller race that killing xdg-desktop-portal caused.
+      # polaris must Wants= (not Requires=) this unit so rebind never cascade-stops it.
+      systemctl --user restart polaris-portal-gamescope.service 2>/dev/null || true
+      portal_bus="unix:path=$rt/polaris-portal/bus"
+      portal_ready=0
+      for _ in $(seq 1 80); do
+        if busctl --address="$portal_bus" --no-pager \
+            status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1; then
+          portal_ready=1
+          break
+        fi
+        sleep 0.1
+      done
+      if [ "$portal_ready" != 1 ]; then
+        echo "polaris-gamescope-session: portal-gamescope did not rebind after nested start" >&2
+        # Non-fatal: stream may still gamescopegrab the PW node.
+      else
+        echo "polaris-gamescope-session: portal-gamescope rebound to nested gamescope-0" >&2
+      fi
+      # Brief settle so Steam's first controller udev events land after portal is up.
+      sleep 1
       echo "polaris-gamescope-session: nested ${POLARIS_GAMESCOPE_BIN:-gamescope} ready; WSI logs → $steam_log and ~/.local/share/Steam/logs/console-linux.txt" >&2
       echo "polaris-gamescope-session: pass = 'Creating Gamescope surface' + 'hdr formats exposed: true'" >&2
     else
@@ -334,12 +374,12 @@ case "${1:-}" in
             echo "polaris-gamescope-session: nested owner did not stop" >&2
             exit 1
           }
-        elif [ -e "$rt/gamescope-0" ] || [ -e "$rt/gamescope-1" ]; then
+        elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
           echo "polaris-gamescope-session: refusing to clean unowned nested sockets" >&2
           exit 1
         fi
         rm -f "$rt/polaris-gamescope-wsi-nested"
-        systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null || true
+        polaris_unmask_idle_unit_runtime
         systemctl --user start polaris-gamescope-idle.service || true
       elif ! systemctl --user is-active --quiet polaris-gamescope-idle.service 2>/dev/null; then
         systemctl --user start polaris-gamescope-idle.service || true
@@ -461,13 +501,41 @@ case "${1:-}" in
       if polaris_validate_marker "$marker" nested; then
         polaris_stop_marked_gamescope "$marker" nested "$rt" ||
           echo "polaris-gamescope-session: nested owner did not reach terminal state" >&2
-      elif [ -e "$rt/gamescope-0" ] || [ -e "$rt/gamescope-1" ]; then
-        echo "polaris-gamescope-session: leaving unowned gamescope sockets untouched" >&2
+      elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+        echo "polaris-gamescope-session: leaving live unowned gamescope sockets untouched" >&2
       fi
       rm -f "$rt/polaris-gamescope-wsi-nested"
       printf '0\n' >"$rt/polaris-gamescope-force"
-      systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null || true
+      # Ordered handoff: idle must own gamescope-0 before portal capture can
+      # reconnect. Otherwise portal-gamescope hits "failed to connect to wayland
+      # socket" (Response code 2) during the gap.
+      polaris_unmask_idle_unit_runtime
+      systemctl --user reset-failed polaris-gamescope-idle.service 2>/dev/null || true
       systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true
+      idle_ready=0
+      for _ in $(seq 1 100); do
+        if polaris_validate_marker "$marker" idle &&
+           polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle; then
+          polaris_write_runtime_env "$marker" gamescope-0 idle "$rt" 2>/dev/null || true
+          idle_ready=1
+          break
+        fi
+        sleep 0.1
+      done
+      if [ "$idle_ready" != 1 ]; then
+        echo "polaris-gamescope-session: idle gamescope-0 not ready after nested stop" >&2
+      else
+        echo "polaris-gamescope-session: idle gamescope restored after nested stop" >&2
+      fi
+      # Rebind backend to idle generation. polaris must Wants= (not Requires=)
+      # this unit so the restart does not cascade-stop the stream host.
+      systemctl --user restart polaris-portal-gamescope.service 2>/dev/null || true
+      portal_bus="unix:path=$rt/polaris-portal/bus"
+      for _ in $(seq 1 50); do
+        busctl --address="$portal_bus" --no-pager \
+          status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1 && break
+        sleep 0.1
+      done
     elif [ -f "$rt/polaris-gamescope-force" ] && [ "$(tr -d '[:space:]' <"$rt/polaris-gamescope-force")" = "1" ]; then
       printf '0\n' >"$rt/polaris-gamescope-force"
       systemctl --user restart polaris-gamescope-idle.service || true

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -20,6 +20,7 @@ gs_refresh="${POLARIS_HDR_REFRESH:-120}"
 
 session_id_file="$rt/polaris-gamescope-session-id"
 session_mode_file="$rt/polaris-gamescope-session-mode"
+session_state_file="$rt/polaris-gamescope-session-state"
 
 publish_nested_claim() (
   local new_state="$1" expected_state="${2:-absent}"
@@ -40,24 +41,34 @@ publish_session_mode() (
   case "$mode" in attach|nested) ;; *) return 1 ;; esac
   exec 9>>"$rt/polaris-gamescope.lock" || return 1
   "$lock_bin" -x 9 || return 1
-  [ ! -e "$session_id_file" ] && [ ! -e "$session_mode_file" ] || return 1
-  local id_tmp="$session_id_file.tmp.$$"
-  printf '%s\n' "$POLARIS_SESSION_INSTANCE_ID" >"$id_tmp" || return 1
-  mv -f -- "$id_tmp" "$session_id_file" || return 1
-  tmp="$session_mode_file.tmp.$$"
-  printf '%s\n' "$mode" >"$tmp" || return 1
-  mv -f -- "$tmp" "$session_mode_file"
+  [ ! -e "$session_state_file" ] \
+    && [ ! -e "$session_id_file" ] \
+    && [ ! -e "$session_mode_file" ] || return 1
+  tmp="$session_state_file.tmp.$$"
+  trap 'rm -f -- "$tmp"' EXIT
+  printf '%s %s\n' "$POLARIS_SESSION_INSTANCE_ID" "$mode" >"$tmp" || return 1
+  if [ -n "${POLARIS_SESSION_STATE_BEFORE_COMMIT_HOOK:-}" ]; then
+    eval "$POLARIS_SESSION_STATE_BEFORE_COMMIT_HOOK" || return 1
+  fi
+  mv -f -- "$tmp" "$session_state_file"
 )
 
 recover_missing_nested_claim() (
-  local lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp
+  local lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp persisted persisted_mode extra
   exec 9>>"$rt/polaris-gamescope.lock" || return 1
   "$lock_bin" -x 9 || return 1
   [ ! -e "$rt/polaris-gamescope-wsi-nested" ] || return 0
-  [ -s "$session_id_file" ] \
-    && [ "$(tr -d '\r\n' <"$session_id_file")" = "$POLARIS_SESSION_INSTANCE_ID" ] \
-    && [ -f "$session_mode_file" ] \
-    && [ "$(tr -d '[:space:]' <"$session_mode_file")" = nested ] || return 1
+  if [ -f "$session_state_file" ]; then
+    read -r persisted persisted_mode extra <"$session_state_file" || return 1
+    [ -z "${extra:-}" ] \
+      && [ "$persisted" = "$POLARIS_SESSION_INSTANCE_ID" ] \
+      && [ "$persisted_mode" = nested ] || return 1
+  else
+    [ -s "$session_id_file" ] \
+      && [ "$(tr -d '\r\n' <"$session_id_file")" = "$POLARIS_SESSION_INSTANCE_ID" ] \
+      && [ -f "$session_mode_file" ] \
+      && [ "$(tr -d '[:space:]' <"$session_mode_file")" = nested ] || return 1
+  fi
   export POLARIS_GAMESCOPE_LOCK_HELD=1
   if ! polaris_validate_marker "$marker" idle \
       && ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
@@ -79,7 +90,21 @@ remove_nested_claim() (
 )
 
 load_session_instance_id() {
-  local persisted
+  local persisted persisted_mode extra
+  POLARIS_PERSISTED_SESSION_MODE=""
+  if [ -f "$session_state_file" ]; then
+    read -r persisted persisted_mode extra <"$session_state_file" || return 1
+    [ -z "${extra:-}" ] || return 1
+    case "$persisted_mode" in attach|nested) ;; *) return 1 ;; esac
+    [ -n "$persisted" ] || return 1
+    if [ -n "${POLARIS_SESSION_INSTANCE_ID:-}" ]; then
+      [ "$persisted" = "$POLARIS_SESSION_INSTANCE_ID" ] || return 1
+    else
+      export POLARIS_SESSION_INSTANCE_ID="$persisted"
+    fi
+    POLARIS_PERSISTED_SESSION_MODE="$persisted_mode"
+    return 0
+  fi
   if [ -n "${POLARIS_SESSION_INSTANCE_ID:-}" ]; then
     if [ -f "$session_id_file" ]; then
       persisted="$(tr -d '\n' <"$session_id_file")" || return 1
@@ -198,7 +223,7 @@ case "${1:-}" in
       echo "polaris-gamescope-session: missing immutable session credential" >&2
       exit 1
     }
-    if [ -s "$session_id_file" ]; then
+    if [ -e "$session_state_file" ] || [ -s "$session_id_file" ]; then
       echo "polaris-gamescope-session: complete prior session recovery before new launch" >&2
       POLARIS_SESSION_INSTANCE_ID= "$0" stop || exit 1
       POLARIS_SESSION_INSTANCE_ID="$requested_session_id"
@@ -668,11 +693,15 @@ case "${1:-}" in
       echo "polaris-gamescope-session: missing or mismatched session credential during stop" >&2
       exit 1
     }
-    [ -f "$session_mode_file" ] || {
-      echo "polaris-gamescope-session: durable session mode missing; retaining credential" >&2
-      exit 1
-    }
-    session_mode="$(tr -d '[:space:]' <"$session_mode_file")"
+    if [ -n "${POLARIS_PERSISTED_SESSION_MODE:-}" ]; then
+      session_mode="$POLARIS_PERSISTED_SESSION_MODE"
+    else
+      [ -f "$session_mode_file" ] || {
+        echo "polaris-gamescope-session: durable session mode missing; retaining credential" >&2
+        exit 1
+      }
+      session_mode="$(tr -d '[:space:]' <"$session_mode_file")"
+    fi
     case "$session_mode" in attach|nested) ;; *)
       echo "polaris-gamescope-session: invalid durable session mode; retaining credential" >&2
       exit 1
@@ -824,7 +853,7 @@ case "${1:-}" in
         systemctl --user restart polaris-gamescope-idle.service || true
       fi
     fi
-    rm -f "$session_mode_file" "$session_id_file"
+    rm -f "$session_state_file" "$session_mode_file" "$session_id_file"
     ;;
   *)
     echo "usage: polaris-gamescope-session start [steam_appid]|wait|stop" >&2

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -19,6 +19,7 @@ gs_height="${POLARIS_HDR_HEIGHT:-2160}"
 gs_refresh="${POLARIS_HDR_REFRESH:-120}"
 
 session_id_file="$rt/polaris-gamescope-session-id"
+session_mode_file="$rt/polaris-gamescope-session-mode"
 
 publish_nested_claim() (
   local new_state="$1" expected_state="${2:-absent}"
@@ -32,6 +33,20 @@ publish_nested_claim() (
   tmp="$rt/.polaris-gamescope-wsi-nested.$$"
   printf '%s\n' "$new_state" >"$tmp" || return 1
   mv -f -- "$tmp" "$rt/polaris-gamescope-wsi-nested"
+)
+
+publish_session_mode() (
+  local mode="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp
+  case "$mode" in attach|nested) ;; *) return 1 ;; esac
+  exec 9>>"$rt/polaris-gamescope.lock" || return 1
+  "$lock_bin" -x 9 || return 1
+  [ ! -e "$session_id_file" ] && [ ! -e "$session_mode_file" ] || return 1
+  local id_tmp="$session_id_file.tmp.$$"
+  printf '%s\n' "$POLARIS_SESSION_INSTANCE_ID" >"$id_tmp" || return 1
+  mv -f -- "$id_tmp" "$session_id_file" || return 1
+  tmp="$session_mode_file.tmp.$$"
+  printf '%s\n' "$mode" >"$tmp" || return 1
+  mv -f -- "$tmp" "$session_mode_file"
 )
 
 remove_nested_claim() (
@@ -173,9 +188,6 @@ case "${1:-}" in
       echo "polaris-gamescope-session: recovery claim lacks its immutable session credential" >&2
       exit 1
     fi
-    session_id_tmp="$session_id_file.tmp.$$"
-    printf '%s\n' "$POLARIS_SESSION_INSTANCE_ID" >"$session_id_tmp"
-    mv -f "$session_id_tmp" "$session_id_file"
     # Soft env hint for nested games (PULSE_SINK / PIPEWIRE_NODE).
     # Polaris itself picks the capture sink: EasyEffects when it is the
     # host default (FMOD target.object sticks there); otherwise virtual
@@ -258,6 +270,17 @@ case "${1:-}" in
     case "${POLARIS_GAMESCOPE_WSI:-1}" in
       false|FALSE|0|no|NO) want_wsi=0 ;;
     esac
+    if [ "$want_wsi" = 1 ]; then
+      publish_session_mode nested || {
+        echo "polaris-gamescope-session: could not publish durable nested recovery mode" >&2
+        exit 1
+      }
+    else
+      publish_session_mode attach || {
+        echo "polaris-gamescope-session: could not publish durable attach recovery mode" >&2
+        exit 1
+      }
+    fi
 
     # Nested WSI: gamescope --steam with Steam as primary child.
     # Plain "-silent -applaunch" creates a WSI surface but often no
@@ -623,6 +646,16 @@ case "${1:-}" in
       echo "polaris-gamescope-session: missing or mismatched session credential during stop" >&2
       exit 1
     }
+    [ -f "$session_mode_file" ] || {
+      echo "polaris-gamescope-session: durable session mode missing; retaining credential" >&2
+      exit 1
+    }
+    session_mode="$(tr -d '[:space:]' <"$session_mode_file")"
+    case "$session_mode" in attach|nested) ;; *)
+      echo "polaris-gamescope-session: invalid durable session mode; retaining credential" >&2
+      exit 1
+      ;;
+    esac
     rm -f "$rt/polaris-gamescope-appid" "$rt/polaris-gamescope-audio-sink" "$rt/polaris-gamescope-audio-skip-pin"
     # Keep null sinks loaded (permanent capture targets).
     rm -f "$rt/polaris-gamescope-sink-module"
@@ -630,6 +663,10 @@ case "${1:-}" in
     rm -f "$rt/polaris-gamescope-prev-default-sink" "$rt/polaris-gamescope-easyeffects-units"
     nested_claim="$rt/polaris-gamescope-wsi-nested"
     if [ -f "$nested_claim" ]; then
+      [ "$session_mode" = nested ] || {
+        echo "polaris-gamescope-session: nested claim conflicts with durable attach mode" >&2
+        exit 1
+      }
       claim_state="$(tr -d '[:space:]' <"$nested_claim")"
       case "$claim_state" in
         transition)
@@ -740,12 +777,26 @@ case "${1:-}" in
       rm -f -- "$nested_claim"
       "${POLARIS_FLOCK_BIN:-flock}" -u 8
       export POLARIS_GAMESCOPE_LOCK_HELD=0
-    elif [ -f "$rt/polaris-gamescope-force" ] && [ "$(tr -d '[:space:]' <"$rt/polaris-gamescope-force")" = "1" ]; then
-      kill_session_steam || exit 1
-      printf '0\n' >"$rt/polaris-gamescope-force"
-      systemctl --user restart polaris-gamescope-idle.service || true
+    else
+      [ "$session_mode" = attach ] || {
+        echo "polaris-gamescope-session: nested mode lost its recovery claim; retaining credential" >&2
+        exit 1
+      }
+      kill_session_steam || {
+        echo "polaris-gamescope-session: attach recovery could not terminate exact-session Steam" >&2
+        exit 1
+      }
+      session_steam_absent || {
+        echo "polaris-gamescope-session: attach generation still alive; retaining credential" >&2
+        exit 1
+      }
+      if [ -f "$rt/polaris-gamescope-force" ] \
+          && [ "$(tr -d '[:space:]' <"$rt/polaris-gamescope-force")" = "1" ]; then
+        printf '0\n' >"$rt/polaris-gamescope-force"
+        systemctl --user restart polaris-gamescope-idle.service || true
+      fi
     fi
-    rm -f "$session_id_file"
+    rm -f "$session_mode_file" "$session_id_file"
     ;;
   *)
     echo "usage: polaris-gamescope-session start [steam_appid]|wait|stop" >&2

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -49,6 +49,25 @@ publish_session_mode() (
   mv -f -- "$tmp" "$session_mode_file"
 )
 
+recover_missing_nested_claim() (
+  local lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp
+  exec 9>>"$rt/polaris-gamescope.lock" || return 1
+  "$lock_bin" -x 9 || return 1
+  [ ! -e "$rt/polaris-gamescope-wsi-nested" ] || return 0
+  [ -s "$session_id_file" ] \
+    && [ "$(tr -d '\r\n' <"$session_id_file")" = "$POLARIS_SESSION_INSTANCE_ID" ] \
+    && [ -f "$session_mode_file" ] \
+    && [ "$(tr -d '[:space:]' <"$session_mode_file")" = nested ] || return 1
+  export POLARIS_GAMESCOPE_LOCK_HELD=1
+  if ! polaris_validate_marker "$marker" idle \
+      && ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+    return 1
+  fi
+  tmp="$rt/.polaris-gamescope-wsi-nested.$$"
+  printf 'transition\n' >"$tmp" || return 1
+  mv -f -- "$tmp" "$rt/polaris-gamescope-wsi-nested"
+)
+
 remove_nested_claim() (
   local expected_state="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}" current_state
   exec 9>>"$rt/polaris-gamescope.lock" || return 1
@@ -665,6 +684,12 @@ case "${1:-}" in
     # Legacy flags from builds that killed EasyEffects / hijacked default.
     rm -f "$rt/polaris-gamescope-prev-default-sink" "$rt/polaris-gamescope-easyeffects-units"
     nested_claim="$rt/polaris-gamescope-wsi-nested"
+    if [ "$session_mode" = nested ] && [ ! -e "$nested_claim" ]; then
+      recover_missing_nested_claim || {
+        echo "polaris-gamescope-session: claimless nested credential is not provably pre-transition; retaining it" >&2
+        exit 1
+      }
+    fi
     if [ -f "$nested_claim" ]; then
       [ "$session_mode" = nested ] || {
         echo "polaris-gamescope-session: nested claim conflicts with durable attach mode" >&2

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -21,12 +21,27 @@ gs_refresh="${POLARIS_HDR_REFRESH:-120}"
 session_id_file="$rt/polaris-gamescope-session-id"
 
 publish_nested_claim() (
-  local lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp
+  local new_state="$1" expected_state="${2:-absent}"
+  local lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp current_state=absent
   exec 9>>"$rt/polaris-gamescope.lock" || return 1
   "$lock_bin" -x 9 || return 1
+  if [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
+    current_state="$(tr -d '[:space:]' <"$rt/polaris-gamescope-wsi-nested")"
+  fi
+  [ "$current_state" = "$expected_state" ] || return 1
   tmp="$rt/.polaris-gamescope-wsi-nested.$$"
-  printf 'nested\n' >"$tmp" || return 1
+  printf '%s\n' "$new_state" >"$tmp" || return 1
   mv -f -- "$tmp" "$rt/polaris-gamescope-wsi-nested"
+)
+
+remove_nested_claim() (
+  local expected_state="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}" current_state
+  exec 9>>"$rt/polaris-gamescope.lock" || return 1
+  "$lock_bin" -x 9 || return 1
+  [ -f "$rt/polaris-gamescope-wsi-nested" ] || return 1
+  current_state="$(tr -d '[:space:]' <"$rt/polaris-gamescope-wsi-nested")"
+  [ "$current_state" = "$expected_state" ] || return 1
+  rm -f -- "$rt/polaris-gamescope-wsi-nested"
 )
 
 load_session_instance_id() {
@@ -278,6 +293,12 @@ case "${1:-}" in
     if [ "$want_wsi" = 1 ]; then
       # --- Nested WSI path (games as gamescope child) ---
       echo "polaris-gamescope-session: WSI nested mode — Steam is ${POLARIS_GAMESCOPE_BIN:-gamescope} primary child" >&2
+      # Publish a fenced transition before masking/stopping idle ownership so no
+      # readiness actor can interpret the destructive handoff as an unowned gap.
+      publish_nested_claim transition absent || {
+        echo "polaris-gamescope-session: another ownership transition is already active" >&2
+        exit 1
+      }
       # Runtime-mask so polaris Wants= / portal-gamescope Wants= cannot respawn
       # idle while nested needs exclusive gamescope-0 (portal is hard-wired).
       # Use user.control — plain mask --runtime loses to Hjem ~/.config units.
@@ -358,7 +379,10 @@ case "${1:-}" in
       echo "polaris-gamescope-session: nested geometry ${gs_width}x${gs_height}@${gs_refresh}" >&2
       # Claim ownership before launch so marker-capture failure remains
       # recoverable without an unsafe numeric PGID fallback.
-      publish_nested_claim
+      publish_nested_claim nested transition || {
+        echo "polaris-gamescope-session: ownership transition changed before nested launch" >&2
+        exit 1
+      }
       setsid env -u WAYLAND_DISPLAY -u DISPLAY -u ENABLE_HDR_WSI \
         "${child_env[@]}" "${POLARIS_GAMESCOPE_BIN:-gamescope}" \
         --backend headless \
@@ -608,6 +632,21 @@ case "${1:-}" in
     if [ -f "$nested_claim" ]; then
       claim_state="$(tr -d '[:space:]' <"$nested_claim")"
       case "$claim_state" in
+        transition)
+          if polaris_validate_marker "$marker" nested; then
+            echo "polaris-gamescope-session: transition claim unexpectedly owns a nested generation" >&2
+            exit 1
+          fi
+          if ! polaris_validate_marker "$marker" idle \
+              && ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+            echo "polaris-gamescope-session: transition recovery cannot prove idle-or-orphan ownership" >&2
+            exit 1
+          fi
+          publish_nested_claim restore-idle "$claim_state" || {
+            echo "polaris-gamescope-session: transition claim changed before idle restoration" >&2
+            exit 1
+          }
+          ;;
         1|nested)
           echo "polaris-gamescope-session: tearing down marked nested WSI gamescope" >&2
           if polaris_validate_marker "$marker" nested; then
@@ -623,9 +662,10 @@ case "${1:-}" in
             echo "polaris-gamescope-session: exact-session Steam did not reach terminal state; retaining recovery claim" >&2
             exit 1
           fi
-          claim_tmp="$nested_claim.tmp.$$"
-          printf 'restore-idle\n' >"$claim_tmp"
-          mv -f "$claim_tmp" "$nested_claim"
+          publish_nested_claim restore-idle "$claim_state" || {
+            echo "polaris-gamescope-session: transition claim changed before idle restoration" >&2
+            exit 1
+          }
           ;;
         restore-idle)
           ;;
@@ -659,6 +699,17 @@ case "${1:-}" in
         echo "polaris-gamescope-session: idle gamescope-0 not ready; retaining restore-idle claim" >&2
         exit 1
       fi
+      exec 8>>"$rt/polaris-gamescope.lock" || exit 1
+      "${POLARIS_FLOCK_BIN:-flock}" -x 8 || exit 1
+      export POLARIS_GAMESCOPE_LOCK_HELD=1
+      [ -f "$nested_claim" ] \
+        && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ] \
+        && polaris_validate_marker "$marker" idle \
+        && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
+        && polaris_write_runtime_env "$marker" gamescope-0 idle "$rt" || {
+          echo "polaris-gamescope-session: idle ownership changed before portal handoff" >&2
+          exit 1
+        }
       echo "polaris-gamescope-session: idle gamescope restored after nested stop" >&2
 
       if ! systemctl --user restart polaris-portal-gamescope.service 2>/dev/null; then
@@ -679,7 +730,16 @@ case "${1:-}" in
         echo "polaris-gamescope-session: portal did not bind idle generation; retaining restore-idle claim" >&2
         exit 1
       fi
-      rm -f "$nested_claim"
+      polaris_validate_marker "$marker" idle \
+        && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
+        && [ -f "$nested_claim" ] \
+        && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ] || {
+          echo "polaris-gamescope-session: ownership changed during portal readiness" >&2
+          exit 1
+        }
+      rm -f -- "$nested_claim"
+      "${POLARIS_FLOCK_BIN:-flock}" -u 8
+      export POLARIS_GAMESCOPE_LOCK_HELD=0
     elif [ -f "$rt/polaris-gamescope-force" ] && [ "$(tr -d '[:space:]' <"$rt/polaris-gamescope-force")" = "1" ]; then
       kill_session_steam || exit 1
       printf '0\n' >"$rt/polaris-gamescope-force"

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -18,23 +18,67 @@ gs_width="${POLARIS_HDR_WIDTH:-3840}"
 gs_height="${POLARIS_HDR_HEIGHT:-2160}"
 gs_refresh="${POLARIS_HDR_REFRESH:-120}"
 
+session_id_file="$rt/polaris-gamescope-session-id"
+
+load_session_instance_id() {
+  local persisted
+  if [ -n "${POLARIS_SESSION_INSTANCE_ID:-}" ]; then
+    if [ -f "$session_id_file" ]; then
+      persisted="$(tr -d '\n' <"$session_id_file")" || return 1
+      [ "$persisted" = "$POLARIS_SESSION_INSTANCE_ID" ] || return 1
+    fi
+    return 0
+  fi
+  [ -f "$session_id_file" ] || return 1
+  persisted="$(tr -d '\n' <"$session_id_file")" || return 1
+  [ -n "$persisted" ] || return 1
+  export POLARIS_SESSION_INSTANCE_ID="$persisted"
+}
+
 session_steam_pids() {
-  local p envf session_id="${POLARIS_SESSION_INSTANCE_ID:-}" proc_root
-  [ -n "$session_id" ] || return 1
+  local p pids rc envf env_lines session_id="${POLARIS_SESSION_INSTANCE_ID:-}" proc_root
+  [ -n "$session_id" ] || return 2
   proc_root="$(polaris_proc_root)"
-  for p in $(pgrep -x steam 2>/dev/null || true); do
-    case "$p" in ''|*[!0-9]*) continue ;; esac
+  if pids="$(pgrep -x steam 2>/dev/null)"; then
+    :
+  else
+    rc=$?
+    [ "$rc" -eq 1 ] || return 2
+    pids=""
+  fi
+  for p in $pids; do
+    case "$p" in ''|*[!0-9]*) return 2 ;; esac
     envf="$proc_root/$p/environ"
-    tr '\0' '\n' <"$envf" 2>/dev/null |
-      grep -qxF "POLARIS_SESSION_INSTANCE_ID=$session_id" || continue
+    if [ ! -r "$envf" ]; then
+      [ ! -e "$proc_root/$p" ] && continue
+      return 2
+    fi
+    env_lines="$(tr '\0' '\n' <"$envf" 2>/dev/null)" || return 2
+    grep -qxF "POLARIS_SESSION_INSTANCE_ID=$session_id" <<<"$env_lines" || continue
     printf '%s\n' "$p"
   done
 }
-session_steam_alive() { [ -n "$(session_steam_pids)" ]; }
+
+session_steam_alive() {
+  local pids
+  pids="$(session_steam_pids)" || return 2
+  [ -n "$pids" ]
+}
+
+session_steam_absent() {
+  local rc
+  if session_steam_alive; then
+    return 1
+  else
+    rc=$?
+  fi
+  [ "$rc" -eq 1 ]
+}
 
 kill_session_steam() {
-  local pid start_time kill_bin="${POLARIS_KILL_BIN:-kill}" session_id="${POLARIS_SESSION_INSTANCE_ID:-}"
-  [ -n "$session_id" ] || return 0
+  local pid pids start_time kill_bin="${POLARIS_KILL_BIN:-kill}" session_id="${POLARIS_SESSION_INSTANCE_ID:-}"
+  [ -n "$session_id" ] || return 1
+  pids="$(session_steam_pids)" || return 1
   while read -r pid; do
     [ -n "$pid" ] || continue
     polaris_process_fields "$pid" || return 1
@@ -47,12 +91,13 @@ kill_session_steam() {
            grep -qxF "POLARIS_SESSION_INSTANCE_ID=$session_id" \
       || return 1
     "$kill_bin" -TERM "$pid" 2>/dev/null || return 1
-  done < <(session_steam_pids)
+  done <<<"$pids"
   for _ in $(seq 1 40); do
-    session_steam_alive || return 0
+    session_steam_absent && return 0
+    session_steam_alive || [ "$?" -eq 1 ] || return 1
     sleep 0.25
   done
-  ! session_steam_alive
+  session_steam_absent
 }
 
 # True while a real game process for $1 (Steam appid) is running.
@@ -90,6 +135,13 @@ steam_app_game_alive() {
 
 case "${1:-}" in
   start)
+    [ -n "${POLARIS_SESSION_INSTANCE_ID:-}" ] || {
+      echo "polaris-gamescope-session: missing immutable session credential" >&2
+      exit 1
+    }
+    session_id_tmp="$session_id_file.tmp.$$"
+    printf '%s\n' "$POLARIS_SESSION_INSTANCE_ID" >"$session_id_tmp"
+    mv -f "$session_id_tmp" "$session_id_file"
     # Soft env hint for nested games (PULSE_SINK / PIPEWIRE_NODE).
     # Polaris itself picks the capture sink: EasyEffects when it is the
     # host default (FMOD target.object sticks there); otherwise virtual
@@ -285,6 +337,9 @@ case "${1:-}" in
       # (WSI X11 path). Portal uses compositor socket gamescope-0, not child WAYLAND.
       # env -u: drop host KWin Wayland/DISPLAY inherited from polaris user session.
       echo "polaris-gamescope-session: nested geometry ${gs_width}x${gs_height}@${gs_refresh}" >&2
+      # Claim ownership before launch so marker-capture failure remains
+      # recoverable without an unsafe numeric PGID fallback.
+      printf 'nested\n' >"$rt/polaris-gamescope-wsi-nested"
       setsid env -u WAYLAND_DISPLAY -u DISPLAY -u ENABLE_HDR_WSI \
         "${child_env[@]}" "${POLARIS_GAMESCOPE_BIN:-gamescope}" \
         --backend headless \
@@ -336,10 +391,10 @@ case "${1:-}" in
         echo "polaris-gamescope-session: failed to record an exact nested gamescope generation in its private setsid group" >&2
         if [ -f "$marker" ] && polaris_validate_marker "$marker" nested; then
           polaris_stop_marked_gamescope "$marker" nested "$rt" || true
-        else
-          kill -TERM "-$nested_launch_pid" 2>/dev/null || true
         fi
-        wait "$nested_launch_pid" 2>/dev/null || true
+        # Without an exact marker plus PGID/SID proof there is no safe numeric
+        # fallback. Preserve the recovery claim and let service/cgroup teardown
+        # contain an unclassified launch instead of risking PID/PGID reuse.
         exit 1
       fi
 
@@ -466,8 +521,16 @@ case "${1:-}" in
     fi
     ;;
   wait)
+    load_session_instance_id || {
+      echo "polaris-gamescope-session: missing or mismatched session credential during wait" >&2
+      exit 1
+    }
     for _ in $(seq 1 60); do
-      session_steam_alive && break
+      if session_steam_alive; then
+        break
+      fi
+      steam_rc=$?
+      [ "$steam_rc" -eq 1 ] || exit 1
       sleep 0.5
     done
     appid="$(tr -d '[:space:]' <"$rt/polaris-gamescope-appid" 2>/dev/null || true)"
@@ -479,9 +542,15 @@ case "${1:-}" in
       seen=0
       gone=0
       while :; do
-        if ! session_steam_alive; then
-          # Steam already gone (user quit BP / crash).
-          break
+        if session_steam_alive; then
+          :
+        else
+          steam_rc=$?
+          if [ "$steam_rc" -eq 1 ]; then
+            # Steam already gone (user quit BP / crash).
+            break
+          fi
+          exit 1
         fi
         if steam_app_game_alive "$appid"; then
           if [ "$seen" = 0 ]; then
@@ -507,6 +576,8 @@ case "${1:-}" in
         if session_steam_alive; then
           gone=0
         else
+          steam_rc=$?
+          [ "$steam_rc" -eq 1 ] || exit 1
           gone=$((gone + 1))
           [ "$gone" -ge 6 ] && break
         fi
@@ -515,6 +586,10 @@ case "${1:-}" in
     fi
     ;;
   stop)
+    load_session_instance_id || {
+      echo "polaris-gamescope-session: missing or mismatched session credential during stop" >&2
+      exit 1
+    }
     rm -f "$rt/polaris-gamescope-appid" "$rt/polaris-gamescope-audio-sink" "$rt/polaris-gamescope-audio-skip-pin"
     # Keep null sinks loaded (permanent capture targets).
     rm -f "$rt/polaris-gamescope-sink-module"
@@ -535,7 +610,7 @@ case "${1:-}" in
             echo "polaris-gamescope-session: live or unknown gamescope sockets block teardown; retaining recovery claim" >&2
             exit 1
           fi
-          if ! kill_session_steam || session_steam_alive; then
+          if ! kill_session_steam || ! session_steam_absent; then
             echo "polaris-gamescope-session: exact-session Steam did not reach terminal state; retaining recovery claim" >&2
             exit 1
           fi
@@ -601,6 +676,7 @@ case "${1:-}" in
       printf '0\n' >"$rt/polaris-gamescope-force"
       systemctl --user restart polaris-gamescope-idle.service || true
     fi
+    rm -f "$session_id_file"
     ;;
   *)
     echo "usage: polaris-gamescope-session start [steam_appid]|wait|stop" >&2

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -20,6 +20,15 @@ gs_refresh="${POLARIS_HDR_REFRESH:-120}"
 
 session_id_file="$rt/polaris-gamescope-session-id"
 
+publish_nested_claim() (
+  local lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp
+  exec 9>>"$rt/polaris-gamescope.lock" || return 1
+  "$lock_bin" -x 9 || return 1
+  tmp="$rt/.polaris-gamescope-wsi-nested.$$"
+  printf 'nested\n' >"$tmp" || return 1
+  mv -f -- "$tmp" "$rt/polaris-gamescope-wsi-nested"
+)
+
 load_session_instance_id() {
   local persisted
   if [ -n "${POLARIS_SESSION_INSTANCE_ID:-}" ]; then
@@ -350,7 +359,7 @@ case "${1:-}" in
       echo "polaris-gamescope-session: nested geometry ${gs_width}x${gs_height}@${gs_refresh}" >&2
       # Claim ownership before launch so marker-capture failure remains
       # recoverable without an unsafe numeric PGID fallback.
-      printf 'nested\n' >"$rt/polaris-gamescope-wsi-nested"
+      publish_nested_claim
       setsid env -u WAYLAND_DISPLAY -u DISPLAY -u ENABLE_HDR_WSI \
         "${child_env[@]}" "${POLARIS_GAMESCOPE_BIN:-gamescope}" \
         --backend headless \
@@ -423,7 +432,7 @@ case "${1:-}" in
         polaris_stop_marked_gamescope "$marker" nested "$rt" || true
         exit 1
       fi
-      printf 'nested\n' >"$rt/polaris-gamescope-wsi-nested"
+      publish_nested_claim
       # Portal + polaris-gamescope.env assume gamescope-0. Bail if we lost the race.
       if rg -q "wayland display 'gamescope-1'" "$steam_log" 2>/dev/null; then
         echo "polaris-gamescope-session: nested bound gamescope-1 (portal captures gamescope-0) — see $steam_log" >&2

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -135,10 +135,21 @@ steam_app_game_alive() {
 
 case "${1:-}" in
   start)
-    [ -n "${POLARIS_SESSION_INSTANCE_ID:-}" ] || {
+    requested_session_id="${POLARIS_SESSION_INSTANCE_ID:-}"
+    [ -n "$requested_session_id" ] || {
       echo "polaris-gamescope-session: missing immutable session credential" >&2
       exit 1
     }
+    if [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
+      [ -s "$session_id_file" ] || {
+        echo "polaris-gamescope-session: nested recovery lacks its immutable session credential" >&2
+        exit 1
+      }
+      echo "polaris-gamescope-session: complete prior nested recovery before new launch" >&2
+      POLARIS_SESSION_INSTANCE_ID= "$0" stop || exit 1
+      POLARIS_SESSION_INSTANCE_ID="$requested_session_id"
+      export POLARIS_SESSION_INSTANCE_ID
+    fi
     session_id_tmp="$session_id_file.tmp.$$"
     printf '%s\n' "$POLARIS_SESSION_INSTANCE_ID" >"$session_id_tmp"
     mv -f "$session_id_tmp" "$session_id_file"
@@ -449,18 +460,8 @@ case "${1:-}" in
     else
       # --- Attach path (known-good stream, no WSI) ---
       if [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
-        if polaris_validate_marker "$marker" nested; then
-          polaris_stop_marked_gamescope "$marker" nested "$rt" || {
-            echo "polaris-gamescope-session: nested owner did not stop" >&2
-            exit 1
-          }
-        elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
-          echo "polaris-gamescope-session: refusing to clean unowned nested sockets" >&2
-          exit 1
-        fi
-        rm -f "$rt/polaris-gamescope-wsi-nested"
-        polaris_unmask_idle_unit_runtime
-        systemctl --user start polaris-gamescope-idle.service || true
+        echo "polaris-gamescope-session: nested recovery claim changed during attach setup" >&2
+        exit 1
       elif ! systemctl --user is-active --quiet polaris-gamescope-idle.service 2>/dev/null; then
         systemctl --user start polaris-gamescope-idle.service || true
       elif [ "${prev_force:-}" != "$want_hdr" ]; then

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -478,7 +478,10 @@ case "${1:-}" in
         polaris_stop_marked_gamescope "$marker" nested "$rt" || true
         exit 1
       fi
-      publish_nested_claim
+      publish_nested_claim nested nested || {
+        echo "polaris-gamescope-session: nested ownership changed before portal rebind" >&2
+        exit 1
+      }
       # Portal + polaris-gamescope.env assume gamescope-0. Bail if we lost the race.
       if rg -q "wayland display 'gamescope-1'" "$steam_log" 2>/dev/null; then
         echo "polaris-gamescope-session: nested bound gamescope-1 (portal captures gamescope-0) — see $steam_log" >&2

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -19,44 +19,61 @@ gs_height="${POLARIS_HDR_HEIGHT:-2160}"
 gs_refresh="${POLARIS_HDR_REFRESH:-120}"
 
 session_steam_pids() {
-  local p h
+  local p envf session_id="${POLARIS_SESSION_INSTANCE_ID:-}" proc_root
+  [ -n "$session_id" ] || return 1
+  proc_root="$(polaris_proc_root)"
   for p in $(pgrep -x steam 2>/dev/null || true); do
-    h="$(tr '\0' '\n' <"/proc/$p/environ" 2>/dev/null | sed -n 's/^HOME=//p' | head -n1 || true)"
-    if [ "$h" = "${HOME}" ]; then
-      printf '%s\n' "$p"
-    fi
+    case "$p" in ''|*[!0-9]*) continue ;; esac
+    envf="$proc_root/$p/environ"
+    tr '\0' '\n' <"$envf" 2>/dev/null |
+      grep -qxF "POLARIS_SESSION_INSTANCE_ID=$session_id" || continue
+    printf '%s\n' "$p"
   done
 }
 session_steam_alive() { [ -n "$(session_steam_pids)" ]; }
 
 kill_session_steam() {
-  if session_steam_alive; then
-    steam -shutdown 2>/dev/null || true
-    sleep 1
-    pkill -TERM -x steam 2>/dev/null || true
-    for _ in $(seq 1 40); do
-      session_steam_alive || break
-      sleep 0.25
-    done
-  fi
+  local pid start_time kill_bin="${POLARIS_KILL_BIN:-kill}" session_id="${POLARIS_SESSION_INSTANCE_ID:-}"
+  [ -n "$session_id" ] || return 0
+  while read -r pid; do
+    [ -n "$pid" ] || continue
+    polaris_process_fields "$pid" || return 1
+    start_time="$POLARIS_PROCESS_START_TIME"
+    # Bind the numeric PID and environment classification immediately before
+    # signaling. Desktop Steam lacks this exact session credential and survives.
+    polaris_process_fields "$pid" \
+      && [ "$POLARIS_PROCESS_START_TIME" = "$start_time" ] \
+      && tr '\0' '\n' <"$(polaris_proc_root)/$pid/environ" 2>/dev/null |
+           grep -qxF "POLARIS_SESSION_INSTANCE_ID=$session_id" \
+      || return 1
+    "$kill_bin" -TERM "$pid" 2>/dev/null || return 1
+  done < <(session_steam_pids)
+  for _ in $(seq 1 40); do
+    session_steam_alive || return 0
+    sleep 0.25
+  done
+  ! session_steam_alive
 }
 
 # True while a real game process for $1 (Steam appid) is running.
 # Steam client / webhelper also inherit SteamAppId — exclude those so
 # Big Picture alone does not count as "game still up".
 steam_app_game_alive() {
-  local appid="$1" pid cmd envf
-  [ -n "$appid" ] || return 1
-  for envf in /proc/[0-9]*/environ; do
-    pid="${envf#/proc/}"
+  local appid="$1" pid cmd envf env_lines proc_root session_id="${POLARIS_SESSION_INSTANCE_ID:-}"
+  [ -n "$appid" ] && [ -n "$session_id" ] || return 1
+  proc_root="$(polaris_proc_root)"
+  for envf in "$proc_root"/[0-9]*/environ; do
+    pid="${envf#"$proc_root"/}"
     pid="${pid%/environ}"
     case "$pid" in
       *[!0-9]*) continue ;;
     esac
-    if ! tr '\0' '\n' <"$envf" 2>/dev/null | grep -qx "SteamAppId=${appid}"; then
+    env_lines="$(tr '\0' '\n' <"$envf" 2>/dev/null)" || continue
+    if ! grep -qxF "POLARIS_SESSION_INSTANCE_ID=$session_id" <<<"$env_lines" \
+        || ! grep -qx "SteamAppId=${appid}" <<<"$env_lines"; then
       continue
     fi
-    cmd="$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null || true)"
+    cmd="$(tr '\0' ' ' <"$proc_root/$pid/cmdline" 2>/dev/null || true)"
     # Skip empty / Steam client helpers (not the game binary).
     if [ -z "$cmd" ]; then
       continue
@@ -187,8 +204,6 @@ case "${1:-}" in
       echo "polaris-gamescope-session: true SDR (force=0, no --hdr-enabled; not hybrid PQ+SDR)" >&2
     fi
 
-    kill_session_steam
-
     if [ "$want_wsi" = 1 ]; then
       # --- Nested WSI path (games as gamescope child) ---
       echo "polaris-gamescope-session: WSI nested mode — Steam is ${POLARIS_GAMESCOPE_BIN:-gamescope} primary child" >&2
@@ -215,7 +230,7 @@ case "${1:-}" in
         echo "polaris-gamescope-session: refusing unowned gamescope socket cleanup" >&2
         exit 1
       fi
-      for _ in $(seq 1 100); do
+      for _ in $(seq 1 "${POLARIS_IDLE_WAIT_STEPS:-100}"); do
         [ ! -S "$rt/gamescope-0" ] && [ ! -S "$rt/gamescope-1" ] && break
         sleep 0.1
       done
@@ -281,10 +296,11 @@ case "${1:-}" in
         -w "$gs_width" -h "$gs_height" \
         -- "${steam_launch[@]}" \
         >"$steam_log" 2>&1 &
-      nested_pid=$!
+      nested_launch_pid=$!
 
       # Resolve the real headless gamescope PID. setsid/env/wrapProgram may leave
-      # $! as a short-lived parent; marker must pin the compositor generation.
+      # $! as a launcher; preserve that PID as the private PGID/SID and pin the
+      # separately discovered compositor generation in the marker.
       resolve_nested_gamescope_pid() {
         local root="$1" p
         if polaris_headless_gamescope_pid "$root" 2>/dev/null; then
@@ -301,20 +317,29 @@ case "${1:-}" in
       }
 
       nested_marked=0
+      nested_gamescope_pid=""
       for _ in $(seq 1 150); do
-        gs_pid="$(resolve_nested_gamescope_pid "$nested_pid" 2>/dev/null || true)"
-        if [ -n "${gs_pid:-}" ] && polaris_write_marker_for_pid "$marker" "$gs_pid" nested; then
+        gs_pid="$(resolve_nested_gamescope_pid "$nested_launch_pid" 2>/dev/null || true)"
+        if [ -n "${gs_pid:-}" ] \
+            && polaris_write_marker_for_pid "$marker" "$gs_pid" nested \
+            && polaris_validate_marker "$marker" nested \
+            && [ "$POLARIS_PROCESS_PGID" = "$nested_launch_pid" ] \
+            && [ "$POLARIS_PROCESS_SESSION_ID" = "$nested_launch_pid" ]; then
           nested_marked=1
-          nested_pid="$gs_pid"
+          nested_gamescope_pid="$gs_pid"
           break
         fi
-        kill -0 "$nested_pid" 2>/dev/null || break
+        kill -0 "$nested_launch_pid" 2>/dev/null || break
         sleep 0.02
       done
       if [ "$nested_marked" != 1 ]; then
-        echo "polaris-gamescope-session: failed to record exact nested gamescope generation" >&2
-        kill "$nested_pid" 2>/dev/null || true
-        wait "$nested_pid" 2>/dev/null || true
+        echo "polaris-gamescope-session: failed to record an exact nested gamescope generation in its private setsid group" >&2
+        if [ -f "$marker" ] && polaris_validate_marker "$marker" nested; then
+          polaris_stop_marked_gamescope "$marker" nested "$rt" || true
+        else
+          kill -TERM "-$nested_launch_pid" 2>/dev/null || true
+        fi
+        wait "$nested_launch_pid" 2>/dev/null || true
         exit 1
       fi
 
@@ -324,7 +349,7 @@ case "${1:-}" in
           ready=1
           break
         fi
-        kill -0 "$nested_pid" 2>/dev/null || break
+        kill -0 "$nested_gamescope_pid" 2>/dev/null || break
         sleep 0.1
       done
       if [ "$ready" != 1 ]; then
@@ -332,7 +357,7 @@ case "${1:-}" in
         polaris_stop_marked_gamescope "$marker" nested "$rt" || true
         exit 1
       fi
-      printf '1\n' >"$rt/polaris-gamescope-wsi-nested"
+      printf 'nested\n' >"$rt/polaris-gamescope-wsi-nested"
       # Portal + polaris-gamescope.env assume gamescope-0. Bail if we lost the race.
       if rg -q "wayland display 'gamescope-1'" "$steam_log" 2>/dev/null; then
         echo "polaris-gamescope-session: nested bound gamescope-1 (portal captures gamescope-0) — see $steam_log" >&2
@@ -490,53 +515,89 @@ case "${1:-}" in
     fi
     ;;
   stop)
-    kill_session_steam
     rm -f "$rt/polaris-gamescope-appid" "$rt/polaris-gamescope-audio-sink" "$rt/polaris-gamescope-audio-skip-pin"
     # Keep null sinks loaded (permanent capture targets).
     rm -f "$rt/polaris-gamescope-sink-module"
     # Legacy flags from builds that killed EasyEffects / hijacked default.
     rm -f "$rt/polaris-gamescope-prev-default-sink" "$rt/polaris-gamescope-easyeffects-units"
-    if [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
-      echo "polaris-gamescope-session: tearing down marked nested WSI gamescope" >&2
-      if polaris_validate_marker "$marker" nested; then
-        polaris_stop_marked_gamescope "$marker" nested "$rt" ||
-          echo "polaris-gamescope-session: nested owner did not reach terminal state" >&2
-      elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
-        echo "polaris-gamescope-session: leaving live unowned gamescope sockets untouched" >&2
-      fi
-      rm -f "$rt/polaris-gamescope-wsi-nested"
+    nested_claim="$rt/polaris-gamescope-wsi-nested"
+    if [ -f "$nested_claim" ]; then
+      claim_state="$(tr -d '[:space:]' <"$nested_claim")"
+      case "$claim_state" in
+        1|nested)
+          echo "polaris-gamescope-session: tearing down marked nested WSI gamescope" >&2
+          if polaris_validate_marker "$marker" nested; then
+            if ! polaris_stop_marked_gamescope "$marker" nested "$rt"; then
+              echo "polaris-gamescope-session: nested owner did not reach terminal state; retaining recovery claim" >&2
+              exit 1
+            fi
+          elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+            echo "polaris-gamescope-session: live or unknown gamescope sockets block teardown; retaining recovery claim" >&2
+            exit 1
+          fi
+          if ! kill_session_steam || session_steam_alive; then
+            echo "polaris-gamescope-session: exact-session Steam did not reach terminal state; retaining recovery claim" >&2
+            exit 1
+          fi
+          claim_tmp="$nested_claim.tmp.$$"
+          printf 'restore-idle\n' >"$claim_tmp"
+          mv -f "$claim_tmp" "$nested_claim"
+          ;;
+        restore-idle)
+          ;;
+        *)
+          echo "polaris-gamescope-session: invalid nested recovery state '$claim_state'" >&2
+          exit 1
+          ;;
+      esac
+
+      # Ordered handoff: idle must own gamescope-0 and publish an exact runtime
+      # environment before the portal may rebind. The restore-idle claim stays
+      # durable across every failure so a retry never repeats nested signaling.
       printf '0\n' >"$rt/polaris-gamescope-force"
-      # Ordered handoff: idle must own gamescope-0 before portal capture can
-      # reconnect. Otherwise portal-gamescope hits "failed to connect to wayland
-      # socket" (Response code 2) during the gap.
       polaris_unmask_idle_unit_runtime
       systemctl --user reset-failed polaris-gamescope-idle.service 2>/dev/null || true
-      systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true
+      if ! systemctl --user start polaris-gamescope-idle.service 2>/dev/null; then
+        echo "polaris-gamescope-session: failed to start idle gamescope; retaining restore-idle claim" >&2
+        exit 1
+      fi
       idle_ready=0
-      for _ in $(seq 1 100); do
-        if polaris_validate_marker "$marker" idle &&
-           polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle; then
-          polaris_write_runtime_env "$marker" gamescope-0 idle "$rt" 2>/dev/null || true
+      for _ in $(seq 1 "${POLARIS_IDLE_WAIT_STEPS:-100}"); do
+        if polaris_validate_marker "$marker" idle \
+            && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
+            && polaris_write_runtime_env "$marker" gamescope-0 idle "$rt" 2>/dev/null; then
           idle_ready=1
           break
         fi
         sleep 0.1
       done
       if [ "$idle_ready" != 1 ]; then
-        echo "polaris-gamescope-session: idle gamescope-0 not ready after nested stop" >&2
-      else
-        echo "polaris-gamescope-session: idle gamescope restored after nested stop" >&2
+        echo "polaris-gamescope-session: idle gamescope-0 not ready; retaining restore-idle claim" >&2
+        exit 1
       fi
-      # Rebind backend to idle generation. polaris must Wants= (not Requires=)
-      # this unit so the restart does not cascade-stop the stream host.
-      systemctl --user restart polaris-portal-gamescope.service 2>/dev/null || true
+      echo "polaris-gamescope-session: idle gamescope restored after nested stop" >&2
+
+      if ! systemctl --user restart polaris-portal-gamescope.service 2>/dev/null; then
+        echo "polaris-gamescope-session: portal restart failed; retaining restore-idle claim" >&2
+        exit 1
+      fi
       portal_bus="unix:path=$rt/polaris-portal/bus"
-      for _ in $(seq 1 50); do
-        busctl --address="$portal_bus" --no-pager \
-          status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1 && break
+      portal_ready=0
+      for _ in $(seq 1 "${POLARIS_PORTAL_WAIT_STEPS:-50}"); do
+        if busctl --address="$portal_bus" --no-pager \
+            status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1; then
+          portal_ready=1
+          break
+        fi
         sleep 0.1
       done
+      if [ "$portal_ready" != 1 ]; then
+        echo "polaris-gamescope-session: portal did not bind idle generation; retaining restore-idle claim" >&2
+        exit 1
+      fi
+      rm -f "$nested_claim"
     elif [ -f "$rt/polaris-gamescope-force" ] && [ "$(tr -d '[:space:]' <"$rt/polaris-gamescope-force")" = "1" ]; then
+      kill_session_steam || exit 1
       printf '0\n' >"$rt/polaris-gamescope-force"
       systemctl --user restart polaris-gamescope-idle.service || true
     fi

--- a/nix/modules/session-lib.nix
+++ b/nix/modules/session-lib.nix
@@ -158,36 +158,15 @@ let
     # durable recovery claim until exact nested teardown and idle handoff finish.
     nested_claim="$rt/polaris-gamescope-wsi-nested"
     if [ -f "$nested_claim" ]; then
-      claim_state="$(tr -d '[:space:]' <"$nested_claim")"
-      case "$claim_state" in
-        1|nested)
-          echo "polaris: recover exact nested gamescope generation" >&2
-          if polaris_validate_marker "$rt/polaris-gamescope.pid" nested; then
-            polaris_stop_marked_gamescope "$rt/polaris-gamescope.pid" nested "$rt" || {
-              echo "polaris: nested recovery could not prove terminal state" >&2
-              exit 1
-            }
-          elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
-            echo "polaris: live or unknown sockets block nested recovery" >&2
-            exit 1
-          fi
-          claim_tmp="$nested_claim.tmp.$$"
-          printf 'restore-idle\n' >"$claim_tmp"
-          mv -f "$claim_tmp" "$nested_claim"
-          ;;
-        restore-idle) ;;
-        *)
-          echo "polaris: invalid nested recovery state '$claim_state'" >&2
-          exit 1
-          ;;
-      esac
-      rm -f "$rt/polaris-gamescope-appid" "$rt/polaris-gamescope-audio-sink" || true
-      polaris_unmask_idle_unit_runtime
-      if [ ! -S "$rt/gamescope-0" ]; then
-        ${pkgs.systemd}/bin/systemctl --user restart polaris-gamescope-idle.service 2>/dev/null \
-          || ${pkgs.systemd}/bin/systemctl --user start polaris-gamescope-idle.service 2>/dev/null \
-          || exit 1
+      echo "polaris: recover nested generation through the exact session stop state machine" >&2
+      if [ ! -s "$rt/polaris-gamescope-session-id" ]; then
+        echo "polaris: nested recovery is missing its immutable session credential" >&2
+        exit 1
       fi
+      ${lib.getExe sessionBin} stop || {
+        echo "polaris: nested recovery did not reach idle/portal terminal state" >&2
+        exit 1
+      }
     elif [ ! -S "$rt/gamescope-0" ]; then
       echo "polaris: gamescope-0 missing; starting idle owner" >&2
       polaris_unmask_idle_unit_runtime

--- a/nix/modules/session-lib.nix
+++ b/nix/modules/session-lib.nix
@@ -204,18 +204,44 @@ let
         org.freedesktop.impl.portal.ScreenCast AvailableCursorModes 2>/dev/null \
         | ${pkgs.gawk}/bin/awk '{print $2}' || true)"
       if [ -n "''${modes:-}" ] && [ "''${modes}" != "0" ]; then
-        if ! polaris_validate_marker "$rt/polaris-gamescope.pid" idle \
+        exec 8>>"$rt/polaris-gamescope.lock" || exit 1
+        ${lib.getExe' pkgs.util-linux "flock"} -x 8 || exit 1
+        export POLARIS_GAMESCOPE_LOCK_HELD=1
+        claim_state=absent
+        if [ -f "''${nested_claim:-}" ]; then
+          claim_state="$(tr -d '[:space:]' <"$nested_claim")"
+        fi
+        case "$claim_state" in
+          absent|restore-idle) ;;
+          *)
+            ${lib.getExe' pkgs.util-linux "flock"} -u 8
+            export POLARIS_GAMESCOPE_LOCK_HELD=0
+            echo "polaris: ownership transition changed during readiness ($claim_state)" >&2
+            sleep 0.1
+            continue
+            ;;
+        esac
+        locked_modes="$(${pkgs.systemd}/bin/busctl --address="$private_address" get-property \
+          org.freedesktop.impl.portal.desktop.gamescope \
+          /org/freedesktop/portal/desktop \
+          org.freedesktop.impl.portal.ScreenCast AvailableCursorModes 2>/dev/null \
+          | ${pkgs.gawk}/bin/awk '{print $2}' || true)"
+        if [ -z "''${locked_modes:-}" ] || [ "''${locked_modes}" = 0 ] \
+            || ! polaris_validate_marker "$rt/polaris-gamescope.pid" idle \
             || ! polaris_marker_owns_socket "$rt/polaris-gamescope.pid" "$rt/gamescope-0" idle \
             || ! polaris_write_runtime_env "$rt/polaris-gamescope.pid" gamescope-0 idle "$rt"; then
+          ${lib.getExe' pkgs.util-linux "flock"} -u 8
+          export POLARIS_GAMESCOPE_LOCK_HELD=0
           echo "polaris: portal is up but exact idle gamescope ownership is not ready" >&2
           sleep 0.1
           continue
         fi
-        if [ -f "''${nested_claim:-}" ] \
-            && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ]; then
-          rm -f "$nested_claim"
+        if [ "$claim_state" = restore-idle ]; then
+          rm -f -- "$nested_claim"
         fi
-        echo "polaris: private ScreenCast ready (gamescope-0 + portal, cursor_modes=$modes)" >&2
+        ${lib.getExe' pkgs.util-linux "flock"} -u 8
+        export POLARIS_GAMESCOPE_LOCK_HELD=0
+        echo "polaris: private ScreenCast ready (gamescope-0 + portal, cursor_modes=$locked_modes)" >&2
         exit 0
       fi
       if [ "$SECONDS" -ge "$deadline" ]; then

--- a/nix/modules/session-lib.nix
+++ b/nix/modules/session-lib.nix
@@ -77,8 +77,13 @@ let
 
   idleApp = pkgs.writeShellApplication {
     name = "polaris-gamescope-idle";
-    runtimeInputs = with pkgs; [
-      bash coreutils gnugrep gnused util-linux gamescope
+    runtimeInputs = [
+      pkgs.bash
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.util-linux
+      gamescope # cfg.packageGamescope (gamescope-polaris), not stock pkgs.gamescope
     ];
     text = ''
       export POLARIS_HDR_WIDTH="''${POLARIS_HDR_WIDTH:-${toString cfg.width}}"
@@ -93,16 +98,16 @@ let
 
   sessionBin = pkgs.writeShellApplication {
     name = "polaris-gamescope-session";
-    runtimeInputs = with pkgs; [
-      coreutils
-      gamescope
-      gnugrep
-      gnused
-      procps
-      pulseaudio
-      systemd
-      util-linux
-      wireplumber
+    runtimeInputs = [
+      pkgs.coreutils
+      gamescope # cfg.packageGamescope
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.procps
+      pkgs.pulseaudio
+      pkgs.systemd
+      pkgs.util-linux
+      pkgs.wireplumber
     ];
     text = ''
       export POLARIS_GAMESCOPE_BIN=${lib.getExe gamescope}
@@ -157,7 +162,7 @@ let
       fi
       rm -f "$rt/polaris-gamescope-wsi-nested" "$rt/polaris-gamescope-appid" \
         "$rt/polaris-gamescope-audio-sink" || true
-      ${pkgs.systemd}/bin/systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null || true
+      polaris_unmask_idle_unit_runtime
       if [ ! -S "$rt/gamescope-0" ]; then
         ${pkgs.systemd}/bin/systemctl --user restart polaris-gamescope-idle.service 2>/dev/null \
           || ${pkgs.systemd}/bin/systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true
@@ -243,8 +248,11 @@ let
       serviceConfig = ''
         Type=simple
         ExecStart=${lib.getExe idleApp}
-        # on-abnormal: stop/mask for nested WSI must not look like a crash restart.
-        Restart=on-abnormal
+        # on-failure: gamescope ABRT ends the wrapper with exit 134; on-abnormal
+        # ignores that and leaves idle permanently failed (orphan sockets stick).
+        # Nested WSI masks via user.control (not plain mask --runtime) so
+        # portal-gamescope Wants= cannot respawn idle under ~/.config units.
+        Restart=on-failure
         RestartSec=5s
         TimeoutStopSec=10s
         ${envToUnitLines baseEnvironment}
@@ -291,7 +299,9 @@ let
       serviceConfig = ''
         Type=simple
         ExecStart=${portalFrontendExec}
-        Restart=on-failure
+        # always: frontend can be cleanly stopped while polaris stays up; stream
+        # needs org.freedesktop.portal.Desktop on the private bus.
+        Restart=always
         RestartSec=1s
         ${envToUnitLines portalEnvironment}
       '';
@@ -305,15 +315,17 @@ let
         "polaris-portal-gamescope.service"
         "polaris-portal.service"
       ];
+      # Soft deps: nested↔idle handoff restarts portal-gamescope (and sometimes
+      # portal frontend). Requires= would stop polaris mid-stream teardown.
+      # Hard dep: private bus only — without it the portal path cannot exist.
+      # Start readiness is still gated by ExecStartPre=waitPortal.
       wants = [
         "polaris-gamescope-idle.service"
-        "polaris-portal.service"
-      ];
-      requires = [
         "polaris-portal-dbus.service"
         "polaris-portal-gamescope.service"
         "polaris-portal.service"
       ];
+      requires = [ "polaris-portal-dbus.service" ];
       serviceConfig = ''
         Type=simple
         ExecStartPre=${waitPortal}

--- a/nix/modules/session-lib.nix
+++ b/nix/modules/session-lib.nix
@@ -159,7 +159,8 @@ let
     nested_claim="$rt/polaris-gamescope-wsi-nested"
     if [ -f "$nested_claim" ]; then
       echo "polaris: recover nested generation through the exact session stop state machine" >&2
-      if [ ! -s "$rt/polaris-gamescope-session-id" ]; then
+      if [ ! -s "$rt/polaris-gamescope-session-state" ] \
+          && [ ! -s "$rt/polaris-gamescope-session-id" ]; then
         echo "polaris: nested recovery is missing its immutable session credential" >&2
         exit 1
       fi

--- a/nix/modules/session-lib.nix
+++ b/nix/modules/session-lib.nix
@@ -154,19 +154,46 @@ let
     export POLARIS_FLOCK_BIN=${lib.getExe' pkgs.util-linux "flock"}
     ${builtins.readFile ./polaris-gamescope-runtime-lib.sh}
 
-    # Nested stop can leave runtime-masked idle / no gamescope-0.
-    if [ -f "$rt/polaris-gamescope-wsi-nested" ] || [ ! -S "$rt/gamescope-0" ]; then
-      echo "polaris: recover idle gamescope-0 (nested leftover or missing socket)" >&2
-      if polaris_validate_marker "$rt/polaris-gamescope.pid" nested; then
-        polaris_stop_marked_gamescope "$rt/polaris-gamescope.pid" nested "$rt" || true
-      fi
-      rm -f "$rt/polaris-gamescope-wsi-nested" "$rt/polaris-gamescope-appid" \
-        "$rt/polaris-gamescope-audio-sink" || true
+    # Nested stop can leave runtime-masked idle / no gamescope-0. Preserve a
+    # durable recovery claim until exact nested teardown and idle handoff finish.
+    nested_claim="$rt/polaris-gamescope-wsi-nested"
+    if [ -f "$nested_claim" ]; then
+      claim_state="$(tr -d '[:space:]' <"$nested_claim")"
+      case "$claim_state" in
+        1|nested)
+          echo "polaris: recover exact nested gamescope generation" >&2
+          if polaris_validate_marker "$rt/polaris-gamescope.pid" nested; then
+            polaris_stop_marked_gamescope "$rt/polaris-gamescope.pid" nested "$rt" || {
+              echo "polaris: nested recovery could not prove terminal state" >&2
+              exit 1
+            }
+          elif ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+            echo "polaris: live or unknown sockets block nested recovery" >&2
+            exit 1
+          fi
+          claim_tmp="$nested_claim.tmp.$$"
+          printf 'restore-idle\n' >"$claim_tmp"
+          mv -f "$claim_tmp" "$nested_claim"
+          ;;
+        restore-idle) ;;
+        *)
+          echo "polaris: invalid nested recovery state '$claim_state'" >&2
+          exit 1
+          ;;
+      esac
+      rm -f "$rt/polaris-gamescope-appid" "$rt/polaris-gamescope-audio-sink" || true
       polaris_unmask_idle_unit_runtime
       if [ ! -S "$rt/gamescope-0" ]; then
         ${pkgs.systemd}/bin/systemctl --user restart polaris-gamescope-idle.service 2>/dev/null \
-          || ${pkgs.systemd}/bin/systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true
+          || ${pkgs.systemd}/bin/systemctl --user start polaris-gamescope-idle.service 2>/dev/null \
+          || exit 1
       fi
+    elif [ ! -S "$rt/gamescope-0" ]; then
+      echo "polaris: gamescope-0 missing; starting idle owner" >&2
+      polaris_unmask_idle_unit_runtime
+      ${pkgs.systemd}/bin/systemctl --user restart polaris-gamescope-idle.service 2>/dev/null \
+        || ${pkgs.systemd}/bin/systemctl --user start polaris-gamescope-idle.service 2>/dev/null \
+        || exit 1
     fi
 
     bus_path="$rt/polaris-portal/bus"
@@ -198,6 +225,17 @@ let
         org.freedesktop.impl.portal.ScreenCast AvailableCursorModes 2>/dev/null \
         | ${pkgs.gawk}/bin/awk '{print $2}' || true)"
       if [ -n "''${modes:-}" ] && [ "''${modes}" != "0" ]; then
+        if ! polaris_validate_marker "$rt/polaris-gamescope.pid" idle \
+            || ! polaris_marker_owns_socket "$rt/polaris-gamescope.pid" "$rt/gamescope-0" idle \
+            || ! polaris_write_runtime_env "$rt/polaris-gamescope.pid" gamescope-0 idle "$rt"; then
+          echo "polaris: portal is up but exact idle gamescope ownership is not ready" >&2
+          sleep 0.1
+          continue
+        fi
+        if [ -f "''${nested_claim:-}" ] \
+            && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ]; then
+          rm -f "$nested_claim"
+        fi
         echo "polaris: private ScreenCast ready (gamescope-0 + portal, cursor_modes=$modes)" >&2
         exit 0
       fi

--- a/scripts/install/lib/polaris-gamescope-idle.sh
+++ b/scripts/install/lib/polaris-gamescope-idle.sh
@@ -18,6 +18,25 @@ marker="$rt/polaris-gamescope.pid"
 child=""
 child_start=""
 
+exec 8>>"$rt/polaris-gamescope.lock" || exit 1
+"${POLARIS_FLOCK_BIN:-flock}" -x 8 || exit 1
+export POLARIS_GAMESCOPE_LOCK_HELD=1
+nested_claim="$rt/polaris-gamescope-wsi-nested"
+if [ -f "$nested_claim" ]; then
+  claim_state="$(tr -d '[:space:]' <"$nested_claim")"
+  case "$claim_state" in
+    restore-idle) ;;
+    transition|nested|1)
+      echo "polaris-gamescope-idle: yielding to active ownership transition ($claim_state)" >&2
+      exit 0
+      ;;
+    *)
+      echo "polaris-gamescope-idle: refusing unknown ownership claim ($claim_state)" >&2
+      exit 1
+      ;;
+  esac
+fi
+
 command -v "$gs" >/dev/null 2>&1 || {
   echo "polaris-gamescope-idle: gamescope not found (set POLARIS_GAMESCOPE_BIN)" >&2
   exit 1
@@ -136,6 +155,9 @@ if [ "$ready" != 1 ]; then
   echo "polaris-gamescope-idle: owned gamescope-0/Xwayland did not become ready" >&2
   exit 1
 fi
+
+"${POLARIS_FLOCK_BIN:-flock}" -u 8
+export POLARIS_GAMESCOPE_LOCK_HELD=0
 
 echo "polaris-gamescope-idle: ready pid=$child generation=$child_start" >&2
 wait "$child"

--- a/scripts/install/lib/polaris-gamescope-idle.sh
+++ b/scripts/install/lib/polaris-gamescope-idle.sh
@@ -35,26 +35,43 @@ trap cleanup EXIT
 trap 'exit 143' TERM INT
 
 if polaris_validate_marker "$marker"; then
-  if [ "$POLARIS_MARKER_ROLE" = idle ]; then
-    polaris_stop_marked_gamescope "$marker" idle "$rt" || {
-      echo "polaris-gamescope-idle: existing idle owner did not stop" >&2
+  case "$POLARIS_MARKER_ROLE" in
+    idle)
+      polaris_stop_marked_gamescope "$marker" idle "$rt" || {
+        echo "polaris-gamescope-idle: existing idle owner did not stop" >&2
+        exit 1
+      }
+      ;;
+    nested|runtime)
+      # Nested WSI / owned spawn holds gamescope-0. Exit 0 so Restart=on-failure
+      # does not fight polaris-gamescope-session (mask can race with restart).
+      echo "polaris-gamescope-idle: yielding to active $POLARIS_MARKER_ROLE owner pid=$POLARIS_MARKER_PID" >&2
+      exit 0
+      ;;
+    *)
+      echo "polaris-gamescope-idle: refusing to replace active $POLARIS_MARKER_ROLE owner pid=$POLARIS_MARKER_PID" >&2
       exit 1
-    }
-  else
-    echo "polaris-gamescope-idle: refusing to replace active $POLARIS_MARKER_ROLE owner pid=$POLARIS_MARKER_PID" >&2
-    exit 1
-  fi
+      ;;
+  esac
 else
-  # Invalid marker metadata is safe to discard; unknown sockets are not.
+  # No valid marker. If gamescope-0 is still live (nested race, or marker write
+  # lag), yield cleanly — do NOT delete someone else's state or restart-loop.
+  if [ -e "$rt/gamescope-0" ] || [ -S "$rt/gamescope-0" ]; then
+    if ! polaris_socket_is_orphan "$rt/gamescope-0"; then
+      echo "polaris-gamescope-idle: yielding to live gamescope-0 holder (not idle-owned)" >&2
+      exit 0
+    fi
+  fi
+  # Invalid marker + orphan sockets only: safe to discard and reclaim residue.
   rm -f "$marker"
+  rm -f "$rt/polaris-gamescope.env"
 fi
 
-for socket in gamescope-0 gamescope-1; do
-  if [ -e "$rt/$socket" ]; then
-    echo "polaris-gamescope-idle: refusing destructive cleanup of unowned $rt/$socket" >&2
-    exit 1
-  fi
-done
+if ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+  # Live holder appeared between checks (nested start race): yield, don't loop.
+  echo "polaris-gamescope-idle: yielding; live gamescope sockets remain" >&2
+  exit 0
+fi
 
 prefer_vk=()
 if [ -n "${POLARIS_GAMESCOPE_PREFER_VK:-}" ]; then

--- a/scripts/install/lib/polaris-gamescope-idle.sh
+++ b/scripts/install/lib/polaris-gamescope-idle.sh
@@ -156,8 +156,10 @@ if [ "$ready" != 1 ]; then
   exit 1
 fi
 
+trap '' HUP INT TERM
 "${POLARIS_FLOCK_BIN:-flock}" -u 8
 export POLARIS_GAMESCOPE_LOCK_HELD=0
+trap cleanup EXIT HUP INT TERM
 
 echo "polaris-gamescope-idle: ready pid=$child generation=$child_start" >&2
 wait "$child"

--- a/scripts/install/lib/polaris-wait-gamescope.sh
+++ b/scripts/install/lib/polaris-wait-gamescope.sh
@@ -25,27 +25,27 @@ elif ! polaris_marker_owns_socket "$marker" "$rt/gamescope-0" 2>/dev/null; then
   polaris_reclaim_orphan_gamescope_sockets "$rt" || true
 fi
 
-# Nested stop can leave runtime-masked idle / no gamescope-0.
-if [ -f "$rt/polaris-gamescope-wsi-nested" ] || [ ! -S "$rt/gamescope-0" ]; then
-  echo "polaris: recover idle gamescope-0 (nested leftover or missing socket)" >&2
-  marker_role=""
-  if polaris_validate_marker "$marker"; then
-    marker_role="$POLARIS_MARKER_ROLE"
-    if [ "$marker_role" = nested ]; then
-      polaris_stop_marked_gamescope "$marker" nested "$rt" || {
-        echo "polaris: refusing to replace a live nested gamescope generation" >&2
-        exit 1
-      }
-      marker_role=""
-    fi
-  fi
-  rm -f "$rt/polaris-gamescope-wsi-nested" "$rt/polaris-gamescope-appid" \
-    "$rt/polaris-gamescope-audio-sink" || true
+# Nested recovery is credentialed and transactional: only the session stop state
+# machine may drain exact-session Steam, restore idle ownership, rebind the
+# private portal, and clear the durable claim.
+if [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
+  session_cmd="${POLARIS_GAMESCOPE_SESSION_BIN:-polaris-gamescope-session}"
+  [ -s "$rt/polaris-gamescope-session-id" ] || {
+    echo "polaris: nested recovery lacks its immutable session credential" >&2
+    exit 1
+  }
+  command -v "$session_cmd" >/dev/null 2>&1 || {
+    echo "polaris: credentialed gamescope session recovery command is unavailable" >&2
+    exit 1
+  }
+  echo "polaris: complete credentialed nested recovery" >&2
+  POLARIS_SESSION_INSTANCE_ID= "$session_cmd" stop || exit 1
+  [ ! -e "$rt/polaris-gamescope-wsi-nested" ] || exit 1
+elif [ ! -S "$rt/gamescope-0" ]; then
+  echo "polaris: restore missing idle gamescope-0" >&2
   polaris_unmask_idle_unit_runtime
-  if [ ! -S "$rt/gamescope-0" ] && [ "$marker_role" != runtime ]; then
-    systemctl --user restart polaris-gamescope-idle.service 2>/dev/null \
-      || systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true
-  fi
+  systemctl --user restart polaris-gamescope-idle.service 2>/dev/null \
+    || systemctl --user start polaris-gamescope-idle.service 2>/dev/null || exit 1
 fi
 
 deadline=$((SECONDS + 60))
@@ -57,6 +57,12 @@ while [ ! -S "$rt/gamescope-0" ]; do
   sleep 0.2
 done
 
+if ! polaris_validate_marker "$marker" \
+    || ! polaris_marker_owns_socket "$marker" "$rt/gamescope-0" 2>/dev/null; then
+  echo "polaris: gamescope-0 appeared without exact idle ownership" >&2
+  exit 1
+fi
+
 bus_path="$rt/polaris-portal/bus"
 if [ ! -e "$bus_path" ]; then
   echo "polaris: gamescope-0 ready (no private portal bus — host portal or gamescopegrab OK)" >&2
@@ -64,6 +70,10 @@ if [ ! -e "$bus_path" ]; then
 fi
 
 export DBUS_SESSION_BUS_ADDRESS="unix:path=$bus_path"
+systemctl --user restart polaris-portal-gamescope.service >/dev/null 2>&1 || {
+  echo "polaris: failed to restart private gamescope portal" >&2
+  exit 1
+}
 deadline=$((SECONDS + 45))
 while true; do
   modes=""
@@ -78,8 +88,8 @@ while true; do
     exit 0
   fi
   if [ "$SECONDS" -ge "$deadline" ]; then
-    echo "polaris: portal not ready; continuing (gamescopegrab may still work)" >&2
-    exit 0
+    echo "polaris: private ScreenCast portal did not become ready" >&2
+    exit 1
   fi
   sleep 0.25
 done

--- a/scripts/install/lib/polaris-wait-gamescope.sh
+++ b/scripts/install/lib/polaris-wait-gamescope.sh
@@ -12,10 +12,26 @@ fi
 rt="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 marker="$rt/polaris-gamescope.pid"
 
-# Crash residue: a gamescope-0 path without a live holder looks "ready" to -S
-# but cannot accept clients. Reclaim orphans before treating the socket as up.
+clear_invalid_marker() (
+  local lock_bin="${POLARIS_FLOCK_BIN:-flock}"
+  exec 9>>"$rt/polaris-gamescope.lock" || return 1
+  "$lock_bin" -x 9 || return 1
+  polaris_validate_marker "$marker" && return 0
+  [ ! -e "$marker" ] || rm -f -- "$marker"
+)
+
+idle_ownership_is_current() {
+  [ ! -e "$rt/polaris-gamescope-wsi-nested" ] \
+    && polaris_validate_marker "$marker" idle \
+    && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" 2>/dev/null
+}
+
+# Serialize invalid-marker removal with every cooperating ownership publisher,
+# then revalidate: never unlink a marker based on a lockless stale observation.
 if ! polaris_validate_marker "$marker"; then
-  rm -f "$marker"
+  clear_invalid_marker || exit 1
+fi
+if ! polaris_validate_marker "$marker"; then
   if ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
     echo "polaris: live unowned gamescope sockets block startup" >&2
     exit 1
@@ -57,19 +73,28 @@ while [ ! -S "$rt/gamescope-0" ]; do
   sleep 0.2
 done
 
-if ! polaris_validate_marker "$marker" \
-    || ! polaris_marker_owns_socket "$marker" "$rt/gamescope-0" 2>/dev/null; then
+# Hold the same ownership-transition lock used by marker writers and nested
+# claim publication through idle validation and portal rebinding.
+exec 8>>"$rt/polaris-gamescope.lock" || exit 1
+"${POLARIS_FLOCK_BIN:-flock}" -x 8 || exit 1
+
+if ! idle_ownership_is_current; then
   echo "polaris: gamescope-0 appeared without exact idle ownership" >&2
   exit 1
 fi
 
 bus_path="$rt/polaris-portal/bus"
 if [ ! -e "$bus_path" ]; then
+  idle_ownership_is_current || exit 1
   echo "polaris: gamescope-0 ready (no private portal bus — host portal or gamescopegrab OK)" >&2
   exit 0
 fi
 
 export DBUS_SESSION_BUS_ADDRESS="unix:path=$bus_path"
+idle_ownership_is_current || {
+  echo "polaris: idle ownership changed before private portal restart" >&2
+  exit 1
+}
 systemctl --user restart polaris-portal-gamescope.service >/dev/null 2>&1 || {
   echo "polaris: failed to restart private gamescope portal" >&2
   exit 1
@@ -84,6 +109,10 @@ while true; do
       | awk '{print $2}' || true)"
   fi
   if [ -n "${modes:-}" ] && [ "${modes}" != "0" ]; then
+    idle_ownership_is_current || {
+      echo "polaris: nested generation replaced idle ownership during portal recovery" >&2
+      exit 1
+    }
     echo "polaris: private ScreenCast ready (gamescope-0 + portal, cursor_modes=$modes)" >&2
     exit 0
   fi

--- a/scripts/install/lib/polaris-wait-gamescope.sh
+++ b/scripts/install/lib/polaris-wait-gamescope.sh
@@ -12,6 +12,19 @@ fi
 rt="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 marker="$rt/polaris-gamescope.pid"
 
+# Crash residue: a gamescope-0 path without a live holder looks "ready" to -S
+# but cannot accept clients. Reclaim orphans before treating the socket as up.
+if ! polaris_validate_marker "$marker"; then
+  rm -f "$marker"
+  if ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+    echo "polaris: live unowned gamescope sockets block startup" >&2
+    exit 1
+  fi
+elif ! polaris_marker_owns_socket "$marker" "$rt/gamescope-0" 2>/dev/null; then
+  # Valid marker but not holding gamescope-0 — still drop dead residue only.
+  polaris_reclaim_orphan_gamescope_sockets "$rt" || true
+fi
+
 # Nested stop can leave runtime-masked idle / no gamescope-0.
 if [ -f "$rt/polaris-gamescope-wsi-nested" ] || [ ! -S "$rt/gamescope-0" ]; then
   echo "polaris: recover idle gamescope-0 (nested leftover or missing socket)" >&2
@@ -28,7 +41,7 @@ if [ -f "$rt/polaris-gamescope-wsi-nested" ] || [ ! -S "$rt/gamescope-0" ]; then
   fi
   rm -f "$rt/polaris-gamescope-wsi-nested" "$rt/polaris-gamescope-appid" \
     "$rt/polaris-gamescope-audio-sink" || true
-  systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null || true
+  polaris_unmask_idle_unit_runtime
   if [ ! -S "$rt/gamescope-0" ] && [ "$marker_role" != runtime ]; then
     systemctl --user restart polaris-gamescope-idle.service 2>/dev/null \
       || systemctl --user start polaris-gamescope-idle.service 2>/dev/null || true

--- a/scripts/install/lib/polaris-wait-gamescope.sh
+++ b/scripts/install/lib/polaris-wait-gamescope.sh
@@ -46,7 +46,8 @@ fi
 # private portal, and clear the durable claim.
 if [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
   session_cmd="${POLARIS_GAMESCOPE_SESSION_BIN:-polaris-gamescope-session}"
-  [ -s "$rt/polaris-gamescope-session-id" ] || {
+  { [ -s "$rt/polaris-gamescope-session-state" ] \
+      || [ -s "$rt/polaris-gamescope-session-id" ]; } || {
     echo "polaris: nested recovery lacks its immutable session credential" >&2
     exit 1
   }

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -266,6 +266,42 @@ namespace stream_runtime::gamescope_process {
       return false;
     }
 
+    std::optional<std::string> read_cgroup(const lookup_paths_t &paths, int pid) {
+      std::ifstream input(paths.proc_root / std::to_string(pid) / "cgroup");
+      std::string line;
+      std::string last;
+      while (std::getline(input, line)) {
+        if (!line.empty()) {
+          last = line;
+        }
+      }
+      if (last.empty()) {
+        return std::nullopt;
+      }
+      return last;
+    }
+
+    bool same_cgroup(const lookup_paths_t &paths, int a, int b) {
+      const auto ca = read_cgroup(paths, a);
+      const auto cb = read_cgroup(paths, b);
+      return ca && cb && *ca == *cb;
+    }
+
+    bool related_to_root(
+      int pid,
+      int root,
+      const std::map<int, process_t> &processes,
+      const lookup_paths_t &paths
+    ) {
+      if (pid == root) {
+        return true;
+      }
+      if (is_descendant_of(pid, root, processes)) {
+        return true;
+      }
+      return same_cgroup(paths, pid, root);
+    }
+
     std::optional<std::uint64_t> inode_for_path(
       const socket_inode_map_t &inodes,
       const fs::path &path
@@ -275,6 +311,39 @@ namespace stream_runtime::gamescope_process {
         return std::nullopt;
       }
       return *found->second;
+    }
+
+    // All inode numbers listed for pathname (including ambiguous multi-row sets).
+    std::vector<std::uint64_t> all_inodes_for_path(
+      const fs::path &proc_net_unix,
+      const fs::path &path
+    ) {
+      std::vector<std::uint64_t> out;
+      std::ifstream input(proc_net_unix);
+      std::string line;
+      std::getline(input, line);  // header
+      while (std::getline(input, line)) {
+        std::istringstream row(line);
+        std::string num;
+        std::string ref_count;
+        std::string protocol;
+        std::string flags;
+        std::string type;
+        std::string state;
+        std::string inode_text;
+        if (!(row >> num >> ref_count >> protocol >> flags >> type >> state >> inode_text)) {
+          continue;
+        }
+        std::string sock_path;
+        std::getline(row >> std::ws, sock_path);
+        if (sock_path != path.string()) {
+          continue;
+        }
+        if (const auto inode = parse_integer<std::uint64_t>(inode_text)) {
+          out.push_back(*inode);
+        }
+      }
+      return out;
     }
   }  // namespace
 
@@ -408,6 +477,51 @@ namespace stream_runtime::gamescope_process {
     return false;
   }
 
+  bool socket_has_live_holder(
+    const fs::path &socket_path,
+    const lookup_paths_t &paths
+  ) {
+    std::error_code ec;
+    if (!fs::exists(socket_path, ec) || ec) {
+      return false;
+    }
+    const auto inodes = read_unix_socket_inodes(paths.proc_net_unix);
+    const auto found = inodes.find(socket_path.string());
+    // No /proc/net/unix row → filesystem residue only.
+    if (found == inodes.end()) {
+      return false;
+    }
+    // Ambiguous duplicate pathname rows: treat as live so callers fail closed.
+    if (!found->second) {
+      return true;
+    }
+    const auto processes = read_processes(paths.proc_root);
+    for (const auto &[pid, process] : processes) {
+      (void) process;
+      if (process_holds_inode(paths, pid, *found->second)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool remove_orphan_socket(
+    const fs::path &socket_path,
+    const lookup_paths_t &paths
+  ) {
+    std::error_code ec;
+    if (!fs::exists(socket_path, ec) || ec) {
+      fs::remove(fs::path(socket_path.string() + ".lock"), ec);
+      return true;
+    }
+    if (socket_has_live_holder(socket_path, paths)) {
+      return false;
+    }
+    fs::remove(socket_path, ec);
+    fs::remove(fs::path(socket_path.string() + ".lock"), ec);
+    return !fs::exists(socket_path, ec);
+  }
+
   std::optional<std::string> discover_owned_x11_display(
     const marker_t &marker,
     const lookup_paths_t &paths
@@ -415,41 +529,41 @@ namespace stream_runtime::gamescope_process {
     if (!validate_process(marker, paths)) {
       return std::nullopt;
     }
-    const auto inodes = read_unix_socket_inodes(paths.proc_net_unix);
     const auto processes = read_processes(paths.proc_root);
-    std::vector<std::pair<int, std::uint64_t>> candidates;
-    for (const auto &[path, inode] : inodes) {
-      if (!inode) {
-        continue;
+    std::optional<int> best;
+
+    std::error_code ec;
+    for (const auto &entry : fs::directory_iterator(paths.x11_socket_dir, ec)) {
+      if (ec) {
+        break;
       }
-      const fs::path socket_path(path);
-      if (socket_path.parent_path() != paths.x11_socket_dir) {
-        continue;
-      }
-      const auto name = socket_path.filename().string();
+      const auto name = entry.path().filename().string();
       if (name.size() < 2 || name.front() != 'X') {
         continue;
       }
       const auto display = parse_integer<int>(std::string_view {name}.substr(1));
-      std::error_code ec;
-      if (display && *display >= 0 && fs::exists(socket_path, ec) && !ec) {
-        candidates.emplace_back(*display, *inode);
+      if (!display || *display < 0 || !entry.exists(ec)) {
+        continue;
+      }
+      // Include every inode row for this path so unlink/rebind residue does not
+      // hide a live Xwayland still related to the marker generation.
+      for (const auto inode : all_inodes_for_path(paths.proc_net_unix, entry.path())) {
+        for (const auto &[pid, process] : processes) {
+          if (pid == marker.pid || !executable_named(process, "Xwayland") ||
+              !related_to_root(pid, marker.pid, processes, paths) ||
+              !process_holds_inode(paths, pid, inode)) {
+            continue;
+          }
+          if (!best || *display < *best) {
+            best = *display;
+          }
+        }
       }
     }
-    std::sort(candidates.begin(), candidates.end());
-
-    for (const auto &[display, inode] : candidates) {
-      for (const auto &[pid, process] : processes) {
-        if (pid == marker.pid || !is_descendant_of(pid, marker.pid, processes) ||
-            !executable_named(process, "Xwayland")) {
-          continue;
-        }
-        if (process_holds_inode(paths, pid, inode)) {
-          return ":" + std::to_string(display);
-        }
-      }
+    if (!best) {
+      return std::nullopt;
     }
-    return std::nullopt;
+    return ":" + std::to_string(*best);
   }
 
 }  // namespace stream_runtime::gamescope_process

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <charconv>
 #include <chrono>
+#include <cctype>
 #include <fstream>
 #include <map>
 #include <set>
@@ -18,6 +19,7 @@
 
 #include <fcntl.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 namespace stream_runtime::gamescope_process {
@@ -48,21 +50,82 @@ namespace stream_runtime::gamescope_process {
         }
       }
 
+      bool still_names(const fs::path &path) const {
+        struct stat fd_stat {};
+        struct stat path_stat {};
+        return fd_ >= 0 && fstat(fd_, &fd_stat) == 0 && lstat(path.c_str(), &path_stat) == 0 &&
+               S_ISREG(fd_stat.st_mode) && S_ISREG(path_stat.st_mode) &&
+               fd_stat.st_dev == path_stat.st_dev && fd_stat.st_ino == path_stat.st_ino;
+      }
+
     private:
       int fd_;
     };
 
-    std::optional<locked_fd_t> lock_wayland_socket_path(const fs::path &socket_path) {
+    bool process_holds_deleted_path(const fs::path &proc_root, const fs::path &path, uid_t owner) {
+      const auto expected = path.string() + " (deleted)";
+      std::error_code ec;
+      for (const auto &process : fs::directory_iterator(proc_root, ec)) {
+        if (ec) {
+          return true;
+        }
+        const auto name = process.path().filename().string();
+        if (name.empty() || !std::all_of(name.begin(), name.end(), [](unsigned char ch) { return std::isdigit(ch); })) {
+          continue;
+        }
+        struct stat process_stat {};
+        if (lstat(process.path().c_str(), &process_stat) != 0) {
+          return true;
+        }
+        if (process_stat.st_uid != owner) {
+          continue;
+        }
+        std::error_code fd_ec;
+        for (const auto &entry : fs::directory_iterator(process.path() / "fd", fd_ec)) {
+          if (fd_ec) {
+            return true;
+          }
+          std::error_code link_ec;
+          const auto target = fs::read_symlink(entry.path(), link_ec);
+          if (!link_ec && target == expected) {
+            return true;
+          }
+        }
+        if (fd_ec) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    bool deleted_lock_state_unsafe(const fs::path &proc_root, const fs::path &lock_path) {
+      struct stat lock_stat {};
+      if (lstat(lock_path.c_str(), &lock_stat) != 0 || !S_ISREG(lock_stat.st_mode)) {
+        return true;
+      }
+      return process_holds_deleted_path(proc_root, lock_path, lock_stat.st_uid);
+    }
+
+    std::optional<locked_fd_t> lock_wayland_socket_path(
+      const fs::path &socket_path,
+      const lookup_paths_t &paths
+    ) {
       const fs::path lock_path {socket_path.string() + ".lock"};
+      if (deleted_lock_state_unsafe(paths.proc_root, lock_path)) {
+        return std::nullopt;
+      }
       const int fd = open(lock_path.c_str(), O_RDWR | O_CLOEXEC | O_NOFOLLOW);
       if (fd < 0) {
         return std::nullopt;
       }
-      if (flock(fd, LOCK_EX | LOCK_NB) != 0) {
-        close(fd);
+      locked_fd_t locked {fd};
+      if (!locked.still_names(lock_path) || flock(fd, LOCK_EX | LOCK_NB) != 0) {
         return std::nullopt;
       }
-      return locked_fd_t {fd};
+      if (!locked.still_names(lock_path) || deleted_lock_state_unsafe(paths.proc_root, lock_path)) {
+        return std::nullopt;
+      }
+      return locked;
     }
 
     template<typename T>
@@ -530,14 +593,21 @@ namespace stream_runtime::gamescope_process {
     // Libwayland holds this advisory lock from bind through display teardown.
     // Taking it non-blocking closes the check/unlink race with a compositor
     // that has locked the name but has not created its socket yet.
-    auto socket_lock = lock_wayland_socket_path(socket_path);
+    const fs::path lock_path {socket_path.string() + ".lock"};
+    auto socket_lock = lock_wayland_socket_path(socket_path, paths);
     if (!socket_lock) {
       return false;
     }
     if (!fs::exists(socket_path, ec) || ec) {
       return !ec;
     }
+    if (!socket_lock->still_names(lock_path) || deleted_lock_state_unsafe(paths.proc_root, lock_path)) {
+      return false;
+    }
     if (socket_has_live_holder(socket_path, paths)) {
+      return false;
+    }
+    if (!socket_lock->still_names(lock_path) || deleted_lock_state_unsafe(paths.proc_root, lock_path)) {
       return false;
     }
     if (!fs::remove(socket_path, ec) || ec) {

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -58,6 +58,15 @@ namespace stream_runtime::gamescope_process {
                fd_stat.st_dev == path_stat.st_dev && fd_stat.st_ino == path_stat.st_ino;
       }
 
+      bool still_names_node(const fs::path &path) const {
+        struct stat fd_stat {};
+        struct stat path_stat {};
+        return fd_ >= 0 && fstat(fd_, &fd_stat) == 0 && lstat(path.c_str(), &path_stat) == 0 &&
+               !S_ISLNK(path_stat.st_mode) &&
+               fd_stat.st_dev == path_stat.st_dev && fd_stat.st_ino == path_stat.st_ino &&
+               fd_stat.st_mode == path_stat.st_mode;
+      }
+
     private:
       int fd_;
     };
@@ -596,8 +605,12 @@ namespace stream_runtime::gamescope_process {
     if (!fs::exists(socket_path, ec) || ec) {
       return !ec;
     }
-    struct stat socket_identity {};
-    if (lstat(socket_path.c_str(), &socket_identity) != 0 || S_ISLNK(socket_identity.st_mode)) {
+    const int socket_pin_fd = open(socket_path.c_str(), O_PATH | O_CLOEXEC | O_NOFOLLOW);
+    if (socket_pin_fd < 0) {
+      return false;
+    }
+    locked_fd_t socket_pin {socket_pin_fd};
+    if (!socket_pin.still_names_node(socket_path)) {
       return false;
     }
     if (!socket_lock->still_names(lock_path) || deleted_lock_state_unsafe(paths.proc_root, lock_path)) {
@@ -612,11 +625,9 @@ namespace stream_runtime::gamescope_process {
     if (!socket_lock->still_names(lock_path) || deleted_lock_state_unsafe(paths.proc_root, lock_path)) {
       return false;
     }
-    struct stat socket_now {};
-    if (lstat(socket_path.c_str(), &socket_now) != 0 ||
-        socket_now.st_dev != socket_identity.st_dev ||
-        socket_now.st_ino != socket_identity.st_ino ||
-        socket_now.st_mode != socket_identity.st_mode) {
+    // Keep an O_PATH descriptor for the original node until unlink completes.
+    // A replacement path therefore cannot reuse the original inode allocation.
+    if (!socket_pin.still_names_node(socket_path)) {
       return false;
     }
     if (!fs::remove(socket_path, ec) || ec) {

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -16,6 +16,10 @@
 #include <utility>
 #include <vector>
 
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
 namespace stream_runtime::gamescope_process {
   namespace {
     namespace fs = std::filesystem;
@@ -27,6 +31,39 @@ namespace stream_runtime::gamescope_process {
       fs::path executable;
       std::vector<std::string> argv;
     };
+
+    class locked_fd_t {
+    public:
+      explicit locked_fd_t(int fd):
+          fd_(fd) {}
+
+      locked_fd_t(const locked_fd_t &) = delete;
+      locked_fd_t &operator=(const locked_fd_t &) = delete;
+      locked_fd_t(locked_fd_t &&other) noexcept:
+          fd_(std::exchange(other.fd_, -1)) {}
+
+      ~locked_fd_t() {
+        if (fd_ >= 0) {
+          close(fd_);
+        }
+      }
+
+    private:
+      int fd_;
+    };
+
+    std::optional<locked_fd_t> lock_wayland_socket_path(const fs::path &socket_path) {
+      const fs::path lock_path {socket_path.string() + ".lock"};
+      const int fd = open(lock_path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0600);
+      if (fd < 0) {
+        return std::nullopt;
+      }
+      if (flock(fd, LOCK_EX | LOCK_NB) != 0) {
+        close(fd);
+        return std::nullopt;
+      }
+      return locked_fd_t {fd};
+    }
 
     template<typename T>
     std::optional<T> parse_integer(std::string_view value) {
@@ -518,12 +555,25 @@ namespace stream_runtime::gamescope_process {
     if (!fs::exists(socket_path, ec) || ec) {
       return !ec;
     }
+    // Libwayland holds this advisory lock from bind through display teardown.
+    // Taking it non-blocking closes the check/unlink race with a compositor
+    // that has locked the name but has not created its socket yet.
+    auto socket_lock = lock_wayland_socket_path(socket_path);
+    if (!socket_lock) {
+      return false;
+    }
+    if (!fs::exists(socket_path, ec) || ec) {
+      return !ec;
+    }
     if (socket_has_live_holder(socket_path, paths)) {
       return false;
     }
-    fs::remove(socket_path, ec);
-    fs::remove(fs::path(socket_path.string() + ".lock"), ec);
-    return !fs::exists(socket_path, ec);
+    if (!fs::remove(socket_path, ec) || ec) {
+      return false;
+    }
+    // Leave the unlocked lock file in place. Unlinking a held lock creates a
+    // second inode that another binder can acquire concurrently.
+    return true;
   }
 
   std::optional<std::string> discover_owned_x11_display(

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -209,11 +209,14 @@ namespace stream_runtime::gamescope_process {
 
     using socket_inode_map_t = std::unordered_map<std::string, std::optional<std::uint64_t>>;
 
-    socket_inode_map_t read_unix_socket_inodes(
+    std::optional<socket_inode_map_t> read_unix_socket_inodes(
       const fs::path &proc_net_unix
     ) {
-      socket_inode_map_t inodes;
       std::ifstream input(proc_net_unix);
+      if (!input) {
+        return std::nullopt;
+      }
+      socket_inode_map_t inodes;
       std::string line;
       std::getline(input, line);  // header
       while (std::getline(input, line)) {
@@ -463,7 +466,10 @@ namespace stream_runtime::gamescope_process {
       return false;
     }
     const auto inodes = read_unix_socket_inodes(paths.proc_net_unix);
-    const auto inode = inode_for_path(inodes, socket_path);
+    if (!inodes) {
+      return false;
+    }
+    const auto inode = inode_for_path(*inodes, socket_path);
     if (!inode) {
       return false;
     }
@@ -482,27 +488,26 @@ namespace stream_runtime::gamescope_process {
     const lookup_paths_t &paths
   ) {
     std::error_code ec;
-    if (!fs::exists(socket_path, ec) || ec) {
+    const bool socket_exists = fs::exists(socket_path, ec);
+    if (ec) {
+      return true;
+    }
+    if (!socket_exists) {
       return false;
     }
     const auto inodes = read_unix_socket_inodes(paths.proc_net_unix);
-    const auto found = inodes.find(socket_path.string());
-    // No /proc/net/unix row → filesystem residue only.
-    if (found == inodes.end()) {
-      return false;
-    }
-    // Ambiguous duplicate pathname rows: treat as live so callers fail closed.
-    if (!found->second) {
+    if (!inodes) {
       return true;
     }
-    const auto processes = read_processes(paths.proc_root);
-    for (const auto &[pid, process] : processes) {
-      (void) process;
-      if (process_holds_inode(paths, pid, *found->second)) {
-        return true;
-      }
+    const auto found = inodes->find(socket_path.string());
+    // No /proc/net/unix row → filesystem residue only.
+    if (found == inodes->end()) {
+      return false;
     }
-    return false;
+    // Any kernel socket-table row means the socket is still referenced. The
+    // owning fd may be hidden by procfs permissions, so never use a failed fd
+    // scan as permission to unlink the pathname.
+    return true;
   }
 
   bool remove_orphan_socket(
@@ -511,8 +516,7 @@ namespace stream_runtime::gamescope_process {
   ) {
     std::error_code ec;
     if (!fs::exists(socket_path, ec) || ec) {
-      fs::remove(fs::path(socket_path.string() + ".lock"), ec);
-      return true;
+      return !ec;
     }
     if (socket_has_live_holder(socket_path, paths)) {
       return false;

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -523,13 +523,31 @@ namespace stream_runtime::gamescope_process {
       return false;
     }
     const auto processes = read_processes(paths.proc_root);
+    std::optional<pid_t> holder_pid;
     for (const auto &[pid, process] : processes) {
       (void) process;
       if (is_descendant_of(pid, marker.pid, processes) && process_holds_inode(paths, pid, *inode)) {
-        return true;
+        holder_pid = pid;
+        break;
       }
     }
-    return false;
+    if (!holder_pid) {
+      return false;
+    }
+    if (paths.before_socket_ownership_return_for_tests) {
+      paths.before_socket_ownership_return_for_tests();
+    }
+    if (!validate_process(marker, paths)) {
+      return false;
+    }
+    const auto final_inodes = read_unix_socket_inodes(paths.proc_net_unix);
+    const auto final_inode = final_inodes ? inode_for_path(*final_inodes, socket_path) : std::nullopt;
+    if (!final_inode || *final_inode != *inode) {
+      return false;
+    }
+    const auto final_processes = read_processes(paths.proc_root);
+    return is_descendant_of(*holder_pid, marker.pid, final_processes) &&
+           process_holds_inode(paths, *holder_pid, *inode);
   }
 
   bool socket_has_live_holder(

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -388,38 +388,6 @@ namespace stream_runtime::gamescope_process {
       return *found->second;
     }
 
-    // All inode numbers listed for pathname (including ambiguous multi-row sets).
-    std::vector<std::uint64_t> all_inodes_for_path(
-      const fs::path &proc_net_unix,
-      const fs::path &path
-    ) {
-      std::vector<std::uint64_t> out;
-      std::ifstream input(proc_net_unix);
-      std::string line;
-      std::getline(input, line);  // header
-      while (std::getline(input, line)) {
-        std::istringstream row(line);
-        std::string num;
-        std::string ref_count;
-        std::string protocol;
-        std::string flags;
-        std::string type;
-        std::string state;
-        std::string inode_text;
-        if (!(row >> num >> ref_count >> protocol >> flags >> type >> state >> inode_text)) {
-          continue;
-        }
-        std::string sock_path;
-        std::getline(row >> std::ws, sock_path);
-        if (sock_path != path.string()) {
-          continue;
-        }
-        if (const auto inode = parse_integer<std::uint64_t>(inode_text)) {
-          out.push_back(*inode);
-        }
-      }
-      return out;
-    }
   }  // namespace
 
   std::optional<marker_t> read_marker(const fs::path &path) {
@@ -626,6 +594,10 @@ namespace stream_runtime::gamescope_process {
       return std::nullopt;
     }
     const auto processes = read_processes(paths.proc_root);
+    const auto x11_inodes = read_unix_socket_inodes(paths.proc_net_unix);
+    if (!x11_inodes) {
+      return std::nullopt;
+    }
     struct candidate_t {
       int display;
       int pid;
@@ -648,24 +620,27 @@ namespace stream_runtime::gamescope_process {
       if (!display || *display < 0 || !entry.exists(ec)) {
         continue;
       }
-      // Include every inode row for this path so unlink/rebind residue does not
-      // hide a live Xwayland still related to the marker generation.
-      for (const auto inode : all_inodes_for_path(paths.proc_net_unix, entry.path())) {
-        for (const auto &[pid, process] : processes) {
-          if (pid == marker.pid || !executable_named(process, "Xwayland") ||
-              !related_to_root(pid, marker.pid, processes) ||
-              !process_holds_inode(paths, pid, inode)) {
-            continue;
-          }
-          if (!best || *display < best->display) {
-            best = candidate_t {
-              .display = *display,
-              .pid = pid,
-              .start_time = process.start_time,
-              .executable = process.executable,
-              .inode = inode,
-            };
-          }
+      // Routing by pathname is authoritative only when the kernel exposes one
+      // unambiguous inode for that X socket. Duplicate rows can represent an
+      // unlinked predecessor plus a successor rebind.
+      const auto inode = inode_for_path(*x11_inodes, entry.path());
+      if (!inode) {
+        continue;
+      }
+      for (const auto &[pid, process] : processes) {
+        if (pid == marker.pid || !executable_named(process, "Xwayland") ||
+            !related_to_root(pid, marker.pid, processes) ||
+            !process_holds_inode(paths, pid, *inode)) {
+          continue;
+        }
+        if (!best || *display < best->display) {
+          best = candidate_t {
+            .display = *display,
+            .pid = pid,
+            .start_time = process.start_time,
+            .executable = process.executable,
+            .inode = *inode,
+          };
         }
       }
     }
@@ -678,6 +653,12 @@ namespace stream_runtime::gamescope_process {
       return std::nullopt;
     }
     const auto final_processes = read_processes(paths.proc_root);
+    const auto root = final_processes.find(marker.pid);
+    if (root == final_processes.end() ||
+        root->second.start_time != marker.start_time ||
+        root->second.executable != marker.executable) {
+      return std::nullopt;
+    }
     const auto found = final_processes.find(best->pid);
     if (found == final_processes.end() ||
         found->second.start_time != best->start_time ||

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -578,6 +578,10 @@ namespace stream_runtime::gamescope_process {
     if (!fs::exists(socket_path, ec) || ec) {
       return !ec;
     }
+    struct stat socket_identity {};
+    if (lstat(socket_path.c_str(), &socket_identity) != 0 || S_ISLNK(socket_identity.st_mode)) {
+      return false;
+    }
     if (!socket_lock->still_names(lock_path) || deleted_lock_state_unsafe(paths.proc_root, lock_path)) {
       return false;
     }
@@ -588,6 +592,13 @@ namespace stream_runtime::gamescope_process {
       paths.before_socket_unlink_for_tests();
     }
     if (!socket_lock->still_names(lock_path) || deleted_lock_state_unsafe(paths.proc_root, lock_path)) {
+      return false;
+    }
+    struct stat socket_now {};
+    if (lstat(socket_path.c_str(), &socket_now) != 0 ||
+        socket_now.st_dev != socket_identity.st_dev ||
+        socket_now.st_ino != socket_identity.st_ino ||
+        socket_now.st_mode != socket_identity.st_mode) {
       return false;
     }
     if (!fs::remove(socket_path, ec) || ec) {

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -54,7 +54,7 @@ namespace stream_runtime::gamescope_process {
 
     std::optional<locked_fd_t> lock_wayland_socket_path(const fs::path &socket_path) {
       const fs::path lock_path {socket_path.string() + ".lock"};
-      const int fd = open(lock_path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0600);
+      const int fd = open(lock_path.c_str(), O_RDWR | O_CLOEXEC | O_NOFOLLOW);
       if (fd < 0) {
         return std::nullopt;
       }

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -87,13 +87,22 @@ namespace stream_runtime::gamescope_process {
           }
           std::error_code link_ec;
           const auto target = fs::read_symlink(entry.path(), link_ec);
-          if (!link_ec && target == expected) {
+          if (link_ec) {
+            if (link_ec == std::errc::no_such_file_or_directory) {
+              continue;
+            }
+            return true;
+          }
+          if (target == expected) {
             return true;
           }
         }
         if (fd_ec) {
           return true;
         }
+      }
+      if (ec) {
+        return true;
       }
       return false;
     }
@@ -574,6 +583,9 @@ namespace stream_runtime::gamescope_process {
     }
     if (socket_has_live_holder(socket_path, paths)) {
       return false;
+    }
+    if (paths.before_socket_unlink_for_tests) {
+      paths.before_socket_unlink_for_tests();
     }
     if (!socket_lock->still_names(lock_path) || deleted_lock_state_unsafe(paths.proc_root, lock_path)) {
       return false;

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -670,6 +670,9 @@ namespace stream_runtime::gamescope_process {
     if (!best) {
       return std::nullopt;
     }
+    if (paths.before_x11_return_for_tests) {
+      paths.before_x11_return_for_tests();
+    }
     // Rebuild the process snapshot and prove both generations and fd ownership
     // again immediately before returning a routing decision.
     if (!validate_process(marker, paths)) {
@@ -689,6 +692,12 @@ namespace stream_runtime::gamescope_process {
         !executable_named(found->second, "Xwayland") ||
         !related_to_root(best->pid, marker.pid, final_processes) ||
         !process_holds_inode(paths, best->pid, best->inode)) {
+      return std::nullopt;
+    }
+    const auto final_x11_inodes = read_unix_socket_inodes(paths.proc_net_unix);
+    const auto socket_path = paths.x11_socket_dir / ("X" + std::to_string(best->display));
+    const auto final_inode = final_x11_inodes ? inode_for_path(*final_x11_inodes, socket_path) : std::nullopt;
+    if (!final_inode || *final_inode != best->inode) {
       return std::nullopt;
     }
     return ":" + std::to_string(best->display);

--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -306,40 +306,12 @@ namespace stream_runtime::gamescope_process {
       return false;
     }
 
-    std::optional<std::string> read_cgroup(const lookup_paths_t &paths, int pid) {
-      std::ifstream input(paths.proc_root / std::to_string(pid) / "cgroup");
-      std::string line;
-      std::string last;
-      while (std::getline(input, line)) {
-        if (!line.empty()) {
-          last = line;
-        }
-      }
-      if (last.empty()) {
-        return std::nullopt;
-      }
-      return last;
-    }
-
-    bool same_cgroup(const lookup_paths_t &paths, int a, int b) {
-      const auto ca = read_cgroup(paths, a);
-      const auto cb = read_cgroup(paths, b);
-      return ca && cb && *ca == *cb;
-    }
-
     bool related_to_root(
       int pid,
       int root,
-      const std::map<int, process_t> &processes,
-      const lookup_paths_t &paths
+      const std::map<int, process_t> &processes
     ) {
-      if (pid == root) {
-        return true;
-      }
-      if (is_descendant_of(pid, root, processes)) {
-        return true;
-      }
-      return same_cgroup(paths, pid, root);
+      return pid != root && is_descendant_of(pid, root, processes);
     }
 
     std::optional<std::uint64_t> inode_for_path(
@@ -584,7 +556,14 @@ namespace stream_runtime::gamescope_process {
       return std::nullopt;
     }
     const auto processes = read_processes(paths.proc_root);
-    std::optional<int> best;
+    struct candidate_t {
+      int display;
+      int pid;
+      std::uint64_t start_time;
+      fs::path executable;
+      std::uint64_t inode;
+    };
+    std::optional<candidate_t> best;
 
     std::error_code ec;
     for (const auto &entry : fs::directory_iterator(paths.x11_socket_dir, ec)) {
@@ -604,12 +583,18 @@ namespace stream_runtime::gamescope_process {
       for (const auto inode : all_inodes_for_path(paths.proc_net_unix, entry.path())) {
         for (const auto &[pid, process] : processes) {
           if (pid == marker.pid || !executable_named(process, "Xwayland") ||
-              !related_to_root(pid, marker.pid, processes, paths) ||
+              !related_to_root(pid, marker.pid, processes) ||
               !process_holds_inode(paths, pid, inode)) {
             continue;
           }
-          if (!best || *display < *best) {
-            best = *display;
+          if (!best || *display < best->display) {
+            best = candidate_t {
+              .display = *display,
+              .pid = pid,
+              .start_time = process.start_time,
+              .executable = process.executable,
+              .inode = inode,
+            };
           }
         }
       }
@@ -617,7 +602,22 @@ namespace stream_runtime::gamescope_process {
     if (!best) {
       return std::nullopt;
     }
-    return ":" + std::to_string(*best);
+    // Rebuild the process snapshot and prove both generations and fd ownership
+    // again immediately before returning a routing decision.
+    if (!validate_process(marker, paths)) {
+      return std::nullopt;
+    }
+    const auto final_processes = read_processes(paths.proc_root);
+    const auto found = final_processes.find(best->pid);
+    if (found == final_processes.end() ||
+        found->second.start_time != best->start_time ||
+        found->second.executable != best->executable ||
+        !executable_named(found->second, "Xwayland") ||
+        !related_to_root(best->pid, marker.pid, final_processes) ||
+        !process_holds_inode(paths, best->pid, best->inode)) {
+      return std::nullopt;
+    }
+    return ":" + std::to_string(best->display);
   }
 
 }  // namespace stream_runtime::gamescope_process

--- a/src/platform/linux/gamescope_process.h
+++ b/src/platform/linux/gamescope_process.h
@@ -64,6 +64,26 @@ namespace stream_runtime::gamescope_process {
     const lookup_paths_t &paths = {}
   );
 
+  /**
+   * True when any process holds the unique /proc/net/unix inode for socket_path.
+   * False when missing, filesystem-only residue, or no live holder.
+   * Ambiguous duplicate pathname rows fail closed as "live" (not safe to unlink).
+   */
+  bool socket_has_live_holder(
+    const std::filesystem::path &socket_path,
+    const lookup_paths_t &paths = {}
+  );
+
+  /**
+   * Unlink a crash-orphaned Wayland socket (and .lock) when no live holder exists.
+   * Returns true when the path is gone afterward; false if a live holder (or
+   * ambiguous pathname) still owns it.
+   */
+  bool remove_orphan_socket(
+    const std::filesystem::path &socket_path,
+    const lookup_paths_t &paths = {}
+  );
+
   /** Lowest numbered X socket held by an Xwayland descendant of marker.pid. */
   std::optional<std::string> discover_owned_x11_display(
     const marker_t &marker,

--- a/src/platform/linux/gamescope_process.h
+++ b/src/platform/linux/gamescope_process.h
@@ -27,6 +27,7 @@ namespace stream_runtime::gamescope_process {
     std::filesystem::path proc_net_unix = "/proc/net/unix";
     std::filesystem::path x11_socket_dir = "/tmp/.X11-unix";
     std::function<void()> before_socket_unlink_for_tests;
+    std::function<void()> before_x11_return_for_tests;
   };
 
   std::optional<marker_t> read_marker(const std::filesystem::path &path);

--- a/src/platform/linux/gamescope_process.h
+++ b/src/platform/linux/gamescope_process.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -25,6 +26,7 @@ namespace stream_runtime::gamescope_process {
     std::filesystem::path proc_root = "/proc";
     std::filesystem::path proc_net_unix = "/proc/net/unix";
     std::filesystem::path x11_socket_dir = "/tmp/.X11-unix";
+    std::function<void()> before_socket_unlink_for_tests;
   };
 
   std::optional<marker_t> read_marker(const std::filesystem::path &path);
@@ -75,7 +77,7 @@ namespace stream_runtime::gamescope_process {
   );
 
   /**
-   * Unlink a crash-orphaned Wayland socket (and .lock) when no live holder exists.
+   * Unlink a crash-orphaned Wayland socket while preserving its existing lock.
    * Returns true when the path is gone afterward; false if a live holder (or
    * ambiguous pathname) still owns it.
    */

--- a/src/platform/linux/gamescope_process.h
+++ b/src/platform/linux/gamescope_process.h
@@ -28,6 +28,7 @@ namespace stream_runtime::gamescope_process {
     std::filesystem::path x11_socket_dir = "/tmp/.X11-unix";
     std::function<void()> before_socket_unlink_for_tests;
     std::function<void()> before_x11_return_for_tests;
+    std::function<void()> before_socket_ownership_return_for_tests;
   };
 
   std::optional<marker_t> read_marker(const std::filesystem::path &path);

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -257,10 +257,27 @@ namespace portal {
   static bool ensure_session_unlocked() {
     if (!g_media.portal || !g_media.portal->ready || g_media.portal->pw_node_id == 0) {
       g_media.portal.reset();
-      g_media.portal = create_portal_session(capture_type_for_stream_display(
-        config::video.linux_display.headless_mode,
-        config::video.linux_display.use_cage_compositor,
-        config::video.linux_display.stream_mode));
+      auto try_create = []() {
+        return create_portal_session(capture_type_for_stream_display(
+          config::video.linux_display.headless_mode,
+          config::video.linux_display.use_cage_compositor,
+          config::video.linux_display.stream_mode));
+      };
+      g_media.portal = try_create();
+      // Nested↔idle gamescope handoff: portal-gamescope may briefly fail Start with
+      // "failed to connect to wayland socket" until the new generation owns
+      // gamescope-0. Retry a few times rather than fail the whole stream.
+      for (int attempt = 1;
+           attempt <= 4 &&
+           (!g_media.portal || g_media.portal->failed || !g_media.portal->ready ||
+            g_media.portal->pw_node_id == 0);
+           ++attempt) {
+        BOOST_LOG(warning) << "portal: create session attempt "sv << attempt
+                           << " failed; waiting for gamescope-0 before retry"sv;
+        g_media.portal.reset();
+        std::this_thread::sleep_for(std::chrono::milliseconds(400 * attempt));
+        g_media.portal = try_create();
+      }
       if (!g_media.portal || g_media.portal->failed || !g_media.portal->ready ||
           g_media.portal->pw_node_id == 0) {
         BOOST_LOG(warning) << "portal: Failed to create global session"sv;

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -701,6 +701,11 @@ namespace portal {
         // Bad/stale restore token often hangs Start with no Response; drop it so
         // the next connect can re-bootstrap with a visible picker.
         clear_restore_token();
+        // Nested↔idle gamescope handoff leaves a short window where
+        // xdg-desktop-portal-gamescope cannot open WAYLAND_DISPLAY=gamescope-0
+        // ("failed to connect to wayland socket" → Response code 2). One delayed
+        // retry on a *fresh* session is owned by the caller; here we only clear
+        // the token so the next CreateSession is clean.
         BOOST_LOG(warning) << "portal: Start timeout/failure — cleared restore_token (no Start retry; session is single-use)"sv;
         session->failed = true;
         return session;

--- a/src/platform/linux/session_manager.cpp
+++ b/src/platform/linux/session_manager.cpp
@@ -326,15 +326,28 @@ namespace session_manager {
     const bool private_headless_runtime =
       config::video.linux_display.headless_mode &&
       config::video.linux_display.use_cage_compositor;
+    // gamescope_stream / unit hosts intentionally unset host WAYLAND_DISPLAY so
+    // probes do not bind KWin; capture uses GAMESCOPE_WAYLAND_DISPLAY=gamescope-0.
+    const char *gamescope_wl = getenv("GAMESCOPE_WAYLAND_DISPLAY");
+    const bool gamescope_stream_host =
+      config::video.linux_display.stream_mode == "gamescope_stream" ||
+      (gamescope_wl && gamescope_wl[0] != '\0');
+    const bool wayland_optional = private_headless_runtime || gamescope_stream_host;
 
     const char *vars[] = {"WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "XDG_RUNTIME_DIR"};
     for (auto var : vars) {
       const char *val = getenv(var);
       if (!val || val[0] == '\0') {
-        if (std::string_view {var} == "WAYLAND_DISPLAY"sv && private_headless_runtime) {
-          BOOST_LOG(info) << "session_manager: WAYLAND_DISPLAY is not set; continuing because Private Stream "
-                          << "will start a private labwc socket. Desktop preview and portal capture may be "
-                          << "unavailable until Polaris is launched from a desktop session."sv;
+        if (std::string_view {var} == "WAYLAND_DISPLAY"sv && wayland_optional) {
+          if (gamescope_stream_host) {
+            BOOST_LOG(info) << "session_manager: WAYLAND_DISPLAY unset (expected for gamescope_stream); "
+                            << "using GAMESCOPE_WAYLAND_DISPLAY="sv
+                            << (gamescope_wl && gamescope_wl[0] ? gamescope_wl : "gamescope-0") << ""sv;
+          } else {
+            BOOST_LOG(info) << "session_manager: WAYLAND_DISPLAY is not set; continuing because Private Stream "
+                            << "will start a private labwc socket. Desktop preview and portal capture may be "
+                            << "unavailable until Polaris is launched from a desktop session."sv;
+          }
           continue;
         }
 
@@ -445,7 +458,9 @@ namespace session_manager {
       } catch (...) {}
     }
 
-    BOOST_LOG(warning) << "session_manager: Failed to inhibit lock screen via D-Bus"sv;
+    // D-Bus ScreenSaver is often missing under pure gamescope/headless user units;
+    // systemd-inhibit is the normal path there — do not warn as if streaming is broken.
+    BOOST_LOG(info) << "session_manager: ScreenSaver.Inhibit unavailable; using systemd-inhibit fallback"sv;
 
     // Fallback: use systemd-inhibit style via loginctl
     run("systemd-inhibit --what=idle:sleep --who=polaris "

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -55,7 +55,7 @@ namespace stream_runtime {
   );
 
   bool drain_gamescope_private_group_for_tests(pid_t pgid);
-  bool rollback_gamescope_spawn_for_tests(pid_t pgid, bool leader_reaped);
+  bool rollback_gamescope_spawn_for_tests(pid_t pgid, int leader_pidfd);
 
   /**
    * Labwc-only free functions — only stream_runtime_labwc.cpp may include

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -55,6 +55,7 @@ namespace stream_runtime {
   );
 
   bool drain_gamescope_private_group_for_tests(pid_t pgid);
+  bool rollback_gamescope_spawn_for_tests(pid_t pgid, bool leader_reaped);
 
   /**
    * Labwc-only free functions — only stream_runtime_labwc.cpp may include

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -56,6 +56,7 @@ namespace stream_runtime {
 
   bool drain_gamescope_private_group_for_tests(pid_t pgid);
   bool rollback_gamescope_spawn_for_tests(pid_t pgid, int leader_pidfd);
+  bool gamescope_runtime_acquisition_allowed_for_tests();
 
   /**
    * Labwc-only free functions — only stream_runtime_labwc.cpp may include

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -54,6 +54,8 @@ namespace stream_runtime {
     bool runtime_gpu_native_override_active = false
   );
 
+  bool drain_gamescope_private_group_for_tests(pid_t pgid);
+
   /**
    * Labwc-only free functions — only stream_runtime_labwc.cpp may include
    * cage_display_router. All other TUs call through this namespace.

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -126,16 +126,20 @@ namespace stream_runtime {
       bool start(const start_params_t &params) override {
         std::lock_guard lock(mu_);
         if (is_running_unlocked()) {
-          refresh_runtime_state(params);
-          if (!write_env_file()) {
-            return false;
+          // Crash/teardown can leave in-memory attach state while gamescope is dead.
+          // Re-validate exact generation + socket ownership before reuse.
+          if (revalidate_running_unlocked(params)) {
+            BOOST_LOG(info) << "gamescope_runtime: already "sv
+                            << (owned_ ? "owned"sv : "attached"sv)
+                            << " "sv << (socket_name_.empty() ? "gamescope-0" : socket_name_)
+                            << "; reusing"sv;
+            return true;
           }
-          BOOST_LOG(info) << "gamescope_runtime: already "sv
-                          << (owned_ ? "owned"sv : "attached"sv)
-                          << " "sv << (socket_name_.empty() ? "gamescope-0" : socket_name_)
-                          << "; reusing"sv;
-          return true;
+          BOOST_LOG(warning) << "gamescope_runtime: dropping stale in-memory gamescope state"sv;
+          clear_runtime_state_unlocked();
         }
+
+        ensure_portal_stack();
 
         // 1) Prefer attach to idle gamescope-0 (portal + polaris-gamescope.env contract).
         if (try_attach_gamescope0(params)) {
@@ -154,8 +158,14 @@ namespace stream_runtime {
 
         // 3) Spawn owned headless gamescope — only if gamescope-0 is still free.
         // Never attach/spawn onto gamescope-1 (portal is hard-wired to gamescope-0).
+        // Crash residue with no live holder is reclaimed; live unowned holders fail closed.
+        reclaim_orphan_gamescope_sockets();
         if (socket_exists("gamescope-0") && wait_for_stable_socket("gamescope-0", 1500)) {
-          return try_attach_gamescope0(params);
+          if (try_attach_gamescope0(params)) {
+            return true;
+          }
+          BOOST_LOG(error) << "gamescope_runtime: gamescope-0 exists but is not a validated owner; refusing destructive cleanup"sv;
+          return false;
         }
         if (socket_exists("gamescope-1") && !socket_exists("gamescope-0")) {
           BOOST_LOG(error) << "gamescope_runtime: gamescope-1 exists without a validated gamescope-0 owner; refusing destructive cleanup"sv;
@@ -499,6 +509,55 @@ namespace stream_runtime {
         (void) params;
       }
 
+      void clear_runtime_state_unlocked() {
+        marker_.reset();
+        owned_ = false;
+        pid_ = 0;
+        socket_name_.clear();
+        x11_display_.clear();
+        state_ = {};
+      }
+
+      bool revalidate_running_unlocked(const start_params_t &params) {
+        if (!marker_ || socket_name_.empty() || x11_display_.empty()) {
+          return false;
+        }
+        const auto current = validated_marker_for_socket(socket_name_, marker_->role);
+        if (!current || *current != *marker_) {
+          return false;
+        }
+        const auto display = gp::discover_owned_x11_display(*marker_);
+        if (!display || *display != x11_display_) {
+          return false;
+        }
+        refresh_runtime_state(params);
+        return write_env_file();
+      }
+
+      static void ensure_portal_stack() {
+        // Best-effort: private portal frontend can be TERM'd while polaris stays up.
+        // Idle recovery alone is not enough — CreateSession needs org.freedesktop.portal.Desktop.
+        (void) std::system(
+          "systemctl --user start polaris-portal-dbus.service "
+          "polaris-portal-gamescope.service polaris-portal.service 2>/dev/null"
+        );
+      }
+
+      // Best-effort: drop crash residue only. Live holders are left for attach / fail-closed.
+      static void reclaim_orphan_gamescope_sockets() {
+        const auto rt = fs::path(xdg_runtime_dir());
+        for (const char *name : {"gamescope-0", "gamescope-1", "gamescope-0-ei", "gamescope-1-ei"}) {
+          const auto path = rt / name;
+          std::error_code ec;
+          if (!fs::exists(path, ec) || ec) {
+            continue;
+          }
+          if (gp::remove_orphan_socket(path)) {
+            BOOST_LOG(info) << "gamescope_runtime: reclaimed orphan socket "sv << path.string();
+          }
+        }
+      }
+
       bool try_attach_gamescope0(const start_params_t &params) {
         if (!wait_for_stable_socket("gamescope-0", 2000)) {
           return false;
@@ -546,6 +605,7 @@ namespace stream_runtime {
       }
 
       static bool restart_or_start_idle_unit() {
+        ensure_portal_stack();
         const int rc = std::system(
           "systemctl --user restart polaris-gamescope-idle.service 2>/dev/null || "
           "systemctl --user start polaris-gamescope-idle.service 2>/dev/null");
@@ -554,6 +614,8 @@ namespace stream_runtime {
 
       bool try_start_idle_unit_and_attach(const start_params_t &params) {
         // Best-effort: host may ship polaris-gamescope-idle.service that owns gamescope-0.
+        // Clear crash residue so idle can bind gamescope-0 again.
+        reclaim_orphan_gamescope_sockets();
         const bool active =
           std::system("systemctl --user is-active --quiet polaris-gamescope-idle.service 2>/dev/null") == 0;
         const bool activating =

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -51,7 +51,10 @@ namespace stream_runtime {
 
     class owner_transition_lock_t {
     public:
-      owner_transition_lock_t() {
+      explicit owner_transition_lock_t(bool acquire = true) {
+        if (!acquire) {
+          return;
+        }
         const auto path = fs::path(xdg_runtime_dir()) / "polaris-gamescope.lock";
         fd_ = open(path.c_str(), O_CREAT | O_CLOEXEC | O_RDWR, 0600);
         if (fd_ >= 0 && flock(fd_, LOCK_EX) != 0) {
@@ -72,6 +75,14 @@ namespace stream_runtime {
 
       explicit operator bool() const { return fd_ >= 0; }
 
+      void unlock() {
+        if (fd_ >= 0) {
+          flock(fd_, LOCK_UN);
+          close(fd_);
+          fd_ = -1;
+        }
+      }
+
     private:
       int fd_ = -1;
     };
@@ -81,6 +92,51 @@ namespace stream_runtime {
         return xdg;
       }
       return "/run/user/" + std::to_string(getuid());
+    }
+
+    bool runtime_acquisition_allowed_locked() {
+      const auto rt = fs::path(xdg_runtime_dir());
+      const auto path_is_absent = [](const fs::path &path) {
+        std::error_code ec;
+        const auto status = fs::symlink_status(path, ec);
+        if (ec == std::errc::no_such_file_or_directory) {
+          return true;
+        }
+        return !ec && status.type() == fs::file_type::not_found;
+      };
+      if (!path_is_absent(rt / "polaris-gamescope-wsi-nested")) {
+        return false;
+      }
+
+      const auto state_path = rt / "polaris-gamescope-session-state";
+      if (!path_is_absent(state_path)) {
+        std::ifstream state(state_path);
+        std::string session_id;
+        std::string mode;
+        std::string extra;
+        if (!(state >> session_id >> mode) || (state >> extra) || session_id.empty()) {
+          return false;
+        }
+        return mode == "attach";
+      }
+
+      const auto legacy_id = rt / "polaris-gamescope-session-id";
+      const auto legacy_mode = rt / "polaris-gamescope-session-mode";
+      const bool id_absent = path_is_absent(legacy_id);
+      const bool mode_absent = path_is_absent(legacy_mode);
+      if (id_absent && mode_absent) {
+        return true;
+      }
+      if (id_absent || mode_absent) {
+        return false;
+      }
+      std::ifstream mode_file(legacy_mode);
+      std::string mode;
+      std::string extra;
+      if (!(mode_file >> mode) || (mode_file >> extra)) {
+        return false;
+      }
+      return mode == "attach";
     }
 
     bool socket_exists(const std::string &name) {
@@ -296,13 +352,19 @@ namespace stream_runtime {
           owned_ || pid_ > 0 || leader_pidfd_ >= 0 || marker_ ||
           !socket_name_.empty() || !x11_display_.empty();
         if (retained_state) {
-          if (is_running_unlocked() && revalidate_running_unlocked(params)) {
+          owner_transition_lock_t retained_lock;
+          if (!retained_lock || !runtime_acquisition_allowed_locked()) {
+            BOOST_LOG(warning) << "gamescope_runtime: nested ownership claim blocks retained runtime reuse"sv;
+            return false;
+          }
+          if (is_running_unlocked() && revalidate_running_unlocked(params, true)) {
             BOOST_LOG(info) << "gamescope_runtime: already "sv
                             << (owned_ ? "owned"sv : "attached"sv)
                             << " "sv << (socket_name_.empty() ? "gamescope-0" : socket_name_)
                             << "; reusing"sv;
             return true;
           }
+          retained_lock.unlock();
           if (owned_) {
             if (!marker_) {
               BOOST_LOG(error) << "gamescope_runtime: retained owned state lacks immutable marker authority; refusing restart"sv;
@@ -323,12 +385,22 @@ namespace stream_runtime {
 
         ensure_portal_stack();
 
-        // 1) Prefer attach to idle gamescope-0 (portal + polaris-gamescope.env contract).
-        if (try_attach_gamescope0(params)) {
-          return true;
+        // 1) Prefer attach to idle gamescope-0, but participate in the same
+        // locked durable-claim protocol as nested shell recovery.
+        {
+          owner_transition_lock_t acquisition_lock;
+          if (!acquisition_lock || !runtime_acquisition_allowed_locked()) {
+            BOOST_LOG(warning) << "gamescope_runtime: nested ownership claim blocks runtime acquisition"sv;
+            return false;
+          }
+          if (try_attach_gamescope0(params, true)) {
+            return true;
+          }
         }
 
-        // 2) Ask the host idle unit to start (if present) before we spawn our own.
+        // 2) Ask the host idle unit to start. This helper releases the ownership
+        // lock around systemd activation, then reacquires and rechecks the claim
+        // before attaching.
         if (try_start_idle_unit_and_attach(params)) {
           return true;
         }
@@ -338,12 +410,18 @@ namespace stream_runtime {
           return false;
         }
 
-        // 3) Spawn owned headless gamescope — only if gamescope-0 is still free.
+        // 3) Spawn owned headless gamescope only inside the same ownership lock
+        // and after proving no durable nested transition/recovery claim exists.
+        owner_transition_lock_t acquisition_lock;
+        if (!acquisition_lock || !runtime_acquisition_allowed_locked()) {
+          BOOST_LOG(warning) << "gamescope_runtime: nested claim appeared before owned spawn"sv;
+          return false;
+        }
         // Never attach/spawn onto gamescope-1 (portal is hard-wired to gamescope-0).
-        // Crash residue with no live holder is reclaimed; live unowned holders fail closed.
+        // Crash residue with no live holder is reclaimed under this transaction.
         reclaim_orphan_gamescope_sockets();
         if (socket_exists("gamescope-0") && wait_for_stable_socket("gamescope-0", 1500)) {
-          if (try_attach_gamescope0(params)) {
+          if (try_attach_gamescope0(params, true)) {
             return true;
           }
           BOOST_LOG(error) << "gamescope_runtime: gamescope-0 exists but is not a validated owner; refusing destructive cleanup"sv;
@@ -441,14 +519,15 @@ namespace stream_runtime {
           marker_.reset();
         }
         bool marker_written = false;
-        if (marker_) {
-          owner_transition_lock_t owner_lock;
-          if (owner_lock) {
-            const auto current_owner = gp::validated_marker(marker_path());
-            const bool authority_free = !current_owner ||
-              *current_owner == *marker_;
-            marker_written = authority_free && gp::write_marker(marker_path(), *marker_);
-          }
+        if (marker_ && runtime_acquisition_allowed_locked()) {
+          const auto current_owner = gp::validated_marker(marker_path());
+          const bool authority_free = !current_owner || *current_owner == *marker_;
+          marker_written = authority_free && gp::write_marker(marker_path(), *marker_);
+        }
+        if (marker_written) {
+          // The exact runtime generation is now durable. Release the acquisition
+          // transaction so nested recovery can observe and stop this marker.
+          acquisition_lock.unlock();
         }
         if (!marker_written) {
           BOOST_LOG(error) << "gamescope_runtime: could not record exact owned gamescope generation"sv;
@@ -733,7 +812,7 @@ namespace stream_runtime {
         state_ = {};
       }
 
-      bool revalidate_running_unlocked(const start_params_t &params) {
+      bool revalidate_running_unlocked(const start_params_t &params, bool ownership_lock_held = false) {
         if (!marker_ || socket_name_.empty() || x11_display_.empty()) {
           return false;
         }
@@ -746,7 +825,7 @@ namespace stream_runtime {
           return false;
         }
         refresh_runtime_state(params);
-        return write_env_file();
+        return write_env_file(ownership_lock_held);
       }
 
       static void ensure_portal_stack() {
@@ -773,7 +852,7 @@ namespace stream_runtime {
         }
       }
 
-      bool try_attach_gamescope0(const start_params_t &params) {
+      bool try_attach_gamescope0(const start_params_t &params, bool ownership_lock_held = false) {
         if (!wait_for_stable_socket("gamescope-0", 2000)) {
           return false;
         }
@@ -794,7 +873,7 @@ namespace stream_runtime {
         socket_name_ = "gamescope-0";
         x11_display_ = display;
         refresh_runtime_state(params);
-        if (!write_env_file()) {
+        if (!write_env_file(ownership_lock_held)) {
           marker_.reset();
           pid_ = 0;
           socket_name_.clear();
@@ -829,9 +908,8 @@ namespace stream_runtime {
       }
 
       bool try_start_idle_unit_and_attach(const start_params_t &params) {
-        // Best-effort: host may ship polaris-gamescope-idle.service that owns gamescope-0.
-        // Clear crash residue so idle can bind gamescope-0 again.
-        reclaim_orphan_gamescope_sockets();
+        // Best-effort: host may ship polaris-gamescope-idle.service. Its own
+        // startup transaction reclaims residue under the shared ownership lock.
         const bool active =
           std::system("systemctl --user is-active --quiet polaris-gamescope-idle.service 2>/dev/null") == 0;
         const bool activating =
@@ -839,28 +917,38 @@ namespace stream_runtime {
             "test \"$(systemctl --user show -p ActiveState --value polaris-gamescope-idle.service 2>/dev/null)\" = activating") == 0;
         if ((active || activating) && idle_hdr_flags_match_force()) {
           if (wait_for_stable_socket("gamescope-0", 8000)) {
-            return try_attach_gamescope0(params);
+            owner_transition_lock_t acquisition_lock;
+            if (!acquisition_lock || !runtime_acquisition_allowed_locked()) {
+              return false;
+            }
+            return try_attach_gamescope0(params, true);
           }
         }
         if (active && !idle_hdr_flags_match_force()) {
           BOOST_LOG(info) << "gamescope_runtime: restarting polaris-gamescope-idle to match polaris-gamescope-force"sv;
         }
         if (restart_or_start_idle_unit()) {
-          if (wait_for_stable_socket("gamescope-0", 12000) && try_attach_gamescope0(params)) {
-            BOOST_LOG(info) << "gamescope_runtime: polaris-gamescope-idle ready (HDR flags synced); attached to gamescope-0"sv;
-            return true;
+          if (wait_for_stable_socket("gamescope-0", 12000)) {
+            owner_transition_lock_t acquisition_lock;
+            if (!acquisition_lock || !runtime_acquisition_allowed_locked()) {
+              return false;
+            }
+            if (try_attach_gamescope0(params, true)) {
+              BOOST_LOG(info) << "gamescope_runtime: polaris-gamescope-idle ready (HDR flags synced); attached to gamescope-0"sv;
+              return true;
+            }
           }
           BOOST_LOG(warning) << "gamescope_runtime: polaris-gamescope-idle started but gamescope-0 not ready; will try owned spawn"sv;
         }
         return false;
       }
 
-      bool write_env_file() const {
+      bool write_env_file(bool ownership_lock_held = false) const {
         if (!marker_ || x11_display_.empty() || socket_name_.empty()) {
           return false;
         }
-        owner_transition_lock_t owner_lock;
-        if (!owner_lock) {
+        owner_transition_lock_t owner_lock(!ownership_lock_held);
+        if ((!ownership_lock_held && !owner_lock) || !runtime_acquisition_allowed_locked()) {
           return false;
         }
         const auto revalidate_publication_pair = [this]() {
@@ -919,6 +1007,11 @@ namespace stream_runtime {
 
   bool rollback_gamescope_spawn_for_tests(pid_t pgid, int leader_pidfd) {
     return rollback_spawned_private_group(pgid, leader_pidfd);
+  }
+
+  bool gamescope_runtime_acquisition_allowed_for_tests() {
+    owner_transition_lock_t owner_lock;
+    return owner_lock && runtime_acquisition_allowed_locked();
   }
 
   stream_runtime_t *gamescope_runtime_instance() {

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -20,6 +20,7 @@
   #include <cstring>
   #include <filesystem>
   #include <fstream>
+  #include <functional>
   #include <fcntl.h>
   #include <mutex>
   #include <optional>
@@ -107,6 +108,39 @@ namespace stream_runtime {
       }
       const auto sid = getsid(pid);
       return sid >= 0 && pgid == pid && sid == pid;
+    }
+
+    bool drain_private_process_group(
+      pid_t pgid,
+      const std::function<bool()> &authority_still_current,
+      int term_steps = 30,
+      int kill_steps = 20
+    ) {
+      if (!is_private_group_leader(pgid) || !authority_still_current()) {
+        return false;
+      }
+      if (kill(-pgid, SIGTERM) != 0 && errno != ESRCH) {
+        return false;
+      }
+      int status = 0;
+      auto state = private_group_state(pgid);
+      for (int i = 0; i < term_steps && state == private_group_state_e::alive; ++i) {
+        (void) waitpid(pgid, &status, WNOHANG);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        state = private_group_state(pgid);
+      }
+      if (state == private_group_state_e::alive) {
+        if (!authority_still_current() || (kill(-pgid, SIGKILL) != 0 && errno != ESRCH)) {
+          return false;
+        }
+        for (int i = 0; i < kill_steps && state == private_group_state_e::alive; ++i) {
+          (void) waitpid(pgid, &status, WNOHANG);
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          state = private_group_state(pgid);
+        }
+      }
+      (void) waitpid(pgid, &status, WNOHANG);
+      return state == private_group_state_e::drained;
     }
 
     /// Wait until socket exists for two consecutive polls (avoids attach races).
@@ -517,39 +551,14 @@ namespace stream_runtime {
                                << marker_->pid;
             return;
           }
-          if (kill(-marker_->pid, SIGTERM) != 0 && errno != ESRCH) {
-            BOOST_LOG(error) << "gamescope_runtime: failed to signal owned group="sv << marker_->pid;
-            return;
-          }
-          int status = 0;
-          (void) waitpid(marker_->pid, &status, WNOHANG);
-          auto group_state = private_group_state(marker_->pid);
-          for (int i = 0; i < 30 && group_state == private_group_state_e::alive; ++i) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            (void) waitpid(marker_->pid, &status, WNOHANG);
-            group_state = private_group_state(marker_->pid);
-          }
-          if (group_state == private_group_state_e::alive) {
+          const auto authority_still_current = [this]() {
             const auto marker_on_disk = gp::read_marker(marker_path());
-            if (!marker_on_disk || *marker_on_disk != *marker_ ||
-                (kill(-marker_->pid, SIGKILL) != 0 && errno != ESRCH)) {
-              BOOST_LOG(error) << "gamescope_runtime: ownership changed before group escalation"sv;
-              return;
-            }
-            for (int i = 0; i < 20; ++i) {
-              (void) waitpid(marker_->pid, &status, WNOHANG);
-              group_state = private_group_state(marker_->pid);
-              if (group_state != private_group_state_e::alive) {
-                break;
-              }
-              std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            }
-          }
-          if (group_state != private_group_state_e::drained) {
+            return marker_on_disk && *marker_on_disk == *marker_;
+          };
+          if (!drain_private_process_group(marker_->pid, authority_still_current)) {
             BOOST_LOG(error) << "gamescope_runtime: private group did not drain; preserving ownership state"sv;
             return;
           }
-          (void) waitpid(marker_->pid, &status, WNOHANG);
           BOOST_LOG(info) << "gamescope_runtime: drained owned gamescope group="sv << marker_->pid;
           remove_owned_files_if_current_unlocked();
         }
@@ -748,6 +757,10 @@ namespace stream_runtime {
     gamescope_runtime_t g_gamescope_runtime;
 
   }  // namespace
+
+  bool drain_gamescope_private_group_for_tests(pid_t pgid) {
+    return drain_private_process_group(pgid, []() { return true; }, 3, 20);
+  }
 
   stream_runtime_t *gamescope_runtime_instance() {
     return &g_gamescope_runtime;

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -18,17 +18,21 @@
   #include <cstdio>
   #include <cstdlib>
   #include <cstring>
+  #include <dirent.h>
   #include <filesystem>
   #include <fstream>
   #include <functional>
   #include <fcntl.h>
   #include <mutex>
   #include <optional>
+  #include <poll.h>
   #include <signal.h>
+  #include <sstream>
   #include <string>
   #include <string_view>
   #include <sys/file.h>
   #include <sys/stat.h>
+  #include <sys/syscall.h>
   #include <sys/types.h>
   #include <sys/wait.h>
   #include <thread>
@@ -90,14 +94,64 @@ namespace stream_runtime {
     };
 
     private_group_state_e private_group_state(pid_t pgid) {
-      errno = 0;
-      if (kill(-pgid, 0) == 0 || errno == EPERM) {
-        return private_group_state_e::alive;
+      DIR *proc = opendir("/proc");
+      if (!proc) {
+        return private_group_state_e::unknown;
       }
-      if (errno == ESRCH) {
-        return private_group_state_e::drained;
+      bool alive = false;
+      bool complete = true;
+      while (true) {
+        errno = 0;
+        auto *entry = readdir(proc);
+        if (!entry) {
+          if (errno != 0) {
+            complete = false;
+          }
+          break;
+        }
+        char *end = nullptr;
+        const long parsed = std::strtol(entry->d_name, &end, 10);
+        if (parsed <= 1 || !end || *end != '\0') {
+          continue;
+        }
+        const pid_t pid = static_cast<pid_t>(parsed);
+        std::ifstream stat_file("/proc/" + std::to_string(pid) + "/stat");
+        std::string stat_line;
+        if (!std::getline(stat_file, stat_line)) {
+          if (kill(pid, 0) == 0 || errno == EPERM) {
+            complete = false;
+          }
+          continue;
+        }
+        const auto close = stat_line.rfind(')');
+        if (close == std::string::npos || close + 2 >= stat_line.size()) {
+          complete = false;
+          continue;
+        }
+        std::istringstream fields(stat_line.substr(close + 2));
+        char state = '\0';
+        pid_t ppid = 0;
+        pid_t process_group = 0;
+        pid_t session = 0;
+        if (!(fields >> state >> ppid >> process_group >> session)) {
+          complete = false;
+          continue;
+        }
+        if (process_group == pgid) {
+          if (session != pgid) {
+            complete = false;
+            continue;
+          }
+          if (state != 'Z' && state != 'X') {
+            alive = true;
+          }
+        }
       }
-      return private_group_state_e::unknown;
+      closedir(proc);
+      if (!complete) {
+        return private_group_state_e::unknown;
+      }
+      return alive ? private_group_state_e::alive : private_group_state_e::drained;
     }
 
     bool is_private_group_leader(pid_t pid) {
@@ -110,13 +164,20 @@ namespace stream_runtime {
       return sid >= 0 && pgid == pid && sid == pid;
     }
 
+    bool pidfd_has_exited(int pidfd) {
+      pollfd descriptor {.fd = pidfd, .events = POLLIN, .revents = 0};
+      const int result = poll(&descriptor, 1, 0);
+      return result == 1 && (descriptor.revents & (POLLIN | POLLHUP)) != 0;
+    }
+
     bool drain_private_process_group(
       pid_t pgid,
+      int leader_pidfd,
       const std::function<bool()> &authority_still_current,
       int term_steps = 30,
       int kill_steps = 20
     ) {
-      if (!authority_still_current()) {
+      if (leader_pidfd < 0 || fcntl(leader_pidfd, F_GETFD) < 0 || !authority_still_current()) {
         return false;
       }
       auto state = private_group_state(pgid);
@@ -131,7 +192,6 @@ namespace stream_runtime {
       }
       int status = 0;
       for (int i = 0; i < term_steps && state == private_group_state_e::alive; ++i) {
-        (void) waitpid(pgid, &status, WNOHANG);
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         state = private_group_state(pgid);
       }
@@ -140,7 +200,6 @@ namespace stream_runtime {
           return false;
         }
         for (int i = 0; i < kill_steps && state == private_group_state_e::alive; ++i) {
-          (void) waitpid(pgid, &status, WNOHANG);
           std::this_thread::sleep_for(std::chrono::milliseconds(100));
           state = private_group_state(pgid);
         }
@@ -149,16 +208,13 @@ namespace stream_runtime {
       return state == private_group_state_e::drained;
     }
 
-    bool rollback_spawned_private_group(pid_t child, bool child_reaped) {
+    bool rollback_spawned_private_group(pid_t child, int leader_pidfd) {
       const auto group_state = private_group_state(child);
       if (group_state == private_group_state_e::unknown) {
         return false;
       }
       if (group_state == private_group_state_e::alive) {
-        return drain_private_process_group(child, []() { return true; });
-      }
-      if (child_reaped) {
-        return true;
+        return drain_private_process_group(child, leader_pidfd, []() { return true; });
       }
       int status = 0;
       const auto child_state = waitpid(child, &status, WNOHANG);
@@ -320,19 +376,25 @@ namespace stream_runtime {
           _exit(127);
         }
 
+        leader_pidfd_ = static_cast<int>(syscall(SYS_pidfd_open, child, 0));
+        if (leader_pidfd_ < 0) {
+          (void) kill(child, SIGKILL);
+          (void) waitpid(child, nullptr, 0);
+          BOOST_LOG(error) << "gamescope_runtime: pidfd_open failed for owned leader"sv;
+          return false;
+        }
         pid_ = child;
         owned_ = true;
         socket_name_ = "gamescope-0";
 
         // Capture the exact PID generation only after exec has exposed the
         // expected gamescope --backend headless argv.
-        bool child_reaped = false;
+        // Keep the leader unreaped until every negative-PGID operation finishes;
+        // its live/zombie PID allocation prevents the numeric PGID from being reused.
         for (int i = 0; i < 100 && !marker_; ++i) {
           marker_ = gp::marker_for_pid(child, "runtime");
           if (!marker_) {
-            int status = 0;
-            if (waitpid(child, &status, WNOHANG) == child) {
-              child_reaped = true;
+            if (pidfd_has_exited(leader_pidfd_)) {
               break;
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
@@ -354,11 +416,12 @@ namespace stream_runtime {
         if (!marker_written) {
           BOOST_LOG(error) << "gamescope_runtime: could not record exact owned gamescope generation"sv;
 
-          const bool rollback_drained = rollback_spawned_private_group(child, child_reaped);
+          const bool rollback_drained = rollback_spawned_private_group(child, leader_pidfd_);
           if (!rollback_drained) {
             BOOST_LOG(error) << "gamescope_runtime: launch rollback could not prove private group drained; preserving state"sv;
             return false;
           }
+          close_leader_pidfd();
           pid_ = 0;
           owned_ = false;
           marker_.reset();
@@ -374,14 +437,13 @@ namespace stream_runtime {
             stop_unlocked();
             return false;
           }
-          int status = 0;
-          if (waitpid(pid_, &status, WNOHANG) == pid_) {
+          if (pidfd_has_exited(leader_pidfd_)) {
             BOOST_LOG(error) << "gamescope_runtime: gamescope exited before socket appeared"sv;
             const auto marker_matches = [this]() {
               const auto marker_on_disk = gp::read_marker(marker_path());
               return marker_ && marker_on_disk && *marker_on_disk == *marker_;
             };
-            if (!drain_private_process_group(pid_, marker_matches)) {
+            if (!drain_private_process_group(pid_, leader_pidfd_, marker_matches)) {
               BOOST_LOG(error) << "gamescope_runtime: exited leader left an unverified private group; preserving ownership"sv;
               return false;
             }
@@ -389,6 +451,7 @@ namespace stream_runtime {
               BOOST_LOG(error) << "gamescope_runtime: failed to remove drained generation marker; preserving ownership"sv;
               return false;
             }
+            close_leader_pidfd();
             pid_ = 0;
             owned_ = false;
             marker_.reset();
@@ -435,6 +498,7 @@ namespace stream_runtime {
           int status = 0;
           waitpid(pid_, &status, WNOHANG);
         }
+        close_leader_pidfd();
         pid_ = 0;
         owned_ = false;
         marker_.reset();
@@ -485,6 +549,7 @@ namespace stream_runtime {
     private:
       mutable std::mutex mu_;
       pid_t pid_ = 0;
+      int leader_pidfd_ = -1;
       bool owned_ = false;
       std::optional<gp::marker_t> marker_;
       std::string socket_name_;
@@ -496,6 +561,13 @@ namespace stream_runtime {
         .backend_name = "gamescope",
         .path_id = "gamescope_stream",
       };
+
+      void close_leader_pidfd() {
+        if (leader_pidfd_ >= 0) {
+          close(leader_pidfd_);
+          leader_pidfd_ = -1;
+        }
+      }
 
       fs::path marker_path() const {
         return fs::path(xdg_runtime_dir()) / "polaris-gamescope.pid";
@@ -578,7 +650,7 @@ namespace stream_runtime {
             const auto marker_on_disk = gp::read_marker(marker_path());
             return marker_on_disk && *marker_on_disk == *marker_;
           };
-          if (!drain_private_process_group(marker_->pid, authority_still_current)) {
+          if (!drain_private_process_group(marker_->pid, leader_pidfd_, authority_still_current)) {
             BOOST_LOG(error) << "gamescope_runtime: private group did not drain; preserving ownership state"sv;
             return;
           }
@@ -592,6 +664,7 @@ namespace stream_runtime {
           BOOST_LOG(info) << "gamescope_runtime: detached from validated "sv << socket_name_
                           << " owner pid="sv << marker_->pid << " (left running)"sv;
         }
+        close_leader_pidfd();
         pid_ = 0;
         owned_ = false;
         marker_.reset();
@@ -610,6 +683,7 @@ namespace stream_runtime {
       }
 
       void clear_runtime_state_unlocked() {
+        close_leader_pidfd();
         marker_.reset();
         owned_ = false;
         pid_ = 0;
@@ -672,6 +746,7 @@ namespace stream_runtime {
           BOOST_LOG(warning) << "gamescope_runtime: marked gamescope-0 has no owned Xwayland socket"sv;
           return false;
         }
+        close_leader_pidfd();
         marker_ = marker;
         owned_ = false;
         pid_ = marker->pid;
@@ -785,11 +860,17 @@ namespace stream_runtime {
   }  // namespace
 
   bool drain_gamescope_private_group_for_tests(pid_t pgid) {
-    return drain_private_process_group(pgid, []() { return true; }, 3, 20);
+    const int pidfd = static_cast<int>(syscall(SYS_pidfd_open, pgid, 0));
+    if (pidfd < 0) {
+      return false;
+    }
+    const bool drained = drain_private_process_group(pgid, pidfd, []() { return true; }, 3, 20);
+    close(pidfd);
+    return drained;
   }
 
-  bool rollback_gamescope_spawn_for_tests(pid_t pgid, bool leader_reaped) {
-    return rollback_spawned_private_group(pgid, leader_reaped);
+  bool rollback_gamescope_spawn_for_tests(pid_t pgid, int leader_pidfd) {
+    return rollback_spawned_private_group(pgid, leader_pidfd);
   }
 
   stream_runtime_t *gamescope_runtime_instance() {

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -683,6 +683,10 @@ namespace stream_runtime {
                                << marker_->pid;
             return;
           }
+          // The pidfd keeps the unreaped leader allocation as the PGID barrier.
+          // After TERM the leader may be a zombie, so this callback deliberately
+          // fences only the immutable marker record instead of requiring live
+          // cmdline/exe/socket validation before SIGKILL escalation.
           const auto authority_still_current = [this]() {
             const auto marker_on_disk = gp::read_marker(marker_path());
             return marker_on_disk && *marker_on_disk == *marker_;

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -82,6 +82,33 @@ namespace stream_runtime {
       return fs::exists(xdg_runtime_dir() + "/" + name);
     }
 
+    enum class private_group_state_e {
+      alive,
+      drained,
+      unknown,
+    };
+
+    private_group_state_e private_group_state(pid_t pgid) {
+      errno = 0;
+      if (kill(-pgid, 0) == 0 || errno == EPERM) {
+        return private_group_state_e::alive;
+      }
+      if (errno == ESRCH) {
+        return private_group_state_e::drained;
+      }
+      return private_group_state_e::unknown;
+    }
+
+    bool is_private_group_leader(pid_t pid) {
+      errno = 0;
+      const auto pgid = getpgid(pid);
+      if (pgid < 0) {
+        return false;
+      }
+      const auto sid = getsid(pid);
+      return sid >= 0 && pgid == pid && sid == pid;
+    }
+
     /// Wait until socket exists for two consecutive polls (avoids attach races).
     bool wait_for_stable_socket(const std::string &name, int timeout_ms = 8000) {
       const auto step = 50;
@@ -219,7 +246,9 @@ namespace stream_runtime {
           return false;
         }
         if (child == 0) {
-          setsid();
+          if (setsid() < 0) {
+            _exit(126);
+          }
           unsetenv("WAYLAND_DISPLAY");
           unsetenv("ENABLE_GAMESCOPE_WSI");
           unsetenv("ENABLE_HDR_WSI");
@@ -247,6 +276,9 @@ namespace stream_runtime {
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
           }
         }
+        if (marker_ && !is_private_group_leader(child)) {
+          marker_.reset();
+        }
         bool marker_written = false;
         if (marker_) {
           owner_transition_lock_t owner_lock;
@@ -266,8 +298,24 @@ namespace stream_runtime {
             int status = 0;
             const auto child_state = waitpid(child, &status, WNOHANG);
             if (child_state == 0) {
-              kill(child, SIGTERM);
-              waitpid(child, nullptr, 0);
+              if (is_private_group_leader(child)) {
+                (void) kill(-child, SIGTERM);
+                for (int i = 0; i < 20 && private_group_state(child) == private_group_state_e::alive; ++i) {
+                  (void) waitpid(child, &status, WNOHANG);
+                  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                }
+                const auto final_group_state = private_group_state(child);
+                if (final_group_state == private_group_state_e::alive) {
+                  (void) kill(-child, SIGKILL);
+                }
+                else if (final_group_state == private_group_state_e::unknown) {
+                  (void) kill(child, SIGKILL);
+                }
+              }
+              else {
+                (void) kill(child, SIGTERM);
+              }
+              (void) waitpid(child, nullptr, 0);
             }
           }
           pid_ = 0;
@@ -464,28 +512,45 @@ namespace stream_runtime {
             return;
           }
           const auto current = gp::validated_marker(marker_path(), "runtime");
-          if (current && *current == *marker_) {
-            // The marker validates this exact PID generation immediately before
-            // signalling its setsid-owned process group.
-            kill(-marker_->pid, SIGTERM);
-            for (int i = 0; i < 30; ++i) {
-              int status = 0;
-              const auto result = waitpid(marker_->pid, &status, WNOHANG);
-              if (result == marker_->pid || (result < 0 && errno == ECHILD)) {
+          if (!current || *current != *marker_ || !is_private_group_leader(marker_->pid)) {
+            BOOST_LOG(warning) << "gamescope_runtime: refusing to signal stale or unverified group="sv
+                               << marker_->pid;
+            return;
+          }
+          if (kill(-marker_->pid, SIGTERM) != 0 && errno != ESRCH) {
+            BOOST_LOG(error) << "gamescope_runtime: failed to signal owned group="sv << marker_->pid;
+            return;
+          }
+          int status = 0;
+          (void) waitpid(marker_->pid, &status, WNOHANG);
+          auto group_state = private_group_state(marker_->pid);
+          for (int i = 0; i < 30 && group_state == private_group_state_e::alive; ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            (void) waitpid(marker_->pid, &status, WNOHANG);
+            group_state = private_group_state(marker_->pid);
+          }
+          if (group_state == private_group_state_e::alive) {
+            const auto marker_on_disk = gp::read_marker(marker_path());
+            if (!marker_on_disk || *marker_on_disk != *marker_ ||
+                (kill(-marker_->pid, SIGKILL) != 0 && errno != ESRCH)) {
+              BOOST_LOG(error) << "gamescope_runtime: ownership changed before group escalation"sv;
+              return;
+            }
+            for (int i = 0; i < 20; ++i) {
+              (void) waitpid(marker_->pid, &status, WNOHANG);
+              group_state = private_group_state(marker_->pid);
+              if (group_state != private_group_state_e::alive) {
                 break;
               }
               std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
-            if (gp::is_valid_headless_gamescope(*marker_)) {
-              kill(-marker_->pid, SIGKILL);
-              waitpid(marker_->pid, nullptr, 0);
-            }
-            BOOST_LOG(info) << "gamescope_runtime: stopped owned gamescope pid="sv << marker_->pid;
           }
-          else {
-            BOOST_LOG(warning) << "gamescope_runtime: refusing to signal stale/reused owned pid="sv
-                               << marker_->pid;
+          if (group_state != private_group_state_e::drained) {
+            BOOST_LOG(error) << "gamescope_runtime: private group did not drain; preserving ownership state"sv;
+            return;
           }
+          (void) waitpid(marker_->pid, &status, WNOHANG);
+          BOOST_LOG(info) << "gamescope_runtime: drained owned gamescope group="sv << marker_->pid;
           remove_owned_files_if_current_unlocked();
         }
         else if (!owned_ && marker_) {

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -137,14 +137,18 @@ namespace stream_runtime {
           complete = false;
           continue;
         }
-        if (process_group == pgid) {
-          if (session != pgid) {
-            complete = false;
-            continue;
-          }
+        if (session == pgid) {
+          // The SID is the private ownership domain. Descendants may move to a
+          // separate process group while remaining in this exact session; they
+          // must keep teardown live so marker/environment authority is retained.
           if (state != 'Z' && state != 'X') {
             alive = true;
           }
+        }
+        else if (process_group == pgid) {
+          // The numeric PGID is now associated with another session. Authority
+          // is ambiguous and negative-PGID signaling must fail closed.
+          complete = false;
         }
       }
       closedir(proc);

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -170,6 +170,23 @@ namespace stream_runtime {
       return result == 1 && (descriptor.revents & (POLLIN | POLLHUP)) != 0;
     }
 
+    bool pidfd_targets_pid(int pidfd, pid_t expected_pid) {
+      if (pidfd < 0 || expected_pid <= 1) {
+        return false;
+      }
+      std::ifstream info("/proc/self/fdinfo/" + std::to_string(pidfd));
+      std::string key;
+      pid_t pid = -1;
+      while (info >> key) {
+        if (key == "Pid:") {
+          return (info >> pid) && pid == expected_pid;
+        }
+        std::string ignored;
+        std::getline(info, ignored);
+      }
+      return false;
+    }
+
     bool drain_private_process_group(
       pid_t pgid,
       int leader_pidfd,
@@ -177,7 +194,7 @@ namespace stream_runtime {
       int term_steps = 30,
       int kill_steps = 20
     ) {
-      if (leader_pidfd < 0 || fcntl(leader_pidfd, F_GETFD) < 0 || !authority_still_current()) {
+      if (!pidfd_targets_pid(leader_pidfd, pgid) || !authority_still_current()) {
         return false;
       }
       auto state = private_group_state(pgid);
@@ -196,7 +213,8 @@ namespace stream_runtime {
         state = private_group_state(pgid);
       }
       if (state == private_group_state_e::alive) {
-        if (!authority_still_current() || (kill(-pgid, SIGKILL) != 0 && errno != ESRCH)) {
+        if (!pidfd_targets_pid(leader_pidfd, pgid) || !authority_still_current() ||
+            (kill(-pgid, SIGKILL) != 0 && errno != ESRCH)) {
           return false;
         }
         for (int i = 0; i < kill_steps && state == private_group_state_e::alive; ++i) {
@@ -270,18 +288,33 @@ namespace stream_runtime {
 
       bool start(const start_params_t &params) override {
         std::lock_guard lock(mu_);
-        if (is_running_unlocked()) {
-          // Crash/teardown can leave in-memory attach state while gamescope is dead.
-          // Re-validate exact generation + socket ownership before reuse.
-          if (revalidate_running_unlocked(params)) {
+        const bool retained_state =
+          owned_ || pid_ > 0 || leader_pidfd_ >= 0 || marker_ ||
+          !socket_name_.empty() || !x11_display_.empty();
+        if (retained_state) {
+          if (is_running_unlocked() && revalidate_running_unlocked(params)) {
             BOOST_LOG(info) << "gamescope_runtime: already "sv
                             << (owned_ ? "owned"sv : "attached"sv)
                             << " "sv << (socket_name_.empty() ? "gamescope-0" : socket_name_)
                             << "; reusing"sv;
             return true;
           }
-          BOOST_LOG(warning) << "gamescope_runtime: dropping stale in-memory gamescope state"sv;
-          clear_runtime_state_unlocked();
+          if (owned_) {
+            if (!marker_) {
+              BOOST_LOG(error) << "gamescope_runtime: retained owned state lacks immutable marker authority; refusing restart"sv;
+              return false;
+            }
+            BOOST_LOG(warning) << "gamescope_runtime: draining retained owned generation before restart"sv;
+            stop_unlocked();
+            if (owned_ || pid_ > 0 || leader_pidfd_ >= 0 || marker_) {
+              BOOST_LOG(error) << "gamescope_runtime: retained owned generation did not drain; refusing replacement launch"sv;
+              return false;
+            }
+          }
+          else {
+            BOOST_LOG(warning) << "gamescope_runtime: dropping stale attached gamescope state"sv;
+            clear_runtime_state_unlocked();
+          }
         }
 
         ensure_portal_stack();
@@ -822,10 +855,13 @@ namespace stream_runtime {
         if (!owner_lock) {
           return false;
         }
-        const auto current = validated_marker_for_socket(socket_name_, marker_->role);
-        const auto current_display = gp::discover_owned_x11_display(*marker_);
-        if (!current || *current != *marker_ ||
-            !current_display || *current_display != x11_display_) {
+        const auto revalidate_publication_pair = [this]() {
+          const auto current = validated_marker_for_socket(socket_name_, marker_->role);
+          const auto current_display = gp::discover_owned_x11_display(*marker_);
+          return current && *current == *marker_ &&
+                 current_display && *current_display == x11_display_;
+        };
+        if (!revalidate_publication_pair()) {
           return false;
         }
 
@@ -845,6 +881,10 @@ namespace stream_runtime {
           out << "POLARIS_GAMESCOPE_EXECUTABLE=" << marker_->executable.string() << "\n";
         }
         std::error_code ec;
+        if (!revalidate_publication_pair()) {
+          fs::remove(temporary, ec);
+          return false;
+        }
         fs::rename(temporary, path, ec);
         if (ec) {
           fs::remove(temporary, ec);

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -116,14 +116,20 @@ namespace stream_runtime {
       int term_steps = 30,
       int kill_steps = 20
     ) {
-      if (!is_private_group_leader(pgid) || !authority_still_current()) {
+      if (!authority_still_current()) {
         return false;
+      }
+      auto state = private_group_state(pgid);
+      if (state == private_group_state_e::unknown) {
+        return false;
+      }
+      if (state == private_group_state_e::drained) {
+        return true;
       }
       if (kill(-pgid, SIGTERM) != 0 && errno != ESRCH) {
         return false;
       }
       int status = 0;
-      auto state = private_group_state(pgid);
       for (int i = 0; i < term_steps && state == private_group_state_e::alive; ++i) {
         (void) waitpid(pgid, &status, WNOHANG);
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -141,6 +147,28 @@ namespace stream_runtime {
       }
       (void) waitpid(pgid, &status, WNOHANG);
       return state == private_group_state_e::drained;
+    }
+
+    bool rollback_spawned_private_group(pid_t child, bool child_reaped) {
+      const auto group_state = private_group_state(child);
+      if (group_state == private_group_state_e::unknown) {
+        return false;
+      }
+      if (group_state == private_group_state_e::alive) {
+        return drain_private_process_group(child, []() { return true; });
+      }
+      if (child_reaped) {
+        return true;
+      }
+      int status = 0;
+      const auto child_state = waitpid(child, &status, WNOHANG);
+      if (child_state == child) {
+        return true;
+      }
+      if (child_state != 0 || kill(child, SIGTERM) != 0) {
+        return false;
+      }
+      return waitpid(child, nullptr, 0) == child;
     }
 
     /// Wait until socket exists for two consecutive polls (avoids attach races).
@@ -325,32 +353,11 @@ namespace stream_runtime {
         }
         if (!marker_written) {
           BOOST_LOG(error) << "gamescope_runtime: could not record exact owned gamescope generation"sv;
-          // An unreaped child PID cannot be reused. Re-check that relationship
-          // immediately before signaling; if the loop already reaped it (or it
-          // is no longer our child), the numeric PID is no longer authority.
-          if (!child_reaped) {
-            int status = 0;
-            const auto child_state = waitpid(child, &status, WNOHANG);
-            if (child_state == 0) {
-              if (is_private_group_leader(child)) {
-                (void) kill(-child, SIGTERM);
-                for (int i = 0; i < 20 && private_group_state(child) == private_group_state_e::alive; ++i) {
-                  (void) waitpid(child, &status, WNOHANG);
-                  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                }
-                const auto final_group_state = private_group_state(child);
-                if (final_group_state == private_group_state_e::alive) {
-                  (void) kill(-child, SIGKILL);
-                }
-                else if (final_group_state == private_group_state_e::unknown) {
-                  (void) kill(child, SIGKILL);
-                }
-              }
-              else {
-                (void) kill(child, SIGTERM);
-              }
-              (void) waitpid(child, nullptr, 0);
-            }
+
+          const bool rollback_drained = rollback_spawned_private_group(child, child_reaped);
+          if (!rollback_drained) {
+            BOOST_LOG(error) << "gamescope_runtime: launch rollback could not prove private group drained; preserving state"sv;
+            return false;
           }
           pid_ = 0;
           owned_ = false;
@@ -370,7 +377,18 @@ namespace stream_runtime {
           int status = 0;
           if (waitpid(pid_, &status, WNOHANG) == pid_) {
             BOOST_LOG(error) << "gamescope_runtime: gamescope exited before socket appeared"sv;
-            remove_owned_files_if_current();
+            const auto marker_matches = [this]() {
+              const auto marker_on_disk = gp::read_marker(marker_path());
+              return marker_ && marker_on_disk && *marker_on_disk == *marker_;
+            };
+            if (!drain_private_process_group(pid_, marker_matches)) {
+              BOOST_LOG(error) << "gamescope_runtime: exited leader left an unverified private group; preserving ownership"sv;
+              return false;
+            }
+            if (!remove_owned_files_if_current()) {
+              BOOST_LOG(error) << "gamescope_runtime: failed to remove drained generation marker; preserving ownership"sv;
+              return false;
+            }
             pid_ = 0;
             owned_ = false;
             marker_.reset();
@@ -517,25 +535,30 @@ namespace stream_runtime {
         return current && *current == *marker_;
       }
 
-      void remove_owned_files_if_current() const {
+      bool remove_owned_files_if_current() const {
         owner_transition_lock_t owner_lock;
         if (!owner_lock) {
-          return;
+          return false;
         }
-        remove_owned_files_if_current_unlocked();
+        return remove_owned_files_if_current_unlocked();
       }
 
-      void remove_owned_files_if_current_unlocked() const {
+      bool remove_owned_files_if_current_unlocked() const {
         if (!marker_) {
-          return;
+          return false;
         }
         const auto current = gp::read_marker(marker_path());
         if (!current || *current != *marker_) {
-          return;
+          return false;
         }
         std::error_code ec;
-        fs::remove(marker_path(), ec);
-        fs::remove(fs::path(xdg_runtime_dir()) / "polaris-gamescope.env", ec);
+        const auto env_path = fs::path(xdg_runtime_dir()) / "polaris-gamescope.env";
+        const bool env_exists = fs::exists(env_path, ec);
+        if (ec || (env_exists && (!fs::remove(env_path, ec) || ec))) {
+          return false;
+        }
+        ec.clear();
+        return fs::remove(marker_path(), ec) && !ec;
       }
 
       void stop_unlocked() {
@@ -560,7 +583,10 @@ namespace stream_runtime {
             return;
           }
           BOOST_LOG(info) << "gamescope_runtime: drained owned gamescope group="sv << marker_->pid;
-          remove_owned_files_if_current_unlocked();
+          if (!remove_owned_files_if_current_unlocked()) {
+            BOOST_LOG(error) << "gamescope_runtime: failed to clear drained ownership files; preserving state"sv;
+            return;
+          }
         }
         else if (!owned_ && marker_) {
           BOOST_LOG(info) << "gamescope_runtime: detached from validated "sv << socket_name_
@@ -760,6 +786,10 @@ namespace stream_runtime {
 
   bool drain_gamescope_private_group_for_tests(pid_t pgid) {
     return drain_private_process_group(pgid, []() { return true; }, 3, 20);
+  }
+
+  bool rollback_gamescope_spawn_for_tests(pid_t pgid, bool leader_reaped) {
+    return rollback_spawned_private_group(pgid, leader_reaped);
   }
 
   stream_runtime_t *gamescope_runtime_instance() {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -5726,6 +5726,19 @@ namespace proc {
 #endif
     }
 
+    _session_env_keys.clear();
+#ifdef __linux__
+    // Prep commands are child processes too. Publish the immutable session
+    // credential before the nested gamescope start command executes, while
+    // keeping it out of the daemon's real environment.
+    set_child_only_session_env_var(
+      _env,
+      _session_env_keys,
+      "POLARIS_SESSION_INSTANCE_ID",
+      _session_instance_id
+    );
+#endif
+
     std::error_code ec;
     _app_prep_begin = std::begin(_app.prep_cmds);
     _app_prep_it = _app_prep_begin;
@@ -5738,6 +5751,13 @@ namespace proc {
         continue;
       }
 
+#ifdef __linux__
+      const bool critical_nested_session_prep =
+        nested_wsi_hdr_session && command_uses_polaris_gamescope_session(cmd.do_cmd);
+#else
+      const bool critical_nested_session_prep = false;
+#endif
+
       boost::filesystem::path working_dir = _app.working_dir.empty() ?
                                               find_working_directory(cmd.do_cmd, _env) :
                                               boost::filesystem::path(_app.working_dir);
@@ -5747,7 +5767,12 @@ namespace proc {
       if (ec) {
         BOOST_LOG(warning) << "Couldn't run ["sv << cmd.do_cmd << "]: System: "sv << ec.message();
         confighttp::emit_session_event("warning", "Prep command failed: " + cmd.do_cmd);
-        // Non-fatal: continue session even if prep-cmd fails
+        if (critical_nested_session_prep) {
+          BOOST_LOG(error) << "session_manager: critical nested gamescope prep command failed to execute"sv;
+          confighttp::emit_session_event("error", "Nested gamescope session failed to start");
+          return 503;
+        }
+        // Non-fatal: continue session even if ordinary prep-cmd fails
         continue;
       }
 
@@ -5756,7 +5781,15 @@ namespace proc {
       if (ret != 0) {
         BOOST_LOG(warning) << '[' << cmd.do_cmd << "] returned code ["sv << ret << ']';
         confighttp::emit_session_event("warning", "Prep command returned " + std::to_string(ret));
-        // Non-fatal: continue session
+        if (critical_nested_session_prep) {
+          // The command may have published durable recovery state before failing.
+          // Mark its undo as eligible so terminate_impl can drive credentialed stop.
+          ++_app_prep_it;
+          BOOST_LOG(error) << "session_manager: critical nested gamescope prep command failed"sv;
+          confighttp::emit_session_event("error", "Nested gamescope session failed to start");
+          return 503;
+        }
+        // Non-fatal: continue session for ordinary prep commands
       }
     }
 
@@ -5769,15 +5802,8 @@ namespace proc {
       platf::set_env(key, val);
       BOOST_LOG(info) << "Per-app env: " << key << "=" << val;
     }
-    _session_env_keys.clear();
 
 #ifdef __linux__
-    set_child_only_session_env_var(
-      _env,
-      _session_env_keys,
-      "POLARIS_SESSION_INSTANCE_ID",
-      _session_instance_id
-    );
     _audio_context = {};
     if (config::audio.stream) {
       _audio_context = audio::get_audio_ctx_ref();

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6740,15 +6740,16 @@ namespace proc {
   }
 
   void proc_t::terminate_isolated_session_generation() {
-    _exact_generation_cleanup_complete = true;
+    const bool prior_cleanup_complete = _exact_generation_cleanup_complete;
     if (!_session_used_cage_compositor) {
       return;
     }
 
-    _exact_generation_cleanup_complete = terminate_isolated_session_processes(
+    const bool isolated_cleanup_complete = terminate_isolated_session_processes(
       _session_instance_id,
       "after private Steam pre-cage termination"sv
     );
+    _exact_generation_cleanup_complete = prior_cleanup_complete && isolated_cleanup_complete;
     if (isolated_session_cleanup_resets_router(
           _session_used_cage_compositor,
           !_session_instance_id.empty(),

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1524,6 +1524,7 @@ namespace proc {
     thread_local pid_t forced_proc_directory_error_after_capture_pid = -1;
     thread_local pid_t forced_reused_exact_generation_pid = -1;
     thread_local pid_t forced_reused_gamescope_attached_pid = -1;
+    thread_local pid_t forced_unreadable_gamescope_attached_pid = -1;
     thread_local pid_t forced_steam_ownership_capture_failure_pid = -1;
 #endif
 
@@ -2049,12 +2050,7 @@ namespace proc {
         }
         const bool gamescope_attached = proc_environ_is_gamescope_stream_attached(environ);
         const bool game_client = is_steam_or_game_client_process(comm, cmdline, environ, steam_appid);
-        const bool steam_launch_for_app =
-          !steam_appid.empty() &&
-          (cmdline.find("AppId=" + steam_appid) != std::string::npos ||
-           cmdline.find("steam://rungameid/" + steam_appid) != std::string::npos ||
-           cmdline.find("rungameid/" + steam_appid) != std::string::npos);
-        return (gamescope_attached && game_client) || steam_launch_for_app;
+        return gamescope_attached && game_client;
       };
 
       for (;;) {
@@ -2070,13 +2066,54 @@ namespace proc {
         if (pid <= 1 || pid == this_pid) {
           continue;
         }
+        struct stat proc_dir_stat {};
+        const auto proc_dir_path = "/proc/" + std::to_string(pid);
+        if (lstat(proc_dir_path.c_str(), &proc_dir_stat) != 0) {
+          if (errno != ENOENT && errno != ESRCH) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+        if (proc_dir_stat.st_uid != geteuid()) {
+          continue;
+        }
 
         const auto identity_before = proc_start_time_ticks(pid);
-        const auto comm_before = read_proc_status_file_result(pid, "comm");
-        const auto cmdline_before = read_proc_status_file_result(pid, "cmdline");
-        const auto environ_before = read_proc_status_file_result(pid, "environ");
-        if (!identity_before || !comm_before.ok() || !cmdline_before.ok() || !environ_before.ok() ||
-            !is_candidate(comm_before.bytes, cmdline_before.bytes, environ_before.bytes)) {
+        auto comm_before = read_proc_status_file_result(pid, "comm");
+        auto cmdline_before = read_proc_status_file_result(pid, "cmdline");
+        auto environ_before = read_proc_status_file_result(pid, "environ");
+#ifdef POLARIS_TESTS
+        const bool forced_unreadable = pid == forced_unreadable_gamescope_attached_pid;
+        if (forced_unreadable) {
+          environ_before = {{}, EACCES};
+        }
+#else
+        constexpr bool forced_unreadable = false;
+#endif
+        if (!identity_before || !comm_before.ok() || !cmdline_before.ok()) {
+          errno = 0;
+          if (kill(pid, 0) != 0 && errno == ESRCH) {
+            continue;
+          }
+          if (forced_unreadable ||
+              (comm_before.ok() && cmdline_before.ok() &&
+               is_steam_or_game_client_process(comm_before.bytes, cmdline_before.bytes, "", steam_appid))) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+        if (!environ_before.ok()) {
+          errno = 0;
+          if (kill(pid, 0) != 0 && errno == ESRCH) {
+            continue;
+          }
+          if (forced_unreadable ||
+              is_steam_or_game_client_process(comm_before.bytes, cmdline_before.bytes, "", steam_appid)) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+        if (!is_candidate(comm_before.bytes, cmdline_before.bytes, environ_before.bytes)) {
           continue;
         }
 
@@ -4139,13 +4176,17 @@ namespace proc {
 
   bool terminate_gamescope_attached_clients_for_tests(
     const std::string &steam_appid,
-    pid_t forced_reused_pid
+    pid_t forced_reused_pid,
+    pid_t forced_unreadable_pid
   ) {
-    const auto previous = forced_reused_gamescope_attached_pid;
-    auto restore = util::fail_guard([previous]() {
-      forced_reused_gamescope_attached_pid = previous;
+    const auto previous_reused = forced_reused_gamescope_attached_pid;
+    const auto previous_unreadable = forced_unreadable_gamescope_attached_pid;
+    auto restore = util::fail_guard([previous_reused, previous_unreadable]() {
+      forced_reused_gamescope_attached_pid = previous_reused;
+      forced_unreadable_gamescope_attached_pid = previous_unreadable;
     });
     forced_reused_gamescope_attached_pid = forced_reused_pid;
+    forced_unreadable_gamescope_attached_pid = forced_unreadable_pid;
     return terminate_gamescope_attached_session_clients(steam_appid);
   }
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -71,6 +71,7 @@
   #include "platform/linux/stream_runtime.h"
   #include "platform/linux/session_launch_linux.h"
   #include "platform/linux/display_topology.h"
+  #include "platform/linux/gamescope_process.h"
   #include "platform/linux/input/inputtino_gamepad_isolation.h"
   #include <dirent.h>
   #include <fcntl.h>
@@ -995,15 +996,83 @@ namespace proc {
       return false;
     }
 
+    // True when environ looks like a Polaris session / Steam / Proton game client
+    // rather than a host helper that merely inherited gamescope attach keys.
+    bool proc_environ_is_session_game_client(std::string_view environ) {
+      std::size_t start = 0;
+      while (start < environ.size()) {
+        const auto end = environ.find('\0', start);
+        if (end == std::string_view::npos) {
+          break;
+        }
+        const auto entry = environ.substr(start, end - start);
+        if (entry.starts_with("POLARIS_SESSION_INSTANCE_ID="sv) && entry.size() > 28) {
+          return true;
+        }
+        if (entry.starts_with("STEAM_COMPAT_APP_ID="sv) ||
+            entry.starts_with("SteamAppId="sv) ||
+            entry.starts_with("SteamGameId="sv) ||
+            entry.starts_with("STEAM_COMPAT_DATA_PATH="sv) ||
+            entry.starts_with("PRESSURE_VESSEL_"sv) ||
+            entry.starts_with("WINEPREFIX="sv) ||
+            entry.starts_with("PROTON_"sv)) {
+          return true;
+        }
+        start = end + 1;
+      }
+      return false;
+    }
+
+    bool is_steam_or_game_client_process(
+      std::string_view comm,
+      std::string_view cmdline,
+      std::string_view environ,
+      const std::string &steam_appid
+    ) {
+      if (proc_environ_is_session_game_client(environ)) {
+        return true;
+      }
+      if (!steam_appid.empty()) {
+        const std::string appid_marker = "AppId=" + steam_appid;
+        if (cmdline.find(appid_marker) != std::string_view::npos ||
+            cmdline.find("steam://rungameid/" + steam_appid) != std::string_view::npos ||
+            cmdline.find("rungameid/" + steam_appid) != std::string_view::npos) {
+          return true;
+        }
+      }
+      if (comm.find("steam") != std::string_view::npos ||
+          comm == "reaper" ||
+          comm.find("pressure-vessel") != std::string_view::npos ||
+          comm.find("proton") != std::string_view::npos ||
+          comm.find("wine") != std::string_view::npos ||
+          comm.find("wineserver") != std::string_view::npos) {
+        return true;
+      }
+      if (cmdline.find("SteamLaunch") != std::string_view::npos ||
+          cmdline.find("steam://rungameid/") != std::string_view::npos ||
+          cmdline.find("pressure-vessel") != std::string_view::npos ||
+          cmdline.find("/proton") != std::string_view::npos ||
+          cmdline.find("steam-runtime") != std::string_view::npos ||
+          cmdline.find("steamapps/common/") != std::string_view::npos ||
+          cmdline.find("steamapps\\common\\") != std::string_view::npos) {
+        return true;
+      }
+      return false;
+    }
+
     bool is_gamescope_infrastructure_process(std::string_view comm, std::string_view cmdline) {
       if (comm == "gamescope" || comm == "gamescope-wl" || comm == "gamescopereaper" ||
-          comm == "Xwayland" || comm == "Xwayland.bin") {
+          comm == ".gamescope-wrapped" || comm == "Xwayland" || comm == "Xwayland.bin") {
         return true;
       }
       if (comm.find("portal-gamescope") != std::string_view::npos) {
         return true;
       }
       if (cmdline.find("xdg-desktop-portal-gamescope") != std::string_view::npos) {
+        return true;
+      }
+      // Idle unit primary child: setsid gamescope … -- sleep infinity
+      if (comm == "sleep" && cmdline.find("infinity") != std::string_view::npos) {
         return true;
       }
       if (cmdline.find("gamescope --backend") != std::string_view::npos ||
@@ -1015,6 +1084,46 @@ namespace proc {
         }
       }
       return false;
+    }
+
+    // After attach-path client cleanup, gamescope may ABRT on X11 I/O when Steam
+    // disconnects. Idle must stay up for portal capture on the next session.
+    void ensure_idle_gamescope_alive_for_portal() {
+      namespace fs = std::filesystem;
+      namespace gp = stream_runtime::gamescope_process;
+
+      const char *xdg = std::getenv("XDG_RUNTIME_DIR");
+      const fs::path rt = (xdg && *xdg) ? fs::path(xdg) : fs::path("/run/user") / std::to_string(getuid());
+      const auto marker_path = rt / "polaris-gamescope.pid";
+      const auto socket_path = rt / "gamescope-0";
+
+      if (const auto marker = gp::validated_marker(marker_path)) {
+        if (marker->role == "nested" || marker->role == "runtime") {
+          // Owned session compositor — not the idle portal path.
+          return;
+        }
+        if (marker->role == "idle" && gp::process_tree_owns_socket(*marker, socket_path)) {
+          return;
+        }
+      }
+
+      BOOST_LOG(info) << "process: idle gamescope not healthy after session client cleanup; restarting unit"sv;
+      (void) std::system(
+        "systemctl --user start polaris-portal-dbus.service "
+        "polaris-portal-gamescope.service polaris-portal.service 2>/dev/null"
+      );
+      // Hjem units live under ~/.config/systemd/user (higher priority than
+      // mask --runtime). Clear user.control mask so start can succeed.
+      (void) std::system(
+        "rt=\"${XDG_RUNTIME_DIR:-/run/user/$(id -u)}\"; "
+        "rm -f \"$rt/systemd/user.control/polaris-gamescope-idle.service\" "
+        "\"$rt/systemd/user/polaris-gamescope-idle.service\"; "
+        "systemctl --user daemon-reload 2>/dev/null; "
+        "systemctl --user unmask --runtime polaris-gamescope-idle.service 2>/dev/null; "
+        "systemctl --user reset-failed polaris-gamescope-idle.service 2>/dev/null; "
+        "systemctl --user restart polaris-gamescope-idle.service 2>/dev/null || "
+        "systemctl --user start polaris-gamescope-idle.service 2>/dev/null"
+      );
     }
 
     struct pidfd_handle_t {
@@ -1900,9 +2009,13 @@ namespace proc {
     }
 
     /**
-     * Kill gamescope-attached clients (games reaper, game binary, leftover Steam)
-     * that pressure-vessel stripped of POLARIS_SESSION_INSTANCE_ID. Does not touch
-     * the gamescope compositor or desktop processes without gamescope attach env.
+     * Kill gamescope-attached Steam/game clients that pressure-vessel stripped of
+     * POLARIS_SESSION_INSTANCE_ID. Does not touch the idle gamescope compositor,
+     * Xwayland, reaper, or host helpers that only inherited attach env keys.
+     *
+     * Attach-env alone is not enough: hard-killing arbitrary X11 clients on the
+     * idle compositor causes gamescope xwm "X11 I/O error" ABRT and takes down
+     * the portal capture target.
      */
     bool terminate_gamescope_attached_session_clients(const std::string &steam_appid) {
       std::vector<pidfd_handle_t> targets;
@@ -1915,7 +2028,6 @@ namespace proc {
       });
 
       const auto this_pid = getpid();
-      const std::string appid_marker = steam_appid.empty() ? std::string {} : ("AppId=" + steam_appid);
 
       for (;;) {
         auto *entry = read_next_proc_entry(dir);
@@ -1954,14 +2066,22 @@ namespace proc {
         }
 
         const bool gamescope_attached = proc_environ_is_gamescope_stream_attached(environ_r.bytes);
+        const bool game_client = is_steam_or_game_client_process(
+          comm,
+          cmdline,
+          environ_r.bytes,
+          steam_appid
+        );
+        // Fallback without attach env: only the same appid (not any SteamLaunch).
         const bool steam_launch_for_app =
-          !appid_marker.empty() && cmdline.find(appid_marker) != std::string::npos &&
-          (cmdline.find("SteamLaunch") != std::string::npos ||
-           cmdline.find("steam://rungameid/") != std::string::npos ||
-           cmdline.find("rungameid/") != std::string::npos);
+          !steam_appid.empty() &&
+          (cmdline.find("AppId=" + steam_appid) != std::string::npos ||
+           cmdline.find("steam://rungameid/" + steam_appid) != std::string::npos ||
+           cmdline.find("rungameid/" + steam_appid) != std::string::npos);
 
-        // Gamescope-attached Steam/game, or reaper for this appid (may lose attach env).
-        if (!gamescope_attached && !steam_launch_for_app) {
+        // Require attach env + steam/game identity, or an explicit same-app launch line.
+        // Bare attach-env matches are too broad and can crash idle gamescope.
+        if (!(gamescope_attached && game_client) && !steam_launch_for_app) {
           continue;
         }
 
@@ -1970,17 +2090,23 @@ namespace proc {
         if (!handle) {
           continue;
         }
+        BOOST_LOG(debug) << "process: gamescope session client candidate pid="sv << pid
+                         << " comm="sv << comm;
         targets.emplace_back(std::move(*handle));
       }
 
       if (targets.empty()) {
         BOOST_LOG(info) << "process: no gamescope-attached session clients to terminate"sv;
+        ensure_idle_gamescope_alive_for_portal();
         return true;
       }
 
       BOOST_LOG(info) << "process: terminating "sv << targets.size()
                       << " gamescope-attached session client(s) (game/reaper/steam)"sv;
-      return terminate_pidfds(targets, 3s, 2s, "gamescope session client"sv);
+      const bool ok = terminate_pidfds(targets, 3s, 2s, "gamescope session client"sv);
+      // Steam disconnect often ABRTs idle gamescope (xwm X11 I/O). Restore portal target.
+      ensure_idle_gamescope_alive_for_portal();
+      return ok;
     }
 
     bool is_active_desktop_steam_client_process(
@@ -6416,10 +6542,20 @@ namespace proc {
     std::error_code ec;
     placebo = false;
 
+    // Function-scoped so the Linux media fence outlives undo cmds. Nesting the
+    // fence in an early #ifdef block used to drop it before
+    // polaris-gamescope-session stop, and the video path reopened portal against
+    // a dying gamescope-0 (Response code 2).
+    struct media_stop_fence_holder_t {
+#ifdef __linux__
+      session_media::teardown_owner_t fence;
+#endif
+    } media_stop;
+
 #ifdef __linux__
     // Single media owner: signal → portal release → bounded front-end wait →
     // terminal ownership fence. Nested kill only after every owned cleanup exits.
-    [[maybe_unused]] auto media_stop_fence = session_media::prepare_for_stop();
+    media_stop.fence = session_media::prepare_for_stop();
     stop_steam_big_picture_input_guard();
     if (!immediate) {
       terminate_session_owned_steam_before_cage_stop();
@@ -6432,7 +6568,8 @@ namespace proc {
 
     // Gamescope Steam/pressure-vessel often strips POLARIS_SESSION_INSTANCE_ID, so
     // exact-generation + session-owned Steam paths find nothing and webui close
-    // leaves the game running. Always sweep gamescope-attached clients by attach env.
+    // leaves the game running. Sweep attach-env Steam/game clients only (not bare
+    // infrastructure), then ensure idle gamescope survives for portal capture.
     if (_session_used_cage_compositor && !immediate) {
       const bool gamescope_session =
         config::video.linux_display.stream_mode == "gamescope_stream" ||
@@ -6441,9 +6578,7 @@ namespace proc {
         terminate_gamescope_attached_session_clients(steam_appid_for_context(_app));
       }
     }
-#endif
 
-#ifdef __linux__
     if (isolated_session_uses_legacy_group_termination(
           _session_used_cage_compositor,
           immediate
@@ -6483,6 +6618,18 @@ namespace proc {
     _session_env_keys.clear();
     _audio_context = {};
 
+#ifdef __linux__
+    // Nested prep undoes via polaris-gamescope-session stop (kills Steam). Bare
+    // steam -shutdown first would boot a headless client without DISPLAY.
+    const bool gamescope_session_stop_undo = std::any_of(
+      _app_prep_begin,
+      _app_prep_it,
+      [](const cmd_t &cmd) {
+        return !cmd.undo_cmd.empty() && command_uses_polaris_gamescope_session(cmd.undo_cmd);
+      }
+    );
+#endif
+
     for (; _app_prep_it != _app_prep_begin; --_app_prep_it) {
       auto &cmd = *(_app_prep_it - 1);
 
@@ -6503,6 +6650,12 @@ namespace proc {
             _session_used_cage_compositor
           )) {
         BOOST_LOG(info) << "Skipping Steam shutdown undo after isolated cage Steam cleanup ["sv
+                        << cmd.undo_cmd << ']';
+        continue;
+      }
+
+      if (gamescope_session_stop_undo && command_requests_steam_shutdown(cmd.undo_cmd)) {
+        BOOST_LOG(info) << "Skipping Steam -shutdown undo; polaris-gamescope-session stop owns nested Steam cleanup ["sv
                         << cmd.undo_cmd << ']';
         continue;
       }
@@ -6534,6 +6687,9 @@ namespace proc {
     if (!linux_vdisplay.has_value() || !linux_vdisplay->active) {
       linux_display::disable_streaming_display();
     }
+    // Explicitly drop after undo so portal reconnect cannot race nested stop /
+    // idle handoff. (Holder also ends at function exit.)
+    media_stop.fence.reset();
 #endif
 
     _pipe.reset();

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2993,6 +2993,10 @@ namespace proc {
       tracked_keys.insert(key);
     }
 
+    bool is_reserved_session_env_key(std::string_view key) {
+      return key == "POLARIS_SESSION_INSTANCE_ID"sv;
+    }
+
     void set_child_only_session_env_var(boost::process::v1::environment &env,
                                         std::unordered_set<std::string> &tracked_keys,
                                         const std::string &key,
@@ -5798,12 +5802,26 @@ namespace proc {
     // Apply per-app environment variables (e.g., MANGOHUD=1, PROTON_NO_FSYNC=1)
     // Set on both boost _env (for non-cage launches) and real environ (for fork/exec in cage)
     for (const auto &[key, val] : _app.env_vars) {
+      if (is_reserved_session_env_key(key)) {
+        BOOST_LOG(warning) << "Ignoring reserved per-app environment key: " << key;
+        continue;
+      }
       _env[key] = val;
       platf::set_env(key, val);
       BOOST_LOG(info) << "Per-app env: " << key << "=" << val;
     }
 
 #ifdef __linux__
+    // Generic app environment is untrusted configuration. Reassert the exact
+    // generated credential child-only after overlay application and ensure no
+    // value remains in the daemon environment for later sessions to inherit.
+    platf::unset_env("POLARIS_SESSION_INSTANCE_ID");
+    set_child_only_session_env_var(
+      _env,
+      _session_env_keys,
+      "POLARIS_SESSION_INSTANCE_ID",
+      _session_instance_id
+    );
     _audio_context = {};
     if (config::audio.stream) {
       _audio_context = audio::get_audio_ctx_ref();

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1389,6 +1389,27 @@ namespace proc {
       return parent_pid;
     }
 
+    struct proc_group_session_t {
+      pid_t process_group;
+      pid_t session;
+    };
+
+    std::optional<proc_group_session_t> proc_group_session_from_stat(std::string_view stat) {
+      const auto comm_end = stat.rfind(')');
+      if (comm_end == std::string_view::npos || comm_end + 1 >= stat.size()) {
+        return std::nullopt;
+      }
+      std::istringstream fields(std::string {stat.substr(comm_end + 1)});
+      std::string state;
+      pid_t parent_pid = -1;
+      proc_group_session_t result {};
+      if (!(fields >> state >> parent_pid >> result.process_group >> result.session) ||
+          result.process_group <= 1 || result.session <= 1) {
+        return std::nullopt;
+      }
+      return result;
+    }
+
 #ifdef POLARIS_TESTS
     thread_local pid_t forced_proc_ancestry_unknown_pid = -1;
 #endif
@@ -1943,7 +1964,11 @@ namespace proc {
       } snapshot;
       std::vector<pidfd_handle_t> owned_frozen_generation;
       auto &frozen = frozen_generation ? *frozen_generation : owned_frozen_generation;
-      auto resume_on_failure = util::fail_guard([&frozen]() {
+      std::set<pid_t> authorized_private_groups;
+      auto resume_on_failure = util::fail_guard([&frozen, &authorized_private_groups]() {
+        for (const auto group : authorized_private_groups) {
+          (void) kill(-group, SIGCONT);
+        }
         for (const auto &handle : frozen) {
           (void) send_pidfd_signal(handle, SIGCONT);
         }
@@ -1953,20 +1978,64 @@ namespace proc {
       if (!authority.capture_complete || authority.owned.empty()) {
         return false;
       }
-      const auto has_exact_generation_ancestry = [&authority](pid_t pid) -> std::optional<bool> {
-        for (const auto &root : authority.owned) {
-          if (pid == root.pid) {
-            return true;
-          }
-          const auto descends = proc_pid_descends_from(pid, root.pid);
-          if (!descends) {
-            return std::nullopt;
-          }
-          if (*descends) {
-            return true;
-          }
+      for (auto &root : authority.owned) {
+#ifdef POLARIS_TESTS
+        if (root.pid == forced_reused_gamescope_attached_pid ||
+            root.pid == forced_unreadable_gamescope_attached_pid) {
+          return false;
         }
+#endif
+        const auto root_group = proc_group_session_from_stat(read_proc_status_file(root.pid, "stat"));
+        if (!root_group) {
+          BOOST_LOG(error) << "process: exact Gamescope root lacks stable PGID/SID metadata pid="sv << root.pid;
+          return false;
+        }
+        if (root.pid == root_group->process_group && root_group->process_group == root_group->session) {
+          authorized_private_groups.insert(root_group->session);
+        }
+      }
+      if (authorized_private_groups.empty()) {
+        BOOST_LOG(error) << "process: exact Gamescope generation lacks a private session leader"sv;
         return false;
+      }
+      for (const auto &root : authority.owned) {
+        const auto root_group = proc_group_session_from_stat(read_proc_status_file(root.pid, "stat"));
+        if (!root_group || !authorized_private_groups.contains(root_group->session)) {
+          BOOST_LOG(error) << "process: exact Gamescope root is outside the authorized private session pid="sv << root.pid;
+          return false;
+        }
+      }
+      for (const auto group : authorized_private_groups) {
+        if (kill(-group, SIGSTOP) != 0) {
+          BOOST_LOG(error) << "process: failed to freeze exact Gamescope private group="sv << group;
+          return false;
+        }
+      }
+      std::this_thread::sleep_for(10ms);
+      for (auto &root : authority.owned) {
+#ifdef POLARIS_TESTS
+        if (root.pid == forced_reused_gamescope_attached_pid ||
+            root.pid == forced_unreadable_gamescope_attached_pid) {
+          return false;
+        }
+#endif
+        const auto root_group = proc_group_session_from_stat(read_proc_status_file(root.pid, "stat"));
+        if (!root_group ||
+            !authorized_private_groups.contains(root_group->session) || pidfd_has_exited(root)) {
+          return false;
+        }
+        if (std::none_of(frozen.begin(), frozen.end(), [&root](const auto &handle) {
+              return handle.pid == root.pid;
+            })) {
+          frozen.emplace_back(std::move(root));
+        }
+      }
+      const auto has_exact_private_group = [&authorized_private_groups](pid_t pid) -> std::optional<bool> {
+        const auto membership = proc_group_session_from_stat(read_proc_status_file(pid, "stat"));
+        if (!membership) {
+          return std::nullopt;
+        }
+        return authorized_private_groups.contains(membership->session);
       };
       DIR *dir = opendir("/proc");
       if (!dir) {
@@ -2002,12 +2071,13 @@ namespace proc {
         if (proc_dir_stat.st_uid != geteuid()) {
           continue;
         }
-        const auto exact_generation_ancestry = has_exact_generation_ancestry(pid);
-        if (!exact_generation_ancestry) {
+        const auto exact_private_group = has_exact_private_group(pid);
+        if (!exact_private_group) {
+          BOOST_LOG(error) << "process: incomplete private-group membership for pid="sv << pid;
           snapshot.capture_complete = false;
           continue;
         }
-        if (!*exact_generation_ancestry) {
+        if (!*exact_private_group) {
           continue;
         }
         if (std::any_of(frozen.begin(), frozen.end(), [pid](const auto &handle) {
@@ -2068,13 +2138,14 @@ namespace proc {
           ++*identity_after;
         }
 #endif
-        const auto ancestry_after = has_exact_generation_ancestry(pid);
+        const auto group_after = has_exact_private_group(pid);
         const bool capture_matches =
-          ancestry_after && *ancestry_after &&
+          group_after && *group_after &&
           steam_pidfd_capture_identity_matches(identity_before, identity_after) &&
           comm_after.ok() && cmdline_after.ok() && environ_after.ok();
         if (!capture_matches) {
           if (!pidfd_has_exited(*handle)) {
+            BOOST_LOG(error) << "process: private-group pidfd capture changed for pid="sv << pid;
             snapshot.capture_complete = false;
           }
           continue;
@@ -2086,7 +2157,7 @@ namespace proc {
       if (errno != 0) {
         snapshot.capture_complete = false;
       }
-      for (const auto &root : authority.owned) {
+      for (const auto &root : frozen) {
         if (pidfd_has_exited(root)) {
           snapshot.capture_complete = false;
         }
@@ -4805,6 +4876,7 @@ namespace proc {
 #ifdef __linux__
     _session_instance_id = generate_session_token();
     _session_used_cage_compositor = false;
+    _session_used_gamescope_runtime = false;
 #endif
     _app = app;
     _app_id = util::from_view(app.id);
@@ -4823,6 +4895,7 @@ namespace proc {
     const bool gamescope_stream_session =
       config::video.linux_display.stream_mode == "gamescope_stream" ||
       config::video.linux_display.private_runtime == "gamescope";
+    _session_used_gamescope_runtime = gamescope_stream_session;
     // Set true after enable_hdr when rewiring to polaris-gamescope-session nested WSI.
     bool nested_wsi_hdr_session = false;
     // Private nested runtime: labwc cage and/or owned/attach gamescope.
@@ -6769,6 +6842,7 @@ namespace proc {
         )) {
       _session_instance_id.clear();
       _session_used_cage_compositor = false;
+      _session_used_gamescope_runtime = false;
     }
   }
 
@@ -6799,18 +6873,17 @@ namespace proc {
     // Gamescope Steam/pressure-vessel may strip POLARIS_SESSION_INSTANCE_ID.
     // Freeze and capture the full ancestry closure while its exact credentialed
     // roots are still alive, then terminate only that immutable closure.
-    if (_session_used_cage_compositor && !immediate) {
-      const bool gamescope_session =
-        config::video.linux_display.stream_mode == "gamescope_stream" ||
-        config::video.linux_display.private_runtime == "gamescope";
-      if (gamescope_session) {
-        const bool attached_cleanup_complete =
-          terminate_gamescope_attached_session_clients(
-            steam_appid_for_context(_app),
-            _session_instance_id
-          );
-        _exact_generation_cleanup_complete =
-          _exact_generation_cleanup_complete && attached_cleanup_complete;
+    if (_session_used_cage_compositor && !immediate && _session_used_gamescope_runtime) {
+      const bool attached_cleanup_complete =
+        terminate_gamescope_attached_session_clients(
+          steam_appid_for_context(_app),
+          _session_instance_id
+        );
+      _exact_generation_cleanup_complete =
+        _exact_generation_cleanup_complete && attached_cleanup_complete;
+      if (!attached_cleanup_complete) {
+        BOOST_LOG(error) << "process: refusing all later teardown because exact Gamescope ancestry closure was incomplete"sv;
+        return;
       }
     }
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6794,14 +6794,10 @@ namespace proc {
     // terminal ownership fence. Nested kill only after every owned cleanup exits.
     media_stop.fence = session_media::prepare_for_stop();
     stop_steam_big_picture_input_guard();
-    if (!immediate) {
-      terminate_session_owned_steam_before_cage_stop();
-    }
 
-    // Gamescope Steam/pressure-vessel often strips POLARIS_SESSION_INSTANCE_ID, so
-    // exact-generation + session-owned Steam paths find nothing and webui close
-    // leaves the game running. Sweep attach-env Steam/game clients only (not bare
-    // infrastructure), then ensure idle gamescope survives for portal capture.
+    // Gamescope Steam/pressure-vessel may strip POLARIS_SESSION_INSTANCE_ID.
+    // Freeze and capture the full ancestry closure while its exact credentialed
+    // roots are still alive, then terminate only that immutable closure.
     if (_session_used_cage_compositor && !immediate) {
       const bool gamescope_session =
         config::video.linux_display.stream_mode == "gamescope_stream" ||
@@ -6815,6 +6811,13 @@ namespace proc {
         _exact_generation_cleanup_complete =
           _exact_generation_cleanup_complete && attached_cleanup_complete;
       }
+    }
+
+    // Preserve exact-generation roots until the Gamescope ancestry closure is
+    // frozen. Steam cleanup may otherwise destroy the authority needed to prove
+    // stripped pressure-vessel descendants.
+    if (!immediate) {
+      terminate_session_owned_steam_before_cage_stop();
     }
 
     // The immutable launch generation, not mutable config, owns this cleanup.

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2034,18 +2034,26 @@ namespace proc {
       });
 
       const auto this_pid = getpid();
-      const auto is_candidate = [&steam_appid](
+      const auto is_trusted_host_infrastructure = [](std::string comm, const std::string &cmdline) {
+        boost::to_lower(comm);
+        boost::trim(comm);
+        return comm == "polaris" || comm.find("polaris") != std::string::npos ||
+          comm == "sleep" || comm == "dbus-daemon" || comm == "systemd" ||
+          comm == "(sd-pam)" || comm == "kwin_wayland" ||
+          comm == "polkit-kde-auth" || comm == "ssh-agent" ||
+          comm == "sshd-session" || comm == "kscreenlocker_g" ||
+          cmdline.find("systemd-inhibit") != std::string::npos ||
+          cmdline.find("srt-logger") != std::string::npos ||
+          is_gamescope_infrastructure_process(comm, cmdline);
+      };
+      const auto is_candidate = [&steam_appid, &is_trusted_host_infrastructure](
                                   std::string comm,
                                   const std::string &cmdline,
                                   const std::string &environ
                                 ) {
         boost::to_lower(comm);
         boost::trim(comm);
-        if (comm == "polaris" || comm.find("polaris") != std::string::npos ||
-            comm == "sleep" || comm == "dbus-daemon" || comm == "systemd" ||
-            cmdline.find("systemd-inhibit") != std::string::npos ||
-            cmdline.find("srt-logger") != std::string::npos ||
-            is_gamescope_infrastructure_process(comm, cmdline)) {
+        if (is_trusted_host_infrastructure(comm, cmdline)) {
           return false;
         }
         const bool gamescope_attached = proc_environ_is_gamescope_stream_attached(environ);
@@ -2083,34 +2091,36 @@ namespace proc {
         auto cmdline_before = read_proc_status_file_result(pid, "cmdline");
         auto environ_before = read_proc_status_file_result(pid, "environ");
 #ifdef POLARIS_TESTS
-        const bool forced_unreadable = pid == forced_unreadable_gamescope_attached_pid;
-        if (forced_unreadable) {
+        if (pid == forced_unreadable_gamescope_attached_pid) {
           environ_before = {{}, EACCES};
         }
-#else
-        constexpr bool forced_unreadable = false;
 #endif
+        if (comm_before.ok() && cmdline_before.ok() &&
+            is_trusted_host_infrastructure(comm_before.bytes, cmdline_before.bytes)) {
+          continue;
+        }
         if (!identity_before || !comm_before.ok() || !cmdline_before.ok()) {
+          const auto status = read_proc_status_file_result(pid, "status");
+          if (status.ok() && proc_status_is_zombie(status.bytes)) {
+            continue;
+          }
           errno = 0;
           if (kill(pid, 0) != 0 && errno == ESRCH) {
             continue;
           }
-          if (forced_unreadable ||
-              (comm_before.ok() && cmdline_before.ok() &&
-               is_steam_or_game_client_process(comm_before.bytes, cmdline_before.bytes, "", steam_appid))) {
-            snapshot.capture_complete = false;
-          }
+          snapshot.capture_complete = false;
           continue;
         }
         if (!environ_before.ok()) {
+          const auto status = read_proc_status_file_result(pid, "status");
+          if (status.ok() && proc_status_is_zombie(status.bytes)) {
+            continue;
+          }
           errno = 0;
           if (kill(pid, 0) != 0 && errno == ESRCH) {
             continue;
           }
-          if (forced_unreadable ||
-              is_steam_or_game_client_process(comm_before.bytes, cmdline_before.bytes, "", steam_appid)) {
-            snapshot.capture_complete = false;
-          }
+          snapshot.capture_complete = false;
           continue;
         }
         if (!is_candidate(comm_before.bytes, cmdline_before.bytes, environ_before.bytes)) {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2020,11 +2020,33 @@ namespace proc {
      * idle compositor causes gamescope xwm "X11 I/O error" ABRT and takes down
      * the portal capture target.
      */
-    bool terminate_gamescope_attached_session_clients(const std::string &steam_appid) {
+    bool terminate_gamescope_attached_session_clients(
+      const std::string &steam_appid,
+      std::string_view session_instance_id
+    ) {
       struct snapshot_t {
         std::vector<pidfd_handle_t> targets;
         bool capture_complete = true;
       } snapshot;
+      auto authority = isolated_session_process_snapshot(session_instance_id);
+      if (!authority.capture_complete || authority.owned.empty()) {
+        return false;
+      }
+      const auto has_exact_generation_ancestry = [&authority](pid_t pid) -> std::optional<bool> {
+        for (const auto &root : authority.owned) {
+          if (pid == root.pid) {
+            return true;
+          }
+          const auto descends = proc_pid_descends_from(pid, root.pid);
+          if (!descends) {
+            return std::nullopt;
+          }
+          if (*descends) {
+            return true;
+          }
+        }
+        return false;
+      };
       DIR *dir = opendir("/proc");
       if (!dir) {
         return false;
@@ -2083,6 +2105,14 @@ namespace proc {
           continue;
         }
         if (proc_dir_stat.st_uid != geteuid()) {
+          continue;
+        }
+        const auto exact_generation_ancestry = has_exact_generation_ancestry(pid);
+        if (!exact_generation_ancestry) {
+          snapshot.capture_complete = false;
+          continue;
+        }
+        if (!*exact_generation_ancestry) {
           continue;
         }
 
@@ -2145,7 +2175,9 @@ namespace proc {
           ++*identity_after;
         }
 #endif
+        const auto ancestry_after = has_exact_generation_ancestry(pid);
         const bool capture_matches =
+          ancestry_after && *ancestry_after &&
           steam_pidfd_capture_identity_matches(identity_before, identity_after) &&
           comm_after.ok() && cmdline_after.ok() && environ_after.ok() &&
           is_candidate(comm_after.bytes, cmdline_after.bytes, environ_after.bytes);
@@ -2161,6 +2193,11 @@ namespace proc {
       }
       if (errno != 0) {
         snapshot.capture_complete = false;
+      }
+      for (const auto &root : authority.owned) {
+        if (pidfd_has_exited(root)) {
+          snapshot.capture_complete = false;
+        }
       }
       if (!snapshot.capture_complete) {
         BOOST_LOG(error) << "process: gamescope-attached client capture incomplete; refusing partial termination"sv;
@@ -4197,7 +4234,7 @@ namespace proc {
     });
     forced_reused_gamescope_attached_pid = forced_reused_pid;
     forced_unreadable_gamescope_attached_pid = forced_unreadable_pid;
-    return terminate_gamescope_attached_session_clients(steam_appid);
+    return terminate_gamescope_attached_session_clients(steam_appid, "gamescope-attached-test");
   }
 
   bool terminate_pid_with_pidfd_for_tests(
@@ -6845,11 +6882,6 @@ namespace proc {
       terminate_session_owned_steam_before_cage_stop();
     }
 
-    // The immutable launch generation, not mutable config, owns this cleanup.
-    // Capture and terminate every exact-generation process through pidfds before
-    // any legacy child/group handle can signal or be destroyed.
-    terminate_isolated_session_generation();
-
     // Gamescope Steam/pressure-vessel often strips POLARIS_SESSION_INSTANCE_ID, so
     // exact-generation + session-owned Steam paths find nothing and webui close
     // leaves the game running. Sweep attach-env Steam/game clients only (not bare
@@ -6860,11 +6892,19 @@ namespace proc {
         config::video.linux_display.private_runtime == "gamescope";
       if (gamescope_session) {
         const bool attached_cleanup_complete =
-          terminate_gamescope_attached_session_clients(steam_appid_for_context(_app));
+          terminate_gamescope_attached_session_clients(
+            steam_appid_for_context(_app),
+            _session_instance_id
+          );
         _exact_generation_cleanup_complete =
           _exact_generation_cleanup_complete && attached_cleanup_complete;
       }
     }
+
+    // The immutable launch generation, not mutable config, owns this cleanup.
+    // Keep exact-generation ancestors alive while proving pressure-vessel client
+    // ancestry above, then terminate every exact-generation process via pidfds.
+    terminate_isolated_session_generation();
 
     if (isolated_session_uses_legacy_group_termination(
           _session_used_cage_compositor,

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -997,95 +997,6 @@ namespace proc {
       return false;
     }
 
-    // True when environ looks like a Polaris session / Steam / Proton game client
-    // rather than a host helper that merely inherited gamescope attach keys.
-    bool proc_environ_is_session_game_client(std::string_view environ) {
-      std::size_t start = 0;
-      while (start < environ.size()) {
-        const auto end = environ.find('\0', start);
-        if (end == std::string_view::npos) {
-          break;
-        }
-        const auto entry = environ.substr(start, end - start);
-        if (entry.starts_with("POLARIS_SESSION_INSTANCE_ID="sv) && entry.size() > 28) {
-          return true;
-        }
-        if (entry.starts_with("STEAM_COMPAT_APP_ID="sv) ||
-            entry.starts_with("SteamAppId="sv) ||
-            entry.starts_with("SteamGameId="sv) ||
-            entry.starts_with("STEAM_COMPAT_DATA_PATH="sv) ||
-            entry.starts_with("PRESSURE_VESSEL_"sv) ||
-            entry.starts_with("WINEPREFIX="sv) ||
-            entry.starts_with("PROTON_"sv)) {
-          return true;
-        }
-        start = end + 1;
-      }
-      return false;
-    }
-
-    bool is_steam_or_game_client_process(
-      std::string_view comm,
-      std::string_view cmdline,
-      std::string_view environ,
-      const std::string &steam_appid
-    ) {
-      if (proc_environ_is_session_game_client(environ)) {
-        return true;
-      }
-      if (!steam_appid.empty()) {
-        const std::string appid_marker = "AppId=" + steam_appid;
-        if (cmdline.find(appid_marker) != std::string_view::npos ||
-            cmdline.find("steam://rungameid/" + steam_appid) != std::string_view::npos ||
-            cmdline.find("rungameid/" + steam_appid) != std::string_view::npos) {
-          return true;
-        }
-      }
-      if (comm.find("steam") != std::string_view::npos ||
-          comm == "reaper" ||
-          comm.find("pressure-vessel") != std::string_view::npos ||
-          comm.find("proton") != std::string_view::npos ||
-          comm.find("wine") != std::string_view::npos ||
-          comm.find("wineserver") != std::string_view::npos) {
-        return true;
-      }
-      if (cmdline.find("SteamLaunch") != std::string_view::npos ||
-          cmdline.find("steam://rungameid/") != std::string_view::npos ||
-          cmdline.find("pressure-vessel") != std::string_view::npos ||
-          cmdline.find("/proton") != std::string_view::npos ||
-          cmdline.find("steam-runtime") != std::string_view::npos ||
-          cmdline.find("steamapps/common/") != std::string_view::npos ||
-          cmdline.find("steamapps\\common\\") != std::string_view::npos) {
-        return true;
-      }
-      return false;
-    }
-
-    bool is_gamescope_infrastructure_process(std::string_view comm, std::string_view cmdline) {
-      if (comm == "gamescope" || comm == "gamescope-wl" || comm == "gamescopereaper" ||
-          comm == ".gamescope-wrapped" || comm == "Xwayland" || comm == "Xwayland.bin") {
-        return true;
-      }
-      if (comm.find("portal-gamescope") != std::string_view::npos) {
-        return true;
-      }
-      if (cmdline.find("xdg-desktop-portal-gamescope") != std::string_view::npos) {
-        return true;
-      }
-      // Idle unit primary child: setsid gamescope … -- sleep infinity
-      if (comm == "sleep" && cmdline.find("infinity") != std::string_view::npos) {
-        return true;
-      }
-      if (cmdline.find("gamescope --backend") != std::string_view::npos ||
-          cmdline.find("gamescope --") != std::string_view::npos) {
-        // Parent gamescope compositor itself (comm may be .gamescope-wrappe).
-        if (cmdline.find("steam://") == std::string_view::npos &&
-            cmdline.find("SteamLaunch") == std::string_view::npos) {
-          return true;
-        }
-      }
-      return false;
-    }
 
     // After attach-path client cleanup, gamescope may ABRT on X11 I/O when Steam
     // disconnects. Idle must stay up for portal capture on the next session.
@@ -2022,12 +1933,22 @@ namespace proc {
      */
     bool terminate_gamescope_attached_session_clients(
       const std::string &steam_appid,
-      std::string_view session_instance_id
+      std::string_view session_instance_id,
+      std::vector<pidfd_handle_t> *frozen_generation = nullptr,
+      unsigned capture_pass = 0
     ) {
       struct snapshot_t {
         std::vector<pidfd_handle_t> targets;
         bool capture_complete = true;
       } snapshot;
+      std::vector<pidfd_handle_t> owned_frozen_generation;
+      auto &frozen = frozen_generation ? *frozen_generation : owned_frozen_generation;
+      auto resume_on_failure = util::fail_guard([&frozen]() {
+        for (const auto &handle : frozen) {
+          (void) send_pidfd_signal(handle, SIGCONT);
+        }
+      });
+      (void) steam_appid;
       auto authority = isolated_session_process_snapshot(session_instance_id);
       if (!authority.capture_complete || authority.owned.empty()) {
         return false;
@@ -2056,32 +1977,6 @@ namespace proc {
       });
 
       const auto this_pid = getpid();
-      const auto is_trusted_host_infrastructure = [](std::string comm, const std::string &cmdline) {
-        boost::to_lower(comm);
-        boost::trim(comm);
-        return comm == "polaris" || comm.find("polaris") != std::string::npos ||
-          comm == "sleep" || comm == "dbus-daemon" || comm == "systemd" ||
-          comm == "(sd-pam)" || comm == "kwin_wayland" ||
-          comm == "polkit-kde-auth" || comm == "ssh-agent" ||
-          comm == "sshd-session" || comm == "kscreenlocker_g" ||
-          cmdline.find("systemd-inhibit") != std::string::npos ||
-          cmdline.find("srt-logger") != std::string::npos ||
-          is_gamescope_infrastructure_process(comm, cmdline);
-      };
-      const auto is_candidate = [&steam_appid, &is_trusted_host_infrastructure](
-                                  std::string comm,
-                                  const std::string &cmdline,
-                                  const std::string &environ
-                                ) {
-        boost::to_lower(comm);
-        boost::trim(comm);
-        if (is_trusted_host_infrastructure(comm, cmdline)) {
-          return false;
-        }
-        const bool gamescope_attached = proc_environ_is_gamescope_stream_attached(environ);
-        const bool game_client = is_steam_or_game_client_process(comm, cmdline, environ, steam_appid);
-        return gamescope_attached && game_client;
-      };
 
       for (;;) {
         auto *entry = read_next_proc_entry(dir);
@@ -2115,6 +2010,11 @@ namespace proc {
         if (!*exact_generation_ancestry) {
           continue;
         }
+        if (std::any_of(frozen.begin(), frozen.end(), [pid](const auto &handle) {
+              return handle.pid == pid;
+            })) {
+          continue;
+        }
 
         const auto identity_before = proc_start_time_ticks(pid);
         auto comm_before = read_proc_status_file_result(pid, "comm");
@@ -2125,10 +2025,7 @@ namespace proc {
           environ_before = {{}, EACCES};
         }
 #endif
-        if (comm_before.ok() && cmdline_before.ok() &&
-            is_trusted_host_infrastructure(comm_before.bytes, cmdline_before.bytes)) {
-          continue;
-        }
+
         if (!identity_before || !comm_before.ok() || !cmdline_before.ok()) {
           const auto status = read_proc_status_file_result(pid, "status");
           if (status.ok() && proc_status_is_zombie(status.bytes)) {
@@ -2153,10 +2050,6 @@ namespace proc {
           snapshot.capture_complete = false;
           continue;
         }
-        if (!is_candidate(comm_before.bytes, cmdline_before.bytes, environ_before.bytes)) {
-          continue;
-        }
-
         int open_error = 0;
         auto handle = open_process_pidfd(pid, open_error);
         if (!handle) {
@@ -2179,8 +2072,7 @@ namespace proc {
         const bool capture_matches =
           ancestry_after && *ancestry_after &&
           steam_pidfd_capture_identity_matches(identity_before, identity_after) &&
-          comm_after.ok() && cmdline_after.ok() && environ_after.ok() &&
-          is_candidate(comm_after.bytes, cmdline_after.bytes, environ_after.bytes);
+          comm_after.ok() && cmdline_after.ok() && environ_after.ok();
         if (!capture_matches) {
           if (!pidfd_has_exited(*handle)) {
             snapshot.capture_complete = false;
@@ -2200,18 +2092,42 @@ namespace proc {
         }
       }
       if (!snapshot.capture_complete) {
-        BOOST_LOG(error) << "process: gamescope-attached client capture incomplete; refusing partial termination"sv;
+        BOOST_LOG(error) << "process: exact-generation capture incomplete; refusing partial termination"sv;
         return false;
       }
-      if (snapshot.targets.empty()) {
-        BOOST_LOG(info) << "process: no gamescope-attached session clients to terminate"sv;
-        ensure_idle_gamescope_alive_for_portal();
-        return true;
+      if (!snapshot.targets.empty()) {
+        if (capture_pass >= 8) {
+          BOOST_LOG(error) << "process: exact-generation process tree did not quiesce"sv;
+          return false;
+        }
+        for (const auto &handle : snapshot.targets) {
+          if (!send_pidfd_signal(handle, SIGSTOP)) {
+            return false;
+          }
+        }
+        for (auto &handle : snapshot.targets) {
+          frozen.emplace_back(std::move(handle));
+        }
+        std::this_thread::sleep_for(10ms);
+        return terminate_gamescope_attached_session_clients(
+          steam_appid,
+          session_instance_id,
+          &frozen,
+          capture_pass + 1
+        );
       }
 
-      BOOST_LOG(info) << "process: terminating "sv << snapshot.targets.size()
-                      << " exact gamescope-attached session client(s)"sv;
-      const bool ok = terminate_pidfds(snapshot.targets, 3s, 2s, "gamescope session client"sv);
+      if (frozen.empty()) {
+        return false;
+      }
+      BOOST_LOG(info) << "process: terminating frozen exact-generation closure of "sv
+                      << frozen.size() << " process(es)"sv;
+      for (const auto &handle : frozen) {
+        if (!send_pidfd_signal(handle, SIGKILL)) {
+          return false;
+        }
+      }
+      const bool ok = wait_for_pidfds_exit(frozen, 2s);
       ensure_idle_gamescope_alive_for_portal();
       return ok;
     }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1523,6 +1523,7 @@ namespace proc {
     thread_local bool forced_proc_directory_enumeration_error = false;
     thread_local pid_t forced_proc_directory_error_after_capture_pid = -1;
     thread_local pid_t forced_reused_exact_generation_pid = -1;
+    thread_local pid_t forced_reused_gamescope_attached_pid = -1;
     thread_local pid_t forced_steam_ownership_capture_failure_pid = -1;
 #endif
 
@@ -2019,7 +2020,10 @@ namespace proc {
      * the portal capture target.
      */
     bool terminate_gamescope_attached_session_clients(const std::string &steam_appid) {
-      std::vector<pidfd_handle_t> targets;
+      struct snapshot_t {
+        std::vector<pidfd_handle_t> targets;
+        bool capture_complete = true;
+      } snapshot;
       DIR *dir = opendir("/proc");
       if (!dir) {
         return false;
@@ -2029,6 +2033,29 @@ namespace proc {
       });
 
       const auto this_pid = getpid();
+      const auto is_candidate = [&steam_appid](
+                                  std::string comm,
+                                  const std::string &cmdline,
+                                  const std::string &environ
+                                ) {
+        boost::to_lower(comm);
+        boost::trim(comm);
+        if (comm == "polaris" || comm.find("polaris") != std::string::npos ||
+            comm == "sleep" || comm == "dbus-daemon" || comm == "systemd" ||
+            cmdline.find("systemd-inhibit") != std::string::npos ||
+            cmdline.find("srt-logger") != std::string::npos ||
+            is_gamescope_infrastructure_process(comm, cmdline)) {
+          return false;
+        }
+        const bool gamescope_attached = proc_environ_is_gamescope_stream_attached(environ);
+        const bool game_client = is_steam_or_game_client_process(comm, cmdline, environ, steam_appid);
+        const bool steam_launch_for_app =
+          !steam_appid.empty() &&
+          (cmdline.find("AppId=" + steam_appid) != std::string::npos ||
+           cmdline.find("steam://rungameid/" + steam_appid) != std::string::npos ||
+           cmdline.find("rungameid/" + steam_appid) != std::string::npos);
+        return (gamescope_attached && game_client) || steam_launch_for_app;
+      };
 
       for (;;) {
         auto *entry = read_next_proc_entry(dir);
@@ -2044,68 +2071,63 @@ namespace proc {
           continue;
         }
 
-        const auto comm_r = read_proc_status_file_result(pid, "comm");
-        const auto cmdline_r = read_proc_status_file_result(pid, "cmdline");
-        const auto environ_r = read_proc_status_file_result(pid, "environ");
-        if (!comm_r.ok() || !cmdline_r.ok() || !environ_r.ok()) {
-          continue;
-        }
-        auto comm = boost::to_lower_copy(comm_r.bytes);
-        boost::trim(comm);
-        const auto &cmdline = cmdline_r.bytes;
-        if (comm == "polaris" || comm.find("polaris") != std::string::npos) {
-          continue;
-        }
-        // Host helpers that inherit gamescope env from the polaris unit — not game clients.
-        if (comm == "sleep" || comm == "dbus-daemon" || comm == "systemd" ||
-            cmdline.find("systemd-inhibit") != std::string::npos ||
-            cmdline.find("srt-logger") != std::string::npos) {
-          continue;
-        }
-        if (is_gamescope_infrastructure_process(comm, cmdline)) {
-          continue;
-        }
-
-        const bool gamescope_attached = proc_environ_is_gamescope_stream_attached(environ_r.bytes);
-        const bool game_client = is_steam_or_game_client_process(
-          comm,
-          cmdline,
-          environ_r.bytes,
-          steam_appid
-        );
-        // Fallback without attach env: only the same appid (not any SteamLaunch).
-        const bool steam_launch_for_app =
-          !steam_appid.empty() &&
-          (cmdline.find("AppId=" + steam_appid) != std::string::npos ||
-           cmdline.find("steam://rungameid/" + steam_appid) != std::string::npos ||
-           cmdline.find("rungameid/" + steam_appid) != std::string::npos);
-
-        // Require attach env + steam/game identity, or an explicit same-app launch line.
-        // Bare attach-env matches are too broad and can crash idle gamescope.
-        if (!(gamescope_attached && game_client) && !steam_launch_for_app) {
+        const auto identity_before = proc_start_time_ticks(pid);
+        const auto comm_before = read_proc_status_file_result(pid, "comm");
+        const auto cmdline_before = read_proc_status_file_result(pid, "cmdline");
+        const auto environ_before = read_proc_status_file_result(pid, "environ");
+        if (!identity_before || !comm_before.ok() || !cmdline_before.ok() || !environ_before.ok() ||
+            !is_candidate(comm_before.bytes, cmdline_before.bytes, environ_before.bytes)) {
           continue;
         }
 
         int open_error = 0;
         auto handle = open_process_pidfd(pid, open_error);
         if (!handle) {
+          if (!process_vanished_during_proc_read(open_error)) {
+            snapshot.capture_complete = false;
+          }
           continue;
         }
-        BOOST_LOG(debug) << "process: gamescope session client candidate pid="sv << pid
-                         << " comm="sv << comm;
-        targets.emplace_back(std::move(*handle));
-      }
 
-      if (targets.empty()) {
+        const auto comm_after = read_proc_status_file_result(pid, "comm");
+        const auto cmdline_after = read_proc_status_file_result(pid, "cmdline");
+        const auto environ_after = read_proc_status_file_result(pid, "environ");
+        auto identity_after = proc_start_time_ticks(pid);
+#ifdef POLARIS_TESTS
+        if (pid == forced_reused_gamescope_attached_pid && identity_after) {
+          ++*identity_after;
+        }
+#endif
+        const bool capture_matches =
+          steam_pidfd_capture_identity_matches(identity_before, identity_after) &&
+          comm_after.ok() && cmdline_after.ok() && environ_after.ok() &&
+          is_candidate(comm_after.bytes, cmdline_after.bytes, environ_after.bytes);
+        if (!capture_matches) {
+          if (!pidfd_has_exited(*handle)) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+
+        BOOST_LOG(debug) << "process: exact gamescope session client pidfd captured pid="sv << pid;
+        snapshot.targets.emplace_back(std::move(*handle));
+      }
+      if (errno != 0) {
+        snapshot.capture_complete = false;
+      }
+      if (!snapshot.capture_complete) {
+        BOOST_LOG(error) << "process: gamescope-attached client capture incomplete; refusing partial termination"sv;
+        return false;
+      }
+      if (snapshot.targets.empty()) {
         BOOST_LOG(info) << "process: no gamescope-attached session clients to terminate"sv;
         ensure_idle_gamescope_alive_for_portal();
         return true;
       }
 
-      BOOST_LOG(info) << "process: terminating "sv << targets.size()
-                      << " gamescope-attached session client(s) (game/reaper/steam)"sv;
-      const bool ok = terminate_pidfds(targets, 3s, 2s, "gamescope session client"sv);
-      // Steam disconnect often ABRTs idle gamescope (xwm X11 I/O). Restore portal target.
+      BOOST_LOG(info) << "process: terminating "sv << snapshot.targets.size()
+                      << " exact gamescope-attached session client(s)"sv;
+      const bool ok = terminate_pidfds(snapshot.targets, 3s, 2s, "gamescope session client"sv);
       ensure_idle_gamescope_alive_for_portal();
       return ok;
     }
@@ -4113,6 +4135,18 @@ namespace proc {
     std::optional<std::uint64_t> after
   ) {
     return steam_pidfd_capture_identity_matches(before, after);
+  }
+
+  bool terminate_gamescope_attached_clients_for_tests(
+    const std::string &steam_appid,
+    pid_t forced_reused_pid
+  ) {
+    const auto previous = forced_reused_gamescope_attached_pid;
+    auto restore = util::fail_guard([previous]() {
+      forced_reused_gamescope_attached_pid = previous;
+    });
+    forced_reused_gamescope_attached_pid = forced_reused_pid;
+    return terminate_gamescope_attached_session_clients(steam_appid);
   }
 
   bool terminate_pid_with_pidfd_for_tests(
@@ -6774,7 +6808,10 @@ namespace proc {
         config::video.linux_display.stream_mode == "gamescope_stream" ||
         config::video.linux_display.private_runtime == "gamescope";
       if (gamescope_session) {
-        terminate_gamescope_attached_session_clients(steam_appid_for_context(_app));
+        const bool attached_cleanup_complete =
+          terminate_gamescope_attached_session_clients(steam_appid_for_context(_app));
+        _exact_generation_cleanup_complete =
+          _exact_generation_cleanup_complete && attached_cleanup_complete;
       }
     }
 
@@ -6811,10 +6848,11 @@ namespace proc {
       platf::unset_env(key);
     }
     for (const auto &key : _session_env_keys) {
-      _env.erase(key);
+      // Parent state must not leak, but preserve the immutable child environment
+      // until prep undo completes. polaris-gamescope-session stop consumes the
+      // exact session credential to avoid targeting desktop Steam.
       platf::unset_env(key);
     }
-    _session_env_keys.clear();
     _audio_context = {};
 
 #ifdef __linux__
@@ -6877,6 +6915,11 @@ namespace proc {
         BOOST_LOG(warning) << "Return code ["sv << ret << ']';
       }
     }
+
+    for (const auto &key : _session_env_keys) {
+      _env.erase(key);
+    }
+    _session_env_keys.clear();
 
 #ifdef __linux__
     finish_isolated_session_generation_cleanup();

--- a/src/process.h
+++ b/src/process.h
@@ -230,6 +230,10 @@ namespace proc {
     std::optional<std::uint64_t> before,
     std::optional<std::uint64_t> after
   );
+  bool terminate_gamescope_attached_clients_for_tests(
+    const std::string &steam_appid,
+    pid_t forced_reused_pid = -1
+  );
   bool terminate_pid_with_pidfd_for_tests(
     pid_t pid,
     std::chrono::milliseconds graceful_timeout,

--- a/src/process.h
+++ b/src/process.h
@@ -232,7 +232,8 @@ namespace proc {
   );
   bool terminate_gamescope_attached_clients_for_tests(
     const std::string &steam_appid,
-    pid_t forced_reused_pid = -1
+    pid_t forced_reused_pid = -1,
+    pid_t forced_unreadable_pid = -1
   );
   bool terminate_pid_with_pidfd_for_tests(
     pid_t pid,

--- a/src/process.h
+++ b/src/process.h
@@ -650,6 +650,7 @@ namespace proc {
     std::shared_ptr<steam_big_picture_guard_runtime_t> _steam_big_picture_guard;
     std::string _session_instance_id;
     bool _session_used_cage_compositor = false;
+    bool _session_used_gamescope_runtime = false;
     bool _exact_generation_cleanup_complete = true;
 #endif
     std::vector<cmd_t>::const_iterator _app_prep_it;

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -599,7 +599,13 @@ namespace rtsp_stream {
 
     void handle_accept(const boost::system::error_code &ec) {
       if (ec) {
-        BOOST_LOG(error) << "Couldn't accept incoming connections: "sv << ec.message();
+        // Service stop/restart cancels the acceptor — expected, not a fault.
+        if (ec == boost::asio::error::operation_aborted ||
+            ec == boost::system::errc::operation_canceled) {
+          BOOST_LOG(info) << "RTSP acceptor stopped: "sv << ec.message();
+        } else {
+          BOOST_LOG(error) << "Couldn't accept incoming connections: "sv << ec.message();
+        }
 
         // Stop server
         clear();

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -204,7 +204,12 @@ namespace system_tray {
   #endif
 
     if (tray_init(&tray) < 0) {
-      BOOST_LOG(warning) << "Failed to create system tray"sv;
+      // Headless / gamescope user services often have no tray host — not a fault.
+      static bool logged_once = false;
+      if (!logged_once) {
+        logged_once = true;
+        BOOST_LOG(info) << "System tray unavailable (no tray host / headless session); continuing without it"sv;
+      }
       return 1;
     }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3385,9 +3385,20 @@ namespace video {
       // full SDR — bit_depth=8 alone still attaches Rec.2020+PQ metadata and the
       // client shows dark/red "HDR garbage" over SDR pixels.
       if (result && result->prefer_8bit_encode && colorspace_is_hdr(colorspace)) {
-        BOOST_LOG(warning)
-          << "Forcing SDR colorspace: capture path cannot produce 10-bit HDR frames "
-             "(host portal SHM/MemFd is 8-bit BGRx). Use gamescope_stream for real HDR."sv;
+        // Probe / host-portal SHM paths demote often; gamescope_stream still gets real
+        // 10-bit later via dmabuf — keep that path at info to avoid session spam.
+        const bool gamescope_stream =
+          config::video.linux_display.stream_mode == "gamescope_stream";
+        if (gamescope_stream) {
+          BOOST_LOG(info)
+            << "Forcing SDR colorspace for this encode device: capture path reported "
+               "8-bit-only frames (common during portal probe); gamescope_stream HDR "
+               "may still negotiate 10-bit on the live capture path."sv;
+        } else {
+          BOOST_LOG(warning)
+            << "Forcing SDR colorspace: capture path cannot produce 10-bit HDR frames "
+               "(host portal SHM/MemFd is 8-bit BGRx). Use gamescope_stream for real HDR."sv;
+        }
         colorspace = colorspace_from_client_config(config, /*hdr_metadata_available=*/false);
         colorspace.bit_depth = 8;
         if (auto pix8 = select_encoder_output_pix_fmt(encoder, config, colorspace)) {

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -85,6 +85,8 @@ describe('Linux packaging contracts', () => {
     expect(session).toContain('XDG_DESKTOP_PORTAL_DIR')
     expect(session).toContain('org.freedesktop.impl.portal.desktop.gamescope')
     expect(homeManager).toContain('RuntimeDirectory = "polaris-portal";')
+    // Hard dep: private bus only. Portal backend/frontend are Wants= so nested
+    // handoff can restart polaris-portal-gamescope without cascade-stopping polaris.
     expect(homeManager).toContain('Requires = [ "polaris-portal-dbus.service" ];')
     const polarisUnit = section(
       homeManager,
@@ -92,16 +94,24 @@ describe('Linux packaging contracts', () => {
       'home.activation.polarisConfSeed',
     )
     const homeRequires = section(polarisUnit, 'Requires = [', '];')
+    const homeWants = section(polarisUnit, 'Wants = [', '];')
     const generatedPolaris = section(session, '"polaris.service" = mkUnit {', '\n    };')
     const generatedRequires = section(generatedPolaris, 'requires = [', '];')
+    const generatedWants = section(generatedPolaris, 'wants = [', '];')
+    expect(homeRequires).toContain('"polaris-portal-dbus.service"')
+    expect(homeRequires).not.toContain('"polaris-portal-gamescope.service"')
+    expect(homeRequires).not.toContain('"polaris-portal.service"')
+    expect(generatedRequires).toContain('"polaris-portal-dbus.service"')
+    expect(generatedRequires).not.toContain('"polaris-portal-gamescope.service"')
+    expect(generatedRequires).not.toContain('"polaris-portal.service"')
     for (const unit of [
       'polaris-portal-dbus.service',
       'polaris-portal-gamescope.service',
       'polaris-portal.service',
     ]) {
       expect(polarisUnit).toContain(`"${unit}"`)
-      expect(homeRequires).toContain(`"${unit}"`)
-      expect(generatedRequires).toContain(`"${unit}"`)
+      expect(homeWants).toContain(`"${unit}"`)
+      expect(generatedWants).toContain(`"${unit}"`)
     }
   })
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -292,6 +292,12 @@ if (UNIX)
         NAME polaris_gamescope_runtime_shell
         COMMAND bash ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamescope_runtime_shell.sh
     )
+    add_test(
+        NAME polaris_gamescope_session_stop_shell
+        COMMAND ${CMAKE_COMMAND} -E env
+                POLARIS_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+                bash ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamescope_session_stop_shell.sh
+    )
 endif()
 
 if (BUILD_FULL_TESTS)

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -313,6 +313,21 @@ TEST(GamescopeProcessOwnershipTests, RefusesLockReplacementBetweenValidationAndU
   EXPECT_TRUE(fs::exists(lock_path));
 }
 
+TEST(GamescopeProcessOwnershipTests, RefusesSocketReplacementBeforeUnlink) {
+  fake_proc_tree_t tree;
+  const auto socket = tree.runtime / "gamescope-0";
+  std::ofstream(socket).put('\n');
+  std::ofstream(socket.string() + ".lock").put('\n');
+  tree.flush_unix_sockets();
+  auto paths = paths_for(tree);
+  paths.before_socket_unlink_for_tests = [&]() {
+    fs::remove(socket);
+    std::ofstream(socket).put('x');
+  };
+  EXPECT_FALSE(gp::remove_orphan_socket(socket, paths));
+  EXPECT_TRUE(fs::exists(socket));
+}
+
 TEST(GamescopeProcessOwnershipTests, MissingSocketDoesNotUnlinkPotentiallyHeldLock) {
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -295,6 +295,24 @@ TEST(GamescopeProcessOwnershipTests, RefusesReplacementLockWhileDeletedLockIsHel
   EXPECT_TRUE(fs::exists(lock_path));
 }
 
+TEST(GamescopeProcessOwnershipTests, RefusesLockReplacementBetweenValidationAndUnlink) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  const fs::path lock_path {gamescope_socket.string() + ".lock"};
+  std::ofstream(gamescope_socket).put('\n');
+  std::ofstream(lock_path).put('\n');
+  tree.flush_unix_sockets();
+  auto paths = paths_for(tree);
+  paths.before_socket_unlink_for_tests = [&]() {
+    fs::remove(lock_path);
+    std::ofstream(lock_path).put('\n');
+  };
+
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
+  EXPECT_TRUE(fs::exists(lock_path));
+}
+
 TEST(GamescopeProcessOwnershipTests, MissingSocketDoesNotUnlinkPotentiallyHeldLock) {
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";
@@ -333,6 +351,19 @@ TEST(GamescopeProcessOwnershipTests, RefusesKernelSocketRowWithoutVisibleHolder)
 
   EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
   EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
+}
+
+TEST(GamescopeProcessOwnershipTests, RefusesReclaimWhenProcEnumerationIsUnavailable) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  std::ofstream(gamescope_socket).put('\n');
+  std::ofstream(gamescope_socket.string() + ".lock").put('\n');
+  tree.flush_unix_sockets();
+  auto paths = paths_for(tree);
+  paths.proc_root = tree.root / "missing-proc";
+
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths));
   EXPECT_TRUE(fs::exists(gamescope_socket));
 }
 

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -13,6 +13,10 @@
   #include <string>
   #include <vector>
 
+  #include <fcntl.h>
+  #include <sys/file.h>
+  #include <unistd.h>
+
 namespace {
   namespace fs = std::filesystem;
   namespace gp = stream_runtime::gamescope_process;
@@ -258,6 +262,24 @@ TEST(GamescopeProcessOwnershipTests, MissingSocketDoesNotUnlinkPotentiallyHeldLo
 
   EXPECT_TRUE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
   EXPECT_TRUE(fs::exists(lock_path));
+}
+
+TEST(GamescopeProcessOwnershipTests, HeldWaylandSocketLockBlocksReclaim) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  const fs::path lock_path {gamescope_socket.string() + ".lock"};
+  std::ofstream(gamescope_socket).put('\n');
+  tree.flush_unix_sockets();
+
+  const int lock_fd = open(lock_path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0600);
+  ASSERT_GE(lock_fd, 0);
+  ASSERT_EQ(flock(lock_fd, LOCK_EX | LOCK_NB), 0);
+
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
+
+  EXPECT_EQ(flock(lock_fd, LOCK_UN), 0);
+  EXPECT_EQ(close(lock_fd), 0);
 }
 
 TEST(GamescopeProcessOwnershipTests, RefusesKernelSocketRowWithoutVisibleHolder) {

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -228,7 +228,49 @@ TEST(GamescopeProcessOwnershipTests, FailsClosedOnDuplicateSocketPathRows) {
   const gp::marker_t marker {
     .pid = 410, .start_time = 9001, .role = "runtime", .executable = "/usr/bin/gamescope"
   };
+  // Pathname is ambiguous → cannot claim exclusive ownership of gamescope-0.
   EXPECT_FALSE(gp::process_tree_owns_socket(marker, gamescope_socket, paths_for(tree)));
-  EXPECT_FALSE(gp::discover_owned_x11_display(marker, paths_for(tree)).has_value());
+  // X11 discovery still finds related Xwayland across multi-row residue (the
+  // process holds a concrete inode; display routing must not go blind).
+  EXPECT_EQ(gp::discover_owned_x11_display(marker, paths_for(tree)), std::optional<std::string> {":4"});
+  // Ambiguous pathnames are not safe to reclaim.
+  EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
+}
+
+TEST(GamescopeProcessOwnershipTests, ReclaimsFilesystemResidueWithoutListener) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  std::ofstream(gamescope_socket).put('\n');
+  tree.flush_unix_sockets();  // header only — no listener row
+
+  EXPECT_FALSE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_FALSE(fs::exists(gamescope_socket));
+}
+
+TEST(GamescopeProcessOwnershipTests, ReclaimsDeadListenerWithoutHolder) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  tree.add_unix_socket(700, gamescope_socket);
+  tree.flush_unix_sockets();
+  // No process holds inode 700.
+
+  EXPECT_FALSE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_FALSE(fs::exists(gamescope_socket));
+}
+
+TEST(GamescopeProcessOwnershipTests, RefusesLiveUnownedSocketReclaim) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  tree.add_unix_socket(701, gamescope_socket);
+  tree.flush_unix_sockets();
+  tree.add_process(440, 1, 9400, {"/usr/bin/gamescope", "--backend=headless"}, {701});
+
+  EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
 }
 #endif

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -226,6 +226,7 @@ TEST(GamescopeProcessOwnershipTests, FailsClosedWhenOnlyUnrelatedXwaylandExists)
 TEST(GamescopeProcessOwnershipTests, FailsClosedOnDuplicateSocketPathRows) {
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";
+  std::ofstream(gamescope_socket.string() + ".lock").put('\n');
   const auto x4 = tree.x11 / "X4";
 
   // /proc/net/unix may retain an unlinked old listener while a successor has
@@ -278,6 +279,22 @@ TEST(GamescopeProcessOwnershipTests, RefusesReclaimWhenWaylandLockIsMissing) {
   EXPECT_FALSE(fs::exists(lock_path));
 }
 
+TEST(GamescopeProcessOwnershipTests, RefusesReplacementLockWhileDeletedLockIsHeld) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  const fs::path lock_path {gamescope_socket.string() + ".lock"};
+  std::ofstream(gamescope_socket).put('\n');
+  std::ofstream(lock_path).put('\n');
+  tree.flush_unix_sockets();
+  const auto fd_dir = tree.proc / "990" / "fd";
+  fs::create_directories(fd_dir);
+  fs::create_symlink(lock_path.string() + " (deleted)", fd_dir / "8");
+
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
+  EXPECT_TRUE(fs::exists(lock_path));
+}
+
 TEST(GamescopeProcessOwnershipTests, MissingSocketDoesNotUnlinkPotentiallyHeldLock) {
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";
@@ -309,6 +326,7 @@ TEST(GamescopeProcessOwnershipTests, HeldWaylandSocketLockBlocksReclaim) {
 TEST(GamescopeProcessOwnershipTests, RefusesKernelSocketRowWithoutVisibleHolder) {
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";
+  std::ofstream(gamescope_socket.string() + ".lock").put('\n');
   tree.add_unix_socket(700, gamescope_socket);
   tree.flush_unix_sockets();
   // Procfs permissions can hide the holder. A kernel row is still unsafe.
@@ -322,6 +340,7 @@ TEST(GamescopeProcessOwnershipTests, RefusesReclaimWhenProcSocketMetadataIsUnava
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";
   std::ofstream(gamescope_socket).put('\n');
+  std::ofstream(gamescope_socket.string() + ".lock").put('\n');
   auto paths = paths_for(tree);
   paths.proc_net_unix = tree.proc / "net" / "missing-unix";
 
@@ -333,6 +352,7 @@ TEST(GamescopeProcessOwnershipTests, RefusesReclaimWhenProcSocketMetadataIsUnava
 TEST(GamescopeProcessOwnershipTests, RefusesLiveUnownedSocketReclaim) {
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";
+  std::ofstream(gamescope_socket.string() + ".lock").put('\n');
   tree.add_unix_socket(701, gamescope_socket);
   tree.flush_unix_sockets();
   tree.add_process(440, 1, 9400, {"/usr/bin/gamescope", "--backend=headless"}, {701});

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -207,6 +207,14 @@ TEST(GamescopeProcessOwnershipTests, SelectsOnlyXwaylandDescendedFromMarkedRunti
     .pid = 410, .start_time = 9001, .role = "idle", .executable = "/usr/bin/gamescope"
   };
   EXPECT_TRUE(gp::process_tree_owns_socket(marker, gamescope_socket, paths_for(tree)));
+  const auto original_unix_rows = tree.unix_rows;
+  auto rebound_wayland_paths = paths_for(tree);
+  rebound_wayland_paths.before_socket_ownership_return_for_tests = [&]() {
+    tree.replace_unix_socket(501, gamescope_socket);
+  };
+  EXPECT_FALSE(gp::process_tree_owns_socket(marker, gamescope_socket, rebound_wayland_paths));
+  tree.unix_rows = original_unix_rows;
+  tree.flush_unix_sockets();
   EXPECT_EQ(gp::discover_owned_x11_display(marker, paths_for(tree)), std::optional<std::string>(":4"));
   auto rebound_paths = paths_for(tree);
   rebound_paths.before_x11_return_for_tests = [&]() { tree.replace_unix_socket(605, owned_x4); };

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -255,12 +255,27 @@ TEST(GamescopeProcessOwnershipTests, FailsClosedOnDuplicateSocketPathRows) {
 TEST(GamescopeProcessOwnershipTests, ReclaimsFilesystemResidueWithoutListener) {
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";
+  const fs::path lock_path {gamescope_socket.string() + ".lock"};
   std::ofstream(gamescope_socket).put('\n');
+  std::ofstream(lock_path).put('\n');
   tree.flush_unix_sockets();  // header only — no listener row
 
   EXPECT_FALSE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
   EXPECT_TRUE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
   EXPECT_FALSE(fs::exists(gamescope_socket));
+  EXPECT_TRUE(fs::exists(lock_path));
+}
+
+TEST(GamescopeProcessOwnershipTests, RefusesReclaimWhenWaylandLockIsMissing) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  const fs::path lock_path {gamescope_socket.string() + ".lock"};
+  std::ofstream(gamescope_socket).put('\n');
+  tree.flush_unix_sockets();
+
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
+  EXPECT_FALSE(fs::exists(lock_path));
 }
 
 TEST(GamescopeProcessOwnershipTests, MissingSocketDoesNotUnlinkPotentiallyHeldLock) {

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -244,9 +244,9 @@ TEST(GamescopeProcessOwnershipTests, FailsClosedOnDuplicateSocketPathRows) {
   };
   // Pathname is ambiguous → cannot claim exclusive ownership of gamescope-0.
   EXPECT_FALSE(gp::process_tree_owns_socket(marker, gamescope_socket, paths_for(tree)));
-  // X11 discovery still finds related Xwayland across multi-row residue (the
-  // process holds a concrete inode; display routing must not go blind).
-  EXPECT_EQ(gp::discover_owned_x11_display(marker, paths_for(tree)), std::optional<std::string> {":4"});
+  // Duplicate X11 pathname rows are ambiguous after unlink/rebind; routing must
+  // fail closed even when one stale inode is held by a related Xwayland.
+  EXPECT_EQ(gp::discover_owned_x11_display(marker, paths_for(tree)), std::nullopt);
   // Ambiguous pathnames are not safe to reclaim.
   EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
   EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -91,6 +91,12 @@ namespace {
         << unix_rows;
     }
 
+    void replace_unix_socket(std::uint64_t inode, const fs::path &path) {
+      unix_rows.clear();
+      add_unix_socket(inode, path);
+      flush_unix_sockets();
+    }
+
     fs::path root;
     fs::path proc;
     fs::path runtime;
@@ -202,6 +208,9 @@ TEST(GamescopeProcessOwnershipTests, SelectsOnlyXwaylandDescendedFromMarkedRunti
   };
   EXPECT_TRUE(gp::process_tree_owns_socket(marker, gamescope_socket, paths_for(tree)));
   EXPECT_EQ(gp::discover_owned_x11_display(marker, paths_for(tree)), std::optional<std::string>(":4"));
+  auto rebound_paths = paths_for(tree);
+  rebound_paths.before_x11_return_for_tests = [&]() { tree.replace_unix_socket(605, owned_x4); };
+  EXPECT_FALSE(gp::discover_owned_x11_display(marker, rebound_paths));
   EXPECT_TRUE(fs::exists(host_x0));
 }
 

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -81,6 +81,10 @@ namespace {
                    std::to_string(inode) + " " + path.string() + "\n";
     }
 
+    void set_cgroup(int pid, const std::string &cgroup) const {
+      std::ofstream(proc / std::to_string(pid) / "cgroup") << cgroup << '\n';
+    }
+
     void flush_unix_sockets() const {
       std::ofstream(proc / "net" / "unix")
         << "Num RefCount Protocol Flags Type St Inode Path\n"
@@ -171,11 +175,13 @@ TEST(GamescopeProcessOwnershipTests, SelectsOnlyXwaylandDescendedFromMarkedRunti
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";
   const auto host_x0 = tree.x11 / "X0";
+  const auto stale_x2 = tree.x11 / "X2";
   const auto spoofed_x3 = tree.x11 / "X3";
   const auto owned_x4 = tree.x11 / "X4";
 
   tree.add_unix_socket(500, gamescope_socket);
   tree.add_unix_socket(600, host_x0);
+  tree.add_unix_socket(602, stale_x2);
   tree.add_unix_socket(603, spoofed_x3);
   tree.add_unix_socket(604, owned_x4);
   tree.flush_unix_sockets();
@@ -183,6 +189,9 @@ TEST(GamescopeProcessOwnershipTests, SelectsOnlyXwaylandDescendedFromMarkedRunti
   tree.add_process(410, 1, 9001,
                    {"/usr/bin/gamescope", "--backend", "headless", "--xwayland-count", "2"}, {500});
   tree.add_process(411, 410, 9002, {"/usr/bin/Xwayland", ":4"}, {604});
+  tree.add_process(413, 1, 8000, {"/usr/bin/Xwayland", ":2"}, {602});
+  tree.set_cgroup(410, "0::/user.slice/polaris.service");
+  tree.set_cgroup(413, "0::/user.slice/polaris.service");
   tree.add_process(412, 410, 9003, {"/usr/bin/Xwayland", ":3"}, {603});
   fs::remove(tree.proc / "412" / "exe");
   fs::create_symlink("/usr/bin/sleep", tree.proc / "412" / "exe");

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -250,16 +250,38 @@ TEST(GamescopeProcessOwnershipTests, ReclaimsFilesystemResidueWithoutListener) {
   EXPECT_FALSE(fs::exists(gamescope_socket));
 }
 
-TEST(GamescopeProcessOwnershipTests, ReclaimsDeadListenerWithoutHolder) {
+TEST(GamescopeProcessOwnershipTests, MissingSocketDoesNotUnlinkPotentiallyHeldLock) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  const fs::path lock_path {gamescope_socket.string() + ".lock"};
+  std::ofstream(lock_path).put('\n');
+
+  EXPECT_TRUE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(lock_path));
+}
+
+TEST(GamescopeProcessOwnershipTests, RefusesKernelSocketRowWithoutVisibleHolder) {
   fake_proc_tree_t tree;
   const auto gamescope_socket = tree.runtime / "gamescope-0";
   tree.add_unix_socket(700, gamescope_socket);
   tree.flush_unix_sockets();
-  // No process holds inode 700.
+  // Procfs permissions can hide the holder. A kernel row is still unsafe.
 
-  EXPECT_FALSE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
-  EXPECT_TRUE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
-  EXPECT_FALSE(fs::exists(gamescope_socket));
+  EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths_for(tree)));
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths_for(tree)));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
+}
+
+TEST(GamescopeProcessOwnershipTests, RefusesReclaimWhenProcSocketMetadataIsUnavailable) {
+  fake_proc_tree_t tree;
+  const auto gamescope_socket = tree.runtime / "gamescope-0";
+  std::ofstream(gamescope_socket).put('\n');
+  auto paths = paths_for(tree);
+  paths.proc_net_unix = tree.proc / "net" / "missing-unix";
+
+  EXPECT_TRUE(gp::socket_has_live_holder(gamescope_socket, paths));
+  EXPECT_FALSE(gp::remove_orphan_socket(gamescope_socket, paths));
+  EXPECT_TRUE(fs::exists(gamescope_socket));
 }
 
 TEST(GamescopeProcessOwnershipTests, RefusesLiveUnownedSocketReclaim) {

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+runtime_lib="$repo_root/nix/modules/polaris-gamescope-runtime-lib.sh"
 # shellcheck source=/dev/null
-. "$repo_root/nix/modules/polaris-gamescope-runtime-lib.sh"
+. "$runtime_lib"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -285,6 +286,37 @@ if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
 fi
 [ -e "$work/run/gamescope-0" ] || fail "symlink-lock socket was removed"
 rm -f "$work/run/gamescope-0" "$work/run/gamescope-0.lock" "$work/run/foreign-lock"
+
+# An unlocked regular replacement lock is still unsafe while a producer holds
+# the deleted predecessor inode under the same pathname.
+: >"$work/run/gamescope-0"
+: >"$work/run/gamescope-0.lock"
+mkdir -p "$POLARIS_PROC_ROOT/990/fd"
+ln -s "$work/run/gamescope-0.lock (deleted)" "$POLARIS_PROC_ROOT/990/fd/8"
+if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
+  fail "replacement lock was accepted while deleted predecessor was held"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "split-lock socket was removed"
+rm -rf "$POLARIS_PROC_ROOT/990"
+rm -f "$work/run/gamescope-0" "$work/run/gamescope-0.lock"
+
+# Replacing the lock after socket-table validation must revoke cleanup before
+# unlink, even if the replacement is an unlocked regular file.
+: >"$work/run/gamescope-0"
+: >"$work/run/gamescope-0.lock"
+polaris_socket_is_orphan() {
+  rm -f "$1.lock"
+  : >"$1.lock"
+  return 0
+}
+if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
+  fail "bind-window lock replacement did not revoke reclaim"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "bind-window socket was removed"
+# Restore the production helper overridden by this deterministic race fixture.
+# shellcheck source=/dev/null
+source "$runtime_lib"
+rm -f "$work/run/gamescope-0" "$work/run/gamescope-0.lock"
 
 # Reclaim must take the authoritative Wayland socket lock. A compositor may
 # hold that lock before its socket path becomes visible.

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -202,6 +202,8 @@ polaris_reclaim_orphan_gamescope_sockets "$work/run" || fail "orphan reclaim fai
 : >"$work/run/gamescope-0.lock"
 polaris_remove_orphan_socket "$work/run/gamescope-0" || fail "missing socket was not accepted"
 [ -e "$work/run/gamescope-0.lock" ] || fail "missing socket caused lock-only race cleanup"
+polaris_reclaim_orphan_gamescope_sockets "$work/run" || fail "lock-only wrapper state was rejected"
+[ -e "$work/run/gamescope-0.lock" ] || fail "production wrapper removed a lock-only state"
 rm -f "$work/run/gamescope-0.lock"
 
 # Reclaim must take the authoritative Wayland socket lock. A compositor may
@@ -212,8 +214,8 @@ saved_flock_bin="$POLARIS_FLOCK_BIN"
 export POLARIS_FLOCK_BIN=flock
 exec 8>>"$work/run/gamescope-0.lock"
 flock -x 8
-if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
-  fail "held Wayland socket lock did not block reclaim"
+if polaris_reclaim_orphan_gamescope_sockets "$work/run"; then
+  fail "held Wayland socket lock did not block production reclaim"
 fi
 [ -e "$work/run/gamescope-0" ] || fail "socket was removed while its lock was held"
 flock -u 8

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -443,6 +443,9 @@ if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
   fail "socket replacement did not revoke reclaim"
 fi
 [ -e "$work/run/gamescope-0" ] || fail "replacement socket was removed"
+if compgen -G "$work/run/gamescope-0.polaris-pin.*" >/dev/null; then
+  fail "socket replacement left an inode pin behind"
+fi
 source "$runtime_lib"
 rm -f "$work/run/gamescope-0" "$work/run/gamescope-0.lock"
 
@@ -557,6 +560,11 @@ grep -q 'user.control' \
 if grep -E 'systemctl --user mask --runtime polaris-gamescope-idle' \
     "$repo_root/nix/modules/polaris-gamescope-session.sh"; then
   fail "session still uses ineffective mask --runtime for idle"
+fi
+grep -Fq 'ln -- "$socket" "$socket_pin"' "$runtime_lib" ||
+  fail "shell socket reclaim does not pin the original inode"
+if compgen -G "$work/run/*.polaris-pin.*" >/dev/null; then
+  fail "socket reclaim retained an inode pin"
 fi
 
 printf 'PASS: gamescope shell ownership and display routing\n'

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -111,6 +111,7 @@ EOF
 chmod +x "$work/bin/kill"
 polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run" ||
   fail "private child compositor group did not stop"
+grep -qx -- '-STOP 400' "$work/kills" || fail "private-session leader was not pinned before TERM"
 grep -qx -- '-TERM -400' "$work/kills" || fail "validated PGID was not signalled"
 grep -qx -- '-KILL -400' "$work/kills" || fail "TERM-resistant group sibling was not escalated"
 if grep -q -- '-410' "$work/kills"; then

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -85,6 +85,7 @@ fi
 # The exact compositor may be a child of the setsid launcher. Signal the
 # validated private process group, never assume compositor PID equals PGID.
 write_process_with_group 410 1 400 400 9001 /usr/bin/gamescope --backend headless
+write_process_with_group 411 410 400 400 9002 /usr/bin/tail -f /dev/null
 : >"$work/run/gamescope-0"
 write_unix_header
 printf '0000000000000000: 00000002 00000000 00010000 0001 01 501 %s\n' \
@@ -101,12 +102,15 @@ echo "\$*" >>"$work/kills"
 if [ "\${1:-}" = -TERM ] && [ "\${2:-}" = -400 ]; then
   rm -rf "$POLARIS_PROC_ROOT/410"
   rm -f "$work/run/gamescope-0"
+elif [ "\${1:-}" = -KILL ] && [ "\${2:-}" = -400 ]; then
+  rm -rf "$POLARIS_PROC_ROOT/411"
 fi
 EOF
 chmod +x "$work/bin/kill"
 polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run" ||
   fail "private child compositor group did not stop"
 grep -qx -- '-TERM -400' "$work/kills" || fail "validated PGID was not signalled"
+grep -qx -- '-KILL -400' "$work/kills" || fail "TERM-resistant group sibling was not escalated"
 if grep -q -- '-410' "$work/kills"; then
   fail "compositor PID was used as a process group"
 fi

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -185,6 +185,51 @@ fi
 [ -e "$work/run/polaris-gamescope.env" ] || fail "missing marker allowed runtime env cleanup"
 [ -e "$work/run/gamescope-0" ] || fail "missing marker allowed socket cleanup"
 
+# Crash residue: filesystem socket with no /proc/net/unix listener is reclaimable.
+: >"$work/run/gamescope-0"
+: >"$work/run/gamescope-0.lock"
+: >"$work/run/gamescope-0-ei"
+write_unix_header
+polaris_socket_is_orphan "$work/run/gamescope-0" || fail "filesystem residue not treated as orphan"
+polaris_reclaim_orphan_gamescope_sockets "$work/run" || fail "orphan reclaim failed"
+[ ! -e "$work/run/gamescope-0" ] || fail "orphan gamescope-0 survived reclaim"
+[ ! -e "$work/run/gamescope-0-ei" ] || fail "orphan gamescope-0-ei survived reclaim"
+[ ! -e "$work/run/gamescope-0.lock" ] || fail "orphan lock survived reclaim"
+
+# Dead listener inode with no process holder is reclaimable.
+: >"$work/run/gamescope-0"
+write_unix_header
+printf '0000000000000000: 00000002 00000000 00010000 0001 01 901 %s\n' \
+  "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+polaris_socket_is_orphan "$work/run/gamescope-0" || fail "dead listener not treated as orphan"
+polaris_remove_orphan_socket "$work/run/gamescope-0" || fail "dead listener not removed"
+[ ! -e "$work/run/gamescope-0" ] || fail "dead listener socket survived"
+
+# Live unowned holder must fail closed (do not unlink).
+write_process 430 1 9300 /usr/bin/gamescope --backend headless
+: >"$work/run/gamescope-0"
+ln -s 'socket:[902]' "$POLARIS_PROC_ROOT/430/fd/3"
+write_unix_header
+printf '0000000000000000: 00000002 00000000 00010000 0001 01 902 %s\n' \
+  "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+if polaris_socket_is_orphan "$work/run/gamescope-0"; then
+  fail "live unowned holder treated as orphan"
+fi
+if polaris_reclaim_orphan_gamescope_sockets "$work/run"; then
+  fail "live unowned reclaim was allowed"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "live unowned socket was removed"
+
+# Ambiguous duplicate pathname rows fail closed.
+write_unix_header
+printf '0000000000000000: 00000002 00000000 00010000 0001 01 903 %s\n' \
+  "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+printf '0000000000000001: 00000002 00000000 00010000 0001 01 904 %s\n' \
+  "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+if polaris_socket_is_orphan "$work/run/gamescope-0"; then
+  fail "ambiguous socket pathname treated as orphan"
+fi
+
 # Production call sites must use exact markers, never process-name-wide pkill/pgrep.
 for source in \
   "$repo_root/src/platform/linux/stream_runtime_gamescope.cpp" \
@@ -202,9 +247,23 @@ grep -q 'polaris_stop_marked_gamescope' "$repo_root/nix/modules/polaris-gamescop
   fail "session lifecycle does not stop the marked generation"
 grep -q 'polaris_stop_marked_gamescope' "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh" ||
   fail "non-Nix readiness helper does not stop nested ownership exactly"
+grep -q 'polaris_reclaim_orphan_gamescope_sockets' \
+  "$repo_root/scripts/install/lib/polaris-gamescope-idle.sh" ||
+  fail "idle unit does not reclaim orphan gamescope sockets"
 if grep -Eq 'rm .*polaris-gamescope\.pid|rm -f .*polaris-gamescope\.pid' \
     "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh"; then
   fail "non-Nix readiness helper still removes ownership markers unconditionally"
+fi
+# Nested mask must use user.control (Hjem ~/.config units beat mask --runtime).
+grep -q 'polaris_mask_idle_unit_runtime' \
+  "$repo_root/nix/modules/polaris-gamescope-session.sh" ||
+  fail "nested session does not mask idle via polaris_mask_idle_unit_runtime"
+grep -q 'user.control' \
+  "$repo_root/nix/modules/polaris-gamescope-runtime-lib.sh" ||
+  fail "runtime lib mask helpers do not target user.control"
+if grep -E 'systemctl --user mask --runtime polaris-gamescope-idle' \
+    "$repo_root/nix/modules/polaris-gamescope-session.sh"; then
+  fail "session still uses ineffective mask --runtime for idle"
 fi
 
 printf 'PASS: gamescope shell ownership and display routing\n'

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -196,14 +196,27 @@ polaris_reclaim_orphan_gamescope_sockets "$work/run" || fail "orphan reclaim fai
 [ ! -e "$work/run/gamescope-0-ei" ] || fail "orphan gamescope-0-ei survived reclaim"
 [ ! -e "$work/run/gamescope-0.lock" ] || fail "orphan lock survived reclaim"
 
-# Dead listener inode with no process holder is reclaimable.
+# A lock file without a socket may belong to a compositor between lock and
+# bind. It is harmless when stale and unsafe to unlink while another process
+# may hold it.
+: >"$work/run/gamescope-0.lock"
+polaris_remove_orphan_socket "$work/run/gamescope-0" || fail "missing socket was not accepted"
+[ -e "$work/run/gamescope-0.lock" ] || fail "missing socket caused lock-only race cleanup"
+rm -f "$work/run/gamescope-0.lock"
+
+# A kernel socket-table row without a visible process holder is still unknown.
+# The holder may be hidden by procfs permissions, so fail closed.
 : >"$work/run/gamescope-0"
 write_unix_header
 printf '0000000000000000: 00000002 00000000 00010000 0001 01 901 %s\n' \
   "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
-polaris_socket_is_orphan "$work/run/gamescope-0" || fail "dead listener not treated as orphan"
-polaris_remove_orphan_socket "$work/run/gamescope-0" || fail "dead listener not removed"
-[ ! -e "$work/run/gamescope-0" ] || fail "dead listener socket survived"
+if polaris_socket_is_orphan "$work/run/gamescope-0"; then
+  fail "kernel socket row without a visible holder treated as orphan"
+fi
+if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
+  fail "kernel socket row without a visible holder was removed"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "unknown kernel socket row was removed"
 
 # Live unowned holder must fail closed (do not unlink).
 write_process 430 1 9300 /usr/bin/gamescope --backend headless
@@ -229,6 +242,19 @@ printf '0000000000000001: 00000002 00000000 00010000 0001 01 904 %s\n' \
 if polaris_socket_is_orphan "$work/run/gamescope-0"; then
   fail "ambiguous socket pathname treated as orphan"
 fi
+
+# Missing ownership metadata is unknown, not proof of an orphan. Reclaim must
+# fail closed and leave the socket path untouched.
+saved_proc_net_unix="$POLARIS_PROC_NET_UNIX"
+export POLARIS_PROC_NET_UNIX="$work/proc/net/missing-unix"
+if polaris_socket_is_orphan "$work/run/gamescope-0"; then
+  fail "missing /proc/net/unix treated as proof of an orphan"
+fi
+if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
+  fail "missing /proc/net/unix authorized destructive reclaim"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "unknown ownership removed the socket"
+export POLARIS_PROC_NET_UNIX="$saved_proc_net_unix"
 
 # Production call sites must use exact markers, never process-name-wide pkill/pgrep.
 for source in \

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -451,6 +451,12 @@ grep -q 'POLARIS_GAMESCOPE_SESSION_BIN' "$repo_root/scripts/install/lib/polaris-
   || fail "non-Nix readiness helper does not use credentialed session recovery"
 grep -q 'polaris-gamescope-session-id' "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh" \
   || fail "non-Nix readiness helper does not require durable session identity"
+grep -q 'publish_nested_claim' "$repo_root/nix/modules/polaris-gamescope-session.sh" \
+  || fail "nested claim publication is not ownership-lock serialized"
+grep -q 'polaris_validate_marker "$marker" idle' "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh" \
+  || fail "non-Nix readiness helper does not require idle marker role"
+grep -q 'POLARIS_FLOCK_BIN' "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh" \
+  || fail "non-Nix recovery does not hold the ownership transition lock"
 grep -q 'polaris_reclaim_orphan_gamescope_sockets' \
   "$repo_root/scripts/install/lib/polaris-gamescope-idle.sh" ||
   fail "idle unit does not reclaim orphan gamescope sockets"

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -173,6 +173,15 @@ grep -qx 'DISPLAY=:4' "$work/run/polaris-gamescope.env" || fail "runtime env rou
 grep -qx 'POLARIS_GAMESCOPE_PID=410' "$work/run/polaris-gamescope.env" || fail "runtime env lacks owner pid"
 [ -e "$POLARIS_X11_SOCKET_DIR/X0" ] || fail "host X0 was removed"
 
+# Duplicate pathname rows represent unlink/rebind generations; holding the old
+# inode must not authorize clients to route to the replacement.
+cp "$POLARIS_PROC_NET_UNIX" "$work/unix.unique"
+printf 'row row row row row row 605 %s\n' "$POLARIS_X11_SOCKET_DIR/X4" >>"$POLARIS_PROC_NET_UNIX"
+if polaris_discover_xwayland_display "$work/run/polaris-gamescope.pid" idle >/dev/null; then
+  fail duplicate
+fi
+mv "$work/unix.unique" "$POLARIS_PROC_NET_UNIX"
+
 # Exact valid ownership is signalled by process group and only its runtime
 # metadata/socket are removed. The unrelated host X display survives.
 polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" idle "$work/run" ||
@@ -304,6 +313,15 @@ fi
 rm -rf "$POLARIS_PROC_ROOT/990"
 rm -f "$work/run/gamescope-0" "$work/run/gamescope-0.lock"
 
+# Incomplete procfs enumeration is unknown ownership, not an empty holder set.
+: >"$work/run/gamescope-0.lock"
+mv "$POLARIS_PROC_ROOT" "$work/proc-hidden"
+if polaris_wayland_lock_has_no_deleted_holder "$work/run/gamescope-0.lock"; then
+  fail "missing proc root was treated as a complete deleted-lock scan"
+fi
+mv "$work/proc-hidden" "$POLARIS_PROC_ROOT"
+rm -f "$work/run/gamescope-0.lock"
+
 # Replacing the lock after socket-table validation must revoke cleanup before
 # unlink, even if the replacement is an unlocked regular file.
 : >"$work/run/gamescope-0"
@@ -406,8 +424,10 @@ grep -q 'gamescope_process::validated_marker' "$repo_root/src/platform/linux/str
   fail "C++ runtime does not validate exact marker generation"
 grep -q 'polaris_stop_marked_gamescope' "$repo_root/nix/modules/polaris-gamescope-session.sh" ||
   fail "session lifecycle does not stop the marked generation"
-grep -q 'polaris_stop_marked_gamescope' "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh" ||
-  fail "non-Nix readiness helper does not stop nested ownership exactly"
+grep -q 'POLARIS_GAMESCOPE_SESSION_BIN' "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh" \
+  || fail "non-Nix readiness helper does not use credentialed session recovery"
+grep -q 'polaris-gamescope-session-id' "$repo_root/scripts/install/lib/polaris-wait-gamescope.sh" \
+  || fail "non-Nix readiness helper does not require durable session identity"
 grep -q 'polaris_reclaim_orphan_gamescope_sockets' \
   "$repo_root/scripts/install/lib/polaris-gamescope-idle.sh" ||
   fail "idle unit does not reclaim orphan gamescope sockets"

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -85,6 +85,7 @@ write_process_with_group 999 1 999 999 9999 /usr/bin/sleep infinity
 
 # The exact compositor may be a child of the setsid launcher. Signal the
 # validated private process group, never assume compositor PID equals PGID.
+write_process_with_group 400 1 400 400 9000 /usr/bin/sleep infinity
 write_process_with_group 410 1 400 400 9001 /usr/bin/gamescope --backend headless
 write_process_with_group 411 410 400 400 9002 /usr/bin/tail -f /dev/null
 : >"$work/run/gamescope-0"
@@ -104,7 +105,7 @@ if [ "\${1:-}" = -TERM ] && [ "\${2:-}" = -400 ]; then
   rm -rf "$POLARIS_PROC_ROOT/410"
   rm -f "$work/run/gamescope-0"
 elif [ "\${1:-}" = -KILL ] && [ "\${2:-}" = -400 ]; then
-  rm -rf "$POLARIS_PROC_ROOT/411"
+  rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/411"
 fi
 EOF
 chmod +x "$work/bin/kill"
@@ -117,6 +118,34 @@ if grep -q -- '-410' "$work/kills"; then
 fi
 mv "$work/bin/kill.default" "$work/bin/kill"
 chmod +x "$work/bin/kill"
+
+# If the private-session leader generation changes after TERM, numeric PGID
+# escalation loses its immutable reuse barrier and must fail closed.
+write_process_with_group 400 1 400 400 9300 /usr/bin/sleep infinity
+write_process_with_group 410 400 400 400 9301 /usr/bin/gamescope --backend headless
+write_process_with_group 411 410 400 400 9302 /usr/bin/tail -f /dev/null
+: >"$work/run/gamescope-0"
+write_unix_header
+printf 'row row row row row row 801 %s\n' "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+ln -sfn 'socket:[801]' "$POLARIS_PROC_ROOT/410/fd/3"
+printf '410 9301 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
+: >"$work/kills"
+cat >"$work/bin/kill-reused-leader" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >>"$work/kills"
+if [ "\${1:-}" = -TERM ]; then
+  printf '400 (sleep) S 1 400 400 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 9400\n' >"$POLARIS_PROC_ROOT/400/stat"
+  rm -rf "$POLARIS_PROC_ROOT/410"
+fi
+EOF
+chmod +x "$work/bin/kill-reused-leader"
+if POLARIS_KILL_BIN="$work/bin/kill-reused-leader" \
+    polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run"; then
+  fail "recycled private-session leader authorized PGID escalation"
+fi
+! grep -q -- '-KILL' "$work/kills" || fail "recycled PGID received KILL"
+[ -e "$work/run/polaris-gamescope.pid" ] || fail "leader-reuse failure cleared marker authority"
+rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410" "$POLARIS_PROC_ROOT/411"
 
 # A non-private or moved compositor group is not authorized for negative
 # signaling even when PID/start/executable still match the marker.
@@ -181,6 +210,31 @@ polaris_write_runtime_env "$work/run/polaris-gamescope.pid" gamescope-0 idle "$w
 grep -qx 'DISPLAY=:4' "$work/run/polaris-gamescope.env" || fail "runtime env routed to host X display"
 grep -qx 'POLARIS_GAMESCOPE_PID=410' "$work/run/polaris-gamescope.env" || fail "runtime env lacks owner pid"
 [ -e "$POLARIS_X11_SOCKET_DIR/X0" ] || fail "host X0 was removed"
+
+# Rebinding Wayland after X11 selection but before env publication must reject
+# the entire Wayland/X11 pair and leave no committed environment.
+cp "$POLARIS_PROC_NET_UNIX" "$work/unix.before-env-rebind"
+cat >"$work/bin/rebind-wayland-before-env" <<EOF
+#!/usr/bin/env bash
+python3 - "$POLARIS_PROC_NET_UNIX" "$work/run/gamescope-0" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+socket = sys.argv[2]
+data = path.read_text()
+data = data.replace(f" 500 {socket}\\n", f" 501 {socket}\\n")
+path.write_text(data)
+PY
+EOF
+chmod +x "$work/bin/rebind-wayland-before-env"
+rm -f "$work/run/polaris-gamescope.env"
+if POLARIS_RUNTIME_ENV_BEFORE_COMMIT_HOOK="$work/bin/rebind-wayland-before-env" \
+    polaris_write_runtime_env "$work/run/polaris-gamescope.pid" gamescope-0 idle "$work/run"; then
+  fail "Wayland pathname rebound was accepted at runtime-env commit"
+fi
+[ ! -e "$work/run/polaris-gamescope.env" ] || fail "rebound ownership published a runtime env"
+mv "$work/unix.before-env-rebind" "$POLARIS_PROC_NET_UNIX"
+polaris_write_runtime_env "$work/run/polaris-gamescope.pid" gamescope-0 idle "$work/run" ||
+  fail "runtime env did not recover after rejected rebound"
 
 # Duplicate pathname rows represent unlink/rebind generations; holding the old
 # inode must not authorize clients to route to the replacement.

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -26,17 +26,27 @@ chmod +x "$work/bin/flock"
 export POLARIS_FLOCK_BIN="$work/bin/flock"
 printf 'lock-sentinel\n' >"$work/run/polaris-gamescope.lock"
 
-write_process() {
-  local pid="$1" ppid="$2" start_time="$3" exe="$4"
-  shift 4
+write_process_with_group() {
+  local pid="$1" ppid="$2" pgrp="$3" sid="$4" start_time="$5" exe="$6"
+  shift 6
   local dir="$POLARIS_PROC_ROOT/$pid"
   rm -rf "$dir"
   mkdir -p "$dir/fd"
   ln -s "$exe" "$dir/exe"
-  # state(field 3), ppid(field 4), fields 5..21, starttime(field 22)
-  printf '%s (%s) S %s 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 %s\n' \
-    "$pid" "${exe##*/}" "$ppid" "$start_time" >"$dir/stat"
+  # state(field 3), ppid(field 4), pgrp(field 5), session(field 6),
+  # fields 7..21, starttime(field 22)
+  {
+    printf '%s (%s) S %s %s %s' "$pid" "${exe##*/}" "$ppid" "$pgrp" "$sid"
+    for _ in $(seq 1 15); do printf ' 0'; done
+    printf ' %s\n' "$start_time"
+  } >"$dir/stat"
   printf '%s\0' "$exe" "$@" >"$dir/cmdline"
+}
+
+write_process() {
+  local pid="$1" ppid="$2" start_time="$3" exe="$4"
+  shift 4
+  write_process_with_group "$pid" "$ppid" "$pid" "$pid" "$start_time" "$exe" "$@"
 }
 
 write_unix_header() {
@@ -71,6 +81,48 @@ fi
 [ -e "$work/run/polaris-gamescope.env" ] || fail "stale generation removed runtime env"
 [ "$(<"$work/run/polaris-gamescope.lock")" = "lock-sentinel" ] || fail "owner lock open truncated existing data"
 
+# The exact compositor may be a child of the setsid launcher. Signal the
+# validated private process group, never assume compositor PID equals PGID.
+write_process_with_group 410 1 400 400 9001 /usr/bin/gamescope --backend headless
+: >"$work/run/gamescope-0"
+write_unix_header
+printf '0000000000000000: 00000002 00000000 00010000 0001 01 501 %s\n' \
+  "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+ln -s 'socket:[501]' "$POLARIS_PROC_ROOT/410/fd/3"
+printf '410 9001 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
+printf 'POLARIS_GAMESCOPE_PID=410\nPOLARIS_GAMESCOPE_START_TIME=9001\nPOLARIS_GAMESCOPE_EXECUTABLE=/usr/bin/gamescope\n' \
+  >"$work/run/polaris-gamescope.env"
+: >"$work/kills"
+cp "$work/bin/kill" "$work/bin/kill.default"
+cat >"$work/bin/kill" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >>"$work/kills"
+if [ "\${1:-}" = -TERM ] && [ "\${2:-}" = -400 ]; then
+  rm -rf "$POLARIS_PROC_ROOT/410"
+  rm -f "$work/run/gamescope-0"
+fi
+EOF
+chmod +x "$work/bin/kill"
+polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run" ||
+  fail "private child compositor group did not stop"
+grep -qx -- '-TERM -400' "$work/kills" || fail "validated PGID was not signalled"
+if grep -q -- '-410' "$work/kills"; then
+  fail "compositor PID was used as a process group"
+fi
+mv "$work/bin/kill.default" "$work/bin/kill"
+chmod +x "$work/bin/kill"
+
+# A non-private or moved compositor group is not authorized for negative
+# signaling even when PID/start/executable still match the marker.
+write_process_with_group 410 1 400 401 9050 /usr/bin/gamescope --backend headless
+printf '410 9050 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
+: >"$work/kills"
+if polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run"; then
+  fail "mismatched process-group/session identity was accepted"
+fi
+[ ! -s "$work/kills" ] || fail "non-private process group was signalled"
+[ -e "$work/run/polaris-gamescope.pid" ] || fail "failed group proof removed marker authority"
+
 # Nix wrapProgram executes .gamescope-wrapped while preserving argv[0] as
 # gamescope. Capture and validate that exact executable instead of rejecting it.
 write_process 420 1 9200 /nix/store/fake-gamescope/bin/.gamescope-wrapped --backend headless
@@ -82,19 +134,25 @@ polaris_validate_marker "$work/run/polaris-gamescope.pid" idle || fail "Nix-wrap
 write_process 410 1 9001 /usr/bin/gamescope --backend headless --hdr-enabled
 write_process 411 410 9002 /usr/bin/Xwayland :4
 write_process 412 410 9003 /usr/bin/Xwayland :3
+write_process 413 1 8000 /usr/bin/Xwayland :2
 rm -f "$POLARIS_PROC_ROOT/412/exe"
 ln -s /usr/bin/sleep "$POLARIS_PROC_ROOT/412/exe"
+printf '0::/user.slice/polaris.service\n' >"$POLARIS_PROC_ROOT/410/cgroup"
+printf '0::/user.slice/polaris.service\n' >"$POLARIS_PROC_ROOT/413/cgroup"
 write_process 99 1 100 /usr/bin/Xorg :0
 : >"$POLARIS_X11_SOCKET_DIR/X0"
+: >"$POLARIS_X11_SOCKET_DIR/X2"
 : >"$POLARIS_X11_SOCKET_DIR/X3"
 : >"$POLARIS_X11_SOCKET_DIR/X4"
 ln -s 'socket:[500]' "$POLARIS_PROC_ROOT/410/fd/3"
+ln -s 'socket:[602]' "$POLARIS_PROC_ROOT/413/fd/3"
 ln -s 'socket:[603]' "$POLARIS_PROC_ROOT/412/fd/3"
 ln -s 'socket:[604]' "$POLARIS_PROC_ROOT/411/fd/3"
 ln -s 'socket:[600]' "$POLARIS_PROC_ROOT/99/fd/3"
 write_unix_header
 printf '0000000000000000: 00000002 00000000 00010000 0001 01 500 %s\n' "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
 printf '0000000000000000: 00000002 00000000 00010000 0001 01 600 %s\n' "$POLARIS_X11_SOCKET_DIR/X0" >>"$POLARIS_PROC_NET_UNIX"
+printf '0000000000000000: 00000002 00000000 00010000 0001 01 602 %s\n' "$POLARIS_X11_SOCKET_DIR/X2" >>"$POLARIS_PROC_NET_UNIX"
 printf '0000000000000000: 00000002 00000000 00010000 0001 01 603 %s\n' "$POLARIS_X11_SOCKET_DIR/X3" >>"$POLARIS_PROC_NET_UNIX"
 printf '0000000000000000: 00000002 00000000 00010000 0001 01 604 %s\n' "$POLARIS_X11_SOCKET_DIR/X4" >>"$POLARIS_PROC_NET_UNIX"
 printf '410 9001 idle /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -120,6 +120,34 @@ fi
 mv "$work/bin/kill.default" "$work/bin/kill"
 chmod +x "$work/bin/kill"
 
+# A descendant that moved to another PGID but retained the private SID must
+# prevent marker/environment deletion after the original group is drained.
+write_process_with_group 400 1 400 400 9200 /usr/bin/sleep infinity
+write_process_with_group 410 400 400 400 9201 /usr/bin/gamescope --backend headless
+write_process_with_group 420 410 420 400 9202 /usr/bin/sleep infinity
+: >"$work/run/gamescope-0"
+write_unix_header
+printf 'row row row row row row 802 %s\n' "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+ln -sfn 'socket:[802]' "$POLARIS_PROC_ROOT/410/fd/3"
+printf '410 9201 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
+printf 'DISPLAY=:2\n' >"$work/run/polaris-gamescope.env"
+cat >"$work/bin/kill-escaped-sid" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = -TERM ]; then
+  rm -rf "$POLARIS_PROC_ROOT/410"
+elif [ "\${1:-}" = -KILL ]; then
+  rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410"
+fi
+EOF
+chmod +x "$work/bin/kill-escaped-sid"
+if POLARIS_KILL_BIN="$work/bin/kill-escaped-sid" POLARIS_STOP_WAIT_STEPS=1 POLARIS_KILL_WAIT_STEPS=1 \
+    polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run"; then
+  fail "separate-PGID private-session descendant was reported drained"
+fi
+[ -e "$work/run/polaris-gamescope.pid" ] || fail "escaped SID descendant allowed marker deletion"
+[ -e "$work/run/polaris-gamescope.env" ] || fail "escaped SID descendant allowed env deletion"
+rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410" "$POLARIS_PROC_ROOT/420"
+
 # If the private-session leader generation changes after TERM, numeric PGID
 # escalation loses its immutable reuse barrier and must fail closed.
 write_process_with_group 400 1 400 400 9300 /usr/bin/sleep infinity
@@ -160,7 +188,7 @@ fi
 [ -e "$work/run/polaris-gamescope.pid" ] || fail "failed group proof removed marker authority"
 
 mv "$POLARIS_PROC_ROOT" "$work/proc-group-hidden"
-if polaris_private_group_alive 400; then
+if polaris_private_session_alive 400; then
   fail "missing proc root was treated as a drained private group"
 else
   [ "$?" -eq 2 ] || fail "missing proc root did not return unknown group state"

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -81,6 +81,7 @@ fi
 [ -e "$work/run/gamescope-0" ] || fail "stale generation removed a socket"
 [ -e "$work/run/polaris-gamescope.env" ] || fail "stale generation removed runtime env"
 [ "$(<"$work/run/polaris-gamescope.lock")" = "lock-sentinel" ] || fail "owner lock open truncated existing data"
+write_process_with_group 999 1 999 999 9999 /usr/bin/sleep infinity
 
 # The exact compositor may be a child of the setsid launcher. Signal the
 # validated private process group, never assume compositor PID equals PGID.
@@ -127,6 +128,14 @@ if polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work
 fi
 [ ! -s "$work/kills" ] || fail "non-private process group was signalled"
 [ -e "$work/run/polaris-gamescope.pid" ] || fail "failed group proof removed marker authority"
+
+mv "$POLARIS_PROC_ROOT" "$work/proc-group-hidden"
+if polaris_private_group_alive 400; then
+  fail "missing proc root was treated as a drained private group"
+else
+  [ "$?" -eq 2 ] || fail "missing proc root did not return unknown group state"
+fi
+mv "$work/proc-group-hidden" "$POLARIS_PROC_ROOT"
 
 # Nix wrapProgram executes .gamescope-wrapped while preserving argv[0] as
 # gamescope. Capture and validate that exact executable instead of rejecting it.
@@ -337,6 +346,20 @@ fi
 [ -e "$work/run/gamescope-0" ] || fail "bind-window socket was removed"
 # Restore the production helper overridden by this deterministic race fixture.
 # shellcheck source=/dev/null
+source "$runtime_lib"
+rm -f "$work/run/gamescope-0" "$work/run/gamescope-0.lock"
+
+: >"$work/run/gamescope-0"
+: >"$work/run/gamescope-0.lock"
+polaris_socket_is_orphan() {
+  rm -f "$1"
+  : >"$1"
+  return 0
+}
+if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
+  fail "socket replacement did not revoke reclaim"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "replacement socket was removed"
 source "$runtime_lib"
 rm -f "$work/run/gamescope-0" "$work/run/gamescope-0.lock"
 

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -276,6 +276,16 @@ fi
 [ ! -e "$work/run/gamescope-0.lock" ] || fail "reclaim created a replacement lock inode"
 rm -f "$work/run/gamescope-0"
 
+# A symlink is not the authoritative Wayland lock inode and must not be followed.
+: >"$work/run/gamescope-0"
+: >"$work/run/foreign-lock"
+ln -s "$work/run/foreign-lock" "$work/run/gamescope-0.lock"
+if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
+  fail "symlinked Wayland lock was accepted"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "symlink-lock socket was removed"
+rm -f "$work/run/gamescope-0" "$work/run/gamescope-0.lock" "$work/run/foreign-lock"
+
 # Reclaim must take the authoritative Wayland socket lock. A compositor may
 # hold that lock before its socket path becomes visible.
 : >"$work/run/gamescope-0"

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -247,6 +247,7 @@ fi
 : >"$work/run/gamescope-0"
 : >"$work/run/gamescope-0.lock"
 : >"$work/run/gamescope-0-ei"
+: >"$work/run/gamescope-0-ei.lock"
 write_unix_header
 polaris_socket_is_orphan "$work/run/gamescope-0" || fail "filesystem residue not treated as orphan"
 polaris_reclaim_orphan_gamescope_sockets "$work/run" || fail "orphan reclaim failed"
@@ -263,6 +264,17 @@ polaris_remove_orphan_socket "$work/run/gamescope-0" || fail "missing socket was
 polaris_reclaim_orphan_gamescope_sockets "$work/run" || fail "lock-only wrapper state was rejected"
 [ -e "$work/run/gamescope-0.lock" ] || fail "production wrapper removed a lock-only state"
 rm -f "$work/run/gamescope-0.lock"
+
+# A socket without its authoritative lock can be a split-lock generation from
+# an earlier unlink. Reclaim must not create a replacement lock inode.
+: >"$work/run/gamescope-0"
+write_unix_header
+if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
+  fail "socket without authoritative lock was reclaimed"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "lockless socket was removed"
+[ ! -e "$work/run/gamescope-0.lock" ] || fail "reclaim created a replacement lock inode"
+rm -f "$work/run/gamescope-0"
 
 # Reclaim must take the authoritative Wayland socket lock. A compositor may
 # hold that lock before its socket path becomes visible.

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -194,7 +194,7 @@ polaris_socket_is_orphan "$work/run/gamescope-0" || fail "filesystem residue not
 polaris_reclaim_orphan_gamescope_sockets "$work/run" || fail "orphan reclaim failed"
 [ ! -e "$work/run/gamescope-0" ] || fail "orphan gamescope-0 survived reclaim"
 [ ! -e "$work/run/gamescope-0-ei" ] || fail "orphan gamescope-0-ei survived reclaim"
-[ ! -e "$work/run/gamescope-0.lock" ] || fail "orphan lock survived reclaim"
+[ -e "$work/run/gamescope-0.lock" ] || fail "reclaim unlinked the reusable Wayland lock"
 
 # A lock file without a socket may belong to a compositor between lock and
 # bind. It is harmless when stale and unsafe to unlink while another process
@@ -203,6 +203,23 @@ polaris_reclaim_orphan_gamescope_sockets "$work/run" || fail "orphan reclaim fai
 polaris_remove_orphan_socket "$work/run/gamescope-0" || fail "missing socket was not accepted"
 [ -e "$work/run/gamescope-0.lock" ] || fail "missing socket caused lock-only race cleanup"
 rm -f "$work/run/gamescope-0.lock"
+
+# Reclaim must take the authoritative Wayland socket lock. A compositor may
+# hold that lock before its socket path becomes visible.
+: >"$work/run/gamescope-0"
+write_unix_header
+saved_flock_bin="$POLARIS_FLOCK_BIN"
+export POLARIS_FLOCK_BIN=flock
+exec 8>>"$work/run/gamescope-0.lock"
+flock -x 8
+if polaris_remove_orphan_socket "$work/run/gamescope-0"; then
+  fail "held Wayland socket lock did not block reclaim"
+fi
+[ -e "$work/run/gamescope-0" ] || fail "socket was removed while its lock was held"
+flock -u 8
+exec 8>&-
+export POLARIS_FLOCK_BIN="$saved_flock_bin"
+rm -f "$work/run/gamescope-0" "$work/run/gamescope-0.lock"
 
 # A kernel socket-table row without a visible process holder is still unknown.
 # The holder may be hidden by procfs permissions, so fail closed.

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -104,14 +104,17 @@ fi
 ! grep -Eq 'unmask|start polaris-gamescope-idle|restart polaris-portal|busctl' "$actions" ||
   fail "stop failure advanced idle/portal handoff"
 
-# Unknown/live socket ownership must fail with the same durable state.
+# An unclassified nested launch is never converted into orphan-socket cleanup:
+# without an exact marker, recovery authority is incomplete and the claim stays.
 reset_state
-if NESTED_VALID=0 RECLAIM_OK=0 run_stop >/dev/null 2>&1; then
-  fail "unknown socket reclaim failure returned success"
+if NESTED_VALID=0 RECLAIM_OK=1 run_stop >/dev/null 2>&1; then
+  fail "unclassified nested launch returned success"
 fi
-[ -e "$work/run/polaris-gamescope-wsi-nested" ] || fail "reclaim failure cleared nested claim"
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-wsi-nested")" = 1 ] ||
+  fail "unclassified launch advanced its recovery claim"
+! grep -qx 'reclaim' "$actions" || fail "unclassified launch attempted orphan reclaim"
 ! grep -Eq 'unmask|start polaris-gamescope-idle|restart polaris-portal|busctl' "$actions" ||
-  fail "reclaim failure advanced idle/portal handoff"
+  fail "unclassified launch advanced idle/portal handoff"
 
 # A failed idle handoff retains restore-idle state for a safe retry.
 reset_state
@@ -175,5 +178,10 @@ POLARIS_SESSION_INSTANCE_ID= POLARIS_PGREP_OUTPUT=101 \
   PORTAL_READY=1 run_stop >/dev/null 2>&1 || fail "persisted-session recovery failed"
 grep -qx 'kill -TERM 101' "$actions" || fail "recovery did not use persisted exact-session credential"
 [ ! -e "$work/run/polaris-gamescope-session-id" ] || fail "successful recovery retained session credential"
+
+grep -Fq 'if [ -s "$session_id_file" ]; then' "$script" ||
+  fail "start does not recover every persisted session credential before replacement"
+grep -Fq 'POLARIS_SESSION_INSTANCE_ID= "$0" stop || exit 1' "$script" ||
+  fail "start does not route persisted attach/nested recovery through credentialed stop"
 
 echo "PASS: gamescope session stop state machine"

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -134,8 +134,8 @@ reset_state
 mkdir -p "$work/proc/100" "$work/proc/101"
 printf '10\n' >"$work/proc/100/start"
 printf '11\n' >"$work/proc/101/start"
-printf 'HOME=/home/papi\0' >"$work/proc/100/environ"
-printf 'HOME=/home/papi\0POLARIS_SESSION_INSTANCE_ID=session-A\0' >"$work/proc/101/environ"
+printf 'HOME=/srv/example\0' >"$work/proc/100/environ"
+printf 'HOME=/srv/example\0POLARIS_SESSION_INSTANCE_ID=session-A\0' >"$work/proc/101/environ"
 POLARIS_SESSION_INSTANCE_ID=session-A POLARIS_PGREP_OUTPUT=$'100\n101' \
   NESTED_VALID=1 STOP_OK=1 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
   PORTAL_READY=1 run_stop >/dev/null 2>&1 || fail "exact-session Steam handoff failed"

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -54,6 +54,7 @@ EOF
 cat >"$work/bin/pgrep" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "${POLARIS_PGREP_OUTPUT:-}"
+exit "${POLARIS_PGREP_STATUS:-0}"
 EOF
 cat >"$work/bin/kill" <<'EOF'
 #!/usr/bin/env bash
@@ -73,8 +74,9 @@ run_stop() {
     POLARIS_PROC_ROOT="$work/proc" \
     POLARIS_ACTIONS="$actions" \
     POLARIS_KILL_BIN="$work/bin/kill" \
-    POLARIS_SESSION_INSTANCE_ID="${POLARIS_SESSION_INSTANCE_ID:-}" \
+    POLARIS_SESSION_INSTANCE_ID="${POLARIS_SESSION_INSTANCE_ID-session-test}" \
     POLARIS_PGREP_OUTPUT="${POLARIS_PGREP_OUTPUT:-}" \
+    POLARIS_PGREP_STATUS="${POLARIS_PGREP_STATUS:-0}" \
     POLARIS_IDLE_WAIT_STEPS=2 POLARIS_PORTAL_WAIT_STEPS=2 \
     NESTED_VALID="${NESTED_VALID:-0}" STOP_OK="${STOP_OK:-0}" \
     RECLAIM_OK="${RECLAIM_OK:-0}" IDLE_VALID="${IDLE_VALID:-0}" \
@@ -129,6 +131,24 @@ NESTED_VALID=0 STOP_OK=0 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
 grep -qx 'write-idle-env' "$actions" || fail "idle runtime environment was not committed"
 grep -q 'restart polaris-portal-gamescope.service' "$actions" || fail "portal was not rebound"
 
+# Enumeration and procfs failures are unknown ownership, never "no Steam".
+reset_state
+if POLARIS_PGREP_STATUS=2 NESTED_VALID=1 STOP_OK=1 run_stop >/dev/null 2>&1; then
+  fail "pgrep failure was treated as an empty exact-session drain"
+fi
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-wsi-nested")" = 1 ] ||
+  fail "pgrep failure advanced the recovery claim"
+
+reset_state
+mkdir -p "$work/proc/102"
+printf '12\n' >"$work/proc/102/start"
+if POLARIS_PGREP_OUTPUT=102 NESTED_VALID=1 STOP_OK=1 run_stop >/dev/null 2>&1; then
+  fail "unreadable Steam environment was treated as unowned"
+fi
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-wsi-nested")" = 1 ] ||
+  fail "unreadable Steam metadata advanced the recovery claim"
+rm -rf "$work/proc/102"
+
 # Only Steam carrying the exact Polaris session credential may be signalled.
 reset_state
 mkdir -p "$work/proc/100" "$work/proc/101"
@@ -142,5 +162,18 @@ POLARIS_SESSION_INSTANCE_ID=session-A POLARIS_PGREP_OUTPUT=$'100\n101' \
 grep -qx 'kill -TERM 101' "$actions" || fail "exact-session Steam was not signalled"
 ! grep -q 'kill .*100' "$actions" || fail "desktop Steam was signalled"
 [ -d "$work/proc/100" ] || fail "desktop Steam process was removed"
+
+# Recovery may run in a fresh process environment; the immutable credential is
+# persisted until the full idle/portal handoff completes.
+reset_state
+mkdir -p "$work/proc/101"
+printf '11\n' >"$work/proc/101/start"
+printf 'POLARIS_SESSION_INSTANCE_ID=session-A\0' >"$work/proc/101/environ"
+printf 'session-A\n' >"$work/run/polaris-gamescope-session-id"
+POLARIS_SESSION_INSTANCE_ID= POLARIS_PGREP_OUTPUT=101 \
+  NESTED_VALID=1 STOP_OK=1 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
+  PORTAL_READY=1 run_stop >/dev/null 2>&1 || fail "persisted-session recovery failed"
+grep -qx 'kill -TERM 101' "$actions" || fail "recovery did not use persisted exact-session credential"
+[ ! -e "$work/run/polaris-gamescope-session-id" ] || fail "successful recovery retained session credential"
 
 echo "PASS: gamescope session stop state machine"

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -216,6 +216,11 @@ mask_line="$(grep -nF 'polaris_mask_idle_unit_runtime' "$script" | tail -n1 | cu
   fail "nested transition claim is not published before idle destruction"
 grep -Fq 'publish_nested_claim nested transition' "$script" ||
   fail "nested launch does not CAS transition ownership before spawn"
+grep -Fq 'publish_nested_claim nested nested' "$script" ||
+  fail "nested portal rebind does not revalidate its claim"
+if grep -Eq '^[[:space:]]*publish_nested_claim[[:space:]]*$' "$script"; then
+  fail "nested claim helper was called without CAS arguments"
+fi
 grep -Fq '[ ! -e "$session_id_file" ] && [ ! -e "$session_mode_file" ]' "$script" ||
   fail "credential and mode publication is not fenced against concurrent starts"
 grep -Fq 'export POLARIS_GAMESCOPE_LOCK_HELD=1' "$script" ||

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -183,5 +183,13 @@ grep -Fq 'if [ -s "$session_id_file" ]; then' "$script" ||
   fail "start does not recover every persisted session credential before replacement"
 grep -Fq 'POLARIS_SESSION_INSTANCE_ID= "$0" stop || exit 1' "$script" ||
   fail "start does not route persisted attach/nested recovery through credentialed stop"
+transition_line="$(grep -nF 'publish_nested_claim transition absent' "$script" | head -n1 | cut -d: -f1)"
+mask_line="$(grep -nF 'polaris_mask_idle_unit_runtime' "$script" | tail -n1 | cut -d: -f1)"
+[ -n "$transition_line" ] && [ -n "$mask_line" ] && [ "$transition_line" -lt "$mask_line" ] ||
+  fail "nested transition claim is not published before idle destruction"
+grep -Fq 'publish_nested_claim nested transition' "$script" ||
+  fail "nested launch does not CAS transition ownership before spawn"
+grep -Fq 'export POLARIS_GAMESCOPE_LOCK_HELD=1' "$script" ||
+  fail "portal handoff is not finalized under the ownership lock"
 
 echo "PASS: gamescope session stop state machine"

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/polaris-gamescope-session-stop.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin" "$work/run" "$work/proc"
+actions="$work/actions"
+: >"$actions"
+
+cat >"$work/runtime-stub.sh" <<'EOF'
+polaris_proc_root() { printf '%s\n' "$POLARIS_PROC_ROOT"; }
+polaris_process_fields() {
+  [ -r "$POLARIS_PROC_ROOT/$1/start" ] || return 1
+  POLARIS_PROCESS_START_TIME="$(<"$POLARIS_PROC_ROOT/$1/start")"
+}
+polaris_validate_marker() {
+  case "${2:-}" in
+    nested) [ "${NESTED_VALID:-0}" = 1 ] ;;
+    idle) [ "${IDLE_VALID:-0}" = 1 ] ;;
+    *) return 1 ;;
+  esac
+}
+polaris_stop_marked_gamescope() {
+  printf 'stop-nested\n' >>"$POLARIS_ACTIONS"
+  [ "${STOP_OK:-0}" = 1 ]
+}
+polaris_reclaim_orphan_gamescope_sockets() {
+  printf 'reclaim\n' >>"$POLARIS_ACTIONS"
+  [ "${RECLAIM_OK:-0}" = 1 ]
+}
+polaris_unmask_idle_unit_runtime() { printf 'unmask-idle\n' >>"$POLARIS_ACTIONS"; }
+polaris_marker_owns_socket() { [ "${IDLE_OWNS_SOCKET:-0}" = 1 ]; }
+polaris_write_runtime_env() {
+  printf 'write-idle-env\n' >>"$POLARIS_ACTIONS"
+  [ "${WRITE_ENV_OK:-0}" = 1 ]
+}
+EOF
+
+cat >"$work/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+printf 'systemctl %s\n' "$*" >>"$POLARIS_ACTIONS"
+case "$*" in
+  *'start polaris-gamescope-idle.service'*) [ "${IDLE_START_OK:-1}" = 1 ] ;;
+  *'restart polaris-portal-gamescope.service'*) [ "${PORTAL_RESTART_OK:-1}" = 1 ] ;;
+  *) exit 0 ;;
+esac
+EOF
+cat >"$work/bin/busctl" <<'EOF'
+#!/usr/bin/env bash
+printf 'busctl\n' >>"$POLARIS_ACTIONS"
+[ "${PORTAL_READY:-1}" = 1 ]
+EOF
+cat >"$work/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${POLARIS_PGREP_OUTPUT:-}"
+EOF
+cat >"$work/bin/kill" <<'EOF'
+#!/usr/bin/env bash
+printf 'kill %s\n' "$*" >>"$POLARIS_ACTIONS"
+pid="${2:-}"
+case "$pid" in ''|*[!0-9]*) exit 1 ;; esac
+rm -rf "$POLARIS_PROC_ROOT/$pid"
+EOF
+chmod +x "$work/bin/"*
+
+script="${POLARIS_SOURCE_DIR:?}/nix/modules/polaris-gamescope-session.sh"
+run_stop() {
+  env \
+    PATH="$work/bin:$PATH" \
+    XDG_RUNTIME_DIR="$work/run" \
+    POLARIS_GAMESCOPE_RUNTIME_LIB="$work/runtime-stub.sh" \
+    POLARIS_PROC_ROOT="$work/proc" \
+    POLARIS_ACTIONS="$actions" \
+    POLARIS_KILL_BIN="$work/bin/kill" \
+    POLARIS_SESSION_INSTANCE_ID="${POLARIS_SESSION_INSTANCE_ID:-}" \
+    POLARIS_PGREP_OUTPUT="${POLARIS_PGREP_OUTPUT:-}" \
+    POLARIS_IDLE_WAIT_STEPS=2 POLARIS_PORTAL_WAIT_STEPS=2 \
+    NESTED_VALID="${NESTED_VALID:-0}" STOP_OK="${STOP_OK:-0}" \
+    RECLAIM_OK="${RECLAIM_OK:-0}" IDLE_VALID="${IDLE_VALID:-0}" \
+    IDLE_OWNS_SOCKET="${IDLE_OWNS_SOCKET:-0}" WRITE_ENV_OK="${WRITE_ENV_OK:-0}" \
+    IDLE_START_OK="${IDLE_START_OK:-1}" PORTAL_RESTART_OK="${PORTAL_RESTART_OK:-1}" \
+    PORTAL_READY="${PORTAL_READY:-1}" \
+    bash "$script" stop
+}
+reset_state() {
+  rm -rf "$work/run"/*
+  mkdir -p "$work/run"
+  printf '1\n' >"$work/run/polaris-gamescope-wsi-nested"
+  printf '1\n' >"$work/run/polaris-gamescope-force"
+  : >"$work/run/polaris-gamescope.pid"
+  : >"$actions"
+}
+
+# Exact nested stop failure is a recovery state, never a successful handoff.
+reset_state
+if NESTED_VALID=1 STOP_OK=0 run_stop >/dev/null 2>&1; then
+  fail "exact nested stop failure returned success"
+fi
+[ -e "$work/run/polaris-gamescope-wsi-nested" ] || fail "stop failure cleared nested claim"
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-force")" = 1 ] || fail "stop failure reset force state"
+! grep -Eq 'unmask|start polaris-gamescope-idle|restart polaris-portal|busctl' "$actions" ||
+  fail "stop failure advanced idle/portal handoff"
+
+# Unknown/live socket ownership must fail with the same durable state.
+reset_state
+if NESTED_VALID=0 RECLAIM_OK=0 run_stop >/dev/null 2>&1; then
+  fail "unknown socket reclaim failure returned success"
+fi
+[ -e "$work/run/polaris-gamescope-wsi-nested" ] || fail "reclaim failure cleared nested claim"
+! grep -Eq 'unmask|start polaris-gamescope-idle|restart polaris-portal|busctl' "$actions" ||
+  fail "reclaim failure advanced idle/portal handoff"
+
+# A failed idle handoff retains restore-idle state for a safe retry.
+reset_state
+if NESTED_VALID=1 STOP_OK=1 IDLE_VALID=0 run_stop >/dev/null 2>&1; then
+  fail "missing idle owner returned success"
+fi
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-wsi-nested")" = restore-idle ] ||
+  fail "idle failure did not retain restore-idle claim"
+
+# Retry from restore-idle skips nested teardown and commits only after portal readiness.
+: >"$actions"
+NESTED_VALID=0 STOP_OK=0 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
+  PORTAL_READY=1 run_stop >/dev/null 2>&1 || fail "restore-idle retry failed"
+[ ! -e "$work/run/polaris-gamescope-wsi-nested" ] || fail "successful handoff retained nested claim"
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-force")" = 0 ] || fail "successful handoff did not reset force"
+! grep -qx 'stop-nested' "$actions" || fail "restore-idle retry repeated nested stop"
+grep -qx 'write-idle-env' "$actions" || fail "idle runtime environment was not committed"
+grep -q 'restart polaris-portal-gamescope.service' "$actions" || fail "portal was not rebound"
+
+# Only Steam carrying the exact Polaris session credential may be signalled.
+reset_state
+mkdir -p "$work/proc/100" "$work/proc/101"
+printf '10\n' >"$work/proc/100/start"
+printf '11\n' >"$work/proc/101/start"
+printf 'HOME=/home/papi\0' >"$work/proc/100/environ"
+printf 'HOME=/home/papi\0POLARIS_SESSION_INSTANCE_ID=session-A\0' >"$work/proc/101/environ"
+POLARIS_SESSION_INSTANCE_ID=session-A POLARIS_PGREP_OUTPUT=$'100\n101' \
+  NESTED_VALID=1 STOP_OK=1 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
+  PORTAL_READY=1 run_stop >/dev/null 2>&1 || fail "exact-session Steam handoff failed"
+grep -qx 'kill -TERM 101' "$actions" || fail "exact-session Steam was not signalled"
+! grep -q 'kill .*100' "$actions" || fail "desktop Steam was signalled"
+[ -d "$work/proc/100" ] || fail "desktop Steam process was removed"
+
+echo "PASS: gamescope session stop state machine"

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -196,15 +196,25 @@ grep -qx 'kill -TERM 101' "$actions" || fail "attach recovery did not terminate 
 [ ! -e "$work/run/polaris-gamescope-session-id" ] || fail "attach recovery cleared no credential"
 [ ! -e "$work/run/polaris-gamescope-session-mode" ] || fail "attach recovery retained mode"
 
-# Lost nested claims cannot be misclassified as attach recovery.
+# A crash after nested mode publication but before transition publication is
+# recoverable only while exact idle ownership proves destruction never began.
 reset_state
 rm -f "$work/run/polaris-gamescope-wsi-nested"
 printf 'nested\n' >"$work/run/polaris-gamescope-session-mode"
 printf 'session-A\n' >"$work/run/polaris-gamescope-session-id"
-if POLARIS_SESSION_INSTANCE_ID= run_stop >/dev/null 2>&1; then
-  fail "claimless nested mode fell back to attach recovery"
+POLARIS_SESSION_INSTANCE_ID= IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 PORTAL_READY=1 \
+  run_stop >/dev/null 2>&1 || fail "pre-transition nested credential recovery failed"
+[ ! -e "$work/run/polaris-gamescope-session-id" ] || fail "pre-transition recovery retained credential"
+
+# A missing claim with a live nested marker remains ambiguous and fails closed.
+reset_state
+rm -f "$work/run/polaris-gamescope-wsi-nested"
+printf 'nested\n' >"$work/run/polaris-gamescope-session-mode"
+printf 'session-A\n' >"$work/run/polaris-gamescope-session-id"
+if POLARIS_SESSION_INSTANCE_ID= NESTED_VALID=1 IDLE_VALID=0 run_stop >/dev/null 2>&1; then
+  fail "claimless live nested generation was adopted without its claim"
 fi
-[ -e "$work/run/polaris-gamescope-session-id" ] || fail "claimless nested failure cleared credential"
+[ -e "$work/run/polaris-gamescope-session-id" ] || fail "ambiguous nested failure cleared credential"
 
 grep -Fq 'if [ -s "$session_id_file" ]; then' "$script" ||
   fail "start does not recover every persisted session credential before replacement"

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -89,6 +89,7 @@ reset_state() {
   rm -rf "$work/run"/*
   mkdir -p "$work/run"
   printf '1\n' >"$work/run/polaris-gamescope-wsi-nested"
+  printf 'nested\n' >"$work/run/polaris-gamescope-session-mode"
   printf '1\n' >"$work/run/polaris-gamescope-force"
   : >"$work/run/polaris-gamescope.pid"
   : >"$actions"
@@ -179,6 +180,32 @@ POLARIS_SESSION_INSTANCE_ID= POLARIS_PGREP_OUTPUT=101 \
 grep -qx 'kill -TERM 101' "$actions" || fail "recovery did not use persisted exact-session credential"
 [ ! -e "$work/run/polaris-gamescope-session-id" ] || fail "successful recovery retained session credential"
 
+# Persisted attach mode is also a durable recovery claim: exact-session Steam
+# must be absent before either the mode or credential can be cleared.
+reset_state
+rm -f "$work/run/polaris-gamescope-wsi-nested"
+printf 'attach\n' >"$work/run/polaris-gamescope-session-mode"
+printf '0\n' >"$work/run/polaris-gamescope-force"
+printf 'session-A\n' >"$work/run/polaris-gamescope-session-id"
+mkdir -p "$work/proc/101"
+printf '11\n' >"$work/proc/101/start"
+printf 'POLARIS_SESSION_INSTANCE_ID=session-A\0' >"$work/proc/101/environ"
+POLARIS_SESSION_INSTANCE_ID= POLARIS_PGREP_OUTPUT=101 run_stop >/dev/null 2>&1 ||
+  fail "persisted attach recovery failed"
+grep -qx 'kill -TERM 101' "$actions" || fail "attach recovery did not terminate exact-session Steam"
+[ ! -e "$work/run/polaris-gamescope-session-id" ] || fail "attach recovery cleared no credential"
+[ ! -e "$work/run/polaris-gamescope-session-mode" ] || fail "attach recovery retained mode"
+
+# Lost nested claims cannot be misclassified as attach recovery.
+reset_state
+rm -f "$work/run/polaris-gamescope-wsi-nested"
+printf 'nested\n' >"$work/run/polaris-gamescope-session-mode"
+printf 'session-A\n' >"$work/run/polaris-gamescope-session-id"
+if POLARIS_SESSION_INSTANCE_ID= run_stop >/dev/null 2>&1; then
+  fail "claimless nested mode fell back to attach recovery"
+fi
+[ -e "$work/run/polaris-gamescope-session-id" ] || fail "claimless nested failure cleared credential"
+
 grep -Fq 'if [ -s "$session_id_file" ]; then' "$script" ||
   fail "start does not recover every persisted session credential before replacement"
 grep -Fq 'POLARIS_SESSION_INSTANCE_ID= "$0" stop || exit 1' "$script" ||
@@ -189,6 +216,8 @@ mask_line="$(grep -nF 'polaris_mask_idle_unit_runtime' "$script" | tail -n1 | cu
   fail "nested transition claim is not published before idle destruction"
 grep -Fq 'publish_nested_claim nested transition' "$script" ||
   fail "nested launch does not CAS transition ownership before spawn"
+grep -Fq '[ ! -e "$session_id_file" ] && [ ! -e "$session_mode_file" ]' "$script" ||
+  fail "credential and mode publication is not fenced against concurrent starts"
 grep -Fq 'export POLARIS_GAMESCOPE_LOCK_HELD=1' "$script" ||
   fail "portal handoff is not finalized under the ownership lock"
 

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -196,6 +196,48 @@ grep -qx 'kill -TERM 101' "$actions" || fail "attach recovery did not terminate 
 [ ! -e "$work/run/polaris-gamescope-session-id" ] || fail "attach recovery cleared no credential"
 [ ! -e "$work/run/polaris-gamescope-session-mode" ] || fail "attach recovery retained mode"
 
+# New credentials publish ID+mode as one atomic record; stop must consume that
+# record and clear it only after exact-session Steam is absent.
+reset_state
+rm -f "$work/run/polaris-gamescope-wsi-nested" \
+  "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode"
+printf 'session-A attach\n' >"$work/run/polaris-gamescope-session-state"
+mkdir -p "$work/proc/101"
+printf '11\n' >"$work/proc/101/start"
+printf 'POLARIS_SESSION_INSTANCE_ID=session-A\0' >"$work/proc/101/environ"
+POLARIS_SESSION_INSTANCE_ID= POLARIS_PGREP_OUTPUT=101 run_stop >/dev/null 2>&1 ||
+  fail "atomic persisted attach recovery failed"
+[ ! -e "$work/run/polaris-gamescope-session-state" ] || fail "atomic credential survived complete stop"
+
+# Interruption before the one rename leaves no half credential; retry commits one
+# complete ID+mode record.
+prefix="$work/session-functions.sh"
+: >"$prefix"
+while IFS= read -r line; do
+  [ "$line" = 'case "${1:-}" in' ] && break
+  printf '%s\n' "$line" >>"$prefix"
+done <"$script"
+(
+  export XDG_RUNTIME_DIR="$work/run"
+  export POLARIS_GAMESCOPE_RUNTIME_LIB="$work/runtime-stub.sh"
+  export POLARIS_SESSION_INSTANCE_ID=session-B
+  rm -f "$work/run/polaris-gamescope-session-state" \
+    "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode"
+  # shellcheck source=/dev/null
+  . "$prefix"
+  if POLARIS_SESSION_STATE_BEFORE_COMMIT_HOOK=false publish_session_mode nested; then
+    fail "interrupted atomic session publication unexpectedly succeeded"
+  fi
+  [ ! -e "$session_state_file" ] || fail "interrupted publication exposed a half credential"
+  if compgen -G "$session_state_file.tmp.*" >/dev/null; then
+    fail "interrupted publication retained a temporary credential"
+  fi
+  publish_session_mode nested || fail "atomic session publication retry failed"
+  [ "$(<"$session_state_file")" = 'session-B nested' ] ||
+    fail "atomic session record did not contain exact ID and mode"
+)
+rm -f "$work/run/polaris-gamescope-session-state"
+
 # A crash after nested mode publication but before transition publication is
 # recoverable only while exact idle ownership proves destruction never began.
 reset_state
@@ -216,8 +258,8 @@ if POLARIS_SESSION_INSTANCE_ID= NESTED_VALID=1 IDLE_VALID=0 run_stop >/dev/null 
 fi
 [ -e "$work/run/polaris-gamescope-session-id" ] || fail "ambiguous nested failure cleared credential"
 
-grep -Fq 'if [ -s "$session_id_file" ]; then' "$script" ||
-  fail "start does not recover every persisted session credential before replacement"
+grep -Fq 'if [ -e "$session_state_file" ] || [ -s "$session_id_file" ]; then' "$script" ||
+  fail "start does not recover every atomic or legacy credential before replacement"
 grep -Fq 'POLARIS_SESSION_INSTANCE_ID= "$0" stop || exit 1' "$script" ||
   fail "start does not route persisted attach/nested recovery through credentialed stop"
 transition_line="$(grep -nF 'publish_nested_claim transition absent' "$script" | head -n1 | cut -d: -f1)"
@@ -231,8 +273,12 @@ grep -Fq 'publish_nested_claim nested nested' "$script" ||
 if grep -Eq '^[[:space:]]*publish_nested_claim[[:space:]]*$' "$script"; then
   fail "nested claim helper was called without CAS arguments"
 fi
-grep -Fq '[ ! -e "$session_id_file" ] && [ ! -e "$session_mode_file" ]' "$script" ||
-  fail "credential and mode publication is not fenced against concurrent starts"
+grep -Fq "printf '%s %s\\n' \"\$POLARIS_SESSION_INSTANCE_ID\" \"\$mode\" >\"\$tmp\"" "$script" ||
+  fail "session ID and mode are not assembled into one atomic record"
+grep -Fq 'mv -f -- "$tmp" "$session_state_file"' "$script" ||
+  fail "atomic session record is not committed by one rename"
+grep -Fq 'POLARIS_SESSION_STATE_BEFORE_COMMIT_HOOK' "$script" ||
+  fail "atomic publication interruption hook is missing"
 grep -Fq 'export POLARIS_GAMESCOPE_LOCK_HELD=1' "$script" ||
   fail "portal handoff is not finalized under the ownership lock"
 

--- a/tests/unit/test_linux_stream_contract.cpp
+++ b/tests/unit/test_linux_stream_contract.cpp
@@ -66,7 +66,7 @@ TEST(LinuxStreamContractTests, GamescopeOwnershipTransitionsUseOneCrossProcessLo
 
   const auto marker_failure = runtime.find("if (!marker_written)");
   ASSERT_NE(marker_failure, std::string::npos);
-  const auto failure_body = runtime.substr(marker_failure, 1200);
+  const auto failure_body = runtime.substr(marker_failure, 5000);
   const auto child_check = failure_body.find("waitpid(child, &status, WNOHANG)");
   const auto signal = failure_body.find("kill(child, SIGTERM)");
   ASSERT_NE(child_check, std::string::npos);

--- a/tests/unit/test_linux_stream_contract.cpp
+++ b/tests/unit/test_linux_stream_contract.cpp
@@ -104,7 +104,8 @@ TEST(LinuxStreamContractTests, RootMediaFenceSurvivesThroughCompositorTerminatio
   const auto terminate = process.find("void proc_t::terminate_impl(");
   ASSERT_NE(terminate, std::string::npos);
   const auto body = process.substr(terminate, 4200);
-  const auto fence = body.find("media_stop_fence = session_media::prepare_for_stop()");
+  // Function-scoped holder so the fence outlives early #ifdef blocks through undo.
+  const auto fence = body.find("media_stop.fence = session_media::prepare_for_stop()");
   const auto compositor = body.find("terminate_isolated_session_generation()");
   ASSERT_NE(fence, std::string::npos);
   ASSERT_NE(compositor, std::string::npos);

--- a/tests/unit/test_linux_stream_contract.cpp
+++ b/tests/unit/test_linux_stream_contract.cpp
@@ -67,7 +67,7 @@ TEST(LinuxStreamContractTests, GamescopeOwnershipTransitionsUseOneCrossProcessLo
   const auto marker_failure = runtime.find("if (!marker_written)");
   ASSERT_NE(marker_failure, std::string::npos);
   const auto failure_body = runtime.substr(marker_failure, 5000);
-  const auto rollback = failure_body.find("rollback_spawned_private_group(child, child_reaped)");
+  const auto rollback = failure_body.find("rollback_spawned_private_group(child, leader_pidfd_)");
   const auto clear_state = failure_body.find("pid_ = 0");
   ASSERT_NE(rollback, std::string::npos);
   ASSERT_NE(clear_state, std::string::npos);

--- a/tests/unit/test_linux_stream_contract.cpp
+++ b/tests/unit/test_linux_stream_contract.cpp
@@ -67,12 +67,13 @@ TEST(LinuxStreamContractTests, GamescopeOwnershipTransitionsUseOneCrossProcessLo
   const auto marker_failure = runtime.find("if (!marker_written)");
   ASSERT_NE(marker_failure, std::string::npos);
   const auto failure_body = runtime.substr(marker_failure, 5000);
-  const auto child_check = failure_body.find("waitpid(child, &status, WNOHANG)");
-  const auto signal = failure_body.find("kill(child, SIGTERM)");
-  ASSERT_NE(child_check, std::string::npos);
-  ASSERT_NE(signal, std::string::npos);
-  EXPECT_LT(child_check, signal);
-  EXPECT_NE(failure_body.find("if (!child_reaped)"), std::string::npos);
+  const auto rollback = failure_body.find("rollback_spawned_private_group(child, child_reaped)");
+  const auto clear_state = failure_body.find("pid_ = 0");
+  ASSERT_NE(rollback, std::string::npos);
+  ASSERT_NE(clear_state, std::string::npos);
+  EXPECT_LT(rollback, clear_state);
+  EXPECT_NE(runtime.find("drain_private_process_group(child"), std::string::npos);
+  EXPECT_NE(failure_body.find("preserving state"), std::string::npos);
 }
 
 TEST(LinuxStreamContractTests, PipeWireLoopCallbacksNeverTakeShutdownMutex) {

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -314,6 +314,15 @@ TEST(ProcessRuntimeConfigTests, NestedSessionPrepReceivesCredentialAndFailsLaunc
   EXPECT_LT(credential, prep_loop);
   EXPECT_NE(body.find("critical nested gamescope prep command failed"), std::string::npos);
   EXPECT_NE(body.find("return 503;", prep_loop), std::string::npos);
+  const auto app_env_loop = body.find("for (const auto &[key, val] : _app.env_vars)", prep_loop);
+  ASSERT_NE(app_env_loop, std::string::npos);
+  const auto reserved_filter = body.find("is_reserved_session_env_key(key)", app_env_loop);
+  ASSERT_NE(reserved_filter, std::string::npos);
+  const auto credential_reassert = body.find("set_child_only_session_env_var(", credential + 1);
+  ASSERT_NE(credential_reassert, std::string::npos);
+  EXPECT_LT(app_env_loop, reserved_filter);
+  EXPECT_LT(reserved_filter, credential_reassert);
+  EXPECT_NE(body.find("platf::unset_env(\"POLARIS_SESSION_INSTANCE_ID\")", app_env_loop), std::string::npos);
 }
 
 TEST(ProcessRuntimeConfigTests, SessionLifecycleGateOwnsLaunchRaiseAndTeardownWithoutCrossLockingRtsp) {

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1166,6 +1166,44 @@ TEST(ProcessRuntimeConfigTests, SteamPidfdCaptureRejectsStartTimeMismatch) {
   EXPECT_FALSE(proc::steam_pidfd_capture_identity_matches_for_tests(4242, std::nullopt));
 }
 
+TEST(ProcessRuntimeConfigTests, GamescopeAttachedClientPidReuseFailsClosedBeforePidfdSignal) {
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const pid_t child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    if (dup2(ready_pipe[1], 3) < 0) {
+      _exit(126);
+    }
+    close(ready_pipe[1]);
+    execl(
+      "/usr/bin/env",
+      "env",
+      "GAMESCOPE_WAYLAND_DISPLAY=gamescope-0",
+      "STEAM_COMPAT_APP_ID=4242",
+      "/bin/sh",
+      "-c",
+      "printf x >&3; exec /usr/bin/tail -f /dev/null",
+      static_cast<char *>(nullptr)
+    );
+    _exit(127);
+  }
+  linux_child_guard_t child_guard {child};
+  close(ready_pipe[1]);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+
+  EXPECT_FALSE(proc::terminate_gamescope_attached_clients_for_tests("4242", child));
+  EXPECT_EQ(kill(child, 0), 0) << "PID-reuse simulation signalled the captured process";
+
+  EXPECT_TRUE(proc::terminate_gamescope_attached_clients_for_tests("4242"));
+  int status = 0;
+  ASSERT_EQ(child_guard.wait(&status, 0), child);
+  EXPECT_TRUE(WIFSIGNALED(status));
+}
+
 TEST(ProcessRuntimeConfigTests, SteamShutdownOwnershipRejectsUnmarkedActiveClients) {
   const std::string running_status = "Name:\tsteam\nState:\tS (sleeping)\n";
   const std::string zombie_status = "Name:\tsteam\nState:\tZ (zombie)\n";

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1198,10 +1198,49 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedClientPidReuseFailsClosedBefore
   EXPECT_FALSE(proc::terminate_gamescope_attached_clients_for_tests("4242", child));
   EXPECT_EQ(kill(child, 0), 0) << "PID-reuse simulation signalled the captured process";
 
+  EXPECT_FALSE(proc::terminate_gamescope_attached_clients_for_tests("4242", -1, child));
+  EXPECT_EQ(kill(child, 0), 0) << "unreadable live candidate allowed partial pidfd signaling";
+
   EXPECT_TRUE(proc::terminate_gamescope_attached_clients_for_tests("4242"));
   int status = 0;
   ASSERT_EQ(child_guard.wait(&status, 0), child);
   EXPECT_TRUE(WIFSIGNALED(status));
+}
+
+TEST(ProcessRuntimeConfigTests, GamescopeAttachedCleanupRejectsUnownedSameAppProcess) {
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const pid_t child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    const char ready = 'x';
+    (void) write(ready_pipe[1], &ready, 1);
+    close(ready_pipe[1]);
+    execl("/bin/bash", "bash", "-c", "exec -a AppId=4242 /usr/bin/tail -f /dev/null", static_cast<char *>(nullptr));
+    _exit(127);
+  }
+  linux_child_guard_t child_guard {child};
+  close(ready_pipe[1]);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+
+  bool observed = false;
+  for (int attempt = 0; attempt < 100; ++attempt) {
+    std::ifstream cmdline("/proc/" + std::to_string(child) + "/cmdline", std::ios::binary);
+    const std::string bytes {
+      std::istreambuf_iterator<char> {cmdline}, std::istreambuf_iterator<char> {}
+    };
+    if (bytes.find("AppId=4242") != std::string::npos) {
+      observed = true;
+      break;
+    }
+    usleep(10000);
+  }
+  ASSERT_TRUE(observed);
+  EXPECT_TRUE(proc::terminate_gamescope_attached_clients_for_tests("4242"));
+  EXPECT_EQ(kill(child, 0), 0) << "same-app process without gamescope attachment was signalled";
 }
 
 TEST(ProcessRuntimeConfigTests, SteamShutdownOwnershipRejectsUnmarkedActiveClients) {

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1172,6 +1172,7 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedClientPidReuseFailsClosedBefore
   const pid_t child = fork();
   ASSERT_GE(child, 0);
   if (child == 0) {
+    if (setsid() < 0) _exit(124);
     close(ready_pipe[0]);
     if (dup2(ready_pipe[1], 3) < 0) {
       _exit(126);
@@ -1214,6 +1215,7 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedUnreadableLiveProcessFailsClose
   const pid_t child = fork();
   ASSERT_GE(child, 0);
   if (child == 0) {
+    if (setsid() < 0) _exit(124);
     close(ready_pipe[0]);
     setenv("GAMESCOPE_WAYLAND_DISPLAY", "gamescope-0", 1);
     setenv("STEAM_COMPAT_APP_ID", "4242", 1);
@@ -1243,6 +1245,7 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedCleanupDrainsStrippedExactGener
   const pid_t root = fork();
   ASSERT_GE(root, 0);
   if (root == 0) {
+    if (setsid() < 0) _exit(124);
     close(ready_pipe[0]);
     const std::string fd = std::to_string(ready_pipe[1]);
     const std::string command =
@@ -1266,6 +1269,56 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedCleanupDrainsStrippedExactGener
   if (!terminated) {
     (void) kill(root, SIGKILL);
     (void) kill(descendant, SIGKILL);
+  }
+  EXPECT_TRUE(terminated);
+  EXPECT_EQ(waitpid(root, nullptr, 0), root);
+  errno = 0;
+  EXPECT_EQ(kill(descendant, 0), -1);
+  EXPECT_EQ(errno, ESRCH);
+}
+
+TEST(ProcessRuntimeConfigTests, GamescopeAttachedCleanupDrainsReparentedPrivateGroupDescendant) {
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  setenv("POLARIS_SESSION_INSTANCE_ID", "gamescope-attached-test", 1);
+  const pid_t root = fork();
+  ASSERT_GE(root, 0);
+  if (root == 0) {
+    close(ready_pipe[0]);
+    if (setsid() < 0 || dup2(ready_pipe[1], 3) < 0) _exit(124);
+    close(ready_pipe[1]);
+    const char *program =
+      "import os,signal,time\n"
+      "middle=os.fork()\n"
+      "if middle==0:\n"
+      " descendant=os.fork()\n"
+      " if descendant==0:\n"
+      "  time.sleep(0.05)\n"
+      "  os.setpgid(0,0)\n"
+      "  os.write(3, str(os.getpid()).encode()+b'\\n')\n"
+      "  os.environ.clear()\n"
+      "  signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+      "  while True: time.sleep(1)\n"
+      " os._exit(0)\n"
+      "os.waitpid(middle,0)\n"
+      "signal.pause()\n";
+    execl(
+      "/usr/bin/env", "env",
+      "POLARIS_SESSION_INSTANCE_ID=gamescope-attached-test",
+      "/usr/bin/python3", "-c", program,
+      static_cast<char *>(nullptr)
+    );
+    _exit(127);
+  }
+  close(ready_pipe[1]);
+  char descendant_text[32] {};
+  ASSERT_GT(read(ready_pipe[0], descendant_text, sizeof(descendant_text) - 1), 0);
+  close(ready_pipe[0]);
+  const pid_t descendant = static_cast<pid_t>(std::strtol(descendant_text, nullptr, 10));
+  ASSERT_GT(descendant, 1);
+  const bool terminated = proc::terminate_gamescope_attached_clients_for_tests("4242");
+  if (!terminated) {
+    (void) kill(-root, SIGKILL);
   }
   EXPECT_TRUE(terminated);
   EXPECT_EQ(waitpid(root, nullptr, 0), root);
@@ -2358,6 +2411,7 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   const auto terminate = source.substr(terminate_start, terminate_end - terminate_start);
   const auto terminate_private_steam = terminate.find("terminate_session_owned_steam_before_cage_stop(");
   const auto terminate_attached = terminate.find("terminate_gamescope_attached_session_clients(");
+  const auto attached_failure_barrier = terminate.find("refusing all later teardown because exact Gamescope ancestry closure was incomplete");
   const auto terminate_generation = terminate.find("terminate_isolated_session_generation();");
   const auto terminate_main = terminate.find("terminate_process_group(");
   const auto legacy_group_gate = terminate.find(
@@ -2373,6 +2427,7 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   const auto finish_generation = terminate.find("finish_isolated_session_generation_cleanup();");
   ASSERT_NE(terminate_private_steam, std::string::npos);
   ASSERT_NE(terminate_attached, std::string::npos);
+  ASSERT_NE(attached_failure_barrier, std::string::npos);
   ASSERT_NE(terminate_generation, std::string::npos);
   ASSERT_NE(terminate_main, std::string::npos);
   ASSERT_NE(legacy_group_gate, std::string::npos);
@@ -2382,8 +2437,11 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   ASSERT_NE(clear_legacy_child, std::string::npos);
   ASSERT_NE(immutable_undo_guard, std::string::npos);
   ASSERT_NE(finish_generation, std::string::npos);
-  EXPECT_LT(terminate_attached, terminate_private_steam);
+  EXPECT_LT(terminate_attached, attached_failure_barrier);
+  EXPECT_LT(attached_failure_barrier, terminate_private_steam);
   EXPECT_LT(terminate_private_steam, terminate_generation);
+  EXPECT_NE(source.find("_session_used_gamescope_runtime = gamescope_stream_session;"), std::string::npos);
+  EXPECT_NE(terminate.find("_session_used_gamescope_runtime"), std::string::npos);
   EXPECT_NE(source.find("const bool prior_cleanup_complete = _exact_generation_cleanup_complete;"), std::string::npos);
   EXPECT_NE(source.find("prior_cleanup_complete && isolated_cleanup_complete"), std::string::npos);
   EXPECT_LT(terminate_generation, terminate_main);

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -299,6 +299,23 @@ TEST(ProcessRuntimeConfigTests, PolarisV1SessionStopContractIsAdvertisedAndRoute
   );
 }
 
+TEST(ProcessRuntimeConfigTests, NestedSessionPrepReceivesCredentialAndFailsLaunchClosed) {
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto execute_start = source.find("int proc_t::execute_impl(");
+  const auto terminate_start = source.find("void proc_t::terminate_impl(", execute_start);
+  ASSERT_NE(execute_start, std::string::npos);
+  ASSERT_NE(terminate_start, std::string::npos);
+  const auto body = source.substr(execute_start, terminate_start - execute_start);
+  const auto credential = body.find("set_child_only_session_env_var(");
+  const auto prep_loop = body.find("for (; _app_prep_it != std::end(_app.prep_cmds)");
+  ASSERT_NE(credential, std::string::npos);
+  ASSERT_NE(prep_loop, std::string::npos);
+  EXPECT_LT(credential, prep_loop);
+  EXPECT_NE(body.find("critical nested gamescope prep command failed"), std::string::npos);
+  EXPECT_NE(body.find("return 503;", prep_loop), std::string::npos);
+}
+
 TEST(ProcessRuntimeConfigTests, SessionLifecycleGateOwnsLaunchRaiseAndTeardownWithoutCrossLockingRtsp) {
   const auto header = read_source_file_for_contract("src/process.h");
   const auto source = read_source_file_for_contract("src/process.cpp");

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -2382,8 +2382,8 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   ASSERT_NE(clear_legacy_child, std::string::npos);
   ASSERT_NE(immutable_undo_guard, std::string::npos);
   ASSERT_NE(finish_generation, std::string::npos);
-  EXPECT_LT(terminate_private_steam, terminate_attached);
-  EXPECT_LT(terminate_attached, terminate_generation);
+  EXPECT_LT(terminate_attached, terminate_private_steam);
+  EXPECT_LT(terminate_private_steam, terminate_generation);
   EXPECT_LT(terminate_generation, terminate_main);
   EXPECT_LT(terminate_generation, legacy_group_gate);
   EXPECT_LT(legacy_group_gate, legacy_detach_gate);

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1182,6 +1182,7 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedClientPidReuseFailsClosedBefore
       "env",
       "GAMESCOPE_WAYLAND_DISPLAY=gamescope-0",
       "STEAM_COMPAT_APP_ID=4242",
+      "POLARIS_SESSION_INSTANCE_ID=gamescope-attached-test",
       "/bin/sh",
       "-c",
       "printf x >&3; exec /usr/bin/tail -f /dev/null",
@@ -1216,6 +1217,7 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedUnreadableLiveProcessFailsClose
     close(ready_pipe[0]);
     setenv("GAMESCOPE_WAYLAND_DISPLAY", "gamescope-0", 1);
     setenv("STEAM_COMPAT_APP_ID", "4242", 1);
+    setenv("POLARIS_SESSION_INSTANCE_ID", "gamescope-attached-test", 1);
     if (prctl(PR_SET_NAME, "game-client", 0, 0, 0) != 0) _exit(125);
     if (prctl(PR_SET_DUMPABLE, 0) != 0) _exit(126);
     const char ready = 'x';
@@ -1239,6 +1241,9 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedCleanupRejectsUnownedSameAppPro
   ASSERT_GE(child, 0);
   if (child == 0) {
     close(ready_pipe[0]);
+    setenv("GAMESCOPE_WAYLAND_DISPLAY", "gamescope-0", 1);
+    setenv("STEAM_COMPAT_APP_ID", "4242", 1);
+    setenv("POLARIS_SESSION_INSTANCE_ID", "other-generation", 1);
     const char ready = 'x';
     (void) write(ready_pipe[1], &ready, 1);
     close(ready_pipe[1]);
@@ -1264,8 +1269,8 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedCleanupRejectsUnownedSameAppPro
     usleep(10000);
   }
   ASSERT_TRUE(observed);
-  EXPECT_TRUE(proc::terminate_gamescope_attached_clients_for_tests("4242"));
-  EXPECT_EQ(kill(child, 0), 0) << "same-app process without gamescope attachment was signalled";
+  EXPECT_FALSE(proc::terminate_gamescope_attached_clients_for_tests("4242"));
+  EXPECT_EQ(kill(child, 0), 0) << "other-generation gamescope client was signalled";
 }
 
 TEST(ProcessRuntimeConfigTests, SteamShutdownOwnershipRejectsUnmarkedActiveClients) {
@@ -2312,6 +2317,7 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
 
   const auto terminate = source.substr(terminate_start, terminate_end - terminate_start);
   const auto terminate_private_steam = terminate.find("terminate_session_owned_steam_before_cage_stop(");
+  const auto terminate_attached = terminate.find("terminate_gamescope_attached_session_clients(");
   const auto terminate_generation = terminate.find("terminate_isolated_session_generation();");
   const auto terminate_main = terminate.find("terminate_process_group(");
   const auto legacy_group_gate = terminate.find(
@@ -2326,6 +2332,7 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   const auto immutable_undo_guard = terminate.find("_session_used_cage_compositor", clear_legacy_child);
   const auto finish_generation = terminate.find("finish_isolated_session_generation_cleanup();");
   ASSERT_NE(terminate_private_steam, std::string::npos);
+  ASSERT_NE(terminate_attached, std::string::npos);
   ASSERT_NE(terminate_generation, std::string::npos);
   ASSERT_NE(terminate_main, std::string::npos);
   ASSERT_NE(legacy_group_gate, std::string::npos);
@@ -2335,7 +2342,8 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   ASSERT_NE(clear_legacy_child, std::string::npos);
   ASSERT_NE(immutable_undo_guard, std::string::npos);
   ASSERT_NE(finish_generation, std::string::npos);
-  EXPECT_LT(terminate_private_steam, terminate_generation);
+  EXPECT_LT(terminate_private_steam, terminate_attached);
+  EXPECT_LT(terminate_attached, terminate_generation);
   EXPECT_LT(terminate_generation, terminate_main);
   EXPECT_LT(terminate_generation, legacy_group_gate);
   EXPECT_LT(legacy_group_gate, legacy_detach_gate);

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -2384,6 +2384,8 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   ASSERT_NE(finish_generation, std::string::npos);
   EXPECT_LT(terminate_attached, terminate_private_steam);
   EXPECT_LT(terminate_private_steam, terminate_generation);
+  EXPECT_NE(source.find("const bool prior_cleanup_complete = _exact_generation_cleanup_complete;"), std::string::npos);
+  EXPECT_NE(source.find("prior_cleanup_complete && isolated_cleanup_complete"), std::string::npos);
   EXPECT_LT(terminate_generation, terminate_main);
   EXPECT_LT(terminate_generation, legacy_group_gate);
   EXPECT_LT(legacy_group_gate, legacy_detach_gate);
@@ -2410,7 +2412,7 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
     generation_finish_end - generation_finish_start
   );
   const auto cleanup_result = generation_cleanup.find(
-    "_exact_generation_cleanup_complete = terminate_isolated_session_processes("
+    "const bool isolated_cleanup_complete = terminate_isolated_session_processes("
   );
   const auto cleanup_success_gate = generation_cleanup.find("isolated_session_cleanup_resets_router(");
   const auto reset_cage = generation_cleanup.find("cage_display_router::reset_after_external_stop()");

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1207,6 +1207,31 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedClientPidReuseFailsClosedBefore
   EXPECT_TRUE(WIFSIGNALED(status));
 }
 
+TEST(ProcessRuntimeConfigTests, GamescopeAttachedUnreadableLiveProcessFailsClosed) {
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  const pid_t child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    close(ready_pipe[0]);
+    setenv("GAMESCOPE_WAYLAND_DISPLAY", "gamescope-0", 1);
+    setenv("STEAM_COMPAT_APP_ID", "4242", 1);
+    if (prctl(PR_SET_NAME, "game-client", 0, 0, 0) != 0) _exit(125);
+    if (prctl(PR_SET_DUMPABLE, 0) != 0) _exit(126);
+    const char ready = 'x';
+    (void) write(ready_pipe[1], &ready, 1);
+    close(ready_pipe[1]);
+    for (;;) pause();
+  }
+  linux_child_guard_t child_guard {child};
+  close(ready_pipe[1]);
+  char ready = 0;
+  ASSERT_EQ(read(ready_pipe[0], &ready, 1), 1);
+  close(ready_pipe[0]);
+  EXPECT_FALSE(proc::terminate_gamescope_attached_clients_for_tests("4242"));
+  EXPECT_EQ(kill(child, 0), 0);
+}
+
 TEST(ProcessRuntimeConfigTests, GamescopeAttachedCleanupRejectsUnownedSameAppProcess) {
   int ready_pipe[2] {-1, -1};
   ASSERT_EQ(pipe(ready_pipe), 0);

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1234,6 +1234,46 @@ TEST(ProcessRuntimeConfigTests, GamescopeAttachedUnreadableLiveProcessFailsClose
   EXPECT_EQ(kill(child, 0), 0);
 }
 
+TEST(ProcessRuntimeConfigTests, GamescopeAttachedCleanupDrainsStrippedExactGenerationDescendant) {
+  int ready_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(ready_pipe), 0);
+  setenv("GAMESCOPE_WAYLAND_DISPLAY", "gamescope-0", 1);
+  setenv("STEAM_COMPAT_APP_ID", "4242", 1);
+  setenv("POLARIS_SESSION_INSTANCE_ID", "gamescope-attached-test", 1);
+  const pid_t root = fork();
+  ASSERT_GE(root, 0);
+  if (root == 0) {
+    close(ready_pipe[0]);
+    const std::string fd = std::to_string(ready_pipe[1]);
+    const std::string command =
+      "trap '' TERM; env -u GAMESCOPE_WAYLAND_DISPLAY -u STEAM_COMPAT_APP_ID "
+      "-u POLARIS_SESSION_INSTANCE_ID /bin/sh -c 'trap \"\" TERM; while :; do sleep 1; done' & "
+      "printf '%s\\n' \"$!\" >&" + fd + "; while :; do sleep 1; done";
+    execl("/bin/sh", "sh", "-c", command.c_str(), static_cast<char *>(nullptr));
+    _exit(127);
+  }
+  unsetenv("GAMESCOPE_WAYLAND_DISPLAY");
+  unsetenv("STEAM_COMPAT_APP_ID");
+  unsetenv("POLARIS_SESSION_INSTANCE_ID");
+  close(ready_pipe[1]);
+  char descendant_text[32] {};
+  const auto count = read(ready_pipe[0], descendant_text, sizeof(descendant_text) - 1);
+  ASSERT_GT(count, 0);
+  close(ready_pipe[0]);
+  const pid_t descendant = static_cast<pid_t>(std::strtol(descendant_text, nullptr, 10));
+  ASSERT_GT(descendant, 1);
+  const bool terminated = proc::terminate_gamescope_attached_clients_for_tests("4242");
+  if (!terminated) {
+    (void) kill(root, SIGKILL);
+    (void) kill(descendant, SIGKILL);
+  }
+  EXPECT_TRUE(terminated);
+  EXPECT_EQ(waitpid(root, nullptr, 0), root);
+  errno = 0;
+  EXPECT_EQ(kill(descendant, 0), -1);
+  EXPECT_EQ(errno, ESRCH);
+}
+
 TEST(ProcessRuntimeConfigTests, GamescopeAttachedCleanupRejectsUnownedSameAppProcess) {
   int ready_pipe[2] {-1, -1};
   ASSERT_EQ(pipe(ready_pipe), 0);

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -289,6 +289,13 @@ TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState
   ASSERT_NE(pair_validation, std::string::npos);
   EXPECT_NE(source.find("revalidate_publication_pair()", pair_validation + 1), std::string::npos);
   EXPECT_NE(source.find("Keep the leader unreaped until every negative-PGID operation finishes"), std::string::npos);
+  const auto stop_start = source.find("void stop_unlocked()");
+  const auto refresh_start = source.find("void refresh_runtime_state(", stop_start);
+  ASSERT_NE(stop_start, std::string::npos);
+  ASSERT_NE(refresh_start, std::string::npos);
+  const auto stop_body = source.substr(stop_start, refresh_start - stop_start);
+  EXPECT_NE(stop_body.find("gp::read_marker(marker_path())"), std::string::npos);
+  EXPECT_EQ(stop_body.find("validated_marker_for_socket"), std::string::npos);
   const auto drain_start = source.find("bool drain_private_process_group(");
   const auto rollback_start = source.find("bool rollback_spawned_private_group(", drain_start);
   ASSERT_NE(drain_start, std::string::npos);
@@ -307,6 +314,38 @@ TEST(SessionStopContractTests, OwnedRuntimeEscalatesTermResistantPrivateGroup) {
     close(ready[0]);
     if (setsid() < 0) _exit(125);
     signal(SIGTERM, SIG_IGN);
+    const pid_t sibling = fork();
+    if (sibling < 0) _exit(126);
+    if (sibling == 0) {
+      signal(SIGTERM, SIG_IGN);
+      for (;;) pause();
+    }
+    (void) write(ready[1], &sibling, sizeof(sibling));
+    close(ready[1]);
+    for (;;) pause();
+  }
+  close(ready[1]);
+  pid_t sibling = -1;
+  ASSERT_EQ(read(ready[0], &sibling, sizeof(sibling)), sizeof(sibling));
+  close(ready[0]);
+  const bool drained = stream_runtime::drain_gamescope_private_group_for_tests(leader);
+  if (!drained) (void) kill(-leader, SIGKILL);
+  EXPECT_TRUE(drained);
+  errno = 0;
+  EXPECT_EQ(kill(sibling, 0), -1);
+  EXPECT_EQ(errno, ESRCH);
+#endif
+}
+
+TEST(SessionStopContractTests, OwnedRuntimeEscalatesAfterLeaderExitsOnTerm) {
+#ifdef __linux__
+  int ready[2] {-1, -1};
+  ASSERT_EQ(pipe(ready), 0);
+  const pid_t leader = fork();
+  ASSERT_GE(leader, 0);
+  if (leader == 0) {
+    close(ready[0]);
+    if (setsid() < 0) _exit(125);
     const pid_t sibling = fork();
     if (sibling < 0) _exit(126);
     if (sibling == 0) {

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -286,6 +286,10 @@ TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebin
 TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState) {
   const auto source = read_source_for_contract("src/platform/linux/stream_runtime_gamescope.cpp");
   ASSERT_FALSE(source.empty());
+  const auto ownership_source = read_source_for_contract("src/platform/linux/gamescope_process.cpp");
+  ASSERT_FALSE(ownership_source.empty());
+  EXPECT_NE(ownership_source.find("O_PATH | O_CLOEXEC | O_NOFOLLOW"), std::string::npos);
+  EXPECT_NE(ownership_source.find("socket_pin.still_names_node(socket_path)"), std::string::npos);
   EXPECT_NE(source.find("private_group_state"), std::string::npos);
   EXPECT_NE(source.find("private group did not drain"), std::string::npos);
   EXPECT_NE(source.find("SIGKILL"), std::string::npos);

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -242,7 +242,7 @@ TEST(SessionStopContractTests, UnclassifiedNestedLaunchHasNoNumericGroupKillFall
   const auto source = read_source_for_contract("nix/modules/polaris-gamescope-session.sh");
   ASSERT_FALSE(source.empty());
   EXPECT_EQ(source.find("kill -TERM \"-$nested_launch_pid\""), std::string::npos);
-  const auto claim = source.find("printf 'nested\\n' >\"$rt/polaris-gamescope-wsi-nested\"");
+  const auto claim = source.find("      publish_nested_claim", source.find("start)"));
   const auto launch = source.find("setsid env -u WAYLAND_DISPLAY");
   ASSERT_NE(claim, std::string::npos);
   ASSERT_NE(launch, std::string::npos);
@@ -298,6 +298,39 @@ TEST(SessionStopContractTests, OwnedRuntimeEscalatesTermResistantPrivateGroup) {
   ASSERT_EQ(read(ready[0], &sibling, sizeof(sibling)), sizeof(sibling));
   close(ready[0]);
   const bool drained = stream_runtime::drain_gamescope_private_group_for_tests(leader);
+  if (!drained) (void) kill(-leader, SIGKILL);
+  EXPECT_TRUE(drained);
+  errno = 0;
+  EXPECT_EQ(kill(sibling, 0), -1);
+  EXPECT_EQ(errno, ESRCH);
+#endif
+}
+
+TEST(SessionStopContractTests, SpawnRollbackDrainsSiblingAfterLeaderExit) {
+#ifdef __linux__
+  int ready[2] {-1, -1};
+  ASSERT_EQ(pipe(ready), 0);
+  const pid_t leader = fork();
+  ASSERT_GE(leader, 0);
+  if (leader == 0) {
+    close(ready[0]);
+    if (setsid() < 0) _exit(125);
+    const pid_t sibling = fork();
+    if (sibling < 0) _exit(126);
+    if (sibling == 0) {
+      signal(SIGTERM, SIG_IGN);
+      for (;;) pause();
+    }
+    (void) write(ready[1], &sibling, sizeof(sibling));
+    close(ready[1]);
+    _exit(0);
+  }
+  close(ready[1]);
+  pid_t sibling = -1;
+  ASSERT_EQ(read(ready[0], &sibling, sizeof(sibling)), sizeof(sibling));
+  close(ready[0]);
+  ASSERT_EQ(waitpid(leader, nullptr, 0), leader);
+  const bool drained = stream_runtime::rollback_gamescope_spawn_for_tests(leader, true);
   if (!drained) (void) kill(-leader, SIGKILL);
   EXPECT_TRUE(drained);
   errno = 0;

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -264,6 +264,8 @@ TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebin
   EXPECT_NE(recovery.find("claim_state=absent"), std::string::npos);
   EXPECT_NE(session.find("restart polaris-portal-gamescope.service"), std::string::npos);
   EXPECT_NE(session.find("publish_nested_claim transition absent"), std::string::npos);
+  EXPECT_NE(session.find("polaris-gamescope-session-mode"), std::string::npos);
+  EXPECT_NE(session.find("attach recovery could not terminate exact-session Steam"), std::string::npos);
   const auto idle = read_source_for_contract("scripts/install/lib/polaris-gamescope-idle.sh");
   ASSERT_FALSE(idle.empty());
   EXPECT_NE(idle.find("polaris-gamescope.lock"), std::string::npos);
@@ -281,6 +283,11 @@ TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState
   EXPECT_NE(source.find("private group did not drain"), std::string::npos);
   EXPECT_NE(source.find("SIGKILL"), std::string::npos);
   EXPECT_NE(source.find("SYS_pidfd_open"), std::string::npos);
+  EXPECT_NE(source.find("pidfd_targets_pid(leader_pidfd, pgid)"), std::string::npos);
+  EXPECT_NE(source.find("retained owned generation did not drain; refusing replacement launch"), std::string::npos);
+  const auto pair_validation = source.find("revalidate_publication_pair()");
+  ASSERT_NE(pair_validation, std::string::npos);
+  EXPECT_NE(source.find("revalidate_publication_pair()", pair_validation + 1), std::string::npos);
   EXPECT_NE(source.find("Keep the leader unreaped until every negative-PGID operation finishes"), std::string::npos);
   const auto drain_start = source.find("bool drain_private_process_group(");
   const auto rollback_start = source.find("bool rollback_spawned_private_group(", drain_start);
@@ -357,6 +364,35 @@ TEST(SessionStopContractTests, SpawnRollbackDrainsSiblingAfterLeaderExit) {
   errno = 0;
   EXPECT_EQ(kill(sibling, 0), -1);
   EXPECT_EQ(errno, ESRCH);
+#endif
+}
+
+TEST(SessionStopContractTests, SpawnRollbackRejectsPidfdForDifferentLeader) {
+#ifdef __linux__
+  const pid_t first = fork();
+  ASSERT_GE(first, 0);
+  if (first == 0) {
+    if (setsid() < 0) _exit(125);
+    signal(SIGTERM, SIG_IGN);
+    for (;;) pause();
+  }
+  const pid_t second = fork();
+  ASSERT_GE(second, 0);
+  if (second == 0) {
+    if (setsid() < 0) _exit(126);
+    signal(SIGTERM, SIG_IGN);
+    for (;;) pause();
+  }
+  const int second_pidfd = static_cast<int>(syscall(SYS_pidfd_open, second, 0));
+  ASSERT_GE(second_pidfd, 0);
+  EXPECT_FALSE(stream_runtime::rollback_gamescope_spawn_for_tests(first, second_pidfd));
+  close(second_pidfd);
+  EXPECT_EQ(kill(first, 0), 0);
+  EXPECT_EQ(kill(second, 0), 0);
+  (void) kill(-first, SIGKILL);
+  (void) kill(-second, SIGKILL);
+  EXPECT_EQ(waitpid(first, nullptr, 0), first);
+  EXPECT_EQ(waitpid(second, nullptr, 0), second);
 #endif
 }
 

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -15,9 +15,11 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <poll.h>
 #include <sstream>
 #include <thread>
 #include <signal.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -271,6 +273,14 @@ TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState
   EXPECT_NE(source.find("private_group_state"), std::string::npos);
   EXPECT_NE(source.find("private group did not drain"), std::string::npos);
   EXPECT_NE(source.find("SIGKILL"), std::string::npos);
+  EXPECT_NE(source.find("SYS_pidfd_open"), std::string::npos);
+  EXPECT_NE(source.find("Keep the leader unreaped until every negative-PGID operation finishes"), std::string::npos);
+  const auto drain_start = source.find("bool drain_private_process_group(");
+  const auto rollback_start = source.find("bool rollback_spawned_private_group(", drain_start);
+  ASSERT_NE(drain_start, std::string::npos);
+  ASSERT_NE(rollback_start, std::string::npos);
+  const auto drain = source.substr(drain_start, rollback_start - drain_start);
+  EXPECT_EQ(drain.find("waitpid(pgid", drain.find("for (int i = 0")), drain.rfind("waitpid(pgid"));
 }
 
 TEST(SessionStopContractTests, OwnedRuntimeEscalatesTermResistantPrivateGroup) {
@@ -329,8 +339,12 @@ TEST(SessionStopContractTests, SpawnRollbackDrainsSiblingAfterLeaderExit) {
   pid_t sibling = -1;
   ASSERT_EQ(read(ready[0], &sibling, sizeof(sibling)), sizeof(sibling));
   close(ready[0]);
-  ASSERT_EQ(waitpid(leader, nullptr, 0), leader);
-  const bool drained = stream_runtime::rollback_gamescope_spawn_for_tests(leader, true);
+  const int leader_pidfd = static_cast<int>(syscall(SYS_pidfd_open, leader, 0));
+  ASSERT_GE(leader_pidfd, 0);
+  pollfd leader_exit {.fd = leader_pidfd, .events = POLLIN, .revents = 0};
+  ASSERT_EQ(poll(&leader_exit, 1, 5000), 1);
+  const bool drained = stream_runtime::rollback_gamescope_spawn_for_tests(leader, leader_pidfd);
+  close(leader_pidfd);
   if (!drained) (void) kill(-leader, SIGKILL);
   EXPECT_TRUE(drained);
   errno = 0;

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -402,7 +402,8 @@ TEST(SessionStopContractTests, CompositorTerminationRetainsRootMediaFenceUntilCl
   const auto terminate = process.find("void proc_t::terminate_impl(");
   ASSERT_NE(terminate, std::string::npos);
   const auto terminate_body = process.substr(terminate, 4200);
-  const auto fence = terminate_body.find("media_stop_fence = session_media::prepare_for_stop()");
+  // Function-scoped holder so the fence outlives early #ifdef blocks through undo.
+  const auto fence = terminate_body.find("media_stop.fence = session_media::prepare_for_stop()");
   const auto compositor_stop = terminate_body.find("terminate_isolated_session_generation()");
   ASSERT_NE(fence, std::string::npos);
   ASSERT_NE(compositor_stop, std::string::npos);

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -6,15 +6,20 @@
 #include <src/nvhttp.h>
 #include <src/process.h>
 #include <src/rtsp.h>
+#include <src/platform/linux/stream_runtime.h>
 
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cerrno>
 #include <filesystem>
 #include <fstream>
 #include <future>
 #include <sstream>
 #include <thread>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 namespace {
   using proc::session_stop_outcome_t;
@@ -266,6 +271,39 @@ TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState
   EXPECT_NE(source.find("private_group_state"), std::string::npos);
   EXPECT_NE(source.find("private group did not drain"), std::string::npos);
   EXPECT_NE(source.find("SIGKILL"), std::string::npos);
+}
+
+TEST(SessionStopContractTests, OwnedRuntimeEscalatesTermResistantPrivateGroup) {
+#ifdef __linux__
+  int ready[2] {-1, -1};
+  ASSERT_EQ(pipe(ready), 0);
+  const pid_t leader = fork();
+  ASSERT_GE(leader, 0);
+  if (leader == 0) {
+    close(ready[0]);
+    if (setsid() < 0) _exit(125);
+    signal(SIGTERM, SIG_IGN);
+    const pid_t sibling = fork();
+    if (sibling < 0) _exit(126);
+    if (sibling == 0) {
+      signal(SIGTERM, SIG_IGN);
+      for (;;) pause();
+    }
+    (void) write(ready[1], &sibling, sizeof(sibling));
+    close(ready[1]);
+    for (;;) pause();
+  }
+  close(ready[1]);
+  pid_t sibling = -1;
+  ASSERT_EQ(read(ready[0], &sibling, sizeof(sibling)), sizeof(sibling));
+  close(ready[0]);
+  const bool drained = stream_runtime::drain_gamescope_private_group_for_tests(leader);
+  if (!drained) (void) kill(-leader, SIGKILL);
+  EXPECT_TRUE(drained);
+  errno = 0;
+  EXPECT_EQ(kill(sibling, 0), -1);
+  EXPECT_EQ(errno, ESRCH);
+#endif
 }
 
 TEST(SessionStopContractTests, StreamingWillStopReleasesPortalCapture) {

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -242,6 +242,8 @@ TEST(SessionStopContractTests, UnclassifiedNestedLaunchHasNoNumericGroupKillFall
   ASSERT_NE(claim, std::string::npos);
   ASSERT_NE(launch, std::string::npos);
   EXPECT_LT(claim, launch);
+  const auto recover = source.find("\"$0\" stop");
+  ASSERT_NE(recover, std::string::npos);
 }
 
 TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebind) {
@@ -252,6 +254,18 @@ TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebin
   EXPECT_NE(recovery.find("${lib.getExe sessionBin} stop"), std::string::npos);
   EXPECT_NE(recovery.find("polaris-gamescope-session-id"), std::string::npos);
   EXPECT_NE(session.find("restart polaris-portal-gamescope.service"), std::string::npos);
+  const auto non_nix = read_source_for_contract("scripts/install/lib/polaris-wait-gamescope.sh");
+  ASSERT_FALSE(non_nix.empty());
+  EXPECT_NE(non_nix.find("POLARIS_GAMESCOPE_SESSION_BIN"), std::string::npos);
+  EXPECT_NE(non_nix.find("polaris-gamescope-session-id"), std::string::npos);
+}
+
+TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState) {
+  const auto source = read_source_for_contract("src/platform/linux/stream_runtime_gamescope.cpp");
+  ASSERT_FALSE(source.empty());
+  EXPECT_NE(source.find("private_group_state"), std::string::npos);
+  EXPECT_NE(source.find("private group did not drain"), std::string::npos);
+  EXPECT_NE(source.find("SIGKILL"), std::string::npos);
 }
 
 TEST(SessionStopContractTests, StreamingWillStopReleasesPortalCapture) {

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -15,10 +15,12 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <fcntl.h>
 #include <poll.h>
 #include <sstream>
 #include <thread>
 #include <signal.h>
+#include <sys/file.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -260,11 +262,15 @@ TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebin
   ASSERT_FALSE(session.empty());
   EXPECT_NE(recovery.find("${lib.getExe sessionBin} stop"), std::string::npos);
   EXPECT_NE(recovery.find("polaris-gamescope-session-id"), std::string::npos);
+  EXPECT_NE(recovery.find("polaris-gamescope-session-state"), std::string::npos);
   EXPECT_NE(recovery.find("POLARIS_GAMESCOPE_LOCK_HELD=1"), std::string::npos);
   EXPECT_NE(recovery.find("claim_state=absent"), std::string::npos);
   EXPECT_NE(session.find("restart polaris-portal-gamescope.service"), std::string::npos);
   EXPECT_NE(session.find("publish_nested_claim transition absent"), std::string::npos);
   EXPECT_NE(session.find("polaris-gamescope-session-mode"), std::string::npos);
+  EXPECT_NE(session.find("polaris-gamescope-session-state"), std::string::npos);
+  EXPECT_NE(session.find("printf '%s %s\\n' \"$POLARIS_SESSION_INSTANCE_ID\" \"$mode\""), std::string::npos);
+  EXPECT_NE(session.find("mv -f -- \"$tmp\" \"$session_state_file\""), std::string::npos);
   EXPECT_NE(session.find("attach recovery could not terminate exact-session Steam"), std::string::npos);
   const auto idle = read_source_for_contract("scripts/install/lib/polaris-gamescope-idle.sh");
   ASSERT_FALSE(idle.empty());
@@ -274,6 +280,7 @@ TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebin
   ASSERT_FALSE(non_nix.empty());
   EXPECT_NE(non_nix.find("POLARIS_GAMESCOPE_SESSION_BIN"), std::string::npos);
   EXPECT_NE(non_nix.find("polaris-gamescope-session-id"), std::string::npos);
+  EXPECT_NE(non_nix.find("polaris-gamescope-session-state"), std::string::npos);
 }
 
 TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState) {
@@ -296,12 +303,106 @@ TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState
   const auto stop_body = source.substr(stop_start, refresh_start - stop_start);
   EXPECT_NE(stop_body.find("gp::read_marker(marker_path())"), std::string::npos);
   EXPECT_EQ(stop_body.find("validated_marker_for_socket"), std::string::npos);
+  const auto runtime_start = source.find("bool start(const start_params_t &params) override");
+  const auto runtime_stop = source.find("void stop() override", runtime_start);
+  ASSERT_NE(runtime_start, std::string::npos);
+  ASSERT_NE(runtime_stop, std::string::npos);
+  const auto start_body = source.substr(runtime_start, runtime_stop - runtime_start);
+  const auto acquisition = start_body.find("owner_transition_lock_t acquisition_lock");
+  const auto reclaim = start_body.find("reclaim_orphan_gamescope_sockets()");
+  const auto spawn = start_body.find("const pid_t child = fork()");
+  const auto marker_write = start_body.find("gp::write_marker(marker_path(), *marker_)");
+  ASSERT_NE(acquisition, std::string::npos);
+  ASSERT_NE(reclaim, std::string::npos);
+  ASSERT_NE(spawn, std::string::npos);
+  ASSERT_NE(marker_write, std::string::npos);
+  EXPECT_LT(acquisition, reclaim);
+  EXPECT_LT(reclaim, spawn);
+  EXPECT_LT(spawn, marker_write);
+  EXPECT_NE(start_body.find("runtime_acquisition_allowed_locked()"), std::string::npos);
+  EXPECT_NE(source.find("try_attach_gamescope0(params, true)"), std::string::npos);
   const auto drain_start = source.find("bool drain_private_process_group(");
   const auto rollback_start = source.find("bool rollback_spawned_private_group(", drain_start);
   ASSERT_NE(drain_start, std::string::npos);
   ASSERT_NE(rollback_start, std::string::npos);
   const auto drain = source.substr(drain_start, rollback_start - drain_start);
   EXPECT_EQ(drain.find("waitpid(pgid", drain.find("for (int i = 0")), drain.rfind("waitpid(pgid"));
+}
+
+TEST(SessionStopContractTests, RuntimeAcquisitionRejectsNestedOrIncompleteDurableClaims) {
+#ifdef __linux__
+  namespace fs = std::filesystem;
+  const auto dir = fs::temp_directory_path() /
+    ("polaris-runtime-claim-test-" + std::to_string(getpid()));
+  fs::remove_all(dir);
+  ASSERT_TRUE(fs::create_directories(dir));
+  const char *old_runtime = std::getenv("XDG_RUNTIME_DIR");
+  const std::string saved_runtime = old_runtime ? old_runtime : "";
+  ASSERT_EQ(setenv("XDG_RUNTIME_DIR", dir.c_str(), 1), 0);
+
+  EXPECT_TRUE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  const int lock_fd = open((dir / "polaris-gamescope.lock").c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0600);
+  ASSERT_GE(lock_fd, 0);
+  ASSERT_EQ(flock(lock_fd, LOCK_EX), 0);
+  auto blocked_acquisition = std::async(std::launch::async, []() {
+    return stream_runtime::gamescope_runtime_acquisition_allowed_for_tests();
+  });
+  EXPECT_EQ(blocked_acquisition.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
+  {
+    std::ofstream state(dir / "polaris-gamescope-session-state");
+    state << "session-A nested\n";
+  }
+  ASSERT_EQ(flock(lock_fd, LOCK_UN), 0);
+  close(lock_fd);
+  EXPECT_FALSE(blocked_acquisition.get());
+  fs::remove(dir / "polaris-gamescope-session-state");
+
+  {
+    std::ofstream state(dir / "polaris-gamescope-session-state");
+    state << "session-A nested\n";
+  }
+  EXPECT_FALSE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  {
+    std::ofstream state(dir / "polaris-gamescope-session-state", std::ios::trunc);
+    state << "session-A attach\n";
+  }
+  EXPECT_TRUE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  {
+    std::ofstream claim(dir / "polaris-gamescope-wsi-nested");
+    claim << "transition\n";
+  }
+  EXPECT_FALSE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  fs::remove(dir / "polaris-gamescope-wsi-nested");
+  {
+    std::ofstream state(dir / "polaris-gamescope-session-state", std::ios::trunc);
+    state << "session-A\n";
+  }
+  EXPECT_FALSE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  fs::remove(dir / "polaris-gamescope-session-state");
+  {
+    std::ofstream id(dir / "polaris-gamescope-session-id");
+    id << "session-A\n";
+  }
+  EXPECT_FALSE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  {
+    std::ofstream mode(dir / "polaris-gamescope-session-mode");
+    mode << "attach\n";
+  }
+  EXPECT_TRUE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  {
+    std::ofstream mode(dir / "polaris-gamescope-session-mode", std::ios::trunc);
+    mode << "nested\n";
+  }
+  EXPECT_FALSE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+
+  if (old_runtime) {
+    ASSERT_EQ(setenv("XDG_RUNTIME_DIR", saved_runtime.c_str(), 1), 0);
+  }
+  else {
+    ASSERT_EQ(unsetenv("XDG_RUNTIME_DIR"), 0);
+  }
+  fs::remove_all(dir);
+#endif
 }
 
 TEST(SessionStopContractTests, OwnedRuntimeEscalatesTermResistantPrivateGroup) {

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -330,6 +330,42 @@ TEST(SessionStopContractTests, OwnedRuntimeEscalatesTermResistantPrivateGroup) {
 #endif
 }
 
+TEST(SessionStopContractTests, OwnedRuntimeDoesNotClearSameSessionEscapedGroup) {
+#ifdef __linux__
+  int ready[2] {-1, -1};
+  ASSERT_EQ(pipe(ready), 0);
+  const pid_t leader = fork();
+  ASSERT_GE(leader, 0);
+  if (leader == 0) {
+    close(ready[0]);
+    if (setsid() < 0) _exit(125);
+    signal(SIGTERM, SIG_IGN);
+    const pid_t escaped = fork();
+    if (escaped < 0) _exit(126);
+    if (escaped == 0) {
+      if (setpgid(0, 0) < 0) _exit(127);
+      signal(SIGTERM, SIG_IGN);
+      const pid_t escaped_pid = getpid();
+      (void) write(ready[1], &escaped_pid, sizeof(escaped_pid));
+      close(ready[1]);
+      for (;;) pause();
+    }
+    close(ready[1]);
+    for (;;) pause();
+  }
+  close(ready[1]);
+  pid_t escaped = -1;
+  ASSERT_EQ(read(ready[0], &escaped, sizeof(escaped)), sizeof(escaped));
+  close(ready[0]);
+  const bool drained = stream_runtime::drain_gamescope_private_group_for_tests(leader);
+  EXPECT_FALSE(drained);
+  EXPECT_EQ(kill(escaped, 0), 0);
+  (void) kill(escaped, SIGKILL);
+  (void) kill(-leader, SIGKILL);
+  (void) waitpid(leader, nullptr, 0);
+#endif
+}
+
 TEST(SessionStopContractTests, SpawnRollbackDrainsSiblingAfterLeaderExit) {
 #ifdef __linux__
   int ready[2] {-1, -1};

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -260,7 +260,14 @@ TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebin
   ASSERT_FALSE(session.empty());
   EXPECT_NE(recovery.find("${lib.getExe sessionBin} stop"), std::string::npos);
   EXPECT_NE(recovery.find("polaris-gamescope-session-id"), std::string::npos);
+  EXPECT_NE(recovery.find("POLARIS_GAMESCOPE_LOCK_HELD=1"), std::string::npos);
+  EXPECT_NE(recovery.find("claim_state=absent"), std::string::npos);
   EXPECT_NE(session.find("restart polaris-portal-gamescope.service"), std::string::npos);
+  EXPECT_NE(session.find("publish_nested_claim transition absent"), std::string::npos);
+  const auto idle = read_source_for_contract("scripts/install/lib/polaris-gamescope-idle.sh");
+  ASSERT_FALSE(idle.empty());
+  EXPECT_NE(idle.find("polaris-gamescope.lock"), std::string::npos);
+  EXPECT_NE(idle.find("transition|nested|1"), std::string::npos);
   const auto non_nix = read_source_for_contract("scripts/install/lib/polaris-wait-gamescope.sh");
   ASSERT_FALSE(non_nix.empty());
   EXPECT_NE(non_nix.find("POLARIS_GAMESCOPE_SESSION_BIN"), std::string::npos);

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -377,7 +377,7 @@ TEST(SessionStopContractTests, TerminateImplStopsBrowserCaptureBeforeIsolatedKil
   ASSERT_FALSE(source.empty());
   const auto start = source.find("void proc_t::terminate_impl(");
   ASSERT_NE(start, std::string::npos);
-  const auto body = source.substr(start, 1600);
+  const auto body = source.substr(start, 3500);
   const auto prepare = body.find("session_media::prepare_for_stop(");
   const auto kill = body.find("terminate_isolated_session_generation(");
   ASSERT_NE(prepare, std::string::npos);

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -220,7 +220,7 @@ TEST(SessionStopContractTests, PortalReleaseRunsBeforeNestedCompositorKill) {
   ASSERT_FALSE(source.empty());
   const auto start = source.find("void proc_t::terminate_impl(");
   ASSERT_NE(start, std::string::npos);
-  const auto body = source.substr(start, 1200);
+  const auto body = source.substr(start, 5000);
   const auto prepare = body.find("session_media::prepare_for_stop(");
   const auto steam = body.find("terminate_session_owned_steam_before_cage_stop(");
   const auto gen = body.find("terminate_isolated_session_generation(");
@@ -231,6 +231,27 @@ TEST(SessionStopContractTests, PortalReleaseRunsBeforeNestedCompositorKill) {
   EXPECT_LT(prepare, gen);
   // Double portal release is forbidden — only session_media may release.
   EXPECT_EQ(body.find("portal::release_global_capture("), std::string::npos);
+}
+
+TEST(SessionStopContractTests, UnclassifiedNestedLaunchHasNoNumericGroupKillFallback) {
+  const auto source = read_source_for_contract("nix/modules/polaris-gamescope-session.sh");
+  ASSERT_FALSE(source.empty());
+  EXPECT_EQ(source.find("kill -TERM \"-$nested_launch_pid\""), std::string::npos);
+  const auto claim = source.find("printf 'nested\\n' >\"$rt/polaris-gamescope-wsi-nested\"");
+  const auto launch = source.find("setsid env -u WAYLAND_DISPLAY");
+  ASSERT_NE(claim, std::string::npos);
+  ASSERT_NE(launch, std::string::npos);
+  EXPECT_LT(claim, launch);
+}
+
+TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebind) {
+  const auto recovery = read_source_for_contract("nix/modules/session-lib.nix");
+  const auto session = read_source_for_contract("nix/modules/polaris-gamescope-session.sh");
+  ASSERT_FALSE(recovery.empty());
+  ASSERT_FALSE(session.empty());
+  EXPECT_NE(recovery.find("${lib.getExe sessionBin} stop"), std::string::npos);
+  EXPECT_NE(recovery.find("polaris-gamescope-session-id"), std::string::npos);
+  EXPECT_NE(session.find("restart polaris-portal-gamescope.service"), std::string::npos);
 }
 
 TEST(SessionStopContractTests, StreamingWillStopReleasesPortalCapture) {


### PR DESCRIPTION
## Summary

Follow-up to the linux stream-runtime ownership work. After gamescope ABRT / nested WSI stop, fail-closed ownership left the portal stack stuck (orphan `gamescope-0`, idle permanently failed, polaris cascade-restarted on portal rebind).

- **Orphan reclaim**: remove gamescope sockets only when there is no live holder (still refuse live unowned / ambiguous pathnames). Wired into idle, session, wait-gamescope, and C++ spawn/attach.
- **Idle survival**: client teardown only kills Steam/Proton/game-like processes; restart idle+portal when the idle generation is unhealthy after cleanup.
- **Idle yield / mask**: yield exit 0 when another holder owns `gamescope-0`; nested masks via `$XDG_RUNTIME_DIR/systemd/user.control` (plain `mask --runtime` loses to Hjem `~/.config` units).
- **Nested handoff**: rebind `polaris-portal-gamescope` after nested start/stop; wait for idle to own `gamescope-0` before returning from stop.
- **Teardown fence**: hold media stop fence through prep undo so portal reconnect cannot race a dying nested gamescope (was Response code 2).
- **Unit deps**: `polaris.service` **Requires** only `polaris-portal-dbus`; **Wants** portal frontend/backend + idle so portal rebind does not cascade-stop the stream host.
- **Undo**: skip bare `steam -shutdown` when `polaris-gamescope-session stop` owns nested Steam (no headless DISPLAY SEGV spam).
- **Log hygiene**: demote expected headless noise (WAYLAND_DISPLAY unset, tray, RTSP cancel, ScreenSaver inhibit, gamescope_stream SDR probe).

## Test plan

- [x] `tests/unit/platform/test_gamescope_runtime_shell.sh`
- [x] C++ ownership unit tests (orphan reclaim / duplicate pathname / X11 multi-inode)
- [x] Deploy on lea; nested BG3 stream + stop
  - [x] No idle yield restart-loop under nested
  - [x] No portal Response code 2 on stop
  - [x] No polaris unit restart when portal-gamescope rebinds (`Wants=` only)
  - [x] Steam `-shutdown` undo skipped when session stop owns cleanup
  - [x] Idle ready after nested stop for next stream
- [x] CI green on this PR

## Notes

Single squashed commit for review (`5242829`). Supersedes closed draft #238 (closed to avoid CI burn while iterating offline).