### PR TITLE
feat(packaging): serve the release packages as dnf and pacman repositories

### DIFF
--- a/.github/workflows/package-repos.yml
+++ b/.github/workflows/package-repos.yml
@@ -1,0 +1,181 @@
+name: Package Repositories
+
+# Publishes the release packages as dnf and pacman repositories, so a host can
+# take an upgrade with `dnf upgrade` or `pacman -Syu` instead of downloading a
+# file and installing it by exact name.
+#
+# Nothing is rebuilt. Each repository serves the package the release published
+# and CI already tested; the repository copy only gains a signature. Rebuilding
+# would ship a second binary nobody tested, and the Fedora packaging pulls a
+# CUDA toolkit over the network at build time, which no sandboxed rebuild
+# service will do.
+#
+# Each ecosystem needs its own toolchain, so the two repositories are assembled
+# in their own containers and combined by the publish job.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish repositories for (e.g. v1.3.7)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  POLARIS_RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+
+jobs:
+  fedora-repo:
+    name: Assemble dnf repository
+    runs-on: ubuntu-24.04
+    container:
+      image: fedora:44
+
+    steps:
+      - name: Install repository tools
+        run: dnf install -y --setopt=install_weak_deps=False createrepo_c rpm-sign gnupg2 git tar
+
+      - uses: actions/checkout@v7
+
+      - name: Download the release package
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p assets
+          gh release download "$POLARIS_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'Polaris-fedora44-x86_64.rpm' --dir assets
+
+      - name: Import the signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.POLARIS_REPO_GPG_PRIVATE_KEY }}
+        run: |
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "POLARIS_REPO_GPG_PRIVATE_KEY is not set. A published repository must be signed." >&2
+            exit 1
+          fi
+          export GNUPGHOME="$RUNNER_TEMP/gnupg"
+          mkdir -p -m 700 "$GNUPGHOME"
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --quiet --import
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
+
+      - name: Assemble the repository
+        run: |
+          version="${POLARIS_RELEASE_TAG#v}"
+          bash scripts/build-package-repos.sh --only fedora \
+            --assets assets --version "$version" --output repo \
+            --gpg-key-id "${{ secrets.POLARIS_REPO_GPG_KEY_ID }}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: repo-fedora
+          path: repo/
+          if-no-files-found: error
+
+  arch-repo:
+    name: Assemble pacman repository
+    runs-on: ubuntu-24.04
+    container:
+      image: archlinux:latest
+
+    steps:
+      - name: Bootstrap Arch container
+        run: pacman -Syu --noconfirm --needed archlinux-keyring git gnupg github-cli tar
+
+      - uses: actions/checkout@v7
+
+      - name: Download the release package
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p assets
+          gh release download "$POLARIS_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'Polaris-arch-x86_64.pkg.tar.zst' --dir assets
+
+      - name: Import the signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.POLARIS_REPO_GPG_PRIVATE_KEY }}
+        run: |
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "POLARIS_REPO_GPG_PRIVATE_KEY is not set. A published repository must be signed." >&2
+            exit 1
+          fi
+          export GNUPGHOME="$RUNNER_TEMP/gnupg"
+          mkdir -p -m 700 "$GNUPGHOME"
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --quiet --import
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
+
+      - name: Assemble the repository
+        run: |
+          version="${POLARIS_RELEASE_TAG#v}"
+          bash scripts/build-package-repos.sh --only arch \
+            --assets assets --version "$version" --output repo \
+            --gpg-key-id "${{ secrets.POLARIS_REPO_GPG_KEY_ID }}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: repo-arch
+          path: repo/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to GitHub Pages
+    needs:
+      - fedora-repo
+      - arch-repo
+    runs-on: ubuntu-24.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: repo-fedora
+          path: site/repo
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: repo-arch
+          path: site/repo
+
+      - name: Check the combined tree
+        # Both jobs export the public key to the same path, so the merge is only
+        # safe if they agree. A mismatch means the two repositories were signed
+        # by different keys, which no client could resolve.
+        run: |
+          for required in \
+            repo/polaris.gpg \
+            repo/fedora/polaris.repo \
+            repo/fedora/x86_64/repodata/repomd.xml \
+            repo/fedora/x86_64/repodata/repomd.xml.asc \
+            repo/arch/polaris.conf \
+            repo/arch/x86_64/polaris.db \
+            repo/arch/x86_64/polaris.db.sig
+          do
+            if [ ! -f "site/$required" ]; then
+              echo "missing from the published tree: $required" >&2
+              exit 1
+            fi
+          done
+          if find site -type l | grep -q .; then
+            echo 'the published tree contains a symlink; a static host serves it as text' >&2
+            find site -type l >&2
+            exit 1
+          fi
+          echo 'Publishing:'
+          find site -type f | sort | sed 's/^/  /'
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -1,0 +1,149 @@
+# Package repositories
+
+Polaris publishes dnf and pacman repositories, so an upgrade is part of the
+host's normal update rather than a download and an exact filename.
+
+```bash
+sudo dnf upgrade          # Fedora, Bazzite
+sudo pacman -Syu          # Arch, CachyOS
+```
+
+Adding the repository is a one-time step. Downloading a release package by hand
+still works and is still supported; the repository is an easier path to the same
+package, not a different one.
+
+## Fedora
+
+```bash
+sudo rpm --import https://papi-ux.github.io/polaris/repo/polaris.gpg
+sudo curl --location --output /etc/yum.repos.d/polaris.repo \
+  https://papi-ux.github.io/polaris/repo/fedora/polaris.repo
+sudo dnf install polaris
+sudo -H polaris --setup-host
+systemctl --user restart polaris
+```
+
+After that, `sudo dnf upgrade` carries Polaris with everything else.
+
+## Bazzite and other ostree hosts
+
+The same repository works, layered rather than installed:
+
+```bash
+sudo rpm --import https://papi-ux.github.io/polaris/repo/polaris.gpg
+sudo curl --location --output /etc/yum.repos.d/polaris.repo \
+  https://papi-ux.github.io/polaris/repo/fedora/polaris.repo
+rpm-ostree install polaris
+systemctl reboot
+```
+
+Layered packages are updated by `rpm-ostree upgrade`, so Polaris follows the
+image update instead of needing to be re-layered from a downloaded RPM.
+
+Seat isolation still needs the input group, which on ostree hosts lives in
+`/usr/lib/group`. See the [Bazzite guide](bazzite.md#controller-and-input-group).
+
+## Arch and CachyOS
+
+```bash
+sudo pacman-key --recv-keys <KEY-ID> --keyserver keyserver.ubuntu.com
+sudo pacman-key --lsign-key <KEY-ID>
+```
+
+Then append to `/etc/pacman.conf`:
+
+```ini
+[polaris]
+SigLevel = Required DatabaseRequired
+Server = https://papi-ux.github.io/polaris/repo/arch/$arch
+```
+
+```bash
+sudo pacman -Sy polaris
+sudo -H polaris --setup-host
+systemctl --user restart polaris
+```
+
+`SigLevel = Required DatabaseRequired` is deliberate. Without it pacman falls
+back to the checksum recorded in the database and reports `Validated By: SHA-256
+Sum` — it never looks at the signature, so anyone who can rewrite the database
+rewrites the checksum with it.
+
+## SteamOS
+
+SteamOS is not served by a repository and will not be. The rootfs is read-only
+and pacman state does not survive a SteamOS update, so a repository would
+promise upgrades it cannot deliver. Follow the [SteamOS guide](steamos.md).
+
+## Ubuntu
+
+Not yet served by a repository. The Ubuntu package remains the download-and-
+install path described in the release notes.
+
+## What the repository serves
+
+The package a repository serves is the package the release published, byte for
+byte, with a signature added to the repository copy. Nothing is rebuilt:
+a rebuild would ship a binary that CI never tested, and the Fedora packaging
+pulls a CUDA toolkit over the network at build time, which no sandboxed rebuild
+service permits.
+
+The repository currently carries the latest release only. Rolling back means
+installing an older release package by hand from the
+[releases page](https://github.com/papi-ux/polaris/releases).
+
+---
+
+## Maintaining the repository
+
+`.github/workflows/package-repos.yml` runs when a release is published, and can
+be run by hand against any existing tag.
+
+### One-time setup
+
+The signing key must be RSA. `rpmsign` exits 0 on an Ed25519 key and silently
+signs nothing — `scripts/build-package-repos.sh` verifies the signature after
+signing for exactly that reason, so a wrong key type fails the build rather than
+publishing an unsigned package.
+
+```bash
+gpg --batch --gen-key <<'EOF'
+%no-protection
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: Polaris
+Name-Email: papi@papi-ux.com
+Expire-Date: 0
+%commit
+EOF
+
+gpg --list-keys --with-colons | awk -F: '/^fpr/{print $10; exit}'   # the key id
+gpg --armor --export-secret-keys <KEY-ID>                           # the secret
+```
+
+Set two repository secrets:
+
+| Secret | Value |
+|---|---|
+| `POLARIS_REPO_GPG_KEY_ID` | the key fingerprint |
+| `POLARIS_REPO_GPG_PRIVATE_KEY` | the armored secret key |
+
+Then set Pages to deploy from GitHub Actions in the repository settings, and
+publish the public key somewhere clients can reach it — the workflow serves it
+at `repo/polaris.gpg`, and uploading it to a keyserver makes the `pacman-key
+--recv-keys` flow above work.
+
+Back the secret key up somewhere that is not this repository. Losing it means
+every host that trusts it has to be re-pointed at a new one.
+
+### Checking the layout locally
+
+`scripts/build-package-repos.sh` runs without a key, which assembles the
+repositories unsigned so the layout can be inspected:
+
+```bash
+scripts/build-package-repos.sh --only fedora --assets ./assets --version 1.3.7 --output ./repo
+```
+
+Each ecosystem needs its own toolchain — `createrepo_c` and `rpmsign` on Fedora,
+`repo-add` on Arch — so run each `--only` in the matching container.

--- a/scripts/build-package-repos.sh
+++ b/scripts/build-package-repos.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Assemble dnf and pacman repositories from release assets that already exist.
+#
+# Polaris publishes four packages per tag, and until now the only way to take an
+# upgrade was to download one by hand and install it by exact filename. This
+# turns those same packages into repositories, so `dnf upgrade` and `pacman -Syu`
+# carry Polaris along with everything else on the host.
+#
+# Nothing is rebuilt. The package a repository serves is the package the release
+# published and CI tested; the only difference is a signature on the repository
+# copy. Rebuilding would mean shipping a second binary nobody tested, and the
+# Fedora spec pulls a CUDA toolkit over the network during %build, which no
+# sandboxed rebuild service will do anyway.
+#
+# Each ecosystem needs its own toolchain, so --only runs one at a time and the
+# results are combined into a single output tree:
+#
+#   --only fedora   needs createrepo_c, rpm, rpmsign   (Fedora container)
+#   --only arch     needs repo-add                     (Arch container)
+#
+# Usage:
+#   scripts/build-package-repos.sh --only fedora --assets DIR --version 1.3.7 \
+#       --output DIR [--base-url URL] [--gpg-key-id KEYID]
+#
+# Without --gpg-key-id the repositories are assembled unsigned, which is useful
+# for checking the layout locally. Publishing unsigned is not supported.
+
+set -euo pipefail
+
+BASE_URL_DEFAULT='https://papi-ux.github.io/polaris/repo'
+
+only=''
+assets_dir=''
+version=''
+output_dir=''
+base_url="$BASE_URL_DEFAULT"
+gpg_key_id=''
+
+die() {
+  printf 'build-package-repos: %s\n' "$1" >&2
+  exit 1
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --only) only="${2:-}"; shift 2 ;;
+    --assets) assets_dir="${2:-}"; shift 2 ;;
+    --version) version="${2:-}"; shift 2 ;;
+    --output) output_dir="${2:-}"; shift 2 ;;
+    --base-url) base_url="${2:-}"; shift 2 ;;
+    --gpg-key-id) gpg_key_id="${2:-}"; shift 2 ;;
+    -h|--help) sed -n '2,27p' "$0"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+case "$only" in
+  fedora|arch) ;;
+  '') die 'missing --only (fedora or arch)' ;;
+  *) die "--only must be fedora or arch, not: $only" ;;
+esac
+[ -n "$assets_dir" ] || die 'missing --assets'
+[ -n "$version" ] || die 'missing --version'
+[ -n "$output_dir" ] || die 'missing --output'
+[ -d "$assets_dir" ] || die "assets directory does not exist: $assets_dir"
+
+require gpg
+
+mkdir -p "$output_dir"
+
+# The exact release asset. Naming it rather than globbing means a renamed or
+# missing asset fails here, instead of publishing a repository that quietly
+# offers nothing.
+case "$only" in
+  fedora) asset="$assets_dir/Polaris-fedora44-x86_64.rpm" ;;
+  arch) asset="$assets_dir/Polaris-arch-x86_64.pkg.tar.zst" ;;
+esac
+[ -f "$asset" ] || die "missing release asset: $asset"
+
+printf 'Assembling %s repository for Polaris %s\n' "$only" "$version"
+
+if [ "$only" = fedora ]; then
+  require createrepo_c
+  require rpm
+
+  # Both package managers decide "is there an upgrade" from metadata inside the
+  # package, never from its filename. A package whose internal version disagrees
+  # with the release is one nobody ever upgrades to, and the failure is silent:
+  # the repository works, it just never offers anything.
+  # Packages carry the release version plus the commit -- 1.3.6.f851fad -- so
+  # this is a prefix match on whole segments. Matching "$version"* instead would
+  # accept 1.3.60 as a 1.3.6 package.
+  rpm_version="$(rpm --queryformat '%{VERSION}' -qp "$asset" 2>/dev/null)"
+  case "$rpm_version" in
+    "$version"|"$version".*) ;;
+    *) die "RPM reports version $rpm_version but the release is $version" ;;
+  esac
+
+  fedora_dir="$output_dir/fedora/x86_64"
+  rm -rf "$output_dir/fedora"
+  mkdir -p "$fedora_dir"
+  cp "$asset" "$fedora_dir/"
+  rpm_in_repo="$fedora_dir/$(basename "$asset")"
+
+  if [ -n "$gpg_key_id" ]; then
+    require rpmsign
+    # Signs the repository copy only. The published release asset is untouched,
+    # so a package installed by hand and one installed from the repository are
+    # the same build.
+    rpmsign --define "_gpg_name $gpg_key_id" --addsign "$rpm_in_repo"
+
+    # The signature lands in the RSAHEADER header, not SIGPGP -- SIGPGP reads
+    # back empty on a correctly signed package, so checking it would reject
+    # every good build. The key has to be RSA: rpmsign exits 0 on an Ed25519
+    # key and signs nothing at all, which is why this is verified rather than
+    # trusted.
+    signature="$(rpm --queryformat '%{RSAHEADER:pgpsig}' -qp "$rpm_in_repo" 2>/dev/null)"
+    case "$signature" in
+      *'Key ID'*) ;;
+      *) die 'rpmsign exited 0 but the RPM carries no signature (is the key RSA?)' ;;
+    esac
+    printf '  signed %s (%s)\n' "$(basename "$rpm_in_repo")" "$signature"
+  fi
+
+  createrepo_c --quiet "$fedora_dir"
+  [ -f "$fedora_dir/repodata/repomd.xml" ] || die 'createrepo_c produced no repomd.xml'
+
+  if [ -n "$gpg_key_id" ]; then
+    gpg --batch --yes --detach-sign --armor --local-user "$gpg_key_id" \
+      "$fedora_dir/repodata/repomd.xml"
+  fi
+
+  cat > "$output_dir/fedora/polaris.repo" <<EOF
+[polaris]
+name=Polaris
+baseurl=$base_url/fedora/\$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=$base_url/polaris.gpg
+metadata_expire=6h
+EOF
+fi
+
+if [ "$only" = arch ]; then
+  require repo-add
+
+  arch_dir="$output_dir/arch/x86_64"
+  rm -rf "$output_dir/arch"
+  mkdir -p "$arch_dir"
+  cp "$asset" "$arch_dir/"
+  arch_in_repo="$arch_dir/$(basename "$asset")"
+
+  if [ -n "$gpg_key_id" ]; then
+    gpg --batch --yes --detach-sign --no-armor --local-user "$gpg_key_id" "$arch_in_repo"
+    [ -f "$arch_in_repo.sig" ] || die 'gpg reported success but no detached signature exists'
+  fi
+
+  # repo-add records the filename it is handed and pacman fetches exactly that,
+  # so a release asset does not have to be named like a pacman package.
+  if [ -n "$gpg_key_id" ]; then
+    ( cd "$arch_dir" && repo-add --quiet --sign --key "$gpg_key_id" \
+        polaris.db.tar.gz "$(basename "$arch_in_repo")" )
+    [ -f "$arch_dir/polaris.db.tar.gz.sig" ] || die 'repo-add did not sign the database'
+  else
+    ( cd "$arch_dir" && repo-add --quiet polaris.db.tar.gz "$(basename "$arch_in_repo")" )
+  fi
+  [ -f "$arch_dir/polaris.db" ] || die 'repo-add produced no polaris.db'
+
+  # repo-add leaves polaris.db and polaris.files as symlinks to the .tar.gz.
+  # pacman fetches polaris.db by name over HTTP, and a static host serves a
+  # symlink as its target's name in a text file rather than following it, so
+  # these are materialized as real files.
+  for link in polaris.db polaris.files polaris.db.sig polaris.files.sig; do
+    if [ -L "$arch_dir/$link" ]; then
+      target="$(readlink "$arch_dir/$link")"
+      rm "$arch_dir/$link"
+      cp "$arch_dir/$target" "$arch_dir/$link"
+    fi
+  done
+
+  # The version pacman will compare against, read back out of the database it
+  # just wrote rather than trusted from the filename.
+  db_version="$(tar -xzOf "$arch_dir/polaris.db.tar.gz" --wildcards '*/desc' |
+    awk '/^%VERSION%$/ { getline; print; exit }')"
+  # Same shape as the RPM, with pacman's -pkgrel suffix on the end.
+  case "$db_version" in
+    "$version"-*|"$version".*-*) ;;
+    *) die "pacman database reports version $db_version but the release is $version" ;;
+  esac
+  printf '  database records %s\n' "$db_version"
+
+  # Without an explicit SigLevel pacman falls back to the checksum in the
+  # database and reports "Validated By: SHA-256 Sum" -- it never looks at the
+  # signature, so an attacker who can rewrite the database rewrites the
+  # checksum with it. Requiring both closes that.
+  cat > "$output_dir/arch/polaris.conf" <<EOF
+[polaris]
+SigLevel = Required DatabaseRequired
+Server = $base_url/arch/\$arch
+EOF
+fi
+
+if [ -n "$gpg_key_id" ]; then
+  gpg --batch --yes --armor --export "$gpg_key_id" > "$output_dir/polaris.gpg"
+  [ -s "$output_dir/polaris.gpg" ] || die 'exported public key is empty'
+fi
+
+printf 'Done. %s repository contents:\n' "$only"
+find "$output_dir/$only" -type f | sort | sed 's/^/  /'


