### PR TITLE
fix(logging): stamp records at creation and demote per-frame capture spam

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -10,6 +10,7 @@
 
 // lib includes
 #include <boost/core/null_deleter.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/format.hpp>
 #include <boost/log/attributes/clock.hpp>
 #include <boost/log/common.hpp>
@@ -101,15 +102,28 @@ namespace logging {
 #endif
     };
 
-    auto now = std::chrono::system_clock::now();
-    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-      now - std::chrono::time_point_cast<std::chrono::seconds>(now)
-    );
+    // Print the RECORD's creation time, not "now". This formatter runs on the
+    // asynchronous sink's consumer thread, so with wall-clock-at-format the
+    // printed time is the FLUSH time — observed live 2026-08-10: the consumer
+    // stalled behind journald backpressure for a whole streaming session and
+    // then drained a 37,500-line backlog in one second, every line stamped
+    // with the drain moment. That fabricated a convincing-but-fake "second
+    // launch" transcript (a full RTSP handshake apparently completing in 1 ms)
+    // and made the real teardown impossible to reconstruct from the journal.
+    // The TimeStamp attribute is stamped at record creation by the global
+    // local_clock registered in init(); the wall-clock fallback only covers
+    // records logged before init() has run.
+    boost::posix_time::ptime record_time;
+    if (auto stamp = view.attribute_values()["TimeStamp"].extract<boost::posix_time::ptime>()) {
+      record_time = stamp.get();
+    } else {
+      record_time = boost::posix_time::microsec_clock::local_time();
+    }
 
-    auto t = std::chrono::system_clock::to_time_t(now);
-    auto lt = *std::localtime(&t);
+    auto lt = boost::posix_time::to_tm(record_time);
+    const auto ms = record_time.time_of_day().total_milliseconds() % 1000;
 
-    os << "["sv << std::put_time(&lt, "%Y-%m-%d %H:%M:%S.") << boost::format("%03u") % ms.count() << "]: "sv
+    os << "["sv << std::put_time(&lt, "%Y-%m-%d %H:%M:%S.") << boost::format("%03u") % ms << "]: "sv
        << log_type << view.attribute_values()[message].extract<std::string>();
   }
 #ifdef __ANDROID__
@@ -203,6 +217,16 @@ namespace logging {
     // Flush after each log record to ensure log file contents on disk isn't stale.
     // This is particularly important when running from a Windows service.
     sink->locked_backend()->auto_flush(true);
+
+    // Stamp every record with its creation time. The formatter runs later, on
+    // the asynchronous sink's consumer thread, and must print this attribute
+    // rather than the wall clock — otherwise a stalled consumer rewrites
+    // history with flush-time stamps (see the formatter comment). Idempotent
+    // across re-init: the attribute survives deinit() and a duplicate add
+    // would be rejected, so only add it when absent.
+    if (bl::core::get()->get_global_attributes().count("TimeStamp") == 0) {
+      bl::core::get()->add_global_attribute("TimeStamp", bl::attributes::local_clock());
+    }
 
     bl::core::get()->add_sink(sink);
 

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -715,7 +715,11 @@ namespace wl {
     shm_info.height = height;
     shm_info.stride = stride;
 
-    BOOST_LOG(debug) << "Screencopy supports SHM format: "sv << format;
+    // Per-frame lines log at verbose, not debug: at 120 fps the screencopy
+    // callbacks emit hundreds of records per second, which is enough to stall
+    // the async log consumer behind journald backpressure and blow journald's
+    // burst cap right when teardown records matter (observed 2026-08-10).
+    BOOST_LOG(verbose) << "Screencopy supports SHM format: "sv << format;
   }
 
   // DMA-BUF format callback
@@ -730,13 +734,13 @@ namespace wl {
     dmabuf_info.width = width;
     dmabuf_info.height = height;
 
-    BOOST_LOG(debug) << "Screencopy supports DMA-BUF format: "sv << format;
+    BOOST_LOG(verbose) << "Screencopy supports DMA-BUF format: "sv << format;
   }
 
   // Flags callback
   void dmabuf_t::flags(zwlr_screencopy_frame_v1 *frame, std::uint32_t flags) {
     y_invert = flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT;
-    BOOST_LOG(debug) << "Frame flags: "sv << flags << (y_invert ? " (y_invert)" : "");
+    BOOST_LOG(verbose) << "Frame flags: "sv << flags << (y_invert ? " (y_invert)" : "");
   }
 
   // DMA-BUF creation helper
@@ -839,8 +843,8 @@ namespace wl {
         return;
       }
 
-      BOOST_LOG(debug) << "Reusing DMA-BUF screencopy buffer for "
-                       << dmabuf_info.width << 'x' << dmabuf_info.height;
+      BOOST_LOG(verbose) << "Reusing DMA-BUF screencopy buffer for "
+                         << dmabuf_info.width << 'x' << dmabuf_info.height;
       zwlr_screencopy_frame_v1_copy(frame, next_frame->buffer);
       return;
     }
