### PR TITLE
fix(logging): bound GL info-log length so a broken context can't flood the log

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -124,7 +124,19 @@ namespace logging {
     const auto ms = record_time.time_of_day().total_milliseconds() % 1000;
 
     os << "["sv << std::put_time(&lt, "%Y-%m-%d %H:%M:%S.") << boost::format("%03u") % ms << "]: "sv
-       << log_type << view.attribute_values()[message].extract<std::string>();
+       << log_type;
+
+    // Cap any single record so one pathological message (e.g. a broken GL driver
+    // returning a multi-megabyte info log) cannot flood the log file unbounded.
+    constexpr std::size_t max_message_chars = 16 * 1024;
+    auto message_value = view.attribute_values()[message].extract<std::string>();
+    if (message_value && message_value.get().size() > max_message_chars) {
+      const auto &full = message_value.get();
+      os << std::string_view(full.data(), max_message_chars)
+         << "\u2026 [truncated "sv << (full.size() - max_message_chars) << " chars]"sv;
+    } else {
+      os << message_value;
+    }
   }
 #ifdef __ANDROID__
   namespace sinks = boost::log::sinks;

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -118,15 +118,26 @@ namespace gl {
   }
 
   std::string shader_t::err_str() {
-    int length;
+    // length must be initialized: a failed GetShaderiv (e.g. a broken GL context)
+    // leaves it untouched, and an uninitialized garbage length made string.resize()
+    // allocate a multi-megabyte run of NULs that then flooded the log. resize(length - 1)
+    // also underflows to SIZE_MAX when length is 0.
+    int length = 0;
     ctx.GetShaderiv(handle(), GL_INFO_LOG_LENGTH, &length);
+    if (length <= 0) {
+      return {};
+    }
 
     std::string string;
     string.resize(length);
 
     ctx.GetShaderInfoLog(handle(), length, &length, string.data());
 
-    string.resize(length - 1);
+    if (length > 0) {
+      string.resize(length - 1);
+    } else {
+      string.clear();
+    }
 
     return string;
   }
@@ -194,8 +205,13 @@ namespace gl {
   }
 
   std::string program_t::err_str() {
-    int length;
+    // See shader_t::err_str: length must be initialized so a failed GetProgramiv
+    // cannot leave a garbage size that string.resize() turns into a giant allocation.
+    int length = 0;
     ctx.GetProgramiv(handle(), GL_INFO_LOG_LENGTH, &length);
+    if (length <= 0) {
+      return {};
+    }
 
     std::string string;
     string.resize(length);

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -132,3 +132,47 @@ TEST(LoggingTimeStamp, FormatterPrintsTheRecordTimeStampAttribute) {
   EXPECT_NE(source.find("add_global_attribute(\"TimeStamp\""), std::string::npos)
     << "init() must register the TimeStamp global attribute";
 }
+
+// Source guard: a broken GL context must not be able to flood the log file.
+// See the "bound GL info-log length" fix -- an uninitialized GL_INFO_LOG_LENGTH
+// turned string.resize() into a multi-megabyte NUL record, and the formatter now
+// also caps any single record as a backstop.
+TEST(LoggingRunaway, FormatterCapsRecordSize) {
+  const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / "src/logging.cpp";
+  std::ifstream file {path};
+  ASSERT_TRUE(file.good()) << "could not read src/logging.cpp via POLARIS_SOURCE_DIR";
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  const auto source = buffer.str();
+
+  const auto formatter_start = source.find("void formatter(");
+  ASSERT_NE(formatter_start, std::string::npos);
+  const auto formatter_body = source.substr(formatter_start, source.find("\n  }", formatter_start) - formatter_start);
+
+  EXPECT_NE(formatter_body.find("max_message_chars"), std::string::npos)
+    << "the formatter must cap the per-record message size so one pathological "
+       "message cannot grow the log file without bound";
+}
+
+TEST(LoggingRunaway, GlInfoLogLengthIsInitializedAndGuarded) {
+  const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / "src/platform/linux/graphics.cpp";
+  std::ifstream file {path};
+  ASSERT_TRUE(file.good()) << "could not read src/platform/linux/graphics.cpp via POLARIS_SOURCE_DIR";
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  const auto source = buffer.str();
+
+  for (const auto *fn : {"shader_t::err_str()", "program_t::err_str()"}) {
+    const auto start = source.find(fn);
+    ASSERT_NE(start, std::string::npos) << fn << " not found in graphics.cpp";
+    const auto body = source.substr(start, source.find("\n  }", start) - start);
+
+    // A failed GetShader/Programiv(GL_INFO_LOG_LENGTH) leaves length untouched;
+    // an uninitialized garbage length made string.resize() allocate a
+    // multi-megabyte run of NULs that flooded the log.
+    EXPECT_NE(body.find("int length = 0"), std::string::npos)
+      << fn << " must initialize the info-log length to 0";
+    EXPECT_NE(body.find("length <= 0"), std::string::npos)
+      << fn << " must return early on a non-positive info-log length";
+  }
+}


### PR DESCRIPTION
## Summary

`polaris.log` intermittently ballooned to several GB within minutes of streaming and filled the disk on pc-papi (observed ~3.5 GB in ~2 min; an 18.9 GB rotated backup earlier, `/home` at 95%). The flood was a small number of enormous single records — megabytes of NUL/whitespace each.

Root cause: a broken/unusable GL context makes `GetShaderiv`/`GetProgramiv(GL_INFO_LOG_LENGTH)` fail and leave an **uninitialized** `int length` untouched. `err_str()` then calls `string.resize(length)` on that garbage size, allocating a multi-megabyte run of NUL bytes that is written to the log as one record. `shader_t::err_str()` additionally ran `string.resize(length - 1)` unconditionally, underflowing to `SIZE_MAX` when the info log was empty (`program_t::err_str` already guarded that second case, but not the first).

## Fix

- **graphics.cpp** — `shader_t::err_str()` and `program_t::err_str()`: initialize `length = 0`, return early on a non-positive length, and guard the trailing `resize(length - 1)`.
- **logging.cpp** — cap any single formatted record at 16 KB with a truncation marker, as a backstop so no future pathological message can grow the log file unbounded.

## Verification

- Builds clean (CUDA, `-j4`).
- By inspection: the change initializes the length that directly caused the giant records, and mirrors the already-correct empty-info-log guard from `program_t::err_str`.
- No functional test: the trigger is a driver-level condition (a GL context returning a garbage info-log length) that isn't reproducible in a unit test. A source-guard test can be added if wanted.
- Independent of the headless-renderer work; branches off `master`.
