### PR TITLE
docs(bazzite): restore Sunshine after uninstall

### DIFF
--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -270,6 +270,20 @@ systemctl --user disable --now polaris
 sudo rpm-ostree uninstall -r polaris
 ```
 
+After rebooting, re-enable the Sunshine user service that matches the previous
+installation. The unit names are alternatives; run only the applicable command:
+
+```bash
+# Homebrew Sunshine
+systemctl --user enable --now homebrew.sunshine.service
+
+# Flatpak Sunshine
+systemctl --user enable --now app-dev.lizardbyte.app.Sunshine.service
+```
+
+Polaris and Sunshine use the same default GameStream ports, so do not enable both
+hosts at the same time.
+
 ## Known Bazzite Log Messages
 
 `labwc: No new Wayland socket appeared within 10s` means the isolated `labwc`


### PR DESCRIPTION
## Summary
- document restoring the Homebrew or Flatpak Sunshine user service after removing Polaris
- make the service choices explicitly mutually exclusive
- warn that Polaris and Sunshine share the default GameStream ports

## Verification
- `bash scripts/check-public-docs.sh`
- `bash scripts/check-public-surface.sh`
- `python3 scripts/check-release-package-dependencies.py`
- `git diff --check`
- independent review: PASS, no blockers

Fixes #256
Refs #235