### PR TITLE
docs: add quickstart, per-distro, FAQ, and compatibility guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,11 @@ Full config tables, AI provider examples, HDR notes, and credential recovery ste
 
 | Guide | Use it for |
 |---|---|
+| [Quick Start](docs/quickstart.md) | Package install, web console account, first stream, verifying the runtime path |
+| [Support and Compatibility](docs/compatibility.md) | Per-distro and per-GPU status, feature status, best-tested setup, known limitations |
+| [FAQ](docs/faq.md) | Hardware requirements, Moonlight clients, coexisting with Sunshine, HDR, AI questions |
+| [Fedora 44 Install Guide](docs/fedora.md) | RPM install, host setup, autostart, upgrade and uninstall |
+| [Arch Linux and CachyOS Install Guide](docs/arch.md) | Arch package install, derivative notes, upgrade and uninstall, debug package |
 | [Runtime and Streaming Model](docs/runtime.md) | Headless Stream, capture/encoder paths, Browser Stream, session lifecycle, HDR/Main10 behavior |
 | [Configuration](docs/configuration.md) | Config file paths, common options, AI provider settings, credential reset |
 | [Building Polaris](docs/building.md) | Source builds, local packages, distro dependencies, Browser Stream build flags |

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -1,0 +1,90 @@
+# Arch Linux and CachyOS Install Guide
+
+Arch Linux is one of the two recommended Polaris package paths, and the official
+`Polaris-arch-x86_64.pkg.tar.zst` asset ships with every release. CachyOS and most pacman-compatible
+Arch derivatives should start with this same package.
+
+SteamOS is pacman-based but is **not** covered by this page: it has its own versioned package and a
+read-only root, so follow the [SteamOS guide](steamos.md) instead. The two packages are not
+interchangeable.
+
+## Install
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/latest/download/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+polaris
+```
+
+The package installs the host binary, the web console assets, desktop metadata, and the user service
+file. Host integration stays explicit: `--setup-host` is a separate step you run yourself.
+
+Open **https://localhost:47990/#/welcome**, create your web UI account, and pair a client.
+
+## What `--setup-host` does
+
+It installs the udev rules and modules-load configuration that make virtual input work, and reports
+anything it could not complete.
+
+> [!WARNING]
+> Only add `--enable-kms` when you actually need DRM/KMS capture:
+> `sudo -H polaris --setup-host --enable-kms` grants `cap_sys_admin`. Polaris works without it on the
+> default compositor and Headless Stream paths.
+
+If you ran `--setup-host` on a version before v1.3.5, a copy of the udev rules may still sit in
+`/etc/udev/rules.d/60-polaris.rules` and override the packaged file. Host setup keeps it and warns
+rather than deleting it; see [Troubleshooting](troubleshooting.md) for the check and removal.
+
+## Autostart
+
+```bash
+systemctl --user enable --now polaris
+```
+
+## Arch derivatives
+
+CachyOS is expected to work through this package path. If a derivative renames dependencies or ships
+different runtime helpers, the package may refuse to install or Polaris may fail to find a helper at
+launch. In that case use the local package or source build in
+[Building Polaris](building.md), and please report the derivative-specific gap with your distro, GPU,
+driver, compositor, and package details.
+
+## Verify the stream path
+
+Confirm the recommended Linux configuration:
+
+```ini
+headless_mode = enabled
+linux_use_cage_compositor = enabled
+linux_prefer_gpu_native_capture = enabled
+```
+
+Then start a game and read the active runtime, capture path, and encoder in Mission Control. See
+[Runtime and Streaming Model](runtime.md) for what those values mean.
+
+## Upgrade
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/latest/download/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+Your configuration, pairing keys, and library stay in `~/.config/polaris` across upgrades.
+
+## Uninstall
+
+```bash
+systemctl --user disable --now polaris
+sudo pacman -R polaris
+```
+
+Package-owned udev rules and modules-load configuration are removed with the package. Host
+configuration in `~/.config/polaris` is left in place.
+
+## Debug package
+
+Arch and SteamOS also publish a `polaris-debug` package. Install it when you need
+`coredumpctl info polaris` to produce a real backtrace for a crash report.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,83 @@
+# Support and Compatibility
+
+What Polaris supports today, how well each path is validated, and where the honest limits are. Status
+words mean specific things here: **Recommended** paths have official package assets and the most
+validation, **Experimental** paths ship but need broader real-hardware coverage, and
+**Source-build** paths have no published package yet.
+
+Polaris is Linux-only by design. Windows and macOS host ports are not planned.
+
+## Host distributions
+
+| Area | Status | Notes |
+|---|---|---|
+| Fedora 44 | Recommended | Official RPM asset and most validated release path. See the [Fedora guide](fedora.md). |
+| Arch Linux | Recommended | Official package asset. See the [Arch guide](arch.md). |
+| CachyOS / Arch derivatives | Expected via Arch package | Pacman-compatible derivatives should start there; report derivative-specific dependency or runtime gaps. |
+| SteamOS 3.8 x86_64 | Experimental Desktop Mode package | Dedicated package; physical Steam Deck gameplay, Game Mode, suspend, and update persistence are not yet certified. See the [SteamOS guide](steamos.md). |
+| Bazzite | Experimental | Layer the Fedora RPM with `rpm-ostree`; Desktop Mode validated on NVIDIA with Headless Stream, real Steam and Game Mode need more coverage. See the [Bazzite guide](bazzite.md). |
+| Ubuntu 24.04 | Experimental tester path | The DEB asset exists but this path needs broader real-hardware validation. See the [Ubuntu guide](ubuntu.md). |
+| openSUSE Tumbleweed | Source-build supported | Dedicated dependency and build guide plus CI build coverage; no published package asset yet. See the [openSUSE guide](openSUSE.md). |
+| Debian-family distros | Source-build oriented | Ubuntu 24.04 is the only direct DEB asset today. |
+| Other Linux distros | Source-build / community validation | Bring distro, GPU, driver, compositor, and package details when reporting success or breakage. |
+
+## GPU and encoding
+
+| Area | Status | Notes |
+|---|---|---|
+| NVIDIA / NVENC | Best-tested | The main fast path and most validated encoder and runtime combination. |
+| AMD / VAAPI | Supported, expanding validation | Mesa VAAPI is the Linux AMD baseline; GPU-native DMA-BUF is preferred when available and reported truthfully when it falls back. |
+| Software encode | Supported fallback | Useful for diagnostics and unsupported hardware, but not the performance target. |
+| HDR / Main10 | Conditional | Main10 SDR can work when requested; true HDR requires real HDR metadata from the active capture path. |
+
+## Clients
+
+| Area | Status | Notes |
+|---|---|---|
+| Nova for Android | Best experience | Full launch contract, watch mode, tuning, and richer live state. |
+| Standard Moonlight clients | Compatible | Core streaming works without Nova-specific UX. |
+| Browser Stream | Experimental | Browser-based path using WebTransport and WebCodecs; best tested on Chromium-family browsers. |
+
+## Feature status
+
+| Feature | Status | Why it matters |
+|---|---|---|
+| Headless Stream runtime | Recommended path | Launches games into a stream-only compositor instead of rearranging your physical desktop. |
+| Nova-aware launch contract | Supported | Lets Nova show Private Stream, Host Virtual Display, Mirror Desktop, watch and resume, and safety state before launch. |
+| Mission Control | Supported | Shows runtime, capture path, encoder, clients, stream health, and host actions in one cockpit. |
+| Game Control pairing preset | Supported | Trusted clients can browse, launch, and send input without broad server-admin permissions. |
+| AI Auto Quality | Optional | Provider-configured tuning and recovery guidance; core streaming requires no AI or cloud service. |
+
+## Best-tested first setup
+
+For the smoothest first run:
+
+- **Host distro**: Fedora 44 or Arch Linux / CachyOS.
+- **GPU path**: NVIDIA with NVENC is the most validated; AMD with Mesa VAAPI is supported and uses the
+  same Headless Stream flow, with capture-path truth visible in Mission Control.
+- **Desktop**: KDE Plasma Wayland is the most exercised daily driver, but Headless Stream launches its
+  own compositor and is not KDE-only.
+- **Config**: `headless_mode = enabled`, `linux_use_cage_compositor = enabled`,
+  `linux_prefer_gpu_native_capture = enabled`.
+- **Client**: Nova on an ARM64 Android handheld or Android TV device, or a standard Moonlight client
+  for the core stream path.
+
+The [headless fallback matrix](runtime.md#linux-lts-headless-fallback-matrix) shows which capture path
+to expect on older LTS hosts and what packages each one needs.
+
+## Known limitations
+
+- Polaris is a Linux-only host. Windows and macOS host ports are not planned.
+- Fedora and Arch are the most validated package paths. CachyOS should use the Arch path first, but
+  derivative-specific issues still need reports.
+- Bazzite support is experimental. Desktop Mode has Headless Stream validation on NVIDIA and growing
+  AMD Mesa VAAPI coverage; real Steam and Game Mode flows need more hardware reports.
+- Ubuntu 24.04 DEB packaging is experimental; other Debian-family distros are still source-build
+  oriented.
+- openSUSE Tumbleweed has source-build guidance and CI coverage but no published package asset yet.
+  Leap and other RPM distros should start from source.
+- NVIDIA and NVENC are the most heavily validated hardware path. AMD and Mesa VAAPI are supported but
+  still need broader real-hardware coverage before claiming parity.
+- Some UX surfaced in Nova — explicit launch recommendations, watch mode polish, live tuning —
+  depends on the Nova Android client.
+- MangoHud can still be risky on Steam Big Picture and some Steam and Proton launches.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,107 @@
+# Frequently Asked Questions
+
+Common questions about hardware requirements, client compatibility, coexisting with other GameStream
+hosts, HDR, and the optional AI features. If your question is about a specific failure, start with
+[Troubleshooting](troubleshooting.md) instead.
+
+## Hardware and encoding
+
+### Do I need an NVIDIA GPU?
+
+No. NVIDIA and NVENC are the most heavily tested path today, but AMD and Intel Mesa VAAPI and
+software encode are supported. GPU-native DMA-BUF capture is an optimization request on both NVIDIA
+and AMD-capable stacks, and Polaris reports the actual path when a host falls back to SHM or system
+memory.
+
+### Can Polaris stream 10-bit to an SDR handheld screen?
+
+Yes, if the client explicitly requests a 10-bit path and the active encoder and runtime support
+Main10. See [Runtime and Streaming Model](runtime.md) for the difference between 10-bit SDR and true
+HDR.
+
+### Can Polaris stream true HDR on Linux?
+
+Yes, but Polaris only advertises true HDR when the active capture path reports HDR display metadata.
+Headless labwc and wlroots sessions stay honestly SDR until the runtime can provide real metadata.
+[Runtime and Streaming Model](runtime.md) has the details.
+
+## Clients
+
+### Does Polaris work with Moonlight on iOS, macOS, and PC?
+
+Yes. Polaris speaks the Moonlight protocol, so any Moonlight client can connect. Polaris-specific
+features — launch-mode selection, watch mode, optimization guidance, and richer session state —
+require Nova on Android.
+
+### Does Moonlight lock streams to 60 FPS?
+
+No. Moonlight can request higher frame rates on clients that expose them, and Polaris treats the
+client's requested display mode as the ceiling. If a client requests `1280x800x60`, Polaris will not
+force a 90 FPS optimization above that request even when the device profile supports it.
+
+### Can multiple people watch the same stream?
+
+Yes. Set `max_sessions` above `1`. Polaris tracks owner and viewer roles explicitly, and passive
+watch mode is designed so a second client can observe without taking over. Viewers match the active
+owner profile rather than silently creating a different, downgraded stream.
+
+## Coexisting with other hosts
+
+### Do I need to uninstall Sunshine before trying Polaris?
+
+No. Polaris keeps its host configuration separate at `~/.config/polaris`, so installing it should not
+remove or overwrite an existing Sunshine setup. For testing, stop Sunshine before starting Polaris,
+because both are GameStream hosts and can collide on the same default ports and discovery records.
+
+```bash
+systemctl --user stop sunshine
+systemctl --user enable --now polaris
+```
+
+If your Sunshine install runs as a system service instead of a user service, use the matching service
+command for your distro. Switch back by stopping Polaris and starting Sunshine again.
+
+## Desktop environments and sessions
+
+### Does headless mode work on Hyprland, Sway, or GNOME?
+
+Yes. The headless `labwc` runtime creates its own Wayland instance, so it is not tied to one desktop
+environment. Polaris is tested most heavily on KDE Plasma Wayland, but the model is not KDE-specific.
+
+### My KDE layout gets corrupted after streaming
+
+That failure mode is the reason Polaris exists. Set `headless_mode = enabled` and
+`linux_use_cage_compositor = enabled`, and Polaris stops treating your physical displays as the
+stream path.
+
+### Steam Big Picture shows a black screen or tiny window
+
+First clear Steam's HTML cache:
+
+```bash
+rm -rf ~/.local/share/Steam/config/htmlcache/
+```
+
+Then avoid MangoHud on Steam Big Picture and Steam/Proton launches. Polaris and Nova warn about this
+because MangoHud can crash helper processes before the session gets a usable frame.
+
+## Pairing
+
+### How does Trusted Pair work?
+
+Trusted Pair is Polaris' TOFU flow. If the client is on a configured trusted subnet, Polaris can
+auto-approve first pairing. QR and manual PIN pairing remain available if you want a stricter or more
+traditional flow.
+
+## AI features
+
+### Is AI required?
+
+No. Core streaming, pairing, library management, and diagnostics work without AI and without a cloud
+account.
+
+### How does the AI optimizer work?
+
+The AI optimizer is optional and disabled by default. When enabled, it sends device specs, app
+metadata, and recent session history to the provider you configure: Anthropic, OpenAI, Gemini, or a
+local OpenAI-compatible endpoint such as Ollama or LM Studio. Results are cached locally.

--- a/docs/fedora.md
+++ b/docs/fedora.md
@@ -1,0 +1,92 @@
+# Fedora 44 Install Guide
+
+Fedora 44 is one of the two recommended Polaris package paths, and the official
+`Polaris-fedora44-x86_64.rpm` asset ships with every release. Fedora 44 is the only Fedora release
+with a published package; earlier Fedora versions should build from source.
+
+For an atomic Fedora derivative such as Bazzite, do not follow this page directly — layer the same
+RPM with `rpm-ostree` using the [Bazzite guide](bazzite.md) instead.
+
+## Install
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install ./Polaris-fedora44-x86_64.rpm &&
+sudo -H polaris --setup-host &&
+polaris
+```
+
+The package installs the host binary, the web console assets, desktop metadata, and the user service
+file. Host integration stays explicit: `--setup-host` is a separate step you run yourself.
+
+Open **https://localhost:47990/#/welcome**, create your web UI account, and pair a client.
+
+## What `--setup-host` does
+
+It installs the udev rules and modules-load configuration that make virtual input work, and reports
+anything it could not complete. It does not silently take privileges you did not ask for.
+
+> [!WARNING]
+> Only add `--enable-kms` when you actually need DRM/KMS capture:
+> `sudo -H polaris --setup-host --enable-kms` grants `cap_sys_admin`. Polaris works without it on the
+> default compositor and Headless Stream paths.
+
+If you ran `--setup-host` on a version before v1.3.5, a copy of the udev rules may still sit in
+`/etc/udev/rules.d/60-polaris.rules` and override the packaged file. Host setup keeps it and warns
+rather than deleting something it cannot prove is disposable; see
+[Troubleshooting](troubleshooting.md) for the check and the removal.
+
+## Autostart
+
+```bash
+systemctl --user enable --now polaris
+```
+
+Polaris runs as a user service, so it starts with your graphical session and has access to it. Check
+status with `systemctl --user status polaris`.
+
+## Verify the stream path
+
+Confirm the recommended Linux configuration in the first-run wizard or
+`~/.config/polaris/polaris.conf`:
+
+```ini
+headless_mode = enabled
+linux_use_cage_compositor = enabled
+linux_prefer_gpu_native_capture = enabled
+```
+
+Then start a game and read the active runtime, capture path, and encoder in Mission Control. See
+[Runtime and Streaming Model](runtime.md) for what each value means, and
+[Configuration](configuration.md) for the full setting reference.
+
+## Upgrade
+
+Install the newer RPM the same way. `dnf` replaces the package in place, and your configuration,
+pairing keys, and library stay in `~/.config/polaris`.
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install ./Polaris-fedora44-x86_64.rpm &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+Re-running `--setup-host` after an upgrade is how packaged udev rules and module configuration get
+refreshed.
+
+## Uninstall
+
+```bash
+systemctl --user disable --now polaris
+sudo dnf remove polaris
+```
+
+Package-owned udev rules and modules-load configuration are removed with the package. Your host
+configuration in `~/.config/polaris` is left alone; delete it yourself if you want a clean slate.
+
+## GPU notes
+
+NVIDIA with NVENC is the most validated path. AMD and Intel Mesa VAAPI are supported and use the same
+Headless Stream flow, with the real capture path reported in Mission Control rather than assumed. See
+[Compatibility](compatibility.md) for the current status of each combination.

