### PR TITLE
feat(api): derive the Nova contract from the source that serves it

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -52,6 +52,183 @@
         "file": "app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt",
         "function": "fromJson",
         "receiver": "json"
+      },
+      "required_by_nova": {
+        "$comment": "Fields Nova reads. Anything else Polaris serves here is informational.",
+        "note": "Nova reads every field this object serves."
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "variable": "game",
+        "style": "subscript"
+      }
+    },
+    "launch_mode": {
+      "$comment": "Nested under game, built by build_launch_mode_contract. Aligned in both directions. An earlier revision recorded drift here because the field list was extracted from the thin launch_mode_contract_for_app wrapper, and the range ran on into steam_launch_contract_for_app and reported that object's fields instead.",
+      "fields": [
+        "allowed_modes",
+        "mode_reason",
+        "preferred_mode",
+        "recommended_mode"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt",
+        "function": "fromJson",
+        "receiver": "modeJson"
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "function": "build_launch_mode_contract",
+        "variable": "launch_mode",
+        "style": "subscript"
+      }
+    },
+    "steam_launch": {
+      "$comment": "Nested under game. The reference case: identical shape to launch_mode and currently aligned in both directions.",
+      "fields": [
+        "allowed_modes",
+        "available",
+        "mode",
+        "mode_reason",
+        "recommended_mode"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt",
+        "function": "fromJson",
+        "receiver": "launchJson"
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "function": "steam_launch_contract_for_app",
+        "variable": "contract",
+        "style": "subscript"
+      }
+    },
+    "session_capture": {
+      "$comment": [
+        "The `capture` object of /polaris/v1/session/status.",
+        "Most of this is diagnostic and going unread is not a defect. The exceptions are",
+        "called out in informational_ok below."
+      ],
+      "fields": [
+        "backend",
+        "cpu_copy",
+        "cross_gpu_dmabuf_risk",
+        "device",
+        "effective_headless",
+        "encoder_adapter",
+        "format",
+        "gpu_native",
+        "gpu_native_override_active",
+        "path",
+        "reason",
+        "reason_message",
+        "requested_headless",
+        "residency",
+        "resolution",
+        "transport"
+      ],
+      "informational_ok": [
+        "backend",
+        "cpu_copy",
+        "device",
+        "effective_headless",
+        "encoder_adapter",
+        "reason_message",
+        "requested_headless",
+        "resolution",
+        "cross_gpu_dmabuf_risk",
+        "gpu_native",
+        "gpu_native_override_active"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/api/PolarisApiClient.kt",
+        "function": "parseSessionStatusResponse",
+        "receiver": "capture"
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "variable": "capture_info",
+        "style": "subscript"
+      }
+    },
+    "session_encoder": {
+      "$comment": "The `encoder` object of /polaris/v1/session/status.",
+      "fields": [
+        "active_backend",
+        "bitrate_kbps",
+        "codec",
+        "encode_target_fps",
+        "fps",
+        "optimization_cache_status",
+        "optimization_confidence",
+        "optimization_normalization_reason",
+        "optimization_reasoning",
+        "optimization_source",
+        "pacing_policy",
+        "recommendation_version",
+        "requested_client_fps",
+        "session_target_fps",
+        "target_device",
+        "target_format",
+        "target_residency"
+      ],
+      "informational_ok": [
+        "active_backend"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/api/PolarisApiClient.kt",
+        "function": "parseSessionStatusResponse",
+        "receiver": "encoder"
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "variable": "encoder",
+        "style": "subscript"
+      }
+    },
+    "linux_gpu_profile": {
+      "$comment": [
+        "The `linux_gpu_profile` object of /polaris/v1/session/status.",
+        "This is where Nova gets its authoritative GPU-native answer, not from the capture",
+        "object, which is why capture.gpu_native and capture.cross_gpu_dmabuf_risk going",
+        "unread is redundancy rather than a gap."
+      ],
+      "fields": [
+        "adapter_matches_capture_device",
+        "adapter_matches_wayland_main_device",
+        "adapter_pairing_device",
+        "adapter_pairing_device_source",
+        "adapter_pairing_status",
+        "capture_device",
+        "configuration_warnings",
+        "cross_gpu_dmabuf_risk",
+        "encoder_adapter",
+        "encoder_api",
+        "gpu_native_attempted",
+        "gpu_native_requested",
+        "gpu_native_succeeded",
+        "vaapi_vendor",
+        "wayland_main_device"
+      ],
+      "informational_ok": [
+        "adapter_matches_wayland_main_device",
+        "adapter_pairing_device",
+        "adapter_pairing_device_source",
+        "adapter_pairing_status",
+        "configuration_warnings",
+        "wayland_main_device"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/api/PolarisApiClient.kt",
+        "function": "parseLinuxGpuProfile",
+        "receiver": "json"
+      },
+      "polaris_emitter": {
+        "file": "src/stream_stats.cpp",
+        "function": "linux_gpu_profile_json",
+        "declaration": "nlohmann::json profile = {",
+        "style": "initializer_list"
       }
     }
   },
