### PR TITLE
feat(telemetry): wire record_benchmark_sample into the send-thread hot path

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1530,6 +1530,10 @@ namespace stream {
 
         if (packet->encode_done_timestamp) {
           stream_stats::record_frame_timing(session->device_uuid, session->session_generation, *packet->frame_timestamp, *packet->encode_done_timestamp, t2_send_time);
+          // P0-5 gate-authoritative run capture (measurement-spec-v1.md 6.4) -
+          // independent of the rolling ring above; a no-op unless a benchmark
+          // run is currently active/draining for this exact session.
+          stream_stats::record_benchmark_sample(session->device_uuid, session->session_generation, *packet->frame_timestamp, *packet->encode_done_timestamp, t2_send_time);
         }
       } else {
         frame_header.frame_processing_latency = 0;

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -1795,6 +1795,41 @@ namespace stream_stats {
       : benchmark_run_delete_result_e::rejected_run_not_found;
   }
 
+  void record_benchmark_sample(const std::string &device_uuid,
+                                std::uint64_t session_generation,
+                                std::chrono::steady_clock::time_point capture_time,
+                                std::chrono::steady_clock::time_point encode_done_time,
+                                std::chrono::steady_clock::time_point send_time) {
+    // Cheap common-case exit before touching benchmark_run_mutex at all -
+    // today (no control surface exists yet to ever flip this on) every
+    // real call takes this path, so the hot-path cost of the whole P0-5
+    // engine is one relaxed atomic load until that surface ships.
+    if (!benchmark_control_plane_enabled()) {
+      return;
+    }
+
+    std::lock_guard<std::mutex> lock(benchmark_run_mutex);
+    auto it = std::find_if(benchmark_runs.begin(), benchmark_runs.end(),
+      [&device_uuid, session_generation](const benchmark_run_t &r) {
+        return (r.state == benchmark_run_state_e::active || r.state == benchmark_run_state_e::draining) &&
+               r.owning_device_uuid == device_uuid &&
+               r.owning_session_generation == session_generation;
+      });
+    if (it == benchmark_runs.end() || !it->started_monotonic) {
+      return;
+    }
+
+    const auto start = *it->started_monotonic;
+    const auto window_end_us = std::chrono::duration_cast<std::chrono::microseconds>(it->expected_duration_ns).count();
+    const auto a_offset_us = std::chrono::duration_cast<std::chrono::microseconds>(capture_time - start).count();
+    const auto b_offset_us = std::chrono::duration_cast<std::chrono::microseconds>(encode_done_time - start).count();
+    const auto c_offset_us = std::chrono::duration_cast<std::chrono::microseconds>(send_time - start).count();
+
+    it->capture_to_encode.record(a_offset_us, b_offset_us, window_end_us);
+    it->encode_to_send_release.record(b_offset_us, c_offset_us, window_end_us);
+    it->capture_to_send_release.record(a_offset_us, c_offset_us, window_end_us);
+  }
+
   int active_client_count() {
     std::lock_guard<std::mutex> lock(stats_mutex);
     return static_cast<int>(current_stats.clients.size());

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -1007,6 +1007,51 @@ namespace stream_stats {
     bool caller_is_authorized_harness);
 
   /**
+   * @brief Record one frame's T0/T1/T2 timestamps into whichever active or
+   * draining benchmark run, if any, is owned by (device_uuid,
+   * session_generation) - a no-op if there is none. Intended to be called
+   * from the same send-thread call site as record_frame_timing(), with the
+   * same five arguments, right alongside it; the two are independent
+   * (this engine's bounded run capture vs. the always-on rolling
+   * diagnostics ring) and neither reads the other's state.
+   *
+   * This is the hot path measurement-spec-v1.md 6.4 describes: no
+   * allocation after run start (classify_boundary()/
+   * benchmark_stage_capture_t::record() only ever write into each stage's
+   * already-reserved arrays), no sorting/serializing/logging/percentiles,
+   * and at most one record per frame/session (one call per already-bundled
+   * T0/T1/T2 triple, same as record_frame_timing).
+   *
+   * Deliberately does NOT run apply_lazy_transitions_locked - checking the
+   * abort triggers on every frame would mean an extra get_session_timing()
+   * call (a second mutex) on every single frame, which the hot-path
+   * constraints above rule out. This does not corrupt anything: a sample
+   * arriving after the run's true deadline but before something else
+   * (start/stop/get/delete) lazily notices is still classified correctly
+   * by each stage's own window-relative boundary check below, just under
+   * whatever state label happened to be stored at the time. Being active
+   * or draining is precondition enough to look - a draining run's own
+   * drain grace exists specifically to let already-in-flight frames like
+   * this keep arriving and being classified without being admitted past
+   * the window.
+   *
+   * A generation that no longer owns (device_uuid)'s run - the run's own
+   * owning_session_generation simply won't match session_generation - is
+   * silently dropped by the same lookup, same as record_frame_timing.
+   *
+   * @param device_uuid The frame's owning session (session_t::device_uuid).
+   * @param session_generation The frame's owning session's generation (session_t::session_generation).
+   * @param capture_time T0.
+   * @param encode_done_time T1.
+   * @param send_time T2.
+   */
+  void record_benchmark_sample(const std::string &device_uuid,
+                                std::uint64_t session_generation,
+                                std::chrono::steady_clock::time_point capture_time,
+                                std::chrono::steady_clock::time_point encode_done_time,
+                                std::chrono::steady_clock::time_point send_time);
+
+  /**
    * @brief Get the number of active client sessions.
    * @return Count of active clients.
    */

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -2160,3 +2160,137 @@ TEST(BenchmarkRunLifecycleTests, DeleteWorksRegardlessOfRunState) {
   EXPECT_EQ(result, stream_stats::benchmark_run_delete_result_e::deleted)
     << "delete must not require a terminal state first";
 }
+
+// P0-5 benchmark-run-capture engine, piece 5 (final): record_benchmark_sample(),
+// the hot-path recorder wired into stream.cpp's send thread right alongside
+// record_frame_timing() (same call site, same five arguments, same already-
+// taken T0/T1/T2 timestamps - see stream.cpp's video packet send path).
+// Reuses ArmedRunFixture/BenchmarkControlPlaneGuard/make_valid_create_request
+// from the piece 3/4 tests above.
+
+TEST(BenchmarkRunHotPathTests, RecordIsANoOpWhenControlPlaneIsNotEnabled) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.70", "device-hotpath-cp-disabled", 1, "hotpath-cp-disabled");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  stream_stats::set_benchmark_control_plane_enabled(false);
+  const auto now = std::chrono::steady_clock::now();
+  stream_stats::record_benchmark_sample(fixture.device_uuid, fixture.session_generation,
+                                         now, now + std::chrono::milliseconds(5), now + std::chrono::milliseconds(9));
+  stream_stats::set_benchmark_control_plane_enabled(true);
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.capture_to_encode.accepted_count, 0u);
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunHotPathTests, RecordIsANoOpWhenNoMatchingRunExists) {
+  BenchmarkControlPlaneGuard guard(true);
+
+  const auto now = std::chrono::steady_clock::now();
+  stream_stats::record_benchmark_sample("device-hotpath-no-run", 1,
+                                         now, now + std::chrono::milliseconds(5), now + std::chrono::milliseconds(9));
+  // Nothing to assert beyond "this did not crash" - there is no run to
+  // inspect, which is the point of this test.
+}
+
+TEST(BenchmarkRunHotPathTests, RecordIsANoOpForAnArmedRunThatHasNotStarted) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.71", "device-hotpath-armed", 1, "hotpath-armed");
+
+  const auto now = std::chrono::steady_clock::now();
+  stream_stats::record_benchmark_sample(fixture.device_uuid, fixture.session_generation,
+                                         now, now + std::chrono::milliseconds(5), now + std::chrono::milliseconds(9));
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.state, stream_stats::benchmark_run_state_e::armed);
+    EXPECT_EQ(run.capture_to_encode.accepted_count, 0u);
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunHotPathTests, RecordIsANoOpForWrongSessionGeneration) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.72", "device-hotpath-wrong-generation", 1, "hotpath-wrong-generation");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  const auto now = std::chrono::steady_clock::now();
+  stream_stats::record_benchmark_sample(fixture.device_uuid, fixture.session_generation + 1,
+                                         now, now + std::chrono::milliseconds(5), now + std::chrono::milliseconds(9));
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.capture_to_encode.accepted_count, 0u)
+      << "a write from a stale/foreign generation must be silently dropped, same as record_frame_timing";
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunHotPathTests, RecordAcceptsAWithinWindowSampleOnAnActiveRun) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.73", "device-hotpath-active", 1, "hotpath-active");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  const auto t0 = std::chrono::steady_clock::now();
+  const auto t1 = t0 + std::chrono::milliseconds(5);
+  const auto t2 = t0 + std::chrono::milliseconds(9);
+  stream_stats::record_benchmark_sample(fixture.device_uuid, fixture.session_generation, t0, t1, t2);
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    EXPECT_EQ(run.capture_to_encode.accepted_count, 1u);
+    EXPECT_EQ(run.encode_to_send_release.accepted_count, 1u);
+    EXPECT_EQ(run.capture_to_send_release.accepted_count, 1u);
+    ASSERT_EQ(run.capture_to_send_release.duration_us.size(), 1u);
+    EXPECT_EQ(run.capture_to_send_release.duration_us[0], 9000u)
+      << "T0->T2 duration must be the full 9ms in microseconds";
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}
+
+TEST(BenchmarkRunHotPathTests, RecordDuringDrainAcceptsInWindowStartsAndExcludesPostWindowCompletions) {
+  BenchmarkControlPlaneGuard guard(true);
+  ArmedRunFixture fixture("203.0.113.74", "device-hotpath-drain", 1, "hotpath-drain");
+  ASSERT_EQ(stream_stats::start_benchmark_run(fixture.run_id, fixture.device_uuid, fixture.session_generation, true),
+            stream_stats::benchmark_run_start_result_e::started);
+
+  // Put the run in draining with plenty of drain grace left, without
+  // touching real wall-clock time - the same backdating technique used
+  // throughout BenchmarkRunLifecycleTests above. started_monotonic is set
+  // 10s in the past purely so the synthetic T0/T1/T2 offsets below (all
+  // ~120s past it) land on real steady_clock::time_points; the hot-path
+  // recorder only ever computes offsets relative to started_monotonic, so
+  // this has no effect on the classification math itself.
+  const auto backdated_start = std::chrono::steady_clock::now() - std::chrono::seconds(10);
+  stream_stats::with_benchmark_run(fixture.run_id, [&](stream_stats::benchmark_run_t &run) {
+    run.started_monotonic = backdated_start;
+    run.stopped_monotonic = backdated_start + std::chrono::seconds(120);  // = started + expected_duration_ns
+    run.state = stream_stats::benchmark_run_state_e::draining;
+  });
+
+  // T0/T1 both land before E=120s; T2 lands just after it - exactly the
+  // "in flight when the deadline hit" scenario drain grace exists for.
+  const auto t0 = backdated_start + std::chrono::milliseconds(119900);
+  const auto t1 = backdated_start + std::chrono::milliseconds(119950);
+  const auto t2 = backdated_start + std::chrono::milliseconds(120100);
+  stream_stats::record_benchmark_sample(fixture.device_uuid, fixture.session_generation, t0, t1, t2);
+
+  const auto result = stream_stats::get_benchmark_run(fixture.run_id, true, [](stream_stats::benchmark_run_t &run) {
+    ASSERT_EQ(run.state, stream_stats::benchmark_run_state_e::draining)
+      << "stopped_monotonic (60s+ in the future) must not have let this cascade to frozen yet";
+
+    EXPECT_EQ(run.capture_to_encode.accepted_count, 1u)
+      << "T0->T1: both endpoints inside the window";
+
+    EXPECT_EQ(run.encode_to_send_release.accepted_count, 0u);
+    EXPECT_EQ(run.encode_to_send_release.excluded_completed_after_window, 1u)
+      << "T1->T2: started inside the window, completed at/after E - recorded, not silently dropped, but not admitted either";
+
+    EXPECT_EQ(run.capture_to_send_release.accepted_count, 0u);
+    EXPECT_EQ(run.capture_to_send_release.excluded_completed_after_window, 1u)
+      << "T0->T2: same shape as T1->T2 above";
+  });
+  EXPECT_EQ(result, stream_stats::benchmark_run_get_result_e::found);
+}


