### PR TITLE
fix(updates): overwrite downloaded package targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,18 @@ AI Auto Quality is optional. If you enable it, Polaris uses the provider you con
 ### Fedora 44
 
 ```bash
-wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora44-x86_64.rpm
-sudo dnf install ./Polaris-fedora44-x86_64.rpm
-sudo -H polaris --setup-host
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install ./Polaris-fedora44-x86_64.rpm &&
+sudo -H polaris --setup-host &&
 polaris
 ```
 
 ### Arch Linux / CachyOS
 
 ```bash
-wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-arch-x86_64.pkg.tar.zst
-sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst
-sudo -H polaris --setup-host
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/latest/download/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
 polaris
 ```
 

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -47,7 +47,7 @@ Install Polaris from the Fedora 44 release RPM:
 
 ```bash
 rpm_name="Polaris-fedora44-x86_64.rpm"
-wget "https://github.com/papi-ux/polaris/releases/latest/download/${rpm_name}"
+wget --output-document="./${rpm_name}" "https://github.com/papi-ux/polaris/releases/latest/download/${rpm_name}" &&
 sudo rpm-ostree install -r "./${rpm_name}"
 ```
 
@@ -248,7 +248,7 @@ newer local RPM over the existing layered Polaris package:
 
 ```bash
 rpm_name="Polaris-fedora44-x86_64.rpm"
-wget -O "${rpm_name}" "https://github.com/papi-ux/polaris/releases/latest/download/${rpm_name}"
+wget --output-document="./${rpm_name}" "https://github.com/papi-ux/polaris/releases/latest/download/${rpm_name}" &&
 sudo rpm-ostree install -r "./${rpm_name}"
 ```
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -11,16 +11,16 @@ need broader real-hardware validation. openSUSE Tumbleweed is source-build suppo
 ## Release packages
 
 ```bash
-wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora44-x86_64.rpm
-sudo dnf install ./Polaris-fedora44-x86_64.rpm
-sudo -H polaris --setup-host
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install ./Polaris-fedora44-x86_64.rpm &&
+sudo -H polaris --setup-host &&
 polaris
 ```
 
 ```bash
-wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-arch-x86_64.pkg.tar.zst
-sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst
-sudo -H polaris --setup-host
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/latest/download/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
 polaris
 ```
 
@@ -41,15 +41,15 @@ systemctl --user enable --now polaris
 ```
 
 ```bash
-wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb
-sudo apt install ./Polaris-ubuntu24.04-x86_64.deb
-sudo -H polaris --setup-host
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
 polaris
 ```
 
 ```bash
 rpm_name="Polaris-fedora44-x86_64.rpm"
-wget "https://github.com/papi-ux/polaris/releases/latest/download/${rpm_name}"
+wget --output-document="./${rpm_name}" "https://github.com/papi-ux/polaris/releases/latest/download/${rpm_name}" &&
 sudo rpm-ostree install -r "./${rpm_name}"
 
 # After reboot:

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -14,9 +14,9 @@ releases.
 ## Release Package
 
 ```bash
-wget https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb
-sudo apt install ./Polaris-ubuntu24.04-x86_64.deb
-sudo -H polaris --setup-host
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
 polaris
 ```
 

--- a/src_assets/common/assets/web/update-center.js
+++ b/src_assets/common/assets/web/update-center.js
@@ -122,9 +122,7 @@ export function buildManualInstallCommand(asset, host = {}) {
   if (!isSafeAssetForFamily(asset, family)) return ''
   const fileName = asset.name
   const downloadUrl = asset.browser_download_url
-  const lines = family === 'steamos'
-    ? [`wget --output-document=./${fileName} ${downloadUrl} &&`]
-    : [`wget ${downloadUrl}`]
+  const lines = [`wget --output-document=./${fileName} ${downloadUrl} &&`]
 
   if (family === 'steamos') {
     lines.push('(')
@@ -141,16 +139,16 @@ export function buildManualInstallCommand(asset, host = {}) {
   }
 
   if (family === 'arch') {
-    lines.push(`sudo pacman -U ./${fileName}`)
+    lines.push(`sudo pacman -U ./${fileName} &&`)
   } else if (family === 'fedora') {
-    lines.push(`sudo dnf install "./${fileName}"`)
+    lines.push(`sudo dnf install "./${fileName}" &&`)
   } else if (family === 'ubuntu') {
-    lines.push(`sudo apt install ./${fileName}`)
+    lines.push(`sudo apt install ./${fileName} &&`)
   } else {
     return ''
   }
 
-  lines.push('sudo -H polaris --setup-host')
+  lines.push('sudo -H polaris --setup-host &&')
   lines.push('systemctl --user restart polaris')
   return lines.join('\n')
 }

--- a/src_assets/common/assets/web/update-center.test.js
+++ b/src_assets/common/assets/web/update-center.test.js
@@ -38,6 +38,27 @@ const release = {
   ],
 }
 
