### PR TITLE
feat(logging): add bounded versioned log-tail API

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -124,6 +124,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/entry_handler.h"
         "${CMAKE_SOURCE_DIR}/src/file_handler.cpp"
         "${CMAKE_SOURCE_DIR}/src/file_handler.h"
+        "${CMAKE_SOURCE_DIR}/src/log_tail_api.cpp"
+        "${CMAKE_SOURCE_DIR}/src/log_tail_api.h"
         "${CMAKE_SOURCE_DIR}/src/private_state_file.cpp"
         "${CMAKE_SOURCE_DIR}/src/private_state_file.h"
         "${CMAKE_SOURCE_DIR}/src/web_session_store.cpp"

--- a/docs/log-tail-api-v1.md
+++ b/docs/log-tail-api-v1.md
@@ -1,0 +1,67 @@
+# Bounded log-tail API v1
+
+Polaris exposes an authenticated, cache-disabled diagnostic log tail at:
+
+```text
+GET /polaris/v1/diagnostics/logs/tail
+```
+
+This endpoint never reads the whole active log. It is intended for the Web UI and diagnostic tooling that needs recent log content without making host or browser memory proportional to the log file's lifetime size.
+
+## Request
+
+All query values are strict unsigned decimal integers. Signs, whitespace, trailing characters, duplicate parameters, unknown parameters, zero limits, overflow, and values above the documented maximum return HTTP `400`.
+
+| Parameter | Default | Maximum | Meaning |
+|---|---:|---:|---|
+| `max_bytes` | 262144 | 1048576 | Maximum source bytes read from the end of the active log. |
+| `max_lines` | 2000 | 10000 | Maximum logical lines retained after applying the byte bound. |
+| `after` | omitted | uintmax | Optional prior `end_offset` for an incremental response. Zero is valid. |
+| `after_generation` | omitted | uint64 | Prior response generation. It must appear together with `after`. |
+
+The route uses the same Web UI authentication and origin policy as the legacy log route.
+
+## Response
+
+Successful responses are JSON with `Cache-Control: no-store`:
+
+```json
+{
+  "status": true,
+  "schema_version": 1,
+  "content_encoding": "base64",
+  "content": "WzIwMjYtMDgtMTJdOiBJbmZvOiByZWFkeQo=",
+  "content_bytes": 29,
+  "media_type": "text/plain",
+  "charset": "utf-8",
+  "start_offset": 4096,
+  "end_offset": 4125,
+  "generation": 7,
+  "truncated": true,
+  "reset": true
+}
+```
+
+Offsets describe the half-open source byte range `[start_offset, end_offset)`. `generation` identifies the active log lifecycle and changes after initialization or a successful clear. `content_bytes` is the decoded byte count, not the Base64 string length. Base64 is mandatory so embedded NULs, invalid text bytes, and platform code pages cannot make the JSON invalid or change the offset contract.
+
+`truncated` is true when source bytes before `start_offset` were omitted by either the byte or line bound.
+
+`reset` tells an incremental consumer how to apply the response:
+
+- With no `after`, `reset` is true and the response replaces local state.
+- When `after_generation` matches the active generation and `after` lies inside the available byte range, the response begins at `after` and `reset` is false; it is safe to append.
+- When the generation differs, or `after` is older than the available range or newer than the current file end, `reset` is true. The generation check prevents a clear or rotation from reusing a numerically plausible offset and being mistaken for a contiguous delta.
+- If the line limit removes part of an otherwise incremental delta, `reset` is true because appending would hide a gap.
+
+Consumers must keep their own decoded state bounded even when appending contiguous deltas.
+
+## Legacy compatibility
+
+`GET /api/logs` remains authenticated and returns a plain-text body with the platform charset, but it is capped at the newest 1048576 bytes. It also returns:
+
+- `X-Polaris-Log-Start-Offset`
+- `X-Polaris-Log-End-Offset`
+- `X-Polaris-Log-Truncated`
+- `Cache-Control: no-store`
+
+Existing clients can continue treating the body as text. New clients should use the v1 endpoint so truncation and reset behavior are part of the response schema.

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <set>
 #include <sstream>
+#include <stdexcept>
 #include <thread>
 #include <unordered_map>
 #include <numeric>
@@ -49,6 +50,7 @@
 #include "globals.h"
 #include "httpcommon.h"
 #include "logging.h"
