### PR TITLE
fix(https): set a TLS session id context so resuming clients don't fail

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3191,6 +3191,11 @@ namespace nvhttp {
       context.set_options(boost::asio::ssl::context::no_tlsv1_1);
       context.use_certificate_chain_file(certification_file);
       context.use_private_key_file(private_key_file, boost::asio::ssl::context::pem);
+      // A server that requests client certificates must also set a session id
+      // context, or OpenSSL rejects TLS session resumption with a fatal
+      // internal_error alert (SSL_R_SESSION_ID_CONTEXT_UNINITIALIZED).
+      static constexpr unsigned char session_id_context[] = "polaris";
+      SSL_CTX_set_session_id_context(context.native_handle(), session_id_context, sizeof(session_id_context) - 1);
     }
 
     std::function<bool(std::shared_ptr<Request>, SSL*)> verify;


### PR DESCRIPTION
## Summary

The HTTPS server requests client certificates but never sets an OpenSSL session id context, so any client that attempts TLS session resumption gets a fatal `internal_error` alert (`SSL_R_SESSION_ID_CONTEXT_UNINITIALIZED`) before a request is read. Nova started resuming sessions when its TLS client became instance-scoped (nova#203, shipped in v1.3.5): on the Retroid this presents as **Reset Game Profile always failing** (`/optimizer/profile/clear` rides the no-retry POST path) and intermittent client-settings sync failures, with nothing in the server logs because the connection dies mid-handshake. Live logcat shows six consecutive `SSLHandshakeException` / `TLSV1_ALERT_INTERNAL_ERROR` failures on exactly this call.

## Exact candidate

One change in `PolarisHTTPSServer`'s constructor (`src/nvhttp.cpp`): call `SSL_CTX_set_session_id_context` with a stable application-scoped id after loading the certificate and key. This is the standard OpenSSL requirement whenever client-certificate verification and session reuse coexist; it keeps resumption working rather than disabling it. No config surface, no served-field changes (`docs/nova-contract.json` untouched).

## Verification

- Full rebuild in a fresh worktree off `master` (Release, CUDA off + `POLARIS_ALLOW_CUDA_DISABLED_ON_NVIDIA=ON`, shared Boost, tests on).
- `ctest`: **17/17 passed** (serial run; a parallel `-j4` run flakes `Logging/LogLevelsTest` by log-sink contention — pre-existing, passes in isolation and serially).
- Post-deploy on-device check planned: spam Reset Game Profile ×10 from the RP6 (Control Ultimate Edition), expect 10× "Game profile reset", zero `TLSV1_ALERT_INTERNAL_ERROR` lines in logcat, and `Cleared game profile` entries in the host journal.
