### PR TITLE
fix(input): rebind preallocated gamepad feedback

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1798,6 +1798,7 @@ namespace input {
       std::scoped_lock lock {preallocated_gamepad_mutex};
       if (preallocated_controller_number == 0 && preallocated_gamepad_id >= 0) {
         input->gamepads[0].id = preallocated_gamepad_id;
+        platf::rebind_gamepad_feedback(platf_input, preallocated_gamepad_id, input->feedback_queue);
         preallocated_controller_number = -1;
         preallocated_gamepad_id = -1;
         preallocated_gamepad_mail.reset();

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -941,6 +941,7 @@ namespace platf {
    * @return 0 on success.
    */
   int alloc_gamepad(input_t &input, const gamepad_id_t &id, const gamepad_arrival_t &metadata, feedback_queue_t feedback_queue);
+  void rebind_gamepad_feedback(input_t &input, int nr, feedback_queue_t feedback_queue);
   void free_gamepad(input_t &input, int nr);
 
   /**

--- a/src/platform/gamepad_feedback_router.h
+++ b/src/platform/gamepad_feedback_router.h
@@ -1,0 +1,53 @@
+/**
+ * @file src/platform/gamepad_feedback_router.h
+ * @brief Stable feedback routing for virtual gamepads that outlive a client session queue.
+ */
+#pragma once
+
+#include <chrono>
+#include <mutex>
+#include <utility>
+
+#include "src/platform/common.h"
+
+namespace platf {
+  /**
+   * Keeps virtual-device callbacks bound to one stable object while allowing their
+   * destination mail queue to change when a preallocated gamepad is adopted.
+   */
+  class gamepad_feedback_router_t {
+  public:
+    explicit gamepad_feedback_router_t(feedback_queue_t queue):
+        queue_ {std::move(queue)} {
+    }
+
+    void raise(gamepad_feedback_msg_t message) {
+      std::scoped_lock lock {mutex_};
+      if (queue_) {
+        queue_->raise(std::move(message));
+      }
+    }
+
+    void rebind(feedback_queue_t queue) {
+      std::scoped_lock lock {mutex_};
+      if (queue_ == queue) {
+        return;
+      }
+
+      if (queue) {
+        while (queue_) {
+          auto message = queue_->pop(std::chrono::milliseconds {0});
+          if (!message) {
+            break;
+          }
+          queue->raise(std::move(*message));
+        }
+      }
+      queue_ = std::move(queue);
+    }
+
+  private:
+    std::mutex mutex_;
+    feedback_queue_t queue_;
+  };
+}  // namespace platf

--- a/src/platform/linux/input/inputtino.cpp
+++ b/src/platform/linux/input/inputtino.cpp
@@ -84,6 +84,11 @@ namespace platf {
     return platf::gamepad::alloc(raw, id, metadata, feedback_queue);
   }
 
+  void rebind_gamepad_feedback(input_t &input, int nr, feedback_queue_t feedback_queue) {
+    auto raw = (input_raw_t *) input.get();
+    platf::gamepad::rebind_feedback(raw, nr, std::move(feedback_queue));
+  }
+
   void free_gamepad(input_t &input, int nr) {
     auto raw = (input_raw_t *) input.get();
     platf::gamepad::free(raw, nr);

--- a/src/platform/linux/input/inputtino_common.h
+++ b/src/platform/linux/input/inputtino_common.h
@@ -17,6 +17,7 @@
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
+#include "src/platform/gamepad_feedback_router.h"
 #include "src/utility.h"
 
 using namespace std::literals;
@@ -27,6 +28,7 @@ namespace platf {
 
   struct joypad_state {
     std::unique_ptr<joypads_t> joypad;
+    std::shared_ptr<gamepad_feedback_router_t> feedback_router;
     gamepad_feedback_msg_t last_rumble;
     gamepad_feedback_msg_t last_rgb_led;
   };

--- a/src/platform/linux/input/inputtino_gamepad.cpp
+++ b/src/platform/linux/input/inputtino_gamepad.cpp
@@ -132,14 +132,15 @@ namespace platf::gamepad {
     }
 
     auto gamepad = std::make_shared<joypad_state>(joypad_state {});
-    auto on_rumble_fn = [feedback_queue, idx = id.clientRelativeIndex, gamepad](int low_freq, int high_freq) {
+    gamepad->feedback_router = std::make_shared<gamepad_feedback_router_t>(std::move(feedback_queue));
+    auto on_rumble_fn = [feedback_router = gamepad->feedback_router, idx = id.clientRelativeIndex, gamepad](int low_freq, int high_freq) {
       // Don't resend duplicate rumble data
       if (gamepad->last_rumble.type == platf::gamepad_feedback_e::rumble && gamepad->last_rumble.data.rumble.lowfreq == low_freq && gamepad->last_rumble.data.rumble.highfreq == high_freq) {
         return;
       }
 
       gamepad_feedback_msg_t msg = gamepad_feedback_msg_t::make_rumble(idx, low_freq, high_freq);
-      feedback_queue->raise(msg);
+      feedback_router->raise(msg);
       gamepad->last_rumble = msg;
     };
 
@@ -177,24 +178,24 @@ namespace platf::gamepad {
           auto ds5 = create_ds5(id.globalIndex);
           if (ds5) {
             (*ds5).set_on_rumble(on_rumble_fn);
-            (*ds5).set_on_led([feedback_queue, idx = id.clientRelativeIndex, gamepad](int r, int g, int b) {
+            (*ds5).set_on_led([feedback_router = gamepad->feedback_router, idx = id.clientRelativeIndex, gamepad](int r, int g, int b) {
               // Don't resend duplicate LED data
               if (gamepad->last_rgb_led.type == platf::gamepad_feedback_e::set_rgb_led && gamepad->last_rgb_led.data.rgb_led.r == r && gamepad->last_rgb_led.data.rgb_led.g == g && gamepad->last_rgb_led.data.rgb_led.b == b) {
                 return;
               }
 
               auto msg = gamepad_feedback_msg_t::make_rgb_led(idx, r, g, b);
-              feedback_queue->raise(msg);
+              feedback_router->raise(msg);
               gamepad->last_rgb_led = msg;
             });
 
-            (*ds5).set_on_trigger_effect([feedback_queue, idx = id.clientRelativeIndex](const inputtino::PS5Joypad::TriggerEffect &trigger_effect) {
-              feedback_queue->raise(gamepad_feedback_msg_t::make_adaptive_triggers(idx, trigger_effect.event_flags, trigger_effect.type_left, trigger_effect.type_right, trigger_effect.left, trigger_effect.right));
+            (*ds5).set_on_trigger_effect([feedback_router = gamepad->feedback_router, idx = id.clientRelativeIndex](const inputtino::PS5Joypad::TriggerEffect &trigger_effect) {
+              feedback_router->raise(gamepad_feedback_msg_t::make_adaptive_triggers(idx, trigger_effect.event_flags, trigger_effect.type_left, trigger_effect.type_right, trigger_effect.left, trigger_effect.right));
             });
 
             // Activate the motion sensors
-            feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_ACCEL, 100));
-            feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_GYRO, 100));
+            gamepad->feedback_router->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_ACCEL, 100));
+            gamepad->feedback_router->raise(gamepad_feedback_msg_t::make_motion_event_state(id.clientRelativeIndex, LI_MOTION_TYPE_GYRO, 100));
 
             gamepad->joypad = std::make_unique<joypads_t>(std::move(*ds5));
             register_created_joypad_nodes(id.globalIndex, *gamepad->joypad);
@@ -207,6 +208,16 @@ namespace platf::gamepad {
         }
     }
     return -1;
+  }
+
+  void rebind_feedback(input_raw_t *raw, int nr, feedback_queue_t feedback_queue) {
+    if (nr < 0 || static_cast<std::size_t>(nr) >= raw->gamepads.size()) {
+      return;
+    }
+    auto &gamepad = raw->gamepads[nr];
+    if (gamepad && gamepad->feedback_router) {
+      gamepad->feedback_router->rebind(std::move(feedback_queue));
+    }
   }
 
   void free(input_raw_t *raw, int nr) {

--- a/src/platform/linux/input/inputtino_gamepad.h
+++ b/src/platform/linux/input/inputtino_gamepad.h
@@ -25,6 +25,8 @@ namespace platf::gamepad {
 
   int alloc(input_raw_t *raw, const gamepad_id_t &id, const gamepad_arrival_t &metadata, feedback_queue_t feedback_queue);
 
+  void rebind_feedback(input_raw_t *raw, int nr, feedback_queue_t feedback_queue);
+
   void free(input_raw_t *raw, int nr);
 
   void update(input_raw_t *raw, int nr, const gamepad_state_t &gamepad_state);

--- a/src/platform/macos/input.cpp
+++ b/src/platform/macos/input.cpp
@@ -303,6 +303,10 @@ const KeyCodeMap kKeyCodesMap[] = {
     return -1;
   }
 
+  void rebind_gamepad_feedback(input_t &input, int nr, feedback_queue_t feedback_queue) {
+    BOOST_LOG(info) << "rebind_gamepad_feedback: Gamepad not yet implemented for MacOS."sv;
+  }
+
   void free_gamepad(input_t &input, int nr) {
     BOOST_LOG(info) << "free_gamepad: Gamepad not yet implemented for MacOS."sv;
   }

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -21,6 +21,7 @@
 #include "src/globals.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
+#include "src/platform/gamepad_feedback_router.h"
 
 #ifdef __MINGW32__
 // DECLARE_HANDLE(HSYNTHETICPOINTERDEVICE);
@@ -70,7 +71,7 @@ namespace platf {
 
   struct gamepad_context_t {
     target_t gp;
-    feedback_queue_t feedback_queue;
+    std::shared_ptr<gamepad_feedback_router_t> feedback_router;
 
     union {
       XUSB_REPORT x360;
@@ -227,6 +228,7 @@ namespace platf {
 
       gamepad.client_relative_index = id.clientRelativeIndex;
       gamepad.last_report_ts = std::chrono::steady_clock::now();
+      gamepad.feedback_router = std::make_shared<gamepad_feedback_router_t>(std::move(feedback_queue));
 
       // Establish a connect to the ViGEm driver if we don't have one yet
       if (!client) {
@@ -255,8 +257,8 @@ namespace platf {
         ds4_update_motion(gamepad, LI_MOTION_TYPE_GYRO, 0.0f, 0.0f, 0.0f);
 
         // Request motion events from the client at 100 Hz
-        feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(gamepad.client_relative_index, LI_MOTION_TYPE_ACCEL, 100));
-        feedback_queue->raise(gamepad_feedback_msg_t::make_motion_event_state(gamepad.client_relative_index, LI_MOTION_TYPE_GYRO, 100));
+        gamepad.feedback_router->raise(gamepad_feedback_msg_t::make_motion_event_state(gamepad.client_relative_index, LI_MOTION_TYPE_ACCEL, 100));
+        gamepad.feedback_router->raise(gamepad_feedback_msg_t::make_motion_event_state(gamepad.client_relative_index, LI_MOTION_TYPE_GYRO, 100));
 
         // We support pointer index 0 and 1
         gamepad.available_pointers = 0x3;
@@ -269,8 +271,6 @@ namespace platf {
         return -1;
       }
 
-      gamepad.feedback_queue = std::move(feedback_queue);
-
       if (gp_type == Xbox360Wired) {
         status = vigem_target_x360_register_notification(client.get(), gamepad.gp.get(), x360_notify, this);
       } else {
@@ -282,6 +282,16 @@ namespace platf {
       }
 
       return 0;
+    }
+
+    void rebind_feedback(int nr, feedback_queue_t feedback_queue) {
+      if (nr < 0 || static_cast<std::size_t>(nr) >= gamepads.size()) {
+        return;
+      }
+      auto &gamepad = gamepads[nr];
+      if (gamepad.feedback_router) {
+        gamepad.feedback_router->rebind(std::move(feedback_queue));
+      }
     }
 
     /**
@@ -304,6 +314,7 @@ namespace platf {
       }
 
       gamepad.gp.reset();
+      gamepad.feedback_router.reset();
 
       // Disconnect from ViGEm if we just removed the last gamepad
       bool disconnect = true;
@@ -349,7 +360,7 @@ namespace platf {
               normalizedLargeMotor,
               normalizedSmallMotor
             );
-            gamepad.feedback_queue->raise(msg);
+            gamepad.feedback_router->raise(msg);
             gamepad.last_rumble = msg;
           }
           return;
@@ -375,7 +386,7 @@ namespace platf {
               b != gamepad.last_rgb_led.data.rgb_led.b) {
             // We have to use the client-relative index when communicating back to the client
             gamepad_feedback_msg_t msg = gamepad_feedback_msg_t::make_rgb_led(gamepad.client_relative_index, r, g, b);
-            gamepad.feedback_queue->raise(msg);
+            gamepad.feedback_router->raise(msg);
             gamepad.last_rgb_led = msg;
           }
           return;
@@ -1224,6 +1235,13 @@ namespace platf {
     }
 
     return raw->vigem->alloc_gamepad_internal(id, feedback_queue, selectedGamepadType);
+  }
+
+  void rebind_gamepad_feedback(input_t &input, int nr, feedback_queue_t feedback_queue) {
+    auto raw = (input_raw_t *) input.get();
+    if (raw->vigem) {
+      raw->vigem->rebind_feedback(nr, std::move(feedback_queue));
+    }
   }
 
   void free_gamepad(input_t &input, int nr) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -149,6 +149,7 @@ if (NOT WIN32 AND NOT APPLE)
 endif()
 
 set(TEST_INPUT_SOURCES
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_gamepad_feedback_router.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_mouse.cpp
 )
 

--- a/tests/unit/test_gamepad_feedback_router.cpp
+++ b/tests/unit/test_gamepad_feedback_router.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file tests/unit/test_gamepad_feedback_router.cpp
+ * @brief Regression coverage for feedback routing across preallocated gamepad adoption.
+ */
+#include "../tests_common.h"
+
+#include "src/platform/gamepad_feedback_router.h"
+
+TEST(GamepadFeedbackRouter, TransfersQueuedAndFutureFeedbackWhenRebound) {
+  auto prelaunch_mail = std::make_shared<safe::mail_raw_t>();
+  auto live_mail = std::make_shared<safe::mail_raw_t>();
+  auto prelaunch = prelaunch_mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback);
+  auto live = live_mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback);
+  platf::gamepad_feedback_router_t router {prelaunch};
+
+  router.raise(platf::gamepad_feedback_msg_t::make_motion_event_state(0, LI_MOTION_TYPE_ACCEL, 100));
+  router.raise(platf::gamepad_feedback_msg_t::make_motion_event_state(0, LI_MOTION_TYPE_GYRO, 100));
+  ASSERT_TRUE(prelaunch->peek());
+  EXPECT_FALSE(live->peek());
+
+  router.rebind(live);
+  EXPECT_FALSE(prelaunch->peek());
+
+  auto accel = live->pop();
+  auto gyro = live->pop();
+  ASSERT_TRUE(accel);
+  ASSERT_TRUE(gyro);
+  EXPECT_EQ(accel->type, platf::gamepad_feedback_e::set_motion_event_state);
+  EXPECT_EQ(accel->data.motion_event_state.motion_type, LI_MOTION_TYPE_ACCEL);
+  EXPECT_EQ(gyro->type, platf::gamepad_feedback_e::set_motion_event_state);
+  EXPECT_EQ(gyro->data.motion_event_state.motion_type, LI_MOTION_TYPE_GYRO);
+
+  router.raise(platf::gamepad_feedback_msg_t::make_rumble(0, 1000, 2000));
+  auto rumble = live->pop();
+  ASSERT_TRUE(rumble);
+  EXPECT_EQ(rumble->type, platf::gamepad_feedback_e::rumble);
+  EXPECT_EQ(rumble->data.rumble.lowfreq, 1000);
+  EXPECT_EQ(rumble->data.rumble.highfreq, 2000);
+  EXPECT_FALSE(prelaunch->peek());
+}
+
+TEST(GamepadFeedbackRouter, RebindingToCurrentQueueIsANoOp) {
+  auto mail = std::make_shared<safe::mail_raw_t>();
+  auto queue = mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback);
+  platf::gamepad_feedback_router_t router {queue};
+
+  router.raise(platf::gamepad_feedback_msg_t::make_rgb_led(0, 1, 2, 3));
+  router.rebind(queue);
+
+  auto message = queue->pop();
+  ASSERT_TRUE(message);
+  EXPECT_EQ(message->type, platf::gamepad_feedback_e::set_rgb_led);
+  EXPECT_FALSE(queue->peek());
+}


### PR DESCRIPTION
## Summary
- route long-lived virtual-gamepad callbacks through a stable feedback router
- transfer queued DS5 motion-enable requests when the preallocated controller is adopted by a live session
- rebind future rumble, LED, adaptive-trigger, and motion-state feedback on Linux and Windows
- retain a no-op platform hook on macOS, where virtual gamepads are not implemented

## Scope
This is the routing-only defect demonstrated by #232. Existing pre-launch allocation policy remains unchanged. In particular, late client-arrival metadata for an already preallocated `auto` controller is **not** reconciled by this PR and is not claimed as fixed.

## Verification
- `polaris` Linux target built
- `test_polaris_input` built and ran
- router regressions: 2/2 passed
- input suite: 4 passed; 4 existing Inputtino mouse TODO skips
- `git diff --check`
- independent review: PASS, no blocking correctness/security findings

Fixes #232