### PR TITLE
feat(telemetry): boundary-inclusion classifier + stage capture (run-capture engine 1/5)

### DIFF
--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -1307,6 +1307,64 @@ namespace stream_stats {
     return result;
   }
 
+  // ---------------------------------------------------------------------
+  // P0-5 benchmark-run-capture engine, piece 1: boundary classification and
+  // bounded per-stage capture. See the section comment in stream_stats.h.
+  // ---------------------------------------------------------------------
+
+  boundary_classification_e classify_boundary(std::int64_t a_offset_us, std::int64_t b_offset_us, std::int64_t window_end_us) {
+    if (a_offset_us < 0) {
+      return boundary_classification_e::excluded_before_window;
+    }
+    if (a_offset_us >= window_end_us) {
+      return boundary_classification_e::ignored_post_window;
+    }
+    if (b_offset_us >= window_end_us) {
+      return boundary_classification_e::excluded_after_window;
+    }
+    if (a_offset_us <= b_offset_us) {
+      return boundary_classification_e::accepted;
+    }
+    return boundary_classification_e::invalid_non_monotonic;
+  }
+
+  benchmark_stage_capture_t::benchmark_stage_capture_t(std::size_t sample_capacity):
+      capacity(sample_capacity) {
+    start_offset_us.reserve(capacity);
+    end_offset_us.reserve(capacity);
+    duration_us.reserve(capacity);
+  }
+
+  boundary_classification_e benchmark_stage_capture_t::record(std::int64_t a_offset_us, std::int64_t b_offset_us, std::int64_t window_end_us) {
+    const auto classification = classify_boundary(a_offset_us, b_offset_us, window_end_us);
+    switch (classification) {
+      case boundary_classification_e::excluded_before_window:
+        excluded_started_before_window++;
+        break;
+      case boundary_classification_e::excluded_after_window:
+        excluded_completed_after_window++;
+        break;
+      case boundary_classification_e::ignored_post_window:
+        // No state created - matches 6.5's "do not create run-owned
+        // in-flight state" for this case.
+        break;
+      case boundary_classification_e::invalid_non_monotonic:
+        invalid_count++;
+        break;
+      case boundary_classification_e::accepted:
+        if (accepted_count >= capacity) {
+          overflow_count++;
+          break;
+        }
+        start_offset_us.push_back(static_cast<std::uint32_t>(a_offset_us));
+        end_offset_us.push_back(static_cast<std::uint32_t>(b_offset_us));
+        duration_us.push_back(static_cast<std::uint32_t>(b_offset_us - a_offset_us));
+        accepted_count++;
+        break;
+    }
+    return classification;
+  }
+
   int active_client_count() {
     std::lock_guard<std::mutex> lock(stats_mutex);
     return static_cast<int>(current_stats.clients.size());

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -552,6 +552,126 @@ namespace stream_stats {
    */
   session_timing_t get_session_timing(const std::string &device_uuid);
 
+  // ---------------------------------------------------------------------
+  // P0-5 benchmark-run-capture engine (measurement-spec-v1.md 6.4-6.5).
+  // Gate-authoritative, bounded-duration raw sample capture for an armed
+  // benchmark run - distinct from the always-on rolling diagnostics above.
+  // Built incrementally, one reviewable piece at a time: this piece is
+  // pure, state-machine-free logic (boundary classification + bounded
+  // per-stage storage) that a later piece builds the run lifecycle
+  // (armed/active/draining/frozen/aborted/expired) on top of. Nothing
+  // here is reachable yet - no run can be armed, so none of this executes
+  // in production until the remaining pieces land.
+  // ---------------------------------------------------------------------
+
+  /**
+   * @brief Lifecycle state of one benchmark run (measurement-spec-v1.md 6.4).
+   */
+  enum class benchmark_run_state_e {
+    armed,
+    active,
+    draining,
+    frozen,
+    aborted,
+    expired
+  };
+
+  /**
+   * @brief Why a benchmark run aborted. none for a run that hasn't (or
+   * didn't) abort.
+   */
+  enum class benchmark_abort_reason_e {
+    none,
+    session_ended,
+    session_generation_changed,
+    client_population_revision_changed,
+    sample_capacity_exceeded,
+    invalid_stage_duration,
+    stopped_before_duration_lower_bound,
+    explicit_harness_abort,
+    internal_telemetry_failure
+  };
+
+  /**
+   * @brief Outcome of classifying one stage observation against a
+   * benchmark run's half-open active window [S, E) (measurement-spec-v1.md
+   * 6.5).
+   */
+  enum class boundary_classification_e {
+    accepted,
+    excluded_before_window,
+    excluded_after_window,
+    ignored_post_window,
+    invalid_non_monotonic
+  };
+
+  /**
+   * @brief Classify one stage observation's endpoints against a run's
+   * active window, per measurement-spec-v1.md 6.5's 5-step rule, applied
+   * in this order:
+   *   1. a < 0 (before S)              -> excluded_before_window
+   *   2. else a >= window_end_us (>=E) -> ignored_post_window
+   *   3. else b >= window_end_us       -> excluded_after_window
+   *   4. else a <= b                   -> accepted
+   *   5. else (a > b)                  -> invalid_non_monotonic
+   * a_offset_us/b_offset_us are already relative to S (the run's active
+   * start) - a negative value means "before S".
+   * @param a_offset_us The stage's first endpoint, in microseconds since S.
+   * @param b_offset_us The stage's second endpoint, in microseconds since S.
+   * @param window_end_us The window's end (E - S), in microseconds.
+   */
+  boundary_classification_e classify_boundary(std::int64_t a_offset_us, std::int64_t b_offset_us, std::int64_t window_end_us);
+
+  /**
+   * @brief Bounded raw-sample capture for one pipeline stage within one
+   * benchmark run. Preallocated at construction (arm time) to a fixed
+   * capacity; record() performs no allocation, matching the hot-path
+   * contract in measurement-spec-v1.md 6.4.
+   *
+   * started_in_window_without_terminal_count is intentionally always 0 in
+   * this implementation. Polaris's send thread only calls record() once
+   * both of a stage's endpoints are already known - T0/T1/T2 all arrive
+   * bundled on packet_raw_t by the time record_frame_timing() (P0-3/P0-3A)
+   * or its benchmark-capture counterpart is called - so there is no
+   * "endpoint a registered, waiting for b" gap the way the general spec
+   * model assumes. A frame that gets T0/T1 but is dropped before ever
+   * reaching the send thread currently produces no record() call at all,
+   * rather than counting as an unresolved in-window sample. That is a
+   * known, documented gap relative to the full spec model, not silent
+   * data loss within what this capture does observe.
+   */
+  struct benchmark_stage_capture_t {
+    std::size_t capacity = 0;
+    std::vector<std::uint32_t> start_offset_us;
+    std::vector<std::uint32_t> end_offset_us;
+    std::vector<std::uint32_t> duration_us;
+
+    std::size_t accepted_count = 0;
+    std::size_t excluded_started_before_window = 0;
+    std::size_t excluded_completed_after_window = 0;
+    std::size_t started_in_window_without_terminal_count = 0;
+    std::size_t overflow_count = 0;
+    std::size_t invalid_count = 0;
+
+    /**
+     * @param sample_capacity Reserved size of the three parallel arrays -
+     * the run's declared per-stage frame budget. Zero is a valid, harmless
+     * default (every observation simply overflows).
+     */
+    explicit benchmark_stage_capture_t(std::size_t sample_capacity = 0);
+
+    /**
+     * @brief Classify and, if accepted, record one observation. An
+     * accepted observation that would exceed capacity is counted in
+     * overflow_count instead of being stored.
+     * @param a_offset_us The stage's first endpoint, in microseconds since S.
+     * @param b_offset_us The stage's second endpoint, in microseconds since S.
+     * @param window_end_us The window's end (E - S), in microseconds.
+     * @return The classification this observation received.
+     */
+    boundary_classification_e record(std::int64_t a_offset_us, std::int64_t b_offset_us, std::int64_t window_end_us);
+  };
+
   /**
    * @brief Get the number of active client sessions.
    * @return Count of active clients.

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -1122,3 +1122,133 @@ TEST(StreamStatsClientPopulationRevisionTests, SurvivesTheFullStatsResetOnStream
   EXPECT_EQ(stream_stats::client_population_revision(), revision_after_add)
     << "the population revision must not be rewound by the stats_t reset";
 }
+
+// P0-5 benchmark-run-capture engine, piece 1: classify_boundary() and
+// benchmark_stage_capture_t are pure logic with no global state, so unlike
+// the tests above, these need no unique IDs or delta comparisons - each
+// test constructs its own local instance.
+
+TEST(ClassifyBoundaryTests, AcceptsAnObservationEntirelyWithinTheWindow) {
+  EXPECT_EQ(stream_stats::classify_boundary(10, 20, 100), stream_stats::boundary_classification_e::accepted);
+}
+
+TEST(ClassifyBoundaryTests, AcceptsAZeroDurationObservation) {
+  EXPECT_EQ(stream_stats::classify_boundary(10, 10, 100), stream_stats::boundary_classification_e::accepted);
+}
+
+TEST(ClassifyBoundaryTests, AcceptsAnObservationStartingExactlyAtS) {
+  // The spec's rule is the closed lower bound S <= a - a == 0 (== S) must
+  // still be accepted, not excluded.
+  EXPECT_EQ(stream_stats::classify_boundary(0, 5, 100), stream_stats::boundary_classification_e::accepted);
+}
+
+TEST(ClassifyBoundaryTests, ExcludesAnObservationThatStartedBeforeTheWindow) {
+  EXPECT_EQ(stream_stats::classify_boundary(-5, 20, 100), stream_stats::boundary_classification_e::excluded_before_window);
+}
+
+TEST(ClassifyBoundaryTests, IgnoresAnObservationStartingAtOrAfterTheWindowEnd) {
+  EXPECT_EQ(stream_stats::classify_boundary(100, 110, 100), stream_stats::boundary_classification_e::ignored_post_window)
+    << "a == E is already post-window (E is exclusive)";
+  EXPECT_EQ(stream_stats::classify_boundary(150, 160, 100), stream_stats::boundary_classification_e::ignored_post_window);
+}
+
+TEST(ClassifyBoundaryTests, ExcludesAnObservationThatCompletesExactlyAtOrAfterTheWindowEnd) {
+  // The spec's rule is the open upper bound b < E - b == E must be
+  // excluded, not accepted, even though a is still in-window.
+  EXPECT_EQ(stream_stats::classify_boundary(10, 100, 100), stream_stats::boundary_classification_e::excluded_after_window);
+  EXPECT_EQ(stream_stats::classify_boundary(10, 150, 100), stream_stats::boundary_classification_e::excluded_after_window);
+}
+
+TEST(ClassifyBoundaryTests, RejectsANonMonotonicObservationAsInvalid) {
+  EXPECT_EQ(stream_stats::classify_boundary(20, 10, 100), stream_stats::boundary_classification_e::invalid_non_monotonic);
+}
+
+TEST(ClassifyBoundaryTests, ClassificationOrderPrefersBeforeWindowOverNonMonotonic) {
+  // a < 0 and a > b are both true here - rule 1 (before-window) must win,
+  // matching the spec's "classified exactly once, in this order".
+  EXPECT_EQ(stream_stats::classify_boundary(-10, -20, 100), stream_stats::boundary_classification_e::excluded_before_window);
+}
+
+TEST(BenchmarkStageCaptureTests, RecordAcceptsAndStoresWithinCapacity) {
+  stream_stats::benchmark_stage_capture_t stage(10);
+
+  const auto classification = stage.record(10, 25, 1000);
+
+  EXPECT_EQ(classification, stream_stats::boundary_classification_e::accepted);
+  EXPECT_EQ(stage.accepted_count, 1u);
+  ASSERT_EQ(stage.start_offset_us.size(), 1u);
+  ASSERT_EQ(stage.end_offset_us.size(), 1u);
+  ASSERT_EQ(stage.duration_us.size(), 1u);
+  EXPECT_EQ(stage.start_offset_us[0], 10u);
+  EXPECT_EQ(stage.end_offset_us[0], 25u);
+  EXPECT_EQ(stage.duration_us[0], 15u);
+}
+
+TEST(BenchmarkStageCaptureTests, OverflowsPastCapacityWithoutGrowingStorage) {
+  stream_stats::benchmark_stage_capture_t stage(2);
+
+  stage.record(0, 1, 1000);
+  stage.record(2, 3, 1000);
+  stage.record(4, 5, 1000);  // Third accepted-shaped observation, capacity is 2.
+
+  EXPECT_EQ(stage.accepted_count, 2u);
+  EXPECT_EQ(stage.overflow_count, 1u);
+  EXPECT_EQ(stage.start_offset_us.size(), 2u) << "the third observation must not have been stored";
+}
+
+TEST(BenchmarkStageCaptureTests, CountsExcludedBeforeWindowWithoutStoring) {
+  stream_stats::benchmark_stage_capture_t stage(10);
+
+  stage.record(-5, 20, 100);
+
+  EXPECT_EQ(stage.excluded_started_before_window, 1u);
+  EXPECT_EQ(stage.accepted_count, 0u);
+  EXPECT_TRUE(stage.start_offset_us.empty());
+}
+
+TEST(BenchmarkStageCaptureTests, CountsExcludedAfterWindowWithoutStoring) {
+  stream_stats::benchmark_stage_capture_t stage(10);
+
+  stage.record(10, 100, 100);
+
+  EXPECT_EQ(stage.excluded_completed_after_window, 1u);
+  EXPECT_EQ(stage.accepted_count, 0u);
+  EXPECT_TRUE(stage.start_offset_us.empty());
+}
+
+TEST(BenchmarkStageCaptureTests, CountsInvalidNonMonotonicWithoutStoring) {
+  stream_stats::benchmark_stage_capture_t stage(10);
+
+  stage.record(20, 10, 100);
+
+  EXPECT_EQ(stage.invalid_count, 1u);
+  EXPECT_EQ(stage.accepted_count, 0u);
+  EXPECT_TRUE(stage.start_offset_us.empty());
+}
+
+TEST(BenchmarkStageCaptureTests, IgnoredPostWindowObservationIncrementsNoCounterAtAll) {
+  stream_stats::benchmark_stage_capture_t stage(10);
+
+  const auto classification = stage.record(150, 160, 100);
+
+  EXPECT_EQ(classification, stream_stats::boundary_classification_e::ignored_post_window);
+  EXPECT_EQ(stage.accepted_count, 0u);
+  EXPECT_EQ(stage.excluded_started_before_window, 0u);
+  EXPECT_EQ(stage.excluded_completed_after_window, 0u);
+  EXPECT_EQ(stage.invalid_count, 0u);
+  EXPECT_EQ(stage.overflow_count, 0u);
+  EXPECT_EQ(stage.started_in_window_without_terminal_count, 0u);
+}
+
+TEST(BenchmarkStageCaptureTests, MultipleAcceptedObservationsStayInInsertionOrder) {
+  stream_stats::benchmark_stage_capture_t stage(5);
+
+  stage.record(0, 5, 1000);
+  stage.record(100, 108, 1000);
+  stage.record(200, 203, 1000);
+
+  ASSERT_EQ(stage.duration_us.size(), 3u);
+  EXPECT_EQ(stage.duration_us[0], 5u);
+  EXPECT_EQ(stage.duration_us[1], 8u);
+  EXPECT_EQ(stage.duration_us[2], 3u);
+}


### PR DESCRIPTION
## Summary

First of five pieces (approved pacing: one piece per PR, in order) for the benchmark-run-capture engine `~/.hermes/artifacts/polaris/nordstern/measurement-spec-v1.md` §6.4 calls for. Pure logic, no state machine yet - nothing in this PR is reachable in production, since no run can be armed until the remaining pieces land.

- **`classify_boundary()`** implements the 5-step half-open-interval rule from §6.5: the authoritative window is `[S, E)`, a stage sample is accepted only when `S <= a <= b < E`, and every observation is classified exactly once in a fixed order (before-window → post-window-ignore → after-window → accept → non-monotonic-invalid) so the boundary counters stay disjoint.
- **`benchmark_stage_capture_t`** wraps it with preallocated, fixed-capacity storage - three parallel microsecond arrays (`start_offset_us`/`end_offset_us`/`duration_us`) plus the `accepted`/`excluded_started_before_window`/`excluded_completed_after_window`/`overflow`/`invalid` counters the spec's authoritative run output requires per stage. `record()` never allocates past construction, matching the hot-path contract (§6.4: "performs no allocation after run start").
- **`started_in_window_without_terminal_count` is intentionally always 0 here**, documented as a known gap rather than hidden: Polaris's send thread only calls this once both of a stage's endpoints (T0/T1/T2, all bundled on `packet_raw_t`) are already known, so there's no "endpoint a registered, waiting for b" state the general spec model assumes. A frame that gets T0/T1 but is dropped before reaching the send thread produces no call at all right now, rather than counting as unresolved - real, but a separate and larger piece than this slice.

## Exact candidate

```
Commit: dccd1b66addf2491ff297c8e5a7b10ae8aecbe8e
Tree:   1e903d876d0f517e43efe906caa8e6ff6237117e
Parent: 138c7eb693b12e991d75902453a828eb825e2c7b
Base:   138c7eb693b12e991d75902453a828eb825e2c7b
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all 17 CTest binaries built with no errors.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries, run from repo root.
- [x] `test_polaris_stream` - 130/130 tests, including 15 new: 8 `ClassifyBoundaryTests` covering every rule (including the exact-boundary edge cases `a == 0` and `b == E`, and that classification order prefers before-window over non-monotonic when both would apply) and 7 `BenchmarkStageCaptureTests` covering storage/ordering, overflow-without-growth, each counter incrementing on its own path, and that a post-window-ignored observation increments nothing at all.

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): the `benchmark_run_t` struct and its storage/retention, `create_benchmark_run`'s preconditions, `start`/`stop`/`get`/`delete` and the lazy draining→frozen transition, and wiring this into the hot path. Those are pieces 2-5.
