### PR TITLE
release: prepare Polaris v1.3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.3.5
+project(Polaris VERSION 1.3.6
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/README.md
+++ b/README.md
@@ -91,18 +91,17 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at `https://localhost:<port + 1>`. If you want background autostart, enable the user service with `systemctl --user enable --now polaris`.
 
-## What is New in v1.3.5
+## What is New in v1.3.6
 
-Polaris v1.3.5 makes manual package updates deterministic, hands the Linux host integration files to the package that owns them, and teaches the library what your launchers already know.
+Polaris v1.3.6 makes the Nova client work against a Polaris host in places it never has, corrects host setup advice that could not succeed on ostree systems, and hardens the gamescope session and its HDR capture.
 
-- **Exact download targets**: Update Center now writes every mutable-distro download to the exact package filename with `wget --output-document`, so an existing file cannot redirect the new payload to `.1` or `.2` while the package manager reads stale bytes.
-- **Failure-safe command chains**: Fedora, Arch, and Ubuntu update commands short-circuit after a failed download, package installation, `sudo -H polaris --setup-host`, or service restart instead of continuing with later side effects.
-- **Host files owned by the package**: udev rules and modules-load configuration install to `/usr/lib`, so uninstalling Polaris removes them. An unmodified `/etc` copy from an older install is retired, because it would otherwise shadow every future fix to the rules. `--setup-host` no longer asks for root when there is nothing privileged left to do.
-- **`polaris-debug` package**: Arch and SteamOS builds ship debug symbols separately, so `coredumpctl info polaris` gives a real backtrace instead of `no debugging symbols`.
-- **Seat isolation tells you what it needs**: enabling client gamepad or keyboard/mouse seat isolation without being in the `input` group now warns at startup, rather than presenting as a controller that never appears.
-- **Playtime and completion estimates**: the library reports the hours Steam and Lutris already record, and serves completion estimates from a local dataset before reaching for How Long To Beat.
-- **Host audio released properly**: turning host audio off in a session now unloads the loopback an earlier session created, instead of playing through the host speakers for the life of the process.
-- **v1.3.4 bootstrap guidance**: the command generator bundled with v1.3.4 predates this fix, so use the exact-output commands in Quick Start or the [v1.3.5 release notes](docs/release-notes/v1.3.5.md) for the first upgrade.
+- **Input group advice that works on Bazzite**: on ostree hosts the `input` group lives in `/usr/lib/group`, so `usermod -aG input` finds no group to add anyone to. Polaris now prints `ujust add-user-to-input-group` there, and the equivalent steps on an ostree host without `ujust`.
+- **Nova library artwork update works at all**: the resolve endpoint now reports what it did, which Nova requires. Without it the client reported the host as unsupported against every build that has ever shipped.
+- **Library entries carry platform and runtime**: derived from the Lutris runner recorded at import, and served only where the runner determines them — no badge beats a wrong badge.
+- **Corrected completion estimates stay corrected**: a manual artwork match decides which game an estimate is for, and no longer falls back to the Steam app id that made the wrong estimate confident.
+- **Gamescope sessions recover**: teardown and reconnect survive a dead nested marker, a non-leader attach, and an incomplete attach generation that used to refuse every later launch until Polaris restarted.
+- **HDR capture follows the encode**: 10-bit PQ only when gamescope is in HDR mode and the client asked for HDR, 8-bit when the stream is SDR, so PQ capture cannot feed an SDR encoder.
+- **Stream audio follows the session**: the stream sink is claimed as the session default while streaming, and only the session that took that claim releases it.
 - **Security gate**: `npm audit --audit-level=high` remains mandatory.
 - **Exact release set**: the official artifacts are `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb`.
 See the [changelog](docs/changelog.md) for the full release history.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,21 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## v1.3.6 - 2026-08-07
+
+Client-facing fixes for Nova, host setup advice that works on ostree systems, and gamescope session and HDR capture hardening.
+
+- Prints the input-group command that works on ostree hosts, where the group lives in `/usr/lib/group` and `usermod -aG input` cannot find it; Bazzite gets `ujust add-user-to-input-group`
+- Reports what the artwork resolve endpoint actually did, which Nova requires and no shipped build had ever sent, so library artwork update reported the host as unsupported
+- Serves `platform` and `runtime` on library entries from the Lutris runner recorded at import, and only where the runner determines them
+- Lets a manual artwork match decide which game a completion estimate is for, without falling back to the Steam app id that made the wrong estimate confident
+- Records the fields Polaris serves to Nova in `docs/nova-contract.json`, derived from the source that serves them, and serves `vaapi_vendor` so a crash report names the driver generation
+- Recovers gamescope session teardown from a dead nested marker, a non-leader attach, and an incomplete attach generation that refused later launches until restart
+- Negotiates PipeWire capture formats against what the stream encodes, so 10-bit PQ cannot feed an SDR encode
+- Claims the stream sink as the session default while streaming, and releases that claim only from the session that took it
+- Keeps `npm audit --audit-level=high` mandatory
+- Retains exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
+
 ## v1.3.5 - 2026-08-06
 
 Package-update safety, Linux host integration owned by the package, and library playtime and completion estimates.

--- a/docs/release-notes/v1.3.6.md
+++ b/docs/release-notes/v1.3.6.md
@@ -1,0 +1,66 @@
+# Polaris v1.3.6
+
+Polaris v1.3.6 makes the Nova client work against a Polaris host in places it never has, corrects host setup advice that could not succeed on ostree systems, and hardens the gamescope session and its HDR capture.
+
+## Important: upgrading from v1.3.5
+
+Nothing extra is required beyond the usual upgrade. Two notes are worth reading.
+
+**If you use seat isolation on Bazzite or another ostree host**, the command v1.3.5 told you to run does not work there, and Polaris now prints the one that does. See [controller and input group](../bazzite.md#controller-and-input-group).
+
+**If you ran `--setup-host` on any version before v1.3.5**, a copy of the udev rules may still sit in `/etc` and override the packaged ones. Host setup keeps it and warns rather than deleting something it cannot prove is disposable. The check and removal are in [troubleshooting](../troubleshooting.md).
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.6/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.6/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.6/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 already uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md).
+
+## Changes
+
+### Host setup
+
+- Tells ostree hosts the input-group command that actually works. On Bazzite the `input` group is defined in `/usr/lib/group` rather than `/etc/group`, so `usermod -aG input` finds no group to add anyone to and fails; the warning now prints `ujust add-user-to-input-group` there, the equivalent two steps on an ostree host without `ujust`, and plain `usermod` everywhere else.
+
+### Nova and the client API
+
+- The artwork resolve endpoint now reports what it actually did. Nova's library artwork update requires that block and returned nothing without it, so the feature reported the host as unsupported against every build that has ever shipped.
+- The game library serves `platform` and `runtime`, derived from the Lutris runner recorded at import, so a client can label an entry rather than guessing. Values are served only where the runner determines them; a Steam or manual entry whose runtime was never recorded serves neither, and renders no badge.
+- A manual artwork match now decides which game a completion estimate is for, and a curated identity no longer falls back to the Steam app id — the id is usually what made a wrong estimate confident, so falling back would serve the estimate the correction rejected.
+- The fields Polaris serves to Nova are recorded in `docs/nova-contract.json` and derived from the source that serves them, so the two cannot drift apart unnoticed. `vaapi_vendor` is now served, which names the driver generation in a crash report.
+
+### Linux session and capture
+
+- Gamescope session teardown and reconnect recover from a dead nested marker, an attach that is not a private session leader, and an incomplete attach generation that previously refused every later launch until Polaris restarted.
+- PipeWire format negotiation follows what the stream will actually encode: 10-bit PQ only when gamescope is in HDR mode and the client requested HDR, and 8-bit only when the stream is SDR, so PQ capture cannot feed an SDR encode.
+- The stream sink is claimed as the session default while streaming, so applications follow it instead of the host output, and only a session that took that claim releases it — releasing one it never took could restore the host default underneath another stream still running.
+
+## Official assets
+
+- `Polaris-arch-x86_64.pkg.tar.zst`
+- `Polaris-fedora44-x86_64.rpm`
+- `Polaris-steamos3.8-x86_64.pkg.tar.zst`
+- `Polaris-ubuntu24.04-x86_64.deb`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.3.5') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.3.6') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -614,7 +614,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.3.5.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.3.6.md").read_text(encoding="utf-8")
 )
 
 
