### PR TITLE
feat(nix): align gamescope-polaris with the HDR capture patch stack

### DIFF
--- a/nix/packages/gamescope-polaris/default.nix
+++ b/nix/packages/gamescope-polaris/default.nix
@@ -52,19 +52,16 @@ in
       lib.hasInfix "shaders-path" s || lib.hasInfix "gamescopereaper" s
     ) (old.patches or [ ]))
     ++ [
-      # ValveSoftware/gamescope#2270 — SPA xBGR_210LE + HDR metadata + renegotiate.
-      # DROP when #2270 merges. Grep: POLARIS-UPSTREAM-REMOVE.*2270
-      ../../patches/gamescope/01-pipewire-xbgr-210le-2270.patch
+      # HDR capture stack (format negotiation + optional cursor + stamp).
+      # DROP 10/11 when equivalent upstream lands; stamp is Polaris-only.
+      ../../patches/gamescope/10-pipewire-offer-10-bit-BT2020-PQ.patch
+      ../../patches/gamescope/11-pipewire-composite-cursor.patch
+      ../../patches/gamescope/12-polaris-stamp-version-polhdrN.patch
+      # Polaris-only keepers until proven redundant with 10:
       ../../patches/gamescope/02-headless-hdr-colorimetry.patch
       ../../patches/gamescope/03-pipewire-prefer-dmabuf.patch
-      # Screenshot SDR/HDR LUTs on PW paint (locked to EOTF).
-      ../../patches/gamescope/04-pipewire-color-mgmt.patch
       # ValveSoftware/gamescope#2217: headless prefers discrete GPU if unpinned.
-      # DROP when #2217 merges. Grep: POLARIS-UPSTREAM-REMOVE.*2217
       ../../patches/gamescope/06-prefer-discrete-gpu-2217.patch
-      # Companion to #2270: paint_pipewire EOTF_PQ + SDR-on-HDR screenshot defaults.
-      # DROP when upstream paint matches SPA HDR metadata. Grep: companion to.*2270
-      ../../patches/gamescope/07-paint-pipewire-eotf-pq.patch
     ];
 
   # Master dropped glm_include_dir / stb_include_dir meson options.
@@ -86,9 +83,30 @@ in
       cp -f subprojects/packagefiles/stb/meson.build subprojects/stb/meson.build
     '';
 
+  # Capability stamp from patch 12 — fail the build if patches did not apply.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    # wrapProgram may hide --version on the outer wrapper; try both.
+    # Ignore --version exit status: only the version string matters, and pipefail
+    # would fail the check if gamescope exits non-zero after printing it.
+    ver_out="$("$out/bin/gamescope" --version 2>&1 || true)"
+    if ! printf '%s\n' "$ver_out" | grep -q '+polhdr'; then
+      if [ -x "$out/bin/.gamescope-wrapped" ]; then
+        ver_out="$("$out/bin/.gamescope-wrapped" --version 2>&1 || true)"
+      fi
+      if ! printf '%s\n' "$ver_out" | grep -q '+polhdr'; then
+        echo "gamescope-polaris: +polhdr marker missing from --version" >&2
+        printf '%s\n' "$ver_out" || true
+        exit 1
+      fi
+    fi
+    runHook postInstallCheck
+  '';
+
   meta = old.meta // {
     description = "${
       old.meta.description or "gamescope"
-    } (polaris HDR PW stack; #2270/#2217; master ${lib.substring 0 7 gamescopeRev})";
+    } (polaris HDR PW +polhdr2; #2217; master ${lib.substring 0 7 gamescopeRev})";
   };
 })

