### PR TITLE
release: prepare Polaris v1.3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.3.4
+project(Polaris VERSION 1.3.5
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/README.md
+++ b/README.md
@@ -91,16 +91,19 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at `https://localhost:<port + 1>`. If you want background autostart, enable the user service with `systemctl --user enable --now polaris`.
 
-## What is New in v1.3.4
+## What is New in v1.3.5
 
-Polaris v1.3.4 adds a dedicated SteamOS 3.8 package lane and tightens Linux package, setup, and import safety.
+Polaris v1.3.5 makes manual package updates deterministic, hands the Linux host integration files to the package that owns them, and teaches the library what your launchers already know.
 
-- **Package checks**: fail-closed packaged binary path validation now rejects invalid layouts, preserves source-prefix remapping, and records exact validation receipts.
-- **Secure Bazzite paths**: Bazzite provides secure support for the `/home` to `var/home` layout without broad canonicalization, keeping path validation narrow and explicit.
-- **Predictable host setup**: setup-host dispatch happens early and public instructions consistently use `sudo -H polaris --setup-host`.
-- **Reliable cover imports**: locale-safe ImageMagick discovery keeps Steam cover import working across localized tool output.
-- **Dedicated SteamOS support**: SteamOS 3.8 x86_64 receives a separate Valve-repository package and failure-safe Desktop Mode installation path. Physical Steam Deck gameplay and Game Mode are not certified by this release.
-- **Security gates**: `npm audit --audit-level=high` remains mandatory, and the forbidden `webtransport-go v0.10.0` dependency remains absent.
+- **Exact download targets**: Update Center now writes every mutable-distro download to the exact package filename with `wget --output-document`, so an existing file cannot redirect the new payload to `.1` or `.2` while the package manager reads stale bytes.
+- **Failure-safe command chains**: Fedora, Arch, and Ubuntu update commands short-circuit after a failed download, package installation, `sudo -H polaris --setup-host`, or service restart instead of continuing with later side effects.
+- **Host files owned by the package**: udev rules and modules-load configuration install to `/usr/lib`, so uninstalling Polaris removes them. An unmodified `/etc` copy from an older install is retired, because it would otherwise shadow every future fix to the rules. `--setup-host` no longer asks for root when there is nothing privileged left to do.
+- **`polaris-debug` package**: Arch and SteamOS builds ship debug symbols separately, so `coredumpctl info polaris` gives a real backtrace instead of `no debugging symbols`.
+- **Seat isolation tells you what it needs**: enabling client gamepad or keyboard/mouse seat isolation without being in the `input` group now warns at startup, rather than presenting as a controller that never appears.
+- **Playtime and completion estimates**: the library reports the hours Steam and Lutris already record, and serves completion estimates from a local dataset before reaching for How Long To Beat. Shown in the Polaris web console; Nova display support is still to come.
+- **Host audio released properly**: turning host audio off in a session now unloads the loopback an earlier session created, instead of playing through the host speakers for the life of the process.
+- **v1.3.4 bootstrap guidance**: the command generator bundled with v1.3.4 predates this fix, so use the exact-output commands in Quick Start or the [v1.3.5 release notes](docs/release-notes/v1.3.5.md) for the first upgrade.
+- **Security gate**: `npm audit --audit-level=high` remains mandatory.
 - **Exact release set**: the official artifacts are `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb`.
 See the [changelog](docs/changelog.md) for the full release history.
 
@@ -453,6 +456,15 @@ Great bug reports save everyone time. When reporting a Polaris host issue, inclu
 - Encoder path and whether Headless Stream is enabled.
 - Relevant logs from `journalctl --user -u polaris` around the failed launch or stream.
 - Screenshots or recordings for UI/video/input issues. Redact hostnames, tokens, LAN-only URLs, and pairing material if needed.
+
+If Polaris **crashed** rather than failed cleanly, a backtrace is worth more than everything above
+combined. Released builds are stripped, so install the matching debug package first — see
+[reporting a crash](docs/troubleshooting.md#reporting-a-crash):
+
+```bash
+sudo pacman -S polaris-debug   # Arch and SteamOS
+coredumpctl info polaris
+```
 
 If you are comparing clients, say whether the same host/app works differently in Nova and in a standard Moonlight client. That comparison is extremely useful for separating host bugs from client UI bugs.
 

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -369,9 +369,3 @@ Please include these details when reporting Bazzite issues:
 - requested client resolution, FPS, codec, and whether the web UI preview was open
 - whether headless mode and virtual display behavior worked after a reboot
 
-## Current Status
-
-Fedora 44 RPMs are release-tested in CI. Bazzite uses the Fedora 44 RPM through
-`rpm-ostree`; `bazzite-nvidia-open:stable`
-`44.20260430` has Desktop Mode service and port validation only. Game Mode still
-needs validation on a Bazzite image that exposes a real gamescope Steam session.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,29 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## v1.3.5 - 2026-08-06
+
+Package-update safety, Linux host integration owned by the package, and library playtime and completion estimates.
+
+- Writes each mutable-distro download to the exact package filename with `wget --output-document`, preventing a pre-existing file from redirecting the new payload to `.1` or `.2` while a stale unsuffixed package is installed
+- Makes Fedora, Arch, and Ubuntu update commands short-circuit after download, package-install, `sudo -H polaris --setup-host`, or restart failures
+- Adds executable regression coverage for failed download, install, setup-host, and successful command paths across all three mutable package families
+- Documents the v1.3.4 bootstrap caveat and provides exact-output commands for the first upgrade to v1.3.5
+- Installs the udev rules and modules-load configuration as package files under `/usr/lib`, so the package manager owns them and removes them on uninstall
+- Retires an unmodified `/etc` copy from an older install that would otherwise shadow the packaged rules, and keeps an edited copy with a warning naming the file in effect
+- Lets `--setup-host` exit without root when the package already provides everything and the virtual input nodes are usable
+- Adds a `polaris-debug` package to the Arch and SteamOS builds so `coredumpctl info polaris` yields a real backtrace
+- Closes a `systemd-inhibit` process leaked on every session, and keeps a private session's virtual keyboard and mouse out of the desktop session logged in at the machine
+- Warns at startup when seat isolation is enabled and the account Polaris runs as is not in the `input` group, which otherwise leaves the isolated devices unopenable by Polaris and by the streamed game
+- Warns when `back_button_timeout` is shorter than the 100ms Home press it emulates, since the setting is milliseconds and a value like `2` turns nearly every Back/Select press into Home
+- Reports the playtime Steam and Lutris already record on disk, and serves completion estimates from a local dataset first, with `beat_times_lookup` controlling the How Long To Beat fallback; both are host-side and announced through `/polaris/v1/capabilities`, and Nova does not display them yet
+- Adds a transactional custom artwork workflow with an authenticated resolver, bounded downloads, and atomic caching
+- Surfaces per-app environment variables in the web UI
+- Releases the host loopback when a session turns host audio off, instead of leaving an earlier session's loopback loaded for the life of the process
+- Applies the session's requested resolution and refresh when preparing the streaming display
+- Keeps `npm audit --audit-level=high` mandatory and clears the advisories that were failing every web build
+- Retains exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
+
 ## v1.3.4 - 2026-07-31
 
 Patch release adding a dedicated SteamOS 3.8 package lane and tightening Linux package, path, setup, and import safety.

--- a/docs/release-notes/v1.3.5.md
+++ b/docs/release-notes/v1.3.5.md
@@ -1,0 +1,94 @@
+# Polaris v1.3.5
+
+Polaris v1.3.5 makes repeated manual package updates deterministic and failure-safe by writing each download to the exact package filename, moves the Linux host integration files into the package that owns them, and adds playtime and completion estimates to the library.
+
+## Important: upgrading from v1.3.4
+
+Two things about this upgrade are worth reading before you run it.
+
+**Use the exact-output command below.** The Update Center bundled with v1.3.4 can let `wget` create a `.1` or `.2` file when the package already exists, while the package manager continues to read the stale unsuffixed file.
+
+**The host integration files move.** The udev rules and modules-load configuration are now installed by the package to `/usr/lib/udev/rules.d` and `/usr/lib/modules-load.d`, so your package manager owns them and removes them on uninstall. If an older Polaris wrote its own copy into `/etc`, that copy takes precedence over the packaged one and would silently shadow every future fix to the rules. `polaris --setup-host` retires an unmodified `/etc` copy for you and warns instead of deleting one you edited yourself.
+
+`--setup-host` also no longer needs `sudo` when the package already provides everything and the virtual input nodes are usable — it reports that there is nothing to do and exits. It still needs root when it has to write `/etc` or apply `--enable-kms`.
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.5/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.5/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.5/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 already uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md).
+
+## Changes
+
+### Package updates
+
+- Overwrites the exact target selected by `dnf`, `pacman`, or `apt` instead of allowing numbered sibling downloads.
+- Short-circuits package installation, host setup, and service restart after any earlier failure.
+- Adds executable failure-path coverage for Fedora, Arch, and Ubuntu command generation.
+- Preserves the existing manual-install trust boundary.
+
+### Linux host integration
+
+- Ships the udev rules and modules-load configuration as package files under `/usr/lib`, so they are package-manager owned and removed on uninstall.
+- Retires an unmodified `/etc` copy left by an older install, which would otherwise shadow the packaged file; a copy you edited yourself is kept, with a warning naming the file in effect.
+- Makes `--setup-host` exit without asking for root when there is nothing privileged left to do.
+- Adds a **`polaris-debug`** package alongside the Arch and SteamOS builds. Installing it makes `coredumpctl info polaris` produce a real backtrace instead of `no debugging symbols`, which is what a useful crash report needs.
+- Closes a `systemd-inhibit` process leaked on every session and stops a private session's virtual keyboard and mouse from typing into the desktop session logged in at the machine.
+- Warns at startup when client gamepad or keyboard/mouse seat isolation is enabled and the account Polaris runs as is not in the `input` group. Isolated devices are deliberately denied the logind ACL, so without that group membership neither Polaris nor the streamed game can open the devices it just created.
+
+### Input
+
+- Warns when `back_button_timeout` is set to a value shorter than the 100ms Home press it emulates. The setting is in milliseconds, so `2` meant two thousandths of a second: Back/Select was released and turned into Home on essentially every press, and the controller looked broken rather than misconfigured. The warning names the value that was almost certainly intended.
+
+### Library
+
+- Reports the playtime Steam and Lutris already record on disk, instead of leaving clients to ask a third party for a number that was sitting there.
+- Serves completion estimates from a local dataset first, falling back to How Long To Beat only for titles the dataset does not cover. `beat_times_lookup` turns the network lookup off.
+
+> Playtime and completion estimates are served by the host and read by the Polaris web console. Nova
+> does not display them yet, so a Nova-only user will not see a change from these two until client
+> support lands. The host announces both through `/polaris/v1/capabilities` as `library_playtime_v1`
+> and `library_beat_times_v1`, so a client can adopt them without guessing.
+- Adds a transactional custom artwork workflow with an authenticated resolver, bounded provider downloads, and atomic source-aware caching.
+- Surfaces per-app environment variables in the web UI.
+
+### Audio and capture
+
+- Releases the host loopback when a session turns host audio off. Previously a loopback created by an earlier session stayed loaded, so a client that launched with host audio disabled still played through the host speakers for the rest of the Polaris process.
+- Applies the session's requested resolution and refresh when preparing the streaming display, rather than a fixed default.
+
+### Build
+
+- Clears the dependency advisories that were failing every web build, and keeps `npm audit --audit-level=high` mandatory.
+- Fixes a link failure that had been breaking the sanitizer job on clean builds.
+- Drops the local gamescope patch now that it has merged upstream.
+
+## Official assets
+
+- `Polaris-arch-x86_64.pkg.tar.zst`
+- `Polaris-fedora44-x86_64.rpm`
+- `Polaris-steamos3.8-x86_64.pkg.tar.zst`
+- `Polaris-ubuntu24.04-x86_64.deb`

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -55,6 +55,22 @@ polaris
 Use `-DPOLARIS_ENABLE_CUDA=ON` only when the CUDA toolkit is installed and you specifically want a
 CUDA-enabled local build.
 
+## Update
+
+Download the newer `.deb` to the exact filename and repeat the failure-safe chain. Writing to the
+exact name matters: an existing file otherwise becomes `Polaris-ubuntu24.04-x86_64.deb.1` while
+`apt` installs the stale original.
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/latest/download/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+`--setup-host` exits without asking for root when the package already provides the udev rules and
+modules-load configuration and the virtual input nodes are usable.
+
 ## Optional Setup
 
 Enable the user service if you want Polaris to start in the background:

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.3.4') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.3.5') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -613,6 +613,9 @@ contributing = strip_html_comments(
 )
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
+release_notes = strip_html_comments(
+    Path("docs/release-notes/v1.3.5.md").read_text(encoding="utf-8")
+)
 
 
 def markdown_section(
@@ -1242,26 +1245,19 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.3.5 - 2026-08-06",
     "## v1.3.4 - 2026-07-31",
-    "## v1.3.3 - 2026-07-30",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "fail-closed",
-    "packaged binary path",
-    "source-prefix",
-    "locale-safe",
-    "ImageMagick",
-    "secure",
-    "Bazzite",
-    "/home",
-    "var/home",
-    "without broad canonicalization",
+    "v1.3.4",
+    "exact package filename",
+    "wget --output-document",
+    ".1",
+    ".2",
+    "short-circuit",
     "sudo -H",
-    "SteamOS 3.8",
-    "Desktop Mode",
     "npm audit --audit-level=high",
-    "webtransport-go v0.10.0",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
     "Polaris-steamos3.8-x86_64.pkg.tar.zst",
@@ -1269,19 +1265,19 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.3.4 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.3.5 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 readme_release_body = markdown_section(
     readme,
-    "## What is New in v1.3.4",
+    "## What is New in v1.3.5",
     "## Install",
 )
 readme_release_prose = rendered_markdown(readme_release_body)
 required_readme_facts = required_release_facts
 for fact in required_readme_facts:
     if fact not in readme_release_prose:
-        print(f"README v1.3.4 summary is missing: {fact}", file=sys.stderr)
+        print(f"README v1.3.5 summary is missing: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1291,8 +1287,8 @@ asset_phrase = (
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
 for label, section in (
-    ("README v1.3.4 summary", readme_release_prose),
-    ("v1.3.4 changelog", current_release_prose),
+    ("README v1.3.5 summary", readme_release_prose),
+    ("v1.3.5 changelog", current_release_prose),
 ):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
@@ -1311,8 +1307,8 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
     ("docs/building.md Packaging", building_packaging_prose),
-    ("README v1.3.4 summary", readme_release_prose),
-    ("v1.3.4 changelog", current_release_prose),
+    ("README v1.3.5 summary", readme_release_prose),
+    ("v1.3.5 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_assets:
@@ -1322,6 +1318,29 @@ for label, section in (
             file=sys.stderr,
         )
         sys.exit(1)
+
+release_notes_facts = (
+    "v1.3.4",
+    "exact package filename",
+    ".1",
+    ".2",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.5/Polaris-fedora44-x86_64.rpm &&",
+    "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.5/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.5/Polaris-ubuntu24.04-x86_64.deb &&",
+    "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
+)
+for fact in release_notes_facts:
+    if fact not in release_notes:
+        print(f"v1.3.5 release notes are missing bootstrap fact: {fact}", file=sys.stderr)
+        sys.exit(1)
+if release_notes.count("sudo -H polaris --setup-host &&") != 3:
+    print("v1.3.5 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    sys.exit(1)
+if release_notes.count("systemctl --user restart polaris") != 3:
+    print("v1.3.5 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    sys.exit(1)
 
 if "bash scripts/check-public-docs.sh" not in contributing:
     print("CONTRIBUTING.md must invoke the non-executable checker through bash", file=sys.stderr)

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.4-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.5-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -667,7 +667,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.3.4-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.3.5-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v134-contract.test.js
+++ b/src_assets/common/assets/web/release-v134-contract.test.js
@@ -7,15 +7,16 @@ const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
 const sectionBetween = (source, startHeading, endHeading) => {
   const start = source.indexOf(startHeading)
   const end = source.indexOf(endHeading, start + startHeading.length)
-  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
-  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  expect(start, `missing historical release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing historical release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
   return source.slice(start, end)
 }
 
-const releaseSections = () => [
-  sectionBetween(read('README.md'), '## What is New in v1.3.4', '## Install'),
-  sectionBetween(read('docs/changelog.md'), '## v1.3.4 - 2026-07-31', '## v1.3.3'),
-]
+const historicalRelease = () => sectionBetween(
+  read('docs/changelog.md'),
+  '## v1.3.4 - 2026-07-31',
+  '## v1.3.3',
+)
 
 const requiredFixFacts = [
   'fail-closed',
@@ -29,6 +30,10 @@ const requiredFixFacts = [
   'var/home',
   'without broad canonicalization',
   'sudo -H',
+  'SteamOS 3.8',
+  'Desktop Mode',
+  'npm audit --audit-level=high',
+  'webtransport-go v0.10.0',
 ]
 
 const expectedAssets = [
@@ -38,67 +43,18 @@ const expectedAssets = [
   'Polaris-ubuntu24.04-x86_64.deb',
 ].sort()
 
-describe('v1.3.4 release contract', () => {
-  it('moves the CMake version and public release headings together', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.4')
-    expect(read('README.md')).toContain('## What is New in v1.3.4')
-    expect(read('docs/changelog.md')).toContain('## v1.3.4 - 2026-07-31')
-  })
+describe('historical v1.3.4 release contract', () => {
+  it('preserves the v1.3.4 release facts', () => {
+    const release = historicalRelease()
 
-  it('aligns the public checker with the v1.3.4 release contract', () => {
-    const publicDocsGate = read('scripts/check-public-docs.sh')
-
-    expect(publicDocsGate).toContain('"## What is New in v1.3.4"')
-    expect(publicDocsGate).not.toContain('"## What is New in v1.3.3"')
-    expect(publicDocsGate).toContain('"## v1.3.4 - 2026-07-31"')
-    for (const fact of [...requiredFixFacts, 'npm audit --audit-level=high', 'webtransport-go v0.10.0']) {
-      expect(publicDocsGate, `public checker must require: ${fact}`).toContain(fact)
-    }
-    for (const asset of expectedAssets) {
-      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
-    }
-    expect(publicDocsGate).toContain('building_packaging = markdown_section(')
-    expect(publicDocsGate).toContain('("docs/building.md Packaging", building_packaging_prose)')
-  })
-
-  it('records the #264, #265, and #266 release facts', () => {
-    for (const releaseSection of releaseSections()) {
-      for (const fact of requiredFixFacts) {
-        expect(releaseSection, `release notes must include: ${fact}`).toContain(fact)
-      }
+    for (const fact of requiredFixFacts) {
+      expect(release, `historical release must include: ${fact}`).toContain(fact)
     }
   })
 
-  it('keeps npm audit mandatory and the forbidden webtransport-go version absent', () => {
-    expect(read('.github/workflows/build.yml')).toContain('npm audit --audit-level=high')
-    expect(read('browser_stream_helper/go.mod')).not.toContain('github.com/quic-go/webtransport-go v0.10.0')
-    expect(read('browser_stream_helper/go.sum')).not.toContain('github.com/quic-go/webtransport-go v0.10.0')
-
-    for (const releaseSection of releaseSections()) {
-      expect(releaseSection).toContain('npm audit --audit-level=high')
-      expect(releaseSection).toContain('webtransport-go v0.10.0')
-    }
-  })
-
-  it('keeps the official release asset set exact', () => {
-    for (const releaseSection of releaseSections()) {
-      const actualAssets = releaseSection.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
-      expect(actualAssets.sort()).toEqual(expectedAssets)
-    }
-  })
-
-  it('lists exactly the four official artifacts in the bounded build guide packaging section', () => {
-    const building = read('docs/building.md')
-    const heading = '## Packaging'
-    const packagingStart = building.indexOf(heading)
-    expect(packagingStart, 'missing build-guide packaging section').toBeGreaterThanOrEqual(0)
-    const afterHeading = building.slice(packagingStart + heading.length)
-    const nextHeading = afterHeading.search(/^#{1,2}\s+/m)
-    const packaging = afterHeading.slice(0, nextHeading >= 0 ? nextHeading : undefined)
-    const actualAssets = packaging.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
+  it('preserves the exact historical four-asset set', () => {
+    const actualAssets = historicalRelease().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
 
     expect(actualAssets.sort()).toEqual(expectedAssets)
-    expect(packaging).toContain('SteamOS 3.8')
-    expect(packaging).toContain('(steamos.md)')
   })
 })

--- a/src_assets/common/assets/web/release-v135-contract.test.js
+++ b/src_assets/common/assets/web/release-v135-contract.test.js
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buildManualInstallCommand } from './update-center.js'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+
+const sectionBetween = (source, startHeading, endHeading) => {
+  const start = source.indexOf(startHeading)
+  const end = source.indexOf(endHeading, start + startHeading.length)
+  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+const releaseSections = () => [
+  sectionBetween(read('README.md'), '## What is New in v1.3.5', '## Install'),
+  sectionBetween(read('docs/changelog.md'), '## v1.3.5 - 2026-08-06', '## v1.3.4'),
+]
+
+const requiredUpdateFacts = [
+  'v1.3.4',
+  'exact package filename',
+  'wget --output-document',
+  '.1',
+  '.2',
+  'short-circuit',
+  'sudo -H',
+  'npm audit --audit-level=high',
+]
+
+// A release that changes files on the host at upgrade has to say so. v1.3.5 was
+// first written as an updater-only patch and went out of date silently as eleven
+// further commits landed; asserting the user-visible packaging change keeps the
+// next release from omitting one the same way.
+const requiredHostIntegrationFacts = [
+  '/usr/lib',
+  '/etc',
+  'polaris-debug',
+  'input',
+]
+
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+
+describe('v1.3.5 release contract', () => {
+  it('moves the CMake version and public release headings together', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.5')
+    expect(read('README.md')).toContain('## What is New in v1.3.5')
+    expect(read('docs/changelog.md')).toContain('## v1.3.5 - 2026-08-06')
+  })
+
+  it('records the updater bootstrap and failure-safety facts', () => {
+    for (const releaseSection of releaseSections()) {
+      for (const fact of requiredUpdateFacts) {
+        expect(releaseSection, `release notes must include: ${fact}`).toContain(fact)
+      }
+    }
+  })
+
+  it('states the host integration changes that alter files on upgrade', () => {
+    const releaseNotes = read('docs/release-notes/v1.3.5.md')
+    for (const fact of requiredHostIntegrationFacts) {
+      expect(releaseNotes, `release notes must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('aligns the public checker with the v1.3.5 release contract', () => {
+    const publicDocsGate = read('scripts/check-public-docs.sh')
+
+    expect(publicDocsGate).toContain('"## What is New in v1.3.5"')
+    expect(publicDocsGate).not.toContain('"## What is New in v1.3.4"')
+    expect(publicDocsGate).toContain('"## v1.3.5 - 2026-08-06"')
+    for (const fact of requiredUpdateFacts) {
+      expect(publicDocsGate, `public checker must require: ${fact}`).toContain(fact)
+    }
+    for (const asset of expectedAssets) {
+      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
+    }
+  })
+
+  it('moves versioned package-review metadata to v1.3.5', () => {
+    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
+    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
+
+    expect(reviewedWarnings).toContain("usr/bin/polaris-1.3.5")
+    expect(reviewedWarnings).not.toContain("usr/bin/polaris-1.3.4")
+    expect(steamOsBuildScript).toContain("'polaris|1.3.5-1|x86_64'")
+    expect(steamOsBuildScript).not.toContain("'polaris|1.3.4-1|x86_64'")
+  })
+
+  it('ships ready-to-publish v1.3.4 bootstrap release notes', () => {
+    const releaseNotes = read('docs/release-notes/v1.3.5.md')
+    const packageCases = [
+      ['fedora', 'Polaris-fedora44-x86_64.rpm'],
+      ['arch', 'Polaris-arch-x86_64.pkg.tar.zst'],
+      ['ubuntu', 'Polaris-ubuntu24.04-x86_64.deb'],
+    ]
+    const expectedCommands = packageCases.map(([packageFamily, name]) => buildManualInstallCommand({
+      name,
+      browser_download_url: `https://github.com/papi-ux/polaris/releases/download/v1.3.5/${name}`,
+      packageFamily,
+    }))
+    const documentedCommands = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)].map((match) => match[1])
+
+    for (const fact of ['v1.3.4', '.1', '.2', 'exact package filename']) {
+      expect(releaseNotes).toContain(fact)
+    }
+    expect(documentedCommands).toEqual(expectedCommands)
+    expect(releaseNotes.match(/sudo -H polaris --setup-host &&/g)).toHaveLength(3)
+    expect(releaseNotes.match(/systemctl --user restart polaris/g)).toHaveLength(3)
+  })
+
+  it('keeps the official release asset set exact', () => {
+    for (const releaseSection of releaseSections()) {
+      const actualAssets = releaseSection.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
+      expect(actualAssets.sort()).toEqual(expectedAssets)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- prepare the Polaris v1.3.5 release
- move CMake, SteamOS package identity validation, and reviewed namcap metadata from 1.3.4 to 1.3.5
- publish current v1.3.5 README/changelog contracts while preserving v1.3.4 as historical
- add ready-to-publish v1.3.4 bootstrap notes with exact, failure-safe Fedora, Arch, and Ubuntu commands
- require the public-docs gate and release tests to keep release metadata, asset inventory, and bootstrap commands synchronized

## Included product changes

Refreshed 2026-08-06. This PR was opened on 2 August describing an updater-only patch; eleven commits have landed on `master` since, and the release notes, changelog and README now describe all of them rather than #271 alone.

| PR | Change |
|---|---|
| #271 | Exact download filenames and failure-safe update command chains |
| #285 | udev rules and modules-load config become package files under `/usr/lib`; `/etc` shadow copies retired; `polaris-debug` package; `systemd-inhibit` and private-session input leaks closed |
| #288 | Startup warning when seat isolation is enabled without `input` group membership |
| #286 | Host audio loopback released when a session turns host audio off |
| #289 | Per-session display mode in stream prep, and GPU-native capture safety |
| #282 | Completion estimates served from a local dataset first |
| #280 | Playtime reported from Steam and Lutris |
| #276 | Transactional custom artwork workflow |
| #277 | Per-app environment variables surfaced in the web UI |
| #283 | Web dependency advisories cleared |
| #284 | Link failure fixed that was breaking the sanitizer job |
| #273 | Local gamescope patch dropped after upstream merge |

**#285 changes files on the host at upgrade**, so it leads the release notes' upgrade section rather than being buried in a change list.

## Documentation refresh

- Release notes, changelog and README rewritten to cover the above, grouped by area.
- Release date moved 2026-08-02 → 2026-08-06 across the changelog, README, `release-v135-contract.test.js` (3 references) and `check-public-docs.sh`. **If publication slips, all four move together.**
- README's Support section gains crash reporting via `polaris-debug` and `coredumpctl`; it previously asked only for logs.
- New Ubuntu **Update** section — Bazzite and SteamOS had one and Ubuntu did not.
- Bazzite's trailing "Current Status" removed as a duplicate of the "Validation Status" table in the same file.
- New contract assertion, `states the host integration changes that alter files on upgrade`, requiring the notes to mention `/usr/lib`, `/etc`, `polaris-debug` and `input`. This release went stale silently; that test makes the next one fail loudly.

## Publication boundary

This PR prepares the release candidate only. It does **not** create or push `v1.3.5`, create a GitHub release, or upload public release assets. Publication remains a separate explicit approval after this PR merges and the exact merged commit is verified.

## Verification

Re-verified on pc-papi at `c101f58` after the refresh:

- `npx vitest run` — **50 files, 297 tests passed**
- `bash scripts/check-public-docs.sh` — exit 0, "Public docs and release references look clean"

Original verification of the 2 August candidate, retained as the record for the release metadata itself:

- `env -u NODE_ENV npm test` — 49 files, 295 tests passed
- `env -u NODE_ENV npm run lint`
- `env -u NODE_ENV npm run build-clean`
- `env -u NODE_ENV npm run budget:web`
- `env -u NODE_ENV npm audit --audit-level=high` — 0 vulnerabilities
- `bash scripts/check-public-docs.sh`
- `bash scripts/check-public-surface.sh`
- release-note Fedora, Arch, and Ubuntu shell blocks pass `bash -n`
- `git diff --cached --check`
- independent fail-closed release/security review

