### PR TITLE
feat(library): let a curated artwork identity decide the estimate

### DIFF
--- a/src/beat_times.cpp
+++ b/src/beat_times.cpp
@@ -293,6 +293,16 @@ namespace beat_times {
     return by_name->second;
   }
 
+  std::optional<estimate_t> lookup_for_identity(const dataset_t &data,
+                                                std::string_view curated_title,
+                                                std::string_view steam_appid,
+                                                std::string_view name) {
+    if (!curated_title.empty()) {
+      return lookup(data, "", curated_title);
+    }
+    return lookup(data, steam_appid, name);
+  }
+
   std::string match_key(std::string_view name) {
     std::string folded;
     folded.reserve(name.size());

--- a/src/beat_times.h
+++ b/src/beat_times.h
@@ -101,4 +101,21 @@ namespace beat_times {
    */
   std::optional<estimate_t> lookup(const dataset_t &data, std::string_view steam_appid, std::string_view name);
 
+  /**
+   * @brief The estimate for a game somebody has told us the identity of.
+   *
+   * A curated title is a correction, and the app id is usually what made the wrong
+   * estimate confident in the first place, so a curated entry never falls back to it:
+   * it answers with its own title or answers with nothing. Falling back would serve the
+   * exact estimate the correction rejected, and it would do so most often when the
+   * curated title is one the dataset does not carry yet — which is the case somebody is
+   * most likely correcting.
+   *
+   * @param curated_title Title from a manual match, or empty when there is none.
+   */
+  std::optional<estimate_t> lookup_for_identity(const dataset_t &data,
+                                                std::string_view curated_title,
+                                                std::string_view steam_appid,
+                                                std::string_view name);
+
 }  // namespace beat_times

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2813,12 +2813,42 @@ namespace nvhttp {
      * rotates the endpoint deliberately, so a distributed product cannot depend on it
      * without breaking for every install at once.
      */
-    std::optional<nlohmann::json> beat_time_for_app(const proc::ctx_t &app) {
-      const auto estimate = beat_times::lookup(beat_times::dataset(), app.steam_appid, app.name);
+    /**
+     * @brief The title someone has told us this entry actually is, if they have.
+     *
+     * Only a manual match counts. An automatic one is the same guess the estimate would
+     * make on its own, so treating it as authority would just launder a guess into a fact.
+     */
+    std::string curated_title(const nlohmann::json &artwork) {
+      if (!artwork.is_object()) {
+        return {};
+      }
+      const auto match = artwork.find("match");
+      if (match == artwork.end() || !match->is_object() || !match->value("manual", false)) {
+        return {};
+      }
+      return match->value("title", "");
+    }
+
+    std::optional<nlohmann::json> beat_time_for_app(const proc::ctx_t &app, const nlohmann::json &artwork) {
+      const auto &data = beat_times::dataset();
+      const auto curated = curated_title(artwork);
+
+      // A curated identity outranks the app id. The id is what made a wrong estimate
+      // confident, so a correction the id overrules is not a correction.
+      std::optional<beat_times::estimate_t> estimate;
+      if (!curated.empty()) {
+        estimate = beat_times::lookup(data, "", curated);
+      }
+      if (!estimate) {
+        estimate = beat_times::lookup(data, app.steam_appid, app.name);
+      }
+
       if (!estimate) {
         // Ask about it once, in the background. This request is already being answered
-        // and nineteen games would be nineteen round trips; the next one serves it.
-        beat_times::request_lookup(app.steam_appid, app.name);
+        // and nineteen games would be nineteen round trips; the next one serves it. The
+        // id still travels, so the answer replaces the wrong entry instead of joining it.
+        beat_times::request_lookup(app.steam_appid, curated.empty() ? app.name : curated);
         return std::nullopt;
       }
 
@@ -6708,7 +6738,7 @@ namespace nvhttp {
         if (const auto play_time = play_time_for_app(app)) {
           game["play_time"] = *play_time;
         }
-        if (const auto beat_time = beat_time_for_app(app)) {
+        if (const auto beat_time = beat_time_for_app(app, game["artwork"])) {
           game["beat_time"] = *beat_time;
         }
         game["launch_mode"] = launch_mode_contract_for_app(app);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2834,15 +2834,9 @@ namespace nvhttp {
       const auto &data = beat_times::dataset();
       const auto curated = curated_title(artwork);
 
-      // A curated identity outranks the app id. The id is what made a wrong estimate
-      // confident, so a correction the id overrules is not a correction.
-      std::optional<beat_times::estimate_t> estimate;
-      if (!curated.empty()) {
-        estimate = beat_times::lookup(data, "", curated);
-      }
-      if (!estimate) {
-        estimate = beat_times::lookup(data, app.steam_appid, app.name);
-      }
+      // A curated identity outranks the app id, and never falls back to it — see
+      // lookup_for_identity for why a fallback would undo the correction.
+      const auto estimate = beat_times::lookup_for_identity(data, curated, app.steam_appid, app.name);
 
       if (!estimate) {
         // Ask about it once, in the background. This request is already being answered

--- a/tests/unit/test_beat_times.cpp
+++ b/tests/unit/test_beat_times.cpp
@@ -81,6 +81,34 @@ TEST(BeatTimesTests, FallsBackToTheTitleWhenThereIsNoAppId) {
   EXPECT_FALSE(beat_times::lookup(data, "999999", "").has_value());
 }
 
+TEST(BeatTimesTests, ACuratedTitleDecidesInsteadOfTheAppId) {
+  const auto data = beat_times::parse(kDataset);
+
+  // Same inputs as PrefersTheAppIdOverTheTitle, where the id wins. Once somebody has
+  // said which game this is, it does not.
+  const auto found = beat_times::lookup_for_identity(data, "Slay the Spire II", "870780", "Control Ultimate Edition");
+  ASSERT_TRUE(found.has_value());
+  EXPECT_EQ(found->main_seconds, 90000);
+}
+
+TEST(BeatTimesTests, ACuratedTitleTheDatasetLacksAnswersWithNothing) {
+  const auto data = beat_times::parse(kDataset);
+
+  // The case a correction is most likely made for: the curated title is not catalogued
+  // yet. Falling back to the id here would serve the estimate the correction rejected,
+  // and the caller would never ask about the curated title at all, so the correction
+  // could never take effect.
+  EXPECT_FALSE(beat_times::lookup_for_identity(data, "Some Game Nobody Catalogued", "870780", "Control Ultimate Edition").has_value());
+}
+
+TEST(BeatTimesTests, WithoutACuratedTitleIdentityLookupIsTheOrdinaryOne) {
+  const auto data = beat_times::parse(kDataset);
+
+  const auto found = beat_times::lookup_for_identity(data, "", "870780", "Slay the Spire II");
+  ASSERT_TRUE(found.has_value());
+  EXPECT_EQ(found->matched_name, "Control Ultimate Edition");
+}
+
 TEST(BeatTimesTests, SurvivesEmptyAndMalformedPayloads) {
   EXPECT_TRUE(beat_times::parse("").by_name.empty());
   EXPECT_TRUE(beat_times::parse("not json").by_name.empty());


### PR DESCRIPTION
## Summary

A wrong completion estimate was visible but not fixable. #282 carries `matched_name` so a
client can show which game an estimate is actually for, but seeing it was the whole of it
— correcting it meant hand-editing `beat_times.json` on the host.

The concept answers its own question here:

> the artwork studio already resolves a game to a canonical identity through
> `PolarisArtworkMatchCandidate`. If you have told Polaris that this entry **is** Slay the
> Spire 2 for artwork purposes, that is the same answer HLTB needs — the match should be
> shared rather than resolved twice, and corrected in one place.

So a **manual** artwork match now decides which game the estimate is for. Two calls in that
worth stating:

- **It outranks the Steam app id.** The id is what made a wrong estimate confident in the
  first place, so a correction the id overrules is not a correction.
- **Only a manual match counts.** An automatic one is the same guess the estimate would
  make on its own, and treating it as authority would launder a guess into a fact.

The id still travels with the lookup, so a corrected answer replaces the wrong entry
rather than sitting beside it.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [x] I included screenshots or recordings for visible UI changes, when practical.
- [ ] I updated docs or release notes when user-facing behavior changed.

`tests/test_polaris` — 184 tests, 0 failures.

Verified on a Retroid against this host: Slay the Spire 2 reads its estimate for `Slay the
Spire II`, and the client line that admits the mismatch now lands on Artwork Studio for
that entry, where the identity is set. Correcting it there is what changes the estimate.

## Notes

No behaviour change for any entry whose artwork match is automatic, which is all of them
until somebody curates one. No changes to pairing, certificates, trusted subnets, client
commands, shell hooks, packaging, or privilege boundaries.