### PR TITLE
fix(telemetry): session-generation safety and duration validation (P0-3A inc.2)

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -333,9 +333,9 @@
         "capture_to_encode",
         "capture_to_send",
         "encode_to_send",
-        "epoch_start_ns",
         "ring_complete",
         "session_active",
+        "session_generation",
         "stage_vocabulary"
       ],
       "polaris_emitter": {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -738,7 +738,8 @@ namespace nvhttp {
         return nlohmann::json {
           {"p50_ms", p.p50_ms},
           {"p99_ms", p.p99_ms},
-          {"sample_count", p.sample_count}
+          {"sample_count", p.sample_count},
+          {"invalid_count", p.invalid_count}
         };
       };
 
@@ -748,7 +749,7 @@ namespace nvhttp {
       output["capture_to_send"] = percentile_json(timing.capture_to_send);
       output["stage_vocabulary"] = "T0=capture frame available, T1=encoder finished this frame, T2=packet handed off to send-thread packetization (before FEC/encrypt/pace/sendmsg)";
       output["session_active"] = timing.session_active;
-      output["epoch_start_ns"] = timing.epoch_start_ns;
+      output["session_generation"] = timing.session_generation;
       output["ring_complete"] = timing.ring_complete;
       return output;
     }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -462,6 +462,13 @@ namespace stream {
     std::string device_name;
     std::string device_uuid;
     std::string session_token;
+
+    // Process-lifetime-monotonic, assigned fresh in alloc() for every
+    // session_t - unlike device_uuid, never repeats across a reconnect.
+    // stream_stats uses this to reject a stale write/stop that arrives
+    // after this uuid's slot has already been handed to a newer session.
+    std::uint64_t session_generation = 0;
+
     bool watch_only;
     int requested_fps = 0;
     int session_target_fps = 0;
@@ -1522,7 +1529,7 @@ namespace stream {
         frame_processing_latency_logger.collect_and_log(latency / 10.);
 
         if (packet->encode_done_timestamp) {
-          stream_stats::record_frame_timing(session->device_uuid, *packet->frame_timestamp, *packet->encode_done_timestamp, t2_send_time);
+          stream_stats::record_frame_timing(session->device_uuid, session->session_generation, *packet->frame_timestamp, *packet->encode_done_timestamp, t2_send_time);
         }
       } else {
         frame_header.frame_processing_latency = 0;
@@ -2081,6 +2088,10 @@ namespace stream {
   namespace session {
     std::atomic_uint running_sessions;
 
+    // Source of session_t::session_generation. Starts at 1 so 0 stays
+    // available as an obviously-invalid/unset sentinel.
+    std::atomic<std::uint64_t> next_session_generation {1};
+
     unsigned active_count() {
       return running_sessions.load(std::memory_order_relaxed);
     }
@@ -2240,7 +2251,7 @@ namespace stream {
 
       // Remove this client from multi-client stats
       stream_stats::remove_client(session.control.expected_peer_address);
-      stream_stats::stop_session_timing(session.device_uuid);
+      stream_stats::stop_session_timing(session.device_uuid, session.session_generation);
 
       // If this is the last session, invoke the platform callbacks
       auto remaining = --running_sessions;
@@ -2335,7 +2346,7 @@ namespace stream {
 
       // Track this client in multi-client stats
       stream_stats::add_client(addr_string, session.device_name);
-      stream_stats::start_session_timing(session.device_uuid);
+      stream_stats::start_session_timing(session.device_uuid, session.session_generation);
       stream_stats::update_session_targets(
         session.requested_fps > 0 ? static_cast<double>(session.requested_fps) / 1000.0 : 0.0,
         session.session_target_fps > 0 ? static_cast<double>(session.session_target_fps) / 1000.0 : 0.0,
@@ -2417,6 +2428,7 @@ namespace stream {
       session->device_name = launch_session.device_name;
       session->device_uuid = launch_session.unique_id;
       session->session_token = launch_session.session_token;
+      session->session_generation = next_session_generation.fetch_add(1, std::memory_order_relaxed);
       session->requested_fps = launch_session.requested_fps;
       session->session_target_fps = launch_session.fps;
       session->pacing_policy = launch_session.pacing_policy;

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -191,6 +191,12 @@ namespace stream_stats {
       std::size_t next_index = 0;
       std::size_t filled = 0;
 
+      // Rejected (negative/non-monotonic) samples for this stage - see
+      // record_frame_timing()'s validation. Counted here rather than in
+      // session_timing_state_t so each of the three stages tracks its own
+      // rejection count independently.
+      int invalid_count = 0;
+
       void push(double value_ms) {
         samples_ms[next_index] = value_ms;
         next_index = (next_index + 1) % FRAME_TIMING_RING_CAPACITY;
@@ -199,7 +205,7 @@ namespace stream_stats {
 
       frame_timing_percentiles_t percentiles() const {
         if (filled == 0) {
-          return {};
+          return {0, 0, 0, invalid_count};
         }
         std::vector<double> sorted(samples_ms.begin(), samples_ms.begin() + static_cast<long>(filled));
         std::sort(sorted.begin(), sorted.end());
@@ -207,7 +213,7 @@ namespace stream_stats {
           auto idx = static_cast<std::size_t>(p * static_cast<double>(sorted.size() - 1));
           return sorted[idx];
         };
-        return {pick(0.50), pick(0.99), static_cast<int>(filled)};
+        return {pick(0.50), pick(0.99), static_cast<int>(filled), invalid_count};
       }
     };
 
@@ -217,10 +223,17 @@ namespace stream_stats {
     // hashed lookup without being any slower at this size.
     struct session_timing_state_t {
       std::string device_uuid;
+
+      // Matches the owning session_t::session_generation. A reconnecting
+      // device reuses device_uuid but gets a new generation, which is what
+      // lets record_frame_timing()/stop_session_timing() tell a stale
+      // write/stop (from a session that already lost its uuid slot) apart
+      // from a legitimate one.
+      std::uint64_t session_generation = 0;
+
       timing_ring_t capture_to_encode_ring;
       timing_ring_t encode_to_send_ring;
       timing_ring_t capture_to_send_ring;
-      std::chrono::steady_clock::time_point epoch_start;
     };
 
     std::mutex frame_timing_mutex;
@@ -1210,7 +1223,7 @@ namespace stream_stats {
     bucket.total_us.clear();
   }
 
-  void start_session_timing(const std::string &device_uuid) {
+  void start_session_timing(const std::string &device_uuid, std::uint64_t session_generation) {
     std::lock_guard<std::mutex> lock(frame_timing_mutex);
     session_timings.erase(
       std::remove_if(session_timings.begin(), session_timings.end(),
@@ -1219,34 +1232,42 @@ namespace stream_stats {
 
     session_timing_state_t state;
     state.device_uuid = device_uuid;
-    state.epoch_start = std::chrono::steady_clock::now();
+    state.session_generation = session_generation;
     session_timings.push_back(std::move(state));
   }
 
-  void stop_session_timing(const std::string &device_uuid) {
+  void stop_session_timing(const std::string &device_uuid, std::uint64_t session_generation) {
     std::lock_guard<std::mutex> lock(frame_timing_mutex);
     session_timings.erase(
       std::remove_if(session_timings.begin(), session_timings.end(),
-        [&device_uuid](const session_timing_state_t &s) { return s.device_uuid == device_uuid; }),
+        [&device_uuid, session_generation](const session_timing_state_t &s) {
+          return s.device_uuid == device_uuid && s.session_generation == session_generation;
+        }),
       session_timings.end());
   }
 
   void record_frame_timing(const std::string &device_uuid,
+                           std::uint64_t session_generation,
                            std::chrono::steady_clock::time_point capture_time,
                            std::chrono::steady_clock::time_point encode_done_time,
                            std::chrono::steady_clock::time_point send_time) {
-    auto to_ms = [](std::chrono::steady_clock::duration d) {
-      return std::chrono::duration<double, std::milli>(d).count();
-    };
-
     std::lock_guard<std::mutex> lock(frame_timing_mutex);
     auto *state = find_session_timing_locked(device_uuid);
-    if (!state) {
+    if (!state || state->session_generation != session_generation) {
       return;
     }
-    state->capture_to_encode_ring.push(to_ms(encode_done_time - capture_time));
-    state->encode_to_send_ring.push(to_ms(send_time - encode_done_time));
-    state->capture_to_send_ring.push(to_ms(send_time - capture_time));
+
+    auto record_stage = [](timing_ring_t &ring, std::chrono::steady_clock::duration d) {
+      if (d < std::chrono::steady_clock::duration::zero()) {
+        ring.invalid_count++;
+        return;
+      }
+      ring.push(std::chrono::duration<double, std::milli>(d).count());
+    };
+
+    record_stage(state->capture_to_encode_ring, encode_done_time - capture_time);
+    record_stage(state->encode_to_send_ring, send_time - encode_done_time);
+    record_stage(state->capture_to_send_ring, send_time - capture_time);
   }
 
   session_timing_t get_session_timing(const std::string &device_uuid) {
@@ -1261,8 +1282,7 @@ namespace stream_stats {
       state->encode_to_send_ring.percentiles(),
       state->capture_to_send_ring.percentiles()
     };
-    result.epoch_start_ns = static_cast<std::uint64_t>(
-      std::chrono::duration_cast<std::chrono::nanoseconds>(state->epoch_start.time_since_epoch()).count());
+    result.session_generation = state->session_generation;
     result.session_active = true;
     result.ring_complete = state->capture_to_encode_ring.filled < FRAME_TIMING_RING_CAPACITY;
     return result;

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -433,6 +433,11 @@ namespace stream_stats {
     double p50_ms = 0;
     double p99_ms = 0;
     int sample_count = 0;
+
+    /// Samples rejected for a non-monotonic or negative stage duration
+    /// (e.g. a corrupted or misordered timestamp pair). Counted, not
+    /// silently dropped - and never folded into p50_ms/p99_ms/sample_count.
+    int invalid_count = 0;
   };
 
   /**
@@ -465,15 +470,18 @@ namespace stream_stats {
     frame_timing_percentiles_t capture_to_send;  ///< T0 -> T2
 
     /**
-     * Opaque, same-process-only marker of which "epoch" (continuous span
-     * between start_session_timing() and stop_session_timing()) produced
-     * this snapshot. A steady_clock::now().time_since_epoch() count in
-     * nanoseconds - not a wall-clock timestamp, not meaningful across a
-     * host restart. Two reads with the same value are from the same
-     * uninterrupted session; a changed value means the session was torn
-     * down and restarted (e.g. a reconnect) between reads.
+     * The session_t generation that produced this snapshot - a
+     * process-lifetime-monotonic counter assigned once per session_t
+     * allocation (session_t::session_generation), not per device. Two
+     * sessions from the same reconnecting device get different
+     * generations even though they share the same device_uuid, which is
+     * what lets record_frame_timing()/stop_session_timing() reject a
+     * write or stop from a session that already lost ownership of its
+     * uuid slot to a newer generation, instead of corrupting or
+     * prematurely discarding the new one. A changed value between two
+     * reads means the session was torn down and restarted between them.
      */
-    std::uint64_t epoch_start_ns = 0;
+    std::uint64_t session_generation = 0;
 
     /// Whether the queried device_uuid currently has any timing state at
     /// all. False (with all percentiles empty) means no session is active
@@ -484,7 +492,7 @@ namespace stream_stats {
     /// True until this session's rings wrap. False means the ring evicted
     /// its oldest samples to make room for newer ones, so the percentiles
     /// above reflect only the most recent capacity's worth of frames, not
-    /// every frame since epoch_start_ns.
+    /// every frame since this generation started.
     bool ring_complete = false;
   };
 
@@ -493,31 +501,45 @@ namespace stream_stats {
    * for one device. Call once the session is admitted, alongside
    * add_client(). An existing entry for the same uuid is discarded and
    * replaced with a fresh, empty one - this is how a reconnecting device
-   * gets a clean epoch rather than inheriting its previous session's tail.
+   * gets a clean generation rather than inheriting its previous session's
+   * tail.
    * @param device_uuid The connecting device's paired UUID (session_t::device_uuid).
+   * @param session_generation The new session_t's own generation (session_t::session_generation).
    */
-  void start_session_timing(const std::string &device_uuid);
+  void start_session_timing(const std::string &device_uuid, std::uint64_t session_generation);
 
   /**
-   * @brief Stop and discard per-session T0-T2 timing state for one device.
-   * Call once the session has fully ended, alongside remove_client().
+   * @brief Stop and discard per-session T0-T2 timing state for one device -
+   * but only if session_generation still matches the currently-registered
+   * generation for that uuid. A stop from a generation that already lost
+   * its uuid slot to a newer session (e.g. a fast reconnect racing this
+   * session's own teardown) is a safe no-op, so it cannot discard the
+   * newer session's state.
    * @param device_uuid The device UUID passed to the matching start_session_timing().
+   * @param session_generation The generation passed to that same start_session_timing() call.
    */
-  void stop_session_timing(const std::string &device_uuid);
+  void stop_session_timing(const std::string &device_uuid, std::uint64_t session_generation);
 
   /**
    * @brief Record one frame's T0/T1/T2 timestamps into device_uuid's
    * session timing histograms. Wire-format telemetry
    * (frame_processing_latency) is untouched by this - this is purely an
    * additional, out-of-band record. A no-op if device_uuid has no active
-   * timing state (e.g. a few packets still in flight right as a session
-   * tears down) - there is nowhere safe to attribute the sample.
+   * timing state, or if session_generation no longer matches the
+   * currently-registered generation (a stale write from a session that
+   * already retired and lost its uuid slot to a newer one - e.g. packets
+   * still draining through the send thread right as a fast reconnect
+   * hands the same uuid to a new session). Per-stage durations that come
+   * out negative or non-monotonic are rejected and counted rather than
+   * silently corrupting the percentiles.
    * @param device_uuid The frame's owning session (session_t::device_uuid).
+   * @param session_generation The frame's owning session's generation (session_t::session_generation).
    * @param capture_time T0.
    * @param encode_done_time T1.
    * @param send_time T2.
    */
   void record_frame_timing(const std::string &device_uuid,
+                           std::uint64_t session_generation,
                            std::chrono::steady_clock::time_point capture_time,
                            std::chrono::steady_clock::time_point encode_done_time,
                            std::chrono::steady_clock::time_point send_time);

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -777,11 +777,19 @@ TEST(StreamStatsHotFieldTests, UpdateNetworkStatsIsVisibleThroughGetCurrent) {
   stream_stats::update_stream_active(false);
 }
 
-// P0-3A: T0-T2 timing state is now per-session, keyed by device_uuid, with
-// real start/stop lifecycle primitives (mirroring add_client()/remove_client()
-// in stream.cpp). That gives every test below a genuinely clean, isolated
-// slate via a unique uuid + start_session_timing() - no more need to
-// flood-fill past a shared ring's capacity to drown out other tests' state.
+// P0-3A: T0-T2 timing state is per-session, keyed by device_uuid plus a
+// session_generation (measurement-spec-v1.md's ownership model - a
+// process-lifetime-monotonic counter, distinct from device_uuid, assigned
+// fresh to every session_t including a reconnecting device that reuses its
+// uuid). start_session_timing()/stop_session_timing() mirror
+// add_client()/remove_client() in stream.cpp. Real lifecycle primitives give
+// every test below a genuinely clean, isolated slate via a unique uuid - no
+// need to flood-fill past a shared ring's capacity to drown out other
+// tests' state. Generation numbers in these tests are arbitrary opaque
+// values chosen for readability, not the real global counter in stream.cpp
+// (start_session_timing()/record_frame_timing() take whatever the caller
+// hands them - stream.cpp's session_t::session_generation is just one
+// caller).
 
 TEST(StreamStatsSessionTimingTests, RecordFrameTimingReportsExactPercentilesForAFreshSession) {
   using namespace std::chrono;
@@ -790,20 +798,21 @@ TEST(StreamStatsSessionTimingTests, RecordFrameTimingReportsExactPercentilesForA
   const auto t1 = t0 + milliseconds(3);
   const auto t2 = t1 + milliseconds(2);
 
-  stream_stats::start_session_timing(uuid);
+  stream_stats::start_session_timing(uuid, 1);
   for (int i = 0; i < 10; ++i) {
-    stream_stats::record_frame_timing(uuid, t0, t1, t2);
+    stream_stats::record_frame_timing(uuid, 1, t0, t1, t2);
   }
 
   const auto timing = stream_stats::get_session_timing(uuid);
 
   EXPECT_TRUE(timing.session_active);
   EXPECT_TRUE(timing.ring_complete);
-  EXPECT_NE(timing.epoch_start_ns, 0u);
+  EXPECT_EQ(timing.session_generation, 1u);
 
   EXPECT_DOUBLE_EQ(timing.capture_to_encode.p50_ms, 3.0);
   EXPECT_DOUBLE_EQ(timing.capture_to_encode.p99_ms, 3.0);
   EXPECT_EQ(timing.capture_to_encode.sample_count, 10);
+  EXPECT_EQ(timing.capture_to_encode.invalid_count, 0);
 
   EXPECT_DOUBLE_EQ(timing.encode_to_send.p50_ms, 2.0);
   EXPECT_EQ(timing.encode_to_send.sample_count, 10);
@@ -811,13 +820,13 @@ TEST(StreamStatsSessionTimingTests, RecordFrameTimingReportsExactPercentilesForA
   EXPECT_DOUBLE_EQ(timing.capture_to_send.p50_ms, 5.0);
   EXPECT_EQ(timing.capture_to_send.sample_count, 10);
 
-  stream_stats::stop_session_timing(uuid);
+  stream_stats::stop_session_timing(uuid, 1);
 }
 
 TEST(StreamStatsSessionTimingTests, SessionWithNoRecordedFramesReportsActiveButEmpty) {
   const std::string uuid = "test-uuid-active-empty";
 
-  stream_stats::start_session_timing(uuid);
+  stream_stats::start_session_timing(uuid, 1);
   const auto timing = stream_stats::get_session_timing(uuid);
 
   EXPECT_TRUE(timing.session_active);
@@ -825,7 +834,7 @@ TEST(StreamStatsSessionTimingTests, SessionWithNoRecordedFramesReportsActiveButE
   EXPECT_EQ(timing.encode_to_send.sample_count, 0);
   EXPECT_EQ(timing.capture_to_send.sample_count, 0);
 
-  stream_stats::stop_session_timing(uuid);
+  stream_stats::stop_session_timing(uuid, 1);
 }
 
 TEST(StreamStatsSessionTimingTests, RecordFrameTimingIsANoOpForASessionThatWasNeverStarted) {
@@ -836,7 +845,7 @@ TEST(StreamStatsSessionTimingTests, RecordFrameTimingIsANoOpForASessionThatWasNe
   // No start_session_timing() call - there is nowhere safe to attribute
   // this sample, so it must be silently dropped rather than crash or
   // fabricate a phantom session.
-  stream_stats::record_frame_timing(uuid, t0, t0, t0);
+  stream_stats::record_frame_timing(uuid, 1, t0, t0, t0);
 
   const auto timing = stream_stats::get_session_timing(uuid);
   EXPECT_FALSE(timing.session_active);
@@ -845,7 +854,11 @@ TEST(StreamStatsSessionTimingTests, RecordFrameTimingIsANoOpForASessionThatWasNe
 
 // The fix this whole slice is about: two concurrent sessions (Polaris runs
 // one independent encoder per client, default max_sessions 2) must not see
-// each other's frame timings.
+// each other's frame timings. Different uuids here also stands in for
+// measurement-spec-v1.md's "two sessions share one source IP" case
+// (§15.1.3): stream_stats never sees an IP at all, only device_uuid, so
+// nothing about a shared source address could make two distinct uuids
+// collide in the first place.
 TEST(StreamStatsSessionTimingTests, TwoConcurrentSessionsDoNotShareTimingState) {
   using namespace std::chrono;
   const std::string uuid_a = "test-uuid-concurrent-a";
@@ -854,12 +867,12 @@ TEST(StreamStatsSessionTimingTests, TwoConcurrentSessionsDoNotShareTimingState) 
   const auto fast = t0 + milliseconds(1);
   const auto slow = t0 + milliseconds(11);
 
-  stream_stats::start_session_timing(uuid_a);
-  stream_stats::start_session_timing(uuid_b);
+  stream_stats::start_session_timing(uuid_a, 1);
+  stream_stats::start_session_timing(uuid_b, 2);
 
   for (int i = 0; i < 5; ++i) {
-    stream_stats::record_frame_timing(uuid_a, t0, t0, fast);
-    stream_stats::record_frame_timing(uuid_b, t0, t0, slow);
+    stream_stats::record_frame_timing(uuid_a, 1, t0, t0, fast);
+    stream_stats::record_frame_timing(uuid_b, 2, t0, t0, slow);
   }
 
   const auto timing_a = stream_stats::get_session_timing(uuid_a);
@@ -871,8 +884,8 @@ TEST(StreamStatsSessionTimingTests, TwoConcurrentSessionsDoNotShareTimingState) 
   EXPECT_DOUBLE_EQ(timing_b.capture_to_send.p50_ms, 11.0);
   EXPECT_EQ(timing_b.capture_to_send.sample_count, 5);
 
-  stream_stats::stop_session_timing(uuid_a);
-  stream_stats::stop_session_timing(uuid_b);
+  stream_stats::stop_session_timing(uuid_a, 1);
+  stream_stats::stop_session_timing(uuid_b, 2);
 }
 
 TEST(StreamStatsSessionTimingTests, StopSessionTimingDiscardsState) {
@@ -880,35 +893,119 @@ TEST(StreamStatsSessionTimingTests, StopSessionTimingDiscardsState) {
   const std::string uuid = "test-uuid-stop-discards";
   const auto t0 = steady_clock::now();
 
-  stream_stats::start_session_timing(uuid);
-  stream_stats::record_frame_timing(uuid, t0, t0, t0 + std::chrono::milliseconds(4));
+  stream_stats::start_session_timing(uuid, 1);
+  stream_stats::record_frame_timing(uuid, 1, t0, t0, t0 + std::chrono::milliseconds(4));
   ASSERT_TRUE(stream_stats::get_session_timing(uuid).session_active);
 
-  stream_stats::stop_session_timing(uuid);
+  stream_stats::stop_session_timing(uuid, 1);
 
   EXPECT_FALSE(stream_stats::get_session_timing(uuid).session_active);
 }
 
-TEST(StreamStatsSessionTimingTests, RestartingASessionGetsAFreshEpochAndDiscardsOldSamples) {
+TEST(StreamStatsSessionTimingTests, RestartingASessionGetsAFreshGenerationAndDiscardsOldSamples) {
   using namespace std::chrono;
   const std::string uuid = "test-uuid-reconnect";
   const auto t0 = steady_clock::now();
 
-  stream_stats::start_session_timing(uuid);
-  stream_stats::record_frame_timing(uuid, t0, t0, t0 + milliseconds(4));
-  const auto first_epoch = stream_stats::get_session_timing(uuid);
-  ASSERT_EQ(first_epoch.capture_to_send.sample_count, 1);
-  stream_stats::stop_session_timing(uuid);
+  stream_stats::start_session_timing(uuid, 1);
+  stream_stats::record_frame_timing(uuid, 1, t0, t0, t0 + milliseconds(4));
+  const auto first = stream_stats::get_session_timing(uuid);
+  ASSERT_EQ(first.capture_to_send.sample_count, 1);
+  stream_stats::stop_session_timing(uuid, 1);
 
-  // Same device reconnecting - same uuid, new session.
-  stream_stats::start_session_timing(uuid);
-  const auto second_epoch = stream_stats::get_session_timing(uuid);
+  // Same device reconnecting - same uuid, new (higher) generation, matching
+  // stream.cpp's next_session_generation: it only ever increases.
+  stream_stats::start_session_timing(uuid, 2);
+  const auto second = stream_stats::get_session_timing(uuid);
 
-  EXPECT_TRUE(second_epoch.session_active);
-  EXPECT_NE(second_epoch.epoch_start_ns, first_epoch.epoch_start_ns);
-  EXPECT_EQ(second_epoch.capture_to_send.sample_count, 0);
+  EXPECT_TRUE(second.session_active);
+  EXPECT_GT(second.session_generation, first.session_generation);
+  EXPECT_EQ(second.capture_to_send.sample_count, 0);
 
-  stream_stats::stop_session_timing(uuid);
+  stream_stats::stop_session_timing(uuid, 2);
+}
+
+// measurement-spec-v1.md §6.1/§15.1.2: "Old queued work drains after A
+// retires. It cannot mutate B." The video send thread reads a packet's
+// owning session_t (and hence its device_uuid/session_generation) from a
+// queue that can still hold a few of session A's already-encoded packets
+// at the exact moment A retires and a fast reconnect hands the same
+// device_uuid to session B. Without the generation check, those stale
+// writes would land in B's fresh state under A's old device_uuid.
+TEST(StreamStatsSessionTimingTests, StaleGenerationWriteIsRejectedAfterANewerSessionTakesTheUuid) {
+  using namespace std::chrono;
+  const std::string uuid = "test-uuid-stale-write";
+  const auto t0 = steady_clock::now();
+
+  stream_stats::start_session_timing(uuid, 1);
+  stream_stats::stop_session_timing(uuid, 1);  // Session A retires...
+  stream_stats::start_session_timing(uuid, 2);  // ...B immediately reconnects.
+
+  // A late-arriving packet from the drained queue, still carrying A's old
+  // generation.
+  stream_stats::record_frame_timing(uuid, 1, t0, t0, t0 + milliseconds(4));
+
+  const auto timing = stream_stats::get_session_timing(uuid);
+  EXPECT_EQ(timing.session_generation, 2u);
+  EXPECT_EQ(timing.capture_to_send.sample_count, 0)
+    << "session A's stale write must not appear in session B's data";
+
+  stream_stats::stop_session_timing(uuid, 2);
+}
+
+// The other half of the same race: a stop() call for a retired generation
+// must not discard a newer session's state, even though it targets the
+// same device_uuid.
+TEST(StreamStatsSessionTimingTests, StaleGenerationStopDoesNotDiscardANewerSessionsState) {
+  using namespace std::chrono;
+  const std::string uuid = "test-uuid-stale-stop";
+  const auto t0 = steady_clock::now();
+
+  stream_stats::start_session_timing(uuid, 1);
+  stream_stats::start_session_timing(uuid, 2);  // B has already taken over.
+  stream_stats::record_frame_timing(uuid, 2, t0, t0, t0 + milliseconds(4));
+
+  // A's teardown path calls stop_session_timing() after B already exists.
+  stream_stats::stop_session_timing(uuid, 1);
+
+  const auto timing = stream_stats::get_session_timing(uuid);
+  EXPECT_TRUE(timing.session_active) << "B's session must survive A's stale stop";
+  EXPECT_EQ(timing.session_generation, 2u);
+  EXPECT_EQ(timing.capture_to_send.sample_count, 1);
+
+  stream_stats::stop_session_timing(uuid, 2);
+}
+
+// measurement-spec-v1.md §15.1.8: negative or non-monotonic durations
+// (a corrupted or misordered timestamp pair) must be rejected and counted,
+// never pushed into the percentile ring.
+TEST(StreamStatsSessionTimingTests, NegativeOrNonMonotonicDurationsAreRejectedAndCounted) {
+  using namespace std::chrono;
+  const std::string uuid = "test-uuid-invalid-durations";
+  const auto t0 = steady_clock::now();
+
+  stream_stats::start_session_timing(uuid, 1);
+
+  // encode_done_time before capture_time: capture_to_encode and
+  // capture_to_send both go negative; encode_to_send stays valid (positive).
+  stream_stats::record_frame_timing(uuid, 1, t0, t0 - milliseconds(1), t0 + milliseconds(5));
+  // A fully valid sample too, to prove valid and invalid samples don't
+  // interfere with each other's bookkeeping.
+  stream_stats::record_frame_timing(uuid, 1, t0, t0 + milliseconds(2), t0 + milliseconds(5));
+
+  const auto timing = stream_stats::get_session_timing(uuid);
+
+  EXPECT_EQ(timing.capture_to_encode.invalid_count, 1);
+  EXPECT_EQ(timing.capture_to_encode.sample_count, 1);
+
+  EXPECT_EQ(timing.capture_to_send.invalid_count, 0)
+    << "t0 -> t2 stayed monotonic in both samples even though t0 -> t1 didn't";
+  EXPECT_EQ(timing.capture_to_send.sample_count, 2);
+
+  EXPECT_EQ(timing.encode_to_send.invalid_count, 0);
+  EXPECT_EQ(timing.encode_to_send.sample_count, 2);
+
+  stream_stats::stop_session_timing(uuid, 1);
 }
 
 // Mixing two distinct values should keep p50 and p99 both within the
@@ -922,12 +1019,12 @@ TEST(StreamStatsSessionTimingTests, RecordFrameTimingMixedValuesStayWithinObserv
   const auto fast_t2 = t0 + milliseconds(1);
   const auto slow_t2 = t0 + milliseconds(9);
 
-  stream_stats::start_session_timing(uuid);
+  stream_stats::start_session_timing(uuid, 1);
   for (int i = 0; i < 300; ++i) {
-    stream_stats::record_frame_timing(uuid, t0, t0, fast_t2);
+    stream_stats::record_frame_timing(uuid, 1, t0, t0, fast_t2);
   }
   for (int i = 0; i < 300; ++i) {
-    stream_stats::record_frame_timing(uuid, t0, t0, slow_t2);
+    stream_stats::record_frame_timing(uuid, 1, t0, t0, slow_t2);
   }
 
   const auto timing = stream_stats::get_session_timing(uuid);
@@ -938,7 +1035,7 @@ TEST(StreamStatsSessionTimingTests, RecordFrameTimingMixedValuesStayWithinObserv
   EXPECT_LE(timing.capture_to_send.p99_ms, 9.0);
   EXPECT_EQ(timing.capture_to_send.sample_count, 600);
 
-  stream_stats::stop_session_timing(uuid);
+  stream_stats::stop_session_timing(uuid, 1);
 }
 
 // The ring capacity (16384, matching FRAME_TIMING_RING_CAPACITY in
@@ -954,9 +1051,9 @@ TEST(StreamStatsSessionTimingTests, RingWrapsAndReportsIncompleteOnceCapacityIsE
   const auto t2 = t0 + milliseconds(7);
   constexpr int kRingCapacity = 16384;
 
-  stream_stats::start_session_timing(uuid);
+  stream_stats::start_session_timing(uuid, 1);
   for (int i = 0; i < kRingCapacity + 100; ++i) {
-    stream_stats::record_frame_timing(uuid, t0, t0, t2);
+    stream_stats::record_frame_timing(uuid, 1, t0, t0, t2);
   }
 
   const auto timing = stream_stats::get_session_timing(uuid);
@@ -968,5 +1065,5 @@ TEST(StreamStatsSessionTimingTests, RingWrapsAndReportsIncompleteOnceCapacityIsE
   EXPECT_DOUBLE_EQ(timing.capture_to_send.p50_ms, 7.0);
   EXPECT_DOUBLE_EQ(timing.capture_to_send.p99_ms, 7.0);
 
-  stream_stats::stop_session_timing(uuid);
+  stream_stats::stop_session_timing(uuid, 1);
 }


### PR DESCRIPTION
## Summary

Second P0-3A increment. A parallel process produced `measurement-spec-v1.md` (`~/.hermes/artifacts/polaris/nordstern/`) the same day the first increment ([papi-ux/polaris#323](https://github.com/papi-ux/polaris/pull/323)) shipped - a formal ownership-model contract, considerably more detailed than what #323 built. Papi's call: merge #323 as-is (it fixed a real bug) and treat the spec as the *next* increment rather than a reason to redo it. This PR is that increment's first slice, scoped to two of the spec's named P0-3A defects (§15.1 items #2 and #8) - not the full spec, which also calls for a much richer identity model (`session_id`/`process_instance_id`/`client_population_revision`), a whole benchmark-run-capture control plane (§6.4 - closer to P0-5 itself), full schema v2 (`p95`, a `window{}` object), and a new P0-4A slice on Nova. Those remain open.

- **Fixes a real race, not just a spec-compliance gap.** #323 keyed T0-T2 state by `device_uuid` alone. The video send thread processes packets off a queue, so a session that just retired can still have a few already-encoded packets in flight. If a reconnecting device grabs the same `device_uuid` before that queue drains, the old session's trailing writes would land in the new session's fresh state - `record_frame_timing()` had no way to tell "this uuid's current owner" from "this uuid's previous owner, mid-drain."
- **Adds `session_generation`**: a process-lifetime-monotonic counter on `session_t`, assigned fresh in `alloc()`, that a reconnecting device does *not* reuse even though its `device_uuid` stays the same. `record_frame_timing()`/`stop_session_timing()` now take it and silently no-op if it no longer matches the currently-registered generation for that uuid.
- **Rejects and counts invalid durations** (measurement-spec-v1.md §15.1.8): a negative or non-monotonic per-stage duration (a corrupted or misordered timestamp pair) now increments a new `invalid_count` per stage instead of being pushed into the percentile ring uncritically.
- **Retires `epoch_start_ns`**, replaced by `session_generation` - same read-side purpose (detect a reconnect between two polls) but `session_generation` also does the write-path staleness check, so there's no reason to carry both.

## Exact candidate

```
Commit: 065f12d0d59819f8d121ba29e94c475e9897077c
Tree:   bd5c08a807e053e6754a711d782c34412a743052
Parent: e570deac8fdbabae61f3e00b3b8f09612844e529
Base:   cc2194b1549f7fde9d20f32e5d034ddd4bcc6801
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all 17 CTest binaries built with no errors.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries, run from repo root.
- [x] `test_polaris_stream` - 112/112 tests, including 11 `StreamStatsSessionTimingTests`: the 8 carried over from #323 (updated for the new signatures) plus 3 new - `StaleGenerationWriteIsRejectedAfterANewerSessionTakesTheUuid`, `StaleGenerationStopDoesNotDiscardANewerSessionsState` (the exact race this PR fixes), and `NegativeOrNonMonotonicDurationsAreRejectedAndCounted`.
- [x] `test_polaris_audit` - all 4 `NovaContractTests` passing, confirming the manifest's updated `session_timing.fields` matches what `build_session_timing_json` actually emits.

**Not covered by this PR** (deliberately, per the scoping above): the richer `session_id`/`process_instance_id`/`client_population_revision` identity fields, the benchmark-run-capture control plane, schema v2's remaining fields, and P0-4A. See `~/.hermes/artifacts/polaris/nordstern/measurement-spec-v1.md` (§6, §15.1, §17) before picking any of those up.
