### PR TITLE
fix(capture): route host_virtual_display capture through portal, not auto-wlr

### DIFF
--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -1297,6 +1297,21 @@ std::string get_local_ip_for_gateway() {
     return std::make_unique<linux_deinit_t>();
   }
 
+  // host_virtual_display is composited by KWin: its EVDI output is an ordinary
+  // KWin monitor, not a private cage. Capture must reach portal_grab, which
+  // routes it to kwingrab's output-pinned KWin ScreenCast (see PR #351). The
+  // auto-selected direct wlr/wlgrab path below would instead bind the desktop
+  // wayland-0, which does not advertise wlr-export-dmabuf — observed live to
+  // hard-fail every encoder (nvenc/vaapi/software) and produce no stream. So
+  // this mode must be kept off the auto WAYLAND source, letting PORTAL be
+  // chosen. An explicit capture=wlr still forces wlr (operator's call);
+  // cage-compositor modes (windowed/headless_stream) are unaffected because
+  // they set use_cage and are not host_virtual_display.
+  bool host_virtual_display_needs_portal() {
+    return !config::video.linux_display.use_cage_compositor
+        && config::video.linux_display.stream_mode == "host_virtual_display";
+  }
+
   void reevaluate_capture_sources() {
     sources.reset();
 
@@ -1311,8 +1326,10 @@ std::string get_local_ip_for_gateway() {
     }
 #endif
 #ifdef POLARIS_BUILD_WAYLAND
-    if ((config::video.capture.empty() && sources.none()) || config::video.capture == "wlr"
-        || config::video.linux_display.use_cage_compositor) {
+    const bool hvd_needs_portal = host_virtual_display_needs_portal();
+    if (((config::video.capture.empty() && sources.none() && !hvd_needs_portal)
+         || config::video.capture == "wlr"
+         || config::video.linux_display.use_cage_compositor)) {
       // When cage/labwc is configured, prefer direct wlr capture over portal
       // and connect to labwc's socket instead of the desktop compositor.
       // In windowed mode this is the fast DMA-BUF path; in headless mode the

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -79,6 +79,49 @@ TEST(PortalGrabPolicyTests, KwingrabPreferredForHostKdeModesIncludingVirtualDisp
 }
 #endif
 
+namespace platf {
+  bool host_virtual_display_needs_portal();
+}
+
+TEST(PortalGrabPolicyTests, HostVirtualDisplayIsKeptOffTheAutoWlrSource) {
+  // Companion to PR #351's kwingrab routing: even with the right kwingrab
+  // preference, host_virtual_display only reaches portal_grab (hence kwingrab)
+  // if reevaluate_capture_sources does NOT auto-select the direct WAYLAND/wlr
+  // source first — which binds the desktop wayland-0 (no wlr-export-dmabuf) and
+  // hard-fails every encoder. This guards the source-selection half of that fix.
+  struct config_guard_t {
+    config::video_t::linux_display_t linux_display = config::video.linux_display;
+    std::string capture = config::video.capture;
+
+    ~config_guard_t() {
+      config::video.linux_display = linux_display;
+      config::video.capture = capture;
+    }
+  } guard;
+
+  auto &ld = config::video.linux_display;
+  config::video.capture.clear();  // the auto path is where the bug lived
+
+  // host_virtual_display composites through KWin (use_cage stays false): must
+  // be kept off the auto wlr source so PORTAL (→ kwingrab) is chosen.
+  ld.stream_mode = "host_virtual_display";
+  ld.use_cage_compositor = false;
+  EXPECT_TRUE(platf::host_virtual_display_needs_portal());
+
+  // A cage-compositor session (the booleans HVD never carries) streams through
+  // labwc's own wlr socket, not portal — must NOT be diverted.
+  ld.use_cage_compositor = true;
+  EXPECT_FALSE(platf::host_virtual_display_needs_portal());
+
+  // Every other mode keeps its existing source selection untouched.
+  ld.use_cage_compositor = false;
+  for (const char *mode :
+       {"windowed_stream", "headless_stream", "gamescope_stream", "desktop_display", "headless_dongle", ""}) {
+    ld.stream_mode = mode;
+    EXPECT_FALSE(platf::host_virtual_display_needs_portal()) << mode;
+  }
+}
+
 TEST(PortalGrabPolicyTests, PrivateAndWindowedCagePathsRequestWindowSource) {
   EXPECT_EQ(portal::capture_type_for_stream_display(true, true), 2u);
   EXPECT_EQ(portal::capture_type_for_stream_display(false, true), 2u);


### PR DESCRIPTION
## Summary

Companion to #351. That PR pinned `host_virtual_display` capture to its EVDI output inside `portal_grab`'s kwingrab path — but on a KWin desktop the fix was **never reached**, because `reevaluate_capture_sources()` auto-selects the direct WAYLAND/wlr source first (`verify_wl()` succeeds against the desktop session) and the `display()` factory prefers WAYLAND over PORTAL. So capture went to `wlgrab` bound to the desktop `wayland-0`, which does not advertise `wlr-export-dmabuf`.

**Observed live** on `polaris-1.3.7.08d514ad.cuda`: EVDI creates `DVI-I-1` correctly, then `Screencasting with Wayland's protocol` → `Missing Wayland wire for wlr-export-dmabuf` → every encoder (nvenc/vaapi/software) fails → no stream.

`host_virtual_display` is composited by **KWin** (its EVDI output is an ordinary KWin monitor), not a private cage, so the direct-wlr path is the wrong backend for it — kwingrab (reached via `portal_grab`) is the one that can bind that output by name. This keeps the mode off the auto WAYLAND source so PORTAL is chosen and #351's kwingrab routing actually runs.

## Exact candidate

- Branch `fix/hvd-capture-source-selection` off `polaris/master` `08d514ad` (#351).
- Two hunks in `misc.cpp` (a new `host_virtual_display_needs_portal()` + one condition) and one new test.

## Scope (deliberately narrow)

- Only `host_virtual_display` with `use_cage_compositor=false` is diverted. Cage modes (`windowed_stream`/`headless_stream`) keep the WAYLAND/labwc source they require — they set `use_cage`, which `host_virtual_display` never does.
- Explicit `capture=wlr` still forces wlr (operator's call), unchanged.
- `desktop_display` and `headless_dongle` share the same latent path but are **not** touched here — mirroring the real desktop / needing physical dongle hardware, they deserve their own device-tested change.

## Verification

- Full CUDA-OFF gate on pc-papi: clean build, `ctest` 17/17.
- `test_polaris_platform --gtest_filter='PortalGrabPolicyTests.*'`: all pass including the new `HostVirtualDisplayIsKeptOffTheAutoWlrSource` (true only for host_virtual_display + non-cage; false for cage sessions and every other mode).
- **Not yet device-verified end to end** — the on-device confirmation (HVD launch shows kwingrab binding `DVI-I-1` and a real 1080p stream of the virtual output instead of encoder failure) is queued for the next coordinated device window.
