### PR TITLE
feat(logging): bound runtime log retention

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -81,6 +81,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/doctor_actions.h"
         "${CMAKE_SOURCE_DIR}/src/doctor_actions.cpp"
         "${CMAKE_SOURCE_DIR}/src/browser_stream_protocol.h"
+        "${CMAKE_SOURCE_DIR}/src/bounded_log_file.cpp"
+        "${CMAKE_SOURCE_DIR}/src/bounded_log_file.h"
         "${CMAKE_SOURCE_DIR}/src/browser_stream_protocol.cpp"
         "${CMAKE_SOURCE_DIR}/src/browser_stream.h"
         "${CMAKE_SOURCE_DIR}/src/browser_stream.cpp"

--- a/docs/log-tail-api-v1.md
+++ b/docs/log-tail-api-v1.md
@@ -8,6 +8,10 @@ GET /polaris/v1/diagnostics/logs/tail
 
 This endpoint never reads the whole active log. It is intended for the Web UI and diagnostic tooling that needs recent log content without making host or browser memory proportional to the log file's lifetime size.
 
+## Runtime retention
+
+The active runtime log is fixed at 8388608 bytes, with one backup of at most the same size. Polaris rotates only between complete formatted records, replaces the prior backup, and advances the log generation before writing any bytes into the replacement active file. A prior active log that is already oversized is reduced to its newest 8388608 bytes during startup instead of being copied in full. An orphaned oversized backup is reduced the same way when no active log survived. The active and backup logs therefore have a 16777216-byte combined logical bound, apart from filesystem allocation granularity.
+
 ## Request
 
 All query values are strict unsigned decimal integers. Signs, whitespace, trailing characters, duplicate parameters, unknown parameters, zero limits, overflow, and values above the documented maximum return HTTP `400`.
