### PR TITLE
fix(nvhttp): always send a status_code on /launch and /resume

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -464,6 +464,26 @@ namespace nvhttp {
     }
 #endif
 
+    // Guarantee an XML response ptree carries a status_code before it is written
+    // back to the client. The launch/resume handlers arm a fail_guard that
+    // writes `tree` on *every* exit and set the status_code explicitly on each
+    // known path — but a throw after the tree is partially filled (e.g. the
+    // launchPolicy is already in it) and before a status_code is set would
+    // otherwise ship a <root> with no status_code attribute at all. Older Nova
+    // clients dereferenced that missing attribute and crashed (companion to
+    // nova #225, which now tolerates it); the host must never emit it in the
+    // first place. Explicit status_code puts win because they run before the
+    // guard fires.
+    void ensure_response_status_code(pt::ptree &tree, int fallback_code, const std::string &fallback_message) {
+      if (tree.get_optional<int>("root.<xmlattr>.status_code")) {
+        return;
+      }
+      // No status_code means the handler exited before deciding one (a throw);
+      // a status_message without a code is malformed, so set a coherent pair.
+      tree.put("root.<xmlattr>.status_code", fallback_code);
+      tree.put("root.<xmlattr>.status_message", fallback_message);
+    }
+
     proc::desktop_launch_safety_policy_t resolve_streaming_launch_safety_policy(
       const args_t &args,
       const proc::ctx_t &app,
@@ -2688,6 +2708,10 @@ namespace nvhttp {
     );
   }
 #endif
+
+  void ensure_response_status_code_for_tests(pt::ptree &tree, int fallback_code, const std::string &fallback_message) {
+    ensure_response_status_code(tree, fallback_code, fallback_message);
+  }
 #endif
 
 #ifdef __linux__
@@ -5487,6 +5511,8 @@ namespace nvhttp {
 
     pt::ptree tree;
     auto g = util::fail_guard([&]() {
+      ensure_response_status_code(tree, 500, "The launch failed unexpectedly");
+
       std::ostringstream data;
 
       pt::write_xml(data, tree);
@@ -5824,6 +5850,8 @@ namespace nvhttp {
 
     pt::ptree tree;
     auto g = util::fail_guard([&]() {
+      ensure_response_status_code(tree, 500, "The resume failed unexpectedly");
+
       std::ostringstream data;
 
       pt::write_xml(data, tree);

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -419,5 +419,10 @@ namespace nvhttp {
   );
   bool save_pairing_state_for_tests();
   void load_pairing_state_for_tests();
+  void ensure_response_status_code_for_tests(
+    boost::property_tree::ptree &tree,
+    int fallback_code,
+    const std::string &fallback_message
+  );
 #endif
 }  // namespace nvhttp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ set(TEST_PAIRING_SOURCES
 set(TEST_HTTP_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_httpcommon.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_mode_contract.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_response_status.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_session_stop_contract.cpp
 )
 

--- a/tests/unit/test_launch_response_status.cpp
+++ b/tests/unit/test_launch_response_status.cpp
@@ -1,0 +1,61 @@
+/**
+ * @file tests/unit/test_launch_response_status.cpp
+ * @brief The /launch and /resume handlers must never ship a response with no
+ *        status_code, even when the handler throws mid-flight after partially
+ *        filling the response tree. This is the host-side companion to nova
+ *        #225, which stopped the client crashing (NPE) on such a body.
+ */
+
+#include <src/nvhttp.h>
+
+#include <boost/property_tree/ptree.hpp>
+#include <gtest/gtest.h>
+
+namespace pt = boost::property_tree;
+
+TEST(LaunchResponseStatus, FillsMissingStatusCodeOnAPartiallyBuiltTree) {
+  // The shape a thrown launch leaves behind: launchPolicy already in the tree,
+  // no status_code yet — exactly the malformed <root> nova #225 had to survive.
+  pt::ptree tree;
+  tree.put("root.launchPolicy.mode", "headless_stream");
+
+  nvhttp::ensure_response_status_code_for_tests(tree, 500, "The launch failed unexpectedly");
+
+  EXPECT_EQ(tree.get<int>("root.<xmlattr>.status_code"), 500);
+  EXPECT_EQ(tree.get<std::string>("root.<xmlattr>.status_message"), "The launch failed unexpectedly");
+  // Content already in the tree is left untouched.
+  EXPECT_EQ(tree.get<std::string>("root.launchPolicy.mode"), "headless_stream");
+}
+
+TEST(LaunchResponseStatus, FillsMissingStatusCodeOnAnEmptyTree) {
+  pt::ptree tree;
+
+  nvhttp::ensure_response_status_code_for_tests(tree, 500, "boom");
+
+  EXPECT_EQ(tree.get<int>("root.<xmlattr>.status_code"), 500);
+  EXPECT_EQ(tree.get<std::string>("root.<xmlattr>.status_message"), "boom");
+}
+
+TEST(LaunchResponseStatus, PreservesAnExplicitSuccessStatus) {
+  pt::ptree tree;
+  tree.put("root.<xmlattr>.status_code", 200);
+  tree.put("root.<xmlattr>.status_message", "OK");
+
+  nvhttp::ensure_response_status_code_for_tests(tree, 500, "should not overwrite");
+
+  EXPECT_EQ(tree.get<int>("root.<xmlattr>.status_code"), 200);
+  EXPECT_EQ(tree.get<std::string>("root.<xmlattr>.status_message"), "OK");
+}
+
+TEST(LaunchResponseStatus, PreservesAnExplicitErrorStatus) {
+  // A handler that already decided on a specific error (e.g. 403 permission
+  // denied) must keep it, not be flattened to the generic 500 fallback.
+  pt::ptree tree;
+  tree.put("root.<xmlattr>.status_code", 403);
+  tree.put("root.<xmlattr>.status_message", "Permission denied");
+
+  nvhttp::ensure_response_status_code_for_tests(tree, 500, "should not overwrite");
+
+  EXPECT_EQ(tree.get<int>("root.<xmlattr>.status_code"), 403);
+  EXPECT_EQ(tree.get<std::string>("root.<xmlattr>.status_message"), "Permission denied");
+}


### PR DESCRIPTION
## Summary

Host-side companion to nova #225. `/launch` and `/resume` arm a fail_guard that writes their response ptree on **every** exit; each known path sets `root.status_code` explicitly, but a throw after the tree is partially filled (e.g. `make_launch_session` raises once the `launchPolicy` is already in the tree) ships a `<root>` with **no `status_code` attribute at all**. Nova ≤ #225 dereferenced that missing attribute and NPE'd; #225 made the client tolerate it, and this makes the host never emit it in the first place.

- New `ensure_response_status_code()` runs at the top of each handler's fail_guard and fills a coherent `500` error pair **only if** no `status_code` was set.
- Every explicit put still wins because it runs before the guard fires, so success (`200`) and deliberate errors (`401/403/409/...`) are unchanged. The fallback applies solely to the throw-before-status path, for both `/launch` and `/resume`.

## Test

`tests/unit/test_launch_response_status.cpp` (new — pure, CI-runnable via a `_for_tests` hook):
- a partially-built tree (`launchPolicy`, no `status_code`) gains `500`, other content untouched
- an empty tree gains `500`
- an explicit `200` is preserved
- an explicit `403` is preserved

## Verification

- The unit test above runs in CI — no hardware needed.
- Built by the CI matrix (no local `-j4` build during papi's hardware window).
- **Deferred to a hardware window**: trigger a mid-launch throw on the host and confirm the wire response now carries the `status_code`.
