### PR TITLE
refactor(api): drop the game source assignment that never reached a client

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -6685,7 +6685,6 @@ namespace nvhttp {
         game["id"] = app.uuid;
         game["app_id"] = app.id;
         game["name"] = app.name;
-        game["source"] = app.steam_appid.empty() ? "other" : "steam";
         game["steam_appid"] = app.steam_appid;
         game["category"] = app.game_category;
         game["source"] = app.source;


### PR DESCRIPTION
## Summary

The served game object set `source` twice, three lines apart, with nothing reading it in between. The first derived `"other"` or `"steam"` from `steam_appid`; the second overwrote it unconditionally with `app.source`. Only the second was ever observable.

Removing the first changes nothing a client sees. The fallback it encoded is already handled where it belongs: apps.json loading defaults `source` to `"manual"` or `"steam"` when the field is absent, so `app.source` is populated by the time the library is served.

The dead line also **disagreed** with that default — offering `"other"` where loading says `"manual"`. So it was not merely redundant; anyone reading it would have taken away the wrong idea about which values `source` can hold.

## Exact candidate

- `Commit: 4aec0071f0ed3e3fad45e94c66747a452464f8b9`

The branch was cut before the six commits currently on `master`. The deletion targets `src/nvhttp.cpp:6688`, which none of them touched — the platform/runtime work in #298 landed further down the same object — so it still applies to the region it was written against.

## Verification

Built and run on pc-papi (Fedora) when the commit was written:

- [x] Full `ninja`, exit 0
- [x] `ctest` — 17/17
- [x] `test_polaris_audit` — `NovaContractTests` pass, confirming `source` is still served exactly once and the contract manifest still matches

Not covered, and worth stating plainly:

- Not rebuilt against current `master`. The change is a one-line deletion in a region unchanged since, and the contract test derives the served field list from source, so a mistake here would fail that test rather than pass silently.
