### PR TITLE
fix(nvhttp): serialize the one-time pairing pin across both server threads

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3294,11 +3294,56 @@ namespace nvhttp {
   struct pair_session_t;
 
   crypto::cert_chain_t cert_chain;
+  // Written by request_otp() on the confighttp thread and consumed by pair() on
+  // the nvhttp one (main.cpp starts a thread for each server), so every access
+  // has to hold otp_state_mutex. Unsynchronized, request_otp() reallocating
+  // otp_passphrase while pair() hashes it is a use-after-free, and a torn read
+  // of otp_pairing_perm grants a client permissions nobody approved.
+  static std::mutex otp_state_mutex;
   static std::string one_time_pin;
   static std::string otp_passphrase;
   static std::string otp_device_name;
   static std::optional<PERM> otp_pairing_perm;
   static std::chrono::time_point<std::chrono::steady_clock> otp_creation_time;
+
+  /**
+   * @brief Match a presented OTP hash and consume the pin behind it.
+   *
+   * Does the whole read-compare-clear under one lock so the values cannot be
+   * replaced by a concurrent request_otp() partway through. An outstanding pin
+   * is dropped whether it matched or expired; a miss is reported as no claim
+   * rather than a distinct status, matching how callers answer every failure
+   * identically.
+   */
+  static otp_claim_t claim_one_time_pin(const std::string &salt, std::string_view presented_hash) {
+    std::lock_guard lock {otp_state_mutex};
+
+    const auto expired = std::chrono::steady_clock::now() - otp_creation_time > OTP_EXPIRE_DURATION;
+    if (one_time_pin.empty() || expired) {
+      one_time_pin.clear();
+      otp_passphrase.clear();
+      otp_device_name.clear();
+      otp_pairing_perm.reset();
+      return {};
+    }
+
+    const auto expected = util::hex(crypto::hash(one_time_pin + salt + otp_passphrase), true);
+    if (!crypto::constant_time_equals(expected.to_string_view(), presented_hash)) {
+      return {};
+    }
+
+    otp_claim_t claim;
+    claim.matched = true;
+    claim.pin = one_time_pin;
+    claim.device_name = std::move(otp_device_name);
+    claim.pairing_perm = otp_pairing_perm;
+
+    one_time_pin.clear();
+    otp_passphrase.clear();
+    otp_device_name.clear();
+    otp_pairing_perm.reset();
+    return claim;
+  }
 
   class PolarisHTTPSServer: public SimpleWeb::ServerBase<PolarisHTTPS> {
   public:
@@ -5066,31 +5111,15 @@ namespace nvhttp {
 
         auto it = args.find("otpauth");
         if (it != std::end(args)) {
-          if (one_time_pin.empty() || (std::chrono::steady_clock::now() - otp_creation_time > OTP_EXPIRE_DURATION)) {
-            one_time_pin.clear();
-            otp_passphrase.clear();
-            otp_device_name.clear();
-            otp_pairing_perm.reset();
-            tree.put("root.<xmlattr>.status_code", 503);
-            tree.put("root.<xmlattr>.status_message", "OTP auth not available.");
-          } else {
-            auto hash = util::hex(crypto::hash(one_time_pin + ptr->second.async_insert_pin.salt + otp_passphrase), true);
-
-            if (hash.to_string_view() == it->second) {
-
-              if (!otp_device_name.empty()) {
-                ptr->second.client.name = std::move(otp_device_name);
-              }
-              ptr->second.pairing_perm = otp_pairing_perm;
-
-              getservercert(ptr->second, tree, one_time_pin);
-
-              one_time_pin.clear();
-              otp_passphrase.clear();
-              otp_device_name.clear();
-              otp_pairing_perm.reset();
-              return;
+          const auto claim = claim_one_time_pin(ptr->second.async_insert_pin.salt, it->second);
+          if (claim.matched) {
+            if (!claim.device_name.empty()) {
+              ptr->second.client.name = claim.device_name;
             }
+            ptr->second.pairing_perm = claim.pairing_perm;
+
+            getservercert(ptr->second, tree, claim.pin);
+            return;
           }
 
           // Always return positive, attackers will fail in the next steps.
@@ -8865,13 +8894,15 @@ namespace nvhttp {
     // Wait for any event
     shutdown_event->view();
 
-    map_id_sess.clear();
-
     https_server.stop();
     http_server.stop();
 
     ssl.join();
     tcp.join();
+
+    // Only once the server threads are joined: an in-flight pair() holds a
+    // reference into this map for the rest of its handler.
+    map_id_sess.clear();
   }
 
   std::string request_otp(
@@ -8883,12 +8914,16 @@ namespace nvhttp {
       return "";
     }
 
+    std::lock_guard lock {otp_state_mutex};
+
     one_time_pin = crypto::rand_alphabet(4, "0123456789"sv);
     otp_passphrase = passphrase;
     otp_device_name = deviceName;
     otp_pairing_perm = pairing_perm;
     otp_creation_time = std::chrono::steady_clock::now();
 
+    // Copied while the lock is held: the return object is initialized before
+    // the guard runs.
     return one_time_pin;
   }
 
@@ -8898,11 +8933,17 @@ namespace nvhttp {
     map_id_sess.clear();
     client_root.named_devices.clear();
     cert_chain.clear();
+
+    std::lock_guard otp_lock {otp_state_mutex};
     one_time_pin.clear();
     otp_passphrase.clear();
     otp_device_name.clear();
     otp_pairing_perm.reset();
     otp_creation_time = {};
+  }
+
+  otp_claim_t claim_one_time_pin_for_tests(const std::string &salt, std::string_view presented_hash) {
+    return claim_one_time_pin(salt, presented_hash);
   }
 
   void add_legacy_authorized_client_for_tests(const crypto::p_named_cert_t &named_cert_p) {

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -77,6 +77,20 @@ namespace nvhttp {
   constexpr auto OTP_EXPIRE_DURATION = 180s;
 
   /**
+   * @brief What an accepted one-time pin authorizes, lifted out under the lock.
+   *
+   * The OTP state itself is shared between the confighttp and nvhttp threads,
+   * so a caller gets a copy taken while the lock is held rather than a view of
+   * globals that the other thread can replace mid-use.
+   */
+  struct otp_claim_t {
+    bool matched = false;
+    std::string pin;
+    std::string device_name;
+    std::optional<crypto::PERM> pairing_perm;
+  };
+
+  /**
    * @brief Start the nvhttp server.
    * @examples
    * nvhttp::start();
@@ -408,6 +422,7 @@ namespace nvhttp {
   );
 #endif
   void reset_pairing_state_for_tests();
+  otp_claim_t claim_one_time_pin_for_tests(const std::string &salt, std::string_view presented_hash);
   void add_legacy_authorized_client_for_tests(const crypto::p_named_cert_t &named_cert_p);
   bool add_authorized_client_for_tests(
     const crypto::p_named_cert_t &named_cert_p,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -194,6 +194,7 @@ set(TEST_HTTP_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_mode_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_response_status.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_session_key.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_otp_claim.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_session_stop_contract.cpp
 )
 

--- a/tests/unit/test_otp_claim.cpp
+++ b/tests/unit/test_otp_claim.cpp
@@ -1,0 +1,83 @@
+/**
+ * @file tests/unit/test_otp_claim.cpp
+ * @brief The one-time pin is issued on the confighttp thread and redeemed on
+ *        the nvhttp one, so matching it, reading what it authorizes, and
+ *        clearing it all have to happen as a single locked step. These cover
+ *        the observable half of that: a pin is redeemable exactly once, and a
+ *        miss neither reveals anything nor leaves the pin usable.
+ */
+
+#include <src/crypto.h>
+#include <src/nvhttp.h>
+#include <src/utility.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+  constexpr auto salt = "0123456789abcdef0123456789abcdef";
+  constexpr auto passphrase = "correct horse battery staple";
+
+  std::string presented_hash_for(const std::string &pin) {
+    return std::string {util::hex(crypto::hash(pin + salt + passphrase), true).to_string_view()};
+  }
+
+  class OtpClaim: public ::testing::Test {
+  protected:
+    void SetUp() override {
+      nvhttp::reset_pairing_state_for_tests();
+    }
+
+    void TearDown() override {
+      nvhttp::reset_pairing_state_for_tests();
+    }
+  };
+
+}  // namespace
+
+TEST_F(OtpClaim, NoOutstandingPinMatchesNothing) {
+  const auto claim = nvhttp::claim_one_time_pin_for_tests(salt, presented_hash_for("1234"));
+  EXPECT_FALSE(claim.matched);
+  EXPECT_TRUE(claim.pin.empty());
+}
+
+TEST_F(OtpClaim, MatchingHashYieldsThePinAndWhatItAuthorizes) {
+  const auto pin = nvhttp::request_otp(passphrase, "Living Room TV", crypto::PERM::_game_control);
+  ASSERT_FALSE(pin.empty());
+
+  const auto claim = nvhttp::claim_one_time_pin_for_tests(salt, presented_hash_for(pin));
+
+  ASSERT_TRUE(claim.matched);
+  EXPECT_EQ(claim.pin, pin);
+  EXPECT_EQ(claim.device_name, "Living Room TV");
+  ASSERT_TRUE(claim.pairing_perm.has_value());
+  EXPECT_EQ(*claim.pairing_perm, crypto::PERM::_game_control);
+}
+
+TEST_F(OtpClaim, APinIsRedeemableOnlyOnce) {
+  const auto pin = nvhttp::request_otp(passphrase, "Living Room TV", crypto::PERM::_game_control);
+  ASSERT_FALSE(pin.empty());
+
+  ASSERT_TRUE(nvhttp::claim_one_time_pin_for_tests(salt, presented_hash_for(pin)).matched);
+
+  const auto replay = nvhttp::claim_one_time_pin_for_tests(salt, presented_hash_for(pin));
+  EXPECT_FALSE(replay.matched);
+  EXPECT_TRUE(replay.pin.empty());
+}
+
+TEST_F(OtpClaim, AWrongHashNeitherMatchesNorBurnsThePin) {
+  const auto pin = nvhttp::request_otp(passphrase, "Living Room TV", crypto::PERM::_game_control);
+  ASSERT_FALSE(pin.empty());
+
+  // A mismatched salt is the same shape of failure as a guessed hash.
+  EXPECT_FALSE(nvhttp::claim_one_time_pin_for_tests("ffffffffffffffffffffffffffffffff", presented_hash_for(pin)).matched);
+  EXPECT_FALSE(nvhttp::claim_one_time_pin_for_tests(salt, "not-a-hash").matched);
+
+  // The legitimate client can still redeem it afterwards.
+  EXPECT_TRUE(nvhttp::claim_one_time_pin_for_tests(salt, presented_hash_for(pin)).matched);
+}
+
+TEST_F(OtpClaim, ARejectedPassphraseIssuesNoPin) {
+  EXPECT_TRUE(nvhttp::request_otp("abc", "Living Room TV", crypto::PERM::_game_control).empty());
+  EXPECT_FALSE(nvhttp::claim_one_time_pin_for_tests(salt, presented_hash_for("1234")).matched);
+}


### PR DESCRIPTION
Closes the last two findings from the nvhttp audit round.

### The one-time pairing pin was shared across two threads with no lock

`main.cpp` starts a thread per server — `nvhttp::start` and `confighttp::start`. `request_otp()` runs on the confighttp thread; `pair()` consumes the pin on the nvhttp one. The five globals behind that handshake (`one_time_pin`, `otp_passphrase`, `otp_device_name`, `otp_pairing_perm`, `otp_creation_time`) were plain statics, read and written from both.

The race is the workflow the feature is designed around: an admin generates a pairing OTP in the Web UI while the client posts `/pair?otpauth=`.

- `otp_passphrase = passphrase` frees the old heap buffer while `pair()` is hashing it. The passphrase only has to be 4 characters to be accepted but is routinely longer than the SSO threshold, so this is a genuine use-after-free rather than a torn read.
- `otp_pairing_perm` is a non-atomic `std::optional<PERM>` read at the moment it decides what the newly paired client may do.

Match, read, and clear now happen inside `claim_one_time_pin()` under a single lock, which returns a copy rather than a view of the globals; `request_otp()` takes the same lock. The presented hash is compared with `crypto::constant_time_equals` instead of `==`.

No behaviour change for callers: the expired-OTP branch previously wrote a 503 into the response tree that `getservercert` overwrote with 200 two lines later, so both paths already answered every failure identically.

### Pairing sessions were cleared while the servers still accepted requests

`map_id_sess.clear()` ran on the shutdown thread before `https_server.stop()` and the joins, so an in-flight `pair()` could be inside `find`/`emplace`/`erase` or holding the `ptr->second` reference it uses through the rest of the handler. Moved after both threads are joined.

### Testing

New `tests/unit/test_otp_claim.cpp` covers the observable half of the locked step: a pin is redeemable exactly once, a wrong hash neither matches nor burns it, an absent or rejected pin matches nothing, and a successful claim carries the device name and permissions through.

Full `ctest -j1`: 17/17 passing.
