### PR TITLE
release: prepare Polaris v1.3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
-project(Polaris VERSION 1.3.6
+project(Polaris VERSION 1.3.7
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/README.md
+++ b/README.md
@@ -91,17 +91,13 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at `https://localhost:<port + 1>`. If you want background autostart, enable the user service with `systemctl --user enable --now polaris`.
 
-## What is New in v1.3.6
+## What is New in v1.3.7
 
-Polaris v1.3.6 makes the Nova client work against a Polaris host in places it never has, corrects host setup advice that could not succeed on ostree systems, and hardens the gamescope session and its HDR capture.
+Polaris v1.3.7 fixes a use-after-free in VAAPI DMA-BUF capture that AMD hosts have been running into, and puts the nix packaging under CI for the first time.
 
-- **Input group advice that works on Bazzite**: on ostree hosts the `input` group lives in `/usr/lib/group`, so `usermod -aG input` finds no group to add anyone to. Polaris now prints `ujust add-user-to-input-group` there, and the equivalent steps on an ostree host without `ujust`.
-- **Nova library artwork update works at all**: the resolve endpoint now reports what it did, which Nova requires. Without it the client reported the host as unsupported against every build that has ever shipped.
-- **Library entries carry platform and runtime**: derived from the Lutris runner recorded at import, and served only where the runner determines them — no badge beats a wrong badge.
-- **Corrected completion estimates stay corrected**: a manual artwork match decides which game an estimate is for, and no longer falls back to the Steam app id that made the wrong estimate confident.
-- **Gamescope sessions recover**: teardown and reconnect survive a dead nested marker, a non-leader attach, and an incomplete attach generation that used to refuse every later launch until Polaris restarted.
-- **HDR capture follows the encode**: 10-bit PQ only when gamescope is in HDR mode and the client asked for HDR, 8-bit when the stream is SDR, so PQ capture cannot feed an SDR encoder.
-- **Stream audio follows the session**: the stream sink is claimed as the session default while streaming, and only the session that took that claim releases it.
+- **VAAPI capture no longer frees a surface it is still reading**: a use-after-free in the VRAM converter, which destroyed its imported DMA-BUF surface before importing the replacement while a conversion in flight could still be holding it. Imports now live in a buffer-keyed cache, so a newly captured frame cannot pull the surface out from under an active conversion.
+- **This was reachable, not theoretical**: the VAAPI refusal in earlier releases only gated the gamescope windowed override. DRM/KMS capture and the non-cage wlroots VRAM path build the converter directly, so AMD hosts on those paths were running the unfixed version.
+- **Nix packaging is built and checked**: the vendored gamescope patch stacks are verified on every push, and CI builds the patched compositor, so a stack that cannot apply — or that applies without taking effect — fails before it reaches a host.
 - **Security gate**: `npm audit --audit-level=high` remains mandatory.
 - **Exact release set**: the official artifacts are `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb`.
 See the [changelog](docs/changelog.md) for the full release history.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,17 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## v1.3.7 - 2026-08-07
+
+A use-after-free in VAAPI DMA-BUF capture that AMD hosts on DRM/KMS have been running, and CI that finally builds the nix packaging it patches.
+
+- Fixes a use-after-free at the VAAPI DMA-BUF import boundary: the VRAM converter destroyed its imported surface before importing the replacement, while an in-flight conversion could still be using it. Reachable on DRM/KMS capture and the non-cage wlroots VRAM path, which is what AMD hosts have been running
+- Fails closed on an invalid surface or texture selection rather than converting it, and closes duplicated DMA-BUF descriptors once ownership transfers
+- Keeps the gamescope-polaris patch stack and the packaged compositor in step, so the `+polhdr2` stamp a session negotiates against is one a build proved
+- Checks the vendored patch stacks on every push and builds the nix packages in CI, so a patch that cannot apply fails there rather than on a host
+- Keeps `npm audit --audit-level=high` mandatory
+- Retains exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
+
 ## v1.3.6 - 2026-08-07
 
 Client-facing fixes for Nova, host setup advice that works on ostree systems, and gamescope session and HDR capture hardening.

--- a/docs/release-notes/v1.3.7.md
+++ b/docs/release-notes/v1.3.7.md
@@ -1,0 +1,58 @@
+# Polaris v1.3.7
+
+Polaris v1.3.7 fixes a use-after-free in VAAPI DMA-BUF capture that AMD hosts have been running into, and puts the nix packaging under CI for the first time.
+
+## Important: upgrading from v1.3.6
+
+Nothing extra is required beyond the usual upgrade. The package, `--setup-host`, and restart sequence are unchanged.
+
+**If you are on an AMD GPU and capture through DRM/KMS, this is the release to take.** The VAAPI VRAM converter could destroy an imported surface while a conversion was still reading it. The blanket VAAPI refusal in earlier releases covered only the gamescope windowed override, so DRM/KMS capture and the non-cage wlroots VRAM path were never behind it — those paths build the converter directly.
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.7/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.7/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.7/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 already uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md).
+
+## Changes
+
+### Capture and encoding
+
+- Hardens the VAAPI DMA-BUF surface lifetime. The VRAM converter kept a single imported RGB surface; on a new frame it assigned an empty surface over it, destroying the EGLImage and texture, and only then imported the replacement — while an in-flight conversion could still be holding the old one. Imports now live in a two-slot buffer-keyed cache with the blank dummy surface kept separately, so a newly captured frame cannot destroy the surface an active conversion is using.
+- Closes duplicated DMA-BUF descriptors once ownership transfers, and fails closed on an invalid surface or texture selection instead of converting it.
+- The VAAPI refusal for the gamescope windowed GPU-native override stays in place. Removing it is gated on RDNA3 and RDNA4 field evidence and is not part of this release.
+
+### Nix packaging
+
+- The gamescope-polaris patch stack and the packaged compositor stay in step, so the `+polhdr2` capability stamp a session negotiates against is one a build has proved rather than one a patch claimed.
+- CI checks the vendored patch stacks on every push — every hunk header against its own body, every patch either applied or archived — and builds the patched compositor and the ScreenCast portal. `nix/` had no CI coverage at all before this, so a patch that could not apply, or applied without taking effect, reached the repository with every check green.
+
+## Official assets
+
+- `Polaris-arch-x86_64.pkg.tar.zst`
+- `Polaris-fedora44-x86_64.rpm`
+- `Polaris-steamos3.8-x86_64.pkg.tar.zst`
+- `Polaris-ubuntu24.04-x86_64.deb`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.3.6') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.3.7') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -614,7 +614,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.3.6.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.3.7.md").read_text(encoding="utf-8")
 )
 
 
