### PR TITLE
Restore the AI transparency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Ultimate Edition leads this representative Aurora capture.
 See motion and compare Portable Chrome, Console OLED, Miami Nebula, and High
 Contrast in the [website theme gallery](https://papi-ux.com/polaris/#themes).
 
+Every capture above and across [papi-ux.com](https://papi-ux.com/polaris/) comes from the tagged public release; the [pixel-level provenance manifest](https://papi-ux.com/images/products/showcase-v1.3.8-v1.3.6-provenance.json) ships with the site.
+
 ## Install and start a first stream
 
 Use an official package from the [latest GitHub
@@ -106,6 +108,10 @@ capture path, HDR mode, or experimental Browser Stream setup.
 - [Releases](https://github.com/papi-ux/polaris/releases) · [Issues](https://github.com/papi-ux/polaris/issues) · [Discussions](https://github.com/papi-ux/polaris/discussions)
 - [Security policy](SECURITY.md) · [Contributing](.github/CONTRIBUTING.md) · [Source](https://github.com/papi-ux/polaris)
 
+## Acknowledgments
+
+Polaris builds on the Apollo and Sunshine host lineage and stays protocol-compatible with the wider Moonlight ecosystem. Thanks to those maintainers and communities for the foundation.
+
 ## AI Transparency
 
 Polaris is a maintainer-led project. I use AI-assisted tools as research,
@@ -115,6 +121,10 @@ Linux compositor, packaging, and client behavior.
 Those tools do not decide what Polaris is or what ships. I review changes,
 test every aspect, and own the final decisions around validation,
 trust boundaries, and release quality.
+
+## Contributing
+
+Contributions are welcome, especially focused fixes, docs, translations, packaging improvements, real-hardware testing, and careful feature work. Polaris is still a small maintainer-led project, so the easiest pull requests to review are the ones that explain the problem clearly, keep the change scoped, and say what was tested on Linux. See [CONTRIBUTING](.github/CONTRIBUTING.md) for the full workflow.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ capture path, HDR mode, or experimental Browser Stream setup.
 - [Releases](https://github.com/papi-ux/polaris/releases) · [Issues](https://github.com/papi-ux/polaris/issues) · [Discussions](https://github.com/papi-ux/polaris/discussions)
 - [Security policy](SECURITY.md) · [Contributing](.github/CONTRIBUTING.md) · [Source](https://github.com/papi-ux/polaris)
 
+## AI Transparency
+
+Polaris is a maintainer-led project. I use AI-assisted tools as research,
+debugging, comparison, and drafting aids, especially when validating unfamiliar
+Linux compositor, packaging, and client behavior.
+
+Those tools do not decide what Polaris is or what ships. I review changes,
+test every aspect, and own the final decisions around validation,
+trust boundaries, and release quality.
+
 ## License
 
 Polaris is free and open-source software licensed under the [GNU General Public

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -1364,6 +1364,11 @@ if "./scripts/check-public-docs.sh" in contributing:
     sys.exit(1)
 PY
 
+if ! grep -Fq "https://papi-ux.com/images/products/showcase-v1.3.8-v1.3.6-provenance.json" README.md; then
+  echo "README must link the published provenance manifest." >&2
+  exit 1
+fi
+
 if ! grep -Fq "## AI Transparency" README.md; then
   echo "README must keep the AI Transparency section." >&2
   exit 1

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -1364,4 +1364,9 @@ if "./scripts/check-public-docs.sh" in contributing:
     sys.exit(1)
 PY
 
+if ! grep -Fq "## AI Transparency" README.md; then
+  echo "README must keep the AI Transparency section." >&2
+  exit 1
+fi
+
 echo "Public docs and release references look clean."


### PR DESCRIPTION
## Summary
- Restore the README's AI Transparency section verbatim; the showcase rewrite (#389) dropped it without relocating it, and no docs contract guarded the section.
- Restore the contributing invitation, add an Acknowledgments section crediting the Apollo, Sunshine, and Moonlight lineage, and link the published pixel-level provenance manifest from the visual tour.
- Pin the AI Transparency heading and the provenance manifest URL in `scripts/check-public-docs.sh` so neither can drop silently again.

## Verification
- [x] `bash scripts/check-public-docs.sh` (with the new pins active)
- [x] `git diff --check`
- [x] README: 922 words, within the 2,000-word contract; media untouched.