### PR TITLE
fix(linux): align stream prep mode and capture safety

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -591,6 +591,10 @@ namespace cage_display_router {
     return mode;
   }
 
+  bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type) {
+    return hwdevice_type == platf::mem_type_e::cuda;
+  }
+
   bool should_attempt_headless_extcopy_dmabuf(
     const platf::runtime_state_t &runtime_state,
     platf::mem_type_e hwdevice_type
@@ -604,7 +608,14 @@ namespace cage_display_router {
       return false;
     }
 
-    return hwdevice_type == platf::mem_type_e::cuda;
+    return gpu_native_dmabuf_is_safe(hwdevice_type);
+  }
+
+  bool should_attempt_gpu_native_cage_capture(
+    const platf::runtime_state_t &runtime_state,
+    platf::mem_type_e hwdevice_type
+  ) {
+    return runtime_state.gpu_native_override_active && gpu_native_dmabuf_is_safe(hwdevice_type);
   }
 
   bool should_disable_headless_extcopy_after_conversion_failure(

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -110,6 +110,18 @@ namespace cage_display_router {
   platf::runtime_state_t runtime_state();
 
   /**
+   * @brief Returns whether an encoder memory type has a known-safe GPU-native
+   *        DMA-BUF import/convert path.
+   *
+   * This is the stability policy behind every GPU-native capture route, and it
+   * belongs in one place: it used to be applied only to the true-headless
+   * extcopy path, so a VAAPI host that took the windowed GPU-native override
+   * reached the same conversion boundary the headless path was refusing, and
+   * segfaulted at stream start.
+   */
+  bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type);
+
+  /**
    * @brief Returns whether a headless labwc runtime should try the
    *        ext-image-copy-capture DMA-BUF path before falling back to SHM.
    *
@@ -118,6 +130,19 @@ namespace cage_display_router {
    * crash-prone here, so they stay on the conservative SHM path.
    */
   bool should_attempt_headless_extcopy_dmabuf(
+    const platf::runtime_state_t &runtime_state,
+    platf::mem_type_e hwdevice_type
+  );
+
+  /**
+   * @brief Returns whether a windowed GPU-native override should actually take
+   *        the DMA-BUF capture path.
+   *
+   * The override exists to keep GPU-native capture when true-headless cannot
+   * provide it, so it is worth nothing to an encoder whose GPU-native path is
+   * unsafe: the session gives up true headless and then crashes anyway.
+   */
+  bool should_attempt_gpu_native_cage_capture(
     const platf::runtime_state_t &runtime_state,
     platf::mem_type_e hwdevice_type
   );

--- a/src/platform/linux/display_topology.cpp
+++ b/src/platform/linux/display_topology.cpp
@@ -321,6 +321,41 @@ namespace display_topology {
     return std::system(cmd.c_str());
   }
 
+
+  std::string format_output_mode_arg(int width, int height, int refresh_hz) {
+    if (width <= 0 || height <= 0) {
+      return {};
+    }
+
+    if (refresh_hz <= 0) {
+      return std::to_string(width) + "x" + std::to_string(height);
+    }
+
+    return std::to_string(width) + "x" + std::to_string(height) + "@" + std::to_string(refresh_hz) + "Hz";
+  }
+
+  bool apply_requested_display_mode(const std::string &output_name, int width, int height, int refresh_hz) {
+    if (output_name.empty()) {
+      return false;
+    }
+
+    const auto mode_arg = format_output_mode_arg(width, height, refresh_hz);
+    if (mode_arg.empty()) {
+      return false;
+    }
+
+    const int rc = run_kscreen("output." + output_name + ".mode." + mode_arg);
+    if (rc != 0) {
+      BOOST_LOG(warning) << "display_topology: failed to request mode ["sv << mode_arg
+                         << "] on output ["sv << output_name << "] code="sv << rc;
+      return false;
+    }
+
+    BOOST_LOG(info) << "display_topology: requested mode ["sv << mode_arg << "] on output ["
+                   << output_name << "]"sv;
+    return true;
+  }
+
   /**
    * @brief Poll sysfs connector state with short backoff until predicate or timeout.
    * Replaces fixed sleep_for chains after kscreen-doctor (P1).
@@ -369,7 +404,7 @@ namespace display_topology {
     return false;
   }
 
-  void prepare_for_stream() {
+  void prepare_for_stream(int width, int height, int refresh_hz) {
     if (config::video.linux_display.stream_mode == "headless_dongle" ||
         config::video.linux_display.stream_mode.empty()) {
       ensure_dongle_outputs_configured();
@@ -399,6 +434,9 @@ namespace display_topology {
     }
     // Was fixed 1500ms sleep; poll enabled state with same overall budget.
     wait_output_state(cfg.streaming_output, true, std::chrono::milliseconds(1500), "enable_streaming");
+    if (width > 0 && height > 0) {
+      apply_requested_display_mode(cfg.streaming_output, width, height, refresh_hz);
+    }
 
     const bool portal_capture = config::video.capture.empty() ||
                                 config::video.capture == "auto" ||

--- a/src/platform/linux/display_topology.h
+++ b/src/platform/linux/display_topology.h
@@ -50,8 +50,12 @@ namespace display_topology {
 
   /**
    * @brief Enable streaming output / optional privacy swap before capture.
+   *
+   * @param width Requested stream width in pixels (advisory).
+   * @param height Requested stream height in pixels (advisory).
+   * @param refresh_hz Requested stream refresh in Hz (advisory).
    */
-  void prepare_for_stream();
+  void prepare_for_stream(int width, int height, int refresh_hz);
 
   /**
    * @brief Restore primary display layout after the stream ends.

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -87,7 +87,11 @@ namespace stream_runtime {
       bool prefer_gpu_native_capture,
       bool encoder_requires_gpu_native_capture
     );
-    bool should_attempt_gpu_native_cage_capture(const platf::runtime_state_t &runtime_state);
+    bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type);
+    bool should_attempt_gpu_native_cage_capture(
+      const platf::runtime_state_t &runtime_state,
+      platf::mem_type_e hwdevice_type
+    );
     bool should_attempt_headless_extcopy_dmabuf(
       const platf::runtime_state_t &runtime_state,
       platf::mem_type_e hwdevice_type

--- a/src/platform/linux/stream_runtime_labwc.cpp
+++ b/src/platform/linux/stream_runtime_labwc.cpp
@@ -83,8 +83,15 @@ namespace stream_runtime {
       return requested_headless && prefer_gpu_native_capture && encoder_requires_gpu_native_capture;
     }
 
-    bool should_attempt_gpu_native_cage_capture(const platf::runtime_state_t &runtime_state) {
-      return runtime_state.gpu_native_override_active;
+    bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type) {
+      return cage_display_router::gpu_native_dmabuf_is_safe(hwdevice_type);
+    }
+
+    bool should_attempt_gpu_native_cage_capture(
+      const platf::runtime_state_t &runtime_state,
+      platf::mem_type_e hwdevice_type
+    ) {
+      return cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state, hwdevice_type);
     }
 
     bool should_attempt_headless_extcopy_dmabuf(

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -685,7 +685,7 @@ namespace platf {
         config::video.linux_display.use_cage_compositor &&
         stream_runtime::labwc::is_running()) {
       auto runtime_state = stream_runtime::labwc::runtime_state();
-      if (stream_runtime::labwc::should_attempt_gpu_native_cage_capture(runtime_state)) {
+      if (stream_runtime::labwc::should_attempt_gpu_native_cage_capture(runtime_state, hwdevice_type)) {
         static bool logged_windowed_gpu_native_attempt = false;
         if (!logged_windowed_gpu_native_attempt) {
           BOOST_LOG(info)
@@ -693,6 +693,19 @@ namespace platf {
           logged_windowed_gpu_native_attempt = true;
         }
         prefer_linear_dmabuf = true;
+      } else if (runtime_state.gpu_native_override_active) {
+        // The override is active but this encoder's GPU-native path is not one
+        // Polaris will import from. Falling back to RAM capture here is the
+        // difference between a slower stream and a SIGSEGV at stream start.
+        prefer_ram_capture = true;
+        stream_stats::update_gpu_native_probe_attempt("windowed", "ineligible", "policy", "vaapi_gpu_native_dmabuf_disabled_for_stability");
+        stream_stats::update_gpu_native_probe_selection("windowed_shm", "windowed_shm");
+        static bool logged_windowed_gpu_native_refusal = false;
+        if (!logged_windowed_gpu_native_refusal) {
+          BOOST_LOG(warning)
+            << "wlr: Using RAM capture path for the windowed labwc override because GPU-native DMA-BUF is disabled for VAAPI stability"sv;
+          logged_windowed_gpu_native_refusal = true;
+        }
       } else if (stream_runtime::labwc::should_report_headless_ram_capture_fallback(runtime_state)) {
         prefer_ram_capture = true;
         using_headless_ram_capture = true;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6202,6 +6202,26 @@ namespace proc {
     };
 
     auto resolve_windowed_gpu_native_fallback = [&]() -> bool {
+      // The override trades true headless away to keep GPU-native capture, so
+      // it is worth nothing to an encoder Polaris will not import GPU frames
+      // from: the session would give up headless and then fall back to RAM
+      // anyway. Probing it is worse than pointless — the probe drives the same
+      // conversion path that crashes these stacks, in this process.
+      //
+      // An unresolved encoder reports `unknown` rather than a safe answer, and
+      // refusing on that would take the override away from stacks that are
+      // fine, so only a known-unsafe type is refused here. The capture-time
+      // gate covers the rest, by which point the encoder is always chosen.
+      const auto encoder_mem_type = video::active_encoder_mem_type();
+      if (encoder_mem_type != platf::mem_type_e::unknown &&
+          !stream_runtime::labwc::gpu_native_dmabuf_is_safe(encoder_mem_type)) {
+        stream_stats::update_gpu_native_probe_attempt("windowed", "ineligible", "policy", "vaapi_gpu_native_dmabuf_disabled_for_stability");
+        BOOST_LOG(info) << "session_manager: Skipping the windowed GPU-native fallback for encoder ["
+                        << (video::active_encoder_name().empty() ? "unknown" : video::active_encoder_name())
+                        << "] because its GPU-native DMA-BUF path is disabled for stability; staying headless"sv;
+        return false;
+      }
+
       if (cached_windowed_gpu_native_probe_result == std::optional<bool> {true}) {
         stream_stats::update_gpu_native_probe_attempt("windowed", "succeeded", {}, {}, true);
         BOOST_LOG(info) << "session_manager: Reusing cached windowed_dmabuf_override probe result"sv;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -4594,8 +4594,8 @@ namespace proc {
 
   namespace linux_display {
     // Thin wrappers — topology lives in display_topology for path plugins.
-    void enable_streaming_display() {
-      display_topology::prepare_for_stream();
+    void enable_streaming_display(int width, int height, int refresh_hz) {
+      display_topology::prepare_for_stream(width, height, refresh_hz);
     }
 
     void disable_streaming_display() {
@@ -5602,7 +5602,14 @@ namespace proc {
 #ifdef __linux__
     // Enable streaming display BEFORE encoder probe so HDMI-A-1 is available
     if (config::video.linux_display.auto_manage_displays) {
-      linux_display::enable_streaming_display();
+      int target_fps = launch_session->fps ? launch_session->fps : 60000;
+      if (target_fps >= 1000) {
+        target_fps /= 1000;
+      }
+      if (config::video.double_refreshrate) {
+        target_fps *= 2;
+      }
+      linux_display::enable_streaming_display(render_width, render_height, target_fps);
     }
 #endif
 

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -95,6 +95,89 @@ TEST(CageDisplayRouterPolicyTests, WindowedOverrideDoesNotAttemptHeadlessExtcopy
   ));
 }
 
+TEST(CageDisplayRouterPolicyTests, WindowedOverrideRefusesGpuNativeCaptureForVaapi) {
+  // The crash in #212 and #279: the override put VAAPI on the DMA-BUF path the
+  // headless branch was already refusing for the same encoder, and the
+  // conversion segfaulted at stream start.
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+
+  EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(
+    runtime_state,
+    platf::mem_type_e::vaapi
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, WindowedOverrideAttemptsGpuNativeCaptureForCuda) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+
+  EXPECT_TRUE(cage_display_router::should_attempt_gpu_native_cage_capture(
+    runtime_state,
+    platf::mem_type_e::cuda
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, GpuNativeCaptureNeedsTheOverrideRegardlessOfEncoder) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = true,
+    .gpu_native_override_active = false,
+    .backend_name = "labwc",
+  };
+
+  EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(
+    runtime_state,
+    platf::mem_type_e::cuda
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, BothGpuNativeRoutesShareOneStabilityPolicy) {
+  // Keeping the two routes' policies independent is what let a VAAPI host
+  // crash through one while the other was refusing the same buffers, so this
+  // pins them to the same answer rather than to a literal.
+  for (const auto hwdevice_type : {
+         platf::mem_type_e::cuda,
+         platf::mem_type_e::vaapi,
+         platf::mem_type_e::system,
+         platf::mem_type_e::unknown,
+       }) {
+    const platf::runtime_state_t headless {
+      .requested_headless = true,
+      .effective_headless = true,
+      .gpu_native_override_active = false,
+      .backend_name = "labwc",
+    };
+    const platf::runtime_state_t overridden {
+      .requested_headless = true,
+      .effective_headless = false,
+      .gpu_native_override_active = true,
+      .backend_name = "labwc",
+    };
+
+    EXPECT_EQ(
+      cage_display_router::should_attempt_headless_extcopy_dmabuf(headless, hwdevice_type),
+      cage_display_router::should_attempt_gpu_native_cage_capture(overridden, hwdevice_type)
+    ) << "hwdevice_type=" << static_cast<int>(hwdevice_type);
+  }
+}
+
+TEST(CageDisplayRouterPolicyTests, OnlyCudaHasASafeGpuNativeDmabufPath) {
+  EXPECT_TRUE(cage_display_router::gpu_native_dmabuf_is_safe(platf::mem_type_e::cuda));
+  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(platf::mem_type_e::vaapi));
+  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(platf::mem_type_e::system));
+  // An encoder that has not resolved yet must not read as safe.
+  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(platf::mem_type_e::unknown));
+}
+
 TEST(CageDisplayRouterPolicyTests, HeadlessDmabufGpuConversionFailureDisablesExtcopyFallback) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,


### PR DESCRIPTION
## Summary

Closes #279. Addresses the containment half of #212.

- The true-headless ext-image-copy-capture path refuses VAAPI deliberately — those stacks have proven crash-prone at the DMA-BUF import and convert boundary, so they stay on conservative SHM capture. The windowed GPU-native override never got the same treatment. `should_attempt_gpu_native_cage_capture` took no encoder memory type at all and returned `runtime_state.gpu_native_override_active` directly, so a VAAPI host that enabled `linux_prefer_gpu_native_capture` was routed onto exactly the conversion path the headless branch was refusing for the same encoder.
- The probe that discovers this runs in-process: `probe_windowed_gpu_native_cage` calls `video::active_encoder_runtime_supports_live_gpu_capture`, which drives real capture. A SIGSEGV there takes Polaris with it, so there is nothing to catch and no way to recover after the fact. The fix has to be to not enter the path.
- Both routes now ask one function, `cage_display_router::gpu_native_dmabuf_is_safe(mem_type)`, whether an encoder memory type has a known-safe GPU-native import. A test pins the two routes to the *same answer* across every memory type rather than to a literal, because their drifting apart is what caused this — asserting `cuda` in two places would just recreate the failure mode.
- Capture time (`wlgrab.cpp`): an active override with a refused encoder now falls back to RAM capture with a warning instead of entering the conversion path.
- Session time (`process.cpp`): the session no longer forces windowed labwc for a refused encoder at all. The override exists to preserve GPU-native capture and buys nothing when capture falls back to RAM regardless, so taking it would sacrifice true headless for no gain. `video::active_encoder_mem_type()` reports `unknown` before an encoder resolves, and refusing on that would take the override away from stacks that are fine, so only a known-unsafe type is refused there; the capture-time gate covers the rest, by which point an encoder is always chosen.
- Both refusals report through `stream_stats`, so requested and effective capture paths stay separate and truthful in the API/UI diagnostics.

Scope note for #212: this is the fail-safe containment its acceptance criteria allow, not a root cause at the DMA-BUF to VAAPI conversion boundary. #212 should stay open for that.

Reported for RDNA4 in #212 and reproduced on RDNA3 (navi31, Mesa 26.1.5) in #279, so this is an AMD/VAAPI GPU-native problem rather than an RDNA4 one.

## Exact candidate

- `Commit: 12a3e9532d754bbae2940816904ad06ff88e2652`
- `Tree:   e1a04c8cfc07ea19e6255b3507fab2e04aeae163`
- `Parent: b8f4a84a104305394d1d0cd7aef87643b63888e7`
- `Base:   b8f4a84a104305394d1d0cd7aef87643b63888e7`

## Verification

Built and run on pc-papi (Fedora) from this branch:

- [x] Full `ninja`, exit 0, no failed targets and no new warnings
- [x] `ctest` — 17/17 targets pass, 0 failures
- [x] `test_polaris_platform` — 31/31 in `CageDisplayRouterPolicyTests`, including 5 new tests: VAAPI refused under an active override, CUDA still attempted, the override still required regardless of encoder, `unknown` never reading as safe, and the two routes agreeing across all four memory types
- [x] Mutation probe. Reverting `should_attempt_gpu_native_cage_capture` to ignore `hwdevice_type` — the exact defect — fails `WindowedOverrideRefusesGpuNativeCaptureForVaapi` and `BothGpuNativeRoutesShareOneStabilityPolicy` and nothing else. Restoring the guard returns 31/31. The guard is load-bearing rather than incidentally green.

Not covered, and worth stating plainly:

- **No AMD hardware reproduction, before or after.** The only GPU on the test host is an RTX 4090, so the crash in #212 and #279 has never been reproduced here and the fix has not been observed to prevent it on affected hardware. The change is derived from reading the two code paths and from the reporters' logs, which reach `avcodec_encode_device target_device=vaapi` immediately before the SIGSEGV. Field confirmation on an RDNA3 or RDNA4 host is still needed, and #212's acceptance criteria ask for five launches per mode with zero coredumps.
- The NVIDIA/CUDA path is unchanged by inspection and by the tests, but was not stream-tested on this branch.
- CI status is recorded on the PR checks. Actions has been dropping `pull_request` events on this repo, so an empty checks list means nothing ran rather than that anything passed.



## Additional update in this push

- Added Linux stream-resolution alignment in the host display prep path used by session launch.
- Updated stream display prepare API to accept advisory stream dimensions/fps and request the target mode on the streaming output (`kscreen-doctor output.<stream>.mode.<WxHx@Hz>`), when width/height are known.
- Threaded launch negotiation values into the Linux stream preflight call site so the output mode request aligns with the session's requested render size.
- This is intentionally narrow: it does not change client negotiation logic outside Linux stream topology and capture path setup.

### Exact update

- Commit: `ae64d85d278c456296f68b594984e917a037cbca`
- Tree: `0936504652eab658402d118d43e158facfdeedf1`
- Parent: `12a3e9532d754bbae2940816904ad06ff88e2652`

### Build validation on this environment

- [ ] `make -C build -j4 polaris` not fully green (fails while building web UI due missing `vite-plugin-ejs` in local dependency setup).
- [x] Updated sources compile-check stage in changed translation units was reached; no C++ compile errors were emitted before the unrelated web-build failure.
- [ ] Full Linux host build/run validation remains to be executed in your CI/Linux environment where this path is exercised.