@@ -1245,17 +1245,16 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.3.7 - 2026-08-07",
     "## v1.3.6 - 2026-08-07",
-    "## v1.3.5 - 2026-08-06",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "ostree",
-    "usermod",
-    "ujust add-user-to-input-group",
-    "/usr/lib/group",
-    "platform",
-    "runtime",
+    "VAAPI",
+    "DMA-BUF",
+    "use-after-free",
+    "DRM/KMS",
+    "wlroots",
     "npm audit --audit-level=high",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
@@ -1264,19 +1263,19 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.3.6 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.3.7 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 readme_release_body = markdown_section(
     readme,
-    "## What is New in v1.3.6",
+    "## What is New in v1.3.7",
     "## Install",
 )
 readme_release_prose = rendered_markdown(readme_release_body)
 required_readme_facts = required_release_facts
 for fact in required_readme_facts:
     if fact not in readme_release_prose:
-        print(f"README v1.3.6 summary is missing: {fact}", file=sys.stderr)
+        print(f"README v1.3.7 summary is missing: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1286,8 +1285,8 @@ asset_phrase = (
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
 for label, section in (
-    ("README v1.3.6 summary", readme_release_prose),
-    ("v1.3.6 changelog", current_release_prose),
+    ("README v1.3.7 summary", readme_release_prose),
+    ("v1.3.7 changelog", current_release_prose),
 ):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
@@ -1306,8 +1305,8 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
     ("docs/building.md Packaging", building_packaging_prose),
-    ("README v1.3.6 summary", readme_release_prose),
-    ("v1.3.6 changelog", current_release_prose),
+    ("README v1.3.7 summary", readme_release_prose),
+    ("v1.3.7 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_assets:
@@ -1319,26 +1318,26 @@ for label, section in (
         sys.exit(1)
 
 release_notes_facts = (
-    "v1.3.5",
-    "ostree",
-    "ujust add-user-to-input-group",
-    "/etc",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.6/Polaris-fedora44-x86_64.rpm &&",
+    "v1.3.6",
+    "VAAPI",
+    "DRM/KMS",
+    "RDNA3 and RDNA4 field evidence",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.7/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.6/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.7/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.6/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.7/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.3.6 release notes are missing bootstrap fact: {fact}", file=sys.stderr)
+        print(f"v1.3.7 release notes are missing bootstrap fact: {fact}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.3.6 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.3.7 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.3.6 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.3.7 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 
 if "bash scripts/check-public-docs.sh" not in contributing:

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.6-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.7-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -667,7 +667,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.3.6-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.3.7-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v136-contract.test.js
+++ b/src_assets/common/assets/web/release-v136-contract.test.js
@@ -7,20 +7,27 @@ const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
 const sectionBetween = (source, startHeading, endHeading) => {
   const start = source.indexOf(startHeading)
   const end = source.indexOf(endHeading, start + startHeading.length)
-  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
-  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  expect(start, `missing historical release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing historical release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
   return source.slice(start, end)
 }
 
-const releaseSections = () => [
-  sectionBetween(read('README.md'), '## What is New in v1.3.6', '## Install'),
-  sectionBetween(read('docs/changelog.md'), '## v1.3.6 - 2026-08-07', '## v1.3.5'),
-]
+const historicalRelease = () => sectionBetween(
+  read('docs/changelog.md'),
+  '## v1.3.6 - 2026-08-07',
+  '## v1.3.5',
+)
 
-const requiredFacts = [
+const requiredFixFacts = [
   'ostree',
-  'usermod',
+  'usermod -aG input',
   'ujust add-user-to-input-group',
+  '/usr/lib/group',
+  'platform',
+  'runtime',
+  'docs/nova-contract.json',
+  'vaapi_vendor',
+  'PipeWire',
   'npm audit --audit-level=high',
 ]
 
@@ -31,71 +38,18 @@ const expectedAssets = [
   'Polaris-ubuntu24.04-x86_64.deb',
 ].sort()
 
-describe('v1.3.6 release contract', () => {
-  it('moves the CMake version and public release headings together', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.6')
-    expect(read('README.md')).toContain('## What is New in v1.3.6')
-    expect(read('docs/changelog.md')).toContain('## v1.3.6 - 2026-08-07')
-  })
+describe('historical v1.3.6 release contract', () => {
+  it('preserves the v1.3.6 release facts', () => {
+    const release = historicalRelease()
 
-  it('states the release facts in both public summaries', () => {
-    for (const releaseSection of releaseSections()) {
-      for (const fact of requiredFacts) {
-        expect(releaseSection, `release summary must include: ${fact}`).toContain(fact)
-      }
+    for (const fact of requiredFixFacts) {
+      expect(release, `historical release must include: ${fact}`).toContain(fact)
     }
   })
 
-  it('aligns the public checker with the v1.3.6 release contract', () => {
-    const publicDocsGate = read('scripts/check-public-docs.sh')
+  it('preserves the exact historical four-asset set', () => {
+    const actualAssets = historicalRelease().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
 
-    expect(publicDocsGate).toContain('"## What is New in v1.3.6"')
-    expect(publicDocsGate).not.toContain('"## What is New in v1.3.5"')
-    expect(publicDocsGate).toContain('"## v1.3.6 - 2026-08-07"')
-    for (const asset of expectedAssets) {
-      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
-    }
-  })
-
-  it('moves versioned package-review metadata to v1.3.6', () => {
-    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
-    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
-
-    expect(reviewedWarnings).toContain('usr/bin/polaris-1.3.6')
-    expect(reviewedWarnings).not.toContain('usr/bin/polaris-1.3.5')
-    expect(steamOsBuildScript).toContain("'polaris|1.3.6-1|x86_64'")
-    expect(steamOsBuildScript).not.toContain("'polaris|1.3.5-1|x86_64'")
-  })
-
-  it('ships release notes whose install commands target v1.3.6', () => {
-    const releaseNotes = read('docs/release-notes/v1.3.6.md')
-
-    // The upgrade section has to name the release being upgraded from, and the
-    // ostree remedy, because following the v1.3.5 advice on Bazzite did nothing.
-    for (const fact of ['v1.3.5', 'ostree', 'ujust add-user-to-input-group']) {
-      expect(releaseNotes, `release notes must include: ${fact}`).toContain(fact)
-    }
-
-    // Install blocks only. The property is that documented install commands
-    // point at this release; other examples in the notes are not install
-    // commands and must not be forced to look like them.
-    const installBlocks = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
-      .map((match) => match[1])
-      .filter((block) => block.includes('wget --output-document='))
-
-    expect(installBlocks.length).toBe(3)
-    for (const block of installBlocks) {
-      expect(block).toContain('releases/download/v1.3.6/')
-      expect(block).not.toContain('releases/download/v1.3.5/')
-      expect(block).toContain('polaris --setup-host')
-      expect(block).toContain('systemctl --user restart polaris')
-    }
-  })
-
-  it('keeps the exact four-asset set in the release notes', () => {
-    const notes = read('docs/release-notes/v1.3.6.md')
-    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
-
-    expect(listed.sort()).toEqual(expectedAssets)
+    expect(actualAssets.sort()).toEqual(expectedAssets)
   })
 })

--- a/src_assets/common/assets/web/release-v137-contract.test.js
+++ b/src_assets/common/assets/web/release-v137-contract.test.js
@@ -1,0 +1,103 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+
+const sectionBetween = (source, startHeading, endHeading) => {
+  const start = source.indexOf(startHeading)
+  const end = source.indexOf(endHeading, start + startHeading.length)
+  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+const releaseSections = () => [
+  sectionBetween(read('README.md'), '## What is New in v1.3.7', '## Install'),
+  sectionBetween(read('docs/changelog.md'), '## v1.3.7 - 2026-08-07', '## v1.3.6'),
+]
+
+const requiredFacts = [
+  'VAAPI',
+  'DMA-BUF',
+  'use-after-free',
+  'DRM/KMS',
+  'npm audit --audit-level=high',
+]
+
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+
+describe('v1.3.7 release contract', () => {
+  it('moves the CMake version and public release headings together', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.7')
+    expect(read('README.md')).toContain('## What is New in v1.3.7')
+    expect(read('docs/changelog.md')).toContain('## v1.3.7 - 2026-08-07')
+  })
+
+  it('states the release facts in both public summaries', () => {
+    for (const releaseSection of releaseSections()) {
+      for (const fact of requiredFacts) {
+        expect(releaseSection, `release summary must include: ${fact}`).toContain(fact)
+      }
+    }
+  })
+
+  it('aligns the public checker with the v1.3.7 release contract', () => {
+    const publicDocsGate = read('scripts/check-public-docs.sh')
+
+    expect(publicDocsGate).toContain('"## What is New in v1.3.7"')
+    expect(publicDocsGate).not.toContain('"## What is New in v1.3.6"')
+    expect(publicDocsGate).toContain('"## v1.3.7 - 2026-08-07"')
+    for (const asset of expectedAssets) {
+      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
+    }
+  })
+
+  it('moves versioned package-review metadata to v1.3.7', () => {
+    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
+    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
+
+    expect(reviewedWarnings).toContain('usr/bin/polaris-1.3.7')
+    expect(reviewedWarnings).not.toContain('usr/bin/polaris-1.3.6')
+    expect(steamOsBuildScript).toContain("'polaris|1.3.7-1|x86_64'")
+    expect(steamOsBuildScript).not.toContain("'polaris|1.3.6-1|x86_64'")
+  })
+
+  it('ships release notes whose install commands target v1.3.7', () => {
+    const releaseNotes = read('docs/release-notes/v1.3.7.md')
+
+    // The upgrade section has to name the release being upgraded from, and say
+    // which hosts this one actually matters for -- a use-after-free only some
+    // capture paths reach is worth stating plainly rather than burying.
+    for (const fact of ['v1.3.6', 'VAAPI', 'DRM/KMS']) {
+      expect(releaseNotes, `release notes must include: ${fact}`).toContain(fact)
+    }
+
+    // Install blocks only. The property is that documented install commands
+    // point at this release; other examples in the notes are not install
+    // commands and must not be forced to look like them.
+    const installBlocks = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
+
+    expect(installBlocks.length).toBe(3)
+    for (const block of installBlocks) {
+      expect(block).toContain('releases/download/v1.3.7/')
+      expect(block).not.toContain('releases/download/v1.3.6/')
+      expect(block).toContain('polaris --setup-host')
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+  })
+
+  it('keeps the exact four-asset set in the release notes', () => {
+    const notes = read('docs/release-notes/v1.3.7.md')
+    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+
+    expect(listed.sort()).toEqual(expectedAssets)
+  })
+})


### PR DESCRIPTION
## Summary

Prepares v1.3.7. Three commits have landed since v1.3.6, and one of them is the reason this release exists rather than waiting.

**#306 fixes a use-after-free that v1.3.6 shipped with.** The VAAPI VRAM converter destroyed its imported DMA-BUF surface before importing the replacement, while a conversion already in flight could still be holding it. The blanket VAAPI refusal covered only the gamescope windowed GPU-native override — `kmsgrab` and the non-cage wlroots VRAM path construct that converter directly and were never behind it. AMD hosts capturing through DRM/KMS have been running the unfixed version.

**#305 and #308 are packaging and CI.** The gamescope-polaris patch stack now matches the compositor it patches, and `nix/` has CI coverage for the first time: the vendored patch stacks are checked on every push and the patched compositor is built, so the `+polhdr2` stamp a session negotiates against is one a build has proved rather than one a patch claimed.

Moves the CMake version, package-review metadata, SteamOS package identity, public docs gate and release contract together, and retires the v1.3.6 contract test to the historical form that only guards its changelog entry.

**Both releases carry 2026-08-07.** That is accurate, not a copy-paste — v1.3.6 went out this morning and the fix landed hours later.

No tag, release, or asset upload is created here. Publication stays a separate explicit step against the exact merged commit.

## Exact candidate

`c7160ba`

## Verification

- `bash scripts/check-public-docs.sh` → exit 0. Checked the script's own status rather than a pipeline's.
- `npm run test` → **300 passed**, 51 files. All five release contract tests pass: v1.3.3, v1.3.4, v1.3.5, the newly historical v1.3.6, and v1.3.7.
- `npm run lint` → exit 0.
- `bash scripts/check-public-surface.sh`, `check-release-package-dependencies.py`, `check-nix-patches.py` → all pass.
- Every remaining `1.3.6` reference in the tree is deliberate: changelog and gate section boundaries, the release-notes "upgrading from" fact, and the negative assertions that would catch a version left behind.

The v1.3.7 contract test earned its keep during this prep — a global rename ran ahead of one targeted edit and left a v1.3.6 fact list in place. The test failed on exactly that block.

## Release facts now gated

The docs gate and contract test were rebound from the v1.3.6 facts (`ostree`, `usermod`, `ujust …`) to this release's: `VAAPI`, `DMA-BUF`, `use-after-free`, `DRM/KMS`, `wlroots`, alongside the standing `npm audit --audit-level=high` and the exact four-asset set.
