### PR TITLE
feat(launch): session-scoped streamMode override with session-aware capture

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -445,6 +445,12 @@
       "Verified against origin/master with function scoping, Nova reads every field Polaris",
       "serves; only the reverse direction drifts."
     ],
+    "polaris_accepts_nova_does_not_send_yet": {
+      "$comment": "Session-scoped stream-mode override (step 2 of the launch-must-not-clobber-host-default fix; nova#222 was step 1). GET /launch accepts streamMode=<stream path registry id>: nvhttp::make_launch_session validates it via stream_display_policy::selection_valid, mirrorDesktop wins over it, and headless_dongle is rejected as a session override (host-default-only). proc_t::execute applies the accepted mode to the in-memory config for that session only and re-bakes capture sources (platf::reevaluate_capture_sources); terminate_impl restores the host values after teardown. Nothing persists. Nova does not send streamMode yet; the Nova-side change lands separately, at which point this entry moves to objects.",
+      "launch": [
+        "streamMode"
+      ]
+    },
     "nova_reads_polaris_never_sends": {
       "$comment": "Nova defaults each of these, so platform and runtime resolve to \"unknown\" and the labels to empty strings rather than failing.",
       "game": [

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -411,6 +411,39 @@ namespace nvhttp {
       return launch_mode == "force_private_stream" || launch_mode == "forceprivate";
     }
 
+    std::string session_stream_mode_requested(const args_t &args) {
+      const auto it = args.find("streamMode");
+      if (it == args.end()) {
+        return {};
+      }
+      return lower_copy(it->second);
+    }
+
+    std::string session_stream_mode_requested(const nlohmann::json &body) {
+      return lower_copy(body.value("streamMode", std::string {}));
+    }
+
+  #if defined(__linux__)
+    // Session-scoped stream-mode override gate: returns the requested mode when
+    // it may drive this session, empty otherwise (the host default applies).
+    // headless_dongle swaps host output topology, so it stays host-default-only.
+    std::string accepted_session_stream_mode(const std::string &requested, std::string &reject_reason) {
+      if (requested.empty()) {
+        return {};
+      }
+      if (requested == "headless_dongle") {
+        reject_reason = "headless_dongle is not supported as a per-session override";
+        return {};
+      }
+      std::string error;
+      if (!stream_display_policy::selection_valid(requested, error)) {
+        reject_reason = error;
+        return {};
+      }
+      return requested;
+    }
+  #endif
+
 #if defined(POLARIS_TESTS)
     proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy(
       const args_t &args,
@@ -436,13 +469,27 @@ namespace nvhttp {
       const proc::ctx_t &app,
       bool active_desktop_game
     ) {
-      const bool private_stream_requested =
+      bool private_stream_requested =
         proc::streaming_launch_requests_private_family(
           config::video.linux_display.headless_mode,
           config::video.linux_display.use_cage_compositor,
           config::video.linux_display.stream_mode,
           config::video.linux_display.private_runtime
         );
+#ifdef __linux__
+      // A per-session override changes which family this launch actually is.
+      std::string session_mode_reject_reason;
+      const auto session_mode = accepted_session_stream_mode(session_stream_mode_requested(args), session_mode_reject_reason);
+      if (!session_mode.empty() && !explicit_mirror_desktop_requested(args)) {
+        const auto session_booleans = stream_display_policy::legacy_booleans_for_selection(session_mode);
+        private_stream_requested = proc::streaming_launch_requests_private_family(
+          session_booleans.headless_mode,
+          session_booleans.use_cage_compositor,
+          session_mode,
+          std::string {}
+        );
+      }
+#endif
       return proc::resolve_desktop_launch_safety_policy(
         private_stream_requested,
         explicit_mirror_desktop_requested(args),
@@ -458,13 +505,27 @@ namespace nvhttp {
       const proc::ctx_t &app,
       bool active_desktop_game
     ) {
-      const bool private_stream_requested =
+      bool private_stream_requested =
         proc::streaming_launch_requests_private_family(
           config::video.linux_display.headless_mode,
           config::video.linux_display.use_cage_compositor,
           config::video.linux_display.stream_mode,
           config::video.linux_display.private_runtime
         );
+#ifdef __linux__
+      // A per-session override changes which family this launch actually is.
+      std::string session_mode_reject_reason;
+      const auto session_mode = accepted_session_stream_mode(session_stream_mode_requested(body), session_mode_reject_reason);
+      if (!session_mode.empty() && !explicit_mirror_desktop_requested(body)) {
+        const auto session_booleans = stream_display_policy::legacy_booleans_for_selection(session_mode);
+        private_stream_requested = proc::streaming_launch_requests_private_family(
+          session_booleans.headless_mode,
+          session_booleans.use_cage_compositor,
+          session_mode,
+          std::string {}
+        );
+      }
+#endif
       return proc::resolve_desktop_launch_safety_policy(
         private_stream_requested,
         explicit_mirror_desktop_requested(body),
@@ -2602,6 +2663,13 @@ namespace nvhttp {
   }
 
 #if defined(__linux__)
+  std::string accepted_session_stream_mode_for_tests(const std::string &requested) {
+    std::string reject_reason;
+    return accepted_session_stream_mode(requested, reject_reason);
+  }
+#endif
+
+#if defined(__linux__)
   proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy_for_tests(
     const args_t &args,
     bool app_uses_steam,
@@ -4433,6 +4501,20 @@ namespace nvhttp {
     #if defined(__linux__)
     launch_session->mirror_desktop = explicit_mirror_desktop_requested(args);
     launch_session->force_private_after_desktop_steam_shutdown = force_private_after_desktop_steam_shutdown_requested(args);
+    if (const auto requested_mode = session_stream_mode_requested(args); !requested_mode.empty()) {
+      if (launch_session->mirror_desktop) {
+        BOOST_LOG(info) << "Ignoring streamMode ["sv << requested_mode << "] because mirrorDesktop wins for this launch"sv;
+      } else {
+        std::string reject_reason;
+        const auto accepted = accepted_session_stream_mode(requested_mode, reject_reason);
+        if (!accepted.empty()) {
+          launch_session->stream_mode = accepted;
+          BOOST_LOG(info) << "Session stream mode override requested: ["sv << accepted << ']';
+        } else {
+          BOOST_LOG(warning) << "Ignoring streamMode ["sv << requested_mode << "]: "sv << reject_reason << "; the host default applies"sv;
+        }
+      }
+    }
     #else
     launch_session->mirror_desktop = false;
     launch_session->force_private_after_desktop_steam_shutdown = false;

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -389,6 +389,7 @@ namespace nvhttp {
                                                       bool host_virtual_display_available,
                                                       bool host_prefers_headless);
 #if defined(__linux__)
+  std::string accepted_session_stream_mode_for_tests(const std::string &requested);
   proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy_for_tests(
     const args_t &args,
     bool app_uses_steam,

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -762,6 +762,13 @@ namespace platf {
    */
   boost::process::v1::child run_command_shell(bool elevated, const std::string &cmd, boost::filesystem::path &working_dir, const boost::process::v1::environment &env, FILE *file, std::error_code &ec, boost::process::v1::group *group);
 
+  /**
+   * @brief Re-evaluates capture-source selection from the current in-memory config.
+   * Runs at startup and again around session-scoped stream-mode overrides so a
+   * per-session mode can cross capture families without a restart (Linux).
+   */
+  void reevaluate_capture_sources();
+
   enum class thread_priority_e : int {
     low,  ///< Low priority
     normal,  ///< Normal priority

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -1297,35 +1297,8 @@ std::string get_local_ip_for_gateway() {
     return std::make_unique<linux_deinit_t>();
   }
 
-  std::unique_ptr<deinit_t> init() {
-    // enable low latency mode for AMD
-    // https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30039
-    set_env("AMD_DEBUG", "lowlatencyenc");
-
-    // Seat isolation trades the logind ACL for group ownership, so an account
-    // outside `input` loses access to its own virtual devices. Report it here
-    // rather than leaving it to be inferred from a controller that never
-    // appears.
-    input_access::warn_if_seat_isolation_lacks_input_group();
-
-    // These are allowed to fail.
-    gbm::init();
-
-    window_system = window_system_e::NONE;
-#ifdef POLARIS_BUILD_WAYLAND
-    if (std::getenv("WAYLAND_DISPLAY")) {
-      window_system = window_system_e::WAYLAND;
-    }
-#endif
-#if defined(POLARIS_BUILD_X11) || defined(POLARIS_BUILD_CUDA)
-    if (std::getenv("DISPLAY") && window_system != window_system_e::WAYLAND) {
-      if (std::getenv("WAYLAND_DISPLAY")) {
-        BOOST_LOG(warning) << "Wayland detected, yet Polaris will use X11 for screencasting, screencasting will only work on XWayland applications"sv;
-      }
-
-      window_system = window_system_e::X11;
-    }
-#endif
+  void reevaluate_capture_sources() {
+    sources.reset();
 
 #ifdef POLARIS_BUILD_CUDA
     const bool force_cage_wlr_capture = config::video.linux_display.use_cage_compositor
@@ -1389,6 +1362,43 @@ std::string get_local_ip_for_gateway() {
       }
     }
 #endif
+
+    if (sources.none()) {
+      BOOST_LOG(warning) << "reevaluate_capture_sources: no capture method available for the current mode"sv;
+    }
+  }
+
+  std::unique_ptr<deinit_t> init() {
+    // enable low latency mode for AMD
+    // https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30039
+    set_env("AMD_DEBUG", "lowlatencyenc");
+
+    // Seat isolation trades the logind ACL for group ownership, so an account
+    // outside `input` loses access to its own virtual devices. Report it here
+    // rather than leaving it to be inferred from a controller that never
+    // appears.
+    input_access::warn_if_seat_isolation_lacks_input_group();
+
+    // These are allowed to fail.
+    gbm::init();
+
+    window_system = window_system_e::NONE;
+#ifdef POLARIS_BUILD_WAYLAND
+    if (std::getenv("WAYLAND_DISPLAY")) {
+      window_system = window_system_e::WAYLAND;
+    }
+#endif
+#if defined(POLARIS_BUILD_X11) || defined(POLARIS_BUILD_CUDA)
+    if (std::getenv("DISPLAY") && window_system != window_system_e::WAYLAND) {
+      if (std::getenv("WAYLAND_DISPLAY")) {
+        BOOST_LOG(warning) << "Wayland detected, yet Polaris will use X11 for screencasting, screencasting will only work on XWayland applications"sv;
+      }
+
+      window_system = window_system_e::X11;
+    }
+#endif
+
+    reevaluate_capture_sources();
 
     if (sources.none()) {
       BOOST_LOG(error) << "Unable to initialize capture method"sv;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -5040,6 +5040,39 @@ namespace proc {
     allow_client_commands = app.allow_client_commands;
 
 #ifdef __linux__
+    // Session-scoped stream-mode override (/launch streamMode): apply the mode
+    // to the IN-MEMORY config for this session only. Nothing here persists to
+    // disk; terminate_impl restores the saved values after teardown, so the
+    // host default survives every launch. Without an override this block only
+    // snapshots current values and behavior is identical to before.
+    {
+      auto &linux_display = config::video.linux_display;
+      this->initial_stream_mode = linux_display.stream_mode;
+      this->initial_private_runtime = linux_display.private_runtime;
+      this->initial_headless_swap_mode = linux_display.headless_swap_mode;
+      this->initial_capture = config::video.capture;
+      this->initial_headless_mode = linux_display.headless_mode;
+      this->initial_use_cage_compositor = linux_display.use_cage_compositor;
+      this->initial_prefer_gpu_native_capture = linux_display.prefer_gpu_native_capture;
+      this->initial_auto_manage_displays = linux_display.auto_manage_displays;
+      const std::string session_mode = launch_session ? launch_session->stream_mode : std::string {};
+      if (!session_mode.empty() &&
+          !(launch_session && launch_session->mirror_desktop) &&
+          session_mode != linux_display.stream_mode) {
+        std::string mode_error;
+        if (stream_display_policy::apply_selection(session_mode, mode_error)) {
+          // Saved-state restore is armed only when a mode was actually applied,
+          // so a no-override session touches nothing at save or teardown.
+          this->initial_linux_display_saved = true;
+          BOOST_LOG(info) << "process: session stream mode override ["sv << session_mode
+                          << "] applied in-memory for this session; host default restored at teardown"sv;
+          platf::reevaluate_capture_sources();
+        } else {
+          BOOST_LOG(warning) << "process: session stream mode override ["sv << session_mode
+                             << "] rejected: "sv << mode_error << "; using the host default"sv;
+        }
+      }
+    }
     const bool mirror_desktop_session = launch_session && launch_session->mirror_desktop;
     const bool gamescope_stream_session =
       config::video.linux_display.stream_mode == "gamescope_stream" ||
@@ -7353,6 +7386,25 @@ namespace proc {
       config::video.adaptive_bitrate.max_bitrate_kbps = initial_adaptive_max_bitrate;
     }
 
+    if (initial_linux_display_saved) {
+      // Armed only when a session stream-mode override was actually applied.
+      auto &linux_display = config::video.linux_display;
+      linux_display.stream_mode = initial_stream_mode;
+      linux_display.private_runtime = initial_private_runtime;
+      linux_display.headless_swap_mode = initial_headless_swap_mode;
+      linux_display.headless_mode = initial_headless_mode;
+      linux_display.use_cage_compositor = initial_use_cage_compositor;
+      linux_display.prefer_gpu_native_capture = initial_prefer_gpu_native_capture;
+      linux_display.auto_manage_displays = initial_auto_manage_displays;
+      config::video.capture = initial_capture;
+#ifdef __linux__
+      // The capture source selection was re-baked for the session override;
+      // re-bake it for the restored host default. Teardown above already ran
+      // against the session's effective mode, which is why this sits here.
+      platf::reevaluate_capture_sources();
+#endif
+    }
+
     _app_id = -1;
     _app_name.clear();
     _app = {};
@@ -7363,6 +7415,15 @@ namespace proc {
     initial_max_bitrate = 0;
     initial_adaptive_max_bitrate = 0;
     initial_video_config_saved = false;
+    initial_stream_mode.clear();
+    initial_private_runtime.clear();
+    initial_headless_swap_mode.clear();
+    initial_capture.clear();
+    initial_headless_mode = false;
+    initial_use_cage_compositor = false;
+    initial_prefer_gpu_native_capture = false;
+    initial_auto_manage_displays = false;
+    initial_linux_display_saved = false;
     mode_changed_display.clear();
     _launch_session.reset();
     virtual_display = false;

--- a/src/process.h
+++ b/src/process.h
@@ -540,6 +540,17 @@ namespace proc {
     int initial_max_bitrate = 0;
     int initial_adaptive_max_bitrate = 0;
     bool initial_video_config_saved = false;
+    // Session-scoped linux_display override bookkeeping (/launch streamMode):
+    // host values saved by execute(), restored in terminate_impl after teardown.
+    std::string initial_stream_mode;
+    std::string initial_private_runtime;
+    std::string initial_headless_swap_mode;
+    std::string initial_capture;
+    bool initial_headless_mode = false;
+    bool initial_use_cage_compositor = false;
+    bool initial_prefer_gpu_native_capture = false;
+    bool initial_auto_manage_displays = false;
+    bool initial_linux_display_saved = false;
 
     proc_t(
       boost::process::v1::environment &&env,

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -121,6 +121,10 @@ namespace rtsp_stream {
     bool virtual_display;
     bool mirror_desktop = false;
     bool force_private_after_desktop_steam_shutdown = false;
+    // Session-scoped stream mode override from the /launch streamMode arg.
+    // Empty = host default. Validated in make_launch_session; applied to the
+    // in-memory config by proc_t::execute and restored at teardown.
+    std::string stream_mode;
     bool user_locked_display_mode;
     bool user_locked_virtual_display;
     uint32_t scale_factor;

--- a/tests/unit/test_launch_mode_contract.cpp
+++ b/tests/unit/test_launch_mode_contract.cpp
@@ -82,4 +82,22 @@ TEST(LaunchModeContractTests, ReservedAndUnknownIdsAreRejectedWithGuidance) {
     EXPECT_NE(error.find("known stream path id"), std::string::npos) << id;
   }
 }
+
+TEST(SessionStreamMode, AcceptsRegistryModesItCanRunPerSession) {
+  // Deterministic on CI: these registry paths are statically available and do
+  // not depend on host probes (gamescope/EVDI availability is environmental,
+  // so those ids are deliberately not asserted here).
+  EXPECT_EQ(nvhttp::accepted_session_stream_mode_for_tests("headless_stream"), "headless_stream");
+  EXPECT_EQ(nvhttp::accepted_session_stream_mode_for_tests("windowed_stream"), "windowed_stream");
+  EXPECT_EQ(nvhttp::accepted_session_stream_mode_for_tests("desktop_display"), "desktop_display");
+}
+
+TEST(SessionStreamMode, RejectsDongleReservedUnknownAndEmpty) {
+  // headless_dongle swaps host output topology: host-default-only by design.
+  EXPECT_EQ(nvhttp::accepted_session_stream_mode_for_tests("headless_dongle"), "");
+  // Reserved/unknown ids and absence all resolve to "host default applies".
+  EXPECT_EQ(nvhttp::accepted_session_stream_mode_for_tests("family_isolated"), "");
+  EXPECT_EQ(nvhttp::accepted_session_stream_mode_for_tests("garbage_mode"), "");
+  EXPECT_EQ(nvhttp::accepted_session_stream_mode_for_tests(""), "");
+}
 #endif


### PR DESCRIPTION
## Summary

Step 2 of the launch-must-not-clobber-host-default fix (nova#222 was step 1),
in the approved session-aware shape: a game launch can now request a stream
mode for **that session only**. `GET /launch` accepts
`streamMode=<stream path registry id>`; the host applies it to the in-memory
config for the session and restores the host default at teardown. Nothing is
persisted — the host-wide default survives every launch, in memory and on disk.

This also makes the capture backend session-aware: the capture source
selection used to be baked once at startup (`platf::init()`), which is why
every served mode is `restart_required: true`. The selection now lives in
`platf::reevaluate_capture_sources()`, re-baked around a session override, so
a per-session mode can cross capture families (e.g. a portal-family host
default running a wlroots-family private session) without restarting Polaris.
Polaris is strictly single-session, which is what makes the session-scoped
re-bake of process-wide capture state sound.

## Exact candidate

- `rtsp.h`: `launch_session_t::stream_mode` (follows the `mirror_desktop`
  session-scoped precedent).
- `nvhttp.cpp`: parse (`session_stream_mode_requested`, args+body) + gate
  (`accepted_session_stream_mode`): validated with
  `stream_display_policy::selection_valid`; `mirrorDesktop` wins over
  `streamMode`; `headless_dongle` is rejected as a session override (it swaps
  host output topology — host-default-only). Invalid/unsupported values are
  logged and ignored: the host default applies, the launch proceeds. Both
  desktop-Steam launch-safety resolvers honor a valid override when computing
  private-family, so drain/refuse policy matches the session actually being
  launched.
- `process.cpp` / `process.h`: `execute()` snapshots the linux_display mode
  fields (+ `capture`) into new `initial_*` members — the same save/restore
  pattern the session already uses for `output_name`/encoder prefs — applies
  the override with `stream_display_policy::apply_selection` (in-memory only;
  `persist_config_values` is never called) and re-bakes capture sources.
  `terminate_impl` restores the snapshot **after** teardown (teardown must see
  the session's effective mode) and re-bakes again. Every downstream config
  reader (compositor spawn, wlgrab/kwingrab targeting, doctor, launch policy)
  follows the session mode through the config it already reads.
- `misc.cpp` / `common.h`: startup source-selection block extracted verbatim
  into `platf::reevaluate_capture_sources()` (+`sources.reset()`, none()
  warning); `init()` calls it unchanged.
- `docs/nova-contract.json`: `known_drift.polaris_accepts_nova_does_not_send_yet`
  documents `streamMode` — Nova does not send it yet; the Nova-side change
  lands separately and moves the entry to `objects`.

**No-override behavior is byte-identical:** the saved-state restore is armed
only when an override was actually applied. A launch without `streamMode` (all
current clients) snapshots nothing, restores nothing, never re-bakes, and can
never shadow a deliberate mid-session Every Game change — it resolves exactly
as before this change.

## Verification

- CUDA-OFF gate tree: full `ninja` build + `ctest` green (includes the new
  `SessionStreamMode` acceptance/rejection tests in
  `test_launch_mode_contract`; only deterministically-available registry ids
  are asserted — gamescope/EVDI availability is environmental).
- `scripts/check-nova-contract.py --nova <checkout>`: "no new drift".
- `test_polaris_audit` from repo root: green.
- **On-device: deferred to the next coordinated device window.** The
  behavioral checks queued there: (a) a `streamMode=gamescope_stream` launch
  over a `windowed_stream` host default actually runs gamescope and restores
  windowed at teardown; (b) a cross-family override (private over
  `desktop_display`) captures without a restart; (c) a launch with no
  `streamMode` behaves identically to today; (d) conf on disk never changes.

Trade-offs called out: `headless_dongle` deliberately excluded from session
overrides; the session re-bake logs its source selection at session
boundaries (only when an override is active).