@@ -76,7 +253,21 @@
     },
     "polaris_sends_nova_never_reads": {
       "$comment": "None. Nova's game adapter on origin/master reads every field Polaris serves, including play_time, beat_time and artwork.",
-      "game": []
+      "game": [],
+      "session_capture": []
+    },
+    "$detail": {
+      "session_capture": [
+        "Corrected. Nova reads gpu_native_succeeded and cross_gpu_dmabuf_risk from the",
+        "linux_gpu_profile object instead, so the same fields on capture are redundant rather",
+        "than missed. An earlier revision recorded them as drift because linux_gpu_profile was",
+        "not modelled at all."
+      ],
+      "linux_gpu_profile": [
+        "Resolved. Nova read vaapi_vendor and Polaris never served it; vaapi.cpp logged the",
+        "string at encoder creation without publishing it. It is now recorded in stats and",
+        "served in this object, which is what names the driver generation in a crash report."
+      ]
     }
   }
 }

--- a/scripts/check-nova-contract.py
+++ b/scripts/check-nova-contract.py
@@ -51,7 +51,12 @@ def function_body(source: str, name: str) -> str:
 def reads_for_object(source: str, reader: dict) -> set[str]:
     """Keys read for one contract object."""
     body = function_body(source, reader["function"])
-    pattern = re.compile(rf'\b{re.escape(reader["receiver"])}\.(?:{ACCESSORS})\(\s*"([a-zA-Z_0-9]+)"')
+    # `?.` as well as `.`: Nova reaches nullable sub-objects with the safe-call
+    # operator, and requiring a bare dot silently reports every one of their
+    # fields as unread.
+    pattern = re.compile(
+        rf'\b{re.escape(reader["receiver"])}\??\.(?:{ACCESSORS})\(\s*"([a-zA-Z_0-9]+)"'
+    )
     return set(pattern.findall(body))
 
 
@@ -74,40 +79,51 @@ def main() -> int:
     args = parser.parse_args()
 
     manifest = polaris_manifest(args.polaris)
-    game = manifest["objects"]["game"]
-    served = set(game["fields"])
-    read = nova_reads(args.nova, game["nova_reader"])
-
     drift = manifest.get("known_drift", {})
-    known_missing = set(drift.get("nova_reads_polaris_never_sends", {}).get("game", []))
-    known_unread = set(drift.get("polaris_sends_nova_never_reads", {}).get("game", []))
+    known_missing = drift.get("nova_reads_polaris_never_sends", {})
+    known_unread = drift.get("polaris_sends_nova_never_reads", {})
 
-    # Nova asks, Polaris never answers. Nova defaults these, so the symptom is a
-    # blank or "unknown" in the UI rather than an error.
-    missing = read - served
-    # Polaris answers, Nova never asks. The feature ships and stays invisible.
-    unread = served - read
+    sources: dict[Path, str] = {}
+    new_findings = 0
 
