### PR TITLE
fix(linux): report the input-group requirement seat isolation depends on

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -409,6 +409,8 @@ list(APPEND PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/linux/session_manager.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/private_session_input.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/private_session_input.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/input/input_group_access.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/input/input_group_access.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/cage_display_router.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/cage_display_router.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/display_topology.h"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,28 @@ dedicated device names and marker. Existing virtual controller nodes keep their 
 until recreated; stop active streams and restart Polaris after host setup. AppImage users should
 re-run the AppImage install action for the same reason.
 
+The `input` group requirement is not optional and there is no fallback: the isolated nodes are
+deliberately denied the logind ACL, so an account outside the group cannot open the devices Polaris
+just created, and neither can the streamed game. Polaris logs an `input_access:` warning at startup
+when seat isolation is enabled and the account it runs as is not a member, and `--setup-host` reports
+the same thing. Add the account with `sudo usermod -aG input <user>` and log out and back in;
+membership only applies to new sessions.
+
+#### Verifying that isolation is applied
+
+Check the device, not the seat list:
+
+```bash
+udevadm info -q property -n /dev/input/eventN | grep ID_SEAT
+```
+
+`ID_SEAT=seat-polaris` means the rules applied and the device is isolated.
+
+`loginctl list-seats` will keep showing only `seat0`, and that is expected — it is not a sign that
+isolation failed. logind only materializes a seat that owns a device tagged `master-of-seat`, which
+in practice means a graphics device. `seat-polaris` exists purely as a udev property that keeps
+logind from handing the device to the seat0 session, so it never becomes a seat logind lists.
+
 This is a Unix-user boundary, not a same-account process sandbox. Local users who are deliberately
 members of `input`, and local applications running under the same Unix account as Polaris, can still
 open the virtual controller. For concurrent gaming, run Polaris under a dedicated Unix account and

--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -21,6 +21,9 @@
 #include "logging.h"
 #include "network.h"
 #include "platform/common.h"
+#ifdef __linux__
+  #include "platform/linux/input/input_group_access.h"
+#endif
 
 extern "C" {
 #ifdef __linux__
@@ -206,6 +209,7 @@ namespace {
       << "    - remove an /etc copy left by an older Polaris that now shadows the packaged file"sv << std::endl
       << "    - reload udev and trigger /dev/uinput and /dev/uhid"sv << std::endl
       << "    - load uinput and uhid now via modprobe"sv << std::endl
+      << "    - report whether the calling account is in the input group, which seat isolation needs"sv << std::endl
       << "    - optionally apply cap_sys_admin for DRM/KMS capture"sv << std::endl
       << std::endl
       << "  Options:"sv << std::endl
@@ -296,12 +300,22 @@ namespace args {
                                    !fs::exists("/etc/modules-load.d/60-polaris.conf");
     const bool input_nodes_ready = access("/dev/uinput", R_OK | W_OK) == 0 &&
                                    access("/dev/uhid", R_OK | W_OK) == 0;
+    // Membership is not something host setup can arrange — usermod would have to
+    // pick a target account, and this command deliberately never guesses which
+    // account streams. It reports it so a user preparing the host learns it here
+    // rather than from a controller that silently never appears.
+    const auto input_group_advice = platf::input_access::setup_host_input_group_advice();
+
     if (!enable_kms && udev_from_package && modules_from_package && etc_copies_absent && input_nodes_ready) {
       std::cout
         << "Linux host setup: nothing to do."sv << std::endl
         << "The package provides the udev rules and modules-load configuration, and /dev/uinput"sv << std::endl
         << "and /dev/uhid are already usable by this account. Re-run with --enable-kms only if you"sv << std::endl
         << "need DRM/KMS capture."sv << std::endl;
+      if (!input_group_advice.empty()) {
+        std::cout << std::endl
+                  << input_group_advice << std::endl;
+      }
       return 0;
     }
 
@@ -356,6 +370,10 @@ namespace args {
     std::cout
       << "Existing virtual gamepad nodes keep their previous access policy until recreated; stop active streams and restart Polaris after changing client gamepad seat isolation."sv << std::endl
       << "Start Polaris directly with `polaris`, or opt into background autostart with `systemctl --user enable --now polaris`."sv << std::endl;
+    if (!input_group_advice.empty()) {
+      std::cout << std::endl
+                << input_group_advice << std::endl;
+    }
     return 0;
   }
 #endif

--- a/src/platform/linux/input/input_group_access.cpp
+++ b/src/platform/linux/input/input_group_access.cpp
@@ -1,0 +1,227 @@
+/**
+ * @file src/platform/linux/input/input_group_access.cpp
+ * @brief Whether the streaming account can still open its own isolated input devices.
+ */
+#include "input_group_access.h"
+#include "src/config.h"
+#include "src/logging.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <grp.h>
+#include <mutex>
+#include <optional>
+#include <pwd.h>
+#include <sstream>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+
+using namespace std::literals;
+
+namespace platf::input_access {
+  namespace {
+    std::string account_name_for(uid_t uid) {
+      if (const auto *entry = getpwuid(uid); entry && entry->pw_name) {
+        return entry->pw_name;
+      }
+
+      // An account with no passwd entry still has to be named in the remedy, and
+      // usermod takes a uid just as well as a name.
+      return std::to_string(uid);
+    }
+
+    /// The `input` group's gid, when the host has one.
+    std::optional<gid_t> input_group_id() {
+      if (const auto *entry = getgrnam(std::string(input_group).c_str()); entry) {
+        return entry->gr_gid;
+      }
+
+      return std::nullopt;
+    }
+
+    bool process_belongs_to(gid_t gid) {
+      if (getegid() == gid || getgid() == gid) {
+        return true;
+      }
+
+      const auto count = getgroups(0, nullptr);
+      if (count <= 0) {
+        return false;
+      }
+
+      std::vector<gid_t> groups(static_cast<std::size_t>(count));
+      if (getgroups(count, groups.data()) < 0) {
+        return false;
+      }
+
+      return std::find(groups.begin(), groups.end(), gid) != groups.end();
+    }
+
+    bool account_belongs_to(const passwd &account, gid_t gid) {
+      if (account.pw_gid == gid) {
+        return true;
+      }
+
+      // getgrouplist reports how many entries it needed when the buffer was too
+      // small, so the first call sizes the second.
+      int count = 0;
+      getgrouplist(account.pw_name, account.pw_gid, nullptr, &count);
+      if (count <= 0) {
+        return false;
+      }
+
+      std::vector<gid_t> groups(static_cast<std::size_t>(count));
+      if (getgrouplist(account.pw_name, account.pw_gid, groups.data(), &count) < 0) {
+        return false;
+      }
+
+      groups.resize(static_cast<std::size_t>(count));
+      return std::find(groups.begin(), groups.end(), gid) != groups.end();
+    }
+  }  // namespace
+
+  seat_isolation_options_t configured_seat_isolation() {
+    return {
+      config::input.client_gamepad_seat_isolation,
+      config::input.client_keyboard_mouse_seat_isolation,
+    };
+  }
+
+  std::string isolated_device_summary(const seat_isolation_options_t &options) {
+    if (options.gamepad && options.keyboard_mouse) {
+      return "client gamepads and the virtual keyboard and mouse";
+    }
+    if (options.gamepad) {
+      return "client gamepads";
+    }
+    if (options.keyboard_mouse) {
+      return "the virtual keyboard and mouse";
+    }
+
+    return {};
+  }
+
+  std::string input_group_remedy_command(std::string_view user) {
+    std::string command = "sudo usermod -aG ";
+    command += input_group;
+    command += ' ';
+    command += user;
+    return command;
+  }
+
+  std::string seat_isolation_access_warning(
+    const seat_isolation_options_t &options,
+    const input_group_status_t &status
+  ) {
+    if (!options.any() || status.member) {
+      return {};
+    }
+
+    std::ostringstream message;
+    message << "seat isolation is enabled for "sv << isolated_device_summary(options) << ", but ";
+
+    if (!status.group_exists) {
+      // Without the group, udev cannot apply GROUP="input" and the nodes end up
+      // owned by root alone — a harder failure than a missing membership.
+      message << "this host has no ["sv << input_group << "] group. The bundled udev rules give the "sv
+              << "isolated devices to that group, so they are created without an owner Polaris can "sv
+              << "reach."sv;
+    } else {
+      message << "the account Polaris runs as ["sv << status.user << "] is not in the ["sv << input_group
+              << "] group. Isolated devices are created root:"sv << input_group << " mode 0660 and "sv
+              << "deliberately get no logind ACL, so the group is the only way in."sv;
+    }
+
+    message << " Polaris cannot open the devices it creates for the client and the streamed game will "sv
+            << "not see them at all."sv;
+
+    if (status.group_exists) {
+      message << " Fix it with ["sv << input_group_remedy_command(status.user)
+              << "] and then log out and back in — group membership only applies to new sessions."sv;
+    }
+
+    message << " Disabling seat isolation restores the previous uaccess behaviour."sv;
+    return message.str();
+  }
+
+  input_group_status_t input_group_status_for_user(std::string_view user) {
+    input_group_status_t status;
+    status.user = user;
+
+    const auto gid = input_group_id();
+    status.group_exists = gid.has_value();
+    if (!gid) {
+      return status;
+    }
+
+    if (const auto *account = getpwnam(status.user.c_str()); account) {
+      status.member = account_belongs_to(*account, *gid);
+    }
+
+    return status;
+  }
+
+  input_group_status_t current_input_group_status() {
+    input_group_status_t status;
+    status.user = account_name_for(geteuid());
+
+    const auto gid = input_group_id();
+    status.group_exists = gid.has_value();
+    if (gid) {
+      // The running process' supplementary groups are what the kernel will
+      // actually check, and they can differ from the passwd database when the
+      // session predates a usermod.
+      status.member = process_belongs_to(*gid);
+    }
+
+    return status;
+  }
+
+  std::string setup_host_target_user() {
+    if (const auto *sudo_user = std::getenv("SUDO_USER"); sudo_user && *sudo_user) {
+      return sudo_user;
+    }
+
+    return account_name_for(geteuid());
+  }
+
+  std::string setup_host_input_group_advice() {
+    const auto status = input_group_status_for_user(setup_host_target_user());
+    if (status.member) {
+      return {};
+    }
+
+    std::ostringstream advice;
+    advice << "Client gamepad and keyboard/mouse seat isolation additionally need ["sv << status.user
+           << "] to be in the ["sv << input_group << "] group; isolated devices get no logind ACL, so "sv
+           << "the group is the only way Polaris and the streamed game can open them."sv;
+
+    if (status.group_exists) {
+      advice << " Run ["sv << input_group_remedy_command(status.user)
+             << "] and log out and back in. Leaving seat isolation disabled needs nothing."sv;
+    } else {
+      advice << " This host has no ["sv << input_group << "] group, so seat isolation cannot work here."sv;
+    }
+
+    return advice.str();
+  }
+
+  void warn_if_seat_isolation_lacks_input_group() {
+    static std::once_flag reported;
+    std::call_once(reported, [] {
+      const auto options = configured_seat_isolation();
+      if (!options.any()) {
+        return;
+      }
+
+      const auto advice = seat_isolation_access_warning(options, current_input_group_status());
+      if (advice.empty()) {
+        return;
+      }
+
+      BOOST_LOG(warning) << "input_access: "sv << advice;
+    });
+  }
+
+}  // namespace platf::input_access

--- a/src/platform/linux/input/input_group_access.h
+++ b/src/platform/linux/input/input_group_access.h
@@ -1,0 +1,97 @@
+/**
+ * @file src/platform/linux/input/input_group_access.h
+ * @brief Whether the streaming account can still open its own isolated input devices.
+ *
+ * Seat isolation assigns the devices Polaris creates for a client to the
+ * `seat-polaris` seat, which stops logind from granting the local desktop
+ * session an automatic `uaccess` ACL for them. That ACL is also what normally
+ * gives Polaris itself access, so once it is gone the bundled rules'
+ * `GROUP="input"` and mode `0660` are the entire access policy. An account
+ * outside `input` can no longer open the devices Polaris just created, and
+ * neither can the streamed game: gamepads and the virtual keyboard and mouse
+ * stop working with nothing in the failure pointing at group membership.
+ *
+ * Enumeration reports zero visible virtual gamepads and the game sees no
+ * controller at all, which reads as a broken isolation feature rather than a
+ * missing group. It is cheap to check up front, so it is checked and reported
+ * once instead of being diagnosed from a support thread.
+ *
+ * See input_seat_isolation.h for the marker the udev rules match on.
+ */
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace platf::input_access {
+
+  /// The group the bundled udev rules give the isolated devices to.
+  constexpr std::string_view input_group = "input";
+
+  /// What the host says about one account's `input` group membership.
+  struct input_group_status_t {
+    std::string user;  ///< Account the check applies to, for the message.
+    bool group_exists = false;  ///< Whether the host has an `input` group at all.
+    bool member = false;  ///< Whether the account is in it.
+  };
+
+  /// Which seat isolation options a configuration has turned on.
+  struct seat_isolation_options_t {
+    bool gamepad = false;
+    bool keyboard_mouse = false;
+
+    bool any() const {
+      return gamepad || keyboard_mouse;
+    }
+  };
+
+  /// Read the two seat isolation options out of the active configuration.
+  seat_isolation_options_t configured_seat_isolation();
+
+  /// Name the devices the enabled options apply to, for the message.
+  std::string isolated_device_summary(const seat_isolation_options_t &options);
+
+  /// The command that adds an account to the group.
+  std::string input_group_remedy_command(std::string_view user);
+
+  /**
+   * @brief Explain a configuration that cannot work as configured.
+   *
+   * Pure: the caller supplies both the configuration and what was found on the
+   * host, so the message is testable without a host that reproduces it.
+   *
+   * @return The warning, or empty when the configuration is fine.
+   */
+  std::string seat_isolation_access_warning(
+    const seat_isolation_options_t &options,
+    const input_group_status_t &status
+  );
+
+  /// Look up one account's membership by name.
+  input_group_status_t input_group_status_for_user(std::string_view user);
+
+  /// Look up the membership of the account this process runs as.
+  input_group_status_t current_input_group_status();
+
+  /**
+   * @brief The account `--setup-host` should report on.
+   *
+   * Host setup runs under `sudo`, so the process' own membership is root's and
+   * says nothing about the account that will actually stream. `SUDO_USER` names
+   * the account that asked for it.
+   */
+  std::string setup_host_target_user();
+
+  /**
+   * @brief Advice for `--setup-host` to print, or empty when the account is ready.
+   *
+   * Host setup runs before the configuration is parsed, so it cannot know
+   * whether seat isolation is enabled and states the requirement conditionally.
+   * Preparing the host is the moment to mention it either way.
+   */
+  std::string setup_host_input_group_advice();
+
+  /// Warn once at startup when seat isolation cannot work for this account.
+  void warn_if_seat_isolation_lacks_input_group();
+
+}  // namespace platf::input_access

--- a/src/platform/linux/input/inputtino_gamepad_isolation.cpp
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.cpp
@@ -58,7 +58,14 @@ namespace {
     const auto phys = lowercase(device.phys);
     const auto uniq = lowercase(device.uniq);
 
-    return starts_with(phys, xbox_private_prefix) ||
+    // With seat isolation enabled the phys attribute carries the marker instead
+    // of the per-pad MAC, so a classifier that only knew the MAC prefixes would
+    // have to fall back to the device name — and mistaking one of Polaris' own
+    // pads for a host controller means hiding it from the game it was created
+    // for.
+    return starts_with(phys, seat_isolated_phys_prefix) ||
+           starts_with(uniq, seat_isolated_phys_prefix) ||
+           starts_with(phys, xbox_private_prefix) ||
            starts_with(uniq, xbox_private_prefix) ||
            starts_with(phys, switch_private_prefix) ||
            starts_with(uniq, switch_private_prefix) ||

--- a/src/platform/linux/input/inputtino_gamepad_isolation.h
+++ b/src/platform/linux/input/inputtino_gamepad_isolation.h
@@ -76,8 +76,11 @@ namespace platf::gamepad::isolation {
     }
   };
 
+  /// Marker written to the device's phys attribute; matched by 60-polaris.rules.
+  constexpr std::string_view seat_isolated_phys_prefix = "polaris/client-gamepad-seat-isolated/";
+
   inline std::string client_gamepad_phys_marker(bool enabled, int index) {
-    return enabled ? "polaris/client-gamepad-seat-isolated/" + std::to_string(index) : "";
+    return enabled ? std::string {seat_isolated_phys_prefix} + std::to_string(index) : "";
   }
 
   inline std::string client_gamepad_device_name(bool enabled, std::string_view legacy_name, std::string_view isolated_name) {

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -46,6 +46,7 @@
 // local includes
 #include "executable_path.h"
 #include "graphics.h"
+#include "input/input_group_access.h"
 #include "misc.h"
 #include "src/config.h"
 #include "src/entry_handler.h"
@@ -1277,6 +1278,12 @@ std::string get_local_ip_for_gateway() {
     // enable low latency mode for AMD
     // https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30039
     set_env("AMD_DEBUG", "lowlatencyenc");
+
+    // Seat isolation trades the logind ACL for group ownership, so an account
+    // outside `input` loses access to its own virtual devices. Report it here
+    // rather than leaving it to be inferred from a controller that never
+    // appears.
+    input_access::warn_if_seat_isolation_lacks_input_group();
 
     // These are allowed to fail.
     gbm::init();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,6 +148,7 @@ set(TEST_PLATFORM_SOURCES
 if (NOT WIN32 AND NOT APPLE)
     list(APPEND TEST_PLATFORM_SOURCES
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamepad_isolation.cpp
+        ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_input_group_access.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_wayland_virtual_input.cpp
     )
 endif()

--- a/tests/unit/platform/test_gamepad_isolation.cpp
+++ b/tests/unit/platform/test_gamepad_isolation.cpp
@@ -130,6 +130,29 @@ TEST(GamepadIsolationTests, PrivateInputtinoPhysOrUniqClassifiesAsPolarisVirtual
             )));
 }
 
+TEST(GamepadIsolationTests, SeatIsolationPhysMarkerClassifiesAsPolarisVirtual) {
+  // Seat isolation replaces the per-pad MAC in phys with the marker the udev
+  // rules match on. The name is the only other hook, and a kernel driver that
+  // renames the node would leave Polaris hiding its own pad from the game.
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "DualSense Wireless Controller",
+              std::optional<uint16_t> {0x054c},
+              std::optional<uint16_t> {0x0ce6},
+              platf::gamepad::isolation::client_gamepad_phys_marker(true, 0),
+              ""
+            )));
+
+  EXPECT_EQ(device_classification_e::polaris_virtual,
+            classify_device(gamepad(
+              "renamed by some driver",
+              std::optional<uint16_t> {0x045e},
+              std::optional<uint16_t> {0x02ea},
+              platf::gamepad::isolation::client_gamepad_phys_marker(true, 3),
+              ""
+            )));
+}
+
 TEST(GamepadIsolationTests, PhysicalControllerWithVirtualVidPidRemainsHostVisible) {
   const auto physical_xbox = gamepad(
     "Microsoft X-Box One pad",

--- a/tests/unit/platform/test_input_group_access.cpp
+++ b/tests/unit/platform/test_input_group_access.cpp
@@ -1,0 +1,153 @@
+/**
+ * @file tests/unit/platform/test_input_group_access.cpp
+ * @brief Test the input-group preflight that seat isolation depends on.
+ */
+#include "../../tests_common.h"
+
+#ifdef __linux__
+  #include <src/platform/linux/input/input_group_access.h>
+
+  #include <cstdlib>
+  #include <string>
+
+namespace {
+  using platf::input_access::input_group_status_t;
+  using platf::input_access::seat_isolation_access_warning;
+  using platf::input_access::seat_isolation_options_t;
+
+  constexpr seat_isolation_options_t gamepad_only {true, false};
+  constexpr seat_isolation_options_t keyboard_mouse_only {false, true};
+  constexpr seat_isolation_options_t both {true, true};
+  constexpr seat_isolation_options_t neither {false, false};
+
+  input_group_status_t member() {
+    return {"papi", true, true};
+  }
+
+  input_group_status_t not_a_member() {
+    return {"papi", true, false};
+  }
+
+  input_group_status_t no_such_group() {
+    return {"papi", false, false};
+  }
+
+  bool contains(const std::string &text, std::string_view needle) {
+    return text.find(needle) != std::string::npos;
+  }
+}  // namespace
+
+TEST(InputGroupAccessTests, NothingIsReportedWhenTheAccountCanOpenTheDevices) {
+  EXPECT_TRUE(seat_isolation_access_warning(both, member()).empty());
+  EXPECT_TRUE(seat_isolation_access_warning(gamepad_only, member()).empty());
+  EXPECT_TRUE(seat_isolation_access_warning(keyboard_mouse_only, member()).empty());
+}
+
+TEST(InputGroupAccessTests, NothingIsReportedWhenSeatIsolationIsDisabled) {
+  // Isolation off means the devices keep their uaccess ACL, so membership does
+  // not matter and warning about it would be noise on every default install.
+  EXPECT_TRUE(seat_isolation_access_warning(neither, not_a_member()).empty());
+  EXPECT_TRUE(seat_isolation_access_warning(neither, no_such_group()).empty());
+}
+
+TEST(InputGroupAccessTests, MissingMembershipNamesTheAccountAndTheFix) {
+  const auto warning = seat_isolation_access_warning(gamepad_only, not_a_member());
+  ASSERT_FALSE(warning.empty());
+
+  EXPECT_TRUE(contains(warning, "papi"));
+  EXPECT_TRUE(contains(warning, "sudo usermod -aG input papi"));
+  // A usermod that appears to do nothing until the next login is the second
+  // support round-trip, so the message has to say so.
+  EXPECT_TRUE(contains(warning, "log out and back in"));
+  EXPECT_TRUE(contains(warning, "Disabling seat isolation"));
+}
+
+TEST(InputGroupAccessTests, TheWarningNamesOnlyTheDevicesTheEnabledOptionsCover) {
+  EXPECT_TRUE(contains(seat_isolation_access_warning(gamepad_only, not_a_member()), "client gamepads"));
+  EXPECT_FALSE(contains(seat_isolation_access_warning(gamepad_only, not_a_member()), "keyboard"));
+
+  EXPECT_TRUE(contains(
+    seat_isolation_access_warning(keyboard_mouse_only, not_a_member()),
+    "the virtual keyboard and mouse"
+  ));
+  EXPECT_FALSE(contains(seat_isolation_access_warning(keyboard_mouse_only, not_a_member()), "gamepads"));
+
+  const auto warning = seat_isolation_access_warning(both, not_a_member());
+  EXPECT_TRUE(contains(warning, "client gamepads"));
+  EXPECT_TRUE(contains(warning, "keyboard and mouse"));
+}
+
+TEST(InputGroupAccessTests, AHostWithoutTheGroupIsReportedAsADifferentProblem) {
+  const auto warning = seat_isolation_access_warning(both, no_such_group());
+  ASSERT_FALSE(warning.empty());
+
+  EXPECT_TRUE(contains(warning, "no [input] group"));
+  // usermod cannot add anybody to a group that does not exist, so offering the
+  // command here would send the user down a dead end.
+  EXPECT_FALSE(contains(warning, "usermod"));
+  EXPECT_FALSE(contains(warning, "log out and back in"));
+  EXPECT_TRUE(contains(warning, "Disabling seat isolation"));
+}
+
+TEST(InputGroupAccessTests, TheWarningSaysWhatActuallyBreaks) {
+  // The reported symptom is a controller that never appears, which reads as a
+  // broken feature. The message has to connect the two.
+  const auto warning = seat_isolation_access_warning(gamepad_only, not_a_member());
+  EXPECT_TRUE(contains(warning, "streamed game will not see them"));
+}
+
+TEST(InputGroupAccessTests, SetupHostReportsOnTheAccountThatInvokedSudo) {
+  using platf::input_access::setup_host_target_user;
+
+  // A name no account on the machine running this can hold, so the assertions
+  // cannot pass by coincidence on a host whose user happens to share it.
+  constexpr auto sentinel = "polaris-setup-host-sentinel";
+
+  const auto *original = std::getenv("SUDO_USER");
+  const std::string restore = original ? original : "";
+
+  // Host setup runs as root, so the process' own account is never the one that
+  // will stream.
+  ASSERT_EQ(0, ::setenv("SUDO_USER", sentinel, 1));
+  EXPECT_EQ(sentinel, setup_host_target_user());
+
+  ASSERT_EQ(0, ::unsetenv("SUDO_USER"));
+  const auto fallback = setup_host_target_user();
+  EXPECT_NE(sentinel, fallback);
+  EXPECT_FALSE(fallback.empty());
+
+  if (!restore.empty()) {
+    ASSERT_EQ(0, ::setenv("SUDO_USER", restore.c_str(), 1));
+  }
+}
+
+TEST(InputGroupAccessTests, TheProcessAndDatabaseLookupsAgreeOnThisHost) {
+  // The startup warning reads the process' own supplementary groups and
+  // --setup-host reads the passwd/group database, because the two answer
+  // different questions: what the kernel will enforce now, and what the account
+  // is configured for. On a host where nothing has changed mid-session they
+  // have to agree, and disagreeing means one of the two lookups is wrong.
+  const auto from_process = platf::input_access::current_input_group_status();
+  const auto from_database = platf::input_access::input_group_status_for_user(from_process.user);
+
+  EXPECT_EQ(from_process.group_exists, from_database.group_exists);
+  EXPECT_EQ(from_process.member, from_database.member);
+}
+
+TEST(InputGroupAccessTests, SetupHostAdviceIsSilentForAnAccountThatIsAlreadyReady) {
+  using platf::input_access::setup_host_input_group_advice;
+
+  // Host setup cannot read the configuration, so its advice is conditional
+  // rather than gated on the options; the one thing it can tell is whether the
+  // account would be ready if seat isolation were turned on.
+  const auto status = platf::input_access::input_group_status_for_user(
+    platf::input_access::setup_host_target_user()
+  );
+  if (status.member) {
+    EXPECT_TRUE(setup_host_input_group_advice().empty());
+  } else {
+    EXPECT_FALSE(setup_host_input_group_advice().empty());
+  }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Closes #274.

- Seat isolation assigns Polaris' virtual devices to the `seat-polaris` seat so logind stops handing them to the session at seat0. That also removes the `uaccess` ACL, which is normally what gives Polaris itself access, leaving the bundled rules' `GROUP="input"` and mode `0660` as the entire access policy. An account outside the `input` group can no longer open the devices Polaris just created, and neither can the streamed game.
- Nothing in that failure points at group membership. Enumeration reports `polaris_virtual=0` immediately after creating a pad, the game sees no controller, and the feature reads as broken. The requirement was documented in one sentence and checked nowhere.
- New `src/platform/linux/input/input_group_access.{h,cpp}` adds the check. `platf::init()` warns once, only when seat isolation is actually enabled, naming the account, the command that fixes it, and the fact that membership only applies to new sessions — a `usermod` that appears to do nothing until the next login is otherwise the second support round-trip.
- `--setup-host` reports the same requirement. That path is dispatched before `config::parse` so sudo never initializes the caller's per-user state as root, so it cannot know whether isolation is enabled and states the requirement conditionally. It resolves the account from `SUDO_USER`, because the process' own membership under sudo is root's and says nothing about the account that will stream.
- The two lookups are deliberately different: the startup warning reads the process' supplementary groups, which is what the kernel will enforce for the devices it is about to create, and `--setup-host` reads the passwd/group database, which is what the account is configured for. They answer different questions and can legitimately disagree across a `usermod` without a re-login.
- `docs/configuration.md` states the `input` group requirement as having no fallback, and adds a verification section. `udevadm info -q property -n /dev/input/eventN | grep ID_SEAT` is the check that shows isolation applied. `loginctl list-seats` showing only `seat0` is expected and is not a failure: logind only materializes a seat that owns a device tagged `master-of-seat`, which in practice means a graphics device. That expectation is the reporter's headline in #274, and their own `udevadm` output already showed `ID_SEAT=seat-polaris`.
- The gamepad classifier learns the seat-isolated `phys` marker. With isolation enabled the marker replaces the per-pad MAC in `phys`, which left the device name as the only remaining hook; a kernel driver that renames a node would have had Polaris classify one of its own pads as a host controller and hide it from the game it was created for.

## Exact candidate

- `Commit: d456fb9a522099e43c21855395d3ce614203fa47`
- `Tree:   289968de23205131a856f1b44fed539631fbd6a9`
- `Parent: b8f4a84a104305394d1d0cd7aef87643b63888e7`
- `Base:   b8f4a84a104305394d1d0cd7aef87643b63888e7`

## Verification

Built and run on pc-papi (Fedora) from this branch:

- [x] `cmake -GNinja -DBUILD_FULL_TESTS=ON` reconfigure, then full `ninja`, exit 0, no failed targets and no new warnings
- [x] `ctest` — 17/17 targets pass, 0 failures
- [x] `test_polaris_platform` — 33/33 in `InputGroupAccessTests` and `GamepadIsolationTests`, including 9 new tests covering every branch of the message: silent when the account is a member, silent when isolation is disabled, the account name and `usermod` command when membership is missing, only the devices the enabled options actually cover, and a host with no `input` group reported as a different problem with no dead-end `usermod` suggestion
- [x] A non-circular cross-check that the process-group lookup (`getgroups`) and the database lookup (`getgrnam`/`getgrouplist`) agree on a real host, so a bug in either is caught rather than hidden behind the other

Not covered, and worth stating plainly:

- The "account is not a member" path has not been seen fire on real hardware. `papi` is in `input` on the test host, so the live run exercises the negative case — no warning, which is correct — and the positive case rests on unit tests. Reproducing it would mean either changing the host's group membership or starting a second Polaris alongside the running instance, and neither was worth it for a log line.
- `--setup-host` output was not run end to end. The test host has no packaged rules under `/usr/lib/udev/rules.d`, so it takes the writing path rather than the no-op early exit, and running it would have mutated the machine's udev configuration. The advice string itself is unit-tested against the real passwd database via `setup_host_input_group_advice()`.
- The `input` group cause for #274 specifically is a strong hypothesis, not a confirmed diagnosis. The reporter's log shows `polaris_virtual=0` immediately after a successful pad creation, which is what losing access looks like, but `id -nG` on their host has been requested rather than assumed. This change is correct regardless of what that returns: the requirement is real and was unchecked.
