### PR TITLE
feat(web): bound incremental log tail state

### DIFF
--- a/src_assets/common/assets/web/log-tail-state.js
+++ b/src_assets/common/assets/web/log-tail-state.js
@@ -1,0 +1,160 @@
+export const MAX_BROWSER_LOG_BYTES = 256 * 1024
+export const MAX_BROWSER_LOG_LINES = 2000
+
+const LOG_TAIL_ENDPOINT = './polaris/v1/diagnostics/logs/tail'
+
+export function createLogTailState() {
+  return {
+    bytes: new Uint8Array(),
+    text: '',
+    startOffset: null,
+    endOffset: null,
+    generation: null,
+    truncated: false,
+    reset: true,
+  }
+}
+
+function decodeBase64(value) {
+  if (typeof value !== 'string' || value.length % 4 !== 0 ||
+      !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+    throw new Error('Invalid Base64 log-tail content')
+  }
+
+  let binary
+  try {
+    binary = globalThis.atob(value)
+  } catch {
+    throw new Error('Invalid Base64 log-tail content')
+  }
+
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; ++index) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes
+}
+
+function validatePayload(payload) {
+  if (!payload || payload.status !== true || payload.schema_version !== 1) {
+    throw new Error('Unsupported log-tail schema')
+  }
+  if (payload.content_encoding !== 'base64') {
+    throw new Error('Unsupported log-tail content encoding')
+  }
+  if (!Number.isSafeInteger(payload.content_bytes) || payload.content_bytes < 0) {
+    throw new Error('Invalid log-tail byte count')
+  }
+  if (!Number.isSafeInteger(payload.start_offset) || !Number.isSafeInteger(payload.end_offset) ||
+      payload.start_offset < 0 || payload.end_offset < payload.start_offset) {
+    throw new Error('Invalid log-tail offsets')
+  }
+  if (!Number.isSafeInteger(payload.generation) || payload.generation < 0) {
+    throw new Error('Invalid log-tail generation')
+  }
+  if (payload.end_offset - payload.start_offset !== payload.content_bytes) {
+    throw new Error('Log-tail offsets do not match byte count')
+  }
+  if (typeof payload.truncated !== 'boolean' || typeof payload.reset !== 'boolean') {
+    throw new Error('Invalid log-tail state flags')
+  }
+
+  const bytes = decodeBase64(payload.content)
+  if (bytes.byteLength !== payload.content_bytes) {
+    throw new Error('Decoded log-tail byte count does not match response')
+  }
+  return bytes
+}
+
+function concatenate(left, right) {
+  const combined = new Uint8Array(left.byteLength + right.byteLength)
+  combined.set(left, 0)
+  combined.set(right, left.byteLength)
+  return combined
+}
+
+function trimBytes(bytes, maxBytes, maxLines) {
+  let removed = Math.max(0, bytes.byteLength - maxBytes)
+  let bounded = bytes.subarray(removed)
+
+  if (bounded.byteLength > 0) {
+    let lineCount = bounded[bounded.byteLength - 1] === 0x0a ? 0 : 1
+    for (const byte of bounded) {
+      if (byte === 0x0a) ++lineCount
+    }
+
+    let linesToSkip = Math.max(0, lineCount - maxLines)
+    let lineBytesToSkip = 0
+    while (linesToSkip > 0 && lineBytesToSkip < bounded.byteLength) {
+      if (bounded[lineBytesToSkip++] === 0x0a) --linesToSkip
+    }
+    removed += lineBytesToSkip
+    bounded = bounded.subarray(lineBytesToSkip)
+  }
+
+  return {
+    bytes: bounded.slice(),
+    removed,
+  }
+}
+
+function decodeText(bytes, charset) {
+  const label = typeof charset === 'string' && charset ? charset : 'utf-8'
+  return new TextDecoder(label).decode(bytes)
+}
+
+export function applyLogTailPayload(state, payload, {
+  maxBytes = MAX_BROWSER_LOG_BYTES,
+  maxLines = MAX_BROWSER_LOG_LINES,
+} = {}) {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1 ||
+      !Number.isSafeInteger(maxLines) || maxLines < 1) {
+    throw new Error('Browser log-tail bounds must be positive integers')
+  }
+
+  const incoming = validatePayload(payload)
+  const previous = state || createLogTailState()
+  const contiguous = previous.endOffset !== null && payload.start_offset === previous.endOffset &&
+    previous.generation === payload.generation
+  const append = payload.reset === false && contiguous && previous.startOffset !== null
+  const combined = append ? concatenate(previous.bytes, incoming) : incoming
+  const initialStartOffset = append ? previous.startOffset : payload.start_offset
+  const bounded = trimBytes(combined, maxBytes, maxLines)
+
+  return {
+    bytes: bounded.bytes,
+    text: decodeText(bounded.bytes, payload.charset),
+    startOffset: initialStartOffset + bounded.removed,
+    endOffset: payload.end_offset,
+    generation: payload.generation,
+    truncated: payload.truncated || bounded.removed > 0,
+    reset: payload.reset || !append,
+  }
+}
+
+export async function fetchLogTail(state = createLogTailState(), {
+  fetchImpl = globalThis.fetch,
+  maxBytes = MAX_BROWSER_LOG_BYTES,
+  maxLines = MAX_BROWSER_LOG_LINES,
+  endpoint = LOG_TAIL_ENDPOINT,
+} = {}) {
+  const query = new URLSearchParams({
+    max_bytes: String(maxBytes),
+    max_lines: String(maxLines),
+  })
+  if (Number.isSafeInteger(state.endOffset) && state.endOffset >= 0 &&
+      Number.isSafeInteger(state.generation) && state.generation >= 0) {
+    query.set('after', String(state.endOffset))
+    query.set('after_generation', String(state.generation))
+  }
+
+  const response = await fetchImpl(`${endpoint}?${query}`, {
+    credentials: 'include',
+    cache: 'no-store',
+  })
+  if (!response.ok) {
+    throw new Error(`Log-tail request failed with HTTP ${response.status || 'error'}`)
+  }
+
+  return applyLogTailPayload(state, await response.json(), { maxBytes, maxLines })
+}

