### PR TITLE
fix(build): stop de-optimizing the whole target for two files' sake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -405,6 +405,119 @@ jobs:
             build/dev.polaris-stream.app.Polaris.terminal.desktop
           if-no-files-found: warn
 
+  fedora-clang-build:
+    name: Fedora 44 Clang compile check
+    needs: web-checks
+    runs-on: ubuntu-24.04
+    container:
+      image: fedora:44
+    env:
+      CCACHE_DIR: /github/home/.cache/ccache
+      CCACHE_COMPILERCHECK: content
+      NPM_CONFIG_CACHE: /github/home/.npm
+      CC: clang
+      CXX: clang++
+
+    steps:
+      - name: Bootstrap Fedora container
+        run: |
+          for attempt in 1 2 3; do
+            dnf install -y dnf-plugins-core git && exit 0
+            echo "dnf bootstrap failed on attempt ${attempt}" >&2
+            dnf clean expire-cache || true
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.POLARIS_CHECKOUT_REF }}
+
+      - name: Initialize submodules
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          for attempt in 1 2 3 4 5; do
+            git submodule sync --recursive
+            if git -c protocol.version=2 submodule update --init --force --recursive --jobs 1; then
+              exit 0
+            fi
+            echo "submodule update failed on attempt ${attempt}" >&2
+            git submodule deinit --force --all || true
+            sleep $((attempt * 15))
+          done
+          exit 1
+
+      - name: Cache C++ compiler outputs
+        uses: actions/cache@v6
+        with:
+          path: /github/home/.cache/ccache
+          key: polaris-fedora-44-clang-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'src/**/*', 'tests/**/*') }}
+          restore-keys: |
+            polaris-fedora-44-clang-ccache-
+
+      - name: Cache npm downloads
+        uses: actions/cache@v6
+        with:
+          path: /github/home/.npm
+          key: polaris-fedora-44-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            polaris-fedora-44-npm-
+
+      - name: Install Fedora build dependencies
+        run: |
+          for attempt in 1 2 3; do
+            dnf builddep -y packaging/linux/fedora/Polaris.spec && exit 0
+            echo "dnf builddep failed on attempt ${attempt}" >&2
+            dnf clean expire-cache || true
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - name: Install CI helper packages
+        run: |
+          for attempt in 1 2 3; do
+            dnf install -y ccache clang golang ninja-build patch python3 && exit 0
+            echo "dnf helper package install failed on attempt ${attempt}" >&2
+            dnf clean expire-cache || true
+            sleep $((attempt * 10))
+          done
+          exit 1
+
+      - name: Configure
+        run: |
+          cmake -B build -G Ninja \
+            -DBUILD_TESTS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            "-DCMAKE_C_FLAGS=-ffile-prefix-map=${GITHUB_WORKSPACE}=." \
+            "-DCMAKE_CXX_FLAGS=-ffile-prefix-map=${GITHUB_WORKSPACE}=." \
+            -DBOOST_USE_STATIC=OFF \
+            -DPOLARIS_ASSETS_DIR=share/polaris \
+            -DPOLARIS_EXECUTABLE_PATH=/usr/bin/polaris \
+            -DPOLARIS_ENABLE_BROWSER_STREAM=ON \
+            -DPOLARIS_ENABLE_CUDA=OFF \
+            -DCUDA_FAIL_ON_MISSING=OFF
+
+      - name: Download prebuilt web UI bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: web-ui-build
+          path: .
+
+      - name: Prepare prebuilt web UI bundle
+        run: |
+          mkdir -p build/assets build/CMakeFiles node_modules
+          tar -xzf web-ui-build.tar.gz -C build/assets
+          touch node_modules/.polaris-web-ui-npm.stamp build/CMakeFiles/web-ui-build.stamp
+
+      - name: Build
+        run: cmake --build build -j"$(nproc)"
+
+      - name: Run fast C++ tests
+        run: ctest --test-dir build/tests --output-on-failure -R '^test_polaris$'
+
   steamos-build:
     name: SteamOS 3.8 build
     needs: web-checks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -616,7 +616,7 @@ jobs:
           if-no-files-found: warn
 
   fedora-rpm-build:
