### PR TITLE
feat(confighttp): add the benchmark control surface's auth gate

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -140,6 +140,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/httpcommon.h"
         "${CMAKE_SOURCE_DIR}/src/confighttp.cpp"
         "${CMAKE_SOURCE_DIR}/src/confighttp.h"
+        "${CMAKE_SOURCE_DIR}/src/confighttp_benchmark_auth.cpp"
+        "${CMAKE_SOURCE_DIR}/src/confighttp_benchmark_auth.h"
         "${CMAKE_SOURCE_DIR}/src/confighttp_validation.cpp"
         "${CMAKE_SOURCE_DIR}/src/confighttp_validation.h"
         "${CMAKE_SOURCE_DIR}/src/update_status.h"

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -40,6 +40,7 @@
 #include "adaptive_bitrate.h"
 #include "browser_stream.h"
 #include "confighttp.h"
+#include "confighttp_benchmark_auth.h"
 #include "confighttp_validation.h"
 #include "crypto.h"
 #include "display_device.h"
@@ -1322,6 +1323,71 @@ namespace confighttp {
       return true;
     }
     return authenticate(response, request, needsRedirect);
+  }
+
+  namespace {
+    // 20 requests per 10s per IP (~2/sec average) - generous enough for a
+    // harness polling GET .../runs/{run_id} every 1-2s during a run, while
+    // still bounding a runaway/malicious loop. Not spec-mandated (measurement-
+    // spec-v1.md 6.4 only requires *some* rate limit exists), chosen as a
+    // reasonable default.
+    confighttp::benchmark_auth::rate_limiter_t &benchmark_control_rate_limiter() {
+      static confighttp::benchmark_auth::rate_limiter_t limiter(20, std::chrono::seconds(10));
+      return limiter;
+    }
+  }  // namespace
+
+  /**
+   * @brief Authorize an incoming request as the local benchmark harness for
+   * the P0-5 control surface (measurement-spec-v1.md 6.4). Every layer the
+   * spec requires beyond ordinary paired-client pairing:
+   *  - loopback/origin policy (checkIPOrigin, same as the rest of the Web UI);
+   *  - a dedicated per-IP request rate limit (separate from login's, whose
+   *    escalating-lockout shape fits failed-password attempts, not the
+   *    steady polling a benchmark harness does while a run is active);
+   *  - an authenticated confighttp Web UI session or API key (authenticate() -
+   *    deliberately NOT authenticatePolarisSession(), which also accepts any
+   *    verified streaming-client cert; the spec is explicit that "viewer/
+   *    watch certificates cannot activate or retrieve a benchmark run").
+   *
+   * Deliberately does NOT check stream_stats::benchmark_control_plane_enabled() -
+   * every engine function (create/start/stop/get/delete_benchmark_run)
+   * already checks that itself and reports a specific rejection reason, so
+   * this gate's job is purely "is this caller even allowed to attempt a
+   * benchmark control operation," not "is benchmarking itself turned on."
+   *
+   * Writes an appropriate error response and returns false on any failure;
+   * callers must return immediately without writing anything further.
+   */
+  bool authorizeBenchmarkHarnessRequest(resp_https_t response, req_https_t request) {
+    if (!checkIPOrigin(response, request)) {
+      return false;
+    }
+
+    auto address = net::addr_to_normalized_string(request->remote_endpoint().address());
+    auto &limiter = benchmark_control_rate_limiter();
+    const auto now = std::chrono::steady_clock::now();
+
+    const bool rate_limited = limiter.is_rate_limited(address, now);
+    limiter.record_request(address, now);
+    if (rate_limited) {
+      BOOST_LOG(warning) << "Benchmark control: ["sv << address << "] -- rate limited"sv;
+      nlohmann::json tree;
+      tree["status"] = false;
+      tree["error"] = "Too many requests. Please try again later.";
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      append_json_security_headers(headers);
+      response->write(SimpleWeb::StatusCode::client_error_too_many_requests, tree.dump(), headers);
+      return false;
+    }
+
+    if (!authenticate(response, request, /*needsRedirect=*/false)) {
+      BOOST_LOG(warning) << "Benchmark control: ["sv << address << "] -- unauthorized"sv;
+      return false;
+    }
+
+    BOOST_LOG(info) << "Benchmark control: ["sv << address << "] -- authorized"sv;
+    return true;
   }
 
   /**

--- a/src/confighttp_benchmark_auth.cpp
+++ b/src/confighttp_benchmark_auth.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file src/confighttp_benchmark_auth.cpp
+ * @brief Request-rate limiting for the P0-5 benchmark control surface.
+ */
+#include "confighttp_benchmark_auth.h"
+
+namespace confighttp::benchmark_auth {
+  rate_limiter_t::rate_limiter_t(int max_requests, std::chrono::steady_clock::duration window):
+      max_requests_(max_requests),
+      window_(window) {
+  }
+
+  bool rate_limiter_t::is_rate_limited(const std::string &ip, std::chrono::steady_clock::time_point now) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = requests_by_ip_.find(ip);
+    if (it == requests_by_ip_.end()) {
+      return false;
+    }
+
+    auto &timestamps = it->second;
+    while (!timestamps.empty() && now - timestamps.front() > window_) {
+      timestamps.pop_front();
+    }
+    return static_cast<int>(timestamps.size()) >= max_requests_;
+  }
+
+  void rate_limiter_t::record_request(const std::string &ip, std::chrono::steady_clock::time_point now) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto &timestamps = requests_by_ip_[ip];
+    while (!timestamps.empty() && now - timestamps.front() > window_) {
+      timestamps.pop_front();
+    }
+    timestamps.push_back(now);
+  }
+}  // namespace confighttp::benchmark_auth

