### PR TITLE
feat(telemetry): add start/stop/get/delete for benchmark runs

### DIFF
--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -1603,6 +1603,198 @@ namespace stream_stats {
     return benchmark_run_create_result_e::created;
   }
 
+  namespace {
+    // Caller must hold benchmark_run_mutex. Returns none if run is not
+    // currently active or draining, or if reality still matches what was
+    // true at arm time.
+    benchmark_abort_reason_e detect_abort_trigger_locked(const benchmark_run_t &run) {
+      const auto timing = get_session_timing(run.owning_device_uuid);
+      if (!timing.session_active) {
+        return benchmark_abort_reason_e::session_ended;
+      }
+      if (timing.session_generation != run.owning_session_generation) {
+        return benchmark_abort_reason_e::session_generation_changed;
+      }
+      if (client_population_revision() != run.client_population_revision_at_arm) {
+        return benchmark_abort_reason_e::client_population_revision_changed;
+      }
+      return benchmark_abort_reason_e::none;
+    }
+
+    // Caller must hold benchmark_run_mutex. Reconciles run's state with
+    // reality before whichever operation invoked this evaluates its own
+    // preconditions - see start_benchmark_run's header comment for why
+    // this exists instead of a background timer. Transitions can cascade
+    // (active -> draining -> frozen) within a single call if nobody
+    // touched this run for long enough that both deadlines already
+    // passed.
+    void apply_lazy_transitions_locked(benchmark_run_t &run) {
+      const auto now = std::chrono::steady_clock::now();
+
+      if (run.state == benchmark_run_state_e::active || run.state == benchmark_run_state_e::draining) {
+        const auto reason = detect_abort_trigger_locked(run);
+        if (reason != benchmark_abort_reason_e::none) {
+          run.state = benchmark_run_state_e::aborted;
+          run.abort_reason = reason;
+          run.frozen_monotonic = now;
+          enforce_terminal_retention_locked(benchmark_runs);
+          return;
+        }
+      }
+
+      if (run.state == benchmark_run_state_e::active && run.started_monotonic &&
+          now >= *run.started_monotonic + run.expected_duration_ns) {
+        // The declared deadline, not "now" - so actual_duration_ns reflects
+        // the run's own contract rather than however long it took for some
+        // caller to next touch this run and trigger this reconciliation.
+        run.stopped_monotonic = *run.started_monotonic + run.expected_duration_ns;
+        run.state = benchmark_run_state_e::draining;
+      }
+
+      if (run.state == benchmark_run_state_e::draining && run.stopped_monotonic &&
+          now >= *run.stopped_monotonic + run.drain_grace_ns) {
+        run.frozen_monotonic = now;
+        run.client_population_revision_at_freeze = client_population_revision();
+        run.state = benchmark_run_state_e::frozen;
+        enforce_terminal_retention_locked(benchmark_runs);
+      }
+    }
+  }  // namespace
+
+  benchmark_run_start_result_e start_benchmark_run(
+      const std::string &run_id,
+      const std::string &device_uuid,
+      std::uint64_t session_generation,
+      bool caller_is_authorized_harness) {
+    if (!benchmark_control_plane_enabled()) {
+      return benchmark_run_start_result_e::rejected_control_plane_not_enabled;
+    }
+    if (!caller_is_authorized_harness) {
+      return benchmark_run_start_result_e::rejected_caller_not_authorized_as_harness;
+    }
+
+    auto result = benchmark_run_start_result_e::rejected_run_not_found;
+    const bool found = with_benchmark_run(run_id, [&](benchmark_run_t &run) {
+      apply_lazy_transitions_locked(run);
+
+      if (run.owning_device_uuid != device_uuid || run.owning_session_generation != session_generation) {
+        result = benchmark_run_start_result_e::rejected_wrong_session;
+        return;
+      }
+      if (run.state != benchmark_run_state_e::armed) {
+        result = benchmark_run_start_result_e::rejected_run_not_in_armed_state;
+        return;
+      }
+      if (client_population_revision() != run.client_population_revision_at_arm) {
+        result = benchmark_run_start_result_e::rejected_population_changed_since_arm;
+        return;
+      }
+      if (!get_session_timing(device_uuid).session_active) {
+        result = benchmark_run_start_result_e::rejected_session_no_longer_active;
+        return;
+      }
+
+      run.started_monotonic = std::chrono::steady_clock::now();
+      run.state = benchmark_run_state_e::active;
+      result = benchmark_run_start_result_e::started;
+    });
+
+    return found ? result : benchmark_run_start_result_e::rejected_run_not_found;
+  }
+
+  benchmark_run_stop_result_e stop_benchmark_run(
+      const std::string &run_id,
+      const std::string &device_uuid,
+      std::uint64_t session_generation,
+      bool caller_is_authorized_harness) {
+    if (!benchmark_control_plane_enabled()) {
+      return benchmark_run_stop_result_e::rejected_control_plane_not_enabled;
+    }
+    if (!caller_is_authorized_harness) {
+      return benchmark_run_stop_result_e::rejected_caller_not_authorized_as_harness;
+    }
+
+    auto result = benchmark_run_stop_result_e::rejected_run_not_found;
+    const bool found = with_benchmark_run(run_id, [&](benchmark_run_t &run) {
+      apply_lazy_transitions_locked(run);
+
+      if (run.owning_device_uuid != device_uuid || run.owning_session_generation != session_generation) {
+        result = benchmark_run_stop_result_e::rejected_wrong_session;
+        return;
+      }
+      // started_monotonic is always set alongside state=active by
+      // start_benchmark_run - the "|| !run.started_monotonic" half is
+      // unreachable through any real call path, kept only so the
+      // dereference just below can never be undefined behavior if that
+      // invariant is ever violated (matches apply_lazy_transitions_locked's
+      // own defensive style on the same optional fields just above).
+      if (run.state != benchmark_run_state_e::active || !run.started_monotonic) {
+        result = benchmark_run_stop_result_e::rejected_not_currently_active;
+        return;
+      }
+
+      const auto now = std::chrono::steady_clock::now();
+      const auto elapsed = now - *run.started_monotonic;
+      const auto lower_bound = run.expected_duration_ns - run.duration_tolerance_ns;
+
+      if (elapsed < lower_bound) {
+        run.state = benchmark_run_state_e::aborted;
+        run.abort_reason = benchmark_abort_reason_e::stopped_before_duration_lower_bound;
+        run.frozen_monotonic = now;
+        enforce_terminal_retention_locked(benchmark_runs);
+        result = benchmark_run_stop_result_e::stopped_early_and_aborted;
+        return;
+      }
+
+      run.stopped_monotonic = now;
+      run.state = benchmark_run_state_e::draining;
+      result = benchmark_run_stop_result_e::stopped;
+    });
+
+    return found ? result : benchmark_run_stop_result_e::rejected_run_not_found;
+  }
+
+  benchmark_run_get_result_e get_benchmark_run(
+      const std::string &run_id,
+      bool caller_is_authorized_harness,
+      const std::function<void(benchmark_run_t &)> &fn) {
+    if (!benchmark_control_plane_enabled()) {
+      return benchmark_run_get_result_e::rejected_control_plane_not_enabled;
+    }
+    if (!caller_is_authorized_harness) {
+      return benchmark_run_get_result_e::rejected_caller_not_authorized_as_harness;
+    }
+
+    const bool found = with_benchmark_run(run_id, [&](benchmark_run_t &run) {
+      apply_lazy_transitions_locked(run);
+      fn(run);
+    });
+
+    return found ? benchmark_run_get_result_e::found : benchmark_run_get_result_e::rejected_run_not_found;
+  }
+
+  benchmark_run_delete_result_e delete_benchmark_run(
+      const std::string &run_id,
+      bool caller_is_authorized_harness) {
+    if (!benchmark_control_plane_enabled()) {
+      return benchmark_run_delete_result_e::rejected_control_plane_not_enabled;
+    }
+    if (!caller_is_authorized_harness) {
+      return benchmark_run_delete_result_e::rejected_caller_not_authorized_as_harness;
+    }
+
+    std::lock_guard<std::mutex> lock(benchmark_run_mutex);
+    const auto before = benchmark_runs.size();
+    benchmark_runs.erase(
+      std::remove_if(benchmark_runs.begin(), benchmark_runs.end(),
+        [&run_id](const benchmark_run_t &r) { return r.run_id == run_id; }),
+      benchmark_runs.end());
+
+    return benchmark_runs.size() < before
+      ? benchmark_run_delete_result_e::deleted
+      : benchmark_run_delete_result_e::rejected_run_not_found;
+  }
+
   int active_client_count() {
     std::lock_guard<std::mutex> lock(stats_mutex);
     return static_cast<int>(current_stats.clients.size());

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -863,6 +863,150 @@ namespace stream_stats {
     bool caller_is_authorized_harness);
 
   /**
+   * @brief Outcome of start_benchmark_run().
+   */
+  enum class benchmark_run_start_result_e {
+    started,
+    rejected_control_plane_not_enabled,
+    rejected_caller_not_authorized_as_harness,
+    rejected_run_not_found,
+    rejected_wrong_session,
+    rejected_run_not_in_armed_state,
+    rejected_population_changed_since_arm,
+    rejected_session_no_longer_active
+  };
+
+  /**
+   * @brief Transition an armed run to active, starting its measurement
+   * window. Every access to a run (this function and stop/get/delete
+   * below) first reconciles its state with reality via an internal lazy
+   * transition check - measurement-spec-v1.md 6.4's active->draining and
+   * draining->frozen deadlines, and the abort triggers (session ended,
+   * session generation changed, population changed) for a run already in
+   * its measurement window - since there is no background timer driving
+   * these; whichever caller happens to touch a run next is what notices.
+   * That reconciliation runs regardless of whether this call's own
+   * preconditions below end up rejecting it, so a stale run's state never
+   * depends on who last happened to ask about it.
+   *
+   * device_uuid/session_generation are a sanity/integrity check, not the
+   * authorization mechanism (that is caller_is_authorized_harness, same
+   * as create_benchmark_run) - the harness is expected to pass the
+   * identity of the session it is benchmarking, and this rejects a
+   * mismatch against what the run recorded at arm time, catching a stale
+   * run_id or a harness bookkeeping bug rather than silently starting the
+   * wrong run.
+   *
+   * rejected_population_changed_since_arm covers a gap the abort-trigger
+   * machinery above doesn't: that machinery only watches already-active or
+   * -draining runs, so a population change that happens while still
+   * *armed* (before start) needs its own check here, before the
+   * measurement window - and the abort semantics that assume one - even
+   * begins.
+   *
+   * @param run_id The run to start.
+   * @param device_uuid The session being benchmarked (session_t::device_uuid).
+   * @param session_generation That session's generation (session_t::session_generation).
+   * @param caller_is_authorized_harness See create_benchmark_run's parameter of the same name.
+   */
+  benchmark_run_start_result_e start_benchmark_run(
+    const std::string &run_id,
+    const std::string &device_uuid,
+    std::uint64_t session_generation,
+    bool caller_is_authorized_harness);
+
+  /**
+   * @brief Outcome of stop_benchmark_run().
+   */
+  enum class benchmark_run_stop_result_e {
+    stopped,
+    stopped_early_and_aborted,
+    rejected_control_plane_not_enabled,
+    rejected_caller_not_authorized_as_harness,
+    rejected_run_not_found,
+    rejected_wrong_session,
+    rejected_not_currently_active
+  };
+
+  /**
+   * @brief Explicitly stop an active run. measurement-spec-v1.md 6.4: "An
+   * explicit stop before the lower bound aborts the run; it cannot freeze
+   * a short run as valid merely because percentile sample floors were
+   * met." The lower bound is expected_duration_ns - duration_tolerance_ns;
+   * stopping at or after it transitions to draining (a normal stop, same
+   * as the automatic lazy transition at the declared deadline would have
+   * done); stopping before it aborts with stopped_before_duration_lower_bound.
+   *
+   * Calling this on a run that is not (after the same lazy reconciliation
+   * start_benchmark_run runs) currently active - already draining, frozen,
+   * aborted, still armed, or unknown - is rejected rather than treated as
+   * a no-op success, so a duplicate stop is visible as such to the caller.
+   *
+   * @param run_id The run to stop.
+   * @param device_uuid The session being benchmarked - see start_benchmark_run.
+   * @param session_generation That session's generation - see start_benchmark_run.
+   * @param caller_is_authorized_harness See create_benchmark_run's parameter of the same name.
+   */
+  benchmark_run_stop_result_e stop_benchmark_run(
+    const std::string &run_id,
+    const std::string &device_uuid,
+    std::uint64_t session_generation,
+    bool caller_is_authorized_harness);
+
+  /**
+   * @brief Outcome of get_benchmark_run().
+   */
+  enum class benchmark_run_get_result_e {
+    found,
+    rejected_control_plane_not_enabled,
+    rejected_caller_not_authorized_as_harness,
+    rejected_run_not_found
+  };
+
+  /**
+   * @brief Look up a run by ID, applying the same lazy state reconciliation
+   * described on start_benchmark_run first, then invoke fn with the
+   * up-to-date run while still holding the storage lock - the same
+   * locked-visitor contract as with_benchmark_run (piece 2), reused here
+   * rather than copying a potentially large run (up to 65,536 samples per
+   * stage) out on every read. fn must not call back into any
+   * stream_stats function that takes benchmark_run_mutex.
+   *
+   * Unlike start/stop, this takes no device_uuid/session_generation - the
+   * harness reads any run by its ID directly, not scoped to "the session
+   * it currently owns."
+   *
+   * @param run_id The run to look up.
+   * @param caller_is_authorized_harness See create_benchmark_run's parameter of the same name.
+   * @param fn Invoked with the run if found.
+   */
+  benchmark_run_get_result_e get_benchmark_run(
+    const std::string &run_id,
+    bool caller_is_authorized_harness,
+    const std::function<void(benchmark_run_t &)> &fn);
+
+  /**
+   * @brief Outcome of delete_benchmark_run().
+   */
+  enum class benchmark_run_delete_result_e {
+    deleted,
+    rejected_control_plane_not_enabled,
+    rejected_caller_not_authorized_as_harness,
+    rejected_run_not_found
+  };
+
+  /**
+   * @brief Delete a run's storage immediately, regardless of its current
+   * state (measurement-spec-v1.md 6.4: "DELETE releases payload storage
+   * immediately") - unlike expire, this leaves no tombstone at all.
+   * @param run_id The run to delete.
+   * @param caller_is_authorized_harness See create_benchmark_run's parameter of the same name.
+   */
+  benchmark_run_delete_result_e delete_benchmark_run(
+    const std::string &run_id,
+    bool caller_is_authorized_harness);
+
+  /**
    * @brief Get the number of active client sessions.
    * @return Count of active clients.
    */

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -1730,3 +1730,433 @@ TEST(BenchmarkRunCreateTests, CreatesAndArmsWhenAllPreconditionsPass) {
 
   stream_stats::remove_client("203.0.113.33");
 }
+
+// P0-5 benchmark-run-capture engine, piece 4: start_benchmark_run(),
+// stop_benchmark_run(), get_benchmark_run(), delete_benchmark_run(), and
+// the lazy state-reconciliation they all share (measurement-spec-v1.md
+// 6.4's active->draining and draining->frozen deadlines, plus the
+// session-ended/generation-changed/population-changed abort triggers for
+// an already-active-or-draining run). "Lazy" means there is no timer
+// thread - reconciliation only happens when something next calls one of
+// these four functions for a given run_id, which is why several tests
+// below backdate a run's started_monotonic/stopped_monotonic directly
+// (the same technique BenchmarkRunRetentionTests uses for frozen_monotonic
+// above) rather than actually sleeping past a 60-180s duration in a unit
+// test.
+
+namespace {
+  // RAII: stands up one active client + one live session-timing entry +
+  // one armed benchmark run owned by that session - the trio every
+  // start/stop/get/delete test needs, since start_benchmark_run and the
+  // abort-trigger check both call get_session_timing(). Control plane must
+  // already be enabled (via BenchmarkControlPlaneGuard) before construction,
+  // since arming goes through the real create_benchmark_run. Teardown uses
+  // the ungated erase_benchmark_run/stop_session_timing/remove_client
+  // directly rather than the gated public delete/stop calls under test, so
+  // cleanup can't itself be blocked by whatever state a test left behind
+  // (e.g. control plane disabled, or the run already deleted).
+  struct ArmedRunFixture {
+    std::string ip;
+    std::string device_uuid;
+    std::uint64_t session_generation;
+    std::string run_id;
+
+    ArmedRunFixture(std::string ip_in, std::string device_uuid_in, std::uint64_t session_generation_in, std::string run_id_in):
+        ip(std::move(ip_in)), device_uuid(std::move(device_uuid_in)),
+        session_generation(session_generation_in), run_id(std::move(run_id_in)) {
+      stream_stats::add_client(ip, device_uuid);
+      stream_stats::start_session_timing(device_uuid, session_generation);
+      const auto result = stream_stats::create_benchmark_run(
+        make_valid_create_request(run_id), device_uuid, session_generation, true);
+      EXPECT_EQ(result, stream_stats::benchmark_run_create_result_e::created);
+    }
+
+    ~ArmedRunFixture() {
+      stream_stats::erase_benchmark_run(run_id);
+      stream_stats::stop_session_timing(device_uuid, session_generation);
+      stream_stats::remove_client(ip);
+    }
+  };
+
+  // The exact lower bound make_valid_create_request()'s 120s/250ms pair
+  // implies, per measurement-spec-v1.md 6.4's
+  // abs(actual_duration_ns - expected_duration_ns) <= duration_tolerance_ns.
+  std::chrono::nanoseconds valid_request_duration_lower_bound() {
+    return std::chrono::seconds(120) - std::chrono::milliseconds(250);
+  }
+}  // namespace
+
+TEST(BenchmarkRunLifecycleTests, StartRejectsWhenControlPlaneIsNotEnabled) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.40", "device-start-cp-disabled", 1, "lifecycle-start-cp-disabled");
+
+  stream_stats::set_benchmark_control_plane_enabled(false);
+  const auto result = stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_start_result_e::rejected_control_plane_not_enabled);
+  stream_stats::set_benchmark_control_plane_enabled(true);
+}
+
+TEST(BenchmarkRunLifecycleTests, StartRejectsWhenCallerIsNotAuthorizedAsHarness) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.41", "device-start-unauthorized", 1, "lifecycle-start-unauthorized");
+
+  const auto result = stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, false);
+  EXPECT_EQ(result, stream_stats::benchmark_run_start_result_e::rejected_caller_not_authorized_as_harness);
+}
+
+TEST(BenchmarkRunLifecycleTests, StartRejectsWhenRunNotFound) {
+  BenchmarkControlPlaneGuard guard(true);
+
+  const auto result = stream_stats::start_benchmark_run("lifecycle-start-unknown-run", "device-x", 1, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_start_result_e::rejected_run_not_found);
+}
+
+TEST(BenchmarkRunLifecycleTests, StartRejectsWrongSession) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.42", "device-start-wrong-session", 1, "lifecycle-start-wrong-session");
+
+  EXPECT_EQ(stream_stats::start_benchmark_run(fixture.run_id, "some-other-device", fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::rejected_wrong_session)
+    << "wrong device_uuid";
+  EXPECT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation + 1, true),
+            stream_stats::benchmark_run_start_result_e::rejected_wrong_session)
+    << "right device_uuid, wrong session_generation";
+}
+
+TEST(BenchmarkRunLifecycleTests, StartRejectsWhenRunNotInArmedState) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.43", "device-start-duplicate", 1, "lifecycle-start-duplicate");
+
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  const auto second = stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  EXPECT_EQ(second, stream_stats::benchmark_run_start_result_e::rejected_run_not_in_armed_state)
+    << "a duplicate start must be rejected, not silently re-accepted";
+}
+
+TEST(BenchmarkRunLifecycleTests, StartRejectsWhenPopulationChangedSinceArm) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.44", "device-start-population-drift", 1, "lifecycle-start-population-drift");
+
+  stream_stats::add_client("203.0.113.45", "lifecycle-start-population-churn");
+  stream_stats::remove_client("203.0.113.45");
+
+  const auto result = stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_start_result_e::rejected_population_changed_since_arm);
+}
+
+TEST(BenchmarkRunLifecycleTests, StartRejectsWhenSessionNoLongerActive) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.46", "device-start-session-ended", 1, "lifecycle-start-session-ended");
+
+  stream_stats::stop_session_timing(fixture.device_uuid, fixture.session_generation);
+
+  const auto result = stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_start_result_e::rejected_session_no_longer_active);
+}
+
+TEST(BenchmarkRunLifecycleTests, StartSucceedsAndActivatesWhenAllPreconditionsPass) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.47", "device-start-happy-path", 1, "lifecycle-start-happy-path");
+
+  const auto before = std::chrono::steady_clock::now();
+  const auto result = stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  const auto after = std::chrono::steady_clock::now();
+  ASSERT_EQ(result, stream_stats::benchmark_run_start_result_e::started);
+
+  const auto get_result = stream_stats::get_benchmark_run(fixture.run_id, true, [&](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::active);
+    ASSERT_TRUE(run.started_monotonic.has_value());
+    EXPECT_GE(*run.started_monotonic, before);
+    EXPECT_LE(*run.started_monotonic, after);
+  });
+  EXPECT_EQ(get_result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunLifecycleTests, StopRejectsWhenControlPlaneIsNotEnabled) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.48", "device-stop-cp-disabled", 1, "lifecycle-stop-cp-disabled");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  stream_stats::set_benchmark_control_plane_enabled(false);
+  const auto result = stream_stats::stop_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_stop_result_e::rejected_control_plane_not_enabled);
+  stream_stats::set_benchmark_control_plane_enabled(true);
+}
+
+TEST(BenchmarkRunLifecycleTests, StopRejectsWhenCallerIsNotAuthorizedAsHarness) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.49", "device-stop-unauthorized", 1, "lifecycle-stop-unauthorized");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  const auto result = stream_stats::stop_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, false);
+  EXPECT_EQ(result, stream_stats::benchmark_run_stop_result_e::rejected_caller_not_authorized_as_harness);
+}
+
+TEST(BenchmarkRunLifecycleTests, StopRejectsWhenRunNotFound) {
+  BenchmarkControlPlaneGuard guard(true);
+
+  const auto result = stream_stats::stop_benchmark_run("lifecycle-stop-unknown-run", "device-x", 1, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_stop_result_e::rejected_run_not_found);
+}
+
+TEST(BenchmarkRunLifecycleTests, StopRejectsWrongSession) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.50", "device-stop-wrong-session", 1, "lifecycle-stop-wrong-session");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  const auto result = stream_stats::stop_benchmark_run(fixture.run_id, "some-other-device", fixture.session_generation, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_stop_result_e::rejected_wrong_session);
+}
+
+TEST(BenchmarkRunLifecycleTests, StopRejectsWhenNotCurrentlyActive) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.51", "device-stop-not-active", 1, "lifecycle-stop-not-active");
+
+  const auto stop_while_armed = stream_stats::stop_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  EXPECT_EQ(stop_while_armed, stream_stats::benchmark_run_stop_result_e::rejected_not_currently_active)
+    << "never started";
+
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+  // Real elapsed time here is microseconds, well before the 119.75s lower
+  // bound, so this first stop is correctly an early abort, not a plain
+  // stop - StopAbortsWhenCalledBeforeTheDurationLowerBound covers that
+  // path directly. What this test cares about is that state is no longer
+  // active either way, so the second call below must still be rejected.
+  ASSERT_EQ(stream_stats::stop_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_stop_result_e::stopped_early_and_aborted);
+
+  const auto duplicate_stop = stream_stats::stop_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  EXPECT_EQ(duplicate_stop, stream_stats::benchmark_run_stop_result_e::rejected_not_currently_active)
+    << "a duplicate stop must be rejected, not silently re-accepted";
+}
+
+TEST(BenchmarkRunLifecycleTests, StopAbortsWhenCalledBeforeTheDurationLowerBound) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.52", "device-stop-early", 1, "lifecycle-stop-early");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  const auto result = stream_stats::stop_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_stop_result_e::stopped_early_and_aborted)
+    << "this test stops within milliseconds of starting, nowhere near the 119.75s lower bound";
+
+  const auto get_result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::aborted);
+    EXPECT_EQ(run.abort_reason, stream_stats::benchmark_abort_reason_e::stopped_before_duration_lower_bound);
+  });
+  EXPECT_EQ(get_result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunLifecycleTests, StopTransitionsToDrainingWhenCalledExactlyAtTheDurationLowerBound) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.53", "device-stop-at-lower-bound", 1, "lifecycle-stop-at-lower-bound");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  // Backdate started_monotonic so "elapsed" already equals the lower bound
+  // exactly, without sleeping through a 60-180s duration in a unit test -
+  // the same technique BenchmarkRunRetentionTests uses on frozen_monotonic.
+  stream_stats::with_benchmark_run(fixture.run_id, [](stream_stats::benchmark_run_t &run) {
+    run.started_monotonic = std::chrono::steady_clock::now() - valid_request_duration_lower_bound();
+  });
+
+  const auto result = stream_stats::stop_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_stop_result_e::stopped)
+    << "exactly at the lower bound must be accepted, not aborted";
+
+  const auto get_result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::draining);
+  });
+  EXPECT_EQ(get_result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunLifecycleTests, GetRejectsWhenControlPlaneIsNotEnabled) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.54", "device-get-cp-disabled", 1, "lifecycle-get-cp-disabled");
+
+  stream_stats::set_benchmark_control_plane_enabled(false);
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &) {
+    FAIL() << "callback must not run when the control plane is disabled";
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::rejected_control_plane_not_enabled);
+  stream_stats::set_benchmark_control_plane_enabled(true);
+}
+
+TEST(BenchmarkRunLifecycleTests, GetRejectsWhenCallerIsNotAuthorizedAsHarness) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.55", "device-get-unauthorized", 1, "lifecycle-get-unauthorized");
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, false, [](stream_stats::benchmark_run_t &) {
+    FAIL() << "callback must not run for an unauthorized caller";
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::rejected_caller_not_authorized_as_harness);
+}
+
+TEST(BenchmarkRunLifecycleTests, GetRejectsWhenRunNotFound) {
+  BenchmarkControlPlaneGuard guard(true);
+
+  const auto result = stream_stats::get_benchmark_run("lifecycle-get-unknown-run", true, [](stream_stats::benchmark_run_t &) {
+    FAIL() << "callback must not run for an unknown run_id";
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::rejected_run_not_found);
+}
+
+TEST(BenchmarkRunLifecycleTests, GetFindsAnArmedRunAndAppliesNoTransition) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.56", "device-get-armed", 1, "lifecycle-get-armed");
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::armed);
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunLifecycleTests, GetAppliesLazyTransitionFromActiveToDrainingBeforeReturning) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.57", "device-get-lazy-draining", 1, "lifecycle-get-lazy-draining");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  // The full expected duration has "already elapsed" but drain grace has
+  // not - stop_benchmark_run is never called, so this is purely GET
+  // noticing the deadline on its own.
+  stream_stats::with_benchmark_run(fixture.run_id, [](stream_stats::benchmark_run_t &run) {
+    run.started_monotonic = std::chrono::steady_clock::now() - std::chrono::seconds(120);
+  });
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::draining);
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunLifecycleTests, GetCascadesLazyTransitionAllTheWayToFrozen) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.58", "device-get-lazy-frozen", 1, "lifecycle-get-lazy-frozen");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  const auto revision_before_freeze = stream_stats::client_population_revision();
+
+  // Both the full duration AND the drain grace have "already elapsed" -
+  // a single get() call must cascade active -> draining -> frozen, not
+  // require two separate lazy checks to fully resolve.
+  stream_stats::with_benchmark_run(fixture.run_id, [](stream_stats::benchmark_run_t &run) {
+    run.started_monotonic = std::chrono::steady_clock::now() - std::chrono::seconds(123);
+  });
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [&](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::frozen);
+    EXPECT_TRUE(run.frozen_monotonic.has_value());
+    EXPECT_EQ(run.client_population_revision_at_freeze, revision_before_freeze);
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunLifecycleTests, GetObservesAbortWhenSessionEndedMidRun) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.59", "device-get-abort-session-ended", 1, "lifecycle-get-abort-session-ended");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  stream_stats::stop_session_timing(fixture.device_uuid, fixture.session_generation);
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::aborted);
+    EXPECT_EQ(run.abort_reason, stream_stats::benchmark_abort_reason_e::session_ended);
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunLifecycleTests, GetObservesAbortWhenPopulationChangedMidRun) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.60", "device-get-abort-population", 1, "lifecycle-get-abort-population");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  stream_stats::add_client("203.0.113.61", "lifecycle-get-abort-population-churn");
+  stream_stats::remove_client("203.0.113.61");
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::aborted);
+    EXPECT_EQ(run.abort_reason, stream_stats::benchmark_abort_reason_e::client_population_revision_changed);
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunLifecycleTests, GetObservesAbortWhenSessionGenerationChangedMidRun) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.62", "device-get-abort-generation", 1, "lifecycle-get-abort-generation");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  // Simulates the same device reconnecting mid-run and claiming a new
+  // generation - start_session_timing() discards and replaces any existing
+  // entry for this uuid, same as a real reconnect would.
+  stream_stats::start_session_timing(fixture.device_uuid, fixture.session_generation + 1);
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::aborted);
+    EXPECT_EQ(run.abort_reason, stream_stats::benchmark_abort_reason_e::session_generation_changed);
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+
+  // The fixture's own teardown stops session_generation, which the newer
+  // generation registered above has already displaced - clean that one up
+  // too so it doesn't leak into a later test.
+  stream_stats::stop_session_timing(fixture.device_uuid, fixture.session_generation + 1);
+}
+
+TEST(BenchmarkRunLifecycleTests, DeleteRejectsWhenControlPlaneIsNotEnabled) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.63", "device-delete-cp-disabled", 1, "lifecycle-delete-cp-disabled");
+
+  stream_stats::set_benchmark_control_plane_enabled(false);
+  const auto result = stream_stats::delete_benchmark_run(fixture.run_id, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_delete_result_e::rejected_control_plane_not_enabled);
+  stream_stats::set_benchmark_control_plane_enabled(true);
+}
+
+TEST(BenchmarkRunLifecycleTests, DeleteRejectsWhenCallerIsNotAuthorizedAsHarness) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.64", "device-delete-unauthorized", 1, "lifecycle-delete-unauthorized");
+
+  const auto result = stream_stats::delete_benchmark_run(fixture.run_id, false);
+  EXPECT_EQ(result, stream_stats::benchmark_run_delete_result_e::rejected_caller_not_authorized_as_harness);
+}
+
+TEST(BenchmarkRunLifecycleTests, DeleteRejectsWhenRunNotFound) {
+  BenchmarkControlPlaneGuard guard(true);
+
+  const auto result = stream_stats::delete_benchmark_run("lifecycle-delete-unknown-run", true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_delete_result_e::rejected_run_not_found);
+}
+
+TEST(BenchmarkRunLifecycleTests, DeleteRemovesAnArmedRunImmediatelyAndLeavesNoTombstone) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.65", "device-delete-armed", 1, "lifecycle-delete-armed");
+
+  ASSERT_EQ(stream_stats::delete_benchmark_run(fixture.run_id, true), stream_stats::benchmark_run_delete_result_e::deleted);
+
+  const auto get_result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &) {
+    FAIL() << "deleted runs must leave no tombstone, unlike expiry";
+  });
+  EXPECT_EQ(get_result, stream_stats::benchmark_run_get_result_e::rejected_run_not_found);
+}
+
+TEST(BenchmarkRunLifecycleTests, DeleteWorksRegardlessOfRunState) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.66", "device-delete-active", 1, "lifecycle-delete-active");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  const auto result = stream_stats::delete_benchmark_run(fixture.run_id, true);
+  EXPECT_EQ(result, stream_stats::benchmark_run_delete_result_e::deleted)
+    << "delete must not require a terminal state first";
+}


