### PR TITLE
fix(config): warn when back_button_timeout is set in seconds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ Stream when you want a stream-only runtime that leaves the host desktop layout a
 | `headless_gamepad_isolation` | `enabled` | Hide host-connected gamepads from private headless streams; disable only when you intentionally want a wired host controller visible inside the stream |
 | `client_gamepad_seat_isolation` | `disabled` | Assign Polaris-created client gamepads to a dedicated Linux seat so other active-seat users do not receive automatic device ACLs |
 | `client_keyboard_mouse_seat_isolation` | `disabled` | Assign the virtual keyboard, mouse, touch and pen Polaris creates for clients to a dedicated Linux seat, so a client streaming a private session does not also type and click into the desktop session logged in at the machine |
+| `back_button_timeout` | `-1` | **Milliseconds**, not seconds, that Back/Select must be held to emulate Home/Guide. `-1` disables it. A small value such as `2` means two *milliseconds*, which turns nearly every Back/Select press into Home and makes the button look broken — use `2000` for two seconds |
 | `encoder` | `nvenc` / `vaapi` / `software` | Primary encoder backend |
 | `nvenc_split_encode_mode` | `disabled` | Experimental Linux/FFmpeg NVENC split-frame encoding for HEVC/AV1 |
 | `adaptive_bitrate_enabled` | `enabled` | Allow mid-stream bitrate adjustment |

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <sstream>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -131,6 +132,31 @@ namespace config {
     }
 
   }  // namespace nv
