### PR TITLE
fix(gamescope): run detached launches through a shell so the game starts

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -753,6 +753,15 @@ namespace platf {
 
   boost::process::v1::child run_command(bool elevated, bool interactive, const std::string &cmd, boost::filesystem::path &working_dir, const boost::process::v1::environment &env, FILE *file, std::error_code &ec, boost::process::v1::group *group);
 
+  /**
+   * @brief Run a shell-quoted command line through `/bin/sh -lc`.
+   *
+   * For detached children that are not launched inside a compositor's own
+   * shell (the gamescope private runtime): the command carries shell quoting
+   * that a bare exec cannot interpret. Linux only.
+   */
+  boost::process::v1::child run_command_shell(bool elevated, const std::string &cmd, boost::filesystem::path &working_dir, const boost::process::v1::environment &env, FILE *file, std::error_code &ec, boost::process::v1::group *group);
+
   enum class thread_priority_e : int {
     low,  ///< Low priority
     normal,  ///< Normal priority

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -508,6 +508,29 @@ std::string get_local_ip_for_gateway() {
     // clang-format on
   }
 
+  bp::child run_command_shell(bool elevated, const std::string &cmd, boost::filesystem::path &working_dir, const bp::environment &env, FILE *file, std::error_code &ec, bp::group *group) {
+    (void) elevated;
+    // The command arrives shell-quoted (the gamepad-isolation wrapper emits
+    // shell_quote()'d bwrap argv). bp::child(string) tokenizes on whitespace
+    // and does not strip those quotes, so it tries to exec a file literally
+    // named "'/usr/bin/bwrap'". Hand the whole line to a shell as a single
+    // argv element instead — the same interpretation labwc's `bash -c` gives
+    // its own children, which is why only the shell-less detached path broke.
+    const std::vector<std::string> args {"-lc", cmd};
+    // clang-format off
+    if (!group) {
+      if (!file) {
+        return bp::child("/bin/sh", args, env, bp::start_dir(working_dir), bp::std_in < bp::null, bp::std_out > bp::null, bp::std_err > bp::null, bp::limit_handles, ec);
+      }
+      return bp::child("/bin/sh", args, env, bp::start_dir(working_dir), bp::std_in < bp::null, bp::std_out > file, bp::std_err > file, bp::limit_handles, ec);
+    }
+    if (!file) {
+      return bp::child("/bin/sh", args, env, bp::start_dir(working_dir), bp::std_in < bp::null, bp::std_out > bp::null, bp::std_err > bp::null, bp::limit_handles, ec, *group);
+    }
+    return bp::child("/bin/sh", args, env, bp::start_dir(working_dir), bp::std_in < bp::null, bp::std_out > file, bp::std_err > file, bp::limit_handles, ec, *group);
+    // clang-format on
+  }
+
   /**
    * @brief Open a url in the default web browser.
    * @param url The url to open.

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6538,7 +6538,13 @@ namespace proc {
                                               boost::filesystem::path(_app.working_dir);
       BOOST_LOG(info) << (gamescope_private_runtime ? "gamescope_runtime: spawning detached ["sv : "Spawning ["sv)
                       << launch_cmd << "] in ["sv << working_dir << ']';
-      auto child = platf::run_command(_app.elevated, true, launch_cmd, working_dir, cmd_env, _pipe.get(), ec, &_process_group);
+      // The gamescope runtime launches detached children with no compositor
+      // shell of its own to interpret the shell-quoted isolation wrapper, so
+      // route them through a shell; labwc children keep the direct path, which
+      // is byte-identical to before.
+      auto child = gamescope_private_runtime ?
+        platf::run_command_shell(_app.elevated, launch_cmd, working_dir, cmd_env, _pipe.get(), ec, &_process_group) :
+        platf::run_command(_app.elevated, true, launch_cmd, working_dir, cmd_env, _pipe.get(), ec, &_process_group);
       if (ec) {
         BOOST_LOG(warning) << "Couldn't spawn ["sv << cmd << "]: System: "sv << ec.message();
       }


### PR DESCRIPTION
fix(gamescope): run detached launches through a shell so the game starts

Selecting Gamescope Stream started the compositor, streamed, and then sat on
its idle sleep-infinity placeholder forever — the game never entered the
session. The detached launch failed at exec: "Couldn't spawn [steam
steam://rungameid/870780]: System: No such file or directory", followed by
"App command is empty; continuing with cage startup client".

The command handed to the runtime is shell-quoted — the gamepad-isolation
wrapper emits a shell_quote()'d bwrap argv, e.g. '/usr/bin/bwrap' --bind /
/ ... -- /bin/sh -lc 'steam steam://rungameid/870780'. The labwc runtime
launches its children inside `bash -c`, which interprets that quoting; the
gamescope runtime launched detached children straight through run_command,
whose bp::child(string) tokenizes on whitespace and never strips the quotes,
so it tried to exec a file literally named "'/usr/bin/bwrap'" and got ENOENT.

New run_command_shell() runs the quoted line through `/bin/sh -lc` as a
single argv element — the same interpretation labwc's children already get.
Only the gamescope detached path uses it; labwc's detached spawn keeps the
direct call and is byte-identical to before.

This is the launch-side half of Gamescope Stream. A game still lands in the
session only when the host desktop Steam is not holding the singleton (the
detached `steam steam://` URI otherwise messages the running desktop client);
that handoff is a separate change.

Verification: on the live host with desktop Steam stopped, launching Control
in Gamescope Stream now starts Control inside the gamescope session with
frames delivered, where the same launch previously left the compositor on
sleep infinity. Full ctest suite green.
