### PR TITLE
fix(linux): harden portal startup and teardown

### DIFF
--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -366,8 +366,8 @@ namespace portal {
            (!g_media.portal || g_media.portal->failed || !g_media.portal->ready ||
             g_media.portal->pw_node_id == 0);
            ++attempt) {
-        if (session_media::teardown_in_progress()) {
-          BOOST_LOG(info) << "portal: teardown requested; skipping failed-session retry backoff"sv;
+        if (session_media::teardown_in_progress() || session_media::pending_start_cancelled(session_media::pending_start_owner())) {
+          BOOST_LOG(info) << "portal: stop requested; skipping failed-session retry backoff"sv;
           g_media.portal.reset();
           break;
         }

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -366,6 +366,11 @@ namespace portal {
            (!g_media.portal || g_media.portal->failed || !g_media.portal->ready ||
             g_media.portal->pw_node_id == 0);
            ++attempt) {
+        if (session_media::teardown_in_progress()) {
+          BOOST_LOG(info) << "portal: teardown requested; skipping failed-session retry backoff"sv;
+          g_media.portal.reset();
+          break;
+        }
         BOOST_LOG(warning) << "portal: create session attempt "sv << attempt
                            << " failed; waiting for gamescope-0 before retry"sv;
         g_media.portal.reset();

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -57,10 +57,14 @@ namespace portal {
     const std::string legacy = base + "/portal_restore_token.txt";
     std::error_code ec;
     if (!std::filesystem::exists(host, ec) && std::filesystem::is_regular_file(legacy, ec)) {
-      std::error_code copy_ec;
-      std::filesystem::copy_file(legacy, host, copy_ec);
-      if (!copy_ec) {
+      // Consume the legacy token instead of copying it. If a migrated host
+      // token later proves stale, clear_restore_token() must not let the next
+      // retry resurrect the same invalid token from the legacy path.
+      std::filesystem::rename(legacy, host, ec);
+      if (!ec) {
         BOOST_LOG(info) << "portal: migrated legacy restore token to "sv << host;
+      } else {
+        BOOST_LOG(warning) << "portal: failed to migrate legacy restore token: "sv << ec.message();
       }
     }
     return host;

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -40,8 +40,13 @@ using namespace std::literals;
 namespace portal {
 
   namespace {
+    struct pending_request_t {
+      GCancellable *cancellable = nullptr;
+      const void *owner_tag = nullptr;
+    };
+
     std::mutex g_pending_request_mutex;
-    std::vector<GCancellable *> g_pending_requests;
+    std::vector<pending_request_t> g_pending_requests;
 
     struct cancellable_unref_t {
       void operator()(GCancellable *cancellable) const {
@@ -55,15 +60,19 @@ namespace portal {
 
     class pending_request_registration_t {
     public:
-      explicit pending_request_registration_t(GCancellable *cancellable):
+      explicit pending_request_registration_t(
+        GCancellable *cancellable,
+        const void *owner_tag = session_media::pending_start_owner()
+      ):
           cancellable_ {cancellable} {
         if (!cancellable_) {
           return;
         }
         std::lock_guard lock(g_pending_request_mutex);
-        g_pending_requests.push_back(
-          G_CANCELLABLE(g_object_ref(cancellable_))
-        );
+        g_pending_requests.push_back({
+          G_CANCELLABLE(g_object_ref(cancellable_)),
+          owner_tag
+        });
       }
 
       pending_request_registration_t(const pending_request_registration_t &) = delete;
@@ -74,9 +83,15 @@ namespace portal {
           return;
         }
         std::lock_guard lock(g_pending_request_mutex);
-        const auto it = std::find(g_pending_requests.begin(), g_pending_requests.end(), cancellable_);
+        const auto it = std::find_if(
+          g_pending_requests.begin(),
+          g_pending_requests.end(),
+          [this](const pending_request_t &request) {
+            return request.cancellable == cancellable_;
+          }
+        );
         if (it != g_pending_requests.end()) {
-          g_object_unref(*it);
+          g_object_unref(it->cancellable);
           g_pending_requests.erase(it);
         }
       }
@@ -86,13 +101,15 @@ namespace portal {
     };
   }  // namespace
 
-  void cancel_pending_requests() {
+  void cancel_pending_requests(const void *owner_tag) {
     std::vector<GCancellable *> pending;
     {
       std::lock_guard lock(g_pending_request_mutex);
       pending.reserve(g_pending_requests.size());
-      for (auto *cancellable : g_pending_requests) {
-        pending.push_back(G_CANCELLABLE(g_object_ref(cancellable)));
+      for (const auto &request : g_pending_requests) {
+        if (!owner_tag || request.owner_tag == owner_tag) {
+          pending.push_back(G_CANCELLABLE(g_object_ref(request.cancellable)));
+        }
       }
     }
 
@@ -113,6 +130,23 @@ namespace portal {
     }
     g_object_unref(cancellable);
     return cancelled;
+  }
+
+  bool portal_cancel_request_owner_for_tests() {
+    int owner_a = 0;
+    int owner_b = 0;
+    auto *first = g_cancellable_new();
+    auto *second = g_cancellable_new();
+    bool matched = false;
+    {
+      pending_request_registration_t first_registration {first, &owner_a};
+      pending_request_registration_t second_registration {second, &owner_b};
+      cancel_pending_requests(&owner_a);
+      matched = g_cancellable_is_cancelled(first) && !g_cancellable_is_cancelled(second);
+    }
+    g_object_unref(first);
+    g_object_unref(second);
+    return matched;
   }
 #endif
 
@@ -495,7 +529,7 @@ namespace portal {
     cancellable_ptr_t cancellable_owner {g_cancellable_new()};
     auto *cancellable = cancellable_owner.get();
     pending_request_registration_t registration {cancellable};
-    if (session_media::teardown_in_progress()) {
+    if (session_media::teardown_in_progress() || session_media::pending_start_cancelled(session_media::pending_start_owner())) {
       g_cancellable_cancel(cancellable);
     }
 
@@ -701,7 +735,7 @@ namespace portal {
     cancellable_ptr_t cancellable_owner {g_cancellable_new()};
     auto *cancellable = cancellable_owner.get();
     pending_request_registration_t registration {cancellable};
-    if (session_media::teardown_in_progress()) {
+    if (session_media::teardown_in_progress() || session_media::pending_start_cancelled(session_media::pending_start_owner())) {
       g_cancellable_cancel(cancellable);
     }
 

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -443,26 +443,31 @@ namespace portal {
     return fd;
   }
 
-  // Helper: wait for a Response signal on a request path.
-  // Uses a dedicated GMainLoop thread to ensure D-Bus signals are delivered.
-  static GVariant *wait_for_response(GDBusConnection *conn, const std::string &request_path,
-    int timeout_ms = 30000) {
+  // Subscribe to Request::Response before issuing the portal method call.
+  // Fast KDE responses can otherwise arrive between call_sync() returning and
+  // signal subscription, leaving the caller blocked until its timeout.
+  static GVariant *portal_call_and_wait_for_response(
+    GDBusConnection *conn,
+    const char *method,
+    GVariant *params,
+    const std::string &request_path,
+    int call_timeout_ms = 5000,
+    int response_timeout_ms = 30000) {
 
     struct cb_data_t {
       GVariant *result = nullptr;
-      std::atomic<bool> done{false};
+      std::atomic<bool> done {false};
       uint32_t response = 99;
       GMainLoop *loop = nullptr;
     } cb_data;
 
-    // Create a dedicated main context and loop for this wait
+    // Capture signal delivery on a dedicated thread-default context before the
+    // synchronous method call can trigger a fast Response signal.
     auto *ctx = g_main_context_new();
     cb_data.loop = g_main_loop_new(ctx, FALSE);
-
-    // Push this context as the thread default so GDBus dispatches signals here
     g_main_context_push_thread_default(ctx);
 
-    auto sub_id = g_dbus_connection_signal_subscribe(conn,
+    const auto sub_id = g_dbus_connection_signal_subscribe(conn,
       "org.freedesktop.portal.Desktop",
       "org.freedesktop.portal.Request",
       "Response",
@@ -482,24 +487,38 @@ namespace portal {
       },
       &cb_data, nullptr);
 
-    // Run the main loop with a timeout
-    auto timeout_source = g_timeout_source_new(timeout_ms);
-    g_source_set_callback(timeout_source, [](gpointer userdata) -> gboolean {
-      auto *data = static_cast<cb_data_t *>(userdata);
-      if (!data->done) {
-        if (data->loop) g_main_loop_quit(data->loop);
-      }
-      return G_SOURCE_REMOVE;
-    }, &cb_data, nullptr);
-    g_source_attach(timeout_source, ctx);
-    g_source_unref(timeout_source);
+    const auto cleanup = [&] {
+      g_dbus_connection_signal_unsubscribe(conn, sub_id);
+      g_main_context_pop_thread_default(ctx);
+      g_main_loop_unref(cb_data.loop);
+      g_main_context_unref(ctx);
+    };
 
-    g_main_loop_run(cb_data.loop);
+    auto *call_result = portal_call_sync(conn, method, params, call_timeout_ms);
+    if (!call_result) {
+      cleanup();
+      if (cb_data.result) g_variant_unref(cb_data.result);
+      return nullptr;
+    }
+    g_variant_unref(call_result);
 
-    g_dbus_connection_signal_unsubscribe(conn, sub_id);
-    g_main_context_pop_thread_default(ctx);
-    g_main_loop_unref(cb_data.loop);
-    g_main_context_unref(ctx);
+    // The callback may already have run while call_sync() dispatched D-Bus
+    // traffic. Do not enter the loop after a completed fast response.
+    if (!cb_data.done) {
+      auto *timeout_source = g_timeout_source_new(response_timeout_ms);
+      g_source_set_callback(timeout_source, [](gpointer userdata) -> gboolean {
+        auto *data = static_cast<cb_data_t *>(userdata);
+        if (!data->done && data->loop) {
+          g_main_loop_quit(data->loop);
+        }
+        return G_SOURCE_REMOVE;
+      }, &cb_data, nullptr);
+      g_source_attach(timeout_source, ctx);
+      g_source_unref(timeout_source);
+      g_main_loop_run(cb_data.loop);
+    }
+
+    cleanup();
 
     if (!cb_data.done) {
       BOOST_LOG(warning) << "portal: Timeout waiting for response on "sv << request_path;
@@ -564,11 +583,13 @@ namespace portal {
       g_variant_builder_add(&builder, "{sv}", "handle_token",
         g_variant_new_string(handle_token.c_str()));
 
-      auto *result = portal_call_sync(session->conn, "CreateSession",
-        g_variant_new("(a{sv})", &builder));
-      if (result) g_variant_unref(result);
-
-      auto *resp = wait_for_response(session->conn, req_path, 10000);
+      auto *resp = portal_call_and_wait_for_response(
+        session->conn,
+        "CreateSession",
+        g_variant_new("(a{sv})", &builder),
+        req_path,
+        5000,
+        10000);
       if (!resp) {
         session->failed = true;
         return session;
@@ -631,23 +652,15 @@ namespace portal {
           }
         }
 
-        auto *result = portal_call_sync(session->conn, "SelectSources",
-          g_variant_new("(oa{sv})", session->session_handle.c_str(), &builder));
-        if (!result) {
-          // InvalidArgument / failed restore often fails the method call itself
-          // (no Response signal). Treat as SelectSources failure immediately.
-          BOOST_LOG(warning) << "portal: SelectSources D-Bus call failed"
-                             << (use_restore_token && !saved_token.empty() ?
-                                   " (restore token or cursor mode rejected)" :
-                                   "")
-                             << ""sv;
-          return nullptr;
-        }
-        g_variant_unref(result);
-
-        auto *resp = wait_for_response(session->conn, req_path, 10000);
+        auto *resp = portal_call_and_wait_for_response(
+          session->conn,
+          "SelectSources",
+          g_variant_new("(oa{sv})", session->session_handle.c_str(), &builder),
+          req_path,
+          5000,
+          10000);
         if (!resp) {
-          BOOST_LOG(warning) << "portal: SelectSources response missing or non-zero"
+          BOOST_LOG(warning) << "portal: SelectSources request failed or response missing"
                              << (use_restore_token && !saved_token.empty() ?
                                    " (stale restore token likely)" :
                                    "")
@@ -697,12 +710,13 @@ namespace portal {
         g_variant_builder_add(&builder, "{sv}", "handle_token",
           g_variant_new_string(handle_token.c_str()));
 
-        auto *result = portal_call_sync(session->conn, "Start",
+        return portal_call_and_wait_for_response(
+          session->conn,
+          "Start",
           g_variant_new("(osa{sv})", session->session_handle.c_str(), "", &builder),
+          req_path,
+          start_timeout_ms,
           start_timeout_ms);
-        if (result) g_variant_unref(result);
-
-        return wait_for_response(session->conn, req_path, start_timeout_ms);
       };
 
       auto *resp = try_start(next_handle_token("polaris_st"));

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -45,6 +45,23 @@ namespace portal {
       const void *owner_tag = nullptr;
     };
 
+    struct portal_response_wait_data_t {
+      GVariant *result = nullptr;
+      std::atomic<bool> done {false};
+      std::atomic<bool> cancelled {false};
+      uint32_t response = 99;
+      GMainLoop *loop = nullptr;
+    };
+
+    gboolean cancel_portal_response_wait(GCancellable *, gpointer userdata) {
+      auto *data = static_cast<portal_response_wait_data_t *>(userdata);
+      data->cancelled = true;
+      if (data->loop) {
+        g_main_loop_quit(data->loop);
+      }
+      return G_SOURCE_REMOVE;
+    }
+
     std::mutex g_pending_request_mutex;
     std::vector<pending_request_t> g_pending_requests;
 
@@ -147,6 +164,25 @@ namespace portal {
     g_object_unref(first);
     g_object_unref(second);
     return matched;
+  }
+
+  bool portal_cancel_source_wakes_wait_for_tests() {
+    portal_response_wait_data_t data;
+    auto *context = g_main_context_new();
+    data.loop = g_main_loop_new(context, FALSE);
+    auto *cancellable = g_cancellable_new();
+    auto *source = g_cancellable_source_new(cancellable);
+    g_source_set_callback(source, G_SOURCE_FUNC(cancel_portal_response_wait), &data, nullptr);
+    g_source_attach(source, context);
+    g_cancellable_cancel(cancellable);
+    const bool dispatched = g_main_context_iteration(context, FALSE);
+    const bool woke = dispatched && data.cancelled;
+    g_source_destroy(source);
+    g_source_unref(source);
+    g_object_unref(cancellable);
+    g_main_loop_unref(data.loop);
+    g_main_context_unref(context);
+    return woke;
   }
 #endif
 
@@ -600,13 +636,7 @@ namespace portal {
     int call_timeout_ms = 5000,
     int response_timeout_ms = 30000) {
 
-    struct cb_data_t {
-      GVariant *result = nullptr;
-      std::atomic<bool> done {false};
-      std::atomic<bool> cancelled {false};
-      uint32_t response = 99;
-      GMainLoop *loop = nullptr;
-    } cb_data;
+    portal_response_wait_data_t cb_data;
 
     // Capture signal delivery on a dedicated thread-default context before the
     // synchronous method call can trigger a fast Response signal.
@@ -615,14 +645,12 @@ namespace portal {
     g_main_context_push_thread_default(ctx);
 
     auto *cancel_source = g_cancellable_source_new(cancellable);
-    g_source_set_callback(cancel_source, [](gpointer userdata) -> gboolean {
-      auto *data = static_cast<cb_data_t *>(userdata);
-      data->cancelled = true;
-      if (data->loop) {
-        g_main_loop_quit(data->loop);
-      }
-      return G_SOURCE_REMOVE;
-    }, &cb_data, nullptr);
+    g_source_set_callback(
+      cancel_source,
+      G_SOURCE_FUNC(cancel_portal_response_wait),
+      &cb_data,
+      nullptr
+    );
     g_source_attach(cancel_source, ctx);
     GSource *timeout_source = nullptr;
 
@@ -635,7 +663,7 @@ namespace portal {
       G_DBUS_SIGNAL_FLAGS_NO_MATCH_RULE,
       [](GDBusConnection *, const gchar *, const gchar *, const gchar *,
          const gchar *, GVariant *parameters, gpointer userdata) {
-        auto *data = static_cast<cb_data_t *>(userdata);
+        auto *data = static_cast<portal_response_wait_data_t *>(userdata);
         uint32_t resp = 0;
         GVariant *results = nullptr;
         g_variant_get(parameters, "(u@a{sv})", &resp, &results);
@@ -676,7 +704,7 @@ namespace portal {
     if (!cb_data.done && !cb_data.cancelled) {
       timeout_source = g_timeout_source_new(response_timeout_ms);
       g_source_set_callback(timeout_source, [](gpointer userdata) -> gboolean {
-        auto *data = static_cast<cb_data_t *>(userdata);
+        auto *data = static_cast<portal_response_wait_data_t *>(userdata);
         if (!data->done && data->loop) {
           g_main_loop_quit(data->loop);
         }

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -33,10 +33,88 @@
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/linux/pipewire_capture.h"
+#include "src/platform/linux/session_media.h"
 
 using namespace std::literals;
 
 namespace portal {
+
+  namespace {
+    std::mutex g_pending_request_mutex;
+    std::vector<GCancellable *> g_pending_requests;
+
+    struct cancellable_unref_t {
+      void operator()(GCancellable *cancellable) const {
+        if (cancellable) {
+          g_object_unref(cancellable);
+        }
+      }
+    };
+
+    using cancellable_ptr_t = std::unique_ptr<GCancellable, cancellable_unref_t>;
+
+    class pending_request_registration_t {
+    public:
+      explicit pending_request_registration_t(GCancellable *cancellable):
+          cancellable_ {cancellable} {
+        if (!cancellable_) {
+          return;
+        }
+        std::lock_guard lock(g_pending_request_mutex);
+        g_pending_requests.push_back(
+          G_CANCELLABLE(g_object_ref(cancellable_))
+        );
+      }
+
+      pending_request_registration_t(const pending_request_registration_t &) = delete;
+      pending_request_registration_t &operator=(const pending_request_registration_t &) = delete;
+
+      ~pending_request_registration_t() {
+        if (!cancellable_) {
+          return;
+        }
+        std::lock_guard lock(g_pending_request_mutex);
+        const auto it = std::find(g_pending_requests.begin(), g_pending_requests.end(), cancellable_);
+        if (it != g_pending_requests.end()) {
+          g_object_unref(*it);
+          g_pending_requests.erase(it);
+        }
+      }
+
+    private:
+      GCancellable *cancellable_ = nullptr;
+    };
+  }  // namespace
+
+  void cancel_pending_requests() {
+    std::vector<GCancellable *> pending;
+    {
+      std::lock_guard lock(g_pending_request_mutex);
+      pending.reserve(g_pending_requests.size());
+      for (auto *cancellable : g_pending_requests) {
+        pending.push_back(G_CANCELLABLE(g_object_ref(cancellable)));
+      }
+    }
+
+    for (auto *cancellable : pending) {
+      g_cancellable_cancel(cancellable);
+      g_object_unref(cancellable);
+    }
+  }
+
+#if defined(POLARIS_TESTS)
+  bool portal_cancel_pending_request_for_tests() {
+    auto *cancellable = g_cancellable_new();
+    bool cancelled = false;
+    {
+      pending_request_registration_t registration {cancellable};
+      cancel_pending_requests();
+      cancelled = g_cancellable_is_cancelled(cancellable);
+    }
+    g_object_unref(cancellable);
+    return cancelled;
+  }
+#endif
 
   // -----------------------------------------------------------------------
   // Restore token persistence
@@ -234,16 +312,20 @@ namespace portal {
 
   // Helper: call a portal method synchronously via D-Bus
   static GVariant *portal_call_sync(GDBusConnection *conn, const char *method,
-    GVariant *params, int timeout_ms = 5000) {
+    GVariant *params, int timeout_ms = 5000, GCancellable *cancellable = nullptr) {
     GError *gerr = nullptr;
     auto *result = g_dbus_connection_call_sync(conn,
       "org.freedesktop.portal.Desktop",
       "/org/freedesktop/portal/desktop",
       "org.freedesktop.portal.ScreenCast",
       method, params, nullptr,
-      G_DBUS_CALL_FLAGS_NONE, timeout_ms, nullptr, &gerr);
+      G_DBUS_CALL_FLAGS_NONE, timeout_ms, cancellable, &gerr);
     if (!result && gerr) {
-      BOOST_LOG(warning) << "portal: D-Bus call "sv << method << " failed: "sv << gerr->message;
+      if (g_error_matches(gerr, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+        BOOST_LOG(info) << "portal: D-Bus call "sv << method << " cancelled for teardown"sv;
+      } else {
+        BOOST_LOG(warning) << "portal: D-Bus call "sv << method << " failed: "sv << gerr->message;
+      }
       g_error_free(gerr);
     }
     return result;
@@ -253,7 +335,10 @@ namespace portal {
   // 1 = Hidden, 2 = Embedded, 4 = Metadata.
   // gamescope portal may report 0 until it is bound to a live compositor; never
   // hard-require Embedded (2) — that yields InvalidArgument and hangs handshake.
-  static uint32_t portal_available_cursor_modes(GDBusConnection *conn) {
+  static uint32_t portal_available_cursor_modes(
+    GDBusConnection *conn,
+    GCancellable *cancellable
+  ) {
     GError *gerr = nullptr;
     auto *result = g_dbus_connection_call_sync(conn,
       "org.freedesktop.portal.Desktop",
@@ -264,11 +349,15 @@ namespace portal {
       G_VARIANT_TYPE("(v)"),
       G_DBUS_CALL_FLAGS_NONE,
       3000,
-      nullptr,
+      cancellable,
       &gerr);
     if (!result) {
       if (gerr) {
-        BOOST_LOG(warning) << "portal: AvailableCursorModes query failed: "sv << gerr->message;
+        if (g_error_matches(gerr, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
+          BOOST_LOG(info) << "portal: AvailableCursorModes query cancelled for teardown"sv;
+        } else {
+          BOOST_LOG(warning) << "portal: AvailableCursorModes query failed: "sv << gerr->message;
+        }
         g_error_free(gerr);
       }
       return 0;
@@ -312,15 +401,22 @@ namespace portal {
   // Brief wait for gamescope/xdg-desktop-portal-gamescope to advertise cursor
   // modes after bind. Avoids a cold-start AvailableCursorModes=0 path that ends
   // up omitting cursor_mode (which works but loses embedded cursors).
-  static uint32_t portal_wait_cursor_modes(GDBusConnection *conn, int timeout_ms = 2000) {
-    uint32_t modes = portal_available_cursor_modes(conn);
-    if (modes != 0 || timeout_ms <= 0) {
+  static uint32_t portal_wait_cursor_modes(
+    GDBusConnection *conn,
+    GCancellable *cancellable,
+    int timeout_ms = 2000
+  ) {
+    uint32_t modes = portal_available_cursor_modes(conn, cancellable);
+    if (modes != 0 || timeout_ms <= 0 || g_cancellable_is_cancelled(cancellable)) {
       return modes;
     }
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
     while (std::chrono::steady_clock::now() < deadline) {
+      if (g_cancellable_is_cancelled(cancellable)) {
+        break;
+      }
       std::this_thread::sleep_for(100ms);
-      modes = portal_available_cursor_modes(conn);
+      modes = portal_available_cursor_modes(conn, cancellable);
       if (modes != 0) {
         BOOST_LOG(info) << "portal: AvailableCursorModes became "sv << modes
                         << " after wait"sv;
@@ -392,7 +488,17 @@ namespace portal {
     return std::nullopt;
   }
 
-  int open_pipewire_remote_fd(GDBusConnection *conn, const std::string &session_handle) {
+  int open_pipewire_remote_fd(
+    GDBusConnection *conn,
+    const std::string &session_handle
+  ) {
+    cancellable_ptr_t cancellable_owner {g_cancellable_new()};
+    auto *cancellable = cancellable_owner.get();
+    pending_request_registration_t registration {cancellable};
+    if (session_media::teardown_in_progress()) {
+      g_cancellable_cancel(cancellable);
+    }
+
     GVariantBuilder builder;
     g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sv}"));
 
@@ -410,7 +516,7 @@ namespace portal {
       10000,
       nullptr,
       &out_fd_list,
-      nullptr,
+      cancellable,
       &gerr);
 
     if (!result) {
@@ -443,20 +549,27 @@ namespace portal {
     return fd;
   }
 
+  struct portal_request_result_t {
+    GVariant *response = nullptr;
+    bool cancelled = false;
+  };
+
   // Subscribe to Request::Response before issuing the portal method call.
   // Fast KDE responses can otherwise arrive between call_sync() returning and
   // signal subscription, leaving the caller blocked until its timeout.
-  static GVariant *portal_call_and_wait_for_response(
+  static portal_request_result_t portal_call_and_wait_for_response(
     GDBusConnection *conn,
     const char *method,
     GVariant *params,
     const std::string &request_path,
+    GCancellable *cancellable,
     int call_timeout_ms = 5000,
     int response_timeout_ms = 30000) {
 
     struct cb_data_t {
       GVariant *result = nullptr;
       std::atomic<bool> done {false};
+      std::atomic<bool> cancelled {false};
       uint32_t response = 99;
       GMainLoop *loop = nullptr;
     } cb_data;
@@ -466,6 +579,18 @@ namespace portal {
     auto *ctx = g_main_context_new();
     cb_data.loop = g_main_loop_new(ctx, FALSE);
     g_main_context_push_thread_default(ctx);
+
+    auto *cancel_source = g_cancellable_source_new(cancellable);
+    g_source_set_callback(cancel_source, [](gpointer userdata) -> gboolean {
+      auto *data = static_cast<cb_data_t *>(userdata);
+      data->cancelled = true;
+      if (data->loop) {
+        g_main_loop_quit(data->loop);
+      }
+      return G_SOURCE_REMOVE;
+    }, &cb_data, nullptr);
+    g_source_attach(cancel_source, ctx);
+    GSource *timeout_source = nullptr;
 
     const auto sub_id = g_dbus_connection_signal_subscribe(conn,
       "org.freedesktop.portal.Desktop",
@@ -489,23 +614,33 @@ namespace portal {
 
     const auto cleanup = [&] {
       g_dbus_connection_signal_unsubscribe(conn, sub_id);
+      if (timeout_source) {
+        g_source_destroy(timeout_source);
+        g_source_unref(timeout_source);
+      }
+      g_source_destroy(cancel_source);
+      g_source_unref(cancel_source);
       g_main_context_pop_thread_default(ctx);
       g_main_loop_unref(cb_data.loop);
       g_main_context_unref(ctx);
     };
 
-    auto *call_result = portal_call_sync(conn, method, params, call_timeout_ms);
+    auto *call_result = portal_call_sync(conn, method, params, call_timeout_ms, cancellable);
     if (!call_result) {
       cleanup();
       if (cb_data.result) g_variant_unref(cb_data.result);
-      return nullptr;
+      return {nullptr, g_cancellable_is_cancelled(cancellable) != FALSE};
     }
     g_variant_unref(call_result);
 
+    if (g_cancellable_is_cancelled(cancellable)) {
+      cb_data.cancelled = true;
+    }
+
     // The callback may already have run while call_sync() dispatched D-Bus
     // traffic. Do not enter the loop after a completed fast response.
-    if (!cb_data.done) {
-      auto *timeout_source = g_timeout_source_new(response_timeout_ms);
+    if (!cb_data.done && !cb_data.cancelled) {
+      timeout_source = g_timeout_source_new(response_timeout_ms);
       g_source_set_callback(timeout_source, [](gpointer userdata) -> gboolean {
         auto *data = static_cast<cb_data_t *>(userdata);
         if (!data->done && data->loop) {
@@ -514,23 +649,27 @@ namespace portal {
         return G_SOURCE_REMOVE;
       }, &cb_data, nullptr);
       g_source_attach(timeout_source, ctx);
-      g_source_unref(timeout_source);
       g_main_loop_run(cb_data.loop);
     }
 
     cleanup();
 
+    if (cb_data.cancelled) {
+      BOOST_LOG(info) << "portal: Request cancelled for teardown on "sv << request_path;
+      if (cb_data.result) g_variant_unref(cb_data.result);
+      return {nullptr, true};
+    }
     if (!cb_data.done) {
       BOOST_LOG(warning) << "portal: Timeout waiting for response on "sv << request_path;
-      return nullptr;
+      return {};
     }
     if (cb_data.response != 0) {
       BOOST_LOG(warning) << "portal: Response code "sv << cb_data.response
                          << " on "sv << request_path;
       if (cb_data.result) g_variant_unref(cb_data.result);
-      return nullptr;
+      return {};
     }
-    return cb_data.result;
+    return {cb_data.result, false};
   }
 
   // Build the request object path from the connection's unique name and a token
@@ -559,6 +698,12 @@ namespace portal {
 
   std::unique_ptr<portal_session_t> create_portal_session(uint32_t capture_type) {
     auto session = std::make_unique<portal_session_t>();
+    cancellable_ptr_t cancellable_owner {g_cancellable_new()};
+    auto *cancellable = cancellable_owner.get();
+    pending_request_registration_t registration {cancellable};
+    if (session_media::teardown_in_progress()) {
+      g_cancellable_cancel(cancellable);
+    }
 
     GError *gerr = nullptr;
     session->conn = portal_bus_connection(&gerr);
@@ -583,17 +728,19 @@ namespace portal {
       g_variant_builder_add(&builder, "{sv}", "handle_token",
         g_variant_new_string(handle_token.c_str()));
 
-      auto *resp = portal_call_and_wait_for_response(
+      auto result = portal_call_and_wait_for_response(
         session->conn,
         "CreateSession",
         g_variant_new("(a{sv})", &builder),
         req_path,
+        cancellable,
         5000,
         10000);
-      if (!resp) {
+      if (!result.response) {
         session->failed = true;
         return session;
       }
+      auto *resp = result.response;
 
       GVariant *handle_v = g_variant_lookup_value(resp, "session_handle", G_VARIANT_TYPE_STRING);
       if (handle_v) {
@@ -615,8 +762,11 @@ namespace portal {
     // retry SelectSources once without it; Start will persist a fresh token.
     BOOST_LOG(info) << "portal: Selecting sources (type="sv << capture_type << ")..."sv;
     {
-      auto try_select_sources = [&](const std::string &handle_token, bool use_restore_token) -> GVariant * {
-        const uint32_t available_cursor = portal_wait_cursor_modes(session->conn);
+      auto try_select_sources = [&](const std::string &handle_token, bool use_restore_token) -> portal_request_result_t {
+        const uint32_t available_cursor = portal_wait_cursor_modes(session->conn, cancellable);
+        if (g_cancellable_is_cancelled(cancellable)) {
+          return {nullptr, true};
+        }
         const uint32_t cursor_mode = portal_pick_cursor_mode(available_cursor);
         BOOST_LOG(info) << "portal: AvailableCursorModes="sv << available_cursor
                         << " selected_cursor_mode="sv << cursor_mode
@@ -652,28 +802,33 @@ namespace portal {
           }
         }
 
-        auto *resp = portal_call_and_wait_for_response(
+        auto result = portal_call_and_wait_for_response(
           session->conn,
           "SelectSources",
           g_variant_new("(oa{sv})", session->session_handle.c_str(), &builder),
           req_path,
+          cancellable,
           5000,
           10000);
-        if (!resp) {
+        if (!result.response && !result.cancelled) {
           BOOST_LOG(warning) << "portal: SelectSources request failed or response missing"
                              << (use_restore_token && !saved_token.empty() ?
                                    " (stale restore token likely)" :
                                    "")
                              << ""sv;
         }
-        return resp;
+        return result;
       };
 
       // Always prefer restore tokens when present. Host vs private gamescope portals
       // use separate on-disk files (token_path), so they cannot cross-contaminate.
       const bool had_saved_token = !load_restore_token().empty();
-      auto *resp = try_select_sources(next_handle_token("polaris_ss"), true);
-      if (!resp) {
+      auto result = try_select_sources(next_handle_token("polaris_ss"), true);
+      if (!result.response) {
+        if (result.cancelled) {
+          session->failed = true;
+          return session;
+        }
         if (had_saved_token) {
           // Policy: always invalidate the on-disk token after SelectSources
           // failure, then retry once without restore_token. Cursor is re-queried
@@ -681,13 +836,13 @@ namespace portal {
           clear_restore_token();
         }
         BOOST_LOG(warning) << "portal: SelectSources failed — retry once without restore_token"sv;
-        resp = try_select_sources(next_handle_token("polaris_ss"), false);
-        if (!resp) {
+        result = try_select_sources(next_handle_token("polaris_ss"), false);
+        if (!result.response) {
           session->failed = true;
           return session;
         }
       }
-      g_variant_unref(resp);
+      g_variant_unref(result.response);
     }
 
     // Step 3: Start. With a host restore token this is non-interactive and must
@@ -702,7 +857,7 @@ namespace portal {
                                               " (ScreenCast picker may appear on host — approve once)"sv)
                     << " timeout_ms="sv << start_timeout_ms << ""sv;
     {
-      auto try_start = [&](const std::string &handle_token) -> GVariant * {
+      auto try_start = [&](const std::string &handle_token) -> portal_request_result_t {
         std::string req_path = make_request_path(session->conn, handle_token);
 
         GVariantBuilder builder;
@@ -715,24 +870,28 @@ namespace portal {
           "Start",
           g_variant_new("(osa{sv})", session->session_handle.c_str(), "", &builder),
           req_path,
+          cancellable,
           start_timeout_ms,
           start_timeout_ms);
       };
 
-      auto *resp = try_start(next_handle_token("polaris_st"));
-      if (!resp) {
-        // Bad/stale restore token often hangs Start with no Response; drop it so
-        // the next connect can re-bootstrap with a visible picker.
-        clear_restore_token();
-        // Nested↔idle gamescope handoff leaves a short window where
-        // xdg-desktop-portal-gamescope cannot open WAYLAND_DISPLAY=gamescope-0
-        // ("failed to connect to wayland socket" → Response code 2). One delayed
-        // retry on a *fresh* session is owned by the caller; here we only clear
-        // the token so the next CreateSession is clean.
-        BOOST_LOG(warning) << "portal: Start timeout/failure — cleared restore_token (no Start retry; session is single-use)"sv;
+      auto result = try_start(next_handle_token("polaris_st"));
+      if (!result.response) {
+        if (!result.cancelled) {
+          // Bad/stale restore token often hangs Start with no Response; drop it so
+          // the next connect can re-bootstrap with a visible picker.
+          clear_restore_token();
+          // Nested↔idle gamescope handoff leaves a short window where
+          // xdg-desktop-portal-gamescope cannot open WAYLAND_DISPLAY=gamescope-0
+          // ("failed to connect to wayland socket" → Response code 2). One delayed
+          // retry on a *fresh* session is owned by the caller; here we only clear
+          // the token so the next CreateSession is clean.
+          BOOST_LOG(warning) << "portal: Start timeout/failure — cleared restore_token (no Start retry; session is single-use)"sv;
+        }
         session->failed = true;
         return session;
       }
+      auto *resp = result.response;
 
       // Parse streams
       GVariant *streams_v = g_variant_lookup_value(resp, "streams", nullptr);
@@ -773,7 +932,10 @@ namespace portal {
       g_variant_unref(resp);
 
       if (session->pw_node_id > 0) {
-        session->pw_remote_fd = open_pipewire_remote_fd(session->conn, session->session_handle);
+        session->pw_remote_fd = open_pipewire_remote_fd(
+          session->conn,
+          session->session_handle
+        );
         if (session->pw_remote_fd < 0) {
           session->failed = true;
           return session;

--- a/src/platform/linux/portal_session.h
+++ b/src/platform/linux/portal_session.h
@@ -80,6 +80,7 @@ namespace portal {
   uint32_t portal_pick_cursor_mode_for_tests(uint32_t available);
   bool portal_cancel_pending_request_for_tests();
   bool portal_cancel_request_owner_for_tests();
+  bool portal_cancel_source_wakes_wait_for_tests();
 #endif
 
   /**

--- a/src/platform/linux/portal_session.h
+++ b/src/platform/linux/portal_session.h
@@ -57,7 +57,7 @@ namespace portal {
    *
    * Safe to call from teardown before waiting for admitted media starts.
    */
-  void cancel_pending_requests();
+  void cancel_pending_requests(const void *owner_tag = nullptr);
 
   uint32_t capture_type_for_stream_display(bool headless_mode, bool use_cage_compositor,
                                            std::string_view stream_mode = {});
@@ -79,6 +79,7 @@ namespace portal {
 #if defined(POLARIS_TESTS)
   uint32_t portal_pick_cursor_mode_for_tests(uint32_t available);
   bool portal_cancel_pending_request_for_tests();
+  bool portal_cancel_request_owner_for_tests();
 #endif
 
   /**

--- a/src/platform/linux/portal_session.h
+++ b/src/platform/linux/portal_session.h
@@ -52,6 +52,13 @@ namespace portal {
 
   bool is_portal_available();
 
+  /**
+   * @brief Cancel in-flight portal D-Bus calls and response waits.
+   *
+   * Safe to call from teardown before waiting for admitted media starts.
+   */
+  void cancel_pending_requests();
+
   uint32_t capture_type_for_stream_display(bool headless_mode, bool use_cage_compositor,
                                            std::string_view stream_mode = {});
 
@@ -64,10 +71,14 @@ namespace portal {
    * @brief OpenPipeWireRemote on an existing ScreenCast session handle.
    * @return Owned fd, or -1 on failure.
    */
-  int open_pipewire_remote_fd(GDBusConnection *conn, const std::string &session_handle);
+  int open_pipewire_remote_fd(
+    GDBusConnection *conn,
+    const std::string &session_handle
+  );
 
 #if defined(POLARIS_TESTS)
   uint32_t portal_pick_cursor_mode_for_tests(uint32_t available);
+  bool portal_cancel_pending_request_for_tests();
 #endif
 
   /**

--- a/src/platform/linux/session_media.cpp
+++ b/src/platform/linux/session_media.cpp
@@ -9,7 +9,9 @@
 
   #include "src/browser_stream.h"
   #include "src/logging.h"
-  #include "src/platform/linux/portal_session.h"
+  #ifdef POLARIS_BUILD_PORTAL
+    #include "src/platform/linux/portal_session.h"
+  #endif
 
   #include <condition_variable>
   #include <deque>
@@ -146,7 +148,9 @@ namespace session_media {
       std::lock_guard lock(state.mutex);
       ++state.owners[owner_tag];
     }
+  #ifdef POLARIS_BUILD_PORTAL
     portal::cancel_pending_requests(owner_tag);
+  #endif
     return owner;
   }
 
@@ -178,7 +182,9 @@ namespace session_media {
 
   teardown_owner_t begin_teardown() {
     return media_gate().begin_teardown([] {
+  #ifdef POLARIS_BUILD_PORTAL
       portal::cancel_pending_requests();
+  #endif
     });
   }
 

--- a/src/platform/linux/session_media.cpp
+++ b/src/platform/linux/session_media.cpp
@@ -15,6 +15,8 @@
   #include <deque>
   #include <mutex>
   #include <thread>
+  #include <unordered_map>
+  #include <utility>
 
 using namespace std::literals;
 
@@ -41,6 +43,18 @@ namespace session_media {
       static auto *gate = new teardown_gate_t;
       return *gate;
     }
+
+    struct pending_cancel_state_t {
+      std::mutex mutex;
+      std::unordered_map<const void *, unsigned> owners;
+    };
+
+    pending_cancel_state_t &pending_cancel_state() {
+      static auto *state = new pending_cancel_state_t;
+      return *state;
+    }
+
+    thread_local const void *current_pending_start_owner = nullptr;
 
     void worker_main(worker_state_t *state) {
       for (;;) {
@@ -89,6 +103,74 @@ namespace session_media {
       }
     }
   }  // namespace
+
+  pending_start_cancel_owner_t::pending_start_cancel_owner_t(
+    pending_start_cancel_owner_t &&other
+  ) noexcept:
+      owner_tag_(std::exchange(other.owner_tag_, nullptr)) {}
+
+  pending_start_cancel_owner_t &pending_start_cancel_owner_t::operator=(
+    pending_start_cancel_owner_t &&other
+  ) noexcept {
+    if (this != &other) {
+      reset();
+      owner_tag_ = std::exchange(other.owner_tag_, nullptr);
+    }
+    return *this;
+  }
+
+  pending_start_cancel_owner_t::~pending_start_cancel_owner_t() {
+    reset();
+  }
+
+  void pending_start_cancel_owner_t::reset() noexcept {
+    const auto *owner_tag = std::exchange(owner_tag_, nullptr);
+    if (!owner_tag) {
+      return;
+    }
+    auto &state = pending_cancel_state();
+    std::lock_guard lock(state.mutex);
+    const auto it = state.owners.find(owner_tag);
+    if (it != state.owners.end() && --it->second == 0) {
+      state.owners.erase(it);
+    }
+  }
+
+  pending_start_cancel_owner_t cancel_pending_starts(const void *owner_tag) {
+    if (!owner_tag) {
+      return {};
+    }
+    auto owner = pending_start_cancel_owner_t {owner_tag};
+    auto &state = pending_cancel_state();
+    {
+      std::lock_guard lock(state.mutex);
+      ++state.owners[owner_tag];
+    }
+    portal::cancel_pending_requests(owner_tag);
+    return owner;
+  }
+
+  bool pending_start_cancelled(const void *owner_tag) {
+    if (!owner_tag) {
+      return false;
+    }
+    auto &state = pending_cancel_state();
+    std::lock_guard lock(state.mutex);
+    return state.owners.contains(owner_tag);
+  }
+
+  pending_start_owner_scope_t::pending_start_owner_scope_t(const void *owner_tag):
+      previous_(current_pending_start_owner) {
+    current_pending_start_owner = owner_tag;
+  }
+
+  pending_start_owner_scope_t::~pending_start_owner_scope_t() {
+    current_pending_start_owner = previous_;
+  }
+
+  const void *pending_start_owner() {
+    return current_pending_start_owner;
+  }
 
   start_owner_t begin_start() {
     return media_gate().begin_start();

--- a/src/platform/linux/session_media.cpp
+++ b/src/platform/linux/session_media.cpp
@@ -9,6 +9,7 @@
 
   #include "src/browser_stream.h"
   #include "src/logging.h"
+  #include "src/platform/linux/portal_session.h"
 
   #include <condition_variable>
   #include <deque>
@@ -94,7 +95,13 @@ namespace session_media {
   }
 
   teardown_owner_t begin_teardown() {
-    return media_gate().begin_teardown();
+    return media_gate().begin_teardown([] {
+      portal::cancel_pending_requests();
+    });
+  }
+
+  bool teardown_in_progress() {
+    return media_gate().teardown_in_progress();
   }
 
   teardown_owner_t prepare_for_stop() {

--- a/src/platform/linux/session_media.h
+++ b/src/platform/linux/session_media.h
@@ -33,6 +33,11 @@ namespace session_media {
   teardown_owner_t begin_teardown();
 
   /**
+   * @brief Whether teardown has closed admission for new media starts.
+   */
+  bool teardown_in_progress();
+
+  /**
    * @brief Ordered media teardown for an ending stream session.
    *
    * 1) signal Browser Stream capture shutdown (if any)

--- a/src/platform/linux/session_media.h
+++ b/src/platform/linux/session_media.h
@@ -16,6 +16,37 @@
 
 namespace session_media {
 
+  class pending_start_cancel_owner_t {
+  public:
+    pending_start_cancel_owner_t() = default;
+    pending_start_cancel_owner_t(const pending_start_cancel_owner_t &) = delete;
+    pending_start_cancel_owner_t &operator=(const pending_start_cancel_owner_t &) = delete;
+    pending_start_cancel_owner_t(pending_start_cancel_owner_t &&other) noexcept;
+    pending_start_cancel_owner_t &operator=(pending_start_cancel_owner_t &&other) noexcept;
+    ~pending_start_cancel_owner_t();
+
+  private:
+    friend pending_start_cancel_owner_t cancel_pending_starts(const void *owner_tag);
+    explicit pending_start_cancel_owner_t(const void *owner_tag): owner_tag_(owner_tag) {}
+    void reset() noexcept;
+    const void *owner_tag_ = nullptr;
+  };
+
+  class pending_start_owner_scope_t {
+  public:
+    explicit pending_start_owner_scope_t(const void *owner_tag);
+    pending_start_owner_scope_t(const pending_start_owner_scope_t &) = delete;
+    pending_start_owner_scope_t &operator=(const pending_start_owner_scope_t &) = delete;
+    ~pending_start_owner_scope_t();
+
+  private:
+    const void *previous_ = nullptr;
+  };
+
+  pending_start_cancel_owner_t cancel_pending_starts(const void *owner_tag);
+  bool pending_start_cancelled(const void *owner_tag);
+  const void *pending_start_owner();
+
   /**
    * @brief Admit a capture/runtime start after all prior teardown owners finish.
    *

--- a/src/platform/linux/session_media_gate.h
+++ b/src/platform/linux/session_media_gate.h
@@ -137,9 +137,24 @@ namespace session_media {
     }
 
     teardown_owner_t begin_teardown() {
+      return begin_teardown([]() {});
+    }
+
+    template <typename Announcement>
+    teardown_owner_t begin_teardown(Announcement &&announce) {
       std::unique_lock lock(state_->mutex);
       ++state_->teardown_owners;
       state_->changed.notify_all();
+      try {
+        // The announcement runs after admission closes but before waiting for
+        // existing starts. Keep it non-blocking and do not re-enter this gate.
+        std::forward<Announcement>(announce)();
+      } catch (...) {
+        --state_->teardown_owners;
+        lock.unlock();
+        state_->changed.notify_all();
+        throw;
+      }
       state_->changed.wait(lock, [this]() {
         return state_->start_owners == 0;
       });

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -31,6 +31,9 @@ extern "C" {
 #include "logging.h"
 #include "network.h"
 #include "platform/common.h"
+#ifdef __linux__
+  #include "platform/linux/session_media.h"
+#endif
 #include "process.h"
 #include "stream.h"
 #include "stream_recorder.h"
@@ -2247,6 +2250,9 @@ namespace stream {
       });
 
       BOOST_LOG(debug) << "Waiting for video to end..."sv;
+#ifdef __linux__
+      auto pending_start_cancel = session_media::cancel_pending_starts(&session);
+#endif
       session.videoThread.join();
       BOOST_LOG(debug) << "Waiting for audio to end..."sv;
       session.audioThread.join();

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -43,6 +43,7 @@ extern "C" {
 
 #ifdef __linux__
   #include "platform/linux/stream_runtime.h"
+  #include "platform/linux/session_media.h"
   #include "platform/linux/cuda.h"
   #include "platform/linux/graphics.h"
   #include "platform/linux/vaapi.h"
@@ -1424,6 +1425,7 @@ namespace video {
   struct capture_ctx_t {
     img_event_t images;
     config_t config;
+    void *channel_data;
   };
 
   struct capture_thread_async_ctx_t {
@@ -2154,6 +2156,12 @@ namespace video {
     std::vector<std::string> display_names;
     int display_p = -1;
     std::shared_ptr<platf::display_t> disp;
+    {
+#ifdef __linux__
+    session_media::pending_start_owner_scope_t initial_owner_scope {
+      capture_ctxs.front().channel_data
+    };
+#endif
     if (!proc::proc.display_name.empty()) {
       disp = platf::display(encoder.platform_formats->dev_type, proc::proc.display_name, capture_ctxs.front().config);
     }
@@ -2171,6 +2179,7 @@ namespace video {
       } else {
         return;
       }
+    }
     }
 
     display_wp = disp;
@@ -2381,7 +2390,14 @@ namespace video {
               }
 
               // reset_display() will sleep between retries
-              reset_display(disp, encoder.platform_formats->dev_type, display_names[display_p], capture_ctxs.front().config);
+              {
+#ifdef __linux__
+                session_media::pending_start_owner_scope_t owner_scope {
+                  capture_ctxs.front().channel_data
+                };
+#endif
+                reset_display(disp, encoder.platform_formats->dev_type, display_names[display_p], capture_ctxs.front().config);
+              }
               if (disp) {
                 proc::proc.display_name = display_names[display_p];
                 break;
@@ -3562,7 +3578,14 @@ namespace video {
       }
 
       // reset_display() will sleep between retries
-      reset_display(disp, encoder.platform_formats->dev_type, display_names[display_p], synced_session_ctxs.front()->config);
+      {
+#ifdef __linux__
+        session_media::pending_start_owner_scope_t owner_scope {
+          synced_session_ctxs.front()->channel_data
+        };
+#endif
+        reset_display(disp, encoder.platform_formats->dev_type, display_names[display_p], synced_session_ctxs.front()->config);
+      }
       if (disp) {
         break;
       }
@@ -3739,7 +3762,7 @@ namespace video {
       return;
     }
 
-    ref->capture_ctx_queue->raise(capture_ctx_t {images, config});
+    ref->capture_ctx_queue->raise(capture_ctx_t {images, config, channel_data});
 
     if (!ref->capture_ctx_queue->running()) {
       return;

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -23,6 +23,7 @@
 #include "src/platform/common.h"
 #include "src/platform/linux/pipewire_capture.h"
 #include "src/platform/linux/portal_session.h"
+#include "src/platform/linux/session_media.h"
 
 #ifdef POLARIS_BUILD_WAYLAND
   #include "src/platform/linux/kwingrab.h"
@@ -31,6 +32,7 @@
 namespace portal {
   std::uint32_t portal_pick_cursor_mode_for_tests(std::uint32_t available);
   bool portal_cancel_pending_request_for_tests();
+  bool portal_cancel_request_owner_for_tests();
 }
 
 TEST(PortalGrabPolicyTests, DesktopDisplayRequestsMonitorSource) {
@@ -142,6 +144,22 @@ TEST(PortalGrabPolicyTests, CursorModePrefersEmbeddedThenMetadataThenHidden) {
 
 TEST(PortalGrabPolicyTests, CancelPendingRequestsCancelsRegisteredRequest) {
   EXPECT_TRUE(portal::portal_cancel_pending_request_for_tests());
+}
+
+TEST(PortalGrabPolicyTests, CancelPendingRequestsMatchesOwner) {
+  EXPECT_TRUE(portal::portal_cancel_request_owner_for_tests());
+}
+
+TEST(PortalGrabPolicyTests, PendingStartCancellationScopeIsOwnerBounded) {
+  int owner_a = 0;
+  int owner_b = 0;
+  EXPECT_FALSE(session_media::pending_start_cancelled(&owner_a));
+  {
+    auto owner = session_media::cancel_pending_starts(&owner_a);
+    EXPECT_TRUE(session_media::pending_start_cancelled(&owner_a));
+    EXPECT_FALSE(session_media::pending_start_cancelled(&owner_b));
+  }
+  EXPECT_FALSE(session_media::pending_start_cancelled(&owner_a));
 }
 
 TEST(PortalGrabPolicyTests, TeardownCancelsPortalWaitBeforeWaitingForStartFence) {
@@ -265,10 +283,12 @@ TEST(PortalGrabPolicyTests, TeardownCancellationCoversRemoteReopenAndRetryLoop) 
   ASSERT_NE(ensure_begin, std::string::npos);
   ASSERT_NE(ensure_end, std::string::npos);
   const auto ensure_body = grab_source.substr(ensure_begin, ensure_end - ensure_begin);
-  const auto shutdown_guard = ensure_body.find("if (session_media::teardown_in_progress())");
+  const auto shutdown_guard = ensure_body.find(
+    "if (session_media::teardown_in_progress() || session_media::pending_start_cancelled(session_media::pending_start_owner()))"
+  );
   const auto retry_sleep = ensure_body.find("std::this_thread::sleep_for");
   ASSERT_NE(shutdown_guard, std::string::npos)
-    << "a cancelled portal session must not enter the retry backoff during teardown";
+    << "a cancelled portal session must not enter retry backoff during stop";
   ASSERT_NE(retry_sleep, std::string::npos);
   EXPECT_LT(shutdown_guard, retry_sleep);
 }

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -178,6 +178,27 @@ TEST(PortalGrabPolicyTests, LegacyRestoreTokenMigrationIsOneShot) {
     << "copying leaves the legacy token behind and reimports it after clear_restore_token()";
 }
 
+TEST(PortalGrabPolicyTests, ResponseSignalSubscriptionPrecedesPortalMethodCall) {
+  const auto path = std::filesystem::path(POLARIS_SOURCE_DIR) / "src/platform/linux/portal_session.cpp";
+  std::ifstream in(path);
+  ASSERT_TRUE(in.good());
+  std::ostringstream out;
+  out << in.rdbuf();
+  const auto body = out.str();
+
+  const auto helper = body.find("portal_call_and_wait_for_response");
+  ASSERT_NE(helper, std::string::npos)
+    << "portal requests need one helper that subscribes before issuing the synchronous method call";
+  const auto subscribe = body.find("g_dbus_connection_signal_subscribe", helper);
+  const auto call = body.find("portal_call_sync(conn, method", helper);
+  ASSERT_NE(subscribe, std::string::npos);
+  ASSERT_NE(call, std::string::npos);
+  EXPECT_LT(subscribe, call)
+    << "a fast Request::Response signal is lost when subscription starts after the portal method returns";
+  EXPECT_EQ(body.find("wait_for_response(session->conn"), std::string::npos)
+    << "CreateSession, SelectSources, and Start must all use the subscribe-before-call helper";
+}
+
 TEST(PortalGrabPolicyTests, EnsureGlobalCaptureLockContractAndUniqueTokens) {
   // S4: single media_cache_t + g_media_mu (no dual-mutex). Negotiation waits
   // outside the lock so release_global_capture can progress. Session/token

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -157,6 +157,27 @@ TEST(PortalGrabPolicyTests, SelectSourcesInvalidatesRestoreTokenOnFailure) {
   EXPECT_EQ(body.find("restore_token_disabled"), std::string::npos);
 }
 
+TEST(PortalGrabPolicyTests, LegacyRestoreTokenMigrationIsOneShot) {
+  const auto path = std::filesystem::path(POLARIS_SOURCE_DIR) / "src/platform/linux/portal_session.cpp";
+  std::ifstream in(path);
+  ASSERT_TRUE(in.good());
+  std::ostringstream out;
+  out << in.rdbuf();
+  const auto body = out.str();
+
+  const auto migration_start =
+    body.find("const std::string legacy = base + \"/portal_restore_token.txt\";");
+  ASSERT_NE(migration_start, std::string::npos);
+  const auto migration_end = body.find("return host;", migration_start);
+  ASSERT_NE(migration_end, std::string::npos);
+  const auto migration = body.substr(migration_start, migration_end - migration_start);
+
+  EXPECT_NE(migration.find("std::filesystem::rename(legacy, host, ec)"), std::string::npos)
+    << "legacy token migration must consume the source so a cleared stale host token is not resurrected";
+  EXPECT_EQ(migration.find("copy_file(legacy, host"), std::string::npos)
+    << "copying leaves the legacy token behind and reimports it after clear_restore_token()";
+}
+
 TEST(PortalGrabPolicyTests, EnsureGlobalCaptureLockContractAndUniqueTokens) {
   // S4: single media_cache_t + g_media_mu (no dual-mutex). Negotiation waits
   // outside the lock so release_global_capture can progress. Session/token

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -33,6 +33,7 @@ namespace portal {
   std::uint32_t portal_pick_cursor_mode_for_tests(std::uint32_t available);
   bool portal_cancel_pending_request_for_tests();
   bool portal_cancel_request_owner_for_tests();
+  bool portal_cancel_source_wakes_wait_for_tests();
 }
 
 TEST(PortalGrabPolicyTests, DesktopDisplayRequestsMonitorSource) {
@@ -148,6 +149,10 @@ TEST(PortalGrabPolicyTests, CancelPendingRequestsCancelsRegisteredRequest) {
 
 TEST(PortalGrabPolicyTests, CancelPendingRequestsMatchesOwner) {
   EXPECT_TRUE(portal::portal_cancel_request_owner_for_tests());
+}
+
+TEST(PortalGrabPolicyTests, CancellableSourceWakesWaitLoop) {
+  EXPECT_TRUE(portal::portal_cancel_source_wakes_wait_for_tests());
 }
 
 TEST(PortalGrabPolicyTests, PendingStartCancellationScopeIsOwnerBounded) {

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -30,6 +30,7 @@
 
 namespace portal {
   std::uint32_t portal_pick_cursor_mode_for_tests(std::uint32_t available);
+  bool portal_cancel_pending_request_for_tests();
 }
 
 TEST(PortalGrabPolicyTests, DesktopDisplayRequestsMonitorSource) {
@@ -137,6 +138,139 @@ TEST(PortalGrabPolicyTests, CursorModePrefersEmbeddedThenMetadataThenHidden) {
   EXPECT_EQ(portal::portal_pick_cursor_mode_for_tests(7), 2u);  // all → Embedded
   EXPECT_EQ(portal::portal_pick_cursor_mode_for_tests(5), 4u);  // Hidden|Metadata → Metadata
   EXPECT_EQ(portal::portal_pick_cursor_mode_for_tests(3), 2u);  // Hidden|Embedded → Embedded
+}
+
+TEST(PortalGrabPolicyTests, CancelPendingRequestsCancelsRegisteredRequest) {
+  EXPECT_TRUE(portal::portal_cancel_pending_request_for_tests());
+}
+
+TEST(PortalGrabPolicyTests, TeardownCancelsPortalWaitBeforeWaitingForStartFence) {
+  const auto portal_path =
+    std::filesystem::path(POLARIS_SOURCE_DIR) / "src/platform/linux/portal_session.cpp";
+  const auto media_path =
+    std::filesystem::path(POLARIS_SOURCE_DIR) / "src/platform/linux/session_media.cpp";
+  std::ifstream portal_in(portal_path);
+  std::ifstream media_in(media_path);
+  ASSERT_TRUE(portal_in.good());
+  ASSERT_TRUE(media_in.good());
+  std::ostringstream portal_out;
+  std::ostringstream media_out;
+  portal_out << portal_in.rdbuf();
+  media_out << media_in.rdbuf();
+  const auto portal_source = portal_out.str();
+  const auto media_source = media_out.str();
+
+  const auto begin = media_source.find("teardown_owner_t begin_teardown()");
+  const auto begin_end = media_source.find("teardown_owner_t prepare_for_stop()", begin);
+  ASSERT_NE(begin, std::string::npos);
+  ASSERT_NE(begin_end, std::string::npos);
+  const auto begin_body = media_source.substr(begin, begin_end - begin);
+  const auto gate_wait = begin_body.find("media_gate().begin_teardown([]");
+  const auto cancel = begin_body.find("portal::cancel_pending_requests()", gate_wait);
+  ASSERT_NE(gate_wait, std::string::npos)
+    << "teardown must announce cancellation atomically with closing start admission";
+  ASSERT_NE(cancel, std::string::npos)
+    << "the gate announcement must cancel in-flight portal calls before waiting for starts";
+
+  const auto helper = portal_source.find("static portal_request_result_t portal_call_and_wait_for_response");
+  const auto helper_end = portal_source.find("static std::string make_request_path", helper);
+  ASSERT_NE(helper, std::string::npos);
+  ASSERT_NE(helper_end, std::string::npos);
+  const auto helper_body = portal_source.substr(helper, helper_end - helper);
+  EXPECT_NE(helper_body.find("g_cancellable_source_new(cancellable)"), std::string::npos)
+    << "cancellation must also wake a Response wait after the method call returns";
+  EXPECT_NE(
+    helper_body.find("portal_call_sync(conn, method, params, call_timeout_ms, cancellable)"),
+    std::string::npos
+  ) << "the synchronous D-Bus call must receive the same cancellable";
+
+  const auto create = portal_source.find("std::unique_ptr<portal_session_t> create_portal_session");
+  ASSERT_NE(create, std::string::npos);
+  const auto create_body = portal_source.substr(create);
+  EXPECT_NE(create_body.find("pending_request_registration_t registration"), std::string::npos)
+    << "the cancellable must cover cursor queries and every portal request";
+  EXPECT_NE(
+    create_body.find("portal_wait_cursor_modes(session->conn, cancellable)"),
+    std::string::npos
+  ) << "cursor-mode property calls must be teardown-cancellable";
+  EXPECT_NE(create_body.find("session_media::teardown_in_progress()"), std::string::npos)
+    << "a session registered after teardown announcement must cancel itself";
+}
+
+TEST(PortalGrabPolicyTests, TeardownCancellationPreservesRestoreToken) {
+  const auto path =
+    std::filesystem::path(POLARIS_SOURCE_DIR) / "src/platform/linux/portal_session.cpp";
+  std::ifstream input(path);
+  ASSERT_TRUE(input.good());
+  std::ostringstream output;
+  output << input.rdbuf();
+  const auto source = output.str();
+
+  EXPECT_NE(source.find("struct portal_request_result_t"), std::string::npos)
+    << "portal cancellation must be distinguishable from timeout/failure";
+
+  const auto select_begin = source.find("// Step 2: SelectSources");
+  const auto select_end = source.find("// Step 3: Start", select_begin);
+  ASSERT_NE(select_begin, std::string::npos);
+  ASSERT_NE(select_end, std::string::npos);
+  const auto select_body = source.substr(select_begin, select_end - select_begin);
+  const auto select_cancelled = select_body.find("if (result.cancelled)");
+  const auto select_clear = select_body.find("clear_restore_token()");
+  ASSERT_NE(select_cancelled, std::string::npos);
+  ASSERT_NE(select_clear, std::string::npos);
+  EXPECT_LT(select_cancelled, select_clear)
+    << "SelectSources cancellation must exit before stale-token invalidation";
+
+  const auto start_begin = select_end;
+  const auto start_end = source.find("session->ready = true", start_begin);
+  ASSERT_NE(start_end, std::string::npos);
+  const auto start_body = source.substr(start_begin, start_end - start_begin);
+  const auto preserve_guard = start_body.find("if (!result.cancelled)");
+  const auto start_clear = start_body.find("clear_restore_token()", preserve_guard);
+  ASSERT_NE(preserve_guard, std::string::npos);
+  ASSERT_NE(start_clear, std::string::npos)
+    << "Start may clear a failed token only inside the non-cancelled path";
+}
+
+TEST(PortalGrabPolicyTests, TeardownCancellationCoversRemoteReopenAndRetryLoop) {
+  const auto session_path =
+    std::filesystem::path(POLARIS_SOURCE_DIR) / "src/platform/linux/portal_session.cpp";
+  const auto grab_path =
+    std::filesystem::path(POLARIS_SOURCE_DIR) / "src/platform/linux/portal_grab.cpp";
+  std::ifstream session_in(session_path);
+  std::ifstream grab_in(grab_path);
+  ASSERT_TRUE(session_in.good());
+  ASSERT_TRUE(grab_in.good());
+  std::ostringstream session_out;
+  std::ostringstream grab_out;
+  session_out << session_in.rdbuf();
+  grab_out << grab_in.rdbuf();
+  const auto session_source = session_out.str();
+  const auto grab_source = grab_out.str();
+
+  const auto open_begin = session_source.find("int open_pipewire_remote_fd(");
+  const auto open_end = session_source.find("struct portal_request_result_t", open_begin);
+  ASSERT_NE(open_begin, std::string::npos);
+  ASSERT_NE(open_end, std::string::npos);
+  const auto open_body = session_source.substr(open_begin, open_end - open_begin);
+  EXPECT_NE(open_body.find("pending_request_registration_t registration"), std::string::npos)
+    << "an existing session remote reopen must register its own cancellable";
+  EXPECT_NE(open_body.find("session_media::teardown_in_progress()"), std::string::npos)
+    << "a reopen racing a previously announced teardown must self-cancel";
+  EXPECT_NE(open_body.find("&out_fd_list,\n      cancellable,"), std::string::npos)
+    << "OpenPipeWireRemote must receive the registered cancellable";
+
+  const auto ensure_begin = grab_source.find("static bool ensure_session_unlocked()");
+  const auto ensure_end = grab_source.find("static bool ensure_global_session()", ensure_begin);
+  ASSERT_NE(ensure_begin, std::string::npos);
+  ASSERT_NE(ensure_end, std::string::npos);
+  const auto ensure_body = grab_source.substr(ensure_begin, ensure_end - ensure_begin);
+  const auto shutdown_guard = ensure_body.find("if (session_media::teardown_in_progress())");
+  const auto retry_sleep = ensure_body.find("std::this_thread::sleep_for");
+  ASSERT_NE(shutdown_guard, std::string::npos)
+    << "a cancelled portal session must not enter the retry backoff during teardown";
+  ASSERT_NE(retry_sleep, std::string::npos);
+  EXPECT_LT(shutdown_guard, retry_sleep);
 }
 
 TEST(PortalGrabPolicyTests, SelectSourcesInvalidatesRestoreTokenOnFailure) {

--- a/tests/unit/test_session_media_gate.cpp
+++ b/tests/unit/test_session_media_gate.cpp
@@ -71,6 +71,26 @@ TEST(SessionMediaGateTests, TeardownWaitsForAnAdmittedStartBeforeTakingOwnership
   EXPECT_TRUE(teardown.owns_teardown());
 }
 
+TEST(SessionMediaGateTests, TeardownAnnouncementRunsBeforeWaitingForAdmittedStart) {
+  session_media::teardown_gate_t gate;
+  std::optional<session_media::start_owner_t> admitted_start {gate.begin_start()};
+  std::promise<void> announced;
+  auto announcement = announced.get_future();
+
+  auto pending_teardown = std::async(std::launch::async, [&gate, &announced]() {
+    return gate.begin_teardown([&announced]() {
+      announced.set_value();
+    });
+  });
+
+  EXPECT_EQ(announcement.wait_for(1s), std::future_status::ready)
+    << "teardown cancellation must be announced before waiting for active starts";
+  EXPECT_EQ(pending_teardown.wait_for(20ms), std::future_status::timeout);
+  admitted_start.reset();
+  ASSERT_EQ(pending_teardown.wait_for(1s), std::future_status::ready);
+  EXPECT_TRUE(pending_teardown.get().owns_teardown());
+}
+
 TEST(SessionMediaGateTests, TerminalWaitDoesNotReturnWhileAnOwnedCleanupIsRunning) {
   session_media::teardown_gate_t gate;
   std::optional<session_media::teardown_owner_t> cleanup_owner {gate.begin_teardown()};

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -171,6 +171,41 @@ TEST(SessionStopContractTests, VideoCaptureTagsPortalStartOwner) {
   EXPECT_LT(scope, reset);
 }
 
+TEST(SessionStopContractTests, PortalCancellationIsGuardedWhenBackendIsUnavailable) {
+  const auto source = read_source_for_contract("src/platform/linux/session_media.cpp");
+  ASSERT_FALSE(source.empty());
+
+  const auto include = source.find("#include \"src/platform/linux/portal_session.h\"");
+  ASSERT_NE(include, std::string::npos);
+  const auto include_guard = source.rfind("#ifdef POLARIS_BUILD_PORTAL", include);
+  const auto include_guard_end = source.find("#endif", include_guard);
+  ASSERT_NE(include_guard, std::string::npos)
+    << "portal_session.h requires GIO and must only be included when the portal backend is built";
+  ASSERT_NE(include_guard_end, std::string::npos);
+  EXPECT_LT(include_guard, include);
+  EXPECT_LT(include, include_guard_end);
+
+  const auto owner_cancel = source.find("portal::cancel_pending_requests(owner_tag)");
+  ASSERT_NE(owner_cancel, std::string::npos);
+  const auto owner_guard = source.rfind("#ifdef POLARIS_BUILD_PORTAL", owner_cancel);
+  const auto owner_guard_end = source.find("#endif", owner_guard);
+  ASSERT_NE(owner_guard, std::string::npos);
+  ASSERT_NE(owner_guard_end, std::string::npos);
+  EXPECT_LT(owner_guard, owner_cancel);
+  EXPECT_LT(owner_cancel, owner_guard_end);
+
+  const auto teardown_cancel = source.find("portal::cancel_pending_requests()", owner_cancel + 1);
+  ASSERT_NE(teardown_cancel, std::string::npos);
+  const auto teardown_guard = source.rfind("#ifdef POLARIS_BUILD_PORTAL", teardown_cancel);
+  const auto teardown_guard_end = source.find("#endif", teardown_guard);
+  ASSERT_NE(teardown_guard, std::string::npos);
+  ASSERT_NE(teardown_guard_end, std::string::npos);
+  EXPECT_LT(teardown_guard, teardown_cancel);
+  EXPECT_LT(teardown_cancel, teardown_guard_end);
+  EXPECT_EQ(source.find("portal::cancel_pending_requests", teardown_cancel + 1), std::string::npos)
+    << "every optional portal cancellation call must be feature guarded";
+}
+
 TEST(SessionStopContractTests, CancelAnswersClientBeforeNestedTeardown) {
   // SB-2 residual: nested gamescope undo can SEGV mid-cancel; Moonlight must
   // already have cancel=1 or it maps the failed HTTP as "another device".

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -141,6 +141,36 @@ TEST(SessionStopContractTests, TerminateSessionsUsesGracefulStopBeforeJoin) {
   EXPECT_EQ(clear_body.find("stream::session::stop("), std::string::npos);
 }
 
+TEST(SessionStopContractTests, StreamJoinCancelsOwnPendingMediaStartBeforeVideoJoin) {
+  const auto source = read_source_for_contract("src/stream.cpp");
+  const auto start = source.find("void join(session_t &session)");
+  const auto end = source.find("int start(session_t &session", start);
+  ASSERT_NE(start, std::string::npos);
+  ASSERT_NE(end, std::string::npos);
+  const auto body = source.substr(start, end - start);
+  const auto cancel = body.find("session_media::cancel_pending_starts(&session)");
+  const auto join = body.find("session.videoThread.join()", cancel);
+  ASSERT_NE(cancel, std::string::npos);
+  ASSERT_NE(join, std::string::npos);
+  EXPECT_LT(cancel, join);
+  EXPECT_EQ(body.find("session_media::begin_teardown()"), std::string::npos);
+  EXPECT_EQ(body.find("session_media::prepare_for_stop()"), std::string::npos);
+}
+
+TEST(SessionStopContractTests, VideoCaptureTagsPortalStartOwner) {
+  const auto source = read_source_for_contract("src/video.cpp");
+  const auto start = source.find("encode_e encode_run_sync(");
+  const auto end = source.find("void captureThreadSync()", start);
+  ASSERT_NE(start, std::string::npos);
+  ASSERT_NE(end, std::string::npos);
+  const auto body = source.substr(start, end - start);
+  const auto scope = body.find("pending_start_owner_scope_t");
+  const auto reset = body.find("reset_display(", scope);
+  ASSERT_NE(scope, std::string::npos);
+  ASSERT_NE(reset, std::string::npos);
+  EXPECT_LT(scope, reset);
+}
+
 TEST(SessionStopContractTests, CancelAnswersClientBeforeNestedTeardown) {
   // SB-2 residual: nested gamescope undo can SEGV mid-cancel; Moonlight must
   // already have cancel=1 or it maps the failed HTTP as "another device".


### PR DESCRIPTION
## Summary

- consume the legacy host ScreenCast restore token as a one-shot migration so an invalidated token cannot be resurrected on the next attempt
- subscribe to `Request::Response` before synchronous `CreateSession`, `SelectSources`, and `Start` calls so fast KDE responses cannot be lost
- make portal D-Bus calls and response waits cancellable during teardown, preserve restore tokens on local cancellation, and publish cancellation before waiting on the media-start fence
- propagate the owning stream session into shared capture startup so disconnect cancels only that session's pending portal request
- use GLib's documented `GCancellableSourceFunc(GCancellable *, gpointer)` callback shape so cancellation actually wakes the response loop

## Testing

- [x] I tested the affected install, build, stream, or UI path.
  - clean CUDA configure/build of the portal-enabled Polaris executable and all three test executables
  - clean Polaris executable build with `POLARIS_ENABLE_PORTAL=OFF` to cover optional-backend linking
  - `test_polaris`: 217/217 passed
  - `test_polaris_platform`: 165/165 passed
  - `test_polaris_http`: 106/106 passed
  - `git diff --check` passed
  - read-only Codex review returned no findings after checking the GLib callback contract and optional-backend guards
  - live pending-picker disconnect: cancellation logged 0.532 seconds after disconnect; stable Polaris PID; no watchdog, restart, or coredump
  - live KDE portal HVD stream on Retroid Pocket 6: 154.2 seconds, 1920x1080, changing frames, runtime verifier exit 0
  - the initial Fedora RPM and Clang jobs exposed the same unguarded optional-portal link; the follow-up commit guards the portal header and calls and adds a focused regression
- [x] I included screenshots or recordings for visible UI changes, when practical. No UI changed; changing-frame screenshots were retained with the private test evidence.
- [ ] I updated docs or release notes when user-facing behavior changed. No new user-facing option or workflow was introduced.

## Notes

- The deployed smoke-test binary remained capability-free; this does not add or require `CAP_SYS_ADMIN`.
- Teardown cancellation is distinguished from portal rejection so a usable restore token is not deleted during local disconnect.
- This PR intentionally excludes the separate process-reaping experiment. Its unit regression passed, but live Synthetic Frame Counter termination did not, so no workload-termination claim is included here.
