### PR TITLE
feat(capture): auto-detect the render node for DMA-BUF on single-GPU hosts

### DIFF
--- a/src/platform/linux/pipewire_capture.cpp
+++ b/src/platform/linux/pipewire_capture.cpp
@@ -140,6 +140,13 @@ namespace pipewire_capture {
     return std::string(path);
   }
 
+  std::optional<std::string> pick_sole_render_node(const std::vector<std::string> &nodes) {
+    if (nodes.size() != 1) {
+      return std::nullopt;
+    }
+    return canonical_render_node(nodes.front());
+  }
+
   bool may_offer_dmabuf(const dmabuf_eligibility_t &eligibility) {
     if (!eligibility.capture_render_node) {
       return false;

--- a/src/platform/linux/pipewire_capture.h
+++ b/src/platform/linux/pipewire_capture.h
@@ -99,6 +99,12 @@ namespace pipewire_capture {
 
   std::optional<std::uint32_t> drm_format_for_spa(std::uint32_t spa_format);
   std::optional<std::string> canonical_render_node(std::string_view path);
+  /**
+   * @brief The sole canonical render node from a candidate list, or nullopt.
+   * Exactly one candidate — a single-GPU host — resolves; anything else stays
+   * fail-closed so DMA-BUF never imports across GPUs by guess.
+   */
+  std::optional<std::string> pick_sole_render_node(const std::vector<std::string> &nodes);
   // When the portal stream omits capture render node, assume the operator-pinned
   // encoder adapter (same-GPU headless/gamescope). Enables DmaBuf offer; MemFd stays fallback.
   std::optional<std::string> resolve_capture_render_node(

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -12,6 +12,7 @@
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <memory>
@@ -177,6 +178,33 @@ namespace portal {
     return client_dynamic_range <= 0;
   }
 
+  // Encoder render node for DMA-BUF eligibility: the configured adapter_name
+  // when it names a canonical render node, else the host's sole render node.
+  // Single-GPU hosts get zero-copy without configuration; multi-GPU hosts stay
+  // fail-closed so DMA-BUF never imports across GPUs by guess.
+  static std::optional<std::string> encoder_render_node_for_dmabuf() {
+    if (auto configured = pipewire_capture::canonical_render_node(config::video.adapter_name)) {
+      return configured;
+    }
+    std::vector<std::string> nodes;
+    std::error_code ec;
+    for (const auto &entry : std::filesystem::directory_iterator("/dev/dri", ec)) {
+      if (entry.path().filename().string().starts_with("renderD")) {
+        nodes.push_back(entry.path().string());
+      }
+    }
+    auto sole = pipewire_capture::pick_sole_render_node(nodes);
+    if (sole) {
+      static bool logged_auto_render_node = false;
+      if (!logged_auto_render_node) {
+        logged_auto_render_node = true;
+        BOOST_LOG(info) << "portal: adapter_name is unset; using the host's sole render node ["sv
+                        << *sole << "] for DMA-BUF eligibility"sv;
+      }
+    }
+    return sole;
+  }
+
   // Local-graph PW capture (gamescopegrab / kwingrab): remote_fd=-1, no portal session.
   static std::shared_ptr<pipewire_capture::capture_t> start_local_pw_capture(
     std::uint32_t node_id,
@@ -186,7 +214,7 @@ namespace portal {
     platf::mem_type_e mem_type,
     int client_dynamic_range
   ) {
-    const auto encoder_render_node = pipewire_capture::canonical_render_node(config::video.adapter_name);
+    const auto encoder_render_node = encoder_render_node_for_dmabuf();
     std::vector<pipewire_capture::dmabuf_format_modifier_t> dmabuf_formats;
     bool may_use_dmabuf = false;
     const bool prefer_hdr = portal_prefer_hdr_formats(client_dynamic_range);
@@ -523,7 +551,7 @@ namespace portal {
       }
       else {
         auto *session = g_media.portal.get();
-        const auto encoder_render_node = pipewire_capture::canonical_render_node(config::video.adapter_name);
+        const auto encoder_render_node = encoder_render_node_for_dmabuf();
         // Headless gamescope often omits SPA capture.device / render_node. If the
         // operator set adapter_name to a render node (same GPU as NVENC), assume it.
         if (!session->capture_render_node) {

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -459,3 +459,17 @@ TEST(PipeWireCapturePolicyTests, ResolveCaptureRenderNodeRejectsNonRenderPaths) 
   ASSERT_TRUE(resolved);
   EXPECT_EQ(*resolved, "/dev/dri/renderD128");
 }
+
+TEST(PipeWireCapturePolicyTests, PickSoleRenderNodeResolvesOnlySingleGpuHosts) {
+  // Exactly one canonical candidate — a single-GPU host — resolves.
+  EXPECT_EQ(
+    pipewire_capture::pick_sole_render_node({"/dev/dri/renderD128"}),
+    (std::optional<std::string> {"/dev/dri/renderD128"}));
+  // A sole candidate that is not a canonical render node stays fail-closed.
+  EXPECT_EQ(pipewire_capture::pick_sole_render_node({"/dev/dri/card0"}), std::nullopt);
+  // Multi-GPU and empty lists stay fail-closed: DMA-BUF never crosses GPUs by guess.
+  EXPECT_EQ(
+    pipewire_capture::pick_sole_render_node({"/dev/dri/renderD128", "/dev/dri/renderD129"}),
+    std::nullopt);
+  EXPECT_EQ(pipewire_capture::pick_sole_render_node({}), std::nullopt);
+}


### PR DESCRIPTION
## Summary

With `adapter_name` unset — the default on essentially every install — DMA-BUF
eligibility silently failed closed on the pipewire capture paths: the encoder
render node resolved to nullopt, the dmabuf format list stayed empty, and
capture negotiated SHM with a CPU-side copy. On this host that was the
difference between a gamescope session limping at ~23fps (`capture_transport=shm
frame_residency=cpu`) and the GPU-native path the hardware supports. The
tonight-fix was one conf line (`adapter_name = /dev/dri/renderD128`); this PR
makes that line unnecessary on single-GPU hosts.

## Exact candidate

- `pipewire_capture::pick_sole_render_node(nodes)` — pure choice-of-one core:
  exactly one candidate resolves (via the existing `canonical_render_node`
  validation); zero, several, or a non-canonical sole candidate all return
  nullopt.
- `portal_grab.cpp`: static `encoder_render_node_for_dmabuf()` — the configured
  `adapter_name` when canonical, else the host's sole `/dev/dri/renderD*` node
  (enumerated with a non-throwing `directory_iterator`). Both call sites (the
  local-graph gamescopegrab/kwingrab path in `start_local_pw_capture`, and the
  portal-session branch) resolve through it. First auto-detect per process logs
  the chosen node.
- Deliberate conservatism: an operator-set `adapter_name` always wins;
  multi-GPU hosts (or a malformed `adapter_name` on one) keep today's
  fail-closed behavior — DMA-BUF never imports across GPUs by guess.

## Verification

- CUDA-OFF gate tree: full build + ctest green, including the new
  `PickSoleRenderNodeResolvesOnlySingleGpuHosts` coverage in
  `test_portal_grab_policy` (sole canonical resolves; non-canonical sole,
  multi-node, and empty all fail closed).
- `test_polaris_audit` green; contract checker: no served-field changes.
- **pc-papi deploy: deliberately not needed** — the host now has `adapter_name`
  set explicitly, and the explicit value takes precedence, so this change is
  behaviorally inert there. It matters for fresh installs and unset-adapter
  hosts. The empirical gamescope `dmabuf_negotiate offered=true` line is queued
  for the next clean gamescope session on the deployed binary.
