### PR TITLE
fix(stream): debounce the served network risk and calibrate it for ENet

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -474,9 +474,6 @@
         "capture",
         "runtime",
         "topology"
-      ],
-      "optimization": [
-        "ai_recommended_mode"
       ]
     },
     "$detail": {
@@ -505,8 +502,8 @@
         "nova_reads_polaris_never_sends are served by the /optimize route handler, which",
         "attaches the profile-state and stability blocks beside the serializer; the object",
         "models append_optimization_json because that is the one named function the audit",
-        "extractor can hold to. ai_recommended_mode under polaris_sends_nova_never_reads is",
-        "simply early: it ships host-first and moves out when the Nova picker badge lands."
+        "extractor can hold to. ai_recommended_mode moved out of the ledger on",
+        "2026-08-08 when the Nova picker badge landed (papi-ux/nova#215)."
       ]
     }
   }

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2322,7 +2322,7 @@ namespace nvhttp {
       const bool meaningful_fps_shortfall =
         stream_stats::is_meaningful_fps_shortfall(target_fps, stats.fps);
 
-      const bool network_risk = stats.packet_loss >= 0.35 || stats.latency_ms >= 28.0;
+      const bool network_risk = stats.network_risk;
       const bool pacing_risk =
         stats.frame_jitter_ms >= 2.2 ||
         stats.duplicate_frame_ratio >= 0.10 ||

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -420,7 +420,7 @@ namespace proc {
       host_pause_session_classification_t classification;
       const bool meaningful_fps_shortfall =
         stream_stats::is_meaningful_fps_shortfall(target_fps, stats.fps);
-      classification.network_risk = stats.packet_loss >= 0.35 || stats.latency_ms >= 28.0;
+      classification.network_risk = stats.network_risk;
       classification.pacing_risk =
         stats.frame_jitter_ms >= 2.2 ||
         stats.duplicate_frame_ratio >= 0.10 ||

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -73,7 +73,13 @@ namespace stream_stats {
     std::atomic<double> hot_frame_jitter_ms {0.0};
     std::atomic<double> hot_latency_ms {0.0};
     std::atomic<double> hot_packet_loss {0.0};
+    std::atomic<bool> hot_network_risk {false};
     std::atomic<uint64_t> hot_bytes_sent {0};
+
+    // Guarded by its own lock so the lock-free update_network_stats
+    // overload stays clear of stats_mutex.
+    network_risk_tracker_t network_risk_tracker;
+    std::mutex network_risk_mutex;
 
     // Recovery counters: monotonic for the life of the process, matching
     // the roadmap's P0-2 ask; a per-session view is a get_current() delta.
@@ -113,6 +119,11 @@ namespace stream_stats {
       hot_frame_jitter_ms.store(0.0, std::memory_order_relaxed);
       hot_latency_ms.store(0.0, std::memory_order_relaxed);
       hot_packet_loss.store(0.0, std::memory_order_relaxed);
+      {
+        std::lock_guard<std::mutex> risk_lock(network_risk_mutex);
+        network_risk_tracker.reset();
+      }
+      hot_network_risk.store(false, std::memory_order_relaxed);
       hot_bytes_sent.store(0, std::memory_order_relaxed);
       // idr_requests_total / invalidate_ref_frames_requests_total are
       // intentionally NOT reset here: they are process-lifetime recovery
@@ -1084,11 +1095,22 @@ namespace stream_stats {
     return std::clamp((double) scaled_loss * 100.0 / (double) scale, 0.0, 100.0);
   }
 
+  namespace {
+    void ingest_network_risk(double latency_ms, double packet_loss) {
+      std::lock_guard<std::mutex> risk_lock(network_risk_mutex);
+      hot_network_risk.store(
+        network_risk_tracker.update(packet_loss, latency_ms),
+        std::memory_order_relaxed);
+    }
+  }  // namespace
+
   void update_network_stats(double latency_ms, double packet_loss, uint64_t bytes_sent) {
-    // Fully lock-free: no per-client mirror exists on this overload.
+    // No per-client mirror on this overload, and the risk tracker has its
+    // own lock, so stats_mutex stays out of this path.
     hot_latency_ms.store(latency_ms, std::memory_order_relaxed);
     hot_packet_loss.store(packet_loss, std::memory_order_relaxed);
     hot_bytes_sent.store(bytes_sent, std::memory_order_relaxed);
+    ingest_network_risk(latency_ms, packet_loss);
   }
 
   void update_network_stats(const std::string &client_ip, double latency_ms, double packet_loss, uint64_t bytes_sent) {
@@ -1109,6 +1131,7 @@ namespace stream_stats {
       hot_packet_loss.store(packet_loss, std::memory_order_relaxed);
       hot_bytes_sent.store(bytes_sent, std::memory_order_relaxed);
     }
+    ingest_network_risk(latency_ms, packet_loss);
   }
 
   void update_runtime_state(const platf::runtime_state_t &state) {
@@ -1897,6 +1920,7 @@ namespace stream_stats {
     result.frame_jitter_ms = hot_frame_jitter_ms.load(std::memory_order_relaxed);
     result.latency_ms = hot_latency_ms.load(std::memory_order_relaxed);
     result.packet_loss = hot_packet_loss.load(std::memory_order_relaxed);
+    result.network_risk = hot_network_risk.load(std::memory_order_relaxed);
     result.bytes_sent = hot_bytes_sent.load(std::memory_order_relaxed);
     result.idr_requests_total = hot_idr_requests_total.load(std::memory_order_relaxed);
     result.invalidate_ref_frames_requests_total = hot_invalidate_ref_frames_requests_total.load(std::memory_order_relaxed);

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -132,6 +132,8 @@ namespace stream_stats {
     // Network
     double latency_ms = 0;
     double packet_loss = 0;
+    /// Debounced by network_risk_tracker_t; the single truth every reader serves.
+    bool network_risk = false;
     uint64_t bytes_sent = 0;
 
     // Adaptive bitrate
@@ -348,6 +350,53 @@ namespace stream_stats {
    * @return Packet loss percentage clamped to [0.0, 100.0].
    */
   double packet_loss_percent(uint64_t scaled_loss, uint64_t scale);
+
+  /**
+   * @brief Debounced elevated/normal state behind the served network_risk.
+   *
+   * ENet's packetLoss is an EWMA computed over the low-rate control channel,
+   * so a single retransmit reads as whole percents for a while - a 0.35%
+   * cut flagged "Network jitter" on objectively perfect streams. The 2%
+   * cut matches the session-grading "fair" line, the warm-up skips the
+   * samples computed from the fewest packets, and the two-sample debounce
+   * keeps one noisy reading from flipping the HUD either way.
+   */
+  struct network_risk_tracker_t {
+    static constexpr double k_loss_elevated_pct = 2.0;
+    static constexpr double k_rtt_elevated_ms = 28.0;
+    static constexpr int k_warmup_samples = 5;
+    static constexpr int k_debounce_samples = 2;
+
+    int samples_seen = 0;
+    int consecutive_elevated = 0;
+    int consecutive_calm = 0;
+    bool elevated = false;
+
+    /** @return The debounced state after folding in one reading. */
+    bool update(double loss_pct, double rtt_ms) {
+      ++samples_seen;
+      const bool raw = loss_pct >= k_loss_elevated_pct || rtt_ms >= k_rtt_elevated_ms;
+      if (samples_seen <= k_warmup_samples) {
+        return elevated;
+      }
+      if (raw) {
+        consecutive_calm = 0;
+        if (++consecutive_elevated >= k_debounce_samples) {
+          elevated = true;
+        }
+      } else {
+        consecutive_elevated = 0;
+        if (++consecutive_calm >= k_debounce_samples) {
+          elevated = false;
+        }
+      }
+      return elevated;
+    }
+
+    void reset() {
+      *this = network_risk_tracker_t {};
+    }
+  };
 
   /**
    * @brief Update runtime mode metadata exposed to the dashboard.

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -779,7 +779,8 @@ TEST(StreamStatsHotFieldTests, UpdateNetworkStatsIsVisibleThroughGetCurrent) {
 
 // The periodic-ping handler in stream.cpp sources loss from ENet's scaled
 // peer->packetLoss; this module stores percent (0-100), matching the readers
-// (network_risk thresholds at 0.35%, session grading at 0.5/2/5%).
+// (served network_risk elevates at 2% after warm-up and debounce; session
+// grading stays at 0.5/2/5%).
 TEST(StreamStatsHotFieldTests, RuntimeDisplayWarningIsServedAndResetWithTheStream) {
   stream_stats::update_stream_active(true);
   stream_stats::update_runtime_display_warning("Host Virtual Display could not be created");
@@ -798,8 +799,47 @@ TEST(StreamStatsHotFieldTests, PacketLossPercentConvertsScaledRatios) {
   EXPECT_DOUBLE_EQ(stream_stats::packet_loss_percent(0, scale), 0.0);
   EXPECT_DOUBLE_EQ(stream_stats::packet_loss_percent(scale, scale), 100.0);
   EXPECT_DOUBLE_EQ(stream_stats::packet_loss_percent(scale / 2, scale), 50.0);
-  // 0.35% loss - exactly the network_risk threshold - survives the conversion.
+  // 0.35% loss - the old hair-trigger risk threshold, now well inside calm -
+  // survives the conversion.
   EXPECT_NEAR(stream_stats::packet_loss_percent(229, scale), 0.3494, 0.001);
+}
+
+TEST(NetworkRiskTrackerTests, WarmupNeverGrades) {
+  stream_stats::network_risk_tracker_t tracker;
+  // Session start is exactly when ENet's ratio comes from the fewest
+  // packets; even absurd readings must not elevate yet.
+  for (int i = 0; i < stream_stats::network_risk_tracker_t::k_warmup_samples; ++i) {
+    EXPECT_FALSE(tracker.update(100.0, 500.0));
+  }
+}
+
+TEST(NetworkRiskTrackerTests, TheLiveFalsePositiveStaysCalm) {
+  stream_stats::network_risk_tracker_t tracker;
+  // The regression this exists for: a perfect 115/120fps 3ms stream held a
+  // permanent "Network jitter" because ENet's EWMA hovered past 0.35%.
+  for (int i = 0; i < 50; ++i) {
+    EXPECT_FALSE(tracker.update(0.5, 3.0));
+  }
+}
+
+TEST(NetworkRiskTrackerTests, TwoElevatedFlipAndTwoCalmClear) {
+  stream_stats::network_risk_tracker_t tracker;
+  for (int i = 0; i < stream_stats::network_risk_tracker_t::k_warmup_samples; ++i) {
+    tracker.update(0.0, 1.0);
+  }
+  EXPECT_FALSE(tracker.update(3.0, 1.0));  // one bad reading is noise
+  EXPECT_TRUE(tracker.update(3.0, 1.0));  // two in a row is a state
+  EXPECT_TRUE(tracker.update(0.0, 1.0));  // one calm reading is noise too
+  EXPECT_FALSE(tracker.update(0.0, 1.0));  // two clear it
+}
+
+TEST(NetworkRiskTrackerTests, RttAloneElevates) {
+  stream_stats::network_risk_tracker_t tracker;
+  for (int i = 0; i < stream_stats::network_risk_tracker_t::k_warmup_samples; ++i) {
+    tracker.update(0.0, 1.0);
+  }
+  tracker.update(0.0, 30.0);
+  EXPECT_TRUE(tracker.update(0.0, 30.0));
 }
 
 TEST(StreamStatsHotFieldTests, PacketLossPercentClampsDegenerateInputs) {


### PR DESCRIPTION
## Summary

Kills the last half of the "Network Jitter" complaint: the false-positive *mechanics* were fixed earlier (HUD only warns on `elevated`, host metrics actually flow), but the live stream still held a permanent warning because the thresholds were calibrated for the old dead estimator. ENet's `packetLoss` is an EWMA over the low-rate control channel — one retransmit reads as whole percents for a while — and the 0.35% cut with zero hysteresis made perfect streams (115/120fps, 3ms RTT) warn forever.

## Exact candidate

- `stream_stats::network_risk_tracker_t`: one debounced truth behind the served risk. 2% loss cut (matches the session-grading "fair" line), 28ms RTT cut unchanged, five-sample warm-up (session start is exactly when the EWMA is computed from the fewest packets), two-sample debounce both directions. Pure struct, unit-tested directly.
- Both `update_network_stats` overloads feed the tracker under its own lock — the lock-free overload stays clear of `stats_mutex` — and the wholesale end-of-stream reset clears it, keeping the risk per-session.
- Both readers (`nvhttp` session-status insights, `process` host-pause classifier) consume `stats.network_risk` instead of re-deriving thresholds, so they can never drift apart again.
- Deliberately untouched: `ai_optimizer`'s 0.35 sites grade end-of-session aggregates for the optimizer, not live EWMA snapshots — recalibrating those changes what the AI learns and deserves its own look if grading proves noisy.
- Rides along: `ai_recommended_mode` leaves `known_drift` (consumed by the Nova badge since papi-ux/nova#215), with the `$detail` note updated.

## Verification

- Full rebuild + serial ctest 17/17, including four new `NetworkRiskTrackerTests` — one is the literal live regression (steady 0.5% EWMA at 3ms stays calm forever), plus warm-up, flip/clear debounce, and RTT-alone cases.
- `check-nova-contract.py`: `optimization: Polaris serves 19, Nova reads 16 [ok]`, no new drift.
- Stale test comments re-pinned to the new semantics rather than deleted.
- On-device after deploy: healthy Control Ultimate Edition stream shows the Stable chip instead of "Network jitter · Stream 120".
