### PR TITLE
ci(packaging): keep Fedora 44 release lane

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     attributes:
       label: Host OS
       description: Linux distribution and version running Polaris.
-      placeholder: e.g. Fedora 43, Bazzite stable, Ubuntu 24.04, Arch Linux, Debian 13
+      placeholder: e.g. Fedora 44, Bazzite stable, Ubuntu 24.04, Arch Linux, Debian 13
     validations:
       required: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -577,14 +577,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - fedora: '42'
-            cc: gcc-14
-            cxx: g++-14
-            boost_static: ON
-          - fedora: '43'
-            cc: gcc-14
-            cxx: g++-14
-            boost_static: ON
           - fedora: '44'
             cc: gcc-15
             cxx: g++-15
@@ -668,7 +660,7 @@ jobs:
 
           architecture="$(uname -m)"
           cuda_supported_architectures=("x86_64" "aarch64")
-          if [[ ! " ${cuda_supported_architectures[*]} " =~ " ${architecture} " ]]; then
+          if [[ " ${cuda_supported_architectures[*]} " != *" ${architecture} "* ]]; then
             echo "CUDA toolkit install skipped for unsupported architecture ${architecture}"
             exit 0
           fi
@@ -891,18 +883,6 @@ jobs:
           name: arch-package-outputs
           path: release-assets/raw/arch
 
-      - name: Download Fedora 42 RPM artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: fedora-42-rpm-artifacts
-          path: release-assets/raw/fedora42
-
-      - name: Download Fedora 43 RPM artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: fedora-43-rpm-artifacts
-          path: release-assets/raw/fedora43
-
       - name: Download Fedora 44 RPM artifacts
         uses: actions/download-artifact@v8
         with:
@@ -985,8 +965,6 @@ jobs:
             fi
           }
 
-          copy_fedora_rpms 42 release-assets/raw/fedora42
-          copy_fedora_rpms 43 release-assets/raw/fedora43
           copy_fedora_rpms 44 release-assets/raw/fedora44
 
           ubuntu_debs=()
@@ -1011,8 +989,16 @@ jobs:
           if ! gh release view "${POLARIS_PACKAGE_REF_NAME}" >/dev/null 2>&1; then
             gh release create "${POLARIS_PACKAGE_REF_NAME}" \
               --title "${POLARIS_PACKAGE_REF_NAME}" \
-              --notes "Automated Fedora, Ubuntu, and Arch release assets for ${POLARIS_PACKAGE_REF_NAME}."
+              --notes "Automated Fedora 44, Ubuntu, and Arch release assets for ${POLARIS_PACKAGE_REF_NAME}."
           fi
