### PR TITLE
feat(api): record the Nova field contract and catch drift in it

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -1,0 +1,76 @@
+{
+  "$comment": [
+    "Fields Polaris serves to Nova, per response object.",
+    "",
+    "Nova and Polaris ship from separate repositories on separate schedules, and both",
+    "sides address these fields by string literal. Nothing in either build can see the",
+    "other, so a rename on one side degrades silently: a reader falls back to its",
+    "default and the feature quietly stops working rather than failing.",
+    "",
+    "This manifest is the shared record. tests/integration/test_nova_contract.cpp keeps",
+    "Polaris honest about it, and scripts/check-nova-contract.py diffs it against a Nova",
+    "checkout. Adding a field to a response means adding it here in the same commit.",
+    "",
+    "Drift found when this manifest was introduced, on 2026-08-06, is recorded under",
+    "known_drift so it is tracked rather than rediscovered."
+  ],
+  "version": 1,
+  "objects": {
+    "game": {
+      "$comment": "Emitted per app by the game library endpoint.",
+      "fields": [
+        "app_id",
+        "artwork",
+        "beat_time",
+        "category",
+        "cover_url",
+        "genres",
+        "hdr_supported",
+        "id",
+        "installed",
+        "last_launched",
+        "launch_mode",
+        "mangohud",
+        "name",
+        "play_time",
+        "source",
+        "steam_appid",
+        "steam_launch"
+      ],
+      "optional": [
+        "beat_time",
+        "play_time"
+      ],
+      "nova_reader": {
+        "$comment": "Nova unpacks nested launch_mode/mode objects in the same file, so the receiver variable is what scopes this to the game object itself.",
+        "file": "app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt",
+        "receiver": "json"
+      }
+    }
+  },
+  "known_drift": {
+    "$comment": [
+      "Recorded 2026-08-06. Neither direction crashes: Nova defaults missing fields, and",
+      "Polaris does not care what goes unread. Both cost real behaviour anyway."
+    ],
+    "nova_reads_polaris_never_sends": {
+      "$comment": "Nova's PolarisGameJsonAdapter falls back for each of these, so the UI is permanently degraded rather than broken.",
+      "game": [
+        "launcher_source",
+        "launcher_detail",
+        "platform",
+        "runtime",
+        "platform_label",
+        "runtime_label"
+      ]
+    },
+    "polaris_sends_nova_never_reads": {
+      "$comment": "Shipped by Polaris v1.3.5 and invisible in Nova until it reads them.",
+      "game": [
+        "artwork",
+        "beat_time",
+        "play_time"
+      ]
+    }
+  }
+}

