### PR TITLE
feat(session): say on session status when the display mode fell back

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -409,10 +409,8 @@
       "session_capture": [],
       "client_settings_mode_option": [
         "capture",
-        "group",
         "runtime",
-        "topology",
-        "unavailable_reason"
+        "topology"
       ]
     },
     "$detail": {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -6469,6 +6469,7 @@ namespace nvhttp {
       display_mode["requested_headless"] = stats.runtime_requested_headless;
       display_mode["effective_headless"] = stats.runtime_effective_headless;
       display_mode["gpu_native_override_active"] = stats.runtime_gpu_native_override_active;
+      display_mode["warning"] = stats.runtime_display_warning;
       display_mode["selection"] = stream_display_mode;
       display_mode["stream_display_mode"] = stream_display_mode;
       display_mode["explicit_choice"] = status_snapshot.display_mode_explicit;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -5342,6 +5342,9 @@ namespace proc {
     if (using_headless_cage_runtime && launch_session->virtual_display) {
       BOOST_LOG(info) << "session_optimization: normalized virtual_display from true to false for headless cage runtime"sv;
       launch_session->virtual_display = false;
+      stream_stats::update_runtime_display_warning(
+        "Virtual display request skipped: the private stream runtime provides this session's display."
+      );
       resolved_optimization.virtual_display = false;
       resolved_optimization.virtual_display_source = "runtime_policy";
       note_layer(resolved_optimization, "runtime_policy");
@@ -5624,10 +5627,26 @@ namespace proc {
         } else {
           BOOST_LOG(warning) << "Virtual Display creation failed on Linux"sv;
           launch_session->virtual_display = false;
+          {
+            auto warning = std::string {"Host Virtual Display could not be created; this session streams the host's current output instead."};
+            const auto reason = virtual_display::unavailable_reason();
+            if (!reason.empty()) {
+              warning += " " + reason;
+            }
+            stream_stats::update_runtime_display_warning(warning);
+          }
         }
       } else {
         BOOST_LOG(warning) << "Virtual display requested but no backend available on Linux"sv;
         launch_session->virtual_display = false;
+        {
+          auto warning = std::string {"Host Virtual Display is unavailable on this host; this session streams the host's current output instead."};
+          const auto reason = virtual_display::unavailable_reason();
+          if (!reason.empty()) {
+            warning += " " + reason;
+          }
+          stream_stats::update_runtime_display_warning(warning);
+        }
       }
     } else if (using_headless_cage) {
       BOOST_LOG(info) << "Linux virtual display: skipped because "sv

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -279,6 +279,7 @@ namespace stream_stats {
     j["runtime_requested_headless"] = runtime_requested_headless;
     j["runtime_effective_headless"] = runtime_effective_headless;
     j["runtime_gpu_native_override_active"] = runtime_gpu_native_override_active;
+    j["runtime_display_warning"] = runtime_display_warning;
     j["capture_transport"] = platf::from_frame_transport(capture_transport);
     j["capture_residency"] = platf::from_frame_residency(capture_residency);
     j["capture_format"] = platf::from_frame_format(capture_format);
@@ -1118,6 +1119,11 @@ namespace stream_stats {
     current_stats.runtime_requested_headless = state.requested_headless;
     current_stats.runtime_effective_headless = state.effective_headless;
     current_stats.runtime_gpu_native_override_active = state.gpu_native_override_active;
+  }
+
+  void update_runtime_display_warning(const std::string &warning) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.runtime_display_warning = warning;
   }
 
   void update_capture_metadata(const platf::frame_metadata_t &metadata) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -89,6 +89,8 @@ namespace stream_stats {
     bool runtime_requested_headless = false;
     bool runtime_effective_headless = false;
     bool runtime_gpu_native_override_active = false;
+    /** Why this session is not on the display the client asked for; empty when it is. */
+    std::string runtime_display_warning;
     platf::frame_transport_e capture_transport = platf::frame_transport_e::unknown;
     platf::frame_residency_e capture_residency = platf::frame_residency_e::unknown;
     platf::frame_format_e capture_format = platf::frame_format_e::unknown;
@@ -352,6 +354,14 @@ namespace stream_stats {
    * @param state Current runtime state for the active backend.
    */
   void update_runtime_state(const platf::runtime_state_t &state);
+
+  /**
+   * @brief Record why the session fell back from the display mode the client asked for.
+   *
+   * Set at the launch-time fallback sites and served on session status; the
+   * end-of-stream stats reset clears it, so it is per-session state.
+   */
+  void update_runtime_display_warning(const std::string &warning);
 
   /**
    * @brief Update current capture path metadata exposed to the dashboard.

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -780,6 +780,18 @@ TEST(StreamStatsHotFieldTests, UpdateNetworkStatsIsVisibleThroughGetCurrent) {
 // The periodic-ping handler in stream.cpp sources loss from ENet's scaled
 // peer->packetLoss; this module stores percent (0-100), matching the readers
 // (network_risk thresholds at 0.35%, session grading at 0.5/2/5%).
+TEST(StreamStatsHotFieldTests, RuntimeDisplayWarningIsServedAndResetWithTheStream) {
+  stream_stats::update_stream_active(true);
+  stream_stats::update_runtime_display_warning("Host Virtual Display could not be created");
+
+  EXPECT_EQ(stream_stats::get_current().runtime_display_warning,
+            "Host Virtual Display could not be created");
+
+  // The end-of-stream wholesale reset is what makes the warning per-session.
+  stream_stats::update_stream_active(false);
+  EXPECT_TRUE(stream_stats::get_current().runtime_display_warning.empty());
+}
+
 TEST(StreamStatsHotFieldTests, PacketLossPercentConvertsScaledRatios) {
   constexpr uint64_t scale = 1ull << 16;  // ENET_PEER_PACKET_LOSS_SCALE
 


### PR DESCRIPTION
## Summary

When a session doesn't get the display the client asked for — the private runtime supersedes a virtual-display request, or Host Virtual Display fails to create / has no usable backend — the host logged a journal line and streamed on silently. That silence is exactly how the "Host Virtual Display is broken" report stayed client-invisible: the stream worked, just not where it was asked to, and only `journalctl` knew. This is the last piece of the plan's Wave-0 honesty work (#333 made *advertising* honest; this makes *fallback at launch* honest).

## Exact candidate

- `stream_stats`: new per-session `runtime_display_warning` (+ `update_runtime_display_warning`), cleared by the existing end-of-stream wholesale reset — no new lifecycle.
- `process.cpp`: the three fallback sites record their story, appending `virtual_display::unavailable_reason()` (from #333) when it has one — so the client sees e.g. "Host Virtual Display could not be created; this session streams the host's current output instead. EVDI module is loaded but no device can be created…".
- `nvhttp.cpp`: served as `display_mode.warning` on `GET /polaris/v1/session/status`.
- `docs/nova-contract.json`: drops the now-stale `known_drift` entries for `group`/`unavailable_reason` (Nova reads both since nova#212); `capture`/`runtime`/`topology` stay recorded. `display_mode` itself is not a guarded object, so the new field needs no manifest entry — noted rather than hidden.
- **Deliberate deviation from the plan**: no `status_message` on the `/launch` response — stock Moonlight clients only render that field on error responses, and this launch deliberately succeeds, so session status is the channel with an actual consumer. The Nova half (parse + once-per-session notice) is the companion PR.

## Verification

- New `RuntimeDisplayWarningIsServedAndResetWithTheStream` unit test (set → served via `get_current`, cleared by `update_stream_active(false)`).
- Full rebuild + serial `ctest` green.
- Live scenario already reproduced earlier in this arc: remove the evdi card and launch with a virtual-display default → journal shows the creation failure; post-deploy, session status must now carry the same story in `display_mode.warning` and Nova toasts it once.
