### PR TITLE
fix(packaging): declare release Vulkan dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,8 @@ jobs:
             desktop-file-utils ffmpeg gtk3 libayatana-appindicator libcap \
             gcc go libdrm libevdev libmfx libnotify libpulse libva libx11 libxcb \
             libxfixes libxi libxrandr libxtst mesa miniupnpc ninja nodejs \
-            nlohmann-json npm numactl openssl opus pipewire python wayland wayland-protocols which
+            nlohmann-json npm numactl openssl opus pipewire python vulkan-headers vulkan-icd-loader \
+            wayland wayland-protocols which
 
       - name: Configure
         if: ${{ !(startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '') }}

--- a/.github/workflows/public-hygiene.yml
+++ b/.github/workflows/public-hygiene.yml
@@ -19,3 +19,6 @@ jobs:
 
       - name: Check public docs and release references
         run: bash scripts/check-public-docs.sh
+
+      - name: Check release package dependency contracts
+        run: python3 scripts/check-release-package-dependencies.py

--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -44,6 +44,7 @@ depends=(
   'opus'
   'pipewire'
   'udev'
+  'vulkan-icd-loader'
   'wayland'
   'which'
   'wlr-randr'
@@ -64,6 +65,7 @@ makedepends=(
   'nlohmann-json'
   'nodejs'
   'npm'
+  'vulkan-headers'
 )
 
 optdepends=(

--- a/packaging/linux/fedora/Polaris.spec
+++ b/packaging/linux/fedora/Polaris.spec
@@ -52,6 +52,7 @@ BuildRequires: python3
 BuildRequires: rpm-build
 BuildRequires: systemd-udev
 BuildRequires: systemd-rpm-macros
+BuildRequires: vulkan-loader-devel
 %{?sysusers_requires_compat}
 BuildRequires: wget
 BuildRequires: which

--- a/scripts/check-release-package-dependencies.py
+++ b/scripts/check-release-package-dependencies.py
@@ -23,6 +23,16 @@ def require_package(section: str, package: str, context: str) -> None:
         raise AssertionError(f"{context} must explicitly include {package}")
 
 
+def workflow_job(text: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        text,
+    )
+    if not match:
+        raise AssertionError(f"missing {name} workflow job")
+    return match.group("body")
+
+
 arch = read("packaging/linux/Arch/PKGBUILD")
 require_package(shell_array(arch, "depends"), "vulkan-icd-loader", "Arch runtime dependencies")
 require_package(shell_array(arch, "makedepends"), "vulkan-headers", "Arch build dependencies")
@@ -32,14 +42,15 @@ if not re.search(r"(?m)^BuildRequires:\s+vulkan-loader-devel\s*$", fedora):
     raise AssertionError("Fedora build dependencies must explicitly include vulkan-loader-devel")
 
 workflow = read(".github/workflows/build.yml")
+arch_job = workflow_job(workflow, "arch-build")
 arch_install = re.search(
-    r"(?ms)^\s+- name: Install dependencies\n.*?^\s+- name: Configure\n",
-    workflow,
+    r"(?ms)^      - name: Install dependencies\n(?P<body>.*?)(?=^      - name:|\Z)",
+    arch_job,
 )
 if not arch_install:
     raise AssertionError("missing Arch Install dependencies workflow step")
 for package in ("vulkan-headers", "vulkan-icd-loader"):
-    if not re.search(rf"\b{re.escape(package)}\b", arch_install.group(0)):
+    if not re.search(rf"\b{re.escape(package)}\b", arch_install.group("body")):
         raise AssertionError(f"Arch CI dependencies must explicitly install {package}")
 
 print("Release package Vulkan dependency contracts look correct.")

--- a/scripts/check-release-package-dependencies.py
+++ b/scripts/check-release-package-dependencies.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Validate explicit Vulkan dependencies for release-only CUDA package builds."""
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def shell_array(text: str, name: str) -> str:
+    match = re.search(rf"(?ms)^{re.escape(name)}=\(\n(?P<body>.*?)^\)", text)
+    if not match:
+        raise AssertionError(f"missing {name} array")
+    return match.group("body")
+
+
+def require_package(section: str, package: str, context: str) -> None:
+    if not re.search(rf"(?m)^\s*'{re.escape(package)}'\s*$", section):
+        raise AssertionError(f"{context} must explicitly include {package}")
+
+
+arch = read("packaging/linux/Arch/PKGBUILD")
+require_package(shell_array(arch, "depends"), "vulkan-icd-loader", "Arch runtime dependencies")
+require_package(shell_array(arch, "makedepends"), "vulkan-headers", "Arch build dependencies")
+
+fedora = read("packaging/linux/fedora/Polaris.spec")
+if not re.search(r"(?m)^BuildRequires:\s+vulkan-loader-devel\s*$", fedora):
+    raise AssertionError("Fedora build dependencies must explicitly include vulkan-loader-devel")
+
+workflow = read(".github/workflows/build.yml")
+arch_install = re.search(
+    r"(?ms)^\s+- name: Install dependencies\n.*?^\s+- name: Configure\n",
+    workflow,
+)
+if not arch_install:
+    raise AssertionError("missing Arch Install dependencies workflow step")
+for package in ("vulkan-headers", "vulkan-icd-loader"):
+    if not re.search(rf"\b{re.escape(package)}\b", arch_install.group(0)):
+        raise AssertionError(f"Arch CI dependencies must explicitly install {package}")
+
+print("Release package Vulkan dependency contracts look correct.")


### PR DESCRIPTION
## Summary

- declare Vulkan headers and loader explicitly for Arch release package builds
- declare `vulkan-loader-devel` explicitly in the Fedora spec
- install Arch Vulkan dependencies explicitly in release CI
- add a Public Hygiene regression contract scoped specifically to the `arch-build` job

## Failure corrected

Official tag run `30504717568` failed only on release-CUDA package paths because Arch and Fedora relied on Vulkan development files arriving transitively. Ubuntu, sanitizers, and web checks passed.

## Verification

- RED: contract failed against the old package manifests
- GREEN: corrected package declarations pass
- adversarial: moving Vulkan names to another workflow job no longer satisfies the Arch contract
- Fedora 42/44 package and spec resolution passed
- Arch package-name resolution passed
- workflow YAML parsing passed
- Public Hygiene/docs checks passed
- `git diff --check` passed

## Release sequence

This PR is merged before retargeting `v1.3.2`. The tag will then move atomically to the exact verified merge commit for a fresh official tag build; the failed old tag run is not reused.

Exact candidate: `2dc73d0d21bb5c3b023cc5a0744fcd1d72039518`.