--- a/scripts/check-nova-contract.py
+++ b/scripts/check-nova-contract.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Diff Polaris' served fields against what a Nova checkout actually reads.
+
+Nova and Polaris ship from separate repositories, so neither build can see the
+other. Both address the same JSON by string literal, and both sides fail soft:
+Nova defaults a field it cannot find, Polaris never learns that something went
+unread. The result is a feature that quietly stops working instead of breaking.
+
+This is the half that needs both trees present, so it is a developer tool rather
+than a CI gate. tests/integration/test_nova_contract.cpp covers the half that can
+run inside Polaris alone.
+
+    scripts/check-nova-contract.py --nova ~/Documents/github/nova
+
+Exits non-zero when drift is found that is not already recorded under
+`known_drift` in docs/nova-contract.json, so it is usable as a gate once a repo
+has both checkouts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Nova reads responses through org.json accessors. Anything it asks for by name
+# is a field it expects Polaris to serve.
+ACCESSORS = "optString|optBoolean|optInt|optLong|optDouble|optJSONObject|optJSONArray|getString|getBoolean|getInt|getLong"
+
+
+def reads_for_receiver(source: str, receiver: str) -> set[str]:
+    """Keys read from one JSON object.
+
+    Scoping to the receiver matters more than it looks. Nova's game adapter also
+    unpacks nested objects — launch_mode and its mode entry — from the same file,
+    and a file-wide scan reports their fields as game fields Polaris fails to
+    serve. That is a false alarm that would train everyone to ignore this tool.
+    """
+    pattern = re.compile(rf'\b{re.escape(receiver)}\.(?:{ACCESSORS})\(\s*"([a-zA-Z_0-9]+)"')
+    return set(pattern.findall(source))
+
+
+def polaris_manifest(repo: Path) -> dict:
+    return json.loads((repo / "docs" / "nova-contract.json").read_text())
+
+
+def nova_reads(nova: Path, reader: dict) -> set[str]:
+    """Fields Nova reads for one contract object."""
+    path = nova / reader["file"]
+    if not path.is_file():
+        raise SystemExit(f"not found: {path}\nIs --nova pointing at a Nova checkout?")
+    return reads_for_receiver(path.read_text(), reader["receiver"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--nova", required=True, type=Path, help="path to a Nova checkout")
+    parser.add_argument("--polaris", type=Path, default=Path(__file__).resolve().parent.parent)
+    args = parser.parse_args()
+
+    manifest = polaris_manifest(args.polaris)
+    game = manifest["objects"]["game"]
+    served = set(game["fields"])
+    read = nova_reads(args.nova, game["nova_reader"])
+
+    drift = manifest.get("known_drift", {})
+    known_missing = set(drift.get("nova_reads_polaris_never_sends", {}).get("game", []))
+    known_unread = set(drift.get("polaris_sends_nova_never_reads", {}).get("game", []))
+
+    # Nova asks, Polaris never answers. Nova defaults these, so the symptom is a
+    # blank or "unknown" in the UI rather than an error.
+    missing = read - served
+    # Polaris answers, Nova never asks. The feature ships and stays invisible.
+    unread = served - read
+
+    new_missing = sorted(missing - known_missing)
+    new_unread = sorted(unread - known_unread)
+    fixed = sorted((known_missing - missing) | (known_unread - unread))
+
+    print(f"game object: Polaris serves {len(served)}, Nova reads {len(read)}")
+
+    for field in new_missing:
+        print(f"  DRIFT  Nova reads [{field}] that Polaris never serves")
+    for field in new_unread:
+        print(f"  DRIFT  Polaris serves [{field}] that Nova never reads")
+    for field in fixed:
+        print(f"  FIXED  [{field}] is no longer drifting; remove it from known_drift")
+
+    if not (new_missing or new_unread or fixed):
+        print("  no new drift")
+
+    if missing & known_missing or unread & known_unread:
+        print(f"\n{len(missing & known_missing) + len(unread & known_unread)} known drift field(s) still outstanding")
+
+    return 1 if (new_missing or new_unread) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -6044,6 +6044,16 @@ namespace nvhttp {
       features["ai_optimizer_control"] = true;
       features["adaptive_bitrate_control"] = true;
       features["game_library"] = true;
+      // Declared so a client can light up the UI conditionally instead of
+      // guessing from the presence of a field. Both landed in v1.3.5 and are
+      // served on the game object as `play_time` and `beat_time`.
+      features["library_playtime_v1"] = true;
+      // The estimate itself comes from the bundled dataset and is always
+      // served; `beat_times_lookup` only decides whether unknown titles are
+      // resolved over the network, so it is reported separately rather than
+      // making the feature look absent.
+      features["library_beat_times_v1"] = true;
+      features["library_beat_times_lookup"] = config::sunshine.beat_times_lookup;
       features["artwork_manifest_v1"] = true;
       features["artwork_manual_match_v1"] = nonblank_artwork_api_key(
         config::sunshine.steamgriddb_api_key);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,6 +130,7 @@ endif()
 set(TEST_AUDIT_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/integration/test_config_consistency.cpp
     ${CMAKE_SOURCE_DIR}/tests/integration/test_locale_consistency.cpp
+    ${CMAKE_SOURCE_DIR}/tests/integration/test_nova_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_virtual_input_udev_contract.cpp
 )
 

--- a/tests/integration/test_nova_contract.cpp
+++ b/tests/integration/test_nova_contract.cpp
@@ -1,0 +1,127 @@
+/**
+ * @file tests/integration/test_nova_contract.cpp
+ * @brief Keep Polaris' served fields and the Nova contract manifest in step.
+ *
+ * Nova addresses Polaris' JSON by string literal and defaults anything missing,
+ * so a renamed or dropped field does not fail on either side — the reader just
+ * silently gets its fallback. Nova ships from a separate repository, so no build
+ * here can check it directly.
+ *
+ * What this can do is refuse to let Polaris change the shape of a response
+ * without saying so in docs/nova-contract.json, which is the record both sides
+ * review against. scripts/check-nova-contract.py does the other half against a
+ * Nova checkout.
+ */
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace {
+  std::string read_source_file(std::string_view relative_path) {
+    const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / relative_path;
+    std::ifstream input {path};
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+  }
+
+  /// Every key assigned as `game["<key>"]` in the served source.
+  std::set<std::string> emitted_game_fields() {
+    const auto source = read_source_file("src/nvhttp.cpp");
+    std::set<std::string> fields;
+
+    constexpr std::string_view prefix = "game[\"";
+    std::size_t pos = 0;
+    while ((pos = source.find(prefix, pos)) != std::string::npos) {
+      const auto start = pos + prefix.size();
+      const auto end = source.find('"', start);
+      if (end == std::string::npos) {
+        break;
+      }
+      // Only assignments define the response shape; a read would not.
+      const auto after = source.find_first_not_of(" \t", source.find(']', end) + 1);
+      if (after != std::string::npos && source[after] == '=' && source[after + 1] != '=') {
+        fields.insert(source.substr(start, end - start));
+      }
+      pos = end;
+    }
+
+    return fields;
+  }
+
+  std::set<std::string> manifest_game_fields() {
+    const auto manifest = nlohmann::json::parse(read_source_file("docs/nova-contract.json"));
+    std::set<std::string> fields;
+    for (const auto &field : manifest["objects"]["game"]["fields"]) {
+      fields.insert(field.get<std::string>());
+    }
+    return fields;
+  }
+}  // namespace
+
+TEST(NovaContractTests, TheManifestListsExactlyTheGameFieldsPolarisServes) {
+  const auto emitted = emitted_game_fields();
+  const auto declared = manifest_game_fields();
+
+  ASSERT_FALSE(emitted.empty()) << "no game fields found in src/nvhttp.cpp; the scan is broken, "
+                                   "not the contract";
+
+  std::vector<std::string> undeclared;
+  std::set_difference(
+    emitted.begin(), emitted.end(),
+    declared.begin(), declared.end(),
+    std::back_inserter(undeclared)
+  );
+  std::vector<std::string> unserved;
+  std::set_difference(
+    declared.begin(), declared.end(),
+    emitted.begin(), emitted.end(),
+    std::back_inserter(unserved)
+  );
+
+  for (const auto &field : undeclared) {
+    ADD_FAILURE() << "game field [" << field << "] is served but missing from docs/nova-contract.json. "
+                  << "Add it there in this commit so the Nova side has something to review against.";
+  }
+  for (const auto &field : unserved) {
+    ADD_FAILURE() << "docs/nova-contract.json declares game field [" << field << "] that Polaris no "
+                  << "longer serves. Removing a field Nova may still read is exactly the change "
+                  << "that degrades silently — remove it here only once Nova has stopped reading it.";
+  }
+}
+
+TEST(NovaContractTests, NewLibraryFeaturesAreDeclaredInCapabilities) {
+  // Nova cannot tell an absent feature from an absent value, so anything it is
+  // expected to render conditionally has to be announced rather than inferred.
+  const auto source = read_source_file("src/nvhttp.cpp");
+
+  for (const auto flag : {"library_playtime_v1", "library_beat_times_v1"}) {
+    SCOPED_TRACE(flag);
+    EXPECT_NE(source.find(std::string {"features[\""} + flag + "\"]"), std::string::npos);
+  }
+}
+
+TEST(NovaContractTests, KnownDriftStaysRecordedUntilItIsFixed) {
+  const auto manifest = nlohmann::json::parse(read_source_file("docs/nova-contract.json"));
+  const auto &drift = manifest["known_drift"];
+
+  ASSERT_TRUE(drift.contains("nova_reads_polaris_never_sends"));
+  ASSERT_TRUE(drift.contains("polaris_sends_nova_never_reads"));
+
+  // The fields Polaris serves that Nova ignores must at least be fields Polaris
+  // really serves, or the record is describing something that no longer exists.
+  const auto emitted = emitted_game_fields();
+  for (const auto &field : drift["polaris_sends_nova_never_reads"]["game"]) {
+    const auto name = field.get<std::string>();
+    SCOPED_TRACE(name);
+    EXPECT_TRUE(emitted.count(name) > 0)
+      << "known_drift claims Polaris serves [" << name << "] but it is no longer emitted; "
+      << "update docs/nova-contract.json";
+  }
+}


### PR DESCRIPTION
## Summary

- Nova and Polaris ship from separate repositories and both address the same JSON by string literal, so neither build can see the other. Both sides also fail soft: Nova defaults a field it cannot find, and Polaris never learns that something went unread. A rename on either side therefore degrades a feature quietly instead of breaking it.
- Checking the game object today finds drift running in **both** directions, and it has been there long enough that nobody noticed.

| Direction | Fields | Effect |
|---|---|---|
| Nova reads, Polaris never serves | `launcher_source`, `launcher_detail`, `platform`, `runtime`, `platform_label`, `runtime_label` | `platform` and `runtime` resolve to `"unknown"`, the labels to `""`; the UI is permanently degraded rather than broken |
| Polaris serves, Nova never reads | `artwork`, `play_time`, `beat_time` | the library work in v1.3.5 is invisible to Nova users |

- `docs/nova-contract.json` records what Polaris serves per response object, and records the nine drifting fields so they are tracked rather than rediscovered.
- `tests/integration/test_nova_contract.cpp` refuses to let the served shape change without the manifest changing in the same commit. It fails in both directions, including the manifest still claiming a field Polaris has stopped serving — removing something Nova may still read is the change that degrades most quietly of all.
- `scripts/check-nova-contract.py` does the half that needs both trees present, so it is a developer tool rather than a CI gate. It exits non-zero only on **new** drift, so the known items cannot mask a fresh one.
- The capabilities response gains `library_playtime_v1` and `library_beat_times_v1`. Nova cannot distinguish an absent feature from an absent value, so anything it should render conditionally has to be announced rather than inferred. Availability is reported separately from `beat_times_lookup`: the estimate comes from the bundled dataset and is always served, while that setting only decides whether unknown titles are resolved over the network.

This records and detects the drift. It does not fix it — that needs Nova to read the three fields it ignores, and a decision on whether Polaris should serve the six Nova asks for or Nova should stop asking.

## Scoping, and two false starts worth recording

Both mistakes were the same one, and it is the mistake this tooling exists to prevent.

A first cross-check compared Nova's 212 read keys against Polaris file-wide and reported only 4 mismatches. It missed `platform` and `runtime`, because those literals do appear in Polaris — just not on the game object.

The script then repeated the error at file scope and reported six fields as missing that are really nested `launch_mode` and `mode` fields, unpacked from the same Nova file through different receiver variables. The manifest now pins the receiver (`json`), which is what actually scopes a read to one object. A checker that cries wolf gets ignored, so this mattered more than it appears.

## Exact candidate

- `Commit: 6e21631dfb691f42ddf95b5632e9cdb91f339bf5`
- `Tree:   89f02ed8925ab0147a553ea069653a78f284207d`
- `Parent: f2b971d59f0ae6d4f9076310f96477d1d7519e4d`
- `Base:   f2b971d59f0ae6d4f9076310f96477d1d7519e4d`

## Verification

Built and run on pc-papi (Fedora) from this branch:

- [x] Full `ninja`, exit 0, no failed targets and no new warnings
- [x] `ctest` — 17/17 targets pass, 0 failures
- [x] `test_polaris_audit` — `NovaContractTests` 3/3
- [x] Mutation probe: renaming a served field (`play_time` → `playtime`) fails the manifest test in both directions with the actionable message, naming the added field and the now-unserved one. Restoring returns 3/3, so the guard is load-bearing rather than incidentally green.
- [x] `scripts/check-nova-contract.py --nova ~/Documents/github/nova` against the real Nova checkout — `Polaris serves 17, Nova reads 20`, no new drift, 9 known outstanding, exit 0.

Not covered, and worth stating plainly:

- Only the `game` object is modelled. It is where the drift was found and the largest shared surface, but `/polaris/v1/` has many other responses — `capabilities`, `session/status`, `client-settings`, `stream-policy`, `optimizer/*` — and none are covered yet. The manifest is versioned to grow.
- The script cannot run in Polaris CI, because Nova is not present. It is a local tool until something has both checkouts.
- Nothing here changes what Polaris serves, so no client behaviour changes from this PR alone.
