### PR TITLE
fix(packaging): point the repositories at the domain Pages actually serves

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -15,9 +15,9 @@ package, not a different one.
 ## Fedora
 
 ```bash
-sudo rpm --import https://papi-ux.github.io/polaris/repo/polaris.gpg
+sudo rpm --import https://papi-ux.com/polaris/repo/polaris.gpg
 sudo curl --location --output /etc/yum.repos.d/polaris.repo \
-  https://papi-ux.github.io/polaris/repo/fedora/polaris.repo
+  https://papi-ux.com/polaris/repo/fedora/polaris.repo
 sudo dnf install polaris
 sudo -H polaris --setup-host
 systemctl --user restart polaris
@@ -30,9 +30,9 @@ After that, `sudo dnf upgrade` carries Polaris with everything else.
 The same repository works, layered rather than installed:
 
 ```bash
-sudo rpm --import https://papi-ux.github.io/polaris/repo/polaris.gpg
+sudo rpm --import https://papi-ux.com/polaris/repo/polaris.gpg
 sudo curl --location --output /etc/yum.repos.d/polaris.repo \
-  https://papi-ux.github.io/polaris/repo/fedora/polaris.repo
+  https://papi-ux.com/polaris/repo/fedora/polaris.repo
 rpm-ostree install polaris
 systemctl reboot
 ```
@@ -55,7 +55,7 @@ Then append to `/etc/pacman.conf`:
 ```ini
 [polaris]
 SigLevel = Required DatabaseRequired
-Server = https://papi-ux.github.io/polaris/repo/arch/$arch
+Server = https://papi-ux.com/polaris/repo/arch/$arch
 ```
 
 ```bash

--- a/scripts/build-package-repos.sh
+++ b/scripts/build-package-repos.sh
@@ -27,7 +27,7 @@
 
 set -euo pipefail
 
-BASE_URL_DEFAULT='https://papi-ux.github.io/polaris/repo'
+BASE_URL_DEFAULT='https://papi-ux.com/polaris/repo'
 
 only=''
 assets_dir=''


### PR DESCRIPTION
## Summary

The published base url was `papi-ux.github.io/polaris/repo`. That is not where this repository is served from.

`papi-ux.github.io` carries a custom domain, and a project site under a user site with one is served at `<domain>/<repo>`. The Pages API confirms it:

```
build_type=workflow  url=http://papi-ux.com/polaris/
```

That url is written into the `.repo` file and the `pacman.conf` stanza the workflow publishes, so it is what every host would have been configured with — a redirect at best, and a 404 for any client that does not follow one.

Caught before the first publish, so nothing was ever served from the wrong url.

## Exact candidate

`56ca467`

## Verification

- `https://papi-ux.com/polaris/` currently returns 404, so the docs site does not use that path and the project site will not shadow anything it already serves.
- `https://papi-ux.com/` returns 200 over https, so the `http` in the Pages API response is not a working-https problem.
- `bash scripts/check-public-docs.sh` → exit 0.

Six occurrences replaced across the script default and the documented commands. Nothing else references the old host.
