### PR TITLE
fix(web): retain bounded log truncation state

### DIFF
--- a/src_assets/common/assets/web/log-tail-state.js
+++ b/src_assets/common/assets/web/log-tail-state.js
@@ -120,14 +120,15 @@ export function applyLogTailPayload(state, payload, {
   const combined = append ? concatenate(previous.bytes, incoming) : incoming
   const initialStartOffset = append ? previous.startOffset : payload.start_offset
   const bounded = trimBytes(combined, maxBytes, maxLines)
+  const boundedStartOffset = initialStartOffset + bounded.removed
 
   return {
     bytes: bounded.bytes,
     text: decodeText(bounded.bytes, payload.charset),
-    startOffset: initialStartOffset + bounded.removed,
+    startOffset: boundedStartOffset,
     endOffset: payload.end_offset,
     generation: payload.generation,
-    truncated: payload.truncated || bounded.removed > 0,
+    truncated: payload.truncated || boundedStartOffset > 0,
     reset: payload.reset || !append,
   }
 }

--- a/src_assets/common/assets/web/log-tail-state.test.js
+++ b/src_assets/common/assets/web/log-tail-state.test.js
@@ -147,6 +147,27 @@ describe('bounded browser log-tail state', () => {
     expect(state.truncated).toBe(true)
   })
 
+  it('preserves omitted-history state across an empty contiguous delta', () => {
+    const initial = applyLogTailPayload(createLogTailState(), payload('recent\n', {
+      start_offset: 100,
+      end_offset: 107,
+      truncated: true,
+      reset: true,
+    }))
+    const next = applyLogTailPayload(initial, payload('', {
+      start_offset: 107,
+      end_offset: 107,
+      truncated: false,
+      reset: false,
+    }))
+
+    expect(next.text).toBe('recent\n')
+    expect(next.startOffset).toBe(100)
+    expect(next.endOffset).toBe(107)
+    expect(next.truncated).toBe(true)
+    expect(next.reset).toBe(false)
+  })
+
   it('keeps a large response inside the production browser bound', () => {
     const large = `${'x'.repeat(1023)}\n`.repeat(1024)
     const state = applyLogTailPayload(createLogTailState(), payload(large), {


### PR DESCRIPTION
## Summary

- retain the browser log viewer's omitted-history state whenever its bounded buffer begins after byte offset zero
- keep that state across empty contiguous tail polls even when the newest server delta is not itself truncated
- add a regression covering a truncated initial response followed by an empty same-generation delta

## Why

The server's `truncated` flag describes the current response. After a line-limited initial tail, a later empty delta can legitimately report `truncated: false` while the browser still omits earlier history. Clearing the UI indicator in that case made the bounded local state look complete when it was not.

## Validation

- focused log-tail state tests: 11/11 passed
- full web suite: 54 files, 317/317 tests passed
- ESLint: passed
- production build and web performance budget: passed
- initial HTML+JS total: 593.2 KiB raw / 159.1 KiB gzip
- `git diff --check`

This is rebased directly onto Polaris runtime logging merge `83e28e8bec08405650dc17e5fe289795a6eff571` from #383. Live `LOGAPI-01` response/RSS acceptance remains a separate post-merge evidence step and is not claimed here.