### PR TITLE
docs: record v1.3.8 publication proof

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,15 +9,16 @@ starts at `v1.0.0`.
 
 A safer private-stream daily driver: true-headless GPU-native capture, session-only launch choices, exact process ownership, an evidence-gated Doctor, bounded logs, benchmark controls, and a rebuilt web console.
 
-- Enables a true-headless Vulkan/ext-image-copy path with a prefetched initialization frame; the merged implementation head was exercised on the RTX 4090 host and Retroid Pocket 6 with changing frames and clean teardown, while the exact `v1.3.8` candidate still requires its final hash-bound device smoke
+- Enables a true-headless Vulkan/ext-image-copy path with a prefetched initialization frame
 - Accepts a validated session-only `streamMode` launch override, re-evaluates capture sources around that session, reports display fallback explicitly, and leaves the persisted host default untouched; matching client support is versioned separately in Nova `v1.3.6`
-- Owns detached-only workloads through exact PIDFD identity before detaching, signals and reaps only the captured session generation, stops retained private compositors safely, and hardens portal startup/cancellation and restore-token handling
+- Owns detached-only workloads through exact PIDFD identity before detaching, signals and reaps only the captured session generation, stops retained private compositors safely, recaptures demonstrably transient `/proc` races to bounded quiescence while persistent or ambiguous attribution remains fail-closed, and hardens portal startup/cancellation and restore-token handling
 - Exposes evidence-gated Doctor actions to recheck, perform one guarded bitrate reduction, restore a history-safe profile gradually, verify live telemetry, and Undo through the web console; matching Nova controls are versioned and released independently
 - Caps runtime diagnostics at an 8 MiB active file plus one 8 MiB backup, bounds console/file queues, preserves record-time timestamps, and exposes an authenticated binary-safe tail API with a bounded browser view and truthful truncation state
 - Adds authenticated bounded benchmark-run controls and T0-T2 host-stage evidence while keeping benchmark mode explicitly gated
 - Rebuilds Mission Control around one status hero, one live strip, the Doctor, a safer preview, and five Nova-aligned themes
 - Hardens render-node/GPU pairing, VAAPI-safe device selection, resume refresh restoration, HDR/YUV444 capability probes, virtual-display capture routing, and launch/resume status responses
-- Keeps current field-proof limits visible: the reporter's AMD 4K60 scenario and host-virtual-display route still need current-candidate end-to-end confirmation, and SteamOS remains an experimental Desktop Mode package
+- Records the bounded Retroid Pocket 6 release smoke of the exact source commit tagged as `v1.3.8`: true-headless `HEADLESS-1` capture, changing frames, session-only stream mode, durable Doctor apply/verify/Undo, exact-generation teardown, and clean restoration
+- Keeps the remaining field-proof limits visible: the reporter's AMD 4K60 scenario and host-virtual-display route still need current-`v1.3.8` end-to-end confirmation, and SteamOS remains an experimental Desktop Mode package
 - Keeps `npm audit --audit-level=high` mandatory
 - Retains exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
 

--- a/docs/release-notes/v1.3.8.md
+++ b/docs/release-notes/v1.3.8.md
@@ -41,7 +41,7 @@ Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite g
 
 ### Private streaming and launch intent
 
-- Enables a true-headless Vulkan/ext-image-copy path and preserves its initialization frame, allowing supported NVIDIA/NVENC hosts to stream a real `HEADLESS-1` session without a visible-window fallback. The merged implementation head was exercised on the RTX 4090 host and Retroid Pocket 6 with changing frames and clean teardown; that is implementation evidence, not a substitute for the exact `v1.3.8` candidate smoke still required before publication.
+- Enables a true-headless Vulkan/ext-image-copy path and preserves its initialization frame, allowing supported NVIDIA/NVENC hosts to stream a real `HEADLESS-1` session without a visible-window fallback.
 - Accepts a validated per-launch `streamMode` override. It applies to that session only, re-evaluates capture sources at the boundary, and restores the unchanged host default after teardown. Matching client support is versioned separately in Nova `v1.3.6`; it is not embedded in the Polaris repository.
 - Reports display-mode fallback explicitly and keeps mode-aware optimization recommendations tied to the resolved stream path.
 - Hardens single- and multi-GPU render-node selection, VAAPI-safe device choice, virtual-display routing, resume refresh restoration, HDR/YUV444 capability probes, and launch/resume error responses.
@@ -52,6 +52,7 @@ Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite g
 - Fails closed when attribution is incomplete and prevents a replacement launch from inheriting ambiguous ownership.
 - Stops an owned private compositor even when wider generation evidence must remain retained.
 - Makes portal request subscription, cancellation, restore-token handling, media-start fencing, and disconnect teardown session-aware and bounded.
+- Recaptures demonstrably transient `/proc` identity and environment races to bounded quiescence while preserving fail-closed behavior for persistent or ambiguous failures.
 
 ### Doctor and diagnostics
 
@@ -64,11 +65,11 @@ Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite g
 - Adds authenticated benchmark-run create/start/stop/get/delete controls with bounded T0-T2 host-stage evidence and explicit session-generation/population guards.
 - Rebuilds Mission Control around one status hero, one live strip, the Doctor, a safer preview, and five Nova-aligned themes.
 
-## Current field-proof limits
+## Field proof
 
-- The reporter's AMD/VAAPI 4K60 scenario still needs a current-v1.3.8-candidate retest; the post-v1.3.7 GPU-selection and capture-path fixes are included, but that external scenario is not claimed proven yet.
+- The exact source commit tagged as `v1.3.8` passed the bounded Retroid Pocket 6 release smoke with true-headless `HEADLESS-1` capture, changing frames, session-only stream mode, durable Doctor apply/verify/Undo, exact-generation teardown, and clean restoration.
+- The reporter's AMD/VAAPI 4K60 scenario still needs a current `v1.3.8` retest; the post-`v1.3.7` GPU-selection and capture-path fixes are included, but that external scenario is not claimed proven yet.
 - Host Virtual Display source/output routing is included but still needs its queued end-to-end device confirmation.
-- The exact tagged binary still requires one bounded RP6 smoke for true-headless launch, one session-only `streamMode` override without persistent default mutation, one Doctor apply/verify/undo flow, detached-workload teardown, and clean service state before publication is called complete.
 
 ## Official assets
 


### PR DESCRIPTION
## What changed

- replace pre-publication gate language in the `v1.3.8` changelog and release notes with the completed bounded RP6 smoke result
- document the exact-generation bounded `/proc` recapture behavior added before publication
- retain the outstanding AMD/VAAPI 4K60 and Host Virtual Display field-proof limits

## Why

`v1.3.8` is now public and its exact source commit passed the bounded physical release smoke. The repository source still described that smoke as pending. `papi-ux.com` synchronizes these files from Polaris on every deployment, so the source must be corrected before the website release metadata can be merged without reintroducing stale claims.

## User impact

The public changelog and release notes accurately distinguish completed RP6 proof from the two remaining field-test limits. Product behavior and published packages are unchanged.

## Verification

- `git diff --check`
- `bash scripts/check-public-docs.sh`
- `bash scripts/check-public-surface.sh`
- `python3 scripts/check-release-package-dependencies.py`

## Coordination

Merge this documentation correction before the companion `papi-ux.github.io` release-sync PR so the website's deployment-time docs sync reads the corrected source.