+const mutablePackageCases = [
+  {
+    family: 'arch',
+    fileName: 'Polaris-arch-x86_64.pkg.tar.zst',
+    installLine: 'sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&',
+    installLog: 'sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst',
+  },
+  {
+    family: 'fedora',
+    fileName: 'Polaris-fedora44-x86_64.rpm',
+    installLine: 'sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&',
+    installLog: 'sudo dnf install ./Polaris-fedora44-x86_64.rpm',
+  },
+  {
+    family: 'ubuntu',
+    fileName: 'Polaris-ubuntu24.04-x86_64.deb',
+    installLine: 'sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&',
+    installLog: 'sudo apt install ./Polaris-ubuntu24.04-x86_64.deb',
+  },
+]
+
 const buildSteamOsState = () => buildUpdateCenterState({
   currentVersion: '1.2.1',
   latestRelease: release,
@@ -131,6 +152,61 @@ exit 0
   }
 }
 
+const runWithFakeMutableInstallCommands = (command, failStep) => {
+  const fixture = mkdtempSync(join(tmpdir(), 'polaris-mutable-update-'))
+  try {
+    const binDir = join(fixture, 'bin')
+    const commandLog = join(fixture, 'commands.log')
+    mkdirSync(binDir)
+
+    writeFileSync(
+      join(binDir, 'wget'),
+      `#!/usr/bin/env bash
+printf 'wget %s\\n' "$*" >> "$POLARIS_COMMAND_LOG"
+if [[ "$POLARIS_FAIL_STEP" == "download" ]]; then
+  exit 44
+fi
+`,
+    )
+    writeFileSync(
+      join(binDir, 'sudo'),
+      `#!/usr/bin/env bash
+printf 'sudo %s\\n' "$*" >> "$POLARIS_COMMAND_LOG"
+if [[ "$POLARIS_FAIL_STEP" == "install" && "$1" != "-H" ]]; then
+  exit 41
+fi
+if [[ "$POLARIS_FAIL_STEP" == "setup-host" && "$1" == "-H" && "$2" == "polaris" && "$3" == "--setup-host" ]]; then
+  exit 42
+fi
+exit 0
+`,
+    )
+    writeFileSync(
+      join(binDir, 'systemctl'),
+      '#!/usr/bin/env bash\nprintf \'systemctl %s\\n\' "$*" >> "$POLARIS_COMMAND_LOG"\n',
+    )
+    for (const name of ['wget', 'sudo', 'systemctl']) {
+      chmodSync(join(binDir, name), 0o755)
+    }
+
+    const result = spawnSync('bash', ['-c', command], {
+      cwd: fixture,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: fixture,
+        PATH: `${binDir}:${process.env.PATH || ''}`,
+        POLARIS_COMMAND_LOG: commandLog,
+        POLARIS_FAIL_STEP: failStep,
+      },
+    })
+    const commands = readFileSync(commandLog, 'utf8').trim().split('\n').filter(Boolean)
+    return { commands, result }
+  } finally {
+    rmSync(fixture, { force: true, recursive: true })
+  }
+}
+
 const expectFailureSafeSteamOsCommand = (failSudo, failedCommand) => {
   const state = buildSteamOsState()
   const { commands, result } = runWithFakeInstallCommands(state.installCommand, failSudo)
@@ -160,7 +236,7 @@ describe('Update Center release awareness', () => {
     expect(state.latestVersion).toBe('v1.2.2')
     expect(state.asset.name).toBe('Polaris-arch-x86_64.pkg.tar.zst')
     expect(state.packageLabel).toBe('Arch/CachyOS package')
-    expect(state.installCommand).toContain('wget https://example.test/Polaris-arch-x86_64.pkg.tar.zst')
+    expect(state.installCommand).toContain('wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://example.test/Polaris-arch-x86_64.pkg.tar.zst &&')
     expect(state.installCommand).toContain('sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst')
     expect(state.installCommand).toContain('sudo -H polaris --setup-host')
     expect(state.installCommand).toContain('systemctl --user restart polaris')
@@ -306,6 +382,60 @@ describe('Update Center release awareness', () => {
       'sudo dnf install "./Polaris-fedora44-x86_64.rpm"',
     )
   })
+
+  it.each(mutablePackageCases)(
+    'overwrites the exact $family package target and chains install side effects',
+    ({ family, fileName, installLine }) => {
+      const downloadUrl = `https://example.test/${fileName}`
+
+      expect(buildManualInstallCommand({
+        name: fileName,
+        browser_download_url: downloadUrl,
+        packageFamily: family,
+      }).split('\n')).toEqual([
+        `wget --output-document=./${fileName} ${downloadUrl} &&`,
+        installLine,
+        'sudo -H polaris --setup-host &&',
+        'systemctl --user restart polaris',
+      ])
+    },
+  )
+
+  it.each(mutablePackageCases)(
+    'stops $family update side effects after each failed command',
+    ({ family, fileName, installLog }) => {
+      const downloadUrl = `https://example.test/${fileName}`
+      const command = buildManualInstallCommand({
+        name: fileName,
+        browser_download_url: downloadUrl,
+        packageFamily: family,
+      })
+      const downloadLog = `wget --output-document=./${fileName} ${downloadUrl}`
+      const setupLog = 'sudo -H polaris --setup-host'
+      const expectedByFailure = {
+        download: [downloadLog],
+        install: [downloadLog, installLog],
+        'setup-host': [downloadLog, installLog, setupLog],
+      }
+
+      for (const [failStep, expectedCommands] of Object.entries(expectedByFailure)) {
+        const { commands, result } = runWithFakeMutableInstallCommands(command, failStep)
+
+        expect(result.status, `${family}/${failStep} stdout: ${result.stdout}\nstderr: ${result.stderr}`).not.toBe(0)
+        expect(commands).toEqual(expectedCommands)
+        expect(commands.some((entry) => entry.startsWith('systemctl '))).toBe(false)
+      }
+
+      const success = runWithFakeMutableInstallCommands(command, '')
+      expect(success.result.status, `${family}/success stderr: ${success.result.stderr}`).toBe(0)
+      expect(success.commands).toEqual([
+        downloadLog,
+        installLog,
+        setupLog,
+        'systemctl --user restart polaris',
+      ])
+    },
+  )
 
   it('selects the Ubuntu 24.04 package for Debian-family tester hosts', () => {
     const state = buildUpdateCenterState({


### PR DESCRIPTION
## Summary

- download mutable Linux release packages to the exact filename shown to the package manager
- chain download, install, host setup, and service restart so failures stop later side effects
- add executable Arch, Fedora, and Ubuntu failure-path regression coverage
- align Fedora, Arch, Ubuntu, and Bazzite copy-paste install/update documentation

## Root cause

`wget URL` preserves an existing destination by writing `.1`, `.2`, and so on. The generated command still passed the unsuffixed filename to `dnf`, `pacman`, or `apt`, so a repeated update could install an older package while the new asset sat beside it.

## Verification

- `env -u NODE_ENV npm test` — 48 files, 293 tests passed
- `env -u NODE_ENV npm run lint`
- `env -u NODE_ENV npm run build`
- `env -u NODE_ENV npm run budget:web`
- `env -u NODE_ENV npm audit --audit-level=high` — 0 vulnerabilities
- `bash scripts/check-public-docs.sh`
- independent fail-closed security/logic review passed
- live Fedora validation: exact-output download overwrote the target without creating a suffix; the v1.3.4 RPM digest matched GitHub, upgraded pc-papi to `polaris-1.3.4.434b1a6-1.x86_64`, and Polaris returned HTTP 200 after restart
