### PR TITLE
feat(telemetry): benchmark_run_t + storage/retention (run-capture engine 2/5)

### DIFF
--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -1365,6 +1365,123 @@ namespace stream_stats {
     return classification;
   }
 
+  namespace {
+    constexpr std::size_t MAX_TERMINAL_BENCHMARK_RUNS = 4;
+    constexpr auto BENCHMARK_RUN_TTL = std::chrono::minutes(30);
+
+    bool is_terminal_benchmark_run(const benchmark_run_t &run) {
+      return run.state == benchmark_run_state_e::frozen || run.state == benchmark_run_state_e::aborted;
+    }
+
+    void clear_benchmark_run_payload(benchmark_run_t &run) {
+      auto clear_stage = [](benchmark_stage_capture_t &stage) {
+        stage.start_offset_us.clear();
+        stage.start_offset_us.shrink_to_fit();
+        stage.end_offset_us.clear();
+        stage.end_offset_us.shrink_to_fit();
+        stage.duration_us.clear();
+        stage.duration_us.shrink_to_fit();
+      };
+      clear_stage(run.capture_to_encode);
+      clear_stage(run.encode_to_send_release);
+      clear_stage(run.capture_to_send_release);
+    }
+
+    // Caller must hold benchmark_run_mutex.
+    void expire_benchmark_run_locked(benchmark_run_t &run) {
+      run.state = benchmark_run_state_e::expired;
+      clear_benchmark_run_payload(run);
+    }
+
+    // Caller must hold benchmark_run_mutex. Repeatedly expires the oldest
+    // (by frozen_monotonic) terminal run until at most
+    // MAX_TERMINAL_BENCHMARK_RUNS remain - measurement-spec-v1.md 6.4:
+    // "when a fifth retained payload would be created, the oldest
+    // non-active payload expires before the new payload is accepted."
+    void enforce_terminal_retention_locked(std::vector<benchmark_run_t> &runs) {
+      for (;;) {
+        benchmark_run_t *oldest = nullptr;
+        std::size_t terminal_count = 0;
+
+        for (auto &run : runs) {
+          if (!is_terminal_benchmark_run(run)) {
+            continue;
+          }
+          terminal_count++;
+          if (!oldest ||
+              !oldest->frozen_monotonic ||
+              (run.frozen_monotonic && *run.frozen_monotonic < *oldest->frozen_monotonic)) {
+            oldest = &run;
+          }
+        }
+
+        if (terminal_count <= MAX_TERMINAL_BENCHMARK_RUNS || !oldest) {
+          break;
+        }
+        expire_benchmark_run_locked(*oldest);
+      }
+    }
+  }  // namespace
+
+  static std::mutex benchmark_run_mutex;
+  static std::vector<benchmark_run_t> benchmark_runs;
+
+  const std::string &process_instance_id() {
+    static const std::string id = [] {
+      const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+      return "polaris-" + std::to_string(ns);
+    }();
+    return id;
+  }
+
+  void insert_benchmark_run(benchmark_run_t run) {
+    std::lock_guard<std::mutex> lock(benchmark_run_mutex);
+    benchmark_runs.push_back(std::move(run));
+    enforce_terminal_retention_locked(benchmark_runs);
+  }
+
+  bool with_benchmark_run(const std::string &run_id, const std::function<void(benchmark_run_t &)> &fn) {
+    std::lock_guard<std::mutex> lock(benchmark_run_mutex);
+    auto it = std::find_if(benchmark_runs.begin(), benchmark_runs.end(),
+      [&run_id](const benchmark_run_t &r) { return r.run_id == run_id; });
+    if (it == benchmark_runs.end()) {
+      return false;
+    }
+    fn(*it);
+    return true;
+  }
+
+  void erase_benchmark_run(const std::string &run_id) {
+    std::lock_guard<std::mutex> lock(benchmark_run_mutex);
+    benchmark_runs.erase(
+      std::remove_if(benchmark_runs.begin(), benchmark_runs.end(),
+        [&run_id](const benchmark_run_t &r) { return r.run_id == run_id; }),
+      benchmark_runs.end());
+  }
+
+  void expire_benchmark_run(const std::string &run_id) {
+    std::lock_guard<std::mutex> lock(benchmark_run_mutex);
+    auto it = std::find_if(benchmark_runs.begin(), benchmark_runs.end(),
+      [&run_id](const benchmark_run_t &r) { return r.run_id == run_id; });
+    if (it != benchmark_runs.end()) {
+      expire_benchmark_run_locked(*it);
+    }
+  }
+
+  void expire_stale_benchmark_runs() {
+    std::lock_guard<std::mutex> lock(benchmark_run_mutex);
+    const auto now = std::chrono::steady_clock::now();
+    for (auto &run : benchmark_runs) {
+      if (!is_terminal_benchmark_run(run) || !run.frozen_monotonic) {
+        continue;
+      }
+      if (now - *run.frozen_monotonic > BENCHMARK_RUN_TTL) {
+        expire_benchmark_run_locked(run);
+      }
+    }
+  }
+
   int active_client_count() {
     std::lock_guard<std::mutex> lock(stats_mutex);
     return static_cast<int>(current_stats.clients.size());

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -671,6 +672,113 @@ namespace stream_stats {
      */
     boundary_classification_e record(std::int64_t a_offset_us, std::int64_t b_offset_us, std::int64_t window_end_us);
   };
+
+  /**
+   * @brief One gate-authoritative benchmark run (measurement-spec-v1.md 6.4).
+   * Not constructible without a sample capacity - the three stage captures
+   * need it at construction, and there is no meaningful "run" without one.
+   * Everything else is set by the caller after construction (matching
+   * session_timing_state_t's own pattern above) - this piece provides the
+   * struct and its storage; piece 3 (create_benchmark_run) owns validating
+   * and populating one.
+   */
+  struct benchmark_run_t {
+    std::string run_id;
+    benchmark_run_state_e state = benchmark_run_state_e::armed;
+    benchmark_abort_reason_e abort_reason = benchmark_abort_reason_e::none;
+
+    std::string owning_device_uuid;
+    std::uint64_t owning_session_generation = 0;
+
+    std::string manifest_sha256;
+    std::string label;
+    std::string workload_id;
+
+    std::chrono::nanoseconds expected_duration_ns {0};
+    std::chrono::nanoseconds duration_tolerance_ns {0};
+    std::chrono::nanoseconds drain_grace_ns {0};
+    int target_fps = 0;
+    std::size_t sample_capacity = 0;
+
+    std::chrono::steady_clock::time_point armed_monotonic;
+    std::optional<std::chrono::steady_clock::time_point> started_monotonic;
+    std::optional<std::chrono::steady_clock::time_point> stopped_monotonic;
+
+    /// Set when this run becomes immutable, whether by reaching frozen
+    /// normally or by aborting - measurement-spec-v1.md 6.4 only names one
+    /// "frozen_monotonic_ns" output field, used as the terminal-payload
+    /// timestamp either way. Also this run's retention age for eviction/TTL.
+    std::optional<std::chrono::steady_clock::time_point> frozen_monotonic;
+
+    std::uint64_t client_population_revision_at_arm = 0;
+    std::uint64_t client_population_revision_at_freeze = 0;
+
+    benchmark_stage_capture_t capture_to_encode;
+    benchmark_stage_capture_t encode_to_send_release;
+    benchmark_stage_capture_t capture_to_send_release;
+
+    explicit benchmark_run_t(std::size_t sample_capacity_in):
+        sample_capacity(sample_capacity_in),
+        capture_to_encode(sample_capacity_in),
+        encode_to_send_release(sample_capacity_in),
+        capture_to_send_release(sample_capacity_in) {
+    }
+  };
+
+  /**
+   * @brief A process-lifetime-stable identifier, generated on first use.
+   * Doesn't need global uniqueness (nothing compares it across machines) -
+   * only needs to change across a Polaris restart, so a benchmark run's
+   * frozen output can't be mistaken for one produced by a different process
+   * instance.
+   */
+  const std::string &process_instance_id();
+
+  /**
+   * @brief Insert a fully-constructed benchmark run into process-wide
+   * storage. Does not validate uniqueness or any create-and-arm
+   * precondition - that is piece 3 (create_benchmark_run)'s job; this is
+   * the storage primitive it will call after validating. Enforces the
+   * terminal-payload retention limit (measurement-spec-v1.md 6.4: at most
+   * 4 frozen/aborted payloads per process instance) by expiring the oldest
+   * terminal run first if this insert would exceed it.
+   */
+  void insert_benchmark_run(benchmark_run_t run);
+
+  /**
+   * @brief Look up a run by ID and, while still holding the storage lock,
+   * invoke fn on it. This is the only safe way to read or mutate a
+   * benchmark_run_t's fields from outside this file: insert_benchmark_run()
+   * can reallocate the underlying storage, and erase_benchmark_run() can
+   * shift it, so a raw pointer/reference returned across a call boundary
+   * could dangle. Not for the hot path - piece 5's record_benchmark_sample()
+   * will be its own dedicated, allocation-free function instead of using
+   * this generic std::function-based visitor.
+   * @return false (fn not invoked) if no run with that ID exists.
+   */
+  bool with_benchmark_run(const std::string &run_id, const std::function<void(benchmark_run_t &)> &fn);
+
+  /**
+   * @brief Immediately release a run's storage (measurement-spec-v1.md 6.4:
+   * "DELETE releases payload storage immediately").
+   */
+  void erase_benchmark_run(const std::string &run_id);
+
+  /**
+   * @brief Clear a run's heavy payload (the three stage captures' sample
+   * arrays) and mark it expired, leaving only the bounded tombstone
+   * metadata (run_id, state, timestamps, abort_reason, counts) that
+   * measurement-spec-v1.md 6.4 requires survive expiry. A no-op if run_id
+   * doesn't exist.
+   */
+  void expire_benchmark_run(const std::string &run_id);
+
+  /**
+   * @brief Expire every frozen/aborted run whose frozen_monotonic is older
+   * than the 30-minute TTL (measurement-spec-v1.md 6.4). Intended to be
+   * called lazily (e.g. from a future get_benchmark_run()), not on a timer.
+   */
+  void expire_stale_benchmark_runs();
 
   /**
    * @brief Get the number of active client sessions.

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -1252,3 +1252,208 @@ TEST(BenchmarkStageCaptureTests, MultipleAcceptedObservationsStayInInsertionOrde
   EXPECT_EQ(stage.duration_us[1], 8u);
   EXPECT_EQ(stage.duration_us[2], 3u);
 }
+
+// P0-5 benchmark-run-capture engine, piece 2: benchmark_run_t and its
+// process-wide storage/retention. Storage is global (not session-keyed),
+// so - like ClientPopulationRevisionTests - these use unique run_ids per
+// test rather than relying on execution order or isolation between tests.
+
+TEST(BenchmarkRunTests, ConstructorForwardsCapacityToAllThreeStages) {
+  stream_stats::benchmark_run_t run(42);
+
+  EXPECT_EQ(run.sample_capacity, 42u);
+  EXPECT_EQ(run.capture_to_encode.capacity, 42u);
+  EXPECT_EQ(run.encode_to_send_release.capacity, 42u);
+  EXPECT_EQ(run.capture_to_send_release.capacity, 42u);
+  EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::armed)
+    << "a freshly constructed run defaults to armed";
+}
+
+TEST(BenchmarkRunTests, ProcessInstanceIdIsNonEmptyAndStable) {
+  const auto &first = stream_stats::process_instance_id();
+  const auto &second = stream_stats::process_instance_id();
+
+  EXPECT_FALSE(first.empty());
+  EXPECT_EQ(&first, &second) << "must be the same stable value, not regenerated per call";
+}
+
+TEST(BenchmarkRunStorageTests, WithBenchmarkRunFindsAnInsertedRunByItsId) {
+  stream_stats::benchmark_run_t run(10);
+  run.run_id = "test-run-find-me";
+  run.label = "find-me-label";
+  stream_stats::insert_benchmark_run(std::move(run));
+
+  bool visited = false;
+  const bool found = stream_stats::with_benchmark_run("test-run-find-me", [&](stream_stats::benchmark_run_t &r) {
+    visited = true;
+    EXPECT_EQ(r.label, "find-me-label");
+  });
+
+  EXPECT_TRUE(found);
+  EXPECT_TRUE(visited);
+
+  stream_stats::erase_benchmark_run("test-run-find-me");
+}
+
+TEST(BenchmarkRunStorageTests, WithBenchmarkRunReturnsFalseForAnUnknownId) {
+  bool visited = false;
+  const bool found = stream_stats::with_benchmark_run("test-run-does-not-exist", [&](stream_stats::benchmark_run_t &) {
+    visited = true;
+  });
+
+  EXPECT_FALSE(found);
+  EXPECT_FALSE(visited);
+}
+
+TEST(BenchmarkRunStorageTests, WithBenchmarkRunMutationsPersist) {
+  stream_stats::benchmark_run_t run(10);
+  run.run_id = "test-run-mutate";
+  stream_stats::insert_benchmark_run(std::move(run));
+
+  stream_stats::with_benchmark_run("test-run-mutate", [](stream_stats::benchmark_run_t &r) {
+    r.state = stream_stats::benchmark_run_state_e::active;
+  });
+
+  bool state_is_active = false;
+  stream_stats::with_benchmark_run("test-run-mutate", [&](stream_stats::benchmark_run_t &r) {
+    state_is_active = (r.state == stream_stats::benchmark_run_state_e::active);
+  });
+  EXPECT_TRUE(state_is_active);
+
+  stream_stats::erase_benchmark_run("test-run-mutate");
+}
+
+TEST(BenchmarkRunStorageTests, EraseBenchmarkRunRemovesOnlyTheNamedRun) {
+  stream_stats::benchmark_run_t run_a(10);
+  run_a.run_id = "test-run-erase-a";
+  stream_stats::insert_benchmark_run(std::move(run_a));
+
+  stream_stats::benchmark_run_t run_b(10);
+  run_b.run_id = "test-run-erase-b";
+  stream_stats::insert_benchmark_run(std::move(run_b));
+
+  stream_stats::erase_benchmark_run("test-run-erase-a");
+
+  EXPECT_FALSE(stream_stats::with_benchmark_run("test-run-erase-a", [](stream_stats::benchmark_run_t &) {}));
+  EXPECT_TRUE(stream_stats::with_benchmark_run("test-run-erase-b", [](stream_stats::benchmark_run_t &) {}));
+
+  stream_stats::erase_benchmark_run("test-run-erase-b");
+}
+
+TEST(BenchmarkRunStorageTests, ExpireBenchmarkRunClearsPayloadButKeepsTombstoneMetadata) {
+  stream_stats::benchmark_run_t run(10);
+  run.run_id = "test-run-expire";
+  run.label = "expire-me-label";
+  run.capture_to_encode.record(0, 5, 1000);
+  ASSERT_EQ(run.capture_to_encode.accepted_count, 1u);
+  stream_stats::insert_benchmark_run(std::move(run));
+
+  stream_stats::expire_benchmark_run("test-run-expire");
+
+  bool visited = false;
+  stream_stats::with_benchmark_run("test-run-expire", [&](stream_stats::benchmark_run_t &r) {
+    visited = true;
+    EXPECT_EQ(r.state, stream_stats::benchmark_run_state_e::expired);
+    EXPECT_EQ(r.label, "expire-me-label") << "lightweight metadata survives as the tombstone";
+    EXPECT_TRUE(r.capture_to_encode.start_offset_us.empty()) << "the heavy payload must be cleared";
+    // The accepted_count itself is retained - it's a small integer, part
+    // of the "bounded tombstone metadata needed to explain the missing
+    // payload", not the payload itself.
+    EXPECT_EQ(r.capture_to_encode.accepted_count, 1u);
+  });
+  EXPECT_TRUE(visited);
+
+  stream_stats::erase_benchmark_run("test-run-expire");
+}
+
+TEST(BenchmarkRunStorageTests, ExpireBenchmarkRunIsANoOpForAnUnknownId) {
+  // Must not crash or throw.
+  stream_stats::expire_benchmark_run("test-run-expire-unknown-id");
+}
+
+TEST(BenchmarkRunRetentionTests, InsertingAFifthTerminalRunExpiresTheOldestOne) {
+  using namespace std::chrono;
+  const auto base = steady_clock::now();
+
+  for (int i = 0; i < 5; ++i) {
+    stream_stats::benchmark_run_t run(10);
+    run.run_id = "test-run-retention-" + std::to_string(i);
+    run.state = stream_stats::benchmark_run_state_e::frozen;
+    run.frozen_monotonic = base + seconds(i);  // run 0 is oldest, run 4 is newest.
+    stream_stats::insert_benchmark_run(std::move(run));
+  }
+
+  // The oldest of the 5 terminal runs must have been evicted (expired) once
+  // the 5th was inserted - but expiry leaves a tombstone, so it must still
+  // be findable, just no longer frozen.
+  bool oldest_visited = false;
+  ASSERT_TRUE(stream_stats::with_benchmark_run("test-run-retention-0", [&](stream_stats::benchmark_run_t &r) {
+    oldest_visited = true;
+    EXPECT_EQ(r.state, stream_stats::benchmark_run_state_e::expired);
+  })) << "the tombstone must still be findable after eviction";
+  EXPECT_TRUE(oldest_visited);
+
+  for (int i = 1; i < 5; ++i) {
+    EXPECT_TRUE(stream_stats::with_benchmark_run("test-run-retention-" + std::to_string(i), [](stream_stats::benchmark_run_t &r) {
+      EXPECT_EQ(r.state, stream_stats::benchmark_run_state_e::frozen) << "the 4 newer runs must be untouched";
+    }));
+  }
+
+  for (int i = 0; i < 5; ++i) {
+    stream_stats::erase_benchmark_run("test-run-retention-" + std::to_string(i));
+  }
+}
+
+TEST(BenchmarkRunRetentionTests, NonTerminalRunsAreNeverEvictedByTheTerminalRetentionLimit) {
+  using namespace std::chrono;
+  const auto base = steady_clock::now();
+
+  // 5 non-terminal (active) runs - the 4-payload cap only applies to
+  // frozen/aborted runs, so none of these should ever be touched by
+  // insert-time retention.
+  for (int i = 0; i < 5; ++i) {
+    stream_stats::benchmark_run_t run(10);
+    run.run_id = "test-run-non-terminal-" + std::to_string(i);
+    run.state = stream_stats::benchmark_run_state_e::active;
+    run.frozen_monotonic = base + seconds(i);  // Set anyway, to prove state (not timestamp presence) gates eviction.
+    stream_stats::insert_benchmark_run(std::move(run));
+  }
+
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_TRUE(stream_stats::with_benchmark_run("test-run-non-terminal-" + std::to_string(i), [](stream_stats::benchmark_run_t &r) {
+      EXPECT_EQ(r.state, stream_stats::benchmark_run_state_e::active);
+    }));
+  }
+
+  for (int i = 0; i < 5; ++i) {
+    stream_stats::erase_benchmark_run("test-run-non-terminal-" + std::to_string(i));
+  }
+}
+
+TEST(BenchmarkRunRetentionTests, ExpireStaleBenchmarkRunsExpiresOnlyRunsPastTheTtl) {
+  using namespace std::chrono;
+
+  stream_stats::benchmark_run_t stale_run(10);
+  stale_run.run_id = "test-run-stale";
+  stale_run.state = stream_stats::benchmark_run_state_e::aborted;
+  stale_run.frozen_monotonic = steady_clock::now() - minutes(31);
+  stream_stats::insert_benchmark_run(std::move(stale_run));
+
+  stream_stats::benchmark_run_t fresh_run(10);
+  fresh_run.run_id = "test-run-fresh";
+  fresh_run.state = stream_stats::benchmark_run_state_e::frozen;
+  fresh_run.frozen_monotonic = steady_clock::now();
+  stream_stats::insert_benchmark_run(std::move(fresh_run));
+
+  stream_stats::expire_stale_benchmark_runs();
+
+  stream_stats::with_benchmark_run("test-run-stale", [](stream_stats::benchmark_run_t &r) {
+    EXPECT_EQ(r.state, stream_stats::benchmark_run_state_e::expired);
+  });
+  stream_stats::with_benchmark_run("test-run-fresh", [](stream_stats::benchmark_run_t &r) {
+    EXPECT_EQ(r.state, stream_stats::benchmark_run_state_e::frozen) << "well within the 30-minute TTL, must not expire";
+  });
+
+  stream_stats::erase_benchmark_run("test-run-stale");
+  stream_stats::erase_benchmark_run("test-run-fresh");
+}


### PR DESCRIPTION
## Summary

Second of five pieces (approved pacing: one piece per PR, in order) for the benchmark-run-capture engine. Still not reachable in production - nothing calls `insert_benchmark_run()` outside tests yet, since piece 3 (`create_benchmark_run`'s preconditions) hasn't landed.

- **`benchmark_run_t`** holds one run's full identity, manifest fields, lifecycle timestamps, population-revision snapshots, and its three stage captures (piece 1). Its constructor only takes a sample capacity - everything else is set by the caller afterward, matching `session_timing_state_t`'s existing pattern in this file - and it is **not** default-constructible, so a run can't exist in storage without a real capacity.
- **Storage** is a single process-wide vector behind its own mutex. `insert`/`erase`/`expire` are self-contained and safe, but the first draft of a find function returned a raw pointer after releasing the lock - exactly the kind of dangling-pointer risk `find_session_timing_locked` already avoids elsewhere in this file, since `insert_benchmark_run()` can reallocate the vector out from under a caller still holding that pointer. Replaced with **`with_benchmark_run()`**, which invokes the caller's callback while still holding the lock. It's not used for the future hot-path recorder (piece 5 will be its own dedicated, allocation-free function, not a `std::function`-based visitor), so this doesn't cost anything on the path that actually needs to be fast.
- **Retention**: at most 4 frozen/aborted payloads process-wide - inserting a 5th expires the oldest by `frozen_monotonic` first - and a separate `expire_stale_benchmark_runs()` for the 30-minute TTL, intended to be called lazily (piece 4) rather than on a timer. Expiry clears each stage's sample arrays but keeps the lightweight tombstone (`run_id`, `state`, timestamps, counts) findable, per the spec's retention rules. Non-terminal (armed/active/draining) runs are never touched by either mechanism - the "one active run per session" limit is a create-time precondition piece 3 owns, not a storage-level invariant.

## Exact candidate

```
Commit: 5351ad43cd926f10862108c5889c2a1c47d77be9
Tree:   70fb3fe76747fce3069d9ca87edd761520341390
Parent: 2b6e1b401e44c1319a30ca3018414811c5e86197
Base:   2b6e1b401e44c1319a30ca3018414811c5e86197
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all 17 CTest binaries built with no errors.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries, run from repo root.
- [x] `test_polaris_stream` - 141/141 tests, including 11 new: 2 `BenchmarkRunTests` (constructor forwarding, `process_instance_id()` stability), 6 `BenchmarkRunStorageTests` (find/mutate/erase/expire, including that expiry keeps the tombstone findable and clears only the heavy payload), 3 `BenchmarkRunRetentionTests` (5th-terminal-run eviction with the tombstone still present afterward, non-terminal runs immune to the limit, TTL-based expiry only touching runs past 30 minutes).

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): `create_benchmark_run`'s 11 preconditions, `start`/`stop`/`get`/`delete` and the lazy draining→frozen transition, and wiring this into the hot path. Those are pieces 3-5.
