### PR TITLE
fix(linux): harden capture and platform boundaries

### DIFF
--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -789,7 +789,11 @@ namespace platf {
       ctx_t ctx;
       std::string requested_sink;
       // Last time we moved a given sink-input (avoid 1Hz thrash with EasyEffects).
-      std::unordered_map<std::uint32_t, std::chrono::steady_clock::time_point> routed_sink_inputs;
+      struct routed_sink_input_t {
+        pid_t pid;
+        std::chrono::steady_clock::time_point moved_at;
+      };
+      std::unordered_map<std::uint32_t, routed_sink_input_t> routed_sink_inputs;
       // Local hear-through: capture virtual sink.monitor → host default (EE/speakers).
       std::uint32_t local_loopback_module = PA_INVALID_INDEX;
 
@@ -1258,6 +1262,11 @@ namespace platf {
           return;
         }
 
+        const auto routing_started_at = std::chrono::steady_clock::now();
+        std::erase_if(routed_sink_inputs, [&](const auto &entry) {
+          return routing_started_at - entry.second.moved_at >= std::chrono::seconds {10};
+        });
+
         struct sink_input_route_t {
           std::uint32_t index;
           std::uint32_t current_sink;
@@ -1283,14 +1292,6 @@ namespace platf {
           if (input_info->sink == *target_sink) {
             return;
           }
-          // Cooldown: EE reclaim was thrashing at 1Hz (crackle). Re-pin at most every 10s.
-          const auto now = std::chrono::steady_clock::now();
-          if (const auto it = routed_sink_inputs.find(input_info->index); it != routed_sink_inputs.end()) {
-            if (now - it->second < std::chrono::seconds {10}) {
-              return;
-            }
-          }
-
           const char *pid_text = pa_proplist_gets(input_info->proplist, PA_PROP_APPLICATION_PROCESS_ID);
           if (!pid_text || !*pid_text) {
             return;
@@ -1303,6 +1304,12 @@ namespace platf {
           }
 
           const auto pid = static_cast<pid_t>(pid_long);
+          // PulseAudio recycles sink-input indices. Apply the EasyEffects
+          // cooldown only when the index still belongs to the same process.
+          if (const auto it = routed_sink_inputs.find(input_info->index);
+              it != routed_sink_inputs.end() && it->second.pid == pid) {
+            return;
+          }
           if (!process_env_has_session_audio_sink(pid, sink)) {
             return;
           }
@@ -1332,7 +1339,7 @@ namespace platf {
         }
 
         for (const auto &route : routes) {
-          routed_sink_inputs[route.index] = std::chrono::steady_clock::now();
+          routed_sink_inputs[route.index] = routed_sink_input_t {route.pid, std::chrono::steady_clock::now()};
 
           BOOST_LOG(info) << "Linux audio isolation: moving session audio stream ["sv
                           << route.app_name << "] pid="sv << route.pid

--- a/src/platform/linux/cage_screencopy.cpp
+++ b/src/platform/linux/cage_screencopy.cpp
@@ -13,13 +13,14 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstring>
-#include <future>
+#include <limits>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include <errno.h>
+#include <poll.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
@@ -124,7 +125,14 @@ namespace cage_screencopy {
 
     // Create SHM buffer in the compositor's native format
     st->cleanup_buffer();
-    st->shm_size = st->stride * st->height;
+    if (st->height == 0 || st->stride == 0 ||
+        static_cast<std::size_t>(st->stride) > std::numeric_limits<std::size_t>::max() / st->height ||
+        static_cast<std::size_t>(st->stride) * st->height > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+      BOOST_LOG(error) << "screencopy: Invalid SHM frame size"sv;
+      st->frame_failed = true;
+      return;
+    }
+    st->shm_size = static_cast<std::size_t>(st->stride) * st->height;
     st->shm_fd = memfd_create("polaris-sc", MFD_CLOEXEC);
     if (st->shm_fd < 0 || ftruncate(st->shm_fd, st->shm_size) < 0) {
       st->frame_failed = true;
@@ -194,7 +202,12 @@ namespace cage_screencopy {
     // Shared frame buffer between screencopy thread and capture() caller
     std::mutex frame_mtx;
     std::condition_variable frame_cv;
-    std::vector<uint8_t> frame_buf;
+    struct published_frame_t {
+      std::vector<uint8_t> bytes;
+      std::uint32_t width {0};
+      std::uint32_t height {0};
+      std::uint32_t stride {0};
+    } published_frame;
     bool has_frame = false;
     std::atomic<bool> sc_running{true};
     std::atomic<bool> sc_error{false};
@@ -219,11 +232,33 @@ namespace cage_screencopy {
 
         while (!st.frame_ready && !st.frame_failed && sc_running && !g_screencopy_stop) {
           // Flush before dispatch to detect broken connections
-          if (wl_display_flush(st.display) < 0 && errno != EAGAIN) {
+          const int flush_result = wl_display_flush(st.display);
+          if (flush_result < 0 && errno != EAGAIN) {
             BOOST_LOG(warning) << "screencopy: Wayland flush failed (compositor died?), stopping"sv;
             sc_error = true;
             zwlr_screencopy_frame_v1_destroy(frame);
             return;
+          }
+          pollfd display_poll {
+            .fd = wl_display_get_fd(st.display),
+            .events = static_cast<short>(POLLIN | (flush_result < 0 ? POLLOUT : 0)),
+            .revents = 0,
+          };
+          const int poll_result = ::poll(&display_poll, 1, 100);
+          if (poll_result < 0 && errno == EINTR) {
+            continue;
+          }
+          if (poll_result < 0 || (display_poll.revents & (POLLERR | POLLHUP | POLLNVAL))) {
+            BOOST_LOG(warning) << "screencopy: Wayland connection poll failed, stopping"sv;
+            sc_error = true;
+            zwlr_screencopy_frame_v1_destroy(frame);
+            return;
+          }
+          if (poll_result == 0) {
+            continue;
+          }
+          if (!(display_poll.revents & POLLIN)) {
+            continue;
           }
           if (wl_display_dispatch(st.display) < 0) {
             BOOST_LOG(warning) << "screencopy: Wayland dispatch failed, stopping"sv;
@@ -242,8 +277,11 @@ namespace cage_screencopy {
         // Copy frame to shared buffer
         if (st.shm_data && st.shm_size > 0) {
           std::lock_guard lk(frame_mtx);
-          frame_buf.resize(st.shm_size);
-          std::memcpy(frame_buf.data(), st.shm_data, st.shm_size);
+          published_frame.bytes.resize(st.shm_size);
+          std::memcpy(published_frame.bytes.data(), st.shm_data, st.shm_size);
+          published_frame.width = st.width;
+          published_frame.height = st.height;
+          published_frame.stride = st.stride;
           has_frame = true;
           frame_cv.notify_one();
         }
@@ -272,30 +310,45 @@ namespace cage_screencopy {
         continue;
       }
 
-      // Update dimensions
-      if (st.width > 0 && st.height > 0) {
-        out_width = st.width;
-        out_height = st.height;
-      }
+      auto frame = std::move(published_frame);
+      has_frame = false;
+      lk.unlock();
 
-      std::shared_ptr<platf::img_t> img_out;
-      if (!pull_cb(img_out)) {
-        lk.unlock();
+      const auto required_bytes = static_cast<std::size_t>(frame.stride) * frame.height;
+      if (frame.width == 0 || frame.height == 0 || frame.stride == 0 ||
+          frame.height > static_cast<std::uint32_t>(std::numeric_limits<int>::max()) ||
+          frame.width > static_cast<std::uint32_t>(std::numeric_limits<int>::max()) ||
+          frame.stride > frame.bytes.size() || required_bytes > frame.bytes.size()) {
+        BOOST_LOG(error) << "screencopy: Published frame metadata exceeds its buffer"sv;
+        sc_error = true;
         break;
       }
 
-      int copy_h = std::min((int) st.height, img_out->height);
-      int copy_w = std::min((int) st.width, img_out->width);
+      out_width = static_cast<int>(frame.width);
+      out_height = static_cast<int>(frame.height);
 
-      bool is_3bpp = (st.stride == st.width * 3);
+      std::shared_ptr<platf::img_t> img_out;
+      if (!pull_cb(img_out)) {
+        break;
+      }
+
+      int copy_h = std::min(static_cast<int>(frame.height), img_out->height);
+      int copy_w = std::min(static_cast<int>(frame.width), img_out->width);
+
+      bool is_3bpp = static_cast<std::size_t>(frame.stride) == static_cast<std::size_t>(frame.width) * 3;
 
       if (is_3bpp) {
+        if (static_cast<std::size_t>(copy_w) * 4 > static_cast<std::size_t>(img_out->row_pitch)) {
+          BOOST_LOG(error) << "screencopy: Destination row is too small for converted frame"sv;
+          sc_error = true;
+          break;
+        }
         // BGR888 (3 bytes/pixel) → BGRA (4 bytes/pixel) conversion
         // wlroots BGR888 = memory order [B, G, R] per pixel
         // CUDA kernel reads texture as BGRA = memory order [B, G, R, A]
         // But the actual byte order from headless may be [R, G, B] — swap R↔B
         for (int y = 0; y < copy_h; ++y) {
-          const uint8_t *src = frame_buf.data() + y * st.stride;
+          const uint8_t *src = frame.bytes.data() + static_cast<std::size_t>(y) * frame.stride;
           uint8_t *dst = img_out->data + y * img_out->row_pitch;
           for (int x = 0; x < copy_w; ++x) {
             dst[x * 4 + 0] = src[x * 3 + 2];  // B ← src R (swap)
@@ -306,15 +359,13 @@ namespace cage_screencopy {
         }
       } else {
         // 4bpp format (XRGB8888/ARGB8888) — direct copy
-        int copy_bytes = std::min((int) st.stride, img_out->row_pitch);
+        int copy_bytes = std::min(static_cast<int>(frame.stride), img_out->row_pitch);
         for (int y = 0; y < copy_h; ++y) {
           std::memcpy(img_out->data + y * img_out->row_pitch,
-            frame_buf.data() + y * st.stride, copy_bytes);
+            frame.bytes.data() + static_cast<std::size_t>(y) * frame.stride, copy_bytes);
         }
       }
       img_out->frame_timestamp = std::chrono::steady_clock::now();
-      has_frame = false;
-      lk.unlock();
 
       if (!push_cb(std::move(img_out), true)) {
         break;
@@ -325,18 +376,10 @@ namespace cage_screencopy {
     sc_running = false;
     g_screencopy_stop = true;
 
-    // Flush pending events so the thread sees the stop flag on next iteration
-    if (st.display) {
-      wl_display_flush(st.display);
-    }
-
-    // Wait for the capture thread to exit (with timeout to avoid deadlock)
+    // The capture loop polls the Wayland fd with a bounded timeout, so it can
+    // always observe the stop flag without detaching from stack-owned state.
     if (sc_thread.joinable()) {
-      auto future = std::async(std::launch::async, [&] { sc_thread.join(); });
-      if (future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
-        BOOST_LOG(warning) << "screencopy: Capture thread didn't stop in 2s, detaching"sv;
-        sc_thread.detach();
-      }
+      sc_thread.join();
     }
 
     BOOST_LOG(info) << "screencopy: Capture stopped"sv;

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -549,10 +549,15 @@ namespace cuda {
       CU_CHECK(cdf->cuGraphicsMapResources(2, resources, stream.get()), "Couldn't map GL textures in CUDA");
 
       // Copy from the GL textures to the target CUDA frame
+      bool copy_failed = false;
       for (int i = 0; i < 2; i++) {
         CUDA_MEMCPY2D cpy = {};
         cpy.srcMemoryType = CU_MEMORYTYPE_ARRAY;
-        CU_CHECK(cdf->cuGraphicsSubResourceGetMappedArray(&cpy.srcArray, resources[i], 0, 0), "Couldn't get mapped plane array");
+        if (check(cdf->cuGraphicsSubResourceGetMappedArray(&cpy.srcArray, resources[i], 0, 0),
+              "Couldn't get mapped plane array: "sv)) {
+          copy_failed = true;
+          break;
+        }
 
         cpy.dstMemoryType = CU_MEMORYTYPE_DEVICE;
         cpy.dstDevice = (CUdeviceptr) frame->data[i];
@@ -560,12 +565,18 @@ namespace cuda {
         cpy.WidthInBytes = (frame->width * fmt_desc->comp[i].step) >> (i ? fmt_desc->log2_chroma_w : 0);
         cpy.Height = frame->height >> (i ? fmt_desc->log2_chroma_h : 0);
 
-        CU_CHECK_IGNORE(cdf->cuMemcpy2DAsync(&cpy, stream.get()), "Couldn't copy texture to CUDA frame");
+        if (check(cdf->cuMemcpy2DAsync(&cpy, stream.get()), "Couldn't copy texture to CUDA frame: "sv)) {
+          copy_failed = true;
+          break;
+        }
       }
 
       // Unmap the textures to allow modification from GL again
-      CU_CHECK(cdf->cuGraphicsUnmapResources(2, resources, stream.get()), "Couldn't unmap GL textures from CUDA");
-      return 0;
+      const bool unmap_failed = check(
+        cdf->cuGraphicsUnmapResources(2, resources, stream.get()),
+        "Couldn't unmap GL textures from CUDA: "sv
+      );
+      return copy_failed || unmap_failed ? -1 : 0;
     }
 
     /**
@@ -1097,7 +1108,11 @@ namespace cuda {
 
     bool ensure_destination(const layout_t &frame_layout) {
       if (destination_buffer) {
-        return destination_copy_size == frame_layout.copy_size && destination_pitch == frame_layout.pitch;
+        if (destination_copy_size == frame_layout.copy_size &&
+            destination_pitch == frame_layout.pitch && destination_texture) {
+          return true;
+        }
+        release_destination();
       }
       VkExternalMemoryBufferCreateInfo external_info {
         .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO,
@@ -1313,7 +1328,7 @@ namespace cuda {
       }
       // Recreate destination texture when packed format changes (8-bit vs 10-bit).
       if (source_fourcc && source_fourcc != descriptor.sd.fourcc) {
-        release_cuda_destination();
+        release_destination();
       }
       source_fourcc = descriptor.sd.fourcc;
       if (!device || !ensure_destination(*frame_layout)) {
@@ -1415,17 +1430,27 @@ namespace cuda {
       }
     }
 
+    void release_destination() {
+      release_cuda_destination();
+      if (device && destination_buffer) {
+        vkDestroyBuffer(device, destination_buffer, nullptr);
+      }
+      if (device && destination_memory) {
+        vkFreeMemory(device, destination_memory, nullptr);
+      }
+      destination_buffer = VK_NULL_HANDLE;
+      destination_memory = VK_NULL_HANDLE;
+      destination_allocation_size = 0;
+      destination_copy_size = 0;
+      destination_pitch = 0;
+    }
+
     void release_vulkan() {
       if (device) {
         vkDeviceWaitIdle(device);
+        release_destination();
         for (auto &source : sources) {
           release_source(source);
-        }
-        if (destination_buffer) {
-          vkDestroyBuffer(device, destination_buffer, nullptr);
-        }
-        if (destination_memory) {
-          vkFreeMemory(device, destination_memory, nullptr);
         }
         if (fence) {
           vkDestroyFence(device, fence, nullptr);

--- a/src/platform/linux/display_topology.cpp
+++ b/src/platform/linux/display_topology.cpp
@@ -10,6 +10,7 @@
   #include "src/config.h"
   #include "src/logging.h"
   #include "src/platform/common.h"
+  #include "src/platform/linux/misc.h"
   #include "stream_display_policy.h"
 
   #include <algorithm>
@@ -313,12 +314,15 @@ namespace display_topology {
     return false;
   }
 
-  int run_kscreen(const std::string &args) {
+  int run_kscreen(std::vector<std::string> args) {
     // QT_QPA_PLATFORM=wayland avoids kscreen-doctor aborting under a tty agent
     // session; timeout guards against hangs on some hosts.
-    const std::string cmd = "timeout 8 env QT_QPA_PLATFORM=wayland kscreen-doctor " + args;
-    BOOST_LOG(info) << "display_topology: ["sv << cmd << "]"sv;
-    return std::system(cmd.c_str());
+    std::vector<std::string> argv {
+      "timeout", "8", "env", "QT_QPA_PLATFORM=wayland", "kscreen-doctor"
+    };
+    argv.insert(argv.end(), args.begin(), args.end());
+    BOOST_LOG(info) << "display_topology: running kscreen-doctor with "sv << args.size() << " argument(s)"sv;
+    return platf::run_process_argv(argv);
   }
 
 
@@ -344,7 +348,7 @@ namespace display_topology {
       return false;
     }
 
-    const int rc = run_kscreen("output." + output_name + ".mode." + mode_arg);
+    const int rc = run_kscreen({"output." + output_name + ".mode." + mode_arg});
     if (rc != 0) {
       BOOST_LOG(warning) << "display_topology: failed to request mode ["sv << mode_arg
                          << "] on output ["sv << output_name << "] code="sv << rc;
@@ -428,7 +432,7 @@ namespace display_topology {
     // Staged prepare: enable dongle first and let KWin enumerate it before
     // blanking the desk. Atomic enable+disable races to "There are no outputs"
     // and KDE ScreenCast Start hangs on a placeholder 0x0 screen.
-    int ret = run_kscreen("output." + cfg.streaming_output + ".enable");
+    int ret = run_kscreen({"output." + cfg.streaming_output + ".enable"});
     if (ret != 0) {
       BOOST_LOG(error) << "display_topology: enable streaming output failed code="sv << ret;
     }
@@ -444,15 +448,17 @@ namespace display_topology {
     // Host portal ScreenCast is 8-bit SDR. Leave the streaming output in SDR so
     // KWin dumps tone-mapped BGRx instead of an HDR compositor view.
     if (portal_capture) {
-      ret = run_kscreen("output." + cfg.streaming_output + ".hdr.disable output." +
-                        cfg.streaming_output + ".wcg.disable");
+      ret = run_kscreen({
+        "output." + cfg.streaming_output + ".hdr.disable",
+        "output." + cfg.streaming_output + ".wcg.disable",
+      });
       if (ret != 0) {
         BOOST_LOG(warning) << "display_topology: could not disable HDR/WCG on streaming output code="sv << ret;
       }
     }
 
     if (privacy && distinct) {
-      ret = run_kscreen("output." + cfg.streaming_output + ".priority.1");
+      ret = run_kscreen({"output." + cfg.streaming_output + ".priority.1"});
       if (ret != 0) {
         BOOST_LOG(error) << "display_topology: set streaming priority failed code="sv << ret;
       }
@@ -464,7 +470,7 @@ namespace display_topology {
       // token guarantees no video.
       const bool blank_primary = !portal_capture || host_portal_restore_token_present();
       if (blank_primary) {
-        ret = run_kscreen("output." + cfg.primary_output + ".disable");
+        ret = run_kscreen({"output." + cfg.primary_output + ".disable"});
         if (ret != 0) {
           BOOST_LOG(error) << "display_topology: disable primary failed code="sv << ret
                            << " (KDE may refuse if streaming output is not yet active)"sv;
@@ -479,8 +485,10 @@ namespace display_topology {
       }
     }
     else if (distinct) {
-      ret = run_kscreen("output." + cfg.primary_output + ".priority.1 output." +
-                        cfg.streaming_output + ".priority.2");
+      ret = run_kscreen({
+        "output." + cfg.primary_output + ".priority.1",
+        "output." + cfg.streaming_output + ".priority.2",
+      });
       if (ret != 0) {
         BOOST_LOG(error) << "display_topology: extended layout failed code="sv << ret;
       }
@@ -500,17 +508,20 @@ namespace display_topology {
       return;
     }
 
-    std::string args;
+    std::vector<std::string> args;
     if (privacy && distinct) {
-      args = "output." + cfg.primary_output + ".enable output." + cfg.primary_output +
-             ".priority.1 output." + cfg.streaming_output + ".disable";
+      args = {
+        "output." + cfg.primary_output + ".enable",
+        "output." + cfg.primary_output + ".priority.1",
+        "output." + cfg.streaming_output + ".disable",
+      };
     }
     else {
       if (distinct) {
-        args = "output." + cfg.primary_output + ".priority.1 ";
+        args.push_back("output." + cfg.primary_output + ".priority.1");
       }
-      args += "output." + cfg.streaming_output + ".priority.2 output." +
-              cfg.streaming_output + ".disable";
+      args.push_back("output." + cfg.streaming_output + ".priority.2");
+      args.push_back("output." + cfg.streaming_output + ".disable");
     }
 
     const int ret = run_kscreen(args);

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -421,6 +421,10 @@ namespace platf {
 
       int get_crtc_index_by_id(std::uint32_t crtc_id) {
         auto resources = res();
+        if (!resources) {
+          BOOST_LOG(error) << "Couldn't get CRTC resources"sv;
+          return -1;
+        }
         for (int i = 0; i < resources->count_crtcs; i++) {
           if (resources->crtcs[i] == crtc_id) {
             return i;
@@ -443,6 +447,10 @@ namespace platf {
         std::vector<connector_t> monitors;
         std::for_each_n(resources->connectors, resources->count_connectors, [this, &conn_type_count, &monitors](std::uint32_t id) {
           auto conn = connector(id);
+          if (!conn) {
+            BOOST_LOG(warning) << "DRM connector disappeared while enumerating id="sv << id;
+            return;
+          }
 
           std::uint32_t crtc_id = 0;
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -24,8 +24,10 @@
 #include <pthread.h>
 #include <pwd.h>
 #include <sched.h>
+#include <spawn.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
 
 // lib includes
 #include <boost/asio/ip/address.hpp>
@@ -242,6 +244,42 @@ namespace dyn {
 namespace platf {
   using ifaddr_t = util::safe_ptr<ifaddrs, freeifaddrs>;
 
+  int run_process_argv(const std::vector<std::string> &argv) {
+    if (argv.empty() || argv.front().empty()) {
+      return 127;
+    }
+
+    std::vector<char *> native_argv;
+    native_argv.reserve(argv.size() + 1);
+    for (const auto &argument : argv) {
+      native_argv.push_back(const_cast<char *>(argument.c_str()));
+    }
+    native_argv.push_back(nullptr);
+
+    pid_t child = -1;
+    const int spawn_result = posix_spawnp(&child, native_argv.front(), nullptr, nullptr, native_argv.data(), environ);
+    if (spawn_result != 0) {
+      BOOST_LOG(warning) << "Failed to launch ["sv << argv.front() << "]: "sv << strerror(spawn_result);
+      return 127;
+    }
+
+    int status = 0;
+    while (waitpid(child, &status, 0) < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      BOOST_LOG(warning) << "Failed to wait for ["sv << argv.front() << "]: "sv << strerror(errno);
+      return 127;
+    }
+    if (WIFEXITED(status)) {
+      return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+      return 128 + WTERMSIG(status);
+    }
+    return 127;
+  }
+
   ifaddr_t get_ifaddrs() {
     ifaddrs *p {nullptr};
 
@@ -416,54 +454,82 @@ std::string get_local_ip_for_gateway() {
     return "";
   }
 
-  char buffer[8192];
-  struct nlmsghdr *nlMsg = (struct nlmsghdr *)buffer;
-  struct rtmsg *rtMsg = (struct rtmsg *)NLMSG_DATA(nlMsg);
-  struct rtattr *rtAttr;
-  int len = 0;
+  struct {
+    nlmsghdr header;
+    rtmsg route;
+  } request {};
+  request.header.nlmsg_len = NLMSG_LENGTH(sizeof(rtmsg));
+  request.header.nlmsg_type = RTM_GETROUTE;
+  request.header.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
+  request.header.nlmsg_seq = 1;
+  request.header.nlmsg_pid = getpid();
+  request.route.rtm_family = AF_INET;
 
-  memset(nlMsg, 0, sizeof(struct nlmsghdr));
-  nlMsg->nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
-  nlMsg->nlmsg_type = RTM_GETROUTE;
-  nlMsg->nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
-  nlMsg->nlmsg_seq = 1;
-  nlMsg->nlmsg_pid = getpid();
-
-  if (send(fd, nlMsg, nlMsg->nlmsg_len, 0) < 0) {
+  if (::send(fd, &request, request.header.nlmsg_len, 0) < 0) {
     BOOST_LOG(warning) << "Send message failed: " << strerror(errno);
     close(fd);
     return "";
   }
 
   std::string local_ip;
-  bool found = false;
+  bool done = false;
+  alignas(nlmsghdr) char buffer[8192];
 
-  while ((len = recv(fd, nlMsg, sizeof(buffer), 0)) > 0) {
-    for (; NLMSG_OK(nlMsg, len); nlMsg = NLMSG_NEXT(nlMsg, len)) {
-      if (nlMsg->nlmsg_type == NLMSG_DONE) {
-        found = true;
+  while (!done) {
+    const auto bytes = ::recv(fd, buffer, sizeof(buffer), 0);
+    if (bytes < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      BOOST_LOG(warning) << "Route receive failed: " << strerror(errno);
+      break;
+    }
+    if (bytes == 0) {
+      break;
+    }
+
+    int remaining = static_cast<int>(bytes);
+    for (auto *message = reinterpret_cast<nlmsghdr *>(buffer);
+         NLMSG_OK(message, remaining);
+         message = NLMSG_NEXT(message, remaining)) {
+      if (message->nlmsg_type == NLMSG_DONE) {
+        done = true;
         break;
       }
+      if (message->nlmsg_type == NLMSG_ERROR) {
+        BOOST_LOG(warning) << "Route dump returned a netlink error"sv;
+        done = true;
+        break;
+      }
+      if (message->nlmsg_len < NLMSG_LENGTH(sizeof(rtmsg))) {
+        continue;
+      }
 
-      rtMsg = (struct rtmsg *)NLMSG_DATA(nlMsg);
-      if (rtMsg->rtm_family != AF_INET || rtMsg->rtm_table != RT_TABLE_MAIN)
+      auto *route = static_cast<rtmsg *>(NLMSG_DATA(message));
+      if (route->rtm_family != AF_INET || route->rtm_table != RT_TABLE_MAIN)
         continue;
 
-      rtAttr = (struct rtattr *)RTM_RTA(rtMsg);
-      int rtLen = RTM_PAYLOAD(nlMsg);
+      auto *attribute = RTM_RTA(route);
+      int attribute_bytes = RTM_PAYLOAD(message);
 
       in_addr gateway;
       in_addr local;
       memset(&gateway, 0, sizeof(gateway));
       memset(&local, 0, sizeof(local));
 
-      for (; RTA_OK(rtAttr, rtLen); rtAttr = RTA_NEXT(rtAttr, rtLen)) {
-        switch(rtAttr->rta_type) {
+      for (; RTA_OK(attribute, attribute_bytes); attribute = RTA_NEXT(attribute, attribute_bytes)) {
+        if (RTA_PAYLOAD(attribute) < sizeof(std::uint32_t)) {
+          continue;
+        }
+
+        std::uint32_t address = 0;
+        std::memcpy(&address, RTA_DATA(attribute), sizeof(address));
+        switch(attribute->rta_type) {
           case RTA_GATEWAY:
-            gateway.s_addr = *reinterpret_cast<uint32_t *>(RTA_DATA(rtAttr));
+            gateway.s_addr = address;
             break;
           case RTA_PREFSRC:
-            local.s_addr = *reinterpret_cast<uint32_t *>(RTA_DATA(rtAttr));
+            local.s_addr = address;
             break;
           default:
             break;
@@ -472,12 +538,10 @@ std::string get_local_ip_for_gateway() {
 
       if (gateway.s_addr != 0 && local.s_addr != 0) {
         local_ip = inet_ntoa(local);
-        found = true;
+        done = true;
         break;
       }
     }
-
-    if (found) break;
   }
 
   close(fd);

--- a/src/platform/linux/misc.h
+++ b/src/platform/linux/misc.h
@@ -79,4 +79,10 @@ namespace platf {
    */
   std::string default_vaapi_render_device();
 
+  /**
+   * @brief Run a program with an explicit argument vector, without a shell.
+   * @return The exit status, or 128 + signal for a signaled child.
+   */
+  int run_process_argv(const std::vector<std::string> &argv);
+
 }  // namespace platf

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -28,6 +28,8 @@
 
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "src/config.h"
@@ -219,7 +221,19 @@ namespace portal {
   }
 
   static std::string load_restore_token() {
-    std::ifstream f(token_path());
+    const auto path = token_path();
+    std::error_code ec;
+    std::filesystem::permissions(
+      path,
+      std::filesystem::perms::owner_read | std::filesystem::perms::owner_write,
+      std::filesystem::perm_options::replace,
+      ec
+    );
+    if (ec && ec != std::errc::no_such_file_or_directory) {
+      BOOST_LOG(warning) << "portal: Failed to secure existing restore token: "sv << ec.message();
+    }
+
+    std::ifstream f(path);
     if (!f.good()) return "";
     std::string token;
     std::getline(f, token);
@@ -228,8 +242,36 @@ namespace portal {
 
   static void save_restore_token(const std::string &token) {
     if (token.empty()) return;
-    std::ofstream f(token_path());
-    f << token;
+
+    const auto path = token_path();
+    const int fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+      BOOST_LOG(warning) << "portal: Failed to open restore token file: "sv << strerror(errno);
+      return;
+    }
+
+    // open(2)'s mode only applies to newly-created files. Correct permissions
+    // on an existing token that may have been written by an older build.
+    if (::fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
+      BOOST_LOG(warning) << "portal: Failed to secure restore token file: "sv << strerror(errno);
+      ::close(fd);
+      return;
+    }
+
+    std::size_t written = 0;
+    while (written < token.size()) {
+      const auto result = ::write(fd, token.data() + written, token.size() - written);
+      if (result < 0 && errno == EINTR) {
+        continue;
+      }
+      if (result <= 0) {
+        BOOST_LOG(warning) << "portal: Failed to write restore token: "sv << strerror(errno);
+        ::close(fd);
+        return;
+      }
+      written += static_cast<std::size_t>(result);
+    }
+    ::close(fd);
     BOOST_LOG(info) << "portal: Saved restore token for future sessions"sv;
   }
 

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -1249,26 +1249,33 @@ namespace virtual_display {
       // Set mode and enable the output
       std::string mode_str = std::to_string(width) + "x" + std::to_string(height) +
                              "@" + std::to_string(fps);
-      std::string cmd = "kscreen-doctor output." + output + ".enable "
-                        "output." + output + ".mode." + mode_str + " "
-                        "output." + output + ".priority.1";
+      std::vector<std::string> args {
+        "kscreen-doctor",
+        "output." + output + ".enable",
+        "output." + output + ".mode." + mode_str,
+        "output." + output + ".priority.1",
+      };
 
       if (!cfg.primary_output.empty()) {
-        cmd += " output." + cfg.primary_output + ".priority.2";
+        args.push_back("output." + cfg.primary_output + ".priority.2");
       }
 
-      BOOST_LOG(info) << "Virtual display: kscreen-doctor enable ["sv << cmd << "]"sv;
-      int rc = exec_cmd_rc(cmd);
+      BOOST_LOG(info) << "Virtual display: running kscreen-doctor enable with "sv << args.size() - 1 << " argument(s)"sv;
+      int rc = platf::run_process_argv(args);
       if (rc != 0) {
         BOOST_LOG(warning) << "Virtual display: kscreen-doctor enable failed (rc="sv << rc << ")"sv;
 
         // Try without explicit mode setting (just enable)
-        cmd = "kscreen-doctor output." + output + ".enable output." + output + ".priority.1";
+        args = {
+          "kscreen-doctor",
+          "output." + output + ".enable",
+          "output." + output + ".priority.1",
+        };
         if (!cfg.primary_output.empty()) {
-          cmd += " output." + cfg.primary_output + ".priority.2";
+          args.push_back("output." + cfg.primary_output + ".priority.2");
         }
 
-        rc = exec_cmd_rc(cmd);
+        rc = platf::run_process_argv(args);
         if (rc != 0) {
           BOOST_LOG(error) << "Virtual display: kscreen-doctor fallback enable also failed (rc="sv << rc << ")"sv;
           return std::nullopt;
@@ -1295,15 +1302,15 @@ namespace virtual_display {
     static void destroy(vdisplay_t &display) {
       const auto &cfg = config::video.linux_display;
 
-      std::string cmd = "kscreen-doctor";
+      std::vector<std::string> args {"kscreen-doctor"};
       if (!cfg.primary_output.empty()) {
-        cmd += " output." + cfg.primary_output + ".priority.1";
+        args.push_back("output." + cfg.primary_output + ".priority.1");
       }
-      cmd += " output." + display.output_name + ".priority.2"
-             " output." + display.output_name + ".disable";
+      args.push_back("output." + display.output_name + ".priority.2");
+      args.push_back("output." + display.output_name + ".disable");
 
-      BOOST_LOG(info) << "Virtual display: kscreen-doctor disable ["sv << cmd << "]"sv;
-      int rc = exec_cmd_rc(cmd);
+      BOOST_LOG(info) << "Virtual display: running kscreen-doctor disable with "sv << args.size() - 1 << " argument(s)"sv;
+      int rc = platf::run_process_argv(args);
       if (rc != 0) {
         BOOST_LOG(warning) << "Virtual display: kscreen-doctor disable failed (rc="sv << rc << ")"sv;
       }

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
+#include <limits>
 
 // platform includes
 #include <drm_fourcc.h>
@@ -14,6 +15,7 @@
 #include <gbm.h>
 #include <limits.h>
 #include <poll.h>
+#include <utility>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -45,13 +47,6 @@ namespace wl {
       std::uint32_t format;
       std::uint32_t pad;
       std::uint64_t modifier;
-    };
-
-    struct pending_buffer_create_t {
-      dmabuf_t *self {};
-      frame_t *target {};
-      zwlr_screencopy_frame_v1 *frame {};
-      int wl_buffer_fd {-1};
     };
 
     struct pending_extcopy_buffer_create_t {
@@ -665,6 +660,7 @@ namespace wl {
     bool blend_cursor,
     wl_shm *shm
   ) {
+    cancel();
     this->dmabuf_interface = dmabuf_interface;
     this->shm_global = shm;
     // Reset state
@@ -672,22 +668,23 @@ namespace wl {
     dmabuf_info.supported = false;
 
     // Create new frame
-    auto frame = zwlr_screencopy_manager_v1_capture_output(
+    pending_frame = zwlr_screencopy_manager_v1_capture_output(
       screencopy_manager,
       blend_cursor ? 1 : 0,
       output
     );
 
     // Store frame data pointer for callbacks
-    zwlr_screencopy_frame_v1_set_user_data(frame, this);
+    zwlr_screencopy_frame_v1_set_user_data(pending_frame, this);
 
     // Add listener
-    zwlr_screencopy_frame_v1_add_listener(frame, &listener, this);
+    zwlr_screencopy_frame_v1_add_listener(pending_frame, &listener, this);
 
     status = WAITING;
   }
 
   dmabuf_t::~dmabuf_t() {
+    cancel();
     cleanup_gbm();
 
     for (auto &frame : frames) {
@@ -699,6 +696,34 @@ namespace wl {
       gbm_device_destroy(gbm_device);
       gbm_device = nullptr;
     }
+  }
+
+  void dmabuf_t::destroy_capture_frame(zwlr_screencopy_frame_v1 *frame) {
+    if (!frame) {
+      return;
+    }
+    if (pending_frame == frame) {
+      pending_frame = nullptr;
+    }
+    zwlr_screencopy_frame_v1_destroy(frame);
+  }
+
+  void dmabuf_t::cancel() {
+    if (pending_buffer_create) {
+      auto *pending = std::exchange(pending_buffer_create, nullptr);
+      if (pending->params) {
+        zwp_linux_buffer_params_v1_destroy(pending->params);
+      }
+      if (pending->wl_buffer_fd >= 0) {
+        close(pending->wl_buffer_fd);
+      }
+      pending->target->destroy();
+      delete pending;
+    }
+    if (pending_frame) {
+      destroy_capture_frame(pending_frame);
+    }
+    status = READY;
   }
 
   // Buffer format callback
@@ -747,7 +772,7 @@ namespace wl {
   void dmabuf_t::create_and_copy_dmabuf(zwlr_screencopy_frame_v1 *frame) {
     if (!init_gbm()) {
       BOOST_LOG(error) << "Failed to initialize GBM"sv;
-      zwlr_screencopy_frame_v1_destroy(frame);
+      destroy_capture_frame(frame);
       status = REINIT;
       return;
     }
@@ -838,7 +863,7 @@ namespace wl {
     if (!needs_new_buffer) {
       if (!populate_capture_descriptor(*next_frame)) {
         next_frame->destroy();
-        zwlr_screencopy_frame_v1_destroy(frame);
+        destroy_capture_frame(frame);
         status = REINIT;
         return;
       }
@@ -936,7 +961,7 @@ namespace wl {
                        << " format="sv << dmabuf_info.format
                        << " flags="sv << bo_flags
                        << " render_node=["sv << path_for_fd(gbm_device_get_fd(gbm_device)) << ']';
-      zwlr_screencopy_frame_v1_destroy(frame);
+      destroy_capture_frame(frame);
       status = REINIT;
       return;
     }
@@ -956,7 +981,7 @@ namespace wl {
 
     if (!populate_capture_descriptor(*next_frame)) {
       next_frame->destroy();
-      zwlr_screencopy_frame_v1_destroy(frame);
+      destroy_capture_frame(frame);
       status = REINIT;
       return;
     }
@@ -968,7 +993,7 @@ namespace wl {
     if (wl_buffer_fd < 0) {
       BOOST_LOG(error) << "Failed to get buffer FD for wl_buffer creation"sv;
       next_frame->destroy();
-      zwlr_screencopy_frame_v1_destroy(frame);
+      destroy_capture_frame(frame);
       status = REINIT;
       return;
     }
@@ -988,8 +1013,10 @@ namespace wl {
       .self = this,
       .target = next_frame,
       .frame = frame,
+      .params = params,
       .wl_buffer_fd = wl_buffer_fd,
     };
+    pending_buffer_create = pending;
     zwp_linux_buffer_params_v1_add_listener(params, &params_listener, pending);
     zwp_linux_buffer_params_v1_create(params, dmabuf_info.width, dmabuf_info.height, dmabuf_info.format, 0);
   }
@@ -1025,7 +1052,7 @@ namespace wl {
       create_and_copy_shm(frame);
     } else {
       BOOST_LOG(error) << "No supported buffer types"sv;
-      zwlr_screencopy_frame_v1_destroy(frame);
+      destroy_capture_frame(frame);
       status = REINIT;
     }
   }
@@ -1037,7 +1064,9 @@ namespace wl {
     struct wl_buffer *buffer
   ) {
     auto pending = std::unique_ptr<pending_buffer_create_t>(static_cast<pending_buffer_create_t *>(data));
+    pending->self->pending_buffer_create = nullptr;
     zwp_linux_buffer_params_v1_destroy(params);
+    pending->params = nullptr;
 
     pending->target->buffer = buffer;
     if (pending->wl_buffer_fd >= 0) {
@@ -1054,7 +1083,9 @@ namespace wl {
     struct zwp_linux_buffer_params_v1 *params
   ) {
     auto pending = std::unique_ptr<pending_buffer_create_t>(static_cast<pending_buffer_create_t *>(data));
+    pending->self->pending_buffer_create = nullptr;
     zwp_linux_buffer_params_v1_destroy(params);
+    pending->params = nullptr;
     BOOST_LOG(error) << "Failed to create buffer from params"sv;
     if (pending->wl_buffer_fd >= 0) {
       close(pending->wl_buffer_fd);
@@ -1062,7 +1093,7 @@ namespace wl {
     }
     pending->target->destroy();
 
-    zwlr_screencopy_frame_v1_destroy(pending->frame);
+    pending->self->destroy_capture_frame(pending->frame);
     pending->self->status = REINIT;
   }
 
@@ -1070,7 +1101,7 @@ namespace wl {
   void dmabuf_t::create_and_copy_shm(zwlr_screencopy_frame_v1 *frame) {
     if (!shm_global) {
       BOOST_LOG(error) << "SHM: No wl_shm global available"sv;
-      zwlr_screencopy_frame_v1_destroy(frame);
+      destroy_capture_frame(frame);
       status = REINIT;
       return;
     }
@@ -1086,12 +1117,20 @@ namespace wl {
 
     if (needs_new_buffer) {
       cleanup_shm();
-      shm_size = shm_info.stride * shm_info.height;
+      if (shm_info.height == 0 || shm_info.stride == 0 ||
+          static_cast<std::size_t>(shm_info.stride) > std::numeric_limits<std::size_t>::max() / shm_info.height ||
+          static_cast<std::size_t>(shm_info.stride) * shm_info.height > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+        BOOST_LOG(error) << "Invalid SHM screencopy buffer size"sv;
+        destroy_capture_frame(frame);
+        status = REINIT;
+        return;
+      }
+      shm_size = static_cast<std::size_t>(shm_info.stride) * shm_info.height;
 
       shm_fd = memfd_create("polaris-screencopy", MFD_CLOEXEC);
       if (shm_fd < 0) {
         BOOST_LOG(error) << "Failed to create memfd for SHM screencopy"sv;
-        zwlr_screencopy_frame_v1_destroy(frame);
+        destroy_capture_frame(frame);
         status = REINIT;
         return;
       }
@@ -1099,7 +1138,7 @@ namespace wl {
       if (ftruncate(shm_fd, shm_size) < 0) {
         BOOST_LOG(error) << "Failed to resize SHM buffer"sv;
         cleanup_shm();
-        zwlr_screencopy_frame_v1_destroy(frame);
+        destroy_capture_frame(frame);
         status = REINIT;
         return;
       }
@@ -1109,7 +1148,7 @@ namespace wl {
         shm_data = nullptr;
         BOOST_LOG(error) << "Failed to mmap SHM buffer"sv;
         cleanup_shm();
-        zwlr_screencopy_frame_v1_destroy(frame);
+        destroy_capture_frame(frame);
         status = REINIT;
         return;
       }
@@ -1118,7 +1157,7 @@ namespace wl {
       if (!shm_pool) {
         BOOST_LOG(error) << "Failed to create wl_shm_pool"sv;
         cleanup_shm();
-        zwlr_screencopy_frame_v1_destroy(frame);
+        destroy_capture_frame(frame);
         status = REINIT;
         return;
       }
@@ -1128,7 +1167,7 @@ namespace wl {
       if (!shm_buffer) {
         BOOST_LOG(error) << "Failed to create wl_buffer from SHM pool"sv;
         cleanup_shm();
-        zwlr_screencopy_frame_v1_destroy(frame);
+        destroy_capture_frame(frame);
         status = REINIT;
         return;
       }
@@ -1192,7 +1231,7 @@ namespace wl {
       current_frame = get_next_frame();
     }
 
-    zwlr_screencopy_frame_v1_destroy(frame);
+    destroy_capture_frame(frame);
     status = READY;
   }
 
@@ -1208,7 +1247,7 @@ namespace wl {
                      << " target_modifier="sv << next_frame->buffer_modifier;
     next_frame->destroy();
 
-    zwlr_screencopy_frame_v1_destroy(frame);
+    destroy_capture_frame(frame);
     status = REINIT;
   }
 

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -130,6 +130,7 @@ namespace wl {
     dmabuf_t &operator=(dmabuf_t &&) = delete;
 
     void listen(zwlr_screencopy_manager_v1 *screencopy_manager, zwp_linux_dmabuf_v1 *dmabuf_interface, wl_output *output, bool blend_cursor = false, wl_shm *shm = nullptr);
+    void cancel();
     void set_feedback(const dmabuf_feedback_t *feedback) {
       this->feedback = feedback;
     }
@@ -161,13 +162,24 @@ namespace wl {
     } shm_info;
 
   private:
+    struct pending_buffer_create_t {
+      dmabuf_t *self {};
+      frame_t *target {};
+      zwlr_screencopy_frame_v1 *frame {};
+      zwp_linux_buffer_params_v1 *params {};
+      int wl_buffer_fd {-1};
+    };
+
     bool init_gbm();
     void cleanup_gbm();
     void create_and_copy_dmabuf(zwlr_screencopy_frame_v1 *frame);
+    void destroy_capture_frame(zwlr_screencopy_frame_v1 *frame);
 
     zwp_linux_dmabuf_v1 *dmabuf_interface {nullptr};
     wl_shm *shm_global {nullptr};
     const dmabuf_feedback_t *feedback {nullptr};
+    zwlr_screencopy_frame_v1 *pending_frame {nullptr};
+    pending_buffer_create_t *pending_buffer_create {nullptr};
 
     struct {
       bool supported {false};

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -164,10 +164,12 @@ namespace wl {
       do {
         auto remaining_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(to - std::chrono::steady_clock::now());
         if (remaining_time_ms.count() < 0 || !display.dispatch(remaining_time_ms)) {
+          dmabuf.cancel();
           return platf::capture_e::timeout;
         }
         if (interface.consume_output_topology_dirty()) {
           BOOST_LOG(warning) << "wlr: Wayland output topology changed during capture; reinitializing display capture"sv;
+          dmabuf.cancel();
           return platf::capture_e::reinit;
         }
       } while (dmabuf.status == dmabuf_t::WAITING);

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -710,7 +710,7 @@ namespace platf {
       display = iter.data;
       seg = xcb::generate_id(xcb.get());
 
-      shm_id.id = shmget(IPC_PRIVATE, frame_size(), IPC_CREAT | 0777);
+      shm_id.id = shmget(IPC_PRIVATE, frame_size(), IPC_CREAT | 0600);
       if (shm_id.id == -1) {
         BOOST_LOG(error) << "shmget failed"sv;
         return -1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_kmsgrab_logging_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_video_hdr_probe_guard_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_labwc_render_device_source.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_linux_platform_hardening_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_linux_stream_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_prepared_ffmpeg.cpp
@@ -155,6 +156,7 @@ set(TEST_PLATFORM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_default_render_device.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_cuda_gl_encode_device.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_graphics.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_linux_process_argv.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_portal_grab_policy.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_private_session_input.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_session_manager.cpp

--- a/tests/unit/platform/test_linux_process_argv.cpp
+++ b/tests/unit/platform/test_linux_process_argv.cpp
@@ -1,0 +1,24 @@
+/**
+ * @file tests/unit/platform/test_linux_process_argv.cpp
+ * @brief Regression coverage for shell-free Linux child process launches.
+ */
+#include <gtest/gtest.h>
+
+#ifdef __linux__
+
+#include "src/platform/linux/misc.h"
+
+TEST(LinuxProcessArgv, PreservesShellMetacharactersAsLiteralArguments) {
+  constexpr auto value = "output.HDMI-A-1; exit 99";
+  EXPECT_EQ(platf::run_process_argv({"test", value, "=", value}), 0);
+}
+
+TEST(LinuxProcessArgv, ReturnsChildExitStatus) {
+  EXPECT_EQ(platf::run_process_argv({"sh", "-c", "exit 7"}), 7);
+}
+
+TEST(LinuxProcessArgv, ReportsMissingExecutable) {
+  EXPECT_EQ(platf::run_process_argv({"polaris-command-that-does-not-exist"}), 127);
+}
+
+#endif

--- a/tests/unit/test_linux_platform_hardening_source.cpp
+++ b/tests/unit/test_linux_platform_hardening_source.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file tests/unit/test_linux_platform_hardening_source.cpp
+ * @brief Source contracts for Linux backends omitted by some build variants.
+ */
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+  std::string read_source(const std::filesystem::path &relative_path) {
+    std::ifstream input(std::filesystem::path {POLARIS_SOURCE_DIR} / relative_path);
+    EXPECT_TRUE(input.good()) << relative_path;
+    std::ostringstream contents;
+    contents << input.rdbuf();
+    return contents.str();
+  }
+
+}  // namespace
+
+TEST(LinuxPlatformHardeningSource, CageCapturePublishesMetadataAtomicallyAndJoins) {
+  const auto source = read_source("src/platform/linux/cage_screencopy.cpp");
+  EXPECT_NE(source.find("published_frame_t"), std::string::npos);
+  EXPECT_NE(source.find("::poll(&display_poll"), std::string::npos);
+  EXPECT_NE(source.find("sc_thread.join()"), std::string::npos);
+  EXPECT_EQ(source.find("sc_thread.detach()"), std::string::npos);
+}
+
+TEST(LinuxPlatformHardeningSource, TimedOutWlrCaptureCancelsItsRequest) {
+  const auto header = read_source("src/platform/linux/wayland.h");
+  const auto capture = read_source("src/platform/linux/wlgrab.cpp");
+  EXPECT_NE(header.find("pending_frame"), std::string::npos);
+  EXPECT_NE(header.find("pending_buffer_create"), std::string::npos);
+  EXPECT_NE(capture.find("dmabuf.cancel()"), std::string::npos);
+}
+
+TEST(LinuxPlatformHardeningSource, CudaFormatTransitionReleasesCompleteDestination) {
+  const auto source = read_source("src/platform/linux/cuda.cpp");
+  const auto transition = source.find("source_fourcc != descriptor.sd.fourcc");
+  ASSERT_NE(transition, std::string::npos);
+  EXPECT_NE(source.find("release_destination();", transition), std::string::npos);
+
+  const auto release = source.find("void release_destination()");
+  ASSERT_NE(release, std::string::npos);
+  EXPECT_NE(source.find("vkDestroyBuffer", release), std::string::npos);
+  EXPECT_NE(source.find("vkFreeMemory", release), std::string::npos);
+}
+
+TEST(LinuxPlatformHardeningSource, NetlinkReadsAlwaysStartAtBufferBase) {
+  const auto source = read_source("src/platform/linux/misc.cpp");
+  EXPECT_NE(source.find("::recv(fd, buffer, sizeof(buffer), 0)"), std::string::npos);
+  EXPECT_EQ(source.find("recv(fd, nlMsg"), std::string::npos);
+}
+
+TEST(LinuxPlatformHardeningSource, KscreenConfigurationNeverPassesThroughShell) {
+  const auto topology = read_source("src/platform/linux/display_topology.cpp");
+  EXPECT_EQ(topology.find("std::system"), std::string::npos);
+  EXPECT_NE(topology.find("platf::run_process_argv(argv)"), std::string::npos);
+
+  const auto virtual_display = read_source("src/platform/linux/virtual_display.cpp");
+  const auto kscreen = virtual_display.find("namespace kscreen");
+  ASSERT_NE(kscreen, std::string::npos);
+  EXPECT_NE(virtual_display.find("platf::run_process_argv(args)", kscreen), std::string::npos);
+}


### PR DESCRIPTION
## Summary

- replace kscreen shell command construction with an explicit `posix_spawnp` argument-vector runner
- harden Linux route, DRM hotplug, portal-token, X11 SHM, and PulseAudio boundary handling
- make Cage and WLR screencopy requests own their frame metadata and pending protocol objects through timeout and teardown
- fully recreate CUDA/Vulkan destination resources when the packed capture format changes, and propagate CUDA copy/unmap failures
- add regression coverage for the shell-free runner and source-level hardening contracts

## Root cause

Several Linux paths assumed externally changing state remained stable: display names were interpolated into a shell command, netlink and DRM enumeration reused unchecked pointers/cursors, and capture metadata or Wayland callbacks could outlive the buffer/request they described. CUDA format changes also released only the CUDA view while retaining Vulkan allocation state.

These assumptions could produce command execution from authenticated configuration, crashes during route or display changes, stale screencopy callbacks after a timeout, frame over-reads during Cage geometry changes, and invalid CUDA/Vulkan reuse across format transitions.

## Impact

Linux display configuration no longer invokes a shell with user-controlled output names. Capture timeouts and topology changes cancel outstanding Wayland work before returning, Cage publishes bytes and geometry atomically, and the remaining platform boundary fixes fail closed or constrain permissions rather than reusing stale state.

## Validation

- production target rebuilt successfully with CMake/Ninja
- full serial test suite: 17/17 passed
- focused Linux platform tests: 35/35 passed
- hardening contract tests: 5/5 passed
- `git diff --check`
- Retroid Pocket 6 hardware smoke: Nova launched the Synthetic Frame Counter session, received its first video packet after 100 ms, rendered a valid 1920x1080 frame over direct WLR ext-image-copy DMA-BUF -> CUDA -> NVENC, and completed clean teardown with audio restoration
