### PR TITLE
fix(linux): supervise labwc external-exit cleanup

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -36,6 +36,7 @@
 #include <set>
 #include <signal.h>
 #include <poll.h>
+#include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sstream>
@@ -60,10 +61,15 @@ namespace cage_display_router {
    */
   static int cage_pidfd = -1;
 
-  // The direct child tracked by cage_pid is a tiny supervisor. The actual
-  // compositor runs in its own process group beneath that supervisor so a
-  // compositor-initiated exit cannot orphan its startup client and cleanup
-  // never needs to guess whether a recycled PGID still belongs to Polaris.
+#if defined(POLARIS_TESTS)
+  static bool force_cage_pidfd_open_failure = false;
+#endif
+
+  // The direct child tracked by cage_pid is a tiny supervisor and the immutable
+  // leader of the private labwc session/process group. The compositor and every
+  // startup descendant stay inside that anchored group, so a compositor-driven
+  // exit cannot orphan its startup client and parent fallback never has to guess
+  // whether a recycled PGID still belongs to Polaris.
   static volatile sig_atomic_t supervised_runtime_pid = 0;
   static volatile sig_atomic_t supervisor_stop_requested = 0;
 
@@ -117,6 +123,12 @@ namespace cage_display_router {
       cage_pidfd = -1;
     }
 
+#if defined(POLARIS_TESTS)
+    if (force_cage_pidfd_open_failure) {
+      return;
+    }
+#endif
+
     cage_pidfd = static_cast<int>(syscall(SYS_pidfd_open, pid, 0));
     if (cage_pidfd < 0) {
       BOOST_LOG(warning) << "labwc: pidfd_open failed for pid ["sv << pid << "]: "sv << strerror(errno)
@@ -135,7 +147,6 @@ namespace cage_display_router {
     supervisor_stop_requested = 1;
     const auto runtime_pid = static_cast<pid_t>(supervised_runtime_pid);
     if (runtime_pid > 0) {
-      (void) kill(-runtime_pid, signal_number);
       (void) kill(runtime_pid, signal_number);
     }
   }
@@ -168,14 +179,13 @@ namespace cage_display_router {
   }
 
   /**
-   * Keep a stable direct child alive around the actual compositor generation.
+   * Keep a stable direct child alive as the private session/process-group anchor.
    *
    * labwc is free to exit from its own menu while its startup client remains
-   * alive. The supervisor observes that exit without reaping the labwc leader,
-   * drains the immutable labwc process group while the zombie still prevents
-   * PGID reuse, then reaps it and exits. Explicit Polaris teardown reaches the
-   * same path by signalling the supervisor, whose handler forwards to the
-   * runtime group.
+   * alive. The supervisor subreaps that runtime tree, drains the anchored group,
+   * and exits cleanly once no private descendants remain. If a descendant ignores
+   * graceful teardown, the final group SIGKILL includes the supervisor itself;
+   * the parent still owns and pidfd-tracks that immutable group leader.
    */
   [[noreturn]] static void supervise_labwc(
     const std::string &labwc_path,
@@ -184,6 +194,10 @@ namespace cage_display_router {
   ) {
     supervised_runtime_pid = 0;
     supervisor_stop_requested = 0;
+
+    if (setsid() < 0 || prctl(PR_SET_CHILD_SUBREAPER, 1) != 0) {
+      _exit(126);
+    }
 
     sigset_t forwarded_signals {};
     sigset_t previous_mask {};
@@ -206,10 +220,6 @@ namespace cage_display_router {
       restore_default_signal_handler(SIGHUP);
       restore_default_signal_handler(SIGCHLD);
       (void) sigprocmask(SIG_SETMASK, &previous_mask, nullptr);
-
-      if (setsid() < 0) {
-        _exit(126);
-      }
 
       execl(labwc_path.c_str(), "labwc",
         "-C", config_dir.c_str(),
@@ -241,37 +251,59 @@ namespace cage_display_router {
     }
 
     if (!observed_exit && !supervisor_stop_requested) {
-      // Without either an unreaped direct child or an explicit stop request,
-      // there is no immutable ownership proof for a negative-PGID signal.
       supervised_runtime_pid = 0;
       _exit(127);
     }
 
-    // A normally exited runtime is left unreaped until the whole private group
-    // is drained, so runtime_pid cannot be recycled underneath -runtime_pid.
-    // On explicit stop, the direct child is still unreaped by construction.
-    (void) kill(-runtime_pid, SIGTERM);
+    // Ignore graceful signals while the supervisor broadcasts them to its own
+    // private group. Every labwc descendant inherits this anchored PGID.
+    install_signal_handler(SIGTERM, SIG_IGN);
+    install_signal_handler(SIGINT, SIG_IGN);
+    install_signal_handler(SIGHUP, SIG_IGN);
+    (void) kill(-getpgrp(), SIGTERM);
     (void) kill(runtime_pid, SIGTERM);
-    sleep_without_losing_interrupt_time(500ms);
-    (void) kill(-runtime_pid, SIGKILL);
-    (void) kill(runtime_pid, SIGKILL);
 
     int runtime_status = 0;
-    pid_t reaped_pid = -1;
-    do {
-      reaped_pid = waitpid(runtime_pid, &runtime_status, 0);
-    } while (reaped_pid < 0 && errno == EINTR);
-    supervised_runtime_pid = 0;
+    bool runtime_reaped = false;
+    const auto deadline = std::chrono::steady_clock::now() + 500ms;
+    while (std::chrono::steady_clock::now() < deadline) {
+      bool live_children = false;
+      while (true) {
+        int child_status = 0;
+        const auto child_pid = waitpid(-1, &child_status, WNOHANG);
+        if (child_pid > 0) {
+          if (child_pid == runtime_pid) {
+            runtime_status = child_status;
+            runtime_reaped = true;
+          }
+          continue;
+        }
+        if (child_pid == 0) {
+          live_children = true;
+        } else if (errno == EINTR) {
+          continue;
+        } else if (errno != ECHILD) {
+          live_children = true;
+        }
+        break;
+      }
 
-    if (reaped_pid != runtime_pid) {
-      _exit(127);
+      if (!live_children) {
+        supervised_runtime_pid = 0;
+        if (runtime_reaped && WIFEXITED(runtime_status)) {
+          _exit(WEXITSTATUS(runtime_status));
+        }
+        if (runtime_reaped && WIFSIGNALED(runtime_status)) {
+          _exit(128 + WTERMSIG(runtime_status));
+        }
+        _exit(127);
+      }
+      sleep_without_losing_interrupt_time(25ms);
     }
-    if (WIFEXITED(runtime_status)) {
-      _exit(WEXITSTATUS(runtime_status));
-    }
-    if (WIFSIGNALED(runtime_status)) {
-      _exit(128 + WTERMSIG(runtime_status));
-    }
+
+    // The supervisor is the live, unreaped group leader. Killing its group is
+    // therefore generation-safe and cannot land on a recycled PGID.
+    (void) kill(-getpgrp(), SIGKILL);
     _exit(127);
   }
 
@@ -322,6 +354,22 @@ namespace cage_display_router {
     }
 
     return kill(cage_pid, signal_number) == 0 || errno == ESRCH;
+  }
+
+  static bool force_kill_cage_group() {
+    // Freeze the pidfd-bound group leader before addressing -cage_pid. While the
+    // supervisor is stopped and unreaped, its PGID cannot be recycled between
+    // the ownership check and the group SIGKILL.
+    if (!signal_cage_supervisor(SIGSTOP)) {
+      return false;
+    }
+    if (!cage_process_alive()) {
+      return true;
+    }
+
+    const bool group_signalled = kill(-cage_pid, SIGKILL) == 0 || errno == ESRCH;
+    const bool supervisor_signalled = signal_cage_supervisor(SIGKILL);
+    return group_signalled && supervisor_signalled;
   }
 
   static std::string exec_capture(const std::string &cmd) {
@@ -886,6 +934,14 @@ namespace cage_display_router {
   std::string labwc_process_environment_value_for_tests(bool headless, std::string_view key) {
     return labwc_process_environment_value(headless, key);
   }
+
+  void force_cage_pidfd_open_failure_for_tests(bool force_failure) {
+    force_cage_pidfd_open_failure = force_failure;
+  }
+
+  bool cage_pidfd_available_for_tests() {
+    return cage_pidfd >= 0;
+  }
 #endif
 
   // -----------------------------------------------------------------------
@@ -908,7 +964,7 @@ namespace cage_display_router {
       return true;
     }
 
-    // Reset stale state. The pidfd of a compositor that died without going
+    // Reset stale state. The pidfd of a supervisor that died without going
     // through stop() is still open here; every session would otherwise leak one.
     close_cage_pidfd();
     cage_pid = 0;
@@ -1035,10 +1091,9 @@ namespace cage_display_router {
 
     pid_t pid = fork();
     if (pid == 0) {
-      // Child: become the stable supervisor for one private labwc generation.
-      // The compositor itself is forked below into a separate session/process
-      // group, so a menu-driven compositor exit cannot leave its clients behind
-      // or make Polaris signal a stale group.
+      // Child: become the stable session/process-group supervisor for one
+      // private labwc generation. The compositor is forked beneath this anchor,
+      // so menu-driven exit cannot leave its clients unowned.
       if (!session_instance_id.empty()) {
         setenv("POLARIS_SESSION_INSTANCE_ID", session_instance_id.c_str(), 1);
       } else {
@@ -1197,19 +1252,30 @@ namespace cage_display_router {
     // group and forwards graceful teardown without any raw PGID guesswork.
     (void) signal_cage_supervisor(SIGTERM);
 
-    // Poll for exit up to 3 seconds
+    // Poll for exit up to 3 seconds. Once waitpid() reaps this generation (or
+    // reports ECHILD because another synchronized reaper already did), never
+    // consult the numeric PID again: without pidfd support it is recyclable.
+    bool supervisor_reaped = false;
     for (int i = 0; i < 30; ++i) {
-      pid_t ret = waitpid(cage_pid, nullptr, WNOHANG);
-      if (ret > 0) break;
+      const pid_t ret = waitpid(cage_pid, nullptr, WNOHANG);
+      if (ret == cage_pid || (ret < 0 && errno == ECHILD)) {
+        supervisor_reaped = true;
+        break;
+      }
       if (!cage_process_alive()) break;  // process gone
       std::this_thread::sleep_for(100ms);
     }
 
-    // Force kill if still alive
-    if (cage_process_alive()) {
-      BOOST_LOG(warning) << "labwc: Supervisor did not exit gracefully, sending SIGKILL"sv;
-      (void) signal_cage_supervisor(SIGKILL);
-      waitpid(cage_pid, nullptr, WNOHANG);
+    // Force kill only while the original supervisor remains unreaped.
+    if (!supervisor_reaped && cage_process_alive()) {
+      BOOST_LOG(warning) << "labwc: Supervisor did not exit gracefully, killing its private group"sv;
+      if (force_kill_cage_group()) {
+        while (waitpid(cage_pid, nullptr, 0) < 0 && errno == EINTR) {
+        }
+      } else {
+        BOOST_LOG(error) << "labwc: Could not prove ownership for forced private-group cleanup; retaining router state"sv;
+        return;
+      }
     }
 
     BOOST_LOG(info) << "labwc: Stopped"sv;

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -51,15 +51,21 @@ namespace cage_display_router {
   static pid_t cage_pid = 0;
 
   /**
-   * A pidfd for the compositor, opened at spawn.
+   * A pidfd for the owned labwc supervisor, opened at spawn.
    *
-   * `kill(pid, 0)` cannot answer "is the compositor still running": it reports
+   * `kill(pid, 0)` cannot answer "is this runtime generation still running": it reports
    * success for a zombie, and after the pid has been reaped and recycled it
-   * reports on whatever process inherited the number. Signalling a stale
-   * `-cage_pid` on that basis targets an unrelated process group. A pidfd refers
-   * to the process itself, so it stays correct across both.
+   * reports on whatever process inherited the number. A pidfd refers to the
+   * supervisor generation itself, so it stays correct across both.
    */
   static int cage_pidfd = -1;
+
+  // The direct child tracked by cage_pid is a tiny supervisor. The actual
+  // compositor runs in its own process group beneath that supervisor so a
+  // compositor-initiated exit cannot orphan its startup client and cleanup
+  // never needs to guess whether a recycled PGID still belongs to Polaris.
+  static volatile sig_atomic_t supervised_runtime_pid = 0;
+  static volatile sig_atomic_t supervisor_stop_requested = 0;
 
   static std::string cage_wayland_socket;  // e.g., "wayland-5"
   static std::string cage_x11_display;  // e.g., ":1"
@@ -125,6 +131,150 @@ namespace cage_display_router {
     }
   }
 
+  static void forward_supervisor_signal(int signal_number) {
+    supervisor_stop_requested = 1;
+    const auto runtime_pid = static_cast<pid_t>(supervised_runtime_pid);
+    if (runtime_pid > 0) {
+      (void) kill(-runtime_pid, signal_number);
+      (void) kill(runtime_pid, signal_number);
+    }
+  }
+
+  static void install_signal_handler(int signal_number, void (*handler)(int)) {
+    struct sigaction action {};
+    sigemptyset(&action.sa_mask);
+    action.sa_handler = handler;
+    action.sa_flags = 0;
+    (void) sigaction(signal_number, &action, nullptr);
+  }
+
+  static void restore_default_signal_handler(int signal_number) {
+    struct sigaction action {};
+    sigemptyset(&action.sa_mask);
+    action.sa_handler = SIG_DFL;
+    action.sa_flags = 0;
+    (void) sigaction(signal_number, &action, nullptr);
+  }
+
+  static void sleep_without_losing_interrupt_time(std::chrono::milliseconds duration) {
+    auto seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
+    auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds);
+    timespec remaining {
+      .tv_sec = static_cast<time_t>(seconds.count()),
+      .tv_nsec = static_cast<long>(nanoseconds.count()),
+    };
+    while (nanosleep(&remaining, &remaining) != 0 && errno == EINTR) {
+    }
+  }
+
+  /**
+   * Keep a stable direct child alive around the actual compositor generation.
+   *
+   * labwc is free to exit from its own menu while its startup client remains
+   * alive. The supervisor observes that exit without reaping the labwc leader,
+   * drains the immutable labwc process group while the zombie still prevents
+   * PGID reuse, then reaps it and exits. Explicit Polaris teardown reaches the
+   * same path by signalling the supervisor, whose handler forwards to the
+   * runtime group.
+   */
+  [[noreturn]] static void supervise_labwc(
+    const std::string &labwc_path,
+    const std::string &config_dir,
+    const std::string &startup_shell
+  ) {
+    supervised_runtime_pid = 0;
+    supervisor_stop_requested = 0;
+
+    sigset_t forwarded_signals {};
+    sigset_t previous_mask {};
+    sigemptyset(&forwarded_signals);
+    sigaddset(&forwarded_signals, SIGTERM);
+    sigaddset(&forwarded_signals, SIGINT);
+    sigaddset(&forwarded_signals, SIGHUP);
+    (void) sigprocmask(SIG_BLOCK, &forwarded_signals, &previous_mask);
+
+    install_signal_handler(SIGTERM, forward_supervisor_signal);
+    install_signal_handler(SIGINT, forward_supervisor_signal);
+    install_signal_handler(SIGHUP, forward_supervisor_signal);
+    restore_default_signal_handler(SIGCHLD);
+
+    const pid_t runtime_pid = fork();
+    if (runtime_pid == 0) {
+      supervised_runtime_pid = 0;
+      restore_default_signal_handler(SIGTERM);
+      restore_default_signal_handler(SIGINT);
+      restore_default_signal_handler(SIGHUP);
+      restore_default_signal_handler(SIGCHLD);
+      (void) sigprocmask(SIG_SETMASK, &previous_mask, nullptr);
+
+      if (setsid() < 0) {
+        _exit(126);
+      }
+
+      execl(labwc_path.c_str(), "labwc",
+        "-C", config_dir.c_str(),
+        "-s", startup_shell.c_str(),
+        nullptr);
+      _exit(errno == ENOENT ? 127 : 126);
+    }
+
+    if (runtime_pid < 0) {
+      (void) sigprocmask(SIG_SETMASK, &previous_mask, nullptr);
+      _exit(127);
+    }
+
+    supervised_runtime_pid = static_cast<sig_atomic_t>(runtime_pid);
+    (void) sigprocmask(SIG_SETMASK, &previous_mask, nullptr);
+
+    siginfo_t exit_info {};
+    bool observed_exit = false;
+    if (!supervisor_stop_requested) {
+      while (true) {
+        if (waitid(P_PID, static_cast<id_t>(runtime_pid), &exit_info, WEXITED | WNOWAIT) == 0) {
+          observed_exit = true;
+          break;
+        }
+        if (errno != EINTR || supervisor_stop_requested) {
+          break;
+        }
+      }
+    }
+
+    if (!observed_exit && !supervisor_stop_requested) {
+      // Without either an unreaped direct child or an explicit stop request,
+      // there is no immutable ownership proof for a negative-PGID signal.
+      supervised_runtime_pid = 0;
+      _exit(127);
+    }
+
+    // A normally exited runtime is left unreaped until the whole private group
+    // is drained, so runtime_pid cannot be recycled underneath -runtime_pid.
+    // On explicit stop, the direct child is still unreaped by construction.
+    (void) kill(-runtime_pid, SIGTERM);
+    (void) kill(runtime_pid, SIGTERM);
+    sleep_without_losing_interrupt_time(500ms);
+    (void) kill(-runtime_pid, SIGKILL);
+    (void) kill(runtime_pid, SIGKILL);
+
+    int runtime_status = 0;
+    pid_t reaped_pid = -1;
+    do {
+      reaped_pid = waitpid(runtime_pid, &runtime_status, 0);
+    } while (reaped_pid < 0 && errno == EINTR);
+    supervised_runtime_pid = 0;
+
+    if (reaped_pid != runtime_pid) {
+      _exit(127);
+    }
+    if (WIFEXITED(runtime_status)) {
+      _exit(WEXITSTATUS(runtime_status));
+    }
+    if (WIFSIGNALED(runtime_status)) {
+      _exit(128 + WTERMSIG(runtime_status));
+    }
+    _exit(127);
+  }
+
   /**
    * @brief Whether the compositor process is still alive.
    *
@@ -148,12 +298,30 @@ namespace cage_display_router {
         if (errno == EINTR) {
           continue;
         }
-        // An unusable pidfd should not be read as "the compositor is gone":
-        // that would let stop() signal a process group it no longer owns.
+        // An unusable pidfd should not be read as "the supervisor is gone":
+        // teardown must keep waiting rather than discard a live generation.
         return kill(cage_pid, 0) == 0;
       }
       return ready == 0;
     }
+  }
+
+  static bool signal_cage_supervisor(int signal_number) {
+    if (cage_pid <= 0) {
+      return false;
+    }
+
+    if (cage_pidfd >= 0) {
+      if (syscall(SYS_pidfd_send_signal, cage_pidfd, signal_number, nullptr, 0) == 0 ||
+          errno == ESRCH) {
+        return true;
+      }
+      BOOST_LOG(warning) << "labwc: pidfd signal failed for supervisor pid ["sv
+                         << cage_pid << "]: "sv << strerror(errno);
+      return false;
+    }
+
+    return kill(cage_pid, signal_number) == 0 || errno == ESRCH;
   }
 
   static std::string exec_capture(const std::string &cmd) {
@@ -867,7 +1035,10 @@ namespace cage_display_router {
 
     pid_t pid = fork();
     if (pid == 0) {
-      // Child: set wlroots environment, detach, exec labwc
+      // Child: become the stable supervisor for one private labwc generation.
+      // The compositor itself is forked below into a separate session/process
+      // group, so a menu-driven compositor exit cannot leave its clients behind
+      // or make Polaris signal a stale group.
       if (!session_instance_id.empty()) {
         setenv("POLARIS_SESSION_INSTANCE_ID", session_instance_id.c_str(), 1);
       } else {
@@ -897,7 +1068,6 @@ namespace cage_display_router {
       // Clear DISPLAY in ALL modes so games connect to labwc's XWayland,
       // not KDE's :0. labwc will set its own DISPLAY via XWayland.
       unsetenv("DISPLAY");
-      setsid();
 
       // Redirect stdout/stderr
       int devnull = open("/dev/null", O_RDWR);
@@ -917,11 +1087,7 @@ namespace cage_display_router {
 
       // labwc -C: config dir for rc.xml, -s: startup command (game)
       const auto startup_shell = std::string("bash -c " ) + shell_quote(startup_cmd);
-      execl(labwc_path.c_str(), "labwc",
-        "-C", config_dir.c_str(),
-        "-s", startup_shell.c_str(),
-        nullptr);
-      _exit(errno == ENOENT ? 127 : 126);
+      supervise_labwc(labwc_path, config_dir, startup_shell);
     } else if (pid > 0) {
       cage_pid = pid;
       open_cage_pidfd(pid);
@@ -1006,10 +1172,9 @@ namespace cage_display_router {
       return;
     }
 
-    // The compositor may already have exited on its own — the user can quit it
-    // from inside the session. Reap it and stop there. Signalling -cage_pid at
-    // this point would either do nothing or, once the pid has been recycled,
-    // land on an unrelated process group.
+    // The supervisor may already have exited after observing a menu-driven
+    // labwc shutdown. Its private runtime group has been drained before the
+    // supervisor becomes reapable, so only cached router state remains here.
     if (!cage_process_alive()) {
       BOOST_LOG(info) << "labwc: Already exited (pid="sv << cage_pid << "); reaping session state"sv;
       (void) waitpid(cage_pid, nullptr, WNOHANG);
@@ -1028,9 +1193,9 @@ namespace cage_display_router {
 
     BOOST_LOG(info) << "labwc: Stopping (pid="sv << cage_pid << ")"sv;
 
-    // Terminate process group so cage and its children all die
-    kill(-cage_pid, SIGTERM);
-    kill(cage_pid, SIGTERM);
+    // Signal only the pidfd-bound supervisor. It owns the private compositor
+    // group and forwards graceful teardown without any raw PGID guesswork.
+    (void) signal_cage_supervisor(SIGTERM);
 
     // Poll for exit up to 3 seconds
     for (int i = 0; i < 30; ++i) {
@@ -1042,9 +1207,8 @@ namespace cage_display_router {
 
     // Force kill if still alive
     if (cage_process_alive()) {
-      BOOST_LOG(warning) << "labwc: Did not exit gracefully, sending SIGKILL"sv;
-      kill(-cage_pid, SIGKILL);
-      kill(cage_pid, SIGKILL);
+      BOOST_LOG(warning) << "labwc: Supervisor did not exit gracefully, sending SIGKILL"sv;
+      (void) signal_cage_supervisor(SIGKILL);
       waitpid(cage_pid, nullptr, WNOHANG);
     }
 

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -60,7 +60,7 @@ namespace cage_display_router {
 
   /**
    * @brief Stop the owned labwc supervisor and all private runtime processes.
-   * Sends SIGTERM, waits up to 3s, then SIGKILLs the supervisor if needed.
+   * Sends SIGTERM, waits up to 3s, then kills the anchored private group if needed.
    */
   void stop();
 
@@ -74,6 +74,8 @@ namespace cage_display_router {
 
 #if defined(POLARIS_TESTS)
   void reset_after_external_stop_for_tests(pid_t pid);
+  void force_cage_pidfd_open_failure_for_tests(bool force_failure);
+  bool cage_pidfd_available_for_tests();
 #endif
 
   /**

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -59,8 +59,8 @@ namespace cage_display_router {
   std::string wrap_cmd(const std::string &cmd);
 
   /**
-   * @brief Stop cage and all processes running inside it.
-   * Sends SIGTERM, waits up to 3s, then SIGKILL if needed.
+   * @brief Stop the owned labwc supervisor and all private runtime processes.
+   * Sends SIGTERM, waits up to 3s, then SIGKILLs the supervisor if needed.
    */
   void stop();
 
@@ -88,7 +88,7 @@ namespace cage_display_router {
   bool is_healthy();
 
   /**
-   * @brief Returns the PID of the running cage process (0 if not running).
+   * @brief Returns the PID of the owned labwc supervisor (0 if not running).
    */
   pid_t get_pid();
 

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -95,13 +95,14 @@ TEST(CageDisplayRouterLifecycleTests, ExternalExitDrainsPrivateChildrenAcrossRel
     bool had_pid_file;
     bool had_compositor_pid_file;
     fs::path root;
-    std::vector<pid_t> workers;
+    std::vector<pid_t> cleanup_pids;
 
     ~cleanup_t() {
+      cage_display_router::force_cage_pidfd_open_failure_for_tests(false);
       cage_display_router::stop();
-      for (const auto worker : workers) {
-        if (worker > 0 && kill(worker, 0) == 0) {
-          (void) kill(worker, SIGKILL);
+      for (const auto process_pid : cleanup_pids) {
+        if (process_pid > 0 && kill(process_pid, 0) == 0) {
+          (void) kill(process_pid, SIGKILL);
         }
       }
       config::video.linux_display = linux_display;
@@ -140,6 +141,12 @@ TEST(CageDisplayRouterLifecycleTests, ExternalExitDrainsPrivateChildrenAcrossRel
     .had_pid_file = pid_file_env != nullptr,
     .had_compositor_pid_file = compositor_pid_file_env != nullptr,
     .root = fs::temp_directory_path() / ("polaris-cage-external-exit-" + std::to_string(getpid())),
+  };
+  auto remove_cleanup_pid = [&](pid_t pid) {
+    const auto position = std::find(cleanup.cleanup_pids.begin(), cleanup.cleanup_pids.end(), pid);
+    if (position != cleanup.cleanup_pids.end()) {
+      cleanup.cleanup_pids.erase(position);
+    }
   };
 
   const auto bin_dir = cleanup.root / "bin";
@@ -236,11 +243,13 @@ exit 0
     const auto compositor_pid = wait_for_pid_file(compositor_pid_file);
     ASSERT_GT(compositor_pid, 0);
     EXPECT_NE(router_pid, compositor_pid);
-    EXPECT_EQ(getpgid(compositor_pid), compositor_pid);
+    EXPECT_EQ(getpgid(router_pid), router_pid);
+    EXPECT_EQ(getpgid(compositor_pid), router_pid);
+    EXPECT_EQ(getsid(compositor_pid), router_pid);
     EXPECT_NE(getpgid(compositor_pid), getpgrp());
     const auto worker = wait_for_pid_file(pid_file);
     ASSERT_GT(worker, 0);
-    cleanup.workers.push_back(worker);
+    cleanup.cleanup_pids.push_back(worker);
 
     ASSERT_EQ(kill(compositor_pid, SIGTERM), 0);
     ASSERT_TRUE(wait_for_router_exit(std::chrono::seconds(3)));
@@ -250,7 +259,7 @@ exit 0
     EXPECT_TRUE(worker_exited)
       << "cycle " << cycle << " leaked private worker pid " << worker;
     if (worker_exited) {
-      cleanup.workers.pop_back();
+      remove_cleanup_pid(worker);
     }
   }
 
@@ -272,7 +281,7 @@ exit 0
   ASSERT_GT(stopped_compositor_pid, 0);
   const auto stopped_worker_pid = wait_for_pid_file(pid_file);
   ASSERT_GT(stopped_worker_pid, 0);
-  cleanup.workers.push_back(stopped_worker_pid);
+  cleanup.cleanup_pids.push_back(stopped_worker_pid);
 
   ASSERT_EQ(kill(stopped_compositor_pid, SIGSTOP), 0);
   cage_display_router::stop();
@@ -280,7 +289,94 @@ exit 0
   EXPECT_TRUE(stopped_worker_exited)
     << "explicit stop leaked private worker pid " << stopped_worker_pid;
   if (stopped_worker_exited) {
-    cleanup.workers.pop_back();
+    remove_cleanup_pid(stopped_worker_pid);
+  }
+
+  // If the supervisor itself is wedged, the parent fallback must still own an
+  // immutable handle to the separate runtime group. Killing only the frozen
+  // supervisor would strand both labwc and its placeholder.
+  fs::remove(pid_file, ec);
+  fs::remove(compositor_pid_file, ec);
+  ASSERT_TRUE(cage_display_router::start(
+    1280,
+    720,
+    60,
+    "",
+    false,
+    false,
+    "supervisor-hard-stop"
+  ));
+  const auto frozen_supervisor_pid = cage_display_router::get_pid();
+  ASSERT_GT(frozen_supervisor_pid, 0);
+  const auto frozen_compositor_pid = wait_for_pid_file(compositor_pid_file);
+  ASSERT_GT(frozen_compositor_pid, 0);
+  const auto frozen_worker_pid = wait_for_pid_file(pid_file);
+  ASSERT_GT(frozen_worker_pid, 0);
+  cleanup.cleanup_pids.push_back(frozen_compositor_pid);
+  cleanup.cleanup_pids.push_back(frozen_worker_pid);
+
+  ASSERT_EQ(kill(frozen_supervisor_pid, SIGSTOP), 0);
+  cage_display_router::stop();
+  const bool frozen_supervisor_exited = wait_for_process_exit(frozen_supervisor_pid, std::chrono::seconds(2));
+  const bool frozen_worker_exited = wait_for_process_exit(frozen_worker_pid, std::chrono::seconds(2));
+  const bool frozen_compositor_exited = wait_for_process_exit(frozen_compositor_pid, std::chrono::seconds(2));
+  EXPECT_TRUE(frozen_supervisor_exited)
+    << "hard supervisor stop did not reap supervisor pid " << frozen_supervisor_pid;
+  EXPECT_TRUE(frozen_worker_exited)
+    << "hard supervisor stop leaked private worker pid " << frozen_worker_pid;
+  EXPECT_TRUE(frozen_compositor_exited)
+    << "hard supervisor stop leaked compositor pid " << frozen_compositor_pid;
+  if (frozen_worker_exited) {
+    remove_cleanup_pid(frozen_worker_pid);
+  }
+  if (frozen_compositor_exited) {
+    remove_cleanup_pid(frozen_compositor_pid);
+  }
+
+  // Exercise the older-kernel fallback where pidfd_open() is unavailable. The
+  // supervisor exits first and is then reaped by stop(); after that successful
+  // waitpid(), no raw liveness or group signal may consult its numeric PID.
+  cage_display_router::force_cage_pidfd_open_failure_for_tests(true);
+  fs::remove(pid_file, ec);
+  fs::remove(compositor_pid_file, ec);
+  ASSERT_TRUE(cage_display_router::start(
+    1280,
+    720,
+    60,
+    "",
+    false,
+    false,
+    "pidfd-unavailable-external-exit"
+  ));
+  EXPECT_FALSE(cage_display_router::cage_pidfd_available_for_tests());
+  const auto no_pidfd_supervisor_pid = cage_display_router::get_pid();
+  ASSERT_GT(no_pidfd_supervisor_pid, 0);
+  const auto no_pidfd_compositor_pid = wait_for_pid_file(compositor_pid_file);
+  ASSERT_GT(no_pidfd_compositor_pid, 0);
+  const auto no_pidfd_worker_pid = wait_for_pid_file(pid_file);
+  ASSERT_GT(no_pidfd_worker_pid, 0);
+  cleanup.cleanup_pids.push_back(no_pidfd_compositor_pid);
+  cleanup.cleanup_pids.push_back(no_pidfd_worker_pid);
+
+  ASSERT_EQ(kill(no_pidfd_compositor_pid, SIGTERM), 0);
+  std::this_thread::sleep_for(std::chrono::milliseconds(750));
+  cage_display_router::stop();
+  cage_display_router::force_cage_pidfd_open_failure_for_tests(false);
+
+  const bool no_pidfd_supervisor_exited = wait_for_process_exit(no_pidfd_supervisor_pid, std::chrono::seconds(2));
+  const bool no_pidfd_compositor_exited = wait_for_process_exit(no_pidfd_compositor_pid, std::chrono::seconds(2));
+  const bool no_pidfd_worker_exited = wait_for_process_exit(no_pidfd_worker_pid, std::chrono::seconds(2));
+  EXPECT_TRUE(no_pidfd_supervisor_exited)
+    << "pidfd-unavailable stop did not reap supervisor pid " << no_pidfd_supervisor_pid;
+  EXPECT_TRUE(no_pidfd_compositor_exited)
+    << "pidfd-unavailable stop leaked compositor pid " << no_pidfd_compositor_pid;
+  EXPECT_TRUE(no_pidfd_worker_exited)
+    << "pidfd-unavailable stop leaked worker pid " << no_pidfd_worker_pid;
+  if (no_pidfd_compositor_exited) {
+    remove_cleanup_pid(no_pidfd_compositor_pid);
+  }
+  if (no_pidfd_worker_exited) {
+    remove_cleanup_pid(no_pidfd_worker_pid);
   }
 }
 

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -5,8 +5,52 @@
 #include "../../tests_common.h"
 
 #ifdef __linux__
+  #include <src/config.h>
   #include <src/platform/linux/cage_display_router.h>
   #include <src/platform/linux/wayland.h>
+
+  #include <cerrno>
+  #include <csignal>
+  #include <filesystem>
+  #include <fstream>
+  #include <sys/stat.h>
+  #include <unistd.h>
+
+namespace {
+  bool wait_for_process_exit(pid_t pid, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (kill(pid, 0) != 0 && errno == ESRCH) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    return kill(pid, 0) != 0 && errno == ESRCH;
+  }
+
+  pid_t wait_for_pid_file(const std::filesystem::path &path) {
+    for (int attempt = 0; attempt < 80; ++attempt) {
+      std::ifstream in(path);
+      pid_t pid = -1;
+      if (in >> pid && pid > 0) {
+        return pid;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    return -1;
+  }
+
+  bool wait_for_router_exit(std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (!cage_display_router::is_running()) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    return !cage_display_router::is_running();
+  }
+}
 
 TEST(WaylandOutputRegistryStateTests, OutputHotplugMarksTopologyDirtyUntilCleared) {
   wl::output_registry_state_t state;
@@ -35,6 +79,211 @@ TEST(WaylandOutputRegistryStateTests, RemovingNonOutputGlobalDoesNotDirtyOutputT
 }
 
 #ifdef POLARIS_TESTS
+TEST(CageDisplayRouterLifecycleTests, ExternalExitDrainsPrivateChildrenAcrossRelaunch) {
+  namespace fs = std::filesystem;
+
+  struct cleanup_t {
+    config::video_t::linux_display_t linux_display;
+    std::string original_path;
+    std::string original_home;
+    std::string original_runtime_dir;
+    std::string original_pid_file;
+    std::string original_compositor_pid_file;
+    bool had_path;
+    bool had_home;
+    bool had_runtime_dir;
+    bool had_pid_file;
+    bool had_compositor_pid_file;
+    fs::path root;
+    std::vector<pid_t> workers;
+
+    ~cleanup_t() {
+      cage_display_router::stop();
+      for (const auto worker : workers) {
+        if (worker > 0 && kill(worker, 0) == 0) {
+          (void) kill(worker, SIGKILL);
+        }
+      }
+      config::video.linux_display = linux_display;
+      auto restore_env = [](const char *name, const std::string &value, bool had_value) {
+        if (had_value) {
+          (void) setenv(name, value.c_str(), 1);
+        } else {
+          (void) unsetenv(name);
+        }
+      };
+      restore_env("PATH", original_path, had_path);
+      restore_env("HOME", original_home, had_home);
+      restore_env("XDG_RUNTIME_DIR", original_runtime_dir, had_runtime_dir);
+      restore_env("FAKE_LABWC_CHILD_PID_FILE", original_pid_file, had_pid_file);
+      restore_env("FAKE_LABWC_COMPOSITOR_PID_FILE", original_compositor_pid_file, had_compositor_pid_file);
+      std::error_code ec;
+      fs::remove_all(root, ec);
+    }
+  };
+
+  const auto *path_env = std::getenv("PATH");
+  const auto *home_env = std::getenv("HOME");
+  const auto *runtime_env = std::getenv("XDG_RUNTIME_DIR");
+  const auto *pid_file_env = std::getenv("FAKE_LABWC_CHILD_PID_FILE");
+  const auto *compositor_pid_file_env = std::getenv("FAKE_LABWC_COMPOSITOR_PID_FILE");
+  cleanup_t cleanup {
+    .linux_display = config::video.linux_display,
+    .original_path = path_env ? path_env : "",
+    .original_home = home_env ? home_env : "",
+    .original_runtime_dir = runtime_env ? runtime_env : "",
+    .original_pid_file = pid_file_env ? pid_file_env : "",
+    .original_compositor_pid_file = compositor_pid_file_env ? compositor_pid_file_env : "",
+    .had_path = path_env != nullptr,
+    .had_home = home_env != nullptr,
+    .had_runtime_dir = runtime_env != nullptr,
+    .had_pid_file = pid_file_env != nullptr,
+    .had_compositor_pid_file = compositor_pid_file_env != nullptr,
+    .root = fs::temp_directory_path() / ("polaris-cage-external-exit-" + std::to_string(getpid())),
+  };
+
+  const auto bin_dir = cleanup.root / "bin";
+  const auto runtime_dir = cleanup.root / "runtime";
+  const auto pid_file = cleanup.root / "worker.pid";
+  const auto compositor_pid_file = cleanup.root / "compositor.pid";
+  ASSERT_TRUE(fs::create_directories(bin_dir));
+  ASSERT_TRUE(fs::create_directories(runtime_dir));
+
+  const auto fake_labwc = bin_dir / "labwc";
+  {
+    std::ofstream script(fake_labwc);
+    ASSERT_TRUE(script.good());
+    script << R"PY(#!/usr/bin/python3
+import os
+import signal
+import socket
+import subprocess
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "-V":
+    print("fake labwc wlroots headless backend")
+    raise SystemExit(0)
+
+socket_path = os.path.join(os.environ["XDG_RUNTIME_DIR"], f"wayland-{(os.getpid() % 10000) + 100}")
+wayland_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+wayland_socket.bind(socket_path)
+worker = subprocess.Popen(["sleep", "60"])
+with open(os.environ["FAKE_LABWC_COMPOSITOR_PID_FILE"], "w", encoding="utf-8") as out:
+    out.write(f"{os.getpid()}\n")
+with open(os.environ["FAKE_LABWC_CHILD_PID_FILE"], "w", encoding="utf-8") as out:
+    out.write(f"{worker.pid}\n")
+
+def stop(_signum, _frame):
+    raise SystemExit(0)
+
+signal.signal(signal.SIGTERM, stop)
+signal.signal(signal.SIGINT, stop)
+signal.signal(signal.SIGHUP, stop)
+while True:
+    signal.pause()
+)PY";
+  }
+  ASSERT_EQ(chmod(fake_labwc.c_str(), 0755), 0);
+
+  const auto fake_wlr_randr = bin_dir / "wlr-randr";
+  {
+    std::ofstream script(fake_wlr_randr);
+    ASSERT_TRUE(script.good());
+    script << R"SH(#!/bin/sh
+if [ "$#" -eq 0 ]; then
+  cat <<'EOF'
+HEADLESS-1 "Fake headless output"
+  Enabled: yes
+  Modes:
+    1280x720 px, 60.000000 Hz (current)
+EOF
+fi
+exit 0
+)SH";
+  }
+  ASSERT_EQ(chmod(fake_wlr_randr.c_str(), 0755), 0);
+
+  config::video.linux_display.stream_mode.clear();
+  config::video.linux_display.private_runtime = "labwc";
+  config::video.linux_display.use_cage_compositor = true;
+  config::video.linux_display.headless_mode = true;
+  config::video.linux_display.prefer_gpu_native_capture = false;
+  config::video.linux_display.capture_profile = false;
+
+  const auto test_path = bin_dir.string() + ":" + cleanup.original_path;
+  ASSERT_EQ(setenv("PATH", test_path.c_str(), 1), 0);
+  ASSERT_EQ(setenv("HOME", cleanup.root.c_str(), 1), 0);
+  ASSERT_EQ(setenv("XDG_RUNTIME_DIR", runtime_dir.c_str(), 1), 0);
+  ASSERT_EQ(setenv("FAKE_LABWC_CHILD_PID_FILE", pid_file.c_str(), 1), 0);
+  ASSERT_EQ(setenv("FAKE_LABWC_COMPOSITOR_PID_FILE", compositor_pid_file.c_str(), 1), 0);
+
+  for (int cycle = 0; cycle < 2; ++cycle) {
+    std::error_code ec;
+    fs::remove(pid_file, ec);
+    fs::remove(compositor_pid_file, ec);
+    ASSERT_TRUE(cage_display_router::start(
+      1280,
+      720,
+      60,
+      "",
+      false,
+      false,
+      "external-exit-cycle-" + std::to_string(cycle)
+    ));
+
+    const auto router_pid = cage_display_router::get_pid();
+    ASSERT_GT(router_pid, 0);
+    const auto compositor_pid = wait_for_pid_file(compositor_pid_file);
+    ASSERT_GT(compositor_pid, 0);
+    EXPECT_NE(router_pid, compositor_pid);
+    EXPECT_EQ(getpgid(compositor_pid), compositor_pid);
+    EXPECT_NE(getpgid(compositor_pid), getpgrp());
+    const auto worker = wait_for_pid_file(pid_file);
+    ASSERT_GT(worker, 0);
+    cleanup.workers.push_back(worker);
+
+    ASSERT_EQ(kill(compositor_pid, SIGTERM), 0);
+    ASSERT_TRUE(wait_for_router_exit(std::chrono::seconds(3)));
+    cage_display_router::stop();
+
+    const bool worker_exited = wait_for_process_exit(worker, std::chrono::seconds(2));
+    EXPECT_TRUE(worker_exited)
+      << "cycle " << cycle << " leaked private worker pid " << worker;
+    if (worker_exited) {
+      cleanup.workers.pop_back();
+    }
+  }
+
+  // A compositor that cannot honor SIGTERM must still be drained by the
+  // supervisor's bounded escalation, not abandoned when stop() gives up.
+  std::error_code ec;
+  fs::remove(pid_file, ec);
+  fs::remove(compositor_pid_file, ec);
+  ASSERT_TRUE(cage_display_router::start(
+    1280,
+    720,
+    60,
+    "",
+    false,
+    false,
+    "explicit-stop-escalation"
+  ));
+  const auto stopped_compositor_pid = wait_for_pid_file(compositor_pid_file);
+  ASSERT_GT(stopped_compositor_pid, 0);
+  const auto stopped_worker_pid = wait_for_pid_file(pid_file);
+  ASSERT_GT(stopped_worker_pid, 0);
+  cleanup.workers.push_back(stopped_worker_pid);
+
+  ASSERT_EQ(kill(stopped_compositor_pid, SIGSTOP), 0);
+  cage_display_router::stop();
+  const bool stopped_worker_exited = wait_for_process_exit(stopped_worker_pid, std::chrono::seconds(2));
+  EXPECT_TRUE(stopped_worker_exited)
+    << "explicit stop leaked private worker pid " << stopped_worker_pid;
+  if (stopped_worker_exited) {
+    cleanup.workers.pop_back();
+  }
+}
+
 TEST(WaylandInterfaceTests, RemovedOutputMarksDirtyButKeepsMonitorStorageUntilReinit) {
   wl::interface_t interface;
 


### PR DESCRIPTION
## Summary

- put each private labwc generation behind a stable, pidfd-tracked supervisor that anchors the private session/process group
- keep labwc and its startup descendants inside that group, subreap them on compositor exit, and drain them before the supervisor exits
- pidfd-SIGSTOP the supervisor before last-resort group signaling so the PGID cannot be recycled under forced cleanup
- preserve safe fallback behavior when pidfd_open is unavailable: once waitpid reaps the supervisor, no later raw PID liveness or signal check runs
- add real process-level regression coverage for two menu-style compositor exits, frozen-compositor escalation, frozen-supervisor hard fallback, pidfd-unavailable cleanup, worker cleanup, and supervisor reaping

## Root cause

The direct labwc child doubled as both compositor and lifecycle anchor. If labwc exited from its own menu, its startup client (`exec sleep infinity` for a Desktop session or capability probe) could remain alive. The router then saw the compositor pidfd as exited, reaped/cleared only the compositor state, and left the remaining private process without a safe group owner.

The outer exact-generation cleanup cannot cover every instance of this: live pc-papi evidence included two orphaned `sleep infinity` processes whose original labwc session/PGID leaders were gone and whose environments had no `POLARIS_SESSION_INSTANCE_ID`, matching tokenless runtime starts such as probes.

## Fix

The direct child is now a small supervisor and the immutable leader of the private session/process group. labwc is forked beneath it. The supervisor is also a child subreaper, so when labwc exits it adopts and reaps the remaining private descendants. Graceful cleanup broadcasts SIGTERM inside the anchored group; stubborn descendants trigger a final group SIGKILL that includes the supervisor itself.

Normal Polaris stop signals only the pidfd-bound supervisor. If the supervisor is wedged, the parent first freezes that exact pidfd generation with SIGSTOP, then kills the still-anchored group and synchronously reaps the supervisor. If pidfd_open is unavailable, a successful waitpid/ECHILD result permanently suppresses later numeric-PID liveness or signal checks, closing the reuse race found in review.

## Regression

`CageDisplayRouterLifecycleTests.ExternalExitDrainsPrivateChildrenAcrossRelaunch` uses real Linux processes, Unix sockets, sessions, process groups, and signals. It verifies:

1. start a fake labwc generation with a private worker
2. terminate the compositor as if Exit was selected from the labwc menu
3. confirm the supervisor and worker are gone
4. repeat the full launch/exit cycle
5. freeze the compositor and verify bounded supervisor escalation drains it
6. freeze the supervisor and verify the parent hard fallback kills the anchored group and reaps the supervisor
7. force pidfd_open failure and verify external exit still reaps safely without a post-wait raw-PID check

Before the fix, both first and second external-exit cycles leaked their workers. The frozen-supervisor review regression also left both compositor and worker alive. Both paths are green now.

## Verification

- `git diff --check`
- full production target built: `build/polaris-1.3.7.e756c60e`
- focused lifecycle regression: passed
- exact-generation/process migration regression: 86 tests passed
- full CTest matrix: 17/17 targets passed, 0 failed
- release compile command contains `-O3 -DNDEBUG`, not the old accidental target-wide `-O0`
- first draft CI on commit `5895e4b9`: CodeQL, sanitizer, Arch, Fedora, Ubuntu, public-hygiene and web checks passed before the reviewed hardening follow-up

A live Moonlight smoke was not run because pc-papi currently has an active service-launched Polaris, a desktop-launched Polaris unit, two pre-existing orphaned labwc `sleep infinity` children, and another heavy build lane. Starting another live runtime on top of that would make the result ambiguous and risk disrupting active work.

Source report: https://www.reddit.com/r/MoonlightStreaming/comments/1vejx1w/comment/p2g2fte/
