### PR TITLE
feat(update): offer the repository upgrade when the host has one configured

### DIFF
--- a/src/update_status.cpp
+++ b/src/update_status.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -127,6 +128,91 @@ namespace update_status {
     return {};
   }
 
+  bool repository_section_enabled(std::string_view ini_contents) {
+    // dnf and pacman configuration are both ini, and both treat a section with
+    // no `enabled` key as enabled, so absence has to mean yes rather than no.
+    bool in_polaris = false;
+    bool found = false;
+    bool enabled = true;
+
+    std::istringstream stream {std::string(ini_contents)};
+    std::string line;
+    while (std::getline(stream, line)) {
+      const auto text = trim(line);
+      if (text.empty() || text.front() == '#') {
+        continue;
+      }
+
+      if (text.front() == '[') {
+        in_polaris = text == "[polaris]";
+        if (in_polaris) {
+          found = true;
+          enabled = true;
+        }
+        continue;
+      }
+
+      if (!in_polaris) {
+        continue;
+      }
+
+      const auto separator = text.find('=');
+      if (separator == std::string::npos) {
+        continue;
+      }
+
+      if (trim(text.substr(0, separator)) == "enabled") {
+        const auto value = lower_copy(trim(text.substr(separator + 1)));
+        enabled = value == "1" || value == "true" || value == "yes";
+      }
+    }
+
+    return found && enabled;
+  }
+
+  bool host_repository_configured(const distro_info_t &distro) {
+#ifdef __linux__
+    const auto family = package_family(distro);
+
+    std::string path;
+    if (family == "fedora") {
+      path = "/etc/yum.repos.d/polaris.repo";
+    } else if (family == "arch") {
+      path = "/etc/pacman.conf";
+    } else {
+      return false;
+    }
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+      return false;
+    }
+
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return repository_section_enabled(buffer.str());
+#else
+    (void) distro;
+    return false;
+#endif
+  }
+
+  std::string repository_upgrade_command(const distro_info_t &distro, bool ostree_host) {
+    const auto family = package_family(distro);
+    if (family == "fedora") {
+      // On an ostree host dnf is not the thing that changes the system, and
+      // telling a Bazzite user to run `dnf upgrade` is the same shape of wrong
+      // answer as telling them to run `usermod -aG input`.
+      return ostree_host ? "rpm-ostree upgrade" : "sudo dnf upgrade polaris";
+    }
+
+    if (family == "arch") {
+      return "sudo pacman -Syu polaris";
+    }
+
+    return {};
+  }
+
   std::string recommended_release_asset(const distro_info_t &distro) {
     const auto family = package_family(distro);
     if (family == "arch") {
@@ -158,11 +244,21 @@ namespace update_status {
 
   nlohmann::json host_update_status() {
     const auto distro = detect_host_distro();
+
+    std::error_code ec;
+    const bool ostree_host = std::filesystem::exists("/run/ostree-booted", ec);
+    const bool repository = host_repository_configured(distro);
+    const auto upgrade_command = repository ? repository_upgrade_command(distro, ostree_host) : std::string {};
+
     return {
       {"status", true},
       {"platform", POLARIS_PLATFORM},
       {"version", PROJECT_VERSION},
-      {"manual_install_only", true},
+      // A host with the repository configured is no longer on the download-a-
+      // file path, so this stops claiming otherwise.
+      {"manual_install_only", !repository},
+      {"repository_configured", repository},
+      {"repository_upgrade_command", upgrade_command},
       {"auto_install_supported", false},
       {"auto_install_enabled", false},
       {"distro", distro_json(distro)},

--- a/src/update_status.h
+++ b/src/update_status.h
@@ -22,6 +22,19 @@ namespace update_status {
   distro_info_t detect_host_distro();
   std::string package_family(const distro_info_t &distro);
   std::string recommended_release_asset(const distro_info_t &distro);
+
+  /**
+   * @brief Whether an ini file enables a repository section named `polaris`.
+   *
+   * Answers the question the Update Center actually needs: can this host take
+   * an upgrade from its package manager? That is a property of the repository
+   * being configured, not of where the installed package originally came from
+   * -- a package installed by hand upgrades from the repository just fine once
+   * the repository exists.
+   */
+  bool repository_section_enabled(std::string_view ini_contents);
+  bool host_repository_configured(const distro_info_t &distro);
+  std::string repository_upgrade_command(const distro_info_t &distro, bool ostree_host);
   nlohmann::json distro_json(const distro_info_t &distro);
   nlohmann::json host_update_status();
 
@@ -36,6 +49,14 @@ namespace update_status {
 
   inline std::string recommended_release_asset_for_tests(const distro_info_t &distro) {
     return recommended_release_asset(distro);
+  }
+
+  inline bool repository_section_enabled_for_tests(std::string_view ini_contents) {
+    return repository_section_enabled(ini_contents);
+  }
+
+  inline std::string repository_upgrade_command_for_tests(const distro_info_t &distro, bool ostree_host) {
+    return repository_upgrade_command(distro, ostree_host);
   }
 #endif
 

--- a/src_assets/common/assets/web/update-center.js
+++ b/src_assets/common/assets/web/update-center.js
@@ -154,6 +154,20 @@ export function buildManualInstallCommand(asset, host = {}) {
 }
 
 
+export function buildRepositoryUpgradeCommand(host = {}) {
+  if (!host.repository_configured) return ''
+
+  // The command comes from the host rather than being rebuilt here. Only the
+  // host knows whether this is an ostree image, where dnf is not the thing that
+  // changes the system and `dnf upgrade` is the same shape of wrong answer as
+  // `usermod -aG input` was on Bazzite.
+  const command = String(host.repository_upgrade_command || '').trim()
+  if (!command) return ''
+
+  return `${command} &&\nsystemctl --user restart polaris`
+}
+
+
 function buildActionMetadata(status, asset, installCommand, releaseUrl) {
   if (status === 'update_available') {
     if (installCommand) {
@@ -293,7 +307,13 @@ export function buildUpdateCenterState({ currentVersion = '', latestRelease = nu
 
   const asset = selectReleaseAsset(candidateRelease, host)
   const packageFamily = normalizeToken(asset?.packageFamily || inferPackageFamily(host))
-  const installCommand = asset ? buildManualInstallCommand(asset, { ...host, packageFamily }) : ''
+  // A configured repository wins over the download command: it upgrades the
+  // same package with one line and no exact filename to get wrong. The download
+  // path stays for hosts without the repository, which is still every host that
+  // has not opted in.
+  const repositoryCommand = buildRepositoryUpgradeCommand(host)
+  const installCommand = repositoryCommand ||
+    (asset ? buildManualInstallCommand(asset, { ...host, packageFamily }) : '')
   const releaseUrl = candidateRelease.html_url || ''
   const action = buildActionMetadata(status, asset, installCommand, releaseUrl)
 

--- a/src_assets/common/assets/web/update-center.test.js
+++ b/src_assets/common/assets/web/update-center.test.js
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   buildManualInstallCommand,
+  buildRepositoryUpgradeCommand,
   buildUpdateCenterState,
   selectReleaseAsset,
 } from './update-center.js'
@@ -520,5 +521,70 @@ describe('Update Center release awareness', () => {
     expect(state.asset).toBeNull()
     expect(state.installCommand).toBe('')
     expect(state.canCopyInstallCommand).toBe(false)
+  })
+})
+
+describe('repository upgrades', () => {
+  const repositoryHost = {
+    platform: 'linux',
+    distro: { id: 'fedora', version_id: '44' },
+    repository_configured: true,
+    repository_upgrade_command: 'sudo dnf upgrade polaris',
+  }
+
+  it('offers nothing when the host has no repository configured', () => {
+    expect(buildRepositoryUpgradeCommand({ ...repositoryHost, repository_configured: false })).toBe('')
+  })
+
+  it('does not invent a command the host did not send', () => {
+    // A host that reports a repository but no command is one whose family we do
+    // not serve. Guessing `dnf upgrade` there would be advice that cannot work.
+    expect(buildRepositoryUpgradeCommand({ ...repositoryHost, repository_upgrade_command: '' })).toBe('')
+  })
+
+  it('uses the command the host sent rather than rebuilding it', () => {
+    const ostree = { ...repositoryHost, repository_upgrade_command: 'rpm-ostree upgrade' }
+
+    expect(buildRepositoryUpgradeCommand(ostree)).toContain('rpm-ostree upgrade')
+    expect(buildRepositoryUpgradeCommand(ostree)).not.toContain('dnf')
+  })
+
+  it('restarts Polaris after upgrading, like the download path does', () => {
+    expect(buildRepositoryUpgradeCommand(repositoryHost)).toContain('systemctl --user restart polaris')
+  })
+
+  it('prefers the repository command over the download command', () => {
+    const state = buildUpdateCenterState({
+      currentVersion: '1.3.6',
+      latestRelease: {
+        tag_name: 'v1.3.7',
+        html_url: 'https://example.invalid/release',
+        assets: [{
+          name: 'Polaris-fedora44-x86_64.rpm',
+          browser_download_url: 'https://example.invalid/Polaris-fedora44-x86_64.rpm',
+        }],
+      },
+      host: repositoryHost,
+    })
+
+    expect(state.installCommand).toContain('sudo dnf upgrade polaris')
+    expect(state.installCommand).not.toContain('wget')
+  })
+
+  it('still serves the download command to a host without the repository', () => {
+    const state = buildUpdateCenterState({
+      currentVersion: '1.3.6',
+      latestRelease: {
+        tag_name: 'v1.3.7',
+        html_url: 'https://example.invalid/release',
+        assets: [{
+          name: 'Polaris-fedora44-x86_64.rpm',
+          browser_download_url: 'https://example.invalid/Polaris-fedora44-x86_64.rpm',
+        }],
+      },
+      host: { ...repositoryHost, repository_configured: false },
+    })
+
+    expect(state.installCommand).toContain('wget --output-document=')
   })
 })

--- a/tests/unit/test_update_status.cpp
+++ b/tests/unit/test_update_status.cpp
@@ -47,3 +47,54 @@ TEST(UpdateStatusTests, RecommendsUbuntu2404DebAsset) {
   EXPECT_EQ(update_status::recommended_release_asset_for_tests(distro), "Polaris-ubuntu24.04-x86_64.deb");
   EXPECT_EQ(update_status::package_family_for_tests(distro), "ubuntu");
 }
+
+TEST(UpdateStatusTests, RepositorySectionWithNoEnabledKeyCountsAsEnabled) {
+  // dnf and pacman both treat a section with no `enabled` key as enabled, so
+  // absence has to mean yes. Defaulting to no would tell every correctly
+  // configured host that it has no repository.
+  EXPECT_TRUE(update_status::repository_section_enabled_for_tests(
+    "[polaris]\nname=Polaris\nbaseurl=https://example.invalid/fedora/$basearch\n"
+  ));
+}
+
+TEST(UpdateStatusTests, RepositorySectionHonoursExplicitEnabledValues) {
+  EXPECT_TRUE(update_status::repository_section_enabled_for_tests("[polaris]\nenabled=1\n"));
+  EXPECT_TRUE(update_status::repository_section_enabled_for_tests("[polaris]\nenabled=true\n"));
+  EXPECT_FALSE(update_status::repository_section_enabled_for_tests("[polaris]\nenabled=0\n"));
+}
+
+TEST(UpdateStatusTests, RepositorySectionIgnoresOtherSections) {
+  // The disabled repository here is somebody else's. Reading `enabled` without
+  // tracking which section it belongs to would report Polaris as disabled.
+  EXPECT_TRUE(update_status::repository_section_enabled_for_tests(
+    "[polaris]\nenabled=1\n\n[other]\nenabled=0\n"
+  ));
+  EXPECT_FALSE(update_status::repository_section_enabled_for_tests(
+    "[other]\nenabled=1\n"
+  ));
+}
+
+TEST(UpdateStatusTests, RepositorySectionIgnoresCommentedConfiguration) {
+  // A commented-out repository is exactly the host that cannot upgrade from
+  // one, so it must not be read as configured.
+  EXPECT_FALSE(update_status::repository_section_enabled_for_tests(
+    "#[polaris]\n#enabled=1\n"
+  ));
+}
+
+TEST(UpdateStatusTests, RepositoryUpgradeCommandFollowsTheHostShape) {
+  const auto fedora = update_status::parse_os_release_for_tests("ID=fedora\nVERSION_ID=44\n");
+  const auto arch = update_status::parse_os_release_for_tests("ID=arch\n");
+  const auto ubuntu = update_status::parse_os_release_for_tests("ID=ubuntu\nVERSION_ID=\"24.04\"\n");
+
+  EXPECT_EQ(update_status::repository_upgrade_command_for_tests(fedora, false), "sudo dnf upgrade polaris");
+  EXPECT_EQ(update_status::repository_upgrade_command_for_tests(arch, false), "sudo pacman -Syu polaris");
+
+  // On an ostree host dnf does not change the system. Serving `dnf upgrade`
+  // there is the same class of unusable advice as the `usermod -aG input` that
+  // v1.3.6 had to correct.
+  EXPECT_EQ(update_status::repository_upgrade_command_for_tests(fedora, true), "rpm-ostree upgrade");
+
+  // No repository is served for Ubuntu, so there is no command to offer.
+  EXPECT_EQ(update_status::repository_upgrade_command_for_tests(ubuntu, false), "");
+}


### PR DESCRIPTION
## Summary

Step two toward one-click. With the repository configured, the Update Center offers one line instead of the four-line download-by-exact-filename command.

The host reports `repository_configured` and `repository_upgrade_command`; the Update Center prefers them over the download. Hosts without the repository are unchanged.

**What is detected is whether the repository is configured, not where the installed package came from.** That is the question worth answering — a package installed by hand upgrades from the repository fine once the repository exists, so keying off the installed package's origin would keep offering the download to hosts that no longer need it. It is also a cheap file read rather than shelling out to dnf.

**The command is decided host-side**, because only the host knows whether it is an ostree image. `dnf upgrade` does not change the system on Bazzite, so serving it there would be the same shape of unusable advice as the `usermod -aG input` that v1.3.6 had to correct. Bazzite gets `rpm-ostree upgrade`.

`manual_install_only` stops being hardcoded `true` and now means what it says.

## Exact candidate

`aacf3ae`

## Verification

- `npm run test` -> **306 passed** (300 before, 6 new)
- `npm run lint` -> exit 0
- `bash scripts/check-public-docs.sh` -> exit 0

New C++ coverage pins the parts that are easy to get quietly wrong: a section with no `enabled` key counts as enabled (both dnf and pacman treat it that way, and defaulting to no would tell every correctly configured host it has none); `enabled=0` in *another* section does not disable Polaris; a commented-out repository is not configured; and ostree gets `rpm-ostree upgrade` rather than dnf.

C++ tests run in CI's sanitizer job — there is no local build here.

## Not in this change

`auto_install_supported` and `auto_install_enabled` are still `false`. Running the upgrade **from** the web UI needs a privilege mechanism, and that is the decision I want your call on: PackageKit over polkit gives a native auth prompt with no custom privileged code, but it is solid on Fedora and weak on Arch.

Depends on nothing, but only does something useful once #310 gives hosts a repository to configure.