### PR TITLE
fix(build): drop the unreachable build-deps submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,9 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           for attempt in 1 2 3 4 5; do
             git submodule sync --recursive
-            if git -c protocol.version=2 submodule update --init --force --recursive --jobs 1; then
+            # Trees from before the build-deps submodule removal still pin its
+            # dead commit; skip it instead of gambling on the orphaned object.
+            if git -c protocol.version=2 -c submodule.third-party/build-deps.update=none submodule update --init --force --recursive --jobs 1; then
               exit 0
             fi
             echo "submodule update failed on attempt ${attempt}" >&2
@@ -438,7 +440,9 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           for attempt in 1 2 3 4 5; do
             git submodule sync --recursive
-            if git -c protocol.version=2 submodule update --init --force --recursive --jobs 1; then
+            # Trees from before the build-deps submodule removal still pin its
+            # dead commit; skip it instead of gambling on the orphaned object.
+            if git -c protocol.version=2 -c submodule.third-party/build-deps.update=none submodule update --init --force --recursive --jobs 1; then
               exit 0
             fi
             echo "submodule update failed on attempt ${attempt}" >&2
@@ -539,7 +543,9 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git submodule sync --recursive
-          git submodule update --init --recursive
+          # Trees from before the build-deps submodule removal still pin its
+          # dead commit; skip it instead of gambling on the orphaned object.
+          git -c submodule.third-party/build-deps.update=none submodule update --init --recursive
 
       - name: Build and validate SteamOS 3.8 package
         run: |
@@ -583,7 +589,9 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           for attempt in 1 2 3 4 5; do
             git submodule sync --recursive
-            if git -c protocol.version=2 submodule update --init --force --recursive --jobs 1; then
+            # Trees from before the build-deps submodule removal still pin its
+            # dead commit; skip it instead of gambling on the orphaned object.
+            if git -c protocol.version=2 -c submodule.third-party/build-deps.update=none submodule update --init --force --recursive --jobs 1; then
               exit 0
             fi
             echo "submodule update failed on attempt ${attempt}" >&2
@@ -769,7 +777,9 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           for attempt in 1 2 3 4 5; do
             git submodule sync --recursive
-            if git -c protocol.version=2 submodule update --init --force --recursive --jobs 1; then
+            # Trees from before the build-deps submodule removal still pin its
+            # dead commit; skip it instead of gambling on the orphaned object.
+            if git -c protocol.version=2 -c submodule.third-party/build-deps.update=none submodule update --init --force --recursive --jobs 1; then
               exit 0
             fi
             echo "submodule update failed on attempt ${attempt}" >&2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "third-party/build-deps"]
-	path = third-party/build-deps
-	url = https://github.com/LizardByte/build-deps.git
-	branch = dist
 [submodule "third-party/googletest"]
 	path = third-party/googletest
 	url = https://github.com/google/googletest.git

--- a/cmake/dependencies/prepared_ffmpeg.cmake
+++ b/cmake/dependencies/prepared_ffmpeg.cmake
@@ -106,12 +106,12 @@ function(polaris_resolve_prepared_ffmpeg out_var)
 
   set(resolved_dir "")
 
