### PR TITLE
fix(process): stop privileged descendants wedging exact-generation cleanup

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -955,6 +955,25 @@ namespace proc {
       return session_owned_cage || generation_available;
     }
 
+    bool unreadable_environ_latches_capture(
+      int read_error,
+      std::optional<uid_t> real_uid,
+      uid_t own_uid,
+      std::optional<bool> descends_from_polaris
+    ) {
+      // A privileged descendant — Steam's setuid chrome-sandbox helpers gain
+      // a root real uid — keeps /proc/PID/environ root-only forever, and no
+      // signal polaris may send can touch it anyway. It lives and dies with
+      // the same-uid ancestors the snapshot does capture, so treating it as
+      // "capture incomplete" bought no safety and wedged every desktop-Steam
+      // teardown into "retaining immutable cage generation" with the next
+      // launch refused until restart.
+      if (read_error == EACCES && real_uid && *real_uid != own_uid) {
+        return false;
+      }
+      return !descends_from_polaris || *descends_from_polaris;
+    }
+
     bool isolated_session_cleanup_resets_router(
       bool session_owned_cage,
       bool generation_available,
@@ -1328,6 +1347,28 @@ namespace proc {
       return false;
     }
 
+    std::optional<uid_t> proc_status_real_uid(std::string_view status) {
+      const auto label = status.find("Uid:");
+      if (label == std::string_view::npos) {
+        return std::nullopt;
+      }
+      auto pos = label + 4;
+      while (pos < status.size() && std::isspace(static_cast<unsigned char>(status[pos]))) {
+        ++pos;
+      }
+      uid_t uid = 0;
+      bool any_digit = false;
+      while (pos < status.size() && std::isdigit(static_cast<unsigned char>(status[pos]))) {
+        uid = uid * 10 + static_cast<uid_t>(status[pos] - '0');
+        any_digit = true;
+        ++pos;
+      }
+      if (!any_digit) {
+        return std::nullopt;
+      }
+      return uid;
+    }
+
     bool is_active_steam_shutdown_ownership_process(
       std::string_view comm,
       std::string_view argv0_path,
@@ -1531,12 +1572,18 @@ namespace proc {
 
         const auto environ_before = read_proc_status_file_result(pid, "environ");
         if (!environ_before.ok()) {
+          const auto status = read_proc_status_file(pid, "status");
           if (process_vanished_during_proc_read(environ_before.error) ||
-              proc_status_is_zombie(read_proc_status_file(pid, "status"))) {
+              proc_status_is_zombie(status)) {
             continue;
           }
           const auto descends_from_polaris = proc_pid_descends_from(pid, getpid());
-          if (!descends_from_polaris || *descends_from_polaris) {
+          if (unreadable_environ_latches_capture(
+                environ_before.error,
+                proc_status_real_uid(status),
+                getuid(),
+                descends_from_polaris
+              )) {
             snapshot.capture_complete = false;
           }
           continue;
@@ -4568,6 +4615,15 @@ namespace proc {
     return isolated_session_generation_blocks_launch(session_owned_cage, generation_available);
   }
 
+  bool unreadable_environ_latches_capture_for_tests(
+    int read_error,
+    std::optional<uid_t> real_uid,
+    uid_t own_uid,
+    std::optional<bool> descends_from_polaris
+  ) {
+    return unreadable_environ_latches_capture(read_error, real_uid, own_uid, descends_from_polaris);
+  }
+
   bool isolated_session_cleanup_resets_router_for_tests(
     bool session_owned_cage,
     bool generation_available,
@@ -4921,8 +4977,26 @@ namespace proc {
           _session_used_cage_compositor,
           !_session_instance_id.empty()
         )) {
-      BOOST_LOG(error) << "process: refusing launch while an incompletely cleaned isolated session generation remains"sv;
-      return 503;
+      // A teardown that could not prove exact-generation cleanup retained the
+      // generation. Re-validate it now rather than refusing every launch
+      // until restart: the unreadable stragglers that latched it usually exit
+      // with their tree, and once the snapshot completes the retained
+      // processes (if any) are terminated right here.
+      const bool reaped = !_session_instance_id.empty() &&
+                          terminate_isolated_session_processes(
+                            _session_instance_id,
+                            "re-validated at next launch"sv
+                          );
+      if (!reaped) {
+        BOOST_LOG(error) << "process: refusing launch while an incompletely cleaned isolated session generation remains"sv;
+        return 503;
+      }
+      BOOST_LOG(warning) << "process: reaped a retained isolated session generation at launch"sv;
+      stream_runtime::labwc::reset_after_external_stop();
+      _session_instance_id.clear();
+      _session_used_cage_compositor = false;
+      _session_used_gamescope_runtime = false;
+      _exact_generation_cleanup_complete = true;
     }
 #endif
 

--- a/src/process.h
+++ b/src/process.h
@@ -307,6 +307,12 @@ namespace proc {
     pid_t reused_pid
   );
   bool isolated_session_generation_blocks_launch_for_tests(bool session_owned_cage, bool generation_available);
+  bool unreadable_environ_latches_capture_for_tests(
+    int read_error,
+    std::optional<uid_t> real_uid,
+    uid_t own_uid,
+    std::optional<bool> descends_from_polaris
+  );
   bool isolated_session_cleanup_resets_router_for_tests(
     bool session_owned_cage,
     bool generation_available,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -2152,6 +2152,26 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownTerminatesOnlyTheE
 #endif
 }
 
+TEST(ProcessRuntimeConfigTests, UnreadableEnvironLatchSparesPrivilegedDescendants) {
+#ifdef __linux__
+  // Steam's setuid sandbox helpers: EACCES on environ, root real uid,
+  // descended from polaris. Unreadable AND unsignalable — they die with the
+  // captured same-uid ancestors, so they must not wedge the teardown into
+  // "retaining immutable cage generation" and 503s until restart.
+  EXPECT_FALSE(proc::unreadable_environ_latches_capture_for_tests(EACCES, uid_t {0}, uid_t {1000}, true));
+  EXPECT_FALSE(proc::unreadable_environ_latches_capture_for_tests(EACCES, uid_t {0}, uid_t {1000}, std::nullopt));
+  // A same-uid process hiding its environ stays conservative: it may be a
+  // session member the cleanup would otherwise leave running.
+  EXPECT_TRUE(proc::unreadable_environ_latches_capture_for_tests(EACCES, uid_t {1000}, uid_t {1000}, true));
+  // Unknown uid keeps the latch too.
+  EXPECT_TRUE(proc::unreadable_environ_latches_capture_for_tests(EACCES, std::nullopt, uid_t {1000}, true));
+  // Non-EACCES read failures on descendants keep the latch regardless of uid.
+  EXPECT_TRUE(proc::unreadable_environ_latches_capture_for_tests(EIO, uid_t {0}, uid_t {1000}, true));
+  // Non-descendants never latched and still do not.
+  EXPECT_FALSE(proc::unreadable_environ_latches_capture_for_tests(EACCES, uid_t {1000}, uid_t {1000}, false));
+#endif
+}
+
 TEST(ProcessRuntimeConfigTests, IsolatedSessionCleanupPolicyRetainsIncompleteCageGeneration) {
 #ifdef __linux__
   EXPECT_TRUE(proc::isolated_session_generation_blocks_launch_for_tests(true, true));


### PR DESCRIPTION
## Summary

Ending a private session that had drained a desktop Steam client wedged the host into a launch-once loop: teardown logged "exact-generation isolated process capture was incomplete", retained the cage generation, left the orphaned labwc running (the aborted cleanup never killed anything), and refused every subsequent launch with a 503 until polaris was restarted. Reproduced twice back-to-back on the live host; a session-owned Steam teardown on the same host cleaned up fully, isolating the trigger.

The trigger is Steam's setuid chrome-sandbox helpers: root real uid, so `/proc/PID/environ` is root-only by design. The snapshot latched `capture_complete = false` for any polaris-descended process with unreadable environ — but these processes are unreadable *and* unsignalable, and they exit with the same-uid ancestors the snapshot does capture. The latch bought no safety; it guaranteed the wedge.

Two changes:

- **The latch decision is an explicit predicate.** An EACCES-unreadable descendant with a foreign real uid no longer latches capture. A same-uid process hiding its environ stays conservative (it could be a session member the cleanup would otherwise leave running), as do unknown uids, unknown ancestry, and non-EACCES read failures.
- **A retained generation is re-validated at the next launch.** Instead of refusing with 503 until restart, `execute_impl` re-runs the exact-generation cleanup; only if it still cannot complete does the refusal stand. This is the labwc counterpart of the forced-clear that gamescope attach generations already had — gated on the cleanup actually completing rather than clearing unconditionally.

## Exact candidate

`1cc3e7f2` — fix(process): stop privileged descendants wedging exact-generation cleanup

## Verification

- New truth-table pin `UnreadableEnvironLatchSparesPrivilegedDescendants`: privileged descendant spared; same-uid, unknown-uid, non-EACCES, and unknown-ancestry rows all keep the latch; non-descendants unaffected.
- Full ctest suite green (17/17 binaries).
- Live evidence: 2026-08-09 host journal shows the exact pair — "exact-generation isolated process capture was incomplete after private Steam pre-cage termination" → "retaining immutable cage generation" → next launch "refusing launch while an incompletely cleaned isolated session generation remains" (503) — twice, each after draining a desktop Steam; killing the orphan labwc by hand did not clear the latch, only a polaris restart did, which is what the launch-time re-validation now replaces.
