### PR TITLE
fix(linux): fall back from direct VAAPI DMA-BUF capture

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -20,6 +20,7 @@
 #include "../../logging.h"
 #include "misc.h"
 #include "private_session_input.h"
+#include "wlgrab_capture_policy.h"
 
 #include <algorithm>
 #include <atomic>
@@ -890,7 +891,7 @@ namespace cage_display_router {
   }
 
   bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type) {
-    return hwdevice_type == platf::mem_type_e::cuda;
+    return wlgrab_capture_policy::gpu_native_dmabuf_is_safe(hwdevice_type);
   }
 
   bool should_attempt_headless_extcopy_dmabuf(

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -15,6 +15,7 @@
 #include "src/video.h"
 #include "vaapi.h"
 #include "wayland.h"
+#include "wlgrab_capture_policy.h"
 #include "wlgrab_frame_source.h"
 #include "wlgrab_pixel_copy.h"
 
@@ -692,6 +693,10 @@ namespace platf {
 
     bool prefer_ram_capture = (hwdevice_type == platf::mem_type_e::system);
     const bool gpu_native_capture_supported = wl::supports_gpu_native_capture(hwdevice_type);
+    const auto direct_capture_path = wlgrab_capture_policy::select_direct_capture_path(
+      hwdevice_type,
+      gpu_native_capture_supported
+    );
     bool prefer_linear_dmabuf = false;
     bool using_headless_ram_capture = false;
     bool try_headless_extcopy_dmabuf = false;
@@ -745,6 +750,15 @@ namespace platf {
       }
     }
 #endif
+
+    if (!prefer_ram_capture &&
+        gpu_native_capture_supported &&
+        (!config::video.linux_display.use_cage_compositor || !stream_runtime::labwc::is_running()) &&
+        direct_capture_path == wlgrab_capture_policy::direct_capture_path_e::ram) {
+      prefer_ram_capture = true;
+      BOOST_LOG(warning)
+        << "wlr: Using RAM capture path for the direct Wayland desktop because GPU-native DMA-BUF is disabled for VAAPI stability"sv;
+    }
 
     if (!prefer_ram_capture && !gpu_native_capture_supported) {
       BOOST_LOG(info)

--- a/src/platform/linux/wlgrab_capture_policy.h
+++ b/src/platform/linux/wlgrab_capture_policy.h
@@ -1,0 +1,29 @@
+/**
+ * @file src/platform/linux/wlgrab_capture_policy.h
+ * @brief Pure policy helpers for selecting the direct wlroots capture path.
+ */
+#pragma once
+
+#include "src/platform/common.h"
+
+namespace wlgrab_capture_policy {
+  enum class direct_capture_path_e {
+    ram,
+    gpu_native,
+  };
+
+  inline bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type) {
+    return hwdevice_type == platf::mem_type_e::cuda;
+  }
+
+  inline direct_capture_path_e select_direct_capture_path(
+    platf::mem_type_e hwdevice_type,
+    bool gpu_native_backend_available
+  ) {
+    if (!gpu_native_backend_available || !gpu_native_dmabuf_is_safe(hwdevice_type)) {
+      return direct_capture_path_e::ram;
+    }
+
+    return direct_capture_path_e::gpu_native;
+  }
+}  // namespace wlgrab_capture_policy

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ set(TEST_FAST_SOURCES
 if (NOT WIN32 AND NOT APPLE)
     list(APPEND TEST_FAST_SOURCES
         ${CMAKE_SOURCE_DIR}/tests/unit/test_linux_executable_path.cpp
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_wlgrab_capture_policy.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/test_wlgrab_frame_source.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/test_wlgrab_pixel_copy.cpp
     )

--- a/tests/unit/test_wlgrab_capture_policy.cpp
+++ b/tests/unit/test_wlgrab_capture_policy.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file tests/unit/test_wlgrab_capture_policy.cpp
+ * @brief Regression tests for direct wlroots capture-path selection.
+ */
+#include <gtest/gtest.h>
+
+#include "src/platform/linux/wlgrab_capture_policy.h"
+
+TEST(WlgrabCapturePolicy, DirectVaapiCaptureUsesRamFallback) {
+  EXPECT_EQ(
+    wlgrab_capture_policy::select_direct_capture_path(platf::mem_type_e::vaapi, true),
+    wlgrab_capture_policy::direct_capture_path_e::ram
+  );
+}
+
+TEST(WlgrabCapturePolicy, DirectCudaCaptureMayRemainGpuNative) {
+  EXPECT_EQ(
+    wlgrab_capture_policy::select_direct_capture_path(platf::mem_type_e::cuda, true),
+    wlgrab_capture_policy::direct_capture_path_e::gpu_native
+  );
+}
+
+TEST(WlgrabCapturePolicy, MissingGpuNativeBackendUsesRamFallback) {
+  EXPECT_EQ(
+    wlgrab_capture_policy::select_direct_capture_path(platf::mem_type_e::cuda, false),
+    wlgrab_capture_policy::direct_capture_path_e::ram
+  );
+}
+
+TEST(WlgrabCapturePolicy, SystemMemoryEncoderUsesRamCapture) {
+  EXPECT_EQ(
+    wlgrab_capture_policy::select_direct_capture_path(platf::mem_type_e::system, true),
+    wlgrab_capture_policy::direct_capture_path_e::ram
+  );
+}


### PR DESCRIPTION
## Summary

- route direct wlroots desktop capture through SHM/RAM when the selected encoder is VAAPI
- share the known-safe GPU-native DMA-BUF predicate across direct, headless, and windowed-private capture routes
- keep CUDA direct capture eligible for GPU-native DMA-BUF
- add focused regression coverage for direct capture-path selection

## Root cause

The physical-monitor wlroots path constructed `wlr_vram_t` whenever a GPU uploader was available. Unlike the two private-compositor routes, it did not consult the encoder safety policy that currently refuses VAAPI GPU-native DMA-BUF imports.

That allowed Mirrored Desktop on AMD/VAAPI to hand a tiled physical-monitor DMA-BUF modifier to the EGL/VAAPI conversion path and fail with `EGL_BAD_MATCH`.

This change contains the crash by selecting the established SHM/RAM compatibility path for direct VAAPI capture. It does not claim to repair the underlying Mesa/EGL tiled-modifier import.

## Impact

AMD/VAAPI Mirrored Desktop streams favor stability over GPU residency and incur the existing CPU-side copy/conversion cost. CUDA direct desktop capture remains GPU-native eligible.

Fixes #395.

## Validation

- RED before policy fix: 3 passed / 1 failed (`WlgrabCapturePolicy.DirectVaapiCaptureUsesRamFallback`)
- GREEN after policy fix: 4/4 focused `WlgrabCapturePolicy.*` tests
- 265/265 fast tests
- 35/35 `CageDisplayRouterPolicyTests.*` tests
- production `polaris` target builds successfully
- `git diff --check` passes
- reporter validation succeeded on the original AMD RX 7800 XT / Mesa host: the expected SHM/RAM logs appeared, video remained stable, and there was no `EGL_BAD_MATCH`, conversion failure, or Polaris restart
