### PR TITLE
feat(ai): mode-aware optimization profiles

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -380,6 +380,61 @@
         "style": "initializer_list",
         "declaration": "modes.push_back({"
       }
+    },
+    "optimization": {
+      "$comment": [
+        "Top-level GET /optimize response body. append_optimization_json is the",
+        "shared serializer for the AI profile itself (cached, sync, and async",
+        "answers all pass through it); the route handler attaches the",
+        "profile-state and stability blocks beside it. mode echoes the cache",
+        "bucket the answer came from - empty is the legacy mode-less bucket -",
+        "and ai_recommended_mode is the provider's advisory stream-path pick,",
+        "registry-validated, never acted on by the host (roadmap: mode-aware",
+        "AI with an advisory badge; the host never switches modes)."
+      ],
+      "fields": [
+        "ai_recommended_mode",
+        "cache_status",
+        "color_range",
+        "confidence",
+        "display_mode",
+        "expires_at",
+        "generated_at",
+        "hdr",
+        "mode",
+        "normalization_reason",
+        "nvenc_tune",
+        "preferred_codec",
+        "reasoning",
+        "reasoning_summary",
+        "recommendation_version",
+        "signals_used",
+        "source",
+        "target_bitrate_kbps",
+        "virtual_display"
+      ],
+      "informational_ok": [
+        "color_range",
+        "expires_at",
+        "hdr",
+        "mode",
+        "nvenc_tune",
+        "reasoning_summary",
+        "recommendation_version",
+        "signals_used",
+        "virtual_display"
+      ],
+      "nova_reader": {
+        "file": "app/src/main/java/com/papi/nova/ui/NovaGameDetailActivity.kt",
+        "function": "buildOptimizationState",
+        "receiver": "opt"
+      },
+      "polaris_emitter": {
+        "file": "src/nvhttp.cpp",
+        "function": "append_optimization_json",
+        "style": "assignments",
+        "variable": "output"
+      }
     }
   },
   "known_drift": {
@@ -397,6 +452,14 @@
         "launcher_detail",
         "platform_label",
         "runtime_label"
+      ],
+      "optimization": [
+        "consecutive_poor_outcomes",
+        "effective_profile",
+        "effective_target_fps",
+        "profile_state",
+        "requested_target_fps",
+        "stability"
       ]
     },
     "polaris_sends_nova_never_reads": {
@@ -411,6 +474,9 @@
         "capture",
         "runtime",
         "topology"
+      ],
+      "optimization": [
+        "ai_recommended_mode"
       ]
     },
     "$detail": {
@@ -433,6 +499,14 @@
         "launcher_detail has no host-side value to serve; platform_label and runtime_label",
         "exist so a server can label a value the client cannot map, and every value served",
         "today is one Nova already maps."
+      ],
+      "optimization": [
+        "Not drift in reality, in either direction. The reads listed under",
+        "nova_reads_polaris_never_sends are served by the /optimize route handler, which",
+        "attaches the profile-state and stability blocks beside the serializer; the object",
+        "models append_optimization_json because that is the one named function the audit",
+        "extractor can hold to. ai_recommended_mode under polaris_sends_nova_never_reads is",
+        "simply early: it ships host-first and moves out when the Nova picker badge lands."
       ]
     }
   }

--- a/src/ai_optimizer.cpp
+++ b/src/ai_optimizer.cpp
@@ -11,6 +11,7 @@
 #include "stream_stats.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <chrono>
 #include <cmath>
@@ -20,6 +21,7 @@
 #include <iterator>
 #include <mutex>
 #include <sstream>
+#include <string_view>
 #include <thread>
 #include <atomic>
 #include <unordered_map>
@@ -79,6 +81,7 @@ namespace ai_optimizer {
     std::string base_url;
     std::string device_name;
     std::string app_name;
+    std::string mode;
     device_db::optimization_t optimization;
     int64_t timestamp;  // Unix epoch seconds
   };
@@ -231,17 +234,42 @@ namespace ai_optimizer {
                                const std::string &model,
                                const std::string &base_url,
                                const std::string &device,
-                               const std::string &app) {
+                               const std::string &app,
+                               const std::string &mode = "") {
+    // The trailing mode dimension defaults empty, which IS the legacy bucket:
+    // requests that never name a mode keep hitting the entries they always had.
     return std::to_string(OPTIMIZATION_SCHEMA_VERSION) + "\t" +
-      provider + "\t" + model + "\t" + base_url + "\t" + canonical_device_name(device) + "\t" + app;
+      provider + "\t" + model + "\t" + base_url + "\t" + canonical_device_name(device) + "\t" + app + "\t" + mode;
   }
 
