### PR TITLE
fix(linux): isolate client gamepads by seat

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,7 @@ Stream when you want a stream-only runtime that leaves the host desktop layout a
 | `linux_prefer_gpu_native_capture` | `enabled` | Prefer DMA-BUF/GPU-resident capture on NVIDIA and AMD-capable stacks; Polaris reports SHM/system-memory fallback truthfully when the compositor or driver cannot provide it |
 | `trusted_subnets` | CIDR list | Enable Trusted Pair on known local networks |
 | `headless_gamepad_isolation` | `enabled` | Hide host-connected gamepads from private headless streams; disable only when you intentionally want a wired host controller visible inside the stream |
+| `client_gamepad_seat_isolation` | `disabled` | Assign Polaris-created client gamepads to a dedicated Linux seat so other active-seat users do not receive automatic device ACLs |
 | `encoder` | `nvenc` / `vaapi` / `software` | Primary encoder backend |
 | `nvenc_split_encode_mode` | `disabled` | Experimental Linux/FFmpeg NVENC split-frame encoding for HEVC/AV1 |
 | `adaptive_bitrate_enabled` | `enabled` | Allow mid-stream bitrate adjustment |
@@ -55,6 +56,31 @@ Stream when you want a stream-only runtime that leaves the host desktop layout a
 | `enable_discovery` | `enabled` | Advertise Polaris over mDNS |
 | `stream_audio` | `enabled` | Capture and stream audio |
 | `steamgriddb_api_key` | key | Cover art lookups for non-Steam apps |
