### PR TITLE
fix(api): accept every registered stream mode in client-settings

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -344,6 +344,42 @@
         "variable": "output",
         "style": "subscript"
       }
+    },
+    "client_settings_mode_option": {
+      "$comment": [
+        "One entry of capabilities.modes in GET /polaris/v1/client-settings - the",
+        "host-authoritative launch-mode catalog (per-mode availability, server",
+        "labels, disable reasons, and the private/host grouping). Guarded because",
+        "the client-settings surface carried the picker feed with zero drift",
+        "protection (roadmap item: server-authoritative mode pickers). The POST",
+        "validator accepts exactly the ids this catalog can advertise as",
+        "available - stream_display_policy::selection_valid is the shared truth.",
+        "group/unavailable_reason and the runtime/capture/topology vocabulary",
+        "ship ahead of their Nova consumer - see known_drift."
+      ],
+      "fields": [
+        "available",
+        "capture",
+        "group",
+        "label",
+        "reason",
+        "restart_required",
+        "runtime",
+        "topology",
+        "unavailable_reason",
+        "value"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/api/PolarisApiClient.kt",
+        "function": "parseModeOptions",
+        "receiver": "mode"
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "function": "stream_display_mode_options_json",
+        "style": "initializer_list",
+        "declaration": "modes.push_back({"
+      }
     }
   },
   "known_drift": {
@@ -370,7 +406,14 @@
         "nova_reader entries above repointed at the functions that now read it."
       ],
       "game": [],