--- a/src/confighttp_benchmark_auth.h
+++ b/src/confighttp_benchmark_auth.h
@@ -1,0 +1,56 @@
+/**
+ * @file src/confighttp_benchmark_auth.h
+ * @brief Request-rate limiting for the P0-5 benchmark control surface.
+ */
+#pragma once
+
+#include <chrono>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace confighttp::benchmark_auth {
+  /**
+   * @brief Per-IP sliding-window request rate limiter for the P0-5
+   * benchmark control surface (measurement-spec-v1.md 6.4's "request rate
+   * limits" requirement). Deliberately separate from confighttp.cpp's own
+   * login_rate_limits, which guards password-guessing attempts
+   * specifically and uses a different, harsher-lockout shape keyed to
+   * consecutive failures - a benchmark harness polling GET
+   * .../runs/{run_id} every few seconds during a 120-180s run is normal,
+   * expected traffic here, not an attack.
+   *
+   * Time is passed in explicitly rather than read internally from
+   * steady_clock::now(), so this stays unit-testable without real sleeps.
+   */
+  class rate_limiter_t {
+  public:
+    /**
+     * @param max_requests Maximum requests from one IP within window.
+     * @param window The trailing duration max_requests is measured over.
+     */
+    rate_limiter_t(int max_requests, std::chrono::steady_clock::duration window);
+
+    /**
+     * @brief Whether ip has already reached max_requests within the
+     * trailing window as of now. Does not itself record a request -
+     * call record_request() separately for that, regardless of what
+     * this returns.
+     */
+    bool is_rate_limited(const std::string &ip, std::chrono::steady_clock::time_point now);
+
+    /**
+     * @brief Record one request from ip at now, for future
+     * is_rate_limited() calls to weigh. Also opportunistically evicts
+     * this ip's own timestamps older than window.
+     */
+    void record_request(const std::string &ip, std::chrono::steady_clock::time_point now);
+
+  private:
+    int max_requests_;
+    std::chrono::steady_clock::duration window_;
+    std::mutex mutex_;
+    std::unordered_map<std::string, std::deque<std::chrono::steady_clock::time_point>> requests_by_ip_;
+  };
+}  // namespace confighttp::benchmark_auth

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TEST_MAIN_SOURCE
 
 set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/confighttp_validation.cpp
+    ${CMAKE_SOURCE_DIR}/src/confighttp_benchmark_auth.cpp
     ${CMAKE_SOURCE_DIR}/src/browser_stream_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/file_handler.cpp
     ${CMAKE_SOURCE_DIR}/src/private_state_file.cpp