@@ -1245,18 +1245,17 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.3.6 - 2026-08-07",
     "## v1.3.5 - 2026-08-06",
-    "## v1.3.4 - 2026-07-31",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "v1.3.4",
-    "exact package filename",
-    "wget --output-document",
-    ".1",
-    ".2",
-    "short-circuit",
-    "sudo -H",
+    "ostree",
+    "usermod",
+    "ujust add-user-to-input-group",
+    "/usr/lib/group",
+    "platform",
+    "runtime",
     "npm audit --audit-level=high",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
@@ -1265,19 +1264,19 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.3.5 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.3.6 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 readme_release_body = markdown_section(
     readme,
-    "## What is New in v1.3.5",
+    "## What is New in v1.3.6",
     "## Install",
 )
 readme_release_prose = rendered_markdown(readme_release_body)
 required_readme_facts = required_release_facts
 for fact in required_readme_facts:
     if fact not in readme_release_prose:
-        print(f"README v1.3.5 summary is missing: {fact}", file=sys.stderr)
+        print(f"README v1.3.6 summary is missing: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1287,8 +1286,8 @@ asset_phrase = (
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
 for label, section in (
-    ("README v1.3.5 summary", readme_release_prose),
-    ("v1.3.5 changelog", current_release_prose),
+    ("README v1.3.6 summary", readme_release_prose),
+    ("v1.3.6 changelog", current_release_prose),
 ):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
@@ -1307,8 +1306,8 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
     ("docs/building.md Packaging", building_packaging_prose),
-    ("README v1.3.5 summary", readme_release_prose),
-    ("v1.3.5 changelog", current_release_prose),
+    ("README v1.3.6 summary", readme_release_prose),
+    ("v1.3.6 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_assets:
@@ -1320,26 +1319,26 @@ for label, section in (
         sys.exit(1)
 
 release_notes_facts = (
-    "v1.3.4",
-    "exact package filename",
-    ".1",
-    ".2",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.5/Polaris-fedora44-x86_64.rpm &&",
+    "v1.3.5",
+    "ostree",
+    "ujust add-user-to-input-group",
+    "/etc",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.6/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.5/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.6/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.5/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.6/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.3.5 release notes are missing bootstrap fact: {fact}", file=sys.stderr)
+        print(f"v1.3.6 release notes are missing bootstrap fact: {fact}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.3.5 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.3.6 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.3.5 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.3.6 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 
 if "bash scripts/check-public-docs.sh" not in contributing:

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.5-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.6-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -667,7 +667,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.3.5-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.3.6-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v135-contract.test.js
+++ b/src_assets/common/assets/web/release-v135-contract.test.js
@@ -1,43 +1,34 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { buildManualInstallCommand } from './update-center.js'
 
 const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
 
 const sectionBetween = (source, startHeading, endHeading) => {
   const start = source.indexOf(startHeading)
   const end = source.indexOf(endHeading, start + startHeading.length)
-  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
-  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  expect(start, `missing historical release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing historical release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
   return source.slice(start, end)
 }
 
-const releaseSections = () => [
-  sectionBetween(read('README.md'), '## What is New in v1.3.5', '## Install'),
-  sectionBetween(read('docs/changelog.md'), '## v1.3.5 - 2026-08-06', '## v1.3.4'),
-]
+const historicalRelease = () => sectionBetween(
+  read('docs/changelog.md'),
+  '## v1.3.5 - 2026-08-06',
+  '## v1.3.4',
+)
 
-const requiredUpdateFacts = [
-  'v1.3.4',
+const requiredFixFacts = [
   'exact package filename',
   'wget --output-document',
-  '.1',
-  '.2',
   'short-circuit',
-  'sudo -H',
-  'npm audit --audit-level=high',
-]
-
-// A release that changes files on the host at upgrade has to say so. v1.3.5 was
-// first written as an updater-only patch and went out of date silently as eleven
-// further commits landed; asserting the user-visible packaging change keeps the
-// next release from omitting one the same way.
-const requiredHostIntegrationFacts = [
+  'sudo -H polaris --setup-host',
   '/usr/lib',
   '/etc',
   'polaris-debug',
   'input',
+  'playtime',
+  'npm audit --audit-level=high',
 ]
 
 const expectedAssets = [
@@ -47,83 +38,18 @@ const expectedAssets = [
   'Polaris-ubuntu24.04-x86_64.deb',
 ].sort()
 
-describe('v1.3.5 release contract', () => {
-  it('moves the CMake version and public release headings together', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.5')
-    expect(read('README.md')).toContain('## What is New in v1.3.5')
-    expect(read('docs/changelog.md')).toContain('## v1.3.5 - 2026-08-06')
-  })
+describe('historical v1.3.5 release contract', () => {
+  it('preserves the v1.3.5 release facts', () => {
+    const release = historicalRelease()
 
-  it('records the updater bootstrap and failure-safety facts', () => {
-    for (const releaseSection of releaseSections()) {
-      for (const fact of requiredUpdateFacts) {
-        expect(releaseSection, `release notes must include: ${fact}`).toContain(fact)
-      }
+    for (const fact of requiredFixFacts) {
+      expect(release, `historical release must include: ${fact}`).toContain(fact)
     }
   })
 
-  it('states the host integration changes that alter files on upgrade', () => {
-    const releaseNotes = read('docs/release-notes/v1.3.5.md')
-    for (const fact of requiredHostIntegrationFacts) {
-      expect(releaseNotes, `release notes must include: ${fact}`).toContain(fact)
-    }
-  })
+  it('preserves the exact historical four-asset set', () => {
+    const actualAssets = historicalRelease().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
 
-  it('aligns the public checker with the v1.3.5 release contract', () => {
-    const publicDocsGate = read('scripts/check-public-docs.sh')
-
-    expect(publicDocsGate).toContain('"## What is New in v1.3.5"')
-    expect(publicDocsGate).not.toContain('"## What is New in v1.3.4"')
-    expect(publicDocsGate).toContain('"## v1.3.5 - 2026-08-06"')
-    for (const fact of requiredUpdateFacts) {
-      expect(publicDocsGate, `public checker must require: ${fact}`).toContain(fact)
-    }
-    for (const asset of expectedAssets) {
-      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
-    }
-  })
-
-  it('moves versioned package-review metadata to v1.3.5', () => {
-    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
-    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
-
-    expect(reviewedWarnings).toContain("usr/bin/polaris-1.3.5")
-    expect(reviewedWarnings).not.toContain("usr/bin/polaris-1.3.4")
-    expect(steamOsBuildScript).toContain("'polaris|1.3.5-1|x86_64'")
-    expect(steamOsBuildScript).not.toContain("'polaris|1.3.4-1|x86_64'")
-  })
-
-  it('ships ready-to-publish v1.3.4 bootstrap release notes', () => {
-    const releaseNotes = read('docs/release-notes/v1.3.5.md')
-    const packageCases = [
-      ['fedora', 'Polaris-fedora44-x86_64.rpm'],
-      ['arch', 'Polaris-arch-x86_64.pkg.tar.zst'],
-      ['ubuntu', 'Polaris-ubuntu24.04-x86_64.deb'],
-    ]
-    const expectedCommands = packageCases.map(([packageFamily, name]) => buildManualInstallCommand({
-      name,
-      browser_download_url: `https://github.com/papi-ux/polaris/releases/download/v1.3.5/${name}`,
-      packageFamily,
-    }))
-    // Install blocks only. The property under test is that the documented install
-    // commands match what the Update Center generates; treating every bash block as
-    // an install command also forbids the notes from showing any other example.
-    const documentedCommands = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
-      .map((match) => match[1])
-      .filter((block) => block.includes('wget --output-document='))
-
-    for (const fact of ['v1.3.4', '.1', '.2', 'exact package filename']) {
-      expect(releaseNotes).toContain(fact)
-    }
-    expect(documentedCommands).toEqual(expectedCommands)
-    expect(releaseNotes.match(/sudo -H polaris --setup-host &&/g)).toHaveLength(3)
-    expect(releaseNotes.match(/systemctl --user restart polaris/g)).toHaveLength(3)
-  })
-
-  it('keeps the official release asset set exact', () => {
-    for (const releaseSection of releaseSections()) {
-      const actualAssets = releaseSection.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
-      expect(actualAssets.sort()).toEqual(expectedAssets)
-    }
+    expect(actualAssets.sort()).toEqual(expectedAssets)
   })
 })