+
+### Linux client-gamepad access boundary
+
+`headless_gamepad_isolation` controls the **opposite** direction: it hides controllers physically
+connected to the host from a private stream. It does not make a client-created virtual controller
+disappear from the host kernel.
+
+When `client_gamepad_seat_isolation` is enabled, Polaris marks client gamepads for the bundled host
+rules to assign them to the `seat-polaris` seat. This prevents logind from granting the active local
+desktop user an automatic `uaccess` ACL. The device nodes remain `root:input` with mode `0660`, so
+the Polaris streaming user must belong to the `input` group. The option is disabled by default to
+preserve existing virtual-controller identity and local access; enabling it gives isolated gamepads
+Polaris-specific device names so current Inputtino uinput backends can enforce the udev policy.
+
+Re-run `sudo polaris --setup-host` after upgrading so the installed udev rules understand the
+dedicated device names and marker. Existing virtual controller nodes keep their previous access policy
+until recreated; stop active streams and restart Polaris after host setup. AppImage users should
+re-run the AppImage install action for the same reason.
+
+This is a Unix-user boundary, not a same-account process sandbox. Local users who are deliberately
+members of `input`, and local applications running under the same Unix account as Polaris, can still
+open the virtual controller. For concurrent gaming, run Polaris under a dedicated Unix account and
+do not add local desktop users to `input`. Strong same-UID isolation requires a privileged broker,
+container/security-domain boundary, or equivalent system-level policy; a per-session Web toggle
+cannot provide it safely.
 
 ## Linux HDR and Main10
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -673,6 +673,7 @@ namespace config {
     true,  // client gamepads with touchpads are emulated as DS4
     true,  // ds5_inputtino_randomize_mac
     true,  // headless_gamepad_isolation
+    false,  // client_gamepad_seat_isolation
 
     true,  // keyboard enabled
     true,  // mouse enabled
@@ -1463,6 +1464,7 @@ namespace config {
     bool_f(vars, "touchpad_as_ds4", input.touchpad_as_ds4);
     bool_f(vars, "ds5_inputtino_randomize_mac", input.ds5_inputtino_randomize_mac);
     bool_f(vars, "headless_gamepad_isolation", input.headless_gamepad_isolation);
+    bool_f(vars, "client_gamepad_seat_isolation", input.client_gamepad_seat_isolation);
 
     bool_f(vars, "mouse", input.mouse);
     bool_f(vars, "mouse_cursor_visible", input.mouse_cursor_visible);

--- a/src/config.h
+++ b/src/config.h
@@ -260,6 +260,7 @@ namespace config {
     bool touchpad_as_ds4;
     bool ds5_inputtino_randomize_mac;
     bool headless_gamepad_isolation;
+    bool client_gamepad_seat_isolation;
 
     bool keyboard;
     bool mouse;

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -104,6 +104,7 @@ namespace confighttp::validation {
       "capture"sv,
       "cert"sv,
       "color_range"sv,
+      "client_gamepad_seat_isolation"sv,
       "controller"sv,
       "credentials_file"sv,
       "dd_config_revert_delay"sv,

--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -253,6 +253,7 @@ namespace args {
 
     std::cout
       << "Linux host setup complete."sv << std::endl
+      << "Existing virtual gamepad nodes keep their previous access policy until recreated; stop active streams and restart Polaris after changing client gamepad seat isolation."sv << std::endl
       << "Start Polaris directly with `polaris`, or opt into background autostart with `systemctl --user enable --now polaris`."sv << std::endl;
     return 0;
   }

--- a/src/platform/linux/input/inputtino_gamepad.cpp
+++ b/src/platform/linux/input/inputtino_gamepad.cpp
@@ -6,6 +6,8 @@
 #include <boost/locale.hpp>
 #include <inputtino/input.hpp>
 #include <libevdev/libevdev.h>
+#include <string>
+#include <string_view>
 
 // local includes
 #include "inputtino_common.h"
@@ -33,6 +35,19 @@ namespace platf::gamepad {
     }, joypad);
   }
 
+  isolation::client_gamepad_identity_t client_gamepad_identity(int globalIndex,
+                                                                std::string_view legacy_name,
+                                                                std::string_view isolated_name,
+                                                                std::string_view legacy_phys) {
+    return isolation::client_gamepad_identity(
+      config::input.client_gamepad_seat_isolation,
+      globalIndex,
+      legacy_name,
+      isolated_name,
+      legacy_phys
+    );
+  }
+
   void register_created_joypad_nodes(int globalIndex, const joypads_t &joypad) {
     isolation::register_virtual_gamepad_nodes(globalIndex, joypad_nodes(joypad));
   }
@@ -44,12 +59,19 @@ namespace platf::gamepad {
       device_id = std::format("02:00:00:00:10:{:02x}", globalIndex);
     }
 
-    return inputtino::XboxOneJoypad::create({.name = "Sunshine X-Box One (virtual) pad",
+    const auto identity = client_gamepad_identity(
+      globalIndex,
+      "Sunshine X-Box One (virtual) pad",
+      "Polaris X-Box One (virtual) pad",
+      device_id
+    );
+
+    return inputtino::XboxOneJoypad::create({.name = identity.name,
                                              // https://github.com/torvalds/linux/blob/master/drivers/input/joystick/xpad.c#L147
                                              .vendor_id = 0x045E,
                                              .product_id = 0x02EA,
                                              .version = 0x0408,
-                                             .device_phys = device_id,
+                                             .device_phys = identity.phys,
                                              .device_uniq = device_id});
   }
 
@@ -60,12 +82,19 @@ namespace platf::gamepad {
       device_id = std::format("02:00:00:00:20:{:02x}", globalIndex);
     }
 
-    return inputtino::SwitchJoypad::create({.name = "Sunshine Nintendo (virtual) pad",
+    const auto identity = client_gamepad_identity(
+      globalIndex,
+      "Sunshine Nintendo (virtual) pad",
+      "Polaris Nintendo (virtual) pad",
+      device_id
+    );
+
+    return inputtino::SwitchJoypad::create({.name = identity.name,
                                             // https://github.com/torvalds/linux/blob/master/drivers/hid/hid-ids.h#L981
                                             .vendor_id = 0x057e,
                                             .product_id = 0x2009,
                                             .version = 0x8111,
-                                            .device_phys = device_id,
+                                            .device_phys = identity.phys,
                                             .device_uniq = device_id});
   }
 
@@ -77,10 +106,20 @@ namespace platf::gamepad {
       device_mac = std::format("02:00:00:00:00:{:02x}", globalIndex);
     }
 
-    return inputtino::PS5Joypad::create({.name = "Sunshine PS5 (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111, .device_phys = device_mac, .device_uniq = device_mac});
+    const auto identity = client_gamepad_identity(
+      globalIndex,
+      "Sunshine PS5 (virtual) pad",
+      "Polaris PS5 (virtual) pad",
+      device_mac
+    );
+
+    return inputtino::PS5Joypad::create({.name = identity.name, .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111, .device_phys = identity.phys, .device_uniq = device_mac});
   }
 
   int alloc(input_raw_t *raw, const gamepad_id_t &id, const gamepad_arrival_t &metadata, feedback_queue_t feedback_queue) {
+    BOOST_LOG(info) << "Gamepad " << id.globalIndex << " client seat isolation: "
+                    << (config::input.client_gamepad_seat_isolation ? "seat-polaris" : "disabled");
+
     ControllerType selectedGamepadType;
 
     if (config::input.gamepad == "xone"sv) {

--- a/src/platform/linux/input/inputtino_gamepad_isolation.h
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace platf::gamepad::isolation {
@@ -75,6 +76,28 @@ namespace platf::gamepad::isolation {
     }
   };
 
+  inline std::string client_gamepad_phys_marker(bool enabled, int index) {
+    return enabled ? "polaris/client-gamepad-seat-isolated/" + std::to_string(index) : "";
+  }
+
+  inline std::string client_gamepad_device_name(bool enabled, std::string_view legacy_name, std::string_view isolated_name) {
+    return std::string(enabled ? isolated_name : legacy_name);
+  }
+
+  struct client_gamepad_identity_t {
+    std::string name;
+    std::string phys;
+  };
+
+  inline client_gamepad_identity_t client_gamepad_identity(bool enabled, int index,
+                                                            std::string_view legacy_name,
+                                                            std::string_view isolated_name,
+                                                            std::string_view legacy_phys) {
+    return {
+      client_gamepad_device_name(enabled, legacy_name, isolated_name),
+      enabled ? client_gamepad_phys_marker(true, index) : std::string(legacy_phys),
+    };
+  }
   device_classification_e classify_device(const device_snapshot_t &device);
   std::vector<classified_device_t> classify_devices(const std::vector<device_snapshot_t> &devices);
   sdl_hint_plan_t build_sdl_hint_plan(const std::vector<classified_device_t> &devices);

--- a/src_assets/common/assets/web/configs/tabs/Inputs.vue
+++ b/src_assets/common/assets/web/configs/tabs/Inputs.vue
@@ -107,6 +107,13 @@ const config = ref(props.config)
                   v-model="config.headless_gamepad_isolation"
                   default="true"
         ></Checkbox>
+        <Checkbox class="mb-3"
+                  v-if="platform === 'linux'"
+                  id="client_gamepad_seat_isolation"
+                  locale-prefix="config"
+                  v-model="config.client_gamepad_seat_isolation"
+                  default="false"
+        ></Checkbox>
       </template>
 
       <div class="mb-3" v-if="config.controller === 'enabled'">

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -365,6 +365,8 @@
     "gamepad_xone": "XOne (Xbox One)",
     "headless_gamepad_isolation": "Isolate Host Gamepads in Private Stream",
     "headless_gamepad_isolation_desc": "Prevents controllers physically connected to the host from appearing inside Private Stream sessions. Disable only when you intentionally use a host-wired controller, such as a DualSense for haptics or adaptive triggers.",
+    "client_gamepad_seat_isolation": "Isolate Client Gamepads from Other Linux Users",
+    "client_gamepad_seat_isolation_desc": "Disabled by default to preserve controller identity and local access. When enabled, uses Polaris-specific device names and a dedicated Linux seat so logind does not grant the active local desktop user automatic access. This does not isolate applications running under the same Unix account or users in the input group. Re-run Polaris host setup after upgrading, then stop active streams and restart Polaris so existing controller nodes are recreated.",
     "global_prep_cmd": "Command Preparations",
     "global_prep_cmd_desc": "Configure a list of commands to be executed before or after running any application. If any of the specified preparation commands fail, the application launch process will be aborted.",
     "global_state_cmd": "Resume/Pause Commands",

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -342,6 +342,7 @@ const tabs = ref([
       "touchpad_as_ds4": "enabled",
       "ds5_inputtino_randomize_mac": "enabled",
       "headless_gamepad_isolation": "enabled",
+      "client_gamepad_seat_isolation": "disabled",
       "back_button_timeout": -1,
       "keyboard": "enabled",
       "key_repeat_delay": 500,

--- a/src_assets/linux/misc/60-polaris.rules
+++ b/src_assets/linux/misc/60-polaris.rules
@@ -1,11 +1,24 @@
-# Allows Polaris to access /dev/uinput
+# Allows Polaris to create virtual input devices.
 KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", GROUP="input", MODE="0660", TAG+="uaccess"
-
-# Allows Polaris to access /dev/uhid
 KERNEL=="uhid", GROUP="input", MODE="0660", TAG+="uaccess"
 
-# Joypads
-KERNEL=="hidraw*", ATTRS{name}=="Polaris PS5 (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Polaris X-Box One (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Polaris gamepad (virtual) motion sensors", GROUP="input", MODE="0660", TAG+="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Polaris Nintendo (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
+# Legacy Sunshine names preserve active-seat access when isolation is disabled.
+# Polaris names are emitted only when client_gamepad_seat_isolation is enabled.
+KERNEL=="hidraw*", ATTRS{name}=="Sunshine PS5 (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{name}=="Polaris PS5 (virtual) pad", ENV{ID_SEAT}="seat-polaris", GROUP="input", MODE="0660"
+
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine X-Box One (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine Nintendo (virtual) pad", GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine PS5 (virtual) pad*", GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Sunshine gamepad (virtual) motion sensors", GROUP="input", MODE="0660", TAG+="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Polaris X-Box One (virtual) pad", ENV{ID_SEAT}="seat-polaris", GROUP="input", MODE="0660"
+SUBSYSTEMS=="input", ATTRS{name}=="Polaris Nintendo (virtual) pad", ENV{ID_SEAT}="seat-polaris", GROUP="input", MODE="0660"
+SUBSYSTEMS=="input", ATTRS{name}=="Polaris PS5 (virtual) pad*", ENV{ID_SEAT}="seat-polaris", GROUP="input", MODE="0660"
+SUBSYSTEMS=="input", ATTRS{name}=="Polaris gamepad (virtual) motion sensors", ENV{ID_SEAT}="seat-polaris", GROUP="input", MODE="0660"
+
+# Dedicated marker emitted when client_gamepad_seat_isolation is enabled.
+# Assigning the device to a dedicated seat prevents logind from granting the
+# active local desktop user an automatic uaccess ACL. The input-group boundary
+# remains explicit: same-UID processes and members of input are not isolated.
+KERNEL=="hidraw*", ATTRS{phys}=="polaris/client-gamepad-seat-isolated/*", ENV{ID_SEAT}="seat-polaris", GROUP="input", MODE="0660"
+SUBSYSTEMS=="input", ATTRS{phys}=="polaris/client-gamepad-seat-isolated/*", ENV{ID_SEAT}="seat-polaris", GROUP="input", MODE="0660"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,6 +128,7 @@ endif()
 set(TEST_AUDIT_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/integration/test_config_consistency.cpp
     ${CMAKE_SOURCE_DIR}/tests/integration/test_locale_consistency.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_virtual_input_udev_contract.cpp
 )
 
 set(TEST_PLATFORM_SOURCES

--- a/tests/unit/test_confighttp_validation.cpp
+++ b/tests/unit/test_confighttp_validation.cpp
@@ -56,6 +56,15 @@ TEST(ConfigValidationTests, AcceptsNvencSplitEncodeModeConfigKey) {
   EXPECT_TRUE(confighttp::validation::validate_config_payload(payload, error)) << error;
 }
 
+TEST(ConfigValidationTests, AcceptsClientGamepadSeatIsolationConfigKey) {
+  nlohmann::json payload = {
+    {"client_gamepad_seat_isolation", "enabled"}
+  };
+
+  std::string error;
+  EXPECT_TRUE(confighttp::validation::validate_config_payload(payload, error)) << error;
+}
+
 TEST(AppValidationTests, AcceptsAWellFormedAppPayload) {
   nlohmann::json payload = {
     {"name", "Nova"},

--- a/tests/unit/test_virtual_input_udev_contract.cpp
+++ b/tests/unit/test_virtual_input_udev_contract.cpp
@@ -1,0 +1,188 @@
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "src/platform/linux/input/inputtino_gamepad_isolation.h"
+
+namespace {
+  std::string read_source_file(std::string_view relative_path) {
+    const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / relative_path;
+    std::ifstream input {path};
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+  }
+
+  std::string rule_for_name(const std::string &rules, std::string_view device_name) {
+    std::istringstream lines {rules};
+    std::string line;
+    while (std::getline(lines, line)) {
+      const auto first = line.find_first_not_of(" \t");
+      if (first == std::string::npos || line[first] == '#') {
+        continue;
+      }
+      if (line.find(device_name) != std::string::npos) {
+        return line;
+      }
+    }
+    return {};
+  }
+
+  std::vector<std::string> rules_for_name(const std::string &rules, std::string_view device_name) {
+    std::vector<std::string> matches;
+    std::istringstream lines(rules);
+    std::string line;
+    while (std::getline(lines, line)) {
+      const auto first = line.find_first_not_of(" \t");
+      if (first == std::string::npos || line[first] == '#') {
+        continue;
+      }
+      if (line.find(device_name) != std::string::npos) {
+        matches.push_back(line);
+      }
+    }
+    return matches;
+  }
+
+  bool contains(std::string_view text, std::string_view needle) {
+    return text.find(needle) != std::string_view::npos;
+  }
+}  // namespace
+
+TEST(VirtualInputUdevContract, CreatorDevicesRetainInteractiveUserAccess) {
+  const auto rules = read_source_file("src_assets/linux/misc/60-polaris.rules");
+  ASSERT_FALSE(rules.empty());
+
+  const auto uinput = rule_for_name(rules, "uinput");
+  const auto uhid = rule_for_name(rules, "uhid");
+
+  ASSERT_FALSE(uinput.empty());
+  ASSERT_FALSE(uhid.empty());
+  EXPECT_TRUE(contains(uinput, "TAG+=\"uaccess\""));
+  EXPECT_TRUE(contains(uhid, "TAG+=\"uaccess\""));
+}
+
+TEST(VirtualInputUdevContract, LegacyNamesRetainActiveSeatAccess) {
+  const auto rules = read_source_file("src_assets/linux/misc/60-polaris.rules");
+  ASSERT_FALSE(rules.empty());
+
+  for (const auto name : {"Sunshine X-Box One (virtual) pad", "Sunshine Nintendo (virtual) pad", "Sunshine PS5 (virtual) pad"}) {
+    SCOPED_TRACE(name);
+    const auto rule = rule_for_name(rules, name);
+    ASSERT_FALSE(rule.empty());
+    EXPECT_TRUE(contains(rule, "TAG+=\"uaccess\""));
+    EXPECT_FALSE(contains(rule, "seat-polaris"));
+  }
+}
+
+TEST(VirtualInputUdevContract, IsolatedNamesUseDedicatedSeat) {
+  const auto rules = read_source_file("src_assets/linux/misc/60-polaris.rules");
+  const auto creator = read_source_file("src/platform/linux/input/inputtino_gamepad.cpp");
+  ASSERT_FALSE(rules.empty());
+  ASSERT_FALSE(creator.empty());
+
+  for (const auto name : {"Polaris X-Box One (virtual) pad", "Polaris Nintendo (virtual) pad", "Polaris PS5 (virtual) pad"}) {
+    SCOPED_TRACE(name);
+    const auto rule = rule_for_name(rules, name);
+    ASSERT_FALSE(rule.empty());
+    EXPECT_TRUE(contains(rule, "ENV{ID_SEAT}=\"seat-polaris\""));
+    EXPECT_FALSE(contains(rule, "TAG+=\"uaccess\""));
+    EXPECT_TRUE(contains(creator, name));
+  }
+}
+
+TEST(VirtualInputUdevContract, SeatIsolationIdentityHelpersPreserveEnabledAndDisabledBehavior) {
+  using platf::gamepad::isolation::client_gamepad_device_name;
+  using platf::gamepad::isolation::client_gamepad_identity;
+  using platf::gamepad::isolation::client_gamepad_phys_marker;
+
+  EXPECT_EQ("polaris/client-gamepad-seat-isolated/0", client_gamepad_phys_marker(true, 0));
+  EXPECT_EQ("polaris/client-gamepad-seat-isolated/3", client_gamepad_phys_marker(true, 3));
+  EXPECT_TRUE(client_gamepad_phys_marker(false, 0).empty());
+  EXPECT_EQ("Polaris pad", client_gamepad_device_name(true, "Sunshine pad", "Polaris pad"));
+  EXPECT_EQ("Sunshine pad", client_gamepad_device_name(false, "Sunshine pad", "Polaris pad"));
+
+  const auto isolated = client_gamepad_identity(true, 3, "Sunshine pad", "Polaris pad", "02:00:00:00:10:03");
+  EXPECT_EQ("Polaris pad", isolated.name);
+  EXPECT_EQ("polaris/client-gamepad-seat-isolated/3", isolated.phys);
+
+  const auto legacy = client_gamepad_identity(false, 3, "Sunshine pad", "Polaris pad", "02:00:00:00:10:03");
+  EXPECT_EQ("Sunshine pad", legacy.name);
+  EXPECT_EQ("02:00:00:00:10:03", legacy.phys);
+
+  const auto randomized_ds5 = client_gamepad_identity(false, 3, "Sunshine PS5", "Polaris PS5", "");
+  EXPECT_EQ("Sunshine PS5", randomized_ds5.name);
+  EXPECT_TRUE(randomized_ds5.phys.empty());
+}
+
+TEST(VirtualInputUdevContract, DocumentationStatesTheEnforceableBoundary) {
+  const auto docs = read_source_file("docs/configuration.md");
+  ASSERT_FALSE(docs.empty());
+
+  EXPECT_TRUE(contains(docs, "controls the **opposite** direction"));
+  EXPECT_TRUE(contains(docs, "This is a Unix-user boundary, not a same-account process sandbox."));
+  EXPECT_TRUE(contains(docs, "members of `input`"));
+  EXPECT_TRUE(contains(docs, "requires a privileged broker"));
+}
+
+TEST(VirtualInputUdevContract, HostSetupExplainsThatExistingNodesMustBeRecreated) {
+  const auto docs = read_source_file("docs/configuration.md");
+  const auto setup = read_source_file("src/entry_handler.cpp");
+
+  EXPECT_TRUE(contains(docs, "Existing virtual controller nodes keep their previous access policy"));
+  EXPECT_TRUE(contains(setup, "Existing virtual gamepad nodes keep their previous access policy"));
+}
+
+TEST(VirtualInputUdevContract, SeatIsolationIsAnExplicitLinuxInputOption) {
+  const std::vector<std::string_view> files {
+    "src/config.h",
+    "src/config.cpp",
+    "src/confighttp_validation.cpp",
+    "src/platform/linux/input/inputtino_gamepad.cpp",
+    "src_assets/common/assets/web/views/ConfigView.vue",
+    "src_assets/common/assets/web/configs/tabs/Inputs.vue",
+    "src_assets/common/assets/web/public/assets/locale/en.json",
+    "docs/configuration.md",
+  };
+
+  for (const auto file : files) {
+    SCOPED_TRACE(file);
+    const auto source = read_source_file(file);
+    ASSERT_FALSE(source.empty());
+    EXPECT_TRUE(contains(source, "client_gamepad_seat_isolation"));
+  }
+}
+
+TEST(VirtualInputUdevContract, SeatIsolationIsOptInForBackwardCompatibility) {
+  const auto native_config = read_source_file("src/config.cpp");
+  const auto web_config = read_source_file("src_assets/common/assets/web/views/ConfigView.vue");
+  const auto inputs_tab = read_source_file("src_assets/common/assets/web/configs/tabs/Inputs.vue");
+
+  EXPECT_TRUE(contains(native_config, "false,  // client_gamepad_seat_isolation"));
+  EXPECT_TRUE(contains(web_config, "\"client_gamepad_seat_isolation\": \"disabled\""));
+  EXPECT_TRUE(contains(inputs_tab, "v-model=\"config.client_gamepad_seat_isolation\""));
+  EXPECT_TRUE(contains(inputs_tab, "default=\"false\""));
+}
+
+TEST(VirtualInputUdevContract, IsolatedGamepadsUseDedicatedSeatWithoutLocalSeatAcl) {
+  const auto rules = read_source_file("src_assets/linux/misc/60-polaris.rules");
+  ASSERT_FALSE(rules.empty());
+
+  const auto marker_rules = rules_for_name(rules, "polaris/client-gamepad-seat-isolated");
+  ASSERT_EQ(2U, marker_rules.size());
+  EXPECT_TRUE(contains(marker_rules[0], "KERNEL==\"hidraw*\""));
+  EXPECT_TRUE(contains(marker_rules[1], "SUBSYSTEMS==\"input\""));
+
+  for (const auto &rule : marker_rules) {
+    EXPECT_TRUE(contains(rule, "ATTRS{phys}==\"polaris/client-gamepad-seat-isolated/*\""));
+    EXPECT_TRUE(contains(rule, "ENV{ID_SEAT}=\"seat-polaris\""));
+    EXPECT_TRUE(contains(rule, "GROUP=\"input\""));
+    EXPECT_TRUE(contains(rule, "MODE=\"0660\""));
+    EXPECT_FALSE(contains(rule, "TAG+=\"uaccess\""));
+  }
+}


### PR DESCRIPTION
Fixes #260

## Summary

- add an explicit Linux `client_gamepad_seat_isolation` option, disabled by default for backward compatibility
- preserve legacy `Sunshine …` virtual-controller names and active-seat access when disabled
- emit `Polaris …` names plus an indexed `phys` marker when enabled, then assign those devices to `seat-polaris` through the packaged udev policy
- keep `headless_gamepad_isolation` separate: it limits host controllers visible to the streamed app, while this option limits automatic host-user access to client-created controllers

## Inputtino compatibility

The pinned Inputtino Xbox and Switch uinput backends currently propagate the configured device name but do not consume `device_phys`/`device_uniq`. The enabled policy therefore uses dedicated `Polaris …` names as the enforceable selector for those devices. PS5/UHID receives both the dedicated name and indexed `phys` marker. Disabled mode preserves the original name, `phys`, and `uniq` inputs, including randomized DualSense MAC behavior.

## Security boundary

This is a Unix-user/seat access policy, not a kernel namespace or same-account sandbox. It prevents logind from automatically granting an active local desktop user access to isolated client gamepads. It does not protect against root, the Polaris Unix account itself, users deliberately placed in `input`, explicit ACLs, direct device-node access, or already-open file descriptors.

The Polaris service account still needs `input` group membership because isolated nodes remain `root:input` mode `0660`. Existing installations must rerun `sudo polaris --setup-host` (or the AppImage install action) after upgrading, then stop active streams and restart Polaris so existing virtual controller nodes are recreated under the new policy.

## Verification

- CUDA-enabled full Polaris target: passed (CUDA 13.2, GCC/G++ 15, RTX architecture 8.9)
- focused native audit: 23/23 passed
- fast C++ suite: 156/156 passed
- Linux input suite: 4/4 passed
- Web: 46/46 files, 258/258 tests
- Web lint: passed
- production Web build/budget: passed
- `npm audit --audit-level=high`: 0 vulnerabilities
- public docs and repository-surface checks: passed
- `udevadm verify`: 1 passed, 0 failed
- staged install contains the exact verified `60-polaris.rules`
- runtime uinput probe:
  - enabled `Polaris X-Box One (virtual) pad`: `ID_SEAT=seat-polaris`, `root:input 0660`, no active-local-user ACL
  - disabled legacy `Sunshine X-Box One (virtual) pad`: active-seat ACL retained

No issue #260 candidate was deployed to the production service during development or verification.
