### PR TITLE
fix(web): strip response-only config fields

### DIFF
--- a/src_assets/common/assets/web/client-settings-sync.js
+++ b/src_assets/common/assets/web/client-settings-sync.js
@@ -20,6 +20,26 @@ export const CLIENT_SETTINGS_RESPONSE_ONLY_KEYS = [
   'ai_auto_quality_enabled',
 ]
 
+export const CONFIG_RESPONSE_ONLY_KEYS = [
+  'status',
+  'platform',
+  'version',
+  'has_ai_api_key',
+  'has_steamgriddb_api_key',
+  'has_api_key',
+  'vdisplayStatus',
+  'vdisplayAvailable',
+  'vdisplayBackend',
+  'runtime_backend',
+  'runtime_requested_headless',
+  'runtime_effective_headless',
+  'runtime_gpu_native_override_active',
+  'stream_display_mode',
+  'stream_path_id',
+  'stream_path_label',
+  ...CLIENT_SETTINGS_RESPONSE_ONLY_KEYS,
+]
+
 export function isTruthySetting(value) {
   return value === true || value === 'true' || value === 'enabled' || value === 1 || value === '1'
 }
@@ -189,6 +209,13 @@ export function normalizeFieldList(value) {
 
 export function stripClientSettingsResponseOnly(config = {}) {
   for (const key of CLIENT_SETTINGS_RESPONSE_ONLY_KEYS) {
+    delete config[key]
+  }
+  return config
+}
+
+export function stripConfigResponseOnly(config = {}) {
+  for (const key of CONFIG_RESPONSE_ONLY_KEYS) {
     delete config[key]
   }
   return config

--- a/src_assets/common/assets/web/client-settings-sync.test.js
+++ b/src_assets/common/assets/web/client-settings-sync.test.js
@@ -7,6 +7,7 @@ import {
   resolveStreamDisplayRuntimeNotice,
   streamDisplayModeAvailable,
   stripClientSettingsResponseOnly,
+  stripConfigResponseOnly,
 } from './client-settings-sync'
 
 describe('client settings sync helpers', () => {
@@ -228,5 +229,34 @@ describe('client settings sync helpers', () => {
     })
 
     expect(config).toEqual({ headless_mode: 'enabled' })
+  })
+
+  it('strips all GET-only runtime metadata before a config POST', () => {
+    const config = stripConfigResponseOnly({
+      headless_mode: 'enabled',
+      linux_stream_mode: 'headless_stream',
+      status: true,
+      platform: 'linux',
+      version: '1.3.2',
+      has_ai_api_key: true,
+      has_steamgriddb_api_key: true,
+      has_api_key: true,
+      vdisplayStatus: 1,
+      vdisplayAvailable: true,
+      vdisplayBackend: 'evdi',
+      runtime_backend: 'Labwc',
+      runtime_requested_headless: true,
+      runtime_effective_headless: true,
+      runtime_gpu_native_override_active: false,
+      stream_display_mode: 'Private Stream',
+      stream_path_id: 'headless_stream',
+      stream_path_label: 'Private Stream',
+      client_settings_available: true,
+    })
+
+    expect(config).toEqual({
+      headless_mode: 'enabled',
+      linux_stream_mode: 'headless_stream',
+    })
   })
 })

--- a/src_assets/common/assets/web/components/QuickControls.vue
+++ b/src_assets/common/assets/web/components/QuickControls.vue
@@ -1,7 +1,10 @@
 <script setup>
 import { computed, ref, onMounted, onUnmounted, inject } from 'vue'
 import { useToast } from '../composables/useToast'
-import { CLIENT_SETTINGS_RESPONSE_ONLY_KEYS, resolveClientSettingsSync } from '../client-settings-sync'
+import {
+  resolveClientSettingsSync,
+  stripConfigResponseOnly,
+} from '../client-settings-sync'
 import ConfirmActionDialog from './ConfirmActionDialog.vue'
 
 const config = ref({})
@@ -28,24 +31,6 @@ const defaults = {
   enable_discovery: 'enabled',
   enable_pairing: 'enabled',
 }
