### PR TITLE
fix(audio): claim the stream sink as session default, and only release a claim you took

### DIFF
--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -234,10 +234,8 @@ case "${1:-}" in
       exit 1
     fi
     # Soft env hint for nested games (PULSE_SINK / PIPEWIRE_NODE).
-    # Polaris itself picks the capture sink: EasyEffects when it is the
-    # host default (FMOD target.object sticks there); otherwise virtual
-    # sink-sunshine-*. Do NOT re-pin streams here — that thrash fought
-    # WirePlumber and killed main-menu audio.
+    # Polaris claims sink-sunshine-* as the session default (stream capture);
+    # do not point children at EasyEffects and do not re-pin sink-inputs here.
     audio_cfg="${POLARIS_CLIENT_AUDIO_CONFIGURATION:-}"
     # Quoted names: shellcheck SC2100 treats unquoted *51 as arithmetic.
     audio_sink="sink-sunshine-surround51"
@@ -273,7 +271,6 @@ case "${1:-}" in
           >/dev/null 2>&1 || true
       fi
     }
-    # Virtual sinks for non-EE isolation (Polaris also creates them).
     ensure_null_sink "sink-sunshine-stereo" \
       "front-left,front-right" \
       "Polaris-stereo"
@@ -285,18 +282,8 @@ case "${1:-}" in
       "Polaris-7.1"
     ensure_null_sink "$audio_sink" "$audio_map" "$audio_desc"
 
-    # Prefer host processing sink for child env when EE/JamesDSP is default
-    # (matches Polaris capture; avoids PULSE_SINK pointing at empty null).
-    host_default="$(pactl get-default-sink 2>/dev/null || true)"
-    case "$host_default" in
-      *easyeffects*|*EasyEffects*|*jamesdsp*|*JamesDSP*|*pulseeffects*|*PulseEffects*)
-        audio_sink="$host_default"
-        echo "polaris-gamescope-session: host default is processing sink [$host_default] — child env uses it" >&2
-        ;;
-    esac
-
     printf '%s\n' "$audio_sink" >"$rt/polaris-gamescope-audio-sink"