-    name: Fedora ${{ matrix.fedora }} RPM build (${{ matrix.cc }})
+    name: Fedora ${{ matrix.fedora }} RPM build
     needs: web-checks
     runs-on: ubuntu-24.04
     container:
@@ -628,10 +628,6 @@ jobs:
           - fedora: '44'
             cc: gcc-15
             cxx: g++-15
-            boost_static: OFF
-          - fedora: '44'
-            cc: clang
-            cxx: clang++
             boost_static: OFF
     env:
       CCACHE_DIR: /github/home/.cache/ccache
@@ -673,9 +669,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /github/home/.cache/ccache
-          key: polaris-fedora-${{ matrix.fedora }}-${{ matrix.cc }}-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'src/**/*', 'tests/**/*') }}
+          key: polaris-fedora-${{ matrix.fedora }}-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'src/**/*', 'tests/**/*') }}
           restore-keys: |
-            polaris-fedora-${{ matrix.fedora }}-${{ matrix.cc }}-ccache-
+            polaris-fedora-${{ matrix.fedora }}-ccache-
 
       - name: Cache npm downloads
         uses: actions/cache@v6
@@ -698,7 +694,7 @@ jobs:
       - name: Install CI helper packages
         run: |
           for attempt in 1 2 3; do
-            dnf install -y ccache clang golang ninja-build patch python3 && exit 0
+            dnf install -y ccache golang ninja-build patch python3 && exit 0
             echo "dnf helper package install failed on attempt ${attempt}" >&2
             dnf clean expire-cache || true
             sleep $((attempt * 10))
@@ -887,7 +883,7 @@ jobs:
         if: always()
         run: |
           {
-            echo "## Fedora ${{ matrix.fedora }} RPM validation (${{ matrix.cc }})"
+            echo "## Fedora ${{ matrix.fedora }} RPM validation"
             echo
             echo "- Spec dependency source: \`packaging/linux/fedora/Polaris.spec\`"
             echo "- Build tree directory: \`build/\`"
@@ -899,7 +895,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: fedora-${{ matrix.fedora }}-${{ matrix.cc }}-rpm-artifacts
+          name: fedora-${{ matrix.fedora }}-rpm-artifacts
           path: |
             build/cpack_artifacts/*.rpm
             build/cpack_artifacts/*.src.rpm
@@ -909,7 +905,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: fedora-${{ matrix.fedora }}-${{ matrix.cc }}-rpm-metadata
+          name: fedora-${{ matrix.fedora }}-rpm-metadata
           path: |
             build/cpack_artifacts/package-*.txt
             build/cpack_artifacts/_CPack_Packages/Linux/RPM/SPECS/*.spec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -616,7 +616,7 @@ jobs:
           if-no-files-found: warn
 
   fedora-rpm-build:
-    name: Fedora ${{ matrix.fedora }} RPM build
+    name: Fedora ${{ matrix.fedora }} RPM build (${{ matrix.cc }})
     needs: web-checks
     runs-on: ubuntu-24.04
     container:
@@ -628,6 +628,10 @@ jobs:
           - fedora: '44'
             cc: gcc-15
             cxx: g++-15
+            boost_static: OFF
+          - fedora: '44'
+            cc: clang
+            cxx: clang++
             boost_static: OFF
     env:
       CCACHE_DIR: /github/home/.cache/ccache
@@ -669,9 +673,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /github/home/.cache/ccache
-          key: polaris-fedora-${{ matrix.fedora }}-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'src/**/*', 'tests/**/*') }}
+          key: polaris-fedora-${{ matrix.fedora }}-${{ matrix.cc }}-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'src/**/*', 'tests/**/*') }}
           restore-keys: |
-            polaris-fedora-${{ matrix.fedora }}-ccache-
+            polaris-fedora-${{ matrix.fedora }}-${{ matrix.cc }}-ccache-
 
       - name: Cache npm downloads
         uses: actions/cache@v6
