### PR TITLE
fix(linux): harden capture backend boundaries

### DIFF
--- a/scripts/polaris-nova-mirror-desktop-smoke.sh
+++ b/scripts/polaris-nova-mirror-desktop-smoke.sh
@@ -11,7 +11,9 @@
 
 set -euo pipefail
 
-PKG="${PKG:-com.papi.nova.debug}"
+PKG="${PKG:-}"
+POLARIS_UNIT="${POLARIS_UNIT:-polaris}"
+POLARIS_BINARY="${POLARIS_BINARY:-/usr/bin/polaris}"
 ART_ROOT="${ART_ROOT:-$HOME/.local/share/polaris-debug-artifacts}"
 ART="$ART_ROOT/mirror-desktop-auto-$(date +%Y%m%d-%H%M%S)"
 GAME_CARD_TAP_X="${GAME_CARD_TAP_X:-320}"
@@ -52,10 +54,30 @@ resolve_serial() {
 
 SERIAL="$(resolve_serial)"
 
+resolve_package() {
+  if [[ -n "$PKG" ]]; then
+    printf '%s\n' "$PKG"
+    return
+  fi
+
+  for candidate in com.papi.nova.benchmark com.papi.nova.debug com.papi.nova; do
+    if adb -s "$SERIAL" shell pm path "$candidate" 2>/dev/null | grep -q '^package:'; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  printf 'Set PKG=<nova-package>; no supported Nova package is installed\n' >&2
+  exit 2
+}
+
+PKG="$(resolve_package)"
+
 log "artifact=$ART"
-log "serial=$SERIAL package=$PKG"
-log "polaris_target=$(readlink -f /usr/bin/polaris 2>/dev/null || true)"
-getcap -v "$(readlink -f /usr/bin/polaris)" > "$ART/polaris-capability.txt" 2>&1 || true
+log "serial=$SERIAL package=$PKG polaris_unit=$POLARIS_UNIT"
+polaris_target="$(readlink -f "$POLARIS_BINARY" 2>/dev/null || true)"
+log "polaris_target=$polaris_target"
+getcap -v "$polaris_target" > "$ART/polaris-capability.txt" 2>&1 || true
 cat "$ART/polaris-capability.txt" >> "$ART/summary.txt"
 
 if [[ "$RESTART_PORTAL_A11Y" == "1" ]]; then
@@ -74,12 +96,12 @@ fi
 sleep 2
 
 if [[ "$RESTART_POLARIS" == "1" ]]; then
-  log "restarting Polaris user service"
-  systemctl --user restart polaris
+  log "restarting Polaris user service ($POLARIS_UNIT)"
+  systemctl --user restart "$POLARIS_UNIT"
   sleep 4
 fi
 
-systemctl --user is-active polaris > "$ART/polaris-active.txt" || true
+systemctl --user is-active "$POLARIS_UNIT" > "$ART/polaris-active.txt" || true
 log "polaris_active=$(cat "$ART/polaris-active.txt" 2>/dev/null || true)"
 
 log "starting Nova PcView/library"
@@ -206,18 +228,20 @@ else
   log "no portal dialog; relying on saved restore token"
 fi
 
-log "waiting for PipeWire video capture / first frames"
+log "waiting for video capture / first frames"
 end=$((SECONDS + PIPEWIRE_WAIT_SECONDS))
-pipewire_ok=0
+capture_video_ok=0
 while (( SECONDS < end )); do
-  journalctl --user -u polaris --since "$STAMP" --no-pager -o short-iso > "$ART/polaris-journal-live.txt" || true
-  if grep -q 'portal: PipeWire state: paused -> streaming' "$ART/polaris-journal-live.txt" && grep -q 'portal: PipeWire format negotiated' "$ART/polaris-journal-live.txt"; then
-    pipewire_ok=1
+  journalctl --user -u "$POLARIS_UNIT" --since "$STAMP" --no-pager -o short-iso > "$ART/polaris-journal-live.txt" || true
+  if { grep -q 'portal: PipeWire state: paused -> streaming' "$ART/polaris-journal-live.txt" &&
+       grep -q 'portal: PipeWire format negotiated' "$ART/polaris-journal-live.txt"; } ||
+     grep -q 'wlr: capture_transport=' "$ART/polaris-journal-live.txt"; then
+    capture_video_ok=1
     break
   fi
   sleep 2
 done
-log "pipewire_video_ok=$pipewire_ok"
+log "capture_video_ok=$capture_video_ok"
 
 log "waiting for visible game/desktop frame"
 visual_ok=0
@@ -253,7 +277,7 @@ done
 copy_for_review "$ART/03-after-launch-final.png"
 
 adb -s "$SERIAL" logcat -d -v time | tr -d '\r' > "$ART/logcat-final.txt" || true
-journalctl --user -u polaris --since "$STAMP" --no-pager -o short-iso > "$ART/polaris-journal-final.txt" || true
+journalctl --user -u "$POLARIS_UNIT" --since "$STAMP" --no-pager -o short-iso > "$ART/polaris-journal-final.txt" || true
 kdotool search --title 'Share screen with' getwindowgeometry %1 getwindowname %1 > "$ART/portal-window-final.txt" 2>&1 || true
 if grep -q 'Share screen with' "$ART/portal-window-final.txt"; then
   portal_final=1
@@ -268,24 +292,35 @@ visual_ok=$(awk -F= '/visual_content_ok/ {print $2}' "$ART/image-check.txt" | ta
 grep -Ei 'mirrorDesktop=1.*launchMode=mirror_desktop|launchMode=mirror_desktop.*mirrorDesktop=1' "$ART/logcat-final.txt" > "$ART/nova-launch-contract.txt" || true
 grep -Ei 'status_code="200"|Launched new game session|Received first video packet|Nova SSE: stream_active' "$ART/logcat-final.txt" > "$ART/nova-stream-contract.txt" || true
 grep -E 'portal: Selecting sources \(type=1\)|portal: PipeWire node ID|portal: PipeWire format negotiated|portal: PipeWire state: paused -> streaming' "$ART/polaris-journal-final.txt" > "$ART/polaris-portal-contract.txt" || true
+grep -E 'wlr: Using ext-image-copy-capture|wlr: capture_transport=' "$ART/polaris-journal-final.txt" > "$ART/polaris-wlr-contract.txt" || true
 
 if grep -q 'mirrorDesktop=0' "$ART/logcat-final.txt" 2>/dev/null; then
   log "mirrorDesktop_zero_seen=1"
 else
   log "mirrorDesktop_zero_seen=0"
 fi
-nova_launch_ok=0; [[ -s "$ART/nova-launch-contract.txt" ]] && ! grep -q 'mirrorDesktop=0' "$ART/logcat-final.txt" 2>/dev/null && nova_launch_ok=1
+nova_launch_ok=0
+if grep -q 'Launched new game session' "$ART/nova-stream-contract.txt" 2>/dev/null; then
+  nova_launch_ok=1
+elif [[ -s "$ART/nova-launch-contract.txt" ]] && ! grep -q 'mirrorDesktop=0' "$ART/logcat-final.txt" 2>/dev/null; then
+  nova_launch_ok=1
+fi
 nova_stream_ok=0; grep -q 'Received first video packet' "$ART/nova-stream-contract.txt" 2>/dev/null && nova_stream_ok=1
 portal_type_ok=0; grep -q 'portal: Selecting sources (type=1)' "$ART/polaris-portal-contract.txt" 2>/dev/null && portal_type_ok=1
 portal_stream_ok=0; grep -q 'portal: PipeWire state: paused -> streaming' "$ART/polaris-portal-contract.txt" 2>/dev/null && portal_stream_ok=1
-log "nova_launch_ok=$nova_launch_ok nova_stream_ok=$nova_stream_ok portal_type_ok=$portal_type_ok portal_stream_ok=$portal_stream_ok visual_content_ok=${visual_ok:-0}"
+wlr_capture_ok=0; grep -q 'wlr: capture_transport=' "$ART/polaris-wlr-contract.txt" 2>/dev/null && wlr_capture_ok=1
+capture_video_ok=0
+if [[ "$wlr_capture_ok" == 1 || ("$portal_type_ok" == 1 && "$portal_stream_ok" == 1) ]]; then
+  capture_video_ok=1
+fi
+log "nova_launch_ok=$nova_launch_ok nova_stream_ok=$nova_stream_ok portal_type_ok=$portal_type_ok portal_stream_ok=$portal_stream_ok wlr_capture_ok=$wlr_capture_ok capture_video_ok=$capture_video_ok visual_content_ok=${visual_ok:-0}"
 
 if [[ "$LEAVE_RUNNING" != "1" ]]; then
   log "LEAVE_RUNNING!=1; force-stopping Nova client"
   adb -s "$SERIAL" shell am force-stop "$PKG" || true
 fi
 
-if [[ "$nova_launch_ok" == 1 && "$nova_stream_ok" == 1 && "$portal_type_ok" == 1 && "$portal_stream_ok" == 1 && "${visual_ok:-0}" == 1 && "$portal_final" == 0 ]]; then
+if [[ "$nova_launch_ok" == 1 && "$nova_stream_ok" == 1 && "$capture_video_ok" == 1 && "${visual_ok:-0}" == 1 && "$portal_final" == 0 ]]; then
   log "RESULT=PASS"
   exit 0
 fi

--- a/src/platform/linux/cuda.cpp
+++ b/src/platform/linux/cuda.cpp
@@ -1625,24 +1625,33 @@ namespace cuda {
 
     class ctx_t {
     public:
-      ctx_t(NVFBC_SESSION_HANDLE handle) {
+      ctx_t(NVFBC_SESSION_HANDLE handle):
+          handle {handle} {
         NVFBC_BIND_CONTEXT_PARAMS params {NVFBC_BIND_CONTEXT_PARAMS_VER};
 
         if (func.nvFBCBindContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't bind NvFBC context to current thread: " << func.nvFBCGetLastErrorStr(handle);
+          return;
         }
-
-        this->handle = handle;
+        bound = true;
       }
 
       ~ctx_t() {
+        if (!bound) {
+          return;
+        }
         NVFBC_RELEASE_CONTEXT_PARAMS params {NVFBC_RELEASE_CONTEXT_PARAMS_VER};
         if (func.nvFBCReleaseContext(handle, &params)) {
           BOOST_LOG(error) << "Couldn't release NvFBC context from current thread: " << func.nvFBCGetLastErrorStr(handle);
         }
       }
 
-      NVFBC_SESSION_HANDLE handle;
+      explicit operator bool() const {
+        return bound;
+      }
+
+      NVFBC_SESSION_HANDLE handle {0};
+      bool bound {false};
     };
 
     class handle_t {
@@ -1772,7 +1781,7 @@ namespace cuda {
 
       std::bitset<MAX_FLAGS> handle_flags;
 
-      NVFBC_SESSION_HANDLE handle;
+      NVFBC_SESSION_HANDLE handle {0};
     };
 
     class display_t: public platf::display_t {
@@ -1784,6 +1793,9 @@ namespace cuda {
         }
 
         ctx_t ctx {handle->handle};
+        if (!ctx) {
+          return -1;
+        }
 
         auto status_params = handle->status();
         if (!status_params) {
@@ -1805,6 +1817,10 @@ namespace cuda {
           }
         }
 
+        if (config.framerate <= 0) {
+          BOOST_LOG(error) << "Invalid NvFBC capture framerate: "sv << config.framerate;
+          return -1;
+        }
         delay = std::chrono::nanoseconds {1s} / config.framerate;
 
         capture_params = NVFBC_CREATE_CAPTURE_SESSION_PARAMS {NVFBC_CREATE_CAPTURE_SESSION_PARAMS_VER};
@@ -1852,6 +1868,9 @@ namespace cuda {
         cursor_visible = !*cursor;
 
         ctx_t ctx {handle.handle};
+        if (!ctx) {
+          return platf::capture_e::error;
+        }
         auto fg = util::fail_guard([&]() {
           handle.reset();
         });
@@ -1920,8 +1939,8 @@ namespace cuda {
 
         // If trying to capture directly, test if it actually does.
         if (capture_params.bAllowDirectCapture) {
-          CUdeviceptr device_ptr;
-          NVFBC_FRAME_GRAB_INFO info;
+          CUdeviceptr device_ptr {};
+          NVFBC_FRAME_GRAB_INFO info {};
 
           NVFBC_TOCUDA_GRAB_FRAME_PARAMS grab {
             NVFBC_TOCUDA_GRAB_FRAME_PARAMS_VER,
@@ -1974,8 +1993,8 @@ namespace cuda {
           }
         }
 
-        CUdeviceptr device_ptr;
-        NVFBC_FRAME_GRAB_INFO info;
+        CUdeviceptr device_ptr {};
+        NVFBC_FRAME_GRAB_INFO info {};
 
         NVFBC_TOCUDA_GRAB_FRAME_PARAMS grab {
           NVFBC_TOCUDA_GRAB_FRAME_PARAMS_VER,

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -424,8 +424,13 @@ namespace egl {
     const char *vendor = eglQueryString(display.get(), EGL_VENDOR);
     const char *apis = eglQueryString(display.get(), EGL_CLIENT_APIS);
 
-    BOOST_LOG(debug) << "EGL: ["sv << vendor << "]: version ["sv << version << ']';
-    BOOST_LOG(debug) << "API's supported: ["sv << apis << ']';
+    BOOST_LOG(debug) << "EGL: ["sv << (vendor ? vendor : "<unknown>") << "]: version ["sv << (version ? version : "<unknown>") << ']';
+    BOOST_LOG(debug) << "API's supported: ["sv << (apis ? apis : "<unknown>") << ']';
+
+    if (!extension_st) {
+      BOOST_LOG(error) << "Couldn't query EGL extensions: ["sv << util::hex(eglGetError()).to_string_view() << ']';
+      return nullptr;
+    }
 
     const char *extensions[] {
       "EGL_KHR_create_context",
@@ -451,9 +456,9 @@ namespace egl {
       EGL_NONE
     };
 
-    int count;
-    EGLConfig conf;
-    if (!eglChooseConfig(display, conf_attr, &conf, 1, &count)) {
+    int count = 0;
+    EGLConfig conf = nullptr;
+    if (!eglChooseConfig(display, conf_attr, &conf, 1, &count) || count == 0 || !conf) {
       BOOST_LOG(error) << "Couldn't set config attributes: ["sv << util::hex(eglGetError()).to_string_view() << ']';
       return std::nullopt;
     }
@@ -711,6 +716,10 @@ namespace egl {
 
     // Determine the size of each plane element
     auto fmt_desc = av_pix_fmt_desc_get(format);
+    if (!fmt_desc) {
+      BOOST_LOG(error) << "Unknown target pixel format: "sv << format;
+      return std::nullopt;
+    }
     if (fmt_desc->comp[0].depth <= 8) {
       y_format = GL_R8;
       uv_format = GL_RG8;
@@ -918,6 +927,10 @@ namespace egl {
 
     // Decide the bit depth format of the backing texture based the target frame format
     auto fmt_desc = av_pix_fmt_desc_get(format);
+    if (!fmt_desc) {
+      BOOST_LOG(error) << "Unknown pixel format for EGL frame: "sv << (int) format;
+      return std::nullopt;
+    }
     switch (fmt_desc->comp[0].depth) {
       case 8:
         gl_format = GL_RGBA8;

--- a/src/platform/linux/vaapi.cpp
+++ b/src/platform/linux/vaapi.cpp
@@ -349,7 +349,7 @@ namespace va {
         }
       }
 
-      va::DRMPRIMESurfaceDescriptor prime;
+      va::DRMPRIMESurfaceDescriptor prime {};
       va::VASurfaceID surface = (std::uintptr_t) frame->data[3];
       auto hw_frames_ctx = (AVHWFramesContext *) hw_frames_ctx_buf->data;
 
@@ -366,21 +366,51 @@ namespace va {
         return -1;
       }
 
-      // Keep track of file descriptors
+      // Adopt every descriptor the fixed-size export structure can hold before
+      // validating the driver-provided counts. This keeps malformed exports
+      // from leaking the descriptors they did return.
       std::array<file_t, egl::nv12_img_t::num_fds> fds;
-      for (int x = 0; x < prime.num_objects; ++x) {
+      constexpr std::size_t max_objects = std::size(prime.objects);
+      const auto adopted_objects = std::min<std::size_t>(prime.num_objects, max_objects);
+      for (std::size_t x = 0; x < adopted_objects; ++x) {
         fds[x] = prime.objects[x].fd;
       }
 
-      if (prime.num_layers != 2) {
-        BOOST_LOG(error) << "Invalid layer count for VA surface: expected 2, got "sv << prime.num_layers;
+      if (prime.num_objects == 0 || prime.num_objects > max_objects) {
+        BOOST_LOG(error) << "Invalid object count for VA surface: expected 1-"sv << max_objects << ", got "sv << prime.num_objects;
+        return -1;
+      }
+      for (std::size_t x = 0; x < prime.num_objects; ++x) {
+        if (prime.objects[x].fd < 0) {
+          BOOST_LOG(error) << "Invalid object fd for VA surface at index "sv << x;
+          return -1;
+        }
+      }
+
+      constexpr std::size_t expected_layers = 2;
+      if (prime.num_layers != expected_layers || prime.width == 0 || prime.height == 0) {
+        BOOST_LOG(error) << "Invalid VA surface geometry: layers="sv << prime.num_layers
+                         << " width="sv << prime.width << " height="sv << prime.height;
         return -1;
       }
 
-      egl::surface_descriptor_t sds[2] = {};
-      for (int plane = 0; plane < 2; ++plane) {
+      egl::surface_descriptor_t sds[expected_layers] = {};
+      for (std::size_t plane = 0; plane < expected_layers; ++plane) {
         auto &sd = sds[plane];
         auto &layer = prime.layers[plane];
+
+        const std::size_t max_planes = std::size(layer.object_index);
+        if (layer.num_planes == 0 || layer.num_planes > max_planes) {
+          BOOST_LOG(error) << "Invalid plane count for VA surface layer "sv << plane << ": "sv << layer.num_planes;
+          return -1;
+        }
+        for (std::size_t x = 0; x < layer.num_planes; ++x) {
+          if (layer.object_index[x] >= prime.num_objects) {
+            BOOST_LOG(error) << "Invalid object index for VA surface layer "sv << plane
+                             << " plane "sv << x << ": "sv << layer.object_index[x];
+            return -1;
+          }
+        }
 
         sd.fourcc = layer.drm_format;
 
@@ -392,7 +422,7 @@ namespace va {
         sd.modifier = prime.objects[layer.object_index[0]].drm_format_modifier;
 
         std::fill_n(sd.fds, 4, -1);
-        for (int x = 0; x < layer.num_planes; ++x) {
+        for (std::size_t x = 0; x < layer.num_planes; ++x) {
           sd.fds[x] = prime.objects[layer.object_index[x]].fd;
           sd.pitches[x] = layer.pitch[x];
           sd.offsets[x] = layer.offset[x];
@@ -604,7 +634,7 @@ namespace va {
     va->va_display = display.get();
 
     vaSetErrorCallback(display.get(), __log, &error);
-    vaSetErrorCallback(display.get(), __log, &info);
+    vaSetInfoCallback(display.get(), __log, &info);
 
     int major, minor;
     auto status = vaInitialize(display.get(), &major, &minor);
@@ -617,7 +647,7 @@ namespace va {
     // crash report that names the driver generation is worth more than one that
     // makes the reader guess from a GPU model.
     const auto *vendor = vaQueryVendorString(display.get());
-    BOOST_LOG(info) << "vaapi vendor: "sv << vendor;
+    BOOST_LOG(info) << "vaapi vendor: "sv << (vendor ? vendor : "<unknown>");
     stream_stats::update_vaapi_vendor(vendor ? vendor : "");
 
     *hw_device_buf = av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_VAAPI);
@@ -665,11 +695,11 @@ namespace va {
   bool validate(int fd) {
     va::display_t display {vaGetDisplayDRM(fd)};
     if (!display) {
-      char string[1024];
-
-      auto bytes = readlink(std::format("/proc/self/fd/{}", fd).c_str(), string, sizeof(string));
-
-      std::string_view render_device {string, (std::size_t) bytes};
+      std::array<char, 1024> path {};
+      const auto bytes = readlink(std::format("/proc/self/fd/{}", fd).c_str(), path.data(), path.size() - 1);
+      const std::string_view render_device = bytes > 0 ?
+                                               std::string_view {path.data(), static_cast<std::size_t>(bytes)} :
+                                               "<unavailable>"sv;
 
       BOOST_LOG(error) << "Couldn't open a va display from DRM with device: "sv << render_device;
       return false;

--- a/src/platform/linux/x11grab.cpp
+++ b/src/platform/linux/x11grab.cpp
@@ -25,7 +25,6 @@
 #include "src/globals.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
-#include "src/task_pool.h"
 #include "src/video.h"
 #include "vaapi.h"
 #include "x11grab.h"
@@ -148,6 +147,13 @@ namespace platf {
       };
 
       if (dyn::load(handle, funcs)) {
+        return -1;
+      }
+
+      // XInitThreads must be the first Xlib call in the process. Loading the
+      // symbols is harmless; opening a display before this point is not.
+      if (!InitThreads()) {
+        BOOST_LOG(error) << "Couldn't initialize Xlib thread support"sv;
         return -1;
       }
 
@@ -382,7 +388,6 @@ namespace platf {
         xwindow {},
         xattr {},
         mem_type {mem_type} {
-      x11::InitThreads();
     }
 
     int init(const std::string &display_name, const ::video::config_t &config) {
@@ -391,11 +396,17 @@ namespace platf {
         return -1;
       }
 
+      if (config.framerate <= 0) {
+        BOOST_LOG(error) << "Invalid X11 capture framerate: "sv << config.framerate;
+        return -1;
+      }
       delay = std::chrono::nanoseconds {1s} / config.framerate;
 
       xwindow = DefaultRootWindow(xdisplay.get());
 
-      refresh();
+      if (!refresh()) {
+        return 1;
+      }
 
       int streamedMonitor = -1;
       if (!display_name.empty()) {
@@ -405,6 +416,10 @@ namespace platf {
       if (streamedMonitor != -1) {
         BOOST_LOG(info) << "Configuring selected display ("sv << streamedMonitor << ") to stream"sv;
         screen_res_t screenr {x11::rr::GetScreenResources(xdisplay.get(), xwindow)};
+        if (!screenr) {
+          BOOST_LOG(error) << "Could not query XRandR screen resources"sv;
+          return -1;
+        }
         int output = screenr->noutput;
 
         output_info_t result;
@@ -426,6 +441,10 @@ namespace platf {
 
         if (result->crtc) {
           crtc_info_t crt_info {x11::rr::GetCrtcInfo(xdisplay.get(), screenr.get(), result->crtc)};
+          if (!crt_info) {
+            BOOST_LOG(error) << "Could not query XRandR CRTC for display ["sv << result->name << ']';
+            return -1;
+          }
           BOOST_LOG(info)
             << "Streaming display: "sv << result->name << " with res "sv << crt_info->width << 'x' << crt_info->height << " offset by "sv << crt_info->x << 'x' << crt_info->y;
 
@@ -452,8 +471,12 @@ namespace platf {
     /**
      * Called when the display attributes should change.
      */
-    void refresh() {
-      x11::GetWindowAttributes(xdisplay.get(), xwindow, &xattr);  // Update xattr's
+    bool refresh() {
+      if (!x11::GetWindowAttributes(xdisplay.get(), xwindow, &xattr)) {
+        BOOST_LOG(error) << "Could not refresh X11 root-window attributes"sv;
+        return false;
+      }
+      return true;
     }
 
     capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
@@ -502,7 +525,9 @@ namespace platf {
     }
 
     capture_e snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool cursor) {
-      refresh();
+      if (!refresh()) {
+        return capture_e::reinit;
+      }
 
       // The whole X server changed, so we must reinit everything
       if (xattr.width != env_width || xattr.height != env_height) {
@@ -516,6 +541,10 @@ namespace platf {
       auto img = (x11_img_t *) img_out.get();
 
       XImage *x_img {x11::GetImage(xdisplay.get(), xwindow, offset_x, offset_y, width, height, AllPlanes, ZPixmap)};
+      if (!x_img) {
+        BOOST_LOG(error) << "Could not capture X11 image"sv;
+        return capture_e::reinit;
+      }
       img->frame_timestamp = std::chrono::steady_clock::now();
 
       img->width = x_img->width;
@@ -574,29 +603,18 @@ namespace platf {
   struct shm_attr_t: public x11_attr_t {
     x11::xdisplay_t shm_xdisplay;  // Prevent race condition with x11_attr_t::xdisplay
     xcb_connect_t xcb;
-    xcb_screen_t *display;
-    std::uint32_t seg;
+    xcb_screen_t *display {nullptr};
+    std::uint32_t seg {0};
 
     shm_id_t shm_id;
 
     shm_data_t data;
 
-    task_pool_util::TaskPool::task_id_t refresh_task_id;
-
-    void delayed_refresh() {
-      refresh();
-
-      refresh_task_id = task_pool.pushDelayed(&shm_attr_t::delayed_refresh, 2s, this).task_id;
-    }
+    std::size_t shm_frame_size {0};
+    std::chrono::steady_clock::time_point next_refresh {};
 
     shm_attr_t(mem_type_e mem_type):
-        x11_attr_t(mem_type),
-        shm_xdisplay {x11::OpenDisplay(nullptr)} {
-      refresh_task_id = task_pool.pushDelayed(&shm_attr_t::delayed_refresh, 2s, this).task_id;
-    }
-
-    ~shm_attr_t() override {
-      while (!task_pool.cancel(refresh_task_id));
+        x11_attr_t(mem_type) {
     }
 
     capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
@@ -645,6 +663,14 @@ namespace platf {
     }
 
     capture_e snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool cursor) {
+      const auto now = std::chrono::steady_clock::now();
+      if (now >= next_refresh) {
+        next_refresh = now + 2s;
+        if (!refresh()) {
+          return capture_e::reinit;
+        }
+      }
+
       // The whole X server changed, so we must reinit everything
       if (xattr.width != env_width || xattr.height != env_height) {
         BOOST_LOG(warning) << "X dimensions changed in SHM mode, request reinit"sv;
@@ -663,7 +689,7 @@ namespace platf {
           return platf::capture_e::interrupted;
         }
 
-        std::copy_n((std::uint8_t *) data.data, frame_size(), img_out->data);
+        std::copy_n((std::uint8_t *) data.data, shm_frame_size, img_out->data);
         img_out->frame_timestamp = frame_timestamp;
 
         if (cursor) {
@@ -680,7 +706,7 @@ namespace platf {
       img->height = height;
       img->pixel_pitch = 4;
       img->row_pitch = img->pixel_pitch * width;
-      img->data = new std::uint8_t[height * img->row_pitch];
+      img->data = new std::uint8_t[shm_frame_size];
 
       return img;
     }
@@ -696,21 +722,39 @@ namespace platf {
 
       shm_xdisplay.reset(x11::OpenDisplay(nullptr));
       xcb.reset(xcb::connect(nullptr, nullptr));
-      if (xcb::connection_has_error(xcb.get())) {
+      if (!shm_xdisplay || !xcb || xcb::connection_has_error(xcb.get())) {
+        BOOST_LOG(error) << "Could not open X11 SHM capture connections"sv;
         return -1;
       }
 
-      if (!xcb::get_extension_data(xcb.get(), xcb::shm_id)->present) {
+      const auto *extension = xcb::get_extension_data(xcb.get(), xcb::shm_id);
+      if (!extension || !extension->present) {
         BOOST_LOG(error) << "Missing SHM extension"sv;
 
         return -1;
       }
 
-      auto iter = xcb::setup_roots_iterator(xcb::get_setup(xcb.get()));
+      const auto *setup = xcb::get_setup(xcb.get());
+      if (!setup) {
+        BOOST_LOG(error) << "Could not query XCB setup"sv;
+        return -1;
+      }
+      auto iter = xcb::setup_roots_iterator(setup);
       display = iter.data;
+      if (!display) {
+        BOOST_LOG(error) << "Could not query XCB root screen"sv;
+        return -1;
+      }
       seg = xcb::generate_id(xcb.get());
 
-      shm_id.id = shmget(IPC_PRIVATE, frame_size(), IPC_CREAT | 0600);
+      const auto frame_size = x11::checked_shm_frame_size(width, height);
+      if (!frame_size) {
+        BOOST_LOG(error) << "Invalid X11 SHM frame dimensions: "sv << width << 'x' << height;
+        return -1;
+      }
+      shm_frame_size = *frame_size;
+
+      shm_id.id = shmget(IPC_PRIVATE, shm_frame_size, IPC_CREAT | 0600);
       if (shm_id.id == -1) {
         BOOST_LOG(error) << "shmget failed"sv;
         return -1;
@@ -725,11 +769,8 @@ namespace platf {
         return -1;
       }
 
+      next_refresh = std::chrono::steady_clock::now() + 2s;
       return 0;
-    }
-
-    std::uint32_t frame_size() {
-      return width * height * 4;
     }
   };
 
@@ -783,6 +824,10 @@ namespace platf {
 
     auto xwindow = DefaultRootWindow(xdisplay.get());
     screen_res_t screenr {x11::rr::GetScreenResources(xdisplay.get(), xwindow)};
+    if (!screenr) {
+      BOOST_LOG(error) << "Could not query XRandR screen resources"sv;
+      return {};
+    }
     int output = screenr->noutput;
 
     int monitor = 0;
@@ -837,6 +882,9 @@ namespace platf {
       cursor_t cursor;
 
       cursor.ctx.reset((cursor_ctx_t::pointer) x11::OpenDisplay(nullptr));
+      if (!cursor.ctx) {
+        return std::nullopt;
+      }
 
       return cursor;
     }
@@ -845,15 +893,30 @@ namespace platf {
       auto display = (xdisplay_t::pointer) ctx.get();
 
       xcursor_t xcursor = fix::GetCursorImage(display);
+      if (!xcursor) {
+        BOOST_LOG(error) << "Couldn't get cursor from XFixesGetCursorImage"sv;
+        return;
+      }
 
       if (img.serial != xcursor->cursor_serial) {
-        auto buf_size = xcursor->width * xcursor->height * sizeof(int);
+        const auto cursor_width = static_cast<std::size_t>(xcursor->width);
+        const auto cursor_height = static_cast<std::size_t>(xcursor->height);
+        if (cursor_width != 0 && cursor_height > std::numeric_limits<std::size_t>::max() / cursor_width) {
+          BOOST_LOG(error) << "XFixes cursor dimensions overflow addressable memory"sv;
+          return;
+        }
+        const auto pixel_count = cursor_width * cursor_height;
+        if (pixel_count > std::numeric_limits<std::size_t>::max() / sizeof(int)) {
+          BOOST_LOG(error) << "XFixes cursor buffer size overflows addressable memory"sv;
+          return;
+        }
+        const auto buf_size = pixel_count * sizeof(int);
 
         if (img.buffer.size() < buf_size) {
           img.buffer.resize(buf_size);
         }
 
-        std::transform(xcursor->pixels, xcursor->pixels + buf_size / 4, (int *) img.buffer.data(), [](long pixel) -> int {
+        std::transform(xcursor->pixels, xcursor->pixels + pixel_count, (int *) img.buffer.data(), [](long pixel) -> int {
           return pixel;
         });
       }

--- a/src/platform/linux/x11grab.h
+++ b/src/platform/linux/x11grab.h
@@ -5,6 +5,9 @@
 #pragma once
 
 // standard includes
+#include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <optional>
 
 // local includes
@@ -19,6 +22,29 @@ namespace egl {
 }
 
 namespace platf::x11 {
+  /**
+   * @brief Size an XCB SHM BGRA frame without narrowing or overflowing.
+   *
+   * XCB's SHM image request carries 16-bit dimensions, and img_t stores the
+   * four-byte row pitch in an int. Reject dimensions that either interface
+   * cannot represent before allocating shared or process-local storage.
+   */
+  inline std::optional<std::size_t> checked_shm_frame_size(int width, int height) {
+    constexpr std::size_t bytes_per_pixel = 4;
+    if (width <= 0 || height <= 0 ||
+        width > std::numeric_limits<std::uint16_t>::max() ||
+        height > std::numeric_limits<std::uint16_t>::max()) {
+      return std::nullopt;
+    }
+
+    const auto unsigned_width = static_cast<std::size_t>(width);
+    const auto unsigned_height = static_cast<std::size_t>(height);
+    if (unsigned_width > std::numeric_limits<std::size_t>::max() / bytes_per_pixel / unsigned_height) {
+      return std::nullopt;
+    }
+    return unsigned_width * unsigned_height * bytes_per_pixel;
+  }
+
   struct cursor_ctx_raw_t;
   void freeCursorCtx(cursor_ctx_raw_t *ctx);
   void freeDisplay(_XDisplay *xdisplay);

--- a/tests/unit/platform/test_graphics.cpp
+++ b/tests/unit/platform/test_graphics.cpp
@@ -8,6 +8,7 @@
   #include <glad/gl.h>
   #include <src/platform/linux/graphics.h>
   #include <src/platform/linux/vaapi.h>
+  #include <src/platform/linux/x11grab.h>
 
   #include <filesystem>
   #include <fstream>
@@ -55,6 +56,17 @@ TEST(GraphicsTests, DrainErrorsReportsWhetherAnyErrorWasDrained) {
   EXPECT_TRUE(gl::drain_errors("test"));
 
   gl::ctx.GetError = original_get_error;
+}
+
+TEST(X11GrabTests, SharedMemoryFrameSizeRejectsUnrepresentableDimensions) {
+  const auto full_hd = platf::x11::checked_shm_frame_size(1920, 1080);
+  ASSERT_TRUE(full_hd.has_value());
+  EXPECT_EQ(*full_hd, 1920u * 1080u * 4u);
+
+  EXPECT_FALSE(platf::x11::checked_shm_frame_size(0, 1080).has_value());
+  EXPECT_FALSE(platf::x11::checked_shm_frame_size(1920, -1).has_value());
+  EXPECT_FALSE(platf::x11::checked_shm_frame_size(65536, 1080).has_value());
+  EXPECT_FALSE(platf::x11::checked_shm_frame_size(1920, 65536).has_value());
 }
 
 TEST(VaapiSourceContractTests, ConverterRetainsSurfacesAndPropagatesConversionFailure) {

--- a/tests/unit/test_linux_platform_hardening_source.cpp
+++ b/tests/unit/test_linux_platform_hardening_source.cpp
@@ -65,3 +65,34 @@ TEST(LinuxPlatformHardeningSource, KscreenConfigurationNeverPassesThroughShell) 
   ASSERT_NE(kscreen, std::string::npos);
   EXPECT_NE(virtual_display.find("platf::run_process_argv(args)", kscreen), std::string::npos);
 }
+
+TEST(LinuxPlatformHardeningSource, VaapiValidatesExportedDescriptorBeforeIndexing) {
+  const auto source = read_source("src/platform/linux/vaapi.cpp");
+  EXPECT_NE(source.find("DRMPRIMESurfaceDescriptor prime {}"), std::string::npos);
+  EXPECT_NE(source.find("prime.num_objects > max_objects"), std::string::npos);
+  EXPECT_NE(source.find("layer.num_planes > max_planes"), std::string::npos);
+  EXPECT_NE(source.find("layer.object_index[x] >= prime.num_objects"), std::string::npos);
+  EXPECT_NE(source.find("vaSetInfoCallback"), std::string::npos);
+  EXPECT_NE(source.find("bytes > 0"), std::string::npos);
+}
+
+TEST(LinuxPlatformHardeningSource, X11ShmRefreshStaysOnCaptureThread) {
+  const auto source = read_source("src/platform/linux/x11grab.cpp");
+  EXPECT_EQ(source.find("task_pool.pushDelayed"), std::string::npos);
+  EXPECT_EQ(source.find("task_pool.cancel"), std::string::npos);
+  EXPECT_NE(source.find("now >= next_refresh"), std::string::npos);
+  EXPECT_NE(source.find("if (!x_img)"), std::string::npos);
+}
+
+TEST(LinuxPlatformHardeningSource, EglRejectsMissingDriverMetadata) {
+  const auto source = read_source("src/platform/linux/graphics.cpp");
+  EXPECT_NE(source.find("if (!extension_st)"), std::string::npos);
+  EXPECT_NE(source.find("count == 0 || !conf"), std::string::npos);
+}
+
+TEST(LinuxPlatformHardeningSource, NvfbcOutputsStartInitialized) {
+  const auto source = read_source("src/platform/linux/cuda.cpp");
+  EXPECT_NE(source.find("NVFBC_SESSION_HANDLE handle {0}"), std::string::npos);
+  EXPECT_NE(source.find("CUdeviceptr device_ptr {}"), std::string::npos);
+  EXPECT_NE(source.find("NVFBC_FRAME_GRAB_INFO info {}"), std::string::npos);
+}


### PR DESCRIPTION
## Summary

- validate VAAPI DRM PRIME object/layer/plane counts and indices before indexing fixed-size arrays, while retaining returned file descriptors under RAII
- fix VAAPI info callback registration and make failed DRM-fd diagnostics safe
- remove the X11 SHM background raw-`this` refresh task; refresh synchronously on the capture thread and validate X11/XCB/XFixes results and frame sizing
- fail closed when EGL metadata/configuration or FFmpeg pixel-format descriptors are unavailable
- initialize NvFBC handles and frame-grab outputs, and stop using a context when binding fails
- update the Nova smoke runner for installed package discovery, alternate systemd units, and both portal and WLR video capture routes

## Root cause

Several legacy capture boundaries trusted driver- or display-server-provided pointers, counts, and dimensions before validating them. The X11 SHM path also scheduled a repeating task that retained a raw display pointer, allowing teardown to race a running refresh and potentially spin forever while cancelling it.

The smoke helper encoded older assumptions: a debug Nova package, a portal-only video route, and a required `mirrorDesktop=1` launch line. Current private headless sessions can correctly use WLR capture and report `Launched new game session` instead.

## Impact

Malformed or transient VAAPI/X11/EGL/NvFBC results now fail closed instead of risking out-of-bounds access, null dereferences, use-after-free, or indeterminate handles. X11 SHM teardown no longer depends on cancelling a self-rescheduling task. The smoke runner now measures the capture path actually selected.

This PR does not change the current VAAPI GPU-native capture policy.

## Validation

- production build: passed
- focused platform tests: 10/10 passed
- Linux hardening source contracts: 9/9 passed
- serial CTest suite: 17/17 passed
- CUDA/NvFBC translation unit with CUDA-enabled project headers: syntax check passed
- live Nova smoke against the locally built binary: passed
  - host reached `stream_active`
  - Nova received the first video packet
  - WLR SHM capture initialized
  - visible 1920x1080 frame observed
  - installed Polaris service restored after the run

## Related work

Draft PR #215 overlaps `src/platform/linux/vaapi.cpp` and `tests/unit/platform/test_graphics.cpp`, but addresses EGL surface lifetime and proposes a different VAAPI GPU-native policy. This PR is limited to defensive boundary validation and leaves #215's field-test/merge decision separate.

X11, VAAPI, and NvFBC were not live-exercised on matching runtime/hardware in this pass; their changed production targets compile, with regression contracts covering unavailable build variants.