-  static std::string current_cache_key(const std::string &device, const std::string &app) {
-    return cache_key(cfg.provider, cfg.model, cfg.base_url, device, app);
+  static std::string current_cache_key(const std::string &device, const std::string &app, const std::string &mode = "") {
+    return cache_key(cfg.provider, cfg.model, cfg.base_url, device, app, mode);
   }
 
-  static std::string current_cache_key(const config_t &active_cfg, const std::string &device, const std::string &app) {
-    return cache_key(active_cfg.provider, active_cfg.model, active_cfg.base_url, device, app);
+  std::string normalize_stream_mode(const std::string &mode) {
+    auto key = mode;
+    std::transform(key.begin(), key.end(), key.begin(), [](unsigned char ch) { return std::tolower(ch); });
+    // Mirrors stream_path's registry ids; local so this file stays platform-neutral.
+    static const std::array<std::string_view, 6> known {
+      "headless_stream", "windowed_stream", "host_virtual_display",
+      "desktop_display", "gamescope_stream", "headless_dongle"
+    };
+    for (const auto &id : known) {
+      if (key == id) {
+        return key;
+      }
+    }
+    return "";
+  }
+
+  std::string cache_key_for_tests(
+      const std::string &provider, const std::string &model, const std::string &base_url,
+      const std::string &device, const std::string &app, const std::string &mode) {
+    return cache_key(provider, model, base_url, device, app, mode);
+  }
+
+  static std::string current_cache_key(const config_t &active_cfg, const std::string &device, const std::string &app, const std::string &mode = "") {
+    return cache_key(active_cfg.provider, active_cfg.model, active_cfg.base_url, device, app, mode);
   }
 
   static std::string join_url(const std::string &base_url, const std::string &path) {
@@ -1131,6 +1159,7 @@ namespace ai_optimizer {
         entry.base_url = normalize_base_url(entry.provider, val.value("base_url", ""));
         entry.device_name = val.value("device_name", "");
         entry.app_name = val.value("app_name", "");
+        entry.mode = val.value("mode", "");
 
         if (entry.optimization.recommendation_version != OPTIMIZATION_SCHEMA_VERSION) {
           continue;
@@ -1163,6 +1192,7 @@ namespace ai_optimizer {
         if (val.contains("target_bitrate_kbps")) o.target_bitrate_kbps = val["target_bitrate_kbps"].get<int>();
         if (val.contains("nvenc_tune")) o.nvenc_tune = val["nvenc_tune"].get<int>();
         if (val.contains("preferred_codec")) o.preferred_codec = val["preferred_codec"].get<std::string>();
+        if (val.contains("ai_recommended_mode")) o.recommended_mode = val["ai_recommended_mode"].get<std::string>();
         o.reasoning = val.value("reasoning", "");
         o.cache_status = val.value("cache_status", "hit");
         o.confidence = val.value("confidence", "");
@@ -1171,7 +1201,7 @@ namespace ai_optimizer {
         o.generated_at = val.value("generated_at", entry.timestamp);
         o.expires_at = val.value("expires_at", 0);
         o.source = "ai_cached";
-        auto normalized_key = cache_key(entry.provider, entry.model, entry.base_url, entry.device_name, entry.app_name);
+        auto normalized_key = cache_key(entry.provider, entry.model, entry.base_url, entry.device_name, entry.app_name, entry.mode);
         auto existing = cache.find(normalized_key);
         if (existing == cache.end() || entry.timestamp >= existing->second.timestamp) {
           cache[normalized_key] = entry;
@@ -1195,6 +1225,7 @@ namespace ai_optimizer {
       val["base_url"] = entry.base_url;
       val["device_name"] = entry.device_name;
       val["app_name"] = entry.app_name;
+      val["mode"] = entry.mode;
       auto &o = entry.optimization;
       if (o.display_mode) val["display_mode"] = *o.display_mode;
       if (o.color_range) val["color_range"] = *o.color_range;
@@ -1203,6 +1234,7 @@ namespace ai_optimizer {
       if (o.target_bitrate_kbps) val["target_bitrate_kbps"] = *o.target_bitrate_kbps;
       if (o.nvenc_tune) val["nvenc_tune"] = *o.nvenc_tune;
       if (o.preferred_codec) val["preferred_codec"] = *o.preferred_codec;
+      if (o.recommended_mode) val["ai_recommended_mode"] = *o.recommended_mode;
       val["reasoning"] = o.reasoning;
       val["cache_status"] = o.cache_status;
       val["confidence"] = o.confidence;
@@ -1482,7 +1514,7 @@ namespace ai_optimizer {
 
     optimization.expires_at = now + static_cast<std::int64_t>(
       effective_ttl_hours(
-        {active_cfg.provider, active_cfg.model, active_cfg.base_url, device_name, app_name, optimization, now},
+        {active_cfg.provider, active_cfg.model, active_cfg.base_url, device_name, app_name, std::string {}, optimization, now},
         active_cfg.cache_ttl_hours
       ) * 3600LL
     );
@@ -1600,7 +1632,8 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::string &gpu_info,
       const std::string &game_category = "",
-      const std::optional<session_history_t> &history = std::nullopt) {
+      const std::optional<session_history_t> &history = std::nullopt,
+      const std::string &mode = "") {
     auto device_info = device_db::get_device(device_name);
     auto device_baseline = fallback_optimization_for_device(device_name, app_name);
     std::string device_desc = device_info
@@ -1614,6 +1647,10 @@ namespace ai_optimizer {
       if (!hint.empty()) {
         category_line = "Game category: " + hint + "\n";
       }
+    }
+
+    if (!mode.empty()) {
+      category_line += "Streaming display mode for this session: " + mode + "\n";
     }
 
     std::string history_line;
@@ -1762,6 +1799,12 @@ namespace ai_optimizer {
     if (result_json.contains("target_bitrate_kbps")) opt.target_bitrate_kbps = result_json["target_bitrate_kbps"].get<int>();
     if (result_json.contains("nvenc_tune")) opt.nvenc_tune = result_json["nvenc_tune"].get<int>();
     if (result_json.contains("preferred_codec")) opt.preferred_codec = result_json["preferred_codec"].get<std::string>();
+    if (result_json.contains("recommended_mode")) {
+      const auto suggested = normalize_stream_mode(result_json["recommended_mode"].get<std::string>());
+      if (!suggested.empty()) {
+        opt.recommended_mode = suggested;
+      }
+    }
     opt.reasoning = result_json.value("reasoning", "AI-optimized");
     opt.source = "ai_live";
     opt.recommendation_version = OPTIMIZATION_SCHEMA_VERSION;
@@ -1899,9 +1942,10 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::string &gpu_info,
       const std::string &game_category = "",
-      const std::optional<session_history_t> &history = std::nullopt) {
+      const std::optional<session_history_t> &history = std::nullopt,
+      const std::string &mode = "") {
 
-    std::string prompt = build_user_prompt(device_name, app_name, gpu_info, game_category, history);
+    std::string prompt = build_user_prompt(device_name, app_name, gpu_info, game_category, history, mode);
     std::string system = build_system_prompt();
     const std::string home = getenv("HOME") ? getenv("HOME") : "/home";
     const auto claude_bin = resolve_existing_binary(
@@ -1976,7 +2020,8 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::string &gpu_info,
       const std::string &game_category = "",
-      const std::optional<session_history_t> &history = std::nullopt) {
+      const std::optional<session_history_t> &history = std::nullopt,
+      const std::string &mode = "") {
 
     const std::string home = getenv("HOME") ? getenv("HOME") : "/home";
     const auto codex_bin = resolve_existing_binary(
@@ -1992,7 +2037,7 @@ namespace ai_optimizer {
     {
       std::ofstream pf(prompt_file);
       pf << build_system_prompt() << "\n\n"
-         << build_user_prompt(device_name, app_name, gpu_info, game_category, history) << "\n\n"
+         << build_user_prompt(device_name, app_name, gpu_info, game_category, history, mode) << "\n\n"
          << "Return only the JSON object in the requested schema.";
     }
 
@@ -2052,14 +2097,15 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::string &gpu_info,
       const std::string &game_category = "",
-      const std::optional<session_history_t> &history = std::nullopt) {
+      const std::optional<session_history_t> &history = std::nullopt,
+      const std::string &mode = "") {
 
     nlohmann::json request_body;
     request_body["model"] = active_cfg.model;
     request_body["max_tokens"] = 256;
     request_body["temperature"] = 0;
     request_body["messages"] = nlohmann::json::array({
-      {{"role", "user"}, {"content", build_user_prompt(device_name, app_name, gpu_info, game_category, history)}}
+      {{"role", "user"}, {"content", build_user_prompt(device_name, app_name, gpu_info, game_category, history, mode)}}
     });
     request_body["system"] = build_system_prompt();
 
@@ -2104,7 +2150,8 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::string &gpu_info,
       const std::string &game_category = "",
-      const std::optional<session_history_t> &history = std::nullopt) {
+      const std::optional<session_history_t> &history = std::nullopt,
+      const std::string &mode = "") {
 
     nlohmann::json request_body;
     request_body["model"] = active_cfg.model;
@@ -2112,7 +2159,7 @@ namespace ai_optimizer {
     request_body["max_tokens"] = 256;
     request_body["messages"] = nlohmann::json::array({
       {{"role", "system"}, {"content", build_system_prompt()}},
-      {{"role", "user"}, {"content", build_user_prompt(device_name, app_name, gpu_info, game_category, history)}}
+      {{"role", "user"}, {"content", build_user_prompt(device_name, app_name, gpu_info, game_category, history, mode)}}
     });
     request_body["response_format"] = optimization_response_format();
 
@@ -2154,32 +2201,35 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::string &gpu_info,
       const std::string &game_category = "",
-      const std::optional<session_history_t> &history = std::nullopt) {
+      const std::optional<session_history_t> &history = std::nullopt,
+      const std::string &mode = "") {
     if (active_cfg.provider == PROVIDER_ANTHROPIC) {
       if (active_cfg.auth_mode == AUTH_SUBSCRIPTION) {
-        return call_anthropic_cli(active_cfg, device_name, app_name, gpu_info, game_category, history);
+        return call_anthropic_cli(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
       }
-      return call_anthropic_api(active_cfg, device_name, app_name, gpu_info, game_category, history);
+      return call_anthropic_api(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
     }
 
     if (active_cfg.provider == PROVIDER_OPENAI && active_cfg.auth_mode == AUTH_SUBSCRIPTION) {
-      return call_openai_codex_cli(active_cfg, device_name, app_name, gpu_info, game_category, history);
+      return call_openai_codex_cli(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
     }
 
-    return call_openai_compatible_api(active_cfg, device_name, app_name, gpu_info, game_category, history);
+    return call_openai_compatible_api(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
   }
 
   static void store_cache_entry(const config_t &active_cfg,
                                 const std::string &device_name,
                                 const std::string &app_name,
-                                const device_db::optimization_t &optimization) {
+                                const device_db::optimization_t &optimization,
+                                const std::string &mode = "") {
     std::lock_guard<std::mutex> lock(cache_mutex);
-    cache[current_cache_key(active_cfg, device_name, app_name)] = {
+    cache[current_cache_key(active_cfg, device_name, app_name, mode)] = {
       active_cfg.provider,
       active_cfg.model,
       active_cfg.base_url,
       canonical_device_name(device_name),
       app_name,
+      mode,
       optimization,
       unix_time_now()
     };
@@ -2192,8 +2242,9 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::string &gpu_info,
       const std::string &game_category,
-      const std::optional<session_history_t> &history) {
-    const auto key = current_cache_key(active_cfg, device_name, app_name);
+      const std::optional<session_history_t> &history,
+      const std::string &mode) {
+    const auto key = current_cache_key(active_cfg, device_name, app_name, mode);
 
     {
       std::lock_guard<std::mutex> lock(inflight_mutex);
@@ -2212,10 +2263,10 @@ namespace ai_optimizer {
       ++in_flight_requests;
     }
 
-    std::thread([promise, key, active_cfg, device_name, app_name, gpu_info, game_category, history]() {
+    std::thread([promise, key, active_cfg, device_name, app_name, gpu_info, game_category, history, mode]() {
       const auto started_at = std::chrono::steady_clock::now();
       try {
-        auto result = call_provider(active_cfg, device_name, app_name, gpu_info, game_category, history);
+        auto result = call_provider(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
         auto latency_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
           std::chrono::steady_clock::now() - started_at).count();
 
@@ -2230,7 +2281,7 @@ namespace ai_optimizer {
             false
           );
           update_provider_runtime_status(true, static_cast<long>(latency_ms));
-          store_cache_entry(active_cfg, device_name, app_name, normalized);
+          store_cache_entry(active_cfg, device_name, app_name, normalized, mode);
           promise->set_value(normalized);
         } else {
           update_provider_runtime_status(false, static_cast<long>(latency_ms), "Provider returned no optimization result");
@@ -2460,8 +2511,9 @@ namespace ai_optimizer {
   }
 
   std::optional<device_db::optimization_t> get_cached(
-      const std::string &device_name, const std::string &app_name) {
-    const auto key = current_cache_key(device_name, app_name);
+      const std::string &device_name, const std::string &app_name,
+      const std::string &mode) {
+    const auto key = current_cache_key(device_name, app_name, mode);
     std::optional<cache_entry_t> entry;
     {
       std::lock_guard<std::mutex> lock(cache_mutex);
@@ -2811,10 +2863,11 @@ namespace ai_optimizer {
                      const std::string &app_name,
                      const std::string &gpu_info,
                      const std::string &game_category,
-                     const std::optional<session_history_t> &history) {
+                     const std::optional<session_history_t> &history,
+                     const std::string &mode) {
     if (!is_enabled()) return;
     auto active_cfg = cfg;
-    (void)get_or_start_request(active_cfg, device_name, app_name, gpu_info, game_category, history);
+    (void)get_or_start_request(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
   }
 
   std::optional<device_db::optimization_t> request_sync(
@@ -2822,10 +2875,11 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::string &gpu_info,
       const std::string &game_category,
-      const std::optional<session_history_t> &history) {
+      const std::optional<session_history_t> &history,
+      const std::string &mode) {
     if (!is_enabled()) return std::nullopt;
     auto active_cfg = cfg;
-    auto future = get_or_start_request(active_cfg, device_name, app_name, gpu_info, game_category, history);
+    auto future = get_or_start_request(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
     return future.get();
   }
 
@@ -2835,13 +2889,14 @@ namespace ai_optimizer {
       const std::string &app_name,
       const std::string &gpu_info,
       const std::string &game_category,
-      const std::optional<session_history_t> &history) {
+      const std::optional<session_history_t> &history,
+      const std::string &mode) {
     auto active_cfg = resolved_config(config);
     if (!is_config_enabled(active_cfg)) {
       return std::nullopt;
     }
     const auto started_at = std::chrono::steady_clock::now();
-    auto result = call_provider(active_cfg, device_name, app_name, gpu_info, game_category, history);
+    auto result = call_provider(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
     const auto latency_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - started_at).count();
     if (!result) {
@@ -3032,6 +3087,7 @@ namespace ai_optimizer {
       if (o.target_bitrate_kbps) val["target_bitrate_kbps"] = *o.target_bitrate_kbps;
       if (o.nvenc_tune) val["nvenc_tune"] = *o.nvenc_tune;
       if (o.preferred_codec) val["preferred_codec"] = *o.preferred_codec;
+      if (o.recommended_mode) val["ai_recommended_mode"] = *o.recommended_mode;
       val["reasoning"] = o.reasoning;
       val["cache_status"] = "hit";
       val["confidence"] = o.confidence;

--- a/src/ai_optimizer.cpp
+++ b/src/ai_optimizer.cpp
@@ -1622,6 +1622,9 @@ namespace ai_optimizer {
       "nvenc_tune: 1=quality (slow/cinematic games), 2=low-latency (action), 3=ultra-low-latency (competitive/VR). "
       "color_range: 0=client decides, 1=limited/MPEG, 2=full/JPEG. "
       "preferred_codec: 'hevc' for most devices (better quality/bitrate), 'h264' for legacy/low-power devices, 'av1' for newest devices with AV1 decode. "
+      "recommended_mode: optional advisory. ONLY when the user prompt names the session's streaming display mode and a different one of "
+      "headless_stream, windowed_stream, host_virtual_display, desktop_display, gamescope_stream, headless_dongle "
+      "would clearly improve this game's session, name it here; otherwise omit it or return null. The host treats it as a suggestion only. "
       "If previous session data shows packet loss >2% or latency >30ms, reduce bitrate. "
       "If previous session scored A, keep current settings. If B/C, adjust. "
       "If confirmed or repeated previous session feedback scored D/F, significantly reduce quality; low-confidence soft-end observations should be treated as watch signals only.";
@@ -1799,7 +1802,7 @@ namespace ai_optimizer {
     if (result_json.contains("target_bitrate_kbps")) opt.target_bitrate_kbps = result_json["target_bitrate_kbps"].get<int>();
     if (result_json.contains("nvenc_tune")) opt.nvenc_tune = result_json["nvenc_tune"].get<int>();
     if (result_json.contains("preferred_codec")) opt.preferred_codec = result_json["preferred_codec"].get<std::string>();
-    if (result_json.contains("recommended_mode")) {
+    if (result_json.contains("recommended_mode") && result_json["recommended_mode"].is_string()) {
       const auto suggested = normalize_stream_mode(result_json["recommended_mode"].get<std::string>());
       if (!suggested.empty()) {
         opt.recommended_mode = suggested;
@@ -1826,6 +1829,9 @@ namespace ai_optimizer {
       {"target_bitrate_kbps", {{"type", "integer"}, {"minimum", 1000}, {"maximum", 200000}}},
       {"nvenc_tune", {{"type", "integer"}, {"enum", nlohmann::json::array({1, 2, 3})}}},
       {"preferred_codec", {{"type", "string"}, {"enum", nlohmann::json::array({"h264", "hevc", "av1"})}}},
+      // Strict structured outputs require every property listed in required, so
+      // this advisory field expresses "no suggestion" as null rather than absence.
+      {"recommended_mode", {{"type", nlohmann::json::array({"string", "null"})}, {"description", "One of the six Polaris stream path ids, only when a different mode would clearly improve this session; null otherwise."}}},
       {"reasoning", {{"type", "string"}}},
     };
     schema["required"] = nlohmann::json::array({
@@ -1836,6 +1842,7 @@ namespace ai_optimizer {
       "target_bitrate_kbps",
       "nvenc_tune",
       "preferred_codec",
+      "recommended_mode",
       "reasoning"
     });
 

--- a/src/ai_optimizer.h
+++ b/src/ai_optimizer.h
@@ -71,7 +71,22 @@ namespace ai_optimizer {
    * Returns nullopt if no cached result exists.
    */
   std::optional<device_db::optimization_t> get_cached(
-    const std::string &device_name, const std::string &app_name);
+    const std::string &device_name, const std::string &app_name,
+    const std::string &mode = "");
+
+  /**
+   * @brief Canonicalize a stream display mode id; empty when unknown.
+   *
+   * The six ids mirror stream_path's registry, kept as a local list so this
+   * file stays platform-neutral; a mode this rejects simply falls back to the
+   * legacy (mode-less) behavior rather than failing anything.
+   */
+  std::string normalize_stream_mode(const std::string &mode);
+
+  /** Test seam: the cache bucket a device+game (+optional mode) request lands in. */
+  std::string cache_key_for_tests(
+    const std::string &provider, const std::string &model, const std::string &base_url,
+    const std::string &device, const std::string &app, const std::string &mode);
 
   /**
    * @brief Session quality history for a device+game pair.
@@ -173,7 +188,8 @@ namespace ai_optimizer {
                      const std::string &app_name,
                      const std::string &gpu_info,
                      const std::string &game_category = "",
-                     const std::optional<session_history_t> &history = std::nullopt);
+                     const std::optional<session_history_t> &history = std::nullopt,
+                     const std::string &mode = "");
 
   /**
    * @brief Request an AI optimization synchronously (for manual triggers).
@@ -184,7 +200,8 @@ namespace ai_optimizer {
     const std::string &app_name,
     const std::string &gpu_info,
     const std::string &game_category = "",
-    const std::optional<session_history_t> &history = std::nullopt);
+    const std::optional<session_history_t> &history = std::nullopt,
+    const std::string &mode = "");
 
   /**
    * @brief Request an AI optimization synchronously using ad-hoc config.
@@ -196,7 +213,8 @@ namespace ai_optimizer {
     const std::string &app_name,
     const std::string &gpu_info,
     const std::string &game_category = "",
-    const std::optional<session_history_t> &history = std::nullopt);
+    const std::optional<session_history_t> &history = std::nullopt,
+    const std::string &mode = "");
 
   /**
    * @brief Get a provider-aware model catalog as JSON using ad-hoc config.

--- a/src/device_db.h
+++ b/src/device_db.h
@@ -42,6 +42,7 @@ namespace device_db {
     std::optional<int> target_bitrate_kbps;
     std::optional<int> nvenc_tune;
     std::optional<std::string> preferred_codec;  ///< "h264", "hevc", or "av1"
+    std::optional<std::string> recommended_mode;  ///< AI-suggested stream path id, served as ai_recommended_mode
     std::string reasoning;         ///< Human-readable explanation
     std::string source;            ///< "device_db", "ai_cached", "ai_live"
     std::string cache_status;      ///< "hit", "miss", "fallback", "invalidated"

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -309,7 +309,7 @@ namespace nvhttp {
       return (client_bytes[full_bytes] & mask) == (network_bytes[full_bytes] & mask);
     }
 
-    void append_optimization_json(nlohmann::json &output, const device_db::optimization_t &optimization) {
+    void append_optimization_json(nlohmann::json &output, const device_db::optimization_t &optimization, const std::string &mode = "") {
       if (optimization.display_mode) {
         output["display_mode"] = *optimization.display_mode;
       }
@@ -341,6 +341,11 @@ namespace nvhttp {
       output["recommendation_version"] = optimization.recommendation_version;
       output["generated_at"] = optimization.generated_at;
       output["expires_at"] = optimization.expires_at;
+      // The bucket this answer came from; empty is the legacy mode-less bucket.
+      output["mode"] = mode;
+      if (optimization.recommended_mode) {
+        output["ai_recommended_mode"] = *optimization.recommended_mode;
+      }
     }
 
     std::string lower_copy(std::string value) {
@@ -8386,6 +8391,11 @@ namespace nvhttp {
       std::string profile_preference = normalize_profile_preference(
         args.count("preference") ? args.find("preference")->second : std::string {"auto"}
       );
+      // Optional and additive: an unknown or absent mode is the legacy bucket,
+      // so old clients keep hitting exactly the cache entries they always had.
+      const std::string mode = ai_optimizer::normalize_stream_mode(
+        args.count("mode") ? args.find("mode")->second : std::string {}
+      );
       if (!named_cert_p->name.empty()) {
         if (device != named_cert_p->name) {
           BOOST_LOG(info) << "ai_optimizer: Optimize API using paired client profile ["sv
@@ -8408,10 +8418,10 @@ namespace nvhttp {
         : config::video.adapter_name;
 
       // Try AI cache first, then device_db
-      auto ai_opt = ai_optimizer::get_cached(device, game);
+      auto ai_opt = ai_optimizer::get_cached(device, game, mode);
       if (ai_opt) {
         effective_optimization = *ai_opt;
-        append_optimization_json(output, *ai_opt);
+        append_optimization_json(output, *ai_opt, mode);
         if (ai_opt->target_bitrate_kbps) {
           target_bitrate_kbps = *ai_opt->target_bitrate_kbps;
         }
@@ -8423,17 +8433,17 @@ namespace nvhttp {
           opt.cache_status = "invalidated";
         }
         effective_optimization = opt;
-        append_optimization_json(output, opt);
+        append_optimization_json(output, opt, mode);
         target_bitrate_kbps = opt.target_bitrate_kbps;
         suggested_codec = opt.preferred_codec;
         hdr_requested = opt.hdr.value_or(false);
 
         if (ai_optimizer::is_enabled()) {
           if (ai_optimizer::should_sync_on_cache_miss()) {
-            if (auto sync_opt = ai_optimizer::request_sync(device, game, gpu_info, "", session_history)) {
+            if (auto sync_opt = ai_optimizer::request_sync(device, game, gpu_info, "", session_history, mode)) {
               effective_optimization = *sync_opt;
               output = nlohmann::json::object();
-              append_optimization_json(output, *sync_opt);
+              append_optimization_json(output, *sync_opt, mode);
               if (sync_opt->target_bitrate_kbps) {
                 target_bitrate_kbps = *sync_opt->target_bitrate_kbps;
               }
@@ -8442,10 +8452,10 @@ namespace nvhttp {
               BOOST_LOG(info) << "ai_optimizer: Sync-prewarmed optimization for \""sv << device
                               << "\" + \""sv << game << "\" before launch"sv;
             } else {
-              ai_optimizer::request_async(device, game, gpu_info, "", session_history);
+              ai_optimizer::request_async(device, game, gpu_info, "", session_history, mode);
             }
           } else {
-            ai_optimizer::request_async(device, game, gpu_info, "", session_history);
+            ai_optimizer::request_async(device, game, gpu_info, "", session_history, mode);
           }
         }
       }

--- a/tests/unit/test_ai_optimizer.cpp
+++ b/tests/unit/test_ai_optimizer.cpp
@@ -684,3 +684,23 @@ TEST(AiOptimizerDoctorExplanation, DisabledConfigFallsBackToDeterministicEvidenc
   EXPECT_EQ("Capture path warning", result.at("explanation").value("likely_cause", ""));
   EXPECT_FALSE(result.at("explanation").value("destructive_action_allowed", true));
 }
+
+TEST(AiOptimizerModeAwareCache, LegacyRequestsKeepTheirBucketAndModesGetTheirOwn) {
+  const auto legacy = ai_optimizer::cache_key_for_tests(
+    "anthropic", "model", "url", "RetroidPocket6", "Control Ultimate Edition", "");
+  const auto gamescope = ai_optimizer::cache_key_for_tests(
+    "anthropic", "model", "url", "RetroidPocket6", "Control Ultimate Edition", "gamescope_stream");
+
+  // Distinct buckets per mode; the mode-less key is stable so every entry
+  // written before this change keeps answering the requests it always did.
+  EXPECT_NE(legacy, gamescope);
+  EXPECT_EQ(legacy, ai_optimizer::cache_key_for_tests(
+    "anthropic", "model", "url", "RetroidPocket6", "Control Ultimate Edition", ""));
+}
+
+TEST(AiOptimizerModeAwareCache, RecommendedModeValidationKeepsRegistryIdsOnly) {
+  EXPECT_EQ("gamescope_stream", ai_optimizer::normalize_stream_mode("Gamescope_Stream"));
+  EXPECT_EQ("headless_stream", ai_optimizer::normalize_stream_mode("headless_stream"));
+  EXPECT_EQ("", ai_optimizer::normalize_stream_mode("not_a_mode"));
+  EXPECT_EQ("", ai_optimizer::normalize_stream_mode(""));
+}


### PR DESCRIPTION
## Summary

Wave 3's host half: `/optimize` becomes mode-aware. The optimizer cache grows a trailing mode dimension, the prompt tells the provider which of the six stream paths the session will use, and the response can carry an advisory `recommended_mode` back — served as `ai_recommended_mode`, registry-validated, never acted on by the host. An absent or unknown `mode` is the legacy mode-less bucket, byte-identical to today's behavior.

## Exact candidate

- `ai_optimizer`: `cache_key` gains a trailing `mode` defaulting `""` (the legacy bucket); `cache_entry_t`, `store_cache_entry`, `get_cached`, and the persisted round-trip carry it. `load_cache` rebuilds keys from entry fields, so cache files written before this change load into the legacy bucket with no version bump. The in-flight dedup key in `get_or_start_request` is mode-keyed the same way, so a mode request arriving while a legacy request is in flight starts its own provider call instead of coalescing onto the wrong prompt (caught in self-review; the first draft only keyed the cache).
- Prompt/provider chain (`build_user_prompt`, the four `call_*` providers, `call_provider`, the three `request_*` entrypoints) threads `mode` end-to-end; the prompt names the session's display mode beside the game category. `get_history_safe_fallback` deliberately does not take a mode: session history stays keyed by device+game so the safety heuristics never starve.
- `normalize_stream_mode` canonicalizes against the six registry ids locally (file stays platform-neutral); the provider's `recommended_mode` passes through it, so only real ids ever reach `device_db::optimization_t::recommended_mode`.
- Second commit (self-review catch): the providers are now actually *asked* for the field — the system prompt describes the advisory and the strict structured-output schema admits it (`additionalProperties: false` had forbidden it, so the parse was unreachable). Strict mode requires every property in `required`, so optionality is string-or-null; the parse guards `is_string()` so null stays "no suggestion".
- `nvhttp`: the handler parses the optional `mode` query arg; `append_optimization_json` echoes `mode` and serves `ai_recommended_mode` when present.
- `docs/nova-contract.json`: new `optimization` object scoped to `append_optimization_json`'s exact emissions (what `test_polaris_audit`'s extractor can hold to); the route-handler-attached profile-state/stability keys and the not-yet-consumed `ai_recommended_mode` are recorded in the drift ledger with a `$detail` note.

Deviation from the plan: the cache is keyed by mode only, not preference+mode. The prompt does not vary by preference, so preference buckets would be identical entries under different keys.

## Verification

- Full rebuild + serial ctest: 17/17, including two new `AiOptimizerModeAwareCache` tests (legacy bucket stability + registry-only validation of `recommended_mode`).
- `scripts/check-nova-contract.py --nova <wave0 checkout>`: `optimization: Polaris serves 19, Nova reads 15 [ok]`, no new drift.
- `test_polaris_audit`'s `NovaContractTests.EveryManifestObjectMatchesWhatPolarisActuallyServes` passes against the new object.
- Live curl matrix (mode miss→hit beside a modeless hit on the same game) lands with the deploy that follows the Nova half, since `ai_enabled` is currently off on the host.
