### PR TITLE
feat(library): report the playtime the launchers already track

### DIFF
--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -281,9 +281,9 @@ namespace game_library {
     return roots;
   }
 
-  std::map<std::string, playtime_t> steam_playtime_index() {
+  playtime_snapshot_t steam_playtime_snapshot() {
     static std::mutex guard;
-    static std::map<std::string, playtime_t> cached;
+    static playtime_snapshot_t cached;
     static std::chrono::steady_clock::time_point read_at {};
 
     const std::lock_guard<std::mutex> lock {guard};
@@ -309,7 +309,11 @@ namespace game_library {
       }
     }
 
-    cached = std::move(fresh);
+    cached.by_app_id = std::move(fresh);
+    cached.read_at = std::chrono::duration_cast<std::chrono::seconds>(
+                       std::chrono::system_clock::now().time_since_epoch()
+    )
+                       .count();
     read_at = now;
     return cached;
   }

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -7,10 +7,14 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <chrono>
 #include <cstdlib>
 #include <cstdio>
 #include <fstream>
+#include <iterator>
+#include <mutex>
 #include <set>
+#include <sstream>
 #include <string_view>
 #include <utility>
 
@@ -259,6 +263,187 @@ namespace game_library {
     return {};
   }
 
+  std::vector<std::filesystem::path> steam_data_roots(const std::vector<std::filesystem::path> &home_roots) {
+    std::vector<std::filesystem::path> roots;
+    const auto add = [&roots](std::filesystem::path candidate) {
+      if (std::find(roots.begin(), roots.end(), candidate) == roots.end()) {
+        roots.push_back(std::move(candidate));
+      }
+    };
+    for (const auto &home : home_roots) {
+      if (home.empty()) {
+        continue;
+      }
+      add(home / ".steam" / "steam");
+      add(home / ".local" / "share" / "Steam");
+      add(home / ".var" / "app" / "com.valvesoftware.Steam" / ".local" / "share" / "Steam");
+    }
+    return roots;
+  }
+
+  std::map<std::string, playtime_t> steam_playtime_index() {
+    static std::mutex guard;
+    static std::map<std::string, playtime_t> cached;
+    static std::chrono::steady_clock::time_point read_at {};
+
+    const std::lock_guard<std::mutex> lock {guard};
+    const auto now = std::chrono::steady_clock::now();
+    if (read_at != std::chrono::steady_clock::time_point {} && now - read_at < std::chrono::seconds(30)) {
+      return cached;
+    }
+
+    std::map<std::string, playtime_t> fresh;
+    for (const auto &path : steam_localconfig_paths(steam_data_roots(library_home_roots()))) {
+      std::ifstream file(path);
+      if (!file.is_open()) {
+        continue;
+      }
+      const std::string payload {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+      for (auto &[app_id, played] : parse_steam_playtime_vdf(payload)) {
+        // One machine can hold several Steam accounts; the one that played most is the
+        // one whose number means anything to whoever is looking at the library.
+        auto &slot = fresh[app_id];
+        if (played.minutes > slot.minutes) {
+          slot = played;
+        }
+      }
+    }
+
+    cached = std::move(fresh);
+    read_at = now;
+    return cached;
+  }
+
+  std::map<std::string, playtime_t> parse_steam_playtime_vdf(std::string_view vdf_payload) {
+    std::map<std::string, playtime_t> playtime;
+    if (vdf_payload.empty()) {
+      return playtime;
+    }
+
+    // The block a key sits in is what makes it meaningful here: localconfig.vdf holds a
+    // whole user profile, and "apps" is only one branch of it.
+    std::vector<std::string> section;
+    std::string pending_section;
+    std::istringstream stream {std::string(vdf_payload)};
+    std::string line;
+
+    const auto quoted = [](const std::string &text, std::size_t from, std::string &out) -> std::size_t {
+      const auto open = text.find('"', from);
+      if (open == std::string::npos) {
+        return std::string::npos;
+      }
+      const auto close = text.find('"', open + 1);
+      if (close == std::string::npos) {
+        return std::string::npos;
+      }
+      out = text.substr(open + 1, close - open - 1);
+      return close + 1;
+    };
+
+    while (std::getline(stream, line)) {
+      const auto begin = line.find_first_not_of(" \t\r");
+      if (begin == std::string::npos) {
+        continue;
+      }
+      line = line.substr(begin);
+      while (!line.empty() && (line.back() == '\r' || line.back() == ' ' || line.back() == '\t')) {
+        line.pop_back();
+      }
+
+      if (line == "{") {
+        section.push_back(pending_section);
+        pending_section.clear();
+        continue;
+      }
+      if (line == "}") {
+        if (!section.empty()) {
+          section.pop_back();
+        }
+        continue;
+      }
+      if (line.empty() || line[0] != '"') {
+        continue;
+      }
+
+      std::string key;
+      const auto after_key = quoted(line, 0, key);
+      if (after_key == std::string::npos) {
+        continue;
+      }
+
+      std::string value;
+      if (quoted(line, after_key, value) == std::string::npos) {
+        // A bare quoted token opens the block named on the next line.
+        pending_section = key;
+        continue;
+      }
+
+      // Inside "apps" the enclosing section is the app id itself.
+      if (section.size() < 2 || section.back().empty()) {
+        continue;
+      }
+      const auto &owner = section[section.size() - 2];
+      if (owner != "apps") {
+        continue;
+      }
+      const auto &app_id = section.back();
+      if (app_id.find_first_not_of("0123456789") != std::string::npos) {
+        continue;
+      }
+
+      try {
+        if (key == "Playtime") {
+          playtime[app_id].minutes = std::stoll(value);
+        } else if (key == "LastPlayed") {
+          playtime[app_id].last_played = std::stoll(value);
+        }
+      } catch (...) {
+        // A field Steam wrote in a shape we do not understand is not a reason to lose
+        // every other game's playtime.
+        continue;
+      }
+    }
+
+    // An entry that only ever recorded a launch, never a minute, says nothing worth
+    // showing, so it does not travel.
+    for (auto it = playtime.begin(); it != playtime.end();) {
+      it = it->second.minutes > 0 ? std::next(it) : playtime.erase(it);
+    }
+    return playtime;
+  }
+
+  std::vector<std::filesystem::path> steam_localconfig_paths(const std::vector<std::filesystem::path> &roots) {
+    std::vector<std::filesystem::path> found;
+    for (const auto &root : roots) {
+      // A fresh code per query: one shared across the walk stays set after the first
+      // user directory that has no localconfig, and silently swallows every later one.
+      std::error_code root_ec;
+      const auto userdata = root / "userdata";
+      if (!std::filesystem::is_directory(userdata, root_ec) || root_ec) {
+        continue;
+      }
+
+      std::error_code walk_ec;
+      std::filesystem::directory_iterator users(userdata, walk_ec);
+      if (walk_ec) {
+        continue;
+      }
+
+      for (const auto &user : users) {
+        std::error_code entry_ec;
+        if (!user.is_directory(entry_ec) || entry_ec) {
+          continue;
+        }
+        auto candidate = user.path() / "config" / "localconfig.vdf";
+        std::error_code file_ec;
+        if (std::filesystem::is_regular_file(candidate, file_ec) && !file_ec) {
+          found.push_back(std::move(candidate));
+        }
+      }
+    }
+    return found;
+  }
+
   std::vector<lutris_game_t> parse_lutris_list_games_json(std::string_view json_payload) {
     std::vector<lutris_game_t> games;
     if (json_payload.empty()) {
@@ -290,6 +475,9 @@ namespace game_library {
           .image_path = entry.contains("coverPath") && entry["coverPath"].is_string() ?
             supported_image_path_or_empty(entry["coverPath"].get<std::string>()) :
             "",
+          .playtime_seconds = entry.contains("playtimeSeconds") && entry["playtimeSeconds"].is_number() ?
+            static_cast<int64_t>(entry["playtimeSeconds"].get<double>()) :
+            0,
         });
       }
     } catch (...) {

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -4,7 +4,9 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
+#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -18,6 +20,18 @@ namespace game_library {
     std::string runner;
     std::string command;
     std::string image_path;
+    int64_t playtime_seconds = 0;  // as Lutris reports it; 0 when it does not
+  };
+
+  /**
+   * @brief How long a launcher says one of its games has been played.
+   *
+   * Minutes rather than seconds because that is the coarser of the two units the
+   * launchers use, and rounding up to it loses nothing anyone reads.
+   */
+  struct playtime_t {
+    int64_t minutes = 0;      // total, as the owning launcher counts it
+    int64_t last_played = 0;  // unix seconds; 0 when the launcher does not say
   };
 
   bool is_lutris_slug_safe(const std::string &slug);
