### PR TITLE
fix(api): rate limit the Doctor action route and pin its execute contract

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3553,8 +3553,41 @@ namespace confighttp {
     }
   }
 
+  namespace {
+    // Doctor actions mutate the live stream, but their legitimate cadence is
+    // tiny: one click, a verify re-post every 8 seconds, and possibly an undo.
+    // The house 20-per-10s default (see benchmark_control_rate_limiter) never
+    // brushes that while still bounding a runaway retry loop, and it runs
+    // before authenticate() so unauthenticated floods are bounded too.
+    confighttp::benchmark_auth::rate_limiter_t &doctor_action_rate_limiter() {
+      static confighttp::benchmark_auth::rate_limiter_t limiter(20, std::chrono::seconds(10));
+      return limiter;
+    }
+  }  // namespace
+
   void runDoctorAction(resp_https_t response, req_https_t request) {
-    if (!validateContentType(response, request, "application/json") || !authenticate(response, request)) {
+    if (!validateContentType(response, request, "application/json")) {
+      return;
+    }
+
+    const auto address = net::addr_to_normalized_string(request->remote_endpoint().address());
+    auto &limiter = doctor_action_rate_limiter();
+    const auto now = std::chrono::steady_clock::now();
+    const bool rate_limited = limiter.is_rate_limited(address, now);
+    limiter.record_request(address, now);
+    if (rate_limited) {
+      BOOST_LOG(warning) << "Doctor action: ["sv << address << "] -- rate limited"sv;
+      nlohmann::json tree;
+      tree["status"] = false;
+      tree["changed"] = false;
+      tree["error"] = "Too many requests. Please try again later.";
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      append_json_security_headers(headers);
+      response->write(SimpleWeb::StatusCode::client_error_too_many_requests, tree.dump(), headers);
+      return;
+    }
+
+    if (!authenticate(response, request)) {
       return;
     }
     print_req(request);

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -1276,10 +1276,10 @@ const doctorConfidenceLabel = computed(() => {
   return level ? t('dashboard.doctor_confidence', { level }) : ''
 })
 
-// The host describes a safe recovery action. Only /api/ endpoints are
-// reachable from this web server (the host also emits game-stream-server
-// endpoints like /polaris/v1/client-settings, which would 404 here), so
-// anything else renders as advice without an execute button.
+// The host describes a safe recovery action. Every executable action
+// targets this web server's own /api/doctor/action route; the /api/ gate
+// below is a defensive filter so a host emitting an endpoint this web
+// build cannot reach (version skew) degrades to advice, not a dead button.
 const doctorSafeAction = computed(() => {
   // Endpoint-less actions (export diagnostics, safer-next-launch) are real
   // host advice and render as advisory pills; only /api/ ones can execute.

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -6,6 +6,7 @@
 #include <src/stream_stats.h>
 #include <src/config.h>
 #include <src/doctor_actions.h>
+#include <src/adaptive_bitrate.h>
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -785,6 +786,84 @@ TEST(DoctorActionTests, QualityRetryClimbsAtMostTwentyFivePercentPerCheck) {
   EXPECT_EQ(doctor_actions::guarded_quality_retry_target(7580, 20000), 9475);
   EXPECT_EQ(doctor_actions::guarded_quality_retry_target(18000, 20000), 20000);
   EXPECT_EQ(doctor_actions::guarded_quality_retry_target(20000, 20000), 20000);
+}
+
+TEST(DoctorActionTests, ExecuteRefusesLiveTuningAndStaleUndoWithoutAStream) {
+  stream_stats::update_stream_active(false);
+
+  const auto blocked = doctor_actions::execute({{"action_id", "lower_bitrate"}});
+  EXPECT_FALSE(blocked.at("status").get<bool>());
+  EXPECT_FALSE(blocked.at("changed").get<bool>());
+  EXPECT_EQ(blocked.at("state"), "needs_stream");
+  EXPECT_EQ(blocked.at("error"), "Start the affected stream before Doctor applies or verifies a live fix.");
+  EXPECT_TRUE(blocked.contains("evidence"));
+
+  const auto stale_undo = doctor_actions::execute({{"action_id", "undo"}, {"run_id", "doctor-run-missing"}});
+  EXPECT_FALSE(stale_undo.at("status").get<bool>());
+  EXPECT_EQ(stale_undo.at("error"), "This Doctor undo is no longer available.");
+}
+
+TEST(DoctorActionTests, ExecuteAppliesVerifiesAndUndoesOneGuardedStepEndToEnd) {
+  // Earlier suites in this binary leave adaptive_bitrate process state
+  // behind (set_max_bitrate mutates the clamp ceiling itself); normalize
+  // the two pieces this arc depends on before seeding telemetry.
+  adaptive_bitrate::set_max_bitrate(100000);
+  adaptive_bitrate::set_enabled(false);
+
+  stream_stats::update_stream_active(true, "DoctorContractTest", "203.0.113.7");
+  stream_stats::update_video_stats(60.0, 20000, 5.0, "hevc", 1920, 1080);
+  // One calm reading arms the risk tracker past its warm-up grace before the
+  // elevated readings land (network_risk_tracker_t debounces both edges).
+  for (int i = 0; i < 6; ++i) {
+    stream_stats::update_network_stats(5.0, 0.0, 1000);
+  }
+
+  const auto clean = doctor_actions::execute({{"action_id", "lower_bitrate"}});
+  EXPECT_FALSE(clean.at("status").get<bool>());
+  EXPECT_EQ(clean.at("state"), "evidence_changed");
+
+  const auto unsupported = doctor_actions::execute({{"action_id", "defragment_stream"}});
+  EXPECT_FALSE(unsupported.at("status").get<bool>());
+  EXPECT_EQ(unsupported.at("error"), "Unsupported Doctor action.");
+
+  for (int i = 0; i < 3; ++i) {
+    stream_stats::update_network_stats(52.0, 3.4, 1000);
+  }
+  ASSERT_TRUE(stream_stats::get_current().network_risk);
+
+  const auto applied = doctor_actions::execute({{"action_id", "lower_bitrate"}});
+  ASSERT_TRUE(applied.at("status").get<bool>());
+  EXPECT_TRUE(applied.at("changed").get<bool>());
+  EXPECT_EQ(applied.at("state"), "watching");
+  EXPECT_EQ(applied.at("applied").at("bitrate_kbps"), 16000);
+  EXPECT_EQ(applied.at("before").at("bitrate_kbps"), 20000);
+  EXPECT_EQ(applied.at("verification").at("delay_seconds"), 8);
+  const auto run_id = applied.at("run_id").get<std::string>();
+  ASSERT_FALSE(run_id.empty());
+  EXPECT_EQ(adaptive_bitrate::get_target_bitrate_kbps(), 16000);
+
+  const auto wrong_run = doctor_actions::execute({{"action_id", "verify"}, {"run_id", "doctor-run-imposter"}});
+  EXPECT_FALSE(wrong_run.at("status").get<bool>());
+  EXPECT_EQ(wrong_run.at("state"), "expired");
+
+  const auto watching = doctor_actions::execute({{"action_id", "verify"}, {"run_id", run_id}});
+  EXPECT_TRUE(watching.at("status").get<bool>());
+  EXPECT_FALSE(watching.at("changed").get<bool>());
+  EXPECT_EQ(watching.at("state"), "watching");
+  EXPECT_TRUE(watching.at("undo").at("available").get<bool>());
+
+  const auto undone = doctor_actions::execute({{"action_id", "undo"}, {"run_id", run_id}});
+  EXPECT_TRUE(undone.at("status").get<bool>());
+  EXPECT_TRUE(undone.at("changed").get<bool>());
+  EXPECT_EQ(undone.at("state"), "undone");
+  EXPECT_EQ(undone.at("restored_bitrate_kbps"), 20000);
+  EXPECT_EQ(adaptive_bitrate::get_target_bitrate_kbps(), 0);
+
+  const auto replay = doctor_actions::execute({{"action_id", "undo"}, {"run_id", run_id}});
+  EXPECT_FALSE(replay.at("status").get<bool>());
+  EXPECT_EQ(replay.at("error"), "This Doctor undo is no longer available.");
+
+  stream_stats::update_stream_active(false);
 }
 
 TEST(StreamStatsDoctorTests, ClassifiesVaapiShmFallbackAsAdvancedIssue) {


### PR DESCRIPTION
## Summary
- `/api/doctor/action` was the only mutating control surface without a request rate limit. It now uses the same per-IP limiter as the benchmark control plane (20 requests per 10 seconds), checked before authentication so unauthenticated floods are bounded at the same cost as authenticated ones. Limited requests answer HTTP 429 with the standard `{status:false, changed:false, error}` doctor shape, which the dashboard already renders as an error toast. The legitimate cadence (one click, a verify re-post every 8 seconds, an occasional undo) never approaches the cap.
- The Dashboard comment still described the pre-#378 world where the host emitted the unreachable game-server `/polaris/v1/client-settings` endpoint for this action. It now documents the real contract: every executable action targets `/api/doctor/action`, and the `/api/` gate remains as a defensive filter for host/web version skew. Code is untouched; the pinned action mechanism strings in `dashboard-live-hierarchy.test.js` still pass.
- `doctor_actions::execute` had unit coverage only for its three pure helpers. Two new tests pin the full request contract shared by the web and Nova: the `needs_stream` and stale-undo rejections with no stream, and a complete seeded arc through `evidence_changed` on clean telemetry, an unsupported action id, the guarded 20000 to 16000 apply, wrong-run-id verify expiry, a watching verify, undo restoring 20000 kbps and returning adaptive control to disabled, and the single-slot undo replay rejection.

## Verification
- `npm run lint` and `npm run test` green on this branch (320 tests across 55 files, including the dashboard-live-hierarchy pins over the untouched action mechanism).
- Full worktree build (CUDA-off gate tree) and `ctest` listing and passing the two new `DoctorActionTests`, alongside the existing stream-stats suites.
- No new source files, so no CMake list registrations were needed; the tests live in the already-registered `tests/unit/test_stream_stats.cpp`.