-
-const responseOnlyConfigKeys = [
-  'status',
-  'platform',
-  'version',
-  'has_ai_api_key',
-  'has_steamgriddb_api_key',
-  'has_api_key',
-  'vdisplayStatus',
-  'vdisplayAvailable',
-  'vdisplayBackend',
-  'runtime_backend',
-  'runtime_requested_headless',
-  'runtime_effective_headless',
-  'runtime_gpu_native_override_active',
-  'stream_display_mode',
-  ...CLIENT_SETTINGS_RESPONSE_ONLY_KEYS,
-]
 
 function isEnabled(key) {
   const val = config.value[key] ?? defaults[key] ?? 'disabled'
@@ -90,7 +75,7 @@ async function toggle(key) {
 
     // Remove response-only keys injected by getConfig() that aren't real config settings.
     // These come from the server's status probing, not the config file.
-    for (const k of responseOnlyConfigKeys) delete existing[k]
+    stripConfigResponseOnly(existing)
 
     // Merge the toggle change
     existing[key] = newVal

--- a/src_assets/common/assets/web/config-pending-changes.test.js
+++ b/src_assets/common/assets/web/config-pending-changes.test.js
@@ -147,6 +147,49 @@ describe('ConfigView pending changes review', () => {
     expect(wrapper.text()).toContain('Maximum Bitrate')
   })
 
+  it('strips response-only stream path metadata from config saves', async () => {
+    const wrapper = mountConfigView({
+      stream_path_id: 'headless_stream',
+      stream_path_label: 'Private Stream',
+      runtime_backend: 'Labwc',
+      vdisplayAvailable: true,
+    })
+    await flushConfigLoad()
+
+    wrapper.vm.config.sunshine_name = 'Fixed Host'
+    await nextTick()
+
+    global.fetch.mockResolvedValueOnce({ status: 200 })
+    const result = await wrapper.vm.save()
+
+    expect(result).toBe(true)
+    const saveRequest = global.fetch.mock.calls.at(-1)
+    const body = JSON.parse(saveRequest[1].body)
+    expect(body).toHaveProperty('sunshine_name', 'Fixed Host')
+    expect(body).not.toHaveProperty('stream_path_id')
+    expect(body).not.toHaveProperty('stream_path_label')
+    expect(body).not.toHaveProperty('runtime_backend')
+    expect(body).not.toHaveProperty('vdisplayAvailable')
+  })
+
+  it('preserves credential-presence metadata when resetting local changes', async () => {
+    const wrapper = mountConfigView({
+      has_ai_api_key: true,
+      has_steamgriddb_api_key: true,
+      has_api_key: true,
+    })
+    await flushConfigLoad()
+
+    wrapper.vm.config.sunshine_name = 'Temporary Name'
+    await nextTick()
+    wrapper.vm.resetLocalChanges()
+    await nextTick()
+
+    expect(wrapper.vm.config.has_ai_api_key).toBe(true)
+    expect(wrapper.vm.config.has_steamgriddb_api_key).toBe(true)
+    expect(wrapper.vm.config.has_api_key).toBe(true)
+  })
+
   it('shows backend validation details when saving configuration fails', async () => {
     const wrapper = mountConfigView()
     await flushConfigLoad()

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -277,7 +277,10 @@ import AiOptimizer from '../configs/tabs/AiOptimizer.vue'
 import ContainerEncoders from '../configs/tabs/ContainerEncoders.vue'
 import Skeleton from '../components/Skeleton.vue'
 import { useToast } from '../composables/useToast'
-import { CLIENT_SETTINGS_RESPONSE_ONLY_KEYS, stripClientSettingsResponseOnly } from '../client-settings-sync'
+import {
+  CONFIG_RESPONSE_ONLY_KEYS,
+  stripConfigResponseOnly,
+} from '../client-settings-sync'
 import { requestHostRestart } from '../restart-host.js'
 import { rankSettingsSearchTabs } from '../settings-search.js'
 
@@ -789,7 +792,7 @@ function clearSearchHighlight() {
 
 function captureResponseOnlyConfig(source) {
   responseOnlyConfig.value = {}
-  for (const key of CLIENT_SETTINGS_RESPONSE_ONLY_KEYS) {
+  for (const key of CONFIG_RESPONSE_ONLY_KEYS) {
     if (source[key] !== undefined) {
       responseOnlyConfig.value[key] = source[key]
     }
@@ -900,7 +903,7 @@ function serialize() {
     configCopy.trusted_subnets = configCopy.trusted_subnets.filter(s => s && s.trim()).join(',')
   }
 
-  stripClientSettingsResponseOnly(configCopy)
+  stripConfigResponseOnly(configCopy)
 
   return configCopy
 }


### PR DESCRIPTION
## Summary
- centralize config response-only field ownership for Web UI saves
- strip runtime metadata including `stream_path_id` from ConfigView and Quick Controls POSTs
- preserve response-only credential state when resetting local changes

## Regression coverage
- verifies all runtime-only fields are removed while writable settings remain
- verifies actual ConfigView POST payloads omit stream-path metadata
- verifies Reset Local Changes preserves credential-presence indicators

## Verification
- `npm test` — 46 files, 254 tests passed
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm run budget:web`
- `bash scripts/check-public-docs.sh`
- `bash scripts/check-public-surface.sh`
- `git diff --check`

Fixes #251