### PR TITLE
docs: publish the user-facing Polaris roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,50 +1,120 @@
-# Roadmap
+# Polaris Roadmap
 
-Polaris is public and usable today, but it is still early. This roadmap is meant to set expectations and make it easier to see where testing and contributions help most.
+Polaris is public and usable today, but it is still early. This roadmap explains
+where the Linux host is heading and where testing helps most. **Direction, not a
+release calendar:** priorities can move when real hardware, regressions, or
+measurements teach us something better.
 
-## Current Focus
+For the shared host-and-client view, see the
+[Polaris + Nova public roadmap](https://papi-ux.com/docs/roadmap/).
 
-- Keep Fedora 44 and Arch release packages reliable.
-- Keep CachyOS and other pacman-compatible Arch derivatives close to the Arch package path.
-- Validate Bazzite as a tester host path using the Fedora RPM through rpm-ostree.
-- Promote Ubuntu 24.04 from experimental DEB support to a better-tested Debian-family path.
-- Keep openSUSE Tumbleweed source-build guidance current while watching whether a release package is worth the maintenance cost.
-- Tighten Linux compositor, capture, input, and encoder behavior across more GPUs and distros.
-- Improve Mission Control diagnostics so failures are easier to understand without digging through logs.
-- Keep Nova integration clear while preserving compatibility with standard Moonlight clients.
+## How to read this roadmap
 
-## Near-Term Work
+- **What stays true** describes the compatibility and product boundaries users
+  can rely on now.
+- **Now** is active reliability and support work.
+- **Next** is work we expect to evaluate after the current foundations are sound.
+- **Explore later** records real goals, not promised releases or dates.
 
-- Bazzite Desktop Mode and Game Mode validation, especially Bazzite host to Steam Deck/Moonlight/Nova clients.
-- Ubuntu DEB validation on real desktop hosts, followed by broader Debian-family install guidance.
-- More runtime diagnostics for VAAPI and software encode paths.
-- Clearer recovery flows when Steam, MangoHud, input isolation, or compositor startup misbehaves.
-- Better examples for safe web UI deployment on trusted networks.
-- Issue templates and support-bundle guidance that capture distro, GPU, compositor, client, launch mode, and logs up front.
+## What stays true
 
-## Later
+- Polaris remains a Linux-first, self-hosted streaming host.
+- Standard Moonlight-compatible clients remain first-class; Nova adds a richer
+  Polaris-aware experience but is not required.
+- Headless streaming should protect the desktop, restore host state, and clean up
+  every process and display it creates.
+- Fedora 44 and Arch are the recommended package paths. SteamOS has a versioned
+  package; Bazzite and Ubuntu are tester paths; openSUSE Tumbleweed remains a
+  source-build path.
+- Windows and macOS host ports are not planned. The work is deliberately focused
+  on making the Linux host excellent.
 
-- Wider distro packaging if the maintenance cost stays reasonable.
-- Better hardware-specific guidance as more users report results.
-- More automated smoke coverage for common launch, pairing, stop/cleanup, and watch/resume paths.
-- Continued Browser Stream validation once the Chromium/WebTransport path proves useful outside development.
+## Now — make Linux streaming dependable
 
-## Known Limits
+- Harden start, stop, recovery, and teardown so failed sessions do not leave
+  workloads, virtual displays, input devices, or stale state behind.
+- Keep Mission Control diagnostics useful without requiring users to spelunk
+  through giant logs.
+- Continue validating headless capture, compositor behavior, input isolation, and
+  encoder selection across NVIDIA and AMD/Mesa hosts.
+- Keep Fedora, Arch, SteamOS, Bazzite, Ubuntu, and openSUSE guidance honest about
+  what is recommended, tested, experimental, or source-build only.
+- Make Polaris and Nova version pairing easier to understand while preserving
+  standard Moonlight-client compatibility.
 
-- Polaris is Linux-host-only today.
-- Fedora 44 and Arch have the recommended package paths.
-- CachyOS generally follows the Arch package path, but derivative-specific gaps still need reports.
-- Bazzite and Ubuntu 24.04 are tester package paths.
-- openSUSE Tumbleweed is source-build supported; other distros are source-build/community-validation oriented.
-- NVIDIA/NVENC is the most heavily validated encoder path; AMD/Mesa VAAPI is supported and should stay visible while broader validation catches up.
-- Browser Stream is experimental.
-- Some richer live-session behavior depends on Nova.
+## Next — make the current path smoother
 
-## Useful Feedback
+- Tighten frame pacing, queue behavior, send scheduling, bitrate pacing, and
+  120 Hz behavior one measured change at a time.
+- Improve capture and encoder diagnostics so the web console reports the path that
+  actually ran, including safe fallbacks.
+- Broaden AMD/VAAPI and software-encode validation without weakening the heavily
+  tested NVIDIA/NVENC path.
+- Expand reproducible smoke coverage for launch, pairing, input, stream, resume,
+  stop, cleanup, and Browser Stream behavior.
+- Prefer improvements that users can compare and roll back over large bundles of
+  unrelated performance changes.
 
-- Bazzite rpm-ostree status, Desktop Mode/Game Mode state, GPU, and Steam Deck/Moonlight/Nova client results.
-- Ubuntu package/source-build results with GPU, driver, desktop environment, and display server details.
-- openSUSE Tumbleweed source-build results, dependency quirks, and optional local package notes.
-- Distro, GPU, driver, compositor, encoder, and launch-mode details for successful installs.
-- Logs and screenshots for failed pairing, launch, capture, encoder setup, input forwarding, or cleanup.
-- Reports that compare Nova with another Moonlight-compatible client on the same host.
+## Build alongside — clean seams, no hidden rewrite
+
+When current work already touches session lifecycle, capture, encode, media,
+telemetry, or client-facing contracts, Polaris may extract a small
+protocol-neutral boundary first. That should make today's Moonlight-compatible
+path easier to test and maintain. It is not permission to build a replacement
+transport in disguise.
+
+## Explore later — only if evidence says yes
+
+### A native streaming path
+
+The current Moonlight-compatible path remains the production and fallback path.
+A native Polaris/Nova path is research, not a foregone rewrite. It should proceed
+only if measured work shows that the remaining limitation belongs to the
+transport itself and the new path can preserve pairing, input, audio, codecs,
+resume, diagnostics, rollback, and standard-client compatibility.
+
+### Proper HDR10+
+
+The goal is end-to-end dynamic metadata that remains attached to the right frames
+from source through capture, encode, transport, decode, and display, with honest
+HDR10 and SDR fallback. A device advertising HDR10+ is not enough, and static HDR
+or host tone mapping must not be relabeled as HDR10+ support.
+
+### True 240 fps
+
+The goal is 240 unique frames per second through render, capture, encode,
+transport, decode, and physical presentation on a validated 240 Hz display. A
+240 Hz mode, duplicated frames, frame generation, or a 240 fps camera by itself is
+not proof of a 240 fps stream.
+
+Passing each goal separately does not prove a combined HDR10+ at 240 fps profile.
+That combination would need its own exact hardware, codec, color, bitrate,
+quality, latency, thermal, fallback, and rollback evidence.
+
+### Other later work
+
+- Wider distro packaging when user demand justifies the maintenance cost.
+- Continued Browser Stream validation after the Chromium/WebTransport path proves
+  useful outside development.
+- Vulkan Video, Linux 4:4:4, honest HDR headless operation, session continuity,
+  and other hardware-specific work behind separate compatibility gates.
+
+## What this roadmap does not promise
+
+- No feature here has an implied date until it appears in a published release.
+- Research does not require users to migrate away from a working client or host.
+- A benchmark win is not a release if cleanup, compatibility, visual quality, or
+  rollback gets worse.
+- The roadmap may change when public testing or measured evidence disproves an
+  assumption.
+
+## Useful feedback
+
+- Distro, GPU, driver, compositor, encoder, launch mode, and client details for
+  successful and failed streams.
+- Bounded logs and screenshots for pairing, capture, encoder, input, resume, or
+  cleanup failures.
+- Bazzite Desktop/Game Mode, Ubuntu, openSUSE, SteamOS, AMD/VAAPI, and unusual
+  display-topology reports.
+- Comparisons between Nova and another Moonlight-compatible client on the same
+  Polaris host and game.


### PR DESCRIPTION
## Summary

- replace the packaging-only roadmap view with a friendly product-direction page for Polaris users and contributors
- separate what stays true, current reliability work, measured next-step optimization, protocol-neutral seam work, and evidence-gated research
- preserve current package/support detail for Fedora 44, Arch, SteamOS, Bazzite, Ubuntu, openSUSE, NVIDIA, AMD, and standard Moonlight-compatible clients
- explain proper HDR10+, true 240 fps, and native transport as longer-horizon goals rather than current support promises
- link to the shared public ecosystem roadmap at papi-ux.com

## Public truth boundaries

- Polaris remains Linux-host-only; Windows and macOS host ports are not planned
- the current Moonlight-compatible path remains the shipping/fallback path
- protocol-neutral boundaries may be improved alongside concrete work, but a native transport must earn activation through evidence
- HDR10+ and 240 fps remain research goals, and separate passes do not prove a combined profile

## Verification

- Polaris public-surface and public-doc hygiene checks: PASS
- release-package dependency and Nix patch checks: PASS
- GitHub-flavored Markdown render: PASS
- cross-repository roadmap consistency/privacy contract: PASS
- added public copy contains no private harness names, task IDs, incident details, local paths, or private benchmark targets
- independent review findings reconciled; follow-up review PASS

## Coordination

Companion PRs:

- Website: https://github.com/papi-ux/papi-ux.github.io/pull/25
- Nova: https://github.com/papi-ux/nova/pull/227

Preferred merge order is the website PR first so
`https://papi-ux.com/docs/roadmap/` exists before this repository starts linking
to it.

## Non-goals

- no runtime, package, protocol, HDR, 240 fps, release, or support-matrix implementation
- no deployment, release, or merge
