### PR TITLE
fix(nix): silence shellcheck on gamescope idle/session scripts

### DIFF
--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -101,7 +101,7 @@ polaris_process_has_argument() {
 }
 
 polaris_write_marker_for_pid() (
-  local marker="$1" pid="$2" role="$3" tmp lock_bin="${POLARIS_FLOCK_BIN:-flock}"
+  local marker="$1" pid="$2" role="$3" marker_tmp='' lock_bin="${POLARIS_FLOCK_BIN:-flock}"
   umask 077
   if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
     exec 9>>"${marker%/*}/polaris-gamescope.lock" || return 1
@@ -117,9 +117,11 @@ polaris_write_marker_for_pid() (
           && [ "$POLARIS_MARKER_EXECUTABLE" = "$executable_path" ]
         return
       fi
-      tmp="$marker.tmp.$$"
-      (umask 077; printf '%s %s %s %s\n' "$pid" "$start_time" "$role" "$executable_path" >"$tmp") || return 1
-      mv -f "$tmp" "$marker"
+      # umask already 077 for this subshell function; avoid nested (..) so
+      # SC2030/SC2031 do not treat marker_tmp as subshell-local vs other helpers.
+      marker_tmp="$marker.tmp.$$"
+      printf '%s %s %s %s\n' "$pid" "$start_time" "$role" "$executable_path" >"$marker_tmp" || return 1
+      mv -f "$marker_tmp" "$marker"
       return 0
     fi
     sleep 0.02
@@ -319,7 +321,7 @@ polaris_unique_unix_socket_inode() {
 
 polaris_discover_xwayland_display() {
   local marker="$1" expected_role="${2:-}" xdir socket name display inode process pid final_inode
-  local best= best_pid= best_start= best_inode= best_socket= marker_line
+  local best='' best_pid='' best_start='' best_inode='' best_socket='' marker_line
   polaris_validate_marker "$marker" "$expected_role" || return 1
   local root_pid="$POLARIS_MARKER_PID" root_start="$POLARIS_MARKER_START_TIME" root_executable="$POLARIS_MARKER_EXECUTABLE"
   marker_line="$(<"$marker")"
@@ -365,10 +367,10 @@ polaris_discover_xwayland_display() {
 }
 
 polaris_write_runtime_env() (
-  local marker="$1" wayland="$2" expected_role="${3:-}" runtime_dir="$4" display final_display tmp
+  local marker="$1" wayland="$2" expected_role="${3:-}" runtime_dir="$4" display final_display env_tmp=''
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}" marker_line role
   umask 077
-  trap 'rm -f "${tmp:-}"' EXIT
+  trap 'rm -f "${env_tmp:-}"' EXIT
   if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
     exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
     "$lock_bin" -x 9 || return 1
@@ -381,9 +383,10 @@ polaris_write_runtime_env() (
   display="$(polaris_discover_xwayland_display "$marker" "$expected_role")" || return 1
   polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
   [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-  tmp="$runtime_dir/polaris-gamescope.env.tmp.$$"
-  (umask 077; printf 'DISPLAY=%s\nWAYLAND_DISPLAY=%s\nGAMESCOPE_WAYLAND_DISPLAY=%s\nPOLARIS_GAMESCOPE_PID=%s\nPOLARIS_GAMESCOPE_START_TIME=%s\nPOLARIS_GAMESCOPE_ROLE=%s\nPOLARIS_GAMESCOPE_EXECUTABLE=%s\n' \
-    "$display" "$wayland" "$wayland" "$pid" "$start_time" "$role" "$executable_path" >"$tmp") || return 1
+  # umask already 077; write env atomically then rename (no nested subshell).
+  env_tmp="$runtime_dir/polaris-gamescope.env.tmp.$$"
+  printf 'DISPLAY=%s\nWAYLAND_DISPLAY=%s\nGAMESCOPE_WAYLAND_DISPLAY=%s\nPOLARIS_GAMESCOPE_PID=%s\nPOLARIS_GAMESCOPE_START_TIME=%s\nPOLARIS_GAMESCOPE_ROLE=%s\nPOLARIS_GAMESCOPE_EXECUTABLE=%s\n' \
+    "$display" "$wayland" "$wayland" "$pid" "$start_time" "$role" "$executable_path" >"$env_tmp" || return 1
   if [ -n "${POLARIS_RUNTIME_ENV_BEFORE_COMMIT_HOOK:-}" ]; then
     "${POLARIS_RUNTIME_ENV_BEFORE_COMMIT_HOOK}" || return 1
   fi
@@ -394,7 +397,8 @@ polaris_write_runtime_env() (
   polaris_marker_owns_socket "$marker" "$runtime_dir/$wayland" "$expected_role" || return 1
   final_display="$(polaris_discover_xwayland_display "$marker" "$expected_role")" || return 1
   [ "$final_display" = "$display" ] || return 1
-  mv -f "$tmp" "$runtime_dir/polaris-gamescope.env"
+  mv -f "$env_tmp" "$runtime_dir/polaris-gamescope.env"
+  env_tmp=''
 )
 
 # Hjem units live under ~/.config/systemd/user (higher priority than
@@ -477,17 +481,18 @@ polaris_stop_marked_gamescope() (
   polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
   [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
     && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
-  resume_group_leader_on_failure() {
-    [ "$leader_stopped" = 1 ] || return 0
-    if polaris_process_fields "$pgid" \
+  # Inline EXIT trap (not a nested function) so SC2329 does not flag a
+  # "never invoked" helper. CONT only if we STOPped the leader and authorize it.
+  trap '
+    if [ "$leader_stopped" = 1 ] \
+        && polaris_process_fields "$pgid" \
         && [ "$POLARIS_PROCESS_START_TIME" = "$group_leader_start" ] \
         && [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
         && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] \
         && [ "$(readlink -f "$(polaris_proc_root)/$pgid/exe" 2>/dev/null)" = "$group_leader_executable" ]; then
       "$kill_bin" -CONT "$pgid" 2>/dev/null || true
     fi
-  }
-  trap resume_group_leader_on_failure EXIT
+  ' EXIT
   "$kill_bin" -STOP "$pgid" 2>/dev/null || return 1
   leader_stopped=1
   polaris_process_fields "$pgid" || return 1

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -121,7 +121,8 @@ polaris_write_marker_for_pid() (
       # SC2030/SC2031 do not treat marker_tmp as subshell-local vs other helpers.
       marker_tmp="$marker.tmp.$$"
       printf '%s %s %s %s\n' "$pid" "$start_time" "$role" "$executable_path" >"$marker_tmp" || return 1
-      mv -f "$marker_tmp" "$marker"
+      # Explicit status: set -e is ignored when this function is used in if/||.
+      mv -f "$marker_tmp" "$marker" || return 1
       return 0
     fi
     sleep 0.02
@@ -397,7 +398,10 @@ polaris_write_runtime_env() (
   polaris_marker_owns_socket "$marker" "$runtime_dir/$wayland" "$expected_role" || return 1
   final_display="$(polaris_discover_xwayland_display "$marker" "$expected_role")" || return 1
   [ "$final_display" = "$display" ] || return 1
-  mv -f "$env_tmp" "$runtime_dir/polaris-gamescope.env"
+  # Explicit status: set -e is ignored when this function is used in if/||.
+  # Only clear env_tmp after a successful rename so the EXIT trap still
+  # removes a leftover temp when mv fails.
+  mv -f "$env_tmp" "$runtime_dir/polaris-gamescope.env" || return 1
   env_tmp=''
 )
 

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -103,6 +103,7 @@ polaris_process_has_argument() {
 polaris_write_marker_for_pid() (
   local marker="$1" pid="$2" role="$3" marker_tmp='' lock_bin="${POLARIS_FLOCK_BIN:-flock}"
   umask 077
+  trap 'rm -f "${marker_tmp:-}"' EXIT
   if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
     exec 9>>"${marker%/*}/polaris-gamescope.lock" || return 1
     "$lock_bin" -x 9 || return 1
@@ -123,6 +124,7 @@ polaris_write_marker_for_pid() (
       printf '%s %s %s %s\n' "$pid" "$start_time" "$role" "$executable_path" >"$marker_tmp" || return 1
       # Explicit status: set -e is ignored when this function is used in if/||.
       mv -f "$marker_tmp" "$marker" || return 1
+      marker_tmp=''
       return 0
     fi
     sleep 0.02

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -69,7 +69,8 @@ recover_missing_nested_claim() (
       && [ -f "$session_mode_file" ] \
       && [ "$(tr -d '[:space:]' <"$session_mode_file")" = nested ] || return 1
   fi
-  export POLARIS_GAMESCOPE_LOCK_HELD=1
+  # Hold flock only; reclaim/validate do not need POLARIS_GAMESCOPE_LOCK_HELD
+  # (that flag is for write_runtime_env / stop_marked to skip nested flock).
   if ! polaris_validate_marker "$marker" idle \
       && ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
     return 1
@@ -225,7 +226,7 @@ case "${1:-}" in
     }
     if [ -e "$session_state_file" ] || [ -s "$session_id_file" ]; then
       echo "polaris-gamescope-session: complete prior session recovery before new launch" >&2
-      POLARIS_SESSION_INSTANCE_ID= "$0" stop || exit 1
+      POLARIS_SESSION_INSTANCE_ID='' "$0" stop || exit 1
       POLARIS_SESSION_INSTANCE_ID="$requested_session_id"
       export POLARIS_SESSION_INSTANCE_ID
     elif [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
@@ -796,14 +797,16 @@ case "${1:-}" in
       exec 8>>"$rt/polaris-gamescope.lock" || exit 1
       "${POLARIS_FLOCK_BIN:-flock}" -x 8 || exit 1
       export POLARIS_GAMESCOPE_LOCK_HELD=1
-      [ -f "$nested_claim" ] \
-        && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ] \
-        && polaris_validate_marker "$marker" idle \
-        && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
-        && polaris_write_runtime_env "$marker" gamescope-0 idle "$rt" || {
-          echo "polaris-gamescope-session: idle ownership changed before portal handoff" >&2
-          exit 1
-        }
+      if ! {
+        [ -f "$nested_claim" ] \
+          && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ] \
+          && polaris_validate_marker "$marker" idle \
+          && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
+          && polaris_write_runtime_env "$marker" gamescope-0 idle "$rt"
+      }; then
+        echo "polaris-gamescope-session: idle ownership changed before portal handoff" >&2
+        exit 1
+      fi
       echo "polaris-gamescope-session: idle gamescope restored after nested stop" >&2
 
       if ! systemctl --user restart polaris-portal-gamescope.service 2>/dev/null; then
@@ -824,13 +827,15 @@ case "${1:-}" in
         echo "polaris-gamescope-session: portal did not bind idle generation; retaining restore-idle claim" >&2
         exit 1
       fi
-      polaris_validate_marker "$marker" idle \
-        && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
-        && [ -f "$nested_claim" ] \
-        && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ] || {
-          echo "polaris-gamescope-session: ownership changed during portal readiness" >&2
-          exit 1
-        }
+      if ! {
+        polaris_validate_marker "$marker" idle \
+          && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
+          && [ -f "$nested_claim" ] \
+          && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ]
+      }; then
+        echo "polaris-gamescope-session: ownership changed during portal readiness" >&2
+        exit 1
+      fi
       rm -f -- "$nested_claim"
       "${POLARIS_FLOCK_BIN:-flock}" -u 8
       export POLARIS_GAMESCOPE_LOCK_HELD=0

--- a/scripts/install/lib/polaris-wait-gamescope.sh
+++ b/scripts/install/lib/polaris-wait-gamescope.sh
@@ -56,7 +56,7 @@ if [ -f "$rt/polaris-gamescope-wsi-nested" ]; then
     exit 1
   }
   echo "polaris: complete credentialed nested recovery" >&2
-  POLARIS_SESSION_INSTANCE_ID= "$session_cmd" stop || exit 1
+  POLARIS_SESSION_INSTANCE_ID='' "$session_cmd" stop || exit 1
   [ ! -e "$rt/polaris-gamescope-wsi-nested" ] || exit 1
 elif [ ! -S "$rt/gamescope-0" ]; then
   echo "polaris: restore missing idle gamescope-0" >&2

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -54,6 +54,23 @@ write_unix_header() {
   printf 'Num RefCount Protocol Flags Type St Inode Path\n' >"$POLARIS_PROC_NET_UNIX"
 }
 
+# Rename failure must fail marker publication and leave neither authority nor
+# a stale temporary file behind.
+write_process 410 1 9001 /usr/bin/gamescope --backend headless
+marker_rename_test="$work/run/polaris-marker-rename-test.pid"
+mv() { return 1; }
+if polaris_write_marker_for_pid "$marker_rename_test" 410 nested; then
+  fail "failed marker rename was reported as published"
+fi
+unset -f mv
+[ ! -e "$marker_rename_test" ] || fail "failed marker rename published authority"
+if compgen -G "$marker_rename_test.tmp.*" >/dev/null; then
+  fail "failed marker rename left a temporary authority file"
+fi
+polaris_write_marker_for_pid "$marker_rename_test" 410 nested ||
+  fail "marker publication did not recover after rename failure"
+rm -f "$marker_rename_test"
+
 # A reused PID must never be signalled or allowed to remove owner state.
 write_process 410 1 9001 /usr/bin/gamescope --backend headless
 : >"$work/run/gamescope-0"
@@ -239,6 +256,21 @@ polaris_write_runtime_env "$work/run/polaris-gamescope.pid" gamescope-0 idle "$w
 grep -qx 'DISPLAY=:4' "$work/run/polaris-gamescope.env" || fail "runtime env routed to host X display"
 grep -qx 'POLARIS_GAMESCOPE_PID=410' "$work/run/polaris-gamescope.env" || fail "runtime env lacks owner pid"
 [ -e "$POLARIS_X11_SOCKET_DIR/X0" ] || fail "host X0 was removed"
+
+# A failed atomic rename must return failure, publish no environment, remove
+# its temporary file, and allow a subsequent valid publication.
+rm -f "$work/run/polaris-gamescope.env"
+mv() { return 1; }
+if polaris_write_runtime_env "$work/run/polaris-gamescope.pid" gamescope-0 idle "$work/run"; then
+  fail "failed runtime-env rename was reported as published"
+fi
+unset -f mv
+[ ! -e "$work/run/polaris-gamescope.env" ] || fail "failed runtime-env rename published an environment"
+if compgen -G "$work/run/polaris-gamescope.env.tmp.*" >/dev/null; then
+  fail "failed runtime-env rename left a temporary file"
+fi
+polaris_write_runtime_env "$work/run/polaris-gamescope.pid" gamescope-0 idle "$work/run" ||
+  fail "runtime-env publication did not recover after rename failure"
 
 # Rebinding Wayland after X11 selection but before env publication must reject
 # the entire Wayland/X11 pair and leave no committed environment.

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -260,7 +260,7 @@ fi
 
 grep -Fq 'if [ -e "$session_state_file" ] || [ -s "$session_id_file" ]; then' "$script" ||
   fail "start does not recover every atomic or legacy credential before replacement"
-grep -Fq 'POLARIS_SESSION_INSTANCE_ID= "$0" stop || exit 1' "$script" ||
+grep -Fq "POLARIS_SESSION_INSTANCE_ID='' \"\$0\" stop || exit 1" "$script" ||
   fail "start does not route persisted attach/nested recovery through credentialed stop"
 transition_line="$(grep -nF 'publish_nested_claim transition absent' "$script" | head -n1 | cut -d: -f1)"
 mask_line="$(grep -nF 'polaris_mask_idle_unit_runtime' "$script" | tail -n1 | cut -d: -f1)"


### PR DESCRIPTION
## Summary
- Quiet `writeShellApplication` ShellCheck failures for `polaris-gamescope-idle` and `polaris-gamescope-session` (SC1007, SC2030/SC2031, SC2015, SC2329).
- Runtime helpers: rename temp paths, drop redundant nested umask subshells, quote empty locals, inline STOP/CONT EXIT trap.
- Session script: drop unnecessary `POLARIS_GAMESCOPE_LOCK_HELD` export in recover subshell, use `POLARIS_SESSION_INSTANCE_ID=''` for stop env, rewrite `A && B || C` ownership checks as `if ! { … }`.

## Test plan
- [x] `shellcheck` clean on composed idle and session scripts
- [x] `tests/unit/platform/test_gamescope_runtime_shell.sh` PASS
- [x] `tests/unit/platform/test_gamescope_session_stop_shell.sh` PASS
- [x] `writeShellApplication` builds for idle + session without ShellCheck noise
- [x] `nh os switch` on a NixOS host consuming polaris hjem/session modules succeeds