### PR TITLE
fix(web): keep display planner presets idempotent

### DIFF
--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -39,11 +39,22 @@ const isLinux = computed(() => props.platform === 'linux')
 const isWindows = computed(() => props.platform === 'windows')
 const showDisplayPlannerAdvanced = ref(false)
 const customDisplayScale = ref(1)
+const plannerSourceMode = ref(config.value.fallback_mode || '')
+let applyingDisplayPlan = false
 const displayPlanner = computed(() => buildResolutionPlanner({
+  sourceMode: plannerSourceMode.value,
   fallbackMode: config.value.fallback_mode,
   customScale: customDisplayScale.value,
   showAdvanced: showDisplayPlannerAdvanced.value,
 }))
+
+watch(() => config.value.fallback_mode, (mode) => {
+  if (applyingDisplayPlan) {
+    applyingDisplayPlan = false
+    return
+  }
+  plannerSourceMode.value = mode || ''
+}, { flush: 'sync' })
 
 // Path cards mirror the stream_path registry (runtime × capture × topology).
 // Reserved paths (gamescope ownership, Family Mode, EVDI/dongle) stay visible but disabled
@@ -365,7 +376,8 @@ onMounted(() => {
 })
 
 function applyDisplayPlan(choice) {
-  if (!choice?.safe) return
+  if (!choice?.safe || config.value.fallback_mode === choice.targetMode) return
+  applyingDisplayPlan = true
   config.value.fallback_mode = choice.targetMode
 }
 
@@ -378,6 +390,11 @@ const validateFallbackMode = (event) => {
   }
 
   event.target.reportValidity();
+}
+
+function updateDisplayPlannerSource(event) {
+  validateFallbackMode(event)
+  plannerSourceMode.value = event.target.value
 }
 </script>
 
@@ -945,7 +962,7 @@ pactl info | grep Source</pre>
             type="text"
             class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none"
             placeholder="1920x1080x60"
-            @input="validateFallbackMode"
+            @input="updateDisplayPlannerSource"
           />
           <div class="text-sm text-storm mt-1">{{ $t('config.fallback_mode_desc') }}</div>
         </div>

