### PR TITLE
fix(web): surface per-app environment variables

### DIFF
--- a/src_assets/common/assets/web/app-command-environment-guidance.test.js
+++ b/src_assets/common/assets/web/app-command-environment-guidance.test.js
@@ -1,0 +1,99 @@
+import { shallowMount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+import AppsView from './views/AppsView.vue'
+
+const scannerState = {
+  scanning: ref(false),
+  importing: ref(false),
+  steamGames: ref([]),
+  lutrisGames: ref([]),
+  heroicGames: ref([]),
+  error: ref(null),
+  scan: vi.fn(),
+  importSelected: vi.fn(() => Promise.resolve(0)),
+  toggleAll: vi.fn(),
+}
+
+vi.mock('./composables/useGameScanner', () => ({
+  useGameScanner: () => scannerState,
+}))
+
+const i18n = {
+  t(key) { return key },
+}
+
+function flushAppsViewLoad() {
+  return Promise.resolve().then(() => Promise.resolve()).then(() => nextTick())
+}
+
+function mountAppsView() {
+  global.fetch = vi.fn((url) => {
+    if (String(url).includes('./api/apps')) {
+      return Promise.resolve({
+        json: () => Promise.resolve({ apps: [], current_app: '', host_name: 'Test Host', host_uuid: 'host-1' }),
+      })
+    }
+
+    if (String(url).includes('./api/config')) {
+      return Promise.resolve({
+        json: () => Promise.resolve({ platform: 'linux' }),
+      })
+    }
+
+    return Promise.resolve({ json: () => Promise.resolve({ status: true }) })
+  })
+
+  return shallowMount(AppsView, {
+    global: {
+      provide: { i18n },
+      mocks: { $t: i18n.t.bind(i18n) },
+      stubs: {
+        Button: { props: ['disabled'], emits: ['click'], template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>' },
+        InfoHint: { template: '<span><slot /></span>' },
+        Checkbox: { template: '<label />' },
+      },
+    },
+  })
+}
+
+describe('AppsView command environment guidance', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete global.fetch
+    document.body.innerHTML = ''
+  })
+
+  it('keeps environment-variable guidance visible and opens the related editor', async () => {
+    const wrapper = mountAppsView()
+    await flushAppsViewLoad()
+
+    const addButton = wrapper.findAll('button').find((button) => button.text().includes('apps.add_new'))
+    expect(addButton).toBeTruthy()
+    await addButton.trigger('click')
+    await nextTick()
+
+    const guidance = wrapper.find('[data-command-environment-help]')
+    expect(guidance.exists()).toBe(true)
+    expect(guidance.text()).toContain('executable')
+    expect(guidance.text()).toContain('DRI_PRIME=1')
+
+    const shortcut = guidance.find('button[aria-controls="appStreamingTweaks"]')
+    expect(shortcut.exists()).toBe(true)
+    expect(shortcut.text()).toContain('Environment & streaming tweaks')
+    expect(shortcut.attributes('aria-expanded')).toBe('false')
+
+    const tweaks = wrapper.find('#appStreamingTweaks')
+    expect(tweaks.exists()).toBe(true)
+    expect(tweaks.find('summary').text()).toContain('Environment & streaming tweaks')
+    expect(tweaks.attributes('open')).toBeUndefined()
+
+    await shortcut.trigger('click')
+    await nextTick()
+
+    expect(shortcut.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('#appStreamingTweaks').attributes('open')).toBeDefined()
+    expect(wrapper.find('#appStreamingTweaks .app-editor-disclosure-body').exists()).toBe(true)
+  })
+})

--- a/src_assets/common/assets/web/views/AppsView.vue
+++ b/src_assets/common/assets/web/views/AppsView.vue
@@ -783,6 +783,17 @@
                 </InfoHint>
               </div>
               <input type="text" class="app-editor-input app-editor-input-mono" id="appCmd" v-model="editForm.cmd" />
+              <p data-command-environment-help class="mt-2 text-xs leading-5 text-storm">
+                The command must start with an executable. Put assignments such as
+                <code class="font-mono text-silver">DRI_PRIME=1</code> under
+                <button
+                  type="button"
+                  class="focus-ring rounded-sm font-medium text-ice underline decoration-ice/40 underline-offset-2 transition-colors hover:text-white"
+                  aria-controls="appStreamingTweaks"
+                  :aria-expanded="showTweaks"
+                  @click="showTweaks = true"
+                >Environment &amp; streaming tweaks</button> instead.
+              </p>
             </div>
 
             <Checkbox v-if="platform === 'windows'"
@@ -840,15 +851,15 @@
             </div>
           </details>
 
-          <details class="app-editor-inline-disclosure" :open="showTweaks">
+          <details id="appStreamingTweaks" class="app-editor-inline-disclosure" :open="showTweaks">
             <summary class="focus-ring" @click.prevent="showTweaks = !showTweaks">
-              <span>Streaming Tweaks</span>
+              <span>Environment &amp; streaming tweaks</span>
               <span class="control-chip">{{ editEnvVars.length + (editMangoHud ? 1 : 0) }}</span>
             </summary>
             <div v-if="showTweaks" class="app-editor-disclosure-body">
               <div class="settings-field-head">
                 <span class="settings-field-label">Environment variables</span>
-                <InfoHint size="sm" align="right" label="Streaming Tweaks">Environment variables, Proton settings, and per-game launch-time overrides.</InfoHint>
+                <InfoHint size="sm" align="right" label="Environment and streaming tweaks">Environment variables, Proton settings, and per-game launch-time overrides.</InfoHint>
               </div>
               <div v-for="(envVar, i) in editEnvVars" :key="i" class="app-editor-env-row">
                 <input type="text" v-model="envVar.key" placeholder="KEY" class="app-editor-input app-editor-input-mono" />


### PR DESCRIPTION
## Summary

- keep executable-first command guidance visible in the app editor
- point `KEY=value` assignments such as `DRI_PRIME=1` directly to the per-app environment editor
- rename the collapsed disclosure so environment variables are discoverable before opening it
- add a regression test for the visible guidance, disclosure label, and open behavior

Follow-up to discussion #263.

## Verification

- `npm test` — 49 files, 294 tests passed
- `npm run lint`
- `npm run build:budget`
- Playwright static-preview checks at 1440 px and 390 px — guidance rendered cleanly, shortcut opened the disclosure, and no console errors were reported

## Unrelated baseline issue

`npm run smoke:web -- --static --no-login` still times out waiting for the welcome heading; the same failure reproduces on clean `master` and is not introduced by this change.
