### PR TITLE
fix(linux): preserve high-refresh stream cadence

### DIFF
--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -1354,6 +1354,8 @@ namespace wl {
     device_id = {};
     chosen_format = {};
     dmabuf_formats.clear();
+    timing_tracker.reset();
+    invalid_presentation_timestamp_logged = false;
   }
 
   void extcopy_t::destroy_session() {
@@ -1743,6 +1745,7 @@ namespace wl {
     ext_image_copy_capture_frame_v1_add_listener(capture_frame_object, &frame_listener, this);
     ext_image_copy_capture_frame_v1_attach_buffer(capture_frame_object, next_frame->buffer);
     ext_image_copy_capture_frame_v1_damage_buffer(capture_frame_object, 0, 0, frame_width, frame_height);
+    timing_tracker.mark_requested(std::chrono::steady_clock::now());
     ext_image_copy_capture_frame_v1_capture(capture_frame_object);
     status = WAITING;
     wait_for_status(display, 1000ms);
@@ -1849,9 +1852,15 @@ namespace wl {
     std::uint32_t tv_sec_lo,
     std::uint32_t tv_nsec
   ) {
+    if (!timing_tracker.mark_presentation(tv_sec_hi, tv_sec_lo, tv_nsec) &&
+        !invalid_presentation_timestamp_logged) {
+      BOOST_LOG(warning) << "Extcopy frame supplied an invalid presentation timestamp"sv;
+      invalid_presentation_timestamp_logged = true;
+    }
   }
 
   void extcopy_t::frame_ready(ext_image_copy_capture_frame_v1 *frame) {
+    timing_tracker.mark_ready(std::chrono::steady_clock::now());
     current_frame->reset_capture_descriptor();
     current_frame = get_next_frame();
     destroy_capture_frame();

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -26,6 +26,7 @@ struct gbm_device;
 
 // local includes
 #include "graphics.h"
+#include "wlgrab_timing.h"
 
 namespace wl {
   class output_registry_state_t {
@@ -258,6 +259,10 @@ namespace wl {
       return render_node;
     }
 
+    const extcopy_timing_sample_t &last_timing_sample() const {
+      return timing_tracker.last_sample();
+    }
+
     status_e status;
     std::array<frame_t, 2> frames;
     frame_t *current_frame;
@@ -313,12 +318,14 @@ namespace wl {
     bool buffer_create_done {false};
     bool buffer_create_success {false};
     bool probe_failed_unknown_ {false};  ///< frame_failed(reason=0) fired during init probe
+    bool invalid_presentation_timestamp_logged {false};
     std::uint32_t frame_width {0};
     std::uint32_t frame_height {0};
     dev_t device_id {};
     format_constraints_t chosen_format;
     std::vector<format_constraints_t> dmabuf_formats;
     std::uint64_t next_buffer_key {1};
+    extcopy_timing_tracker_t timing_tracker;
   };
 
   class monitor_t {

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -17,6 +17,7 @@
 #include "wayland.h"
 #include "wlgrab_capture_policy.h"
 #include "wlgrab_frame_source.h"
+#include "wlgrab_pacing.h"
 #include "wlgrab_pixel_copy.h"
 
 using namespace std::literals;
@@ -199,6 +200,7 @@ namespace wl {
 
     /**
      * @brief Shared capture pacing loop for RAM / VRAM / extcopy backends.
+     * @param pacing_policy Chooses timer pacing or compositor-driven pacing.
      * @param snapshot_fn Called each tick: (pull_cb, img_out, cursor) → capture_e
      */
     template <class SnapshotFn>
@@ -206,24 +208,24 @@ namespace wl {
       const push_captured_image_cb_t &push_captured_image_cb,
       const pull_free_image_cb_t &pull_free_image_cb,
       bool *cursor,
+      capture_pacing_policy_e pacing_policy,
       SnapshotFn &&snapshot_fn
     ) {
-      auto next_frame = std::chrono::steady_clock::now();
+      capture_pacer_t pacer {pacing_policy, delay, std::chrono::steady_clock::now()};
       sleep_overshoot_logger.reset();
 
       while (true) {
         auto now = std::chrono::steady_clock::now();
+        auto wait_duration = pacer.wait_duration(now);
 
-        if (next_frame > now) {
-          std::this_thread::sleep_for(next_frame - now);
-          sleep_overshoot_logger.first_point(next_frame);
+        if (wait_duration > std::chrono::steady_clock::duration::zero()) {
+          auto wake_time = now + wait_duration;
+          std::this_thread::sleep_for(wait_duration);
+          sleep_overshoot_logger.first_point(wake_time);
           sleep_overshoot_logger.second_point_now_and_log();
         }
 
-        next_frame += delay;
-        if (next_frame < now) {  // some major slowdown happened; we couldn't keep up
-          next_frame = now + delay;
-        }
+        pacer.advance(now);
 
         std::shared_ptr<platf::img_t> img_out;
         auto status = snapshot_fn(pull_free_image_cb, img_out, cursor);
@@ -270,6 +272,7 @@ namespace wl {
   public:
     platf::capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
       return capture_loop(push_captured_image_cb, pull_free_image_cb, cursor,
+        capture_pacing_policy_e::fixed_interval,
         [this](const pull_free_image_cb_t &pull, std::shared_ptr<platf::img_t> &img, bool *c) {
           return snapshot(pull, img, 1000ms, c && *c);
         });
@@ -450,6 +453,7 @@ namespace wl {
   public:
     platf::capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
       return capture_loop(push_captured_image_cb, pull_free_image_cb, cursor,
+        capture_pacing_policy_e::fixed_interval,
         [this](const pull_free_image_cb_t &pull, std::shared_ptr<platf::img_t> &img, bool *c) {
           return snapshot(pull, img, 1000ms, c && *c);
         });
@@ -546,7 +550,9 @@ namespace wl {
   class wlr_extcopy_vram_t: public wlr_t {
   public:
     platf::capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
+      BOOST_LOG(info) << "wlr: ext-image-copy capture pacing=source_driven"sv;
       return capture_loop(push_captured_image_cb, pull_free_image_cb, cursor,
+        capture_pacing_policy_e::source_driven,
         [this](const pull_free_image_cb_t &pull, std::shared_ptr<platf::img_t> &img, bool *c) {
           return snapshot(pull, img, c);
         });
@@ -611,14 +617,23 @@ namespace wl {
       stream_stats::update_capture_metadata(img->frame_metadata);
       log_capture_metadata(img->frame_metadata);
       if (capture_profile_enabled()) {
-        auto total_time = std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - capture_start
+        const auto handoff_end = std::chrono::steady_clock::now();
+        const auto &timing = extcopy.last_timing_sample();
+        const auto snapshot_time = std::chrono::duration_cast<std::chrono::microseconds>(
+          handoff_end - capture_start
         );
+        const auto dispatch_time = timing.request_to_ready.value_or(snapshot_time);
+        const auto ready_to_handoff = timing.ready_at ?
+          std::optional {std::chrono::duration_cast<std::chrono::microseconds>(handoff_end - *timing.ready_at)} :
+          std::nullopt;
+        const auto handoff_time = ready_to_handoff.value_or(0us);
         stream_stats::update_capture_profile({
           .transport = img->frame_metadata.transport,
-          .dispatch_time = total_time,
-          .ingest_time = 0us,
-          .total_time = total_time,
+          .dispatch_time = dispatch_time,
+          .ingest_time = handoff_time,
+          .total_time = dispatch_time + handoff_time,
+          .source_interval = timing.presentation_interval,
+          .ready_to_handoff = ready_to_handoff,
         });
       }
 

--- a/src/platform/linux/wlgrab_pacing.h
+++ b/src/platform/linux/wlgrab_pacing.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <chrono>
+
+namespace wl {
+  enum class capture_pacing_policy_e {
+    fixed_interval,
+    source_driven,
+  };
+
+  class capture_pacer_t {
+  public:
+    using clock_t = std::chrono::steady_clock;
+    using duration_t = clock_t::duration;
+    using time_point_t = clock_t::time_point;
+
+    capture_pacer_t(
+      capture_pacing_policy_e policy,
+      duration_t interval,
+      time_point_t start
+    ):
+        policy_ {policy},
+        interval_ {interval},
+        next_frame_ {start} {
+    }
+
+    duration_t wait_duration(time_point_t now) const {
+      if (policy_ == capture_pacing_policy_e::source_driven || next_frame_ <= now) {
+        return duration_t::zero();
+      }
+
+      return next_frame_ - now;
+    }
+
+    void advance(time_point_t now) {
+      if (policy_ == capture_pacing_policy_e::source_driven) {
+        return;
+      }
+
+      next_frame_ += interval_;
+      if (next_frame_ < now) {
+        next_frame_ = now + interval_;
+      }
+    }
+
+  private:
+    capture_pacing_policy_e policy_;
+    duration_t interval_;
+    time_point_t next_frame_;
+  };
+}  // namespace wl

--- a/src/platform/linux/wlgrab_timing.h
+++ b/src/platform/linux/wlgrab_timing.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+
+namespace wl {
+  struct extcopy_timing_sample_t {
+    std::optional<std::chrono::microseconds> request_to_ready;
+    std::optional<std::chrono::microseconds> presentation_interval;
+    std::optional<std::chrono::steady_clock::time_point> ready_at;
+  };
+
+  class extcopy_timing_tracker_t {
+  public:
+    using time_point_t = std::chrono::steady_clock::time_point;
+
+    void reset() {
+      request_started_at.reset();
+      current_presentation_ns.reset();
+      previous_presentation_ns.reset();
+      sample = {};
+    }
+
+    void mark_requested(time_point_t now) {
+      request_started_at = now;
+      current_presentation_ns.reset();
+    }
+
+    bool mark_presentation(std::uint32_t tv_sec_hi, std::uint32_t tv_sec_lo, std::uint32_t tv_nsec) {
+      if (tv_nsec >= 1'000'000'000U) {
+        current_presentation_ns.reset();
+        return false;
+      }
+
+      const std::uint64_t seconds =
+        (static_cast<std::uint64_t>(tv_sec_hi) << 32U) |
+        static_cast<std::uint64_t>(tv_sec_lo);
+      if (seconds > (UINT64_MAX - tv_nsec) / 1'000'000'000ULL) {
+        current_presentation_ns.reset();
+        return false;
+      }
+
+      current_presentation_ns = seconds * 1'000'000'000ULL + tv_nsec;
+      return true;
+    }
+
+    void mark_ready(time_point_t now) {
+      sample = {};
+      sample.ready_at = now;
+      if (request_started_at && now >= *request_started_at) {
+        sample.request_to_ready = std::chrono::duration_cast<std::chrono::microseconds>(
+          now - *request_started_at
+        );
+      }
+
+      if (current_presentation_ns) {
+        if (previous_presentation_ns && *current_presentation_ns >= *previous_presentation_ns) {
+          sample.presentation_interval = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::nanoseconds {*current_presentation_ns - *previous_presentation_ns}
+          );
+        }
+        previous_presentation_ns = current_presentation_ns;
+      }
+
+      request_started_at.reset();
+      current_presentation_ns.reset();
+    }
+
+    const extcopy_timing_sample_t &last_sample() const {
+      return sample;
+    }
+
+  private:
+    std::optional<time_point_t> request_started_at;
+    std::optional<std::uint64_t> current_presentation_ns;
+    std::optional<std::uint64_t> previous_presentation_ns;
+    extcopy_timing_sample_t sample;
+  };
+}  // namespace wl

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -152,6 +152,8 @@ namespace stream_stats {
       std::vector<long long> dispatch_us;
       std::vector<long long> ingest_us;
       std::vector<long long> total_us;
+      std::vector<long long> source_interval_us;
+      std::vector<long long> ready_to_handoff_us;
     };
 
     std::array<capture_profile_bucket_t, CAPTURE_PROFILE_BUCKET_COUNT> capture_profile_buckets;
@@ -169,6 +171,8 @@ namespace stream_stats {
         bucket.dispatch_us.clear();
         bucket.ingest_us.clear();
         bucket.total_us.clear();
+        bucket.source_interval_us.clear();
+        bucket.ready_to_handoff_us.clear();
       }
     }
 
@@ -1393,6 +1397,12 @@ namespace stream_stats {
     bucket.dispatch_us.push_back(sample.dispatch_time.count());
     bucket.ingest_us.push_back(sample.ingest_time.count());
     bucket.total_us.push_back(sample.total_time.count());
+    if (sample.source_interval) {
+      bucket.source_interval_us.push_back(sample.source_interval->count());
+    }
+    if (sample.ready_to_handoff) {
+      bucket.ready_to_handoff_us.push_back(sample.ready_to_handoff->count());
+    }
 
     if (bucket.total_us.size() < CAPTURE_PROFILE_SUMMARY_FRAMES) {
       return;
@@ -1405,11 +1415,23 @@ namespace stream_stats {
                     << " ingest_us_p50="sv << percentile_value(bucket.ingest_us, 0.50)
                     << " ingest_us_p99="sv << percentile_value(bucket.ingest_us, 0.99)
                     << " total_us_p50="sv << percentile_value(bucket.total_us, 0.50)
-                    << " total_us_p99="sv << percentile_value(bucket.total_us, 0.99);
+                    << " total_us_p99="sv << percentile_value(bucket.total_us, 0.99)
+                    << " source_interval_samples="sv << bucket.source_interval_us.size()
+                    << " source_interval_us_p50="sv
+                    << (bucket.source_interval_us.empty() ? -1 : percentile_value(bucket.source_interval_us, 0.50))
+                    << " source_interval_us_p99="sv
+                    << (bucket.source_interval_us.empty() ? -1 : percentile_value(bucket.source_interval_us, 0.99))
+                    << " ready_to_handoff_samples="sv << bucket.ready_to_handoff_us.size()
+                    << " ready_to_handoff_us_p50="sv
+                    << (bucket.ready_to_handoff_us.empty() ? -1 : percentile_value(bucket.ready_to_handoff_us, 0.50))
+                    << " ready_to_handoff_us_p99="sv
+                    << (bucket.ready_to_handoff_us.empty() ? -1 : percentile_value(bucket.ready_to_handoff_us, 0.99));
 
     bucket.dispatch_us.clear();
     bucket.ingest_us.clear();
     bucket.total_us.clear();
+    bucket.source_interval_us.clear();
+    bucket.ready_to_handoff_us.clear();
   }
 
   void start_session_timing(const std::string &device_uuid, std::uint64_t session_generation) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -62,6 +62,8 @@ namespace stream_stats {
     std::chrono::microseconds dispatch_time {};
     std::chrono::microseconds ingest_time {};
     std::chrono::microseconds total_time {};
+    std::optional<std::chrono::microseconds> source_interval;
+    std::optional<std::chrono::microseconds> ready_to_handoff;
   };
 
   struct gpu_native_probe_attempt_t {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -40,6 +40,7 @@ extern "C" {
 #include "stream_stats.h"
 #include "sync.h"
 #include "video.h"
+#include "video_frame_pacing.h"
 
 #ifdef __linux__
   #include "platform/linux/stream_runtime.h"
@@ -3084,9 +3085,9 @@ namespace video {
     auto max_frametime = std::chrono::nanoseconds(1000ms) * 1000 / minimum_fps_target;
     auto encode_frame_threshold = std::chrono::nanoseconds(1000ms) * 1000 / config.encodingFramerate;
     auto frame_variation_threshold = encode_frame_threshold / 4;
-    auto min_frame_diff = encode_frame_threshold - frame_variation_threshold;
     BOOST_LOG(info) << "Minimum FPS target set to ~"sv << (minimum_fps_target / 2000) << "fps ("sv << max_frametime * 2 << ")"sv;
     BOOST_LOG(info) << "Encoding Frame threshold: "sv << encode_frame_threshold;
+    frame_timestamp_pacer_t frame_timestamp_pacer {encode_frame_threshold, frame_variation_threshold};
 
     auto shutdown_event = mail->event<bool>(mail::shutdown);
     auto idr_events = mail->event<bool>(mail::idr);
@@ -3139,7 +3140,6 @@ namespace video {
       }
     }
 
-    std::chrono::steady_clock::time_point encode_frame_timestamp;
     bool missing_frame_timestamp_warning_logged = false;
     auto fps_window_start = std::chrono::steady_clock::now();
     int fps_window_frames = 0;
@@ -3205,10 +3205,8 @@ namespace video {
           }
 
           auto current_timestamp = *frame_timestamp;
-          auto time_diff = current_timestamp - encode_frame_timestamp;
-
-          // If new frame comes in way too fast, just drop
-          if (time_diff < -frame_variation_threshold) {
+          const auto pacing_decision = frame_timestamp_pacer.evaluate(current_timestamp);
+          if (!pacing_decision.should_encode) {
             dropped_frames++;
             continue;
           }
@@ -3246,13 +3244,7 @@ namespace video {
             break;
           }
 
-          if (time_diff < frame_variation_threshold) {
-            *frame_timestamp = encode_frame_timestamp;
-          } else {
-            encode_frame_timestamp = current_timestamp;
-          }
-
-          encode_frame_timestamp += encode_frame_threshold;
+          *frame_timestamp = pacing_decision.timestamp;
         } else if (!images->running()) {
           break;
         }

--- a/src/video_frame_pacing.h
+++ b/src/video_frame_pacing.h
@@ -1,0 +1,57 @@
+/**
+ * @file src/video_frame_pacing.h
+ * @brief Timestamp pacing for captured frames entering the encoder.
+ */
+#pragma once
+
+#include <chrono>
+#include <optional>
+
+namespace video {
+
+  struct frame_timestamp_decision_t {
+    bool should_encode;
+    std::chrono::steady_clock::time_point timestamp;
+  };
+
+  class frame_timestamp_pacer_t {
+  public:
+    frame_timestamp_pacer_t(
+      std::chrono::steady_clock::duration frame_interval,
+      std::chrono::steady_clock::duration variation_tolerance
+    ):
+        frame_interval_ {frame_interval},
+        variation_tolerance_ {variation_tolerance} {
+    }
+
+    frame_timestamp_decision_t evaluate(std::chrono::steady_clock::time_point source_timestamp) {
+      if (!next_frame_timestamp_) {
+        next_frame_timestamp_ = source_timestamp;
+      }
+
+      const auto time_diff = source_timestamp - *next_frame_timestamp_;
+      if (time_diff < -variation_tolerance_) {
+        return {false, source_timestamp};
+      }
+
+      auto encode_timestamp = source_timestamp;
+      if (time_diff < variation_tolerance_) {
+        encode_timestamp = *next_frame_timestamp_;
+      } else {
+        // Preserve fractional phase across late frames. Snapping the schedule to
+        // the source here makes small refresh-rate differences over-drop.
+        const auto elapsed_intervals = time_diff / frame_interval_;
+        *next_frame_timestamp_ += frame_interval_ * elapsed_intervals;
+      }
+
+      *next_frame_timestamp_ += frame_interval_;
+      return {true, encode_timestamp};
+    }
+
+  private:
+    std::chrono::steady_clock::duration frame_interval_;
+    std::chrono::steady_clock::duration variation_tolerance_;
+    std::optional<std::chrono::steady_clock::time_point> next_frame_timestamp_;
+  };
+
+}  // namespace video

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_session_media_gate.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_session_event_queue.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_update_status.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_video_frame_pacing.cpp
 )
 
 if (NOT WIN32 AND NOT APPLE)

--- a/tests/unit/test_video_frame_pacing.cpp
+++ b/tests/unit/test_video_frame_pacing.cpp
@@ -1,0 +1,87 @@
+/**
+ * @file tests/unit/test_video_frame_pacing.cpp
+ * @brief Tests for encoder frame timestamp pacing.
+ */
+#include "../tests_common.h"
+
+#include <src/video_frame_pacing.h>
+
+namespace {
+  std::size_t count_encoded_frames(
+    std::chrono::nanoseconds source_interval,
+    std::chrono::nanoseconds target_interval,
+    std::size_t source_frame_count
+  ) {
+    video::frame_timestamp_pacer_t pacer {target_interval, target_interval / 4};
+    std::size_t encoded_frames = 0;
+    auto source_timestamp = std::chrono::steady_clock::time_point {};
+    std::optional<std::chrono::steady_clock::time_point> last_encode_timestamp;
+
+    for (std::size_t i = 0; i < source_frame_count; ++i) {
+      const auto decision = pacer.evaluate(source_timestamp);
+      if (decision.should_encode) {
+        if (last_encode_timestamp) {
+          EXPECT_GT(decision.timestamp, *last_encode_timestamp);
+        }
+        last_encode_timestamp = decision.timestamp;
+        encoded_frames++;
+      }
+      source_timestamp += source_interval;
+    }
+
+    return encoded_frames;
+  }
+}  // namespace
+
+TEST(VideoFrameTimestampPacingTests, ResamplesSlightlyFastSourceWithoutPhaseResetLoss) {
+  constexpr auto target_interval = std::chrono::nanoseconds {8'333'333};
+  constexpr auto measured_source_interval = std::chrono::nanoseconds {8'119'500};
+  constexpr std::size_t source_frames = 12'000;
+
+  const auto encoded_frames = count_encoded_frames(
+    measured_source_interval,
+    target_interval,
+    source_frames
+  );
+  const auto expected_frames = static_cast<std::size_t>(
+    (measured_source_interval.count() * (source_frames - 1)) / target_interval.count() + 1
+  );
+
+  EXPECT_LE(
+    std::max(encoded_frames, expected_frames) - std::min(encoded_frames, expected_frames),
+    1
+  );
+}
+
+TEST(VideoFrameTimestampPacingTests, PassesEveryFrameFromSourceBelowTargetRate) {
+  EXPECT_EQ(
+    count_encoded_frames(
+      std::chrono::nanoseconds {16'666'667},
+      std::chrono::nanoseconds {8'333'333},
+      600
+    ),
+    600
+  );
+}
+
+TEST(VideoFrameTimestampPacingTests, DownsamplesSourceAtTwiceTargetRate) {
+  EXPECT_EQ(
+    count_encoded_frames(
+      std::chrono::nanoseconds {4'166'667},
+      std::chrono::nanoseconds {8'333'333},
+      1'200
+    ),
+    600
+  );
+}
+
+TEST(VideoFrameTimestampPacingTests, PreservesFractionalPhaseAfterLongGap) {
+  constexpr auto target_interval = std::chrono::nanoseconds {8'333'333};
+  video::frame_timestamp_pacer_t pacer {target_interval, target_interval / 4};
+  const auto epoch = std::chrono::steady_clock::time_point {};
+
+  EXPECT_TRUE(pacer.evaluate(epoch).should_encode);
+  EXPECT_TRUE(pacer.evaluate(epoch + std::chrono::nanoseconds {8'119'500}).should_encode);
+  EXPECT_TRUE(pacer.evaluate(epoch + std::chrono::milliseconds {100}).should_encode);
+  EXPECT_TRUE(pacer.evaluate(epoch + std::chrono::nanoseconds {108'119'500}).should_encode);
+}

--- a/tests/unit/test_wlgrab_frame_source.cpp
+++ b/tests/unit/test_wlgrab_frame_source.cpp
@@ -1,10 +1,16 @@
 /**
  * @file tests/unit/test_wlgrab_frame_source.cpp
- * @brief Tests for ext-image-copy prefetched-frame handoff.
+ * @brief Tests for ext-image-copy frame sourcing, pacing, and timing.
  */
+#include <chrono>
+
 #include <gtest/gtest.h>
 
 #include "src/platform/linux/wlgrab_frame_source.h"
+#include "src/platform/linux/wlgrab_pacing.h"
+#include "src/platform/linux/wlgrab_timing.h"
+
+using namespace std::chrono_literals;
 
 TEST(ExtcopyFrameSource, ConsumesFramePrefetchedDuringInitialization) {
   bool prefetched_frame_pending = true;
@@ -40,4 +46,114 @@ TEST(ExtcopyFrameSource, ReinitializationSupersedesStalePrefetchedFrame) {
     wl::extcopy_frame_source_e::initialize
   );
   EXPECT_FALSE(prefetched_frame_pending);
+}
+
+TEST(WlgrabCapturePacing, FixedIntervalStartsImmediatelyThenWaits) {
+  const wl::capture_pacer_t::time_point_t start {10s};
+  wl::capture_pacer_t pacer {
+    wl::capture_pacing_policy_e::fixed_interval,
+    10ms,
+    start,
+  };
+
+  EXPECT_EQ(pacer.wait_duration(start), 0ns);
+  pacer.advance(start);
+  EXPECT_EQ(pacer.wait_duration(start), 10ms);
+  EXPECT_EQ(pacer.wait_duration(start + 4ms), 6ms);
+}
+
+TEST(WlgrabCapturePacing, FixedIntervalRecoversAfterFallingBehind) {
+  const wl::capture_pacer_t::time_point_t start {10s};
+  wl::capture_pacer_t pacer {
+    wl::capture_pacing_policy_e::fixed_interval,
+    10ms,
+    start,
+  };
+
+  pacer.advance(start + 25ms);
+  EXPECT_EQ(pacer.wait_duration(start + 25ms), 10ms);
+}
+
+TEST(WlgrabCapturePacing, SourceDrivenNeverAddsASecondClock) {
+  const wl::capture_pacer_t::time_point_t start {10s};
+  wl::capture_pacer_t pacer {
+    wl::capture_pacing_policy_e::source_driven,
+    10ms,
+    start,
+  };
+
+  EXPECT_EQ(pacer.wait_duration(start), 0ns);
+  pacer.advance(start);
+  EXPECT_EQ(pacer.wait_duration(start + 1ms), 0ns);
+  pacer.advance(start + 25ms);
+  EXPECT_EQ(pacer.wait_duration(start + 25ms), 0ns);
+}
+
+TEST(ExtcopyTiming, RecordsRequestReadyAndPresentationIntervals) {
+  wl::extcopy_timing_tracker_t timing;
+  const wl::extcopy_timing_tracker_t::time_point_t start {10s};
+
+  timing.mark_requested(start);
+  EXPECT_TRUE(timing.mark_presentation(0, 1, 100'000'000));
+  timing.mark_ready(start + 8ms);
+  EXPECT_EQ(timing.last_sample().request_to_ready, 8ms);
+  EXPECT_FALSE(timing.last_sample().presentation_interval.has_value());
+
+  timing.mark_requested(start + 9ms);
+  EXPECT_TRUE(timing.mark_presentation(0, 1, 108'333'333));
+  timing.mark_ready(start + 17ms);
+  EXPECT_EQ(timing.last_sample().request_to_ready, 8ms);
+  EXPECT_EQ(timing.last_sample().presentation_interval, 8333us);
+  EXPECT_EQ(timing.last_sample().ready_at, start + 17ms);
+}
+
+TEST(ExtcopyTiming, RejectsInvalidPresentationNanoseconds) {
+  wl::extcopy_timing_tracker_t timing;
+  const wl::extcopy_timing_tracker_t::time_point_t start {10s};
+
+  timing.mark_requested(start);
+  EXPECT_FALSE(timing.mark_presentation(0, 1, 1'000'000'000));
+  timing.mark_ready(start + 8ms);
+
+  EXPECT_EQ(timing.last_sample().request_to_ready, 8ms);
+  EXPECT_FALSE(timing.last_sample().presentation_interval.has_value());
+}
+
+TEST(ExtcopyTiming, RejectsPresentationTimestampOverflow) {
+  wl::extcopy_timing_tracker_t timing;
+
+  EXPECT_FALSE(timing.mark_presentation(UINT32_MAX, UINT32_MAX, 999'999'999));
+}
+
+TEST(ExtcopyTiming, RecoversAfterPresentationClockMovesBackward) {
+  wl::extcopy_timing_tracker_t timing;
+  const wl::extcopy_timing_tracker_t::time_point_t start {10s};
+
+  timing.mark_requested(start);
+  ASSERT_TRUE(timing.mark_presentation(0, 2, 0));
+  timing.mark_ready(start + 8ms);
+  timing.mark_requested(start + 9ms);
+  ASSERT_TRUE(timing.mark_presentation(0, 1, 0));
+  timing.mark_ready(start + 17ms);
+  EXPECT_FALSE(timing.last_sample().presentation_interval.has_value());
+
+  timing.mark_requested(start + 18ms);
+  ASSERT_TRUE(timing.mark_presentation(0, 1, 8'333'333));
+  timing.mark_ready(start + 26ms);
+  EXPECT_EQ(timing.last_sample().presentation_interval, 8333us);
+}
+
+TEST(ExtcopyTiming, ResetPreventsIntervalsAcrossCaptureSessions) {
+  wl::extcopy_timing_tracker_t timing;
+  const wl::extcopy_timing_tracker_t::time_point_t start {10s};
+
+  timing.mark_requested(start);
+  ASSERT_TRUE(timing.mark_presentation(0, 1, 100'000'000));
+  timing.mark_ready(start + 8ms);
+  timing.reset();
+  timing.mark_requested(start + 20ms);
+  ASSERT_TRUE(timing.mark_presentation(0, 5, 200'000'000));
+  timing.mark_ready(start + 28ms);
+
+  EXPECT_FALSE(timing.last_sample().presentation_interval.has_value());
 }


### PR DESCRIPTION
## Summary

- pace ext-image-copy capture from compositor readiness instead of adding a second fixed-interval clock
- preserve fractional encoder timestamp phase when a capture source runs slightly faster than the requested frame rate
- expose source interval and ready-to-handoff capture telemetry
- add deterministic coverage for fixed/source-driven capture pacing, extcopy timing, and encoder resampling

## Root cause

Ext-image-copy capture already blocks until the compositor produces the next frame, but the shared capture loop also slept on a fixed timer. After that was removed, the measured source cadence was about 123-124 FPS for a 120 FPS stream. The encoder scheduler then accumulated the small phase difference, dropped a frame, and reset its phase on the following late frame. Repeating that cycle over-dropped the source and limited delivery to about 112 FPS.

The new timestamp pacer retains fractional phase and advances by whole target intervals after a late frame, so a slightly faster source is resampled near the requested rate.

## Impact

High-refresh ext-image-copy streams can deliver their requested cadence without the extra capture clock or repeated encoder phase-reset drops. Fixed-interval pacing remains in place for the other capture backends.

## Validation

- `test_polaris`: 286/286 passed on current `master`
- `git diff --check`: passed
- exact-base Release CUDA/NVENC production target: compiled
- deterministic 123-to-120 model: approximately 120 FPS over 12,000 source frames
- bounded no-camera Wi-Fi confirmation at 1920x1080, 120 FPS, 20 Mbps:
  - incoming/rendered FPS p50: 120.0199
  - prior profiled source-paced result: 112.5498 FPS
  - frame loss: 0
  - RTT p50: 3 ms
  - measured extcopy source cadence: 124.0387 FPS
  - ready-to-handoff overhead p50: 1 us

The live confirmation was intentionally limited to a 20-second p50 check and does not claim p95, p99, or long-duration stability.
