### PR TITLE
docs: complete v1.3.2 release closeout

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,4 +14,19 @@ AI-assisted drafting and refactoring are allowed. Please treat generated code li
 
 ## Security-Sensitive Changes
 
-Call out changes to authentication, pairing, trusted subnets, client commands, certificates, or privilege boundaries in the PR description. Those areas deserve a slower review pass.
+Call out changes to authentication, pairing, trusted subnets, client commands, certificates, dependencies, release packaging, or privilege boundaries in the PR description. Those areas deserve a slower review pass.
+
+## Before Opening a Pull Request
+
+Run the checks that match your change from a clean checkout or isolated worktree. Documentation, dependency, and release-package changes should include:
+
+```bash
+./scripts/check-public-docs.sh
+python3 scripts/check-release-package-dependencies.py
+npm ci
+npm audit --audit-level=high
+```
+
+For C++ changes, configure and build the affected production targets and run their matching test binaries. Release-package changes also need the relevant package build and installed-layout smoke test; ordinary branch CI does not replace exact-tag verification.
+
+Do not rewrite or force-push another contributor's commits to make a review pass. Follow-up fixes should be additive commits so the review history remains inspectable.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Call out changes to authentication, pairing, trusted subnets, client commands, c
 Run the checks that match your change from a clean checkout or isolated worktree. Documentation, dependency, and release-package changes should include:
 
 ```bash
-./scripts/check-public-docs.sh
+bash scripts/check-public-docs.sh
 python3 scripts/check-release-package-dependencies.py
 npm ci
 npm audit --audit-level=high

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Polaris v1.3.2 is a focused reliability patch for stream lifecycle, Linux privat
 - **Resilient web recovery**: the web console survives transient host outages and preserves authenticated sessions across host restarts.
 - **Truthful stream health**: near-target FPS no longer produces misleading degraded-state noise, and Linux GPU probe topology is easier to diagnose.
 - **Browser Stream security**: `webtransport-go v0.11.1` and `quic-go v0.60.0` fix the unknown-capsule memory-exhaustion vulnerability tracked as CVE-2026-57497 / GHSA-g35j-m5xg-vh3q.
-- **Hardened packages**: the official release is exactly Arch, Fedora 44, and Ubuntu 24.04, with explicit Vulkan dependencies, GCC 15 warning-as-error validation, and a permanent high-severity npm audit gate.
+- **Hardened packages**: the official release is exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, and `Polaris-ubuntu24.04-x86_64.deb`, with explicit Vulkan dependencies, GCC 15 warning-as-error validation, and a permanent high-severity `npm audit` gate.
 See the [changelog](docs/changelog.md) for the full release history.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Polaris v1.3.2 is a focused reliability patch for stream lifecycle, Linux privat
 - **Safer session cleanup**: lifecycle teardown, private Steam ownership, interrupted process waits, and Big Picture input isolation are hardened without broadly touching desktop Steam.
 - **Resilient web recovery**: the web console survives transient host outages and preserves authenticated sessions across host restarts.
 - **Truthful stream health**: near-target FPS no longer produces misleading degraded-state noise, and Linux GPU probe topology is easier to diagnose.
+- **Browser Stream security**: `webtransport-go v0.11.1` and `quic-go v0.60.0` fix the unknown-capsule memory-exhaustion vulnerability tracked as CVE-2026-57497 / GHSA-g35j-m5xg-vh3q.
+- **Hardened packages**: the official release is exactly Arch, Fedora 44, and Ubuntu 24.04, with explicit Vulkan dependencies, GCC 15 warning-as-error validation, and a permanent high-severity npm audit gate.
 See the [changelog](docs/changelog.md) for the full release history.
 
 ## Install

--- a/docs/building.md
+++ b/docs/building.md
@@ -79,7 +79,7 @@ See [`scripts/install/README.md`](../scripts/install/README.md) for steps, PREFI
 | Tool | Notes |
 | --- | --- |
 | CMake 3.20+ | Build system |
-| C++20 compiler | GCC or Clang |
+| C++23 compiler | GCC or Clang |
 | Boost | Core libraries |
 | OpenSSL | TLS and pairing |
 | libevdev | Virtual input |
@@ -112,8 +112,10 @@ sudo pacman -S --needed base-devel git cmake ninja appstream appstream-glib \
   wayland-protocols libdrm libcap libnotify libayatana-appindicator \
   libpulse libva libx11 libxcb libxfixes libxi libxrandr libxtst \
   miniupnpc nlohmann-json numactl avahi opus libmfx mesa which nodejs npm \
-  grim labwc wlr-randr xorg-xwayland xorg-xdpyinfo cuda
+  grim labwc wlr-randr xorg-xwayland xorg-xdpyinfo vulkan-headers vulkan-icd-loader cuda
 ```
+
+`vulkan-headers` supplies the compile-time API headers and `vulkan-icd-loader` supplies the runtime loader expected by the packaged binary.
 
 CachyOS should use the same package/dependency family first. If a CachyOS kernel, NVIDIA/CUDA stack, or pacman package split behaves differently, include those details when opening an issue.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
-## v1.3.2 - 2026-07-29
+## v1.3.2 - 2026-07-30
 
 Reliability patch focused on stream lifecycle, Linux private-session isolation, reconnect recovery, and truthful host diagnostics.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,14 @@ Reliability patch focused on stream lifecycle, Linux private-session isolation, 
 - Exposed clearer Linux GPU probe topology diagnostics for capture-path troubleshooting
 - Hardened Dashboard smoke navigation so release checks do not issue duplicate route requests
 
+### Security and release packaging
+
+- Updated Browser Stream to `webtransport-go v0.11.1` and `quic-go v0.60.0`, fixing remote memory exhaustion from unknown capsule buffering (CVE-2026-57497 / GHSA-g35j-m5xg-vh3q)
+- Removed vulnerable, unnecessary web fixture-server dependencies and added `npm audit --audit-level=high` as a permanent CI gate
+- Standardized the official release on exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, and `Polaris-ubuntu24.04-x86_64.deb`; Fedora 42/43 remain historical rather than current package lanes
+- Added explicit Arch `vulkan-headers` / `vulkan-icd-loader` and Fedora `vulkan-loader-devel` package requirements
+- Cleared GCC 15 warning-as-error blockers in Browser Stream setup, dormant preview diagnostics, and Linux display-topology helpers so exact-tag package validation builds cleanly
+
 ### Linux stream modes / private runtime foundation
 - Add first-class `linux_stream_mode` and `linux_private_runtime` config (Private Stream, Host Virtual Display, Mirror Desktop, GPU-native preference, Gamescope Stream, Headless Dongle).
 - Keep legacy `headless_mode` / `linux_use_cage_compositor` / `linux_prefer_gpu_native_capture` as a compatibility mapping; UI and client-settings write both.

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -116,7 +116,11 @@ readme = Path("README.md").read_text(encoding="utf-8")
 changelog = Path("docs/changelog.md").read_text(encoding="utf-8")
 
 
