### PR TITLE
fix(vdisplay): advertise host_virtual_display only when creation can succeed

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1232,13 +1232,26 @@ namespace nvhttp {
         if (option.value == "host_virtual_display") {
           available = available && host_virtual_display_available();
         }
+        std::string unavailable_reason;
+        if (!available) {
+          unavailable_reason = option.unavailable_reason;
+          if (option.value == "host_virtual_display") {
+            // The backend probe knows exactly why creation would fail; the
+            // policy layer only knows that it would.
+            const auto backend_reason = virtual_display::unavailable_reason();
+            if (!backend_reason.empty()) {
+              unavailable_reason = backend_reason;
+            }
+          }
+          if (unavailable_reason.empty()) {
+            unavailable_reason = "This mode is not available on this host right now.";
+          }
+        }
         modes.push_back({
           {"value", option.value},
           {"label", option.label},
           {"available", available},
-          {"unavailable_reason", available ? "" : (option.unavailable_reason.empty() ?
-            "Host virtual display is not available on this host." :
-            option.unavailable_reason)},
+          {"unavailable_reason", unavailable_reason},
           {"restart_required", true},
           {"reason", option.reason},
           {"group", option.group},

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -511,6 +511,36 @@ namespace virtual_display {
     }
 
     /**
+     * @brief Check whether an evdi DRM card already exists.
+     */
+    static bool evdi_card_exists() {
+      try {
+        for (const auto &entry : fs::directory_iterator("/sys/class/drm/")) {
+          std::string name = entry.path().filename().string();
+          if (name.find("card") == 0 && name.find('-') == std::string::npos) {
+            auto driver_path = entry.path() / "device" / "driver";
+            if (fs::exists(driver_path) &&
+                fs::read_symlink(driver_path).filename().string() == "evdi") {
+              return true;
+            }
+          }
+        }
+      } catch (...) {}
+      return false;
+    }
+
+    /**
+     * @brief Check whether this process could actually obtain an EVDI device.
+     *
+     * Module + library presence is not enough: without a pre-created evdi card
+     * (modprobe initial_device_count=N) creating one requires write access to
+     * /sys/devices/evdi/add, which an unprivileged Polaris does not have.
+     */
+    static bool can_create() {
+      return evdi_card_exists() || access("/sys/devices/evdi/add", W_OK) == 0;
+    }
+
+    /**
      * @brief Find the output name for a newly created EVDI device.
      *
      * After EVDI creates a new card, the DRM subsystem assigns it a connector
@@ -804,12 +834,31 @@ namespace virtual_display {
         return "sway";
       }
 
-      // Check for KDE/KWin on Wayland
+      // Session-manager variables survive into environments the compositor
+      // sockets' variables do not (e.g. systemd user services).
       const char *desktop = std::getenv("XDG_CURRENT_DESKTOP");
-      if (desktop && std::string(desktop).find("KDE") != std::string::npos) {
+      const char *session_desktop = std::getenv("XDG_SESSION_DESKTOP");
+      const auto env_contains = [](const char *value, std::string_view needle) {
+        return value && std::string_view(value).find(needle) != std::string_view::npos;
+      };
+      if (env_contains(desktop, "Hyprland") || env_contains(session_desktop, "Hyprland")) {
+        return "hyprland";
+      }
+      if (env_contains(desktop, "sway") || env_contains(session_desktop, "sway")) {
+        return "sway";
+      }
+
+      // Check for KDE/KWin on Wayland
+      if (env_contains(desktop, "KDE")) {
         if (std::getenv("WAYLAND_DISPLAY")) {
           return "kwin";
         }
+      }
+
+      // A systemd user service under Hyprland may carry none of the variables
+      // above; hyprctl can still reach the compositor through XDG_RUNTIME_DIR.
+      if (exec_cmd_rc("hyprctl -j version >/dev/null 2>&1") == 0) {
+        return "hyprland";
       }
 
       return {};
@@ -838,8 +887,10 @@ namespace virtual_display {
         return false;
       }
 
-      // Check for wlr-randr as a generic wlroots tool
-      return exec_cmd_rc("which wlr-randr >/dev/null 2>&1") == 0;
+      // No supported compositor identified. wlr-randr alone cannot create an
+      // output (create() refuses the generic branch), so reporting available
+      // here would advertise a display that can never appear.
+      return false;
     }
 
     /**
@@ -1071,9 +1122,11 @@ namespace virtual_display {
 
     backend_e backend = backend_e::NONE;
 
-    // Priority 1: EVDI — creates true virtual connectors
+    // Priority 1: EVDI — creates true virtual connectors. Module + library
+    // presence alone is not enough to advertise it: creation must actually be
+    // possible, or the mode is offered and then silently fails at launch.
     if (evdi::is_module_loaded() || evdi::load_module()) {
-      if (evdi::load_library()) {
+      if (evdi::load_library() && evdi::can_create()) {
         backend = backend_e::EVDI;
       }
     }
@@ -1110,6 +1163,36 @@ namespace virtual_display {
   bool is_available() {
     const auto backend = detect_backend();
     return backend_has_required_configuration(backend, config::video.linux_display.streaming_output);
+  }
+
+  std::string unavailable_reason_for(backend_e backend, bool evdi_blocked, bool streaming_output_configured) {
+    switch (backend) {
+      case backend_e::EVDI:
+      case backend_e::WAYLAND_WLR:
+        return {};
+      case backend_e::KSCREEN_DOCTOR:
+        if (streaming_output_configured) {
+          return {};
+        }
+        return "kscreen-doctor backend needs linux_streaming_output set to the output it may reconfigure.";
+      case backend_e::NONE:
+      default:
+        if (evdi_blocked) {
+          return "EVDI module is loaded but no device can be created: no evdi card exists and "
+                 "/sys/devices/evdi/add is not writable by Polaris. Load evdi with "
+                 "initial_device_count=1 or grant write access.";
+        }
+        return "No virtual display backend is available on this host (EVDI not usable, no "
+               "supported Wayland compositor, kscreen-doctor not configured).";
+    }
+  }
+
+  std::string unavailable_reason() {
+    const auto backend = detect_backend();
+    // Probe without side effects: report the module as blocked only when it is
+    // already loaded and usable but a device still cannot be obtained.
+    const bool evdi_blocked = evdi::is_module_loaded() && evdi::load_library() && !evdi::can_create();
+    return unavailable_reason_for(backend, evdi_blocked, !config::video.linux_display.streaming_output.empty());
   }
 
   bool cleanup_stale() {

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -87,6 +87,21 @@ namespace virtual_display {
   bool backend_has_required_configuration(backend_e backend, const std::string &streaming_output);
 
   /**
+   * @brief Human-readable reason a virtual display cannot be created right now.
+   * @return Empty string when creation is possible; otherwise the reason to serve to clients.
+   */
+  std::string unavailable_reason();
+
+  /**
+   * @brief Pure mapping from probed availability state to the served reason.
+   * @param backend The backend detection result.
+   * @param evdi_blocked True when the EVDI module and library are usable but no device can be obtained.
+   * @param streaming_output_configured True when linux_streaming_output is set.
+   * @return Empty string when the combination is usable; otherwise the reason.
+   */
+  std::string unavailable_reason_for(backend_e backend, bool evdi_blocked, bool streaming_output_configured);
+
+  /**
    * @brief Create a virtual display with the given resolution and refresh rate.
    * @param width Horizontal resolution in pixels.
    * @param height Vertical resolution in pixels.

--- a/tests/unit/platform/test_virtual_display.cpp
+++ b/tests/unit/platform/test_virtual_display.cpp
@@ -16,6 +16,30 @@ TEST(VirtualDisplayTests, BackendDetectionLogCacheOnlySignalsOnFirstObservationA
   EXPECT_FALSE(cache.note(virtual_display::backend_e::WAYLAND_WLR));
 }
 
+TEST(VirtualDisplayTests, UnavailableReasonMapsEveryProbedState) {
+  using virtual_display::backend_e;
+  using virtual_display::unavailable_reason_for;
+
+  // Usable backends carry no reason.
+  EXPECT_EQ(unavailable_reason_for(backend_e::EVDI, false, false), "");
+  EXPECT_EQ(unavailable_reason_for(backend_e::WAYLAND_WLR, false, false), "");
+  EXPECT_EQ(unavailable_reason_for(backend_e::KSCREEN_DOCTOR, false, true), "");
+
+  // kscreen-doctor without a configured streaming output names the missing config key.
+  const auto kscreen = unavailable_reason_for(backend_e::KSCREEN_DOCTOR, false, false);
+  EXPECT_NE(kscreen.find("linux_streaming_output"), std::string::npos);
+
+  // A loaded-but-uncreatable EVDI names the actionable fix.
+  const auto evdi_blocked = unavailable_reason_for(backend_e::NONE, true, false);
+  EXPECT_NE(evdi_blocked.find("initial_device_count"), std::string::npos);
+  EXPECT_NE(evdi_blocked.find("/sys/devices/evdi/add"), std::string::npos);
+
+  // No backend at all still yields a non-empty explanation.
+  const auto none = unavailable_reason_for(backend_e::NONE, false, false);
+  EXPECT_FALSE(none.empty());
+  EXPECT_EQ(none.find("initial_device_count"), std::string::npos);
+}
+
 TEST(VirtualDisplayTests, KscreenDoctorRequiresConfiguredStreamingOutput) {
   EXPECT_FALSE(virtual_display::backend_has_required_configuration(
     virtual_display::backend_e::NONE,


### PR DESCRIPTION
## Summary

"Host Virtual Display is broken" — root cause found live on the production host: the availability probe counts EVDI as available on module+library presence alone, but zero evdi devices existed and `/sys/devices/evdi/add` is root-only, so every creation attempt failed with EACCES (`journalctl`: "Virtual display: failed to open EVDI device" → "Virtual Display creation failed on Linux") and the launch **silently fell back** to another output while clients kept seeing `available: true`. The mode flipped from correctly-greyed-out to selectable-but-broken the day the evdi module appeared (Aug 5, via modules-load.d). The generic wlroots branch has the same class of lie (`which wlr-randr` ⇒ available; `create()` refuses the generic path unconditionally), which also mis-advertises on Hyprland hosts running Polaris as a systemd user service — the exact setup our Arch docs recommend.

## Exact candidate

`src/platform/linux/virtual_display.cpp|h`, `src/nvhttp.cpp`:

- `evdi::can_create()` — an evdi card already exists (scan `/sys/class/drm` for `driver == evdi`), or the add node is writable. Backend detection requires it; probing never modprobes or opens devices.
- wlroots generic tail returns unavailable; `detect_compositor()` gains `XDG_CURRENT_DESKTOP`/`XDG_SESSION_DESKTOP` fallbacks and a `hyprctl -j version` probe for env-less user services.
- New `unavailable_reason()` (+ pure `unavailable_reason_for` mapping) serves actionable reasons: the EVDI case names `initial_device_count=1` and the add-node permission; kscreen names `linux_streaming_output`.
- `stream_display_mode_options_json` serves the backend's real reason for `host_virtual_display`, and no longer claims "Host virtual display is not available" for every other unavailable mode (now a mode-neutral fallback).

Not touched: the `window_system == WAYLAND` gate (separate decision), Windows paths, `serverinfo`'s boolean shape (it just becomes honest).

## Verification

- New `UnavailableReasonMapsEveryProbedState` unit test (full matrix incl. the actionable-substring pins); existing `KscreenDoctorRequiresConfiguredStreamingOutput` unchanged and green.
- Full rebuild + serial `ctest`: **17/17 passed**.
- Host-side environment fix applied on the production box (`/etc/modprobe.d/evdi.conf` with `initial_device_count=1`; `/sys/devices/evdi/count` now 1, evdi card0 present) — post-deploy, Host Virtual Display launches must create the display via the existing-card path; a deliberate re-block (remove the card) must gray the mode out in Nova with the served reason instead of silently failing.