+
+  std::string back_button_timeout_warning(int timeout_ms) {
+    // Negative disables the emulation entirely, which is the default and the
+    // documented way to turn it off.
+    if (timeout_ms < 0 || timeout_ms >= back_button_emulated_press_ms) {
+      return {};
+    }
+
+    std::ostringstream advice;
+    advice << "config: back_button_timeout is "sv << timeout_ms
+           << " milliseconds, which is shorter than the "sv << back_button_emulated_press_ms
+           << "ms Home press it emulates. Back/Select will be released and turned into Home on "sv
+           << "essentially every press, so the button will look broken rather than misconfigured."sv;
+
+    // The overwhelmingly likely cause is seconds entered where milliseconds
+    // were meant, and naming the exact replacement value is cheaper than
+    // leaving somebody to work it out from an evtest trace.
+    if (timeout_ms > 0) {
+      advice << " If you meant "sv << timeout_ms << " second"sv << (timeout_ms == 1 ? "" : "s")
+             << ", use "sv << timeout_ms * 1000 << '.';
+    }
+
+    advice << " Use -1 to disable Home emulation."sv;
+    return advice.str();
+  }
 
   namespace amd {
 #if !defined(_WIN32) || defined(DOXYGEN)
@@ -1445,6 +1471,9 @@ namespace config {
 
     if (to > std::numeric_limits<int>::min()) {
       input.back_button_timeout = std::chrono::milliseconds {to};
+      if (const auto advice = back_button_timeout_warning(to); !advice.empty()) {
+        BOOST_LOG(warning) << advice;
+      }
     }
 
     double repeat_frequency {0};

--- a/src/config.h
+++ b/src/config.h
@@ -376,6 +376,28 @@ namespace config {
     nvenc::nvenc_split_encode_mode split_encode_mode_from_view(const std::string_view &mode);
   }
 
+  /**
+   * @brief The Home emulation holds the Home button for this long.
+   *
+   * A `back_button_timeout` shorter than this produces an emulated press longer
+   * than the window that triggers it, which no one configures on purpose.
+   */
+  constexpr int back_button_emulated_press_ms = 100;
+
+  /**
+   * @brief Explain a `back_button_timeout` that makes Back/Select unusable.
+   *
+   * The value is milliseconds, so `2` means two milliseconds rather than two
+   * seconds: Back/Select is released by the emulation almost the instant it goes
+   * down, and every press turns into Home. It reads as a broken controller, not
+   * as a configuration mistake, and it cost a full evtest trace to diagnose the
+   * first time.
+   *
+   * @param timeout_ms Configured value in milliseconds.
+   * @return The warning, or empty when the value is disabled or plausible.
+   */
+  std::string back_button_timeout_warning(int timeout_ms);
+
   int parse(int argc, char *argv[]);
   bool is_valid_command_prefix(std::string_view argument);
   std::unordered_map<std::string, std::string> parse_config(const std::string_view &file_content);

--- a/tests/unit/test_config_parser.cpp
+++ b/tests/unit/test_config_parser.cpp
@@ -18,3 +18,50 @@ TEST(ConfigParserTests, ParsesNvencSplitEncodeModeValues) {
 TEST(ConfigParserTests, UnknownNvencSplitEncodeModeFallsBackToDisabled) {
   EXPECT_EQ(config::nv::split_encode_mode_from_view("not-a-real-mode"), nvenc::nvenc_split_encode_mode::disabled);
 }
+
+namespace {
+  bool contains(const std::string &text, std::string_view needle) {
+    return text.find(needle) != std::string::npos;
+  }
+}  // namespace
+
+TEST(ConfigParserTests, PlausibleBackButtonTimeoutsAreNotWarnedAbout) {
+  // -1 is the documented way to disable Home emulation, and any other negative
+  // value disables it too, so neither is a mistake.
+  EXPECT_TRUE(config::back_button_timeout_warning(-1).empty());
+  EXPECT_TRUE(config::back_button_timeout_warning(-500).empty());
+
+  // At and above the emulated press length the setting behaves as described.
+  EXPECT_TRUE(config::back_button_timeout_warning(config::back_button_emulated_press_ms).empty());
+  EXPECT_TRUE(config::back_button_timeout_warning(2000).empty());
+}
+
+TEST(ConfigParserTests, BackButtonTimeoutShorterThanTheEmulatedPressIsWarnedAbout) {
+  // The value from #222: intended as two seconds, applied as two milliseconds,
+  // which turned every Select press into Home.
+  const auto advice = config::back_button_timeout_warning(2);
+  ASSERT_FALSE(advice.empty());
+
+  EXPECT_TRUE(contains(advice, "2 milliseconds"));
+  // Naming the replacement value is the whole point; a warning that only says
+  // "too small" leaves the reader exactly where they started.
+  EXPECT_TRUE(contains(advice, "use 2000"));
+  EXPECT_TRUE(contains(advice, "-1 to disable"));
+}
+
+TEST(ConfigParserTests, BackButtonTimeoutWarningPluralizesTheSecondsGuess) {
+  EXPECT_TRUE(contains(config::back_button_timeout_warning(1), "1 second, use 1000"));
+  EXPECT_TRUE(contains(config::back_button_timeout_warning(5), "5 seconds, use 5000"));
+}
+
+TEST(ConfigParserTests, ZeroBackButtonTimeoutWarnsWithoutASecondsGuess) {
+  const auto advice = config::back_button_timeout_warning(0);
+  ASSERT_FALSE(advice.empty());
+
+  // Zero fires Home immediately, so it is worth warning about, but "0 seconds"
+  // is not a guess at intent worth printing. Match the guess clause rather than
+  // the word "second", which also occurs inside "milliseconds".
+  EXPECT_FALSE(contains(advice, "If you meant"));
+  EXPECT_TRUE(contains(advice, "0 milliseconds"));
+  EXPECT_TRUE(contains(advice, "-1 to disable"));
+}


### PR DESCRIPTION
## Summary

Addresses the Back/Select half of #222. Does not close it — see the scope note below.

- `back_button_timeout` is milliseconds, and nothing said so at the point where it is easy to get wrong. A host configured with `back_button_timeout = 2` meant two seconds and got two milliseconds: the emulation released Back/Select and pressed Home almost the instant the button went down, so every Select press became Home. The controller looked broken rather than misconfigured, and it took an `evtest` trace to work out — a lot of effort for a units mistake.
- Values below the length of the Home press the emulation itself performs now produce a warning at config parse. **That threshold is not a guess about human reflexes:** `input.cpp` holds Home for 100ms, so a timeout shorter than the press it generates cannot be deliberate — the emulated press outlasts the window that triggered it. The constant is shared, so the two cannot drift apart.
- The warning names the value that was almost certainly intended (`If you meant 2 seconds, use 2000.`) rather than only reporting that the setting is too small. A reader who already believes the units are seconds gains nothing from being told the number is wrong.
- **Nothing is clamped, deliberately.** Clamping looks like the natural fix but fails on inspection: any floor low enough to be safe still leaves Back/Select firing Home on every realistic press, because a real press is far longer than any such floor. Clamping would change the user's configuration *and* leave the button unusable, while hiding the mistake that caused it. Warning and leaving the value intact is both honest and actually actionable.
- Zero is warned about without a seconds guess, since "0 seconds" is not a guess at intent worth printing.
- `docs/configuration.md` gains a row stating the units explicitly; the option was previously undocumented there.

## Scope

This fixes the Select→Home behaviour that was diagnosed from the reporter's `evtest` capture. It does **not** address the original report that all four face buttons are ignored in the Heroic UI, which the last maintainer comment concluded looked Heroic-specific and which is still awaiting a Heroic version and a Steam Big Picture comparison from the reporter. #222 should stay open for that.

## Exact candidate

- `Commit: 71ae85c5da074f3ab1d054b28f928992398da8bb`
- `Tree:   9b998159b4bda333d6384e23819f6aae4e01a325`
- `Parent: f2b971d59f0ae6d4f9076310f96477d1d7519e4d`
- `Base:   f2b971d59f0ae6d4f9076310f96477d1d7519e4d`

## Verification

Built and run on pc-papi (Fedora) from this branch:

- [x] Full `ninja`, exit 0, no failed targets and no new warnings
- [x] `ctest` — 17/17 targets pass, 0 failures
- [x] `test_polaris_config` — `ConfigParserTests` 6/6, covering the disabled values, the threshold boundary, the reported value of `2`, the pluralisation of the seconds guess, and zero warning without a guess
- [x] Behaviour confirmed against the built binary rather than only the unit tests, since the call site is what actually has to fire:

  ```
  back_button_timeout=2000 -> silent   (two seconds, correct)
  back_button_timeout=-1   -> silent   (disabled)
  back_button_timeout=100  -> silent   (at the threshold)
  back_button_timeout=0    -> warns
  back_button_timeout=2    -> warns, with "If you meant 2 seconds, use 2000."
  ```

Not covered, and worth stating plainly:

- The warning prints at `[info]` rather than `[warning]`. Config parsing runs before `logging::init`, so every config warning goes through boost's default sink with that label — the pre-existing `nvenc_twopass` warning was verified to behave identically. This change is consistent with what is already there; making config warnings actually look like warnings means reordering startup logging and belongs in its own change.
- No controller hardware was exercised. The emulation path in `input.cpp` is unchanged by this commit; only the configuration warning is new.