@@ -694,7 +698,7 @@ jobs:
       - name: Install CI helper packages
         run: |
           for attempt in 1 2 3; do
-            dnf install -y ccache golang ninja-build patch python3 && exit 0
+            dnf install -y ccache clang golang ninja-build patch python3 && exit 0
             echo "dnf helper package install failed on attempt ${attempt}" >&2
             dnf clean expire-cache || true
             sleep $((attempt * 10))
@@ -883,7 +887,7 @@ jobs:
         if: always()
         run: |
           {
-            echo "## Fedora ${{ matrix.fedora }} RPM validation"
+            echo "## Fedora ${{ matrix.fedora }} RPM validation (${{ matrix.cc }})"
             echo
             echo "- Spec dependency source: \`packaging/linux/fedora/Polaris.spec\`"
             echo "- Build tree directory: \`build/\`"
@@ -895,7 +899,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: fedora-${{ matrix.fedora }}-rpm-artifacts
+          name: fedora-${{ matrix.fedora }}-${{ matrix.cc }}-rpm-artifacts
           path: |
             build/cpack_artifacts/*.rpm
             build/cpack_artifacts/*.src.rpm
@@ -905,7 +909,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: fedora-${{ matrix.fedora }}-rpm-metadata
+          name: fedora-${{ matrix.fedora }}-${{ matrix.cc }}-rpm-metadata
           path: |
             build/cpack_artifacts/package-*.txt
             build/cpack_artifacts/_CPack_Packages/Linux/RPM/SPECS/*.spec

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,23 @@ cmake_minimum_required(VERSION 3.20)
 # `cmake_path(CONVERT ... TO_NATIVE_PATH_LIST ...)` requires 3.20
 # todo - set this conditionally
 
+# Packaging escape hatch for the GCC>=15 ICEs quarantined in
+# cmake/targets/common.cmake: Clang does not hit them, so a packager on an
+# affected distro can opt out of GCC entirely instead of waiting on upstream
+# GCC fixes. Only takes effect when nothing else already chose a compiler,
+# and must run before project() - that is where CMake locks in the compiler.
+option(POLARIS_PREFER_CLANG "Use Clang instead of GCC when no compiler is otherwise specified" OFF)
+if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
+        AND NOT DEFINED ENV{CC} AND NOT DEFINED ENV{CXX})
+    find_program(POLARIS_CLANG_C_COMPILER NAMES clang)
+    find_program(POLARIS_CLANG_CXX_COMPILER NAMES clang++)
+    if(NOT POLARIS_CLANG_C_COMPILER OR NOT POLARIS_CLANG_CXX_COMPILER)
+        message(FATAL_ERROR "POLARIS_PREFER_CLANG=ON but clang/clang++ was not found on PATH")
+    endif()
+    set(CMAKE_C_COMPILER "${POLARIS_CLANG_C_COMPILER}" CACHE FILEPATH "C compiler" FORCE)
+    set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
+endif()
+
 project(Polaris VERSION 1.3.7
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")

--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -40,25 +40,6 @@ endif()
 
 target_compile_options(polaris PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${POLARIS_COMPILE_OPTIONS}>;$<$<COMPILE_LANGUAGE:CUDA>:${POLARIS_COMPILE_OPTIONS_CUDA};-std=c++17>)  # cmake-lint: disable=C0301
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
-        CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15 AND
-        (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
-    target_compile_options(polaris PRIVATE
-            $<$<COMPILE_LANGUAGE:CXX>:
-            -O0
-            -U_FORTIFY_SOURCE
-            -D_FORTIFY_SOURCE=0
-            -fno-lto
-            -fno-unroll-loops
-            -fno-tree-vectorize
-            -fno-ipa-cp-clone
-            -fno-var-tracking
-            -fno-var-tracking-assignments
-            -fno-ipa-sra
-            -fno-inline-functions
-            -fno-inline-small-functions>)
-endif()
-
 # Homebrew build fails the vite build if we set these environment variables
 if(${POLARIS_BUILD_HOMEBREW})
     set(NPM_SOURCE_ASSETS_DIR "")

--- a/scripts/bisect-gcc-ice.sh
+++ b/scripts/bisect-gcc-ice.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Finds which translation units, if any, trigger an internal compiler error
+# (ICE) on the current C++ compiler at real optimization, beyond the files
+# already quarantined at -O0 in cmake/targets/common.cmake.
+#
+# Run this after bumping the minimum/tested GCC version, or when evaluating
+# a new distro's default compiler, to find out whether the quarantine list
+# needs to grow. It does NOT modify the quarantine itself - it only reports.
+#
+# Usage:
+#   scripts/bisect-gcc-ice.sh [build-dir]
+#
+# CC/CXX (or -DCMAKE_C_COMPILER/-DCMAKE_CXX_COMPILER via
+# POLARIS_BISECT_CMAKE_ARGS) select the compiler under test, same as a
+# normal cmake invocation.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+build_dir="${1:-${root_dir}/build-bisect}"
+
+# shellcheck disable=SC2206 # intentional word-splitting of user-provided extra args
+extra_cmake_args=(${POLARIS_BISECT_CMAKE_ARGS:-})
+
+echo "Bisecting ICE-prone translation units in: ${root_dir}"
+echo "Compiler: ${CXX:-$(command -v c++)}"
+echo "Build directory: ${build_dir}"
+echo
+
+cmake -S "${root_dir}" -B "${build_dir}" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DPOLARIS_ENABLE_CUDA=OFF \
+  -DPOLARIS_ALLOW_CUDA_DISABLED_ON_NVIDIA=ON \
+  -DBOOST_USE_STATIC=OFF \
+  -DBUILD_TESTS=OFF \
+  "${extra_cmake_args[@]}"
+
+log_file="${build_dir}/bisect-ice.log"
+
+# -k 0: keep going past failures so every ICE in this run surfaces, not just
+# the first one ninja happens to hit.
+set +e
+ninja -C "${build_dir}" -k 0 2>&1 | tee "${log_file}"
+build_status=${PIPESTATUS[0]}
+set -e
+
+echo
+echo "=== Bisect result ==="
+
+# GCC reports an ICE as "internal compiler error: ..." on its own line,
+# preceded by the offending source file on the "n: In ..." context line or
+# the ninja "Building CXX object .../<file>.o" line immediately above it.
+mapfile -t ice_files < <(
+  awk '
+    /Building (CXX|C) object/ { last_target = $0 }
+    /internal compiler error/ { print last_target }
+  ' "${log_file}" | sed -E 's#.*CMakeFiles/[^/]+\.dir/##; s#\.o$##' | sort -u
+)
+
+if [ "${#ice_files[@]}" -eq 0 ]; then
+  if [ "${build_status}" -eq 0 ]; then
+    echo "No internal compiler errors. Every translation unit compiled clean at real optimization."
+    exit 0
+  else
+    echo "Build failed, but not with an ICE pattern this script recognizes."
+    echo "Check ${log_file} directly - this may be an unrelated build break, not a compiler bug."
+    exit 1
+  fi
+fi
+
+echo "Internal compiler error(s) found in:"
+for f in "${ice_files[@]}"; do
+  echo "  - ${f}"
+done
+echo
+echo "If any of these are new, quarantine them at -O0 alongside process.cpp/ai_optimizer.cpp"
+echo "in the per-file block in cmake/targets/common.cmake (search for GCC_RELEASE_ICE_WORKAROUND_FLAGS)."
+echo "Do not restore the old target-wide block - quarantine only the files that actually ICE."
+exit 1


### PR DESCRIPTION
## Summary

- Roadmap: Nordstern arc, Phase 0 · P0-1 ("kill the GCC>=15 -O0 block"). Marked "must land before the baseline" — every prior latency measurement was taken from an `-O0` binary on Fedora/Arch.
- `cmake/targets/common.cmake` carried two GCC>=15 ICE-workaround blocks back to back: a target-wide one (`:43-60`) applying `-O0` and ten other de-optimizing flags to *every* translation unit in Release/RelWithDebInfo, and a narrower one right below it (`:172-192`, unchanged) that already quarantines exactly the two files that need it — `process.cpp`, `ai_optimizer.cpp` — via `set_source_files_properties`.
- The broad block was redundant with the narrow one, and because GCC 15 is Fedora 42+'s and current Arch's default compiler, it silently downgraded every Fedora/Arch release binary to `-O0` for the entire codebase — defeating `CMAKE_INTERPROCEDURAL_OPTIMIZATION` and every hot-loop optimization in the send/encode path.
- Removed the target-wide block. Left the narrow per-file quarantine untouched. Full bisect found nothing else needs quarantining.
- All four roadmap sub-pieces are in this branch, **and this PR's own CI now confirms every one of them on the real pinned toolchains:**
  - `POLARIS_PREFER_CLANG` (`CMakeLists.txt`) — a packaging escape hatch. Clang hits neither GCC ICE.
  - `scripts/bisect-gcc-ice.sh` — productizes the manual bisect into a reusable tool for future GCC bumps.
  - A standalone `fedora-clang-build` compile-check job — not a `fedora-rpm-build` matrix entry (that approach was attempted, hit a real collision with the hand-reviewed release-asset contract in `scripts/check-release-package-dependencies.py`, and was reverted within this PR — see the commit history for the full story). The standalone job is not in `release-assets`'s `needs:`, so it structurally cannot block a release regardless of how it fails.

## Exact candidate

- `Commit:` `dd0fcc89` (tip — merge of `polaris/master` picking up the unrelated nanoid audit fix, #319, needed to unblock this branch's own CI)
- Prior commits on this branch: `3f7449c3` (standalone Clang CI job) → `e93d58b1` (revert of the first, matrix-based CI attempt) → `0a5a6567` (Clang hatch + bisect script + first CI attempt) → `3e6120fb` (core `-O0` fix)
- `Base:` `fdeffba5bc87cad4f96968ec18e4b2dc53d6b8f8` (`polaris/master` at branch creation)

## Verification

**Core fix:**
- [x] Full `Release` rebuild on pc-papi's GCC 16.1.1 (also `>=15`) — 131/131 objects, zero internal compiler errors, `stream.cpp` confirmed at real `-O3` via `ninja -t commands`, `process.cpp`/`ai_optimizer.cpp` confirmed still at `-O0` via the untouched narrow quarantine
- [x] Full test suite: 249/249 (`test_polaris` 201/201, `test_game_artwork` 48/48), verified via direct gtest case counts, not just ctest's aggregate
- [x] CUDA also confirmed buildable when pinning GCC 15 as the host compiler (a separate pc-papi environment fix, not part of this diff) — 133/133 objects, clean link
- [x] **This PR's own CI, on the real pinned toolchains — all green:** `Fedora 44 RPM build` (gcc-15) pass in 8m28s, `Arch build` (also gcc-15-pinned) pass in 7m26s, `Fedora 44 Clang compile check` pass in 9m11s, `Ubuntu build` pass, `SteamOS 3.8 build` pass, `C++ sanitizer tests` pass, `Web checks` pass, `public-hygiene` pass, both CodeQL `Analyze` jobs pass. `Release assets` correctly shows `skipping` (gated on release tags only). This is the authoritative confirmation that GCC 15 exactly — the compiler CI and the packaging scripts actually pin — has zero ICEs beyond the two already-quarantined files, and that the new standalone Clang job's container bootstrap / `dnf builddep` / clang install / configure / build / test sequence all work for real, not just in local reasoning.

**Release-safety of the Clang CI redesign:**
- [x] `python3 scripts/check-release-package-dependencies.py` passes clean against this diff — no edit to the hand-reviewed contract needed, because the assertions are scoped to the `fedora-rpm-build` job by name and this is a separate job
- [x] Confirmed by reading the workflow directly: `fedora-clang-build` does not appear in `release-assets`'s `needs:` list

**Not covered:**
- No on-device/on-host runtime latency measurement in this PR — that rides the roadmap's P0-5 bench harness and P0-7 baseline report, which this fix unblocks.