--- a/src_assets/common/assets/web/log-tail-state.test.js
+++ b/src_assets/common/assets/web/log-tail-state.test.js
@@ -1,0 +1,203 @@
+import { Buffer } from 'node:buffer'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  applyLogTailPayload,
+  createLogTailState,
+  fetchLogTail,
+  MAX_BROWSER_LOG_BYTES,
+  MAX_BROWSER_LOG_LINES,
+} from './log-tail-state.js'
+
+function payload(content, overrides = {}) {
+  const bytes = Buffer.from(content)
+  const startOffset = overrides.start_offset ?? 0
+  return {
+    status: true,
+    schema_version: 1,
+    content_encoding: 'base64',
+    content: bytes.toString('base64'),
+    content_bytes: bytes.length,
+    media_type: 'text/plain',
+    charset: 'utf-8',
+    start_offset: startOffset,
+    end_offset: overrides.end_offset ?? startOffset + bytes.length,
+    generation: 7,
+    truncated: false,
+    reset: true,
+    ...overrides,
+  }
+}
+
+describe('bounded browser log-tail state', () => {
+  it('starts empty and bounded', () => {
+    const state = createLogTailState()
+
+    expect(state.text).toBe('')
+    expect(state.bytes).toBeInstanceOf(Uint8Array)
+    expect(state.bytes).toHaveLength(0)
+    expect(state.startOffset).toBeNull()
+    expect(state.endOffset).toBeNull()
+    expect(state.generation).toBeNull()
+  })
+
+  it('replaces state on an initial response and preserves truncation metadata', () => {
+    const next = applyLogTailPayload(createLogTailState(), payload('recent\n', {
+      start_offset: 100,
+      end_offset: 107,
+      truncated: true,
+      reset: true,
+    }))
+
+    expect(next.text).toBe('recent\n')
+    expect(next.startOffset).toBe(100)
+    expect(next.endOffset).toBe(107)
+    expect(next.generation).toBe(7)
+    expect(next.truncated).toBe(true)
+    expect(next.reset).toBe(true)
+  })
+
+  it('appends only a contiguous delta', () => {
+    const initial = applyLogTailPayload(createLogTailState(), payload('one\n', {
+      end_offset: 4,
+    }))
+    const next = applyLogTailPayload(initial, payload('two\n', {
+      start_offset: 4,
+      end_offset: 8,
+      reset: false,
+    }))
+
+    expect(next.text).toBe('one\ntwo\n')
+    expect(next.startOffset).toBe(0)
+    expect(next.endOffset).toBe(8)
+    expect(next.reset).toBe(false)
+  })
+
+  it('fails closed to replacement when a claimed delta is discontinuous', () => {
+    const initial = applyLogTailPayload(createLogTailState(), payload('old\n', {
+      start_offset: 10,
+      end_offset: 14,
+    }))
+    const next = applyLogTailPayload(initial, payload('new\n', {
+      start_offset: 20,
+      end_offset: 24,
+      reset: false,
+    }))
+
+    expect(next.text).toBe('new\n')
+    expect(next.startOffset).toBe(20)
+    expect(next.endOffset).toBe(24)
+    expect(next.reset).toBe(true)
+  })
+
+  it('replaces a prior window when the server reports a reset', () => {
+    const initial = applyLogTailPayload(createLogTailState(), payload('old\n', {
+      start_offset: 10,
+      end_offset: 14,
+    }))
+    const next = applyLogTailPayload(initial, payload('new\n', {
+      start_offset: 14,
+      end_offset: 18,
+      reset: true,
+    }))
+
+    expect(next.text).toBe('new\n')
+    expect(next.startOffset).toBe(14)
+    expect(next.endOffset).toBe(18)
+    expect(next.reset).toBe(true)
+  })
+
+  it('replaces a numerically contiguous window from another generation', () => {
+    const initial = applyLogTailPayload(createLogTailState(), payload('old\n', {
+      start_offset: 10,
+      end_offset: 14,
+    }))
+    const next = applyLogTailPayload(initial, payload('new\n', {
+      start_offset: 14,
+      end_offset: 18,
+      generation: 8,
+      reset: false,
+    }))
+
+    expect(next.text).toBe('new\n')
+    expect(next.generation).toBe(8)
+    expect(next.reset).toBe(true)
+  })
+
+  it('bounds accumulated bytes and lines after incremental appends', () => {
+    let state = createLogTailState()
+    let offset = 0
+    for (let index = 0; index < 20; ++index) {
+      const line = `line-${String(index).padStart(2, '0')}\n`
+      state = applyLogTailPayload(state, payload(line, {
+        start_offset: offset,
+        end_offset: offset + line.length,
+        reset: index === 0,
+      }), {
+        maxBytes: 64,
+        maxLines: 4,
+      })
+      offset += line.length
+    }
+
+    expect(state.bytes.byteLength).toBeLessThanOrEqual(64)
+    expect(state.text.trim().split('\n')).toHaveLength(4)
+    expect(state.text).toContain('line-19')
+    expect(state.text).not.toContain('line-15')
+    expect(state.truncated).toBe(true)
+  })
+
+  it('keeps a large response inside the production browser bound', () => {
+    const large = `${'x'.repeat(1023)}\n`.repeat(1024)
+    const state = applyLogTailPayload(createLogTailState(), payload(large), {
+      maxBytes: MAX_BROWSER_LOG_BYTES,
+      maxLines: MAX_BROWSER_LOG_LINES,
+    })
+
+    expect(state.bytes.byteLength).toBeLessThanOrEqual(MAX_BROWSER_LOG_BYTES)
+    expect(state.text.split('\n').length - 1).toBeLessThanOrEqual(MAX_BROWSER_LOG_LINES)
+    expect(state.truncated).toBe(true)
+  })
+
+  it('rejects malformed or internally inconsistent payloads', () => {
+    const state = createLogTailState()
+
+    expect(() => applyLogTailPayload(state, payload('bad', { schema_version: 2 }))).toThrow(/schema/i)
+    expect(() => applyLogTailPayload(state, payload('bad', { content_encoding: 'utf-8' }))).toThrow(/encoding/i)
+    expect(() => applyLogTailPayload(state, payload('bad', { content_bytes: 99 }))).toThrow(/byte count/i)
+    expect(() => applyLogTailPayload(state, payload('bad', { end_offset: 99 }))).toThrow(/offset/i)
+    expect(() => applyLogTailPayload(state, payload('bad', { generation: -1 }))).toThrow(/generation/i)
+    expect(() => applyLogTailPayload(state, payload('bad', { content: 'not base64!' }))).toThrow(/base64/i)
+  })
+
+  it('fetches the versioned endpoint with bounds and a prior cursor', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload('delta\n', {
+        start_offset: 42,
+        end_offset: 48,
+        reset: false,
+      }),
+    })
+    const state = {
+      ...createLogTailState(),
+      bytes: new TextEncoder().encode('prior'),
+      text: 'prior',
+      startOffset: 37,
+      endOffset: 42,
+      generation: 7,
+    }
+
+    const next = await fetchLogTail(state, { fetchImpl })
+
+    expect(fetchImpl).toHaveBeenCalledOnce()
+    const [url, options] = fetchImpl.mock.calls[0]
+    expect(url).toContain('/polaris/v1/diagnostics/logs/tail?')
+    expect(url).toContain(`max_bytes=${MAX_BROWSER_LOG_BYTES}`)
+    expect(url).toContain(`max_lines=${MAX_BROWSER_LOG_LINES}`)
+    expect(url).toContain('after=42')
+    expect(url).toContain('after_generation=7')
+    expect(options).toMatchObject({ credentials: 'include', cache: 'no-store' })
+    expect(next.text).toBe('priordelta\n')
+  })
+})