### PR DESCRIPTION
## Summary

Step one of one-click upgrades: `sudo dnf upgrade` and `sudo pacman -Syu` now carry Polaris.

Every release note carries the same four-line download-by-exact-filename command, and the Update Center's best offer is to copy it for you. The release already publishes packages CI tests — what was missing was somewhere to serve them from.

`scripts/build-package-repos.sh` assembles a signed dnf repository and a signed pacman repository from the existing release assets. `.github/workflows/package-repos.yml` runs it on publish and deploys to Pages. `docs/repositories.md` covers Fedora, Bazzite via `rpm-ostree`, and Arch, plus the maintainer setup.

**Nothing is rebuilt.** A repository serves the package the release published, with a signature on the repository copy and the published asset untouched.

## Why not COPR

I recommended COPR first and was wrong, for two reasons found while building this:

1. `packaging/linux/fedora/Polaris.spec` pulls a ~4GB CUDA toolkit over the network during `%build`. COPR builds in offline mock, so it cannot run.
2. That spec is not even the packaging path — it is used for `dnf builddep`. The shipped RPM is CPack output, so there is no COPR-buildable spec to submit.

Serving what CI already built is both simpler and the only option that keeps NVENC.

## Exact candidate

`bfab5d9`

## Verification

End-to-end against the **real v1.3.6 release assets**, in the same container images CI uses.

