### PR TITLE
fix(logging): give the bounded runtime log a single owner

### DIFF
--- a/docs/log-tail-api-v1.md
+++ b/docs/log-tail-api-v1.md
@@ -10,7 +10,7 @@ This endpoint never reads the whole active log. It is intended for the Web UI an
 
 ## Runtime retention
 
-The active runtime log is fixed at 8388608 bytes, with one backup of at most the same size. Polaris rotates only between complete formatted records, replaces the prior backup, and advances the log generation before writing any bytes into the replacement active file. A prior active log that is already oversized is reduced to its newest 8388608 bytes during startup instead of being copied in full. An orphaned oversized backup is reduced the same way when no active log survived. The active and backup logs therefore have a 16777216-byte combined logical bound, apart from filesystem allocation granularity.
+The active runtime log is fixed at 8388608 bytes, with one backup of at most the same size. Polaris rotates only between complete formatted records, replaces the prior backup, and advances the log generation before writing any bytes into the replacement active file. A prior active log that is already oversized is reduced to its newest 8388608 bytes during startup instead of being copied in full. An orphaned oversized backup is reduced the same way when no active log survived. The active and backup logs therefore have a 16777216-byte combined logical bound, apart from filesystem allocation granularity. The active log has a single owner per configuration directory: Polaris takes an exclusive advisory lock on a `.lock` sidecar next to the active file at startup, and a second Polaris process that cannot acquire it continues with console-only logging instead of inheriting, rotating, or truncating the owner's files.
 
 ## Request
 

--- a/src/bounded_log_file.cpp
+++ b/src/bounded_log_file.cpp
@@ -12,6 +12,17 @@
 #include <system_error>
 #include <utility>
 
