### PR TITLE
fix(build): clear remaining GCC 15 warning blockers

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -658,16 +658,16 @@ namespace confighttp {
       return capture_kind + "|" + socket_name + "|" + output_name;
     }
 
-    void clear_cage_preview_capture_failure(const std::string &capture_kind,
-                                            const std::string &socket_name,
-                                            const std::string &output_name) {
+    [[maybe_unused]] void clear_cage_preview_capture_failure(const std::string &capture_kind,
+                                                             const std::string &socket_name,
+                                                             const std::string &output_name) {
       std::lock_guard lock(preview_failure_log_mutex);
       preview_failure_log_state.erase(preview_failure_log_key(capture_kind, socket_name, output_name));
     }
 
-    void log_cage_preview_capture_failure(const std::string &capture_kind,
-                                          const std::string &socket_name,
-                                          const std::string &output_name) {
+    [[maybe_unused]] void log_cage_preview_capture_failure(const std::string &capture_kind,
+                                                           const std::string &socket_name,
+                                                           const std::string &output_name) {
       const auto now = std::chrono::steady_clock::now();
       std::uint32_t suppressed_count = 0;
       bool should_log = false;

--- a/src/platform/linux/display_topology.cpp
+++ b/src/platform/linux/display_topology.cpp
@@ -16,7 +16,6 @@
 #include <cctype>
   #include <chrono>
   #include <cstdlib>
-  #include <cstdio>
   #include <filesystem>
   #include <fstream>
   #include <string>
@@ -30,20 +29,6 @@ namespace display_topology {
   namespace {
 
     namespace fs = std::filesystem;
-
-    std::string exec_capture(const std::string &cmd) {
-      FILE *pipe = popen(cmd.c_str(), "r");
-      if (!pipe) {
-        return {};
-      }
-      char buf[512];
-      std::string result;
-      while (fgets(buf, sizeof(buf), pipe)) {
-        result += buf;
-      }
-      pclose(pipe);
-      return result;
-    }
 
     std::string read_sysfs_file(const fs::path &path) {
       std::ifstream in(path);


### PR DESCRIPTION
## Summary

- mark two dormant cage-preview failure logging helpers as intentionally unused
- remove the unreferenced `display_topology::exec_capture` helper and its now-unused `<cstdio>` include
- clear the remaining clean-build GCC 15 `BUILD_WERROR=ON` failures without changing runtime behavior

## Exact source

- Base: `a345720fca41904f1525cee6d6148c42a62510a8`
- Head: `9926aa4487fa00907178c5c7cd7160f04149014d`
- Tree: `55b83b8c1fe37cc272726b712d24d795e6058616`

## Root cause

Official tag run `30512763456` failed the Arch package validator because GCC 15 with `BUILD_WERROR=ON` rejected two dormant internal helper functions as unused. A subsequent clean full-project GCC 15 warning-as-error build found one additional unreferenced helper before another tag attempt.

## Verification

- reproduced official unused-function failures before the fix
- clean full production build: GCC 15.2.1, Release, `BUILD_WERROR=ON`, all 120 project objects: pass
- `test_polaris`: 153/153
- `test_polaris_http`: 95/95
- `test_polaris_steam_shutdown`: 12/12
- release dependency/public-doc contracts: pass
- `git diff --check`: pass

The `v1.3.2` release remains draft and unpublished.