-    echo "polaris-gamescope-session: audio env sink=$audio_sink (no re-pin; EasyEffects left running)" >&2
+    echo "polaris-gamescope-session: audio env sink=$audio_sink (host claims default; soft PULSE_SINK hint only)" >&2
 
     # True SDR when POLARIS_CLIENT_HDR is false: force file 0 + no --hdr-enabled.
     # Hybrid (HDR gamescope + SDR encode) is the iPhone chroma disaster; polaris 06 also syncs force.

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -218,6 +218,7 @@ namespace audio {
         }
         else {
           ref->restore_sink = true;
+          ref->claimed_default = true;
         }
       }
       else if (route_without_default) {
@@ -492,8 +493,9 @@ namespace audio {
 
     ctx.sink_flag = std::make_unique<std::atomic_bool>(false);
 
-    // The default sink has not been replaced yet.
+    // The default sink has not been replaced yet, and no claim is held.
     ctx.restore_sink = false;
+    ctx.claimed_default = false;
 
     if (!(ctx.control = platf::audio_control())) {
       return 0;
@@ -512,16 +514,24 @@ namespace audio {
     return 0;
   }
 
+  bool owns_default_sink_claim(const audio_ctx_t &ctx) {
+    return ctx.claimed_default && ctx.control != nullptr;
+  }
+
   void stop_audio_control(audio_ctx_t &ctx) {
     // restore audio-sink if applicable
     if (!ctx.restore_sink || !ctx.control) {
       return;
     }
 
-    // Prefer refcounted claim release (restores pre-claim default, skips ghosts).
-    // release_default_sink() returns 0 only when a real claim was released;
-    // the base no-op returns -1 so legacy set_sink restore still runs (Windows).
-    if (ctx.control->release_default_sink() == 0) {
+    // Only a session that took a claim may release one. The claim is refcounted
+    // across sessions on the shared control, so releasing one this session never
+    // took would decrement a claim another session still holds — and on the last
+    // decrement, restore the host default underneath a stream still running.
+    //
+    // release_default_sink() returns 0 only when a real claim was released; the
+    // base no-op returns -1 so the legacy set_sink restore still runs (Windows).
+    if (owns_default_sink_claim(ctx) && ctx.control->release_default_sink() == 0) {
       return;
     }
 

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -4,6 +4,7 @@
  */
 // standard includes
 #include <algorithm>
+#include <cstdlib>
 #include <thread>
 
 // lib includes
@@ -200,17 +201,30 @@ namespace audio {
 
     const bool host_audio = config.flags[config_t::HOST_AUDIO];
     const auto sink = select_sink_name(*ref.get(), stream.channelCount, host_audio);
-    const bool route_without_default = should_route_session_sink_without_default(*ref.get(), sink, host_audio);
+    const bool claim_default = should_claim_default_sink(*ref.get(), sink, host_audio);
+    // Re-pin is a legacy escape only when claim is disabled (POLARIS_STREAM_SINK=0).
+    const bool route_without_default =
+      !claim_default && should_route_session_sink_without_default(*ref.get(), sink, host_audio);
 
     BOOST_LOG(info) << "Selected audio sink: "sv << sink;
 
-    // Only the first to start a session may change the default sink
+    // Only the first session may claim/change the default sink (refcounted under the control).
     if (!ref->sink_flag->exchange(true, std::memory_order_acquire)) {
-      // If the selected sink is different than the current one, change sinks.
-      ref->restore_sink = !route_without_default && ref->sink.host != sink;
-      if (route_without_default) {
-        BOOST_LOG(info) << "Linux audio isolation: capturing virtual sink without changing the user's default sink"sv;
-      } else if (ref->restore_sink) {
+      if (claim_default) {
+        BOOST_LOG(info) << "Linux audio: claiming default sink ["sv << sink
+                        << "] for stream session (WirePlumber follow-default)"sv;
+        if (control->claim_default_sink(sink) != 0) {
+          BOOST_LOG(warning) << "Linux audio: could not claim default sink; capture continues, apps may stay on host output"sv;
+        }
+        else {
+          ref->restore_sink = true;
+        }
+      }
+      else if (route_without_default) {
+        BOOST_LOG(info) << "Linux audio isolation: capturing virtual sink without changing the user's default sink (legacy re-pin)"sv;
+      }
+      else if (ref->sink.host != sink) {
+        ref->restore_sink = true;
         if (control->set_sink(sink)) {
           return;
         }
@@ -246,8 +260,7 @@ namespace audio {
     auto next_audio_route_check = std::chrono::steady_clock::now();
 
     while (!shutdown_event->peek()) {
-      // Re-pin session streams that left the capture sink (EE reclaim); 3s poll,
-      // platform side enforces 10s cooldown per sink-input (no 1Hz crackle thrash).
+      // Legacy re-pin only when claim is disabled. Prefer default-sink claim.
       if (route_without_default && std::chrono::steady_clock::now() >= next_audio_route_check) {
         control->route_process_audio_to_sink(sink);
         next_audio_route_check = std::chrono::steady_clock::now() + 3s;
@@ -336,21 +349,14 @@ namespace audio {
   std::string select_sink_name(const audio_ctx_t &ctx, int channels, bool host_audio) {
     // Order of priority:
     // 1. Explicit audio_sink from web UI / conf — always enforced when set
-    // 2. Host processing sink (EasyEffects etc.) when host_audio is off — games
-    //    rebind there after menu reinit; virtual isolation + re-pin loses
-    // 3. Virtual sink by channel count when host_audio is off, OR host default
-    //    is an unusable placeholder (XLRDock null, "do not use")
-    // 4. Host/default sink (only if usable)
+    // 2. Virtual stream sink by channel count when isolating (host_audio off) or
+    //    host default is unusable — claim becomes the session default
+    // 3. Host/default sink (only if usable)
+    // Never prefer EasyEffects/JamesDSP as the capture target: claim the virtual
+    // sink so WirePlumber moves streams instead of fighting target.object.
     if (!config::audio.sink.empty()) {
       BOOST_LOG(info) << "Linux audio: using configured audio_sink ["sv << config::audio.sink << "]"sv;
       return config::audio.sink;
-    }
-
-    if (!host_audio && host_sink_is_processing(ctx.sink.host)) {
-      BOOST_LOG(info) << "Linux audio: host default ["sv << ctx.sink.host
-                      << "] is a processing sink; capturing it instead of virtual isolation "
-                         "(FMOD/EasyEffects target.object cannot be overridden by re-pin)"sv;
-      return ctx.sink.host;
     }
 
     const bool prefer_virtual =
@@ -359,7 +365,12 @@ namespace audio {
     if (prefer_virtual) {
       auto virtual_sink = select_virtual_sink_for_channels(ctx, channels);
       if (!virtual_sink.empty()) {
-        if (host_audio && host_sink_is_unusable_for_stream(ctx.sink.host)) {
+        if (!host_audio && host_sink_is_processing(ctx.sink.host)) {
+          BOOST_LOG(info) << "Linux audio: host default ["sv << ctx.sink.host
+                          << "] is a processing sink; using virtual stream sink ["sv
+                          << virtual_sink << "] (will claim as session default)"sv;
+        }
+        else if (host_audio && host_sink_is_unusable_for_stream(ctx.sink.host)) {
           BOOST_LOG(info) << "Linux audio: host default ["sv << ctx.sink.host
                           << "] is unusable for stream capture; using virtual sink ["sv
                           << virtual_sink << "]"sv;
@@ -382,17 +393,63 @@ namespace audio {
             sink == ctx.sink.null->surround71);
   }
 
+  bool stream_sink_claim_enabled() {
+#ifdef __linux__
+    if (const char *env = std::getenv("POLARIS_STREAM_SINK")) {
+      const std::string_view v {env};
+      if (v == "0" || v == "false" || v == "no" || v == "off") {
+        return false;
+      }
+    }
+    return true;
+#else
+    return false;
+#endif
+  }
+
+  bool should_claim_default_sink(const audio_ctx_t &ctx, const std::string &sink, bool host_audio) {
+#ifdef __linux__
+    if (!stream_sink_claim_enabled() || sink.empty()) {
+      return false;
+    }
+    // Never claim a processing graph as the "stream" sink.
+    if (host_sink_is_processing(sink)) {
+      return false;
+    }
+    // Isolate onto virtual/null stream sinks, or an explicit configured sink
+    // that is not already the host default.
+    if (sink_is_virtual(ctx, sink)) {
+      return true;
+    }
+    if (!config::audio.sink.empty() && sink == config::audio.sink && sink != ctx.sink.host) {
+      return true;
+    }
+    // host_audio off but no virtual sinks: still claim if we selected something
+    // other than the current host default so apps follow capture.
+    if (!host_audio && sink != ctx.sink.host) {
+      return true;
+    }
+    return false;
+#else
+    (void) ctx;
+    (void) sink;
+    (void) host_audio;
+    return false;
+#endif
+  }
+
   bool should_route_session_sink_without_default(const audio_ctx_t &ctx, const std::string &sink, bool host_audio) {
 #ifdef __linux__
     if (sink.empty()) {
       return false;
     }
-    // Never thrash re-pin against EasyEffects — capture host instead (select_sink_name).
+    // Claim path replaces re-pin. Keep re-pin only as an explicit legacy mode.
+    if (should_claim_default_sink(ctx, sink, host_audio)) {
+      return false;
+    }
     if (host_sink_is_processing(ctx.sink.host) || host_sink_is_processing(sink)) {
       return false;
     }
-    // Pin session apps to the capture sink when isolating (host_audio off) or when
-    // we were forced onto a virtual sink because the host default is unusable.
     if (!host_audio) {
       return true;
     }
@@ -457,14 +514,22 @@ namespace audio {
 
   void stop_audio_control(audio_ctx_t &ctx) {
     // restore audio-sink if applicable
-    if (!ctx.restore_sink) {
+    if (!ctx.restore_sink || !ctx.control) {
       return;
     }
 
-    // Change back to the host sink, unless there was none
+    // Prefer refcounted claim release (restores pre-claim default, skips ghosts).
+    // release_default_sink() returns 0 only when a real claim was released;
+    // the base no-op returns -1 so legacy set_sink restore still runs (Windows).
+    if (ctx.control->release_default_sink() == 0) {
+      return;
+    }
+
+    // Fallback: host sink from context, unless it is a stale stream sink name.
     const std::string &sink = ctx.sink.host.empty() ? config::audio.sink : ctx.sink.host;
-    if (!sink.empty()) {
-      // Best effort, it's allowed to fail
+    if (!sink.empty() && !host_sink_is_processing(sink) &&
+        sink.find("sink-sunshine") == std::string::npos &&
+        sink.find("polaris-speaker") == std::string::npos) {
       ctx.control->set_sink(sink);
     }
   }

--- a/src/audio.h
+++ b/src/audio.h
@@ -102,11 +102,18 @@ namespace audio {
 
   bool sink_is_virtual(const audio_ctx_t &ctx, const std::string &sink);
 
-  // EasyEffects / JamesDSP style sinks pin streams via WirePlumber target.object;
-  // virtual-sink re-pin never sticks (silent stream after game audio reinit).
+  // EasyEffects / JamesDSP style sinks pin streams via WirePlumber target.object.
+  // Used for diagnostics only — stream isolation claims a virtual sink as default
+  // instead of capturing the processing graph or re-pinning sink-inputs.
   bool host_sink_is_processing(const std::string &sink_name);
 
+  // Legacy re-pin path (disabled when claim is active). Prefer should_claim_default_sink.
   bool should_route_session_sink_without_default(const audio_ctx_t &ctx, const std::string &sink, bool host_audio);
+
+  // Claim the stream capture sink as the session default so
+  // WirePlumber follows it. Disabled with POLARIS_STREAM_SINK=0.
+  bool stream_sink_claim_enabled();
+  bool should_claim_default_sink(const audio_ctx_t &ctx, const std::string &sink, bool host_audio);
 
   /**
    * @brief Get the reference to the audio context.

--- a/src/audio.h
+++ b/src/audio.h
@@ -88,6 +88,14 @@ namespace audio {
     std::unique_ptr<platf::audio_control_t> control;
 
     bool restore_sink;
+    /**
+     * @brief Whether this session is the one holding a default-sink claim.
+     *
+     * Separate from restore_sink, which only means "something needs undoing at
+     * stop". Releasing a refcounted claim this session never took would
+     * decrement a claim another session still holds.
+     */
+    bool claimed_default;
     platf::sink_t sink;
   };
 
@@ -114,6 +122,19 @@ namespace audio {
   // WirePlumber follows it. Disabled with POLARIS_STREAM_SINK=0.
   bool stream_sink_claim_enabled();
   bool should_claim_default_sink(const audio_ctx_t &ctx, const std::string &sink, bool host_audio);
+
+  /**
+   * @brief Whether this session may release the refcounted default-sink claim.
+   *
+   * The claim is refcounted on the shared audio control, so a session that never
+   * took one must not release one: the decrement would come out of a claim
+   * another session still holds, and on the last decrement it would restore the
+   * host default underneath a stream still running.
+   *
+   * `restore_sink` cannot answer this. It means "something needs undoing at
+   * stop", and the legacy set_sink path sets it too without ever claiming.
+   */
+  bool owns_default_sink_claim(const audio_ctx_t &ctx);
 
   /**
    * @brief Get the reference to the audio context.

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -688,6 +688,24 @@ namespace platf {
     }
 
     /**
+     * @brief Claim `sink` as the system default for the stream session (refcounted).
+     * @return 0 on success, non-zero if the claim could not be applied (capture may continue).
+     */
+    virtual int claim_default_sink(const std::string &sink) {
+      return set_sink(sink);
+    }
+
+    /**
+     * @brief Release one claim; last holder restores the pre-claim default.
+     * @return 0 when a claim was released successfully, non-zero if no claim
+     *         exists or restore failed. Default is "not implemented" (-1) so
+     *         stop_audio_control() falls back to set_sink host restore.
+     */
+    virtual int release_default_sink() {
+      return -1;
+    }
+
+    /**
      * @brief Check if the audio sink is available in the system.
      * @param sink Sink to be checked.
      * @returns True if available, false otherwise.

--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <iterator>
 #include <limits>
+#include <mutex>
 #include <optional>
 #include <sstream>
 #include <string_view>
@@ -1446,6 +1447,65 @@ namespace platf {
 
         return 0;
       }
+
+      // Refcounted default-sink claim (Pulse/WirePlumber default for the stream session).
+      // WirePlumber honors pa_context_set_default_sink for follow-default linking.
+      int claim_default_sink(const std::string &sink) override {
+        if (sink.empty()) {
+          return -1;
+        }
+        std::lock_guard lock {claim_mu};
+        const bool first = claim_holders == 0;
+        if (first) {
+          auto prev = get_default_sink_name();
+          // Never restore a ghost stream sink left by a crash.
+          if (prev.find("sink-sunshine") != std::string::npos || prev.find("polaris-speaker") != std::string::npos) {
+            claim_restore.clear();
+          }
+          else {
+            claim_restore = std::move(prev);
+          }
+        }
+        // Latest claim wins routing even when other sessions hold a claim.
+        if (set_sink(sink) != 0) {
+          if (first) {
+            claim_restore.clear();
+          }
+          return -1;
+        }
+        ++claim_holders;
+        claimed_sink = sink;
+        BOOST_LOG(info) << "Linux audio: claimed default sink ["sv << sink
+                        << "] holders="sv << claim_holders << " restore=["sv
+                        << (claim_restore.empty() ? "<none>" : claim_restore) << "]"sv;
+        return 0;
+      }
+
+      int release_default_sink() override {
+        std::lock_guard lock {claim_mu};
+        if (claim_holders == 0) {
+          return -1;  // no claim on this control — caller may fall back
+        }
+        --claim_holders;
+        if (claim_holders > 0) {
+          BOOST_LOG(info) << "Linux audio: release claim holders remaining="sv << claim_holders;
+          return 0;
+        }
+        const auto restore = std::move(claim_restore);
+        claim_restore.clear();
+        claimed_sink.clear();
+        if (restore.empty()) {
+          BOOST_LOG(info) << "Linux audio: last claim released — no pre-claim default to restore"sv;
+          return 0;
+        }
+        BOOST_LOG(info) << "Linux audio: restoring default sink ["sv << restore << "]"sv;
+        return set_sink(restore);
+      }
+
+      std::mutex claim_mu;
+      unsigned claim_holders = 0;
+      std::string claim_restore;
+      std::string claimed_sink;
 
       ~server_t() override {
         if (mainloop_started) {

--- a/tests/unit/test_audio.cpp
+++ b/tests/unit/test_audio.cpp
@@ -81,6 +81,26 @@ TEST_P(AudioTest, TestEncode) {
   capture.join();
 }
 
+namespace {
+  struct fake_audio_control_t: platf::audio_control_t {
+    int set_sink(const std::string &) override {
+      return 0;
+    }
+
+    std::unique_ptr<platf::mic_t> microphone(const std::uint8_t *, int, std::uint32_t, std::uint32_t, const std::string &, bool) override {
+      return nullptr;
+    }
+
+    bool is_sink_available(const std::string &) override {
+      return true;
+    }
+
+    std::optional<platf::sink_t> sink_info() override {
+      return std::nullopt;
+    }
+  };
+}  // namespace
+
 TEST(AudioSinkSelectionTest, SelectsVirtualSinkWhenHostAudioIsDisabled) {
   auto old_sink = config::audio.sink;
   config::audio.sink.clear();
@@ -169,6 +189,41 @@ TEST(AudioSinkSelectionTest, ExplicitVirtualSinkIsEnforcedAndClaimed) {
 #endif
 
   config::audio.sink = old_sink;
+}
+
+TEST(AudioSinkClaimOwnershipTest, OnlyASessionThatClaimedMayReleaseTheClaim) {
+  // The claim is refcounted across sessions on one shared control. A session
+  // that took the legacy set_sink path also sets restore_sink, so keying the
+  // release off restore_sink would let it decrement a claim it never took —
+  // and on the last decrement, restore the host default underneath a stream
+  // that is still running.
+  auto ctx = make_sink_context();
+  ctx.control = std::make_unique<fake_audio_control_t>();
+
+  ctx.restore_sink = false;
+  ctx.claimed_default = false;
+  EXPECT_FALSE(audio::owns_default_sink_claim(ctx));
+
+  // Legacy path: something to undo at stop, but no claim was taken.
+  ctx.restore_sink = true;
+  ctx.claimed_default = false;
+  EXPECT_FALSE(audio::owns_default_sink_claim(ctx));
+
+  // Claim path.
+  ctx.restore_sink = true;
+  ctx.claimed_default = true;
+  EXPECT_TRUE(audio::owns_default_sink_claim(ctx));
+}
+
+TEST(AudioSinkClaimOwnershipTest, AClaimWithoutAControlIsNotOwned) {
+  // stop runs after the control is gone on some teardown paths; dereferencing
+  // it to release would be worse than skipping the restore.
+  auto ctx = make_sink_context();
+  ctx.control.reset();
+  ctx.restore_sink = true;
+  ctx.claimed_default = true;
+
+  EXPECT_FALSE(audio::owns_default_sink_claim(ctx));
 }
 
 TEST(AudioCaptureBufferDiagnosticsTest, KeepsSixtyMillisecondsOfStereoJitterForFiveMsPackets) {

--- a/tests/unit/test_audio.cpp
+++ b/tests/unit/test_audio.cpp
@@ -91,7 +91,8 @@ TEST(AudioSinkSelectionTest, SelectsVirtualSinkWhenHostAudioIsDisabled) {
   EXPECT_EQ(sink, "sink-sunshine-stereo");
   EXPECT_TRUE(audio::sink_is_virtual(ctx, sink));
 #ifdef __linux__
-  EXPECT_TRUE(audio::should_route_session_sink_without_default(ctx, sink, false));
+  EXPECT_TRUE(audio::should_claim_default_sink(ctx, sink, false));
+  EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, false));
 #else
   EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, false));
 #endif
@@ -109,11 +110,12 @@ TEST(AudioSinkSelectionTest, SelectsHostSinkWhenHostAudioIsEnabled) {
   EXPECT_EQ(sink, "alsa_output.host");
   EXPECT_FALSE(audio::sink_is_virtual(ctx, sink));
   EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, true));
+  EXPECT_FALSE(audio::should_claim_default_sink(ctx, sink, true));
 
   config::audio.sink = old_sink;
 }
 
-TEST(AudioSinkSelectionTest, CapturesEasyEffectsInsteadOfVirtualIsolation) {
+TEST(AudioSinkSelectionTest, PrefersVirtualStreamSinkOverEasyEffectsDefault) {
   auto old_sink = config::audio.sink;
   config::audio.sink.clear();
   auto ctx = make_sink_context();
@@ -121,10 +123,13 @@ TEST(AudioSinkSelectionTest, CapturesEasyEffectsInsteadOfVirtualIsolation) {
 
   const auto sink = audio::select_sink_name(ctx, 6, false);
 
-  EXPECT_EQ(sink, "easyeffects_sink");
+  EXPECT_EQ(sink, "sink-sunshine-surround51");
   EXPECT_TRUE(audio::host_sink_is_processing(ctx.sink.host));
-  EXPECT_FALSE(audio::sink_is_virtual(ctx, sink));
+  EXPECT_TRUE(audio::sink_is_virtual(ctx, sink));
+#ifdef __linux__
+  EXPECT_TRUE(audio::should_claim_default_sink(ctx, sink, false));
   EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, false));
+#endif
 
   config::audio.sink = old_sink;
 }
@@ -140,8 +145,8 @@ TEST(AudioSinkSelectionTest, ExplicitConfiguredSinkIsEnforced) {
   EXPECT_EQ(sink, "alsa_output.configured");
   EXPECT_FALSE(audio::sink_is_virtual(ctx, sink));
 #ifdef __linux__
-  // Still pin session apps to that sink without clobbering the host default.
-  EXPECT_TRUE(audio::should_route_session_sink_without_default(ctx, sink, false));
+  EXPECT_TRUE(audio::should_claim_default_sink(ctx, sink, false));
+  EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, false));
 #else
   EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, false));
 #endif
@@ -149,7 +154,7 @@ TEST(AudioSinkSelectionTest, ExplicitConfiguredSinkIsEnforced) {
   config::audio.sink = old_sink;
 }
 
-TEST(AudioSinkSelectionTest, ExplicitVirtualSinkIsEnforcedAndRouted) {
+TEST(AudioSinkSelectionTest, ExplicitVirtualSinkIsEnforcedAndClaimed) {
   auto old_sink = config::audio.sink;
   config::audio.sink = "sink-sunshine-surround51";
   auto ctx = make_sink_context();
@@ -159,7 +164,8 @@ TEST(AudioSinkSelectionTest, ExplicitVirtualSinkIsEnforcedAndRouted) {
   EXPECT_EQ(sink, "sink-sunshine-surround51");
   EXPECT_TRUE(audio::sink_is_virtual(ctx, sink));
 #ifdef __linux__
-  EXPECT_TRUE(audio::should_route_session_sink_without_default(ctx, sink, false));
+  EXPECT_TRUE(audio::should_claim_default_sink(ctx, sink, false));
+  EXPECT_FALSE(audio::should_route_session_sink_without_default(ctx, sink, false));
 #endif
 
   config::audio.sink = old_sink;


### PR DESCRIPTION
## Summary

Takes the audio half of #295 and lands it independently of the gamescope patch stack, plus a fix for a cross-session bug in it.

#295 is stacked behind #294, so none of it can merge while the vendored-patch question is open. The audio work does not depend on those patches at all — only the nix wiring in that PR does — so `f11ef8f7` is cherry-picked here with luxus' authorship intact, and the nix/gamescope parts stay with the stack.

### The claim, as written

The default-sink claim is refcounted on the shared audio control, and teardown decided whether to release from `restore_sink`:

```cpp
if (!ctx.restore_sink || !ctx.control) return;
if (ctx.control->release_default_sink() == 0) return;
```

But `restore_sink` does not mean "this session claimed". It means "something needs undoing at stop", and the legacy `set_sink` branch sets it too, without ever taking a claim:

```cpp
if (claim_default)          { ... ref->restore_sink = true; }   // claimed
else if (route_without_default) { }                              // nothing to undo
else if (ref->sink.host != sink) { ref->restore_sink = true; }   // did NOT claim
```

So a session on the legacy path still calls `release_default_sink()` at stop, decrementing a claim a **different** session is holding. The default `max_sessions = 2` allows exactly that, and on the last decrement the host default is restored underneath a stream that is still running — its audio lands on the host output mid-stream.

### The fix

Claim ownership is tracked separately from `restore_sink`, and the decision is named rather than inlined, so the two meanings cannot collapse back into one flag. `owns_default_sink_claim()` also refuses to release when the control is already gone, which some teardown paths reach.

The rest of the claim implementation is sound and unchanged: the refcount, the ghost-sink rejection that avoids restoring a stream sink left by a crash, and the no-increment-on-`set_sink`-failure path all behave correctly.

## Exact candidate

- `Commit: b2f49fe2968a2de31d16d2af5b078449988a457f`
- `Tree:   b7ed642dc81ce443e8c45a14bd8792367e5aa72f`
- `Base:   a20dc5d09866e7834600452ac2b23afb838d6994`

## Verification

On pc-papi (Fedora):

- [x] Full `ninja`, exit 0
- [x] `ctest` — 17/17
- [x] `test_polaris_audio` — 7/7 across `AudioSinkClaimOwnershipTest` and `AudioSinkSelectionTest`
- [x] Mutation probe: restoring the original `restore_sink` coupling fails exactly `OnlyASessionThatClaimedMayReleaseTheClaim` and nothing else

Not covered, and worth stating plainly:

- The two-session teardown is covered at the ownership predicate, not by running two live sessions against a real PulseAudio server. The predicate is the decision that was wrong; the refcount either side of it is luxus' code and unchanged.
- #295's own test plan is unchecked, including the sink-selection and claim-policy items. Those paths keep the coverage that already existed in `test_audio.cpp`; nothing here adds live-audio testing.
- The nix session-shell change in #295 (`polaris-gamescope-session.sh`, softening the audio pin loop) is deliberately **not** included — it belongs with the gamescope session work in #296.
