### PR TITLE
fix(process): own detached-only session generation

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -955,6 +955,14 @@ namespace proc {
       return session_owned_cage || generation_available;
     }
 
+    bool isolated_session_requires_exact_generation_cleanup(
+      bool session_owned_cage,
+      bool has_detached_commands,
+      bool has_main_command
+    ) {
+      return session_owned_cage || (has_detached_commands && !has_main_command);
+    }
+
     bool unreadable_environ_latches_capture(
       int read_error,
       std::optional<uid_t> real_uid,
@@ -983,11 +991,11 @@ namespace proc {
     }
 
     bool isolated_session_cleanup_clears_state(
-      bool session_owned_cage,
+      bool exact_cleanup_required,
       bool generation_available,
       bool exact_cleanup_complete
     ) {
-      return !session_owned_cage || (generation_available && exact_cleanup_complete);
+      return !exact_cleanup_required || (generation_available && exact_cleanup_complete);
     }
 
     bool isolated_session_uses_legacy_group_termination(
@@ -1081,37 +1089,6 @@ namespace proc {
         "systemctl --user start polaris-gamescope-idle.service 2>/dev/null"
       );
     }
-
-    struct pidfd_handle_t {
-      pid_t pid = -1;
-      int fd = -1;
-
-      pidfd_handle_t() = default;
-      pidfd_handle_t(pid_t process_id, int descriptor): pid(process_id), fd(descriptor) {}
-      pidfd_handle_t(const pidfd_handle_t &) = delete;
-      pidfd_handle_t &operator=(const pidfd_handle_t &) = delete;
-      pidfd_handle_t(pidfd_handle_t &&other) noexcept: pid(other.pid), fd(other.fd) {
-        other.pid = -1;
-        other.fd = -1;
-      }
-      pidfd_handle_t &operator=(pidfd_handle_t &&other) noexcept {
-        if (this != &other) {
-          if (fd >= 0) {
-            close(fd);
-          }
-          pid = other.pid;
-          fd = other.fd;
-          other.pid = -1;
-          other.fd = -1;
-        }
-        return *this;
-      }
-      ~pidfd_handle_t() {
-        if (fd >= 0) {
-          close(fd);
-        }
-      }
-    };
 
 #ifdef POLARIS_TESTS
     thread_local pid_t forced_pidfd_open_failure_pid = -1;
@@ -1234,6 +1211,83 @@ namespace proc {
         }
       }
       return wait_for_pidfds_exit(handles, kill_timeout);
