### PR TITLE
fix(linux): tell ostree hosts the input-group command that actually works

### DIFF
--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -97,6 +97,28 @@ echo evdi | sudo tee /etc/modules-load.d/evdi.conf
 echo 'options evdi initial_device_count=1' | sudo tee /etc/modprobe.d/evdi-polaris.conf
 ```
 
+## Controller and Input Group
+
+Seat isolation (`client_gamepad_seat_isolation`, `client_keyboard_mouse_seat_isolation`)
+needs the account Polaris runs as to be in the `input` group. Polaris warns at startup when
+it is not.
+
+**`sudo usermod -aG input $USER` does not work on Bazzite.** The `input` group is defined in
+`/usr/lib/group` rather than `/etc/group`, so `usermod` cannot find a group to add anyone to.
+Use the Universal Blue recipe, which copies the definition across first:
+
+```bash
+ujust add-user-to-input-group
+```
+
+Then sign out and back in — group membership only applies to new sessions.
+
+```bash
+id -nG | tr ' ' '\n' | grep -qx input && echo "in the input group" || echo "not in it"
+```
+
+Thanks to [@SVelothi](https://github.com/papi-ux/polaris/issues/274) for finding this.
+
 ## Why rpm-ostree Layering
 
 Polaris needs host-level integration: the binary, web assets, desktop metadata,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,9 @@ deliberately denied the logind ACL, so an account outside the group cannot open 
 just created, and neither can the streamed game. Polaris logs an `input_access:` warning at startup
 when seat isolation is enabled and the account it runs as is not a member, and `--setup-host` reports
 the same thing. Add the account with `sudo usermod -aG input <user>` and log out and back in;
-membership only applies to new sessions.
+membership only applies to new sessions. On ostree hosts such as Bazzite the group is defined
+in `/usr/lib/group` and `usermod` cannot see it, so use `ujust add-user-to-input-group`
+instead. The startup warning prints whichever command applies.
 
 #### Verifying that isolation is applied
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -99,6 +99,17 @@ sudo usermod -aG input "$USER"
 
 Then sign out and back in.
 
+On an ostree host — Bazzite, Bluefin, Silverblue and relatives — that command does nothing
+useful: the `input` group lives in `/usr/lib/group` rather than `/etc/group`, so `usermod`
+finds no group to add anyone to. Universal Blue images ship a recipe that copies the
+definition across first:
+
+```bash
+ujust add-user-to-input-group
+```
+
+Polaris detects this and prints whichever command applies to your host.
+
 If Polaris was installed before the rules became package files, an older copy may still sit in
 `/etc/udev/rules.d/60-polaris.rules`. `/etc` overrides the packaged file, so that copy keeps
 shadowing later fixes — including the seat isolation rules, which then never apply no matter what

--- a/src/platform/linux/input/input_group_access.cpp
+++ b/src/platform/linux/input/input_group_access.cpp
@@ -4,10 +4,12 @@
  */
 #include "input_group_access.h"
 #include "src/config.h"
+#include "src/platform/linux/executable_path.h"
 #include "src/logging.h"
 
 #include <algorithm>
 #include <cstdlib>
+#include <filesystem>
 #include <grp.h>
 #include <mutex>
 #include <optional>
@@ -102,12 +104,42 @@ namespace platf::input_access {
     return {};
   }
 
-  std::string input_group_remedy_command(std::string_view user) {
-    std::string command = "sudo usermod -aG ";
+  bool host_is_ostree_booted() {
+    std::error_code ec;
+    return std::filesystem::exists("/run/ostree-booted", ec);
+  }
+
+  bool host_has_ujust() {
+    return !platf::linux_util::find_executable_in_path("ujust").empty();
+  }
+
+  std::string input_group_remedy_command(std::string_view user, bool ostree_host, bool has_ujust) {
+    if (!ostree_host) {
+      std::string command = "sudo usermod -aG ";
+      command += input_group;
+      command += ' ';
+      command += user;
+      return command;
+    }
+
+    // Universal Blue ships a recipe that copies the group definition out of
+    // /usr/lib/group into /etc/group before running usermod, which is the step
+    // that makes it work at all. Reported from Bazzite in #274, where plain
+    // usermod silently accomplishes nothing.
+    if (has_ujust) {
+      return "ujust add-user-to-input-group";
+    }
+
+    // The same two steps by hand, for an ostree host without ujust.
+    std::string command = "sudo bash -c 'grep ^input: /usr/lib/group >> /etc/group' && sudo usermod -aG ";
     command += input_group;
     command += ' ';
     command += user;
     return command;
+  }
+
+  std::string input_group_remedy_command(std::string_view user) {
+    return input_group_remedy_command(user, host_is_ostree_booted(), host_has_ujust());
   }
 
   std::string seat_isolation_access_warning(

--- a/src/platform/linux/input/input_group_access.h
+++ b/src/platform/linux/input/input_group_access.h
@@ -51,7 +51,30 @@ namespace platf::input_access {
   /// Name the devices the enabled options apply to, for the message.
   std::string isolated_device_summary(const seat_isolation_options_t &options);
 
-  /// The command that adds an account to the group.
+  /**
+   * @brief Whether the host boots an ostree image, where usermod is not enough.
+   *
+   * On ostree systems the `input` group is defined in /usr/lib/group rather than
+   * /etc/group, so `usermod -aG input` fails outright: the group database it
+   * writes has no such group to add anyone to.
+   */
+  bool host_is_ostree_booted();
+
+  /// Whether Universal Blue's `ujust` recipe runner is on PATH.
+  bool host_has_ujust();
+
+  /**
+   * @brief The command that adds an account to the group.
+   *
+   * Pure, so the ostree variants can be tested without an ostree host.
+   *
+   * @param user Account to add.
+   * @param ostree_host Whether the group lives in /usr/lib/group.
+   * @param has_ujust Whether Universal Blue's `ujust` is available.
+   */
+  std::string input_group_remedy_command(std::string_view user, bool ostree_host, bool has_ujust);
+
+  /// The remedy for this host, detected.
   std::string input_group_remedy_command(std::string_view user);
 
   /**

--- a/tests/unit/platform/test_input_group_access.cpp
+++ b/tests/unit/platform/test_input_group_access.cpp
@@ -96,6 +96,34 @@ TEST(InputGroupAccessTests, TheWarningSaysWhatActuallyBreaks) {
   EXPECT_TRUE(contains(warning, "streamed game will not see them"));
 }
 
+TEST(InputGroupAccessTests, AnOstreeHostIsToldTheCommandThatActuallyWorks) {
+  using platf::input_access::input_group_remedy_command;
+
+  // On ostree images the input group is defined in /usr/lib/group, not
+  // /etc/group, so `usermod -aG input` fails outright — the database it writes
+  // has no such group. Reported from Bazzite in #274, where following our
+  // advice accomplished nothing at all.
+  const auto ublue = input_group_remedy_command("papi", true, true);
+  EXPECT_EQ("ujust add-user-to-input-group", ublue);
+
+  // Without ujust, the same two steps by hand: copy the group definition
+  // across first, then the usermod that can now find it.
+  const auto manual = input_group_remedy_command("papi", true, false);
+  EXPECT_NE(manual.find("/usr/lib/group"), std::string::npos);
+  EXPECT_NE(manual.find("/etc/group"), std::string::npos);
+  EXPECT_NE(manual.find("usermod -aG input papi"), std::string::npos);
+}
+
+TEST(InputGroupAccessTests, AnOrdinaryHostStillGetsPlainUsermod) {
+  using platf::input_access::input_group_remedy_command;
+
+  const auto command = input_group_remedy_command("papi", false, false);
+  EXPECT_EQ("sudo usermod -aG input papi", command);
+
+  // ujust being present does not make a non-ostree host use it.
+  EXPECT_EQ("sudo usermod -aG input papi", input_group_remedy_command("papi", false, true));
+}
+
 TEST(InputGroupAccessTests, SetupHostReportsOnTheAccountThatInvokedSudo) {
   using platf::input_access::setup_host_target_user;
 


### PR DESCRIPTION
## Summary

The seat isolation warning shipped in v1.3.5 tells people to run `sudo usermod -aG input <user>`. On Bazzite that does nothing at all, which [SVelothi found the hard way](https://github.com/papi-ux/polaris/issues/274) after following it.

On ostree images the `input` group is defined in `/usr/lib/group`, not `/etc/group`. `usermod` writes the `/etc` database, finds no group of that name to add anyone to, and fails. So the warning sends people to a command that cannot succeed, on a platform with its own install guide in the README table.

**Detection was never wrong.** `nss-altfiles` means `getgrnam` still resolves the group, so Polaris correctly reports the account is not a member. Only the remedy was wrong.

Universal Blue ships a recipe that copies the group definition out of `/usr/lib/group` into `/etc/group` and then runs the same `usermod` — that copy is the step that makes it work:

```bash
if ! grep -q "input" /etc/group; then
  sudo bash -c 'grep "input" /lib/group >> /etc/group'
