### PR TITLE
fix(process): stop the session cage even when the generation is retained

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7105,6 +7105,18 @@ namespace proc {
       stream_runtime::labwc::reset_after_external_stop();
     } else {
       BOOST_LOG(error) << "process: retaining immutable cage generation because exact-generation cleanup was incomplete"sv;
+      // The generation stays retained for whatever the snapshot could not
+      // attribute — that caution is what the next launch's re-validation is
+      // for. It is no reason to leave the session cage running: the cage
+      // supervisor is polaris's own pidfd-bound child, always provable, and
+      // with the session over an unstopped cage is just an orphan compositor
+      // spinning next to a never-reaped supervisor zombie (observed live
+      // 2026-08-10: End Session left labwc rendering shader errors and its
+      // supervisor defunct until a service restart). stop() force-stops and
+      // reaps the supervisor's private group, and fails closed on its own
+      // ownership proof, so it cannot touch anything this session did not
+      // spawn.
+      stream_runtime::labwc::stop();
     }
   }
 

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -2594,15 +2594,28 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   );
   const auto cleanup_clear_gate = generation_finish.find("isolated_session_cleanup_clears_state(");
   const auto clear_generation = generation_finish.find("_session_instance_id.clear()");
+  // Retention must not orphan the cage: the supervisor is polaris's own
+  // pidfd-bound child and always provable, so even when the wider generation
+  // snapshot is incomplete the retention branch has to stop the session cage
+  // (via the labwc facade, whose stop() carries its own ownership proof).
+  // Without this, an incompletely attributable teardown leaves labwc running
+  // as an orphan compositor and its supervisor as a zombie until restart.
+  const auto retention_stops_cage = generation_cleanup.find("stream_runtime::labwc::stop()");
   ASSERT_NE(cleanup_result, std::string::npos);
   ASSERT_NE(cleanup_success_gate, std::string::npos);
   ASSERT_NE(reset_cage, std::string::npos);
   ASSERT_NE(retain_generation, std::string::npos);
+  ASSERT_NE(retention_stops_cage, std::string::npos)
+    << "the retention branch of terminate_isolated_session_generation must stop "
+       "the session cage rather than orphan it";
   ASSERT_NE(cleanup_clear_gate, std::string::npos);
   ASSERT_NE(clear_generation, std::string::npos);
   EXPECT_LT(cleanup_result, cleanup_success_gate);
   EXPECT_LT(cleanup_success_gate, reset_cage);
   EXPECT_LT(reset_cage, retain_generation);
+  EXPECT_LT(retain_generation, retention_stops_cage)
+    << "the cage stop belongs on the retention branch, after the retention "
+       "decision is logged";
   EXPECT_LT(cleanup_clear_gate, clear_generation);
   EXPECT_EQ(terminate.find("config::video.linux_display.use_cage_compositor"), std::string::npos);
   EXPECT_EQ(terminate.find("cage_display_router::stop()"), std::string::npos);


### PR DESCRIPTION
## Summary

When exact-generation teardown cannot fully attribute the session's process tree, `terminate_isolated_session_generation()` retains the generation (correct — the next launch re-validates it, #346) but also skipped stopping the **cage itself** — leaving the labwc supervisor running as an orphan compositor and its polaris fork child unreaped. The retention branch now also calls `stream_runtime::labwc::stop()`.

Why this is safe on an *incompletely attributable* teardown:
- The cage supervisor is polaris's **own pidfd-bound child** — always attributable no matter what the wider `/proc` snapshot missed (enumeration error, non-exempt unreadable environ, mid-scan race — any one marks the whole capture incomplete).
- `stop()` fails closed on its own ownership proof: SIGTERM to the pidfd-bound supervisor → bounded reap → force-kill of the private group only when ownership is proven. It cannot touch anything the session did not spawn.
- The generation itself stays retained; the reap-at-launch re-validation still governs whatever the snapshot could not see. No safety behavior is loosened.

## Exact candidate

Observed live tonight (windowed_stream, Control forwarded through desktop Steam): after Nova's **End Session**, the game died and the client returned to the library, but the host kept:
- an orphan `labwc` spinning `Scene.vert/frag` shader-load errors every ~40s,
- a `polaris <defunct>` supervisor zombie,
- the generation latched — "retaining immutable cage generation because exact-generation cleanup was incomplete" re-fired at the next service shutdown.

(Forensic note: the primary teardown transcript was lost to journald rate-limiting — debug-level logging at 120 fps overran the 37,500-line burst cap and the stalled async sink flushed with flush-time stamps; the latch error at shutdown plus the orphan/zombie pair are the surviving evidence.)

## Verification

- Extended the `SessionOwnedSteamUsesExactGenerationPidfds` source guard: the retention branch must stop the session cage, ordered after the retention decision is logged (assertion messages carry the why).
- Full CUDA-OFF gate suite (`ninja + ctest`) green locally; CI matrix on this PR.
- Live re-verification on the deployed build: launch → End Session → assert zero labwc/cage processes and zero defunct polaris children.
