### PR TITLE
release: prepare Polaris v1.3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
     set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
-project(Polaris VERSION 1.3.7
+project(Polaris VERSION 1.3.8
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/README.md
+++ b/README.md
@@ -91,15 +91,22 @@ Open **https://localhost:47990/#/welcome**, create your web UI account, and pair
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at `https://localhost:<port + 1>`. If you want background autostart, enable the user service with `systemctl --user enable --now polaris`.
 
-## What is New in v1.3.7
+## What is New in v1.3.8
 
-Polaris v1.3.7 fixes a use-after-free in VAAPI DMA-BUF capture that AMD hosts have been running into, and puts the nix packaging under CI for the first time.
+Polaris v1.3.8 turns the private Linux stream path into a safer daily-driver release: true-headless GPU-native capture, session-only launch choices, exact process ownership, an evidence-gated Doctor, and bounded diagnostics.
 
-- **VAAPI capture no longer frees a surface it is still reading**: a use-after-free in the VRAM converter, which destroyed its imported DMA-BUF surface before importing the replacement while a conversion in flight could still be holding it. Imports now live in a buffer-keyed cache, so a newly captured frame cannot pull the surface out from under an active conversion.
-- **This was reachable, not theoretical**: the VAAPI refusal in earlier releases only gated the gamescope windowed override. DRM/KMS capture and the non-cage wlroots VRAM path build the converter directly, so AMD hosts on those paths were running the unfixed version.
-- **Nix packaging is built and checked**: the vendored gamescope patch stacks are verified on every push, and CI builds the patched compositor, so a stack that cannot apply — or that applies without taking effect — fails before it reaches a host.
+- **True-headless GPU-native streaming**: the private headless compositor now uses the Vulkan/ext-image-copy path and preserves its initialization frame, so supported NVIDIA/NVENC hosts can stream a real `HEADLESS-1` session without falling back to a visible window. The merged implementation head was exercised on the RTX 4090 host and Retroid Pocket 6 with live changing frames and clean teardown; the exact `v1.3.8` candidate still requires its final hash-bound device smoke before publication.
+- **One launch changes one session**: Polaris accepts a validated `streamMode` override for a single launch without rewriting the host-wide default. Capture sources are re-evaluated at the session boundary, display-mode fallback is reported explicitly, and mode-aware optimizer advice follows the resolved path. Matching client support is versioned separately in Nova `v1.3.6`; it is not embedded in the Polaris repository.
+- **Fail-closed lifecycle ownership**: detached-only workloads retain exact PIDFD authority before detaching; teardown signals and reaps only the captured generation and blocks replacement launch when attribution is incomplete. Portal startup, cancellation, restore-token handling, and private-compositor cleanup are also hardened.
+- **Doctor can apply and verify**: stale network labels no longer cause another destructive bitrate reduction. Polaris exposes evidence-gated actions to recheck, lower bitrate one guarded step, restore a clean history-capped profile gradually, verify live telemetry, and offer Undo through the web console. Matching Nova client controls are versioned and released independently.
+- **Bounded diagnostics**: runtime logging is capped at an 8 MiB active file plus one 8 MiB backup, queues are bounded, records keep creation-time stamps, and the authenticated binary-safe tail API gives the browser a bounded 256 KiB / 2,000-line view with truthful truncation state.
+- **Benchmark and UI work**: authenticated benchmark-run controls expose bounded T0-T2 host-stage evidence; Mission Control is rebuilt around one status hero, one live strip, the Doctor, a safer preview, and five Nova-aligned themes.
+- **GPU and launch hardening**: single-GPU DMA-BUF render-node discovery, configured/default multi-GPU pairing, VAAPI-safe device selection, resume refresh restoration, guarded HDR/YUV444 probes, and complete launch/resume status responses reduce wrong-GPU, slow-path, and crash-shaped failures.
 - **Security gate**: `npm audit --audit-level=high` remains mandatory.
 - **Exact release set**: the official artifacts are `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb`.
+
+Field-proof caveats remain explicit: the reporter's AMD 4K60 scenario needs a current-candidate retest, host-virtual-display routing still needs its queued end-to-end device confirmation, and SteamOS remains an experimental Desktop Mode package rather than certified Game Mode support.
+
 See the [changelog](docs/changelog.md) for the full release history.
 
 ## Install

--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -530,7 +530,7 @@
         "example": {
           "schema_version": 1,
           "measurement_spec_id": "measurement-spec-v1",
-          "collector_version": "1.3.7",
+          "collector_version": "1.3.8",
           "clock_domain": "CLOCK_MONOTONIC",
           "run_id": "pair-0001-control",
           "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,22 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## v1.3.8 - 2026-08-12
+
+A safer private-stream daily driver: true-headless GPU-native capture, session-only launch choices, exact process ownership, an evidence-gated Doctor, bounded logs, benchmark controls, and a rebuilt web console.
+
+- Enables a true-headless Vulkan/ext-image-copy path with a prefetched initialization frame; the merged implementation head was exercised on the RTX 4090 host and Retroid Pocket 6 with changing frames and clean teardown, while the exact `v1.3.8` candidate still requires its final hash-bound device smoke
+- Accepts a validated session-only `streamMode` launch override, re-evaluates capture sources around that session, reports display fallback explicitly, and leaves the persisted host default untouched; matching client support is versioned separately in Nova `v1.3.6`
+- Owns detached-only workloads through exact PIDFD identity before detaching, signals and reaps only the captured session generation, stops retained private compositors safely, and hardens portal startup/cancellation and restore-token handling
+- Exposes evidence-gated Doctor actions to recheck, perform one guarded bitrate reduction, restore a history-safe profile gradually, verify live telemetry, and Undo through the web console; matching Nova controls are versioned and released independently
+- Caps runtime diagnostics at an 8 MiB active file plus one 8 MiB backup, bounds console/file queues, preserves record-time timestamps, and exposes an authenticated binary-safe tail API with a bounded browser view and truthful truncation state
+- Adds authenticated bounded benchmark-run controls and T0-T2 host-stage evidence while keeping benchmark mode explicitly gated
+- Rebuilds Mission Control around one status hero, one live strip, the Doctor, a safer preview, and five Nova-aligned themes
+- Hardens render-node/GPU pairing, VAAPI-safe device selection, resume refresh restoration, HDR/YUV444 capability probes, virtual-display capture routing, and launch/resume status responses
+- Keeps current field-proof limits visible: the reporter's AMD 4K60 scenario and host-virtual-display route still need current-candidate end-to-end confirmation, and SteamOS remains an experimental Desktop Mode package
+- Keeps `npm audit --audit-level=high` mandatory
+- Retains exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
+
 ## v1.3.7 - 2026-08-07
 
 A use-after-free in VAAPI DMA-BUF capture that AMD hosts on DRM/KMS have been running, and CI that finally builds the nix packaging it patches.

--- a/docs/release-notes/v1.3.8.md
+++ b/docs/release-notes/v1.3.8.md
@@ -1,0 +1,78 @@
+# Polaris v1.3.8
+
+Polaris v1.3.8 turns the private Linux stream path into a safer daily driver: true-headless GPU-native capture, session-only launch choices, exact PIDFD process ownership, an evidence-gated Doctor, bounded diagnostics, and a rebuilt Mission Control.
+
+## Important: upgrading from v1.3.7
+
+Nothing extra is required beyond the usual package, `--setup-host`, and restart sequence. Existing configuration remains valid.
+
+This release is especially relevant if you use the private headless compositor, launch from Nova with per-game mode choices, rely on detached commands, or need diagnostics that cannot grow without bound.
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.8/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.8/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.8/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md). SteamOS remains an experimental Desktop Mode package rather than certified Game Mode support.
+
+## Changes
+
+### Private streaming and launch intent
+
+- Enables a true-headless Vulkan/ext-image-copy path and preserves its initialization frame, allowing supported NVIDIA/NVENC hosts to stream a real `HEADLESS-1` session without a visible-window fallback. The merged implementation head was exercised on the RTX 4090 host and Retroid Pocket 6 with changing frames and clean teardown; that is implementation evidence, not a substitute for the exact `v1.3.8` candidate smoke still required before publication.
+- Accepts a validated per-launch `streamMode` override. It applies to that session only, re-evaluates capture sources at the boundary, and restores the unchanged host default after teardown. Matching client support is versioned separately in Nova `v1.3.6`; it is not embedded in the Polaris repository.
+- Reports display-mode fallback explicitly and keeps mode-aware optimization recommendations tied to the resolved stream path.
+- Hardens single- and multi-GPU render-node selection, VAAPI-safe device choice, virtual-display routing, resume refresh restoration, HDR/YUV444 capability probes, and launch/resume error responses.
+
+### Lifecycle safety
+
+- Retains exact PIDFD identity for detached-only workloads before detaching and signals/reaps only the captured session generation.
+- Fails closed when attribution is incomplete and prevents a replacement launch from inheriting ambiguous ownership.
+- Stops an owned private compositor even when wider generation evidence must remain retained.
+- Makes portal request subscription, cancellation, restore-token handling, media-start fencing, and disconnect teardown session-aware and bounded.
+
+### Doctor and diagnostics
+
+- Makes Doctor require current evidence before reducing quality. Polaris exposes actions to recheck the network, lower bitrate by one guarded step, restore a clean history-capped profile gradually, verify against live telemetry, and offer Undo through the web console. Matching Nova client controls are versioned and released independently.
+- Caps runtime logs at an 8 MiB active file plus one 8 MiB backup, bounds asynchronous queues, preserves record creation timestamps, and rejects oversized records.
+- Adds an authenticated binary-safe tail API and a bounded 256 KiB / 2,000-line browser view whose cursor/generation and truncation state remain truthful across clear, rotation, gaps, and empty polls.
+
+### Benchmark and web console
+
+- Adds authenticated benchmark-run create/start/stop/get/delete controls with bounded T0-T2 host-stage evidence and explicit session-generation/population guards.
+- Rebuilds Mission Control around one status hero, one live strip, the Doctor, a safer preview, and five Nova-aligned themes.
+
+## Current field-proof limits
+
+- The reporter's AMD/VAAPI 4K60 scenario still needs a current-v1.3.8-candidate retest; the post-v1.3.7 GPU-selection and capture-path fixes are included, but that external scenario is not claimed proven yet.
+- Host Virtual Display source/output routing is included but still needs its queued end-to-end device confirmation.
+- The exact tagged binary still requires one bounded RP6 smoke for true-headless launch, one session-only `streamMode` override without persistent default mutation, one Doctor apply/verify/undo flow, detached-workload teardown, and clean service state before publication is called complete.
+
+## Official assets
+
+- `Polaris-arch-x86_64.pkg.tar.zst`
+- `Polaris-fedora44-x86_64.rpm`
+- `Polaris-steamos3.8-x86_64.pkg.tar.zst`
+- `Polaris-ubuntu24.04-x86_64.deb`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.3.7') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.3.8') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -614,7 +614,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.3.7.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.3.8.md").read_text(encoding="utf-8")
 )
 
 