+#ifdef _WIN32
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
+  #include <windows.h>
+#else
+  #include <fcntl.h>
+  #include <sys/file.h>
+  #include <unistd.h>
+#endif
+
 namespace logging {
   bounded_log_file_t::bounded_log_file_t(
     std::filesystem::path active_path,
@@ -225,5 +236,64 @@ namespace logging {
 
     std::filesystem::remove(active_path, error);
     return !error;
+  }
+
+  bounded_log_owner_lock_t::bounded_log_owner_lock_t(const std::filesystem::path &lock_path) {
+    if (lock_path.empty()) {
+      return;
+    }
+#ifdef _WIN32
+    const auto handle = CreateFileW(
+      lock_path.c_str(),
+      GENERIC_READ | GENERIC_WRITE,
+      FILE_SHARE_READ | FILE_SHARE_WRITE,
+      nullptr,
+      OPEN_ALWAYS,
+      FILE_ATTRIBUTE_NORMAL,
+      nullptr
+    );
+    if (handle == INVALID_HANDLE_VALUE) {
+      return;
+    }
+    OVERLAPPED overlapped {};
+    if (!LockFileEx(handle, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped)) {
+      CloseHandle(handle);
+      return;
+    }
+    handle_ = handle;
+#else
+    // O_CLOEXEC keeps spawned session processes from inheriting the lock fd:
+    // flock lives on the open file description, so an inherited descriptor
+    // would keep the claim alive after the owner itself exits.
+    const int fd = ::open(lock_path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0644);
+    if (fd < 0) {
+      return;
+    }
+    if (::flock(fd, LOCK_EX | LOCK_NB) != 0) {
+      ::close(fd);
+      return;
+    }
+    fd_ = fd;
+#endif
+  }
+
+  bounded_log_owner_lock_t::~bounded_log_owner_lock_t() {
+#ifdef _WIN32
+    if (handle_ != nullptr) {
+      CloseHandle(handle_);
+    }
+#else
+    if (fd_ >= 0) {
+      ::close(fd_);
+    }
+#endif
+  }
+
+  bool bounded_log_owner_lock_t::owned() const {
+#ifdef _WIN32
+    return handle_ != nullptr;
+#else
+    return fd_ >= 0;
+#endif
   }
 }  // namespace logging

--- a/src/bounded_log_file.h
+++ b/src/bounded_log_file.h
@@ -19,6 +19,32 @@ namespace logging {
     rejected,
   };
 
+  /**
+   * @brief Process-lifetime exclusive owner claim on the bounded runtime log.
+   *
+   * Advisory lock on a sidecar path next to the active log. The kernel drops
+   * the lock when the owning process exits, so a crashed owner cannot leave
+   * the log orphaned-locked. A process that fails to acquire it must not
+   * inherit, rotate, truncate, or write the owner's files.
+   */
+  class bounded_log_owner_lock_t {
+  public:
+    explicit bounded_log_owner_lock_t(const std::filesystem::path &lock_path);
+    ~bounded_log_owner_lock_t();
+
+    bounded_log_owner_lock_t(const bounded_log_owner_lock_t &) = delete;
+    bounded_log_owner_lock_t &operator=(const bounded_log_owner_lock_t &) = delete;
+
+    [[nodiscard]] bool owned() const;
+
+  private:
+#ifdef _WIN32
+    void *handle_ = nullptr;
+#else
+    int fd_ = -1;
+#endif
+  };
+
   class bounded_log_file_t {
   public:
     using rotation_callback_t = std::function<void()>;
@@ -52,6 +78,9 @@ namespace logging {
 
     /**
      * @brief Preserve at most the newest max_bytes from a prior active log.
+     *
+     * The caller must hold the bounded log owner lock: this renames and
+     * truncates without further ownership checks.
      */
     static bool preserve_existing(
       const std::filesystem::path &active_path,

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -100,6 +100,7 @@ namespace {
     bounded_file_queue_t
   >;
   boost::shared_ptr<bounded_file_sink_t> file_sink;
+  std::unique_ptr<logging::bounded_log_owner_lock_t> runtime_log_owner_lock;
 }  // namespace
 
 bl::sources::severity_logger<int> verbose(0);  // Dominating output
@@ -125,6 +126,7 @@ namespace logging {
       bl::core::get()->remove_sink(file_sink);
       file_sink.reset();
     }
+    runtime_log_owner_lock.reset();
     if (sink) {
       bl::core::get()->remove_sink(sink);
       sink.reset();
@@ -256,6 +258,17 @@ namespace logging {
       backup_log_file = log_file + ".backup";
     }
     auto file_logging_ready = !log_file.empty();
+    if (file_logging_ready) {
+      // Single owner per config directory: a second Polaris reaching this init
+      // while another process owns the runtime log must not inherit, rotate,
+      // or truncate the owner's files out from under its live sink (#393).
+      runtime_log_owner_lock = std::make_unique<bounded_log_owner_lock_t>(log_file + ".lock");
+      if (!runtime_log_owner_lock->owned()) {
+        std::cout << "Another Polaris process owns the runtime log; continuing with console-only logging." << std::endl;
+        runtime_log_owner_lock.reset();
+        file_logging_ready = false;
+      }
+    }
     if (file_logging_ready && !bounded_log_file_t::preserve_existing(
                                 log_file,
                                 backup_log_file,

--- a/tests/unit/test_bounded_log_file.cpp
+++ b/tests/unit/test_bounded_log_file.cpp
@@ -227,3 +227,24 @@ TEST_F(BoundedLogFileTest, OversizedOrphanedBackupIsAlsoReducedToItsNewestBounde
   EXPECT_EQ(read(backup_), "89abcdef");
   EXPECT_EQ(fs::file_size(backup_), 8);
 }
+
+TEST(BoundedLogOwnerLock, ExcludesSecondAcquireWhileHeldAndReleasesOnDestruction) {
+  const auto root = std::filesystem::temp_directory_path() / "polaris-bounded-log-owner-lock";
+  std::error_code error;
+  std::filesystem::remove_all(root, error);
+  std::filesystem::create_directories(root);
+  const auto lock_path = root / "polaris.log.lock";
+
+  {
+    logging::bounded_log_owner_lock_t first {lock_path};
+    ASSERT_TRUE(first.owned());
+
+    logging::bounded_log_owner_lock_t second {lock_path};
+    EXPECT_FALSE(second.owned());
+  }
+
+  logging::bounded_log_owner_lock_t third {lock_path};
+  EXPECT_TRUE(third.owned());
+
+  std::filesystem::remove_all(root, error);
+}

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -242,3 +242,48 @@ TEST(LoggingGeneration, AutomaticRotationAdvancesGenerationAndKeepsBothFilesBoun
   ASSERT_TRUE(logging::clear_log_file());
   EXPECT_FALSE(std::filesystem::exists(backup));
 }
+
+TEST(LoggingOwnerLock, SecondInitFallsBackToConsoleAndLeavesOwnedFilesUntouched) {
+  namespace fs = std::filesystem;
+  const auto root = fs::temp_directory_path() / "polaris-logging-owner-lock";
+  std::error_code error;
+  fs::remove_all(root, error);
+  fs::create_directories(root);
+  const auto active = root / "polaris.log";
+  const std::string sentinel = "owned-by-another-process\n";
+  {
+    std::ofstream seed {active, std::ios::binary};
+    seed << sentinel;
+  }
+
+  {
+    // Simulate a live owner in another process: hold the sidecar lock.
+    logging::bounded_log_owner_lock_t owner {active.string() + ".lock"};
+    ASSERT_TRUE(owner.owned());
+
+    auto guard = logging::init(2, active.string());
+    ASSERT_TRUE(guard);
+    BOOST_LOG(info) << "must not reach the owned file";
+    logging::log_flush();
+
+    std::ifstream in {active, std::ios::binary};
+    std::stringstream contents;
+    contents << in.rdbuf();
+    EXPECT_EQ(contents.str(), sentinel);
+    EXPECT_FALSE(fs::exists(active.string() + ".backup"));
+  }
+
+  // With the owner gone, the same init inherits the prior log normally.
+  auto guard = logging::init(2, active.string());
+  ASSERT_TRUE(guard);
+  EXPECT_TRUE(fs::exists(active.string() + ".backup"));
+  guard.reset();
+
+  // Restore the harness's file logging for later suites; the environment's
+  // lifetime guard still tears logging down at binary exit, so this init's
+  // own guard is intentionally leaked rather than deinitializing on scope
+  // exit and leaving the shared log file sinkless.
+  (void) logging::init(0, test_paths::log_file().string()).release();
+
+  fs::remove_all(root, error);
+}


### PR DESCRIPTION
## Summary

- Closes #393. Any second polaris invocation that reached full logging init against a config directory another process was actively logging into would run startup inheritance against the live files: remove the backup, rename the active log out from under the running sink, and write its banner into a fresh active. The running service's async writer follows the rename, so every later record lands in `polaris.log.backup`, the active file freezes at the banner, and the tail API serves a stale generation that is blind to live records. This fired in production during the #371 acceptance soak (full forensics in #393).
- The bounded backend now claims a process-lifetime exclusive advisory lock on a `.lock` sidecar next to the active file, acquired in `logging::init` before `preserve_existing` can touch anything. A process that cannot acquire it continues with console-only logging and prints why, instead of hijacking the owner's stream. `flock` on Linux (`O_CLOEXEC` so spawned session processes cannot inherit the claim; the kernel releases it if the owner crashes), `LockFileEx` with fail-immediately semantics on Windows.
- `deinit` releases the claim and re-init re-acquires it, so in-process re-initialization (tests, `--setup-host` style early exits) keeps working.
- `docs/log-tail-api-v1.md` documents the single-owner rule in the retention contract.

## Exact candidate

- `Commit:` `8643b9f8aab0e87a357f30e3cf1ffb3c2b5b1c02`
- `Tree:` `a3c369d0a0fcf0dbe922884553585c3fc1f690c6`
- `Parent:` `23d927a14ce7e5d4c21805f4e68f04efd40eb89e`
- `Base:` `master` at `23d927a14ce7e5d4c21805f4e68f04efd40eb89e`

## Verification

- [x] Full build in a fresh worktree at the candidate: 356 targets, canonical CUDA-off configure
- [x] New coverage: `BoundedLogOwnerLock` proves mutual exclusion across separate opens of the sidecar and release on destruction; `LoggingOwnerLock` proves the full second-init contract end to end (held lock leads to console-only fallback with the owner's seeded active and absent backup byte-identical afterward, then normal inheritance once the owner releases)
- [x] Full `ctest --test-dir build/tests`: 17/17 passed, 0 failed (52.99 s), including the two new suites
- [x] A first version of the logging test broke the suite and was root-caused with a suite-order bisect before push: parameterized suites register late, so a test that leaves logging deinitialized starves `Logging/LogLevelsTest` of its file sink afterward. The test now restores the harness's file logging (intentionally leaked guard; the environment's lifetime guard still tears down at exit), and the full suite passes with the fix's tests included
- Live re-verification against the production scenario (second invocation while the deployed service runs) lands with the deploy + clean #371 re-soak after the current showcase capture window ends; the running service on pc-papi stays in its degraded pre-fix logging state until that restart, as documented in #371

One residual accepted for this PR: if two invocations race the lock during a crash-loop style restart overlap, the loser stays on console-only logging for its lifetime rather than retrying acquisition later. Systemd's stop-before-start ordering makes that overlap rare, and a retry-on-clear refinement can come separately if it ever matters in practice.
