### PR TITLE
docs: warn that upgrading is what leaves a shadowing /etc rules copy

### DIFF
--- a/docs/release-notes/v1.3.5.md
+++ b/docs/release-notes/v1.3.5.md
@@ -12,6 +12,14 @@ Two things about this upgrade are worth reading before you run it.
 
 `--setup-host` also no longer needs `sudo` when the package already provides everything and the virtual input nodes are usable — it reports that there is nothing to do and exits. It still needs root when it has to write `/etc` or apply `--enable-kms`.
 
+**If you ran `--setup-host` on any earlier version, check for a shadowing copy.** Host setup removes an `/etc` copy only when its contents still match the file the running Polaris ships. A copy written by an older version does not match, so it is kept with a warning rather than deleted — nothing can distinguish it from one you edited yourself. Until it is removed it overrides the packaged rules, and the seat isolation rules never apply however the option is set. If `--setup-host` warns about `/etc/udev/rules.d/60-polaris.rules` and you did not edit it yourself:
+
+```bash
+sudo rm /etc/udev/rules.d/60-polaris.rules
+sudo udevadm control --reload-rules
+grep -c seat-isolated /usr/lib/udev/rules.d/60-polaris.rules   # expect 4
+```
+
 ### Fedora 44
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -100,12 +100,30 @@ sudo usermod -aG input "$USER"
 Then sign out and back in.
 
 If Polaris was installed before the rules became package files, an older copy may still sit in
-`/etc/udev/rules.d/60-polaris.rules`. `/etc` overrides the packaged file, so that copy would keep
-shadowing later fixes. Running host setup once removes it when it is Polaris' own leftover, and
-leaves it alone with a warning when you have edited it:
+`/etc/udev/rules.d/60-polaris.rules`. `/etc` overrides the packaged file, so that copy keeps
+shadowing later fixes — including the seat isolation rules, which then never apply no matter what
+the configuration says.
 
 ```bash
 sudo -H polaris --setup-host
+```
+
+Host setup removes that copy only when its contents still match the file this Polaris ships. An
+older version's copy does not match — that is what upgrading changed — so it is **kept**, with a
+warning naming the file, because nothing can tell it apart from a copy you edited yourself. Upgrading
+is therefore the case most likely to leave a shadowing file behind.
+
+If you did not edit it, remove it and reload:
+
+```bash
+sudo rm /etc/udev/rules.d/60-polaris.rules
+sudo udevadm control --reload-rules
+```
+
+Then confirm the packaged rules are the ones in effect:
+
+```bash
+grep -c seat-isolated /usr/lib/udev/rules.d/60-polaris.rules
 ```
 
 ## Client input also types into the host desktop

--- a/src_assets/common/assets/web/release-v135-contract.test.js
+++ b/src_assets/common/assets/web/release-v135-contract.test.js
@@ -105,7 +105,12 @@ describe('v1.3.5 release contract', () => {
       browser_download_url: `https://github.com/papi-ux/polaris/releases/download/v1.3.5/${name}`,
       packageFamily,
     }))
-    const documentedCommands = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)].map((match) => match[1])
+    // Install blocks only. The property under test is that the documented install
+    // commands match what the Update Center generates; treating every bash block as
+    // an install command also forbids the notes from showing any other example.
+    const documentedCommands = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
 
     for (const fact of ['v1.3.4', '.1', '.2', 'exact package filename']) {
       expect(releaseNotes).toContain(fact)


### PR DESCRIPTION
## Summary

Both documents described the `/etc` udev rules shadow backwards, and got the one case that matters most exactly wrong.

They said host setup *"removes it when it is Polaris' own leftover, and leaves it alone with a warning when you have edited it."* What the code actually does is remove it only when its contents **still match the file the running Polaris ships**. A copy written by an older version does not match — that is what upgrading changed — so it is kept with a warning instead, because nothing can distinguish it from a copy somebody edited deliberately.

So **upgrading is the case most likely to leave a shadowing file behind**, not the case that cleans it up. The docs promised the opposite.

This matters more than a stale file normally would: `/etc` overrides the packaged rules, so the seat isolation markers never reach udev and the feature silently does nothing however it is configured.

## Confirmed on real hardware, not inferred

Found while installing v1.3.5 on a Fedora host that had been running v1.3.4:

- `/etc/udev/rules.d/60-polaris.rules` was still present, dated from an earlier `--setup-host` run
- `--setup-host` removed the `modules-load` copy automatically, because it still matched, and **kept** the udev copy with the warning, because it did not
- The kept file was verified byte-identical to what `v1.3.4`, `v1.3.3` and pre-#285 shipped, so it was provably an unmodified Polaris leftover rather than a local edit
- It had been shadowing the packaged rules the whole time. The packaged file carries 4 seat isolation markers; none were in effect until the copy was removed by hand

The behaviour is correct — refusing to delete a file it cannot prove is disposable is the right call. Only the documentation was wrong.

## Changes

- `docs/release-notes/v1.3.5.md` gains an upgrade caveat naming the symptom, why upgrading is the risky case, and the removal plus the check that shows which file is in effect.
- `docs/troubleshooting.md` replaces the incorrect "removes leftovers, keeps edits" description with what the code does, and adds the same removal and verification.
- The published v1.3.5 release body has been synced to the corrected notes; its four assets are intact.

### One test assertion narrowed

`release-v135-contract.test.js` compared **every** bash block in the release notes against the three generated install commands, so adding any other example to the notes failed it. It now filters to blocks containing `wget --output-document=`.

The property under test is unchanged and still enforced: the documented install commands must match what the Update Center generates, which is the point of this release. It simply no longer forbids the notes from showing anything else.

## Exact candidate

- `Commit: ef019af0f176cd359c159c70f24d785951ef1d71`
- `Tree:   cbea4aa2334101d9bc004f981788aacc29bafc7d`
- `Parent: e43853e60ed42b002142924d3567fe9d67dedbdb`
- `Base:   e43853e60ed42b002142924d3567fe9d67dedbdb`

## Verification

On pc-papi:

- [x] `npx vitest run` — 50 files, 297 tests pass
- [x] `bash scripts/check-public-docs.sh` — exit 0
- [x] The narrowed assertion was confirmed to still fail on a mismatched install command, not merely to pass

Not covered, and worth stating plainly:

- Documentation only. No behaviour changes; `--setup-host` keeps refusing to delete a file it cannot prove is disposable.
- The tagged `v1.3.5` commit does not contain these notes, since it was tagged before this was written. The published release body was updated in place, so the release page and this branch agree while the tag does not.
- Anyone who already upgraded and did not read the warning still has the shadowing file. Nothing here reaches them; only the warning at their next `--setup-host` does.
