### PR TITLE
fix(stream): feed network stats from the ENet peer on periodic pings

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1012,6 +1012,28 @@ namespace stream {
   void controlBroadcastThread(control_server_t *server) {
     server->map(packetTypes[IDX_PERIODIC_PING], [](session_t *session, const std::string_view &payload) {
       BOOST_LOG(verbose) << "type [IDX_PERIODIC_PING]"sv;
+
+      // Clients on the periodic-ping protocol path never send IDX_LOSS_STATS, so this
+      // is the only packet their sessions can source network health from. ENet already
+      // maintains a smoothed mean RTT and reliable-packet loss ratio on the peer.
+      if (!session->control.peer) {
+        return;
+      }
+
+      const double rtt_ms = (double) session->control.peer->roundTripTime;
+      const double loss_pct = stream_stats::packet_loss_percent(
+        session->control.peer->packetLoss,
+        ENET_PEER_PACKET_LOSS_SCALE);
+
+      if (adaptive_bitrate::is_enabled()) {
+        adaptive_bitrate::update_network_stats(loss_pct, rtt_ms);
+      }
+
+      const auto client_ip = platf::from_sockaddr((sockaddr *) &session->control.peer->address.address);
+      if (!client_ip.empty()) {
+        stream_stats::update_network_stats(client_ip, rtt_ms, loss_pct, 0);
+      }
+      stream_stats::update_network_stats(rtt_ms, loss_pct, 0);
     });
 
     server->map(packetTypes[IDX_START_A], [&](session_t *session, const std::string_view &payload) {

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -1076,6 +1076,13 @@ namespace stream_stats {
     hot_frame_jitter_ms.store(frame_jitter_ms, std::memory_order_relaxed);
   }
 
+  double packet_loss_percent(uint64_t scaled_loss, uint64_t scale) {
+    if (scale == 0) {
+      return 0.0;
+    }
+    return std::clamp((double) scaled_loss * 100.0 / (double) scale, 0.0, 100.0);
+  }
+
   void update_network_stats(double latency_ms, double packet_loss, uint64_t bytes_sent) {
     // Fully lock-free: no per-client mirror exists on this overload.
     hot_latency_ms.store(latency_ms, std::memory_order_relaxed);

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -339,6 +339,15 @@ namespace stream_stats {
   void update_network_stats(const std::string &client_ip, double latency_ms, double packet_loss, uint64_t bytes_sent);
 
   /**
+   * @brief Convert a scaled loss ratio (e.g. ENet's peer packetLoss against
+   *        ENET_PEER_PACKET_LOSS_SCALE) to the 0-100 percentage this module stores.
+   * @param scaled_loss Loss ratio numerator as reported by the transport.
+   * @param scale Value of the transport's full-loss denominator; 0 yields 0.0.
+   * @return Packet loss percentage clamped to [0.0, 100.0].
+   */
+  double packet_loss_percent(uint64_t scaled_loss, uint64_t scale);
+
+  /**
    * @brief Update runtime mode metadata exposed to the dashboard.
    * @param state Current runtime state for the active backend.
    */

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -777,6 +777,29 @@ TEST(StreamStatsHotFieldTests, UpdateNetworkStatsIsVisibleThroughGetCurrent) {
   stream_stats::update_stream_active(false);
 }
 
+// The periodic-ping handler in stream.cpp sources loss from ENet's scaled
+// peer->packetLoss; this module stores percent (0-100), matching the readers
+// (network_risk thresholds at 0.35%, session grading at 0.5/2/5%).
+TEST(StreamStatsHotFieldTests, PacketLossPercentConvertsScaledRatios) {
+  constexpr uint64_t scale = 1ull << 16;  // ENET_PEER_PACKET_LOSS_SCALE
+
+  EXPECT_DOUBLE_EQ(stream_stats::packet_loss_percent(0, scale), 0.0);
+  EXPECT_DOUBLE_EQ(stream_stats::packet_loss_percent(scale, scale), 100.0);
+  EXPECT_DOUBLE_EQ(stream_stats::packet_loss_percent(scale / 2, scale), 50.0);
+  // 0.35% loss - exactly the network_risk threshold - survives the conversion.
+  EXPECT_NEAR(stream_stats::packet_loss_percent(229, scale), 0.3494, 0.001);
+}
+
+TEST(StreamStatsHotFieldTests, PacketLossPercentClampsDegenerateInputs) {
+  constexpr uint64_t scale = 1ull << 16;
+
+  // A transport briefly reporting loss above its own scale must clamp, not
+  // exceed 100%.
+  EXPECT_DOUBLE_EQ(stream_stats::packet_loss_percent(scale * 2, scale), 100.0);
+  // A zero scale is a caller bug; report no loss rather than dividing by zero.
+  EXPECT_DOUBLE_EQ(stream_stats::packet_loss_percent(123, 0), 0.0);
+}
+
 // P0-3A: T0-T2 timing state is per-session, keyed by device_uuid plus a
 // session_generation (measurement-spec-v1.md's ownership model - a
 // process-lifetime-monotonic counter, distinct from device_uuid, assigned


### PR DESCRIPTION
## Summary

`stream_stats`' network fields (`packet_loss`, `latency_ms`) are frozen at 0.0 for every modern client: the only writer was the `IDX_LOSS_STATS` handler, and clients past appversion 7.1.415 use moonlight-common-c's periodic-ping path instead — whose Polaris handler was a log-only no-op. Consequences: `network_risk` can never legitimately fire (Nova's HUD "Network jitter" was a permanent false positive for the unrelated client-side reason fixed in nova#211), session grading always sees zero loss/latency, and adaptive bitrate (when enabled) receives no data.

## Exact candidate

- `src/stream.cpp`: the `IDX_PERIODIC_PING` handler now reads the control-channel ENet peer — `roundTripTime` (smoothed mean RTT, ms) and `packetLoss` (smoothed reliable-packet loss ratio vs `ENET_PEER_PACKET_LOSS_SCALE`) — and calls both `stream_stats::update_network_stats` overloads exactly like the legacy handler, plus `adaptive_bitrate::update_network_stats` under its existing `is_enabled()` gate.
- `src/stream_stats.{h,cpp}`: new pure `packet_loss_percent(scaled_loss, scale)` → percent clamped to [0,100], zero-scale guarded.
- **Units decision (deliberate deviation from the working plan, which said "normalize to a 0..1 fraction"):** percent is provably the module's canonical unit — the header documents `(0-100)`, `process.cpp:3022` grades at `< 0.5 / 2.0 / 5.0`, and `process.cpp:6771` copies the value into `packet_loss_pct`. A fraction would have corrupted those readers. The `network_risk >= 0.35` threshold therefore means 0.35% loss, which is a sane elevation cut for game streaming. Legacy writer unchanged.

## Verification

- New `PacketLossPercentConvertsScaledRatios` + `PacketLossPercentClampsDegenerateInputs` unit tests (exact scale points, the 0.35% threshold value, above-scale clamp, zero-scale guard).
- Full rebuild + serial `ctest`: **17/17 passed**.
- Post-deploy: `GET /polaris/v1/session/status` during an RP6 stream must show nonzero `latency_ms` with `network_risk:"normal"` on the idle LAN; an induced-latency run (`tc netem delay 40ms`) must flip it to `"elevated"` and light the (fixed) Nova HUD warning legitimately.