### PR DESCRIPTION
## Summary

Fourth of five pieces (approved pacing: one piece per PR, in order) for the benchmark-run-capture engine. Still not reachable in production - no control surface calls any of this yet; that is the final, separate increment on top of all five engine pieces.

- **`start_benchmark_run()` / `stop_benchmark_run()` / `get_benchmark_run()` / `delete_benchmark_run()`** round out the run lifecycle `create_benchmark_run` (piece 3) only arms. All four first run a shared lazy state reconciliation (`apply_lazy_transitions_locked`) before evaluating their own preconditions, since there is no background timer driving `measurement-spec-v1.md` §6.4's active→draining and draining→frozen deadlines, or its session-ended/generation-changed/population-changed abort triggers for a run already in its measurement window - whichever caller next touches a run is what notices, and that reconciliation runs unconditionally so a stale run's state never depends on who last happened to ask about it. Transitions can cascade (active→draining→frozen) within one call if nobody touched a run for long enough that both deadlines already passed.
- **`start_benchmark_run()`** checks a precondition the abort-trigger machinery can't: population drift while still *armed* (before a measurement window exists for that machinery to watch). Also verifies `device_uuid`/`session_generation` match what was recorded at arm time (a sanity/integrity check, not the authorization mechanism - that's `caller_is_authorized_harness`, same as `create_benchmark_run`) and that the session is still live.
- **`stop_benchmark_run()`** implements the spec's early-stop rule directly: stopping before `expected_duration_ns - duration_tolerance_ns` aborts (`stopped_before_duration_lower_bound`) rather than freezing a short run as valid; stopping at or after it transitions normally to draining. A duplicate stop (run no longer active) is rejected, not silently re-accepted.
- **`get_benchmark_run()`** reuses piece 2's `with_benchmark_run` locked-visitor contract rather than copying a potentially 65,536-sample-per-stage run out on every read.
- **`delete_benchmark_run()`** is unconditional on state, per the spec's "releases payload storage immediately," and leaves no tombstone at all (unlike expiry).
- **Caught in review before this shipped:** `stop_benchmark_run` dereferenced `*run.started_monotonic` unchecked, while `apply_lazy_transitions_locked` guards the same optional on the same struct one function up. The invariant (`state==active` implies `started_monotonic` is set) holds for every real call path today - only `start_benchmark_run` ever sets `state=active`, always alongside `started_monotonic` in the same statement - but the inconsistency was real, so added the same guard rather than leaving a latent UB risk if that invariant is ever broken by future code.

