### PR TITLE
feat(api): serve the display resolution planner per game

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -116,6 +116,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/config.cpp"
         "${CMAKE_SOURCE_DIR}/src/display_device.h"
         "${CMAKE_SOURCE_DIR}/src/display_device.cpp"
+        "${CMAKE_SOURCE_DIR}/src/display_planner.h"
+        "${CMAKE_SOURCE_DIR}/src/display_planner.cpp"
         "${CMAKE_SOURCE_DIR}/src/entry_handler.cpp"
         "${CMAKE_SOURCE_DIR}/src/entry_handler.h"
         "${CMAKE_SOURCE_DIR}/src/file_handler.cpp"

--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -24,6 +24,7 @@
         "beat_time",
         "category",
         "cover_url",
+        "display_planner",
         "genres",
         "hdr_supported",
         "id",
@@ -59,7 +60,7 @@
       },
       "required_by_nova": {
         "$comment": "Fields Nova reads. Anything else Polaris serves here is informational.",
-        "note": "Nova reads every field this object serves."
+        "note": "Nova reads every field this object serves except display_planner, which is served ahead of its consumer; see known_drift."
       },
       "polaris_emitter": {
         "file": "src/nvhttp.cpp",
@@ -105,6 +106,89 @@
         "file": "src/nvhttp.cpp",
         "function": "steam_launch_contract_for_app",
         "variable": "contract",
+        "style": "subscript"
+      }
+    },
+    "display_planner": {
+      "$comment": [
+        "Nested under game. Per-host, computed once per request from the same fallback",
+        "display mode the web planner plans from, and attached to every game unchanged.",
+        "Served ahead of its Nova consumer: the shared kotlinx model already decodes it",
+        "(PolarisGame.DisplayPlannerContract) and its contract test pins the 2560x1600x90",
+        "fixture, but the app's org.json adapter does not read it yet, so every field",
+        "below is also recorded under known_drift until Nova's Resolution row lands.",
+        "The nova_reader receiver names the wiring that adapter is expected to use.",
+        "Unlike the web planner, `hidden` here means unsafe and nothing else; the",
+        "advanced flag is its own axis so a client can offer its own advanced toggle."
+      ],
+      "fields": [
+        "advanced_scale_factors",
+        "available",
+        "choices",
+        "recommended_id",
+        "recommended_mode",
+        "recommended_title",
+        "source_aspect_ratio",
+        "source_fps",
+        "source_mode"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt",
+        "function": "fromJson",
+        "receiver": "plannerJson"
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "function": "display_planner_contract_json",
+        "variable": "planner",
+        "style": "subscript"
+      }
+    },
+    "display_planner_choice": {
+      "$comment": "One entry of display_planner.choices: a preset of the ported web planner.",
+      "fields": [
+        "advanced",
+        "aspect_ratio",
+        "badge",
+        "custom",
+        "hidden",
+        "id",
+        "intent",
+        "reason",
+        "safe",
+        "scale_factor",
+        "target_mode",
+        "title"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt",
+        "function": "fromJson",
+        "receiver": "choiceJson"
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "function": "display_planner_choice_json",
+        "variable": "choice",
+        "style": "subscript"
+      }
+    },
+    "display_planner_scale_choice": {
+      "$comment": "One entry of display_planner.advanced_scale_factors.",
+      "fields": [
+        "label",
+        "safe",
+        "scale_factor",
+        "target_mode"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/api/PolarisGameJsonAdapter.kt",
+        "function": "fromJson",
+        "receiver": "scaleJson"
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "function": "display_planner_scale_option_json",
+        "variable": "scale_option",
         "style": "subscript"
       }
     },