+#include "log_tail_api.h"
 #include "network.h"
 #include "nvhttp.h"
 #include "platform/common.h"
@@ -4247,6 +4249,98 @@ namespace confighttp {
   }
 
   /**
+   * @brief Get a versioned, bounded tail of the active log file.
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   *
+   * Query parameters are strict decimal values: `max_bytes`, `max_lines`, and
+   * optional `after` plus `after_generation`. The payload is Base64 encoded so
+   * every source byte is representable in JSON. `reset` tells incremental
+   * callers whether the returned content must replace their local state.
+   *
+   * @api_examples{/polaris/v1/diagnostics/logs/tail| GET| ?max_bytes=262144&max_lines=2000&after=0&after_generation=1}
+   */
+  void getLogTail(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+    print_req(request);
+
+    try {
+      const auto query = request->parse_query_string();
+      for (const auto &entry : query) {
+        const auto &name = entry.first;
+        if (name != "max_bytes" && name != "max_lines" && name != "after" && name != "after_generation") {
+          bad_request(response, request, "Unknown query parameter: " + name);
+          return;
+        }
+      }
+
+      const auto query_value = [&](const std::string &name) -> std::optional<std::string_view> {
+        if (query.count(name) > 1) {
+          throw std::invalid_argument(name + " must appear at most once");
+        }
+        const auto value = query.find(name);
+        if (value == query.end()) {
+          return std::nullopt;
+        }
+        return value->second;
+      };
+
+      const auto tail_request = log_tail_api::parse_request(
+        query_value("max_bytes"),
+        query_value("max_lines"),
+        query_value("after"),
+        query_value("after_generation")
+      );
+
+      std::optional<file_handler::tail_result_t> stable_tail;
+      std::uint64_t stable_generation = 0;
+      for (int attempt = 0; attempt < 3; ++attempt) {
+        const auto generation_before = logging::log_file_generation();
+        auto candidate = file_handler::read_file_tail(config::sunshine.log_file.c_str(), tail_request.max_bytes);
+        const auto generation_after = logging::log_file_generation();
+        if (generation_before == generation_after) {
+          stable_tail = std::move(candidate);
+          stable_generation = generation_after;
+          break;
+        }
+      }
+      if (!stable_tail) {
+        nlohmann::json output = {
+          {"status", false},
+          {"error", "The active log changed repeatedly; retry the request."},
+        };
+        SimpleWeb::CaseInsensitiveMultimap headers;
+        headers.emplace("Retry-After", "1");
+        headers.emplace("Cache-Control", "no-store");
+        append_json_security_headers(headers);
+        response->write(SimpleWeb::StatusCode::server_error_service_unavailable, output.dump(), headers);
+        return;
+      }
+
+      auto output = log_tail_api::serialize_response(log_tail_api::build_response(
+        std::move(*stable_tail),
+        tail_request,
+        stable_generation
+      ));
+      output["media_type"] = "text/plain";
+  #ifdef _WIN32
+      output["charset"] = currentCodePageToCharset();
+  #else
+      output["charset"] = "utf-8";
+  #endif
+
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Cache-Control", "no-store");
+      append_json_security_headers(headers);
+      response->write(SimpleWeb::StatusCode::success_ok, output.dump(), headers);
+    } catch (const std::invalid_argument &error) {
+      bad_request(response, request, error.what());
+    }
+  }
+
+  /**
    * @brief Get the logs from the log file.
    * @param response The HTTP response object.
    * @param request The HTTP request object.
@@ -4258,7 +4352,7 @@ namespace confighttp {
       return;
     }
 
-    std::string content = file_handler::read_file(config::sunshine.log_file.c_str());
+    const auto tail = file_handler::read_file_tail(config::sunshine.log_file.c_str(), log_tail_api::legacy_max_bytes);
     SimpleWeb::CaseInsensitiveMultimap headers;
     std::string contentType = "text/plain";
   #ifdef _WIN32
@@ -4266,8 +4360,12 @@ namespace confighttp {
     contentType += currentCodePageToCharset();
   #endif
     headers.emplace("Content-Type", contentType);
+    headers.emplace("Cache-Control", "no-store");
+    headers.emplace("X-Polaris-Log-Start-Offset", std::to_string(tail.start_offset));
+    headers.emplace("X-Polaris-Log-End-Offset", std::to_string(tail.end_offset));
+    headers.emplace("X-Polaris-Log-Truncated", tail.truncated ? "true" : "false");
     append_common_security_headers(headers);
-    response->write(SimpleWeb::StatusCode::success_ok, content, headers);
+    response->write(SimpleWeb::StatusCode::success_ok, tail.content, headers);
   }
 
   /**
@@ -6347,6 +6445,7 @@ namespace confighttp {
     server.resource["^/api/apps/close$"]["POST"] = withCsrf(closeApp);
     server.resource["^/api/games/scan$"]["GET"] = scanGames;
     server.resource["^/api/games/import$"]["POST"] = withCsrf(importGames);
+    server.resource["^/polaris/v1/diagnostics/logs/tail$"]["GET"] = getLogTail;
     server.resource["^/api/logs$"]["GET"] = getLogs;
     server.resource["^/api/logs/clear$"]["POST"] = withCsrf(clearLogs);
     server.resource["^/api/config$"]["GET"] = getConfig;

--- a/src/log_tail_api.cpp
+++ b/src/log_tail_api.cpp
@@ -1,0 +1,171 @@
+/**
+ * @file src/log_tail_api.cpp
+ * @brief Versioned bounded log-tail request and response contract.
+ */
+
+#include "log_tail_api.h"
+
+#include <algorithm>
+#include <charconv>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace log_tail_api {
+  namespace {
+    std::uintmax_t parse_decimal(
+      const std::string_view value,
+      const std::string_view name,
+      const std::uintmax_t minimum,
+      const std::uintmax_t maximum
+    ) {
+      std::uintmax_t parsed = 0;
+      const auto [end, error] = std::from_chars(value.data(), value.data() + value.size(), parsed);
+      if (value.empty() || error != std::errc {} || end != value.data() + value.size() || parsed < minimum || parsed > maximum) {
+        throw std::invalid_argument(std::string {name} + " must be a decimal integer between " + std::to_string(minimum) + " and " + std::to_string(maximum));
+      }
+      return parsed;
+    }
+
+    std::size_t trim_to_line_limit(std::string &content, const std::size_t max_lines) {
+      if (content.empty()) {
+        return 0;
+      }
+
+      std::size_t line_count = static_cast<std::size_t>(std::count(content.begin(), content.end(), '\n'));
+      if (content.back() != '\n') {
+        ++line_count;
+      }
+      if (line_count <= max_lines) {
+        return 0;
+      }
+
+      auto lines_to_skip = line_count - max_lines;
+      std::size_t bytes_to_skip = 0;
+      while (lines_to_skip > 0) {
+        const auto delimiter = content.find('\n', bytes_to_skip);
+        if (delimiter == std::string::npos) {
+          break;
+        }
+        bytes_to_skip = delimiter + 1;
+        --lines_to_skip;
+      }
+      content.erase(0, bytes_to_skip);
+      return bytes_to_skip;
+    }
+
+    std::string base64_encode(const std::string_view content) {
+      static constexpr char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+      std::string encoded;
+      encoded.reserve(((content.size() + 2) / 3) * 4);
+
+      std::size_t index = 0;
+      while (index + 3 <= content.size()) {
+        const auto value =
+          (static_cast<std::uint32_t>(static_cast<unsigned char>(content[index])) << 16) |
+          (static_cast<std::uint32_t>(static_cast<unsigned char>(content[index + 1])) << 8) |
+          static_cast<std::uint32_t>(static_cast<unsigned char>(content[index + 2]));
+        encoded.push_back(alphabet[(value >> 18) & 0x3f]);
+        encoded.push_back(alphabet[(value >> 12) & 0x3f]);
+        encoded.push_back(alphabet[(value >> 6) & 0x3f]);
+        encoded.push_back(alphabet[value & 0x3f]);
+        index += 3;
+      }
+
+      const auto remaining = content.size() - index;
+      if (remaining == 1) {
+        const auto value = static_cast<std::uint32_t>(static_cast<unsigned char>(content[index])) << 16;
+        encoded.push_back(alphabet[(value >> 18) & 0x3f]);
+        encoded.push_back(alphabet[(value >> 12) & 0x3f]);
+        encoded.append("==");
+      } else if (remaining == 2) {
+        const auto value =
+          (static_cast<std::uint32_t>(static_cast<unsigned char>(content[index])) << 16) |
+          (static_cast<std::uint32_t>(static_cast<unsigned char>(content[index + 1])) << 8);
+        encoded.push_back(alphabet[(value >> 18) & 0x3f]);
+        encoded.push_back(alphabet[(value >> 12) & 0x3f]);
+        encoded.push_back(alphabet[(value >> 6) & 0x3f]);
+        encoded.push_back('=');
+      }
+
+      return encoded;
+    }
+  }  // namespace
+
+  request_t parse_request(
+    const std::optional<std::string_view> max_bytes,
+    const std::optional<std::string_view> max_lines,
+    const std::optional<std::string_view> after,
+    const std::optional<std::string_view> after_generation
+  ) {
+    request_t request;
+    if (max_bytes) {
+      request.max_bytes = static_cast<std::size_t>(parse_decimal(*max_bytes, "max_bytes", 1, maximum_max_bytes));
+    }
+    if (max_lines) {
+      request.max_lines = static_cast<std::size_t>(parse_decimal(*max_lines, "max_lines", 1, maximum_max_lines));
+    }
+    if (after) {
+      request.after = parse_decimal(*after, "after", 0, std::numeric_limits<std::uintmax_t>::max());
+    }
+    if (after_generation) {
+      request.after_generation = parse_decimal(*after_generation, "after_generation", 0, std::numeric_limits<std::uint64_t>::max());
+    }
+    if (request.after.has_value() != request.after_generation.has_value()) {
+      throw std::invalid_argument("after and after_generation must appear together");
+    }
+    return request;
+  }
+
+  response_t build_response(
+    file_handler::tail_result_t tail,
+    const request_t &request,
+    const std::uint64_t generation
+  ) {
+    if (tail.end_offset < tail.start_offset || tail.end_offset - tail.start_offset != tail.content.size()) {
+      throw std::invalid_argument("tail offsets do not match content size");
+    }
+
+    response_t response {
+      .content = std::move(tail.content),
+      .start_offset = tail.start_offset,
+      .end_offset = tail.end_offset,
+      .generation = generation,
+      .truncated = tail.truncated,
+      .reset = true,
+    };
+
+    if (request.after && request.after_generation == generation &&
+        *request.after >= response.start_offset && *request.after <= response.end_offset) {
+      const auto bytes_to_skip = static_cast<std::size_t>(*request.after - response.start_offset);
+      response.content.erase(0, bytes_to_skip);
+      response.start_offset = *request.after;
+      response.reset = false;
+    }
+
+    const auto line_prefix_bytes = trim_to_line_limit(response.content, request.max_lines);
+    if (line_prefix_bytes > 0) {
+      response.start_offset += line_prefix_bytes;
+      response.truncated = true;
+      response.reset = true;
+    }
+
+    return response;
+  }
+
+  nlohmann::json serialize_response(const response_t &response) {
+    return {
+      {"status", true},
+      {"schema_version", 1},
+      {"content_encoding", "base64"},
+      {"content", base64_encode(response.content)},
+      {"content_bytes", response.content.size()},
+      {"start_offset", response.start_offset},
+      {"end_offset", response.end_offset},
+      {"generation", response.generation},
+      {"truncated", response.truncated},
+      {"reset", response.reset},
+    };
+  }
+}  // namespace log_tail_api

