### PR TITLE
feat(logging): add bounded binary-safe tail reader

### DIFF
--- a/src/file_handler.cpp
+++ b/src/file_handler.cpp
@@ -4,8 +4,11 @@
  */
 
 // standard includes
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <limits>
+#include <stdexcept>
 
 // local includes
 #include "file_handler.h"
@@ -40,6 +43,57 @@ namespace file_handler {
 
     std::ifstream in(path);
     return std::string {(std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>()};
+  }
+
+  tail_result_t read_file_tail(const char *path, std::size_t max_bytes) {
+    if (max_bytes == 0) {
+      throw std::invalid_argument("max_bytes must be greater than zero");
+    }
+
+    std::ifstream in(path, std::ios::binary | std::ios::ate);
+    if (!in.is_open()) {
+      BOOST_LOG(debug) << "Unable to open file tail: " << path;
+      return {};
+    }
+
+    const std::streampos end_position = in.tellg();
+    if (end_position == std::streampos {-1}) {
+      BOOST_LOG(debug) << "Unable to determine file tail offset: " << path;
+      return {};
+    }
+
+    const auto end_offset = static_cast<std::uintmax_t>(end_position);
+    const auto maximum_stream_read = static_cast<std::uintmax_t>(std::numeric_limits<std::streamsize>::max());
+    const auto requested_bytes = std::min({
+      end_offset,
+      static_cast<std::uintmax_t>(max_bytes),
+      maximum_stream_read,
+    });
+    const auto start_offset = end_offset - requested_bytes;
+
+    tail_result_t result;
+    result.start_offset = start_offset;
+    result.end_offset = end_offset;
+    result.truncated = start_offset != 0;
+
+    if (requested_bytes == 0) {
+      return result;
+    }
+
+    in.seekg(static_cast<std::streamoff>(start_offset), std::ios::beg);
+    if (!in.good()) {
+      BOOST_LOG(debug) << "Unable to seek to file tail: " << path;
+      return {};
+    }
+
+    result.content.resize(static_cast<std::size_t>(requested_bytes));
+    in.read(result.content.data(), static_cast<std::streamsize>(requested_bytes));
+    if (in.gcount() != static_cast<std::streamsize>(requested_bytes)) {
+      BOOST_LOG(debug) << "Unable to read complete file tail: " << path;
+      return {};
+    }
+
+    return result;
   }
 
   int write_file(const char *path, const std::string_view &contents) {

--- a/src/file_handler.h
+++ b/src/file_handler.h
@@ -5,12 +5,29 @@
 #pragma once
 
 // standard includes
+#include <cstddef>
+#include <cstdint>
 #include <string>
+#include <string_view>
 
 /**
  * @brief Responsible for file handling functions.
  */
 namespace file_handler {
+  /**
+   * @brief A bounded byte range read from the end of a file.
+   *
+   * Offsets describe the half-open byte range `[start_offset, end_offset)` in
+   * the file snapshot used for the read. `truncated` is true when bytes before
+   * `start_offset` were omitted.
+   */
+  struct tail_result_t {
+    std::string content;
+    std::uintmax_t start_offset {0};
+    std::uintmax_t end_offset {0};
+    bool truncated {false};
+  };
+
   /**
    * @brief Get the parent directory of a file or directory.
    * @param path The path of the file or directory.
@@ -40,6 +57,16 @@ namespace file_handler {
    * @examples_end
    */
   std::string read_file(const char *path);
+
+  /**
+   * @brief Read at most `max_bytes` from the end of a file.
+   * @param path The path of the file.
+   * @param max_bytes The maximum number of bytes to return. Must be non-zero.
+   * @return The binary-safe tail content and its byte offsets. Missing or
+   * unreadable files return an empty result.
+   * @throws std::invalid_argument when `max_bytes` is zero.
+   */
+  tail_result_t read_file_tail(const char *path, std::size_t max_bytes);
 
   /**
    * @brief Writes a file.

--- a/tests/unit/test_file_handler.cpp
+++ b/tests/unit/test_file_handler.cpp
@@ -97,3 +97,101 @@ TEST(FileHandlerTests, ReadMissingFileTest) {
   // read missing file
   EXPECT_EQ(file_handler::read_file("non-existing-file.txt"), "");
 }
+
+namespace {
+  std::filesystem::path tail_test_file(std::string_view name) {
+    return test_paths::root() / std::format("tail_{}.bin", name);
+  }
+}  // namespace
+
+TEST(FileHandlerTailTests, ReadsOnlyRequestedTailAndReportsOffsets) {
+  const auto path = tail_test_file("lines");
+  ASSERT_EQ(file_handler::write_file(path.string().c_str(), "line-1\nline-2\nline-3\n"), 0);
+
+  const auto result = file_handler::read_file_tail(path.string().c_str(), 14);
+
+  EXPECT_EQ(result.content, "line-2\nline-3\n");
+  EXPECT_EQ(result.start_offset, 7);
+  EXPECT_EQ(result.end_offset, 21);
+  EXPECT_TRUE(result.truncated);
+}
+
+TEST(FileHandlerTailTests, MissingFileReturnsEmptyNonTruncatedResult) {
+  const auto result = file_handler::read_file_tail("missing-tail-file.log", 1024);
+
+  EXPECT_TRUE(result.content.empty());
+  EXPECT_EQ(result.start_offset, 0);
+  EXPECT_EQ(result.end_offset, 0);
+  EXPECT_FALSE(result.truncated);
+}
+
+TEST(FileHandlerTailTests, EmptyFileReturnsEmptyNonTruncatedResult) {
+  const auto path = tail_test_file("empty");
+  ASSERT_EQ(file_handler::write_file(path.string().c_str(), ""), 0);
+
+  const auto result = file_handler::read_file_tail(path.string().c_str(), 1024);
+
+  EXPECT_TRUE(result.content.empty());
+  EXPECT_EQ(result.start_offset, 0);
+  EXPECT_EQ(result.end_offset, 0);
+  EXPECT_FALSE(result.truncated);
+}
+
+TEST(FileHandlerTailTests, ExactBoundaryReadsWholeFileWithoutTruncation) {
+  const auto path = tail_test_file("exact");
+  const std::string content = "exactly-14-byt";
+  ASSERT_EQ(content.size(), 14);
+  ASSERT_EQ(file_handler::write_file(path.string().c_str(), content), 0);
+
+  const auto result = file_handler::read_file_tail(path.string().c_str(), content.size());
+
+  EXPECT_EQ(result.content, content);
+  EXPECT_EQ(result.start_offset, 0);
+  EXPECT_EQ(result.end_offset, content.size());
+  EXPECT_FALSE(result.truncated);
+}
+
+TEST(FileHandlerTailTests, TruncatesAtByteBoundaryWhenNoNewlineIsPresent) {
+  const auto path = tail_test_file("no-newline");
+  ASSERT_EQ(file_handler::write_file(path.string().c_str(), "0123456789"), 0);
+
+  const auto result = file_handler::read_file_tail(path.string().c_str(), 4);
+
+  EXPECT_EQ(result.content, "6789");
+  EXPECT_EQ(result.start_offset, 6);
+  EXPECT_EQ(result.end_offset, 10);
+  EXPECT_TRUE(result.truncated);
+}
+
+TEST(FileHandlerTailTests, EmbeddedNulBytesArePreserved) {
+  const auto path = tail_test_file("nul");
+  const std::string content {"abc\0def", 7};
+  ASSERT_EQ(file_handler::write_file(path.string().c_str(), content), 0);
+
+  const auto result = file_handler::read_file_tail(path.string().c_str(), 5);
+
+  EXPECT_EQ(result.content, std::string("c\0def", 5));
+  EXPECT_EQ(result.start_offset, 2);
+  EXPECT_EQ(result.end_offset, 7);
+  EXPECT_TRUE(result.truncated);
+}
+
+TEST(FileHandlerTailTests, MaximumSizeZeroIsRejected) {
+  EXPECT_THROW(
+    (void) file_handler::read_file_tail("any-file.log", 0),
+    std::invalid_argument
+  );
+}
+
+TEST(FileHandlerTailTests, LargeFileStillReturnsAtMostTheRequestedBytes) {
+  const auto path = tail_test_file("large");
+  const std::string content(1024 * 1024, 'x');
+  ASSERT_EQ(file_handler::write_file(path.string().c_str(), content), 0);
+
+  const auto result = file_handler::read_file_tail(path.string().c_str(), 4096);
+
+  EXPECT_EQ(result.content.size(), 4096);
+  EXPECT_EQ(result.start_offset, content.size() - 4096);
+  EXPECT_EQ(result.end_offset, content.size());
+  EXPECT_TRUE(result.truncated);
+}


### PR DESCRIPTION
## Summary

- add a bounded, binary-safe file-tail primitive for the upcoming authenticated log API
- report the exact half-open byte range and whether earlier content was truncated
- fail closed on incomplete reads and reject zero-byte limits

## Validation

- `FileHandlerTailTests.*`: 8/8 passed locally
- affected production and test translation units compile with C++23
- `git diff --check`
- protected Linux CI is the authoritative repository-wide gate; the macOS fast binary has unrelated existing private-state and prepared-FFmpeg failures