**dnf resolves the package from the repository:**
```
Repository     : polaris
Source         : polaris-1.3.6.f851fad-1.src.rpm
Download size  : 10.9 MiB
```

**pacman syncs and resolves it:**
```
Repository      : polaris
Version         : 1.3.6-1
```

**Signature enforcement is real, not configured-and-hoped.** Same repository with the key not imported:
```
error: polaris: key "ABAD83B8...81AB" is unknown
error: failed to synchronize all databases (invalid or corrupted database (PGP signature))
```

All hygiene scripts pass.

### Bugs the testing caught

- **`rpmsign` exits 0 on an Ed25519 key and signs nothing.** The script verifies the signature after signing rather than trusting the exit code, and the docs require RSA.
- **`SIGPGP:pgpsig` reads back empty on a correctly signed RPM.** My first check queried it and would have rejected every good package. The signature is in `RSAHEADER`.
- **`repo-add` leaves `polaris.db` as a symlink.** A static host serves a symlink as a text file containing its target name, so pacman would fetch garbage. They are materialized as real files, and the publish job refuses a tree containing any symlink.
- **Package version is `1.3.6.f851fad`, not `1.3.6`.** The version check is a whole-segment prefix match, so `1.3.60` is still rejected.
- **`find … | grep -q` under `bash -e` failed the publish step on the good path.** Now an `if`.

