### PR TITLE
feat(api): make the Doctor's safer-bitrate action executable from the web

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3269,6 +3269,11 @@ namespace confighttp {
       }
 
       const auto result = nvhttp::patch_client_stream_settings(uuid, target_bitrate_kbps, display_mode);
+      if (result == nvhttp::client_mutation_result_t::success && target_bitrate_kbps && *target_bitrate_kbps > 0) {
+        // Mirror the game-stream client-settings path: a live_tuning action
+        // must move the running session, not only the persisted record.
+        adaptive_bitrate::set_base_bitrate(*target_bitrate_kbps);
+      }
       output_tree["status"] = result == nvhttp::client_mutation_result_t::success;
       if (result == nvhttp::client_mutation_result_t::not_found) {
         output_tree["error"] = "Paired client was not found";
@@ -6439,7 +6444,6 @@ namespace confighttp {
     server.resource["^/api/clients/unpair-all$"]["POST"] = withCsrf(unpairAll);
     server.resource["^/api/clients/list$"]["GET"] = getClients;
     server.resource["^/api/clients/update$"]["POST"] = withCsrf(updateClient);
-    server.resource["^/api/clients/settings$"]["POST"] = withCsrf(patchClientSettings);
     server.resource["^/api/clients/settings$"]["POST"] = withCsrf(patchClientSettings);
     server.resource["^/api/clients/unpair$"]["POST"] = withCsrf(unpair);
     server.resource["^/api/clients/disconnect$"]["POST"] = withCsrf(disconnect);

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3187,6 +3187,101 @@ namespace confighttp {
    * }
    * @endcode
    */
+  /**
+   * @brief Patch a paired client's stream tuning (bitrate, display mode).
+   *
+   * The web Doctor's safe recovery action posts here; unlike
+   * /api/clients/update this route only ever touches the fields it is given,
+   * mirroring the validation the game-stream client-settings endpoint applies.
+   *
+   * The body for the POST request should be JSON serialized in the following format:
+   * @code{.json}
+   * {
+   *  "uuid": "<uuid>",
+   *  "target_bitrate_kbps": 12000,
+   *  "display_mode": "1920x1080x120"
+   * }
+   * @endcode
+   */
+  void patchClientSettings(resp_https_t response, req_https_t request) {
+    if (!validateContentType(response, request, "application/json") || !authenticate(response, request)) {
+      return;
+    }
+
+    print_req(request);
+
+    std::stringstream ss;
+    ss << request->content.rdbuf();
+    try {
+      nlohmann::json input_tree = nlohmann::json::parse(ss.str());
+      nlohmann::json output_tree;
+      const std::string uuid = input_tree.value("uuid", "");
+      if (uuid.empty()) {
+        output_tree["status"] = false;
+        output_tree["error"] = "uuid is required";
+        send_response(response, output_tree);
+        return;
+      }
+
+      std::optional<int> target_bitrate_kbps;
+      if (input_tree.contains("target_bitrate_kbps")) {
+        if (!input_tree["target_bitrate_kbps"].is_number_integer()) {
+          output_tree["status"] = false;
+          output_tree["error"] = "target_bitrate_kbps must be an integer";
+          send_response(response, output_tree);
+          return;
+        }
+        const int requested = input_tree["target_bitrate_kbps"].get<int>();
+        if (requested != 0 && (requested < 1000 || requested > 300000)) {
+          output_tree["status"] = false;
+          output_tree["error"] = "target_bitrate_kbps must be 0 or between 1000 and 300000";
+          send_response(response, output_tree);
+          return;
+        }
+        target_bitrate_kbps = requested;
+      }
+
+      std::optional<std::string> display_mode;
+      if (input_tree.contains("display_mode")) {
+        if (!input_tree["display_mode"].is_string()) {
+          output_tree["status"] = false;
+          output_tree["error"] = "display_mode must be a string";
+          send_response(response, output_tree);
+          return;
+        }
+        display_mode = input_tree["display_mode"].get<std::string>();
+        int width = 0;
+        int height = 0;
+        double fps = 0.0;
+        if (!display_mode->empty() && !nvhttp::parse_display_mode_selection(*display_mode, width, height, fps)) {
+          output_tree["status"] = false;
+          output_tree["error"] = "display_mode must use WIDTHxHEIGHTxFPS, for example 1920x1080x120";
+          send_response(response, output_tree);
+          return;
+        }
+      }
+
+      if (!target_bitrate_kbps && !display_mode) {
+        output_tree["status"] = false;
+        output_tree["error"] = "provide target_bitrate_kbps or display_mode";
+        send_response(response, output_tree);
+        return;
+      }
+
+      const auto result = nvhttp::patch_client_stream_settings(uuid, target_bitrate_kbps, display_mode);
+      output_tree["status"] = result == nvhttp::client_mutation_result_t::success;
+      if (result == nvhttp::client_mutation_result_t::not_found) {
+        output_tree["error"] = "Paired client was not found";
+      } else if (result == nvhttp::client_mutation_result_t::persistence_failed) {
+        output_tree["error"] = "Client settings patch could not be persisted";
+      }
+      send_response(response, output_tree);
+    } catch (std::exception &e) {
+      BOOST_LOG(warning) << "Patch Client Settings: "sv << e.what();
+      bad_request(response, request, e.what());
+    }
+  }
+
   void updateClient(resp_https_t response, req_https_t request) {
     if (!validateContentType(response, request, "application/json") || !authenticate(response, request)) {
       return;
@@ -6344,6 +6439,8 @@ namespace confighttp {
     server.resource["^/api/clients/unpair-all$"]["POST"] = withCsrf(unpairAll);
     server.resource["^/api/clients/list$"]["GET"] = getClients;
     server.resource["^/api/clients/update$"]["POST"] = withCsrf(updateClient);
+    server.resource["^/api/clients/settings$"]["POST"] = withCsrf(patchClientSettings);
+    server.resource["^/api/clients/settings$"]["POST"] = withCsrf(patchClientSettings);
     server.resource["^/api/clients/unpair$"]["POST"] = withCsrf(unpair);
     server.resource["^/api/clients/disconnect$"]["POST"] = withCsrf(disconnect);
     server.resource["^/api/clients/wol$"]["POST"] = withCsrf(sendWol);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -9006,6 +9006,49 @@ namespace nvhttp {
     return client_mutation_result_t::success;
   }
 
+  bool parse_display_mode_selection(const std::string &value, int &width, int &height, double &fps) {
+    return parse_stream_policy_display_mode(value, width, height, fps);
+  }
+
+  bool parse_display_mode_selection(const std::string &value, int &width, int &height, double &fps) {
+    return parse_stream_policy_display_mode(value, width, height, fps);
+  }
+
+  client_mutation_result_t patch_client_stream_settings(
+    const std::string &uuid,
+    const std::optional<int> &target_bitrate_kbps,
+    const std::optional<std::string> &display_mode
+  ) {
+    // Scoped sibling of update_device_info_result: touches only the stream
+    // tuning fields so a caller (the web Doctor action) can never clobber the
+    // client's name, permissions, or commands with defaults.
+    std::lock_guard lock(client_state_mutex);
+    const auto it = std::find_if(
+      client_root.named_devices.begin(),
+      client_root.named_devices.end(),
+      [&](const crypto::p_named_cert_t &client) { return client->uuid == uuid; }
+    );
+    if (it == client_root.named_devices.end()) {
+      return client_mutation_result_t::not_found;
+    }
+
+    const auto previous = *it;
+    auto replacement = clone_named_cert(previous);
+    if (target_bitrate_kbps) {
+      replacement->target_bitrate_kbps = *target_bitrate_kbps;
+    }
+    if (display_mode) {
+      replacement->display_mode = *display_mode;
+    }
+    *it = replacement;
+    if (!save_state()) {
+      *it = previous;
+      return client_mutation_result_t::persistence_failed;
+    }
+    rebuild_cert_chain_locked();
+    return client_mutation_result_t::success;
+  }
+
   bool update_device_info(
     const std::string& uuid,
     const std::string& name,

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -9010,10 +9010,6 @@ namespace nvhttp {
     return parse_stream_policy_display_mode(value, width, height, fps);
   }
 
-  bool parse_display_mode_selection(const std::string &value, int &width, int &height, double &fps) {
-    return parse_stream_policy_display_mode(value, width, height, fps);
-  }
-
   client_mutation_result_t patch_client_stream_settings(
     const std::string &uuid,
     const std::optional<int> &target_bitrate_kbps,

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -372,11 +372,6 @@ namespace nvhttp {
     const std::optional<std::string> &display_mode
   );
 
-  /**
-   * @brief Validate a WIDTHxHEIGHTxFPS display-mode selection string.
-   */
-  bool parse_display_mode_selection(const std::string &value, int &width, int &height, double &fps);
-
   bool update_device_info(
     const std::string& uuid,
     const std::string& name,

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -354,6 +354,29 @@ namespace nvhttp {
     const bool always_use_virtual_display
   );
 
+  /**
+   * @brief Validate and parse a WIDTHxHEIGHTxFPS display-mode selection.
+   */
+  bool parse_display_mode_selection(const std::string &value, int &width, int &height, double &fps);
+
+  /**
+   * @brief Patch only a paired client's stream tuning fields.
+   *
+   * Unlike update_device_info_result, absent fields keep their current
+   * values, so partial callers (the web Doctor safe action) cannot reset the
+   * client's name, permissions, or commands.
+   */
+  client_mutation_result_t patch_client_stream_settings(
+    const std::string &uuid,
+    const std::optional<int> &target_bitrate_kbps,
+    const std::optional<std::string> &display_mode
+  );
+
+  /**
+   * @brief Validate a WIDTHxHEIGHTxFPS display-mode selection string.
+   */
+  bool parse_display_mode_selection(const std::string &value, int &width, int &height, double &fps);
+
   bool update_device_info(
     const std::string& uuid,
     const std::string& name,

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -784,7 +784,10 @@ namespace stream_stats {
       nlohmann::json payload = nlohmann::json::object();
       std::string rollback = "No change is applied by Doctor.";
 
-      if (primary_issue == "network_jitter" || primary_issue == "encoder_load") {
+      const int safe_bitrate_kbps = health.value("safe_bitrate_kbps", 0);
+      if ((primary_issue == "network_jitter" || primary_issue == "encoder_load") && safe_bitrate_kbps > 0) {
+        // Without a computed safe bitrate there is nothing to apply: emitting
+        // 0 would CLEAR the client's bitrate cap, the opposite of safer.
         id = "lower_bitrate";
         label = "Apply safer bitrate";
         kind = "live_tuning";
@@ -793,7 +796,7 @@ namespace stream_stats {
         // web adds the session's client uuid to the payload when executing.
         endpoint = "/api/clients/settings";
         method = "POST";
-        payload["target_bitrate_kbps"] = health.value("safe_bitrate_kbps", 0);
+        payload["target_bitrate_kbps"] = safe_bitrate_kbps;
         rollback = "Raise bitrate again from the client or Polaris stream settings.";
       } else if (primary_issue == "no_active_stream" || primary_issue == "capture_missing") {
         id = "export_support_bundle";

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -788,7 +788,10 @@ namespace stream_stats {
         id = "lower_bitrate";
         label = "Apply safer bitrate";
         kind = "live_tuning";
-        endpoint = "/polaris/v1/client-settings";
+        // The Doctor JSON is consumed by the web console, so the action must
+        // be reachable on this server: the scoped client-settings patch. The
+        // web adds the session's client uuid to the payload when executing.
+        endpoint = "/api/clients/settings";
         method = "POST";
         payload["target_bitrate_kbps"] = health.value("safe_bitrate_kbps", 0);
         rollback = "Raise bitrate again from the client or Polaris stream settings.";

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -1291,7 +1291,12 @@ async function runDoctorSafeAction() {
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       method: action.method || 'POST',
-      body: JSON.stringify(action.payload_preview || action.payload || {}),
+      // The host's payload names the change; the web supplies which client,
+      // since only this page knows the active session's uuid.
+      body: JSON.stringify({
+        uuid: connectedClientUuid.value || '',
+        ...(action.payload_preview || action.payload || {}),
+      }),
     })
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     showToast(t('dashboard.doctor_action_success') + action.label, 'success')

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -1276,7 +1276,11 @@ const doctorSafeAction = computed(() => {
   return action
 })
 
-const doctorActionExecutable = computed(() => Boolean(doctorSafeAction.value?.endpoint?.startsWith('/api/')))
+const doctorActionExecutable = computed(() => Boolean(
+  doctorSafeAction.value?.endpoint?.startsWith('/api/')
+  // Client-scoped patches need the active session's uuid to address.
+  && (!doctorSafeAction.value.endpoint.startsWith('/api/clients/') || connectedClientUuid.value)
+))
 
 const doctorActionConfirmOpen = ref(false)
 const doctorActionPending = ref(false)
@@ -1299,6 +1303,9 @@ async function runDoctorSafeAction() {
       }),
     })
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    // The settings routes report failures as 200 {status:false, error}.
+    const result = await response.json().catch(() => ({}))
+    if (result.status === false) throw new Error(result.error || 'rejected')
     showToast(t('dashboard.doctor_action_success') + action.label, 'success')
   } catch (e) {
     showToast(t('dashboard.doctor_action_error') + e.message, 'error')

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -779,14 +779,19 @@ TEST(StreamStatsDoctorTests, SlowEncoderStillFailsOnCpuCopyCapture) {
 
   EXPECT_EQ(doctor.at("primary_issue"), "encoder_load");
 
-  // The Doctor JSON is consumed by the web console, so an executable safe
-  // action must target the web server's own API surface; the game-stream
-  // server's endpoints are unreachable from a browser session.
-  const auto action = doctor.at("safe_recovery_action");
+  // Without a computed safe bitrate the verdict must NOT offer lower_bitrate:
+  // a zero payload would clear the client's bitrate cap instead of lowering it.
+  EXPECT_NE(doctor.at("safe_recovery_action").at("id"), "lower_bitrate");
+
+  // With a safe bitrate, the action must target the web server's own API
+  // surface; the game-stream server's endpoints are unreachable from a
+  // browser session.
+  const auto doctor_with_target = stream_stats::build_doctor_json(stats, nlohmann::json {{"safe_bitrate_kbps", 12000}});
+  const auto action = doctor_with_target.at("safe_recovery_action");
   EXPECT_EQ(action.at("id"), "lower_bitrate");
   EXPECT_EQ(action.at("endpoint"), "/api/clients/settings");
   EXPECT_EQ(action.at("method"), "POST");
-  EXPECT_TRUE(action.at("payload_preview").contains("target_bitrate_kbps"));
+  EXPECT_EQ(action.at("payload_preview").at("target_bitrate_kbps"), 12000);
 }
 
 TEST(StreamStatsDoctorTests, CaptureMissingNeedsTelemetryBeforeTuning) {

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -778,6 +778,15 @@ TEST(StreamStatsDoctorTests, SlowEncoderStillFailsOnCpuCopyCapture) {
   const auto doctor = stream_stats::build_doctor_json(stats, nlohmann::json::object());
 
   EXPECT_EQ(doctor.at("primary_issue"), "encoder_load");
+
+  // The Doctor JSON is consumed by the web console, so an executable safe
+  // action must target the web server's own API surface; the game-stream
+  // server's endpoints are unreachable from a browser session.
+  const auto action = doctor.at("safe_recovery_action");
+  EXPECT_EQ(action.at("id"), "lower_bitrate");
+  EXPECT_EQ(action.at("endpoint"), "/api/clients/settings");
+  EXPECT_EQ(action.at("method"), "POST");
+  EXPECT_TRUE(action.at("payload_preview").contains("target_bitrate_kbps"));
 }
 
 TEST(StreamStatsDoctorTests, CaptureMissingNeedsTelemetryBeforeTuning) {


### PR DESCRIPTION
## Summary

Closes the loop the Mission Control redesign left open: the Doctor's lower_bitrate safe action targeted the game-stream server's client-settings route, unreachable from a browser session, so the web rendered the host's own recommendation as inert "Suggested:" text.

- New `POST /api/clients/settings` on the web server (session auth + CSRF): a scoped patch for a paired client's stream tuning (`target_bitrate_kbps`, `display_mode`), same validation ranges as the game-stream handler.
- Backed by `nvhttp::patch_client_stream_settings`: clone-and-replace under the client-state lock, absent fields keep their values, so a partial caller can never reset the client's name/permissions/commands (the hazard a bare `/api/clients/update` call carries). Display-mode format validation exposed as `nvhttp::parse_display_mode_selection`.
- `doctor_safe_action` emits the new endpoint for lower_bitrate; the dashboard merges the active session's client uuid into the payload. The web already gates execution on `/api/` endpoints, so the inert text upgrades to a working confirm-gated button with no further UI change. Nova's `/polaris/v1/client-settings` channel is untouched.

## Exact candidate

`70a819a` on `doctor-web-action`. 6 files, +182/-2.

## Verification

- New unit assertion in `test_stream_stats.cpp`: an encoder_load verdict's action targets `/api/clients/settings` with a `target_bitrate_kbps` payload (POST).
- Web suite 302/302, eslint clean, budgets pass (dashboard change is the uuid merge only).
- C++ compile + stream-stats suite via the CI distro matrix and sanitizer job.