@@ -42,7 +46,7 @@ Successful responses are JSON with `Cache-Control: no-store`:
 }
 ```
 
-Offsets describe the half-open source byte range `[start_offset, end_offset)`. `generation` identifies the active log lifecycle and changes after initialization or a successful clear. `content_bytes` is the decoded byte count, not the Base64 string length. Base64 is mandatory so embedded NULs, invalid text bytes, and platform code pages cannot make the JSON invalid or change the offset contract.
+Offsets describe the half-open source byte range `[start_offset, end_offset)`. `generation` identifies the active log lifecycle and changes after initialization, automatic rotation, or a successful clear. `content_bytes` is the decoded byte count, not the Base64 string length. Base64 is mandatory so embedded NULs, invalid text bytes, and platform code pages cannot make the JSON invalid or change the offset contract.
 
 `truncated` is true when source bytes before `start_offset` were omitted by either the byte or line bound.
 

--- a/src/bounded_log_file.cpp
+++ b/src/bounded_log_file.cpp
@@ -1,0 +1,229 @@
+/**
+ * @file src/bounded_log_file.cpp
+ * @brief Record-atomic bounded active and backup log storage.
+ */
+
+#include "bounded_log_file.h"
+
+#include "file_handler.h"
+
+#include <limits>
+#include <stdexcept>
+#include <system_error>
+#include <utility>
+
+namespace logging {
+  bounded_log_file_t::bounded_log_file_t(
+    std::filesystem::path active_path,
+    std::filesystem::path backup_path,
+    const std::uintmax_t max_bytes,
+    rotation_callback_t on_rotation
+  ):
+      active_path_(std::move(active_path)),
+      backup_path_(std::move(backup_path)),
+      max_bytes_(max_bytes),
+      on_rotation_(std::move(on_rotation)) {
+    if (active_path_.empty() || backup_path_.empty() || active_path_ == backup_path_ || max_bytes_ == 0 ||
+        max_bytes_ > std::numeric_limits<std::streamsize>::max()) {
+      throw std::invalid_argument("bounded log paths must be non-empty and the byte bound must be representable");
+    }
+    open_active(std::ios::out | std::ios::trunc);
+  }
+
+  bool bounded_log_file_t::good() const {
+    return stream_.is_open() && stream_.good();
+  }
+
+  std::uintmax_t bounded_log_file_t::size() const {
+    return size_;
+  }
+
+  bool bounded_log_file_t::open_active(const std::ios_base::openmode mode) {
+    stream_.clear();
+    stream_.open(active_path_, mode | std::ios::binary);
+    if (!stream_.is_open() || !stream_.good()) {
+      return false;
+    }
+
+    std::error_code error;
+    size_ = std::filesystem::file_size(active_path_, error);
+    if (error) {
+      stream_.close();
+      return false;
+    }
+    return true;
+  }
+
+  bool bounded_log_file_t::reopen_active_for_append() {
+    return open_active(std::ios::out | std::ios::app);
+  }
+
+  bool bounded_log_file_t::rotate() {
+    stream_.flush();
+    stream_.close();
+
+    std::error_code error;
+    std::filesystem::remove(backup_path_, error);
+    if (error) {
+      reopen_active_for_append();
+      return false;
+    }
+
+    std::filesystem::rename(active_path_, backup_path_, error);
+    if (error) {
+      reopen_active_for_append();
+      return false;
+    }
+
+    if (open_active(std::ios::out | std::ios::trunc)) {
+      return true;
+    }
+
+    // A failed open may still have created the replacement path. Remove it
+    // before restoring the prior active log, which matters on Windows where a
+    // rename cannot replace an existing destination.
+    stream_.close();
+    std::filesystem::remove(active_path_, error);
+    std::filesystem::rename(backup_path_, active_path_, error);
+    reopen_active_for_append();
+    return false;
+  }
+
+  bounded_log_write_result_e bounded_log_file_t::write_record(const std::string_view record) {
+    if (!good()) {
+      return bounded_log_write_result_e::rejected;
+    }
+
+    const auto append_newline = record.empty() || record.back() != '\n';
+    if (record.size() > max_bytes_ ||
+        (append_newline && record.size() == max_bytes_)) {
+      return bounded_log_write_result_e::rejected;
+    }
+    const auto record_bytes = static_cast<std::uintmax_t>(record.size()) + (append_newline ? 1U : 0U);
+
+    auto result = bounded_log_write_result_e::written;
+    if (size_ > 0 && record_bytes > max_bytes_ - size_) {
+      if (!rotate()) {
+        return bounded_log_write_result_e::rejected;
+      }
+      // Publish the new generation after the replacement active file exists,
+      // but before it can expose any bytes from that generation.
+      if (on_rotation_) {
+        on_rotation_();
+      }
+      result = bounded_log_write_result_e::rotated;
+    }
+
+    if (!record.empty()) {
+      stream_.write(record.data(), static_cast<std::streamsize>(record.size()));
+    }
+    if (append_newline) {
+      stream_.put('\n');
+    }
+    stream_.flush();
+    if (!stream_.good()) {
+      return bounded_log_write_result_e::rejected;
+    }
+    size_ += record_bytes;
+    return result;
+  }
+
+  bool bounded_log_file_t::clear() {
+    if (!stream_.is_open()) {
+      return false;
+    }
+
+    stream_.flush();
+    stream_.close();
+
+    std::error_code error;
+    std::filesystem::remove(backup_path_, error);
+    if (error) {
+      reopen_active_for_append();
+      return false;
+    }
+    return open_active(std::ios::out | std::ios::trunc);
+  }
+
+  void bounded_log_file_t::flush() {
+    if (stream_.is_open()) {
+      stream_.flush();
+    }
+  }
+
+  bool bounded_log_file_t::preserve_existing(
+    const std::filesystem::path &active_path,
+    const std::filesystem::path &backup_path,
+    const std::uintmax_t max_bytes
+  ) {
+    if (active_path.empty() || backup_path.empty() || active_path == backup_path ||
+        max_bytes == 0 || max_bytes > std::numeric_limits<std::size_t>::max() ||
+        max_bytes > std::numeric_limits<std::streamsize>::max()) {
+      return false;
+    }
+
+    std::error_code error;
+    if (!std::filesystem::exists(active_path, error)) {
+      if (error || !std::filesystem::exists(backup_path, error)) {
+        return !error;
+      }
+      if (error) {
+        return false;
+      }
+
+      const auto backup_size = std::filesystem::file_size(backup_path, error);
+      if (error || backup_size <= max_bytes) {
+        return !error;
+      }
+
+      const auto backup_path_string = backup_path.string();
+      const auto tail = file_handler::read_file_tail(
+        backup_path_string.c_str(),
+        static_cast<std::size_t>(max_bytes)
+      );
+      if (tail.content.size() != max_bytes || tail.end_offset != backup_size || !tail.truncated) {
+        return false;
+      }
+
+      std::ofstream bounded_backup {backup_path, std::ios::out | std::ios::trunc | std::ios::binary};
+      bounded_backup.write(tail.content.data(), static_cast<std::streamsize>(tail.content.size()));
+      bounded_backup.flush();
+      return bounded_backup.good();
+    }
+    if (error) {
+      return false;
+    }
+
+    const auto prior_size = std::filesystem::file_size(active_path, error);
+    if (error) {
+      return false;
+    }
+
+    std::filesystem::remove(backup_path, error);
+    if (error) {
+      return false;
+    }
+
+    if (prior_size <= max_bytes) {
+      std::filesystem::rename(active_path, backup_path, error);
+      return !error;
+    }
+
+    const auto active_path_string = active_path.string();
+    const auto tail = file_handler::read_file_tail(active_path_string.c_str(), static_cast<std::size_t>(max_bytes));
+    if (tail.content.size() != max_bytes || tail.end_offset != prior_size || !tail.truncated) {
+      return false;
+    }
+
+    std::ofstream backup {backup_path, std::ios::out | std::ios::trunc | std::ios::binary};
+    backup.write(tail.content.data(), static_cast<std::streamsize>(tail.content.size()));
+    backup.flush();
+    if (!backup.good()) {
+      return false;
+    }
+    backup.close();
+
+    std::filesystem::remove(active_path, error);
+    return !error;
+  }
+}  // namespace logging

--- a/src/bounded_log_file.h
+++ b/src/bounded_log_file.h
@@ -1,0 +1,74 @@
+/**
+ * @file src/bounded_log_file.h
+ * @brief Record-atomic bounded active and backup log storage.
+ */
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <string_view>
+
+namespace logging {
+  inline constexpr std::uintmax_t runtime_log_max_bytes = 8U * 1024U * 1024U;
+
+  enum class bounded_log_write_result_e {
+    written,
+    rotated,
+    rejected,
+  };
+
+  class bounded_log_file_t {
+  public:
+    using rotation_callback_t = std::function<void()>;
+
+    bounded_log_file_t(
+      std::filesystem::path active_path,
+      std::filesystem::path backup_path,
+      std::uintmax_t max_bytes,
+      rotation_callback_t on_rotation = {}
+    );
+
+    bounded_log_file_t(const bounded_log_file_t &) = delete;
+    bounded_log_file_t &operator=(const bounded_log_file_t &) = delete;
+
+    [[nodiscard]] bool good() const;
+    [[nodiscard]] std::uintmax_t size() const;
+
+    /**
+     * @brief Write one complete formatted record, rotating before it if needed.
+     *
+     * A record larger than the configured active-file bound is rejected rather
+     * than allowing the file to exceed the bound.
+     */
+    bounded_log_write_result_e write_record(std::string_view record);
+
+    /**
+     * @brief Remove the retained backup and truncate/reopen the active file.
+     */
+    bool clear();
+    void flush();
+
+    /**
+     * @brief Preserve at most the newest max_bytes from a prior active log.
+     */
+    static bool preserve_existing(
+      const std::filesystem::path &active_path,
+      const std::filesystem::path &backup_path,
+      std::uintmax_t max_bytes
+    );
+
+  private:
+    bool open_active(std::ios_base::openmode mode);
+    bool reopen_active_for_append();
+    bool rotate();
+
+    std::filesystem::path active_path_;
+    std::filesystem::path backup_path_;
+    std::uintmax_t max_bytes_;
+    std::uintmax_t size_ = 0;
+    rotation_callback_t on_rotation_;
+    std::ofstream stream_;
+  };
+}  // namespace logging

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -4,7 +4,6 @@
  */
 // standard includes
 #include <atomic>
-#include <fstream>
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
@@ -16,10 +15,12 @@
 #include <boost/log/attributes/clock.hpp>
 #include <boost/log/common.hpp>
 #include <boost/log/expressions.hpp>
+#include <boost/log/sinks/basic_sink_backend.hpp>
 #include <boost/log/sinks.hpp>
 #include <boost/log/sources/severity_logger.hpp>
 
 // local includes
+#include "bounded_log_file.h"
 #include "logging.h"
 
 // conditional includes
@@ -37,10 +38,69 @@ using namespace std::literals;
 
 namespace bl = boost::log;
 
-boost::shared_ptr<boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>> sink;
-boost::shared_ptr<std::ofstream> log_file_stream;
-std::string active_log_file_path;
+boost::shared_ptr<text_sink> sink;
 std::atomic_uint64_t active_log_file_generation {0};
+
+namespace {
+  using bounded_file_backend_base_t = boost::log::sinks::basic_formatted_sink_backend<
+    char,
+    boost::log::sinks::combine_requirements<
+      boost::log::sinks::synchronized_feeding,
+      boost::log::sinks::flushing
+    >::type
+  >;
+
+  class bounded_file_backend_t: public bounded_file_backend_base_t {
+  public:
+    bounded_file_backend_t(
+      const std::filesystem::path &active_path,
+      const std::filesystem::path &backup_path,
+      const std::uintmax_t max_bytes
+    ):
+        file_(active_path, backup_path, max_bytes, []() {
+          active_log_file_generation.fetch_add(1, std::memory_order_release);
+        }) {
+    }
+
+    void consume(const boost::log::record_view &, const string_type &formatted_message) {
+      const auto result = file_.write_record(formatted_message);
+      if (result == logging::bounded_log_write_result_e::rejected && !reported_failure_) {
+        std::cerr << "Polaris stopped writing the active log because its bounded file backend failed." << std::endl;
+        reported_failure_ = true;
+      }
+    }
+
+    void flush() {
+      file_.flush();
+    }
+
+    [[nodiscard]] bool good() const {
+      return file_.good();
+    }
+
+    bool clear() {
+      const auto cleared = file_.clear();
+      if (cleared) {
+        reported_failure_ = false;
+      }
+      return cleared;
+    }
+
+  private:
+    logging::bounded_log_file_t file_;
+    bool reported_failure_ = false;
+  };
+
+  using bounded_file_queue_t = boost::log::sinks::bounded_fifo_queue<
+    async_log_queue_capacity,
+    boost::log::sinks::block_on_overflow
+  >;
+  using bounded_file_sink_t = boost::log::sinks::asynchronous_sink<
+    bounded_file_backend_t,
+    bounded_file_queue_t
+  >;
+  boost::shared_ptr<bounded_file_sink_t> file_sink;
+}  // namespace
 
 bl::sources::severity_logger<int> verbose(0);  // Dominating output
 bl::sources::severity_logger<int> debug(1);  // Follow what is happening
@@ -61,14 +121,14 @@ namespace logging {
 
   void deinit() {
     log_flush();
-    bl::core::get()->remove_sink(sink);
-    sink.reset();
-    if (log_file_stream) {
-      log_file_stream->flush();
-      log_file_stream->close();
-      log_file_stream.reset();
+    if (file_sink) {
+      bl::core::get()->remove_sink(file_sink);
+      file_sink.reset();
     }
-    active_log_file_path.clear();
+    if (sink) {
+      bl::core::get()->remove_sink(sink);
+      sink.reset();
+    }
   }
 
   void formatter(const boost::log::record_view &view, boost::log::formatting_ostream &os) {
@@ -184,7 +244,7 @@ namespace logging {
 #endif
 
   [[nodiscard]] std::unique_ptr<deinit_t> init(int min_log_level, const std::string &log_file) {
-    if (sink) {
+    if (sink || file_sink) {
       // Deinitialize the logging system before reinitializing it. This can probably only ever be hit in tests.
       deinit();
     }
@@ -195,17 +255,15 @@ namespace logging {
     if (!log_file.empty()) {
       backup_log_file = log_file + ".backup";
     }
-    if (!log_file.empty() && std::filesystem::exists(log_file)) {
-      try {
-        // If the backup file exists, remove it
-        if (std::filesystem::exists(backup_log_file)) {
-          std::filesystem::remove(backup_log_file);
-        }
-        // Rename the current log file to the backup name
-        std::filesystem::rename(log_file, backup_log_file);
-      } catch (std::exception& e) {
-        std::cout << "Failed to rotate log file: " << e.what() << std::endl;
-      }
+    auto file_logging_ready = !log_file.empty();
+    if (file_logging_ready && !bounded_log_file_t::preserve_existing(
+                                log_file,
+                                backup_log_file,
+                                runtime_log_max_bytes
+                              )) {
+      std::cout << "Failed to preserve a bounded backup of the prior log file." << std::endl;
+      // Fail closed instead of truncating the only surviving copy below.
+      file_logging_ready = false;
     }
 
 #ifndef __ANDROID__
@@ -214,17 +272,26 @@ namespace logging {
 #endif
 
     sink = boost::make_shared<text_sink>();
-    active_log_file_path = log_file;
 
 #ifndef POLARIS_TESTS
     boost::shared_ptr<std::ostream> stream {&std::cout, boost::null_deleter()};
     sink->locked_backend()->add_stream(stream);
 #endif
 
-    if (!log_file.empty()) {
-      log_file_stream = boost::make_shared<std::ofstream>(log_file);
-      sink->locked_backend()->add_stream(log_file_stream);
-      active_log_file_generation.fetch_add(1, std::memory_order_release);
+    if (file_logging_ready) {
+      auto backend = boost::make_shared<bounded_file_backend_t>(
+        log_file,
+        backup_log_file,
+        runtime_log_max_bytes
+      );
+      if (backend->good()) {
+        file_sink = boost::make_shared<bounded_file_sink_t>(backend);
+        file_sink->set_filter(severity >= min_log_level);
+        file_sink->set_formatter(&formatter);
+        active_log_file_generation.fetch_add(1, std::memory_order_release);
+      } else {
+        std::cout << "Failed to open the bounded active log file." << std::endl;
+      }
     }
     sink->set_filter(severity >= min_log_level);
     sink->set_formatter(&formatter);
@@ -244,6 +311,9 @@ namespace logging {
     }
 
     bl::core::get()->add_sink(sink);
+    if (file_sink) {
+      bl::core::get()->add_sink(file_sink);
+    }
 
 #ifdef __ANDROID__
     auto android_sink = boost::make_shared<sinks::synchronous_sink<android_sink_backend>>();
@@ -316,6 +386,9 @@ namespace logging {
     if (sink) {
       sink->flush();
     }
+    if (file_sink) {
+      file_sink->flush();
+    }
   }
 
   std::uint64_t log_file_generation() {
@@ -323,18 +396,16 @@ namespace logging {
   }
 
   bool clear_log_file() {
-    if (!sink || !log_file_stream || active_log_file_path.empty()) {
+    if (!file_sink) {
       return false;
     }
 
-    log_flush();
+    // Clear only depends on the file queue. The console consumer can be blocked
+    // by journald or a full pipe and must not prevent log-file recovery.
+    file_sink->flush();
 
-    auto backend = sink->locked_backend();
-    log_file_stream->flush();
-    log_file_stream->close();
-    log_file_stream->clear();
-    log_file_stream->open(active_log_file_path, std::ios::out | std::ios::trunc);
-    const auto reopened = log_file_stream->is_open() && log_file_stream->good();
+    auto backend = file_sink->locked_backend();
+    const auto reopened = backend->clear();
     if (reopened) {
       active_log_file_generation.fetch_add(1, std::memory_order_release);
     }

--- a/src/logging.h
+++ b/src/logging.h
@@ -4,13 +4,22 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 // lib includes
 #include <boost/log/common.hpp>
 #include <boost/log/sinks.hpp>
 
-using text_sink = boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>;
+inline constexpr std::size_t async_log_queue_capacity = 1024;
+using text_queue = boost::log::sinks::bounded_fifo_queue<
+  async_log_queue_capacity,
+  boost::log::sinks::drop_on_overflow
+>;
+using text_sink = boost::log::sinks::asynchronous_sink<
+  boost::log::sinks::text_ostream_backend,
+  text_queue
+>;
 
 extern boost::log::sources::severity_logger<int> verbose;
 extern boost::log::sources::severity_logger<int> debug;
@@ -81,9 +90,9 @@ namespace logging {
   /**
    * @brief Return the process-local generation of the active log file.
    *
-   * The generation changes after initialization and every successful clear so
-   * incremental readers can distinguish reused byte offsets from the same
-   * logical log generation.
+   * The generation changes after initialization, automatic rotation, and every
+   * successful clear so incremental readers can distinguish reused byte offsets
+   * from the same logical log generation.
    */
   std::uint64_t log_file_generation();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(TEST_MAIN_SOURCE
 )
 
 set(TEST_SUPPORT_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/bounded_log_file.cpp
     ${CMAKE_SOURCE_DIR}/src/confighttp_validation.cpp
     ${CMAKE_SOURCE_DIR}/src/confighttp_benchmark_auth.cpp
     ${CMAKE_SOURCE_DIR}/src/browser_stream_protocol.cpp
@@ -91,12 +92,14 @@ if(NOT WIN32)
 endif()
 
 set(TEST_AUDIT_SUPPORT_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/bounded_log_file.cpp
     ${CMAKE_SOURCE_DIR}/src/file_handler.cpp
     ${CMAKE_SOURCE_DIR}/src/globals.cpp
     ${CMAKE_SOURCE_DIR}/src/logging.cpp
 )
 
 set(TEST_FAST_SOURCES
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_bounded_log_file.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_benchmark_control_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_validation.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_benchmark_auth.cpp

--- a/tests/unit/test_bounded_log_file.cpp
+++ b/tests/unit/test_bounded_log_file.cpp
@@ -1,0 +1,229 @@
+/**
+ * @file tests/unit/test_bounded_log_file.cpp
+ * @brief Test record-atomic bounded active and backup log storage.
+ */
+
+#include <gtest/gtest.h>
+#include <src/bounded_log_file.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace {
+  namespace fs = std::filesystem;
+
+  class BoundedLogFileTest: public testing::Test {
+  protected:
+    void SetUp() override {
+      root_ = fs::temp_directory_path() / ("polaris-bounded-log-" + std::to_string(counter_++));
+      std::error_code error;
+      fs::remove_all(root_, error);
+      fs::create_directories(root_);
+      active_ = root_ / "polaris.log";
+      backup_ = root_ / "polaris.log.backup";
+    }
+
+    void TearDown() override {
+      std::error_code error;
+      fs::remove_all(root_, error);
+    }
+
+    static std::string read(const fs::path &path) {
+      std::ifstream input {path, std::ios::binary};
+      return {std::istreambuf_iterator<char> {input}, std::istreambuf_iterator<char> {}};
+    }
+
+    inline static unsigned counter_ = 0;
+    fs::path root_;
+    fs::path active_;
+    fs::path backup_;
+  };
+}
+
+TEST_F(BoundedLogFileTest, RotatesBeforeARecordAndKeepsExactlyOneBoundedBackup) {
+  logging::bounded_log_file_t file {active_, backup_, 12};
+
+  EXPECT_EQ(file.write_record("one"), logging::bounded_log_write_result_e::written);
+  EXPECT_EQ(file.write_record("two"), logging::bounded_log_write_result_e::written);
+  EXPECT_EQ(file.write_record("three"), logging::bounded_log_write_result_e::rotated);
+  EXPECT_EQ(read(backup_), "one\ntwo\n");
+  EXPECT_EQ(read(active_), "three\n");
+
+  EXPECT_EQ(file.write_record("four"), logging::bounded_log_write_result_e::written);
+  EXPECT_EQ(file.write_record("five"), logging::bounded_log_write_result_e::rotated);
+  EXPECT_EQ(read(backup_), "three\nfour\n");
+  EXPECT_EQ(read(active_), "five\n");
+  EXPECT_LE(fs::file_size(active_), 12);
+  EXPECT_LE(fs::file_size(backup_), 12);
+}
+
+TEST_F(BoundedLogFileTest, PublishesRotationBeforeWritingNewGenerationBytes) {
+  unsigned rotations = 0;
+  std::string active_at_rotation;
+  logging::bounded_log_file_t file {
+    active_,
+    backup_,
+    8,
+    [&]() {
+      ++rotations;
+      active_at_rotation = read(active_);
+    }
+  };
+
+  ASSERT_EQ(file.write_record("one"), logging::bounded_log_write_result_e::written);
+  ASSERT_EQ(file.write_record("two"), logging::bounded_log_write_result_e::written);
+  ASSERT_EQ(file.write_record("three"), logging::bounded_log_write_result_e::rotated);
+
+  EXPECT_EQ(rotations, 1);
+  EXPECT_TRUE(active_at_rotation.empty());
+  EXPECT_EQ(read(backup_), "one\ntwo\n");
+  EXPECT_EQ(read(active_), "three\n");
+}
+
+TEST_F(BoundedLogFileTest, RejectsARecordLargerThanTheActiveFileBound) {
+  logging::bounded_log_file_t file {active_, backup_, 4};
+
+  EXPECT_EQ(file.write_record("four"), logging::bounded_log_write_result_e::rejected);
+  EXPECT_TRUE(read(active_).empty());
+  EXPECT_FALSE(fs::exists(backup_));
+}
+
+TEST_F(BoundedLogFileTest, RejectsIdenticalActiveAndBackupPaths) {
+  EXPECT_THROW(
+    (logging::bounded_log_file_t {active_, active_, 8}),
+    std::invalid_argument
+  );
+  EXPECT_FALSE(logging::bounded_log_file_t::preserve_existing(active_, active_, 8));
+  EXPECT_FALSE(logging::bounded_log_file_t::preserve_existing(active_, backup_, 0));
+}
+
+TEST_F(BoundedLogFileTest, ClearRemovesTheBackupAndReopensTheActiveFile) {
+  logging::bounded_log_file_t file {active_, backup_, 8};
+  ASSERT_EQ(file.write_record("one"), logging::bounded_log_write_result_e::written);
+  ASSERT_EQ(file.write_record("two"), logging::bounded_log_write_result_e::written);
+  ASSERT_EQ(file.write_record("x"), logging::bounded_log_write_result_e::rotated);
+  ASSERT_TRUE(fs::exists(backup_));
+
+  ASSERT_TRUE(file.clear());
+  EXPECT_FALSE(fs::exists(backup_));
+  EXPECT_TRUE(read(active_).empty());
+  EXPECT_EQ(file.size(), 0);
+
+  EXPECT_EQ(file.write_record("after"), logging::bounded_log_write_result_e::written);
+  EXPECT_EQ(read(active_), "after\n");
+}
+
+TEST_F(BoundedLogFileTest, PreservesOnlyTheNewestBytesFromAnOversizedPriorLog) {
+  {
+    std::ofstream output {active_, std::ios::binary};
+    output << "0123456789abcdef";
+  }
+
+  ASSERT_TRUE(logging::bounded_log_file_t::preserve_existing(active_, backup_, 8));
+  EXPECT_FALSE(fs::exists(active_));
+  EXPECT_EQ(read(backup_), "89abcdef");
+  EXPECT_EQ(fs::file_size(backup_), 8);
+}
+
+TEST_F(BoundedLogFileTest, RenamesAnAlreadyBoundedPriorLogWithoutChangingIt) {
+  {
+    std::ofstream output {active_, std::ios::binary};
+    output << "prior";
+  }
+
+  ASSERT_TRUE(logging::bounded_log_file_t::preserve_existing(active_, backup_, 8));
+  EXPECT_FALSE(fs::exists(active_));
+  EXPECT_EQ(read(backup_), "prior");
+}
+
+TEST_F(BoundedLogFileTest, PreservesEmbeddedNulBytesWithoutCorruption) {
+  logging::bounded_log_file_t file {active_, backup_, 16};
+  const std::string record {"a\0b", 3};
+
+  ASSERT_EQ(file.write_record(record), logging::bounded_log_write_result_e::written);
+  EXPECT_EQ(read(active_), std::string("a\0b\n", 4));
+  EXPECT_EQ(file.size(), 4);
+}
+
+TEST_F(BoundedLogFileTest, RotationStressKeepsOnlyTwoBoundedWholeRecordFiles) {
+  constexpr std::uintmax_t max_bytes = 128;
+  logging::bounded_log_file_t file {active_, backup_, max_bytes};
+
+  for (unsigned index = 0; index < 5000; ++index) {
+    const auto record = "record-" + std::to_string(index);
+    ASSERT_NE(file.write_record(record), logging::bounded_log_write_result_e::rejected);
+  }
+
+  ASSERT_TRUE(fs::exists(active_));
+  ASSERT_TRUE(fs::exists(backup_));
+  EXPECT_LE(fs::file_size(active_), max_bytes);
+  EXPECT_LE(fs::file_size(backup_), max_bytes);
+  EXPECT_EQ(std::distance(fs::directory_iterator(root_), fs::directory_iterator {}), 2);
+
+  for (const auto &path : std::vector<fs::path> {active_, backup_}) {
+    const auto contents = read(path);
+    ASSERT_FALSE(contents.empty());
+    EXPECT_EQ(contents.back(), '\n');
+
+    std::size_t start = 0;
+    while (start < contents.size()) {
+      const auto end = contents.find('\n', start);
+      ASSERT_NE(end, std::string::npos);
+      EXPECT_EQ(contents.compare(start, 7, "record-"), 0);
+      start = end + 1;
+    }
+  }
+}
+
+TEST_F(BoundedLogFileTest, ClearStressRemovesEveryBackupAndRemainsWritable) {
+  logging::bounded_log_file_t file {active_, backup_, 8};
+
+  for (unsigned index = 0; index < 100; ++index) {
+    ASSERT_EQ(file.write_record("one"), logging::bounded_log_write_result_e::written);
+    ASSERT_EQ(file.write_record("two"), logging::bounded_log_write_result_e::written);
+    ASSERT_EQ(file.write_record("three"), logging::bounded_log_write_result_e::rotated);
+    ASSERT_TRUE(fs::exists(backup_));
+
+    ASSERT_TRUE(file.clear());
+    EXPECT_FALSE(fs::exists(backup_));
+    EXPECT_TRUE(read(active_).empty());
+    EXPECT_EQ(file.size(), 0);
+  }
+
+  EXPECT_EQ(file.write_record("after"), logging::bounded_log_write_result_e::written);
+  EXPECT_EQ(read(active_), "after\n");
+}
+
+TEST_F(BoundedLogFileTest, OversizedSparsePriorLogProducesOnlyABoundedTailBackup) {
+  constexpr std::uintmax_t prior_bytes = 1024U * 1024U;
+  constexpr std::uintmax_t max_bytes = 4096;
+  const std::string marker = "newest-tail-data";
+  {
+    std::ofstream output {active_, std::ios::binary};
+    output.seekp(static_cast<std::streamoff>(prior_bytes - marker.size()));
+    output.write(marker.data(), static_cast<std::streamsize>(marker.size()));
+  }
+  ASSERT_EQ(fs::file_size(active_), prior_bytes);
+
+  ASSERT_TRUE(logging::bounded_log_file_t::preserve_existing(active_, backup_, max_bytes));
+  EXPECT_FALSE(fs::exists(active_));
+  ASSERT_EQ(fs::file_size(backup_), max_bytes);
+  const auto backup = read(backup_);
+  ASSERT_EQ(backup.size(), max_bytes);
+  EXPECT_EQ(backup.substr(backup.size() - marker.size()), marker);
+}
+
+TEST_F(BoundedLogFileTest, OversizedOrphanedBackupIsAlsoReducedToItsNewestBoundedTail) {
+  {
+    std::ofstream output {backup_, std::ios::binary};
+    output << "0123456789abcdef";
+  }
+
+  ASSERT_TRUE(logging::bounded_log_file_t::preserve_existing(active_, backup_, 8));
+  EXPECT_FALSE(fs::exists(active_));
+  EXPECT_EQ(read(backup_), "89abcdef");
+  EXPECT_EQ(fs::file_size(backup_), 8);
+}

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -15,6 +15,7 @@
 #include <random>
 #include <regex>
 #include <sstream>
+#include <src/bounded_log_file.h>
 #include <src/logging.h>
 
 namespace {
@@ -177,6 +178,28 @@ TEST(LoggingRunaway, GlInfoLogLengthIsInitializedAndGuarded) {
   }
 }
 
+TEST(LoggingRunaway, AsyncQueuesAreBoundedAndConsoleBackpressureDrops) {
+  const auto read_source = [](const std::filesystem::path &path) {
+    std::ifstream file {path};
+    EXPECT_TRUE(file.good()) << "could not read " << path;
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+  };
+  const auto source_root = std::filesystem::path {POLARIS_SOURCE_DIR} / "src";
+  const auto header = read_source(source_root / "logging.h");
+  const auto implementation = read_source(source_root / "logging.cpp");
+
+  EXPECT_NE(header.find("bounded_fifo_queue"), std::string::npos)
+    << "the asynchronous console queue must have a fixed record bound";
+  EXPECT_NE(header.find("drop_on_overflow"), std::string::npos)
+    << "a blocked console consumer must not stall Polaris or grow RSS forever";
+  EXPECT_NE(implementation.find("bounded_file_queue_t = boost::log::sinks::bounded_fifo_queue"), std::string::npos)
+    << "the asynchronous file queue must have a fixed record bound";
+  EXPECT_NE(implementation.find("boost::log::sinks::block_on_overflow"), std::string::npos)
+    << "the file queue must backpressure producers instead of losing diagnostic records";
+}
+
 TEST(LoggingGeneration, SuccessfulClearAdvancesGenerationAndKeepsLoggingUsable) {
   const auto before = logging::log_file_generation();
 
@@ -186,4 +209,36 @@ TEST(LoggingGeneration, SuccessfulClearAdvancesGenerationAndKeepsLoggingUsable) 
   const auto marker = std::format("post-clear-generation-{}", before + 1);
   BOOST_LOG(info) << marker;
   ASSERT_TRUE(log_checker::line_contains(test_paths::log_file().string(), marker));
+}
+
+TEST(LoggingGeneration, AutomaticRotationAdvancesGenerationAndKeepsBothFilesBounded) {
+  ASSERT_TRUE(logging::clear_log_file());
+  const auto before = logging::log_file_generation();
+  const std::string record(16U * 1024U, 'r');
+
+  for (unsigned index = 0; index < 520; ++index) {
+    BOOST_LOG(info) << record;
+  }
+  logging::log_flush();
+
+  EXPECT_GT(logging::log_file_generation(), before);
+  const auto active = test_paths::log_file();
+  const auto backup = std::filesystem::path {active.string() + ".backup"};
+  ASSERT_TRUE(std::filesystem::exists(active));
+  ASSERT_TRUE(std::filesystem::exists(backup));
+  EXPECT_LE(std::filesystem::file_size(active), logging::runtime_log_max_bytes);
+  EXPECT_LE(std::filesystem::file_size(backup), logging::runtime_log_max_bytes);
+
+  for (const auto &path : {active, backup}) {
+    std::ifstream file {path, std::ios::binary};
+    const std::string contents {
+      std::istreambuf_iterator<char> {file},
+      std::istreambuf_iterator<char> {}
+    };
+    EXPECT_EQ(contents.find('\0'), std::string::npos)
+      << "bounded logging introduced NUL corruption in " << path;
+  }
+
+  ASSERT_TRUE(logging::clear_log_file());
+  EXPECT_FALSE(std::filesystem::exists(backup));
 }


### PR DESCRIPTION
## Summary

- replace the unbounded runtime log stream with a record-atomic 8 MiB active file plus one 8 MiB backup
- rotate only between formatted records, replace the prior backup, and reject any record that cannot fit the configured bound
- preserve only the newest bounded tail when inheriting an oversized prior active log or orphaned backup
- advance the tail API generation after the replacement active file exists but before it can expose new-generation bytes
- keep clear/reopen serialized with the file backend, remove the backup on clear, and continue logging afterward
- bound both asynchronous queues: console output drops at capacity so journald/pipe backpressure cannot grow RSS forever, while the file queue backpressures producers rather than losing diagnostic records
- document the runtime retention contract

## Validation

- focused bounded-storage, tail API, runaway logging, and generation tests: 38/38 passed
- compatible full native suite on macOS: 239/239 passed before the final isolated orphaned-backup regression; the final focused suite and production translation unit compile are green
- production `bounded_log_file.cpp` and `logging.cpp` translation units compiled with C++23
- stress coverage includes 5,000 rotations, 100 clear/reopen cycles, exact two-file bounds, whole-record boundaries, NUL preservation, generation ordering, oversized active and orphaned-backup recovery, and a large sparse prior log
- `git diff --check`

The compatible full-suite command excludes two existing platform/toolchain-only cases: APFS rejects the directory hard-link fixture, and the prepared Darwin FFmpeg bundle does not expose the Linux NVENC split-mode option. Protected Linux CI is authoritative.

This implements the Polaris product-side bounded-runtime lane for Nordstern `HOST-LOG-01`. The acceptance contract merged in papi-ux/polaris-nightly#60. The 30-minute deployed disk/RSS recurrence proof remains a separate post-merge acceptance step and is not claimed here.