### PR TITLE
fix(tray): never run tray updates on HTTP worker threads

### DIFF
--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -37,7 +37,10 @@
   #include <atomic>
   #include <chrono>
   #include <csignal>
+  #include <deque>
   #include <format>
+  #include <functional>
+  #include <mutex>
   #include <string>
   #include <thread>
 
@@ -66,6 +69,43 @@ namespace system_tray {
   static std::thread tray_thread;
   static std::atomic tray_thread_running = false;
   static std::atomic tray_thread_should_exit = false;
+
+  // The public update_tray_* functions only enqueue here. They used to call
+  // tray_update on the caller's thread, and on a headless user service that
+  // entered glib with nobody iterating the context and blocked forever -
+  // every pairing attempt wedged an HTTP worker on a cosmetic notification.
+  // The tray thread drains the queue between event iterations; when it is
+  // not running (or stuck), updates drop, which is what a machine without a
+  // working tray deserves. Capped so a stuck drain cannot grow it.
+  static std::mutex tray_task_mutex;
+  static std::deque<std::function<void()>> tray_tasks;
+  constexpr std::size_t k_max_pending_tray_tasks = 8;
+
+  static void post_tray_task(std::function<void()> task) {
+    if (!tray_thread_running) {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(tray_task_mutex);
+    if (tray_tasks.size() >= k_max_pending_tray_tasks) {
+      tray_tasks.pop_front();
+    }
+    tray_tasks.push_back(std::move(task));
+  }
+
+  static void drain_tray_tasks() {
+    for (;;) {
+      std::function<void()> task;
+      {
+        std::lock_guard<std::mutex> lock(tray_task_mutex);
+        if (tray_tasks.empty()) {
+          return;
+        }
+        task = std::move(tray_tasks.front());
+        tray_tasks.pop_front();
+      }
+      task();
+    }
+  }
 
   void tray_open_ui_cb([[maybe_unused]] struct tray_menu *item) {
     BOOST_LOG(info) << "Opening UI from system tray"sv;
@@ -240,7 +280,7 @@ namespace system_tray {
     return 0;
   }
 
-  void update_tray_playing(std::string app_name) {
+  static void update_tray_playing_on_tray_thread(std::string app_name) {
     if (!tray_initialized) {
       return;
     }
@@ -269,7 +309,7 @@ namespace system_tray {
     tray_update(&tray);
   }
 
-  void update_tray_pausing(std::string app_name) {
+  static void update_tray_pausing_on_tray_thread(std::string app_name) {
     if (!tray_initialized) {
       return;
     }
@@ -293,7 +333,7 @@ namespace system_tray {
     tray_update(&tray);
   }
 
-  void update_tray_stopped(std::string app_name) {
+  static void update_tray_stopped_on_tray_thread(std::string app_name) {
     if (!tray_initialized) {
       return;
     }
@@ -347,7 +387,7 @@ namespace system_tray {
     tray_update(&tray);
   }
 
-  void update_tray_require_pin() {
+  static void update_tray_require_pin_on_tray_thread() {
     if (!tray_initialized) {
       return;
     }
@@ -369,8 +409,8 @@ namespace system_tray {
     tray_update(&tray);
   }
 
-  void
-  update_tray_paired(std::string device_name) {
+  static void
+  update_tray_paired_on_tray_thread(std::string device_name) {
     if (!tray_initialized) {
       return;
     }
@@ -392,8 +432,8 @@ namespace system_tray {
     tray_update(&tray);
   }
 
-  void
-  update_tray_client_connected(std::string client_name) {
+  static void
+  update_tray_client_connected_on_tray_thread(std::string client_name) {
     if (!tray_initialized) {
       return;
     }
@@ -416,6 +456,42 @@ namespace system_tray {
     tray_update(&tray);
   }
 
+  void update_tray_playing(std::string app_name) {
+    post_tray_task([app_name = std::move(app_name)]() mutable {
+      update_tray_playing_on_tray_thread(std::move(app_name));
+    });
+  }
+
+  void update_tray_pausing(std::string app_name) {
+    post_tray_task([app_name = std::move(app_name)]() mutable {
+      update_tray_pausing_on_tray_thread(std::move(app_name));
+    });
+  }
+
+  void update_tray_stopped(std::string app_name) {
+    post_tray_task([app_name = std::move(app_name)]() mutable {
+      update_tray_stopped_on_tray_thread(std::move(app_name));
+    });
+  }
+
+  void update_tray_require_pin() {
+    post_tray_task([]() {
+      update_tray_require_pin_on_tray_thread();
+    });
+  }
+
+  void update_tray_paired(std::string device_name) {
+    post_tray_task([device_name = std::move(device_name)]() mutable {
+      update_tray_paired_on_tray_thread(std::move(device_name));
+    });
+  }
+
+  void update_tray_client_connected(std::string client_name) {
+    post_tray_task([client_name = std::move(client_name)]() mutable {
+      update_tray_client_connected_on_tray_thread(std::move(client_name));
+    });
+  }
+
   // Threading functions available on all platforms
   static void tray_thread_worker() {
     BOOST_LOG(info) << "System tray thread started"sv;
@@ -431,6 +507,7 @@ namespace system_tray {
 
     // Main tray event loop
     while (!tray_thread_should_exit) {
+      drain_tray_tasks();
       if (process_tray_events() != 0) {
         BOOST_LOG(warning) << "Tray event processing failed in thread"sv;
         break;


### PR DESCRIPTION
## Summary

Fixes the pairing hang found live on 2026-08-08: `update_tray_paired` ran `tray_update` on the HTTP worker thread, and on a headless user service that call enters glib with nobody iterating the context and never returns — each pairing attempt permanently wedged a worker (stack-confirmed with `eu-stack` during a live hang). The interim mitigation was `system_tray = disabled` in polaris.conf; this makes the tray safe to turn back on.

## Exact candidate

- All six public `update_tray_*` functions now only enqueue onto a capped queue (8 entries, oldest dropped); the existing tray thread drains it between event-loop iterations, so `tray_update` always runs on the one thread that owns the tray and its glib context.
- `post_tray_task` drops immediately when the tray thread is not running, and the cap keeps a stuck drain from growing the queue — tray updates are cosmetic notifications, so dropping them on a machine without a working tray is the correct behavior, and no caller can ever block on one again.
- The `tray_initialized` guards stay inside the moved bodies, now evaluated on the tray thread where they are actually meaningful.
- No header or caller changes; nvhttp/process call sites are untouched.

## Verification

- Full rebuild + serial ctest 17/17 (system_tray.cpp compiles into the test targets with `POLARIS_TRAY=1`).
- The structural invariant is the fix: after this change no public tray function contains a `tray_update` call — callers can only enqueue.
- Live after deploy: `system_tray` re-enabled on the headless user service, service healthy, and a Control Ultimate Edition stream start/stop exercises `update_tray_client_connected` through the same post→drain path that pairing uses, with HTTP endpoints verified responsive afterward. A true pairing run is deliberately not part of this pass — it would require re-pairing the daily-driver RP6.