--- a/src_assets/common/assets/web/log-tail-view-integration.test.js
+++ b/src_assets/common/assets/web/log-tail-view-integration.test.js
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function webSource(relativePath) {
+  return readFileSync(join(process.cwd(), 'src_assets/common/assets/web', relativePath), 'utf8')
+}
+
+describe('bounded log-tail view integration', () => {
+  it('migrates both log consumers to the versioned bounded helper', () => {
+    const troubleshooting = webSource('views/TroubleshootingView.vue')
+    const home = webSource('views/HomeView.vue')
+
+    for (const source of [troubleshooting, home]) {
+      expect(source).toContain("from '../log-tail-state.js'")
+      expect(source).toContain('fetchLogTail(')
+      expect(source).not.toContain("fetch('./api/logs',")
+      expect(source).not.toContain('fetch("./api/logs",')
+    }
+  })
+
+  it('exposes truncation and reset state in troubleshooting', () => {
+    const troubleshooting = webSource('views/TroubleshootingView.vue')
+
+    expect(troubleshooting).toContain('data-log-tail-truncated')
+    expect(troubleshooting).toContain('data-log-tail-reset')
+    expect(troubleshooting).toContain('nextState.truncated')
+    expect(troubleshooting).toContain('hadCursor && nextState.reset')
+  })
+
+  it('reuses the bounded in-memory window for support bundles', () => {
+    const troubleshooting = webSource('views/TroubleshootingView.vue')
+
+    expect(troubleshooting).toContain('logs: logs.value')
+    expect(troubleshooting).not.toContain("safeFetchText('./api/logs')")
+  })
+})