-def markdown_section(text: str, heading: str) -> str:
+def markdown_section(
+    text: str,
+    heading: str,
+    expected_following=None,
+) -> str:
     """Return one exact Markdown section, bounded by a same/higher-level heading."""
     level = len(heading) - len(heading.lstrip("#"))
     if level < 1 or heading[level:level + 1] != " ":
@@ -130,10 +134,29 @@ def markdown_section(text: str, heading: str) -> str:
 
     start = starts[0] + 1
     boundary = re.compile(rf"^#{{1,{level}}}\s+")
-    end = next(
-        (index for index in range(start, len(lines)) if boundary.match(lines[index])),
-        len(lines),
-    )
+    fence = None
+    end = len(lines)
+    for index in range(start, len(lines)):
+        fence_match = re.match(r"^\s{0,3}(`{3,}|~{3,})", lines[index])
+        if fence_match:
+            marker = fence_match.group(1)
+            if fence is None:
+                fence = (marker[0], len(marker))
+            elif marker[0] == fence[0] and len(marker) >= fence[1]:
+                fence = None
+            continue
+        if fence is None and boundary.match(lines[index]):
+            end = index
+            break
+    if expected_following is not None:
+        actual_following = lines[end].rstrip("\r\n") if end < len(lines) else None
+        if actual_following != expected_following:
+            print(
+                f"Expected {expected_following!r} immediately after {heading!r}; "
+                f"found {actual_following!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
     return "".join(lines[start:end])
 
 
@@ -188,23 +211,11 @@ def shell_commands(block: str) -> list[list[str]]:
     return commands
 
 
-def bounded_release_section(text: str, current: str, following: str) -> str:
-    current_heading = rf"^## {re.escape(current)}(?:\s+-[^\n]+)?\s*$"
-    following_heading = rf"^## {re.escape(following)}(?:\s+-[^\n]+)?\s*$"
-    match = re.search(
-        rf"(?ms){current_heading}\n(?P<body>.*?)(?={following_heading})",
-        text,
-    )
-    if not match:
-        print(
-            f"Could not find exact, bounded {current} -> {following} changelog headings",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    return match.group("body")
-
-
-requirements_section = markdown_section(building, "### Requirements")
+requirements_section = markdown_section(
+    building,
+    "### Requirements",
+    "### Example packages",
+)
 requirements_rows = markdown_table(requirements_section, "docs/building.md Requirements")
 compiler_rows = [row for row in requirements_rows if row and row[0].startswith("C++")]
 if compiler_rows != [["C++23 compiler", "GCC or Clang"]]:
@@ -214,7 +225,11 @@ if compiler_rows != [["C++23 compiler", "GCC or Clang"]]:
     )
     sys.exit(1)
 
-arch_section = markdown_section(building, "#### Arch / CachyOS")
+arch_section = markdown_section(
+    building,
+    "#### Arch / CachyOS",
+    "#### openSUSE Tumbleweed",
+)
 arch_block = re.search(
     r"(?ms)^```bash\s*$\n(?P<commands>.*?)^```\s*$",
     arch_section,
@@ -240,7 +255,11 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
         )
         sys.exit(1)
 
-current_release = bounded_release_section(changelog, "v1.3.2", "v1.3.1")
+current_release = markdown_section(
+    changelog,
+    "## v1.3.2 - 2026-07-29",
+    "## v1.3.1 - 2026-07-12",
+)
 required_release_facts = (
     "webtransport-go v0.11.1",
     "quic-go v0.60.0",
@@ -258,14 +277,11 @@ for fact in required_release_facts:
         print(f"v1.3.2 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
-readme_release = re.search(
-    r"(?ms)^## What is New in v1\.3\.2\s*$\n(?P<body>.*?)(?=^## Install\s*$)",
+readme_release_body = markdown_section(
     readme,
+    "## What is New in v1.3.2",
+    "## Install",
 )
-if not readme_release:
-    print("README is missing the bounded v1.3.2 summary", file=sys.stderr)
-    sys.exit(1)
-readme_release_body = readme_release.group("body")
 required_readme_facts = (
     "webtransport-go v0.11.1",
     "quic-go v0.60.0",

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -105,6 +105,7 @@ done
 
 python3 <<'PY'
 from collections import Counter
+from html.parser import HTMLParser
 from pathlib import Path
 import re
 import shlex
@@ -243,6 +244,63 @@ def markdown_section(
     return "".join(lines[start:end])
 
 
+class VisibleHTMLText(HTMLParser):
+    """Collect browser-visible text while excluding hidden/raw non-content elements."""
+
+    void_tags = {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    }
+    noncontent_tags = {"script", "style", "template"}
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.parts = []
+        self.stack = []
+        self.hidden_depth = 0
+
+    def _is_hidden(self, tag, attrs):
+        values = {name.lower(): (value or "") for name, value in attrs}
+        if tag in self.noncontent_tags or "hidden" in values:
+            return True
+        if values.get("aria-hidden", "").strip().lower() == "true":
+            return True
+        style = values.get("style", "")
+        return bool(re.search(r"(?:^|;)\s*display\s*:\s*none(?:\s*!important)?\s*(?:;|$)", style, re.I))
+
+    def handle_starttag(self, tag, attrs):
+        tag = tag.lower()
+        hidden = self._is_hidden(tag, attrs)
+        if tag in self.void_tags:
+            return
+        self.stack.append((tag, hidden))
+        if hidden:
+            self.hidden_depth += 1
+
+    def handle_startendtag(self, tag, attrs):
+        return
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        for index in range(len(self.stack) - 1, -1, -1):
+            if self.stack[index][0] == tag:
+                removed = self.stack[index:]
+                del self.stack[index:]
+                self.hidden_depth -= sum(1 for _, hidden in removed if hidden)
+                return
+
+    def handle_data(self, data):
+        if self.hidden_depth == 0:
+            self.parts.append(data)
+
+
+def visible_html_text(text: str) -> str:
+    parser = VisibleHTMLText()
+    parser.feed(text)
+    parser.close()
+    return "".join(parser.parts)
+
+
 def rendered_markdown(text: str) -> str:
     """Return visible Markdown text with fenced blocks and destinations excluded."""
     rendered: list[str] = []
@@ -257,25 +315,6 @@ def rendered_markdown(text: str) -> str:
 
     visible = "".join(rendered)
     visible = re.sub(
-        r"<(script|style|template)\b[^>]*>.*?</\1\s*>",
-        "",
-        visible,
-        flags=re.IGNORECASE | re.DOTALL,
-    )
-    hidden_element = re.compile(
-        r"<([A-Za-z][\w:-]*)\b"
-        r"(?=[^>]*(?:\shidden(?:\s*=\s*(?:\"[^\"]*\"|'[^']*'|[^\s>]+))?"
-        r"|\saria-hidden\s*=\s*(?:\"true\"|'true'|true)"
-        r"|\sstyle\s*=\s*(?:\"[^\"]*display\s*:\s*none[^\"]*\""
-        r"|'[^']*display\s*:\s*none[^']*')))"
-        r"[^>]*>.*?</\1\s*>",
-        flags=re.IGNORECASE | re.DOTALL,
-    )
-    while True:
-        visible, removed = hidden_element.subn("", visible)
-        if removed == 0:
-            break
-    visible = re.sub(
         r"!?\[([^]]*)\]\((?:\\.|[^)\n])*\)",
         lambda match: match.group(1),
         visible,
@@ -285,8 +324,7 @@ def rendered_markdown(text: str) -> str:
         lambda match: match.group(1),
         visible,
     )
-    visible = re.sub(r"</?[A-Za-z][^>]*>", "", visible)
-    return visible
+    return visible_html_text(visible)
 
 
 def markdown_table(section: str, label: str) -> list[list[str]]:

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -105,33 +105,64 @@ done
 
 python3 <<'PY'
 from pathlib import Path
+import re
+import shlex
 import sys
 
 building = Path("docs/building.md").read_text(encoding="utf-8")
 readme = Path("README.md").read_text(encoding="utf-8")
 changelog = Path("docs/changelog.md").read_text(encoding="utf-8")
 
-if "C++23" not in building or "C++20" in building:
-    print("docs/building.md must advertise the required C++23 toolchain", file=sys.stderr)
+
+def bounded_release_section(text: str, current: str, following: str) -> str:
+    current_heading = rf"^## {re.escape(current)}(?:\s+-[^\n]+)?\s*$"
+    following_heading = rf"^## {re.escape(following)}(?:\s+-[^\n]+)?\s*$"
+    match = re.search(
+        rf"(?ms){current_heading}\n(?P<body>.*?)(?={following_heading})",
+        text,
+    )
+    if not match:
+        print(
+            f"Could not find exact, bounded {current} -> {following} changelog headings",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return match.group("body")
+
+
+required_compiler_row = re.compile(
+    r"^\|\s*C\+\+23 compiler\s*\|\s*GCC or Clang\s*\|\s*$",
+    re.MULTILINE,
+)
+if not required_compiler_row.search(building):
+    print("docs/building.md must declare C++23 in the requirements table", file=sys.stderr)
     sys.exit(1)
 
+arch_block = re.search(
+    r"(?ms)^#### Arch / CachyOS\s*$.*?^```bash\s*$\n(?P<commands>.*?)^```\s*$",
+    building,
+)
+if not arch_block:
+    print("docs/building.md is missing the Arch/CachyOS install command", file=sys.stderr)
+    sys.exit(1)
+arch_tokens = set(shlex.split(arch_block.group("commands").replace("\\\n", " ")))
 for dependency in ("vulkan-headers", "vulkan-icd-loader"):
-    if dependency not in building:
-        print(f"docs/building.md is missing the Arch dependency: {dependency}", file=sys.stderr)
+    if dependency not in arch_tokens:
+        print(
+            f"Arch/CachyOS install command is missing dependency: {dependency}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
-try:
-    current_release = changelog.split("## v1.3.2", 1)[1].split("## v1.3.1", 1)[0]
-except IndexError:
-    print("docs/changelog.md is missing a bounded v1.3.2 section", file=sys.stderr)
-    sys.exit(1)
-
+current_release = bounded_release_section(changelog, "v1.3.2", "v1.3.1")
 required_release_facts = (
     "webtransport-go v0.11.1",
     "quic-go v0.60.0",
     "CVE-2026-57497",
     "npm audit --audit-level=high",
+    "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
+    "Polaris-ubuntu24.04-x86_64.deb",
     "vulkan-headers",
     "vulkan-loader-devel",
     "GCC 15",
@@ -141,8 +172,26 @@ for fact in required_release_facts:
         print(f"v1.3.2 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
-for fact in ("webtransport-go v0.11.1", "CVE-2026-57497"):
-    if fact not in readme:
+readme_release = re.search(
+    r"(?ms)^## What is New in v1\.3\.2\s*$\n(?P<body>.*?)(?=^## Install\s*$)",
+    readme,
+)
+if not readme_release:
+    print("README is missing the bounded v1.3.2 summary", file=sys.stderr)
+    sys.exit(1)
+required_readme_facts = (
+    "webtransport-go v0.11.1",
+    "quic-go v0.60.0",
+    "CVE-2026-57497",
+    "npm audit",
+    "Polaris-arch-x86_64.pkg.tar.zst",
+    "Polaris-fedora44-x86_64.rpm",
+    "Polaris-ubuntu24.04-x86_64.deb",
+    "Vulkan",
+    "GCC 15",
+)
+for fact in required_readme_facts:
+    if fact not in readme_release.group("body"):
         print(f"README v1.3.2 summary is missing: {fact}", file=sys.stderr)
         sys.exit(1)
 PY

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -137,6 +137,57 @@ def markdown_section(text: str, heading: str) -> str:
     return "".join(lines[start:end])
 
 
+def markdown_table(section: str, label: str) -> list[list[str]]:
+    """Parse the first contiguous Markdown table in a bounded section."""
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in section.splitlines():
+        if line.strip().startswith("|"):
+            current.append(line)
+        elif current:
+            blocks.append(current)
+            current = []
+    if current:
+        blocks.append(current)
+    if not blocks:
+        print(f"{label} is missing its Markdown table", file=sys.stderr)
+        sys.exit(1)
+
+    rows = [
+        [cell.strip() for cell in line.strip().strip("|").split("|")]
+        for line in blocks[0]
+    ]
+    if len(rows) < 3 or rows[0] != ["Tool", "Notes"]:
+        print(f"{label} has an invalid Tool/Notes table", file=sys.stderr)
+        sys.exit(1)
+    if len(rows[1]) != 2 or not all(
+        re.fullmatch(r":?-{3,}:?", cell) for cell in rows[1]
+    ):
+        print(f"{label} has an invalid table separator", file=sys.stderr)
+        sys.exit(1)
+    return rows[2:]
+
+
+def shell_commands(block: str) -> list[list[str]]:
+    """Return tokenized, uncommented logical shell commands from a fenced block."""
+    commands: list[list[str]] = []
+    pending = ""
+    for raw_line in block.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        continued = stripped.endswith("\\")
+        fragment = stripped[:-1].rstrip() if continued else stripped
+        pending = f"{pending} {fragment}".strip()
+        if continued:
+            continue
+        commands.append(shlex.split(pending, comments=True, posix=True))
+        pending = ""
+    if pending:
+        commands.append(shlex.split(pending, comments=True, posix=True))
+    return commands
+
+
 def bounded_release_section(text: str, current: str, following: str) -> str:
     current_heading = rf"^## {re.escape(current)}(?:\s+-[^\n]+)?\s*$"
     following_heading = rf"^## {re.escape(following)}(?:\s+-[^\n]+)?\s*$"
@@ -154,12 +205,13 @@ def bounded_release_section(text: str, current: str, following: str) -> str:
 
 
 requirements_section = markdown_section(building, "### Requirements")
-required_compiler_row = re.compile(
-    r"^\|\s*C\+\+23 compiler\s*\|\s*GCC or Clang\s*\|\s*$",
-    re.MULTILINE,
-)
-if not required_compiler_row.search(requirements_section):
-    print("docs/building.md must declare C++23 in the Requirements table", file=sys.stderr)
+requirements_rows = markdown_table(requirements_section, "docs/building.md Requirements")
+compiler_rows = [row for row in requirements_rows if row and row[0].startswith("C++")]
+if compiler_rows != [["C++23 compiler", "GCC or Clang"]]:
+    print(
+        "docs/building.md Requirements table must contain exactly the C++23 compiler row",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 arch_section = markdown_section(building, "#### Arch / CachyOS")
@@ -170,7 +222,16 @@ arch_block = re.search(
 if not arch_block:
     print("docs/building.md is missing the bounded Arch/CachyOS install command", file=sys.stderr)
     sys.exit(1)
-arch_tokens = set(shlex.split(arch_block.group("commands").replace("\\\n", " ")))
+arch_commands = shell_commands(arch_block.group("commands"))
+pacman_commands = [
+    tokens
+    for tokens in arch_commands
+    if len(tokens) >= 3 and tokens[:2] == ["sudo", "pacman"] and "-S" in tokens
+]
+if len(pacman_commands) != 1:
+    print("Arch/CachyOS block must contain exactly one sudo pacman -S command", file=sys.stderr)
+    sys.exit(1)
+arch_tokens = set(pacman_commands[0])
 for dependency in ("vulkan-headers", "vulkan-icd-loader"):
     if dependency not in arch_tokens:
         print(

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -444,7 +444,7 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
-    "## v1.3.2 - 2026-07-29",
+    "## v1.3.2 - 2026-07-30",
     "## v1.3.1 - 2026-07-12",
 )
 current_release_prose = rendered_markdown(current_release)

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -111,19 +111,28 @@ import shlex
 import sys
 
 
+def fence_context_line(line: str) -> str:
+    """Remove Markdown blockquote containers before testing a fence delimiter."""
+    return re.sub(r"^(?:[ ]{0,3}>[ \t]?)+", "", line.rstrip("\r\n"))
+
+
 def advance_fence(fence, line: str):
     """Advance CommonMark-style fenced-code state; return (state, delimiter_line)."""
+    candidate = fence_context_line(line)
     if fence is None:
-        opener = re.match(r"^\s{0,3}(`{3,}|~{3,})(.*)$", line.rstrip("\r\n"))
+        opener = re.match(r"^[ ]{0,3}(`{3,}|~{3,})(.*)$", candidate)
         if opener:
             marker = opener.group(1)
+            info = opener.group(2)
+            if marker[0] == "`" and "`" in info:
+                return None, False
             return (marker[0], len(marker)), True
         return None, False
 
     char, minimum = fence
     closer = re.match(
-        rf"^\s{{0,3}}{re.escape(char)}{{{minimum},}}\s*$",
-        line.rstrip("\r\n"),
+        rf"^[ ]{{0,3}}{re.escape(char)}{{{minimum},}}[ \t]*$",
+        candidate,
     )
     if closer:
         return None, True
@@ -235,15 +244,30 @@ def markdown_section(
 
 
 def rendered_markdown(text: str) -> str:
-    """Return rendered prose/table text with fenced code blocks excluded."""
+    """Return visible Markdown text with fenced blocks and destinations excluded."""
     rendered: list[str] = []
     fence = None
     for line in text.splitlines(keepends=True):
         fence, delimiter = advance_fence(fence, line)
         if delimiter or fence is not None:
             continue
+        if re.match(r"^[ ]{0,3}\[[^]]+\]:\s+", line):
+            continue
         rendered.append(line)
-    return "".join(rendered)
+
+    visible = "".join(rendered)
+    visible = re.sub(
+        r"!?\[([^]]*)\]\((?:\\.|[^)\n])*\)",
+        lambda match: match.group(1),
+        visible,
+    )
+    visible = re.sub(
+        r"!?\[([^]]*)\]\[[^]]*\]",
+        lambda match: match.group(1),
+        visible,
+    )
+    visible = re.sub(r"</?[A-Za-z][^>]*>", "", visible)
+    return visible
 
 
 def markdown_table(section: str, label: str) -> list[list[str]]:
@@ -405,6 +429,19 @@ required_readme_facts = (
 for fact in required_readme_facts:
     if fact not in readme_release_prose:
         print(f"README v1.3.2 summary is missing: {fact}", file=sys.stderr)
+        sys.exit(1)
+
+asset_phrase = (
+    "`Polaris-arch-x86_64.pkg.tar.zst`, "
+    "`Polaris-fedora44-x86_64.rpm`, and "
+    "`Polaris-ubuntu24.04-x86_64.deb`"
+)
+for label, section in (
+    ("README v1.3.2 summary", readme_release_prose),
+    ("v1.3.2 changelog", current_release_prose),
+):
+    if section.count(asset_phrase) != 1:
+        print(f"{label} must contain the exact visible three-asset phrase", file=sys.stderr)
         sys.exit(1)
 
 expected_assets = Counter(

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -373,8 +373,7 @@ if len(pacman_commands) != 1:
     print("Arch/CachyOS block must contain exactly one sudo pacman -S command", file=sys.stderr)
     sys.exit(1)
 arch_command = pacman_commands[0]
-shell_operators = {";", "&&", "||", "|", "&", ">", ">>", "<", "<<"}
-if shell_operators.intersection(arch_command):
+if any(token and set(token) <= set(";&|<>") for token in arch_command):
     print("Arch/CachyOS pacman command must not contain chained shell operators", file=sys.stderr)
     sys.exit(1)
 arch_tokens = set(arch_command)

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -110,10 +110,42 @@ import re
 import shlex
 import sys
 
-building = Path("docs/building.md").read_text(encoding="utf-8")
-contributing = Path(".github/CONTRIBUTING.md").read_text(encoding="utf-8")
-readme = Path("README.md").read_text(encoding="utf-8")
-changelog = Path("docs/changelog.md").read_text(encoding="utf-8")
+
+def strip_html_comments(text: str) -> str:
+    """Remove non-rendered HTML comments while preserving line boundaries."""
+    return re.sub(
+        r"<!--.*?-->",
+        lambda match: "\n" * match.group(0).count("\n"),
+        text,
+        flags=re.DOTALL,
+    )
+
+
+building = strip_html_comments(Path("docs/building.md").read_text(encoding="utf-8"))
+contributing = strip_html_comments(
+    Path(".github/CONTRIBUTING.md").read_text(encoding="utf-8")
+)
+readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
+changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
+
+
+def advance_fence(fence, line: str):
+    """Advance CommonMark-style fenced-code state; return (state, delimiter_line)."""
+    if fence is None:
+        opener = re.match(r"^\s{0,3}(`{3,}|~{3,})(.*)$", line.rstrip("\r\n"))
+        if opener:
+            marker = opener.group(1)
+            return (marker[0], len(marker)), True
+        return None, False
+
+    char, minimum = fence
+    closer = re.match(
+        rf"^\s{{0,3}}{re.escape(char)}{{{minimum},}}\s*$",
+        line.rstrip("\r\n"),
+    )
+    if closer:
+        return None, True
+    return fence, False
 
 
 def markdown_section(
@@ -127,7 +159,14 @@ def markdown_section(
         raise ValueError(f"Invalid heading: {heading}")
 
     lines = text.splitlines(keepends=True)
-    starts = [index for index, line in enumerate(lines) if line.rstrip("\r\n") == heading]
+    starts = []
+    fence = None
+    for index, line in enumerate(lines):
+        fence, delimiter = advance_fence(fence, line)
+        if delimiter or fence is not None:
+            continue
+        if line.rstrip("\r\n") == heading:
+            starts.append(index)
     if len(starts) != 1:
         print(f"Expected exactly one Markdown heading: {heading}", file=sys.stderr)
         sys.exit(1)
@@ -137,15 +176,10 @@ def markdown_section(
     fence = None
     end = len(lines)
     for index in range(start, len(lines)):
-        fence_match = re.match(r"^\s{0,3}(`{3,}|~{3,})", lines[index])
-        if fence_match:
-            marker = fence_match.group(1)
-            if fence is None:
-                fence = (marker[0], len(marker))
-            elif marker[0] == fence[0] and len(marker) >= fence[1]:
-                fence = None
+        fence, delimiter = advance_fence(fence, lines[index])
+        if delimiter or fence is not None:
             continue
-        if fence is None and boundary.match(lines[index]):
+        if boundary.match(lines[index]):
             end = index
             break
     if expected_following is not None:
@@ -160,11 +194,32 @@ def markdown_section(
     return "".join(lines[start:end])
 
 
+def rendered_markdown(text: str) -> str:
+    """Return rendered prose/table text with fenced code blocks excluded."""
+    rendered: list[str] = []
+    fence = None
+    for line in text.splitlines(keepends=True):
+        fence, delimiter = advance_fence(fence, line)
+        if delimiter or fence is not None:
+            continue
+        rendered.append(line)
+    return "".join(rendered)
+
+
 def markdown_table(section: str, label: str) -> list[list[str]]:
     """Parse the first contiguous Markdown table in a bounded section."""
     blocks: list[list[str]] = []
     current: list[str] = []
+    fence = None
     for line in section.splitlines():
+        fence, delimiter = advance_fence(fence, line)
+        if delimiter:
+            if current:
+                blocks.append(current)
+                current = []
+            continue
+        if fence is not None:
+            continue
         if line.strip().startswith("|"):
             current.append(line)
         elif current:
@@ -191,6 +246,13 @@ def markdown_table(section: str, label: str) -> list[list[str]]:
     return rows[2:]
 
 
+def tokenize_shell_command(command: str) -> list[str]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>")
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+    return list(lexer)
+
+
 def shell_commands(block: str) -> list[list[str]]:
     """Return tokenized, uncommented logical shell commands from a fenced block."""
     commands: list[list[str]] = []
@@ -204,10 +266,10 @@ def shell_commands(block: str) -> list[list[str]]:
         pending = f"{pending} {fragment}".strip()
         if continued:
             continue
-        commands.append(shlex.split(pending, comments=True, posix=True))
+        commands.append(tokenize_shell_command(pending))
         pending = ""
     if pending:
-        commands.append(shlex.split(pending, comments=True, posix=True))
+        commands.append(tokenize_shell_command(pending))
     return commands
 
 
@@ -246,7 +308,12 @@ pacman_commands = [
 if len(pacman_commands) != 1:
     print("Arch/CachyOS block must contain exactly one sudo pacman -S command", file=sys.stderr)
     sys.exit(1)
-arch_tokens = set(pacman_commands[0])
+arch_command = pacman_commands[0]
+shell_operators = {";", "&&", "||", "|", "&", ">", ">>", "<", "<<"}
+if shell_operators.intersection(arch_command):
+    print("Arch/CachyOS pacman command must not contain chained shell operators", file=sys.stderr)
+    sys.exit(1)
+arch_tokens = set(arch_command)
 for dependency in ("vulkan-headers", "vulkan-icd-loader"):
     if dependency not in arch_tokens:
         print(
@@ -260,6 +327,7 @@ current_release = markdown_section(
     "## v1.3.2 - 2026-07-29",
     "## v1.3.1 - 2026-07-12",
 )
+current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
     "webtransport-go v0.11.1",
     "quic-go v0.60.0",
@@ -273,7 +341,7 @@ required_release_facts = (
     "GCC 15",
 )
 for fact in required_release_facts:
-    if fact not in current_release:
+    if fact not in current_release_prose:
         print(f"v1.3.2 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
@@ -282,6 +350,7 @@ readme_release_body = markdown_section(
     "## What is New in v1.3.2",
     "## Install",
 )
+readme_release_prose = rendered_markdown(readme_release_body)
 required_readme_facts = (
     "webtransport-go v0.11.1",
     "quic-go v0.60.0",
@@ -294,7 +363,7 @@ required_readme_facts = (
     "GCC 15",
 )
 for fact in required_readme_facts:
-    if fact not in readme_release_body:
+    if fact not in readme_release_prose:
         print(f"README v1.3.2 summary is missing: {fact}", file=sys.stderr)
         sys.exit(1)
 
@@ -307,8 +376,8 @@ expected_assets = Counter(
 )
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
-    ("README v1.3.2 summary", readme_release_body),
-    ("v1.3.2 changelog", current_release),
+    ("README v1.3.2 summary", readme_release_prose),
+    ("v1.3.2 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_assets:

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -209,6 +209,7 @@ def markdown_section(
     expected_following=None,
 ) -> str:
     """Return one exact Markdown section, bounded by a same/higher-level heading."""
+    text = mask_hidden_html(text)
     level = len(heading) - len(heading.lstrip("#"))
     if level < 1 or heading[level:level + 1] != " ":
         raise ValueError(f"Invalid heading: {heading}")
@@ -247,6 +248,103 @@ def markdown_section(
             )
             sys.exit(1)
     return "".join(lines[start:end])
+
+
+HTML_VOID_TAGS = {
+    "area", "base", "br", "col", "embed", "hr", "img", "input",
+    "link", "meta", "param", "source", "track", "wbr",
+}
+HTML_NONCONTENT_TAGS = {"script", "style", "template"}
+
+
+def html_element_is_hidden(tag, attrs):
+    values = {name.lower(): (value or "") for name, value in attrs}
+    if tag in HTML_NONCONTENT_TAGS or "hidden" in values:
+        return True
+    if values.get("aria-hidden", "").strip().lower() == "true":
+        return True
+    style = values.get("style", "")
+    return bool(
+        re.search(
+            r"(?:^|;)\s*display\s*:\s*none(?:\s*!important)?\s*(?:;|$)",
+            style,
+            re.I,
+        )
+    )
+
+
+class HiddenHTMLRangeParser(HTMLParser):
+    """Locate non-rendered HTML ranges so Markdown headings cannot hide in them."""
+
+    def __init__(self, source):
+        super().__init__(convert_charrefs=False)
+        self.source = source
+        self.line_offsets = [0]
+        for match in re.finditer(r"\n", source):
+            self.line_offsets.append(match.end())
+        self.stack = []
+        self.hidden_depth = 0
+        self.hidden_start = None
+        self.ranges = []
+
+    def _offset(self):
+        line, column = self.getpos()
+        return self.line_offsets[line - 1] + column
+
+    def _tag_end(self, start):
+        end = self.source.find(">", start)
+        return len(self.source) if end < 0 else end + 1
+
+    def handle_starttag(self, tag, attrs):
+        tag = tag.lower()
+        hidden = html_element_is_hidden(tag, attrs)
+        start = self._offset()
+        if tag in HTML_VOID_TAGS:
+            if hidden and self.hidden_depth == 0:
+                self.ranges.append((start, self._tag_end(start)))
+            return
+        if hidden and self.hidden_depth == 0:
+            self.hidden_start = start
+        self.stack.append((tag, hidden))
+        if hidden:
+            self.hidden_depth += 1
+
+    def handle_startendtag(self, tag, attrs):
+        if html_element_is_hidden(tag.lower(), attrs) and self.hidden_depth == 0:
+            start = self._offset()
+            self.ranges.append((start, self._tag_end(start)))
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        for index in range(len(self.stack) - 1, -1, -1):
+            if self.stack[index][0] != tag:
+                continue
+            removed = self.stack[index:]
+            del self.stack[index:]
+            prior_depth = self.hidden_depth
+            self.hidden_depth -= sum(1 for _, hidden in removed if hidden)
+            if prior_depth > 0 and self.hidden_depth == 0 and self.hidden_start is not None:
+                self.ranges.append((self.hidden_start, self._tag_end(self._offset())))
+                self.hidden_start = None
+            return
+
+    def close(self):
+        super().close()
+        if self.hidden_start is not None:
+            self.ranges.append((self.hidden_start, len(self.source)))
+            self.hidden_start = None
+
+
+def mask_hidden_html(text):
+    parser = HiddenHTMLRangeParser(text)
+    parser.feed(text)
+    parser.close()
+    masked = list(text)
+    for start, end in parser.ranges:
+        for index in range(start, end):
+            if masked[index] not in "\r\n":
+                masked[index] = " "
+    return "".join(masked)
 
 
 class VisibleHTMLText(HTMLParser):
@@ -322,12 +420,18 @@ def rendered_markdown(text: str) -> str:
 
     visible = "".join(rendered)
     visible = re.sub(
-        r"!?\[([^]]*)\]\((?:\\.|[^)\n])*\)",
-        lambda match: match.group(1),
+        r"!\[[^]]*\]\((?:\\.|[^)\n])*\)",
+        "",
         visible,
     )
     visible = re.sub(
-        r"!?\[([^]]*)\]\[[^]]*\]",
+        r"\[([^]]*)\]\((?:\\.|[^)\n])*\)",
+        lambda match: match.group(1),
+        visible,
+    )
+    visible = re.sub(r"!\[[^]]*\]\[[^]]*\]", "", visible)
+    visible = re.sub(
+        r"\[([^]]*)\]\[[^]]*\]",
         lambda match: match.group(1),
         visible,
     )

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -257,6 +257,25 @@ def rendered_markdown(text: str) -> str:
 
     visible = "".join(rendered)
     visible = re.sub(
+        r"<(script|style|template)\b[^>]*>.*?</\1\s*>",
+        "",
+        visible,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    hidden_element = re.compile(
+        r"<([A-Za-z][\w:-]*)\b"
+        r"(?=[^>]*(?:\shidden(?:\s*=\s*(?:\"[^\"]*\"|'[^']*'|[^\s>]+))?"
+        r"|\saria-hidden\s*=\s*(?:\"true\"|'true'|true)"
+        r"|\sstyle\s*=\s*(?:\"[^\"]*display\s*:\s*none[^\"]*\""
+        r"|'[^']*display\s*:\s*none[^']*')))"
+        r"[^>]*>.*?</\1\s*>",
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    while True:
+        visible, removed = hidden_element.subn("", visible)
+        if removed == 0:
+            break
+    visible = re.sub(
         r"!?\[([^]]*)\]\((?:\\.|[^)\n])*\)",
         lambda match: match.group(1),
         visible,

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -117,6 +117,11 @@ def fence_context_line(line: str) -> str:
     return re.sub(r"^(?:[ ]{0,3}>[ \t]?)+", "", line.rstrip("\r\n"))
 
 
+def is_indented_code(line: str) -> bool:
+    candidate = fence_context_line(line)
+    return candidate.startswith("\t") or candidate.startswith("    ")
+
+
 def advance_fence(fence, line: str):
     """Advance CommonMark-style fenced-code state; return (state, delimiter_line)."""
     candidate = fence_context_line(line)
@@ -309,6 +314,8 @@ def rendered_markdown(text: str) -> str:
         fence, delimiter = advance_fence(fence, line)
         if delimiter or fence is not None:
             continue
+        if is_indented_code(line):
+            continue
         if re.match(r"^[ ]{0,3}\[[^]]+\]:\s+", line):
             continue
         rendered.append(line)
@@ -341,6 +348,11 @@ def markdown_table(section: str, label: str) -> list[list[str]]:
             continue
         if fence is not None:
             continue
+        if is_indented_code(line):
+            if current:
+                blocks.append(current)
+                current = []
+            continue
         if line.strip().startswith("|"):
             current.append(line)
         elif current:
@@ -368,7 +380,7 @@ def markdown_table(section: str, label: str) -> list[list[str]]:
 
 
 def tokenize_shell_command(command: str) -> list[str]:
-    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>")
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|<>()")
     lexer.whitespace_split = True
     lexer.commenters = "#"
     return list(lexer)
@@ -430,8 +442,14 @@ if len(pacman_commands) != 1:
     print("Arch/CachyOS block must contain exactly one sudo pacman -S command", file=sys.stderr)
     sys.exit(1)
 arch_command = pacman_commands[0]
-if any(token and set(token) <= set(";&|<>") for token in arch_command):
-    print("Arch/CachyOS pacman command must not contain chained shell operators", file=sys.stderr)
+if any(
+    (token and set(token) <= set(";&|<>()")) or "$" in token or "`" in token
+    for token in arch_command
+):
+    print(
+        "Arch/CachyOS pacman command must use literal arguments without shell control or expansion",
+        file=sys.stderr,
+    )
     sys.exit(1)
 arch_tokens = set(arch_command)
 for dependency in ("vulkan-headers", "vulkan-icd-loader"):

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -104,14 +104,37 @@ for expected_link in "${expected_nova_links[@]}"; do
 done
 
 python3 <<'PY'
+from collections import Counter
 from pathlib import Path
 import re
 import shlex
 import sys
 
 building = Path("docs/building.md").read_text(encoding="utf-8")
+contributing = Path(".github/CONTRIBUTING.md").read_text(encoding="utf-8")
 readme = Path("README.md").read_text(encoding="utf-8")
 changelog = Path("docs/changelog.md").read_text(encoding="utf-8")
+
+
+def markdown_section(text: str, heading: str) -> str:
+    """Return one exact Markdown section, bounded by a same/higher-level heading."""
+    level = len(heading) - len(heading.lstrip("#"))
+    if level < 1 or heading[level:level + 1] != " ":
+        raise ValueError(f"Invalid heading: {heading}")
+
+    lines = text.splitlines(keepends=True)
+    starts = [index for index, line in enumerate(lines) if line.rstrip("\r\n") == heading]
+    if len(starts) != 1:
+        print(f"Expected exactly one Markdown heading: {heading}", file=sys.stderr)
+        sys.exit(1)
+
+    start = starts[0] + 1
+    boundary = re.compile(rf"^#{{1,{level}}}\s+")
+    end = next(
+        (index for index in range(start, len(lines)) if boundary.match(lines[index])),
+        len(lines),
+    )
+    return "".join(lines[start:end])
 
 
 def bounded_release_section(text: str, current: str, following: str) -> str:
@@ -130,20 +153,22 @@ def bounded_release_section(text: str, current: str, following: str) -> str:
     return match.group("body")
 
 
+requirements_section = markdown_section(building, "### Requirements")
 required_compiler_row = re.compile(
     r"^\|\s*C\+\+23 compiler\s*\|\s*GCC or Clang\s*\|\s*$",
     re.MULTILINE,
 )
-if not required_compiler_row.search(building):
-    print("docs/building.md must declare C++23 in the requirements table", file=sys.stderr)
+if not required_compiler_row.search(requirements_section):
+    print("docs/building.md must declare C++23 in the Requirements table", file=sys.stderr)
     sys.exit(1)
 
+arch_section = markdown_section(building, "#### Arch / CachyOS")
 arch_block = re.search(
-    r"(?ms)^#### Arch / CachyOS\s*$.*?^```bash\s*$\n(?P<commands>.*?)^```\s*$",
-    building,
+    r"(?ms)^```bash\s*$\n(?P<commands>.*?)^```\s*$",
+    arch_section,
 )
 if not arch_block:
-    print("docs/building.md is missing the Arch/CachyOS install command", file=sys.stderr)
+    print("docs/building.md is missing the bounded Arch/CachyOS install command", file=sys.stderr)
     sys.exit(1)
 arch_tokens = set(shlex.split(arch_block.group("commands").replace("\\\n", " ")))
 for dependency in ("vulkan-headers", "vulkan-icd-loader"):
@@ -179,6 +204,7 @@ readme_release = re.search(
 if not readme_release:
     print("README is missing the bounded v1.3.2 summary", file=sys.stderr)
     sys.exit(1)
+readme_release_body = readme_release.group("body")
 required_readme_facts = (
     "webtransport-go v0.11.1",
     "quic-go v0.60.0",
@@ -191,9 +217,37 @@ required_readme_facts = (
     "GCC 15",
 )
 for fact in required_readme_facts:
-    if fact not in readme_release.group("body"):
+    if fact not in readme_release_body:
         print(f"README v1.3.2 summary is missing: {fact}", file=sys.stderr)
         sys.exit(1)
+
+expected_assets = Counter(
+    {
+        "Polaris-arch-x86_64.pkg.tar.zst": 1,
+        "Polaris-fedora44-x86_64.rpm": 1,
+        "Polaris-ubuntu24.04-x86_64.deb": 1,
+    }
+)
+asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
+for label, section in (
+    ("README v1.3.2 summary", readme_release_body),
+    ("v1.3.2 changelog", current_release),
+):
+    actual_assets = Counter(asset_pattern.findall(section))
+    if actual_assets != expected_assets:
+        print(
+            f"{label} must name exactly one of each supported asset; "
+            f"expected={dict(expected_assets)}, actual={dict(actual_assets)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+if "bash scripts/check-public-docs.sh" not in contributing:
+    print("CONTRIBUTING.md must invoke the non-executable checker through bash", file=sys.stderr)
+    sys.exit(1)
+if "./scripts/check-public-docs.sh" in contributing:
+    print("CONTRIBUTING.md must not execute the mode-100644 checker directly", file=sys.stderr)
+    sys.exit(1)
 PY
 
 echo "Public docs and release references look clean."

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -103,4 +103,48 @@ for expected_link in "${expected_nova_links[@]}"; do
   grep -Fq "$expected_link" README.md
 done
 
+python3 <<'PY'
+from pathlib import Path
+import sys
+
+building = Path("docs/building.md").read_text(encoding="utf-8")
+readme = Path("README.md").read_text(encoding="utf-8")
+changelog = Path("docs/changelog.md").read_text(encoding="utf-8")
+
+if "C++23" not in building or "C++20" in building:
+    print("docs/building.md must advertise the required C++23 toolchain", file=sys.stderr)
+    sys.exit(1)
+
+for dependency in ("vulkan-headers", "vulkan-icd-loader"):
+    if dependency not in building:
+        print(f"docs/building.md is missing the Arch dependency: {dependency}", file=sys.stderr)
+        sys.exit(1)
+
+try:
+    current_release = changelog.split("## v1.3.2", 1)[1].split("## v1.3.1", 1)[0]
+except IndexError:
+    print("docs/changelog.md is missing a bounded v1.3.2 section", file=sys.stderr)
+    sys.exit(1)
+
+required_release_facts = (
+    "webtransport-go v0.11.1",
+    "quic-go v0.60.0",
+    "CVE-2026-57497",
+    "npm audit --audit-level=high",
+    "Polaris-fedora44-x86_64.rpm",
+    "vulkan-headers",
+    "vulkan-loader-devel",
+    "GCC 15",
+)
+for fact in required_release_facts:
+    if fact not in current_release:
+        print(f"v1.3.2 changelog is missing final release fact: {fact}", file=sys.stderr)
+        sys.exit(1)
+
+for fact in ("webtransport-go v0.11.1", "CVE-2026-57497"):
+    if fact not in readme:
+        print(f"README v1.3.2 summary is missing: {fact}", file=sys.stderr)
+        sys.exit(1)
+PY
+
 echo "Public docs and release references look clean."

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -111,24 +111,6 @@ import shlex
 import sys
 
 
-def strip_html_comments(text: str) -> str:
-    """Remove non-rendered HTML comments while preserving line boundaries."""
-    return re.sub(
-        r"<!--.*?-->",
-        lambda match: "\n" * match.group(0).count("\n"),
-        text,
-        flags=re.DOTALL,
-    )
-
-
-building = strip_html_comments(Path("docs/building.md").read_text(encoding="utf-8"))
-contributing = strip_html_comments(
-    Path(".github/CONTRIBUTING.md").read_text(encoding="utf-8")
-)
-readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
-changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
-
-
 def advance_fence(fence, line: str):
     """Advance CommonMark-style fenced-code state; return (state, delimiter_line)."""
     if fence is None:
@@ -146,6 +128,64 @@ def advance_fence(fence, line: str):
     if closer:
         return None, True
     return fence, False
+
+
+def strip_html_comments(text: str) -> str:
+    """Remove HTML comments outside fenced code while preserving line boundaries."""
+    output: list[str] = []
+    fence = None
+    in_comment = False
+
+    for line in text.splitlines(keepends=True):
+        if fence is not None:
+            output.append(line)
+            fence, _ = advance_fence(fence, line)
+            continue
+
+        if not in_comment:
+            next_fence, delimiter = advance_fence(None, line)
+            if delimiter:
+                output.append(line)
+                fence = next_fence
+                continue
+
+        newline = ""
+        body = line
+        if body.endswith("\r\n"):
+            body, newline = body[:-2], "\r\n"
+        elif body.endswith("\n"):
+            body, newline = body[:-1], "\n"
+
+        visible: list[str] = []
+        position = 0
+        while position < len(body):
+            if in_comment:
+                end = body.find("-->", position)
+                if end < 0:
+                    position = len(body)
+                    break
+                in_comment = False
+                position = end + 3
+                continue
+            start = body.find("<!--", position)
+            if start < 0:
+                visible.append(body[position:])
+                break
+            visible.append(body[position:start])
+            in_comment = True
+            position = start + 4
+
+        output.append("".join(visible) + newline)
+
+    return "".join(output)
+
+
+building = strip_html_comments(Path("docs/building.md").read_text(encoding="utf-8"))
+contributing = strip_html_comments(
+    Path(".github/CONTRIBUTING.md").read_text(encoding="utf-8")
+)
+readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
+changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 
 
 def markdown_section(


### PR DESCRIPTION
## Summary

- complete the published `v1.3.2` README and changelog with the final Browser Stream security update, npm audit gate, exact three-package boundary, Vulkan package dependencies, and GCC 15 release-build fixes
- correct the source-build requirement from C++20 to C++23 and add the missing Arch Vulkan packages
- document the concrete contributor verification gates and encode the new release-documentation facts in `check-public-docs.sh`

## Verification

- `./scripts/check-public-docs.sh`
- `python3 scripts/check-release-package-dependencies.py`
- `bash -n scripts/check-public-docs.sh`
- `npm ci`
- `npm audit --audit-level=high` — 0 vulnerabilities
- semantic mutation probes: reject Arch dependencies moved into comments, unrelated/chained commands, shell substitutions, or later Markdown sections; reject C++23 moved outside the primary Requirements table or into fenced/four-space-indented decoys; ignore valid fenced headings/comments, blockquote-nested fences, and non-closing fence content; reject pseudo-fences, intervening H2s, link-destination-only/hidden-HTML/fenced facts, and missing/duplicate/fourth release assets; accept truthful C++20 compatibility context; enforce `bash` invocation of the mode-100644 checker
- `git diff --check`

## Release boundary

This is an additive post-release documentation correction. It does not mutate the published `v1.3.2` tag, release body, or package assets. Historical Fedora 42/43 changelog references remain intact; current support remains Fedora 44 only.