### PR DESCRIPTION
## Summary

Fifth and final piece (approved pacing: one piece per PR, in order) of the benchmark-run-capture engine. Unlike pieces 1-4, this one is now reachable in production - `stream.cpp` calls it on every frame - but still cannot record anything, since no control surface exists yet to ever enable the control plane, arm a run, or start one. Every real call today takes `record_benchmark_sample`'s cheapest exit (one relaxed atomic load), the whole cost of this engine until that surface ships.

- **`record_benchmark_sample()`** is called from `stream.cpp`'s video packet send path at the exact same call site as the existing `record_frame_timing()`, with the same five already-computed arguments (`session->device_uuid`, `session->session_generation`, `*packet->frame_timestamp`, `*packet->encode_done_timestamp`, `t2_send_time`) - no extra `steady_clock::now()` call, same discipline P0-3's own T2 reuse already established at this site. The two recorders are fully independent: this engine's bounded run capture vs. the always-on rolling diagnostics ring - neither reads the other's state.
- Looks up whichever active-or-draining run, if any, is owned by `(device_uuid, session_generation)` under `benchmark_run_mutex`, then feeds window-relative microsecond offsets into each of the three stage captures' own `record()` (piece 1) - no allocation, no sorting, serialization, logging, or percentile computation, matching `measurement-spec-v1.md` §6.4's hot-path constraints. A generation that no longer owns the run is silently dropped, same as `record_frame_timing`.
- **Deliberately matches active OR draining, not just active** - drain grace (§6.4/§6.5) exists specifically so a frame already in flight when a run's deadline hits still gets recorded and correctly boundary-classified (accepted vs. `excluded_completed_after_window`) rather than silently disappearing the moment the run's state label changes. Caught this while designing the piece: an active-only filter would have quietly broken the exact scenario drain grace exists for.
- **Deliberately does NOT run** the lazy state-reconciliation piece 4's start/stop/get/delete all share - checking the abort triggers on every single frame would cost a second mutex (`get_session_timing`) per frame, which the hot-path constraints rule out. This does not corrupt anything: a sample arriving before something else lazily notices the run's true state is still classified correctly by each stage's own window-relative check, under whatever state label happens to be stored at the time.