--- a/src_assets/common/assets/web/release-v136-contract.test.js
+++ b/src_assets/common/assets/web/release-v136-contract.test.js
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+
+const sectionBetween = (source, startHeading, endHeading) => {
+  const start = source.indexOf(startHeading)
+  const end = source.indexOf(endHeading, start + startHeading.length)
+  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+const releaseSections = () => [
+  sectionBetween(read('README.md'), '## What is New in v1.3.6', '## Install'),
+  sectionBetween(read('docs/changelog.md'), '## v1.3.6 - 2026-08-07', '## v1.3.5'),
+]
+
+const requiredFacts = [
+  'ostree',
+  'usermod',
+  'ujust add-user-to-input-group',
+  'npm audit --audit-level=high',
+]
+
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+
+describe('v1.3.6 release contract', () => {
+  it('moves the CMake version and public release headings together', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.6')
+    expect(read('README.md')).toContain('## What is New in v1.3.6')
+    expect(read('docs/changelog.md')).toContain('## v1.3.6 - 2026-08-07')
+  })
+
+  it('states the release facts in both public summaries', () => {
+    for (const releaseSection of releaseSections()) {
+      for (const fact of requiredFacts) {
+        expect(releaseSection, `release summary must include: ${fact}`).toContain(fact)
+      }
+    }
+  })
+
+  it('aligns the public checker with the v1.3.6 release contract', () => {
+    const publicDocsGate = read('scripts/check-public-docs.sh')
+
+    expect(publicDocsGate).toContain('"## What is New in v1.3.6"')
+    expect(publicDocsGate).not.toContain('"## What is New in v1.3.5"')
+    expect(publicDocsGate).toContain('"## v1.3.6 - 2026-08-07"')
+    for (const asset of expectedAssets) {
+      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
+    }
+  })
+
+  it('moves versioned package-review metadata to v1.3.6', () => {
+    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
+    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
+
+    expect(reviewedWarnings).toContain('usr/bin/polaris-1.3.6')
+    expect(reviewedWarnings).not.toContain('usr/bin/polaris-1.3.5')
+    expect(steamOsBuildScript).toContain("'polaris|1.3.6-1|x86_64'")
+    expect(steamOsBuildScript).not.toContain("'polaris|1.3.5-1|x86_64'")
+  })
+
+  it('ships release notes whose install commands target v1.3.6', () => {
+    const releaseNotes = read('docs/release-notes/v1.3.6.md')
+
+    // The upgrade section has to name the release being upgraded from, and the
+    // ostree remedy, because following the v1.3.5 advice on Bazzite did nothing.
+    for (const fact of ['v1.3.5', 'ostree', 'ujust add-user-to-input-group']) {
+      expect(releaseNotes, `release notes must include: ${fact}`).toContain(fact)
+    }
+
+    // Install blocks only. The property is that documented install commands
+    // point at this release; other examples in the notes are not install
+    // commands and must not be forced to look like them.
+    const installBlocks = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
+
+    expect(installBlocks.length).toBe(3)
+    for (const block of installBlocks) {
+      expect(block).toContain('releases/download/v1.3.6/')
+      expect(block).not.toContain('releases/download/v1.3.5/')
+      expect(block).toContain('polaris --setup-host')
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+  })
+
+  it('keeps the exact four-asset set in the release notes', () => {
+    const notes = read('docs/release-notes/v1.3.6.md')
+    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+
+    expect(listed.sort()).toEqual(expectedAssets)
+  })
+})


### PR DESCRIPTION
## Summary

Prepares Polaris v1.3.6. Eight commits have landed since v1.3.5, and one of them fixes advice that release shipped.

**The reason this is not just a version bump.** v1.3.5's seat isolation warning tells people to run `sudo usermod -aG input <user>`. On ostree hosts the `input` group is defined in `/usr/lib/group`, so that command finds no group to add anyone to and fails. A Bazzite user followed it, got nothing, and reported it. Anyone on Bazzite who enabled seat isolation is stuck until they get a build that prints the right command.

The rest is largely the Nova client working against a Polaris host in places it never has:

| | |
|---|---|
| **#303** | ostree hosts get `ujust add-user-to-input-group`, or the equivalent steps by hand |
| **#299** | artwork resolve reports what it did — Nova required that block and no shipped build ever sent it, so library artwork update reported the host as unsupported everywhere |
| **#298** | library entries carry `platform` and `runtime` from the Lutris runner recorded at import |
| **#287** | a curated artwork identity decides a completion estimate, without falling back to the app id that made the wrong one confident |
| **#302** | gamescope session recovers from states that previously refused every later launch; capture formats follow what the stream encodes |
| **#301** | the stream sink is claimed as session default, and only released by the session that took the claim |
| **#293** | the Nova field contract is derived from the source that serves it, and `vaapi_vendor` is served |
| **#297** | upgrading is documented as the case that leaves a shadowing `/etc` rules copy |

## What moves together

CMake version, `namcap` reviewed-warning path, SteamOS package identity, the public docs gate, the packaging contract and the release contract. The v1.3.5 contract test is retired to the historical form that only guards its changelog entry, matching what v1.3.4 became.

Two things about the gate worth noting rather than burying:

- Its `release_notes_facts` still required `"v1.3.4"`, `"exact package filename"`, `".1"` and `".2"` — v1.3.5's updater facts. Those are replaced with this release's, and `".1"`/`".2"` are gone: as required facts they matched any decimal anywhere in the notes and asserted essentially nothing.
- Three of its error messages still named v1.3.5 while checking the v1.3.6 file.

## Publication boundary

This PR prepares the release only. It does **not** create or push `v1.3.6`, create a GitHub release, or upload assets. Publication remains a separate explicit step against the exact merged commit.

## Exact candidate

- `Commit: ce44796b4053fc15d17f66144d54c337cd57126d`
- `Tree:   e23ada6451ead84fae5aed85f1d37cb0883b1ae2`
- `Base:   b8eaf090fe6d0809b43c7b4d4b3a1d0c74cc438a`

## Verification

On pc-papi (Fedora):

- [x] `npx vitest run` — **51 files, 298 tests**, including the new `release-v136-contract.test.js` (6) and the retired v1.3.5 historical form (2)
- [x] `bash scripts/check-public-docs.sh` — exit 0, checked on its own exit code rather than through a pipe
- [x] Full `ninja`, exit 0
- [x] `ctest` — 17/17

Not covered, and worth stating plainly:

- The date is `2026-08-07`, taken from the host's local time. It is hardcoded in the changelog heading, the README heading boundary, the docs gate and the new contract test; if publication slips past today, all four move together.
- No package artifacts were built locally. The four distro builds run in CI on this PR and are what actually exercise the version-identity changes in `namcap-reviewed-warnings.txt` and `build-steamos-package.sh`.
- The release notes describe #302's HDR behaviour from its own field results on the contributor's hardware. This host has an RTX 4090 and no HDR verification was done here.
