### PR TITLE
fix(linux): make tray URL launch locale-safe

### DIFF
--- a/src/platform/linux/executable_path.h
+++ b/src/platform/linux/executable_path.h
@@ -1,0 +1,48 @@
+/**
+ * @file src/platform/linux/executable_path.h
+ * @brief Locale-independent Linux executable lookup.
+ */
+#pragma once
+
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace platf::linux_util {
+  inline bool is_executable_file(const std::string &path) {
+    struct stat info {};
+    return stat(path.c_str(), &info) == 0 && S_ISREG(info.st_mode) && access(path.c_str(), X_OK) == 0;
+  }
+
+  inline std::string find_executable_in_path(std::string_view name, const char *path_override = nullptr) {
+    if (name.empty()) {
+      return {};
+    }
+    const std::string requested(name);
+    if (requested.find('/') != std::string::npos) {
+      return is_executable_file(requested) ? requested : std::string {};
+    }
+
+    const char *configured_path = path_override ? path_override : std::getenv("PATH");
+    const std::string path = configured_path && *configured_path ? configured_path : "/usr/local/bin:/usr/bin:/bin";
+    std::size_t start = 0;
+    while (start <= path.size()) {
+      const auto end = path.find(':', start);
+      auto dir = path.substr(start, end == std::string::npos ? std::string::npos : end - start);
+      if (dir.empty()) {
+        dir = ".";
+      }
+      const auto candidate = dir + "/" + requested;
+      if (is_executable_file(candidate)) {
+        return candidate;
+      }
+      if (end == std::string::npos) {
+        break;
+      }
+      start = end + 1;
+    }
+    return {};
+  }
+}  // namespace platf::linux_util

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -35,7 +35,6 @@
 #include <boost/process/v1/group.hpp>
 #include <boost/process/v1/handles.hpp>
 #include <boost/process/v1/io.hpp>
-#include <boost/process/v1/search_path.hpp>
 #include <boost/process/v1/start_dir.hpp>
 #include <fcntl.h>
 #include <unistd.h>
@@ -45,6 +44,7 @@
 #endif
 
 // local includes
+#include "executable_path.h"
 #include "graphics.h"
 #include "misc.h"
 #include "src/config.h"
@@ -516,11 +516,12 @@ std::string get_local_ip_for_gateway() {
     auto working_dir = boost::filesystem::path(std::getenv("HOME"));
     boost::process::v1::environment _env = boost::this_process::environment();
     std::error_code ec;
-    const auto opener = bp::search_path("xdg-open");
-    if (opener.empty()) {
+    const auto opener_path = linux_util::find_executable_in_path("xdg-open");
+    if (opener_path.empty()) {
       BOOST_LOG(warning) << "Couldn't open url ["sv << url << "]: xdg-open was not found in PATH"sv;
       return;
     }
+    const boost::filesystem::path opener(opener_path);
 
     auto child = bp::child(
       opener,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ set(TEST_FAST_SOURCES
 
 if (NOT WIN32 AND NOT APPLE)
     list(APPEND TEST_FAST_SOURCES
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_linux_executable_path.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/test_wlgrab_pixel_copy.cpp
     )
 endif()

--- a/tests/unit/test_linux_executable_path.cpp
+++ b/tests/unit/test_linux_executable_path.cpp
@@ -1,0 +1,58 @@
+#include "../tests_common.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "src/platform/linux/executable_path.h"
+
+TEST(LinuxExecutablePath, FindsExecutableWithoutConstructingEnvironmentLocale) {
+  const std::string dir = "/tmp/polaris-path-search-" + std::to_string(getpid());
+  ASSERT_EQ(0, mkdir(dir.c_str(), 0700));
+  const std::string executable = dir + "/xdg-open";
+  {
+    std::ofstream file(executable);
+    file << "#!/bin/sh\nexit 0\n";
+  }
+  ASSERT_EQ(0, chmod(executable.c_str(), 0700));
+
+  const char *lang_value = std::getenv("LANG");
+  const char *lc_all_value = std::getenv("LC_ALL");
+  const std::string old_lang = lang_value ? lang_value : "";
+  const std::string old_lc_all = lc_all_value ? lc_all_value : "";
+  const bool had_lang = lang_value != nullptr;
+  const bool had_lc_all = lc_all_value != nullptr;
+  setenv("LANG", "zz_ZZ.UTF-8", 1);
+  setenv("LC_ALL", "zz_ZZ.UTF-8", 1);
+  EXPECT_EQ(executable, platf::linux_util::find_executable_in_path("xdg-open", dir.c_str()));
+  EXPECT_EQ(executable, platf::linux_util::find_executable_in_path(executable, ""));
+  EXPECT_TRUE(platf::linux_util::find_executable_in_path("missing", dir.c_str()).empty());
+
+  unlink(executable.c_str());
+  rmdir(dir.c_str());
+  if (had_lang) {
+    setenv("LANG", old_lang.c_str(), 1);
+  } else {
+    unsetenv("LANG");
+  }
+  if (had_lc_all) {
+    setenv("LC_ALL", old_lc_all.c_str(), 1);
+  } else {
+    unsetenv("LC_ALL");
+  }
+}
+
+TEST(LinuxExecutablePath, RejectsDirectoriesAndNonExecutableFiles) {
+  const std::string dir = "/tmp/polaris-path-types-" + std::to_string(getpid());
+  ASSERT_EQ(0, mkdir(dir.c_str(), 0700));
+  const std::string plain = dir + "/plain";
+  {
+    std::ofstream file(plain);
+    file << "not executable";
+  }
+  EXPECT_TRUE(platf::linux_util::find_executable_in_path("plain", dir.c_str()).empty());
+  EXPECT_TRUE(platf::linux_util::find_executable_in_path(dir, "").empty());
+  unlink(plain.c_str());
+  rmdir(dir.c_str());
+}


### PR DESCRIPTION
## Summary
- replace Boost.Process `search_path()` in the Linux tray URL path with byte-oriented POSIX `PATH` lookup
- require resolved launchers to be regular executable files
- cover malformed locales, direct paths, missing programs, directories, and non-executable files

## Root cause
The #106 startup guard works, but clicking **Open Polaris** later called `boost::process::v1::search_path("xdg-open")`, which reconstructs locale state from the malformed environment and throws `locale::facet::_S_create_c_locale name not valid`.

## Verification
- 155 fast C++ tests passed
- full Linux `polaris` target built
- `polaris_invalid_locale_startup` passed
- exact malformed-locale child-launch probe passed
- `git diff --check` passed
- independent pre-commit review: PASS, no blockers

Fixes #252