This completes the 5-piece run-capture engine. What's still open, per [[nordstern-measurement-spec-v1]]: the network-facing control surface (loopback HTTP, reusing the existing server, per the earlier-approved transport choice) that will actually let a harness enable the control plane and drive create/start/stop/get/delete - without it, everything in pieces 1-5 stays fully inert in production.

## Exact candidate

```
Commit: cb41ad8920d5d5f8d8d3059c4f8338019baf755b
Tree:   f78d6ba10c100c4eb0a176a4cde1afa9c70436d0
Parent: 0d932d3f18430385c33fbbe6ca7a74e02aafdfbe
Base:   0d932d3f18430385c33fbbe6ca7a74e02aafdfbe
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all 335 targets built with no errors - including `stream.cpp` itself, the first piece in this arc to touch it.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries.
- [x] `test_polaris_stream` - 190/190 tests, including 6 new `BenchmarkRunHotPathTests`: no-op when the control plane is disabled, no-op when no matching run exists (doesn't crash), no-op for a still-armed run, silent drop for a stale/foreign `session_generation`, correct acceptance of a within-window sample on an active run (with an exact microsecond-duration assertion), and the key drain-grace test - a frame whose T0/T1 land inside the window but whose T2 lands just after it, on a run already in `draining`, correctly shows `capture_to_encode` accepted while `encode_to_send_release`/`capture_to_send_release` show `excluded_completed_after_window` rather than either being silently accepted or silently dropped.
- [x] Not quantitatively measured (honest gap, matching P0-2's own precedent for this exact caveat): the spec's `<0.5%` CPU / no-p95-delta hot-path overhead gate. That needs the not-yet-built P0-5 bench harness itself; asserted here by design and code inspection instead - no allocation, no extra `steady_clock::now()` call, one relaxed atomic load in the common (control-plane-disabled) case.

**Not covered by this PR** (out of scope for the engine itself, per the approved plan): the network-facing control surface. That's the next, separate increment.
