### PR TITLE
fix(video): an HDR/YUV444 capability probe must never fail the encoder

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -4022,13 +4022,35 @@ namespace video {
       encoder.av1.capabilities.reset();
     }
 
-    // Test HDR and YUV444 support
+    // Test HDR and YUV444 support.
+    //
+    // These are *capability* probes: each answers "does this optional feature
+    // work?" and its only correct outcomes are supported / not-supported. A
+    // probe must never be able to fail the whole encoder or an SDR session — but
+    // the trial encode it runs can raise, not just return a negative status, on
+    // some capture paths (observed: the 10-bit-SDR -> 8-bit-NV12 demotion in
+    // make_encode_device on labwc ext-image-copy DMA-BUF deterministically threw
+    // during the 10-bit HEVC probe). That exception used to propagate out of
+    // validate_encoder and trip its fail_guard, rejecting nvenc entirely even
+    // though 8-bit SDR encoding works fine and the stream is SDR. So every probe
+    // below treats a raised exception exactly like a negative result: mark the
+    // capability unsupported and keep the encoder.
     {
       // H.264 is special because encoders may support YUV 4:4:4 without supporting 10-bit color depth
       if (encoder.flags & YUV444_SUPPORT) {
         config_t config_h264_yuv444 {1920, 1080, 60, 1000, 1, 0, 1, 0, 0, 1};
-        encoder.h264[encoder_t::YUV444] = disp->is_codec_supported(encoder.h264.name, config_h264_yuv444) &&
-                                          validate_config(disp, encoder, config_h264_yuv444) >= 0;
+        try {
+          encoder.h264[encoder_t::YUV444] = disp->is_codec_supported(encoder.h264.name, config_h264_yuv444) &&
+                                            validate_config(disp, encoder, config_h264_yuv444) >= 0;
+        } catch (const std::exception &e) {
+          BOOST_LOG(warning) << "Encoder ["sv << encoder.name << "] H.264 YUV444 capability probe raised ["sv
+                             << e.what() << "]; marking YUV444 unsupported"sv;
+          encoder.h264[encoder_t::YUV444] = false;
+        } catch (...) {
+          BOOST_LOG(warning) << "Encoder ["sv << encoder.name
+                             << "] H.264 YUV444 capability probe raised a non-standard exception; marking YUV444 unsupported"sv;
+          encoder.h264[encoder_t::YUV444] = false;
+        }
       } else {
         encoder.h264[encoder_t::YUV444] = false;
       }
@@ -4049,26 +4071,41 @@ namespace video {
           return;
         }
 
-        auto encoder_codec_name = encoder.codec_from_config(config).name;
+        // Any failure of this capability probe — negative status OR a raised
+        // exception from the trial encode — means "HDR/YUV444 not available on
+        // this encoder+capture combination", never "this encoder is broken".
+        try {
+          auto encoder_codec_name = encoder.codec_from_config(config).name;
 
-        // Test 4:4:4 HDR first. If 4:4:4 is supported, 4:2:0 should also be supported.
-        config.chromaSamplingType = 1;
-        if ((encoder.flags & YUV444_SUPPORT) &&
-            disp->is_codec_supported(encoder_codec_name, config) &&
-            validate_config(disp, encoder, config) >= 0) {
-          flag_map[encoder_t::DYNAMIC_RANGE] = true;
-          flag_map[encoder_t::YUV444] = true;
-          return;
-        } else {
+          // Test 4:4:4 HDR first. If 4:4:4 is supported, 4:2:0 should also be supported.
+          config.chromaSamplingType = 1;
+          if ((encoder.flags & YUV444_SUPPORT) &&
+              disp->is_codec_supported(encoder_codec_name, config) &&
+              validate_config(disp, encoder, config) >= 0) {
+            flag_map[encoder_t::DYNAMIC_RANGE] = true;
+            flag_map[encoder_t::YUV444] = true;
+            return;
+          } else {
+            flag_map[encoder_t::YUV444] = false;
+          }
+
+          // Test 4:2:0 HDR
+          config.chromaSamplingType = 0;
+          if (disp->is_codec_supported(encoder_codec_name, config) &&
+              validate_config(disp, encoder, config) >= 0) {
+            flag_map[encoder_t::DYNAMIC_RANGE] = true;
+          } else {
+            flag_map[encoder_t::DYNAMIC_RANGE] = false;
+          }
+        } catch (const std::exception &e) {
+          BOOST_LOG(warning) << "Encoder ["sv << encoder.name << "] HDR/YUV444 capability probe raised ["sv
+                             << e.what() << "]; marking HDR/YUV444 unsupported and keeping the encoder for SDR"sv;
           flag_map[encoder_t::YUV444] = false;
-        }
-
-        // Test 4:2:0 HDR
-        config.chromaSamplingType = 0;
-        if (disp->is_codec_supported(encoder_codec_name, config) &&
-            validate_config(disp, encoder, config) >= 0) {
-          flag_map[encoder_t::DYNAMIC_RANGE] = true;
-        } else {
+          flag_map[encoder_t::DYNAMIC_RANGE] = false;
+        } catch (...) {
+          BOOST_LOG(warning) << "Encoder ["sv << encoder.name
+                             << "] HDR/YUV444 capability probe raised a non-standard exception; marking HDR/YUV444 unsupported and keeping the encoder for SDR"sv;
+          flag_map[encoder_t::YUV444] = false;
           flag_map[encoder_t::DYNAMIC_RANGE] = false;
         }
       };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_display_planner.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_game_library_scanner.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_kmsgrab_logging_source.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_video_hdr_probe_guard_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_linux_stream_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_prepared_ffmpeg.cpp

--- a/tests/unit/test_video_hdr_probe_guard_source.cpp
+++ b/tests/unit/test_video_hdr_probe_guard_source.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file tests/unit/test_video_hdr_probe_guard_source.cpp
+ * @brief Source guard: the HDR/YUV444 *capability* probes in validate_encoder
+ *        must never be able to fail the whole encoder.
+ *
+ * The real defect this pins can only reproduce on specific encoder + capture
+ * combinations (observed live: the 10-bit-SDR -> 8-bit-NV12 demotion on a
+ * labwc ext-image-copy DMA-BUF path deterministically THREW during the 10-bit
+ * HEVC capability probe). That exception propagated out of validate_encoder and
+ * tripped its fail_guard, rejecting nvenc entirely and tearing down an
+ * otherwise-fine SDR session — the arc's long-standing "intermittent nvenc"
+ * disconnect. A trial encode that hits real hardware can't be exercised from a
+ * unit test, so this guards the invariant at the source level, the same way
+ * test_kmsgrab_logging_source.cpp guards its non-fatal-probe contract: an HDR /
+ * YUV444 capability probe raising must be caught and downgraded to
+ * "unsupported", never allowed to fail the encoder.
+ */
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+  std::string read_video_source() {
+    const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / "src/video.cpp";
+    std::ifstream file {path};
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+  }
+
+}  // namespace
+
+TEST(VideoHdrProbeGuardSource, HdrCapabilityProbeCannotFailTheEncoder) {
+  const auto source = read_video_source();
+  ASSERT_FALSE(source.empty()) << "could not read src/video.cpp via POLARIS_SOURCE_DIR";
+
+  // The HDR/YUV444 probe lambda must catch anything the trial encode raises and
+  // keep the encoder available for SDR rather than propagating the failure.
+  const auto probe_pos = source.find("auto test_hdr_and_yuv444 = [&]");
+  ASSERT_NE(probe_pos, std::string::npos) << "test_hdr_and_yuv444 probe not found";
+
+  const auto probe_body = source.substr(probe_pos, 2048);
+  EXPECT_NE(probe_body.find("try {"), std::string::npos)
+    << "the HDR/YUV444 capability probe must run inside a try block";
+  EXPECT_NE(probe_body.find("catch (const std::exception"), std::string::npos)
+    << "the HDR/YUV444 capability probe must catch std::exception";
+  EXPECT_NE(probe_body.find("catch (...)"), std::string::npos)
+    << "the HDR/YUV444 capability probe must also catch non-standard exceptions";
+  EXPECT_NE(probe_body.find("keeping the encoder for SDR"), std::string::npos)
+    << "a caught capability-probe exception must keep the encoder for SDR";
+
+  // The H.264 YUV444 capability probe (outside the lambda) must be guarded too.
+  EXPECT_NE(source.find("H.264 YUV444 capability probe raised"), std::string::npos)
+    << "the H.264 YUV444 capability probe must catch and downgrade a raised exception";
+}