@@ -254,9 +338,49 @@
       ]
     },
     "polaris_sends_nova_never_reads": {
-      "$comment": "None. Nova's game adapter on origin/master reads every field Polaris serves, including play_time, beat_time and artwork.",
-      "game": [],
-      "session_capture": []
+      "$comment": [
+        "Before 2026-08-07 this was empty: Nova's game adapter read every field Polaris",
+        "served. display_planner inverted that on purpose — Polaris now serves the planner",
+        "the shared kotlinx model was already prepared to decode, and the app adapter wires",
+        "it when the Resolution row lands. The Nova commit that does so prunes these",
+        "entries and, if its receiver names differ from the nova_reader records above,",
+        "corrects those in the same change."
+      ],
+      "game": [
+        "display_planner"
+      ],
+      "session_capture": [],
+      "display_planner": [
+        "advanced_scale_factors",
+        "available",
+        "choices",
+        "recommended_id",
+        "recommended_mode",
+        "recommended_title",
+        "source_aspect_ratio",
+        "source_fps",
+        "source_mode"
+      ],
+      "display_planner_choice": [
+        "advanced",
+        "aspect_ratio",
+        "badge",
+        "custom",
+        "hidden",
+        "id",
+        "intent",
+        "reason",
+        "safe",
+        "scale_factor",
+        "target_mode",
+        "title"
+      ],
+      "display_planner_scale_choice": [
+        "label",
+        "safe",
+        "scale_factor",
+        "target_mode"
+      ]
     },
     "$detail": {
       "session_capture": [

--- a/src/display_planner.cpp
+++ b/src/display_planner.cpp
@@ -1,0 +1,247 @@
+/**
+ * @file src/display_planner.cpp
+ * @brief The display resolution planner, ported from the web UI.
+ */
+#include "display_planner.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <format>
+
+namespace display_planner {
+  namespace {
+    constexpr mode_t default_device {1920, 1080, 60};
+
+    struct preset_t {
+      std::string_view id;
+      std::string_view title;
+      std::string_view intent;
+      double scale_factor;
+      bool advanced;
+      bool custom;
+    };
+
+    // Order and wording are the contract: DISPLAY_PLANNER_PRESETS in
+    // display-resolution-planner.js, verbatim.
+    constexpr preset_t presets[] = {
+      {"native", "Native", "Match the client panel exactly.", 1.0, false, false},
+      {"balanced", "Balanced", "Best for this device: preserve aspect ratio while easing encoder and network load.", 0.75, false, false},
+      {"sharp", "Sharp / Supersampled", "Render above the client panel and downscale for extra clarity when the host has headroom.", 1.5, true, false},
+      {"performance", "Performance", "Favor frame pacing and bandwidth over raw pixel count.", 0.5, false, false},
+      {"custom", "Custom", "Advanced manual scale factor using the existing fallback display mode field.", 1.0, true, true},
+    };
+
+    constexpr std::string_view unsafe_reason = "Hidden because this would exceed the safe display-mode envelope for normal users.";
+
+    double positive_number(double value, double fallback) {
+      return std::isfinite(value) && value > 0 ? value : fallback;
+    }
+
+    mode_t normalize_device(const mode_t &device) {
+      return {
+        positive_number(device.width, default_device.width),
+        positive_number(device.height, default_device.height),
+        positive_number(device.fps, default_device.fps),
+      };
+    }
+
+    double round_to_even(double value) {
+      const double rounded = std::max(2.0, std::round(value));
+      return std::fmod(rounded, 2.0) == 0.0 ? rounded : rounded + 1;
+    }
+
+    bool is_safe_mode(const mode_t &target, const limits_t &limits) {
+      return target.width <= limits.max_width &&
+             target.height <= limits.max_height &&
+             target.width * target.height <= limits.max_pixels;
+    }
+
+    // "90" for 90, "0.75" for 0.75: what a JS template literal prints for the
+    // numbers this planner produces. Fractions are capped at three decimals so
+    // a rational refresh rate cannot leak its full binary expansion.
+    std::string format_planner_number(double value) {
+      const double rounded = std::round(value * 1000.0) / 1000.0;
+      if (rounded == std::floor(rounded)) {
+        if (std::fabs(rounded) < 9.0e15) {
+          return std::format("{}", static_cast<long long>(rounded));
+        }
+        return std::format("{:.0f}", rounded);
+      }
+      return std::format("{:g}", rounded);
+    }
+
+    bool all_digits(std::string_view value) {
+      return !value.empty() && std::all_of(value.begin(), value.end(), [](char c) {
+        return std::isdigit(static_cast<unsigned char>(c));
+      });
+    }
+
+    std::string preset_badge(std::string_view id, const mode_t &base, double scale_factor) {
+      if (id == "balanced") {
+        return "Best for this device";
+      }
+      if (id == "native") {
+        return std::format("{}×{}", format_planner_number(std::round(base.width)), format_planner_number(std::round(base.height)));
+      }
+      if (id == "sharp") {
+        return format_planner_number(scale_factor) + "x supersample";
+      }
+      if (id == "performance") {
+        return format_planner_number(scale_factor) + "x downscale";
+      }
+      return "Advanced";
+    }
+  }  // namespace
+
+  const std::vector<double> &planner_scale_factors() {
+    static const std::vector<double> factors {0.5, 0.75, 1, 1.25, 1.5, 2};
+    return factors;
+  }
+
+  std::optional<mode_t> parse_display_mode(std::string_view value) {
+    constexpr std::string_view whitespace = " \t\n\r\f\v";
+    const auto first = value.find_first_not_of(whitespace);
+    if (first == std::string_view::npos) {
+      return std::nullopt;
+    }
+    value = value.substr(first, value.find_last_not_of(whitespace) - first + 1);
+
+    const auto first_x = value.find('x');
+    if (first_x == std::string_view::npos) {
+      return std::nullopt;
+    }
+    const auto second_x = value.find('x', first_x + 1);
+    if (second_x == std::string_view::npos || value.find('x', second_x + 1) != std::string_view::npos) {
+      return std::nullopt;
+    }
+
+    const auto width = value.substr(0, first_x);
+    const auto height = value.substr(first_x + 1, second_x - first_x - 1);
+    const auto fps = value.substr(second_x + 1);
+
+    const auto dot = fps.find('.');
+    const bool fps_valid = dot == std::string_view::npos ?
+                             all_digits(fps) :
+                             all_digits(fps.substr(0, dot)) && all_digits(fps.substr(dot + 1));
+    if (!all_digits(width) || !all_digits(height) || !fps_valid) {
+      return std::nullopt;
+    }
+
+    try {
+      return mode_t {
+        std::stod(std::string {width}),
+        std::stod(std::string {height}),
+        std::stod(std::string {fps}),
+      };
+    } catch (const std::exception &) {
+      return std::nullopt;
+    }
+  }
+
+  std::string format_display_mode(const mode_t &mode) {
+    return std::format("{}x{}x{}",
+                       format_planner_number(std::round(mode.width)),
+                       format_planner_number(std::round(mode.height)),
+                       format_planner_number(mode.fps));
+  }
+
+  double clamp_planner_scale(double value) {
+    if (!std::isfinite(value)) {
+      return 1;
+    }
+    return std::min(2.0, std::max(0.5, value));
+  }
+
+  mode_t resolve_scaled_mode(const mode_t &base, double scale_factor) {
+    const double scale = clamp_planner_scale(scale_factor);
+    return {
+      round_to_even(base.width * scale),
+      round_to_even(base.height * scale),
+      base.fps,
+    };
+  }
+
+  std::string aspect_ratio_label(double width, double height) {
+    long long x = std::llabs(std::llround(width));
+    long long y = std::llabs(std::llround(height));
+    while (y != 0) {
+      const long long next = x % y;
+      x = y;
+      y = next;
+    }
+    const long long divisor = x != 0 ? x : 1;
+    return std::format("{}:{}", format_planner_number(width / divisor), format_planner_number(height / divisor));
+  }
+
+  planner_t build_resolution_planner(const mode_t &source, double custom_scale, const limits_t &limits) {
+    const auto base = normalize_device(source);
+    const double custom_factor = clamp_planner_scale(custom_scale);
+    const auto aspect = aspect_ratio_label(base.width, base.height);
+
+    planner_t plan;
+    plan.source = base;
+    plan.source_mode = format_display_mode(base);
+    plan.source_aspect_ratio = aspect;
+
+    for (const auto &preset : presets) {
+      const double scale_factor = preset.custom ? custom_factor : preset.scale_factor;
+      const auto target = resolve_scaled_mode(base, scale_factor);
+      const bool safe = is_safe_mode(target, limits);
+
+      choice_t choice;
+      choice.id = preset.id;
+      choice.title = preset.title;
+      choice.intent = preset.intent;
+      choice.badge = preset_badge(preset.id, base, scale_factor);
+      choice.reason = safe ? std::string {preset.intent} : std::string {unsafe_reason};
+      choice.aspect_ratio = aspect;
+      choice.target = target;
+      choice.target_mode = format_display_mode(target);
+      choice.scale_factor = scale_factor;
+      choice.advanced = preset.advanced;
+      choice.custom = preset.custom;
+      choice.safe = safe;
+      choice.hidden = !safe;
+      plan.choices.push_back(std::move(choice));
+    }
+
+    // The recommendation is what the web UI would recommend with advanced
+    // collapsed: `balanced` when it is safe, else the first safe non-advanced
+    // choice, else the first choice of all.
+    const choice_t *recommended = nullptr;
+    for (const auto &choice : plan.choices) {
+      if (!choice.advanced && choice.safe && choice.id == "balanced") {
+        recommended = &choice;
+        break;
+      }
+    }
+    if (!recommended) {
+      for (const auto &choice : plan.choices) {
+        if (!choice.advanced && choice.safe) {
+          recommended = &choice;
+          break;
+        }
+      }
+    }
+    if (!recommended) {
+      recommended = &plan.choices.front();
+    }
+    plan.recommended_id = recommended->id;
+    plan.recommended_title = "Best for this device";
+    plan.recommended_mode = recommended->target_mode;
+
+    for (const double factor : planner_scale_factors()) {
+      const auto target = resolve_scaled_mode(base, factor);
+      scale_option_t option;
+      option.scale_factor = factor;
+      option.label = format_planner_number(factor) + "x";
+      option.target = target;
+      option.target_mode = format_display_mode(target);
+      option.safe = is_safe_mode(target, limits);
+      plan.advanced_scale_factors.push_back(std::move(option));
+    }
+
+    return plan;
+  }
+}  // namespace display_planner

--- a/src/display_planner.h
+++ b/src/display_planner.h
@@ -1,0 +1,131 @@
+/**
+ * @file src/display_planner.h
+ * @brief The display resolution planner, ported from the web UI.
+ *
+ * src_assets/common/assets/web/display-resolution-planner.js is the reference
+ * implementation; this is the same planner computed host-side so it can be
+ * served to clients that never load the web UI. Behaviour must not drift from
+ * the JS: both surfaces plan from the same fallback display mode, and a client
+ * following a served recommendation should land on the exact mode the web UI
+ * would have shown. tests/unit/test_display_planner.cpp pins the shared
+ * fixture values.
+ */
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace display_planner {
+  /**
+   * @brief A display mode. Dimensions are doubles because the JS plans in
+   * doubles; they hold integral values everywhere a mode came from parsing.
+   */
+  struct mode_t {
+    double width;
+    double height;
+    double fps;
+  };
+
+  /**
+   * @brief The safe-mode envelope. Choices beyond it are served but hidden.
+   */
+  struct limits_t {
+    double max_width = 7680;
+    double max_height = 4320;
+    double max_pixels = 7680.0 * 4320.0;
+  };
+
+  /**
+   * @brief One planned preset: native, balanced, sharp, performance or custom.
+   */
+  struct choice_t {
+    std::string id;
+    std::string title;
+    std::string intent;
+    std::string badge;
+    std::string reason;
+    std::string aspect_ratio;
+    std::string target_mode;
+    mode_t target;
+    double scale_factor;
+    bool advanced;
+    bool custom;
+    bool safe;
+    /**
+     * @brief Hidden means unsafe, nothing else. The JS folds its own
+     * show-advanced toggle into `hidden`; a served contract keeps the axes
+     * separate so a client can offer its own toggle from the `advanced` flag
+     * without a hidden bit fighting it.
+     */
+    bool hidden;
+  };
+
+  /**
+   * @brief One entry of the advanced scale-factor strip.
+   */
+  struct scale_option_t {
+    double scale_factor;
+    std::string label;
+    std::string target_mode;
+    mode_t target;
+    bool safe;
+  };
+
+  /**
+   * @brief The full plan for one source mode.
+   */
+  struct planner_t {
+    mode_t source;
+    std::string source_mode;
+    std::string source_aspect_ratio;
+    std::string recommended_id;
+    std::string recommended_title;
+    std::string recommended_mode;
+    std::vector<choice_t> choices;
+    std::vector<scale_option_t> advanced_scale_factors;
+  };
+
+  /**
+   * @brief The scale factors offered on the advanced strip.
+   */
+  const std::vector<double> &planner_scale_factors();
+
+  /**
+   * @brief Parse a "2560x1600x90" mode string; fps may be fractional.
+   * @returns std::nullopt when the string is not exactly that shape.
+   */
+  std::optional<mode_t> parse_display_mode(std::string_view value);
+
+  /**
+   * @brief Format a mode as "2560x1600x90"; integral fps carries no decimals.
+   */
+  std::string format_display_mode(const mode_t &mode);
+
+  /**
+   * @brief Clamp a scale factor to [0.5, 2]; non-finite values become 1.
+   */
+  double clamp_planner_scale(double value);
+
+  /**
+   * @brief Scale a mode, rounding both dimensions up to even and never below 2.
+   */
+  mode_t resolve_scaled_mode(const mode_t &base, double scale_factor);
+
+  /**
+   * @brief Reduced aspect label, "8:5" for 2560x1600.
+   */
+  std::string aspect_ratio_label(double width, double height);
+
+  /**
+   * @brief Build the plan for a source mode.
+   *
+   * Degenerate source components fall back to 1920x1080x60 exactly as the JS
+   * normalizeDevice does, so this always returns a fully-populated plan. The
+   * recommendation is chosen among safe, non-advanced choices — what the web
+   * UI shows with advanced collapsed — preferring `balanced`, then falling
+   * back to the first such choice, then to the first choice of all.
+   */
+  planner_t build_resolution_planner(const mode_t &source, double custom_scale = 1.0, const limits_t &limits = {});
+}  // namespace display_planner

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -54,6 +54,7 @@
 // local includes
 #include "config.h"
 #include "display_device.h"
+#include "display_planner.h"
 #include "entry_handler.h"
 #include "file_handler.h"
 #include "game_artwork.h"
@@ -2928,6 +2929,148 @@ namespace nvhttp {
         "Steam Big Picture compatibility mode may also receive controller input." :
         "Direct launch avoids opening Steam Big Picture.";
       return contract;
+    }
+
+    std::optional<double> refresh_rate_hz_value(const display_device::FloatingPoint &value) {
+      return std::visit(
+        [](const auto &refresh_rate) -> std::optional<double> {
+          using value_t = std::decay_t<decltype(refresh_rate)>;
+          if constexpr (std::is_same_v<value_t, display_device::Rational>) {
+            if (refresh_rate.m_denominator == 0) {
+              return std::nullopt;
+            }
+
+            return static_cast<double>(refresh_rate.m_numerator) /
+                   static_cast<double>(refresh_rate.m_denominator);
+          } else {
+            return refresh_rate;
+          }
+        },
+        value
+      );
+    }
+
+    // The active display's mode, preferring the configured output, then the
+    // primary display, then any active one. Unlike the launch-rate hint this
+    // wants the panel a session would actually cover, so the first matching
+    // display wins rather than the fastest.
+    std::optional<display_planner::mode_t> active_output_display_mode_hint() {
+      const auto configured_display_name = display_device::map_output_name(config::video.output_name);
+      std::optional<display_planner::mode_t> primary_mode;
+      std::optional<display_planner::mode_t> any_active_mode;
+
+      for (const auto &device : display_device::enumerate_devices()) {
+        if (!device.m_info) {
+          continue;
+        }
+
+        const auto refresh_rate_hz = refresh_rate_hz_value(device.m_info->m_refresh_rate);
+        if (!refresh_rate_hz || *refresh_rate_hz <= 0 ||
+            device.m_info->m_resolution.m_width == 0 || device.m_info->m_resolution.m_height == 0) {
+          continue;
+        }
+
+        const display_planner::mode_t mode {
+          static_cast<double>(device.m_info->m_resolution.m_width),
+          static_cast<double>(device.m_info->m_resolution.m_height),
+          *refresh_rate_hz,
+        };
+
+        const bool matches_configured_output = !configured_display_name.empty() &&
+                                               (device.m_display_name == configured_display_name ||
+                                                device.m_device_id == config::video.output_name);
+        if (matches_configured_output) {
+          return mode;
+        }
+
+        if (device.m_info->m_primary && !primary_mode) {
+          primary_mode = mode;
+        }
+        if (!any_active_mode) {
+          any_active_mode = mode;
+        }
+      }
+
+      return primary_mode ? primary_mode : any_active_mode;
+    }
+
+    struct planner_source_t {
+      display_planner::mode_t mode;
+      bool available;
+    };
+
+    // The same source the web planner plans from: the fallback display mode,
+    // with a live display filling in only when that field was blanked. Both
+    // surfaces must plan from the same numbers, or a mode picked in Nova and
+    // a mode picked in the web UI would disagree about what Balanced means.
+    planner_source_t display_planner_source() {
+      if (const auto configured = display_planner::parse_display_mode(config::video.fallback_mode)) {
+        return {*configured, true};
+      }
+      if (const auto live = active_output_display_mode_hint()) {
+        return {*live, true};
+      }
+      return {{1920, 1080, 60}, false};
+    }
+
+    nlohmann::json planner_number_json(double value) {
+      // Integral values travel as integers, the way the JS planner emits them.
+      if (value == std::floor(value) && std::fabs(value) < 9.0e15) {
+        return static_cast<long long>(value);
+      }
+      return value;
+    }
+
+    nlohmann::json display_planner_scale_option_json(const display_planner::scale_option_t &option) {
+      nlohmann::json scale_option;
+      scale_option["scale_factor"] = planner_number_json(option.scale_factor);
+      scale_option["label"] = option.label;
+      scale_option["target_mode"] = option.target_mode;
+      scale_option["safe"] = option.safe;
+      return scale_option;
+    }
+
+    nlohmann::json display_planner_choice_json(const display_planner::choice_t &planned) {
+      nlohmann::json choice;
+      choice["id"] = planned.id;
+      choice["title"] = planned.title;
+      choice["intent"] = planned.intent;
+      choice["target_mode"] = planned.target_mode;
+      choice["badge"] = planned.badge;
+      choice["reason"] = planned.reason;
+      choice["advanced"] = planned.advanced;
+      choice["custom"] = planned.custom;
+      choice["safe"] = planned.safe;
+      choice["hidden"] = planned.hidden;
+      choice["scale_factor"] = planner_number_json(planned.scale_factor);
+      choice["aspect_ratio"] = planned.aspect_ratio;
+      return choice;
+    }
+
+    nlohmann::json display_planner_contract_json() {
+      const auto source = display_planner_source();
+      const auto plan = display_planner::build_resolution_planner(source.mode);
+
+      auto choices = nlohmann::json::array();
+      for (const auto &planned : plan.choices) {
+        choices.push_back(display_planner_choice_json(planned));
+      }
+      auto advanced_scale_factors = nlohmann::json::array();
+      for (const auto &option : plan.advanced_scale_factors) {
+        advanced_scale_factors.push_back(display_planner_scale_option_json(option));
+      }
+
+      nlohmann::json planner;
+      planner["available"] = source.available;
+      planner["source_mode"] = plan.source_mode;
+      planner["source_aspect_ratio"] = plan.source_aspect_ratio;
+      planner["source_fps"] = planner_number_json(plan.source.fps);
+      planner["recommended_id"] = plan.recommended_id;
+      planner["recommended_title"] = plan.recommended_title;
+      planner["recommended_mode"] = plan.recommended_mode;
+      planner["choices"] = std::move(choices);
+      planner["advanced_scale_factors"] = std::move(advanced_scale_factors);
+      return planner;
     }
 
     fs::path legacy_covers_directory() {
@@ -6078,6 +6221,10 @@ namespace nvhttp {
       // making the feature look absent.
       features["library_beat_times_v1"] = true;
       features["library_beat_times_lookup"] = config::sunshine.beat_times_lookup;
+      // Served per game as `display_planner`, computed from the host's
+      // fallback display mode. Announced so a client can build its resolution
+      // UI against the capability rather than sniffing the first game object.
+      features["display_planner_v1"] = true;
       features["artwork_manifest_v1"] = true;
       features["artwork_manual_match_v1"] = nonblank_artwork_api_key(
         config::sunshine.steamgriddb_api_key);
@@ -6664,6 +6811,9 @@ namespace nvhttp {
         return;
       }
       const auto advertised_codec_support = advertised_codec_support_for_http(true);
+      // Per-host, not per-game: every game plans from the same host display,
+      // so the planner is computed once and attached to each game unchanged.
+      const auto display_planner_contract = display_planner_contract_json();
 
       // Parse query params
       auto query = request->parse_query_string();
@@ -6736,6 +6886,7 @@ namespace nvhttp {
         }
         game["launch_mode"] = launch_mode_contract_for_app(app);
         game["steam_launch"] = steam_launch_contract_for_app(app);
+        game["display_planner"] = display_planner_contract;
 
         nlohmann::json genre_arr = nlohmann::json::array();
         for (const auto &g : app.genres) genre_arr.push_back(g);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/private_state_file.cpp
     ${CMAKE_SOURCE_DIR}/src/web_session_store.cpp
     ${CMAKE_SOURCE_DIR}/src/beat_times.cpp
+    ${CMAKE_SOURCE_DIR}/src/display_planner.cpp
     ${CMAKE_SOURCE_DIR}/src/game_library_scanner.cpp
     ${CMAKE_SOURCE_DIR}/src/globals.cpp
     ${CMAKE_SOURCE_DIR}/src/logging.cpp
@@ -102,6 +103,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_private_state_file.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_web_session_store.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_beat_times.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_display_planner.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_game_library_scanner.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_kmsgrab_logging_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp

--- a/tests/integration/test_nova_contract.cpp
+++ b/tests/integration/test_nova_contract.cpp
@@ -223,7 +223,7 @@ TEST(NovaContractTests, NewLibraryFeaturesAreDeclaredInCapabilities) {
   // expected to render conditionally has to be announced rather than inferred.
   const auto source = read_source_file("src/nvhttp.cpp");
 
-  for (const auto flag : {"library_playtime_v1", "library_beat_times_v1"}) {
+  for (const auto flag : {"library_playtime_v1", "library_beat_times_v1", "display_planner_v1"}) {
     SCOPED_TRACE(flag);
     EXPECT_NE(source.find(std::string {"features[\""} + flag + "\"]"), std::string::npos);
   }

--- a/tests/unit/test_display_planner.cpp
+++ b/tests/unit/test_display_planner.cpp
@@ -1,0 +1,153 @@
+/**
+ * @file tests/unit/test_display_planner.cpp
+ * @brief Pin the display planner to its JS reference and the Nova fixture.
+ *
+ * The planner exists three times: display-resolution-planner.js is the
+ * reference, this port serves it, and Nova's PolarisGameContractTest fixture
+ * decodes it. The 2560x1600x90 values asserted here are the ones that fixture
+ * pins on the Nova side — if these move, that fixture is the other thing that
+ * has to move, in the same breath.
+ */
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "src/display_planner.h"
+
+using display_planner::build_resolution_planner;
+using display_planner::clamp_planner_scale;
+using display_planner::format_display_mode;
+using display_planner::limits_t;
+using display_planner::mode_t;
+using display_planner::parse_display_mode;
+using display_planner::resolve_scaled_mode;
+
+TEST(DisplayPlannerTests, ParsesModeStringsExactlyLikeTheWebPlanner) {
+  const auto mode = parse_display_mode("2560x1600x90");
+  ASSERT_TRUE(mode.has_value());
+  EXPECT_EQ(2560, mode->width);
+  EXPECT_EQ(1600, mode->height);
+  EXPECT_EQ(90, mode->fps);
+
+  const auto fractional = parse_display_mode("  1920x1080x59.94\t");
+  ASSERT_TRUE(fractional.has_value());
+  EXPECT_DOUBLE_EQ(59.94, fractional->fps);
+
+  for (const auto *rejected : {"", "garbage", "1920x1080", "1920x1080x", "1920x1080x60x2", "1920 x1080x60", "-1920x1080x60", "1920x1080x60.", "1920x1080x.5"}) {
+    EXPECT_FALSE(parse_display_mode(rejected).has_value()) << rejected;
+  }
+}
+
+TEST(DisplayPlannerTests, FormatsIntegralFpsWithoutDecimals) {
+  EXPECT_EQ("2560x1600x90", format_display_mode({2560, 1600, 90}));
+  EXPECT_EQ("1920x1080x59.94", format_display_mode({1920, 1080, 59.94}));
+}
+
+TEST(DisplayPlannerTests, ClampsPlannerScaleIntoTheSupportedRange) {
+  EXPECT_DOUBLE_EQ(0.5, clamp_planner_scale(0.1));
+  EXPECT_DOUBLE_EQ(2, clamp_planner_scale(3));
+  EXPECT_DOUBLE_EQ(1.25, clamp_planner_scale(1.25));
+  EXPECT_DOUBLE_EQ(1, clamp_planner_scale(std::numeric_limits<double>::quiet_NaN()));
+}
+
+TEST(DisplayPlannerTests, RoundsScaledDimensionsUpToEvenAndNeverBelowTwo) {
+  // 1366 * 0.75 = 1024.5 rounds to 1025, which is odd, so it becomes 1026.
+  const auto scaled = resolve_scaled_mode({1366, 768, 60}, 0.75);
+  EXPECT_EQ(1026, scaled.width);
+  EXPECT_EQ(576, scaled.height);
+  EXPECT_EQ(60, scaled.fps);
+
+  const auto tiny = resolve_scaled_mode({2, 2, 60}, 0.5);
+  EXPECT_EQ(2, tiny.width);
+  EXPECT_EQ(2, tiny.height);
+}
+
+TEST(DisplayPlannerTests, BuildsTheSharedFixturePlanFor2560x1600x90) {
+  const auto plan = build_resolution_planner({2560, 1600, 90});
+
+  EXPECT_EQ("2560x1600x90", plan.source_mode);
+  EXPECT_EQ("8:5", plan.source_aspect_ratio);
+  EXPECT_EQ(90, plan.source.fps);
+
+  ASSERT_EQ(5U, plan.choices.size());
+  EXPECT_EQ("native", plan.choices[0].id);
+  EXPECT_EQ("balanced", plan.choices[1].id);
+  EXPECT_EQ("sharp", plan.choices[2].id);
+  EXPECT_EQ("performance", plan.choices[3].id);
+  EXPECT_EQ("custom", plan.choices[4].id);
+
+  EXPECT_EQ("balanced", plan.recommended_id);
+  EXPECT_EQ("Best for this device", plan.recommended_title);
+  EXPECT_EQ("1920x1200x90", plan.recommended_mode);
+
+  EXPECT_EQ("2560x1600x90", plan.choices[0].target_mode);
+  EXPECT_EQ("2560×1600", plan.choices[0].badge);
+  EXPECT_EQ("1920x1200x90", plan.choices[1].target_mode);
+  EXPECT_EQ("Best for this device", plan.choices[1].badge);
+  EXPECT_EQ("3840x2400x90", plan.choices[2].target_mode);
+  EXPECT_EQ("1.5x supersample", plan.choices[2].badge);
+  EXPECT_TRUE(plan.choices[2].advanced);
+  EXPECT_EQ("1280x800x90", plan.choices[3].target_mode);
+  EXPECT_EQ("0.5x downscale", plan.choices[3].badge);
+  EXPECT_EQ("Advanced", plan.choices[4].badge);
+  EXPECT_TRUE(plan.choices[4].custom);
+
+  for (const auto &choice : plan.choices) {
+    EXPECT_TRUE(choice.safe) << choice.id;
+    EXPECT_FALSE(choice.hidden) << choice.id;
+    EXPECT_EQ("8:5", choice.aspect_ratio) << choice.id;
+    EXPECT_EQ(choice.intent, choice.reason) << choice.id;
+  }
+
+  ASSERT_EQ(6U, plan.advanced_scale_factors.size());
+  EXPECT_EQ("0.5x", plan.advanced_scale_factors[0].label);
+  EXPECT_EQ("0.75x", plan.advanced_scale_factors[1].label);
+  EXPECT_EQ("1x", plan.advanced_scale_factors[2].label);
+  EXPECT_EQ("1.25x", plan.advanced_scale_factors[3].label);
+  EXPECT_EQ("1.5x", plan.advanced_scale_factors[4].label);
+  EXPECT_EQ("2x", plan.advanced_scale_factors[5].label);
+  EXPECT_EQ("5120x3200x90", plan.advanced_scale_factors[5].target_mode);
+  EXPECT_TRUE(plan.advanced_scale_factors[5].safe);
+}
+
+TEST(DisplayPlannerTests, HidesUnsafeChoicesAndKeepsTheRecommendationSafe) {
+  // At 7680x4320 the native pixel count sits exactly on the envelope, so
+  // native stays safe while every upscale beyond it goes over.
+  const auto plan = build_resolution_planner({7680, 4320, 60}, 2.0);
+
+  EXPECT_TRUE(plan.choices[0].safe);
+  EXPECT_TRUE(plan.choices[1].safe);
+  EXPECT_FALSE(plan.choices[2].safe);
+  EXPECT_TRUE(plan.choices[2].hidden);
+  EXPECT_EQ("Hidden because this would exceed the safe display-mode envelope for normal users.", plan.choices[2].reason);
+  EXPECT_FALSE(plan.choices[4].safe) << "custom at 2x doubles an already-maximal mode";
+
+  EXPECT_EQ("balanced", plan.recommended_id);
+  EXPECT_EQ("5760x3240x60", plan.recommended_mode);
+}
+
+TEST(DisplayPlannerTests, FallsBackToTheFirstChoiceWhenNothingIsSafe) {
+  const auto plan = build_resolution_planner({20000, 20000, 60});
+
+  for (const auto &choice : plan.choices) {
+    EXPECT_FALSE(choice.safe) << choice.id;
+    EXPECT_TRUE(choice.hidden) << choice.id;
+  }
+  EXPECT_EQ("native", plan.recommended_id);
+}
+
+TEST(DisplayPlannerTests, NormalizesDegenerateSourcesToTheDefaultDevice) {
+  const auto plan = build_resolution_planner({0, -5, std::numeric_limits<double>::infinity()});
+  EXPECT_EQ("1920x1080x60", plan.source_mode);
+  EXPECT_EQ("16:9", plan.source_aspect_ratio);
+}
+
+TEST(DisplayPlannerTests, CustomChoiceUsesTheClampedCustomScale) {
+  const auto plan = build_resolution_planner({2560, 1600, 90}, 0.3);
+
+  const auto &custom = plan.choices[4];
+  EXPECT_DOUBLE_EQ(0.5, custom.scale_factor);
+  EXPECT_EQ("1280x800x90", custom.target_mode);
+  EXPECT_TRUE(custom.advanced);
+  EXPECT_TRUE(custom.custom);
+}


### PR DESCRIPTION
## Summary

Nova's Play Setup wants a Resolution row, and the planner that could feed it existed only as web-UI JavaScript. This ports `display-resolution-planner.js` to `src/display_planner.{h,cpp}` and serves the plan on every game object as `display_planner`, with a `display_planner_v1` feature flag announcing it.

### Per-host, folded in per game

The planner is computed **once per request** and attached to each game unchanged: every game plans from the same host display, and `source_mode` / `source_fps` describe the host's capture mode, not the client's panel. The source is the same field the web planner plans from — `fallback_mode` — with a live enumerated display filling in only when that field is blanked, so a mode picked in Nova and a mode picked in the web UI cannot disagree about what Balanced means. When neither source exists the plan is still served, computed from 1920x1080x60, with `available: false` saying so.

### What the port keeps and what it deliberately changes

Kept verbatim: preset order and wording, scale factors, round-to-even targets, the safe-mode envelope, badge strings (including the `×` in the native badge), the recommended choice being what the web UI shows with advanced collapsed, and gcd aspect labels (`8:5` for 2560x1600, matching Nova's fixture).

Changed on purpose, because a served contract is not a Vue view-model:

- **Keys are snake_case** where the JS emits camelCase — the shape Nova's shared `DisplayPlannerContract` already decodes.
- **`hidden` means unsafe and nothing else.** The JS folds its show-advanced toggle into `hidden`; here `advanced` is its own axis so Nova can offer its own toggle without a hidden bit fighting it. All five choices are served with honest flags.
- Integral numbers travel as integers and fractional refresh rates are capped at three decimals, so a Rational refresh rate cannot leak its binary expansion into a mode string.

The JS and its consumers (`AudioVideo.vue`, its tests) are untouched.

### The contract stays honest in both directions

`docs/nova-contract.json` gains `display_planner`, `display_planner_choice` and `display_planner_scale_choice`, and `game` declares the new field — the emitter-derivation test enforces all four against the source that serves them. Because the app-side adapter does not read the planner yet (the shared kotlinx model and its fixture were shipped ahead), every field is also recorded under `known_drift.polaris_sends_nova_never_reads`, which the contract test asserts must stay emitted. The Nova commit that wires the Resolution row prunes that record and corrects the recorded receiver names if its wiring differs. `display_planner_v1` joins the flags the capabilities test pins.

`tests/unit/test_display_planner.cpp` pins the 2560x1600x90 plan — the same values `PolarisGameContractTest` pins on the Nova side of the repository boundary.

## Exact candidate

- `Commit: 77087092c96fe9bd4d0417904706a7ed72276075`
- `Tree:   f885553e16184906c97696692ca31d14116bb3b1`
- `Base:   169e36cdcf6d13b538e6cde9fb72e44e863bedbf`

## Verification

On pc-papi (Fedora, RTX 4090), in a clean worktree of master:

- [x] Full `ninja`, exit 0 (`polaris-1.3.7.169e36cd.dirty`, 187/187 then full-test build 160/160)
- [x] `DisplayPlannerTests` — 9/9
- [x] `NovaContractTests` — 4/4: manifest derivation, drift records, capability flags
- [x] `ctest` (`BUILD_FULL_TESTS=ON`) — 17/17
- [x] `scripts/check-nova-contract.py --nova <origin/master slice>` — `no new drift`, planner fields recorded as outstanding