@@ -30,5 +44,27 @@ namespace game_library {
   std::vector<lutris_game_t> scan_lutris_games(const std::filesystem::path &games_dir);
   std::vector<lutris_game_t> scan_lutris_games(const std::vector<std::filesystem::path> &games_dirs);
   std::vector<lutris_game_t> scan_lutris_library(const std::vector<std::filesystem::path> &games_dirs);
+
+  /**
+   * @brief Steam app id to playtime, read from one localconfig.vdf payload.
+   *
+   * Keyed by app id as a string, because that is how Steam writes it and how the app
+   * catalogue already carries it.
+   */
+  std::map<std::string, playtime_t> parse_steam_playtime_vdf(std::string_view vdf_payload);
+
+  /** @brief Every localconfig.vdf belonging to a Steam user under the given roots. */
+  std::vector<std::filesystem::path> steam_localconfig_paths(const std::vector<std::filesystem::path> &roots);
+
+  /** @brief Where Steam keeps its data, for each home directory we know about. */
+  std::vector<std::filesystem::path> steam_data_roots(const std::vector<std::filesystem::path> &home_roots);
+
+  /**
+   * @brief Steam playtime for every locally known game, cached briefly.
+   *
+   * A library listing serialises every game in one pass, so this is read once for the
+   * request rather than once per game. Playtime that is half a minute stale is still true.
+   */
+  std::map<std::string, playtime_t> steam_playtime_index();
 
 }  // namespace game_library

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -59,12 +59,18 @@ namespace game_library {
   /** @brief Where Steam keeps its data, for each home directory we know about. */
   std::vector<std::filesystem::path> steam_data_roots(const std::vector<std::filesystem::path> &home_roots);
 
+  /** @brief What the launcher files said, and when we last looked. */
+  struct playtime_snapshot_t {
+    std::map<std::string, playtime_t> by_app_id;
+    int64_t read_at = 0;  // unix seconds; localconfig.vdf lags Steam cloud, so this is worth saying
+  };
+
   /**
    * @brief Steam playtime for every locally known game, cached briefly.
    *
    * A library listing serialises every game in one pass, so this is read once for the
    * request rather than once per game. Playtime that is half a minute stale is still true.
    */
-  std::map<std::string, playtime_t> steam_playtime_index();
+  playtime_snapshot_t steam_playtime_snapshot();
 
 }  // namespace game_library

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2805,22 +2805,32 @@ namespace nvhttp {
     }
 
     /**
-     * @brief Minutes this game has been played, as the launcher that owns it counts them.
+     * @brief How long the owning launcher says this game has been played.
+     *
+     * Nothing when no launcher owns the answer, rather than zero. A game nobody has
+     * played and a game nothing can speak for are different things: one should read
+     * "Not started", the other should draw no gauge at all, and a zero cannot say which.
      *
      * Steam only for now. Lutris reports the same figure in the listing the scanner
      * already reads, but reaching it means spawning the lutris CLI, which does not belong
-     * in the path that serialises a library.
-     *
-     * Zero means no local source claims otherwise, which is also what a game nobody has
-     * played looks like. The two are not worth telling apart: neither has a duration to show.
+     * in the path that answers a library request.
      */