### PR DESCRIPTION
## Summary

Fixes the arc's long-standing "intermittent nvenc" disconnect on the labwc/cage capture path — which turned out to be **deterministic**, not intermittent.

The session-time encoder reprobe against the cage socket runs `validate_encoder(nvenc)`. Six-for-six across a night of journals, the signature is identical: the three **8-bit SDR** probes (`client_dynamic_range=0`) pass, then the **10-bit HEVC HDR *capability* probe** (`client_dynamic_range=1`, via `test_hdr_and_yuv444`) is immediately followed by `Encoder [nvenc] failed` → the whole nvenc encoder is rejected → `session_ending`. The stream is SDR (`stream_hdr_enabled=false`), so the 10-bit capability being probed is never used by the stream.

The 10-bit probe **raises an exception** (rather than returning a negative status): it skips the AV1 HDR probe that structurally follows it and jumps straight to the fail-guard — the tell that it threw. The throw originates in `make_encode_device`'s "10-bit-SDR → 8-bit-NV12" demotion (`video.cpp:~3437`, *"avoid p010 cost for 10-bit SDR"*) on the labwc `ext-image-copy` DMA-BUF path: nvenc inits, then the trial convert/encode raises ~25ms later.

**Why it looked intermittent:** sessions that streamed used the encoder *cache* (skipping the fresh reprobe); every fresh session-start reprobe hits the failing probe.

A capability probe answers exactly one question — "does this optional feature work?" — and must never be able to fail the whole encoder or an SDR session. This makes the HDR/YUV444 probes treat a raised exception exactly like a negative result (mark the capability unsupported, keep the encoder) — the graceful outcome the code already intended for the `-1` case.

## Exact candidate

- Branch `fix/hdr-probe-must-not-fail-encoder` off `polaris/master` `1c751b31` (#352).
- `video.cpp`: try/catch (std::exception + `...`) around `test_hdr_and_yuv444` and the standalone H.264 YUV444 probe.
- New `test_video_hdr_probe_guard_source.cpp` + its CMake entry.

## Scope

- **Not** touched: the underlying throw in the 10-bit-SDR demotion path — worth its own fix, but capability probing must be robust to it (and any future capture path that trips it) regardless. Filed as a follow-up.
- A companion server-side robustness gap (also found this session): `/launch` returns an incomplete response — `<launchPolicy>` present, no `status_code` — when the launch throws, which the client then can't parse. Separate small PR; complements nova#225 (the client now fails gracefully on that body).

## Verification

- Full CUDA-OFF gate on pc-papi: clean build, `ctest` (incl. `test_polaris_video` + the new source-guard test).
- **Live verification pending** (the payoff): deploy and launch a private-stream (labwc) session — the reprobe should now log the HDR-probe warning and keep nvenc for SDR, the session should establish, and this should unblock the synthetic retained-pair pilot through the reliable trampoline path. Queued for a coordinated device window (this host is single-session).
