### PR TITLE
fix(video): harden VAAPI DMA-BUF surface lifetime

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -615,7 +615,21 @@ namespace cage_display_router {
     const platf::runtime_state_t &runtime_state,
     platf::mem_type_e hwdevice_type
   ) {
-    return runtime_state.gpu_native_override_active && gpu_native_dmabuf_is_safe(hwdevice_type);
+    if (!runtime_state.gpu_native_override_active) {
+      return false;
+    }
+
+    // Two independent refusals, and both are wanted. The probe result retires a
+    // path that failed for this host in this process, whatever the encoder — a
+    // conversion that already failed once is not worth retrying every session.
+    // The memory-type policy refuses an import Polaris does not consider safe at
+    // all, which is a statement about the encoder rather than about this host.
+    if (auto cached_result = cached_windowed_gpu_native_probe_result();
+        cached_result && !*cached_result) {
+      return false;
+    }
+
+    return gpu_native_dmabuf_is_safe(hwdevice_type);
   }
 
   bool should_disable_headless_extcopy_after_conversion_failure(
@@ -624,6 +638,15 @@ namespace cage_display_router {
   ) {
     return runtime_state.effective_headless &&
            !runtime_state.gpu_native_override_active &&
+           source_metadata.transport == platf::frame_transport_e::dmabuf &&
+           source_metadata.residency == platf::frame_residency_e::gpu;
+  }
+
+  bool should_disable_windowed_gpu_native_after_conversion_failure(
+    const platf::runtime_state_t &runtime_state,
+    const platf::frame_metadata_t &source_metadata
+  ) {
+    return runtime_state.gpu_native_override_active &&
            source_metadata.transport == platf::frame_transport_e::dmabuf &&
            source_metadata.residency == platf::frame_residency_e::gpu;
   }

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -157,6 +157,15 @@ namespace cage_display_router {
   );
 
   /**
+   * @brief Returns whether a live frame conversion failure should disable the
+   *        windowed GPU-native override and retry capture through SHM.
+   */
+  bool should_disable_windowed_gpu_native_after_conversion_failure(
+    const platf::runtime_state_t &runtime_state,
+    const platf::frame_metadata_t &source_metadata
+  );
+
+  /**
    * @brief Returns the cached result of the windowed GPU-native probe for the
    *        current Polaris process, if one exists.
    */

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -100,6 +100,10 @@ namespace stream_runtime {
       const platf::runtime_state_t &runtime_state,
       const platf::frame_metadata_t &source_metadata
     );
+    bool should_disable_windowed_gpu_native_after_conversion_failure(
+      const platf::runtime_state_t &runtime_state,
+      const platf::frame_metadata_t &source_metadata
+    );
     std::optional<bool> cached_windowed_gpu_native_probe_result();
     std::optional<bool> cached_headless_extcopy_dmabuf_probe_result();
     void update_windowed_gpu_native_probe_result(bool supported);

--- a/src/platform/linux/stream_runtime_labwc.cpp
+++ b/src/platform/linux/stream_runtime_labwc.cpp
@@ -111,6 +111,16 @@ namespace stream_runtime {
       );
     }
 