@@ -96,6 +97,7 @@ set(TEST_AUDIT_SUPPORT_SOURCES
 
 set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_validation.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_benchmark_auth.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_client_settings_advertisement.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_browser_stream_protocol.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_cursor_visibility.cpp

--- a/tests/unit/test_confighttp_benchmark_auth.cpp
+++ b/tests/unit/test_confighttp_benchmark_auth.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file tests/unit/test_confighttp_benchmark_auth.cpp
+ * @brief Test src/confighttp_benchmark_auth.*.
+ */
+#include "../tests_common.h"
+
+#include <src/confighttp_benchmark_auth.h>
+
+using confighttp::benchmark_auth::rate_limiter_t;
+
+TEST(BenchmarkAuthRateLimiterTests, AllowsRequestsUpToTheLimit) {
+  rate_limiter_t limiter(3, std::chrono::seconds(10));
+  const auto now = std::chrono::steady_clock::now();
+
+  EXPECT_FALSE(limiter.is_rate_limited("127.0.0.1", now));
+  limiter.record_request("127.0.0.1", now);
+  EXPECT_FALSE(limiter.is_rate_limited("127.0.0.1", now));
+  limiter.record_request("127.0.0.1", now);
+  EXPECT_FALSE(limiter.is_rate_limited("127.0.0.1", now));
+  limiter.record_request("127.0.0.1", now);
+
+  EXPECT_TRUE(limiter.is_rate_limited("127.0.0.1", now))
+    << "the third recorded request reached the limit of 3";
+}
+
+TEST(BenchmarkAuthRateLimiterTests, TracksEachIpIndependently) {
+  rate_limiter_t limiter(1, std::chrono::seconds(10));
+  const auto now = std::chrono::steady_clock::now();
+
+  limiter.record_request("127.0.0.1", now);
+  EXPECT_TRUE(limiter.is_rate_limited("127.0.0.1", now));
+  EXPECT_FALSE(limiter.is_rate_limited("::1", now))
+    << "a different IP must not share the first IP's count";
+}
+
+TEST(BenchmarkAuthRateLimiterTests, OldRequestsFallOutOfTheWindow) {
+  rate_limiter_t limiter(1, std::chrono::seconds(10));
+  const auto start = std::chrono::steady_clock::now();
+
+  limiter.record_request("127.0.0.1", start);
+  EXPECT_TRUE(limiter.is_rate_limited("127.0.0.1", start + std::chrono::seconds(5)))
+    << "still within the 10s window";
+
+  EXPECT_FALSE(limiter.is_rate_limited("127.0.0.1", start + std::chrono::seconds(11)))
+    << "the one recorded request is now outside the window";
+}
+
+TEST(BenchmarkAuthRateLimiterTests, IsRateLimitedDoesNotItselfCountAsARequest) {
+  rate_limiter_t limiter(1, std::chrono::seconds(10));
+  const auto now = std::chrono::steady_clock::now();
+
+  EXPECT_FALSE(limiter.is_rate_limited("127.0.0.1", now));
+  EXPECT_FALSE(limiter.is_rate_limited("127.0.0.1", now))
+    << "calling is_rate_limited() repeatedly without record_request() must never itself trip the limit";
+}
+
+TEST(BenchmarkAuthRateLimiterTests, RecordingAfterTheWindowExpiresEvictsStaleEntriesFirst) {
+  rate_limiter_t limiter(1, std::chrono::seconds(10));
+  const auto start = std::chrono::steady_clock::now();
+
+  limiter.record_request("127.0.0.1", start);
+  ASSERT_TRUE(limiter.is_rate_limited("127.0.0.1", start));
+
+  // A second request arrives after the first has aged out of the window -
+  // it must be accepted (recorded, not itself limited), not perpetually
+  // blocked by a stale entry that record_request() failed to evict.
+  const auto later = start + std::chrono::seconds(11);
+  EXPECT_FALSE(limiter.is_rate_limited("127.0.0.1", later));
+  limiter.record_request("127.0.0.1", later);
+  EXPECT_TRUE(limiter.is_rate_limited("127.0.0.1", later))
+    << "the new request alone should now be at the limit of 1";
+}


### PR DESCRIPTION
## Summary

First of five pieces (same "one piece per PR, in order" pacing as the run-capture engine, papi-ux/polaris#326-#332) for the P0-5 network-facing control surface. Not wired to any route yet - `authorizeBenchmarkHarnessRequest()` is unused until the create/start/stop/get/delete routes call it in the next four pieces.

Per papi's 2026-08-08 decision (reuse confighttp's Web UI auth rather than a new dedicated token), `authorizeBenchmarkHarnessRequest()` composes every layer `measurement-spec-v1.md` §6.4 requires beyond ordinary paired-client pairing:

- **loopback/origin policy**, via the existing `checkIPOrigin()`;
- **a new dedicated per-IP request rate limiter** (`confighttp_benchmark_auth.h`/`.cpp`), separate from `confighttp.cpp`'s own `login_rate_limits` - that one's escalating-lockout shape fits failed-password guessing, not the steady polling a harness does against `GET .../runs/{run_id}` while a run is active;
- **an authenticated confighttp Web UI session or API key**, via the existing `authenticate()` - deliberately not `authenticatePolarisSession()`, which also accepts any verified streaming-client cert. The spec is explicit that viewer/watch certificates cannot activate or retrieve a benchmark run, and there is no admin/owner role in the client-cert pairing model to distinguish a harness from an ordinary paired viewer - exactly why this reuses the Web UI's separate username/password/API-key auth instead.

Deliberately does **not** check `benchmark_control_plane_enabled()` - every engine function (`create`/`start`/`stop`/`get`/`delete_benchmark_run`) already checks that itself and reports a specific rejection reason, so this gate's job is purely "is this caller even allowed to attempt a benchmark control operation," not "is benchmarking itself turned on."

The rate limiter is a new, separate file specifically so it can be unit tested without a live HTTPS request - matching the existing `confighttp_validation.cpp`/`.h` split for the same reason. Time is passed into it explicitly rather than read from `steady_clock::now()` internally, unlike the existing login rate limiter, so tests don't need real sleeps.

**Second commit: a real CI-caught bug, fixed.** The first commit wired `confighttp_benchmark_auth.cpp`/`.h` into `tests/CMakeLists.txt` but not into `POLARIS_TARGET_FILES` (`cmake/compile_definitions/common.cmake`) - the actual production source list the real `polaris` binary and several other test targets (`test_polaris_config`, `test_polaris_http`, `test_polaris_steam_shutdown`) build from. This passed locally (very likely because `authorizeBenchmarkHarnessRequest` has zero callers right now, so a default local build appears to dead-code-eliminate it before symbol resolution is ever needed) but failed CI's sanitizer job, which explicitly builds `-DCMAKE_BUILD_TYPE=Debug` with no such elimination, exposing three undefined references at link time. Reproduced locally by building the exact same target set under `-DCMAKE_BUILD_TYPE=Debug` (pc-papi lacks the ASan/UBSan runtime libraries needed to reproduce the sanitizer flags themselves, but the Debug build type alone was sufficient to reproduce and then confirm the fix), not just inferred from reading the CMake structure.

## Exact candidate

```
Commit: 9ca0ab80bf8aa3e859ce1c0ca03a5a0b2f903710
Tree:   5010ff08d7ec3a25f1cc3cf081da232ff1bb52ea
Parent: 4af26af7656b530fd3dc59a39f21498f49c9bdd6
Base:   882c94ecc3303f1dced247ab7a93274b272f810e
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all 337 targets built with no errors, including `confighttp.cpp` and the new `confighttp_benchmark_auth.cpp`.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries.
- [x] `test_polaris` (the binary `confighttp_validation`'s own tests live in, per `tests/CMakeLists.txt`'s `TEST_SUPPORT_SOURCES`/`TEST_FAST_SOURCES`) - 206/206 tests, including 5 new `BenchmarkAuthRateLimiterTests`: allows up to the limit then blocks, tracks each IP independently, evicts requests once they age out of the window, confirms `is_rate_limited()` alone never counts as a request, and confirms a request arriving after the window has fully elapsed is correctly accepted rather than staying stuck behind a stale entry.
- [x] After the CMake fix: rebuilt `test_polaris`, `test_polaris_config`, `test_polaris_http`, `test_polaris_steam_shutdown`, `test_polaris_stream` (the exact target set CI's sanitizer job builds) under `-DCMAKE_BUILD_TYPE=Debug` - clean build, zero undefined references, and all five binaries pass (255/255, 95/95, 12/12, 192/192, plus the 206/206 above). Also re-verified the regular (non-Debug) build + full `ctest` afterward to confirm the fix doesn't regress the default path.

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): the `benchmark_control_plane_enabled()` config-flag wiring (piece 2) and all five HTTP routes (pieces 3-5). `authorizeBenchmarkHarnessRequest()` is unreachable in production until then.
