### PR TITLE
feat(linux): enable true-headless GPU-native private streaming

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -460,7 +460,13 @@ namespace cage_display_router {
     }
 
     if (key == "WLR_RENDERER") {
-      return headless ? "gles2" : "vulkan";
+      // Both cages use the vulkan renderer. Headless was formerly pinned to gles2 to
+      // dodge a wlroots-0.19 vulkan_instance_destroy teardown SEGV; that crash no longer
+      // reproduces on 0.20.2 (retested 2026-08-10). vulkan is also the renderer whose
+      // ext-image-copy DMA-BUF the CUDA/NVENC import path can consume, which unblocks
+      // true-headless GPU-native capture -- the gles2 headless frame could not be
+      // imported, which is what forced the visible windowed-cage fallback.
+      return "vulkan";
     }
 
     if (headless && key == "WLR_HEADLESS_OUTPUTS") {
@@ -1159,14 +1165,11 @@ namespace cage_display_router {
         // Headless mode: no visible window on desktop, no parent display needed.
         // labwc creates virtual outputs that still support wlr-screencopy.
         //
-        // Known limitations on NVIDIA + wlroots 0.19:
-        // - Vulkan renderer crashes (vulkan_instance_destroy SEGV)
-        // - GLES2/pixman renderers work but screencopy returns SHM/ARGB frames
-        //   which CUDA/NVENC can't consume directly (needs NV12)
-        // - Requires SHM→NV12 conversion in the capture pipeline (future work)
-        //
-        // For now: use headless with GLES2, the SHM capture path in wlgrab
-        // handles the conversion via software scaler (slower but functional).
+        // Renderer is vulkan (see WLR_RENDERER above), same as the windowed cage.
+        // Headless ran on gles2 until the wlroots-0.19 vulkan_instance_destroy SEGV
+        // was confirmed gone on 0.20.2 (retested 2026-08-10). vulkan's ext-image-copy
+        // DMA-BUF is GPU-native and CUDA/NVENC-importable, so headless no longer has
+        // to fall back to a visible windowed cage to reach a GPU-native capture path.
         // Clear inherited display vars so children ONLY talk to labwc.
         // labwc will set its own WAYLAND_DISPLAY and start XWayland (new DISPLAY).
         // Without this, Steam connects to KDE's :0 instead of labwc's XWayland.

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -15,6 +15,7 @@
 #include "src/video.h"
 #include "vaapi.h"
 #include "wayland.h"
+#include "wlgrab_frame_source.h"
 #include "wlgrab_pixel_copy.h"
 
 using namespace std::literals;
@@ -551,15 +552,27 @@ namespace wl {
     platf::capture_e snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, bool *cursor) {
       auto capture_start = std::chrono::steady_clock::now();
       auto cursor_enabled = cursor ? *cursor : false;
+      const auto frame_source = select_extcopy_frame_source(
+        capture_ready,
+        cursor_enabled != blend_cursor,
+        prefetched_frame_pending
+      );
 
-      if (!capture_ready || cursor_enabled != blend_cursor) {
+      if (frame_source == extcopy_frame_source_e::initialize) {
         blend_cursor = cursor_enabled;
         if (extcopy.init(display, interface.copy_capture_manager, interface.output_capture_source_manager, interface.dmabuf_interface, output, blend_cursor)) {
           return platf::capture_e::reinit;
         }
         capture_ready = true;
       } else {
-        extcopy.capture(display);
+        if (frame_source == extcopy_frame_source_e::prefetched) {
+          // extcopy.init() captured this frame while validating the negotiated
+          // DMA-BUF. Hand it to the caller before requesting more damage.
+          BOOST_LOG(debug) << "wlr: Consuming ext-image-copy frame captured during initialization"sv;
+        } else {
+          extcopy.capture(display);
+        }
+
         if (interface.consume_output_topology_dirty()) {
           BOOST_LOG(warning) << "wlr: Wayland output topology changed during ext-image-copy capture; reinitializing display capture"sv;
           return platf::capture_e::reinit;
@@ -657,11 +670,13 @@ namespace wl {
       }
 
       capture_ready = true;
+      prefetched_frame_pending = true;
       return 0;
     }
 
     wl::extcopy_t extcopy;
     bool capture_ready {false};
+    bool prefetched_frame_pending {false};
     bool blend_cursor {false};
     std::uint64_t sequence {};
   };

--- a/src/platform/linux/wlgrab_frame_source.h
+++ b/src/platform/linux/wlgrab_frame_source.h
@@ -1,0 +1,38 @@
+#pragma once
+
+namespace wl {
+  /**
+   * @brief Describes how the next ext-image-copy snapshot obtains its frame.
+   */
+  enum class extcopy_frame_source_e {
+    initialize,
+    prefetched,
+    capture,
+  };
+
+  /**
+   * @brief Select the frame source for an ext-image-copy snapshot.
+   *
+   * extcopy initialization performs a real capture to validate its negotiated
+   * buffer. That frame must be handed to the first snapshot exactly once;
+   * otherwise an idle, damage-driven output waits unnecessarily for a second
+   * frame. Reinitialization always replaces any stale prefetched frame.
+   */
+  inline extcopy_frame_source_e select_extcopy_frame_source(
+    bool capture_ready,
+    bool cursor_changed,
+    bool &prefetched_frame_pending
+  ) {
+    if (!capture_ready || cursor_changed) {
+      prefetched_frame_pending = false;
+      return extcopy_frame_source_e::initialize;
+    }
+
+    if (prefetched_frame_pending) {
+      prefetched_frame_pending = false;
+      return extcopy_frame_source_e::prefetched;
+    }
+
+    return extcopy_frame_source_e::capture;
+  }
+}  // namespace wl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ set(TEST_FAST_SOURCES
 if (NOT WIN32 AND NOT APPLE)
     list(APPEND TEST_FAST_SOURCES
         ${CMAKE_SOURCE_DIR}/tests/unit/test_linux_executable_path.cpp
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_wlgrab_frame_source.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/test_wlgrab_pixel_copy.cpp
     )
 endif()

--- a/tests/unit/test_wlgrab_frame_source.cpp
+++ b/tests/unit/test_wlgrab_frame_source.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file tests/unit/test_wlgrab_frame_source.cpp
+ * @brief Tests for ext-image-copy prefetched-frame handoff.
+ */
+#include <gtest/gtest.h>
+
+#include "src/platform/linux/wlgrab_frame_source.h"
+
+TEST(ExtcopyFrameSource, ConsumesFramePrefetchedDuringInitialization) {
+  bool prefetched_frame_pending = true;
+
+  EXPECT_EQ(
+    wl::select_extcopy_frame_source(true, false, prefetched_frame_pending),
+    wl::extcopy_frame_source_e::prefetched
+  );
+  EXPECT_FALSE(prefetched_frame_pending);
+}
+
+TEST(ExtcopyFrameSource, RequestsNewFrameAfterPrefetchedFrameWasConsumed) {
+  bool prefetched_frame_pending = false;
+
+  EXPECT_EQ(
+    wl::select_extcopy_frame_source(true, false, prefetched_frame_pending),
+    wl::extcopy_frame_source_e::capture
+  );
+}
+
+TEST(ExtcopyFrameSource, ReinitializationSupersedesStalePrefetchedFrame) {
+  bool prefetched_frame_pending = true;
+
+  EXPECT_EQ(
+    wl::select_extcopy_frame_source(false, false, prefetched_frame_pending),
+    wl::extcopy_frame_source_e::initialize
+  );
+  EXPECT_FALSE(prefetched_frame_pending);
+
+  prefetched_frame_pending = true;
+  EXPECT_EQ(
+    wl::select_extcopy_frame_source(true, true, prefetched_frame_pending),
+    wl::extcopy_frame_source_e::initialize
+  );
+  EXPECT_FALSE(prefetched_frame_pending);
+}


### PR DESCRIPTION
## Summary

Enables the private compositor's **headless** path to stream GPU-native, so a `headless_mode` session no longer falls back to a visible windowed cage. Two changes:

1. **Use the vulkan renderer for the headless private compositor** (was gles2). Headless was pinned to gles2 to dodge a `vulkan_instance_destroy` teardown SEGV observed on wlroots 0.19; that crash no longer reproduces on 0.20.2 (retested standalone: a headless labwc on vulkan brings up an output and tears down cleanly, identical to the gles2 control). vulkan is also the renderer whose ext-image-copy DMA-BUF the CUDA/NVENC path can import — which the gles2 headless frame could not, which is what forced the windowed fallback.

2. **Consume the extcopy initialization frame** (wlgrab). ext-image-copy init already captures a DMA-BUF frame while validating the negotiated buffer; the live-capture probe discarded it and then timed out waiting for a second *damaged* frame on an otherwise-empty headless output (no client has drawn into the cage yet at probe time). Preserve that init frame as prefetched and hand it to the first snapshot, so the probe validates instead of giving up. The live-frame conversion safety gate, output topology, and cursor reinitialization are preserved; fresh frames are requested after the one-shot handoff.

Together these move the headless path from "can't initialize the compositor/encoder" → negotiates DMA-BUF → **actually validates and streams**.

## Verification

Device-verified on the RTX 4090 host + Retroid Pocket 6 (Control Ultimate Edition), wlroots 0.20.2 / mesa 26.1.6 / nvidia 610.57.04:

- live cage came up **HEADLESS-1** (true headless, not the windowed `WL-1` fallback);
- headless gamepad-isolation (bwrap) applied — which only happens on a headless session, an independent confirmation of the path;
- ext-image-copy DMA-BUF, GPU residency, CUDA/NV12 conversion, HEVC NVENC;
- two client screenshots 3 s apart hash-differ (live frames); Control rendering; client badge "Private Stream (GPU-native) · GPU-native DMA-BUF", 1080p HEVC, RTT 3 ms;
- clean End-Session teardown, no orphan cage.

Builds clean (CUDA, `-j4`). The windowed path is unchanged; its nested window is painted by the host compositor, so it always captured a frame and never depended on the extcopy init handoff.