@@ -1245,16 +1245,17 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.3.8 - 2026-08-12",
     "## v1.3.7 - 2026-08-07",
-    "## v1.3.6 - 2026-08-07",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "VAAPI",
-    "DMA-BUF",
-    "use-after-free",
-    "DRM/KMS",
-    "wlroots",
+    "true-headless",
+    "GPU-native",
+    "streamMode",
+    "PIDFD",
+    "Doctor",
+    "8 MiB",
     "npm audit --audit-level=high",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
@@ -1263,19 +1264,19 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.3.7 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.3.8 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 readme_release_body = markdown_section(
     readme,
-    "## What is New in v1.3.7",
+    "## What is New in v1.3.8",
     "## Install",
 )
 readme_release_prose = rendered_markdown(readme_release_body)
 required_readme_facts = required_release_facts
 for fact in required_readme_facts:
     if fact not in readme_release_prose:
-        print(f"README v1.3.7 summary is missing: {fact}", file=sys.stderr)
+        print(f"README v1.3.8 summary is missing: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1285,8 +1286,8 @@ asset_phrase = (
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
 for label, section in (
-    ("README v1.3.7 summary", readme_release_prose),
-    ("v1.3.7 changelog", current_release_prose),
+    ("README v1.3.8 summary", readme_release_prose),
+    ("v1.3.8 changelog", current_release_prose),
 ):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
@@ -1305,8 +1306,8 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
     ("docs/building.md Packaging", building_packaging_prose),
-    ("README v1.3.7 summary", readme_release_prose),
-    ("v1.3.7 changelog", current_release_prose),
+    ("README v1.3.8 summary", readme_release_prose),
+    ("v1.3.8 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_assets:
@@ -1318,26 +1319,28 @@ for label, section in (
         sys.exit(1)
 
 release_notes_facts = (
-    "v1.3.6",
-    "VAAPI",
-    "DRM/KMS",
-    "RDNA3 and RDNA4 field evidence",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.7/Polaris-fedora44-x86_64.rpm &&",
+    "v1.3.7",
+    "true-headless",
+    "streamMode",
+    "PIDFD",
+    "Doctor",
+    "8 MiB",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.8/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.7/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.8/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.7/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.8/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.3.7 release notes are missing bootstrap fact: {fact}", file=sys.stderr)
+        print(f"v1.3.8 release notes are missing bootstrap fact: {fact}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.3.7 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.3.8 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.3.7 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.3.8 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 
 if "bash scripts/check-public-docs.sh" not in contributing:

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.7-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.8-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -667,7 +667,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.3.7-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.3.8-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v137-contract.test.js
+++ b/src_assets/common/assets/web/release-v137-contract.test.js
@@ -7,21 +7,25 @@ const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
 const sectionBetween = (source, startHeading, endHeading) => {
   const start = source.indexOf(startHeading)
   const end = source.indexOf(endHeading, start + startHeading.length)
-  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
-  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  expect(start, `missing historical release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing historical release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
   return source.slice(start, end)
 }
 
-const releaseSections = () => [
-  sectionBetween(read('README.md'), '## What is New in v1.3.7', '## Install'),
-  sectionBetween(read('docs/changelog.md'), '## v1.3.7 - 2026-08-07', '## v1.3.6'),
-]
+const historicalRelease = () => sectionBetween(
+  read('docs/changelog.md'),
+  '## v1.3.7 - 2026-08-07',
+  '## v1.3.6 - 2026-08-07',
+)
 
-const requiredFacts = [
+const historicalReleaseNotes = () => read('docs/release-notes/v1.3.7.md')
+
+const requiredFixFacts = [
   'VAAPI',
   'DMA-BUF',
   'use-after-free',
   'DRM/KMS',
+  'wlroots',
   'npm audit --audit-level=high',
 ]
 
@@ -32,72 +36,35 @@ const expectedAssets = [
   'Polaris-ubuntu24.04-x86_64.deb',
 ].sort()
 
-describe('v1.3.7 release contract', () => {
-  it('moves the CMake version and public release headings together', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.7')
-    expect(read('README.md')).toContain('## What is New in v1.3.7')
-    expect(read('docs/changelog.md')).toContain('## v1.3.7 - 2026-08-07')
-  })
+describe('historical v1.3.7 release contract', () => {
+  it('preserves the v1.3.7 release facts', () => {
+    const release = historicalRelease()
 
-  it('states the release facts in both public summaries', () => {
-    for (const releaseSection of releaseSections()) {
-      for (const fact of requiredFacts) {
-        expect(releaseSection, `release summary must include: ${fact}`).toContain(fact)
-      }
+    for (const fact of requiredFixFacts) {
+      expect(release, `historical release must include: ${fact}`).toContain(fact)
     }
   })
 
-  it('aligns the public checker with the v1.3.7 release contract', () => {
-    const publicDocsGate = read('scripts/check-public-docs.sh')
+  it('preserves the exact historical four-asset set', () => {
+    const actualAssets = historicalRelease().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
 
-    expect(publicDocsGate).toContain('"## What is New in v1.3.7"')
-    expect(publicDocsGate).not.toContain('"## What is New in v1.3.6"')
-    expect(publicDocsGate).toContain('"## v1.3.7 - 2026-08-07"')
-    for (const asset of expectedAssets) {
-      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
-    }
+    expect(actualAssets.sort()).toEqual(expectedAssets)
   })
 
-  it('moves versioned package-review metadata to v1.3.7', () => {
-    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
-    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
-
-    expect(reviewedWarnings).toContain('usr/bin/polaris-1.3.7')
-    expect(reviewedWarnings).not.toContain('usr/bin/polaris-1.3.6')
-    expect(steamOsBuildScript).toContain("'polaris|1.3.7-1|x86_64'")
-    expect(steamOsBuildScript).not.toContain("'polaris|1.3.6-1|x86_64'")
-  })
-
-  it('ships release notes whose install commands target v1.3.7', () => {
-    const releaseNotes = read('docs/release-notes/v1.3.7.md')
-
-    // The upgrade section has to name the release being upgraded from, and say
-    // which hosts this one actually matters for -- a use-after-free only some
-    // capture paths reach is worth stating plainly rather than burying.
-    for (const fact of ['v1.3.6', 'VAAPI', 'DRM/KMS']) {
-      expect(releaseNotes, `release notes must include: ${fact}`).toContain(fact)
-    }
-
-    // Install blocks only. The property is that documented install commands
-    // point at this release; other examples in the notes are not install
-    // commands and must not be forced to look like them.
-    const installBlocks = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+  it('preserves the v1.3.7 install commands and lifecycle steps', () => {
+    const notes = historicalReleaseNotes()
+    const installBlocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
       .map((match) => match[1])
       .filter((block) => block.includes('wget --output-document='))
 
     expect(installBlocks.length).toBe(3)
     for (const block of installBlocks) {
       expect(block).toContain('releases/download/v1.3.7/')
-      expect(block).not.toContain('releases/download/v1.3.6/')
       expect(block).toContain('polaris --setup-host')
       expect(block).toContain('systemctl --user restart polaris')
     }
-  })
-
-  it('keeps the exact four-asset set in the release notes', () => {
-    const notes = read('docs/release-notes/v1.3.7.md')
-    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
-
-    expect(listed.sort()).toEqual(expectedAssets)
+    for (const asset of expectedAssets.filter((asset) => !asset.includes('steamos'))) {
+      expect(notes).toContain(asset)
+    }
   })
 })

--- a/src_assets/common/assets/web/release-v138-contract.test.js
+++ b/src_assets/common/assets/web/release-v138-contract.test.js
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+
+const sectionBetween = (source, startHeading, endHeading) => {
+  const start = source.indexOf(startHeading)
+  const end = source.indexOf(endHeading, start + startHeading.length)
+  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+const releaseSections = () => [
+  sectionBetween(read('README.md'), '## What is New in v1.3.8', '## Install'),
+  sectionBetween(read('docs/changelog.md'), '## v1.3.8 - 2026-08-12', '## v1.3.7'),
+]
+
+const requiredFacts = [
+  'true-headless',
+  'GPU-native',
+  'streamMode',
+  'PIDFD',
+  'Doctor',
+  '8 MiB',
+  'npm audit --audit-level=high',
+]
+
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+
+describe('v1.3.8 release contract', () => {
+  it('moves the CMake version and public release headings together', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.8')
+    expect(read('README.md')).toContain('## What is New in v1.3.8')
+    expect(read('docs/changelog.md')).toContain('## v1.3.8 - 2026-08-12')
+    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.3.8"')
+  })
+
+  it('states the release facts in both public summaries', () => {
+    for (const releaseSection of releaseSections()) {
+      for (const fact of requiredFacts) {
+        expect(releaseSection, `release summary must include: ${fact}`).toContain(fact)
+      }
+    }
+  })
+
+  it('aligns the public checker with the v1.3.8 release contract', () => {
+    const publicDocsGate = read('scripts/check-public-docs.sh')
+
+    expect(publicDocsGate).toContain('"## What is New in v1.3.8"')
+    expect(publicDocsGate).not.toContain('"## What is New in v1.3.7"')
+    expect(publicDocsGate).toContain('"## v1.3.8 - 2026-08-12"')
+    for (const asset of expectedAssets) {
+      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
+    }
+  })
+
+  it('moves versioned package-review metadata to v1.3.8', () => {
+    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
+    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
+    const packagingContract = read('src_assets/common/assets/web/packaging-contracts.test.js')
+
+    expect(reviewedWarnings).toContain('usr/bin/polaris-1.3.8')
+    expect(reviewedWarnings).not.toContain('usr/bin/polaris-1.3.7')
+    expect(steamOsBuildScript).toContain("'polaris|1.3.8-1|x86_64'")
+    expect(steamOsBuildScript).not.toContain("'polaris|1.3.7-1|x86_64'")
+    expect(packagingContract).toContain("'polaris|1.3.8-1|x86_64'")
+  })
+
+  it('ships release notes whose install commands target v1.3.8', () => {
+    const releaseNotes = read('docs/release-notes/v1.3.8.md')
+    const benchmarkOpenApi = read('docs/benchmark-control-openapi.json')
+
+    expect(benchmarkOpenApi).toContain('"collector_version": "1.3.8"')
+    expect(benchmarkOpenApi).not.toContain('"collector_version": "1.3.7"')
+    for (const fact of ['v1.3.7', 'true-headless', 'streamMode', 'PIDFD', 'Doctor', '8 MiB']) {
+      expect(releaseNotes, `release notes must include: ${fact}`).toContain(fact)
+    }
+
+    const installBlocks = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
+
+    expect(installBlocks.length).toBe(3)
+    for (const block of installBlocks) {
+      expect(block).toContain('releases/download/v1.3.8/')
+      expect(block).not.toContain('releases/download/v1.3.7/')
+      expect(block).toContain('polaris --setup-host')
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+  })
+
+  it('keeps the exact four-asset set in the release notes', () => {
+    const notes = read('docs/release-notes/v1.3.8.md')
+    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+
+    expect(listed.sort()).toEqual(expectedAssets)
+  })
+})


### PR DESCRIPTION
## Summary

Prepare Polaris `v1.3.8` while keeping the product on the approved `1.3.x` patch line.

- bump CMake and generated package identity to `1.3.8`
- publish README, changelog, and standalone release notes for true-headless GPU-native capture, session-only `streamMode`, PIDFD lifecycle ownership, evidence-gated Doctor actions, bounded logs/tail API, benchmark controls, and the rebuilt Mission Control
- move SteamOS package identity and reviewed-warning metadata to `1.3.8-1`
- move the benchmark OpenAPI collector example to `1.3.8`
- add the current v1.3.8 release contract while preserving v1.3.7 facts and exact install/setup/restart commands as historical contracts
- keep the exact four supported package assets unchanged

## Refreshed exact candidate

- Head: `74a23ea0596d5696dcbec6c1bbdf358606347c7b`
- Tree: `dcf9fac9e3fbe6debe1240fd16787b5d4f7b3769`
- Base: `db003b94307a13d9c6a0294ce568e2c0801f18a2`
- Release-diff SHA-256: `a33fdb91f299b3f0cd03293c01ce7deb6832cf78926ac062f8d8862a813d690a`

The base is the verified squash merge of #385. The release branch was refreshed by a normal merge (no force push). Relative to the new base, the release diff is still exactly the original eleven metadata/docs/package-contract files. `tests/unit/test_process_migration.cpp` has zero release-branch delta and is inherited unchanged from master.

## Verification

### Release-contract TDD

- the new six-assertion v1.3.8 contract failed against the old v1.3.7 surfaces, then passed after the coordinated metadata update
- RED log SHA-256: `c5f357da08b9045efe7c828c78e3e5aeeb7b654974d87c7e2c3c4c94559046ca`

### Original exact release candidate

- public docs and public surface: passed
- current/historical release and packaging contracts: passed
- full web suite, ESLint, production build, and performance budgets: passed
- release-package dependency checker: passed
- combined gate log SHA-256: `99f0c652c094a3e7eb6d4483493807e6b830d58822c9b5d4fc3c4e26aa2eeb0d`
- exact-head GitHub CI passed sanitizer, web, Arch, Fedora Clang/RPM, Ubuntu DEB smoke, and SteamOS package validation

### #385 prerequisite and refreshed base

- #385 merged as squash commit `db003b94307a13d9c6a0294ce568e2c0801f18a2`
- merge tree `8a5b1be71bdc18299cfee9a8926f9031b0b15238` exactly matched reviewed head tree
- post-merge master CI passed web, sanitizer/ownership tests, Arch compile/tests, Fedora Clang/RPM package smoke, Ubuntu DEB package smoke, and SteamOS validation
- Arch's release-only final-package validation was conditionally skipped on the non-tag push; the compile/tests/package-file generation job itself passed

### Refreshed exact candidate

- release diff remains exactly eleven files; release-diff SHA-256 is unchanged
- `git diff <base>...HEAD -- tests/unit/test_process_migration.cpp` is empty
- public docs and public surface: passed
- all current/historical release and packaging contracts: passed
- full web suite, ESLint, production build, and performance budgets: passed
- release-package dependency checker: passed
- inherited #385 regression test: passed
- refreshed local gate log SHA-256: `468ca82aacee41eb5908f23b14437cd0d50f350361351e795875cfcc0ac05a7a`
- independent read-only Codex review: **NO FINDINGS**
- conflict-marker scan and `git diff --check`: passed
- refreshed exact-head GitHub CI run [`31604790292`](https://github.com/papi-ux/polaris/actions/runs/31604790292): passed sanitizer, web, Arch, Fedora Clang/RPM, Ubuntu DEB smoke, and SteamOS package validation/upload/receipt upload
- refreshed exact-head CodeQL run [`31604790327`](https://github.com/papi-ux/polaris/actions/runs/31604790327): both analysis jobs passed
- refreshed exact-head public-hygiene run [`31604790305`](https://github.com/papi-ux/polaris/actions/runs/31604790305): passed

A configure-only package check with CUDA intentionally disabled previously confirmed `CMAKE_PROJECT_VERSION=1.3.8` and generated the expected `1.3.8` SteamOS identity. The fresh local worktree could not discover a CUDA compiler; GitHub's exact-head distro/package matrix is the authoritative build evidence.

## Remaining blockers

This PR remains intentionally **draft** and is **not merge-ready yet**:

1. The exact candidate still needs one bounded runtime smoke covering true-headless launch, one session-only `streamMode` override without persistent default mutation, one Doctor apply/verify/undo flow, detached-workload teardown, and clean service state.
2. The reporter's AMD/VAAPI 4K60 scenario and Host Virtual Display route remain explicitly unproven on the exact candidate; the release notes do not claim otherwise.
3. Final publication requires the exact final candidate's four release assets and verification receipts to be built and checked before tag/release completion.

## Publication boundary

This PR does **not** authorize merge, tagging, release publication, deployment, or announcement. Tagging `v1.3.8` remains a later exact approval because the tag workflow creates/uploads the public release assets automatically.