@@ -1177,7 +1181,7 @@ namespace wl {
     std::uint32_t tv_sec_lo,
     std::uint32_t tv_nsec
   ) {
-    BOOST_LOG(debug) << "Frame ready"sv;
+    BOOST_LOG(verbose) << "Frame ready"sv;
 
     if (shm_data && shm_size > 0) {
       // SHM frame is ready — data is in shm_data

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -6,8 +6,15 @@
 #include "../tests_log_checker.h"
 #include "../tests_paths.h"
 
+#include <boost/log/core.hpp>
+#include <chrono>
+#include <ctime>
+#include <filesystem>
 #include <format>
+#include <fstream>
 #include <random>
+#include <regex>
+#include <sstream>
 #include <src/logging.h>
 
 namespace {
@@ -44,4 +51,84 @@ TEST_P(LogLevelsTest, PutMessage) {
   BOOST_LOG(logger) << test_message;
 
   ASSERT_TRUE(log_checker::line_contains(test_paths::log_file().string(), test_message));
+}
+
+// Records must be stamped at creation. The formatter runs on the asynchronous
+// sink's consumer thread; without a creation-time attribute it can only print
+// the wall clock at format time, and a stalled consumer then rewrites history
+// with flush-time stamps (a whole session's backlog was observed draining in
+// one second with every line stamped at the drain moment). init() registers a
+// global local_clock as "TimeStamp" — this is the registration proof.
+TEST(LoggingTimeStamp, GlobalTimeStampAttributeIsRegistered) {
+  ASSERT_EQ(boost::log::core::get()->get_global_attributes().count("TimeStamp"), 1u)
+    << "init() must register the TimeStamp global attribute so records carry "
+       "their creation time to the async formatter";
+}
+
+TEST(LoggingTimeStamp, PrintedTimestampTracksRecordCreation) {
+  std::random_device rand_dev;
+  std::mt19937_64 rand_gen(rand_dev());
+  const auto test_message = std::format("stamp{}{}", rand_gen(), rand_gen());
+
+  const auto before = std::chrono::system_clock::now();
+  BOOST_LOG(info) << test_message;
+  ASSERT_TRUE(log_checker::line_contains(test_paths::log_file().string(), test_message));
+  const auto after = std::chrono::system_clock::now();
+
+  // Find the line and parse its "[YYYY-MM-DD HH:MM:SS.mmm]: " prefix.
+  std::ifstream file(test_paths::log_file().string());
+  ASSERT_TRUE(file.good());
+  std::string line;
+  std::string matched;
+  while (std::getline(file, line)) {
+    if (line.find(test_message) != std::string::npos) {
+      matched = line;
+    }
+  }
+  ASSERT_FALSE(matched.empty());
+
+  const std::regex stamp_re(R"(^\[(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})\.(\d{3})\]: )");
+  std::smatch parts;
+  ASSERT_TRUE(std::regex_search(matched, parts, stamp_re))
+    << "log line does not start with a parseable timestamp: " << matched;
+
+  std::tm parsed {};
+  parsed.tm_year = std::stoi(parts[1]) - 1900;
+  parsed.tm_mon = std::stoi(parts[2]) - 1;
+  parsed.tm_mday = std::stoi(parts[3]);
+  parsed.tm_hour = std::stoi(parts[4]);
+  parsed.tm_min = std::stoi(parts[5]);
+  parsed.tm_sec = std::stoi(parts[6]);
+  parsed.tm_isdst = -1;  // formatter prints local time
+  const auto parsed_time = std::chrono::system_clock::from_time_t(std::mktime(&parsed)) +
+                           std::chrono::milliseconds(std::stoi(parts[7]));
+
+  // A generous window: this cannot distinguish record time from flush time
+  // when the consumer is healthy (they are milliseconds apart), but it fails
+  // loudly on the bugs a broken extraction produces — an epoch-zero stamp, a
+  // UTC/local mixup, or garbage. The record-vs-flush discrimination itself is
+  // pinned by the source guard below.
+  EXPECT_GE(parsed_time, before - std::chrono::seconds(5));
+  EXPECT_LE(parsed_time, after + std::chrono::seconds(5));
+}
+
+// Source guard: the formatter must print the record's TimeStamp attribute and
+// keep the wall clock only as a fallback for records logged before init().
+TEST(LoggingTimeStamp, FormatterPrintsTheRecordTimeStampAttribute) {
+  const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / "src/logging.cpp";
+  std::ifstream file {path};
+  ASSERT_TRUE(file.good()) << "could not read src/logging.cpp via POLARIS_SOURCE_DIR";
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  const auto source = buffer.str();
+
+  const auto formatter_start = source.find("void formatter(");
+  ASSERT_NE(formatter_start, std::string::npos);
+  const auto formatter_body = source.substr(formatter_start, source.find("\n  }", formatter_start) - formatter_start);
+
+  EXPECT_NE(formatter_body.find("[\"TimeStamp\"].extract<boost::posix_time::ptime>()"), std::string::npos)
+    << "the formatter must extract the record's TimeStamp attribute instead of "
+       "stamping records with the consumer thread's wall clock at flush time";
+  EXPECT_NE(source.find("add_global_attribute(\"TimeStamp\""), std::string::npos)
+    << "init() must register the TimeStamp global attribute";
 }


### PR DESCRIPTION
## Summary

Two halves of one forensic failure, observed live while verifying #360's session teardown:

1. **Record-time stamps.** The formatter generated its timestamp with `system_clock::now()` *at format time* — but it runs on the asynchronous sink's consumer thread, so the printed time is the **flush** time. When the consumer stalled behind journald backpressure for a whole streaming session, the backlog drained as a 37,500-line burst in one second, every line stamped with the drain moment. The journal then showed a convincing-but-fake "second launch" (encoder probe + full RTSP handshake + CLIENT CONNECTED, all "within 1 ms", at a moment when nothing launched) while the real teardown records were pushed past journald's burst cap and dropped. `init()` now registers a global `local_clock` as the `TimeStamp` attribute; the formatter prints that, with wall-clock only as a fallback for records logged before `init()`. **Output format unchanged.**

2. **Per-frame demotion.** The wlr screencopy callbacks logged five lines per captured frame at `debug` (`Frame ready`, `Frame flags`, buffer reuse, two format announcements) — hundreds of records/second at 120 fps, which is exactly what stalled the consumer and blew the burst cap. They now log at `verbose` (the existing level below debug); `min_log_level = verbose` still exposes them when frame-level tracing is wanted.

## Exact candidate

From the incident (journald arrival-time distribution around the teardown window):

```
      1 Aug 10 00:23:06
     19 Aug 10 00:23:07     ← real teardown moment (records dropped)
      6 Aug 10 00:23:10
  37500 Aug 10 00:24:39     ← stalled sink drains; every line stamped 00:24:39
```

## Verification

- New `LoggingTimeStamp` suite: attribute-registration proof, printed-prefix parse + creation-tracking window (fails loudly on epoch/garbage/timezone extraction bugs), and a source guard pinning the formatter to the record's `TimeStamp`.
- Existing log-level round-trip tests cover the unchanged output shape.
- Full CUDA-OFF gate suite locally; CI matrix on this PR.
- No behavior change outside logging; deploy can ride the next scheduled restart (no urgency — the fix pays off at the *next* incident).