--- a/src/log_tail_api.h
+++ b/src/log_tail_api.h
@@ -1,0 +1,67 @@
+/**
+ * @file src/log_tail_api.h
+ * @brief Versioned bounded log-tail request and response contract.
+ */
+#pragma once
+
+#include "file_handler.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace log_tail_api {
+  inline constexpr std::size_t default_max_bytes = 256U * 1024U;
+  inline constexpr std::size_t maximum_max_bytes = 1024U * 1024U;
+  inline constexpr std::size_t default_max_lines = 2000U;
+  inline constexpr std::size_t maximum_max_lines = 10000U;
+  inline constexpr std::size_t legacy_max_bytes = maximum_max_bytes;
+
+  struct request_t {
+    std::size_t max_bytes = default_max_bytes;
+    std::size_t max_lines = default_max_lines;
+    std::optional<std::uintmax_t> after;
+    std::optional<std::uint64_t> after_generation;
+  };
+
+  struct response_t {
+    std::string content;
+    std::uintmax_t start_offset = 0;
+    std::uintmax_t end_offset = 0;
+    std::uint64_t generation = 0;
+    bool truncated = false;
+    bool reset = true;
+  };
+
+  /**
+   * @brief Parse strict decimal query values for the v1 log-tail endpoint.
+   * @throws std::invalid_argument when a value is malformed or out of range.
+   */
+  request_t parse_request(
+    std::optional<std::string_view> max_bytes,
+    std::optional<std::string_view> max_lines,
+    std::optional<std::string_view> after,
+    std::optional<std::string_view> after_generation
+  );
+
+  /**
+   * @brief Apply cursor and logical-line bounds to a bounded file tail.
+   *
+   * `reset` is false only when the returned bytes are a contiguous delta from
+   * the requested `after` offset. Callers must replace local state when it is
+   * true.
+   */
+  response_t build_response(
+    file_handler::tail_result_t tail,
+    const request_t &request,
+    std::uint64_t generation
+  );
+
+  /**
+   * @brief Serialize a binary-safe v1 response. `content` is Base64 encoded.
+   */
+  nlohmann::json serialize_response(const response_t &response);
+}  // namespace log_tail_api

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -3,6 +3,7 @@
  * @brief Definitions for logging related functions.
  */
 // standard includes
