### PR TITLE
feat(telemetry): add create_benchmark_run and its create-and-arm preconditions

### DIFF
--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -1482,6 +1482,127 @@ namespace stream_stats {
     }
   }
 
+  namespace {
+    std::atomic<bool> benchmark_control_plane_enabled_flag {false};
+
+    bool is_valid_manifest_sha256(const std::string &value) {
+      if (value.size() != 64) {
+        return false;
+      }
+      return std::all_of(value.begin(), value.end(), [](unsigned char c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+      });
+    }
+  }  // namespace
+
+  bool benchmark_control_plane_enabled() {
+    return benchmark_control_plane_enabled_flag.load(std::memory_order_relaxed);
+  }
+
+  void set_benchmark_control_plane_enabled(bool enabled) {
+    benchmark_control_plane_enabled_flag.store(enabled, std::memory_order_relaxed);
+  }
+
+  benchmark_run_create_result_e create_benchmark_run(
+      const benchmark_run_create_request_t &request,
+      const std::string &device_uuid,
+      std::uint64_t session_generation,
+      bool caller_is_authorized_harness) {
+    // Cheapest / least-sensitive-information-first ordering. None of these
+    // preconditions require benchmark_run_mutex - only the final
+    // session-dedup + run_id-dedup + insert step does, taken once below so
+    // that check-then-insert can't race a concurrent create call.
+    if (!benchmark_control_plane_enabled()) {
+      return benchmark_run_create_result_e::rejected_control_plane_not_enabled;
+    }
+    if (!caller_is_authorized_harness) {
+      return benchmark_run_create_result_e::rejected_caller_not_authorized_as_harness;
+    }
+    if (active_client_count() != 1) {
+      return benchmark_run_create_result_e::rejected_not_exactly_one_active_session;
+    }
+    if (request.expected_duration_s < 60 || request.expected_duration_s > 180) {
+      return benchmark_run_create_result_e::rejected_duration_out_of_range;
+    }
+    if (request.duration_tolerance_ms < 0 || request.duration_tolerance_ms > 1000) {
+      return benchmark_run_create_result_e::rejected_duration_tolerance_out_of_range;
+    }
+    if (request.drain_grace_ms < 1 || request.drain_grace_ms > 5000) {
+      return benchmark_run_create_result_e::rejected_drain_grace_out_of_range;
+    }
+    if (request.target_fps < 30 || request.target_fps > 240) {
+      return benchmark_run_create_result_e::rejected_target_fps_out_of_range;
+    }
+
+    // measurement-spec-v1.md 6.4: "nominal sample budget expected_duration_s
+    // * target_fps of at least 1,000 frames". Given the range floors just
+    // checked above (60s, 30fps -> 1800), this can't currently fail - kept
+    // anyway as a direct, defensive expression of the spec's own precondition
+    // rather than an assumption that the range floors will never change
+    // independently (e.g. if either becomes config-driven later).
+    const std::uint64_t nominal_sample_budget =
+      static_cast<std::uint64_t>(request.expected_duration_s) * static_cast<std::uint64_t>(request.target_fps);
+    if (nominal_sample_budget < 1000) {
+      return benchmark_run_create_result_e::rejected_nominal_sample_budget_too_small;
+    }
+    if (request.sample_capacity_frames < nominal_sample_budget) {
+      return benchmark_run_create_result_e::rejected_capacity_below_nominal_budget;
+    }
+    if (request.sample_capacity_frames > 65536) {
+      return benchmark_run_create_result_e::rejected_capacity_exceeds_maximum;
+    }
+    if (!is_valid_manifest_sha256(request.manifest_sha256)) {
+      return benchmark_run_create_result_e::rejected_invalid_manifest_sha256_format;
+    }
+
+    // Not checked here (documented gap, matching this engine's established
+    // pattern - see the header comment on this function): "duration,
+    // tolerance, drain grace, target fps, capacity, and workload exactly
+    // match the frozen manifest". There is no manifest file infrastructure
+    // yet for this function to check against; a later piece owns it.
+
+    std::lock_guard<std::mutex> lock(benchmark_run_mutex);
+
+    const bool session_already_has_active_run = std::any_of(
+      benchmark_runs.begin(), benchmark_runs.end(),
+      [&device_uuid](const benchmark_run_t &r) {
+        return r.owning_device_uuid == device_uuid &&
+               (r.state == benchmark_run_state_e::armed ||
+                r.state == benchmark_run_state_e::active ||
+                r.state == benchmark_run_state_e::draining);
+      });
+    if (session_already_has_active_run) {
+      return benchmark_run_create_result_e::rejected_session_already_has_an_active_run;
+    }
+
+    const bool run_id_already_used = std::any_of(
+      benchmark_runs.begin(), benchmark_runs.end(),
+      [&request](const benchmark_run_t &r) { return r.run_id == request.run_id; });
+    if (run_id_already_used) {
+      return benchmark_run_create_result_e::rejected_run_id_already_used;
+    }
+
+    benchmark_run_t run(request.sample_capacity_frames);
+    run.run_id = request.run_id;
+    run.state = benchmark_run_state_e::armed;
+    run.owning_device_uuid = device_uuid;
+    run.owning_session_generation = session_generation;
+    run.manifest_sha256 = request.manifest_sha256;
+    run.label = request.label;
+    run.workload_id = request.workload_id;
+    run.expected_duration_ns = std::chrono::seconds(request.expected_duration_s);
+    run.duration_tolerance_ns = std::chrono::milliseconds(request.duration_tolerance_ms);
+    run.drain_grace_ns = std::chrono::milliseconds(request.drain_grace_ms);
+    run.target_fps = request.target_fps;
+    run.armed_monotonic = std::chrono::steady_clock::now();
+    run.client_population_revision_at_arm = client_population_revision();
+
+    benchmark_runs.push_back(std::move(run));
+    enforce_terminal_retention_locked(benchmark_runs);
+
+    return benchmark_run_create_result_e::created;
+  }
+
   int active_client_count() {
     std::lock_guard<std::mutex> lock(stats_mutex);
     return static_cast<int>(current_stats.clients.size());

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -781,6 +781,88 @@ namespace stream_stats {
   void expire_stale_benchmark_runs();
 
   /**
+   * @brief Whether the host-local benchmark control plane is enabled
+   * (measurement-spec-v1.md 6.4: "disabled by default... must require an
+   * explicit benchmark-mode enable at process start"). Defaults to false.
+   * No production caller flips this on yet - that's the network-facing
+   * control-surface increment's job (config-driven, at process start).
+   * Exposed as a plain setter rather than a "for tests" one because that
+   * future increment will most likely just call this same setter itself
+   * once it reads its config, not reimplement the flag.
+   */
+  bool benchmark_control_plane_enabled();
+  void set_benchmark_control_plane_enabled(bool enabled);
+
+  /**
+   * @brief A validated create-and-arm request for one benchmark run
+   * (measurement-spec-v1.md 6.4's create-and-arm JSON, minus run_id which
+   * create_benchmark_run takes separately since it's also the storage key).
+   */
+  struct benchmark_run_create_request_t {
+    std::string run_id;
+    std::string manifest_sha256;
+    std::string label;
+    std::string workload_id;
+    int expected_duration_s = 0;
+    int duration_tolerance_ms = 0;
+    int drain_grace_ms = 0;
+    int target_fps = 0;
+    std::size_t sample_capacity_frames = 0;
+  };
+
+  /**
+   * @brief Why create_benchmark_run() accepted or rejected a request. Every
+   * rejected value names exactly one precondition from measurement-spec-v1.md
+   * 6.4's create-and-arm list.
+   */
+  enum class benchmark_run_create_result_e {
+    created,
+    rejected_control_plane_not_enabled,
+    rejected_caller_not_authorized_as_harness,
+    rejected_not_exactly_one_active_session,
+    rejected_session_already_has_an_active_run,
+    rejected_duration_out_of_range,
+    rejected_duration_tolerance_out_of_range,
+    rejected_drain_grace_out_of_range,
+    rejected_target_fps_out_of_range,
+    rejected_nominal_sample_budget_too_small,
+    rejected_capacity_below_nominal_budget,
+    rejected_capacity_exceeds_maximum,
+    rejected_run_id_already_used,
+    rejected_invalid_manifest_sha256_format
+  };
+
+  /**
+   * @brief Validate a create-and-arm request against every precondition in
+   * measurement-spec-v1.md 6.4 that this engine can check on its own, and
+   * if all pass, construct and insert the armed run.
+   *
+   * Deliberately NOT checked here (documented gap, matching this engine's
+   * established pattern of naming what it doesn't yet do rather than
+   * silently skipping it): "duration, tolerance, drain grace, target fps,
+   * capacity, and workload exactly match the frozen manifest" - that
+   * requires the manifest file infrastructure a later piece (the
+   * evidence/manifest writer and validator) owns. This function only
+   * validates manifest_sha256's *format* (64 lowercase hex chars), not its
+   * content against anything.
+   *
+   * @param request The request to validate and, if valid, arm.
+   * @param device_uuid The calling session's device UUID (session_t::device_uuid).
+   * @param session_generation The calling session's generation (session_t::session_generation).
+   * @param caller_is_authorized_harness Whether the caller has been
+   * authenticated as the local benchmark harness specifically - not merely
+   * as an ordinary paired client. The actual authorization decision
+   * (loopback/management-source policy, rate limits, audit logging) is the
+   * network-facing control-surface increment's job; this function only
+   * enforces the precondition given whatever the caller asserts.
+   */
+  benchmark_run_create_result_e create_benchmark_run(
+    const benchmark_run_create_request_t &request,
+    const std::string &device_uuid,
+    std::uint64_t session_generation,
+    bool caller_is_authorized_harness);
+
+  /**
    * @brief Get the number of active client sessions.
    * @return Count of active clients.
    */

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -1457,3 +1457,276 @@ TEST(BenchmarkRunRetentionTests, ExpireStaleBenchmarkRunsExpiresOnlyRunsPastTheT
   stream_stats::erase_benchmark_run("test-run-stale");
   stream_stats::erase_benchmark_run("test-run-fresh");
 }
+
+// P0-5 benchmark-run-capture engine, piece 3: create_benchmark_run() and its
+// create-and-arm preconditions (measurement-spec-v1.md 6.4). Each rejection
+// test perturbs exactly one field away from a known-valid baseline request
+// so it exercises exactly the precondition it names. Not tested here:
+// rejected_nominal_sample_budget_too_small - unreachable given the duration
+// (>=60s) and target_fps (>=30) floors already enforced above it, since
+// 60*30 = 1800 is always >= the 1000-frame floor. Kept in the engine as a
+// direct, defensive expression of the spec's own precondition rather than
+// an assumption the range floors can never change independently.
+
+namespace {
+  // RAII: pins the control-plane flag to a known state for one test and
+  // restores whatever it was before, so an early ASSERT failure (which
+  // skips the rest of the test body) can't leak enabled/disabled state
+  // into a later test.
+  struct BenchmarkControlPlaneGuard {
+    explicit BenchmarkControlPlaneGuard(bool enabled):
+        previous(stream_stats::benchmark_control_plane_enabled()) {
+      stream_stats::set_benchmark_control_plane_enabled(enabled);
+    }
+    ~BenchmarkControlPlaneGuard() {
+      stream_stats::set_benchmark_control_plane_enabled(previous);
+    }
+    bool previous;
+  };
+
+  // Matches measurement-spec-v1.md 6.4's create-and-arm example exactly
+  // (120s / 250ms / 2000ms / 120fps / 32768 frames), so nominal_sample_budget
+  // (120 * 120 = 14400) sits comfortably inside the valid capacity range.
+  stream_stats::benchmark_run_create_request_t make_valid_create_request(const std::string &run_id) {
+    stream_stats::benchmark_run_create_request_t request;
+    request.run_id = run_id;
+    request.manifest_sha256 = std::string(64, 'a');
+    request.label = "P0-7-synthetic-A-pair-03";
+    request.workload_id = "synthetic-frame-counter-v1";
+    request.expected_duration_s = 120;
+    request.duration_tolerance_ms = 250;
+    request.drain_grace_ms = 2000;
+    request.target_fps = 120;
+    request.sample_capacity_frames = 32768;
+    return request;
+  }
+}  // namespace
+
+TEST(BenchmarkRunCreateTests, RejectsWhenControlPlaneIsNotEnabled) {
+  BenchmarkControlPlaneGuard guard(false);
+  stream_stats::add_client("203.0.113.20", "create-test-control-plane-disabled");
+
+  const auto result = stream_stats::create_benchmark_run(
+    make_valid_create_request("create-test-control-plane-disabled"),
+    "device-control-plane-disabled", 1, true);
+
+  EXPECT_EQ(result, stream_stats::benchmark_run_create_result_e::rejected_control_plane_not_enabled);
+  stream_stats::remove_client("203.0.113.20");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsWhenCallerIsNotAuthorizedAsHarness) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.21", "create-test-unauthorized");
+
+  const auto result = stream_stats::create_benchmark_run(
+    make_valid_create_request("create-test-unauthorized"),
+    "device-unauthorized", 1, false);
+
+  EXPECT_EQ(result, stream_stats::benchmark_run_create_result_e::rejected_caller_not_authorized_as_harness);
+  stream_stats::remove_client("203.0.113.21");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsWhenNoActiveSession) {
+  BenchmarkControlPlaneGuard guard(true);
+
+  const auto result = stream_stats::create_benchmark_run(
+    make_valid_create_request("create-test-zero-sessions"),
+    "device-zero-sessions", 1, true);
+
+  EXPECT_EQ(result, stream_stats::benchmark_run_create_result_e::rejected_not_exactly_one_active_session);
+}
+
+TEST(BenchmarkRunCreateTests, RejectsWhenMultipleActiveSessions) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.22", "create-test-multi-session-a");
+  stream_stats::add_client("203.0.113.23", "create-test-multi-session-b");
+
+  const auto result = stream_stats::create_benchmark_run(
+    make_valid_create_request("create-test-multi-session"),
+    "device-multi-session", 1, true);
+
+  EXPECT_EQ(result, stream_stats::benchmark_run_create_result_e::rejected_not_exactly_one_active_session);
+  stream_stats::remove_client("203.0.113.22");
+  stream_stats::remove_client("203.0.113.23");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsDurationOutOfRange) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.24", "create-test-duration-range");
+
+  auto too_short = make_valid_create_request("create-test-duration-too-short");
+  too_short.expected_duration_s = 59;
+  EXPECT_EQ(stream_stats::create_benchmark_run(too_short, "device-duration-too-short", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_duration_out_of_range);
+
+  auto too_long = make_valid_create_request("create-test-duration-too-long");
+  too_long.expected_duration_s = 181;
+  EXPECT_EQ(stream_stats::create_benchmark_run(too_long, "device-duration-too-long", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_duration_out_of_range);
+
+  stream_stats::remove_client("203.0.113.24");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsDurationToleranceOutOfRange) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.25", "create-test-tolerance-range");
+
+  auto negative = make_valid_create_request("create-test-tolerance-negative");
+  negative.duration_tolerance_ms = -1;
+  EXPECT_EQ(stream_stats::create_benchmark_run(negative, "device-tolerance-negative", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_duration_tolerance_out_of_range);
+
+  auto too_large = make_valid_create_request("create-test-tolerance-too-large");
+  too_large.duration_tolerance_ms = 1001;
+  EXPECT_EQ(stream_stats::create_benchmark_run(too_large, "device-tolerance-too-large", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_duration_tolerance_out_of_range);
+
+  stream_stats::remove_client("203.0.113.25");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsDrainGraceOutOfRange) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.26", "create-test-drain-grace-range");
+
+  auto too_small = make_valid_create_request("create-test-drain-grace-too-small");
+  too_small.drain_grace_ms = 0;
+  EXPECT_EQ(stream_stats::create_benchmark_run(too_small, "device-drain-grace-too-small", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_drain_grace_out_of_range);
+
+  auto too_large = make_valid_create_request("create-test-drain-grace-too-large");
+  too_large.drain_grace_ms = 5001;
+  EXPECT_EQ(stream_stats::create_benchmark_run(too_large, "device-drain-grace-too-large", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_drain_grace_out_of_range);
+
+  stream_stats::remove_client("203.0.113.26");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsTargetFpsOutOfRange) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.27", "create-test-fps-range");
+
+  auto too_low = make_valid_create_request("create-test-fps-too-low");
+  too_low.target_fps = 29;
+  EXPECT_EQ(stream_stats::create_benchmark_run(too_low, "device-fps-too-low", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_target_fps_out_of_range);
+
+  auto too_high = make_valid_create_request("create-test-fps-too-high");
+  too_high.target_fps = 241;
+  EXPECT_EQ(stream_stats::create_benchmark_run(too_high, "device-fps-too-high", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_target_fps_out_of_range);
+
+  stream_stats::remove_client("203.0.113.27");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsCapacityBelowNominalBudget) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.28", "create-test-capacity-below-nominal");
+
+  auto request = make_valid_create_request("create-test-capacity-below-nominal");
+  request.sample_capacity_frames = (120 * 120) - 1;  // nominal budget minus one frame.
+  const auto result = stream_stats::create_benchmark_run(request, "device-capacity-below-nominal", 1, true);
+
+  EXPECT_EQ(result, stream_stats::benchmark_run_create_result_e::rejected_capacity_below_nominal_budget);
+  stream_stats::remove_client("203.0.113.28");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsCapacityAboveMaximum) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.29", "create-test-capacity-above-maximum");
+
+  auto request = make_valid_create_request("create-test-capacity-above-maximum");
+  request.sample_capacity_frames = 65537;
+  const auto result = stream_stats::create_benchmark_run(request, "device-capacity-above-maximum", 1, true);
+
+  EXPECT_EQ(result, stream_stats::benchmark_run_create_result_e::rejected_capacity_exceeds_maximum);
+  stream_stats::remove_client("203.0.113.29");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsInvalidManifestSha256Format) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.30", "create-test-manifest-format");
+
+  auto wrong_length = make_valid_create_request("create-test-manifest-wrong-length");
+  wrong_length.manifest_sha256 = "abc123";
+  EXPECT_EQ(stream_stats::create_benchmark_run(wrong_length, "device-manifest-wrong-length", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_invalid_manifest_sha256_format);
+
+  auto uppercase = make_valid_create_request("create-test-manifest-uppercase");
+  uppercase.manifest_sha256 = std::string(64, 'A');
+  EXPECT_EQ(stream_stats::create_benchmark_run(uppercase, "device-manifest-uppercase", 1, true),
+            stream_stats::benchmark_run_create_result_e::rejected_invalid_manifest_sha256_format);
+
+  stream_stats::remove_client("203.0.113.30");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsWhenSessionAlreadyHasAnActiveRun) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.31", "create-test-session-already-active");
+
+  const auto first = stream_stats::create_benchmark_run(
+    make_valid_create_request("create-test-session-already-active-first"),
+    "device-session-already-active", 1, true);
+  ASSERT_EQ(first, stream_stats::benchmark_run_create_result_e::created);
+
+  const auto second = stream_stats::create_benchmark_run(
+    make_valid_create_request("create-test-session-already-active-second"),
+    "device-session-already-active", 1, true);
+  EXPECT_EQ(second, stream_stats::benchmark_run_create_result_e::rejected_session_already_has_an_active_run);
+
+  stream_stats::remove_client("203.0.113.31");
+}
+
+TEST(BenchmarkRunCreateTests, RejectsRunIdAlreadyUsed) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.32", "create-test-run-id-reused");
+
+  const auto first = stream_stats::create_benchmark_run(
+    make_valid_create_request("create-test-run-id-reused"),
+    "device-run-id-reused-first", 1, true);
+  ASSERT_EQ(first, stream_stats::benchmark_run_create_result_e::created);
+
+  // Different device_uuid, so the session-already-has-an-active-run
+  // precondition (scoped to owning_device_uuid) doesn't fire first - this
+  // isolates the run_id collision specifically.
+  const auto second = stream_stats::create_benchmark_run(
+    make_valid_create_request("create-test-run-id-reused"),
+    "device-run-id-reused-second", 1, true);
+  EXPECT_EQ(second, stream_stats::benchmark_run_create_result_e::rejected_run_id_already_used);
+
+  stream_stats::remove_client("203.0.113.32");
+}
+
+TEST(BenchmarkRunCreateTests, CreatesAndArmsWhenAllPreconditionsPass) {
+  BenchmarkControlPlaneGuard guard(true);
+  stream_stats::add_client("203.0.113.33", "create-test-happy-path");
+
+  const auto revision_at_arm = stream_stats::client_population_revision();
+  const auto before = std::chrono::steady_clock::now();
+  const auto result = stream_stats::create_benchmark_run(
+    make_valid_create_request("create-test-happy-path"),
+    "device-happy-path", 7, true);
+  const auto after = std::chrono::steady_clock::now();
+
+  ASSERT_EQ(result, stream_stats::benchmark_run_create_result_e::created);
+
+  const bool found = stream_stats::with_benchmark_run("create-test-happy-path",
+    [&](stream_stats::benchmark_run_t &run) {
+      EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::armed);
+      EXPECT_EQ(run.owning_device_uuid, "device-happy-path");
+      EXPECT_EQ(run.owning_session_generation, 7u);
+      EXPECT_EQ(run.manifest_sha256, std::string(64, 'a'));
+      EXPECT_EQ(run.label, "P0-7-synthetic-A-pair-03");
+      EXPECT_EQ(run.workload_id, "synthetic-frame-counter-v1");
+      EXPECT_EQ(run.target_fps, 120);
+      EXPECT_EQ(run.sample_capacity, 32768u);
+      EXPECT_EQ(run.expected_duration_ns, std::chrono::seconds(120));
+      EXPECT_EQ(run.duration_tolerance_ns, std::chrono::milliseconds(250));
+      EXPECT_EQ(run.drain_grace_ns, std::chrono::milliseconds(2000));
+      EXPECT_EQ(run.client_population_revision_at_arm, revision_at_arm);
+      EXPECT_GE(run.armed_monotonic, before);
+      EXPECT_LE(run.armed_monotonic, after);
+    });
+  EXPECT_TRUE(found);
+
+  stream_stats::remove_client("203.0.113.33");
+}


