### PR TITLE
feat(library): serve platform and runtime from the Lutris runner already stored

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -32,14 +32,18 @@
         "launch_mode",
         "mangohud",
         "name",
+        "platform",
         "play_time",
+        "runtime",
         "source",
         "steam_appid",
         "steam_launch"
       ],
       "optional": [
         "beat_time",
-        "play_time"
+        "platform",
+        "play_time",
+        "runtime"
       ],
       "nova_reader": {
         "$comment": [
@@ -245,9 +249,7 @@
       "game": [
         "launcher_source",
         "launcher_detail",
-        "platform",
         "platform_label",
-        "runtime",
         "runtime_label"
       ]
     },
@@ -267,6 +269,15 @@
         "Resolved. Nova read vaapi_vendor and Polaris never served it; vaapi.cpp logged the",
         "string at encoder creation without publishing it. It is now recorded in stats and",
         "served in this object, which is what names the driver generation in a crash report."
+      ],
+      "game": [
+        "platform and runtime are now served, derived from the Lutris runner persisted at",
+        "import; they are omitted for apps whose runtime is not recorded, which Nova renders",
+        "as no badge. The remaining four are deliberate: launcher_source falls back to source",
+        "in Nova and would only matter if Polaris distinguished imported-from vs launched-via;",
+        "launcher_detail has no host-side value to serve; platform_label and runtime_label",
+        "exist so a server can label a value the client cannot map, and every value served",
+        "today is one Nova already maps."
       ]
     }
   }

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -6695,6 +6695,16 @@ namespace nvhttp {
         promote_local_artwork_poster(app);
         game["artwork"] = current_artwork_manifest(platf::appdata(), app.uuid);
         game["last_launched"] = app.last_launched;
+        // Platform and runtime only where the stored Lutris runner determines
+        // them; Nova renders nothing for a missing value, and no badge beats a
+        // wrong one for Steam or manual entries whose runtime is not recorded.
+        if (const auto identity = proc::launcher_identity_from_lutris_runner(app.lutris_runner);
+            !identity.runtime.empty()) {
+          if (!identity.platform.empty()) {
+            game["platform"] = identity.platform;
+          }
+          game["runtime"] = identity.runtime;
+        }
         if (const auto play_time = play_time_for_app(app)) {
           game["play_time"] = *play_time;
         }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -342,6 +342,31 @@ namespace proc {
     return _state == state_e::stopping || _stop_waiting || _launch_to_stop_handoff;
   }
 
+  launcher_identity_t launcher_identity_from_lutris_runner(const std::string &runner) {
+    auto normalized = boost::to_lower_copy(boost::trim_copy(runner));
+
+    // Lutris runner ids, mapped only where the runner determines the answer.
+    // The steam runner can launch native or Proton titles alike, so it names a
+    // runtime but no platform; anything unrecognized stays empty because a
+    // wrong badge in a client library is worse than a missing one.
+    if (normalized == "wine") {
+      return {"windows", "wine"};
+    }
+    if (normalized == "proton") {
+      return {"windows", "proton"};
+    }
+    if (normalized == "umu") {
+      return {"windows", "umu"};
+    }
+    if (normalized == "linux") {
+      return {"linux", "native"};
+    }
+    if (normalized == "steam") {
+      return {"", "steam"};
+    }
+    return {"", ""};
+  }
+
   std::string normalize_steam_launch_mode(std::string mode) {
     boost::trim(mode);
     boost::to_lower(mode);
@@ -8370,6 +8395,7 @@ namespace proc {
           ctx.steam_launch_mode = proc::normalize_steam_launch_mode(app_node.value("steam-launch-mode", "direct"));
           ctx.game_category = app_node.value("game-category", "");
           ctx.source = app_node.value("source", ctx.steam_appid.empty() ? "manual" : "steam");
+          ctx.lutris_runner = app_node.value("lutris-runner", "");
           ctx.last_launched = app_node.value("last-launched", (int64_t)0);
           if (app_node.contains("genres") && app_node["genres"].is_array()) {
             for (const auto &g : app_node["genres"]) {

--- a/src/process.h
+++ b/src/process.h
@@ -369,6 +369,7 @@ namespace proc {
     std::string steam_launch_mode = std::string {STEAM_LAUNCH_MODE_DIRECT};
     std::string game_category;  // "fast_action", "cinematic", "desktop", "vr", or ""
     std::string source;         // "steam", "lutris", "heroic", or "manual"
+    std::string lutris_runner;  // Lutris runner id persisted at import ("wine", "linux", ...), or ""
     std::vector<std::string> genres;
     std::map<std::string, std::string> env_vars;  // per-app environment variables
     int64_t last_launched = 0;  // unix timestamp (seconds since epoch)
@@ -384,6 +385,20 @@ namespace proc {
     int  scale_factor;
     std::chrono::seconds exit_timeout;
   };
+
+  /**
+   * @brief Platform and runtime derived from a Lutris runner id.
+   *
+   * Nova composes its library metadata line from these ("Lutris · Windows ·
+   * Wine") and renders nothing for an empty value, so unknown stays empty
+   * rather than guessed: a wrong label is worse than no label.
+   */
+  struct launcher_identity_t {
+    std::string platform;  ///< "linux", "windows", or "" when unknown.
+    std::string runtime;   ///< "native", "wine", "proton", "steam", "umu", or "".
+  };
+
+  launcher_identity_t launcher_identity_from_lutris_runner(const std::string &runner);
 
   enum class session_stop_outcome_t {
     allowed,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,6 +164,7 @@ set(TEST_CONFIG_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_device_db.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_display_device.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_entry_handler.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_launcher_identity.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_process_migration.cpp
 )
 

--- a/tests/unit/test_launcher_identity.cpp
+++ b/tests/unit/test_launcher_identity.cpp
@@ -1,0 +1,52 @@
+/**
+ * @file tests/unit/test_launcher_identity.cpp
+ * @brief Test the Lutris runner → platform/runtime mapping the library serves.
+ */
+#include "../tests_common.h"
+
+#include <src/process.h>
+
+TEST(LauncherIdentityTests, RunnersThatDetermineTheAnswerAreMapped) {
+  using proc::launcher_identity_from_lutris_runner;
+
+  const auto wine = launcher_identity_from_lutris_runner("wine");
+  EXPECT_EQ("windows", wine.platform);
+  EXPECT_EQ("wine", wine.runtime);
+
+  const auto proton = launcher_identity_from_lutris_runner("proton");
+  EXPECT_EQ("windows", proton.platform);
+  EXPECT_EQ("proton", proton.runtime);
+
+  const auto umu = launcher_identity_from_lutris_runner("umu");
+  EXPECT_EQ("windows", umu.platform);
+  EXPECT_EQ("umu", umu.runtime);
+
+  const auto native = launcher_identity_from_lutris_runner("linux");
+  EXPECT_EQ("linux", native.platform);
+  EXPECT_EQ("native", native.runtime);
+}
+
+TEST(LauncherIdentityTests, TheSteamRunnerNamesARuntimeButNoPlatform) {
+  // Lutris' steam runner launches native and Proton titles alike, so claiming
+  // a platform would be a guess.
+  const auto steam = proc::launcher_identity_from_lutris_runner("steam");
+  EXPECT_TRUE(steam.platform.empty());
+  EXPECT_EQ("steam", steam.runtime);
+}
+
+TEST(LauncherIdentityTests, UnknownStaysEmptyRatherThanGuessed) {
+  // Nova renders nothing for an empty value; a wrong badge in the library is
+  // worse than a missing one.
+  for (const auto runner : {"", "flatpak", "mame", "dosbox", "something-new"}) {
+    SCOPED_TRACE(runner);
+    const auto identity = proc::launcher_identity_from_lutris_runner(runner);
+    EXPECT_TRUE(identity.platform.empty());
+    EXPECT_TRUE(identity.runtime.empty());
+  }
+}
+
+TEST(LauncherIdentityTests, InputIsNormalizedBeforeMapping) {
+  const auto identity = proc::launcher_identity_from_lutris_runner("  Wine \n");
+  EXPECT_EQ("windows", identity.platform);
+  EXPECT_EQ("wine", identity.runtime);
+}


### PR DESCRIPTION
## Summary

- Nova composes its library metadata line ("Lutris · Windows · Wine") from `platform` and `runtime` and has read both since the fields were designed, but Polaris never served them — every deployed client renders no badge. The data was half captured all along: the Lutris import path persists the runner id into apps.json (`confighttp.cpp`), and nothing ever loaded it again.
- `ctx_t` now carries `lutris_runner`, loaded from that key, and a pure helper maps it only where the runner determines the answer: `wine`/`proton`/`umu` are Windows titles under their runtimes, `linux` is a native title. The `steam` runner names a runtime but **no platform**, because it launches native and Proton titles alike and claiming one would be a guess.
- Anything unrecognized — and every Steam or manual entry, whose runtime is simply not recorded — serves neither field. Nova renders nothing for a missing value, and no badge is better than a wrong one.
- The other four fields Nova reads stay deliberately unserved, recorded as such in the contract with the reasoning: `launcher_source` falls back to `source` in Nova and only carries information if Polaris ever distinguishes imported-from vs launched-via; `launcher_detail` has no host-side value; the `*_label` fields exist so a server can label a value the client cannot map, and every value served today is one Nova already maps.
- Host-side on purpose: every deployed Nova picks this up with no client release, the same argument that carried `vaapi_vendor`.

## Exact candidate

- `Commit: ff264d16a036986e4e79d5939f44f939441a0919`
- `Tree:   de01305f1bc0cc0f1a08f9ec621106678bb51d7e`
- `Parent: e43853e60ed42b002142924d3567fe9d67dedbdb`
- `Base:   e43853e60ed42b002142924d3567fe9d67dedbdb`

## Verification

Built and run on pc-papi (Fedora) from this branch:

- [x] Full `ninja`, exit 0
- [x] `ctest` — 17/17
- [x] `test_polaris_config` — `LauncherIdentityTests` 4/4: the determined mappings, the steam-runner platform refusal, unknown-stays-empty across five inputs, whitespace normalization
- [x] `test_polaris_audit` — `NovaContractTests` 4/4. The derivation test from #293 checked the manifest against the new emission automatically — its first real change since landing, and it required the manifest update in the same commit
- [x] `scripts/check-nova-contract.py` against a detached `origin/master` Nova worktree — `game: Polaris serves 19, Nova reads 23`, known drift down from 6 to 4, no new drift, exit 0

Not covered, and worth stating plainly:

- Not stream-tested end to end against a live Nova; the field shapes match Nova's adapter (`json.optString("platform")` etc.) by inspection and by the contract tooling.
- Runner ids beyond the five mapped come through as no badge, by design. If Lutris grows a runner worth mapping, it is one line plus one test case here.
- Only Lutris-imported apps gain badges. Steam titles' Proton-vs-native state is not recorded host-side today; serving it would mean reading Steam's compat config, which is its own change.
