### PR TITLE
feat(telemetry): client_population_revision tracking

### DIFF
--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -42,6 +42,16 @@ namespace stream_stats {
   static std::mutex stats_mutex;
   static stats_t current_stats;
 
+  // measurement-spec-v1.md 6.1: increments on every add_client()/
+  // remove_client() call. Deliberately its own atomic, outside stats_t -
+  // update_stream_active(false) resets current_stats wholesale when all
+  // sessions end, and this counter must survive that (a full stream
+  // restart between a benchmark run's arm and freeze must never be
+  // masked by the revision coincidentally returning to its starting
+  // value). Starts at 1 so 0 stays available as an obviously-invalid/
+  // unset sentinel.
+  static std::atomic<std::uint64_t> client_population_revision_counter {1};
+
   namespace {
     // Hot-path telemetry: written and read without stats_mutex so the
     // encode-loop and network-report call sites - and their get_current()
@@ -934,6 +944,13 @@ namespace stream_stats {
   }
 
   void add_client(const std::string &client_ip, const std::string &client_name) {
+    // Every call is a real attach from rtsp_stream::start() - bump the
+    // population revision unconditionally, matching measurement-spec-v1.md
+    // 6.1's "increments on every client attach or detach" (the dedup guard
+    // just below is only about not duplicating the clients_t bookkeeping
+    // entry, not about whether this call represents a real event).
+    client_population_revision_counter.fetch_add(1, std::memory_order_relaxed);
+
     std::lock_guard<std::mutex> lock(stats_mutex);
 
     // Check if client already exists
@@ -956,6 +973,8 @@ namespace stream_stats {
   }
 
   void remove_client(const std::string &client_ip) {
+    client_population_revision_counter.fetch_add(1, std::memory_order_relaxed);
+
     std::lock_guard<std::mutex> lock(stats_mutex);
 
     current_stats.clients.erase(
@@ -1291,6 +1310,10 @@ namespace stream_stats {
   int active_client_count() {
     std::lock_guard<std::mutex> lock(stats_mutex);
     return static_cast<int>(current_stats.clients.size());
+  }
+
+  std::uint64_t client_population_revision() {
+    return client_population_revision_counter.load(std::memory_order_relaxed);
   }
 
   void record_idr_request() {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -559,6 +559,20 @@ namespace stream_stats {
   int active_client_count();
 
   /**
+   * @brief Get the current client population revision - a monotonic counter
+   * (measurement-spec-v1.md 6.1) that increments on every
+   * add_client()/remove_client() call, so a leave/join replacement that
+   * returns the client count to its original value still moves the
+   * revision. Deliberately NOT reset by update_stream_active(false)'s
+   * stats_t reset ("all sessions ended") - it lives outside stats_t so a
+   * full stream restart between a benchmark run's arm and freeze can never
+   * be masked by the counter coincidentally returning to its starting
+   * value. Used to detect and abort a benchmark run whose client
+   * population changed mid-run.
+   */
+  std::uint64_t client_population_revision();
+
+  /**
    * @brief Record a client-requested full IDR (keyframe) frame reset.
    */
   void record_idr_request();

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -1067,3 +1067,58 @@ TEST(StreamStatsSessionTimingTests, RingWrapsAndReportsIncompleteOnceCapacityIsE
 
   stream_stats::stop_session_timing(uuid, 1);
 }
+
+// measurement-spec-v1.md 6.1: client_population_revision is a global,
+// process-lifetime counter (not session-keyed like the tests above), so -
+// like the pre-existing StreamStatsHotFieldTests - these assert on the
+// delta a single call produces rather than an absolute value, since other
+// tests in this binary call add_client()/remove_client()/
+// update_stream_active() too.
+
+TEST(StreamStatsClientPopulationRevisionTests, AddAndRemoveClientEachAdvanceTheRevisionByOne) {
+  const auto before_add = stream_stats::client_population_revision();
+  stream_stats::add_client("203.0.113.10", "pop-revision-test-add");
+  const auto after_add = stream_stats::client_population_revision();
+  EXPECT_EQ(after_add, before_add + 1);
+
+  stream_stats::remove_client("203.0.113.10");
+  const auto after_remove = stream_stats::client_population_revision();
+  EXPECT_EQ(after_remove, after_add + 1);
+}
+
+// The exact scenario measurement-spec-v1.md 6.1 calls out: a leave/join
+// replacement that returns the active client count to its original value
+// must still move the revision, so an armed benchmark run can't be fooled
+// by a population change that "cancels out" before anyone polls it.
+TEST(StreamStatsClientPopulationRevisionTests, LeaveAndRejoinReplacementAdvancesRevisionDespiteReturningToTheSameCount) {
+  const std::string ip = "203.0.113.11";
+  stream_stats::add_client(ip, "pop-revision-test-steady-state");
+  const auto steady_state_count = stream_stats::active_client_count();
+  const auto revision_before_churn = stream_stats::client_population_revision();
+
+  stream_stats::remove_client(ip);
+  stream_stats::add_client(ip, "pop-revision-test-steady-state");
+
+  EXPECT_EQ(stream_stats::active_client_count(), steady_state_count)
+    << "count should be back to where it started";
+  EXPECT_EQ(stream_stats::client_population_revision(), revision_before_churn + 2)
+    << "but the revision must show the two real events that happened in between";
+
+  stream_stats::remove_client(ip);
+}
+
+// The bug this design specifically guards against: update_stream_active(false)
+// does current_stats = stats_t{} wholesale when all sessions end. If
+// client_population_revision lived inside stats_t (as first implemented,
+// then caught in review before it shipped), that reset would silently
+// rewind the counter, and a benchmark run spanning a full stream restart
+// could see its arm-time and freeze-time revisions coincidentally match.
+TEST(StreamStatsClientPopulationRevisionTests, SurvivesTheFullStatsResetOnStreamEnd) {
+  stream_stats::add_client("203.0.113.12", "pop-revision-test-reset-survival");
+  const auto revision_after_add = stream_stats::client_population_revision();
+
+  stream_stats::update_stream_active(false);
+
+  EXPECT_EQ(stream_stats::client_population_revision(), revision_after_add)
+    << "the population revision must not be rewound by the stats_t reset";
+}


### PR DESCRIPTION
## Summary

First piece of the "engine first" scope approved for the benchmark-run-capture control plane (`~/.hermes/artifacts/polaris/nordstern/measurement-spec-v1.md` §6.4) - building and testing the core measurement logic (population tracking, the run state machine, boundary-inclusion capture) in isolation before any network-facing control surface. This PR is just the first prerequisite: `client_population_revision`.

- Adds a monotonic counter that increments on every `add_client()`/`remove_client()` call, even when active client count later returns to the same number (measurement-spec-v1.md §6.1) - a rapid leave/join replacement during a future armed benchmark run must not be able to evade the population-change abort rule by restoring the count before anyone checks it.
- Deliberately its own `std::atomic`, not a `stats_t` field - caught in review before it shipped that `update_stream_active(false)` does `current_stats = stats_t{}` wholesale when the last session ends, which would have silently rewound the revision on every full stream restart. A benchmark run spanning that restart could then see its arm-time and freeze-time revisions coincidentally match, defeating the whole point of the counter.

## Exact candidate

```
Commit: 06121b4eca29491a362938e20a3c9a97c31a88d2
Tree:   ea96bd310b5d39ac999119985b0e864531265569
Parent: f498a317afe8249a0f242e5127ae5f72515663b5
Base:   f498a317afe8249a0f242e5127ae5f72515663b5
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all 17 CTest binaries built with no errors.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries, run from repo root.
- [x] `test_polaris_stream` - 115/115 tests, including 3 new `StreamStatsClientPopulationRevisionTests`: add/remove each advance the counter by exactly one, a leave/join replacement advances it by two even though the client count returns to its starting value, and - the one that caught the `stats_t`-field mistake before it shipped - the revision survives `update_stream_active(false)`'s full reset.

**Not covered by this PR** (deliberately, per the approved engine-first scoping): the run state machine itself (armed/active/draining/frozen/aborted/expired), raw per-stage sample capture, the boundary-inclusion classification algorithm (§6.5), and the network-facing control surface. Those are the next piece.