--- a/src_assets/common/assets/web/views/HomeView.vue
+++ b/src_assets/common/assets/web/views/HomeView.vue
@@ -357,6 +357,7 @@ import { useSystemStats } from '../composables/useSystemStats'
 import PolarisVersion from '../polaris_version'
 import { buildUpdateCenterState, updateStatusLightClass } from '../update-center.js'
 import InfoHint from '../components/InfoHint.vue'
+import { createLogTailState, fetchLogTail } from '../log-tail-state.js'
 
 const { gpu, displays, audio, sessionType, displaySession, loading: systemLoading } = useSystemStats(3000)
 
@@ -699,7 +700,7 @@ async function refreshUpdateStatus() {
 ;(async () => {
   await refreshUpdateStatus()
   try {
-    logs.value = await fetch('./api/logs', { credentials: 'include' }).then((r) => r.text())
+    logs.value = (await fetchLogTail(createLogTailState())).text
   } catch (error) {
     console.error(error)
   }

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -358,6 +358,12 @@
         <div class="flex w-full flex-col gap-3 xl:w-auto xl:items-end">
           <div class="page-meta">
             <span class="meta-pill">{{ logFilterSummary }}</span>
+            <span v-if="logsTruncated" class="meta-pill" data-log-tail-truncated>
+              Bounded tail · earlier content omitted · bytes {{ logStartOffset }}–{{ logEndOffset }}
+            </span>
+            <span v-if="logsReset" class="meta-pill" data-log-tail-reset>
+              Log window reset after clear, rotation, or a missed range
+            </span>
           </div>
           <div class="flex flex-wrap items-center gap-2">
             <button v-for="level in ['All', 'Error', 'Warning', 'Fatal']" :key="level"
@@ -439,6 +445,7 @@ import {
   buildSupportSelfTestCopy,
 } from '../diagnostics-export.js'
 import { AI_DOCTOR_EXPLANATION_CATEGORIES, explainDoctorWithAi } from '../ai-doctor-explanation.js'
+import { createLogTailState, fetchLogTail } from '../log-tail-state.js'
 
 const { toast: showToast } = useToast()
 const i18n = inject('i18n')
@@ -449,6 +456,10 @@ const closeAppStatus = ref(null)
 const ddResetPressed = ref(false)
 const ddResetStatus = ref(null)
 const logs = ref('Loading...')
+const logsTruncated = ref(false)
+const logsReset = ref(false)
+const logStartOffset = ref(0)
+const logEndOffset = ref(0)
 const clearingLogs = ref(false)
 const clearingAiCache = ref(false)
 const cleaningStaleVirtualDisplay = ref(false)
@@ -459,6 +470,10 @@ const aiDoctorExplanation = ref(null)
 const logFilter = ref(null)
 const logLevelFilter = ref(null)
 let logInterval = null
+let logTailState = createLogTailState()
+let logRefreshInFlight = null
+let logRefreshQueued = false
+let logTailGeneration = 0
 const serverRestarting = ref(false)
 const serverQuitting = ref(false)
 const serverQuit = ref(false)
@@ -903,21 +918,43 @@ const logFilterSummary = computed(() => {
   return parts.join(' · ')
 })
 
+function resetLogTailState() {
+  ++logTailGeneration
+  logTailState = createLogTailState()
+  logs.value = ''
+  logsTruncated.value = false
+  logsReset.value = false
+  logStartOffset.value = 0
+  logEndOffset.value = 0
+}
+
 function refreshLogs() {
-  fetch("./api/logs", { credentials: 'include' })
-    .then(response => {
-      const contentType = response.headers.get("Content-Type") || ""
-      const charsetMatch = contentType.match(/charset=([^;]+)/i)
-      const charset = charsetMatch ? charsetMatch[1].trim() : "utf-8"
-      return response.arrayBuffer().then(buffer => {
-        const decoder = new TextDecoder(charset)
-        return decoder.decode(buffer)
-      })
-    })
-    .then(text => {
-      logs.value = text
+  if (logRefreshInFlight) {
+    logRefreshQueued = true
+    return logRefreshInFlight
+  }
+
+  const generation = logTailGeneration
+  const hadCursor = logTailState.endOffset !== null
+  logRefreshInFlight = fetchLogTail(logTailState)
+    .then((nextState) => {
+      if (generation !== logTailGeneration) return
+      logTailState = nextState
+      logs.value = nextState.text
+      logsTruncated.value = nextState.truncated
+      logsReset.value = hadCursor && nextState.reset
+      logStartOffset.value = nextState.startOffset ?? 0
+      logEndOffset.value = nextState.endOffset ?? 0
     })
     .catch(error => console.error("Error fetching logs:", error))
+    .finally(() => {
+      logRefreshInFlight = null
+      if (logRefreshQueued) {
+        logRefreshQueued = false
+        refreshLogs()
+      }
+    })
+  return logRefreshInFlight
 }
 
 function refreshNetworkPathProbe() {
@@ -992,7 +1029,7 @@ function clearLogs() {
         throw new Error(r.error || "Failed to clear logs")
       }
 
-      logs.value = ''
+      resetLogTailState()
       showToast(i18n.t('troubleshooting.logs_clear_success') || 'Logs cleared.', 'success')
       refreshLogs()
     })
@@ -1014,18 +1051,6 @@ async function safeFetchJson(url) {
     return await response.json()
   } catch (error) {
     return { _error: error instanceof Error ? error.message : String(error) }
-  }
-}
-
-async function safeFetchText(url) {
-  try {
-    const response = await fetch(url, { credentials: 'include' })
-    if (!response.ok) {
-      return `HTTP ${response.status}`
-    }
-    return await response.text()
-  } catch (error) {
-    return error instanceof Error ? error.message : String(error)
   }
 }
 
@@ -1094,12 +1119,11 @@ function cleanupStaleVirtualDisplay() {
 }
 
 async function collectSupportContext() {
-  const [systemStats, aiStatus, aiCache, aiHistory, latestLogs, config] = await Promise.all([
+  const [systemStats, aiStatus, aiCache, aiHistory, config] = await Promise.all([
     safeFetchJson('./api/stats/system'),
     safeFetchJson('./api/ai/status'),
     safeFetchJson('./api/ai/cache'),
     safeFetchJson('./api/ai/history'),
-    safeFetchText('./api/logs'),
     safeFetchJson('./api/config')
   ])
 
@@ -1122,7 +1146,7 @@ async function collectSupportContext() {
     ai_cache: aiCache,
     ai_history: aiHistory,
     recent_issues: groupedRecentIssues.value,
-    logs: latestLogs || logs.value
+    logs: logs.value
   }
 }
 


### PR DESCRIPTION
## Summary

- replace full-file browser log reads with the authenticated versioned bounded-tail API from #381
- keep a strict 256 KiB / 2,000-line client window backed by validated binary bytes and decoded text
- append only contiguous same-generation responses; reset on clear, rotation, truncation, stale requests, or missed ranges
- serialize polling and clear operations so an older in-flight response cannot overwrite newer state
- reuse the bounded state for support bundles and surface truncation/reset state in troubleshooting

## Validation

- targeted log-tail state and view integration tests: 13/13 passed
- full Vitest suite: 54 files, 316 tests passed
- full ESLint pass
- production web build passed
- web budget passed: index CSS 200.2 KiB; initial JS 393.0 KiB raw / 134.7 KiB gzip; initial total 593.2 / 159.1 KiB, within the 680 / 190 KiB limits
- exact committed tree matches the locally validated tree
- the existing static route smoke expects a `Welcome to Polaris` heading that the unchanged current LoginView no longer contains; a direct headless render showed the Login shell with no console or page errors

Depends on and is based exactly on merged #381 (`d2aa43d`).