### PR TITLE
fix(capture): pin host_virtual_display capture to its EVDI output via kwingrab

### DIFF
--- a/src/platform/linux/kwingrab.cpp
+++ b/src/platform/linux/kwingrab.cpp
@@ -229,6 +229,14 @@ namespace kwingrab {
               break;
             }
           }
+          if (!output) {
+            // A requested output that is not in KWin's registry (e.g. a virtual
+            // display that failed to attach) silently streaming some other
+            // output is exactly the wrong-output bug this pinning exists to
+            // prevent — make the miss visible before falling back.
+            BOOST_LOG(warning) << "kwingrab: requested output ["sv << output_name
+                               << "] not found; falling back to configured/first output"sv;
+          }
         }
         if (!output) {
           // Prefer config streaming_output when set (dongle path).
@@ -510,7 +518,13 @@ namespace kwingrab {
     const auto &mode = config::video.linux_display.stream_mode;
     // Host KDE paths only. gamescope_stream / labwc private runtimes stay on
     // gamescopegrab / portal / wlroots — never kwingrab.
-    if (mode == "desktop_display" || mode == "headless_dongle") {
+    // host_virtual_display belongs here too: its EVDI output is composited by
+    // KWin, and only this path can pin capture to that output by name — the
+    // portal ScreenCast picker cannot select a specific monitor, so falling
+    // through to it captures whatever output the restore token last granted
+    // (observed live: the 7680x2160 primary desktop instead of DVI-I-1).
+    if (mode == "desktop_display" || mode == "headless_dongle" ||
+        mode == "host_virtual_display") {
       return true;
     }
     // Empty mode historically maps to desktop-ish host on some configs; only

--- a/src/platform/linux/kwingrab.h
+++ b/src/platform/linux/kwingrab.h
@@ -2,9 +2,10 @@
  * @file src/platform/linux/kwingrab.h
  * @brief KWin direct ScreenCast (zkde_screencast_unstable_v1) → local PipeWire node.
  *
- * Host KDE paths (desktop_display / headless_dongle) try this before portal.
- * Private gamescope/labwc paths are unchanged. HDR: depends on KWin export;
- * do not claim product HDR — see docs/research/kwingrab-spike.md.
+ * Host KDE paths (desktop_display / headless_dongle / host_virtual_display)
+ * try this before portal. Private gamescope/labwc paths are unchanged.
+ * HDR: depends on KWin export; do not claim product HDR — see
+ * docs/research/kwingrab-spike.md.
  */
 #pragma once
 

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -208,8 +208,13 @@ namespace portal {
     // Host-desktop modes stream a physical output after (optional) topology swap.
     // headless_dongle sets headless_mode for privacy swap but must NOT use window
     // SelectSources — KDE ScreenCast hangs on Start with type=window + restore_token.
+    // host_virtual_display streams the created virtual MONITOR (EVDI connector),
+    // never an app window — it sets headless_mode too, so without this entry it
+    // fell through to portal_source_window: the same hang-prone combination, and
+    // a source type that cannot name the virtual output at all.
     const auto mode = stream_mode.empty() ? std::string_view {config::video.linux_display.stream_mode} : stream_mode;
-    if (mode == "headless_dongle" || mode == "desktop_display" || mode == "headless_evdi") {
+    if (mode == "headless_dongle" || mode == "desktop_display" || mode == "headless_evdi" ||
+        mode == "host_virtual_display") {
       return portal_source_monitor;
     }
 

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -19,9 +19,14 @@
 #include <drm_fourcc.h>
 #include <spa/param/video/raw.h>
 
+#include "src/config.h"
 #include "src/platform/common.h"
 #include "src/platform/linux/pipewire_capture.h"
 #include "src/platform/linux/portal_session.h"
+
+#ifdef POLARIS_BUILD_WAYLAND
+  #include "src/platform/linux/kwingrab.h"
+#endif
 
 namespace portal {
   std::uint32_t portal_pick_cursor_mode_for_tests(std::uint32_t available);
@@ -36,6 +41,43 @@ TEST(PortalGrabPolicyTests, DongleRequestsMonitorSourceDespiteHeadlessFlag) {
   // headless_dongle uses headless_mode for topology privacy, not window capture.
   EXPECT_EQ(portal::capture_type_for_stream_display(true, false, "headless_dongle"), 1u);
 }
+
+TEST(PortalGrabPolicyTests, HostVirtualDisplayRequestsMonitorSourceDespiteHeadlessFlag) {
+  // host_virtual_display streams the created EVDI virtual monitor. Its legacy
+  // booleans set headless_mode=true, which previously dropped it into the
+  // window-source branch — the wrong source type for a monitor mode, and the
+  // exact window+restore_token combination the dongle comment above warns
+  // hangs KDE ScreenCast.
+  EXPECT_EQ(portal::capture_type_for_stream_display(true, false, "host_virtual_display"), 1u);
+}
+
+#ifdef POLARIS_BUILD_WAYLAND
+TEST(PortalGrabPolicyTests, KwingrabPreferredForHostKdeModesIncludingVirtualDisplay) {
+  struct config_guard_t {
+    config::video_t::linux_display_t linux_display = config::video.linux_display;
+
+    ~config_guard_t() {
+      config::video.linux_display = linux_display;
+    }
+  } guard;
+
+  auto &ld = config::video.linux_display;
+
+  // Host KDE paths pin capture through kwingrab. host_virtual_display must be
+  // one of them: its EVDI output is composited by KWin, and kwingrab is the
+  // only path that can select that output by name — the portal picker cannot.
+  for (const char *mode : {"desktop_display", "headless_dongle", "host_virtual_display"}) {
+    ld.stream_mode = mode;
+    EXPECT_TRUE(kwingrab::prefer_for_current_stream_mode()) << mode;
+  }
+
+  // Private compositor runtimes stay on gamescopegrab / portal / wlroots.
+  for (const char *mode : {"windowed_stream", "headless_stream", "gamescope_stream"}) {
+    ld.stream_mode = mode;
+    EXPECT_FALSE(kwingrab::prefer_for_current_stream_mode()) << mode;
+  }
+}
+#endif
 
 TEST(PortalGrabPolicyTests, PrivateAndWindowedCagePathsRequestWindowSource) {
   EXPECT_EQ(portal::capture_type_for_stream_display(true, true), 2u);


### PR DESCRIPTION
## Summary

Host Virtual Display sessions stream the wrong output: the EVDI display is created and attached correctly (observed live: `DVI-I-1` 1920x1080@120), but capture returns the host's primary desktop instead (observed live: the whole 7680x2160 G95NC, windowed, 35fps). Three stacked causes in capture selection:

1. `kwingrab::prefer_for_current_stream_mode()` admitted only `desktop_display`/`headless_dongle`, so the only capture path that can pin a KWin output **by name** never engaged for `host_virtual_display` — even though session setup already writes the created connector into `config::video.output_name` precisely so "the capture pipeline uses the correct output".
2. `capture_type_for_stream_display()` had no `host_virtual_display` entry; the mode sets `headless_mode=true`, so it fell through to `portal_source_window` — the wrong source type for a virtual-monitor mode, and the exact `window+restore_token` combination the same function's dongle comment warns hangs KDE ScreenCast.
3. The portal picker structurally cannot select a specific monitor; a restore token re-grants whatever was granted before, which is how the primary desktop kept winning.

Fix: admit `host_virtual_display` to kwingrab's host-KDE gate and to the portal monitor-source list (non-KWin fallback), and log a warning when a requested output name is not in KWin's registry instead of silently streaming the configured/first output — that silent fallback is this bug's exact shape.

Known adjacent behavior, deliberately unchanged: `config::video.output_name` keeps the EVDI name after teardown (pre-existing mutation), so a later `desktop_display` session's pin request can miss and fall back — previously invisible, now at least logged.

## Exact candidate

- `92f24502` on `fix/hvd-capture-output-pinning`, branched from `polaris/master` `c13b5922` (#350).
- Touches only `kwingrab.{h,cpp}`, `portal_session.cpp`, and the portal policy test file; no config surface, no contract changes, no new files.

## Verification

- Full worktree gate on pc-papi (CUDA-OFF tree, canonical configure line): clean build, `ctest` 17/17.
- `test_polaris_platform --gtest_filter='PortalGrabPolicyTests.*'`: 10/10 (8 existing + 2 new), including `KwingrabPreferredForHostKdeModesIncludingVirtualDisplay` (all three host-KDE modes gate true, all three private-runtime modes gate false) and `HostVirtualDisplayRequestsMonitorSourceDespiteHeadlessFlag`.
- Not yet device-verified: the on-device HVD launch (expect journal `kwingrab local PW node=... output=DVI-I-1...` and a 1080p120 stream of the virtual output, not the desktop) is queued for the next coordinated device window rather than run against the live host mid-arc.