## What you need to do

Two repository secrets, and Pages set to deploy from GitHub Actions:

| Secret | Value |
|---|---|
| `POLARIS_REPO_GPG_KEY_ID` | key fingerprint |
| `POLARIS_REPO_GPG_PRIVATE_KEY` | armored secret key |

`docs/repositories.md` has the exact `gpg --batch --gen-key` block. **The key must be RSA.** The workflow fails loudly rather than publishing unsigned if the secret is missing.

## Known limits

- **Latest release only.** Each publish replaces the tree, so rollback still means an older release package by hand. Accumulating versions needs the previous state merged in and is worth doing separately.
- **Ubuntu not served.** Still the download path.
- **SteamOS deliberately never served** — read-only rootfs, and pacman state does not survive a SteamOS update, so a repository would promise upgrades it cannot deliver.
- The workflow itself has not run; it needs the secrets first.

## Next

`src/update_status.cpp` already serves `manual_install_only`, `auto_install_supported`, and `auto_install_enabled`, all hardcoded. Teaching the host to detect a repository install and fill those in is what turns this into the one-click path — that is the next PR, and the privilege mechanism for actually running the upgrade is a decision I want your call on before I build it.

## Unrelated finding

`dnf info` on the shipped RPM shows `License: unknown`, `Vendor: SudoMaker`, and the CPack placeholder description. Harmless while packages are downloaded by hand; once a repository serves them it is what users see in `dnf info` and GNOME Software. Worth fixing separately.
