### PR TITLE
fix(audio): release the host loopback when a session turns host audio off

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -218,7 +218,7 @@ namespace audio {
     }
 
     auto frame_size = config.packetDuration * stream.sampleRate / 1000;
-    auto mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size, sink);
+    auto mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size, sink, host_audio);
     if (!mic) {
       return;
     }
@@ -267,7 +267,7 @@ namespace audio {
             BOOST_LOG(info) << "Reinitializing audio capture"sv;
             mic.reset();
             do {
-              mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size, sink);
+              mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size, sink, host_audio);
               if (!mic) {
                 BOOST_LOG(warning) << "Couldn't re-initialize audio input"sv;
               }

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -675,7 +675,14 @@ namespace platf {
   public:
     virtual int set_sink(const std::string &sink) = 0;
 
-    virtual std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &sink) = 0;
+    virtual std::unique_ptr<mic_t> microphone(
+      const std::uint8_t *mapping,
+      int channels,
+      std::uint32_t sample_rate,
+      std::uint32_t frame_size,
+      const std::string &sink,
+      bool host_audio = true
+    ) = 0;
 
     virtual void route_process_audio_to_sink(const std::string &sink) {
     }

--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -930,8 +930,21 @@ namespace platf {
 
       // Games play into sink-sunshine-* for stream capture; system default stays
       // Easy Effects. Without loopback the host is silent after the game leaves UI.
-      void ensure_local_loopback(const std::string &capture_sink) {
-        if (local_loopback_module != PA_INVALID_INDEX || capture_sink.empty()) {
+      void ensure_local_loopback(const std::string &capture_sink, bool host_audio) {
+        if (capture_sink.empty()) {
+          return;
+        }
+
+        if (!host_audio) {
+          if (local_loopback_module != PA_INVALID_INDEX) {
+            unload_local_loopback();
+          } else {
+            BOOST_LOG(debug) << "Linux audio isolation: local monitor loopback already absent; host audio is disabled"sv;
+          }
+          return;
+        }
+
+        if (local_loopback_module != PA_INVALID_INDEX) {
           return;
         }
         if (capture_sink.rfind("sink-sunshine-", 0) != 0) {
@@ -1353,7 +1366,7 @@ namespace platf {
         }
       }
 
-      std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &selected_sink) override {
+      std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &selected_sink, bool host_audio) override {
         // Sink choice priority:
         // 1. Selected session sink
         // 2. Config sink
@@ -1377,7 +1390,7 @@ namespace platf {
 
         // Stream capture sink is a null sink — without loopback the host is silent
         // after the game leaves Steam UI / Easy Effects.
-        ensure_local_loopback(sink_name);
+        ensure_local_loopback(sink_name, host_audio);
 
 #ifdef POLARIS_BUILD_PIPEWIRE
         // If PipeWire is available, try native capture first

--- a/src/platform/macos/microphone.mm
+++ b/src/platform/macos/microphone.mm
@@ -49,8 +49,9 @@ namespace platf {
       return 0;
     }
 
-    std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &sink) override {
+    std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &sink, bool host_audio) override {
       (void) sink;
+      (void) host_audio;
       auto mic = std::make_unique<av_mic_t>();
       const char *audio_sink = "";
 

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -761,8 +761,9 @@ namespace platf::audio {
       return std::nullopt;
     }
 
-    std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &sink) override {
+    std::unique_ptr<mic_t> microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, const std::string &sink, bool host_audio) override {
       (void) sink;
+      (void) host_audio;
       auto mic = std::make_unique<mic_wasapi_t>();
 
       if (mic->init(sample_rate, frame_size, channels)) {


### PR DESCRIPTION
## Summary

- The Linux local loopback lets the host keep hearing a game while the stream captures the virtual sink. It was created on demand and skipped when a session disabled host audio — but skipping creation is not the same as tearing one down. A loopback created by an earlier session stayed loaded, so a client launching with host audio off still played through the host speakers for the rest of the Polaris process.
- `ensure_local_loopback` now unloads the module when a session turns host audio off, instead of only logging that it is not creating one. The destructor already unloaded it, so the leak was bounded by the process lifetime rather than the boot, but it survived every session change in between.
- The session's intent reaches every audio backend through `microphone()` in `platform/common.h`. Windows and macOS accept the flag and ignore it; only the Linux loopback acts on it. The parameter defaults to `true`, so no caller changes behaviour by omission.

Kept separate from #285 deliberately: that branch is packaging and input isolation, and this is an unrelated audio-path fix.

## Exact candidate

- `Commit: 895a12124bbcb0572f9206c3e19f921a51e64b96`
- `Tree:   9c43b205f4298e9d00252f85b1df46199d863c36`
- `Parent: e3ca517230b3750b8d9482df946d6bf303acdf5f`
- `Base:   e3ca517230b3750b8d9482df946d6bf303acdf5f`

Rebased onto #285 after it merged, so the three failures noted below are gone from the base.

## Verification

Built and run on pc-papi (Fedora) from a clean checkout of this branch:

- [x] `ninja` full build on the rebased tree, exit 0, no failed targets and no new warnings
- [x] `ctest` — 17/17 targets pass, 0 failures
- [x] `test_polaris_audio` — 12/12 pass
- [x] Runtime check on a real host (Fedora, pipewire-pulse): built this branch, deployed it, streamed once with host audio on and once with it off, and confirmed `pactl list modules short | grep module-loopback` reports no loopback after the second session. That is the behaviour this change exists to produce, and the one the previous revision of this section listed as unverified.

An earlier run against the pre-rebase base showed 14 of 17, because that base still carried three failures of its own: a `test_polaris_platform` link error, a config-consistency audit failure, and four teardown-contract tests. #285 fixed all three, and the numbers above are from a clean rebuild on top of it.

Not covered, and worth stating plainly:

- CI never ran on this commit. GitHub Actions dropped the `pull_request` events for this branch and left a manually dispatched run queued without a runner, so the checks list is empty rather than green. Everything above is from a local build and a real host; nothing here rests on CI.
- Windows and macOS were not built. Their `microphone()` overrides take the new parameter and discard it, so they are correct by inspection only.
