### PR TITLE
feat(telemetry): host-side T0-T2 glass-to-glass stage timing (P0-3)

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -316,6 +316,27 @@
         "declaration": "nlohmann::json profile = {",
         "style": "initializer_list"
       }
+    },
+    "session_timing": {
+      "$comment": [
+        "The response of GET /polaris/v1/session/timing (Nordstern P0-3). Host-side",
+        "T0-T2 stage timing, always on. No nova_reader yet: this shipped ahead of any",
+        "consumer, same situation display_planner was in before papi-ux/nova#197 - see",
+        "known_drift.polaris_sends_nova_never_reads for that precedent. Add nova_reader",
+        "here once a Nova build actually reads this endpoint."
+      ],
+      "fields": [
+        "capture_to_encode",
+        "capture_to_send",
+        "encode_to_send",
+        "stage_vocabulary"
+      ],
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "function": "build_session_timing_json",
+        "variable": "output",
+        "style": "subscript"
+      }
     }
   },
   "known_drift": {

--- a/scripts/check-nova-contract.py
+++ b/scripts/check-nova-contract.py
@@ -94,7 +94,15 @@ def main() -> int:
     new_findings = 0
 
     for name, obj in manifest["objects"].items():
-        reader = obj["nova_reader"]
+        reader = obj.get("nova_reader")
+        if reader is None:
+            # Shipped ahead of any Nova consumer (display_planner did this
+            # before papi-ux/nova#197; session_timing does it now). Nothing to
+            # diff against yet, so report it and move on rather than treating
+            # absence as an error.
+            served = set(obj["fields"])
+            print(f"{name}: Polaris serves {len(served)}, no Nova reader yet [not yet consumed]")
+            continue
         path = args.nova / reader["file"]
         if not path.is_file():
             raise SystemExit(f"not found: {path}\nIs --nova pointing at a Nova checkout?")

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -727,6 +727,28 @@ namespace nvhttp {
 #endif
     }
 
+    // P0-3: host-side T0-T2 glass-to-glass stage timing. A named function,
+    // not built inline in the route lambda below, so nova-contract.json's
+    // extractor (tests/integration/test_nova_contract.cpp) can scope to it
+    // the same way it already scopes to build_launch_mode_contract - the
+    // extractor matches named function signatures, not lambda bodies.
+    nlohmann::json build_session_timing_json(const stream_stats::session_timing_t &timing) {
+      auto percentile_json = [](const stream_stats::frame_timing_percentiles_t &p) {
+        return nlohmann::json {
+          {"p50_ms", p.p50_ms},
+          {"p99_ms", p.p99_ms},
+          {"sample_count", p.sample_count}
+        };
+      };
+
+      nlohmann::json output;
+      output["capture_to_encode"] = percentile_json(timing.capture_to_encode);
+      output["encode_to_send"] = percentile_json(timing.encode_to_send);
+      output["capture_to_send"] = percentile_json(timing.capture_to_send);
+      output["stage_vocabulary"] = "T0=capture frame available, T1=encoder finished this frame, T2=packet handed to NIC (post-pacer)";
+      return output;
+    }
+
     nlohmann::json build_launch_mode_contract(bool app_prefers_virtual_display,
                                               std::string_view app_name,
                                               bool virtual_display_available,
@@ -6285,6 +6307,24 @@ namespace nvhttp {
       response->write(output.dump(), headers);
     };
 
+    // Wire format (frame_processing_latency) is untouched by this - a new,
+    // out-of-band read-only diagnostics route, not a protocol change.
+    auto polarisSessionTiming = [](resp_https_t response, req_https_t request) {
+      print_req<PolarisHTTPS>(request);
+
+      const auto named_cert_p = get_verified_cert(request);
+      if (!named_cert_p) {
+        response->write(SimpleWeb::StatusCode::client_error_unauthorized);
+        return;
+      }
+
+      const auto output = build_session_timing_json(stream_stats::get_session_timing());
+
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "application/json");
+      response->write(output.dump(), headers);
+    };
+
     auto polarisSessionStatus = [](resp_https_t response, req_https_t request) {
       print_req<PolarisHTTPS>(request);
 
@@ -8535,6 +8575,7 @@ namespace nvhttp {
     https_server.resource["^/polaris/v1/optimize$"]["GET"] = polarisOptimize;
     https_server.resource["^/polaris/v1/capabilities$"]["GET"] = polarisCapabilities;
     https_server.resource["^/polaris/v1/session/status$"]["GET"] = polarisSessionStatus;
+    https_server.resource["^/polaris/v1/session/timing$"]["GET"] = polarisSessionTiming;
     https_server.resource["^/polaris/v1/session/stop$"]["POST"] = polarisSessionStop;
     https_server.resource["^/polaris/v1/client-settings$"]["GET"] = polarisClientSettings;
     https_server.resource["^/polaris/v1/client-settings$"]["POST"] = polarisClientSettings;

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -1978,6 +1978,12 @@ namespace cuda {
           return platf::capture_e::error;
         }
 
+        // P0-3 T0: this is where the captured frame genuinely becomes
+        // available. Matches the same stamping point used by every other
+        // Linux capture backend (wlgrab, kmsgrab, x11grab, cage_screencopy) -
+        // this one was the only display_t implementer missing it.
+        img_out->frame_timestamp = std::chrono::steady_clock::now();
+
         return platf::capture_e::ok;
       }
 

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -903,6 +903,12 @@ namespace portal {
           return platf::capture_e::reinit;
         }
 
+        // P0-3 T0: the frame is genuinely available as of fill_frame()
+        // succeeding, same moment update_capture_metadata below already
+        // treats as "frame is ready." This backend was the other of the two
+        // display_t implementers missing frame_timestamp.
+        img_out->frame_timestamp = std::chrono::steady_clock::now();
+
         stream_stats::update_capture_metadata(img_out->frame_metadata);
         if (!capture_transport_logged) {
           capture_transport_logged = true;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1511,9 +1511,19 @@ namespace stream {
           return (uint16_t) std::clamp<decltype(duration_us)>((duration_us + 50) / 100, 0, std::numeric_limits<uint16_t>::max());
         };
 
-        uint16_t latency = duration_to_latency(std::chrono::steady_clock::now() - *packet->frame_timestamp);
+        // T2: this is the send thread handing this packet off (the pacer
+        // sleep, if any, already happened earlier in the loop that calls
+        // this). Shared with the wire latency calc below so P0-3's
+        // out-of-band histogram costs no extra steady_clock::now() call.
+        auto t2_send_time = std::chrono::steady_clock::now();
+
+        uint16_t latency = duration_to_latency(t2_send_time - *packet->frame_timestamp);
         frame_header.frame_processing_latency = latency;
         frame_processing_latency_logger.collect_and_log(latency / 10.);
+
+        if (packet->encode_done_timestamp) {
+          stream_stats::record_frame_timing(*packet->frame_timestamp, *packet->encode_done_timestamp, t2_send_time);
+        }
       } else {
         frame_header.frame_processing_latency = 0;
       }

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -172,6 +172,47 @@ namespace stream_stats {
       auto pos = static_cast<std::size_t>(percentile * static_cast<double>(values.size() - 1));
       return values[pos];
     }
+
+    // P0-3 T0-T2 stage timing: unlike capture_profile_buckets above (which
+    // fills, logs, and clears - fine for periodic logging), this backs an
+    // HTTP-queryable endpoint, so a true ring buffer is used instead of a
+    // tumbling window - there is no "just cleared, empty" moment a query can
+    // land on. One dedicated mutex, separate from stats_mutex: the only
+    // writer is the single video send thread (at most ~120 Hz), the only
+    // readers are occasional HTTP handlers, and coupling this to the
+    // already-de-contended stats_mutex would reintroduce exactly the kind of
+    // cross-concern contention P0-2 removed.
+    constexpr std::size_t FRAME_TIMING_RING_CAPACITY = 512;
+
+    struct timing_ring_t {
+      std::array<double, FRAME_TIMING_RING_CAPACITY> samples_ms {};
+      std::size_t next_index = 0;
+      std::size_t filled = 0;
+
+      void push(double value_ms) {
+        samples_ms[next_index] = value_ms;
+        next_index = (next_index + 1) % FRAME_TIMING_RING_CAPACITY;
+        filled = std::min(filled + 1, FRAME_TIMING_RING_CAPACITY);
+      }
+
+      frame_timing_percentiles_t percentiles() const {
+        if (filled == 0) {
+          return {};
+        }
+        std::vector<double> sorted(samples_ms.begin(), samples_ms.begin() + static_cast<long>(filled));
+        std::sort(sorted.begin(), sorted.end());
+        auto pick = [&](double p) {
+          auto idx = static_cast<std::size_t>(p * static_cast<double>(sorted.size() - 1));
+          return sorted[idx];
+        };
+        return {pick(0.50), pick(0.99), static_cast<int>(filled)};
+      }
+    };
+
+    std::mutex frame_timing_mutex;
+    timing_ring_t capture_to_encode_ring;
+    timing_ring_t encode_to_send_ring;
+    timing_ring_t capture_to_send_ring;
   }  // namespace
 
   std::string stats_t::to_json() const {
@@ -1148,6 +1189,28 @@ namespace stream_stats {
     bucket.dispatch_us.clear();
     bucket.ingest_us.clear();
     bucket.total_us.clear();
+  }
+
+  void record_frame_timing(std::chrono::steady_clock::time_point capture_time,
+                           std::chrono::steady_clock::time_point encode_done_time,
+                           std::chrono::steady_clock::time_point send_time) {
+    auto to_ms = [](std::chrono::steady_clock::duration d) {
+      return std::chrono::duration<double, std::milli>(d).count();
+    };
+
+    std::lock_guard<std::mutex> lock(frame_timing_mutex);
+    capture_to_encode_ring.push(to_ms(encode_done_time - capture_time));
+    encode_to_send_ring.push(to_ms(send_time - encode_done_time));
+    capture_to_send_ring.push(to_ms(send_time - capture_time));
+  }
+
+  session_timing_t get_session_timing() {
+    std::lock_guard<std::mutex> lock(frame_timing_mutex);
+    return {
+      capture_to_encode_ring.percentiles(),
+      encode_to_send_ring.percentiles(),
+      capture_to_send_ring.percentiles()
+    };
   }
 
   int active_client_count() {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -427,6 +427,45 @@ namespace stream_stats {
   void update_capture_profile(const capture_profile_sample_t &sample);
 
   /**
+   * @brief p50/p99 over a rolling window of recent samples for one pipeline stage.
+   */
+  struct frame_timing_percentiles_t {
+    double p50_ms = 0;
+    double p99_ms = 0;
+    int sample_count = 0;
+  };
+
+  /**
+   * @brief Host-side T0-T2 glass-to-glass stage timing, always on.
+   *
+   * T0 = capture frame available, T1 = encoder finished this frame,
+   * T2 = this frame's packet handed to the NIC (post-pacer). See the
+   * Nordstern roadmap's canonical stage vocabulary.
+   */
+  struct session_timing_t {
+    frame_timing_percentiles_t capture_to_encode;  ///< T0 -> T1
+    frame_timing_percentiles_t encode_to_send;  ///< T1 -> T2
+    frame_timing_percentiles_t capture_to_send;  ///< T0 -> T2
+  };
+
+  /**
+   * @brief Record one frame's T0/T1/T2 timestamps into the always-on session
+   * timing histograms. Wire-format telemetry (frame_processing_latency) is
+   * untouched by this - this is purely an additional, out-of-band record.
+   * @param capture_time T0.
+   * @param encode_done_time T1.
+   * @param send_time T2.
+   */
+  void record_frame_timing(std::chrono::steady_clock::time_point capture_time,
+                           std::chrono::steady_clock::time_point encode_done_time,
+                           std::chrono::steady_clock::time_point send_time);
+
+  /**
+   * @brief Get a snapshot of the current session timing percentiles.
+   */
+  session_timing_t get_session_timing();
+
+  /**
    * @brief Get the number of active client sessions.
    * @return Count of active clients.
    */

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2478,6 +2478,7 @@ namespace video {
 
       if (av_packet && av_packet->pts == frame_nr) {
         packet->frame_timestamp = frame_timestamp;
+        packet->encode_done_timestamp = std::chrono::steady_clock::now();
       }
 
       packet->replacements = &session.replacements;
@@ -2490,6 +2491,7 @@ namespace video {
 
   int encode_nvenc(int64_t frame_nr, nvenc_encode_session_t &session, safe::mail_raw_t::queue_t<packet_t> &packets, void *channel_data, std::optional<std::chrono::steady_clock::time_point> frame_timestamp) {
     auto encoded_frame = session.encode_frame(frame_nr);
+    auto encode_done_timestamp = std::chrono::steady_clock::now();
     if (encoded_frame.data.empty()) {
       BOOST_LOG(error) << "NvENC returned empty packet";
       return -1;
@@ -2503,6 +2505,7 @@ namespace video {
     packet->channel_data = channel_data;
     packet->after_ref_frame_invalidation = encoded_frame.after_ref_frame_invalidation;
     packet->frame_timestamp = frame_timestamp;
+    packet->encode_done_timestamp = encode_done_timestamp;
     packets->raise(std::move(packet));
 
     return 0;

--- a/src/video.h
+++ b/src/video.h
@@ -371,6 +371,14 @@ namespace video {
     void *channel_data = nullptr;
     bool after_ref_frame_invalidation = false;
     std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
+
+    // T1 (encode-done): stamped by encode_avcodec()/encode_nvenc() right after
+    // the real encode work finishes, before the packet is queued for send.
+    // Travels with the packet to the send thread the same way frame_timestamp
+    // (T0) already does, so the send thread can derive all three P0-3 stages
+    // (T0->T1, T1->T2, T0->T2) from one thread without cross-thread
+    // correlation.
+    std::optional<std::chrono::steady_clock::time_point> encode_done_timestamp;
   };
 
   struct packet_raw_avcodec: packet_raw_t {

--- a/tests/integration/test_nova_contract.cpp
+++ b/tests/integration/test_nova_contract.cpp
@@ -270,8 +270,16 @@ TEST(NovaContractTests, KnownDriftNamesFieldsThatStillExist) {
 TEST(NovaContractTests, EveryObjectNamesTheFunctionScopingItsNovaReads) {
   // Scope is what went wrong repeatedly on the Nova side too, so it is pinned
   // rather than left to whoever edits the manifest next.
+  //
+  // An object may have no nova_reader at all: it shipped ahead of any Nova
+  // consumer (display_planner did this before papi-ux/nova#197; session_timing
+  // does it now). That is a real, documented state, not something this test
+  // should fail on - it only pins scope for objects that claim a reader.
   for (const auto &[name, object] : manifest()["objects"].items()) {
     SCOPED_TRACE(name);
+    if (!object.contains("nova_reader")) {
+      continue;
+    }
     EXPECT_TRUE(object["nova_reader"].contains("function"))
       << "nova_reader must name a function; Nova gives several functions in the same file "
          "a parameter called `json`, so file or receiver scoping silently mixes objects";

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -776,3 +776,62 @@ TEST(StreamStatsHotFieldTests, UpdateNetworkStatsIsVisibleThroughGetCurrent) {
 
   stream_stats::update_stream_active(false);
 }
+
+// The T0-T2 rings are global and never reset (unlike the hot-field atomics
+// above, which update_stream_active(false) can't touch either, but those are
+// tested via exact-delta instead). Other tests, and potentially a live
+// route, may have already pushed samples before this one runs, so a
+// before/after delta on p50/p99 wouldn't be reliable - percentiles aren't
+// additive. Instead this flood-fills the ring past its fixed capacity with
+// one known value, which deterministically leaves the entire ring holding
+// only that value regardless of prior state.
+TEST(StreamStatsSessionTimingTests, RecordFrameTimingFloodFillProducesKnownPercentiles) {
+  using namespace std::chrono;
+  const auto t0 = steady_clock::now();
+  const auto t1 = t0 + milliseconds(3);
+  const auto t2 = t1 + milliseconds(2);
+
+  for (int i = 0; i < 600; ++i) {
+    stream_stats::record_frame_timing(t0, t1, t2);
+  }
+
+  const auto timing = stream_stats::get_session_timing();
+
+  EXPECT_DOUBLE_EQ(timing.capture_to_encode.p50_ms, 3.0);
+  EXPECT_DOUBLE_EQ(timing.capture_to_encode.p99_ms, 3.0);
+  EXPECT_EQ(timing.capture_to_encode.sample_count, 512);
+
+  EXPECT_DOUBLE_EQ(timing.encode_to_send.p50_ms, 2.0);
+  EXPECT_DOUBLE_EQ(timing.encode_to_send.p99_ms, 2.0);
+  EXPECT_EQ(timing.encode_to_send.sample_count, 512);
+
+  EXPECT_DOUBLE_EQ(timing.capture_to_send.p50_ms, 5.0);
+  EXPECT_DOUBLE_EQ(timing.capture_to_send.p99_ms, 5.0);
+  EXPECT_EQ(timing.capture_to_send.sample_count, 512);
+}
+
+// Mixing two distinct flood-filled values should keep p50 and p99 both
+// within the [min, max] of what was actually pushed - this doesn't assume a
+// specific interpolation method or ordering, just that percentiles can't
+// invent values outside the observed range.
+TEST(StreamStatsSessionTimingTests, RecordFrameTimingMixedValuesStayWithinObservedRange) {
+  using namespace std::chrono;
+  const auto t0 = steady_clock::now();
+  const auto fast_t2 = t0 + milliseconds(1);
+  const auto slow_t2 = t0 + milliseconds(9);
+
+  for (int i = 0; i < 300; ++i) {
+    stream_stats::record_frame_timing(t0, t0, fast_t2);
+  }
+  for (int i = 0; i < 300; ++i) {
+    stream_stats::record_frame_timing(t0, t0, slow_t2);
+  }
+
+  const auto timing = stream_stats::get_session_timing();
+
+  EXPECT_GE(timing.capture_to_send.p50_ms, 1.0);
+  EXPECT_LE(timing.capture_to_send.p50_ms, 9.0);
+  EXPECT_GE(timing.capture_to_send.p99_ms, 1.0);
+  EXPECT_LE(timing.capture_to_send.p99_ms, 9.0);
+  EXPECT_EQ(timing.capture_to_send.sample_count, 512);
+}


### PR DESCRIPTION
## Summary

Nordstern P0-3: host-side T0-T2 glass-to-glass stage timing.

- Adds a lock-free-to-write ring buffer per pipeline stage (capture_to_encode, encode_to_send, capture_to_send), 512 samples each, recorded from the existing video send thread with no extra `steady_clock::now()` call on the hot path.
- Adds `encode_done_timestamp` (T1) to `packet_raw_t`, stamped by `encode_avcodec()`/`encode_nvenc()`, traveling with the packet the same way `frame_timestamp` (T0) already does.
- Backfills T0 stamping on the `cuda` and `portal_grab` capture backends, the only two of five Linux `display_t` implementers that didn't already stamp `frame_timestamp`. Without this, sessions on either backend would silently contribute zero samples.
- Serves the histograms read-only via `GET /polaris/v1/session/timing`, cert-verified the same way `/polaris/v1/session/status` is. Wire format (`frame_processing_latency`) is untouched.
- Declares the new response shape in `nova-contract.json` with no `nova_reader` yet (ships ahead of any Nova consumer, same position `display_planner` was in before papi-ux/nova#197), and fixes the two places (`test_nova_contract.cpp`, `check-nova-contract.py`) that assumed every object has a reader and would have thrown on this one.

**What this does *not* cover:** T3-T5 (client-side reassembly/decode/present) is P0-4, not this PR. The rings are also process-lifetime, not session-scoped — nothing here resets them at session start/end, so a query shortly after a new session starts can still reflect tail samples from whatever streamed most recently, not just the current session. Fine for the diagnostics use case this targets; worth knowing before treating a `/session/timing` read as strictly "this session only."

## Exact candidate

```
Commit: fa82174e365773c8689bbafd1285efc54aea8cee
Tree:   c828a8c29b56cfb3662f880075f28cf9e78f608f
Parent: bbdcc9a1ef1fe7195c43562df508a3513db20ee7
Base:   55c17a927792ba3d034373930b6cc6c83bd54d11
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all 17 CTest binaries built with no errors.
- [x] `ctest --test-dir build` — 100% passed, 17/17 test binaries, run from repo root.
- [x] `test_polaris_stream` — 103/103 tests, including 2 new `StreamStatsSessionTimingTests` covering the ring-buffer percentile math (flood-fill-to-known-value, and mixed-value bounds).
- [x] `test_polaris_audit` — 30/30 tests, including all 4 `NovaContractTests` (manifest/emitter match, capability declarations, known-drift, and the `nova_reader`-scoping test now tolerating an absent reader).
- [x] `test_polaris_video`, `test_polaris_platform` — no regressions (pre-existing unrelated skips only: `vaapi` encoder unavailable on this box, `CudaGlEncodeDeviceTests.LinuxCudaOnly`).
