### PR TITLE
release: Polaris v1.3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.3.2
+project(Polaris VERSION 1.3.3
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/README.md
+++ b/README.md
@@ -91,16 +91,15 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at `https://localhost:<port + 1>`. If you want background autostart, enable the user service with `systemctl --user enable --now polaris`.
 
-## What is New in v1.3.2
+## What is New in v1.3.3
 
-Polaris v1.3.2 is a focused reliability patch for stream lifecycle, Linux private sessions, reconnect recovery, and truthful diagnostics.
+Polaris v1.3.3 is a focused patch for clean configuration saves, controller isolation, Linux operator recovery, and Nix session reliability.
 
-- **More reliable stream handoff**: RTSP follow-up control connections and started commands stay bound to the live session while PulseAudio operations remain serialized.
-- **Safer session cleanup**: lifecycle teardown, private Steam ownership, interrupted process waits, and Big Picture input isolation are hardened without broadly touching desktop Steam.
-- **Resilient web recovery**: the web console survives transient host outages and preserves authenticated sessions across host restarts.
-- **Truthful stream health**: near-target FPS no longer produces misleading degraded-state noise, and Linux GPU probe topology is easier to diagnose.
-- **Browser Stream security**: `webtransport-go v0.11.1` and `quic-go v0.60.0` fix the unknown-capsule memory-exhaustion vulnerability tracked as CVE-2026-57497 / GHSA-g35j-m5xg-vh3q.
-- **Hardened packages**: the official release is exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, and `Polaris-ubuntu24.04-x86_64.deb`, with explicit Vulkan dependencies, GCC 15 warning-as-error validation, and a permanent high-severity `npm audit` gate.
+- **Settings that save cleanly**: response-only runtime and stream-path metadata is stripped before configuration writes, while display-planner presets remain idempotent.
+- **Better controller boundaries**: preallocated gamepads rebind controller feedback correctly, and optional client-gamepad seat isolation keeps isolated virtual pads off the active desktop seat.
+- **More predictable Linux tools**: tray URL launching is locale-safe, failed Nix runtime publication cleans temporary authority files, and the composed idle/session applications stay ShellCheck-clean.
+- **Safer host recovery**: fallback planning remains stable and the Bazzite guidance includes explicit Sunshine restoration after testing Polaris.
+- **Hardened packages**: the official release remains exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, and `Polaris-ubuntu24.04-x86_64.deb`, with Fedora 44 as the sole Fedora release lane and a permanent `npm audit --audit-level=high` gate.
 See the [changelog](docs/changelog.md) for the full release history.
 
 ## Install

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,19 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## v1.3.3 - 2026-07-30
+
+Patch release focused on configuration-save hygiene, controller boundaries, Linux recovery guidance, and Nix session reliability.
+
+- Stripped response-only runtime, stream-path, credential-presence, and virtual-display metadata before configuration saves so valid v1.3.2 settings edits no longer fail backend validation
+- Kept display-planner presets idempotent across repeated selection and stale dongle-discovery responses
+- Made tray URL launching locale-safe on Linux desktops
+- Rebound preallocated gamepad controller feedback after device reuse so rumble and related output follow the active client
+- Added default-disabled client-gamepad seat isolation with distinct virtual-controller identities and explicit Linux seat-policy limits
+- Documented how Bazzite users can restore Sunshine after testing or uninstalling Polaris
+- Kept Nix-composed idle/session scripts ShellCheck-clean and removed temporary authority files after failed atomic runtime publication
+- Retained the exact release assets `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, and `Polaris-ubuntu24.04-x86_64.deb`; Fedora 44 remains the sole Fedora package lane and `npm audit --audit-level=high` remains mandatory
+
 ## v1.3.2 - 2026-07-30
 
 Reliability patch focused on stream lifecycle, Linux private-session isolation, reconnect recovery, and truthful host diagnostics.

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -1152,47 +1152,52 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.3.3 - 2026-07-30",
     "## v1.3.2 - 2026-07-30",
-    "## v1.3.1 - 2026-07-12",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "webtransport-go v0.11.1",
-    "quic-go v0.60.0",
-    "CVE-2026-57497",
+    "response-only",
+    "display-planner",
+    "locale-safe",
+    "controller feedback",
+    "seat isolation",
+    "Sunshine",
+    "Nix",
+    "ShellCheck",
     "npm audit --audit-level=high",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
     "Polaris-ubuntu24.04-x86_64.deb",
-    "vulkan-headers",
-    "vulkan-loader-devel",
-    "GCC 15",
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.3.2 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.3.3 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 readme_release_body = markdown_section(
     readme,
-    "## What is New in v1.3.2",
+    "## What is New in v1.3.3",
     "## Install",
 )
 readme_release_prose = rendered_markdown(readme_release_body)
 required_readme_facts = (
-    "webtransport-go v0.11.1",
-    "quic-go v0.60.0",
-    "CVE-2026-57497",
-    "npm audit",
+    "response-only",
+    "display-planner",
+    "controller feedback",
+    "seat isolation",
+    "locale-safe",
+    "Sunshine",
+    "Nix",
+    "ShellCheck",
+    "npm audit --audit-level=high",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
     "Polaris-ubuntu24.04-x86_64.deb",
-    "Vulkan",
-    "GCC 15",
 )
 for fact in required_readme_facts:
     if fact not in readme_release_prose:
-        print(f"README v1.3.2 summary is missing: {fact}", file=sys.stderr)
+        print(f"README v1.3.3 summary is missing: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1201,8 +1206,8 @@ asset_phrase = (
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
 for label, section in (
-    ("README v1.3.2 summary", readme_release_prose),
-    ("v1.3.2 changelog", current_release_prose),
+    ("README v1.3.3 summary", readme_release_prose),
+    ("v1.3.3 changelog", current_release_prose),
 ):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible three-asset phrase", file=sys.stderr)
@@ -1217,8 +1222,8 @@ expected_assets = Counter(
 )
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
-    ("README v1.3.2 summary", readme_release_prose),
-    ("v1.3.2 changelog", current_release_prose),
+    ("README v1.3.3 summary", readme_release_prose),
+    ("v1.3.3 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_assets:

--- a/src_assets/common/assets/web/release-v133-contract.test.js
+++ b/src_assets/common/assets/web/release-v133-contract.test.js
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+
+const sectionBetween = (source, startHeading, endHeading) => {
+  const start = source.indexOf(startHeading)
+  const end = source.indexOf(endHeading, start + startHeading.length)
+  return source.slice(start, end)
+}
+
+describe('v1.3.3 release contract', () => {
+  it('moves version and public release notes together', () => {
+    const cmake = read('CMakeLists.txt')
+    const readme = read('README.md')
+    const changelog = read('docs/changelog.md')
+    const publicDocsGate = read('scripts/check-public-docs.sh')
+
+    expect(cmake).toContain('project(Polaris VERSION 1.3.3')
+    expect(readme).toContain('## What is New in v1.3.3')
+    expect(publicDocsGate).toContain('"## What is New in v1.3.3"')
+    expect(publicDocsGate).not.toContain('"## What is New in v1.3.2"')
+    expect(changelog.indexOf('## v1.3.3 - 2026-07-30')).toBeGreaterThanOrEqual(0)
+    expect(changelog.indexOf('## v1.3.3 - 2026-07-30')).toBeLessThan(changelog.indexOf('## v1.3.2'))
+
+    for (const phrase of ['response-only', 'controller feedback', 'seat isolation', 'Nix']) {
+      expect(`${readme}\n${changelog}`).toContain(phrase)
+    }
+  })
+
+  it('keeps the official release asset set exact', () => {
+    const expectedAssets = [
+      'Polaris-arch-x86_64.pkg.tar.zst',
+      'Polaris-fedora44-x86_64.rpm',
+      'Polaris-ubuntu24.04-x86_64.deb',
+    ].sort()
+    const releaseSections = [
+      sectionBetween(read('README.md'), '## What is New in v1.3.3', '## Install'),
+      sectionBetween(read('docs/changelog.md'), '## v1.3.3 - 2026-07-30', '## v1.3.2'),
+    ]
+
+    for (const section of releaseSections) {
+      const actualAssets = section.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
+      expect(actualAssets.sort()).toEqual(expectedAssets)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- bump the Polaris product version from 1.3.2 to 1.3.3
- publish the v1.3.3 README/changelog summary for the nine post-v1.3.2 trains
- retarget the public-doc checker to enforce the v1.3.3 facts and exact three-asset contract
- add a focused v1.3.3 release-contract test

## Exact candidate

- Base: `f77323ff1f1d6e7f832ad278b11c0a53d2cba10b`
- Head: `b4cf9487a1d587cd601c1defb548232f5d94bfb2`
- Tree: `379c95935700554ef0af3872b65fabc729e48b28`
- Synthetic merge tree: `379c95935700554ef0af3872b65fabc729e48b28`

## Verification

- Web: 47 files, 260/260 tests
- ESLint: pass
- production Web build and performance budget: pass
- `npm audit --audit-level=high`: zero vulnerabilities
- public docs/surface and `git diff --check`: pass
- `scripts/check-public-docs.sh`: mode 100644, invoked through Bash
- Release contract: positive pass plus injected extra-asset mutation rejected by both Vitest and Bash checker
- Fedora 44 CUDA RPM dry run (not installed or uploaded): package digests, files, extracted linkage, version, CUDA feature, and Browser Stream helper verified; SHA-256 `864bda71d03c0f030a0812f4dc0324784a2201e4fb9cea75fe9439cc1d76606d`
- `webtransport-go v0.10.0`: absent; v0.11.1 retained
- Fedora 44 / GCC 15.2 / CUDA 13.2 / RTX SM89 release build: pass
- fast C++: 156/156
- Linux input: 4 pass, 4 existing Inputtino TODO skips
- candidate binary linkage: complete; SHA-256 `68325d44e0f2e735a44c454414779e79ea30edcd051fed5af6a13ac72438591d`
- exact-head Build Polaris: success — https://github.com/papi-ux/polaris/actions/runs/30600282054
- exact-head Public Hygiene: success — https://github.com/papi-ux/polaris/actions/runs/30600282047
- exact-head configured CodeQL workflow: success — https://github.com/papi-ux/polaris/actions/runs/30600282090
- GitHub synthetic merge commit `4d020aba484b17e1bd28b04081d827b562ee8e22` has tree `379c95935700554ef0af3872b65fabc729e48b28`, identical to the reviewed candidate tree

## Additional diagnostic

The optional, non-CI `BUILD_FULL_TESTS=ON` aggregate exposes two pre-existing master defects: missing PipeWire helper symbols in `test_polaris_platform`, and four backend/headless options rejected by `test_polaris_audit` because they are absent from ConfigView/en.json. Every involved blob is identical between base and this candidate. The supported release verifier (`BUILD_TESTS=ON`, `BUILD_FULL_TESTS=OFF`, CUDA ON) builds and passes all registered tests.

## Release contract

The only supported final release assets remain:

- `Polaris-arch-x86_64.pkg.tar.zst`
- `Polaris-fedora44-x86_64.rpm`
- `Polaris-ubuntu24.04-x86_64.deb`

This PR does **not** authorize or perform a merge, tag, GitHub release, asset upload, or production deployment.
