### PR TITLE
fix(deps): bump nanoid past the zero-size generator advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3649,9 +3649,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- `npm audit --audit-level=high` in the `Web checks` job has been failing on every PR/push, unrelated to any particular diff — GHSA-2v37-7h3g-55p8 was disclosed against `nanoid <3.3.17` ("custom generators can loop indefinitely when size is zero"). Confirmed this isn't specific to any one branch: `polaris/master`'s own most recent CI run (green) would fail this exact check if re-run today.
- Because every other build job (`arch-build`, `fedora-rpm-build`, `ubuntu-build`, `steamos-build`) has `needs: web-checks`, this one failure was blocking all CI signal repo-wide, not just this check.
- `nanoid` is transitive only — `vite@6.4.3` → `postcss@8.5.25` → `nanoid@^3.3.16` — nothing in this repo imports it directly.
- `npm audit fix` resolved it to `3.3.18` (satisfies postcss's existing `^3.3.16` range) with a lockfile-only change. No `package.json` edit needed.

## Exact candidate

- `Commit:` `d15a5c503c2b6d33203d924a96cdb9148663f06e`
- `Tree:` `61fd83f2a70b545ad6c7c2e4fc81b53fe60a4a09`
- `Parent:` `fdeffba5bc87cad4f96968ec18e4b2dc53d6b8f8`
- `Base:` `fdeffba5bc87cad4f96968ec18e4b2dc53d6b8f8` (`polaris/master`)

## Verification

- [x] `npm audit --audit-level=high` reproduced the failure before the fix, `found 0 vulnerabilities` after
- [x] `npm run lint` — clean, exit 0
- [x] `npm test` — 306/306 tests passed across 52 files
- [x] `npm run build` — production build succeeds, same output manifest shape as before (verified by inspecting the asset list)
