### PR TITLE
fix(packaging): serve the repositories from their own subdomain

### DIFF
--- a/.github/workflows/package-repos.yml
+++ b/.github/workflows/package-repos.yml
@@ -139,26 +139,33 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: repo-fedora
-          path: site/repo
+          path: site
 
       - uses: actions/download-artifact@v8
         with:
           name: repo-arch
-          path: site/repo
+          path: site
 
       - name: Check the combined tree
         # Both jobs export the public key to the same path, so the merge is only
         # safe if they agree. A mismatch means the two repositories were signed
         # by different keys, which no client could resolve.
         run: |
+          # The custom domain has to reach the deployed tree. Without it GitHub
+          # serves this project site under the apex domain at /polaris/, which
+          # is a real page on the docs site -- publishing without the CNAME
+          # replaces that page with this repository.
+          echo 'repo.papi-ux.com' > site/CNAME
+
           for required in \
-            repo/polaris.gpg \
-            repo/fedora/polaris.repo \
-            repo/fedora/x86_64/repodata/repomd.xml \
-            repo/fedora/x86_64/repodata/repomd.xml.asc \
-            repo/arch/polaris.conf \
-            repo/arch/x86_64/polaris.db \
-            repo/arch/x86_64/polaris.db.sig
+            CNAME \
+            polaris.gpg \
+            fedora/polaris.repo \
+            fedora/x86_64/repodata/repomd.xml \
+            fedora/x86_64/repodata/repomd.xml.asc \
+            arch/polaris.conf \
+            arch/x86_64/polaris.db \
+            arch/x86_64/polaris.db.sig
           do
             if [ ! -f "site/$required" ]; then
               echo "missing from the published tree: $required" >&2
@@ -179,3 +186,22 @@ jobs:
 
       - id: deployment
         uses: actions/deploy-pages@v5
+
+      - name: Check the docs site is still serving its Polaris page
+        # This project site is what took papi-ux.com/polaris/ down once, by
+        # being served under the apex domain instead of its own. If the custom
+        # domain ever stops applying it will happen again, so the deploy that
+        # would cause it fails here instead of being noticed by a visitor.
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            status="$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 20 \
+              "https://papi-ux.com/polaris/?deploy-check=$GITHUB_RUN_ID-$attempt" || echo 000)"
+            if [ "$status" = '200' ]; then
+              echo "docs site still serves /polaris/ (attempt $attempt)"
+              exit 0
+            fi
+            echo "attempt $attempt: /polaris/ returned $status"
+            sleep 20
+          done
+          echo 'papi-ux.com/polaris/ is not serving. This deploy has shadowed the docs site.' >&2
+          exit 1

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -15,9 +15,9 @@ package, not a different one.
 ## Fedora
 
 ```bash
-sudo rpm --import https://papi-ux.com/polaris/repo/polaris.gpg
+sudo rpm --import https://repo.papi-ux.com/polaris.gpg
 sudo curl --location --output /etc/yum.repos.d/polaris.repo \
-  https://papi-ux.com/polaris/repo/fedora/polaris.repo
+  https://repo.papi-ux.com/fedora/polaris.repo
 sudo dnf install polaris
 sudo -H polaris --setup-host
 systemctl --user restart polaris
@@ -30,9 +30,9 @@ After that, `sudo dnf upgrade` carries Polaris with everything else.
 The same repository works, layered rather than installed:
 
 ```bash
-sudo rpm --import https://papi-ux.com/polaris/repo/polaris.gpg
+sudo rpm --import https://repo.papi-ux.com/polaris.gpg
 sudo curl --location --output /etc/yum.repos.d/polaris.repo \
-  https://papi-ux.com/polaris/repo/fedora/polaris.repo
+  https://repo.papi-ux.com/fedora/polaris.repo
 rpm-ostree install polaris
 systemctl reboot
 ```
@@ -55,7 +55,7 @@ Then append to `/etc/pacman.conf`:
 ```ini
 [polaris]
 SigLevel = Required DatabaseRequired
-Server = https://papi-ux.com/polaris/repo/arch/$arch
+Server = https://repo.papi-ux.com/arch/$arch
 ```
 
 ```bash

--- a/scripts/build-package-repos.sh
+++ b/scripts/build-package-repos.sh
@@ -27,7 +27,7 @@
 
 set -euo pipefail
 
-BASE_URL_DEFAULT='https://papi-ux.com/polaris/repo'
+BASE_URL_DEFAULT='https://repo.papi-ux.com'
 
 only=''
 assets_dir=''


### PR DESCRIPTION
## Summary

Moves the package repositories to `repo.papi-ux.com`, and makes the failure that caused this impossible to repeat silently.

## What went wrong

`papi-ux.github.io` carries a custom domain, so a project site under it is served at `papi-ux.com/<repo>` — and `papi-ux.com/polaris/` is a real page on the docs site (`src/pages/polaris/index.astro`, linked from the homepage nav). Enabling Pages on this repository replaced that page with a 404.

Two things made it worse than a quick revert:

- **Deleting the Pages site did not hand the route back.** The 404 initially looked like edge cache (`age: 657`), but a cache-busted request still 404'd. The docs site had to be redeployed before `/polaris/` returned.
- **The check that should have caught it was worthless.** `curl https://papi-ux.com/polaris/` was run *after* Pages had already been enabled, so the 404 it reported was the damage, read as evidence the path was free.

The page is confirmed restored. `./polaris/index.html` was present in the deployed artifact throughout, so nothing was ever lost — only routed away.

## What changes

A subdomain cannot shadow a path under the apex, so the whole class of failure goes away. The published tree loses its `repo/` prefix with it:

| Before | After |
|---|---|
| `papi-ux.com/polaris/repo/fedora/polaris.repo` | `repo.papi-ux.com/fedora/polaris.repo` |
| `papi-ux.com/polaris/repo/polaris.gpg` | `repo.papi-ux.com/polaris.gpg` |

Three guards, because losing the page once was enough:

1. **The CNAME is written into the published tree**, not left only in repository settings, so a deploy carries its own domain.
2. **The layout check requires it**, so a tree without a CNAME never reaches the deploy step.
3. **The deploy is followed by a request for `papi-ux.com/polaris/`**, retried six times. A publish that shadows the docs site fails the workflow instead of being found by a visitor.

## Exact candidate

`ac2b040`

## Verification

- DNS is live: `repo.papi-ux.com` → CNAME `papi-ux.github.io` → `185.199.108–111.153`, unproxied, matching how the apex already resolves.
- `https://papi-ux.com/polaris/` returns 200 on both plain and cache-busted requests.
- Workflow YAML parses; `bash -n` clean; `check-public-docs.sh` exit 0.
- No references to the old base url remain in `scripts/`, `docs/`, or `.github/`.

Pages is currently **disabled** on this repository and stays that way until this merges — re-enabling it before the CNAME exists in the published tree would shadow the docs page again.
