### PR TITLE
feat(config): wire benchmark_mode_enabled to the control plane at startup

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -740,6 +740,7 @@ namespace config {
     {},  // prep commands
     {},  // state commands
     {},  // server commands
+    false,  // benchmark_mode_enabled
   };
 
   recording_t recording {
@@ -1517,6 +1518,7 @@ namespace config {
     bool_f(vars, "envvar_compatibility_mode", sunshine.envvar_compatibility_mode);
     bool_f(vars, "notify_pre_releases", sunshine.notify_pre_releases);
     bool_f(vars, "legacy_ordering", sunshine.legacy_ordering);
+    bool_f(vars, "benchmark_mode_enabled", sunshine.benchmark_mode_enabled);
     bool_f(vars, "forward_rumble", input.forward_rumble);
 
     int port = sunshine.port;

--- a/src/config.h
+++ b/src/config.h
@@ -352,6 +352,13 @@ namespace config {
     std::vector<prep_cmd_t> prep_cmds;
     std::vector<prep_cmd_t> state_cmds;
     std::vector<server_cmd_t> server_cmds;
+
+    // Gate-authoritative benchmark run capture's control plane
+    // (measurement-spec-v1.md 6.4). Disabled by default per spec - a
+    // process restart is required to enable it, matching "must require an
+    // explicit benchmark-mode enable at process start" rather than a
+    // dynamically-toggleable runtime setting.
+    bool benchmark_mode_enabled;
   };
 
   struct recording_t {

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -101,6 +101,7 @@ namespace confighttp::validation {
       "av1_mode"sv,
       "back_button_timeout"sv,
       "beat_times_lookup"sv,
+      "benchmark_mode_enabled"sv,
       "browser_streaming"sv,
       "capture"sv,
       "cert"sv,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "nvhttp.h"
 #include "process.h"
 #include "stream_recorder.h"
+#include "stream_stats.h"
 #include "system_tray.h"
 #include "upnp.h"
 #include "uuid.h"
@@ -250,6 +251,14 @@ int main(int argc, char *argv[]) {
 
   // Initialize stream recorder from config
   stream_recorder::load_config();
+
+  // P0-5 benchmark run-capture's control plane (measurement-spec-v1.md 6.4)
+  // is disabled by default; this is the one-time, startup-only read of
+  // that gate. Every engine precondition and the control-surface auth
+  // gate check stream_stats::benchmark_control_plane_enabled() themselves,
+  // not config::sunshine.benchmark_mode_enabled directly, so this is the
+  // only place the two are ever connected.
+  stream_stats::set_benchmark_control_plane_enabled(config::sunshine.benchmark_mode_enabled);
 
   if (!config::sunshine.cmd.name.empty()) {
     auto fn = cmd_to_func.find(config::sunshine.cmd.name);

--- a/tests/integration/test_config_consistency.cpp
+++ b/tests/integration/test_config_consistency.cpp
@@ -463,6 +463,7 @@ TEST_F(ConfigConsistencyTest, AllConfigOptionsExistInAllFiles) {
   const std::set<std::string, std::less<>> internalOptions = {
     "flags",  // Internal config flags, not user-configurable
     "api_key",  // Backend API secret, intentionally not exposed in the config UI
+    "benchmark_mode_enabled",  // P0-5 benchmark harness control plane - config-file-only, requires a process restart, not a mainstream user-facing toggle
     "color_range",  // Per-client preference surfaced in pairing/client flows instead of host config
     "hdr_mode",  // Internal encoder policy used outside the config page
     "linux_auto_manage_displays",  // Runtime/Linux workflow setting not surfaced in the current config UI


### PR DESCRIPTION
## Summary

Second of five pieces (same "one piece per PR, in order" pacing) for the P0-5 network-facing control surface. Adds the one config option `measurement-spec-v1.md` §6.4 requires - "must require an explicit benchmark-mode enable at process start" - and connects it to `stream_stats::set_benchmark_control_plane_enabled()` once, at startup, right alongside the existing `stream_recorder::load_config()` call.

- `sunshine_t::benchmark_mode_enabled` has no inline default, matching that struct's own established style (unlike `recording_t`, which does use inline defaults) - its default lives in the aggregate initializer alongside every other `sunshine_t` field, appended last to avoid disturbing the positional order of any existing field.
- Every engine precondition (`create`/`start`/`stop`/`get`/`delete_benchmark_run`) and the control-surface auth gate check `stream_stats::benchmark_control_plane_enabled()` themselves, not `config::sunshine.benchmark_mode_enabled` directly - `main.cpp`'s new line is the only place the two are ever connected, and it happens once, matching the spec's "at process start" (not dynamically re-checked) framing.
- **Caught by this repo's own `ConfigConsistencyTest`, not a self-review catch:** a new `config.cpp` option needs listing in two more places or the test suite fails outright - the UI/docs `internalOptions` exemption set (this option is config-file-only, requires a restart, and isn't a mainstream toggle, so it belongs there alongside `api_key`/`max_sessions`/`recording_enabled`, not in `ConfigView.vue`/`en.json`) and, unconditionally regardless of UI exposure, `confighttp_validation.cpp`'s `allowed_config_keys` - the config-save API's allow-list rejects an entire payload on any key it doesn't recognize.

## Exact candidate

```
Commit: 09584266b2105facf89516870a14ab6df61aee45
Tree:   5ad4b6d6fc41d479a8c1812ab0c3f6c086e1f683
Parent: 3cd428e7c005b9801450fe8837dcb8c1054f71ff
Base:   3cd428e7c005b9801450fe8837dcb8c1054f71ff
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`), all targets built with no errors.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries, including `test_polaris_audit`'s `ConfigConsistencyTest` (which failed before the two consistency-list fixes above, confirming they were real requirements, not speculative additions).
- [x] Verified end-to-end beyond the test suite: built the real `polaris` binary and ran it against a config file setting `benchmark_mode_enabled=true`, confirming the startup config log actually shows the key being recognized and parsed (`config: [benchmark_mode_enabled] -- [true]`), not just inferred from reading the `bool_f()` call.

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): all five HTTP routes (pieces 3-5). Even with this flag wired, nothing can reach it yet since there's no route to call `create_benchmark_run` or anything else through.