-    new_missing = sorted(missing - known_missing)
-    new_unread = sorted(unread - known_unread)
-    fixed = sorted((known_missing - missing) | (known_unread - unread))
+    for name, obj in manifest["objects"].items():
+        reader = obj["nova_reader"]
+        path = args.nova / reader["file"]
+        if not path.is_file():
+            raise SystemExit(f"not found: {path}\nIs --nova pointing at a Nova checkout?")
+        if path not in sources:
+            sources[path] = path.read_text()
 
-    print(f"game object: Polaris serves {len(served)}, Nova reads {len(read)}")
+        served = set(obj["fields"])
+        read = reads_for_object(sources[path], reader)
 
-    for field in new_missing:
-        print(f"  DRIFT  Nova reads [{field}] that Polaris never serves")
-    for field in new_unread:
-        print(f"  DRIFT  Polaris serves [{field}] that Nova never reads")
-    for field in fixed:
-        print(f"  FIXED  [{field}] is no longer drifting; remove it from known_drift")
+        # Not every served field has to be consumed. A host may publish diagnostics a
+        # client has no use for, so only fields absent from informational_ok count.
+        informational = set(obj.get("informational_ok", []))
 
-    if not (new_missing or new_unread or fixed):
-        print("  no new drift")
+        missing = read - served
+        unread = served - read - informational
 
-    if missing & known_missing or unread & known_unread:
-        print(f"\n{len(missing & known_missing) + len(unread & known_unread)} known drift field(s) still outstanding")
+        fresh_missing = sorted(missing - set(known_missing.get(name, [])))
+        fresh_unread = sorted(unread - set(known_unread.get(name, [])))
+        outstanding = len(missing & set(known_missing.get(name, []))) + len(
+            unread & set(known_unread.get(name, []))
+        )
 
