### PR TITLE
feat(confighttp): add the benchmark control surface's start/stop routes

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1625,6 +1625,157 @@ namespace confighttp {
     }
   }
 
+  namespace {
+    std::string_view to_string(stream_stats::benchmark_run_start_result_e result) {
+      switch (result) {
+        case stream_stats::benchmark_run_start_result_e::started:
+          return "started"sv;
+        case stream_stats::benchmark_run_start_result_e::rejected_control_plane_not_enabled:
+          return "rejected_control_plane_not_enabled"sv;
+        case stream_stats::benchmark_run_start_result_e::rejected_caller_not_authorized_as_harness:
+          return "rejected_caller_not_authorized_as_harness"sv;
+        case stream_stats::benchmark_run_start_result_e::rejected_run_not_found:
+          return "rejected_run_not_found"sv;
+        case stream_stats::benchmark_run_start_result_e::rejected_wrong_session:
+          return "rejected_wrong_session"sv;
+        case stream_stats::benchmark_run_start_result_e::rejected_run_not_in_armed_state:
+          return "rejected_run_not_in_armed_state"sv;
+        case stream_stats::benchmark_run_start_result_e::rejected_population_changed_since_arm:
+          return "rejected_population_changed_since_arm"sv;
+        case stream_stats::benchmark_run_start_result_e::rejected_session_no_longer_active:
+          return "rejected_session_no_longer_active"sv;
+      }
+      return "unknown"sv;
+    }
+
+    std::string_view to_string(stream_stats::benchmark_run_stop_result_e result) {
+      switch (result) {
+        case stream_stats::benchmark_run_stop_result_e::stopped:
+          return "stopped"sv;
+        case stream_stats::benchmark_run_stop_result_e::stopped_early_and_aborted:
+          return "stopped_early_and_aborted"sv;
+        case stream_stats::benchmark_run_stop_result_e::rejected_control_plane_not_enabled:
+          return "rejected_control_plane_not_enabled"sv;
+        case stream_stats::benchmark_run_stop_result_e::rejected_caller_not_authorized_as_harness:
+          return "rejected_caller_not_authorized_as_harness"sv;
+        case stream_stats::benchmark_run_stop_result_e::rejected_run_not_found:
+          return "rejected_run_not_found"sv;
+        case stream_stats::benchmark_run_stop_result_e::rejected_wrong_session:
+          return "rejected_wrong_session"sv;
+        case stream_stats::benchmark_run_stop_result_e::rejected_not_currently_active:
+          return "rejected_not_currently_active"sv;
+      }
+      return "unknown"sv;
+    }
+
+    // start/stop both need a run_id (from the URL, not the body - see the
+    // route registrations below) plus the identity of the one active
+    // session, exactly like createBenchmarkRun(). A missing/ambiguous
+    // active session here reports as the run's own
+    // rejected_wrong_session/rejected_session_no_longer_active outcomes
+    // rather than a bespoke error, since from the run's perspective a
+    // caller with no resolvable session identity can never be its owning
+    // session either way.
+    struct benchmark_route_context_t {
+      std::string run_id;
+      std::optional<stream_stats::active_session_identity_t> session_identity;
+    };
+
+    benchmark_route_context_t extract_benchmark_route_context(const req_https_t &request) {
+      benchmark_route_context_t context;
+      if (request->path_match.size() > 1) {
+        context.run_id = request->path_match[1].str();
+      }
+      context.session_identity = stream_stats::get_single_active_session_identity();
+      return context;
+    }
+  }  // namespace
+
+  /**
+   * @brief Start an armed benchmark run (measurement-spec-v1.md 6.4's
+   * POST /polaris/v1/session/timing/runs/{run_id}/start). Takes no request
+   * body - run_id comes from the URL, and the owning session's identity is
+   * looked up the same way createBenchmarkRun() does, not supplied by the
+   * caller.
+   *
+   * Always responds 200 with a JSON body naming the outcome in `result`
+   * (see to_string() above) - there is no create-style "this route
+   * couldn't even parse the request" case here, since there's no body to
+   * parse.
+   *
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   */
+  void startBenchmarkRun(resp_https_t response, req_https_t request) {
+    if (!authorizeBenchmarkHarnessRequest(response, request)) {
+      return;
+    }
+
+    print_req(request);
+
+    const auto context = extract_benchmark_route_context(request);
+
+    nlohmann::json outputTree;
+    outputTree["run_id"] = context.run_id;
+
+    if (!context.session_identity) {
+      outputTree["status"] = false;
+      outputTree["result"] = to_string(stream_stats::benchmark_run_start_result_e::rejected_session_no_longer_active);
+      send_response(response, outputTree);
+      return;
+    }
+
+    const auto result = stream_stats::start_benchmark_run(
+      context.run_id, context.session_identity->device_uuid, context.session_identity->session_generation, true);
+
+    outputTree["status"] = result == stream_stats::benchmark_run_start_result_e::started;
+    outputTree["result"] = to_string(result);
+    send_response(response, outputTree);
+  }
+
+  /**
+   * @brief Stop an active benchmark run (measurement-spec-v1.md 6.4's
+   * POST /polaris/v1/session/timing/runs/{run_id}/stop). Same shape as
+   * startBenchmarkRun() - no request body, run_id from the URL, owning
+   * session looked up the same way.
+   *
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   */
+  void stopBenchmarkRun(resp_https_t response, req_https_t request) {
+    if (!authorizeBenchmarkHarnessRequest(response, request)) {
+      return;
+    }
+
+    print_req(request);
+
+    const auto context = extract_benchmark_route_context(request);
+
+    nlohmann::json outputTree;
+    outputTree["run_id"] = context.run_id;
+
+    if (!context.session_identity) {
+      outputTree["status"] = false;
+      outputTree["result"] = to_string(stream_stats::benchmark_run_stop_result_e::rejected_wrong_session);
+      send_response(response, outputTree);
+      return;
+    }
+
+    const auto result = stream_stats::stop_benchmark_run(
+      context.run_id, context.session_identity->device_uuid, context.session_identity->session_generation, true);
+
+    // status=true only for the literal stopped outcome, matching
+    // createBenchmarkRun's own status convention (true iff the
+    // semantically-intended outcome happened, not merely "the stop
+    // request was processed without error"). stopped_early_and_aborted
+    // is a real outcome the caller triggered, not a request-processing
+    // failure, but it's not what a naive status check should read as
+    // success either - the run it produced is invalid for measurement.
+    outputTree["status"] = result == stream_stats::benchmark_run_stop_result_e::stopped;
+    outputTree["result"] = to_string(result);
+    send_response(response, outputTree);
+  }
+
   /**
    * @brief Serve the SPA index.html for any non-API, non-asset route.
    * @param response The HTTP response object.
@@ -5931,6 +6082,8 @@ namespace confighttp {
     // (see that function's own doc comment for why a Bearer-token caller is
     // exempt).
     server.resource["^/polaris/v1/session/timing/runs$"]["POST"] = createBenchmarkRun;
+    server.resource["^/polaris/v1/session/timing/runs/([^/]+)/start$"]["POST"] = startBenchmarkRun;
+    server.resource["^/polaris/v1/session/timing/runs/([^/]+)/stop$"]["POST"] = stopBenchmarkRun;
     server.resource["^/api/apps/close$"]["POST"] = withCsrf(closeApp);
     server.resource["^/api/games/scan$"]["GET"] = scanGames;
     server.resource["^/api/games/import$"]["POST"] = withCsrf(importGames);


### PR DESCRIPTION
## Summary

Fourth of five pieces (same "one piece per PR, in order" pacing) for the P0-5 network-facing control surface. Wires `POST /polaris/v1/session/timing/runs/{run_id}/start` and `.../stop` to `start_benchmark_run()`/`stop_benchmark_run()`.

- `{run_id}` is the first dynamic path segment this codebase's confighttp server has used - every existing route is a fixed path, with any resource ID carried in the JSON body instead. Uses SimpleWeb's own regex-capture mechanism (`request->path_match`, already present in the vendored library, just never exercised here before) rather than inventing anything new: `"^.../runs/([^/]+)/start$"`, extracted via `path_match[1].str()`.
- Neither route takes a request body - `run_id` comes from the URL, and the owning session's identity is looked up the same way `createBenchmarkRun()` does (`get_single_active_session_identity()`, from piece 3), not supplied by the caller. A shared `extract_benchmark_route_context()` pulls both pieces of context; each handler picks its own domain-appropriate rejection reason (`rejected_session_no_longer_active` for start, `rejected_wrong_session` for stop - the closest semantic fit among stop's actual enum values, which has no "session no longer active" case of its own) when no single active session resolves.
- Same 200-always-with-a-`result`-field convention as create. `status` follows create's own precedent exactly: true only for the literal intended-success value (`started` / `stopped`), not for every outcome that isn't a hard failure. Deliberately not true for `stopped_early_and_aborted` - the caller's stop request did do something real, but the run it produced is invalid for measurement, which is not what a naive status check should read as success.

## Exact candidate

```
Commit: 6e202a8400b3f1066b4d9a2c6ab0087d1604e2cc
Tree:   c1bde7b6a6d6b5a90782d5d7818cda0885dd47e5
Parent: 97f39d841d2c90f91182249eacd2d9b27d47ddf4
Base:   97f39d841d2c90f91182249eacd2d9b27d47ddf4
```

## Verification

- [x] Full rebuild from clean (`ninja -j32`) - clean on the first attempt this time, no forward-reference surprises, since both handlers were placed after `createBenchmarkRun`, which already satisfies every dependency they share with it.
- [x] `ctest --test-dir build` - 100% passed, 17/17 test binaries.

**No new pure-logic surface to unit test here:** `get_single_active_session_identity` (piece 3) and `start_benchmark_run`/`stop_benchmark_run` (engine piece 4, already merged earlier this arc) already have full coverage from their own pieces; these two handlers are glue (path extraction, context lookup, JSON formatting) over already-tested logic - same honest gap as create's own route handler (this codebase has no infrastructure for constructing a live `req_https_t`/`resp_https_t` to test against directly, and this route isn't live-server-tested either, to avoid any risk of colliding with pc-papi's actual deployed Polaris instance).

**Not covered by this PR** (deliberately, per the approved piece-by-piece pacing): get/delete routes (piece 5, the last of the five).
