### PR TITLE
fix(stream): grade network risk only after the RTT estimator proves itself

### DIFF
--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -833,8 +833,13 @@ namespace stream_stats {
     const bool capture_known = doctor_has_capture_metadata(stats);
     const double target_fps = doctor_target_fps(stats);
     const bool meaningful_fps_shortfall = is_meaningful_fps_shortfall(target_fps, stats.fps);
-    const bool network_fail = stats.packet_loss > 2.0 || stats.latency_ms >= 45.0;
-    const bool network_watch = !network_fail && (stats.packet_loss > 0.5 || stats.latency_ms >= 28.0);
+    // The network verdict consumes the debounced flag the session status
+    // serves (network_risk_tracker_t). The raw one-sample cuts this replaced
+    // re-created the exact hair-trigger the tracker exists to prevent — the
+    // old 0.5% watch threshold sat below the control channel's steady EWMA
+    // noise, so Doctor said "network jitter" over perfect streams.
+    const bool network_fail = stats.network_risk && (stats.packet_loss > 2.0 || stats.latency_ms >= 45.0);
+    const bool network_watch = stats.network_risk && !network_fail;
     const bool encoder_fail = stats.encode_time_ms >= 12.0 || stats.avg_frame_age_ms >= 22.0;
     const bool encoder_watch = !encoder_fail && (stats.encode_time_ms >= 8.0 || stats.avg_frame_age_ms >= 18.0);
     const bool pacing_watch =

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -366,8 +366,10 @@ namespace stream_stats {
     static constexpr double k_rtt_elevated_ms = 28.0;
     static constexpr int k_warmup_samples = 5;
     static constexpr int k_debounce_samples = 2;
+    static constexpr int k_armed_after_samples = 40;
 
     int samples_seen = 0;
+    bool calm_seen = false;
     int consecutive_elevated = 0;
     int consecutive_calm = 0;
     bool elevated = false;
@@ -376,7 +378,18 @@ namespace stream_stats {
     bool update(double loss_pct, double rtt_ms) {
       ++samples_seen;
       const bool raw = loss_pct >= k_loss_elevated_pct || rtt_ms >= k_rtt_elevated_ms;
-      if (samples_seen <= k_warmup_samples) {
+      if (!raw) {
+        calm_seen = true;
+      }
+      // ENet seeds a fresh peer's RTT at 500ms and converges by roughly an
+      // eighth per ack, so the first stretch of every session reads above the
+      // RTT cut without a single packet actually arriving late — a fixed
+      // warm-up count cannot cover it. Grading starts once the estimator has
+      // proven itself with one calm reading; k_armed_after_samples bounds how
+      // long a genuinely bad link can hide behind that grace (~20s at the
+      // client's ping cadence).
+      if (samples_seen <= k_warmup_samples ||
+          (!calm_seen && samples_seen <= k_armed_after_samples)) {
         return elevated;
       }
       if (raw) {

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -842,6 +842,38 @@ TEST(NetworkRiskTrackerTests, RttAloneElevates) {
   EXPECT_TRUE(tracker.update(0.0, 30.0));
 }
 
+TEST(NetworkRiskTrackerTests, EnetRttConvergenceNeverElevates) {
+  stream_stats::network_risk_tracker_t tracker;
+  // The live regression: ENet seeds a fresh peer at 500ms RTT and converges
+  // by ~1/8 per ack, so early samples sit above the 28ms cut for ~20 samples
+  // on a LAN whose true RTT is 3ms. That descent must never grade as risk.
+  double rtt = 500.0;
+  int calm_at = -1;
+  for (int i = 0; i < 60; ++i) {
+    EXPECT_FALSE(tracker.update(0.2, rtt)) << "sample " << i << " rtt " << rtt;
+    if (calm_at < 0 && rtt < stream_stats::network_risk_tracker_t::k_rtt_elevated_ms) {
+      calm_at = i;
+    }
+    rtt = 3.0 + (rtt - 3.0) * 7.0 / 8.0;
+  }
+  ASSERT_GT(calm_at, stream_stats::network_risk_tracker_t::k_warmup_samples);
+  // Once armed by the calm readings, real degradation still flags promptly.
+  tracker.update(0.2, 80.0);
+  EXPECT_TRUE(tracker.update(0.2, 80.0));
+}
+
+TEST(NetworkRiskTrackerTests, BadFromTheStartStillFlagsAfterBoundedGrace) {
+  stream_stats::network_risk_tracker_t tracker;
+  // A link that never produces a calm reading cannot hide forever behind the
+  // convergence grace: the sample bound arms the tracker and the debounce
+  // flips it on the next confirmation.
+  bool flagged = false;
+  for (int i = 0; i < stream_stats::network_risk_tracker_t::k_armed_after_samples + 2; ++i) {
+    flagged = tracker.update(6.0, 90.0);
+  }
+  EXPECT_TRUE(flagged);
+}
+
 TEST(StreamStatsHotFieldTests, PacketLossPercentClampsDegenerateInputs) {
   constexpr uint64_t scale = 1ull << 16;
 


### PR DESCRIPTION
## Summary

Every session opened with a stretch of false "elevated" network risk. ENet seeds a fresh peer's RTT estimate at 500ms and converges by roughly an eighth per ack, so the first ~20 samples of every stream read far above the 28ms cut on a LAN whose true RTT is 3ms. The five-sample warm-up couldn't cover the descent, the tracker latched elevated right after it, and everything downstream believed it for the opening minute of every stream: Command Center showed "NET: Needs attention" / "Network limited — holding quality", the auto-quality policy blocked, and short sessions were graded "B with elevated network jitter" on objectively perfect streams — grades that then fed recovery profiles which downgraded later launches to 30 FPS.

Two changes, one truth:

- **`network_risk_tracker_t` arms on proof of calm.** Grading starts only once the estimator has produced a single sub-threshold reading — evidence it has converged — with a bounded grace (`k_armed_after_samples = 40`, ~20s at the client's ping cadence) so a link that is genuinely bad from its first packet still flags instead of hiding behind the grace. Warm-up floor and two-sample debounce are untouched; all four existing tracker pins pass as written (their warm-ups feed calm readings, which is itself the distinction: real bad networks never look calm, a converging estimator eventually does).
- **Doctor consumes the debounced flag.** `build_doctor_json` had its own raw one-sample thresholds, and its 0.5% loss "watch" cut sat below the control channel's steady EWMA noise — the exact hair-trigger the tracker exists to prevent, resurrected one layer up. The network verdict is now `stats.network_risk`, with severity split on raw magnitudes only while the debounced flag says the risk is real.

## Exact candidate

`145b8651` — fix(stream): grade network risk only after the RTT estimator proves itself

## Verification

- New pins: `EnetRttConvergenceNeverElevates` replays the live regression (500ms decaying by 7/8 toward 3ms — never elevates through the descent, still flags promptly once armed) and `BadFromTheStartStillFlagsAfterBoundedGrace` (constant 6% loss / 90ms flags within the bound).
- All four existing tracker pins pass unmodified, including `TheLiveFalsePositiveStaysCalm`.
- Full ctest suite green on the CUDA build.
- Live evidence of the regression this closes: tonight's healthy 3ms sessions carried `limiting_factor=network` in their opening status polls, and Play Setup showed "LIMITED BY: NETWORK" with a 30 FPS recovery profile after nothing but clean streams.
