### PR TITLE
fix(labwc): pin the private compositor's render device to adapter_name

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -467,6 +467,29 @@ namespace cage_display_router {
       return "1";
     }
 
+    if (headless && key == "WLR_RENDER_DRM_DEVICE") {
+      // Headless-only, deliberately. On the headless backend wlroots owns DRM
+      // device selection outright and, left to itself, picks the first render
+      // node it enumerates — which on a multi-GPU host is not necessarily the
+      // one the operator configured via adapter_name, so the private compositor
+      // renders on (and the stream is captured from) the wrong card (issue #354).
+      // Pin it to adapter_name, the same render node used for capture/encode.
+      //
+      // The windowed (wayland-backend) path is left alone on purpose: there labwc
+      // is a client of the host compositor and negotiates its device from the
+      // parent's dmabuf feedback, so forcing a device could mismatch the parent
+      // and break buffer sharing on a multi-GPU host.
+      //
+      // Only a real, present /dev/dri device is meaningful: WLR_RENDER_DRM_DEVICE
+      // makes wlroots fail rather than fall back if the path is bogus, so an
+      // unset or non-device adapter_name is left to wlroots' own auto-select.
+      const auto adapter = trimmed(config::video.adapter_name);
+      if (adapter.rfind("/dev/dri/", 0) == 0 && access(adapter.c_str(), F_OK) == 0) {
+        return adapter;
+      }
+      return {};
+    }
+
     return {};
   }
 
@@ -476,11 +499,29 @@ namespace cage_display_router {
            "WLR_BACKENDS"sv,
            "WLR_RENDERER"sv,
            "WLR_HEADLESS_OUTPUTS"sv,
+           "WLR_RENDER_DRM_DEVICE"sv,
          }) {
       const auto value = labwc_process_environment_value(headless, key);
       if (!value.empty()) {
         setenv(std::string {key}.c_str(), value.c_str(), 1);
+        if (key == "WLR_RENDER_DRM_DEVICE") {
+          BOOST_LOG(info) << "labwc: pinning wlroots render device to configured adapter_name ["sv
+                          << value << "]"sv;
+        }
       }
+    }
+
+    // If a headless session has adapter_name set but it could not be used as a
+    // render device, say so — the failure mode this fixes (issue #354) is
+    // otherwise invisible: the user sets adapter_name and wlroots silently grabs
+    // a different card. Only meaningful for headless, since the windowed path
+    // intentionally leaves device selection to the parent compositor.
+    const auto adapter = trimmed(config::video.adapter_name);
+    if (headless && !adapter.empty() &&
+        labwc_process_environment_value(headless, "WLR_RENDER_DRM_DEVICE").empty()) {
+      BOOST_LOG(warning) << "labwc: adapter_name ["sv << adapter
+                         << "] is not a present /dev/dri render-device path; "sv
+                         << "wlroots will auto-select a GPU for the private compositor"sv;
     }
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_game_library_scanner.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_kmsgrab_logging_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_video_hdr_probe_guard_source.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_labwc_render_device_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_linux_stream_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_prepared_ffmpeg.cpp

