### PR TITLE
fix(ci): harden packaged binary path checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -470,6 +470,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            "-DCMAKE_C_FLAGS=-ffile-prefix-map=${GITHUB_WORKSPACE}=." \
+            "-DCMAKE_CXX_FLAGS=-ffile-prefix-map=${GITHUB_WORKSPACE}=." \
             -DPOLARIS_ASSETS_DIR=share/polaris \
             -DPOLARIS_EXECUTABLE_PATH=/usr/bin/polaris \
             -DPOLARIS_ENABLE_CUDA=OFF \
@@ -529,10 +531,9 @@ jobs:
             echo "Installed Ubuntu DEB has unresolved shared-library dependencies" >&2
             exit 1
           fi
-          if strings "$binary" | grep -Eq '/__w/|src_assets/.*/assets/shaders'; then
-            echo "Installed Ubuntu DEB binary contains a source-tree shader path" >&2
-            exit 1
-          fi
+          bash scripts/check-packaged-binary-paths.sh \
+            "$binary" \
+            build/cpack_artifacts/package-strings.txt
 
           polaris --version | tee build/cpack_artifacts/package-version.txt
 
@@ -736,6 +737,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            "-DCMAKE_C_FLAGS=-ffile-prefix-map=${GITHUB_WORKSPACE}=." \
+            "-DCMAKE_CXX_FLAGS=-ffile-prefix-map=${GITHUB_WORKSPACE}=." \
             -DBOOST_USE_STATIC=${{ matrix.boost_static }} \
             -DPOLARIS_ASSETS_DIR=share/polaris \
             -DPOLARIS_EXECUTABLE_PATH=/usr/bin/polaris \
@@ -818,10 +821,9 @@ jobs:
             echo "Installed Fedora RPM has unresolved shared-library dependencies" >&2
             exit 1
           fi
-          if strings "$binary" | grep -Eq '/__w/|src_assets/.*/assets/shaders'; then
-            echo "Installed Fedora RPM binary contains a source-tree shader path" >&2
-            exit 1
-          fi
+          bash scripts/check-packaged-binary-paths.sh \
+            "$binary" \
+            build/cpack_artifacts/package-strings.txt
 
           polaris --version | tee build/cpack_artifacts/package-version.txt
           if [ "${{ startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '' }}" = "true" ] &&

