### PR TITLE
fix(artwork): the resolve response says what it actually did

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -6884,11 +6884,22 @@ namespace nvhttp {
       const auto kind_is_missing = [&](game_artwork::kind_e kind) {
         return !game_artwork::find_cached_asset(appdata, app->uuid, kind).has_value();
       };
-      const bool any_kind_missing =
-        kind_is_missing(game_artwork::kind_e::poster) ||
-        kind_is_missing(game_artwork::kind_e::hero) ||
-        kind_is_missing(game_artwork::kind_e::logo) ||
-        kind_is_missing(game_artwork::kind_e::icon);
+      static constexpr std::array<game_artwork::kind_e, 4> resolvable_kinds {
+        game_artwork::kind_e::poster,
+        game_artwork::kind_e::hero,
+        game_artwork::kind_e::logo,
+        game_artwork::kind_e::icon,
+      };
+      // Whatever is still missing once local promotion and the free Steam assets have run is
+      // exactly the set this request goes on to ask a remote provider for, so it is also what
+      // the response reports as requested.
+      std::vector<game_artwork::kind_e> requested_kinds;
+      for (const auto kind : resolvable_kinds) {
+        if (kind_is_missing(kind)) {
+          requested_kinds.push_back(kind);
+        }
+      }
+      const bool any_kind_missing = !requested_kinds.empty();
 
       if (any_kind_missing && nonblank_artwork_api_key(api_key)) {
         try {
@@ -6934,7 +6945,35 @@ namespace nvhttp {
         }
       }
 
-      const auto manifest = current_artwork_manifest(appdata, app->uuid);
+      auto manifest = current_artwork_manifest(appdata, app->uuid);
+
+      // Clients cannot tell a successful no-op from a silent failure by diffing a manifest,
+      // so the response says what this call actually did. Nova refuses a resolve response
+      // without this block, which is why its library artwork update reported the server as
+      // unsupported against every build that has ever shipped.
+      std::vector<game_artwork::kind_e> remaining_kinds;
+      for (const auto kind : requested_kinds) {
+        if (kind_is_missing(kind)) {
+          remaining_kinds.push_back(kind);
+        }
+      }
+
+      auto &resolution = manifest["resolution"];
+      resolution["status"] =
+        requested_kinds.empty() ? "healthy" :
+        remaining_kinds.empty() ? "updated" :
+                                  "partial_failure";
+      // custom_preserved is the client's call: it knows about studio-protected artwork that
+      // the host has no record of.
+      resolution["requested_kinds"] = nlohmann::json::array();
+      for (const auto kind : requested_kinds) {
+        resolution["requested_kinds"].push_back(std::string(game_artwork::kind_name(kind)));
+      }
+      resolution["remaining_kinds"] = nlohmann::json::array();
+      for (const auto kind : remaining_kinds) {
+        resolution["remaining_kinds"].push_back(std::string(game_artwork::kind_name(kind)));
+      }
+
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "application/json");
       response->write(manifest.dump(), headers);


### PR DESCRIPTION
## Summary

- The artwork resolve endpoint now returns a `resolution` block alongside the manifest: a `status` plus `requested_kinds` and `remaining_kinds`.
- Nova's library artwork update has never worked against any Polaris build. Its parser requires that block and returns null without one, which the client reports as *"This Polaris server does not support library artwork updates yet. Update Polaris, then try again."* — a message that sends people looking for a version that does not exist. `requested_kinds` and `remaining_kinds` appear on no branch in this repository and never have.
- Nothing new is computed to satisfy it. The handler already works out which kinds are still missing once local promotion and the free Steam assets have run, which is exactly the set it then asks a remote provider for, and it asks the same question again afterwards: `requested` empty means `healthy`, `remaining` empty means `updated`, otherwise `partial_failure`.
- `custom_preserved` is the fourth status the client accepts and is deliberately not produced here. That decision belongs to the client, which knows about studio-protected artwork the host has no record of.
- A client cannot tell a successful no-op from a silent failure by diffing a manifest, which is why the counters Nova shows — updated, healthy, preserved, failed — need the host to state the outcome rather than infer it.

## Exact candidate

- `Commit: 7eff97b59c413ddc59664410951c53d52c3645de`
- `Tree: 7c99c978205fd443b84e2d4947947b7a23164374`
- `Parent: 3d910af777fa2dbf36ca7b643e75712efb39f1fb`
- `Base: 3d910af777fa2dbf36ca7b643e75712efb39f1fb` (merge-base with `master`)

`master` has since advanced to `a859bec7`, which also touches `src/nvhttp.cpp`. `git merge-tree` against the merge-base reports no conflicts.

## Verification

- [x] `cmake -B build -G Ninja` with `-DPOLARIS_ENABLE_CUDA=ON`, `-DCMAKE_INSTALL_PREFIX=/usr`, `-DPOLARIS_ASSETS_DIR=share/polaris`, `-DPOLARIS_ENABLE_BROWSER_STREAM=ON` — configured clean
- [x] `ninja -C build` — 0 failures; produced `polaris-1.3.5.7eff97b5` and `polaris-browser-stream-helper`
- [x] `cpack -G RPM` — package file list diffed against the installed package: 122 files vs 122, zero removals, only the versioned binary name differs
- [x] Installed via `rpm -Uvh` on Fedora, service restarted, `Build features: cuda=enabled`, zero error lines since start
- [x] Device QA on a Retroid Pocket 6 against this host: Library Options → Update Artwork Library → Check All Games reported **1 updated, 14 already current, 4 custom preserved, 0 failed** across 19 games. Before this change the same action reported the server as unsupported, with `PolarisArtworkLibraryUpdateUnavailableException` in the client log.

### Not covered

- No automated test accompanies this. The endpoint's behaviour is exercised only by the device QA above.
- Only the `updated` and `healthy` statuses were observed in that run; `partial_failure` was not reproduced, as every requested kind resolved.
- The Go browser-stream helper was built with `-buildvcs=false`, because Go cannot stamp VCS metadata from inside a git worktree. That affects embedded build metadata only.