-    return 1 if (new_missing or new_unread) else 0
+        status = "drift" if (fresh_missing or fresh_unread) else "ok"
+        print(f"{name}: Polaris serves {len(served)}, Nova reads {len(read)} [{status}]")
+        for field in fresh_missing:
+            print(f"    DRIFT  Nova reads [{field}] that Polaris never serves")
+        for field in fresh_unread:
+            print(f"    DRIFT  Polaris serves [{field}] that Nova never reads")
+        if outstanding:
+            print(f"    {outstanding} known drift field(s) still outstanding")
+
+        new_findings += len(fresh_missing) + len(fresh_unread)
+
+    print()
+    print("no new drift" if not new_findings else f"{new_findings} new drift field(s)")
+    return 1 if new_findings else 0
 
 
 if __name__ == "__main__":

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -31,6 +31,7 @@ extern "C" {
 #include "misc.h"
 #include "src/config.h"
 #include "src/logging.h"
+#include "src/stream_stats.h"
 #include "src/platform/common.h"
 #include "src/utility.h"
 #include "src/video.h"
@@ -535,7 +536,12 @@ namespace va {
       return -1;
     }
 
-    BOOST_LOG(info) << "vaapi vendor: "sv << vaQueryVendorString(display.get());
+    // Publish it as well as logging it. Nova asks for this on every session and a
+    // crash report that names the driver generation is worth more than one that
+    // makes the reader guess from a GPU model.
+    const auto *vendor = vaQueryVendorString(display.get());
+    BOOST_LOG(info) << "vaapi vendor: "sv << vendor;
+    stream_stats::update_vaapi_vendor(vendor ? vendor : "");
 
     *hw_device_buf = av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_VAAPI);
     auto ctx = (AVHWDeviceContext *) (*hw_device_buf)->data;

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -325,6 +325,7 @@ namespace stream_stats {
       {"adapter_pairing_status", adapter_pairing_status},
       {"adapter_pairing_device", adapter_pairing_device},
       {"adapter_pairing_device_source", adapter_pairing_device_source},
+      {"vaapi_vendor", stats.vaapi_vendor},
       {"cross_gpu_dmabuf_risk", capture_path_has_cross_gpu_dmabuf_risk(stats)},
       {"gpu_native_requested", gpu_native_requested},
       {"gpu_native_attempted", stats.gpu_native_probe.headless_extcopy.attempted || stats.gpu_native_probe.windowed.attempted || (gpu_native_requested && capture_metadata_reported)},
@@ -962,6 +963,11 @@ namespace stream_stats {
   void update_wayland_main_device(const std::string &device) {
     std::lock_guard<std::mutex> lock(stats_mutex);
     current_stats.wayland_main_device = device;
+  }
+
+  void update_vaapi_vendor(const std::string &vendor) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.vaapi_vendor = vendor;
   }
 
   void reset_gpu_native_probe(bool requested, bool reset_capture_identity) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -93,6 +93,7 @@ namespace stream_stats {
     platf::frame_format_e capture_format = platf::frame_format_e::unknown;
     std::string capture_device;
     std::string wayland_main_device;
+    std::string vaapi_vendor;  ///< VA-API vendor string, e.g. the Mesa driver and its generation.
     gpu_native_probe_t gpu_native_probe;
     std::string encode_target_device;
     platf::frame_residency_e encode_target_residency = platf::frame_residency_e::unknown;
@@ -346,6 +347,17 @@ namespace stream_stats {
    * @param device Render-node path, or empty when the compositor did not advertise one.
    */
   void update_wayland_main_device(const std::string &device);
+
+  /**
+   * @brief Record the VA-API vendor string reported by the driver.
+   *
+   * Nova reads `vaapi_vendor` from the Linux GPU profile and has never received
+   * it. The string names the driver and its generation, which is what separates
+   * one radeonsi generation from another in a crash report.
+   *
+   * @param vendor Vendor string from vaQueryVendorString, or empty when unknown.
+   */
+  void update_vaapi_vendor(const std::string &vendor);
 
   /** @brief Reset GPU-native probe telemetry for a new cage launch decision. */
   void reset_gpu_native_probe(bool requested, bool reset_capture_identity = false);

--- a/tests/integration/test_nova_contract.cpp
+++ b/tests/integration/test_nova_contract.cpp
@@ -7,10 +7,15 @@
  * silently gets its fallback. Nova ships from a separate repository, so no build
  * here can check it directly.
  *
- * What this can do is refuse to let Polaris change the shape of a response
- * without saying so in docs/nova-contract.json, which is the record both sides
- * review against. scripts/check-nova-contract.py does the other half against a
- * Nova checkout.
+ * What this can do is derive what Polaris actually serves, straight from the
+ * source that serves it, and refuse to let docs/nova-contract.json disagree.
+ * That derivation is the point: every field list in that manifest was originally
+ * written by hand from ad-hoc greps, and every one of them was wrong somewhere —
+ * a `"x"` from a "1920x1080" concatenation counted as a field, a function range
+ * that ran past its own body and reported the next object's fields as its own.
+ * A manifest is only worth as much as the extraction behind it.
+ *
+ * scripts/check-nova-contract.py does the other half against a Nova checkout.
  */
 #include <algorithm>
 #include <filesystem>
@@ -18,6 +23,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -31,68 +37,184 @@ namespace {
     return buffer.str();
   }
 
-  /// Every key assigned as `game["<key>"]` in the served source.
-  std::set<std::string> emitted_game_fields() {
-    const auto source = read_source_file("src/nvhttp.cpp");
-    std::set<std::string> fields;
+  bool is_identifier_char(char c) {
+    return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+  }
 
-    constexpr std::string_view prefix = "game[\"";
+  /**
+   * @brief The body of a C++ function, by brace matching from its signature.
+   *
+   * Brace matching rather than "up to the next function", because a range that
+   * overruns its own body is what made an earlier revision of the manifest
+   * report `steam_launch`'s fields as `launch_mode`'s.
+   */
+  std::string function_body(const std::string &source, const std::string &name) {
+    // The definition, not the first mention. A call site appears earlier in the
+    // file for at least one of these, and matching it silently scopes to some
+    // unrelated block — which is how this extractor first derived nothing at all.
+    std::size_t open = std::string::npos;
+    for (std::size_t sig = source.find(name + "("); sig != std::string::npos;
+         sig = source.find(name + "(", sig + 1)) {
+      if (sig > 0 && is_identifier_char(source[sig - 1])) {
+        continue;
+      }
+
+      int parens = 0;
+      std::size_t close = std::string::npos;
+      for (std::size_t i = source.find('(', sig); i < source.size(); ++i) {
+        if (source[i] == '(') {
+          ++parens;
+        } else if (source[i] == ')' && --parens == 0) {
+          close = i;
+          break;
+        }
+      }
+      if (close == std::string::npos) {
+        continue;
+      }
+
+      const auto next = source.find_first_not_of(" \t\n", close + 1);
+      if (next != std::string::npos && source[next] == '{') {
+        open = next;
+        break;
+      }
+    }
+
+    if (open == std::string::npos) {
+      return {};
+    }
+
+    int depth = 0;
+    bool in_string = false;
+    for (std::size_t i = open; i < source.size(); ++i) {
+      const char c = source[i];
+      if (in_string) {
+        if (c == '\\') {
+          ++i;
+        } else if (c == '"') {
+          in_string = false;
+        }
+        continue;
+      }
+      if (c == '"') {
+        in_string = true;
+      } else if (c == '{') {
+        ++depth;
+      } else if (c == '}' && --depth == 0) {
+        return source.substr(open, i - open + 1);
+      }
+    }
+
+    return {};
+  }
+
+  /// Keys from `variable["key"] = ...` assignments.
+  std::set<std::string> subscript_keys(const std::string &scope, const std::string &variable) {
+    std::set<std::string> keys;
+    const std::string needle = variable + "[\"";
+
     std::size_t pos = 0;
-    while ((pos = source.find(prefix, pos)) != std::string::npos) {
-      const auto start = pos + prefix.size();
-      const auto end = source.find('"', start);
+    while ((pos = scope.find(needle, pos)) != std::string::npos) {
+      // Reject a longer identifier ending in the variable name, so `encoder`
+      // does not also match `some_encoder`.
+      if (pos > 0 && is_identifier_char(scope[pos - 1])) {
+        pos += needle.size();
+        continue;
+      }
+
+      const auto start = pos + needle.size();
+      const auto end = scope.find('"', start);
       if (end == std::string::npos) {
         break;
       }
-      // Only assignments define the response shape; a read would not.
-      const auto after = source.find_first_not_of(" \t", source.find(']', end) + 1);
-      if (after != std::string::npos && source[after] == '=' && source[after + 1] != '=') {
-        fields.insert(source.substr(start, end - start));
+
+      // Only assignments define the shape. A read would not, and neither would
+      // a subscript used inside a larger expression.
+      const auto bracket = scope.find(']', end);
+      const auto after = scope.find_first_not_of(" \t\n", bracket + 1);
+      if (after != std::string::npos && scope[after] == '=' && scope[after + 1] != '=') {
+        keys.insert(scope.substr(start, end - start));
       }
       pos = end;
     }
 
-    return fields;
+    return keys;
   }
 
-  std::set<std::string> manifest_game_fields() {
-    const auto manifest = nlohmann::json::parse(read_source_file("docs/nova-contract.json"));
-    std::set<std::string> fields;
-    for (const auto &field : manifest["objects"]["game"]["fields"]) {
-      fields.insert(field.get<std::string>());
+  /// Keys from a brace-initialised object: `{"key", value},`.
+  std::set<std::string> initializer_keys(const std::string &scope) {
+    std::set<std::string> keys;
+    std::size_t pos = 0;
+    while ((pos = scope.find("{\"", pos)) != std::string::npos) {
+      const auto start = pos + 2;
+      const auto end = scope.find('"', start);
+      if (end == std::string::npos) {
+        break;
+      }
+      const auto after = scope.find_first_not_of(" \t\n", end + 1);
+      if (after != std::string::npos && scope[after] == ',') {
+        keys.insert(scope.substr(start, end - start));
+      }
+      pos = end;
     }
-    return fields;
+    return keys;
+  }
+
+  std::set<std::string> emitted_fields(const nlohmann::json &emitter) {
+    const auto source = read_source_file(emitter.at("file").get<std::string>());
+    const auto scope = emitter.contains("function") ?
+                         function_body(source, emitter.at("function").get<std::string>()) :
+                         source;
+
+    if (emitter.at("style") == "initializer_list") {
+      // The declaration only, so sibling objects built in the same function —
+      // configuration_warnings entries, for instance — stay out of it.
+      const auto decl = scope.find(emitter.at("declaration").get<std::string>());
+      return decl == std::string::npos ? std::set<std::string> {} : initializer_keys(scope.substr(decl));
+    }
+
+    return subscript_keys(scope, emitter.at("variable").get<std::string>());
+  }
+
+  nlohmann::json manifest() {
+    return nlohmann::json::parse(read_source_file("docs/nova-contract.json"));
   }
 }  // namespace
 
-TEST(NovaContractTests, TheManifestListsExactlyTheGameFieldsPolarisServes) {
-  const auto emitted = emitted_game_fields();
-  const auto declared = manifest_game_fields();
+TEST(NovaContractTests, EveryManifestObjectMatchesWhatPolarisActuallyServes) {
+  const auto contract = manifest();
 
-  ASSERT_FALSE(emitted.empty()) << "no game fields found in src/nvhttp.cpp; the scan is broken, "
-                                   "not the contract";
+  for (const auto &[name, object] : contract["objects"].items()) {
+    SCOPED_TRACE(name);
+    ASSERT_TRUE(object.contains("polaris_emitter"))
+      << "object [" << name << "] has no polaris_emitter, so its field list is hand-written "
+      << "and nothing checks it against the source that serves it";
 
-  std::vector<std::string> undeclared;
-  std::set_difference(
-    emitted.begin(), emitted.end(),
-    declared.begin(), declared.end(),
-    std::back_inserter(undeclared)
-  );
-  std::vector<std::string> unserved;
-  std::set_difference(
-    declared.begin(), declared.end(),
-    emitted.begin(), emitted.end(),
-    std::back_inserter(unserved)
-  );
+    const auto emitted = emitted_fields(object["polaris_emitter"]);
+    ASSERT_FALSE(emitted.empty())
+      << "derived no fields for [" << name << "]; the extractor is broken, not the contract";
 
-  for (const auto &field : undeclared) {
-    ADD_FAILURE() << "game field [" << field << "] is served but missing from docs/nova-contract.json. "
-                  << "Add it there in this commit so the Nova side has something to review against.";
-  }
-  for (const auto &field : unserved) {
-    ADD_FAILURE() << "docs/nova-contract.json declares game field [" << field << "] that Polaris no "
-                  << "longer serves. Removing a field Nova may still read is exactly the change "
-                  << "that degrades silently — remove it here only once Nova has stopped reading it.";
+    std::set<std::string> declared;
+    for (const auto &field : object["fields"]) {
+      declared.insert(field.get<std::string>());
+    }
+
+    std::vector<std::string> undeclared;
+    std::set_difference(emitted.begin(), emitted.end(), declared.begin(), declared.end(),
+                        std::back_inserter(undeclared));
+    std::vector<std::string> unserved;
+    std::set_difference(declared.begin(), declared.end(), emitted.begin(), emitted.end(),
+                        std::back_inserter(unserved));
+
+    for (const auto &field : undeclared) {
+      ADD_FAILURE() << "[" << name << "] serves [" << field << "] but the manifest omits it. "
+                    << "Add it in this commit so the Nova side has something to review against.";
+    }
+    for (const auto &field : unserved) {
+      ADD_FAILURE() << "[" << name << "] declares [" << field << "] that Polaris does not serve. "
+                    << "Removing a field Nova may still read degrades silently, so drop it here "
+                    << "only once Nova has stopped reading it.";
+    }
   }
 }
 
@@ -107,30 +229,51 @@ TEST(NovaContractTests, NewLibraryFeaturesAreDeclaredInCapabilities) {
   }
 }
 
-TEST(NovaContractTests, KnownDriftStaysRecordedUntilItIsFixed) {
-  const auto manifest = nlohmann::json::parse(read_source_file("docs/nova-contract.json"));
-  const auto &drift = manifest["known_drift"];
+TEST(NovaContractTests, KnownDriftNamesFieldsThatStillExist) {
+  const auto contract = manifest();
+  const auto &drift = contract["known_drift"];
 
   ASSERT_TRUE(drift.contains("nova_reads_polaris_never_sends"));
   ASSERT_TRUE(drift.contains("polaris_sends_nova_never_reads"));
 
-  // A field recorded as served-but-unread must at least still be served, or the
-  // record describes something that no longer exists. The list is empty today:
-  // Nova reads everything Polaris serves on the game object.
-  const auto emitted = emitted_game_fields();
-  for (const auto &field : drift["polaris_sends_nova_never_reads"]["game"]) {
-    const auto name = field.get<std::string>();
-    SCOPED_TRACE(name);
-    EXPECT_TRUE(emitted.count(name) > 0)
-      << "known_drift claims Polaris serves [" << name << "] but it is no longer emitted; "
-      << "update docs/nova-contract.json";
+  // A field recorded as served-but-unread must still be served, or the record
+  // describes something that no longer exists.
+  for (const auto &[object_name, fields] : drift["polaris_sends_nova_never_reads"].items()) {
+    if (object_name.starts_with("$") || !contract["objects"].contains(object_name)) {
+      continue;
+    }
+    const auto emitted = emitted_fields(contract["objects"][object_name]["polaris_emitter"]);
+    for (const auto &field : fields) {
+      const auto name = field.get<std::string>();
+      SCOPED_TRACE(object_name + "." + name);
+      EXPECT_TRUE(emitted.count(name) > 0)
+        << "known_drift claims Polaris serves it, but it is not emitted";
+    }
   }
 
-  // Scope is what made the first version of this record wrong, twice over, so it
-  // is pinned rather than left to whoever edits the manifest next.
-  const auto &reader = manifest["objects"]["game"]["nova_reader"];
-  EXPECT_TRUE(reader.contains("function"))
-    << "nova_reader must name the function to scope reads to; Nova gives four "
-       "functions in that file a parameter called `json`, so receiver scoping "
-       "silently mixes artwork fields into the game set";
+  // And a field recorded as read-but-unserved must genuinely be unserved, or the
+  // drift has been fixed and the record is now the stale part.
+  for (const auto &[object_name, fields] : drift["nova_reads_polaris_never_sends"].items()) {
+    if (object_name.starts_with("$") || !contract["objects"].contains(object_name)) {
+      continue;
+    }
+    const auto emitted = emitted_fields(contract["objects"][object_name]["polaris_emitter"]);
+    for (const auto &field : fields) {
+      const auto name = field.get<std::string>();
+      SCOPED_TRACE(object_name + "." + name);
+      EXPECT_EQ(0U, emitted.count(name))
+        << "known_drift says Polaris never serves this, but it does now; remove the entry";
+    }
+  }
+}
+
+TEST(NovaContractTests, EveryObjectNamesTheFunctionScopingItsNovaReads) {
+  // Scope is what went wrong repeatedly on the Nova side too, so it is pinned
+  // rather than left to whoever edits the manifest next.
+  for (const auto &[name, object] : manifest()["objects"].items()) {
+    SCOPED_TRACE(name);
+    EXPECT_TRUE(object["nova_reader"].contains("function"))
+      << "nova_reader must name a function; Nova gives several functions in the same file "
+         "a parameter called `json`, so file or receiver scoping silently mixes objects";
+  }
 }


### PR DESCRIPTION
## Summary

Extends the Nova contract from one object to six, and — more importantly — makes Polaris' side of every one of them **derived from the source that serves it** rather than written by hand.

The hand-written approach did not survive contact. Every field list in the first version of this branch was extracted with ad-hoc greps, and every one was wrong somewhere:

| Object | Hand-written error |
|---|---|
| `launch_mode` | The extraction range started at a thin wrapper and ran past it into `steam_launch_contract_for_app`, so that object's `mode` and `available` were reported as `launch_mode`'s. Produced a confident, detailed, entirely fictional finding that Nova never receives the host's per-app launch mode. |
| `session_capture` | `"x"` from a `WIDTH "x" HEIGHT` concatenation counted as a field; `screencopy` listed but never served. |
| `linux_gpu_profile` | Not modelled at all, which is why `capture.gpu_native` looked like a gap. |

So the useful change here is not the extra objects, it is that `tests/integration/test_nova_contract.cpp` now derives each object's fields by parsing the emitter — brace-matched function bodies, subscript assignments or brace-initialiser entries — and fails when `docs/nova-contract.json` disagrees in either direction. The manifest can no longer be more optimistic than the code.

That derivation immediately caught two further mistakes in this very branch (`vaapi_vendor` omitted, `screencopy` phantom), which is the argument for it.

## What survived verification

**One real finding, now fixed.** Nova reads `vaapi_vendor` from the Linux GPU profile and Polaris had never served it. Polaris *had* the value — `vaapi.cpp` logged `vaapi vendor: …` at encoder creation — it simply never published it. That is the Mesa driver string that distinguishes radeonsi generations, absent from exactly the diagnostics the AMD/VAAPI crash work in #212 depends on. It is now recorded in `stream_stats` and served in the profile.

**Two apparent findings that were my error, not the code's:**

- `launch_mode` is aligned 4/4. Polaris serves `preferred_mode`, `recommended_mode`, `allowed_modes`, `mode_reason`; Nova reads exactly those.
- `capture.gpu_native` and `capture.cross_gpu_dmabuf_risk` going unread is redundancy, not a gap — Nova takes the same truth from `linux_gpu_profile.gpu_native_succeeded`, which had not been modelled.

**Current state**, all six objects, derived and cross-checked:

```
game:              Polaris 17, Nova 23   6 known outstanding
launch_mode:       Polaris  4, Nova  4   aligned
steam_launch:      Polaris  5, Nova  5   aligned
session_capture:   Polaris 16, Nova  7   aligned
session_encoder:   Polaris 17, Nova 16   aligned
linux_gpu_profile: Polaris 15, Nova  9   aligned
```

`informational_ok` per object keeps unread diagnostics from reading as failures — a host may legitimately publish more than a client needs, and without it this report is noise.

## Exact candidate

- `Commit: 9517c80f4f314b5b52b7f563c1b96feeccba8d1d`
- `Tree:   004d6c231aa48b89893ab83ff32f384ee3dbb9f0`
- `Parent: cbcd044c6b84ca5755474f886192dcb5881167cf`
- `Base:   cbcd044c6b84ca5755474f886192dcb5881167cf`

## Verification

On pc-papi, against a detached `origin/master` worktree of Nova rather than that host's divergent working tree:

- [x] Full `ninja`, exit 0
- [x] `ctest` — 17/17
- [x] `test_polaris_audit` — `NovaContractTests` 4/4
- [x] `scripts/check-nova-contract.py` — six objects, `no new drift`, exit 0
- [x] The derivation was exercised against its own failure modes during development: it correctly reported `vaapi_vendor` missing from the manifest, `screencopy` declared but unserved, and — when the extractor matched a call site instead of a definition — refused to pass with an empty field set rather than silently reporting no drift

Not covered, and worth stating plainly:

- The extractor is regex and brace matching over C++ and Kotlin, not a parser. It handles the six emitters here and the two Nova adapters. A macro-generated field, a computed key, or an expression-bodied Kotlin function would defeat it, and it would report an empty set rather than a wrong one — which is why the empty-set guard is an assertion.
- `informational_ok` is a hand-recorded judgement. If a field later starts mattering to a client, nothing notices until someone moves it.
- The remaining `/polaris/v1/` responses — `capabilities`, `client-settings`, `stream-policy`, `optimizer/*` — are still unmodelled.
- The six `game` fields Nova reads and Polaris never serves are recorded, not fixed. That still needs a decision on whether Polaris serves them or Nova stops asking.