--- a/docs/openSUSE.md
+++ b/docs/openSUSE.md
@@ -4,7 +4,7 @@ Polaris has no prebuilt openSUSE package yet, but it builds cleanly from source 
 **openSUSE Tumbleweed** (x86_64). This guide covers the dependencies, the build, and
 a few openSUSE-specific gotchas. A CI workflow that builds an installable RPM in an
 `opensuse/tumbleweed` container lives at
-[`.github/workflows/opensuse-build.yml`](../.github/workflows/opensuse-build.yml).
+[`.github/workflows/opensuse-build.yml`](https://github.com/papi-ux/polaris/blob/master/.github/workflows/opensuse-build.yml).
 
 > Tested on Tumbleweed with an AMD GPU (VAAPI encode). NVIDIA hosts should add the
 > CUDA toolkit and build with `-DPOLARIS_ENABLE_CUDA=ON`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,88 @@
+# Quick Start
+
+This page takes a Linux host from nothing to a first stream. Fedora 44 and Arch Linux are the
+recommended package paths; if you run something else, start from [Compatibility](compatibility.md)
+to find your path before following the steps here.
+
+## 1. Install the package
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/latest/download/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install ./Polaris-fedora44-x86_64.rpm &&
+sudo -H polaris --setup-host &&
+polaris
+```
+
+The longer walkthrough, including upgrades and uninstall, is in the [Fedora guide](fedora.md).
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/latest/download/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+polaris
+```
+
+CachyOS and most pacman-compatible Arch derivatives should start with the Arch package path. See the
+[Arch guide](arch.md) for details, and fall back to the source flow in
+[Building Polaris](building.md) if a derivative has dependency naming or runtime helper differences.
+
+### Other hosts
+
+| Host | Path |
+|---|---|
+| SteamOS 3.8 | [SteamOS guide](steamos.md) — Desktop Mode validation only |
+| Bazzite 44 | [Bazzite guide](bazzite.md) — layer the Fedora 44 RPM with `rpm-ostree` |
+| Ubuntu 24.04 | [Ubuntu guide](ubuntu.md) — experimental tester DEB |
+| openSUSE Tumbleweed | [openSUSE guide](openSUSE.md) — source build |
+| Anything else | [Building Polaris](building.md) |
+
+## 2. Create your web console account
+
+Open **https://localhost:47990/#/welcome**, create your web UI account, and pair a client. After
+credentials exist, **https://localhost:47990** opens the normal console.
+
+> [!TIP]
+> If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at
+> `https://localhost:<port + 1>`. For background autostart, enable the user service with
+> `systemctl --user enable --now polaris`.
+
+## 3. Confirm the recommended Linux path
+
+In the first-run setup, confirm the three settings that put games in a private runtime instead of on
+your desktop:
+
+```ini
+headless_mode = enabled
+linux_use_cage_compositor = enabled
+linux_prefer_gpu_native_capture = enabled
+```
+
+[Configuration](configuration.md) explains every setting, and
+[Runtime and Streaming Model](runtime.md) explains what these three actually change.
+
+## 4. Pair a client
+
+Pick whichever fits your network:
+
+- **Trusted Pair** on a trusted LAN, for a TOFU flow that auto-approves first pairing on a
+  configured trusted subnet.
+- **QR pairing** for Nova.
+- **Manual PIN** for standard Moonlight clients.
+
+## 5. Start a game and verify the path
+
+Launch from the Polaris library, Nova, or a Moonlight client, then watch the live session dashboard
+in Mission Control to confirm the active runtime and encoder path. Polaris reports the capture path
+it actually used, so if it fell back to system memory you will see that rather than having to infer
+it from logs.
+
+## If something does not work
+
+[Troubleshooting](troubleshooting.md) covers the common failure modes, the log markers worth
+grepping, and what to include in a bug report. The
+[headless fallback matrix](runtime.md#linux-lts-headless-fallback-matrix) explains what capture path
+to expect on older LTS hosts.


### PR DESCRIPTION
## Summary

Fills the documentation gaps that papi-ux.com/docs/ exposed when it started publishing this repo's `docs/` directory. The two **recommended** package paths — Fedora 44 and Arch — were the only ones without a guide of their own, while every tester path (SteamOS, Bazzite, Ubuntu, openSUSE) already had a full page.

New pages:

- **`docs/quickstart.md`** — one entry point from nothing to a first stream: package install per host, web console account, the three recommended Linux settings, pairing options, and verifying the runtime/capture/encoder path in Mission Control.
- **`docs/fedora.md`** — Fedora 44 RPM install, what `--setup-host` does (including the pre-v1.3.5 `/etc` udev override note), autostart, verification, upgrade, uninstall, GPU notes.
- **`docs/arch.md`** — Arch/CachyOS package install, an explicit "SteamOS is not this page" boundary, derivative caveats, upgrade, uninstall, and the `polaris-debug` package.
- **`docs/compatibility.md`** — per-distro / GPU / client / feature status tables, best-tested first setup, and known limitations, with the status vocabulary defined up front.
- **`docs/faq.md`** — the README FAQ as linkable headings grouped by topic rather than collapsed `<details>`, so individual answers can be linked and found by search.

Fix:

- **`docs/openSUSE.md`** — the link to `.github/workflows/opensuse-build.yml` was a repo-relative `../` path that resolves to nothing once the page is published outside the repository; it is now an absolute GitHub URL.

Content is restructured from the README rather than newly invented, so claims and status words match what the README already states (Fedora 44 as the sole Fedora lane, `sudo -H polaris --setup-host`, NVENC best-tested / VAAPI expanding). The README docs table gains rows for the five new pages.

## Exact candidate

Branch `docs-site-pages` @ `c8637c5`, one commit on top of `master` @ `4746207`.

## Verification

- Every relative link and the `runtime.md#linux-lts-headless-fallback-matrix` anchor in the new and edited pages was resolved against the working tree — no broken targets.
- Markdown only; no code, build, or packaging files touched.
- Publishing side: the site's sync script (`scripts/sync-polaris-docs.mjs` in papi-ux.github.io) turns each page's H1 into the title and its first paragraph into the description, and rewrites `*.md` links to `/docs/<slug>/`, so these pages need no frontmatter. Site sidebar entries and the retargeting of marketing links to `/docs/quickstart/` and `/docs/compatibility/` follow in the site repo once this merges.