-    int64_t playtime_minutes_for_app(const proc::ctx_t &app) {
+    std::optional<nlohmann::json> play_time_for_app(const proc::ctx_t &app) {
       if (app.steam_appid.empty()) {
-        return 0;
+        return std::nullopt;
       }
-      const auto index = game_library::steam_playtime_index();
-      const auto found = index.find(app.steam_appid);
-      return found == index.end() ? 0 : found->second.minutes;
+
+      const auto snapshot = game_library::steam_playtime_snapshot();
+      const auto found = snapshot.by_app_id.find(app.steam_appid);
+      if (found == snapshot.by_app_id.end()) {
+        return std::nullopt;
+      }
+
+      return nlohmann::json {
+        {"seconds", found->second.minutes * 60},  // normalised, so Lutris seconds can join later
+        {"source", "steam"},
+        {"read_at", snapshot.read_at},
+      };
     }
 
     nlohmann::json launch_mode_contract_for_app(const proc::ctx_t &app) {
@@ -6637,7 +6647,9 @@ namespace nvhttp {
         promote_local_artwork_poster(app);
         game["artwork"] = current_artwork_manifest(platf::appdata(), app.uuid);
         game["last_launched"] = app.last_launched;
-        game["playtime_minutes"] = playtime_minutes_for_app(app);
+        if (const auto play_time = play_time_for_app(app)) {
+          game["play_time"] = *play_time;
+        }
         game["launch_mode"] = launch_mode_contract_for_app(app);
         game["steam_launch"] = steam_launch_contract_for_app(app);
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -64,6 +64,7 @@
 #include "logging.h"
 #include "network.h"
 #include "nvhttp.h"
+#include "game_library_scanner.h"
 #include "platform/common.h"
 #include "process.h"
 #include "rtsp.h"
@@ -2801,6 +2802,25 @@ namespace nvhttp {
                       << format_watch_profile(*owner_profile);
 
       return std::nullopt;
+    }
+
+    /**
+     * @brief Minutes this game has been played, as the launcher that owns it counts them.
+     *
+     * Steam only for now. Lutris reports the same figure in the listing the scanner
+     * already reads, but reaching it means spawning the lutris CLI, which does not belong
+     * in the path that serialises a library.
+     *
+     * Zero means no local source claims otherwise, which is also what a game nobody has
+     * played looks like. The two are not worth telling apart: neither has a duration to show.
+     */
+    int64_t playtime_minutes_for_app(const proc::ctx_t &app) {
+      if (app.steam_appid.empty()) {
+        return 0;
+      }
+      const auto index = game_library::steam_playtime_index();
+      const auto found = index.find(app.steam_appid);
+      return found == index.end() ? 0 : found->second.minutes;
     }
 
     nlohmann::json launch_mode_contract_for_app(const proc::ctx_t &app) {
@@ -6617,6 +6637,7 @@ namespace nvhttp {
         promote_local_artwork_poster(app);
         game["artwork"] = current_artwork_manifest(platf::appdata(), app.uuid);
         game["last_launched"] = app.last_launched;
+        game["playtime_minutes"] = playtime_minutes_for_app(app);
         game["launch_mode"] = launch_mode_contract_for_app(app);
         game["steam_launch"] = steam_launch_contract_for_app(app);
 

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -153,3 +153,148 @@ TEST(GameLibraryScannerTests, IncludesAccountHomeWhenRuntimeHomeIsProfile) {
   EXPECT_EQ(roots[0], std::filesystem::path("/tmp/agent-profile-home"));
   EXPECT_EQ(roots[1], std::filesystem::path("/tmp/account-home"));
 }
+
+namespace {
+  // Trimmed from a real localconfig.vdf: the apps block sits five levels down, and the
+  // profile around it carries keys that look just like the ones we want.
+  constexpr const char *kLocalConfig = R"vdf(
+"UserLocalConfigStore"
+{
+  "friends"
+  {
+    "PersonaName"  "papi"
+  }
+  "Software"
+  {
+    "Valve"
+    {
+      "Steam"
+      {
+        "apps"
+        {
+          "10"
+          {
+            "LastPlayed"  "86400"
+            "Playtime"    "16"
+          }
+          "440"
+          {
+            "LastPlayed"  "1311404400"
+            "Playtime"    "1684"
+          }
+          "620"
+          {
+            "LastPlayed"  "1500000000"
+            "Playtime"    "0"
+          }
+        }
+      }
+    }
+  }
+}
+)vdf";
+}  // namespace
+
+TEST(SteamPlaytimeTests, ReadsMinutesAndLastPlayedForEachApp) {
+  const auto playtime = game_library::parse_steam_playtime_vdf(kLocalConfig);
+
+  ASSERT_EQ(playtime.count("440"), 1u);
+  EXPECT_EQ(playtime.at("440").minutes, 1684);
+  EXPECT_EQ(playtime.at("440").last_played, 1311404400);
+
+  ASSERT_EQ(playtime.count("10"), 1u);
+  EXPECT_EQ(playtime.at("10").minutes, 16);
+}
+
+TEST(SteamPlaytimeTests, DropsAppsThatWereLaunchedButNeverPlayed) {
+  const auto playtime = game_library::parse_steam_playtime_vdf(kLocalConfig);
+
+  // 620 has a LastPlayed but no minutes, which says nothing worth showing.
+  EXPECT_EQ(playtime.count("620"), 0u);
+}
+
+TEST(SteamPlaytimeTests, IgnoresKeysOutsideTheAppsBlock) {
+  // The same key name, at the same depth, under a different owner.
+  constexpr const char *decoy = R"vdf(
+"UserLocalConfigStore"
+{
+  "Software"
+  {
+    "Valve"
+    {
+      "Steam"
+      {
+        "somethingelse"
+        {
+          "999"
+          {
+            "Playtime"  "99999"
+          }
+        }
+      }
+    }
+  }
+}
+)vdf";
+
+  EXPECT_TRUE(game_library::parse_steam_playtime_vdf(decoy).empty());
+}
+
+TEST(SteamPlaytimeTests, SurvivesEmptyAndMalformedPayloads) {
+  EXPECT_TRUE(game_library::parse_steam_playtime_vdf("").empty());
+  EXPECT_TRUE(game_library::parse_steam_playtime_vdf("not a vdf at all").empty());
+
+  // A value Steam wrote in a shape we do not understand must not cost the others.
+  constexpr const char *mixed = R"vdf(
+"UserLocalConfigStore"
+{
+  "Software"
+  {
+    "Valve"
+    {
+      "Steam"
+      {
+        "apps"
+        {
+          "1"
+          {
+            "Playtime"  "not-a-number"
+          }
+          "2"
+          {
+            "Playtime"  "42"
+          }
+        }
+      }
+    }
+  }
+}
+)vdf";
+
+  const auto playtime = game_library::parse_steam_playtime_vdf(mixed);
+  EXPECT_EQ(playtime.count("1"), 0u);
+  ASSERT_EQ(playtime.count("2"), 1u);
+  EXPECT_EQ(playtime.at("2").minutes, 42);
+}
+
+TEST(SteamPlaytimeTests, FindsLocalconfigForEveryUserUnderARoot) {
+  const auto root = lutris_test_root("steam_userdata");
+  const auto user = root / "userdata" / "11324806" / "config";
+  std::filesystem::create_directories(user);
+  write_text(user / "localconfig.vdf", kLocalConfig);
+
+  // A user directory without the file must not be reported.
+  std::filesystem::create_directories(root / "userdata" / "999" / "config");
+
+  const auto found = game_library::steam_localconfig_paths({root});
+  ASSERT_EQ(found.size(), 1u);
+  EXPECT_EQ(found.front(), user / "localconfig.vdf");
+}
+
+TEST(LutrisLibraryScannerTests, CarriesPlaytimeSecondsFromTheListingJson) {
+  const auto games = game_library::parse_lutris_list_games_json(
+    R"json([{"name":"3DMark","slug":"3dmark","runner":"steam","playtimeSeconds":73.152428}])json");
+
+  ASSERT_EQ(games.size(), 1u);
+  EXPECT_EQ(games.front().playtime_seconds, 73);
+}


### PR DESCRIPTION
## Summary

Reports the playtime the launchers already track, so a client can say how long a game
has been played without asking anyone.

Steam records it per app in `localconfig.vdf` and Lutris reports it in the JSON
`game_library_scanner` already shells out for. Neither was read. Both are local files —
no network, no credential, nothing to configure.

Accumulating it from streamed sessions would have been the wrong answer: a game with two
hundred hours at the desk would read as however long it had been streamed to a handheld.

**The parser tracks section names, not depth.** Depth is enough for `libraryfolders.vdf`,
where only one block nests that far, but `localconfig.vdf` is a whole user profile — a
`Playtime` key has to be recognised by the block it sits in, or a key of the same name
elsewhere in the profile is indistinguishable from the one we want. There is a test with
exactly that decoy.

**Absent is not zero.** A game nobody has played and a game no launcher can speak for are
different answers, and a client holding a `0` has to choose between claiming "none
played" and drawing nothing, without knowing which is true. So `play_time` is omitted
when no launcher owns the answer, and carries its own `source` and `read_at` when one
does. `read_at` is worth carrying because `localconfig.vdf` is a local cache that syncs
from Steam cloud and can lag until Steam next runs.

Seconds rather than minutes, so Lutris's seconds and Steam's minutes normalise to one
unit before they ever meet.

A library listing serialises every game in one pass, so the index is cached for half a
minute rather than re-reading the same megabyte once per game. Where a machine holds
several Steam accounts the largest figure wins.

### Payload

```jsonc
"play_time": { "seconds": 143520, "source": "steam", "read_at": 1754470000 }
```

Omitted entirely when nothing local knows.

### Not included

Lutris playtime is parsed and carried on the scanned game but not served: reaching it at
serialisation time means spawning the `lutris` CLI, which does not belong in the path
that answers a library request.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [x] I included screenshots or recordings for visible UI changes, when practical.
- [ ] I updated docs or release notes when user-facing behavior changed.

`tests/test_polaris` — 172 tests, 0 failures. Six of them cover this: the decoy key, an
app launched but never played, malformed values not costing other games their figures,
and finding `localconfig.vdf` for every user under a root.

Verified end to end against a Nova client on a Retroid Pocket 6: Phasmophobia reads
199 h, matching the 11983 minutes in this host's `localconfig.vdf`.

One bug the tests caught before it shipped: `steam_localconfig_paths` reused a single
`std::error_code` across the directory walk, so the first user directory without a
`localconfig.vdf` set it and `if (ec || …)` then skipped every later one. It would have
looked like "playtime works for some people and not others".

## Notes

No changes to pairing, certificates, trusted subnets, client commands, shell hooks,
packaging or privilege boundaries. Reads two local files that Steam and Lutris already
write, both under the invoking user's home.