+#include <atomic>
 #include <fstream>
 #include <filesystem>
 #include <iomanip>
@@ -39,6 +40,7 @@ namespace bl = boost::log;
 boost::shared_ptr<boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>> sink;
 boost::shared_ptr<std::ofstream> log_file_stream;
 std::string active_log_file_path;
+std::atomic_uint64_t active_log_file_generation {0};
 
 bl::sources::severity_logger<int> verbose(0);  // Dominating output
 bl::sources::severity_logger<int> debug(1);  // Follow what is happening
@@ -222,6 +224,7 @@ namespace logging {
     if (!log_file.empty()) {
       log_file_stream = boost::make_shared<std::ofstream>(log_file);
       sink->locked_backend()->add_stream(log_file_stream);
+      active_log_file_generation.fetch_add(1, std::memory_order_release);
     }
     sink->set_filter(severity >= min_log_level);
     sink->set_formatter(&formatter);
@@ -315,6 +318,10 @@ namespace logging {
     }
   }
 
+  std::uint64_t log_file_generation() {
+    return active_log_file_generation.load(std::memory_order_acquire);
+  }
+
   bool clear_log_file() {
     if (!sink || !log_file_stream || active_log_file_path.empty()) {
       return false;
@@ -327,8 +334,11 @@ namespace logging {
     log_file_stream->close();
     log_file_stream->clear();
     log_file_stream->open(active_log_file_path, std::ios::out | std::ios::trunc);
-
-    return log_file_stream->is_open() && log_file_stream->good();
+    const auto reopened = log_file_stream->is_open() && log_file_stream->good();
+    if (reopened) {
+      active_log_file_generation.fetch_add(1, std::memory_order_release);
+    }
+    return reopened;
   }
 
   void print_help(const char *name) {

--- a/src/logging.h
+++ b/src/logging.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // lib includes
 #include <boost/log/common.hpp>
 #include <boost/log/sinks.hpp>
@@ -75,6 +77,15 @@ namespace logging {
    * @examples_end
    */
   void log_flush();
+
+  /**
+   * @brief Return the process-local generation of the active log file.
+   *
+   * The generation changes after initialization and every successful clear so
+   * incremental readers can distinguish reused byte offsets from the same
+   * logical log generation.
+   */
+  std::uint64_t log_file_generation();
 
   /**
    * @brief Clear the active log file while keeping logging enabled.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/confighttp_benchmark_auth.cpp
     ${CMAKE_SOURCE_DIR}/src/browser_stream_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/file_handler.cpp
+    ${CMAKE_SOURCE_DIR}/src/log_tail_api.cpp
     ${CMAKE_SOURCE_DIR}/src/private_state_file.cpp
     ${CMAKE_SOURCE_DIR}/src/web_session_store.cpp
     ${CMAKE_SOURCE_DIR}/src/beat_times.cpp
@@ -103,6 +104,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_browser_stream_protocol.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_cursor_visibility.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_file_handler.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_log_tail_api.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_private_state_file.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_web_session_store.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_beat_times.cpp

--- a/tests/unit/test_log_tail_api.cpp
+++ b/tests/unit/test_log_tail_api.cpp
@@ -1,0 +1,243 @@
+/**
+ * @file tests/unit/test_log_tail_api.cpp
+ * @brief Test the versioned bounded log-tail contract.
+ */
+#include <array>
+#include <gtest/gtest.h>
+#include <src/log_tail_api.h>
+#include <utility>
+
+using namespace std::literals;
+namespace {
+  constexpr std::uint64_t generation = 7;
+}
+
+TEST(LogTailApiRequestTests, UsesBoundedDefaults) {
+  const auto request = log_tail_api::parse_request(std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+
+  EXPECT_EQ(request.max_bytes, log_tail_api::default_max_bytes);
+  EXPECT_EQ(request.max_lines, log_tail_api::default_max_lines);
+  EXPECT_FALSE(request.after.has_value());
+  EXPECT_FALSE(request.after_generation.has_value());
+}
+
+TEST(LogTailApiRequestTests, ParsesStrictDecimalLimitsAndCursor) {
+  const auto request = log_tail_api::parse_request("4096"sv, "25"sv, "123"sv, "7"sv);
+
+  EXPECT_EQ(request.max_bytes, 4096);
+  EXPECT_EQ(request.max_lines, 25);
+  ASSERT_TRUE(request.after.has_value());
+  EXPECT_EQ(*request.after, 123);
+  ASSERT_TRUE(request.after_generation.has_value());
+  EXPECT_EQ(*request.after_generation, generation);
+}
+
+TEST(LogTailApiRequestTests, RejectsMalformedAndOutOfRangeValues) {
+  for (const auto value : {""sv, "0"sv, "-1"sv, "+1"sv, " 1"sv, "1x"sv, "999999999999999999999999"sv}) {
+    EXPECT_THROW(log_tail_api::parse_request(value, std::nullopt, std::nullopt, std::nullopt), std::invalid_argument) << value;
+  }
+  EXPECT_THROW(
+    log_tail_api::parse_request(std::to_string(log_tail_api::maximum_max_bytes + 1), std::nullopt, std::nullopt, std::nullopt),
+    std::invalid_argument
+  );
+
+  for (const auto value : {""sv, "0"sv, "-1"sv, "+1"sv, " 1"sv, "1x"sv, "999999999999999999999999"sv}) {
+    EXPECT_THROW(log_tail_api::parse_request(std::nullopt, value, std::nullopt, std::nullopt), std::invalid_argument) << value;
+  }
+  EXPECT_THROW(
+    log_tail_api::parse_request(std::nullopt, std::to_string(log_tail_api::maximum_max_lines + 1), std::nullopt, std::nullopt),
+    std::invalid_argument
+  );
+
+  for (const auto value : {""sv, "-1"sv, "+1"sv, " 1"sv, "1x"sv, "999999999999999999999999"sv}) {
+    EXPECT_THROW(log_tail_api::parse_request(std::nullopt, std::nullopt, value, "7"sv), std::invalid_argument) << value;
+    EXPECT_THROW(log_tail_api::parse_request(std::nullopt, std::nullopt, "1"sv, value), std::invalid_argument) << value;
+  }
+
+  EXPECT_THROW(log_tail_api::parse_request(std::nullopt, std::nullopt, "1"sv, std::nullopt), std::invalid_argument);
+  EXPECT_THROW(log_tail_api::parse_request(std::nullopt, std::nullopt, std::nullopt, "7"sv), std::invalid_argument);
+}
+
+TEST(LogTailApiResponseTests, InitialResponseRequiresResetAndPreservesTailMetadata) {
+  file_handler::tail_result_t tail {
+    .content = "recent",
+    .start_offset = 10,
+    .end_offset = 16,
+    .truncated = true,
+  };
+  const auto request = log_tail_api::parse_request(std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+
+  const auto response = log_tail_api::build_response(std::move(tail), request, generation);
+
+  EXPECT_EQ(response.content, "recent");
+  EXPECT_EQ(response.start_offset, 10);
+  EXPECT_EQ(response.end_offset, 16);
+  EXPECT_EQ(response.generation, generation);
+  EXPECT_TRUE(response.truncated);
+  EXPECT_TRUE(response.reset);
+}
+
+TEST(LogTailApiResponseTests, ValidCursorReturnsOnlyContiguousDelta) {
+  file_handler::tail_result_t tail {
+    .content = "abcdefghij",
+    .start_offset = 90,
+    .end_offset = 100,
+    .truncated = true,
+  };
+  const auto request = log_tail_api::parse_request(std::nullopt, std::nullopt, "95"sv, "7"sv);
+
+  const auto response = log_tail_api::build_response(std::move(tail), request, generation);
+
+  EXPECT_EQ(response.content, "fghij");
+  EXPECT_EQ(response.start_offset, 95);
+  EXPECT_EQ(response.end_offset, 100);
+  EXPECT_TRUE(response.truncated);
+  EXPECT_FALSE(response.reset);
+}
+
+TEST(LogTailApiResponseTests, CursorAtEndReturnsAnEmptyContiguousDelta) {
+  file_handler::tail_result_t tail {
+    .content = "abcdefghij",
+    .start_offset = 90,
+    .end_offset = 100,
+    .truncated = true,
+  };
+  const auto request = log_tail_api::parse_request(std::nullopt, std::nullopt, "100"sv, "7"sv);
+
+  const auto response = log_tail_api::build_response(std::move(tail), request, generation);
+
+  EXPECT_TRUE(response.content.empty());
+  EXPECT_EQ(response.start_offset, 100);
+  EXPECT_EQ(response.end_offset, 100);
+  EXPECT_FALSE(response.reset);
+}
+
+TEST(LogTailApiResponseTests, CursorOutsideAvailableRangeRequiresReset) {
+  const auto request_before = log_tail_api::parse_request(std::nullopt, std::nullopt, "89"sv, "7"sv);
+  const auto request_after = log_tail_api::parse_request(std::nullopt, std::nullopt, "101"sv, "7"sv);
+
+  for (const auto &request : {request_before, request_after}) {
+    file_handler::tail_result_t tail {
+      .content = "abcdefghij",
+      .start_offset = 90,
+      .end_offset = 100,
+      .truncated = true,
+    };
+    const auto response = log_tail_api::build_response(std::move(tail), request, generation);
+
+    EXPECT_EQ(response.content, "abcdefghij");
+    EXPECT_EQ(response.start_offset, 90);
+    EXPECT_EQ(response.end_offset, 100);
+    EXPECT_TRUE(response.truncated);
+    EXPECT_TRUE(response.reset);
+  }
+}
+
+TEST(LogTailApiResponseTests, ReusedOffsetsFromAnotherGenerationRequireReset) {
+  file_handler::tail_result_t tail {
+    .content = "new generation",
+    .start_offset = 90,
+    .end_offset = 104,
+    .truncated = false,
+  };
+  const auto request = log_tail_api::parse_request(std::nullopt, std::nullopt, "95"sv, "6"sv);
+
+  const auto response = log_tail_api::build_response(std::move(tail), request, generation);
+
+  EXPECT_EQ(response.content, "new generation");
+  EXPECT_EQ(response.start_offset, 90);
+  EXPECT_EQ(response.generation, generation);
+  EXPECT_TRUE(response.reset);
+}
+
+TEST(LogTailApiResponseTests, LineLimitKeepsNewestLogicalLinesAndAdjustsOffset) {
+  file_handler::tail_result_t tail {
+    .content = "one\ntwo\nthree\nfour\n",
+    .start_offset = 100,
+    .end_offset = 119,
+    .truncated = false,
+  };
+  const auto request = log_tail_api::parse_request(std::nullopt, "2"sv, std::nullopt, std::nullopt);
+
+  const auto response = log_tail_api::build_response(std::move(tail), request, generation);
+
+  EXPECT_EQ(response.content, "three\nfour\n");
+  EXPECT_EQ(response.start_offset, 108);
+  EXPECT_EQ(response.end_offset, 119);
+  EXPECT_TRUE(response.truncated);
+  EXPECT_TRUE(response.reset);
+}
+
+TEST(LogTailApiResponseTests, LineLimitHandlesContentWithoutTrailingNewline) {
+  file_handler::tail_result_t tail {
+    .content = "one\ntwo\nthree",
+    .start_offset = 0,
+    .end_offset = 13,
+    .truncated = false,
+  };
+  const auto request = log_tail_api::parse_request(std::nullopt, "1"sv, std::nullopt, std::nullopt);
+
+  const auto response = log_tail_api::build_response(std::move(tail), request, generation);
+
+  EXPECT_EQ(response.content, "three");
+  EXPECT_EQ(response.start_offset, 8);
+  EXPECT_EQ(response.end_offset, 13);
+  EXPECT_TRUE(response.truncated);
+}
+
+TEST(LogTailApiResponseTests, LineLimitForcesResetWhenItDropsPartOfAnIncrementalDelta) {
+  file_handler::tail_result_t tail {
+    .content = "one\ntwo\nthree\n",
+    .start_offset = 0,
+    .end_offset = 14,
+    .truncated = false,
+  };
+  const auto request = log_tail_api::parse_request(std::nullopt, "1"sv, "4"sv, "7"sv);
+
+  const auto response = log_tail_api::build_response(std::move(tail), request, generation);
+
+  EXPECT_EQ(response.content, "three\n");
+  EXPECT_EQ(response.start_offset, 8);
+  EXPECT_EQ(response.end_offset, 14);
+  EXPECT_TRUE(response.truncated);
+  EXPECT_TRUE(response.reset);
+}
+
+TEST(LogTailApiResponseTests, SerializationIsBinarySafeAndVersioned) {
+  log_tail_api::response_t response {
+    .content = std::string {"\0\xff", 2},
+    .start_offset = 12,
+    .end_offset = 14,
+    .generation = generation,
+    .truncated = true,
+    .reset = false,
+  };
+
+  const auto output = log_tail_api::serialize_response(response);
+
+  EXPECT_TRUE(output.at("status"));
+  EXPECT_EQ(output.at("schema_version"), 1);
+  EXPECT_EQ(output.at("content_encoding"), "base64");
+  EXPECT_EQ(output.at("content"), "AP8=");
+  EXPECT_EQ(output.at("content_bytes"), 2);
+  EXPECT_EQ(output.at("start_offset"), 12);
+  EXPECT_EQ(output.at("end_offset"), 14);
+  EXPECT_EQ(output.at("generation"), generation);
+  EXPECT_TRUE(output.at("truncated"));
+  EXPECT_FALSE(output.at("reset"));
+}
+
+TEST(LogTailApiResponseTests, Base64SerializationCoversEveryQuantumShape) {
+  const std::array examples {
+    std::pair {""s, ""s},
+    std::pair {"f"s, "Zg=="s},
+    std::pair {"fo"s, "Zm8="s},
+    std::pair {"foo"s, "Zm9v"s},
+    std::pair {"foobar"s, "Zm9vYmFy"s},
+  };
+
+  for (const auto &[content, encoded] : examples) {
+    const log_tail_api::response_t response {.content = content};
+    EXPECT_EQ(log_tail_api::serialize_response(response).at("content"), encoded);
+  }
+}

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -176,3 +176,14 @@ TEST(LoggingRunaway, GlInfoLogLengthIsInitializedAndGuarded) {
       << fn << " must return early on a non-positive info-log length";
   }
 }
+
+TEST(LoggingGeneration, SuccessfulClearAdvancesGenerationAndKeepsLoggingUsable) {
+  const auto before = logging::log_file_generation();
+
+  ASSERT_TRUE(logging::clear_log_file());
+  EXPECT_EQ(logging::log_file_generation(), before + 1);
+
+  const auto marker = std::format("post-clear-generation-{}", before + 1);
+  BOOST_LOG(info) << marker;
+  ASSERT_TRUE(log_checker::line_contains(test_paths::log_file().string(), marker));
+}


### PR DESCRIPTION
## Summary

- add an authenticated, cache-disabled `GET /polaris/v1/diagnostics/logs/tail` JSON contract with strict byte, line, cursor, and generation bounds
- make cursor application binary-safe and reset on gaps, line trimming, clear/reopen, or generation changes
- cap the legacy `/api/logs` response at 1 MiB while preserving its plain-text compatibility shape and adding offset/truncation headers
- advance a process-local log generation after initialization and every successful clear so reused offsets cannot be mistaken for contiguous data

## Validation

- `FileHandlerTailTests.*`, `LogTailApi*.*`, and `LoggingGeneration.*`: 22/22 passed locally
- affected production translation units (`confighttp.cpp`, `log_tail_api.cpp`, `logging.cpp`) compile with C++23
- `git diff --check`
- protected Linux CI is the authoritative repository-wide gate; local macOS full-test compilation requires the repository's existing `O_PATH` and Lutris overload workarounds