--- a/src_assets/common/assets/web/display-resolution-planner.js
+++ b/src_assets/common/assets/web/display-resolution-planner.js
@@ -60,13 +60,15 @@ export function clampPlannerScale(value) {
 }
 
 export function buildResolutionPlanner({
+  sourceMode,
   fallbackMode = '',
   device = null,
   customScale = 1,
   showAdvanced = false,
   limits = DEFAULT_LIMITS,
 } = {}) {
-  const base = normalizeDevice(device || parseDisplayMode(fallbackMode))
+  const planningSourceMode = sourceMode === undefined ? fallbackMode : sourceMode
+  const base = normalizeDevice(device || parseDisplayMode(planningSourceMode))
   const effectiveLimits = { ...DEFAULT_LIMITS, ...(limits || {}) }
   const customFactor = clampPlannerScale(customScale)
 

--- a/src_assets/common/assets/web/display-resolution-planner.test.js
+++ b/src_assets/common/assets/web/display-resolution-planner.test.js
@@ -61,6 +61,33 @@ describe('display resolution planner', () => {
     expect(clampPlannerScale(3)).toBe(2)
   })
 
+  it('keeps repeated preset applications anchored to an immutable source mode', () => {
+    const sourceMode = '1920x1080x60'
+    const first = buildResolutionPlanner({ sourceMode })
+    const firstBalanced = first.choices.find((choice) => choice.id === 'balanced')
+    expect(firstBalanced.targetMode).toBe('1440x810x60')
+
+    const rebuilt = buildResolutionPlanner({
+      sourceMode,
+      fallbackMode: firstBalanced.targetMode,
+    })
+    expect(rebuilt.choices.find((choice) => choice.id === 'balanced').targetMode).toBe('1440x810x60')
+    expect(rebuilt.choices.find((choice) => choice.id === 'native').targetMode).toBe('1920x1080x60')
+  })
+
+  it('keeps an explicitly empty source immutable after a preset writes fallback mode', () => {
+    const first = buildResolutionPlanner({ sourceMode: '', fallbackMode: '' })
+    const firstBalanced = first.choices.find((choice) => choice.id === 'balanced')
+    expect(firstBalanced.targetMode).toBe('1440x810x60')
+
+    const rebuilt = buildResolutionPlanner({
+      sourceMode: '',
+      fallbackMode: firstBalanced.targetMode,
+    })
+    expect(rebuilt.choices.find((choice) => choice.id === 'balanced').targetMode).toBe('1440x810x60')
+    expect(rebuilt.choices.find((choice) => choice.id === 'native').targetMode).toBe('1920x1080x60')
+  })
+
   it('parses and formats Moonlight-compatible WxHxFPS display modes', () => {
     expect(parseDisplayMode('3840x2160x120')).toEqual({ width: 3840, height: 2160, fps: 120 })
     expect(formatDisplayMode({ width: 1920, height: 1080, fps: 60 })).toBe('1920x1080x60')

--- a/src_assets/common/assets/web/linux-streaming-setup.test.js
+++ b/src_assets/common/assets/web/linux-streaming-setup.test.js
@@ -1,6 +1,6 @@
 import { shallowMount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, ref } from 'vue'
+import { nextTick, reactive, ref } from 'vue'
 
 import AudioVideo from './configs/tabs/AudioVideo.vue'
 
@@ -123,6 +123,56 @@ describe('Linux Streaming Setup checklist', () => {
     expect(config.capture).toBe('wlr')
     expect(config.linux_auto_manage_displays).toBe('disabled')
     expect(config.headless_swap_mode).toBe('')
+  })
+
+  it('keeps display planner presets idempotent across repeated clicks', async () => {
+    const config = reactive(linuxConfig({ fallback_mode: '1920x1080x60' }))
+    const wrapper = mountAudioVideo(config)
+    const buttons = wrapper.findAll('button')
+    const balanced = buttons.find((button) => button.text().includes('Balanced'))
+    const native = buttons.find((button) => button.text().includes('Native'))
+
+    expect(balanced).toBeDefined()
+    expect(native).toBeDefined()
+    await balanced.trigger('click')
+    expect(config.fallback_mode).toBe('1440x810x60')
+    await balanced.trigger('click')
+    expect(config.fallback_mode).toBe('1440x810x60')
+    await native.trigger('click')
+    expect(config.fallback_mode).toBe('1920x1080x60')
+
+    await balanced.trigger('click')
+    expect(config.fallback_mode).toBe('1440x810x60')
+    await wrapper.find('#fallback_mode').setValue('1440x810x60')
+    const manuallyConfirmedNative = wrapper.findAll('button').find((button) => button.text().includes('Native'))
+    await manuallyConfirmedNative.trigger('click')
+    expect(config.fallback_mode).toBe('1440x810x60')
+
+    await wrapper.find('#fallback_mode').setValue('2560x1440x60')
+    const updatedBalanced = wrapper.findAll('button').find((button) => button.text().includes('Balanced'))
+    await updatedBalanced.trigger('click')
+    expect(config.fallback_mode).toBe('1920x1080x60')
+
+    config.fallback_mode = '1600x900x60'
+    await nextTick()
+    const resetNative = wrapper.findAll('button').find((button) => button.text().includes('Native'))
+    await resetNative.trigger('click')
+    expect(config.fallback_mode).toBe('1600x900x60')
+  })
+
+  it('keeps an initially empty or manually cleared planner source stable', async () => {
+    const config = linuxConfig({ fallback_mode: '' })
+    const wrapper = mountAudioVideo(config)
+    const balanced = () => wrapper.findAll('button').find((button) => button.text().includes('Balanced'))
+
+    await balanced().trigger('click')
+    expect(config.fallback_mode).toBe('1440x810x60')
+    await balanced().trigger('click')
+    expect(config.fallback_mode).toBe('1440x810x60')
+
+    await wrapper.find('#fallback_mode').setValue('')
+    await balanced().trigger('click')
+    expect(config.fallback_mode).toBe('1440x810x60')
   })
 
   it('ignores a stale dongle discovery response after another preset is selected', async () => {


### PR DESCRIPTION
## Summary
- anchor generated display presets to an immutable source mode instead of the previous generated fallback
- preserve legacy helper callers while distinguishing an omitted source from an explicitly empty source
- resynchronize manual and parent/reset edits without treating planner-owned writes as new sources

## Verification
- 46 test files / 258 tests
- focused planner/setup tests: 14/14
- ESLint
- production build
- Web performance budget
- `npm audit --audit-level=high`: 0 vulnerabilities
- public docs/surface checks
- `git diff --check`
- independent review: APPROVE, no findings

Fixes #255
Refs #235