## Exact candidate

```
Commit: 2de5a5f23185068dcd956df5838a700d297fb32f
Tree:   5c4136a3b776717de1cd51d70d97338357609215
Parent: fe9444ba4d7e00effc7f29a6ba00e3c662d71fc0
Base:   fe9444ba4d7e00effc7f29a6ba00e3c662d71fc0
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all 335 targets built with no errors.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries.
- [x] `test_polaris_stream` - 184/184 tests, including 29 new `BenchmarkRunLifecycleTests`: rejection coverage for every enum value across all four functions, duplicate-start/duplicate-stop idempotence, the early-stop-aborts-vs-stop-at-the-exact-lower-bound boundary (backdating `started_monotonic` the same way `BenchmarkRunRetentionTests` backdates `frozen_monotonic`, rather than sleeping through a 60-180s duration), GET observing a lazy transition it didn't cause (both single-step to draining and the full cascade to frozen in one call), all three abort triggers (session ended, session generation changed, population changed) observed via GET mid-run, and DELETE working on both an armed and an active run with no tombstone left behind.
- [x] Caught and fixed one real test bug during this verification pass: `StopRejectsWhenNotCurrentlyActive` originally asserted a plain `stopped` result for a stop call issued microseconds after start - which is actually `stopped_early_and_aborted` by the spec's own lower-bound rule, exactly as `StopAbortsWhenCalledBeforeTheDurationLowerBound` already covers. Fixed the assertion rather than the (correct) implementation.

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): wiring `record_benchmark_sample` into the hot path. That's piece 5, the last of the five.