--- a/tests/unit/test_labwc_render_device_source.cpp
+++ b/tests/unit/test_labwc_render_device_source.cpp
@@ -1,0 +1,70 @@
+/**
+ * @file tests/unit/test_labwc_render_device_source.cpp
+ * @brief Source guard: labwc must pin its wlroots render device to the
+ *        configured adapter_name (issue #354).
+ *
+ * The behaviour depends on a real, present /dev/dri render node, which the
+ * GitHub CI runners do not have (no GPU), so it can't be exercised from a unit
+ * test. This guards the invariant at the source level — the same approach as
+ * test_kmsgrab_logging_source.cpp: the private compositor's renderer must be
+ * pinned to config::video.adapter_name, and an adapter_name that can't be used
+ * must be reported rather than silently ignored.
+ */
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+  std::string read_cage_router_source() {
+    const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / "src/platform/linux/cage_display_router.cpp";
+    std::ifstream file {path};
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+  }
+
+}  // namespace
+
+TEST(LabwcRenderDeviceSource, PinsWlrootsRenderDeviceToConfiguredAdapter) {
+  const auto source = read_cage_router_source();
+  ASSERT_FALSE(source.empty()) << "could not read cage_display_router.cpp via POLARIS_SOURCE_DIR";
+
+  // The render device the wlroots backend uses must come from adapter_name.
+  EXPECT_NE(source.find("WLR_RENDER_DRM_DEVICE"), std::string::npos)
+    << "labwc must set WLR_RENDER_DRM_DEVICE so it does not auto-pick a GPU";
+  EXPECT_NE(source.find("config::video.adapter_name"), std::string::npos)
+    << "the render device must be sourced from the configured adapter_name";
+
+  // The pin is headless-only. On the windowed (wayland-backend) path labwc is a
+  // client of the host compositor and negotiates its device from the parent's
+  // dmabuf feedback, so forcing WLR_RENDER_DRM_DEVICE there could mismatch the
+  // parent and break buffer sharing on a multi-GPU host — it must be gated on the
+  // headless flag (issue #354).
+  EXPECT_NE(source.find("headless && key == \"WLR_RENDER_DRM_DEVICE\""), std::string::npos)
+    << "WLR_RENDER_DRM_DEVICE must be pinned only for the headless backend, "
+       "never on the windowed path that inherits its device from the parent";
+
+  // WLR_RENDER_DRM_DEVICE must be in the set of keys actually pushed into the
+  // labwc process environment, not merely referenced.
+  const auto set_env_pos = source.find("set_labwc_process_environment");
+  ASSERT_NE(set_env_pos, std::string::npos);
+  const auto set_env_body = source.substr(set_env_pos, 1200);
+  EXPECT_NE(set_env_body.find("\"WLR_RENDER_DRM_DEVICE\"sv"), std::string::npos)
+    << "WLR_RENDER_DRM_DEVICE must be exported to labwc, not just computed";
+
+  // Only a present /dev/dri device is used; a bad path is left to auto-select,
+  // never forced (which would make wlroots fail instead of falling back).
+  EXPECT_NE(source.find("/dev/dri/"), std::string::npos)
+    << "adapter_name must be validated as a /dev/dri device path";
+  EXPECT_NE(source.find("access(adapter.c_str(), F_OK)"), std::string::npos)
+    << "adapter_name must be checked for existence before being forced on wlroots";
+
+  // A configured-but-unusable adapter_name must be surfaced, since the bug it
+  // fixes is otherwise invisible (wlroots silently grabs another card).
+  EXPECT_NE(source.find("wlroots will auto-select a GPU"), std::string::npos)
+    << "an ignored adapter_name must be logged, not swallowed";
+}


### PR DESCRIPTION
## Summary

Fixes #354. When Polaris spawns the private labwc compositor it sets `WLR_BACKENDS` / `WLR_RENDERER` / `WLR_HEADLESS_OUTPUTS` but never tells wlroots **which GPU to render on**. wlroots — especially the headless `gles2` backend — then picks the first DRM render node it enumerates. On a multi-GPU host that isn't necessarily the one the operator configured via `adapter_name`, so the private compositor renders on (and the stream is captured from) the wrong card and the session fails to start.

Reported on a dual-GPU AMD host: `adapter_name = /dev/dri/renderD128` set, but labwc grabbed `renderD129`.

`set_labwc_process_environment` now also exports `WLR_RENDER_DRM_DEVICE` from `config::video.adapter_name` — the same render node already used for capture/encode, so the compositor and encoder agree on the GPU.

## Exact candidate

- Branch `fix/labwc-honor-adapter-name-render-device` off `polaris/master` `1c751b31`.
- `cage_display_router.cpp`: one env key + a validation/log block. New `test_labwc_render_device_source.cpp` + its CMake entry.

## Behavior / safety

- **Only a present `/dev/dri` device is forced.** `WLR_RENDER_DRM_DEVICE` makes wlroots *fail* rather than fall back if the path is bogus, so an unset or non-device `adapter_name` is left to wlroots' own auto-select — **unchanged behavior on single-GPU hosts.**
- A configured-but-unusable `adapter_name` is now logged, because the failure this fixes is otherwise invisible (the operator sets a device; wlroots silently grabs another).
- Applies to both the headless (gles2) and windowed (vulkan) private-compositor paths, since both need the renderer on the operator's GPU.

## Verification

- Full CUDA-OFF gate on pc-papi: clean build, `ctest` (incl. the new source-guard test).
- The behavior needs a real `/dev/dri` render node the CI runners lack, so it's guarded at the source level (same as `test_kmsgrab_logging_source.cpp`).
- **Live sanity (single-GPU NVIDIA host):** deployable check that a `windowed_stream`/labwc session still establishes and the journal now logs `labwc: pinning wlroots render device to configured adapter_name [/dev/dri/renderD128]` — queued alongside the next device window (this host is single-GPU, so it verifies no regression; the multi-GPU fix itself is what the reporter can confirm).