### PR DESCRIPTION
## Summary

Third of five pieces (approved pacing: one piece per PR, in order) for the benchmark-run-capture engine. Still not reachable in production - nothing calls `create_benchmark_run()` outside tests yet, since no control surface exists to invoke it (piece 4 adds `start`/`stop`/`get`/`delete`; the network-facing increment that will actually route real requests here comes later).

- **`create_benchmark_run()`** validates a create-and-arm request against every precondition in `measurement-spec-v1.md` §6.4 that this engine can check on its own - control plane enabled, caller authorized as the benchmark harness (not merely a paired client), exactly one active stream session, no active run already owned by that session, duration/tolerance/drain-grace/fps/capacity ranges, the nominal sample budget floor, run ID uniqueness, and `manifest_sha256`'s format - and only if all pass, constructs and inserts the armed run. The session-dedup check, run-ID-dedup check, and insert happen under a single hold of `benchmark_run_mutex` so two concurrent create calls can't both pass their checks and both insert.
- **Not checked**: that duration, tolerance, drain grace, target fps, capacity, and workload exactly match the frozen manifest. There's no manifest file infrastructure yet for this function to check against - a later piece (the evidence/manifest writer and validator) owns that. Documented directly on the function, matching this engine's established pattern (e.g. `started_in_window_without_terminal_count` from piece 1) of naming gaps rather than silently skipping them.
- **Not tested**: `rejected_nominal_sample_budget_too_small`. It's unreachable given the duration (≥60s) and fps (≥30) floors already enforced above it in the check order - 60 × 30 = 1800 always clears the spec's 1,000-frame floor. Kept in the engine anyway as a direct expression of the spec's own precondition, not an assumption those floors can never change independently (e.g. if either becomes config-driven later).
- **Authorization** is a boolean parameter the caller supplies - this piece is transport-agnostic. The real authorization decision (loopback/management-source policy, rate limits, audit logging) belongs to the network-facing control-surface increment. `benchmark_control_plane_enabled()` / `set_benchmark_control_plane_enabled()` are a plain flag (default off) standing in for that increment's real enablement switch, which will most likely just call this same setter once it reads its config.

## Exact candidate

```
Commit: cfadd7ab5b53c41015aa46c55a4b5d9725b173b7
Tree:   31d4c4c1cfc84ae29baab6fbb37c39ce090be5e9
Parent: 1e469d24b5159fd9db27b3275accb6f31ce33a32
Base:   1e469d24b5159fd9db27b3275accb6f31ce33a32
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all 335 targets built with no errors.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries.
- [x] `test_polaris_stream` - 155/155 tests, including 14 new `BenchmarkRunCreateTests`: one rejection test per reachable precondition (control plane disabled, caller unauthorized, zero active sessions, multiple active sessions, duration/tolerance/drain-grace/fps out of range at both bounds, capacity below nominal and above maximum, invalid manifest format, session-already-has-an-active-run, run-ID-already-used), plus a happy-path test asserting the armed run's fields - including the seconds/ms→ns conversions and `client_population_revision_at_arm` - match the request exactly.

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): `start`/`stop`/`get`/`delete` and the lazy draining→frozen transition, and wiring this into the hot path. Those are pieces 4-5.