+
+          for legacy_asset in \
+            Polaris-fedora42-x86_64.rpm \
+            Polaris-fedora42-src.rpm \
+            Polaris-fedora43-x86_64.rpm \
+            Polaris-fedora43-src.rpm; do
+            gh release delete-asset "${POLARIS_PACKAGE_REF_NAME}" "${legacy_asset}" --yes >/dev/null 2>&1 || true
+          done
 
           gh release upload "${POLARIS_PACKAGE_REF_NAME}" release-assets/final/* --clobber
 
@@ -1021,8 +1007,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          asset_count=$(gh release view "${POLARIS_PACKAGE_REF_NAME}" --json assets --jq '[.assets[].name | select(. == "Polaris-fedora42-x86_64.rpm" or . == "Polaris-fedora43-x86_64.rpm" or . == "Polaris-fedora44-x86_64.rpm" or . == "Polaris-ubuntu24.04-x86_64.deb" or . == "Polaris-arch-x86_64.pkg.tar.zst")] | length')
-          if [ "${asset_count}" -ne 5 ]; then
-            echo "Expected Fedora 42, Fedora 43, Fedora 44, Ubuntu 24.04, and Arch binary release assets on ${POLARIS_PACKAGE_REF_NAME}, found ${asset_count}" >&2
+          supported_count=$(gh release view "${POLARIS_PACKAGE_REF_NAME}" --json assets --jq '[.assets[].name | select(. == "Polaris-fedora44-x86_64.rpm" or . == "Polaris-ubuntu24.04-x86_64.deb" or . == "Polaris-arch-x86_64.pkg.tar.zst")] | length')
+          legacy_count=$(gh release view "${POLARIS_PACKAGE_REF_NAME}" --json assets --jq '[.assets[].name | select(startswith("Polaris-fedora42-") or startswith("Polaris-fedora43-"))] | length')
+          if [ "${supported_count}" -ne 3 ] || [ "${legacy_count}" -ne 0 ]; then
+            echo "Expected Fedora 44, Ubuntu 24.04, and Arch binary assets with no Fedora 42/43 assets on ${POLARIS_PACKAGE_REF_NAME}; supported=${supported_count}, legacy=${legacy_count}" >&2
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ what the host is actually doing.
 >
 > Polaris is and will remain free and open source under GPLv3. It is maintainer-led and community-driven: development happens in public, contributions are welcome, and real Linux hardware testing and user feedback shape the roadmap.
 >
-> Fedora 42/43/44 and Arch Linux are the recommended package paths. CachyOS generally follows the Arch package path; Bazzite and Ubuntu 24.04 are tester package paths; openSUSE Tumbleweed builds from source with a dedicated guide.
+> Fedora 44 and Arch Linux are the recommended package paths. CachyOS generally follows the Arch package path; Bazzite and Ubuntu 24.04 are tester package paths; openSUSE Tumbleweed builds from source with a dedicated guide.
 
 > [!NOTE]
 > Start with **Headless Stream** if you want games to launch into a stream-only runtime without changing your KDE, GNOME, or wlroots desktop layout.
@@ -58,12 +58,11 @@ AI Auto Quality is optional. If you enable it, Polaris uses the provider you con
 
 ## Quick Start
 
-### Fedora 42/43/44
+### Fedora 44
 
 ```bash
-fedora_version="$(rpm -E %fedora)"
-wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
-sudo dnf install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora44-x86_64.rpm
+sudo dnf install ./Polaris-fedora44-x86_64.rpm
 sudo polaris --setup-host
 polaris
 ```
@@ -108,8 +107,6 @@ Use the release package for your distro before considering source builds. Packag
 
 | Host | Best path |
 |---|---|
-| Fedora 42 | `Polaris-fedora42-x86_64.rpm` from the latest release |
-| Fedora 43 | `Polaris-fedora43-x86_64.rpm` from the latest release |
 | Fedora 44 | `Polaris-fedora44-x86_64.rpm` from the latest release |
 | Arch Linux | `Polaris-arch-x86_64.pkg.tar.zst` from the latest release |
 | CachyOS / Arch derivatives | Start with the Arch package; source/local package fallback if a derivative drifts |
@@ -128,7 +125,7 @@ Detailed source builds, local Arch package builds, distro dependency lists, open
 | Area | Status | Notes |
 |---|---|---|
 | Linux host OS | Supported | Polaris is Linux-only by design; Linux is the product focus, not a secondary target |
-| Fedora 42/43/44 | Recommended | Official RPM assets and most validated release path |
+| Fedora 44 | Recommended | Official RPM asset and most validated release path |
 | Arch Linux | Recommended | Official package asset |
 | CachyOS / Arch derivatives | Expected via Arch package | Pacman-compatible derivatives should start here; report derivative-specific dependency/runtime gaps |
 | Bazzite | Experimental | Layer the Fedora RPM with `rpm-ostree`; Desktop Mode validated on NVIDIA with Headless Stream; real Steam/Game Mode needs more coverage |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Polaris is public and usable today, but it is still early. This roadmap is meant
 
 ## Current Focus
 
-- Keep Fedora 42/43/44 and Arch release packages reliable.
+- Keep Fedora 44 and Arch release packages reliable.
 - Keep CachyOS and other pacman-compatible Arch derivatives close to the Arch package path.
 - Validate Bazzite as a tester host path using the Fedora RPM through rpm-ostree.
 - Promote Ubuntu 24.04 from experimental DEB support to a better-tested Debian-family path.
@@ -32,7 +32,7 @@ Polaris is public and usable today, but it is still early. This roadmap is meant
 ## Known Limits
 
 - Polaris is Linux-host-only today.
-- Fedora 42/43/44 and Arch have the recommended package paths.
+- Fedora 44 and Arch have the recommended package paths.
 - CachyOS generally follows the Arch package path, but derivative-specific gaps still need reports.
 - Bazzite and Ubuntu 24.04 are tester package paths.
 - openSUSE Tumbleweed is source-build supported; other distros are source-build/community-validation oriented.

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -43,11 +43,10 @@ systemctl --user disable --now homebrew.sunshine.service 2>/dev/null || true
 systemctl --user disable --now app-dev.lizardbyte.app.Sunshine.service 2>/dev/null || true
 ```
 
-Install Polaris from the matching Fedora release RPM:
+Install Polaris from the Fedora 44 release RPM:
 
 ```bash
-fedora_version="$(rpm -E %fedora)"
-rpm_name="Polaris-fedora${fedora_version}-x86_64.rpm"
+rpm_name="Polaris-fedora44-x86_64.rpm"
 wget "https://github.com/papi-ux/polaris/releases/latest/download/${rpm_name}"
 sudo rpm-ostree install -r "./${rpm_name}"
 ```
@@ -244,12 +243,11 @@ warnings should be inspected next.
 
 ## Update
 
-Layer the newer matching Fedora RPM and reboot. `rpm-ostree` will stage the
+Layer the newer Fedora 44 RPM and reboot. `rpm-ostree` will stage the
 newer local RPM over the existing layered Polaris package:
 
 ```bash
-fedora_version="$(rpm -E %fedora)"
-rpm_name="Polaris-fedora${fedora_version}-x86_64.rpm"
+rpm_name="Polaris-fedora44-x86_64.rpm"
 wget -O "${rpm_name}" "https://github.com/papi-ux/polaris/releases/latest/download/${rpm_name}"
 sudo rpm-ostree install -r "./${rpm_name}"
 ```

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -359,7 +359,7 @@ Please include these details when reporting Bazzite issues:
 
 ## Current Status
 
-Fedora 42, Fedora 43, and Fedora 44 RPMs are release-tested in CI. Bazzite uses
-the matching Fedora RPM through `rpm-ostree`; `bazzite-nvidia-open:stable`
+Fedora 44 RPMs are release-tested in CI. Bazzite uses the Fedora 44 RPM through
+`rpm-ostree`; `bazzite-nvidia-open:stable`
 `44.20260430` has Desktop Mode service and port validation only. Game Mode still
 needs validation on a Bazzite image that exposes a real gamescope Steam session.

--- a/docs/building.md
+++ b/docs/building.md
@@ -52,7 +52,7 @@ those less-turnkey paths.
 
 | Host distro | Current path | Notes |
 | --- | --- | --- |
-| Fedora 42/43/44 | Published RPM assets | Most validated package path. |
+| Fedora 44 | Published RPM asset | Most validated package path. |
 | Arch Linux | Published `pkg.tar.zst` asset | Recommended rolling-release path. |
 | CachyOS / Arch derivatives | Start with the Arch package | Pacman-compatible derivatives should work from the Arch asset first; use source/local package fallback if dependency names or runtime helpers drift. |
 | Bazzite 44 | Fedora 44 RPM layered with `rpm-ostree` | Experimental; Desktop Mode has NVIDIA Headless Stream coverage and growing AMD/Mesa VAAPI validation, Steam/Game Mode needs more reports. |
@@ -210,8 +210,6 @@ UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
 
 The public release assets are currently:
 
-- `Polaris-fedora42-x86_64.rpm`
-- `Polaris-fedora43-x86_64.rpm`
 - `Polaris-fedora44-x86_64.rpm`
 - `Polaris-ubuntu24.04-x86_64.deb`
 - `Polaris-arch-x86_64.pkg.tar.zst`

--- a/docs/building.md
+++ b/docs/building.md
@@ -3,16 +3,15 @@
 Polaris is a Linux-first host today. The most validated install paths are the Fedora RPM and Arch
 package from the [latest release](https://github.com/papi-ux/polaris/releases/latest). CachyOS and
 most pacman-compatible Arch derivatives should start with the Arch package path. Bazzite can use the
-matching Fedora RPM through `rpm-ostree`, and Ubuntu 24.04 has a DEB package, but both package paths
+Fedora 44 RPM through `rpm-ostree`, and Ubuntu 24.04 has a DEB package, but both package paths
 need broader real-hardware validation. openSUSE Tumbleweed is source-build supported with a dedicated
 [openSUSE guide](openSUSE.md); other distros remain source-build/community-validation oriented.
 
 ## Release packages
 
 ```bash
-fedora_version="$(rpm -E %fedora)"
-wget "https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora${fedora_version}-x86_64.rpm"
-sudo dnf install "./Polaris-fedora${fedora_version}-x86_64.rpm"
+wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora44-x86_64.rpm
+sudo dnf install ./Polaris-fedora44-x86_64.rpm
 sudo polaris --setup-host
 polaris
 ```
@@ -32,8 +31,7 @@ polaris
 ```
 
 ```bash
-fedora_version="$(rpm -E %fedora)"
-rpm_name="Polaris-fedora${fedora_version}-x86_64.rpm"
+rpm_name="Polaris-fedora44-x86_64.rpm"
 wget "https://github.com/papi-ux/polaris/releases/latest/download/${rpm_name}"
 sudo rpm-ostree install -r "./${rpm_name}"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -313,8 +313,6 @@ Highlights:
 
 Current official public assets:
 
-- `Polaris-fedora42-x86_64.rpm`
-- `Polaris-fedora43-x86_64.rpm`
 - `Polaris-fedora44-x86_64.rpm`
 - `Polaris-ubuntu24.04-x86_64.deb`
 - `Polaris-arch-x86_64.pkg.tar.zst`

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -40,10 +40,14 @@ if missing:
 PY
 
 expected_assets=(
-  "Polaris-fedora42-x86_64.rpm"
-  "Polaris-fedora43-x86_64.rpm"
+  "Polaris-fedora44-x86_64.rpm"
   "Polaris-ubuntu24.04-x86_64.deb"
   "Polaris-arch-x86_64.pkg.tar.zst"
+)
+
+legacy_assets=(
+  "Polaris-fedora42-x86_64.rpm"
+  "Polaris-fedora43-x86_64.rpm"
 )
 
 expected_nova_links=(
@@ -60,9 +64,23 @@ files_to_check=(
   ".github/workflows/build.yml"
 )
 
+current_docs=(
+  "README.md"
+  "docs/building.md"
+)
+
 for expected_asset in "${expected_assets[@]}"; do
   for file in "${files_to_check[@]}"; do
     grep -Fq "$expected_asset" "$file"
+  done
+done
+
+for legacy_asset in "${legacy_assets[@]}"; do
+  for file in "${current_docs[@]}"; do
+    if grep -Fq "$legacy_asset" "$file"; then
+      echo "Legacy Fedora release asset remains in $file: $legacy_asset" >&2
+      exit 1
+    fi
   done
 done
 

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -50,6 +50,11 @@ legacy_assets=(
   "Polaris-fedora43-x86_64.rpm"
 )
 
+variable_fedora_patterns=(
+  'Polaris-fedora${'
+  'fedora_version="$(rpm -E %fedora)"'
+)
+
 expected_nova_links=(
   "https://github.com/papi-ux/nova/releases/latest"
   "https://github-store.org/app?repo=papi-ux/nova"
@@ -67,6 +72,7 @@ files_to_check=(
 current_docs=(
   "README.md"
   "docs/building.md"
+  "docs/bazzite.md"
 )
 
 for expected_asset in "${expected_assets[@]}"; do
@@ -79,6 +85,15 @@ for legacy_asset in "${legacy_assets[@]}"; do
   for file in "${current_docs[@]}"; do
     if grep -Fq "$legacy_asset" "$file"; then
       echo "Legacy Fedora release asset remains in $file: $legacy_asset" >&2
+      exit 1
+    fi
+  done
+done
+
+for variable_pattern in "${variable_fedora_patterns[@]}"; do
+  for file in "${current_docs[@]}"; do
+    if grep -Fq "$variable_pattern" "$file"; then
+      echo "Variable-derived Fedora asset remains in $file: $variable_pattern" >&2
       exit 1
     fi
   done

--- a/scripts/check-release-package-dependencies.py
+++ b/scripts/check-release-package-dependencies.py
@@ -42,7 +42,15 @@ def workflow_run_tokens(step: str) -> list[str]:
     if not run:
         raise AssertionError("missing shell run block in workflow step")
     script = "\n".join(line[10:] for line in run.group("script").splitlines())
-    return shlex.split(script.replace("\\\n", " "), comments=True, posix=True)
+    lexer = shlex.shlex(script.replace("\\\n", " "), posix=True, punctuation_chars=";&|")
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+    return list(lexer)
+
+
+def contains_subsequence(tokens: list[str], expected: list[str]) -> bool:
+    width = len(expected)
+    return any(tokens[index:index + width] == expected for index in range(len(tokens) - width + 1))
 
 
 arch = read("packaging/linux/Arch/PKGBUILD")
@@ -55,7 +63,7 @@ if not re.search(r"(?m)^BuildRequires:\s+vulkan-loader-devel\s*$", fedora):
 
 workflow = read(".github/workflows/build.yml")
 fedora_job = workflow_job(workflow, "fedora-rpm-build")
-fedora_versions = re.findall(r"(?m)^          - fedora: '([0-9]+)'$", fedora_job)
+fedora_versions = re.findall(r'''(?m)^          - fedora:\s*['"]?([0-9]+)['"]?\s*$''', fedora_job)
 if fedora_versions != ["44"]:
     raise AssertionError(f"Fedora CI matrix must contain only Fedora 44, found {fedora_versions}")
 for legacy_version in ("42", "43"):
@@ -66,12 +74,40 @@ for legacy_version in ("42", "43"):
     ):
         if legacy_marker in workflow:
             raise AssertionError(f"release workflow retains Fedora {legacy_version}: {legacy_marker}")
+release_job = workflow_job(workflow, "release-assets")
+release_upload = re.search(
+    r"(?ms)^      - name: Upload release assets to GitHub release\n(?P<body>.*?)(?=^      - name:|\Z)",
+    release_job,
+)
+if not release_upload:
+    raise AssertionError("missing release asset upload workflow step")
+release_upload_tokens = workflow_run_tokens(release_upload.group("body"))
+for legacy_version in ("42", "43"):
     for cleanup_asset in (
         f"Polaris-fedora{legacy_version}-x86_64.rpm",
         f"Polaris-fedora{legacy_version}-src.rpm",
     ):
-        if cleanup_asset not in workflow:
+        if cleanup_asset not in release_upload_tokens:
             raise AssertionError(f"release workflow must delete stale asset: {cleanup_asset}")
+cleanup_command = [
+    "gh", "release", "delete-asset", "${POLARIS_PACKAGE_REF_NAME}", "${legacy_asset}", "--yes",
+]
+if not contains_subsequence(release_upload_tokens, cleanup_command):
+    raise AssertionError("release workflow must invoke gh release delete-asset for each stale Fedora asset")
+release_verify = re.search(
+    r"(?ms)^      - name: Verify release assets on GitHub release\n(?P<body>.*?)(?=^      - name:|\Z)",
+    release_job,
+)
+if not release_verify:
+    raise AssertionError("missing release asset verification workflow step")
+release_verify_body = release_verify.group("body")
+legacy_guard = 'if [ "${supported_count}" -ne 3 ] || [ "${legacy_count}" -ne 0 ]; then'
+if legacy_guard not in release_verify_body:
+    raise AssertionError("release verification must fail when legacy Fedora assets remain")
+for legacy_version in ("42", "43"):
+    legacy_prefix = f'startswith("Polaris-fedora{legacy_version}-")'
+    if legacy_prefix not in release_verify_body:
+        raise AssertionError(f"release verification must count Fedora {legacy_version} assets")
 arch_job = workflow_job(workflow, "arch-build")
 arch_install = re.search(
     r"(?ms)^      - name: Install dependencies\n(?P<body>.*?)(?=^      - name:|\Z)",

--- a/scripts/check-release-package-dependencies.py
+++ b/scripts/check-release-package-dependencies.py
@@ -54,6 +54,24 @@ if not re.search(r"(?m)^BuildRequires:\s+vulkan-loader-devel\s*$", fedora):
     raise AssertionError("Fedora build dependencies must explicitly include vulkan-loader-devel")
 
 workflow = read(".github/workflows/build.yml")
+fedora_job = workflow_job(workflow, "fedora-rpm-build")
+fedora_versions = re.findall(r"(?m)^          - fedora: '([0-9]+)'$", fedora_job)
+if fedora_versions != ["44"]:
+    raise AssertionError(f"Fedora CI matrix must contain only Fedora 44, found {fedora_versions}")
+for legacy_version in ("42", "43"):
+    for legacy_marker in (
+        f"fedora-{legacy_version}-rpm-artifacts",
+        f"release-assets/raw/fedora{legacy_version}",
+        f"copy_fedora_rpms {legacy_version}",
+    ):
+        if legacy_marker in workflow:
+            raise AssertionError(f"release workflow retains Fedora {legacy_version}: {legacy_marker}")
+    for cleanup_asset in (
+        f"Polaris-fedora{legacy_version}-x86_64.rpm",
+        f"Polaris-fedora{legacy_version}-src.rpm",
+    ):
+        if cleanup_asset not in workflow:
+            raise AssertionError(f"release workflow must delete stale asset: {cleanup_asset}")
 arch_job = workflow_job(workflow, "arch-build")
 arch_install = re.search(
     r"(?ms)^      - name: Install dependencies\n(?P<body>.*?)(?=^      - name:|\Z)",

--- a/scripts/check-release-package-dependencies.py
+++ b/scripts/check-release-package-dependencies.py
@@ -42,15 +42,29 @@ def workflow_run_tokens(step: str) -> list[str]:
     if not run:
         raise AssertionError("missing shell run block in workflow step")
     script = "\n".join(line[10:] for line in run.group("script").splitlines())
-    lexer = shlex.shlex(script.replace("\\\n", " "), posix=True, punctuation_chars=";&|")
-    lexer.whitespace_split = True
-    lexer.commenters = "#"
-    return list(lexer)
+    tokens: list[str] = []
+    for line in script.replace("\\\n", " ").splitlines():
+        lexer = shlex.shlex(line, posix=True, punctuation_chars=";&|")
+        lexer.whitespace_split = True
+        lexer.commenters = "#"
+        line_tokens = list(lexer)
+        if not line_tokens:
+            continue
+        if tokens and tokens[-1] != ";":
+            tokens.append(";")
+        tokens.extend(line_tokens)
+    return tokens
 
 
-def contains_subsequence(tokens: list[str], expected: list[str]) -> bool:
+def contains_command(tokens: list[str], expected: list[str]) -> bool:
     width = len(expected)
-    return any(tokens[index:index + width] == expected for index in range(len(tokens) - width + 1))
+    boundaries = {";", "&&", "||", "do", "then"}
+    for index in range(len(tokens) - width + 1):
+        if tokens[index:index + width] != expected:
+            continue
+        if index == 0 or tokens[index - 1] in boundaries:
+            return True
+    return False
 
 
 arch = read("packaging/linux/Arch/PKGBUILD")
@@ -63,7 +77,10 @@ if not re.search(r"(?m)^BuildRequires:\s+vulkan-loader-devel\s*$", fedora):
 
 workflow = read(".github/workflows/build.yml")
 fedora_job = workflow_job(workflow, "fedora-rpm-build")
-fedora_versions = re.findall(r'''(?m)^          - fedora:\s*['"]?([0-9]+)['"]?\s*$''', fedora_job)
+fedora_versions = re.findall(
+    r'''(?m)(?:^\s*-\s*|[{,]\s*)['"]?fedora['"]?\s*:\s*['"]?([0-9]+)['"]?(?=\s*(?:[,}]|#|$))''',
+    fedora_job,
+)
 if fedora_versions != ["44"]:
     raise AssertionError(f"Fedora CI matrix must contain only Fedora 44, found {fedora_versions}")
 for legacy_version in ("42", "43"):
@@ -92,7 +109,7 @@ for legacy_version in ("42", "43"):
 cleanup_command = [
     "gh", "release", "delete-asset", "${POLARIS_PACKAGE_REF_NAME}", "${legacy_asset}", "--yes",
 ]
-if not contains_subsequence(release_upload_tokens, cleanup_command):
+if not contains_command(release_upload_tokens, cleanup_command):
     raise AssertionError("release workflow must invoke gh release delete-asset for each stale Fedora asset")
 release_verify = re.search(
     r"(?ms)^      - name: Verify release assets on GitHub release\n(?P<body>.*?)(?=^      - name:|\Z)",
@@ -100,13 +117,16 @@ release_verify = re.search(
 )
 if not release_verify:
     raise AssertionError("missing release asset verification workflow step")
-release_verify_body = release_verify.group("body")
-legacy_guard = 'if [ "${supported_count}" -ne 3 ] || [ "${legacy_count}" -ne 0 ]; then'
-if legacy_guard not in release_verify_body:
+release_verify_tokens = workflow_run_tokens(release_verify.group("body"))
+legacy_guard = [
+    "if", "[", "${supported_count}", "-ne", "3", "]", "||",
+    "[", "${legacy_count}", "-ne", "0", "]", ";", "then",
+]
+if not contains_command(release_verify_tokens, legacy_guard):
     raise AssertionError("release verification must fail when legacy Fedora assets remain")
 for legacy_version in ("42", "43"):
     legacy_prefix = f'startswith("Polaris-fedora{legacy_version}-")'
-    if legacy_prefix not in release_verify_body:
+    if not any(legacy_prefix in token for token in release_verify_tokens):
         raise AssertionError(f"release verification must count Fedora {legacy_version} assets")
 arch_job = workflow_job(workflow, "arch-build")
 arch_install = re.search(


### PR DESCRIPTION
## Summary

- remove Fedora 42 and Fedora 43 from the official CI/release RPM matrix
- retain Fedora 44 as the sole official RPM lane
- delete stale Fedora 42/43 binary and source RPMs before release upload
- require Fedora 44, Ubuntu 24.04, and Arch binary assets with zero legacy Fedora assets
- hard-code Fedora 44 in current Fedora/Bazzite installation instructions
- preserve historical changelog facts
- parse executable shell tokens and block/flow YAML matrix forms in regression checks

## Adversarial verification

Contracts reject:
- single-, double-, and unquoted extra Fedora lanes
- flow-map and inline-comment Fedora lanes
- no-op and `echo`-prefixed cleanup commands
- cleanup filename lookalikes
- ignored or comment-only `legacy_count` guards
- comment-only legacy-prefix checks
- variable-derived Fedora asset documentation

Also passed: Public Hygiene scripts, public docs/surface, YAML/Python/Bash syntax, actionlint, and `git diff --check`.

Exact head: `aa32cf42c8bfe0090097df44e7b685a9b3962738`
Exact tree: `afd80f4b2bf524134f437800a21d199119af98c4`
Exact base: `7f95dce8cd7bb8ea21712d89e3c193ead16f1950`