--- a/scripts/check-packaged-binary-paths.sh
+++ b/scripts/check-packaged-binary-paths.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <polaris-binary> <strings-report>" >&2
+  exit 2
+fi
+
+binary="$1"
+report="$2"
+
+if [ ! -r "$binary" ]; then
+  echo "Polaris binary is not readable: $binary" >&2
+  exit 2
+fi
+
+if [[ "$binary" -ef "$report" ]]; then
+  echo "Binary and report must be different files" >&2
+  exit 2
+fi
+
+mkdir -p "$(dirname "$report")"
+LC_ALL=C strings -a "$binary" > "$report"
+
+grep_status=0
+grep -Eq '/__w/|src_assets/.*/assets/shaders' "$report" || grep_status=$?
+case "$grep_status" in
+  0)
+    echo "Packaged Polaris binary contains a forbidden build/source path" >&2
+    exit 1
+    ;;
+  1)
+    ;;
+  *)
+    echo "Failed to scan packaged Polaris binary strings (grep status $grep_status)" >&2
+    exit 2
+    ;;
+esac

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -1,5 +1,7 @@
-import { readFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 
 const readSource = (path) => readFileSync(join(process.cwd(), path), 'utf8')
@@ -192,6 +194,146 @@ describe('Linux packaging contracts', () => {
       if (steamIndex >= 0) {
         expect(steamIndex, `${start} Steam must be optional`).toBeGreaterThan(optionalIndex)
       }
+    }
+  })
+
+  it('maps CI source prefixes and materializes package strings before path checks', () => {
+    const workflow = readSource('.github/workflows/build.yml')
+    const ubuntuConfigure = section(workflow, '  ubuntu-build:', '  fedora-rpm-build:')
+    const fedoraConfigure = section(workflow, '  fedora-rpm-build:', '  release-assets:')
+
+    for (const [lane, block] of [
+      ['Ubuntu', ubuntuConfigure],
+      ['Fedora', fedoraConfigure],
+    ]) {
+      expect(block, `${lane} must remap C source paths`).toContain(
+        '"-DCMAKE_C_FLAGS=-ffile-prefix-map=${GITHUB_WORKSPACE}=."',
+      )
+      expect(block, `${lane} must remap C++ source paths`).toContain(
+        '"-DCMAKE_CXX_FLAGS=-ffile-prefix-map=${GITHUB_WORKSPACE}=."',
+      )
+      expect(block, `${lane} must use the full-consumption checker`).toContain(
+        'bash scripts/check-packaged-binary-paths.sh',
+      )
+      expect(block).not.toMatch(/strings "\$binary"\s*\|\s*grep/)
+    }
+  })
+
+  it('rejects contaminated strings without the legacy pipefail false negative', () => {
+    const fixture = mkdtempSync(join(tmpdir(), 'polaris-package-paths-'))
+    try {
+      const binDir = join(fixture, 'bin')
+      const stringsPath = join(binDir, 'strings')
+      const dummyBinary = join(fixture, 'polaris')
+      const report = join(fixture, 'package-strings.txt')
+      mkdirSync(binDir)
+      writeFileSync(dummyBinary, 'fixture')
+      writeFileSync(
+        stringsPath,
+        `#!/usr/bin/env bash
+printf '/__w/polaris/polaris/src/platform/linux/graphics.cpp:593\\n'
+for ((i = 0; i < 50000; i++)); do
+  printf 'safe-symbol-%s\\n' "$i"
+done
+`,
+      )
+      chmodSync(stringsPath, 0o755)
+
+      const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` }
+      const legacy = spawnSync(
+        'bash',
+        [
+          '-c',
+          `set -o pipefail
+if strings "$1" | grep -Eq '/__w/|src_assets/.*/assets/shaders'; then
+  exit 0
+fi
+exit 42`,
+          'legacy-check',
+          dummyBinary,
+        ],
+        { encoding: 'utf8', env },
+      )
+      expect(legacy.status, `legacy stderr: ${legacy.stderr}`).toBe(42)
+
+      const contaminated = spawnSync(
+        'bash',
+        ['scripts/check-packaged-binary-paths.sh', dummyBinary, report],
+        { encoding: 'utf8', env },
+      )
+      expect(contaminated.status, `checker stderr: ${contaminated.stderr}`).toBe(1)
+      expect(contaminated.stderr).toContain('forbidden build/source path')
+
+      writeFileSync(
+        stringsPath,
+        `#!/usr/bin/env bash
+printf '/usr/share/polaris/shaders/opengl\\n'
+printf 'safe-symbol\\n'
+`,
+      )
+      const safe = spawnSync(
+        'bash',
+        ['scripts/check-packaged-binary-paths.sh', dummyBinary, report],
+        { encoding: 'utf8', env },
+      )
+      expect(safe.status, `checker stderr: ${safe.stderr}`).toBe(0)
+    } finally {
+      rmSync(fixture, { force: true, recursive: true })
+    }
+  })
+
+  it('fails closed when grep cannot scan the materialized report', () => {
+    const fixture = mkdtempSync(join(tmpdir(), 'polaris-package-paths-'))
+    try {
+      const binDir = join(fixture, 'bin')
+      const stringsPath = join(binDir, 'strings')
+      const grepPath = join(binDir, 'grep')
+      const dummyBinary = join(fixture, 'polaris')
+      const report = join(fixture, 'package-strings.txt')
+      mkdirSync(binDir)
+      writeFileSync(dummyBinary, 'fixture')
+      writeFileSync(stringsPath, '#!/usr/bin/env bash\nprintf \'safe-symbol\\n\'\n')
+      writeFileSync(grepPath, '#!/usr/bin/env bash\nexit 2\n')
+      chmodSync(stringsPath, 0o755)
+      chmodSync(grepPath, 0o755)
+
+      const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` }
+      const result = spawnSync(
+        'bash',
+        ['scripts/check-packaged-binary-paths.sh', dummyBinary, report],
+        { encoding: 'utf8', env },
+      )
+
+      expect(result.status, `checker stderr: ${result.stderr}`).toBe(2)
+      expect(result.stderr).toContain('Failed to scan packaged Polaris binary strings')
+    } finally {
+      rmSync(fixture, { force: true, recursive: true })
+    }
+  })
+
+  it('rejects aliased binary and report paths before truncating the binary', () => {
+    const fixture = mkdtempSync(join(tmpdir(), 'polaris-package-paths-'))
+    try {
+      const binDir = join(fixture, 'bin')
+      const stringsPath = join(binDir, 'strings')
+      const dummyBinary = join(fixture, 'polaris')
+      mkdirSync(binDir)
+      writeFileSync(dummyBinary, 'fixture')
+      writeFileSync(stringsPath, '#!/usr/bin/env bash\nprintf \'safe-symbol\\n\'\n')
+      chmodSync(stringsPath, 0o755)
+
+      const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` }
+      const result = spawnSync(
+        'bash',
+        ['scripts/check-packaged-binary-paths.sh', dummyBinary, dummyBinary],
+        { encoding: 'utf8', env },
+      )
+
+      expect(result.status, `checker stderr: ${result.stderr}`).toBe(2)
+      expect(result.stderr).toContain('Binary and report must be different files')
+      expect(readFileSync(dummyBinary, 'utf8')).toBe('fixture')
+    } finally {
+      rmSync(fixture, { force: true, recursive: true })
     }
   })
 })


### PR DESCRIPTION
## Summary

- replace Fedora and Ubuntu package audits that piped `strings` into early-exit `grep` under `pipefail`
- materialize complete binary strings through one reusable checker
- fail closed when the scanner itself errors and reject binary/report inode aliases before redirection
- map GitHub workspace prefixes out of packaged C/C++ paths
- add static workflow contracts plus dynamic contaminant, scanner-failure, and alias regressions

## Why

With `set -o pipefail`, a successful `grep -q` can close the pipe early and make `strings` exit on SIGPIPE. The resulting nonzero pipeline can skip a real forbidden-path match. The v1.3.3 packages were independently scanned and did not expose private host data; this PR fixes the verifier and removes Polaris GitHub-workspace provenance from future Fedora/Ubuntu package binaries.

## Verification

Exact candidate: `7aae7822149fcdbd11a96b8a46a993b763b97fa3`

### RED / GREEN

- observed the original focused packaging-contract failure before implementation
- an independent review then found scanner-error and input/report-alias fail-open cases
- added two regressions and observed both fail against the first candidate (`0` instead of required failure)
- focused packaging contract: 11/11 passed after remediation on macOS and Fedora 44
- dynamic tests prove:
  - the legacy early-exit pipeline misses a known contaminant;
  - the materialized checker rejects that contaminant;
  - a scanner status other than `0`/`1` fails closed;
  - aliased binary/report paths are rejected before truncation;
  - installed runtime shader paths remain accepted

### Local and Fedora Web gates

- Web: 47 files / 264 tests passed on macOS and Fedora 44
- ESLint passed
- Web build budget passed
- `npm audit --audit-level=high`: 0 vulnerabilities
- public docs and public surface checks passed
- Bash syntax and ShellCheck passed
- upstream `actionlint` passed
- `git diff --check` passed
- `scripts/check-packaged-binary-paths.sh` remains mode `100644` and is invoked through Bash
- `webtransport-go v0.10.0` remains absent

### Fedora 44 package verification

Built the exact replacement candidate in an isolated Fedora 44 worktree with GCC/G++ 15, CUDA 13.2, Release mode, and `BOOST_USE_STATIC=OFF`:

- fast native test: passed
- RPM generation: passed
- RPM header/payload SHA-256 digests: passed
- extracted package binary has CUDA enabled
- full strings report: 2,451,201 bytes
- packaged-binary guard: passed
- six prior absolute graphics source references are now relative
- `/__w/`: absent
- verifier worktree path: absent
- source-tree shader path: absent

No candidate package was installed and no production deployment occurred.

### Exact-head GitHub Actions

All runs completed successfully at `7aae7822149fcdbd11a96b8a46a993b763b97fa3`:

- Build Polaris: https://github.com/papi-ux/polaris/actions/runs/30633028404
- Public Hygiene: https://github.com/papi-ux/polaris/actions/runs/30633028366
- Configured GitHub CodeQL workflow: https://github.com/papi-ux/polaris/actions/runs/30633028420

## Scope boundary

This PR does not modify release tags/assets, deploy Polaris, delete release branches, or change runtime behavior.