--- a/nix/patches/gamescope/10-pipewire-offer-10-bit-BT2020-PQ.patch
+++ b/nix/patches/gamescope/10-pipewire-offer-10-bit-BT2020-PQ.patch
@@ -1,0 +1,260 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrico=20B=C3=BChler?= <enrico.buehler@unom.io>
+Date: Tue, 28 Jul 2026 13:53:41 +0200
+Subject: [PATCH] pipewire: offer 10-bit BT.2020 PQ capture formats (HDR
+ streams)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+gamescope's built-in PipeWire node has always been SDR: build_format_params()
+offers BGRx and NV12 only, and paint_pipewire() hardcodes a Gamma-2.2 composite
+with the SDR screenshot LUT set, so an HDR game reaches every consumer already
+tone-mapped down. Screen-capture consumers that CAN carry HDR — Steam Remote
+Play (#2126), other remote-play hosts — have no way to ask for it.
+
+Offer SPA xRGB_210LE / xBGR_210LE alongside the existing formats, carrying
+MANDATORY SMPTE ST.2084 (PQ) + BT.2020 colorimetry properties, and map them to
+DRM_FORMAT_XRGB2101010 / XBGR2101010 — the same 10-bit capture texture the HDR
+AVIF screenshot path already allocates. When such a format is negotiated,
+paint_pipewire() switches to g_ScreenshotColorMgmtLutsHDR and EOTF_PQ: exactly
+the bHDRScreenshot branch, which is a fixed BT.2020+PQ target whose LUT set is
+built unconditionally for every input EOTF, so SDR content lands in the PQ
+container at --hdr-sdr-content-nits and HDR content passes through.
+
+The new formats are listed last, so every consumer that negotiates the 8-bit
+stream today keeps negotiating it bit-for-bit; the MANDATORY colorimetry props
+mean a consumer cannot land on 10-bit without agreeing to PQ/BT.2020. Unlike
+bHDRScreenshot the switch does not depend on the focused app being HDR — a
+stream's colorimetry is fixed for the life of the negotiation and must not
+follow what the app happens to render.
+
+Works on the headless backend as well as a real connector: no HDR display is
+involved anywhere in the LUT set.
+---
+ src/pipewire.cpp     | 114 +++++++++++++++++++++++++++++++++----------
+ src/steamcompmgr.cpp |  21 ++++++--
+ 2 files changed, 106 insertions(+), 29 deletions(-)
+
+diff --git a/src/pipewire.cpp b/src/pipewire.cpp
+index 76b3ea8..7beffa8 100644
+--- a/src/pipewire.cpp
++++ b/src/pipewire.cpp
+@@ -18,6 +18,40 @@
+ 
+ static LogScope pwr_log("pipewire");
+ 
++// 10-bit HDR capture.
++//
++// The packed 10-bit RGB SPA formats (xRGB_210LE / xBGR_210LE) predate PipeWire 1.0; the guard
++// only exists so this file still compiles against an ancient libspa, in which case the stream
++// offers exactly the 8-bit formats it always did.
++#if PW_CHECK_VERSION(1, 0, 0)
++#define GAMESCOPE_PIPEWIRE_HDR 1
++#else
++#define GAMESCOPE_PIPEWIRE_HDR 0
++#endif
++
++#if GAMESCOPE_PIPEWIRE_HDR
++// The colorimetry VALUES, spelled out rather than taken from the enums, because the headers that
++// name them are much newer than the ones that name the formats above: SPA grew
++// BT2020_10 / SMPTE2084 / ARIB_STD_B67 as one block, and a libspa without it stops at ADOBERGB —
++// PipeWire 1.4.11 (Fedora 43 / Bazzite) does exactly that, so `SPA_VIDEO_TRANSFER_SMPTE2084`
++// fails to compile there even though the library parses the value perfectly well.
++//
++// Spelling them out is safe because the enum is WIRE ABI, not a private detail: SPA mirrors
++// GStreamer's GstVideoTransferFunction / GstVideoColorPrimaries, where these landed together, so
++// the numbers are identical on every implementation that has them at all. On one that does not,
++// a consumer simply fails to intersect this pod and negotiates 8-bit — the same outcome as not
++// offering HDR. (HDR consumers need the same 14-format offer set for the same reason.)
++static constexpr uint32_t kSpaVideoTransferSmpte2084 = 14;
++static constexpr uint32_t kSpaVideoColorPrimariesBt2020 = 7;
++#endif
++
++#if GAMESCOPE_PIPEWIRE_HDR
++static bool is_hdr_video_format(uint32_t format)
++{
++	return format == SPA_VIDEO_FORMAT_xRGB_210LE || format == SPA_VIDEO_FORMAT_xBGR_210LE;
++}
++#endif
++
+ static struct pipewire_state pipewire_state = { .stream_node_id = SPA_ID_INVALID };
+ static int nudgePipe[2] = { -1, -1 };
+ 
+@@ -94,6 +128,37 @@ static void calculate_capture_size()
+ 	s_nCaptureHeight = SPA_ROUND_UP_N(s_nCaptureHeight, kCaptureAlign);
+ }
+ 
++// The colorimetry properties that go with `format`, appended into an already-open EnumFormat
++// object. NV12 keeps offering the BT.601/BT.709 matrix+range choice it always did; the 10-bit
++// packed-RGB formats carry a FIXED, MANDATORY BT.2020 + SMPTE ST.2084 (PQ) description, because
++// that is exactly what paint_pipewire() encodes into them (the HDR screenshot LUT set — a fixed
++// PQ container, independent of what the focused app renders). MANDATORY means a consumer that
++// does not speak PQ/BT.2020 cannot land on these formats by accident: it fails to intersect this
++// pod and falls back to the 8-bit ones listed before it.
++static void add_format_color_params(struct spa_pod_builder *builder, spa_video_format format)
++{
++	if (format == SPA_VIDEO_FORMAT_NV12) {
++		spa_pod_builder_add(builder,
++			SPA_FORMAT_VIDEO_colorMatrix, SPA_POD_CHOICE_ENUM_Id(3,
++							SPA_VIDEO_COLOR_MATRIX_BT601,
++							SPA_VIDEO_COLOR_MATRIX_BT601,
++							SPA_VIDEO_COLOR_MATRIX_BT709),
++			SPA_FORMAT_VIDEO_colorRange, SPA_POD_CHOICE_ENUM_Id(3,
++							SPA_VIDEO_COLOR_RANGE_16_235,
++							SPA_VIDEO_COLOR_RANGE_16_235,
++							SPA_VIDEO_COLOR_RANGE_0_255),
++			0);
++	}
++#if GAMESCOPE_PIPEWIRE_HDR
++	else if (is_hdr_video_format(format)) {
++		spa_pod_builder_prop(builder, SPA_FORMAT_VIDEO_transferFunction, SPA_POD_PROP_FLAG_MANDATORY);
++		spa_pod_builder_id(builder, kSpaVideoTransferSmpte2084);
++		spa_pod_builder_prop(builder, SPA_FORMAT_VIDEO_colorPrimaries, SPA_POD_PROP_FLAG_MANDATORY);
++		spa_pod_builder_id(builder, kSpaVideoColorPrimariesBt2020);
++	}
++#endif
++}
++
+ static void build_format_params(struct spa_pod_builder *builder, spa_video_format format, std::vector<const struct spa_pod *> &params) {
+ 	struct spa_rectangle size = SPA_RECTANGLE(s_nCaptureWidth, s_nCaptureHeight);
+ 	struct spa_rectangle min_requested_size = { 0, 0 };
+@@ -112,18 +177,7 @@ static void build_format_params(struct spa_pod_builder *builder, spa_video_forma
+ 		SPA_FORMAT_VIDEO_requested_size, SPA_POD_CHOICE_RANGE_Rectangle( &min_requested_size, &min_requested_size, &max_requested_size ),
+ 		SPA_FORMAT_VIDEO_gamescope_focus_appid, SPA_POD_CHOICE_RANGE_Long( 0ll, INT64_MIN, INT64_MAX ),
+ 		0);
+-	if (format == SPA_VIDEO_FORMAT_NV12) {
+-		spa_pod_builder_add(builder,
+-			SPA_FORMAT_VIDEO_colorMatrix, SPA_POD_CHOICE_ENUM_Id(3,
+-							SPA_VIDEO_COLOR_MATRIX_BT601,
+-							SPA_VIDEO_COLOR_MATRIX_BT601,
+-							SPA_VIDEO_COLOR_MATRIX_BT709),
+-			SPA_FORMAT_VIDEO_colorRange, SPA_POD_CHOICE_ENUM_Id(3,
+-							SPA_VIDEO_COLOR_RANGE_16_235,
+-							SPA_VIDEO_COLOR_RANGE_16_235,
+-							SPA_VIDEO_COLOR_RANGE_0_255),
+-			0);
+-	}
++	add_format_color_params(builder, format);
+ 	spa_pod_builder_prop(builder, SPA_FORMAT_VIDEO_modifier, SPA_POD_PROP_FLAG_MANDATORY);
+ 	spa_pod_builder_push_choice(builder, &choice_frame, SPA_CHOICE_Enum, 0);
+ 	spa_pod_builder_long(builder, modifier); // default
+@@ -141,18 +195,7 @@ static void build_format_params(struct spa_pod_builder *builder, spa_video_forma
+ 		SPA_FORMAT_VIDEO_requested_size, SPA_POD_CHOICE_RANGE_Rectangle( &min_requested_size, &min_requested_size, &max_requested_size ),
+ 		SPA_FORMAT_VIDEO_gamescope_focus_appid, SPA_POD_CHOICE_RANGE_Long( 0ll, INT64_MIN, INT64_MAX ),
+ 		0);
+-	if (format == SPA_VIDEO_FORMAT_NV12) {
+-		spa_pod_builder_add(builder,
+-			SPA_FORMAT_VIDEO_colorMatrix, SPA_POD_CHOICE_ENUM_Id(3,
+-							SPA_VIDEO_COLOR_MATRIX_BT601,
+-							SPA_VIDEO_COLOR_MATRIX_BT601,
+-							SPA_VIDEO_COLOR_MATRIX_BT709),
+-			SPA_FORMAT_VIDEO_colorRange, SPA_POD_CHOICE_ENUM_Id(3,
+-							SPA_VIDEO_COLOR_RANGE_16_235,
+-							SPA_VIDEO_COLOR_RANGE_16_235,
+-							SPA_VIDEO_COLOR_RANGE_0_255),
+-			0);
+-	}
++	add_format_color_params(builder, format);
+ 	params.push_back((const struct spa_pod *) spa_pod_builder_pop(builder, &obj_frame));
+ 
+ //	for (auto& param : params)
+@@ -166,6 +209,14 @@ static std::vector<const struct spa_pod *> build_format_params(struct spa_pod_bu
+ 
+ 	build_format_params(builder, SPA_VIDEO_FORMAT_BGRx, params);
+ 	build_format_params(builder, SPA_VIDEO_FORMAT_NV12, params);
++#if GAMESCOPE_PIPEWIRE_HDR
++	// Listed LAST, on purpose: PipeWire intersects in offer order, so every consumer that
++	// negotiates today's 8-bit stream keeps negotiating it bit-for-bit. Only a consumer that
++	// asks for a 10-bit format by name — and accepts the MANDATORY BT.2020 + PQ colorimetry
++	// above — ever reaches these.
++	build_format_params(builder, SPA_VIDEO_FORMAT_xRGB_210LE, params);
++	build_format_params(builder, SPA_VIDEO_FORMAT_xBGR_210LE, params);
++#endif
+ 
+ 	return params;
+ }
+@@ -288,7 +339,7 @@ static void dispatch_nudge(struct pipewire_state *state, int fd)
+ 	if (s_nCaptureWidth != state->video_info.size.width || s_nCaptureHeight != state->video_info.size.height) {
+ 		pwr_log.debugf("renegotiating stream params (size: %dx%d)", s_nCaptureWidth, s_nCaptureHeight);
+ 
+-		uint8_t buf[4096];
++		uint8_t buf[8192];
+ 		struct spa_pod_builder builder = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
+ 		std::vector<const struct spa_pod *> format_params = build_format_params(&builder);
+ 		int ret = pw_stream_update_params(state->stream, format_params.data(), format_params.size());
+@@ -412,6 +463,12 @@ static void stream_handle_param_changed(void *data, uint32_t id, const struct sp
+ 		state->video_info.size.width, state->video_info.size.height,
+ 		s_nRequestedWidth, s_nRequestedHeight,
+ 		state->video_info.format, state->shm_stride, shm_size, state->dmabuf);
++
++#if GAMESCOPE_PIPEWIRE_HDR
++	if (is_hdr_video_format(state->video_info.format)) {
++		pwr_log.infof("negotiated a 10-bit stream — the composite is encoded as BT.2020 + PQ (HDR10)");
++	}
++#endif
+ }
+ 
+ static void randname(char *buf)
+@@ -450,6 +507,11 @@ uint32_t spa_format_to_drm(uint32_t spa_format)
+ 	switch (spa_format)
+ 	{
+ 		case SPA_VIDEO_FORMAT_NV12: return DRM_FORMAT_NV12;
++#if GAMESCOPE_PIPEWIRE_HDR
++		// Same texture machinery the HDR AVIF screenshot path already uses.
++		case SPA_VIDEO_FORMAT_xRGB_210LE: return DRM_FORMAT_XRGB2101010;
++		case SPA_VIDEO_FORMAT_xBGR_210LE: return DRM_FORMAT_XBGR2101010;
++#endif
+ 		default:
+ 		case SPA_VIDEO_FORMAT_BGR: return DRM_FORMAT_XRGB8888;
+ 	}
+@@ -715,7 +777,7 @@ bool init_pipewire(void)
+ 	s_nOutputHeight = g_nOutputHeight;
+ 	calculate_capture_size();
+ 
+-	uint8_t buf[4096];
++	uint8_t buf[8192];
+ 	struct spa_pod_builder builder = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
+ 	std::vector<const struct spa_pod *> format_params = build_format_params(&builder);
+ 
+diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
+index ecb3808..b01a784 100644
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -2335,17 +2335,33 @@ static void paint_pipewire()
+ 	if ( !s_pPipewireBuffer || !s_pPipewireBuffer->texture )
+ 		return;
+ 
++	// The negotiated stream format decides the composite's colorimetry. A 10-bit target (the
++	// xRGB_210LE / xBGR_210LE offer, whose SPA props say BT.2020 + PQ) gets the same fixed
++	// BT.2020/PQ container the HDR AVIF screenshot path uses; everything else keeps the SDR
++	// Gamma-2.2 composite it always had.
++	//
++	// Deliberately NOT conditional on the focused app being HDR, unlike bHDRScreenshot: the
++	// stream's colorimetry is fixed for the lifetime of the negotiation, so it must not follow
++	// what the app happens to render. g_ScreenshotColorMgmtLutsHDR is built for EVERY input EOTF
++	// (see update_screenshot_color_mgmt), so SDR content lands in the PQ container at
++	// --hdr-sdr-content-nits, HDR content passes through, and mixed scenes composite correctly.
++	const uint32_t uStreamDrmFormat = s_pPipewireBuffer->texture->drmFormat();
++	const bool bHDRStream = uStreamDrmFormat == DRM_FORMAT_XRGB2101010 ||
++	                        uStreamDrmFormat == DRM_FORMAT_XBGR2101010;
++
+ 	struct FrameInfo_t frameInfo = {};
+ 	frameInfo.applyOutputColorMgmt = true;
+-	frameInfo.outputEncodingEOTF   = EOTF_Gamma22;
++	frameInfo.outputEncodingEOTF   = bHDRStream ? EOTF_PQ : EOTF_Gamma22;
+ 	frameInfo.allowVRR             = false;
+ 	frameInfo.bFadingOut           = false;
+ 
+ 	// Apply screenshot-style color management.
++	// bHDRStream is fixed for the frame; bind luts once outside the EOTF loop.
++	auto& luts = bHDRStream ? g_ScreenshotColorMgmtLutsHDR : g_ScreenshotColorMgmtLuts;
+ 	for ( uint32_t nInputEOTF = 0; nInputEOTF < EOTF_Count; nInputEOTF++ )
+ 	{
+-		frameInfo.lut3D[nInputEOTF]     = g_ScreenshotColorMgmtLuts[nInputEOTF].vk_lut3d;
+-		frameInfo.shaperLut[nInputEOTF] = g_ScreenshotColorMgmtLuts[nInputEOTF].vk_lut1d;
++		frameInfo.lut3D[nInputEOTF]     = luts[nInputEOTF].vk_lut3d;
++		frameInfo.shaperLut[nInputEOTF] = luts[nInputEOTF].vk_lut1d;
+ 	}
+ 
+ 	const uint64_t ulFocusAppId = s_pPipewireBuffer->gamescope_info.focus_appid;

--- a/nix/patches/gamescope/11-pipewire-composite-cursor.patch
+++ b/nix/patches/gamescope/11-pipewire-composite-cursor.patch
@@ -1,0 +1,163 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrico=20B=C3=BChler?= <enrico.buehler@unom.io>
+Date: Tue, 28 Jul 2026 15:41:45 +0200
+Subject: [PATCH] pipewire: optionally composite the cursor into the capture
+ stream
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+gamescope's PipeWire node has never carried the pointer: it lives on a hardware
+plane for scanout, and `paint_pipewire()` composites a separate, reduced frame
+that never includes it. That is the right default — a remote-play consumer that
+draws its own cursor would end up with two — but it leaves a consumer with no
+cursor of its own nothing to fall back to, because the node is all it gets.
+Such a consumer has to reconstruct the pointer out of band (XFixes plus a
+host-side blend), which forces a full-frame colour-conversion pass it would
+otherwise not need.
+
+Add `--pipewire-composite-cursor` (convar `pipewire_composite_cursor`, off by
+default) to paint it in, using the same guards and the same MouseCursor::paint
+call the scanout composite uses. It scales correctly for free: paint_pipewire
+has already set currentOutputWidth/Height to the capture size, which is what
+MouseCursor::paint scales against.
+
+The repaint test grows the cursor's state alongside the commit ids. A
+pointer-only move produces no new commit, so without it the composited cursor
+would freeze on a static screen while the real one moved — and a cursor that
+became hidden would never be erased. `undirty()` runs before the test, exactly
+as the scanout path does, so the test and the paint agree on
+`ShouldDrawCursor()`.
+
+The cursor is taken from the global focus rather than the stream's: the pointer
+is one device with one position whatever the stream shows, and the
+focus-appid branch hands back a plain focus_t, which carries no cursor.
+---
+ src/main.cpp         |  2 ++
+ src/steamcompmgr.cpp | 63 +++++++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 64 insertions(+), 1 deletion(-)
+
+diff --git a/src/main.cpp b/src/main.cpp
+index 9fc54f0..1eb35b3 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -141,6 +141,7 @@ const struct option *gamescope_options = (struct option[]){
+ 
+ 	{ "disable-color-management", no_argument, nullptr, 0 },
+ 	{ "sdr-gamut-wideness", required_argument, nullptr, 0 },
++	{ "pipewire-composite-cursor", no_argument, nullptr, 0 },
+ 	{ "hdr-enabled", no_argument, nullptr, 0 },
+ 	{ "hdr-sdr-content-nits", required_argument, nullptr, 0 },
+ 	{ "hdr-itm-enabled", no_argument, nullptr, 0 },
+@@ -205,6 +206,7 @@ const char usage[] =
+ 	"  --force-windows-fullscreen     force windows inside of gamescope to be the size of the nested display (fullscreen)\n"
+ 	"  --cursor-scale-height          if specified, sets a base output height to linearly scale the cursor against.\n"
+ 	"  --virtual-connector-strategy   Specifies how we should make virtual connectors.\n"
++	"  --pipewire-composite-cursor    composite the cursor into the PipeWire capture stream (off by default: the node has never carried it, and a consumer that draws its own would get two)\n"
+ 	"  --hdr-enabled                  enable HDR output (needs Gamescope WSI layer enabled for support from clients)\n"
+ 	"                                 If this is not set, and there is a HDR client, it will be tonemapped SDR.\n"
+ 	"  --sdr-gamut-wideness           Set the 'wideness' of the gamut for SDR comment. 0 - 1.\n"
+diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
+index 01b2abf..5c65420 100644
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -2316,6 +2316,13 @@ static void update_touch_scaling( const struct FrameInfo_t *frameInfo )
+ }
+ 
+ #if HAVE_PIPEWIRE
++// Declared here rather than beside the other `cv_paint_*_plane` knobs, which sit BELOW
++// paint_pipewire and so are not in scope for it.
++gamescope::ConVar<bool> cv_pipewire_composite_cursor{ "pipewire_composite_cursor", false,
++	"Composite the cursor into the PipeWire capture stream (--pipewire-composite-cursor). Off by "
++	"default: the node has never carried the pointer, and a consumer that draws its own would get "
++	"two." };
++
+ static void paint_pipewire()
+ {
+ 	static struct pipewire_buffer *s_pPipewireBuffer = nullptr;
+@@ -2402,16 +2409,48 @@ static void paint_pipewire()
+ 	// If the commits are the same as they were last time, don't repaint and don't push a new buffer on the stream.
+ 	static uint64_t s_ulLastFocusCommitId = 0;
+ 	static uint64_t s_ulLastOverrideCommitId = 0;
++	static bool s_bLastCursorDrawn = false;
++	static int s_nLastCursorX = 0;
++	static int s_nLastCursorY = 0;
+ 
+ 	uint64_t ulFocusCommitId = window_last_done_commit_id( pFocus->focusWindow );
+ 	uint64_t ulOverrideCommitId = window_last_done_commit_id( pFocus->overrideWindow );
+ 
++	// With the cursor composited in, the pointer becomes part of what this stream shows — so its
++	// state has to join the repaint test, or it would freeze on a static screen while the real
++	// one moves (and a hidden cursor would never be erased). `undirty()` first, exactly as the
++	// scanout composite does: it refreshes the texture and the grabbed/hidden state that
++	// `ShouldDrawCursor()` reads, so both the test and the paint below see the same answer.
++	//
++	// The cursor comes from the GLOBAL focus, not `pFocus`: the pointer is one device with one
++	// position whatever this stream is showing, and the focus-appid branch above hands back a
++	// plain `focus_t`, which carries no cursor at all.
++	global_focus_t *pGlobalFocus = cv_pipewire_composite_cursor ? GetCurrentFocus() : nullptr;
++	MouseCursor *pCursor = pGlobalFocus ? pGlobalFocus->cursor : nullptr;
++	bool bDrawCursor = false;
++	int nCursorX = 0, nCursorY = 0;
++	if ( pCursor )
++	{
++		pCursor->undirty();
++		bDrawCursor = ShouldDrawCursor();
++		if ( bDrawCursor )
++		{
++			nCursorX = pCursor->x();
++			nCursorY = pCursor->y();
++		}
++	}
++
+ 	if ( ulFocusCommitId == s_ulLastFocusCommitId &&
+-	     ulOverrideCommitId == s_ulLastOverrideCommitId )
++	     ulOverrideCommitId == s_ulLastOverrideCommitId &&
++	     bDrawCursor == s_bLastCursorDrawn &&
++	     nCursorX == s_nLastCursorX && nCursorY == s_nLastCursorY )
+ 		return;
+ 
+ 	s_ulLastFocusCommitId = ulFocusCommitId;
+ 	s_ulLastOverrideCommitId = ulOverrideCommitId;
++	s_bLastCursorDrawn = bDrawCursor;
++	s_nLastCursorX = nCursorX;
++	s_nLastCursorY = nCursorY;
+ 
+ 	uint32_t uWidth = s_pPipewireBuffer->texture->width();
+ 	uint32_t uHeight = s_pPipewireBuffer->texture->height();
+@@ -2436,6 +2475,22 @@ static void paint_pipewire()
+ 				( cv_overlay_unmultiplied_alpha ? PaintWindowFlag::CoverageMode : 0 )  );
+ 	}
+ 
++	// The cursor, when this stream was asked for it. gamescope keeps the pointer OUT of the
++	// PipeWire node by default — it lives on a hardware plane for scanout, and a remote-play
++	// consumer that draws its own would end up with two — so a consumer that has no cursor of
++	// its own (and no way to obtain one, because this node is all it gets) has to ask for it.
++	//
++	// Painted at THIS stream's scale: `currentOutputWidth/Height` were set to the capture size
++	// above, which is exactly what MouseCursor::paint scales against. Already `undirty()`ed by
++	// the repaint test.
++	if ( bDrawCursor )
++	{
++		pCursor->paint(
++			pFocus->focusWindow,
++			pFocus->focusWindow == pFocus->overrideWindow ? nullptr : pFocus->overrideWindow,
++			&frameInfo );
++	}
++
+ 	gamescope::Rc<CVulkanTexture> pRGBTexture = s_pPipewireBuffer->texture->isYcbcr()
+ 		? vulkan_acquire_capture_texture( uWidth, uHeight, false, DRM_FORMAT_XRGB2101010 )
+ 		: gamescope::Rc<CVulkanTexture>{ s_pPipewireBuffer->texture };
+@@ -8397,6 +8452,12 @@ steamcompmgr_main(int argc, char **argv)
+ 					g_FadeOutDuration = atoi(optarg);
+ 				} else if (strcmp(opt_name, "force-windows-fullscreen") == 0) {
+ 					bForceWindowsFullscreen = true;
++				} else if (strcmp(opt_name, "pipewire-composite-cursor") == 0) {
++#if HAVE_PIPEWIRE
++					cv_pipewire_composite_cursor = true;
++#else
++					fprintf( stderr, "gamescope: --pipewire-composite-cursor ignored (built without PipeWire)\n" );
++#endif
+ 				} else if (strcmp(opt_name, "hdr-enabled") == 0 || strcmp(opt_name, "hdr-enable") == 0) {
+ 					cv_hdr_enabled = true;
+ 				} else if (strcmp(opt_name, "hdr-debug-force-support") == 0) {

--- a/nix/patches/gamescope/12-polaris-stamp-version-polhdrN.patch
+++ b/nix/patches/gamescope/12-polaris-stamp-version-polhdrN.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Enrico=20B=C3=BChler?= <enrico.buehler@unom.io>
+Date: Tue, 28 Jul 2026 15:42:01 +0200
+Subject: [PATCH] polaris: stamp the version banner with +polhdrN
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+polaris decides a session's shape before the virtual display exists — the
+bit depth in the Welcome (irrevocable; a PQ stream on an 8-bit encoder is a
+hard error), and whether it must composite the cursor host-side before the
+encoder is even opened. Both answers therefore have to be static properties of
+the resolved binary rather than something negotiated later.
+
+The number is a monotonic patch-set revision, so one probe answers both:
+  +polhdr1  10-bit BT.2020/PQ capture formats
+  +polhdr2  …and --pipewire-composite-cursor
+
+NOT for upstream: drop this once the functional patches land there and plain
+version floors answer the same questions.
+---
+ src/meson.build | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/meson.build b/src/meson.build
+index 662f752..af48d01 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -177,7 +177,12 @@ compiler_version = cc.version()
+ 
+ vcs_tag_cmd = ['git', 'describe', '--always', '--tags', '--dirty=+']
+ vcs_tag = run_command(vcs_tag_cmd, check: false).stdout().strip()
+-version_tag = vcs_tag + ' (' + compiler_name + ' ' + compiler_version + ')'
++# polaris carries patches on top of upstream; stamp the banner so a host can probe what this
++# binary can do from `gamescope --version` alone, before it has to commit a session to it (the
++# polaris/1 Welcome is irrevocable). The number is a monotonic PATCH-SET revision:
++#   +polhdr1 — 10-bit BT.2020/PQ capture formats on the PipeWire node
++#   +polhdr2 — …and `--pipewire-composite-cursor`
++version_tag = vcs_tag + '+polhdr2' + ' (' + compiler_name + ' ' + compiler_version + ')'
+ 
+ gamescope_version_conf = configuration_data()
+ gamescope_version_conf.set('VCS_TAG', version_tag)

--- a/nix/patches/gamescope/README.md
+++ b/nix/patches/gamescope/README.md
@@ -2,33 +2,37 @@
 
 Applied in order by `nix/packages/gamescope-polaris/default.nix`.
 
+Polaris HDR capture patch surface for gamescope PipeWire streaming.
+
 | # | File | Purpose | Drop when |
 |---|------|---------|-----------|
-| **01** | `01-pipewire-xbgr-210le-2270.patch` | SPA `xBGR_210LE` + BT.2020/PQ metadata + HDR renegotiate | **[#2270](https://github.com/ValveSoftware/gamescope/pull/2270)** merges |
-| 02 | `02-headless-hdr-colorimetry.patch` | Headless real SDR vs HDR EDID/expose | Upstream headless HDR API |
-| 03 | `03-pipewire-prefer-dmabuf.patch` | Prefer `SPA_DATA_DmaBuf` when allowed | Upstream if accepted |
-| 04 | `04-pipewire-color-mgmt.patch` | `paint_pipewire` screenshot SDR/HDR LUTs | Companion to #2270 |
+| **10** | `10-pipewire-offer-10-bit-BT2020-PQ.patch` | Offer SPA 10-bit BT.2020/PQ formats; paint switches on negotiated format | Upstream HDR PW formats land |
+| **11** | `11-pipewire-composite-cursor.patch` | Optional `--pipewire-composite-cursor` | Upstream cursor composite lands |
+| **12** | `12-polaris-stamp-version-polhdrN.patch` | Banner `+polhdr2` capability stamp | Functional patches upstream; version floors suffice |
+| 02 | `02-headless-hdr-colorimetry.patch` | Headless real SDR vs HDR EDID/expose | Proven redundant with 10 on headless |
+| 03 | `03-pipewire-prefer-dmabuf.patch` | Advertise DmaBuf\|MemFd\|MemPtr | Portal path no longer needs multi-type |
 | **06** | `06-prefer-discrete-gpu-2217.patch` | Headless prefers discrete GPU if unpinned | **[#2217](https://github.com/ValveSoftware/gamescope/pull/2217)** merges |
-| **07** | `07-paint-pipewire-eotf-pq.patch` | `EOTF_PQ` when HDR on + SDR-on-HDR defaults | Companion to **#2270** paint path |
 
-```bash
-rg -n 'POLARIS-UPSTREAM-REMOVE' nix/patches/gamescope/
+## Superseded (removed from package)
+
+| Old | Why gone |
+|-----|----------|
+| `01-pipewire-xbgr-210le-2270.patch` | Superseded by **10** (full 10-bit PQ offer + paint) |
+| `04-pipewire-color-mgmt.patch` | Folded into **10** paint path |
+| `07-paint-pipewire-eotf-pq.patch` | Folded into **10** |
+
+## Capability stamp
+
+```text
++polhdr1  10-bit BT.2020/PQ capture formats
++polhdr2  …and --pipewire-composite-cursor
 ```
 
-## 01 = #2270
+```bash
+gamescope --version   # expect +polhdr2
+rg -n 'POLARIS-UPSTREAM-REMOVE|polhdr' nix/patches/gamescope/
+```
 
-Vendored from https://github.com/ValveSoftware/gamescope/pull/2270 with
-`POLARIS-UPSTREAM-REMOVE` markers only. Delete when #2270 merges.
+## References
 
-## 04 + 07 = paint companions to #2270
-
-1. **07** — `outputEncodingEOTF = g_bOutputHDREnabled ? EOTF_PQ : EOTF_Gamma22`
-2. **04** — screenshot SDR/HDR LUT sets locked to that EOTF
-3. **07** also pins `k_ScreenshotColorMgmtHDR` (`sdrGamutWideness=0`,
-   `flSDROnHDRBrightness=203`)
-
-(Raw composite / no-LUT experiment removed — no video for client.)
-
-## 06 = #2217
-
-Headless device pick without `--prefer-vk-device`. Drop when #2217 merges.
+- ValveSoftware/gamescope#2270, #2217, #2126

--- a/nix/patches/gamescope/archive/01-pipewire-xbgr-210le-2270.patch
+++ b/nix/patches/gamescope/archive/01-pipewire-xbgr-210le-2270.patch
@@ -1,0 +1,77 @@
+diff --git a/src/pipewire.cpp b/src/pipewire.cpp
+--- a/src/pipewire.cpp
++++ b/src/pipewire.cpp
+@@ -123,6 +123,12 @@ static void build_format_params(struct spa_pod_builder *builder, spa_video_forma
+ 							SPA_VIDEO_COLOR_RANGE_16_235,
+ 							SPA_VIDEO_COLOR_RANGE_0_255),
+ 			0);
++	// POLARIS-UPSTREAM-REMOVE: ValveSoftware/gamescope#2270
++	} else if (g_bOutputHDREnabled && format == SPA_VIDEO_FORMAT_xBGR_210LE) {
++		spa_pod_builder_add(builder,
++			SPA_FORMAT_VIDEO_colorPrimaries, SPA_POD_Id(SPA_VIDEO_COLOR_PRIMARIES_BT2020),
++			SPA_FORMAT_VIDEO_transferFunction, SPA_POD_Id(SPA_VIDEO_TRANSFER_SMPTE2084),
++			0);
+ 	}
+ 	spa_pod_builder_prop(builder, SPA_FORMAT_VIDEO_modifier, SPA_POD_PROP_FLAG_MANDATORY);
+ 	spa_pod_builder_push_choice(builder, &choice_frame, SPA_CHOICE_Enum, 0);
+@@ -152,6 +158,12 @@ static void build_format_params(struct spa_pod_builder *builder, spa_video_forma
+ 							SPA_VIDEO_COLOR_RANGE_16_235,
+ 							SPA_VIDEO_COLOR_RANGE_0_255),
+ 			0);
++	// POLARIS-UPSTREAM-REMOVE: ValveSoftware/gamescope#2270
++	} else if (g_bOutputHDREnabled && format == SPA_VIDEO_FORMAT_xBGR_210LE) {
++		spa_pod_builder_add(builder,
++			SPA_FORMAT_VIDEO_colorPrimaries, SPA_POD_Id(SPA_VIDEO_COLOR_PRIMARIES_BT2020),
++			SPA_FORMAT_VIDEO_transferFunction, SPA_POD_Id(SPA_VIDEO_TRANSFER_SMPTE2084),
++			0);
+ 	}
+ 	params.push_back((const struct spa_pod *) spa_pod_builder_pop(builder, &obj_frame));
+ 
+@@ -166,6 +178,9 @@ static std::vector<const struct spa_pod *> build_format_params(struct spa_pod_bu
+ 
+ 	build_format_params(builder, SPA_VIDEO_FORMAT_BGRx, params);
+ 	build_format_params(builder, SPA_VIDEO_FORMAT_NV12, params);
++	// POLARIS-UPSTREAM-REMOVE: ValveSoftware/gamescope#2270
++	if (g_bOutputHDREnabled)
++		build_format_params(builder, SPA_VIDEO_FORMAT_xBGR_210LE, params);
+ 
+ 	return params;
+ }
+@@ -271,6 +286,8 @@ static void copy_buffer(struct pipewire_state *state, struct pipewire_buffer *bu
+ 
+ static void dispatch_nudge(struct pipewire_state *state, int fd)
+ {
++	// POLARIS-UPSTREAM-REMOVE: ValveSoftware/gamescope#2270
++	static bool s_bLastHDREnabled = false;
+ 	while (true) {
+ 		static char buf[1024];
+ 		if (read(fd, buf, sizeof(buf)) < 0) {
+@@ -285,7 +302,8 @@ static void dispatch_nudge(struct pipewire_state *state, int fd)
+ 		s_nOutputHeight = g_nOutputHeight;
+ 		calculate_capture_size();
+ 	}
+-	if (s_nCaptureWidth != state->video_info.size.width || s_nCaptureHeight != state->video_info.size.height) {
++	if (s_nCaptureWidth != state->video_info.size.width || s_nCaptureHeight != state->video_info.size.height || s_bLastHDREnabled != g_bOutputHDREnabled) {
++		s_bLastHDREnabled = g_bOutputHDREnabled;
+ 		pwr_log.debugf("renegotiating stream params (size: %dx%d)", s_nCaptureWidth, s_nCaptureHeight);
+ 
+ 		uint8_t buf[4096];
+@@ -450,6 +468,8 @@ uint32_t spa_format_to_drm(uint32_t spa_format)
+ 	switch (spa_format)
+ 	{
+ 		case SPA_VIDEO_FORMAT_NV12: return DRM_FORMAT_NV12;
++		// POLARIS-UPSTREAM-REMOVE: ValveSoftware/gamescope#2270
++		case SPA_VIDEO_FORMAT_xBGR_210LE: return DRM_FORMAT_XBGR2101010;
+ 		default:
+ 		case SPA_VIDEO_FORMAT_BGR: return DRM_FORMAT_XRGB8888;
+ 	}
+@@ -507,7 +527,8 @@ static void stream_handle_add_buffer(void *user_data, struct pw_buffer *pw_buffe
+ 	screenshotImageFlags.bMappable = true;
+ 	screenshotImageFlags.bTransferDst = true;
+ 	screenshotImageFlags.bStorage = true;
+-	if (is_dmabuf || drmFormat == DRM_FORMAT_NV12)
++	// POLARIS-UPSTREAM-REMOVE: ValveSoftware/gamescope#2270
++	if (is_dmabuf || drmFormat == DRM_FORMAT_NV12 || drmFormat == DRM_FORMAT_XBGR2101010)
+ 	{
+ 		screenshotImageFlags.bExportable = true;
+ 		screenshotImageFlags.bLinear = true; // TODO: support multi-planar DMA-BUF export via PipeWire

--- a/nix/patches/gamescope/archive/04-pipewire-color-mgmt.patch
+++ b/nix/patches/gamescope/archive/04-pipewire-color-mgmt.patch
@@ -1,0 +1,22 @@
+diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
+index ff9ae1f..a66e886 100644
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -2341,11 +2341,14 @@ static void paint_pipewire()
+ 	frameInfo.allowVRR             = false;
+ 	frameInfo.bFadingOut           = false;
+ 
+-	// Apply screenshot-style color management.
++	// POLARIS-UPSTREAM-REMOVE: companion to ValveSoftware/gamescope#2270
++	// Screenshot SDR/HDR LUT sets locked to outputEncodingEOTF (restored — raw
++	// composite with applyOutputColorMgmt=false produced no video for client).
++	const auto &pipewireLuts = g_bOutputHDREnabled ? g_ScreenshotColorMgmtLutsHDR : g_ScreenshotColorMgmtLuts;
+ 	for ( uint32_t nInputEOTF = 0; nInputEOTF < EOTF_Count; nInputEOTF++ )
+ 	{
+-		frameInfo.lut3D[nInputEOTF]     = g_ScreenshotColorMgmtLuts[nInputEOTF].vk_lut3d;
+-		frameInfo.shaperLut[nInputEOTF] = g_ScreenshotColorMgmtLuts[nInputEOTF].vk_lut1d;
++		frameInfo.lut3D[nInputEOTF]     = pipewireLuts[nInputEOTF].vk_lut3d;
++		frameInfo.shaperLut[nInputEOTF] = pipewireLuts[nInputEOTF].vk_lut1d;
+ 	}
+ 
+ 	const uint64_t ulFocusAppId = s_pPipewireBuffer->gamescope_info.focus_appid;

--- a/nix/patches/gamescope/archive/07-paint-pipewire-eotf-pq.patch
+++ b/nix/patches/gamescope/archive/07-paint-pipewire-eotf-pq.patch
@@ -1,0 +1,26 @@
+diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
+--- a/src/steamcompmgr.cpp	2026-07-29 02:57:21.511111321 +0200
++++ b/src/steamcompmgr.cpp
+@@ -314,6 +314,10 @@
+ static const gamescope_color_mgmt_t k_ScreenshotColorMgmtHDR =
+ {
+ 	.enabled = true,
++	// POLARIS-UPSTREAM-REMOVE: companion to ValveSoftware/gamescope#2270
++	// BT.2408 reference white; no gamut widen — polaris session defaults.
++	.sdrGamutWideness = 0,
++	.flSDROnHDRBrightness = 203.f,
+ 	.displayColorimetry = displaycolorimetry_2020,
+ 	.displayEOTF = EOTF_PQ,
+ 	.outputEncodingColorimetry = displaycolorimetry_2020,
+@@ -2337,7 +2341,10 @@
+ 
+ 	struct FrameInfo_t frameInfo = {};
+ 	frameInfo.applyOutputColorMgmt = true;
+-	frameInfo.outputEncodingEOTF   = EOTF_Gamma22;
++	// POLARIS-UPSTREAM-REMOVE: companion to ValveSoftware/gamescope#2270
++	// SPA advertises BT.2020/PQ for xBGR_210LE when HDR is on; paint must match
++	// or remote clients get washed hybrid PQ+SDR (Gamma22 encode + HDR metadata).
++	frameInfo.outputEncodingEOTF   = g_bOutputHDREnabled ? EOTF_PQ : EOTF_Gamma22;
+ 	frameInfo.allowVRR             = false;
+ 	frameInfo.bFadingOut           = false;
+ 


### PR DESCRIPTION
## Summary

Lands #294's gamescope HDR capture patch stack, with one blocking defect fixed.

Replaces patches 01, 04 and 07 with a consolidated **10** (10-bit BT.2020/PQ capture formats), adds **11** (optional `--pipewire-composite-cursor`) and **12** (a `+polhdr` version stamp), and archives the three it supersedes. Keeps 02, 03 and 06 until they are proven redundant against 10.

The stamp exists so the package can prove the patches applied: `doInstallCheck` greps `gamescope --version` for `+polhdr` and fails the build otherwise, checking both the outer wrapper and the wrapped binary because `wrapProgram` can hide `--version` on the former. That is a good guard and it is the reason the defect below is worth taking seriously — the guard can only run in a build that never happens in CI.

## The blocking defect

**Patch 10 as submitted could not apply.** Its final hunk header claims:

```
@@ -2335,17 +2335,32 @@ static void paint_pipewire()
```

The old side reconciles (14 context + 3 removed = 17). The new side does not: 14 context + 19 added = **33**, not 32. `patch` — which is what the nix builder runs — stops with:

```
patch: **** malformed patch at line 260
```

The diff content was correct; only the header arithmetic was wrong. It is regenerated here from the same content, with the upstream authorship header preserved verbatim.

## Why CI did not catch it

**No workflow in `.github/` references nix.** The four package builds are Arch, SteamOS, Ubuntu and Fedora; none evaluate or build the gamescope expression. So every file #294 changes is uncovered, while the PR presents as nine green checks — the checks are real, they simply do not touch anything that changed.

## Verification

Nix is not installed on the build host, so the expression was not evaluated. What was verified is the thing that actually failed, using the tool the nix builder uses:

- [x] All six patches apply **in order** against the pinned gamescope revision `ff6b924` under `patch -p1`:

  ```
  10-pipewire-offer-10-bit-BT2020-PQ            APPLIES
  11-pipewire-composite-cursor                  APPLIES
  12-polaris-stamp-version-polhdrN              APPLIES
  02-headless-hdr-colorimetry                   APPLIES
  03-pipewire-prefer-dmabuf                     APPLIES
  06-prefer-discrete-gpu-2217                   APPLIES
  ```

- [x] The original patch 10 reproducibly fails the same way, so the fix is load-bearing rather than incidental
- [x] `+polhdr2` reaches `src/meson.build`, so `doInstallCheck` has something to find

A note on method: an earlier pass using `git apply` also reported patch 11 as failing. That was an artifact — `git apply` is stricter about line offsets than `patch`, and 11's offsets shift once 10 applies. Under `patch -p1`, which is what nix runs, 11 was always fine. Only patch 10 was ever broken.

Not covered, and worth stating plainly:

- **The nix package was never built.** No nix on this host, and none in CI. Patch application and the stamp reaching meson are verified; compilation, the `doInstallCheck` actually executing, and runtime behaviour are not.
- No HDR hardware verification. The capture behaviour these patches enable is luxus' field result on their hardware, not reproduced here.
- The archived 01/04/07 remain in the tree under `archive/`. They are not referenced by the explicit patch list, so they are inert; they are kept for reference rather than deleted.
