### PR TITLE
docs: publish benchmark control contract

### DIFF
--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -1,0 +1,621 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Polaris benchmark control API",
+    "version": "1.0.0",
+    "description": "Machine-readable contract for the authenticated benchmark-run control surface consumed by external measurement harnesses. Field, route, unit, or compatibility changes require this file and its source-derived drift test to change together.",
+    "license": {
+      "name": "GPL-3.0-only",
+      "identifier": "GPL-3.0-only"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://localhost:{port}",
+      "description": "Local Polaris Web UI endpoint; benchmark control is loopback/origin restricted",
+      "variables": {
+        "port": {
+          "default": "47990",
+          "description": "Configured Polaris Web UI port"
+        }
+      }
+    }
+  ],
+  "x-polaris-compatibility-policy": {
+    "add_field": "Update this contract and the consumer in the same reviewed change; do not silently reinterpret retained evidence.",
+    "remove_or_rename_field": "Breaking change requiring a run-record schema_version increment and an explicit migration decision.",
+    "change_unit_or_meaning": "Breaking change requiring a run-record schema_version increment; changing only a suffix is insufficient.",
+    "retained_evidence": "Evidence remains interpreted under the schema_version it records."
+  },
+  "security": [
+    {
+      "BenchmarkApiKey": []
+    }
+  ],
+  "paths": {
+    "/polaris/v1/session/timing/runs": {
+      "post": {
+        "operationId": "createBenchmarkRun",
+        "x-polaris-handler": "createBenchmarkRun",
+        "x-polaris-source-regex": "^/polaris/v1/session/timing/runs$",
+        "summary": "Create and arm one benchmark run for the single active session",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBenchmarkRunRequest"
+              },
+              "example": {
+                "run_id": "pair-0001-control",
+                "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "label": "P0-7-synthetic-A-pair-01",
+                "workload_id": "synthetic-frame-counter-v1",
+                "expected_duration_s": 120,
+                "duration_tolerance_ms": 250,
+                "drain_grace_ms": 2000,
+                "target_fps": 120,
+                "sample_capacity_frames": 32768
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created or a named benchmark precondition rejection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed JSON, wrong content type, or missing run_id"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/AuthorizationFailure"
+          }
+        }
+      }
+    },
+    "/polaris/v1/session/timing/runs/{run_id}/start": {
+      "post": {
+        "operationId": "startBenchmarkRun",
+        "x-polaris-handler": "startBenchmarkRun",
+        "x-polaris-source-regex": "^/polaris/v1/session/timing/runs/([^/]+)/start$",
+        "summary": "Start an armed benchmark run",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RunId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/CommandResponse"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/AuthorizationFailure"
+          }
+        }
+      }
+    },
+    "/polaris/v1/session/timing/runs/{run_id}/stop": {
+      "post": {
+        "operationId": "stopBenchmarkRun",
+        "x-polaris-handler": "stopBenchmarkRun",
+        "x-polaris-source-regex": "^/polaris/v1/session/timing/runs/([^/]+)/stop$",
+        "summary": "Stop an active benchmark run and begin its bounded drain",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RunId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/CommandResponse"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/AuthorizationFailure"
+          }
+        }
+      }
+    },
+    "/polaris/v1/session/timing/runs/{run_id}": {
+      "get": {
+        "operationId": "getBenchmarkRun",
+        "x-polaris-handler": "getBenchmarkRun",
+        "x-polaris-source-regex": "^/polaris/v1/session/timing/runs/([^/]+)$",
+        "summary": "Read the full authoritative run record",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RunId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The run record, or a named lookup rejection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/BenchmarkRunRecord"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CommandResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/AuthorizationFailure"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteBenchmarkRun",
+        "x-polaris-handler": "deleteBenchmarkRun",
+        "x-polaris-source-regex": "^/polaris/v1/session/timing/runs/([^/]+)$",
+        "summary": "Release one run's retained payload storage",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RunId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/CommandResponse"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/AuthorizationFailure"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BenchmarkApiKey": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "Polaris API key",
+        "description": "Existing Polaris Web UI API key. Never retain its resolved value in benchmark evidence."
+      }
+    },
+    "parameters": {
+      "RunId": {
+        "name": "run_id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "responses": {
+      "AuthorizationFailure": {
+        "description": "Rejected by loopback/origin policy, authentication, CSRF policy, or the benchmark-specific rate limit"
+      },
+      "CommandResponse": {
+        "description": "Named command outcome",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CommandResponse"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "CreateBenchmarkRunRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "run_id",
+          "manifest_sha256",
+          "label",
+          "workload_id",
+          "expected_duration_s",
+          "duration_tolerance_ms",
+          "drain_grace_ms",
+          "target_fps",
+          "sample_capacity_frames"
+        ],
+        "properties": {
+          "run_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "manifest_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "label": {
+            "type": "string"
+          },
+          "workload_id": {
+            "type": "string"
+          },
+          "expected_duration_s": {
+            "type": "integer",
+            "minimum": 60,
+            "maximum": 180,
+            "x-unit": "seconds",
+            "x-storage-field": "expected_duration_ns",
+            "x-storage-unit": "nanoseconds",
+            "x-chrono-constructor": "seconds"
+          },
+          "duration_tolerance_ms": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1000,
+            "x-unit": "milliseconds",
+            "x-storage-field": "duration_tolerance_ns",
+            "x-storage-unit": "nanoseconds",
+            "x-chrono-constructor": "milliseconds"
+          },
+          "drain_grace_ms": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5000,
+            "x-unit": "milliseconds",
+            "x-storage-field": "drain_grace_ns",
+            "x-storage-unit": "nanoseconds",
+            "x-chrono-constructor": "milliseconds"
+          },
+          "target_fps": {
+            "type": "integer",
+            "minimum": 30,
+            "maximum": 240,
+            "x-unit": "frames_per_second"
+          },
+          "sample_capacity_frames": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65536,
+            "x-unit": "frames",
+            "x-minimum-formula": "expected_duration_s * target_fps"
+          }
+        }
+      },
+      "CommandResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "status",
+          "run_id",
+          "result"
+        ],
+        "properties": {
+          "status": {
+            "type": "boolean"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "result": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "status": true,
+          "run_id": "pair-0001-control",
+          "result": "created"
+        }
+      },
+      "BenchmarkStageCapture": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "accepted_count",
+          "excluded_started_before_window",
+          "excluded_completed_after_window",
+          "started_in_window_without_terminal_count",
+          "overflow_count",
+          "invalid_count",
+          "start_offset_us",
+          "end_offset_us",
+          "duration_us"
+        ],
+        "properties": {
+          "accepted_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "excluded_started_before_window": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "excluded_completed_after_window": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "started_in_window_without_terminal_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "overflow_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "invalid_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "start_offset_us": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "x-unit": "microseconds"
+          },
+          "end_offset_us": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "x-unit": "microseconds"
+          },
+          "duration_us": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "x-unit": "microseconds"
+          }
+        }
+      },
+      "BenchmarkRunRecord": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema_version",
+          "measurement_spec_id",
+          "collector_version",
+          "clock_domain",
+          "run_id",
+          "manifest_sha256",
+          "state",
+          "abort_reason",
+          "process_instance_id",
+          "session_id",
+          "session_generation",
+          "client_population_revision_at_arm",
+          "client_population_revision_at_freeze",
+          "population_change_count",
+          "armed_monotonic_ns",
+          "started_monotonic_ns",
+          "stopped_monotonic_ns",
+          "frozen_monotonic_ns",
+          "expected_duration_ns",
+          "duration_tolerance_ns",
+          "drain_grace_ns",
+          "actual_duration_ns",
+          "duration_within_tolerance",
+          "target_fps",
+          "workload_id",
+          "sample_capacity",
+          "capture_to_encode",
+          "encode_to_send_release",
+          "capture_to_send_release"
+        ],
+        "properties": {
+          "schema_version": {
+            "type": "integer",
+            "const": 1
+          },
+          "measurement_spec_id": {
+            "type": "string",
+            "const": "measurement-spec-v1"
+          },
+          "collector_version": {
+            "type": "string"
+          },
+          "clock_domain": {
+            "type": "string",
+            "const": "CLOCK_MONOTONIC"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "manifest_sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "state": {
+            "type": "string"
+          },
+          "abort_reason": {
+            "type": "string"
+          },
+          "process_instance_id": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "session_generation": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "client_population_revision_at_arm": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "client_population_revision_at_freeze": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "population_change_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "armed_monotonic_ns": {
+            "type": "integer",
+            "x-unit": "nanoseconds"
+          },
+          "started_monotonic_ns": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "x-unit": "nanoseconds"
+          },
+          "stopped_monotonic_ns": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "x-unit": "nanoseconds"
+          },
+          "frozen_monotonic_ns": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "x-unit": "nanoseconds"
+          },
+          "expected_duration_ns": {
+            "type": "integer",
+            "x-unit": "nanoseconds"
+          },
+          "duration_tolerance_ns": {
+            "type": "integer",
+            "x-unit": "nanoseconds"
+          },
+          "drain_grace_ns": {
+            "type": "integer",
+            "x-unit": "nanoseconds"
+          },
+          "actual_duration_ns": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "x-unit": "nanoseconds"
+          },
+          "duration_within_tolerance": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "target_fps": {
+            "type": "integer",
+            "x-unit": "frames_per_second"
+          },
+          "workload_id": {
+            "type": "string"
+          },
+          "sample_capacity": {
+            "type": "integer",
+            "x-unit": "frames"
+          },
+          "capture_to_encode": {
+            "$ref": "#/components/schemas/BenchmarkStageCapture"
+          },
+          "encode_to_send_release": {
+            "$ref": "#/components/schemas/BenchmarkStageCapture"
+          },
+          "capture_to_send_release": {
+            "$ref": "#/components/schemas/BenchmarkStageCapture"
+          }
+        },
+        "example": {
+          "schema_version": 1,
+          "measurement_spec_id": "measurement-spec-v1",
+          "collector_version": "1.3.7",
+          "clock_domain": "CLOCK_MONOTONIC",
+          "run_id": "pair-0001-control",
+          "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "state": "frozen",
+          "abort_reason": "none",
+          "process_instance_id": "host-process-0001",
+          "session_id": "client-device-0001",
+          "session_generation": 7,
+          "client_population_revision_at_arm": 11,
+          "client_population_revision_at_freeze": 11,
+          "population_change_count": 0,
+          "armed_monotonic_ns": 1000000000,
+          "started_monotonic_ns": 2000000000,
+          "stopped_monotonic_ns": 122000000000,
+          "frozen_monotonic_ns": 124000000000,
+          "expected_duration_ns": 120000000000,
+          "duration_tolerance_ns": 250000000,
+          "drain_grace_ns": 2000000000,
+          "actual_duration_ns": 120000000000,
+          "duration_within_tolerance": true,
+          "target_fps": 120,
+          "workload_id": "synthetic-frame-counter-v1",
+          "sample_capacity": 32768,
+          "capture_to_encode": {
+            "accepted_count": 2,
+            "excluded_started_before_window": 0,
+            "excluded_completed_after_window": 0,
+            "started_in_window_without_terminal_count": 0,
+            "overflow_count": 0,
+            "invalid_count": 0,
+            "start_offset_us": [
+              0,
+              8333
+            ],
+            "end_offset_us": [
+              500,
+              8833
+            ],
+            "duration_us": [
+              500,
+              500
+            ]
+          },
+          "encode_to_send_release": {
+            "accepted_count": 2,
+            "excluded_started_before_window": 0,
+            "excluded_completed_after_window": 0,
+            "started_in_window_without_terminal_count": 0,
+            "overflow_count": 0,
+            "invalid_count": 0,
+            "start_offset_us": [
+              500,
+              8833
+            ],
+            "end_offset_us": [
+              1300,
+              9633
+            ],
+            "duration_us": [
+              800,
+              800
+            ]
+          },
+          "capture_to_send_release": {
+            "accepted_count": 2,
+            "excluded_started_before_window": 0,
+            "excluded_completed_after_window": 0,
+            "started_in_window_without_terminal_count": 0,
+            "overflow_count": 0,
+            "invalid_count": 0,
+            "start_offset_us": [
+              0,
+              8333
+            ],
+            "end_offset_us": [
+              1300,
+              9633
+            ],
+            "duration_us": [
+              1300,
+              1300
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,7 @@ set(TEST_AUDIT_SUPPORT_SOURCES
 )
 
 set(TEST_FAST_SOURCES
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_benchmark_control_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_validation.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_benchmark_auth.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_client_settings_advertisement.cpp

--- a/tests/unit/test_benchmark_control_contract.cpp
+++ b/tests/unit/test_benchmark_control_contract.cpp
@@ -1,0 +1,304 @@
+/**
+ * @file tests/unit/test_benchmark_control_contract.cpp
+ * @brief Keep the published benchmark-control OpenAPI contract in lockstep with Polaris.
+ */
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace {
+  std::string read_source_file(std::string_view relative_path) {
+    const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / relative_path;
+    std::ifstream input {path};
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+  }
+
+  bool is_identifier_char(char c) {
+    return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+  }
+
+  std::string function_body(const std::string &source, const std::string &name) {
+    std::size_t open = std::string::npos;
+    for (std::size_t sig = source.find(name + "("); sig != std::string::npos;
+         sig = source.find(name + "(", sig + 1)) {
+      if (sig > 0 && is_identifier_char(source[sig - 1])) {
+        continue;
+      }
+
+      int parens = 0;
+      std::size_t close = std::string::npos;
+      for (std::size_t i = source.find('(', sig); i < source.size(); ++i) {
+        if (source[i] == '(') {
+          ++parens;
+        } else if (source[i] == ')' && --parens == 0) {
+          close = i;
+          break;
+        }
+      }
+      if (close == std::string::npos) {
+        continue;
+      }
+
+      const auto next = source.find_first_not_of(" \t\n", close + 1);
+      if (next != std::string::npos && source[next] == '{') {
+        open = next;
+        break;
+      }
+    }
+
+    if (open == std::string::npos) {
+      return {};
+    }
+
+    int depth = 0;
+    bool in_string = false;
+    for (std::size_t i = open; i < source.size(); ++i) {
+      const char c = source[i];
+      if (in_string) {
+        if (c == '\\') {
+          ++i;
+        } else if (c == '"') {
+          in_string = false;
+        }
+        continue;
+      }
+      if (c == '"') {
+        in_string = true;
+      } else if (c == '{') {
+        ++depth;
+      } else if (c == '}' && --depth == 0) {
+        return source.substr(open, i - open + 1);
+      }
+    }
+
+    return {};
+  }
+
+  std::set<std::string> property_names(const nlohmann::json &schema) {
+    std::set<std::string> fields;
+    for (const auto &[name, unused] : schema.at("properties").items()) {
+      static_cast<void>(unused);
+      fields.insert(name);
+    }
+    return fields;
+  }
+
+  std::set<std::string> required_names(const nlohmann::json &schema) {
+    std::set<std::string> fields;
+    for (const auto &name : schema.at("required")) {
+      fields.insert(name.get<std::string>());
+    }
+    return fields;
+  }
+
+  std::set<std::string> object_keys(const nlohmann::json &object) {
+    std::set<std::string> fields;
+    for (const auto &[name, unused] : object.items()) {
+      static_cast<void>(unused);
+      fields.insert(name);
+    }
+    return fields;
+  }
+
+  std::set<std::string> subscript_assignment_keys(const std::string &scope, const std::string &variable) {
+    std::set<std::string> keys;
+    const std::string needle = variable + "[\"";
+
+    std::size_t pos = 0;
+    while ((pos = scope.find(needle, pos)) != std::string::npos) {
+      if (pos > 0 && is_identifier_char(scope[pos - 1])) {
+        pos += needle.size();
+        continue;
+      }
+      const auto start = pos + needle.size();
+      const auto end = scope.find('"', start);
+      const auto bracket = scope.find(']', end);
+      const auto after = scope.find_first_not_of(" \t\n", bracket + 1);
+      if (end == std::string::npos || bracket == std::string::npos || after == std::string::npos) {
+        break;
+      }
+      if (scope[after] == '=' && (after + 1 >= scope.size() || scope[after + 1] != '=')) {
+        keys.insert(scope.substr(start, end - start));
+      }
+      pos = end;
+    }
+    return keys;
+  }
+
+  std::set<std::string> json_value_keys(const std::string &scope, const std::string &variable) {
+    std::set<std::string> keys;
+    const std::string needle = variable + ".value(\"";
+    std::size_t pos = 0;
+    while ((pos = scope.find(needle, pos)) != std::string::npos) {
+      const auto start = pos + needle.size();
+      const auto end = scope.find('"', start);
+      if (end == std::string::npos) {
+        break;
+      }
+      keys.insert(scope.substr(start, end - start));
+      pos = end;
+    }
+    return keys;
+  }
+
+  std::string without_whitespace(std::string text) {
+    std::erase_if(text, [](unsigned char c) {
+      return std::isspace(c) != 0;
+    });
+    return text;
+  }
+
+  nlohmann::json contract() {
+    return nlohmann::json::parse(read_source_file("docs/benchmark-control-openapi.json"));
+  }
+
+  const nlohmann::json &schema(const nlohmann::json &document, std::string_view name) {
+    return document.at("components").at("schemas").at(name);
+  }
+}  // namespace
+
+TEST(BenchmarkControlContractTests, DeclaresEveryRegisteredRouteAndHandler) {
+  const auto document = contract();
+  const auto source = read_source_file("src/confighttp.cpp");
+  std::size_t operation_count = 0;
+
+  for (const auto &[path, path_item] : document.at("paths").items()) {
+    SCOPED_TRACE(path);
+    for (const auto method : {"get", "post", "delete"}) {
+      if (!path_item.contains(method)) {
+        continue;
+      }
+      ++operation_count;
+      const auto &operation = path_item.at(method);
+      const auto source_regex = operation.at("x-polaris-source-regex").get<std::string>();
+      const auto handler = operation.at("x-polaris-handler").get<std::string>();
+      std::string uppercase_method {method};
+      std::ranges::transform(uppercase_method, uppercase_method.begin(), [](unsigned char c) {
+        return static_cast<char>(std::toupper(c));
+      });
+      const auto registration =
+        "server.resource[\"" + source_regex + "\"][\"" + uppercase_method + "\"] = " + handler + ";";
+      EXPECT_NE(source.find(registration), std::string::npos)
+        << "OpenAPI operation does not match a live Polaris route registration";
+
+      const auto body = function_body(source, handler);
+      ASSERT_FALSE(body.empty()) << "could not find handler body for " << handler;
+      EXPECT_NE(body.find("authorizeBenchmarkHarnessRequest"), std::string::npos)
+        << handler << " does not enforce the contract's bearer API-key security scheme";
+    }
+  }
+
+  EXPECT_EQ(operation_count, 5U);
+  std::size_t registered_count = 0;
+  for (std::size_t pos = 0;
+       (pos = source.find("server.resource[\"^/polaris/v1/session/timing/runs", pos)) != std::string::npos;
+       ++pos) {
+    ++registered_count;
+  }
+  EXPECT_EQ(registered_count, operation_count)
+    << "A live benchmark route exists without a published OpenAPI operation";
+}
+
+TEST(BenchmarkControlContractTests, CreateRequestMatchesParserFieldsAndStorageUnits) {
+  const auto document = contract();
+  const auto &request_schema = schema(document, "CreateBenchmarkRunRequest");
+  const auto confighttp = read_source_file("src/confighttp.cpp");
+  const auto parser = function_body(confighttp, "createBenchmarkRun");
+
+  ASSERT_FALSE(parser.empty());
+  EXPECT_EQ(json_value_keys(parser, "inputTree"), property_names(request_schema));
+  EXPECT_EQ(required_names(request_schema), property_names(request_schema));
+
+  const auto engine = without_whitespace(function_body(read_source_file("src/stream_stats.cpp"), "create_benchmark_run"));
+  ASSERT_FALSE(engine.empty());
+  for (const auto &[field_name, field] : request_schema.at("properties").items()) {
+    if (field.contains("minimum") && field.contains("maximum") && field_name != "sample_capacity_frames") {
+      const auto range_check = without_whitespace(
+        "if (request." + field_name + " < " + field.at("minimum").dump() +
+        " || request." + field_name + " > " + field.at("maximum").dump() + ")");
+      EXPECT_NE(engine.find(range_check), std::string::npos)
+        << field_name << " range in OpenAPI does not match create_benchmark_run";
+    }
+    if (!field.contains("x-storage-field")) {
+      continue;
+    }
+    const auto conversion = without_whitespace(
+      "run." + field.at("x-storage-field").get<std::string>() + " = std::chrono::" +
+      field.at("x-chrono-constructor").get<std::string>() + "(request." + field_name + ");");
+    EXPECT_NE(engine.find(conversion), std::string::npos)
+      << field_name << " unit conversion in OpenAPI does not match create_benchmark_run";
+  }
+}
+
+TEST(BenchmarkControlContractTests, ResponseSchemasMatchLiveEmitters) {
+  const auto document = contract();
+  const auto source = read_source_file("src/confighttp.cpp");
+  const auto &stage_schema = schema(document, "BenchmarkStageCapture");
+  const auto &run_schema = schema(document, "BenchmarkRunRecord");
+  const auto &command_schema = schema(document, "CommandResponse");
+
+  EXPECT_EQ(required_names(stage_schema), property_names(stage_schema));
+  EXPECT_EQ(required_names(run_schema), property_names(run_schema));
+  EXPECT_EQ(required_names(command_schema), property_names(command_schema));
+  EXPECT_EQ(
+    subscript_assignment_keys(function_body(source, "benchmark_stage_capture_json"), "output"),
+    property_names(stage_schema));
+  EXPECT_EQ(
+    subscript_assignment_keys(function_body(source, "benchmark_run_json"), "output"),
+    property_names(run_schema));
+
+  for (const auto handler : {
+         "createBenchmarkRun", "startBenchmarkRun", "stopBenchmarkRun", "getBenchmarkRun", "deleteBenchmarkRun"}) {
+    SCOPED_TRACE(handler);
+    EXPECT_EQ(subscript_assignment_keys(function_body(source, handler), "outputTree"), property_names(command_schema));
+  }
+
+  const auto run_emitter = function_body(source, "benchmark_run_json");
+  for (const auto fixed_field : {"schema_version", "measurement_spec_id", "clock_domain"}) {
+    const auto expected =
+      "output[\"" + std::string {fixed_field} + "\"] = " + run_schema.at("properties").at(fixed_field).at("const").dump() + ";";
+    EXPECT_NE(run_emitter.find(expected), std::string::npos)
+      << fixed_field << " fixed value in OpenAPI does not match benchmark_run_json";
+  }
+}
+
+TEST(BenchmarkControlContractTests, CanonicalExamplesCoverEveryContractField) {
+  const auto document = contract();
+  const auto &request_schema = schema(document, "CreateBenchmarkRunRequest");
+  const auto &command_schema = schema(document, "CommandResponse");
+  const auto &stage_schema = schema(document, "BenchmarkStageCapture");
+  const auto &run_schema = schema(document, "BenchmarkRunRecord");
+  const auto &request_example = document.at("paths")
+                                  .at("/polaris/v1/session/timing/runs")
+                                  .at("post")
+                                  .at("requestBody")
+                                  .at("content")
+                                  .at("application/json")
+                                  .at("example");
+  const auto &command_example = command_schema.at("example");
+  const auto &run_example = run_schema.at("example");
+
+  EXPECT_EQ(object_keys(request_example), property_names(request_schema));
+  EXPECT_EQ(object_keys(command_example), property_names(command_schema));
+  EXPECT_EQ(object_keys(run_example), property_names(run_schema));
+  for (const auto stage_name : {"capture_to_encode", "encode_to_send_release", "capture_to_send_release"}) {
+    SCOPED_TRACE(stage_name);
+    EXPECT_EQ(object_keys(run_example.at(stage_name)), property_names(stage_schema));
+  }
+
+  EXPECT_EQ(run_example.at("schema_version"), run_schema.at("properties").at("schema_version").at("const"));
+  EXPECT_EQ(
+    run_example.at("measurement_spec_id"), run_schema.at("properties").at("measurement_spec_id").at("const"));
+  EXPECT_EQ(run_example.at("clock_domain"), run_schema.at("properties").at("clock_domain").at("const"));
+}


### PR DESCRIPTION
## Summary

- publish the benchmark control surface as an OpenAPI 3.1 contract
- pin routes, authentication, request bounds, field units, fixed schema values, and canonical request/response vectors
- add a fast source-derived drift test that fails when the live C++ routes, parser, unit conversions, or emitters diverge

## Why

The nightly measurement harness currently has to infer this API from Polaris source, including mixed input units (seconds/milliseconds) and nanosecond output fields. A repository-owned contract gives both sides a reviewable compatibility boundary without activating any benchmark or changing runtime behavior.

## Validation

- `python3 -m json.tool docs/benchmark-control-openapi.json`
- `npx --yes @redocly/cli@latest lint docs/benchmark-control-openapi.json` (valid; expected localhost-server warning)
- standalone build/run of `BenchmarkControlContractTests`: 4 passed
- `bash scripts/check-public-surface.sh`
- `bash scripts/check-public-docs.sh`
- `git diff --check`

The aggregate macOS `test_polaris` build also compiled the new test object successfully, then stopped on the existing Linux-only `O_PATH` use in `src/platform/linux/gamescope_process.cpp`. Protected Linux CI is authoritative for the full target.

## Scope

Contract and regression coverage only. No benchmark activation, deployment, tag, release, or runtime behavior change.