-  if(POLARIS_DOWNLOAD_PREPARED_FFMPEG)
-    set(system_processor "${CMAKE_SYSTEM_PROCESSOR}")
-    if(NOT system_processor)
-      set(system_processor "${CMAKE_HOST_SYSTEM_PROCESSOR}")
-    endif()
+  set(system_processor "${CMAKE_SYSTEM_PROCESSOR}")
+  if(NOT system_processor)
+    set(system_processor "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+  endif()
 
+  if(POLARIS_DOWNLOAD_PREPARED_FFMPEG)
     polaris_prepared_ffmpeg_asset_name(asset_name "${CMAKE_SYSTEM_NAME}" "${system_processor}")
     if(asset_name)
       polaris_prepared_ffmpeg_asset_hash(asset_sha256 "${asset_name}")
@@ -152,8 +152,11 @@ function(polaris_resolve_prepared_ffmpeg out_var)
   endif()
 
   if(NOT resolved_dir)
-    set(resolved_dir
-        "${CMAKE_SOURCE_DIR}/third-party/build-deps/dist/${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+    message(FATAL_ERROR
+        "No prepared FFmpeg for ${CMAKE_SYSTEM_NAME}-${system_processor}: prepared "
+        "archive downloads are disabled or no pinned archive exists for this platform. "
+        "Set FFMPEG_PREPARED_BINARIES to a prepared FFmpeg directory, or enable "
+        "POLARIS_DOWNLOAD_PREPARED_FFMPEG on a platform with a pinned archive.")
   endif()
 
   polaris_validate_prepared_ffmpeg_dir("${resolved_dir}")

--- a/scripts/dev-clean.sh
+++ b/scripts/dev-clean.sh
@@ -99,14 +99,14 @@ cleanup_candidates() {
     arch-pkgbuild \
     test-results \
     playwright-report \
-    compile_commands.json
+    compile_commands.json \
+    third-party/build-deps
   do
     path_exists "$path" && printf '%s\n' "$path"
   done
 
   shopt -s nullglob
   for path in build-* cmake-*; do
-    [[ "$path" == "build-deps" ]] && continue
     path_exists "$path" && printf '%s\n' "$path"
   done
   shopt -u nullglob


### PR DESCRIPTION
## Summary

- Closes #390. `third-party/build-deps` is pinned to `a9a7f86` on the `dist` branch of LizardByte/build-deps, and that branch no longer exists upstream. The commit is reachable from no ref, so fresh `--recurse-submodules` clones fail whenever a GitHub replica no longer serves the orphaned object, and the pin can never advance again because the branch it tracked is gone.
- Remove the submodule from `.gitmodules` and drop the gitlink. Nothing consumes it anymore: prepared FFmpeg archives download by default from the pinned build-deps release tag (`v2026.516.30821`, per-platform SHA256 verification), the Nix package fetches its own tarball by URL, and no workflow, script, or doc reads `third-party/build-deps`.
- Replace the dead submodule fallback in `cmake/dependencies/prepared_ffmpeg.cmake` with a `FATAL_ERROR` that names the two supported paths: point `FFMPEG_PREPARED_BINARIES` at a prepared directory, or leave `POLARIS_DOWNLOAD_PREPARED_FFMPEG` on for a platform with a pinned archive.
- Existing checkouts keep an untracked `third-party/build-deps` directory after this lands; it is harmless. Delete the directory (plus `.git/modules/third-party/build-deps` if you want the cached clone gone) to clear it; `git submodule deinit` no longer applies once the path stops being a registered submodule. `scripts/dev-clean.sh prune` now offers the orphan as a cleanup candidate, and the unmatchable root-glob `build-deps` guard in the same script is gone.
- A review pass over the change surfaced a real residual: `workflow_dispatch` rebuilds with `release_tag` (and CI on PR bases that predate this fix) check out historical trees whose `.gitmodules` still pins the dead commit. The workflow's five submodule-init sites now pass `-c submodule.third-party/build-deps.update=none`: inert on post-removal trees, decisive on historical ones. Historical trees resolve FFmpeg the same way master does (`v1.3.8` already defaults `POLARIS_DOWNLOAD_PREPARED_FFMPEG=ON` with the same pinned tag), so skipping the submodule there is safe. Two residuals stay out of reach and are accepted: PKGBUILDs frozen inside already-published tags run their own init, and `cpp-sanitizer-tests` uses `actions/checkout` with `submodules: recursive` (no per-submodule knob), so pre-fix PR bases can still flake there until rebased.
- The configure error for a missing prepared FFmpeg now reports the processor value the asset lookup actually used (`CMAKE_HOST_SYSTEM_PROCESSOR` fallback included) instead of the raw cache variable, which could render as a bare trailing dash under a cross toolchain.

## Exact candidate

- `Commit:` `5e96be5214979869a8934ba4ea6fcffd1bf3dceb`
- `Tree:` `f086f71c4608236e9dd5d6b8d43367740b4ed256`
- `Parent:` `94b5c1d99052f714974e6181edfed8226be0227d`
- `Base:` `master` at `94b5c1d99052f714974e6181edfed8226be0227d`

## Verification

- [x] Fresh worktree at the candidate: `git submodule update --init --recursive` completes with build-deps gone
- [x] Canonical Linux configure (CUDA-off tree) resolves prepared FFmpeg via the default download path: `Using prepared FFmpeg Linux-x86_64-ffmpeg.tar.gz from v2026.516.30821`
- [x] Full `ninja -C build` (356 targets) and `ctest --test-dir build/tests`: 17/17 tests passed, 0 failed (52.98s)
- [x] Configure with `-DPOLARIS_DOWNLOAD_PREPARED_FFMPEG=OFF` fails with the new actionable message instead of pointing at the ghost submodule directory
- [x] Fresh `git clone --depth 1 --recurse-submodules --shallow-submodules` of this branch from GitHub succeeds end to end
- [x] The `update=none` skip form verified live against a fresh clone of pre-fix master: every other submodule materializes, `third-party/build-deps` stays empty, exit 0
- [x] `scripts/dev-clean.sh prune` dry-run lists `Would remove third-party/build-deps/` for an orphaned tree; `bash -n` clean
- [x] Patched `build.yml` parses; the `release_tag` rebuild path itself can only prove out on the next dispatch, since dispatches run the master workflow

One caveat worth stating plainly: a fresh recursive clone of current `master` from this network succeeded today, because a replica still served the orphaned object. The failure is replica-dependent, which is exactly why the pin cannot be relied on: the reporter's refusal in #390, the retry loop in `build.yml`, and today's success are all faces of the same lottery. Release tags `v1.3.8` and earlier keep the dead pin; on those, `git -c submodule."third-party/build-deps".update=none submodule update --init --recursive` skips it.
