### PR TITLE
fix(browser-stream): avoid GCC 15 unused runtime warning

### DIFF
--- a/src/browser_stream.cpp
+++ b/src/browser_stream.cpp
@@ -476,7 +476,7 @@ namespace browser_stream {
     }
 
     bool private_runtime_configured() {
-      if (auto runtime = stream_runtime::acquire_for_current_policy()) {
+      if (stream_runtime::acquire_for_current_policy()) {
         return true;
       }
       const auto &mode = config::video.linux_display.stream_mode;


### PR DESCRIPTION
## Summary

- directly test the current stream-runtime pointer instead of naming a variable that GCC 15 reports as unused
- preserve the existing truth-test semantics and runtime acquisition side effect
- unblock the Arch release package validation under `BUILD_WERROR=ON`

## Root cause

Official `v1.3.2` tag run `30510850220` failed in Arch package validation:

```text
error: unused variable ‘runtime’ [-Werror=unused-variable]
```

The Arch package uses GCC 15 and `BUILD_WERROR=ON`; normal branch lanes did not expose this compiler-specific warning.

## Exact candidate

```text
Head: 6b78249a3ecad03e6ef6c6dcaa5ecbcc73885d26
Tree: db4ce02b8c4c53e6aacea25ae755208f811a110e
Base: 5fc2a35f5afa069d9255646bdc0f9ccbf9d92431
```

## Verification

- reproduced the original declaration-condition warning with GCC 15.2.1, `-Wall -Werror`
- exact `src/browser_stream.cpp` object built with GCC 15.2.1, Release, and `BUILD_WERROR=ON`
- `test_polaris`: 153/153 passed under the same GCC 15/Werror configuration
- release dependency contract passed
- public docs contract passed
- `git diff --check` passed

The `v1.3.2` draft remains unpublished. The tag will not move again until this PR receives exact-head CI/review and post-merge verification.