+    }
+
+    bool reap_exited_direct_children(
+      const std::vector<pidfd_handle_t> &handles,
+      std::string_view label
+    ) {
+      bool complete = true;
+      for (const auto &handle : handles) {
+        siginfo_t child_info {};
+        int result;
+        do {
+          result = waitid(P_PIDFD, static_cast<id_t>(handle.fd), &child_info, WEXITED | WNOHANG);
+        } while (result < 0 && errno == EINTR);
+
+        if (result == 0 && child_info.si_pid != 0) {
+          BOOST_LOG(info) << "process: reaped direct child for "sv << label
+                          << " pid="sv << handle.pid;
+          continue;
+        }
+        if (result < 0 && errno == ECHILD) {
+          // Non-child descendants are reaped by their actual parent. ECHILD also
+          // covers a direct child already consumed by another SIGCHLD owner.
+          continue;
+        }
+
+        complete = false;
+        if (result == 0) {
+          BOOST_LOG(warning) << "process: pidfd reported exit but direct child was not waitable for "sv
+                             << label << " pid="sv << handle.pid;
+        } else {
+          BOOST_LOG(warning) << "process: waitid(P_PIDFD) failed while reaping "sv << label
+                             << " pid="sv << handle.pid << " error="sv << std::strerror(errno);
+        }
+      }
+      return complete;
+    }
+
+    bool reap_tracked_detached_children(
+      std::vector<pidfd_handle_t> &handles,
+      std::string_view label,
+      bool require_exit
+    ) {
+      bool complete = true;
+      for (auto it = handles.begin(); it != handles.end();) {
+        siginfo_t child_info {};
+        int result;
+        do {
+          result = waitid(P_PIDFD, static_cast<id_t>(it->fd), &child_info, WEXITED | WNOHANG);
+        } while (result < 0 && errno == EINTR);
+
+        if (result == 0 && child_info.si_pid != 0) {
+          BOOST_LOG(info) << "process: reaped tracked detached direct child for "sv << label
+                          << " pid="sv << it->pid;
+          it = handles.erase(it);
+          continue;
+        }
+        if (result < 0 && errno == ECHILD) {
+          // The exact child was already consumed by another SIGCHLD owner.
+          it = handles.erase(it);
+          continue;
+        }
+        if (result == 0) {
+          if (require_exit) {
+            complete = false;
+            BOOST_LOG(warning) << "process: tracked detached direct child was not waitable after termination for "sv
+                               << label << " pid="sv << it->pid;
+          }
+          ++it;
+          continue;
+        }
+
+        complete = false;
+        BOOST_LOG(warning) << "process: waitid(P_PIDFD) failed for tracked detached child "sv
+                           << label << " pid="sv << it->pid << " error="sv << std::strerror(errno);
+        ++it;
+      }
+      return complete;
     }
 
     bool proc_pid_dir_name(std::string_view name) {
@@ -1653,12 +1707,21 @@ namespace proc {
 
     bool terminate_isolated_session_processes(
       std::string_view session_instance_id,
-      std::string_view reason
+      std::string_view reason,
+      std::vector<pidfd_handle_t> *tracked_detached_children = nullptr
     ) {
       if (session_instance_id.empty()) {
         return false;
       }
 
+      bool direct_child_reap_complete = true;
+      if (tracked_detached_children != nullptr) {
+        direct_child_reap_complete = reap_tracked_detached_children(
+          *tracked_detached_children,
+          "detached session process"sv,
+          false
+        );
+      }
       for (int pass = 0; pass < 2; ++pass) {
         auto snapshot = isolated_session_process_snapshot(session_instance_id);
         if (!snapshot.capture_complete) {
@@ -1666,19 +1729,53 @@ namespace proc {
           return false;
         }
         if (snapshot.owned.empty()) {
-          return true;
+          if (tracked_detached_children != nullptr) {
+            direct_child_reap_complete = reap_tracked_detached_children(
+                                           *tracked_detached_children,
+                                           "detached session process"sv,
+                                           false
+                                         ) &&
+                                         direct_child_reap_complete;
+          }
+          return direct_child_reap_complete &&
+                 (tracked_detached_children == nullptr || tracked_detached_children->empty());
         }
 
         BOOST_LOG(info) << "process: terminating "sv << snapshot.owned.size()
                         << " exact-generation isolated process(es) "sv << reason;
-        if (!terminate_pidfds(snapshot.owned, 2s, 1s, "isolated session process"sv)) {
+        const bool terminated = terminate_pidfds(snapshot.owned, 2s, 1s, "isolated session process"sv);
+        if (tracked_detached_children != nullptr) {
+          direct_child_reap_complete = reap_exited_direct_children(
+                                         snapshot.owned,
+                                         "detached session process"sv
+                                       ) &&
+                                       direct_child_reap_complete;
+          direct_child_reap_complete = reap_tracked_detached_children(
+                                         *tracked_detached_children,
+                                         "detached session process"sv,
+                                         true
+                                       ) &&
+                                       direct_child_reap_complete;
+        }
+        if (!terminated) {
           BOOST_LOG(warning) << "process: exact-generation isolated processes remained after bounded pidfd cleanup "sv
                              << reason;
         }
       }
 
       const auto final_snapshot = isolated_session_process_snapshot(session_instance_id);
-      return final_snapshot.capture_complete && final_snapshot.owned.empty();
+      if (tracked_detached_children != nullptr) {
+        direct_child_reap_complete = reap_tracked_detached_children(
+                                       *tracked_detached_children,
+                                       "detached session process"sv,
+                                       true
+                                     ) &&
+                                     direct_child_reap_complete;
+      }
+      return final_snapshot.capture_complete &&
+             final_snapshot.owned.empty() &&
+             direct_child_reap_complete &&
+             (tracked_detached_children == nullptr || tracked_detached_children->empty());
     }
 
     struct steam_client_ownership_snapshot_t {
@@ -4497,6 +4594,161 @@ namespace proc {
            );
   }
 
+  bool proc_t::non_cage_detached_generation_cleanup_for_tests(
+    std::string_view session_instance_id,
+    pid_t direct_child_pid
+  ) {
+    int pidfd_open_error = 0;
+    auto tracked_child = open_process_pidfd(direct_child_pid, pidfd_open_error);
+    if (!tracked_child) {
+      return false;
+    }
+    const auto previous_app = _app;
+    const auto previous_instance_id = _session_instance_id;
+    const auto previous_used_cage = _session_used_cage_compositor;
+    const auto previous_used_gamescope = _session_used_gamescope_runtime;
+    const auto previous_cleanup_complete = _exact_generation_cleanup_complete;
+    _app = {};
+    _app.detached = {"detached-generation-test"};
+    _session_instance_id = session_instance_id;
+    _session_used_cage_compositor = false;
+    _session_used_gamescope_runtime = false;
+    _exact_generation_cleanup_complete = true;
+    auto restore_state = util::fail_guard([
+      this,
+      previous_app,
+      previous_instance_id,
+      previous_used_cage,
+      previous_used_gamescope,
+      previous_cleanup_complete
+    ]() {
+      _app = previous_app;
+      _session_instance_id = previous_instance_id;
+      _session_used_cage_compositor = previous_used_cage;
+      _session_used_gamescope_runtime = previous_used_gamescope;
+      _exact_generation_cleanup_complete = previous_cleanup_complete;
+    });
+
+    _detached_child_pidfds.emplace_back(std::move(*tracked_child));
+    terminate_isolated_session_generation();
+    finish_isolated_session_generation_cleanup();
+    return _exact_generation_cleanup_complete && _session_instance_id.empty();
+  }
+
+  bool proc_t::non_cage_detached_capture_failure_retains_generation_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_capture_failure_pid
+  ) {
+    int pidfd_open_error = 0;
+    auto tracked_child = open_process_pidfd(forced_capture_failure_pid, pidfd_open_error);
+    if (!tracked_child) {
+      return false;
+    }
+    const auto previous_failure_pid = forced_isolated_session_capture_failure_pid;
+    const auto previous_app = _app;
+    const auto previous_instance_id = _session_instance_id;
+    const auto previous_used_cage = _session_used_cage_compositor;
+    const auto previous_used_gamescope = _session_used_gamescope_runtime;
+    const auto previous_cleanup_complete = _exact_generation_cleanup_complete;
+    forced_isolated_session_capture_failure_pid = forced_capture_failure_pid;
+    _app = {};
+    _app.detached = {"detached-generation-test"};
+    _session_instance_id = session_instance_id;
+    _session_used_cage_compositor = false;
+    _session_used_gamescope_runtime = false;
+    _exact_generation_cleanup_complete = true;
+    auto restore_state = util::fail_guard([
+      this,
+      previous_failure_pid,
+      previous_app,
+      previous_instance_id,
+      previous_used_cage,
+      previous_used_gamescope,
+      previous_cleanup_complete
+    ]() {
+      forced_isolated_session_capture_failure_pid = previous_failure_pid;
+      _app = previous_app;
+      _session_instance_id = previous_instance_id;
+      _session_used_cage_compositor = previous_used_cage;
+      _session_used_gamescope_runtime = previous_used_gamescope;
+      _exact_generation_cleanup_complete = previous_cleanup_complete;
+    });
+
+    _detached_child_pidfds.emplace_back(std::move(*tracked_child));
+    terminate_isolated_session_generation();
+    finish_isolated_session_generation_cleanup();
+    const bool retained_after_capture_failure =
+      !_exact_generation_cleanup_complete &&
+      !_session_used_cage_compositor &&
+      _session_instance_id == session_instance_id &&
+      isolated_session_generation_blocks_launch(
+        _session_used_cage_compositor,
+        !_session_instance_id.empty()
+      );
+
+    // execute_impl() calls terminate_impl() once more before it reaches the
+    // retained-generation relaunch gate. By then the stopped app metadata has
+    // already been cleared, so the retained credential must remain authoritative
+    // without consulting _app again.
+    _app = {};
+    finish_isolated_session_generation_cleanup();
+    return retained_after_capture_failure &&
+           _session_instance_id == session_instance_id &&
+           isolated_session_generation_blocks_launch(
+             _session_used_cage_compositor,
+             !_session_instance_id.empty()
+           );
+  }
+
+  bool proc_t::non_cage_detached_partial_launch_cleanup_for_tests(
+    std::string_view session_instance_id,
+    pid_t prior_child_pid
+  ) {
+    int pidfd_open_error = 0;
+    auto tracked_child = open_process_pidfd(prior_child_pid, pidfd_open_error);
+    if (!tracked_child) {
+      return false;
+    }
+    const auto previous_app = _app;
+    const auto previous_instance_id = _session_instance_id;
+    const auto previous_used_cage = _session_used_cage_compositor;
+    const auto previous_used_gamescope = _session_used_gamescope_runtime;
+    const auto previous_authority_complete = _detached_child_authority_complete;
+    const auto previous_cleanup_complete = _exact_generation_cleanup_complete;
+    _app = {};
+    _app.detached = {"detached-generation-test-1", "detached-generation-test-2"};
+    _session_instance_id = session_instance_id;
+    _session_used_cage_compositor = false;
+    _session_used_gamescope_runtime = false;
+    _detached_child_authority_complete = true;
+    _exact_generation_cleanup_complete = true;
+    auto restore_state = util::fail_guard([
+      this,
+      previous_app,
+      previous_instance_id,
+      previous_used_cage,
+      previous_used_gamescope,
+      previous_authority_complete,
+      previous_cleanup_complete
+    ]() {
+      _app = previous_app;
+      _session_instance_id = previous_instance_id;
+      _session_used_cage_compositor = previous_used_cage;
+      _session_used_gamescope_runtime = previous_used_gamescope;
+      _detached_child_authority_complete = previous_authority_complete;
+      _exact_generation_cleanup_complete = previous_cleanup_complete;
+    });
+
+    _detached_child_pidfds.emplace_back(std::move(*tracked_child));
+    const bool direct_cleanup_complete = cleanup_tracked_detached_children_after_launch_failure();
+    terminate_isolated_session_generation();
+    finish_isolated_session_generation_cleanup();
+    return direct_cleanup_complete &&
+           _detached_child_pidfds.empty() &&
+           _exact_generation_cleanup_complete &&
+           _session_instance_id.empty();
+  }
+
   bool proc_t::terminate_session_owned_steam_before_cage_stop_for_tests(
     const ctx_t &app,
     bool session_owned_cage,
@@ -4538,6 +4790,42 @@ namespace proc {
     return test_process.isolated_session_capture_failure_retains_generation_for_tests(
       session_instance_id,
       forced_capture_failure_pid
+    );
+  }
+
+  bool non_cage_detached_generation_cleanup_for_tests(
+    std::string_view session_instance_id,
+    pid_t direct_child_pid
+  ) {
+    boost::process::v1::environment env = boost::this_process::environment();
+    proc_t test_process {std::move(env), {}};
+    return test_process.non_cage_detached_generation_cleanup_for_tests(
+      session_instance_id,
+      direct_child_pid
+    );
+  }
+
+  bool non_cage_detached_capture_failure_retains_generation_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_capture_failure_pid
+  ) {
+    boost::process::v1::environment env = boost::this_process::environment();
+    proc_t test_process {std::move(env), {}};
+    return test_process.non_cage_detached_capture_failure_retains_generation_for_tests(
+      session_instance_id,
+      forced_capture_failure_pid
+    );
+  }
+
+  bool non_cage_detached_partial_launch_cleanup_for_tests(
+    std::string_view session_instance_id,
+    pid_t prior_child_pid
+  ) {
+    boost::process::v1::environment env = boost::this_process::environment();
+    proc_t test_process {std::move(env), {}};
+    return test_process.non_cage_detached_partial_launch_cleanup_for_tests(
+      session_instance_id,
+      prior_child_pid
     );
   }
 
@@ -4634,6 +4922,18 @@ namespace proc {
     bool generation_available
   ) {
     return isolated_session_generation_blocks_launch(session_owned_cage, generation_available);
+  }
+
+  bool isolated_session_requires_exact_generation_cleanup_for_tests(
+    bool session_owned_cage,
+    bool has_detached_commands,
+    bool has_main_command
+  ) {
+    return isolated_session_requires_exact_generation_cleanup(
+      session_owned_cage,
+      has_detached_commands,
+      has_main_command
+    );
   }
 
   bool unreadable_environ_latches_capture_for_tests(
@@ -5003,21 +5303,32 @@ namespace proc {
       // until restart: the unreadable stragglers that latched it usually exit
       // with their tree, and once the snapshot completes the retained
       // processes (if any) are terminated right here.
-      const bool reaped = !_session_instance_id.empty() &&
-                          terminate_isolated_session_processes(
-                            _session_instance_id,
-                            "re-validated at next launch"sv
-                          );
+      const bool retained_session_owned_cage = _session_used_cage_compositor;
+      const bool generation_reaped = !_session_instance_id.empty() &&
+                                     terminate_isolated_session_processes(
+                                       _session_instance_id,
+                                       "re-validated at next launch"sv,
+                                       retained_session_owned_cage ? nullptr : &_detached_child_pidfds
+                                     );
+      const bool reaped = generation_reaped &&
+                          (retained_session_owned_cage || _detached_child_authority_complete);
       if (!reaped) {
         BOOST_LOG(error) << "process: refusing launch while an incompletely cleaned isolated session generation remains"sv;
         return 503;
       }
       BOOST_LOG(warning) << "process: reaped a retained isolated session generation at launch"sv;
-      stream_runtime::labwc::reset_after_external_stop();
+      if (retained_session_owned_cage) {
+        stream_runtime::labwc::reset_after_external_stop();
+      }
       _session_instance_id.clear();
       _session_used_cage_compositor = false;
       _session_used_gamescope_runtime = false;
+      _detached_child_authority_complete = true;
       _exact_generation_cleanup_complete = true;
+    }
+    if (!_detached_child_pidfds.empty()) {
+      BOOST_LOG(error) << "process: refusing launch while tracked detached child authority remains"sv;
+      return 503;
     }
 #endif
 
@@ -5026,6 +5337,7 @@ namespace proc {
     _session_instance_id = generate_session_token();
     _session_used_cage_compositor = false;
     _session_used_gamescope_runtime = false;
+    _detached_child_authority_complete = true;
 #endif
     _app = app;
     _app_id = util::from_view(app.id);
@@ -6658,7 +6970,10 @@ namespace proc {
     } else
 #endif
     {
-      // Non-cage path: launch detached commands normally
+      // Non-cage path: launch detached commands normally. Detached-only apps
+      // retain pidfd authority for their direct children so stop can reap exact
+      // children even if they exit before /proc ownership scanning begins.
+      const bool detached_only = !_app.detached.empty() && _app.cmd.empty();
       for (auto &cmd : _app.detached) {
         boost::filesystem::path working_dir = _app.working_dir.empty() ?
                                                 find_working_directory(cmd, _env) :
@@ -6668,6 +6983,49 @@ namespace proc {
         if (ec) {
           BOOST_LOG(warning) << "Couldn't spawn ["sv << cmd << "]: System: "sv << ec.message();
         } else {
+          if (detached_only) {
+            const auto child_pid = static_cast<pid_t>(child.id());
+            int pidfd_open_error = 0;
+            auto child_pidfd = open_process_pidfd(child_pid, pidfd_open_error);
+            if (!child_pidfd) {
+              BOOST_LOG(error) << "process: could not retain pidfd authority for detached-only child pid="sv
+                               << child_pid << " error="sv << std::strerror(pidfd_open_error);
+              const int kill_result = kill(child_pid, SIGKILL);
+              const int kill_error = errno;
+              bool child_reaped = false;
+              if (kill_result == 0 || kill_error == ESRCH) {
+                const auto reap_deadline = std::chrono::steady_clock::now() + 1s;
+                int status = 0;
+                while (std::chrono::steady_clock::now() < reap_deadline) {
+                  pid_t wait_result;
+                  do {
+                    wait_result = waitpid(child_pid, &status, WNOHANG);
+                  } while (wait_result < 0 && errno == EINTR);
+                  if (wait_result == child_pid || (wait_result < 0 && errno == ECHILD)) {
+                    child_reaped = true;
+                    break;
+                  }
+                  if (wait_result < 0) {
+                    BOOST_LOG(warning) << "process: bounded waitpid failed for untracked detached-only child pid="sv
+                                       << child_pid << " error="sv << std::strerror(errno);
+                    break;
+                  }
+                  std::this_thread::sleep_for(10ms);
+                }
+              }
+              if (!child_reaped) {
+                _detached_child_authority_complete = false;
+                _exact_generation_cleanup_complete = false;
+                BOOST_LOG(error) << "process: detached-only child could not be proven reaped after pidfd authority failure pid="sv
+                                 << child_pid;
+              }
+              (void) cleanup_tracked_detached_children_after_launch_failure();
+              terminate_isolated_session_generation();
+              child.detach();
+              return 503;
+            }
+            _detached_child_pidfds.emplace_back(std::move(*child_pidfd));
+          }
           child.detach();
         }
       }
@@ -7086,17 +7444,61 @@ namespace proc {
     );
   }
 
+  bool proc_t::cleanup_tracked_detached_children_after_launch_failure() {
+    const auto graceful_timeout = std::min(_app.exit_timeout, 1s);
+    const bool terminated = terminate_pidfds(
+      _detached_child_pidfds,
+      graceful_timeout,
+      2s,
+      "partial detached-only launch"sv
+    );
+    const bool reaped = reap_tracked_detached_children(
+      _detached_child_pidfds,
+      "partial detached-only launch"sv,
+      true
+    );
+    const bool complete = terminated && reaped && _detached_child_pidfds.empty();
+    if (!complete) {
+      _detached_child_authority_complete = false;
+      _exact_generation_cleanup_complete = false;
+      BOOST_LOG(error) << "process: retained detached child cleanup incomplete after partial launch failure"sv;
+    }
+    return complete;
+  }
+
   void proc_t::terminate_isolated_session_generation() {
     const bool prior_cleanup_complete = _exact_generation_cleanup_complete;
-    if (!_session_used_cage_compositor) {
+    const bool detached_only = !_app.detached.empty() && _app.cmd.empty();
+    const bool exact_cleanup_required = isolated_session_requires_exact_generation_cleanup(
+      _session_used_cage_compositor,
+      !_app.detached.empty(),
+      !_app.cmd.empty()
+    );
+    if (!exact_cleanup_required) {
       return;
     }
 
+    const auto reason = _session_used_cage_compositor ?
+                          "after private Steam pre-cage termination"sv :
+                          "during non-cage detached-only shutdown"sv;
     const bool isolated_cleanup_complete = terminate_isolated_session_processes(
       _session_instance_id,
-      "after private Steam pre-cage termination"sv
+      reason,
+      (!_session_used_cage_compositor && detached_only) ? &_detached_child_pidfds : nullptr
     );
-    _exact_generation_cleanup_complete = prior_cleanup_complete && isolated_cleanup_complete;
+    const bool detached_authority_complete =
+      _session_used_cage_compositor || !detached_only || _detached_child_authority_complete;
+    _exact_generation_cleanup_complete = prior_cleanup_complete &&
+                                         isolated_cleanup_complete &&
+                                         detached_authority_complete;
+
+    if (!_session_used_cage_compositor) {
+      if (!_exact_generation_cleanup_complete) {
+        BOOST_LOG(error) << "process: retaining immutable detached-only generation after incomplete exact cleanup"sv;
+      }
+      return;
+    }
+
     if (isolated_session_cleanup_resets_router(
           _session_used_cage_compositor,
           !_session_instance_id.empty(),
@@ -7121,8 +7523,17 @@ namespace proc {
   }
 
   void proc_t::finish_isolated_session_generation_cleanup() {
+    const bool retained_incomplete_generation =
+      !_exact_generation_cleanup_complete && !_session_instance_id.empty();
+    const bool exact_cleanup_required =
+      retained_incomplete_generation ||
+      isolated_session_requires_exact_generation_cleanup(
+        _session_used_cage_compositor,
+        !_app.detached.empty(),
+        !_app.cmd.empty()
+      );
     if (isolated_session_cleanup_clears_state(
-          _session_used_cage_compositor,
+          exact_cleanup_required,
           !_session_instance_id.empty(),
           _exact_generation_cleanup_complete
         )) {

--- a/src/process.h
+++ b/src/process.h
@@ -28,6 +28,11 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef __linux__
+  #include <sys/types.h>
+  #include <unistd.h>
+#endif
+
 // lib includes
 #include <boost/process/v1/child.hpp>
 #include <boost/process/v1/group.hpp>
@@ -58,6 +63,37 @@ namespace proc {
 #ifdef __linux__
   struct steam_big_picture_guard_runtime_t;
   struct steam_big_picture_guard_snapshot_t;
+
+  struct pidfd_handle_t {
+    pid_t pid = -1;
+    int fd = -1;
+
+    pidfd_handle_t() = default;
+    pidfd_handle_t(pid_t process_id, int descriptor): pid(process_id), fd(descriptor) {}
+    pidfd_handle_t(const pidfd_handle_t &) = delete;
+    pidfd_handle_t &operator=(const pidfd_handle_t &) = delete;
+    pidfd_handle_t(pidfd_handle_t &&other) noexcept: pid(other.pid), fd(other.fd) {
+      other.pid = -1;
+      other.fd = -1;
+    }
+    pidfd_handle_t &operator=(pidfd_handle_t &&other) noexcept {
+      if (this != &other) {
+        if (fd >= 0) {
+          ::close(fd);
+        }
+        pid = other.pid;
+        fd = other.fd;
+        other.pid = -1;
+        other.fd = -1;
+      }
+      return *this;
+    }
+    ~pidfd_handle_t() {
+      if (fd >= 0) {
+        ::close(fd);
+      }
+    }
+  };
 #endif
 
 #ifdef _WIN32
@@ -283,6 +319,18 @@ namespace proc {
     std::string_view session_instance_id,
     pid_t forced_capture_failure_pid
   );
+  bool non_cage_detached_generation_cleanup_for_tests(
+    std::string_view session_instance_id,
+    pid_t direct_child_pid
+  );
+  bool non_cage_detached_capture_failure_retains_generation_for_tests(
+    std::string_view session_instance_id,
+    pid_t forced_capture_failure_pid
+  );
+  bool non_cage_detached_partial_launch_cleanup_for_tests(
+    std::string_view session_instance_id,
+    pid_t prior_child_pid
+  );
   bool terminate_session_owned_steam_before_cage_stop_for_tests(
     const struct ctx_t &app,
     bool session_owned_cage,
@@ -313,6 +361,11 @@ namespace proc {
     pid_t reused_pid
   );
   bool isolated_session_generation_blocks_launch_for_tests(bool session_owned_cage, bool generation_available);
+  bool isolated_session_requires_exact_generation_cleanup_for_tests(
+    bool session_owned_cage,
+    bool has_detached_commands,
+    bool has_main_command
+  );
   bool unreadable_environ_latches_capture_for_tests(
     int read_error,
     std::optional<uid_t> real_uid,
@@ -614,6 +667,18 @@ namespace proc {
       std::string_view session_instance_id,
       pid_t forced_capture_failure_pid
     );
+    bool non_cage_detached_generation_cleanup_for_tests(
+      std::string_view session_instance_id,
+      pid_t direct_child_pid
+    );
+    bool non_cage_detached_capture_failure_retains_generation_for_tests(
+      std::string_view session_instance_id,
+      pid_t forced_capture_failure_pid
+    );
+    bool non_cage_detached_partial_launch_cleanup_for_tests(
+      std::string_view session_instance_id,
+      pid_t prior_child_pid
+    );
     bool terminate_session_owned_steam_before_cage_stop_for_tests(
       const ctx_t &app,
       bool session_owned_cage,
@@ -641,6 +706,7 @@ namespace proc {
     void terminate_impl(bool immediate, bool needs_refresh);
 #ifdef __linux__
     bool terminate_session_owned_steam_before_cage_stop();
+    bool cleanup_tracked_detached_children_after_launch_failure();
     void terminate_isolated_session_generation();
     void finish_isolated_session_generation_cleanup();
     std::shared_ptr<const steam_big_picture_guard_snapshot_t> snapshot_steam_big_picture_input_guard(
@@ -687,6 +753,8 @@ namespace proc {
 #ifdef __linux__
     std::shared_ptr<steam_big_picture_guard_runtime_t> _steam_big_picture_guard;
     std::string _session_instance_id;
+    std::vector<pidfd_handle_t> _detached_child_pidfds;
+    bool _detached_child_authority_complete = true;
     bool _session_used_cage_compositor = false;
     bool _session_used_gamescope_runtime = false;
     bool _exact_generation_cleanup_complete = true;

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -2194,6 +2194,12 @@ TEST(ProcessRuntimeConfigTests, IsolatedSessionCleanupPolicyRetainsIncompleteCag
   EXPECT_TRUE(proc::isolated_session_generation_blocks_launch_for_tests(false, true));
   EXPECT_FALSE(proc::isolated_session_generation_blocks_launch_for_tests(false, false));
 
+  EXPECT_TRUE(proc::isolated_session_requires_exact_generation_cleanup_for_tests(true, false, true));
+  EXPECT_TRUE(proc::isolated_session_requires_exact_generation_cleanup_for_tests(false, true, false));
+  EXPECT_FALSE(proc::isolated_session_requires_exact_generation_cleanup_for_tests(false, true, true));
+  EXPECT_FALSE(proc::isolated_session_requires_exact_generation_cleanup_for_tests(false, false, true));
+  EXPECT_FALSE(proc::isolated_session_requires_exact_generation_cleanup_for_tests(false, false, false));
+
   EXPECT_FALSE(proc::isolated_session_cleanup_resets_router_for_tests(true, true, false));
   EXPECT_FALSE(proc::isolated_session_cleanup_clears_state_for_tests(true, true, false));
   EXPECT_FALSE(proc::isolated_session_cleanup_resets_router_for_tests(true, false, true));
@@ -2287,6 +2293,180 @@ TEST(ProcessRuntimeConfigTests, ExactGenerationCleanupLeavesUnownedControlProces
   EXPECT_EQ(control_guard.wait(&control_status, WNOHANG), 0)
     << "unowned control process must remain alive";
   EXPECT_EQ(control_guard.terminate_and_reap(&control_status), control);
+}
+
+TEST(ProcessRuntimeConfigTests, NonCageDetachedGenerationCleanupTerminatesExactChild) {
+#ifdef __linux__
+  const std::string token = "non-cage-detached-generation-cleanup";
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    execl("/bin/sleep", "sleep", "60", nullptr);
+    _exit(127);
+  }
+  linux_child_guard_t child_guard {child};
+
+  const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
+  bool token_visible = false;
+  for (int attempt = 0; attempt < 40 && !token_visible; ++attempt) {
+    std::ifstream environ_file("/proc/" + std::to_string(child) + "/environ", std::ios::binary);
+    const std::string environ(
+      (std::istreambuf_iterator<char>(environ_file)),
+      std::istreambuf_iterator<char>()
+    );
+    token_visible = environ.find(expected) != std::string::npos;
+    if (!token_visible) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+  }
+  ASSERT_TRUE(token_visible);
+  EXPECT_TRUE(proc::non_cage_detached_generation_cleanup_for_tests(token, child));
+
+  int status = 0;
+  errno = 0;
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), -1)
+    << "non-cage detached exact-generation child was not reaped by cleanup";
+  EXPECT_EQ(errno, ECHILD);
+#else
+  GTEST_SKIP() << "Linux-only detached generation cleanup";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, NonCageDetachedPartialLaunchFailureCleansPreviouslyTrackedChild) {
+#ifdef __linux__
+  const std::string token = "non-cage-detached-partial-launch-failure";
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    execl("/bin/sleep", "sleep", "60", nullptr);
+    _exit(127);
+  }
+  linux_child_guard_t child_guard {child};
+
+  const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
+  bool token_visible = false;
+  for (int attempt = 0; attempt < 40 && !token_visible; ++attempt) {
+    std::ifstream environ_file("/proc/" + std::to_string(child) + "/environ", std::ios::binary);
+    const std::string environ(
+      (std::istreambuf_iterator<char>(environ_file)),
+      std::istreambuf_iterator<char>()
+    );
+    token_visible = environ.find(expected) != std::string::npos;
+    if (!token_visible) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+  }
+  ASSERT_TRUE(token_visible);
+  EXPECT_TRUE(proc::non_cage_detached_partial_launch_cleanup_for_tests(token, child));
+
+  int status = 0;
+  errno = 0;
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), -1)
+    << "partial detached-only launch failure left a previously tracked child alive or unreaped";
+  EXPECT_EQ(errno, ECHILD);
+#else
+  GTEST_SKIP() << "Linux-only detached partial-launch cleanup";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, NonCageDetachedGenerationCleanupReapsAlreadyExitedDirectChild) {
+#ifdef __linux__
+  const std::string token = "non-cage-detached-already-exited";
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    _exit(0);
+  }
+  linux_child_guard_t child_guard {child};
+
+  const auto unrelated = fork();
+  ASSERT_GE(unrelated, 0);
+  if (unrelated == 0) {
+    unsetenv("POLARIS_SESSION_INSTANCE_ID");
+    _exit(0);
+  }
+  linux_child_guard_t unrelated_guard {unrelated};
+
+  const auto zombie_visible_for = [](pid_t pid) {
+    std::ifstream status_file("/proc/" + std::to_string(pid) + "/status");
+    const std::string status(
+      (std::istreambuf_iterator<char>(status_file)),
+      std::istreambuf_iterator<char>()
+    );
+    return status.find("State:\tZ") != std::string::npos;
+  };
+  bool target_zombie_visible = false;
+  bool unrelated_zombie_visible = false;
+  for (int attempt = 0;
+       attempt < 40 && (!target_zombie_visible || !unrelated_zombie_visible);
+       ++attempt) {
+    target_zombie_visible = zombie_visible_for(child);
+    unrelated_zombie_visible = zombie_visible_for(unrelated);
+    if (!target_zombie_visible || !unrelated_zombie_visible) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+  }
+  ASSERT_TRUE(target_zombie_visible);
+  ASSERT_TRUE(unrelated_zombie_visible);
+  EXPECT_TRUE(proc::non_cage_detached_generation_cleanup_for_tests(token, child));
+
+  int status = 0;
+  errno = 0;
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), -1)
+    << "already-exited detached direct child remained waitable after cleanup";
+  EXPECT_EQ(errno, ECHILD);
+
+  int unrelated_status = 0;
+  EXPECT_EQ(unrelated_guard.wait(&unrelated_status, WNOHANG), unrelated)
+    << "detached cleanup must not reap an unrelated exited direct child";
+  EXPECT_TRUE(WIFEXITED(unrelated_status));
+#else
+  GTEST_SKIP() << "Linux-only detached generation zombie cleanup";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, NonCageDetachedCaptureFailureRetainsGenerationAndSendsNoSignal) {
+#ifdef __linux__
+  const std::string token = "non-cage-detached-incomplete-capture";
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    execl("/bin/sleep", "sleep", "60", nullptr);
+    _exit(127);
+  }
+  linux_child_guard_t child_guard {child};
+
+  const auto expected = std::string("POLARIS_SESSION_INSTANCE_ID=") + token;
+  bool token_visible = false;
+  for (int attempt = 0; attempt < 40 && !token_visible; ++attempt) {
+    std::ifstream environ_file("/proc/" + std::to_string(child) + "/environ", std::ios::binary);
+    const std::string environ(
+      (std::istreambuf_iterator<char>(environ_file)),
+      std::istreambuf_iterator<char>()
+    );
+    token_visible = environ.find(expected) != std::string::npos;
+    if (!token_visible) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+  }
+  ASSERT_TRUE(token_visible);
+  EXPECT_TRUE(
+    proc::non_cage_detached_capture_failure_retains_generation_for_tests(token, child)
+  );
+
+  int status = 0;
+  EXPECT_EQ(child_guard.wait(&status, WNOHANG), 0)
+    << "incomplete exact-generation capture must not signal the detached child";
+  EXPECT_TRUE(proc::terminate_exact_generation_processes_for_tests(token));
+  EXPECT_EQ(child_guard.wait(&status, 0), child);
+  EXPECT_TRUE(WIFSIGNALED(status));
+#else
+  GTEST_SKIP() << "Linux-only detached generation capture fault";
+#endif
 }
 
 TEST(ProcessRuntimeConfigTests, ExactGenerationCaptureFailureRetainsGenerationAndLeavesChildUnsignaled) {
@@ -2463,10 +2643,20 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   EXPECT_NE(source.find("SYS_pidfd_send_signal"), std::string::npos);
   EXPECT_NE(source.find("poll("), std::string::npos);
   EXPECT_NE(source.find("proc_environ_contains_exact_entry("), std::string::npos);
+  const auto exact_generation_completion = source.find("return final_snapshot.capture_complete &&");
+  ASSERT_NE(exact_generation_completion, std::string::npos);
+  const auto exact_generation_completion_contract = source.substr(exact_generation_completion, 220);
   EXPECT_NE(
-    source.find("return final_snapshot.capture_complete && final_snapshot.owned.empty();"),
+    exact_generation_completion_contract.find("final_snapshot.owned.empty()"),
     std::string::npos
   );
+  EXPECT_NE(
+    exact_generation_completion_contract.find("direct_child_reap_complete"),
+    std::string::npos
+  );
+  EXPECT_NE(source.find("reap_exited_direct_children("), std::string::npos);
+  EXPECT_NE(source.find("waitid(P_PIDFD"), std::string::npos);
+  EXPECT_EQ(source.find("waitpid(handle.pid"), std::string::npos);
   EXPECT_EQ(source.find("proc_environ_contains_isolated_session_marker("), std::string::npos);
 
   const auto execute = source.substr(execute_start, execute_end - execute_start);
@@ -2482,6 +2672,10 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
     execute.find("isolated_session_generation_blocks_launch("),
     std::string::npos
   );
+  EXPECT_NE(
+    execute.find("retained_session_owned_cage || _detached_child_authority_complete"),
+    std::string::npos
+  );
   ASSERT_NE(generate_instance, std::string::npos);
   ASSERT_NE(inject_instance, std::string::npos);
   ASSERT_NE(start_cage, std::string::npos);
@@ -2490,6 +2684,51 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   EXPECT_LT(generate_instance, inject_instance);
   EXPECT_LT(inject_instance, start_cage);
   EXPECT_LT(start_cage, remember_cage);
+
+  const auto detached_only_gate = execute.find("const bool detached_only = !_app.detached.empty() && _app.cmd.empty()");
+  const auto retain_detached_pidfd = execute.find("_detached_child_pidfds.emplace_back", detached_only_gate);
+  const auto detach_child = execute.find("child.detach()", retain_detached_pidfd);
+  ASSERT_NE(detached_only_gate, std::string::npos);
+  ASSERT_NE(retain_detached_pidfd, std::string::npos);
+  ASSERT_NE(detach_child, std::string::npos);
+  EXPECT_LT(detached_only_gate, retain_detached_pidfd);
+  EXPECT_LT(retain_detached_pidfd, detach_child);
+
+  const auto pidfd_authority_failure = execute.find("could not retain pidfd authority for detached-only child");
+  const auto pidfd_authority_return = execute.find("return 503;", pidfd_authority_failure);
+  ASSERT_NE(pidfd_authority_failure, std::string::npos);
+  ASSERT_NE(pidfd_authority_return, std::string::npos);
+  const auto pidfd_failure_cleanup = execute.substr(
+    pidfd_authority_failure,
+    pidfd_authority_return - pidfd_authority_failure
+  );
+  EXPECT_NE(pidfd_failure_cleanup.find("WNOHANG"), std::string::npos);
+  EXPECT_NE(pidfd_failure_cleanup.find("reap_deadline"), std::string::npos);
+  EXPECT_NE(
+    pidfd_failure_cleanup.find("_detached_child_authority_complete = false"),
+    std::string::npos
+  );
+  EXPECT_EQ(pidfd_failure_cleanup.find("waitpid(child_pid, &status, 0)"), std::string::npos);
+  EXPECT_NE(
+    pidfd_failure_cleanup.find("cleanup_tracked_detached_children_after_launch_failure();"),
+    std::string::npos
+  );
+  EXPECT_NE(
+    pidfd_failure_cleanup.find("terminate_isolated_session_generation();"),
+    std::string::npos
+  );
+
+  const auto tracked_reaper_start = source.find("bool reap_tracked_detached_children(");
+  const auto tracked_reaper_end = source.find("bool proc_pid_dir_name(", tracked_reaper_start);
+  ASSERT_NE(tracked_reaper_start, std::string::npos);
+  ASSERT_NE(tracked_reaper_end, std::string::npos);
+  const auto tracked_reaper = source.substr(
+    tracked_reaper_start,
+    tracked_reaper_end - tracked_reaper_start
+  );
+  EXPECT_NE(tracked_reaper.find("waitid(P_PIDFD"), std::string::npos);
+  EXPECT_EQ(tracked_reaper.find("waitpid(-1"), std::string::npos);
+
   EXPECT_EQ(execute.find("terminate_isolated_session_processes(\"before launching"), std::string::npos);
   const auto cage_child_start = cage_source.find("if (pid == 0)");
   const auto cage_child_end = cage_source.find("set_labwc_process_environment(headless)", cage_child_start);
@@ -2543,7 +2782,13 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   EXPECT_NE(source.find("_session_used_gamescope_runtime = gamescope_stream_session;"), std::string::npos);
   EXPECT_NE(terminate.find("_session_used_gamescope_runtime"), std::string::npos);
   EXPECT_NE(source.find("const bool prior_cleanup_complete = _exact_generation_cleanup_complete;"), std::string::npos);
-  EXPECT_NE(source.find("prior_cleanup_complete && isolated_cleanup_complete"), std::string::npos);
+  const auto cleanup_completion_chain = source.find(
+    "_exact_generation_cleanup_complete = prior_cleanup_complete &&"
+  );
+  ASSERT_NE(cleanup_completion_chain, std::string::npos);
+  const auto cleanup_completion_contract = source.substr(cleanup_completion_chain, 260);
+  EXPECT_NE(cleanup_completion_contract.find("isolated_cleanup_complete"), std::string::npos);
+  EXPECT_NE(cleanup_completion_contract.find("detached_authority_complete"), std::string::npos);
   EXPECT_LT(terminate_generation, terminate_main);
   EXPECT_LT(terminate_generation, legacy_group_gate);
   EXPECT_LT(legacy_group_gate, legacy_detach_gate);


### PR DESCRIPTION
## Problem

Authenticated session shutdown reached Polaris's process teardown, but a non-cage app containing only detached commands had no retained Boost.Process child handle or process group. The exact-generation cleanup path was Cage-only, so a detached workload could survive while the session reported stopped.

## Solution

- Retain an exact PIDFD for each direct child before detaching a non-cage detached-only command.
- Extend exact session-generation cleanup to that launch shape without changing Cage or mixed main-command ownership paths.
- Signal exact-generation processes and reap direct children through `waitid(P_PIDFD, ...)`.
- Preserve the generation and block replacement launch when capture, termination, reaping, or PIDFD authority is incomplete.
- Clean previously tracked children explicitly when a later detached command fails during partial launch.

## Safety properties

- No same-user or process-name killing.
- No broad process-group signaling.
- No `waitpid(-1)` child-status stealing.
- PIDFD identity is retained before `child.detach()`.
- Incomplete attribution sends no speculative signals and fails closed.
- Cage sessions and mixed main-command/detached-command sessions retain their existing paths.

## Verification

- TDD RED proved the original detached survivor and incomplete-generation clear.
- Additional regressions rejected unrelated-child reaping, numeric-PID reaping, unbounded fallback waits, and partial multi-command launch leakage.
- `test_polaris_config`: **261/261 passed**.
- Complete CTest graph: **17/17 passed**, 0 failures.
- CUDA-enabled GCC 15 aggregate production/test build: passed.
- `git diff --check`: passed.
- File-aware production diff scan: no hardcoded secrets, private keys, host-private paths, or shell APIs.
- Final independent hostile review: **No findings**.

Commit: `95ba8e1fa75497a210e17a9817934dd970e69d2b`

Commit diff SHA-256: `bc9af8a93942f5e565f135392eef56f699455bf46dc1961d964255f052e84a1d`

## Live status

This PR has not been deployed or exercised against a live RP6 session. Production remains the capability-free merged portal build at `01f8c571`. Merge, deployment, and one bounded live proof remain separate approval gates.
