### PR TITLE
fix: validate client launch key size and KMS render descriptor

### DIFF
--- a/src/browser_stream.cpp
+++ b/src/browser_stream.cpp
@@ -444,6 +444,10 @@ namespace browser_stream {
       args.emplace("displayModeExplicit", "1");
 
       auto launch_session = nvhttp::make_launch_session(true, false, args, &named_cert);
+      if (!launch_session) {
+        BOOST_LOG(error) << "Browser Stream could not build a launch session"sv;
+        return nullptr;
+      }
       launch_session->virtual_display = false;
       launch_session->user_locked_virtual_display = true;
       return launch_session;
@@ -582,6 +586,10 @@ namespace browser_stream {
       BOOST_LOG(info) << "Launching Browser Stream app session ["sv << app.name
                       << "] runtime=" << private_runtime_backend();
       auto launch_session = browser_launch_session();
+      if (!launch_session) {
+        error_out = "Browser Stream could not build a launch session";
+        return false;
+      }
       const auto err = proc::proc.execute(app, launch_session);
       if (err) {
         error_out = err == 503 ?

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -4806,6 +4806,10 @@ namespace confighttp {
           }
 #endif
           auto launch_session = nvhttp::make_launch_session(true, false, launch_args, &named_cert);
+          if (!launch_session) {
+            bad_request(response, request, "Failed to build a launch session");
+            return;
+          }
           auto err = proc::proc.execute(app, launch_session);
           if (err) {
             nlohmann::json error_tree;

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -177,6 +177,15 @@ namespace crypto {
   namespace cipher {
     constexpr std::size_t tag_size = 16;
 
+    /**
+     * @brief Bytes every AES cipher here reads from the key buffer.
+     *
+     * The contexts use EVP_aes_128_gcm/cbc/ecb, so OpenSSL reads exactly
+     * this many bytes from key.data() regardless of the aes_t vector's size.
+     * Off-host key material must be validated against this size first.
+     */
+    constexpr std::size_t key_size = 16;
+
     constexpr std::size_t round_to_pkcs7_padded(std::size_t size) {
       return ((size + 15) / 16) * 16;
     }

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -4435,8 +4435,17 @@ namespace nvhttp {
 
     // If launched from client
     if (named_cert_p->uuid != http::unique_id) {
-      auto rikey = util::from_hex_vec(get_arg(args, "rikey"), true);
-      std::copy(rikey.cbegin(), rikey.cend(), std::back_inserter(launch_session->gcm_key));
+      // OpenSSL's AES-128 contexts read a full key from key.data() regardless
+      // of the vector's size, so reject malformed client key material before
+      // it can become a session cipher.
+      const auto rikey = util::from_hex_vec(get_arg(args, "rikey"), true);
+      if (rikey.size() != crypto::cipher::key_size) {
+        BOOST_LOG(warning) << "Rejecting launch from ["sv << named_cert_p->name
+                           << "]: rikey decoded to "sv << rikey.size()
+                           << " bytes, expected "sv << crypto::cipher::key_size;
+        return nullptr;
+      }
+      launch_session->gcm_key.assign(rikey.cbegin(), rikey.cend());
 
       launch_session->host_audio = host_audio;
 
@@ -5611,6 +5620,12 @@ namespace nvhttp {
 
     host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     auto launch_session = make_launch_session(host_audio, is_input_only, args, named_cert_p.get());
+    if (!launch_session) {
+      tree.put("root.resume", 0);
+      tree.put("root.<xmlattr>.status_code", 400);
+      tree.put("root.<xmlattr>.status_message", "A launch parameter is malformed");
+      return;
+    }
     const bool watch_only = launch_session->watch_only;
     bool launch_session_raised = false;
 
@@ -5910,6 +5925,12 @@ namespace nvhttp {
       host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     }
     auto launch_session = make_launch_session(host_audio, false, args, named_cert_p.get());
+    if (!launch_session) {
+      tree.put("root.resume", 0);
+      tree.put("root.<xmlattr>.status_code", 400);
+      tree.put("root.<xmlattr>.status_message", "A resume parameter is malformed");
+      return;
+    }
     const bool watch_only = launch_session->watch_only;
 
     if (watch_only && no_active_sessions) {

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -119,6 +119,14 @@ namespace nvhttp {
   cmd_list_t
   extract_command_entries(const nlohmann::json& j, const std::string& key);
 
+  /**
+   * @brief Build the session a launch or resume will run under.
+   * @return The session, or nullptr when client-supplied key material is malformed.
+   *
+   * Callers must check for nullptr before dereferencing or passing the session
+   * to proc::execute. Host-built arguments use the host identity and do not
+   * carry client key material.
+   */
   std::shared_ptr<rtsp_stream::launch_session_t>
   make_launch_session(bool host_audio, bool input_only, const args_t &args, const crypto::named_cert_t* named_cert_p);
 

--- a/src/platform/linux/kmsgrab.cpp
+++ b/src/platform/linux/kmsgrab.cpp
@@ -324,6 +324,14 @@ namespace platf {
           render_fd.el = dup(fd.el);
         }
 
+        // dup() fails once the process is out of descriptors. Reporting success
+        // with render_fd at -1 hands that -1 to every consumer of the render
+        // node, starting with va::validate().
+        if (render_fd.el < 0) {
+          BOOST_LOG(error) << "Couldn't obtain a render descriptor for: "sv << path << ": "sv << strerror(errno);
+          return -1;
+        }
+
         if (drmSetClientCap(fd.el, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1)) {
           BOOST_LOG(error) << "GPU driver doesn't support universal planes: "sv << path;
           return -1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,6 +193,7 @@ set(TEST_HTTP_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_httpcommon.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_mode_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_response_status.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_session_key.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_session_stop_contract.cpp
 )
 

--- a/tests/unit/test_launch_session_key.cpp
+++ b/tests/unit/test_launch_session_key.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file tests/unit/test_launch_session_key.cpp
+ * @brief Validate client key length before OpenSSL receives the key buffer.
+ */
+
+#include <src/crypto.h>
+#include <src/httpcommon.h>
+#include <src/nvhttp.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace {
+  std::unique_ptr<crypto::named_cert_t> client_cert(std::string uuid = "remote-client") {
+    auto cert = std::make_unique<crypto::named_cert_t>();
+    cert->name = "test-client";
+    cert->uuid = std::move(uuid);
+    cert->perm = crypto::PERM::_game_control;
+    cert->enable_legacy_ordering = false;
+    cert->allow_client_commands = false;
+    cert->always_use_virtual_display = false;
+    return cert;
+  }
+
+  nvhttp::args_t launch_args_for_key_bytes(std::size_t bytes) {
+    nvhttp::args_t args;
+    args.emplace("rikey", std::string(bytes * 2, '0'));
+    args.emplace("rikeyid", "1");
+    args.emplace("mode", "1920x1080x60");
+    return args;
+  }
+}
+
+TEST(LaunchSessionKey, AcceptsExactlyOneAes128Key) {
+  auto cert = client_cert();
+  const auto session = nvhttp::make_launch_session(
+    true,
+    false,
+    launch_args_for_key_bytes(crypto::cipher::key_size),
+    cert.get()
+  );
+
+  ASSERT_NE(session, nullptr);
+  EXPECT_EQ(session->gcm_key.size(), crypto::cipher::key_size);
+}
+
+TEST(LaunchSessionKey, RejectsShortClientKeys) {
+  for (const auto bytes : {std::size_t {0}, std::size_t {1}, std::size_t {8}, std::size_t {15}}) {
+    auto cert = client_cert();
+    EXPECT_EQ(nvhttp::make_launch_session(true, false, launch_args_for_key_bytes(bytes), cert.get()), nullptr)
+      << "accepted a " << bytes << "-byte key";
+  }
+}
+
+TEST(LaunchSessionKey, RejectsLongClientKeys) {
+  for (const auto bytes : {std::size_t {17}, std::size_t {32}}) {
+    auto cert = client_cert();
+    EXPECT_EQ(nvhttp::make_launch_session(true, false, launch_args_for_key_bytes(bytes), cert.get()), nullptr)
+      << "accepted a " << bytes << "-byte key";
+  }
+}
+
+TEST(LaunchSessionKey, HostBuiltSessionNeedsNoClientKey) {
+  auto cert = client_cert(http::unique_id);
+  nvhttp::args_t args;
+  args.emplace("mode", "1280x720x60");
+
+  const auto session = nvhttp::make_launch_session(true, false, args, cert.get());
+
+  ASSERT_NE(session, nullptr);
+  EXPECT_TRUE(session->gcm_key.empty());
+}

--- a/tests/unit/test_linux_platform_hardening_source.cpp
+++ b/tests/unit/test_linux_platform_hardening_source.cpp
@@ -55,6 +55,17 @@ TEST(LinuxPlatformHardeningSource, NetlinkReadsAlwaysStartAtBufferBase) {
   EXPECT_EQ(source.find("recv(fd, nlMsg"), std::string::npos);
 }
 
+TEST(LinuxPlatformHardeningSource, KmsCardRejectsAnUnusableRenderDescriptor) {
+  const auto source = read_source("src/platform/linux/kmsgrab.cpp");
+  const auto dup_fallback = source.find("render_fd.el = dup(fd.el);");
+  ASSERT_NE(dup_fallback, std::string::npos);
+
+  // init() must fail rather than publish render_fd == -1 to va::validate().
+  const auto guard = source.find("if (render_fd.el < 0) {", dup_fallback);
+  ASSERT_NE(guard, std::string::npos);
+  EXPECT_NE(source.find("return -1;", guard), std::string::npos);
+}
+
 TEST(LinuxPlatformHardeningSource, KscreenConfigurationNeverPassesThroughShell) {
   const auto topology = read_source("src/platform/linux/display_topology.cpp");
   EXPECT_EQ(topology.find("std::system"), std::string::npos);


### PR DESCRIPTION
Two independent hardening fixes found while auditing the network-facing and Linux platform code.

### `nvhttp`: reject a launch key that is not the size the cipher reads

`make_launch_session` copied the client's decoded `rikey` into `gcm_key` at whatever length arrived. Every cipher built from that key — RTSP, control, video, and the CBC audio cipher — is constructed with `EVP_aes_128_*`, so OpenSSL reads a full key from `key.data()` no matter how short the vector is.

A client sending `rikey=00` gets a one-byte allocation that OpenSSL reads sixteen bytes from, and the session key silently absorbs whatever followed it on the heap. Since the client supplies all but the trailing bytes and can tell whether the stream it receives decrypts, the over-read doubles as a way to read heap bytes back out.

The decoded length is now checked against `crypto::cipher::key_size` — which names what `EVP_aes_128_*` reads — and a mismatch fails the launch with 400. Host-built sessions carry no client key and are unaffected. The `nullptr` return is documented and checked at all four call sites.

### `kmsgrab`: fail card init when no render descriptor is available

`card_t::init()` falls back to `dup()` for the render node, never checks the result, and returns success either way. Out of descriptors, `dup()` returns -1 and `init()` publishes `render_fd == -1` to every consumer of the render node — `va::validate()` first, where the bad descriptor also drives the diagnostic `readlink` to fail.

### Testing

- New `tests/unit/test_launch_session_key.cpp` calls `make_launch_session` directly: accepts a 16-byte key, rejects 0/1/8/15 and 17/32, and confirms host-built sessions still build with no key.
- New source contract in `test_linux_platform_hardening_source.cpp` for the KMS guard.
- Full `ctest -j1`: 17/17 passing.
