### PR TITLE
fix(nix): refresh stale polaris-stream-ui npmDepsHash

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,6 +9,10 @@ name: Nix
 #   patch-stacks  needs no nix at all and runs in about a second, so it is also
 #                 wired into Public Hygiene and runs on every push.
 #   eval / build  install nix; scoped to changes that can reach them.
+#   web-ui-deps   just the npm-deps fixed-output derivation: no CUDA, no CMake,
+#                 seconds long. Runs on every package-lock.json move so a stale
+#                 npmDepsHash (see #392) surfaces on the PR that causes it
+#                 instead of waiting for the weekly polaris-stream run.
 #   polaris-stream  the CUDA build, far too heavy for every push: manual, plus a
 #                 weekly run so npm and source drift surfaces on its own.
 
@@ -19,6 +23,8 @@ on:
       - 'nix/**'
       - 'flake.nix'
       - 'flake.lock'
+      - 'package.json'
+      - 'package-lock.json'
       - 'scripts/check-nix-patches.py'
       - '.github/workflows/nix.yml'
   pull_request:
@@ -27,6 +33,8 @@ on:
       - 'nix/**'
       - 'flake.nix'
       - 'flake.lock'
+      - 'package.json'
+      - 'package-lock.json'
       - 'scripts/check-nix-patches.py'
       - '.github/workflows/nix.yml'
   schedule:
@@ -112,6 +120,27 @@ jobs:
         # Log only — the assertion already ran inside the derivation. Worth
         # printing so the stamp a session negotiates against is visible here.
         run: ./result/bin/gamescope --version || true
+
+  web-ui-deps:
+    name: Build polaris-stream npm deps
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Nix
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSfL https://nixos.org/nix/install -o "$RUNNER_TEMP/install-nix.sh"
+          sh "$RUNNER_TEMP/install-nix.sh" --no-daemon --no-channel-add
+          echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
+
+      - name: Build the npm-deps fixed-output derivation
+        # Just the .ui attribute: npm install + vite build, no CUDA/CMake. This
+        # is the whole surface that npmDepsHash actually pins, so it is what
+        # would have failed on #319's package-lock.json move instead of the
+        # weekly polaris-stream run finding it five days later.
+        run: nix build --print-build-logs '.#polaris-stream.ui'
 
   polaris-stream:
     name: Build polaris-stream

--- a/nix/packages/polaris-stream/default.nix
+++ b/nix/packages/polaris-stream/default.nix
@@ -140,7 +140,7 @@ stdenv'.mkDerivation (finalAttrs: {
   ui = buildNpmPackage {
     inherit (finalAttrs) src version;
     pname = "polaris-stream-ui";
-    npmDepsHash = "sha256-0dUAuV/nrxq3PYTzSVirk8OyM2lZCaa376H2rJ4bgEg=";
+    npmDepsHash = "sha256-mpfQk4k40tMhB9FbXuNntgOqzWEShtXgBtmB4qUXj4o=";
 
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
## Summary
- The weekly `Nix` workflow has been failing since 2026-08-10 with a fixed-output hash mismatch building `polaris-stream-ui`'s npm deps.
- `package-lock.json` moved on in #319 (nanoid advisory bump, 2026-08-08) but `npmDepsHash` in `nix/packages/polaris-stream/default.nix` was last refreshed for the prior lockfile (2026-07-30), so it's out of date:
  ```
  error: hash mismatch in fixed-output derivation '...-polaris-stream-ui-...-npm-deps.drv':
    specified: sha256-0dUAuV/nrxq3PYTzSVirk8OyM2lZCaa376H2rJ4bgEg=
    got:       sha256-mpfQk4k40tMhB9FbXuNntgOqzWEShtXgBtmB4qUXj4o=
  ```
- This updates `npmDepsHash` to the value Nix itself reports as correct for the current lockfile.
- Second commit: nothing in CI would have caught this earlier than the weekly `polaris-stream` run. `push`/`pull_request` never watched `package.json`/`package-lock.json`, and the only job that touches `npmDepsHash` is gated to `workflow_dispatch`/`schedule`. That's how #319 sat broken for 5 days with no PR tying the break to its cause. Added those paths to the trigger, plus a `web-ui-deps` job that builds just the `.ui` attribute (npm install + vite build, no CUDA/CMake, well under a minute) so this surfaces on the PR that causes it next time.

## Test plan
- [x] Built just the affected derivation locally against current `master` + this change: `nix build '.#polaris-stream.ui'` — completes successfully (npm install, vite build, and fixup all succeed).
- [x] `actionlint` clean on the updated `.github/workflows/nix.yml`.
- [ ] CI: this should let the `Build polaris-stream` job in `.github/workflows/nix.yml` pass again, and the new `web-ui-deps` job should run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)