fi
sudo usermod -a -G input "$USER"
```

The warning now prints:

| Host | Command |
|---|---|
| ostree with `ujust` | `ujust add-user-to-input-group` |
| ostree without `ujust` | the two steps by hand |
| everything else | `sudo usermod -aG input <user>` |

Detection is `/run/ostree-booted`. The command builder takes both conditions as parameters, so all three forms are tested without needing an ostree host to test on.

Docs: `docs/bazzite.md` had no input-group section at all and now has one; `docs/troubleshooting.md` and `docs/configuration.md` said `usermod` without qualification and now name the ostree case. SVelothi asked for exactly this and is credited.

## Exact candidate

- `Commit: 5b8a1f0a75109cdc741833ca24e42450920371a0`
- `Tree:   e6695fc5d0e450cbbad0a49c4e5cfad0a2a1e619`
- `Base:   85f4c96e94d43e434a7be3661e11ff537a29baef`

## Verification

On pc-papi (Fedora, not ostree):

- [x] Full `ninja`, exit 0
- [x] `ctest` — 17/17
- [x] `test_polaris_platform` — `InputGroupAccessTests` 11/11, including all three remedy forms and that `ujust` being present does not make a non-ostree host use it
- [x] `bash scripts/check-public-docs.sh` — exit 0
- [x] `npx vitest run` — 50 files, 297 tests

The upstream recipe was read from `ublue-os/bazzite` directly rather than taken on report, which is also where the `/usr/lib/group` mechanism came from.

Not covered, and worth stating plainly:

- **Not run on an ostree host.** This machine is ordinary Fedora, so `host_is_ostree_booted()` returns false here and only the non-ostree branch executes live. The other two are covered by passing the conditions in, not by observation.
- `ujust add-user-to-input-group` is a Universal Blue recipe. A non-ublue ostree host — plain Silverblue — takes the by-hand branch, which is untested against a real one.
- The group-definition grep in the by-hand form matches `^input:` rather than the looser `input` the upstream recipe uses, so it cannot match an unrelated line that happens to contain the word.