+    bool should_disable_windowed_gpu_native_after_conversion_failure(
+      const platf::runtime_state_t &runtime_state,
+      const platf::frame_metadata_t &source_metadata
+    ) {
+      return cage_display_router::should_disable_windowed_gpu_native_after_conversion_failure(
+        runtime_state,
+        source_metadata
+      );
+    }
+
     std::optional<bool> cached_windowed_gpu_native_probe_result() {
       return cage_display_router::cached_windowed_gpu_native_probe_result();
     }

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -29,6 +29,7 @@ extern "C" {
 // local includes
 #include "graphics.h"
 #include "misc.h"
+#include "vaapi.h"
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/stream_stats.h"
@@ -413,28 +414,71 @@ namespace va {
   public:
     int convert(platf::img_t &img) override {
       auto &descriptor = (egl::img_descriptor_t &) img;
-
-      if (descriptor.sequence == 0) {
-        // For dummy images, use a blank RGB texture instead of importing a DMA-BUF
-        rgb = egl::create_blank(img);
-      } else if (descriptor.sequence > sequence) {
-        sequence = descriptor.sequence;
-
-        rgb = egl::rgb_t {};
-
-        auto rgb_opt = egl::import_source(display.get(), descriptor.sd);
-
-        if (!rgb_opt) {
-          return -1;
-        }
-
-        rgb = std::move(*rgb_opt);
+      std::array<bool, dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+      for (std::size_t slot = 0; slot < rgb_cache.size(); ++slot) {
+        valid_slots[slot] = rgb_cache[slot]->tex.size() > 0 &&
+                            rgb_cache[slot]->tex[0] != 0 &&
+                            rgb_cache[slot].el.xrgb8 != EGL_NO_IMAGE;
       }
 
-      sws.load_vram(descriptor, offset_x, offset_y, rgb->tex[0]);
+      auto decision = cache_policy.plan(
+        descriptor.sequence,
+        descriptor.dmabuf_buffer_key,
+        valid_slots
+      );
+      egl::rgb_t *active_rgb = nullptr;
 
-      sws.convert(nv12->buf);
-      return 0;
+      switch (decision.action) {
+        case dmabuf_surface_action_e::blank:
+          if (blank_rgb->tex.size() == 0 || blank_rgb->tex[0] == 0) {
+            blank_rgb = egl::create_blank(img);
+          }
+          cache_policy.commit_blank();
+          active_rgb = &blank_rgb;
+          break;
+
+        case dmabuf_surface_action_e::reuse:
+          active_rgb = &rgb_cache[*decision.slot];
+          cache_policy.commit_live(
+            descriptor.sequence,
+            descriptor.dmabuf_buffer_key,
+            *decision.slot
+          );
+          descriptor.reset();
+          break;
+
+        case dmabuf_surface_action_e::import: {
+          auto rgb_opt = egl::import_source(display.get(), descriptor.sd);
+          if (!rgb_opt) {
+            return -1;
+          }
+
+          auto &slot = rgb_cache[*decision.slot];
+          slot = std::move(*rgb_opt);
+          active_rgb = &slot;
+          cache_policy.commit_live(
+            descriptor.sequence,
+            descriptor.dmabuf_buffer_key,
+            *decision.slot
+          );
+          descriptor.reset();
+          break;
+        }
+
+        case dmabuf_surface_action_e::unavailable:
+          BOOST_LOG(error)
+            << "VAAPI DMA-BUF conversion has no valid active RGB surface for frame sequence "sv
+            << descriptor.sequence;
+          return -1;
+      }
+
+      if (!active_rgb || (*active_rgb)->tex.size() == 0 || (*active_rgb)->tex[0] == 0) {
+        BOOST_LOG(error) << "VAAPI DMA-BUF conversion selected an invalid RGB texture"sv;
+        return -1;
+      }
+
+      sws.load_vram(descriptor, offset_x, offset_y, (*active_rgb)->tex[0]);
+      return sws.convert(nv12->buf);
     }
 
     int init(int in_width, int in_height, file_t &&render_device, int offset_x, int offset_y) {
@@ -442,16 +486,15 @@ namespace va {
         return -1;
       }
 
-      sequence = 0;
-
       this->offset_x = offset_x;
       this->offset_y = offset_y;
 
       return 0;
     }
 
-    std::uint64_t sequence;
-    egl::rgb_t rgb;
+    dmabuf_surface_cache_policy_t cache_policy;
+    egl::rgb_t blank_rgb;
+    std::array<egl::rgb_t, dmabuf_surface_cache_policy_t::capacity> rgb_cache;
 
     int offset_x, offset_y;
   };

--- a/src/platform/linux/vaapi.h
+++ b/src/platform/linux/vaapi.h
@@ -4,6 +4,12 @@
  */
 #pragma once
 
+// standard includes
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
 // local includes
 #include "misc.h"
 #include "src/platform/common.h"
@@ -13,6 +19,76 @@ namespace egl {
 }
 
 namespace va {
+  enum class dmabuf_surface_action_e {
+    blank,
+    reuse,
+    import,
+    unavailable,
+  };
+
+  struct dmabuf_surface_decision_t {
+    dmabuf_surface_action_e action;
+    std::optional<std::size_t> slot;
+  };
+
+  /**
+   * @brief Tracks which imported DMA-BUF surface may be reused without
+   *        destroying the surface currently referenced by the GL pipeline.
+   *
+   * Planning is side-effect free so a failed EGL import leaves the previous
+   * active surface and next import slot unchanged.
+   */
+  class dmabuf_surface_cache_policy_t {
+  public:
+    static constexpr std::size_t capacity = 2;
+
+    dmabuf_surface_decision_t plan(
+      std::uint64_t frame_sequence,
+      std::uint64_t buffer_key,
+      const std::array<bool, capacity> &valid_slots
+    ) const {
+      if (frame_sequence == 0) {
+        return {dmabuf_surface_action_e::blank, std::nullopt};
+      }
+
+      if (frame_sequence <= sequence_) {
+        if (active_slot_ && valid_slots[*active_slot_]) {
+          return {dmabuf_surface_action_e::reuse, active_slot_};
+        }
+        return {dmabuf_surface_action_e::unavailable, std::nullopt};
+      }
+
+      if (buffer_key != 0) {
+        for (std::size_t slot = 0; slot < capacity; ++slot) {
+          if (valid_slots[slot] && buffer_keys_[slot] == buffer_key) {
+            return {dmabuf_surface_action_e::reuse, slot};
+          }
+        }
+      }
+
+      return {dmabuf_surface_action_e::import, next_import_slot_};
+    }
+
+    void commit_blank() {
+      active_slot_.reset();
+    }
+
+    void commit_live(std::uint64_t frame_sequence, std::uint64_t buffer_key, std::size_t slot) {
+      sequence_ = frame_sequence;
+      buffer_keys_[slot] = buffer_key;
+      active_slot_ = slot;
+      if (next_import_slot_ == slot) {
+        next_import_slot_ = (next_import_slot_ + 1) % capacity;
+      }
+    }
+
+  private:
+    std::uint64_t sequence_ {0};
+    std::array<std::uint64_t, capacity> buffer_keys_ {};
+    std::optional<std::size_t> active_slot_;
+    std::size_t next_import_slot_ {0};
+  };
+
   /**
    * Width --> Width of the image
    * Height --> Height of the image

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -459,13 +459,34 @@ namespace video {
       }
     }
 
-    bool handle_headless_extcopy_conversion_failure(const frame_t &frame) {
+    /**
+     * @brief Retire whichever GPU-native route produced a failed live conversion.
+     *
+     * Covers both the windowed override and the headless ext-image-copy
+     * transport, so the name is deliberately broader than either one.
+     */
+    bool handle_linux_gpu_native_conversion_failure(const frame_t &frame) {
       if (!::config::video.linux_display.use_cage_compositor) {
         return false;
       }
       const auto labwc = snapshot_labwc();
       if (!labwc.running) {
         return false;
+      }
+
+      // The windowed override is checked first: it is the path that lets an
+      // encoder attempt GPU-native conversion at all, so a live failure there
+      // has to retire it before the headless transport is considered.
+      if (stream_runtime::labwc::should_disable_windowed_gpu_native_after_conversion_failure(
+            labwc.state,
+            frame.source_metadata
+          )) {
+        stream_runtime::labwc::update_windowed_gpu_native_probe_result(false);
+        stream_stats::update_gpu_native_probe_attempt("windowed", "failed", "frame_conversion", "live_gpu_frame_conversion_failed");
+        stream_stats::update_gpu_native_probe_selection("windowed_shm", "windowed_shm");
+        BOOST_LOG(warning)
+          << "Windowed GPU-native DMA-BUF frame conversion failed; disabling the GPU-native override and reinitializing with SHM/system-memory fallback"sv;
+        return true;
       }
 
       if (!stream_runtime::labwc::should_disable_headless_extcopy_after_conversion_failure(
@@ -3196,7 +3217,7 @@ namespace video {
           if (session->convert(frame)) {
             BOOST_LOG(error) << "Could not convert image"sv;
 #ifdef __linux__
-            if (handle_headless_extcopy_conversion_failure(frame)) {
+            if (handle_linux_gpu_native_conversion_failure(frame)) {
               reinit_request_event.raise(true);
             }
 #endif
@@ -3613,7 +3634,7 @@ namespace video {
           if (frame_captured && frame.valid() && pos->session->convert(frame)) {
             BOOST_LOG(error) << "Could not convert image"sv;
 #ifdef __linux__
-            if (handle_headless_extcopy_conversion_failure(frame)) {
+            if (handle_linux_gpu_native_conversion_failure(frame)) {
               ec = platf::capture_e::reinit;
               return false;
             }

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -216,6 +216,81 @@ TEST(CageDisplayRouterPolicyTests, NonHeadlessDmabufConversionFailureDoesNotDisa
   ));
 }
 
+TEST(CageDisplayRouterPolicyTests, WindowedDmabufGpuConversionFailureDisablesGpuNativeOverride) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+  const platf::frame_metadata_t metadata {
+    .transport = platf::frame_transport_e::dmabuf,
+    .residency = platf::frame_residency_e::gpu,
+    .format = platf::frame_format_e::bgra8,
+  };
+
+  EXPECT_TRUE(cage_display_router::should_disable_windowed_gpu_native_after_conversion_failure(
+    runtime_state,
+    metadata
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, CpuFrameDoesNotDisableWindowedGpuNativeOverride) {
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+  const platf::frame_metadata_t metadata {
+    .transport = platf::frame_transport_e::shm,
+    .residency = platf::frame_residency_e::cpu,
+    .format = platf::frame_format_e::bgra8,
+  };
+
+  EXPECT_FALSE(cage_display_router::should_disable_windowed_gpu_native_after_conversion_failure(
+    runtime_state,
+    metadata
+  ));
+}
+
+TEST(CageDisplayRouterPolicyTests, CachedWindowedProbeFailureSuppressesGpuNativeCapture) {
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+
+  // cuda, so the memory-type policy passes and the cached probe result is what
+  // decides — that is the behaviour under test here.
+  EXPECT_TRUE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state, platf::mem_type_e::cuda));
+  cage_display_router::update_windowed_gpu_native_probe_result(false);
+  EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state, platf::mem_type_e::cuda));
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+}
+
+TEST(CageDisplayRouterPolicyTests, TheTwoGpuNativeRefusalsAreIndependent) {
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+  const platf::runtime_state_t runtime_state {
+    .requested_headless = true,
+    .effective_headless = false,
+    .gpu_native_override_active = true,
+    .backend_name = "labwc",
+  };
+
+  // An unsafe memory type is refused even with no probe result recorded, and a
+  // failed probe refuses a safe one. Collapsing either into the other would let
+  // a host-specific failure look like an encoder policy, or the reverse.
+  EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state, platf::mem_type_e::vaapi));
+  EXPECT_TRUE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state, platf::mem_type_e::cuda));
+
+  cage_display_router::update_windowed_gpu_native_probe_result(false);
+  EXPECT_FALSE(cage_display_router::should_attempt_gpu_native_cage_capture(runtime_state, platf::mem_type_e::cuda));
+  cage_display_router::reset_windowed_ram_capture_warning_for_tests();
+}
+
 TEST(CageDisplayRouterPolicyTests, CpuFrameConversionFailureDoesNotDisableExtcopyFallback) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,

--- a/tests/unit/platform/test_graphics.cpp
+++ b/tests/unit/platform/test_graphics.cpp
@@ -7,6 +7,12 @@
 #ifdef __linux__
   #include <glad/gl.h>
   #include <src/platform/linux/graphics.h>
+  #include <src/platform/linux/vaapi.h>
+
+  #include <filesystem>
+  #include <fstream>
+  #include <sstream>
+  #include <string>
 
 namespace {
   GLenum fake_gl_error_once() {
@@ -16,6 +22,26 @@ namespace {
 
   GLenum fake_gl_no_error() {
     return GL_NO_ERROR;
+  }
+
+  std::string read_source_for_contract(const char *relative_path) {
+    const auto path = std::filesystem::path(POLARIS_SOURCE_DIR) / relative_path;
+    std::ifstream in(path);
+    if (!in) {
+      return {};
+    }
+
+    std::ostringstream out;
+    out << in.rdbuf();
+    return out.str();
+  }
+
+  std::size_t count_occurrences(const std::string &haystack, const std::string &needle) {
+    std::size_t count = 0;
+    for (std::size_t offset = 0; (offset = haystack.find(needle, offset)) != std::string::npos; offset += needle.size()) {
+      ++count;
+    }
+    return count;
   }
 }  // namespace
 
@@ -29,6 +55,130 @@ TEST(GraphicsTests, DrainErrorsReportsWhetherAnyErrorWasDrained) {
   EXPECT_TRUE(gl::drain_errors("test"));
 
   gl::ctx.GetError = original_get_error;
+}
+
+TEST(VaapiSourceContractTests, ConverterRetainsSurfacesAndPropagatesConversionFailure) {
+  const auto source = read_source_for_contract("src/platform/linux/vaapi.cpp");
+  ASSERT_FALSE(source.empty());
+
+  EXPECT_NE(source.find("egl::rgb_t blank_rgb;"), std::string::npos);
+  EXPECT_NE(
+    source.find("std::array<egl::rgb_t, dmabuf_surface_cache_policy_t::capacity> rgb_cache;"),
+    std::string::npos
+  );
+  EXPECT_EQ(count_occurrences(source, "cache_policy.plan("), 1u);
+  EXPECT_EQ(count_occurrences(source, "cache_policy.commit_live("), 2u);
+  EXPECT_EQ(count_occurrences(source, "descriptor.reset();"), 2u);
+  EXPECT_NE(source.find("slot = std::move(*rgb_opt);"), std::string::npos);
+  EXPECT_NE(source.find("return sws.convert(nv12->buf);"), std::string::npos);
+}
+
+TEST(VaapiSourceContractTests, ConversionFailuresRemainWiredToLinuxFallbackHandler) {
+  const auto source = read_source_for_contract("src/video.cpp");
+  ASSERT_FALSE(source.empty());
+
+  EXPECT_EQ(count_occurrences(source, "handle_linux_gpu_native_conversion_failure("), 3u);
+
+  EXPECT_NE(source.find("update_windowed_gpu_native_probe_result(false);"), std::string::npos);
+  EXPECT_NE(
+    source.find("if (handle_linux_gpu_native_conversion_failure(frame)) {\n              reinit_request_event.raise(true);"),
+    std::string::npos
+  );
+  EXPECT_NE(
+    source.find("if (handle_linux_gpu_native_conversion_failure(frame)) {\n              ec = platf::capture_e::reinit;"),
+    std::string::npos
+  );
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, PreservesBlankSurfaceAcrossDummyFrames) {
+  va::dmabuf_surface_cache_policy_t policy;
+  const std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto first = policy.plan(0, 0, valid_slots);
+  EXPECT_EQ(first.action, va::dmabuf_surface_action_e::blank);
+  policy.commit_blank();
+
+  auto repeated = policy.plan(0, 0, valid_slots);
+  EXPECT_EQ(repeated.action, va::dmabuf_surface_action_e::blank);
+  EXPECT_FALSE(repeated.slot.has_value());
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, ReusesImportedSurfaceByBufferKey) {
+  va::dmabuf_surface_cache_policy_t policy;
+  std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto first = policy.plan(1, 41, valid_slots);
+  ASSERT_EQ(first.action, va::dmabuf_surface_action_e::import);
+  ASSERT_EQ(first.slot, 0);
+  policy.commit_live(1, 41, *first.slot);
+  valid_slots[0] = true;
+
+  auto reused = policy.plan(2, 41, valid_slots);
+  EXPECT_EQ(reused.action, va::dmabuf_surface_action_e::reuse);
+  EXPECT_EQ(reused.slot, 0);
+  policy.commit_live(2, 41, *reused.slot);
+
+  auto repeated = policy.plan(2, 41, valid_slots);
+  EXPECT_EQ(repeated.action, va::dmabuf_surface_action_e::reuse);
+  EXPECT_EQ(repeated.slot, 0);
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, RotatesImportsWithoutDestroyingActiveSurfaceImmediately) {
+  va::dmabuf_surface_cache_policy_t policy;
+  std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto first = policy.plan(1, 10, valid_slots);
+  ASSERT_EQ(first.slot, 0);
+  policy.commit_live(1, 10, *first.slot);
+  valid_slots[0] = true;
+
+  auto second = policy.plan(2, 20, valid_slots);
+  ASSERT_EQ(second.action, va::dmabuf_surface_action_e::import);
+  ASSERT_EQ(second.slot, 1);
+  policy.commit_live(2, 20, *second.slot);
+  valid_slots[1] = true;
+
+  auto third = policy.plan(3, 30, valid_slots);
+  EXPECT_EQ(third.action, va::dmabuf_surface_action_e::import);
+  EXPECT_EQ(third.slot, 0);
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, ZeroBufferKeyNeverAliasesANewerFrame) {
+  va::dmabuf_surface_cache_policy_t policy;
+  std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto first = policy.plan(1, 0, valid_slots);
+  ASSERT_EQ(first.action, va::dmabuf_surface_action_e::import);
+  policy.commit_live(1, 0, *first.slot);
+  valid_slots[*first.slot] = true;
+
+  auto second = policy.plan(2, 0, valid_slots);
+  EXPECT_EQ(second.action, va::dmabuf_surface_action_e::import);
+  EXPECT_EQ(second.slot, 1);
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, FailedImportDoesNotMutateSelectionState) {
+  va::dmabuf_surface_cache_policy_t policy;
+  const std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  const auto first = policy.plan(1, 55, valid_slots);
+  const auto retry = policy.plan(1, 55, valid_slots);
+
+  EXPECT_EQ(first.action, va::dmabuf_surface_action_e::import);
+  EXPECT_EQ(retry.action, va::dmabuf_surface_action_e::import);
+  EXPECT_EQ(first.slot, retry.slot);
+}
+
+TEST(VaapiDmabufSurfaceCachePolicyTests, MissingActiveSurfaceFailsClosed) {
+  va::dmabuf_surface_cache_policy_t policy;
+  std::array<bool, va::dmabuf_surface_cache_policy_t::capacity> valid_slots {};
+
+  auto imported = policy.plan(1, 77, valid_slots);
+  policy.commit_live(1, 77, *imported.slot);
+
+  auto repeated = policy.plan(1, 77, valid_slots);
+  EXPECT_EQ(repeated.action, va::dmabuf_surface_action_e::unavailable);
+  EXPECT_FALSE(repeated.slot.has_value());
 }
 #else
 TEST(GraphicsTests, LinuxOnly) {


### PR DESCRIPTION
## Summary

Takes #215's surface-lifetime fix **without its revert commit**, so the defect is fixed while nothing is re-enabled and the field-evidence gate is untouched.

### The defect

The VAAPI VRAM converter kept a single imported RGB surface:

```cpp
} else if (descriptor.sequence > sequence) {
  sequence = descriptor.sequence;
  rgb = egl::rgb_t {};                              // destroys the active surface
  auto rgb_opt = egl::import_source(display.get(), descriptor.sd);
  ...
}
sws.load_vram(descriptor, offset_x, offset_y, rgb->tex[0]);
```

On a new frame it assigns an empty surface over the current one — destroying the EGLImage and texture — and only then imports the replacement, while an in-flight conversion may still be holding the old one. A use-after-free at exactly the DMA-BUF import and convert boundary the RDNA3 and RDNA4 reports point at.

Imports now live in a two-slot buffer-keyed cache with the blank dummy surface kept separately, duplicated DMA-BUF descriptors are closed once ownership transfers, and an invalid surface or texture selection fails closed rather than being converted.

### Why this is worth landing now, without the gate being met

**The bug is reachable on `master` today.** The blanket VAAPI refusal only gates `should_attempt_gpu_native_cage_capture`, which lives inside the cage/labwc block in `wl_display()`. These construct the converter directly and are not gated:

- `kmsgrab.cpp:1346` — DRM/KMS capture with VAAPI
- `wlgrab.cpp:521`, `wlgrab.cpp:630` — wlroots VRAM capture with VAAPI

So an AMD host on `--enable-kms` DRM capture has been running the unfixed converter. I had been treating the containment as covering the crash; it covers one route to it.

Because this changes no policy, it needs no hardware evidence: it does not turn anything on.

### The two containments are combined, not swapped

#215 also replaced the blanket refusal with adaptive containment (a failed probe retires the path). Rather than pick one, both are kept — they say different things:

- **the probe result** retires a path that failed *for this host, this process*, whatever the encoder
- **the memory-type policy** refuses an import Polaris does not consider safe *at all*, which is a statement about the encoder

A test pins them as independent, so collapsing either into the other later shows up as a failure rather than a silent behaviour change.

**Removing the blanket refusal is still gated on RDNA3/RDNA4 field evidence, and is not part of this change.** #215 can stay open for exactly that one-line flip.

## Exact candidate

- `Commit: c3471fbab919b535ed0b2aba21908d5036eb21f4`
- `Tree:   d90e34fa2c8c869cc44526f5da8a04b32bfabb71`
- `Base:   f851fad32423fe8a99024b4f43b5dad11d02be3b`

## Verification

On pc-papi (Fedora, RTX 4090):

- [x] Full `ninja`, exit 0
- [x] `ctest` — 17/17
- [x] `CageDisplayRouterPolicyTests` — 35/35
- [x] `VaapiDmabufSurfaceCachePolicyTests` + `VaapiSourceContractTests` — 8/8: blank surface preserved across dummy frames, import reused by buffer key, rotation without destroying the active surface, zero buffer key never aliasing a newer frame, failed import not mutating selection state, missing active surface failing closed

The cherry-pick brought #215's tests written against the pre-containment single-argument signature; they are updated to pass `cuda`, so the cached-probe behaviour is what they exercise rather than the memory-type policy short-circuiting them.

Not covered, and worth stating plainly:

- **No AMD hardware.** This host has an RTX 4090. The crash has never been reproduced here, and the fix has not been observed to prevent it. The policy tests cover the cache's decisions, not a live import on a radeonsi stack.
- The `va_vram_t` path is not exercised end to end by `ctest`; the tests target the extracted cache policy, not the converter running against a real EGL display.
- Merging this does not close #212 or #279. It removes one concrete use-after-free on a path that was never contained.