-      "session_capture": []
+      "session_capture": [],
+      "client_settings_mode_option": [
+        "capture",
+        "group",
+        "runtime",
+        "topology",
+        "unavailable_reason"
+      ]
     },
     "$detail": {
       "session_capture": [

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1267,13 +1267,21 @@ namespace nvhttp {
              "host_virtual_display"s,
              "windowed_stream"s
            }) {
+        const bool available = selection != "host_virtual_display" || host_virtual_display_available();
+        const bool private_group = selection == "headless_stream" || selection == "windowed_stream";
         modes.push_back({
+          // Same shape as the Linux branch so clients parse one contract;
+          // the runtime/capture/topology vocabulary is Linux-only and empty here.
           {"value", selection},
           {"label", stream_display_mode_label_for_selection(selection)},
-          {"available", selection != "host_virtual_display" || host_virtual_display_available()},
-          {"unavailable_reason", ""},
+          {"available", available},
+          {"unavailable_reason", available ? "" : "Host virtual display is not available on this host."},
           {"restart_required", true},
-          {"reason", stream_display_mode_reason_for_selection(selection)}
+          {"reason", stream_display_mode_reason_for_selection(selection)},
+          {"group", private_group ? "private" : "host"},
+          {"runtime", ""},
+          {"capture", ""},
+          {"topology", ""},
         });
       }
 #endif
@@ -6687,6 +6695,17 @@ namespace nvhttp {
 
             std::string error;
             stream_display_mode = body["stream_display_mode"].get<std::string>();
+#ifdef __linux__
+            // Delegate to the policy layer's own validity check so this
+            // validator can never reject a mode the same response's
+            // allowed_modes/capabilities just advertised (it used to hardcode
+            // four ids and 400 gamescope_stream/headless_dongle). The error is
+            // the host's real reason for registered-but-unavailable modes.
+            if (!stream_display_policy::selection_valid(*stream_display_mode, error)) {
+              write_json({{"error", error}}, SimpleWeb::StatusCode::client_error_bad_request);
+              return;
+            }
+#else
             if (*stream_display_mode != "headless_stream" &&
                 *stream_display_mode != "desktop_display" &&
                 *stream_display_mode != "host_virtual_display" &&
@@ -6695,6 +6714,7 @@ namespace nvhttp {
               write_json({{"error", error}}, SimpleWeb::StatusCode::client_error_bad_request);
               return;
             }
+#endif
           }
 
           std::string display_mode = named_cert_p->display_mode;

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -199,7 +199,7 @@ namespace stream_display_policy {
     return configured;
   }
 
-  bool apply_selection(std::string_view selection, std::string &error) {
+  bool selection_valid(std::string_view selection, std::string &error) {
     const auto key = to_lower_copy(selection);
     if (!stream_path::find(key) && key != k_desktop_display) {
       error = "stream_display_mode must be a known stream path id (see /client-settings modes)";
@@ -209,6 +209,14 @@ namespace stream_display_policy {
       error = selection_unavailable_reason(key);
       return false;
     }
+    return true;
+  }
+
+  bool apply_selection(std::string_view selection, std::string &error) {
+    if (!selection_valid(selection, error)) {
+      return false;
+    }
+    const auto key = to_lower_copy(selection);
 
     auto &linux_display = config::video.linux_display;
 

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -66,7 +66,17 @@ namespace stream_display_policy {
 
   std::string selection_unavailable_reason(std::string_view selection) {
     if (const auto *path = stream_path::find(selection)) {
-      return std::string {path->unavailable_reason};
+      // Probe-dependent reasons are not in the static registry entry; mirror
+      // selection_available so the rejection matches the served catalog.
+      if (path->id == stream_path::k_gamescope_stream &&
+          !stream_path::probe_host_capabilities().gamescope_present) {
+        return "gamescope binary not found on PATH";
+      }
+      if (!path->unavailable_reason.empty()) {
+        return std::string {path->unavailable_reason};
+      }
+      // An unavailable path must still explain itself to a rejected client.
+      return std::string {path->label} + " is not available on this host.";
     }
     return "Unknown stream display mode.";
   }

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -48,6 +48,7 @@ namespace stream_display_policy {
   constexpr std::string_view k_host_virtual_display = stream_path::k_host_virtual_display;
   constexpr std::string_view k_desktop_display = stream_path::k_desktop_display;
   constexpr std::string_view k_gamescope_stream = stream_path::k_gamescope_stream;
+  constexpr std::string_view k_headless_dongle = stream_path::k_headless_dongle;
 
   constexpr std::string_view k_runtime_labwc = stream_path::k_runtime_labwc;
   constexpr std::string_view k_runtime_gamescope = stream_path::k_runtime_gamescope;
@@ -68,6 +69,19 @@ namespace stream_display_policy {
   bool selection_available(std::string_view selection);
 
   std::string selection_unavailable_reason(std::string_view selection);
+
+  /**
+   * @brief Whether a selection would pass apply_selection's id and availability checks.
+   *
+   * The single validity truth for network-facing validators: apply_selection
+   * calls this itself, so a validator delegating here can never accept a mode
+   * apply would then reject - the drift that used to 400 modes the host had
+   * just advertised in allowed_modes.
+   *
+   * @param error On failure, the reason to serve (the host's real unavailable
+   *              reason for registered-but-unavailable modes).
+   */
+  bool selection_valid(std::string_view selection, std::string &error);
 
   /**
    * @brief Derive the configured selection from legacy booleans when

--- a/src_assets/common/assets/web/client-settings-sync.js
+++ b/src_assets/common/assets/web/client-settings-sync.js
@@ -159,6 +159,7 @@ export function labelForStreamDisplayMode(mode) {
   if (mode === 'windowed_stream') return 'Private Stream (GPU-native)'
   if (mode === 'desktop_display') return 'Mirror Desktop'
   if (mode === 'gamescope_stream') return 'Gamescope Stream'
+  if (mode === 'headless_dongle') return 'Headless Dongle'
   return ''
 }
 

--- a/src_assets/common/assets/web/client-settings-sync.test.js
+++ b/src_assets/common/assets/web/client-settings-sync.test.js
@@ -45,6 +45,7 @@ describe('client settings sync helpers', () => {
     expect(streamDisplayModeAvailable('family_isolated')).toBe(false)
     expect(streamDisplayModeAvailable('headless_evdi')).toBe(false)
     expect(labelForStreamDisplayMode('gamescope_stream')).toBe('Gamescope Stream')
+    expect(labelForStreamDisplayMode('headless_dongle')).toBe('Headless Dongle')
 
     const labwc = applyStreamDisplayModeToConfig({}, 'headless_stream')
     expect(labwc.linux_stream_mode).toBe('headless_stream')

--- a/tests/unit/test_launch_mode_contract.cpp
+++ b/tests/unit/test_launch_mode_contract.cpp
@@ -51,3 +51,35 @@ TEST(LaunchModeContractTests, PerGameVirtualDisplayPreferenceIsRecommendedWhenHo
   EXPECT_EQ(contract.at("preferred_mode"), "host_virtual_display");
   EXPECT_EQ(contract.at("recommended_mode"), "host_virtual_display");
 }
+
+#ifdef __linux__
+  #include <src/platform/linux/stream_display_policy.h>
+
+// The client-settings POST validator used to hardcode four ids while
+// allowed_modes advertised the full registry, so gamescope_stream and
+// headless_dongle were advertised and then rejected with 400. The validator now
+// delegates to stream_display_policy::selection_valid - the same check
+// apply_selection itself runs - and this pins that they can never disagree.
+TEST(LaunchModeContractTests, EveryAdvertisedModeVerdictMatchesTheValidator) {
+  for (const bool virtual_display_available : {false, true}) {
+    for (const auto &option : stream_display_policy::mode_options(virtual_display_available)) {
+      std::string error;
+      const bool valid = stream_display_policy::selection_valid(option.value, error);
+      if (option.available) {
+        EXPECT_TRUE(valid) << option.value << ": advertised available but rejected: " << error;
+      } else {
+        EXPECT_FALSE(valid) << option.value << ": advertised unavailable but accepted";
+        EXPECT_FALSE(error.empty()) << option.value << ": rejection must carry the host's reason";
+      }
+    }
+  }
+}
+
+TEST(LaunchModeContractTests, ReservedAndUnknownIdsAreRejectedWithGuidance) {
+  for (const auto *id : {"family_isolated", "headless_evdi", "not_a_mode"}) {
+    std::string error;
+    EXPECT_FALSE(stream_display_policy::selection_valid(id, error)) << id;
+    EXPECT_NE(error.find("known stream path id"), std::string::npos) << id;
+  }
+}
+#endif


### PR DESCRIPTION
## Summary

The client-settings POST validator hardcodes 4 mode ids while the same response advertises all 6 registered stream paths (`capabilities.modes`, per-game `allowed_modes`) — so `gamescope_stream`/`headless_dongle` were advertised and then rejected with a 400 naming the stale four. This is the host-side gate for the server-authoritative mode pickers (Nova currently shows 2/4 hardcoded modes; the picker rework consumes this catalog next).

## Exact candidate

- `stream_display_policy`: extract `selection_valid()` from `apply_selection`'s id+availability head; `apply_selection` now calls it — one truth, structurally incapable of validator/apply drift. Missing `k_headless_dongle` re-export added.
- `nvhttp.cpp`: Linux validator delegates to `selection_valid` (400 body carries the host's real reason, e.g. the gamescope-binary/dongle-outputs messages); non-Linux keeps its honest 4-id check. The non-Linux `capabilities.modes` builder gains shape parity (`group`, `unavailable_reason`, empty `runtime`/`capture`/`topology`).
- Web UI: `labelForStreamDisplayMode` learns `headless_dongle` (was `''`), with a test pin.
- `docs/nova-contract.json`: new `client_settings_mode_option` object (roadmap-flagged gap — the client-settings surface had zero drift protection). `nova_reader` = `PolarisApiClient.parseModeOptions`; the five not-yet-consumed fields are recorded under `known_drift.polaris_sends_nova_never_reads` and get removed when the Nova picker rework reads them.

Everything additive; no `/polaris/v1` field removed or renamed (Perigee unaffected). Deliberately **not** "display policies" — this is validator/contract parity only.

## Verification

- New `LaunchModeContractTests`: `EveryAdvertisedModeVerdictMatchesTheValidator` (both virtual-display-availability arms; available ⇒ accepted, unavailable ⇒ rejected with non-empty reason) and `ReservedAndUnknownIdsAreRejectedWithGuidance`.
- Full rebuild + serial `ctest` green (includes `test_polaris_audit`'s NovaContractTests against the new manifest object) + `scripts/check-nova-contract.py --nova <nova checkout>` clean.
- Post-deploy manual: `POST client-settings {"stream_display_mode":"gamescope_stream"}` → 200 on this host (gamescope on PATH); `"family_isolated"` → 400 with the known-id message.
