### PR TITLE
fix(library): stop beat times reaching for globals it cannot link against

### DIFF
--- a/src/beat_times.cpp
+++ b/src/beat_times.cpp
@@ -4,9 +4,7 @@
  */
 #include "beat_times.h"
 
-#include "config.h"
 #include "logging.h"
-#include "platform/common.h"
 
 #include <algorithm>
 #include <atomic>
@@ -25,12 +23,25 @@
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 
+// The logging macros take sv literals, which config.h used to bring in transitively.
+using namespace std::literals::string_view_literals;
+
 namespace beat_times {
 
   namespace {
 
+    std::mutex settings_guard;
+    std::filesystem::path configured_dataset;
+    bool lookups_allowed = false;
+
     std::filesystem::path dataset_path() {
-      return platf::appdata() / "beat_times.json";
+      const std::lock_guard<std::mutex> lock {settings_guard};
+      return configured_dataset;
+    }
+
+    bool lookups_enabled() {
+      const std::lock_guard<std::mutex> lock {settings_guard};
+      return lookups_allowed;
     }
 
     constexpr const char *HLTB_ORIGIN = "https://howlongtobeat.com";
@@ -214,6 +225,12 @@ namespace beat_times {
     return data;
   }
 
+  void configure(std::filesystem::path dataset, bool lookups_enabled) {
+    const std::lock_guard<std::mutex> lock {settings_guard};
+    configured_dataset = std::move(dataset);
+    lookups_allowed = lookups_enabled;
+  }
+
   const dataset_t &dataset() {
     static std::mutex guard;
     static dataset_t cached;
@@ -224,6 +241,9 @@ namespace beat_times {
 
     std::error_code ec;
     const auto path = dataset_path();
+    if (path.empty()) {
+      return cached;
+    }
     const auto stamp = std::filesystem::last_write_time(path, ec);
     if (ec) {
       // No dataset is a normal state, not a failure: the gauge simply has no estimates.
@@ -585,8 +605,8 @@ namespace beat_times {
       return;
     }
     // A host that should not be talking to the internet on someone's behalf says so
-    // here, and keeps whatever the dataset already holds.
-    if (!config::sunshine.beat_times_lookup) {
+    // here, and keeps whatever the dataset already holds. Unconfigured means no.
+    if (!lookups_enabled()) {
       return;
     }
 

--- a/src/beat_times.h
+++ b/src/beat_times.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <map>
 #include <optional>
 #include <string>
@@ -48,6 +49,18 @@ namespace beat_times {
 
   /** @brief The dataset on disk, re-read when the file changes underneath. */
   const dataset_t &dataset();
+
+  /**
+   * @brief Tell this where its dataset lives and whether it may go looking.
+   *
+   * Taken as arguments rather than read from globals: where the file sits and who is
+   * allowed to fetch both belong to whoever starts the process, and a module that
+   * reaches for them cannot be linked into a unit test without dragging the whole
+   * configuration layer along.
+   *
+   * Until this is called nothing is served and nothing is requested.
+   */
+  void configure(std::filesystem::path dataset, bool lookups_enabled);
 
   /**
    * @brief Fold a title to what a fuzzy match can work with.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -373,6 +373,10 @@ int main(int argc, char *argv[]) {
   task_pool.start(1);
 
   // Create signal handler after logging has been initialized
+  // Where the dataset lives and whether lookups are permitted are both this layer's
+  // to know; the module itself takes them as arguments so it stays linkable on its own.
+  beat_times::configure(platf::appdata() / "beat_times.json", config::sunshine.beat_times_lookup);
+
   // The beat-times worker holds a joinable thread; it has to be stopped before the
   // statics it touches are torn down.
   auto beat_times_guard = util::fail_guard([]() {


### PR DESCRIPTION
## Summary

The sanitizer job has been failing on `master` since #282 landed:

```
beat_times.cpp:33:  undefined reference to `platf::appdata[abi:cxx11]()`
beat_times.cpp:589: undefined reference to `config::sunshine`
```

`test_polaris` compiles `beat_times.cpp` but links neither `config.cpp` nor the platform
translation unit providing `platf::appdata()`. `game_library_scanner.cpp` sits in the same
target and was fine because it never reaches for globals; mine did.

**This got past me because my build directory is long-lived.** It had those objects
already, so the link succeeded locally while a clean configure fails. CI found it on the
first clean build — which is the job doing its work, but I should have been building
clean before claiming a link is good.

Both dependencies are now arguments. Where the dataset lives and whether lookups are
permitted belong to whoever starts the process, not to a module that parses JSON, and
taking them as parameters is what makes it linkable on its own. Unconfigured it serves
nothing and requests nothing — which is also what a unit test wants.

The `sv` literals the logging macros need arrived transitively through `config.h`, so they
are declared explicitly now rather than inherited from a header that no longer belongs.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [ ] I included screenshots or recordings for visible UI changes, when practical.
- [ ] I updated docs or release notes when user-facing behavior changed.

Checked the way the failure actually presented, rather than trusting a rebuild:

| Check | Result |
|---|---|
| `nm -uC beat_times.cpp.o` | neither symbol referenced any more |
| `ninja test_polaris` | links |
| `./tests/test_polaris` | 184 tests, 0 failures |
| main binary target | links |

## Notes

No behaviour change. The dataset path and the `beat_times_lookup` switch resolve exactly
as before — `main.cpp` passes what `config` and `platf` already told it, at the same point
in startup where the worker shutdown guard is installed.

No changes to pairing, certificates, trusted subnets, client commands, shell hooks,
packaging, or privilege boundaries.