### PR TITLE
fix(ci): install gh in the dnf repository job

### DIFF
--- a/.github/workflows/package-repos.yml
+++ b/.github/workflows/package-repos.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Install repository tools
-        run: dnf install -y --setopt=install_weak_deps=False createrepo_c rpm-sign gnupg2 git tar
+        run: dnf install -y --setopt=install_weak_deps=False createrepo_c rpm-sign gnupg2 git tar gh
 
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary

The first run of the repository workflow died at `gh: command not found`.

The job downloads the release package with `gh`, and the Fedora container does not ship it. The Arch job installs `github-cli` and was fine — the pacman repository assembled and signed correctly on that same run.

## Exact candidate

`bd79656`

## Verification

Checked the package exists rather than spending a second failed run finding out:

```
$ docker run --rm fedora:44 dnf install -y gh && gh --version
gh version 2.97.0 (2026-07-31)
```

Workflow YAML parses.

## The run this failed on

https://github.com/papi-ux/polaris/actions/runs/31204329496

`Assemble pacman repository: success`, `Assemble dnf repository: failure`, publish skipped. Nothing was deployed, so no host ever saw a partial repository — the publish job depending on both is what prevented that.
