### PR TITLE
fix(gamescope): treat a gamescope launch as a private-family stream

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -437,8 +437,12 @@ namespace nvhttp {
       bool active_desktop_game
     ) {
       const bool private_stream_requested =
-        config::video.linux_display.headless_mode &&
-        config::video.linux_display.use_cage_compositor;
+        proc::streaming_launch_requests_private_family(
+          config::video.linux_display.headless_mode,
+          config::video.linux_display.use_cage_compositor,
+          config::video.linux_display.stream_mode,
+          config::video.linux_display.private_runtime
+        );
       return proc::resolve_desktop_launch_safety_policy(
         private_stream_requested,
         explicit_mirror_desktop_requested(args),
@@ -455,8 +459,12 @@ namespace nvhttp {
       bool active_desktop_game
     ) {
       const bool private_stream_requested =
-        config::video.linux_display.headless_mode &&
-        config::video.linux_display.use_cage_compositor;
+        proc::streaming_launch_requests_private_family(
+          config::video.linux_display.headless_mode,
+          config::video.linux_display.use_cage_compositor,
+          config::video.linux_display.stream_mode,
+          config::video.linux_display.private_runtime
+        );
       return proc::resolve_desktop_launch_safety_policy(
         private_stream_requested,
         explicit_mirror_desktop_requested(body),

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -4001,6 +4001,27 @@ namespace proc {
 #endif
 
 #if defined(__linux__)
+  bool streaming_launch_requests_private_family(
+    bool headless_mode,
+    bool use_cage_compositor,
+    std::string_view stream_mode,
+    std::string_view private_runtime
+  ) {
+    // labwc private stream is (headless + cage). Gamescope is also a
+    // private-family session that owns its own display and must not share
+    // the host desktop, but it reaches its cage through a separate
+    // stream_mode/private_runtime signal (execute_impl OR-s gamescope onto
+    // use_cage_compositor at session start). Without counting it here, a
+    // gamescope launch was classified as a desktop stream: the desktop Steam
+    // drain/refuse policy never ran, so the game's `steam steam://` URI was
+    // forwarded to the running desktop Steam singleton and never reached the
+    // session.
+    if (headless_mode && use_cage_compositor) {
+      return true;
+    }
+    return stream_mode == "gamescope_stream" || private_runtime == "gamescope";
+  }
+
   desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy(
     bool private_stream_requested,
     bool mirror_desktop_explicit,

--- a/src/process.h
+++ b/src/process.h
@@ -107,6 +107,12 @@ namespace proc {
   );
 
   nlohmann::json desktop_launch_safety_policy_to_json(const desktop_launch_safety_policy_t &policy);
+  bool streaming_launch_requests_private_family(
+    bool headless_mode,
+    bool use_cage_compositor,
+    std::string_view stream_mode,
+    std::string_view private_runtime
+  );
   bool desktop_steam_client_active();
   bool request_desktop_steam_shutdown_for_private_stream();
 #endif

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -2152,6 +2152,21 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownTerminatesOnlyTheE
 #endif
 }
 
+TEST(ProcessRuntimeConfigTests, GamescopeCountsAsPrivateFamilyLaunch) {
+#ifdef __linux__
+  // labwc private stream: headless + cage.
+  EXPECT_TRUE(proc::streaming_launch_requests_private_family(true, true, "headless_stream", ""));
+  // Gamescope reaches its cage through the mode/runtime signal, not the cage
+  // config flag, so it must still be classified private-family or its desktop
+  // Steam drain/refuse policy never runs.
+  EXPECT_TRUE(proc::streaming_launch_requests_private_family(false, false, "gamescope_stream", ""));
+  EXPECT_TRUE(proc::streaming_launch_requests_private_family(false, false, "", "gamescope"));
+  // Genuine desktop/mirror launches stay non-private.
+  EXPECT_FALSE(proc::streaming_launch_requests_private_family(false, false, "desktop_display", ""));
+  EXPECT_FALSE(proc::streaming_launch_requests_private_family(false, false, "host_virtual_display", ""));
+#endif
+}
+
 TEST(ProcessRuntimeConfigTests, UnreadableEnvironLatchSparesPrivilegedDescendants) {
 #ifdef __linux__
   // Steam's setuid sandbox helpers: EACCES on environ, root real uid,


### PR DESCRIPTION
fix(gamescope): treat a gamescope launch as a private-family stream

A Gamescope Stream launched with desktop Steam running never received the
game: the game's `steam steam://rungameid/...` URI was forwarded to the
desktop Steam singleton and swallowed there, leaving the gamescope session on
its idle placeholder. The desktop-Steam drain/refuse policy that the labwc
private stream already runs never fired for gamescope, because the launch was
misclassified as a desktop stream.

`private_stream_requested` was computed as `headless_mode &&
use_cage_compositor` — the labwc shape. Gamescope reaches its cage through a
separate `stream_mode == "gamescope_stream"` / `private_runtime ==
"gamescope"` signal (execute_impl OR-s gamescope onto use_cage_compositor at
session start), so that expression was false for gamescope and the safety
policy classified it launch_desktop_stream.

New pure helper streaming_launch_requests_private_family() keeps the labwc
condition and adds the gamescope signal; both launch-policy resolvers use it.
Gamescope now takes the same path labwc does: with the host desktop idle it
launches normally, with desktop Steam active it either drains it (when the
client requests the force-close the private stream already offers) or refuses
with the existing honest 409 ("Quit the desktop session or retry with
explicit desktop mirroring") instead of silently black-screening.

The client-side opt-in that turns the refusal into an automatic drain for
gamescope (sending forcePrivateAfterSteamClose, which Nova already sends for
the labwc private stream) is a paired Nova change; this host change makes the
refusal honest today and enables the drain the moment the client asks.

Verification: new pin GamescopeCountsAsPrivateFamilyLaunch (labwc headless+
cage true; gamescope by mode and by runtime true; desktop_display and
host_virtual_display false). Full ctest suite green. The desktop-idle
gamescope launch was verified end-to-end in the previous change (Control
streaming through gamescope at 60fps); this change adds the busy-desktop
handling without touching that path.
