### PR TITLE
fix(linux): surface private-session launches that never attach

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -409,6 +409,8 @@ list(APPEND PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/linux/session_manager.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/private_session_input.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/private_session_input.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/private_session_attach.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/private_session_attach.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/input/input_group_access.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/input/input_group_access.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/cage_display_router.h"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -70,6 +70,42 @@ private compositor. If the client connects but shows an empty or black desktop w
 that usually means the headless runtime is alive but nothing visible has been launched in it. Use
 Desktop Display mode when you want to stream the already-running host desktop session.
 
+## Fullscreen Proton or Wine game renders on the physical monitor
+
+The stream connects, audio and input reach the private session correctly, and the client shows an
+empty compositor while the game appears on your real desktop instead.
+
+If the app is launched through Flatpak, this is the Flatpak portal replacing `DISPLAY`. Polaris
+exports the private session's display to the command it launches, but when that command spawns back
+out through the portal (`org.freedesktop.portal.Flatpak`), the portal builds the new sandbox from
+the *portal service's own* environment. The portal service is D-Bus activated and holds the display
+your desktop session had at login, so it overwrites `DISPLAY` and binds only that one X socket into
+the container. Wine and Proton use the X11 driver by default, follow the substituted `DISPLAY`, and
+land on the host desktop.
+
+Nothing set at any layer above the portal survives this. Passing the variable explicitly does not
+help either, because the portal applies its own X11 arguments after the caller's environment.
+
+Confirm it in one command while the game is running, using the game's own mount namespace:
+
+```bash
+GAME=<game-pid>
+sudo ls -la /proc/$GAME/root/tmp/.X11-unix/
+sudo tr '\0' '\n' < /proc/$GAME/environ | grep -E '^(DISPLAY|WAYLAND_DISPLAY)='
+```
+
+If the only socket present is the one for your desktop session rather than the private session's,
+the container never had a path to the private display.
+
+**Workaround:** launch through a native, non-Flatpak build of your launcher (umu-launcher, Lutris,
+Heroic, Steam). The Steam Runtime container itself honors `DISPLAY` correctly, so removing the
+portal hop is enough. A direct `flatpak run` also passes the display through correctly; it is
+specifically the portal spawn underneath a Flatpak launcher that does not.
+
+Polaris logs a warning at launch when an app command can reach the portal, and reports
+`never opened a window in the private session` when a launch produces no window at all, rather than
+streaming an empty compositor silently.
+
 ## Steam Big Picture black screen or tiny window
 
 Clear Steam's HTML cache:

--- a/src/platform/linux/private_session_attach.cpp
+++ b/src/platform/linux/private_session_attach.cpp
@@ -1,0 +1,222 @@
+/**
+ * @file src/platform/linux/private_session_attach.cpp
+ * @brief Prove that a launched app actually attached to the private session.
+ */
+
+#include "private_session_attach.h"
+
+#ifdef __linux__
+
+  #include <filesystem>
+  #include <sstream>
+  #include <string_view>
+  #include <vector>
+
+  #ifdef POLARIS_BUILD_WAYLAND
+    #include <ext-foreign-toplevel-list-v1.h>
+    #include <sys/socket.h>
+    #include <sys/time.h>
+    #include <wayland-client.h>
+  #endif
+
+using namespace std::literals;
+
+namespace private_session_attach {
+  namespace {
+
+  #ifdef POLARIS_BUILD_WAYLAND
+
+    /// A wedged compositor must not strand the watcher thread in a blocking
+    /// roundtrip, so every probe bounds its own reads.
+    constexpr int k_probe_socket_timeout_ms = 3000;
+
+    struct probe_state_t {
+      ext_foreign_toplevel_list_v1 *list = nullptr;
+      int toplevel_count = 0;
+    };
+
+    void handle_global(
+      void *data,
+      wl_registry *registry,
+      std::uint32_t name,
+      const char *interface,
+      std::uint32_t version
+    ) {
+      auto *state = static_cast<probe_state_t *>(data);
+      if (state->list || std::string_view(interface) != ext_foreign_toplevel_list_v1_interface.name) {
+        return;
+      }
+      (void) version;
+      state->list = static_cast<ext_foreign_toplevel_list_v1 *>(
+        wl_registry_bind(registry, name, &ext_foreign_toplevel_list_v1_interface, 1)
+      );
+    }
+
+    void handle_global_remove(void *, wl_registry *, std::uint32_t) {}
+
+    constexpr wl_registry_listener k_registry_listener {
+      .global = handle_global,
+      .global_remove = handle_global_remove,
+    };
+
+    void handle_toplevel(
+      void *data,
+      ext_foreign_toplevel_list_v1 *,
+      ext_foreign_toplevel_handle_v1 *toplevel
+    ) {
+      auto *state = static_cast<probe_state_t *>(data);
+      ++state->toplevel_count;
+      // Only the count matters here. Releasing each handle as it arrives keeps
+      // the probe from accumulating objects for windows it never inspects.
+      ext_foreign_toplevel_handle_v1_destroy(toplevel);
+    }
+
+    void handle_finished(void *, ext_foreign_toplevel_list_v1 *) {}
+
+    constexpr ext_foreign_toplevel_list_v1_listener k_list_listener {
+      .toplevel = handle_toplevel,
+      .finished = handle_finished,
+    };
+
+    void bound_socket_reads(wl_display *display) {
+      const int fd = wl_display_get_fd(display);
+      if (fd < 0) {
+        return;
+      }
+      timeval timeout {};
+      timeout.tv_sec = k_probe_socket_timeout_ms / 1000;
+      timeout.tv_usec = (k_probe_socket_timeout_ms % 1000) * 1000;
+      (void) setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    }
+
+  #endif  // POLARIS_BUILD_WAYLAND
+
+    /// Split a command line on whitespace. Quoting is not honored: this feeds an
+    /// advisory warning, and every launcher form seen in issue #234 is unquoted.
+    std::vector<std::string> split_command(const std::string &cmd) {
+      std::vector<std::string> tokens;
+      std::istringstream stream(cmd);
+      std::string token;
+      while (stream >> token) {
+        tokens.push_back(token);
+      }
+      return tokens;
+    }
+
+    std::string token_basename(const std::string &token) {
+      return std::filesystem::path(token).filename().string();
+    }
+
+  }  // namespace
+
+  probe_result_t probe_toplevels(const std::string &wayland_socket) {
+    probe_result_t result {};
+    if (wayland_socket.empty()) {
+      return result;
+    }
+
+  #ifdef POLARIS_BUILD_WAYLAND
+    wl_display *display = wl_display_connect(wayland_socket.c_str());
+    if (!display) {
+      return result;  // unavailable
+    }
+    bound_socket_reads(display);
+
+    probe_state_t state {};
+    wl_registry *registry = wl_display_get_registry(display);
+    if (!registry) {
+      wl_display_disconnect(display);
+      return result;
+    }
+    wl_registry_add_listener(registry, &k_registry_listener, &state);
+
+    // First roundtrip settles the global advertisement, so a missing toplevel
+    // list after it is a real absence rather than a race.
+    if (wl_display_roundtrip(display) < 0) {
+      wl_registry_destroy(registry);
+      wl_display_disconnect(display);
+      return result;
+    }
+
+    if (!state.list) {
+      result.status = probe_status_e::unsupported;
+      wl_registry_destroy(registry);
+      wl_display_disconnect(display);
+      return result;
+    }
+
+    ext_foreign_toplevel_list_v1_add_listener(state.list, &k_list_listener, &state);
+
+    // The compositor emits one toplevel event per existing window in response to
+    // the bind, and Wayland orders those ahead of this sync's reply, so a single
+    // roundtrip is enough to see all of them.
+    if (wl_display_roundtrip(display) < 0) {
+      ext_foreign_toplevel_list_v1_destroy(state.list);
+      wl_registry_destroy(registry);
+      wl_display_disconnect(display);
+      return result;
+    }
+
+    result.status = probe_status_e::ok;
+    result.toplevel_count = state.toplevel_count;
+
+    ext_foreign_toplevel_list_v1_destroy(state.list);
+    wl_registry_destroy(registry);
+    wl_display_disconnect(display);
+  #endif
+
+    return result;
+  }
+
+  verdict_e evaluate(
+    const probe_result_t &probe,
+    std::chrono::milliseconds elapsed,
+    std::chrono::milliseconds grace
+  ) {
+    switch (probe.status) {
+      case probe_status_e::unsupported:
+        // Nothing to measure with; never accuse a compositor Polaris cannot ask.
+        return verdict_e::skipped;
+      case probe_status_e::unavailable:
+        // The session may still be coming up. Past the grace period this stays a
+        // failed measurement, not a failed launch.
+        return elapsed >= grace ? verdict_e::skipped : verdict_e::waiting;
+      case probe_status_e::ok:
+        break;
+    }
+
+    if (probe.toplevel_count > 0) {
+      return verdict_e::attached;
+    }
+    return elapsed >= grace ? verdict_e::never_attached : verdict_e::waiting;
+  }
+
+  bool may_lose_display_to_flatpak_portal(const std::string &cmd) {
+    const auto tokens = split_command(cmd);
+    bool saw_flatpak = false;
+    for (const auto &token : tokens) {
+      // Exported launcher wrappers run `flatpak run` internally, so the app id is
+      // the only thing on the command line.
+      if (token.find("/flatpak/exports/bin/") != std::string::npos) {
+        return true;
+      }
+      const auto name = token_basename(token);
+      if (name == "flatpak-spawn") {
+        return true;
+      }
+      if (name == "flatpak") {
+        saw_flatpak = true;
+        continue;
+      }
+      // `flatpak run` launches an app; `flatpak list` and friends do not, and
+      // warning on those would be noise.
+      if (saw_flatpak && token == "run") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}  // namespace private_session_attach
+
+#endif

--- a/src/platform/linux/private_session_attach.h
+++ b/src/platform/linux/private_session_attach.h
@@ -1,0 +1,91 @@
+/**
+ * @file src/platform/linux/private_session_attach.h
+ * @brief Prove that a launched app actually attached to the private session.
+ */
+#pragma once
+
+#ifdef __linux__
+
+  #include <chrono>
+  #include <string>
+
+namespace private_session_attach {
+
+  /// Outcome of one enumeration of the private compositor's toplevel list.
+  enum class probe_status_e {
+    ok,  ///< Connected and enumerated; toplevel_count is meaningful.
+    unsupported,  ///< Connected, but no toplevel-list global is advertised.
+    unavailable,  ///< Could not reach the private compositor at all.
+  };
+
+  struct probe_result_t {
+    probe_status_e status = probe_status_e::unavailable;
+    int toplevel_count = 0;
+  };
+
+  /// What the watcher concludes from one probe at one point in time.
+  enum class verdict_e {
+    attached,  ///< A window exists in the private session.
+    waiting,  ///< Nothing yet, and the grace period is still running.
+    never_attached,  ///< Grace elapsed and no window ever appeared. Report only.
+    skipped,  ///< The guard could not measure this session; stay silent.
+  };
+
+  /// Grace period a launch gets before a windowless session is called a failure.
+  inline constexpr std::chrono::milliseconds k_default_attach_grace {120000};
+
+  /// Interval between probes while waiting for a window to appear.
+  inline constexpr std::chrono::milliseconds k_default_attach_poll {2000};
+
+  /**
+   * @brief Enumerate toplevel windows on @p wayland_socket.
+   *
+   * Binds ext-foreign-toplevel-list-v1 and counts the toplevels the compositor
+   * reports. Managed Xwayland windows are included, so one probe covers native
+   * Wayland clients and the ordinary X11 windows Proton and Wine produce.
+   *
+   * It does not see X11 override-redirect windows. wlroots treats those as
+   * unmanaged surfaces, so labwc builds no view and no toplevel handle for them.
+   * Measured against labwc 0.9.6: adding an override-redirect window to a session
+   * already holding one managed window leaves the count at 1. Splash screens and
+   * some fullscreen paths map exactly that kind of window, so a zero count is
+   * evidence of a problem rather than proof of one.
+   *
+   * That blind spot is why the verdict below is reported and never enforced.
+   * Tearing a session down on this signal would sometimes kill a stream whose
+   * app attached correctly and simply mapped a window Polaris cannot enumerate.
+   */
+  probe_result_t probe_toplevels(const std::string &wayland_socket);
+
+  /**
+   * @brief Decide what a probe means. Pure, so it is testable without a compositor.
+   *
+   * A probe that could not measure anything never produces an accusation: an
+   * unreachable compositor resolves to waiting inside the grace period and to
+   * skipped past it, never to never_attached.
+   */
+  verdict_e evaluate(
+    const probe_result_t &probe,
+    std::chrono::milliseconds elapsed,
+    std::chrono::milliseconds grace
+  );
+
+  /**
+   * @brief True when a command can lose the private DISPLAY at a Flatpak portal hop.
+   *
+   * Measured on Fedora/KDE 2026-08-14 against issue #234: the Flatpak portal
+   * builds each sandbox from the portal service's own environment, so it stamps
+   * the login session's DISPLAY over whatever the caller exported and binds only
+   * that one X socket into the container. An explicit --env=DISPLAY override does
+   * not survive it either. Anything that reaches the portal therefore routes X11
+   * clients back to the host session no matter what Polaris sets.
+   *
+   * pressure-vessel and a direct `flatpak run` both honor the caller correctly,
+   * so this is specifically about commands that can spawn back out through the
+   * portal, not about Flatpak or Proton as such. See docs/troubleshooting.md.
+   */
+  bool may_lose_display_to_flatpak_portal(const std::string &cmd);
+
+}  // namespace private_session_attach
+
+#endif

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -69,6 +69,7 @@
   #include "platform/linux/session_manager.h"
   #include "platform/linux/stream_display_policy.h"
   #include "platform/linux/stream_runtime.h"
+  #include "platform/linux/private_session_attach.h"
   #include "platform/linux/session_launch_linux.h"
   #include "platform/linux/display_topology.h"
   #include "platform/linux/gamescope_process.h"
@@ -7313,6 +7314,23 @@ namespace proc {
       private_runtime &&
       private_runtime->backend_id() == stream_display_policy::k_runtime_gamescope;
 
+    // Issue #234: the Flatpak portal builds each sandbox from its own service
+    // environment, so it overwrites DISPLAY with the login session's and binds
+    // only that X socket. Nothing Polaris exports survives the hop, so the most
+    // useful thing it can do is name the hazard at launch instead of leaving a
+    // black stream behind.
+    auto warn_on_portal_display_hop = [](const std::string &cmd) {
+      if (!private_session_attach::may_lose_display_to_flatpak_portal(cmd)) {
+        return;
+      }
+      BOOST_LOG(warning) << "private_session: ["sv << cmd
+                         << "] launches through Flatpak. The Flatpak portal replaces DISPLAY with the "sv
+                         << "host session's and binds only that X socket, so X11 clients such as Proton "sv
+                         << "and Wine can render to the host desktop instead of the private session "sv
+                         << "(issue #234). A native, non-Flatpak launcher avoids the hop. See "sv
+                         << "docs/troubleshooting.md."sv;
+    };
+
     auto spawn_detached_into_runtime = [&](const std::string &raw_cmd) {
       const auto cmd = session_launch_linux::sanitize_cage_command(raw_cmd);
       auto cmd_env = _env;
@@ -7329,6 +7347,7 @@ namespace proc {
       }
       else {
         session_launch_linux::apply_labwc_child_env(cmd_env, private_runtime);
+        warn_on_portal_display_hop(raw_cmd);
       }
       const auto launch_cmd = command_with_gamepad_isolation(cmd);
       boost::filesystem::path working_dir = _app.working_dir.empty() ?
@@ -7369,6 +7388,10 @@ namespace proc {
         }
       }
       else {
+        // The kiosk primary client is launched by the runtime rather than by
+        // spawn_detached_into_runtime, and it is the entry most likely to name a
+        // Flatpak launcher, so it needs the same warning at its own launch site.
+        warn_on_portal_display_hop(_app.detached[0]);
         const std::string game_cmd = session_launch_linux::sanitize_cage_command(_app.detached[0]);
         if (!start_cage_with_runtime_fallback(game_cmd)) {
           BOOST_LOG(error) << "session_manager: Failed to start cage with game"sv;
@@ -7486,6 +7509,7 @@ namespace proc {
       }
       else {
         session_launch_linux::apply_labwc_child_env(launch_env, private_runtime);
+        warn_on_portal_display_hop(_app.cmd);
       }
     }
     if (app_command_uses_cage_runtime) {
@@ -7524,6 +7548,67 @@ namespace proc {
 #endif
 
     _app_launch_time = std::chrono::steady_clock::now();
+
+#ifdef __linux__
+    // A launch that lands on the host session instead of the private one still
+    // connects, still streams, and still reports healthy; the client just sees an
+    // empty compositor. Watch for a window and say so when none ever arrives, so
+    // this surfaces as a stated failure rather than an unexplained black stream.
+    if (use_cage_compositor_for_session && private_runtime && !gamescope_private_runtime) {
+      std::string private_socket = private_runtime->wayland_socket();
+      const pid_t private_compositor_pid = private_runtime->pid();
+      if (!private_socket.empty() && private_compositor_pid > 0) {
+        std::thread attach_watch(
+          [socket = std::move(private_socket), compositor_pid = private_compositor_pid, app_name = _app.name]() {
+            const auto started = std::chrono::steady_clock::now();
+            for (;;) {
+              std::this_thread::sleep_for(private_session_attach::k_default_attach_poll);
+              // Watching a pid rather than the shared runtime keeps this thread
+              // off session state the main thread owns, and stops the watch dead
+              // once the session it was launched for is gone.
+              if (kill(compositor_pid, 0) != 0) {
+                return;
+              }
+              const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - started
+              );
+              const auto probe = private_session_attach::probe_toplevels(socket);
+              const auto verdict = private_session_attach::evaluate(
+                probe,
+                elapsed,
+                private_session_attach::k_default_attach_grace
+              );
+              if (verdict == private_session_attach::verdict_e::waiting) {
+                continue;
+              }
+              if (verdict == private_session_attach::verdict_e::attached) {
+                BOOST_LOG(info) << "private_session: ["sv << app_name
+                                << "] attached to the private session with "sv
+                                << probe.toplevel_count << " window(s)"sv;
+                return;
+              }
+              if (verdict == private_session_attach::verdict_e::skipped) {
+                BOOST_LOG(debug) << "private_session: attach watch ended without a measurement for ["sv
+                                 << app_name << ']';
+                return;
+              }
+              BOOST_LOG(error) << "private_session: ["sv << app_name
+                               << "] never opened a window in the private session after "sv
+                               << std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
+                               << "s. The stream is showing an empty compositor and the app most likely "sv
+                               << "rendered to the host desktop instead. See docs/troubleshooting.md."sv;
+              confighttp::emit_session_event(
+                "warning",
+                app_name + " did not open a window in the private session; the stream is showing an empty compositor"
+              );
+              return;
+            }
+          }
+        );
+        attach_watch.detach();
+      }
+    }
+#endif
 
   #ifdef _WIN32
     auto resetHDRThread = std::thread([this, enable_hdr = launch_session->enable_hdr]{

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -159,6 +159,7 @@ set(TEST_PLATFORM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_graphics.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_linux_process_argv.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_portal_grab_policy.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_private_session_attach.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_private_session_input.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_session_manager.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_virtual_display.cpp

--- a/tests/unit/platform/test_private_session_attach.cpp
+++ b/tests/unit/platform/test_private_session_attach.cpp
@@ -1,0 +1,98 @@
+/**
+ * @file tests/unit/platform/test_private_session_attach.cpp
+ * @brief Test the private-session attach verdict and the Flatpak portal warning.
+ */
+#include "../../tests_common.h"
+
+#ifdef __linux__
+  #include <src/platform/linux/private_session_attach.h>
+
+  #include <chrono>
+  #include <string>
+
+namespace {
+  using namespace std::chrono_literals;
+  using private_session_attach::evaluate;
+  using private_session_attach::may_lose_display_to_flatpak_portal;
+  using private_session_attach::probe_result_t;
+  using private_session_attach::probe_status_e;
+  using private_session_attach::verdict_e;
+
+  constexpr auto k_grace = 60000ms;
+
+  probe_result_t measured(int toplevels) {
+    return probe_result_t {.status = probe_status_e::ok, .toplevel_count = toplevels};
+  }
+}  // namespace
+
+TEST(PrivateSessionAttachTests, AWindowInTheSessionIsAnAttachRegardlessOfElapsedTime) {
+  EXPECT_EQ(evaluate(measured(1), 0ms, k_grace), verdict_e::attached);
+  EXPECT_EQ(evaluate(measured(3), k_grace * 2, k_grace), verdict_e::attached);
+}
+
+TEST(PrivateSessionAttachTests, AnEmptySessionInsideTheGracePeriodIsStillWaiting) {
+  EXPECT_EQ(evaluate(measured(0), 0ms, k_grace), verdict_e::waiting);
+  EXPECT_EQ(evaluate(measured(0), k_grace - 1ms, k_grace), verdict_e::waiting);
+}
+
+TEST(PrivateSessionAttachTests, AnEmptySessionPastTheGracePeriodIsTheReportedFailure) {
+  // Issue #234: the app runs, the stream connects, and nothing ever appears in
+  // the private compositor because the window went to the host session instead.
+  EXPECT_EQ(evaluate(measured(0), k_grace, k_grace), verdict_e::never_attached);
+  EXPECT_EQ(evaluate(measured(0), k_grace * 2, k_grace), verdict_e::never_attached);
+}
+
+TEST(PrivateSessionAttachTests, ACompositorWithoutTheProtocolIsSkippedNotAccused) {
+  const probe_result_t unsupported {.status = probe_status_e::unsupported, .toplevel_count = 0};
+  EXPECT_EQ(evaluate(unsupported, 0ms, k_grace), verdict_e::skipped);
+  EXPECT_EQ(evaluate(unsupported, k_grace * 2, k_grace), verdict_e::skipped);
+}
+
+TEST(PrivateSessionAttachTests, AFailedMeasurementNeverBecomesAFailedLaunch) {
+  // An unreachable compositor means Polaris learned nothing. Reporting that as
+  // "the app never attached" would invent a defect out of a broken probe.
+  const probe_result_t unavailable {.status = probe_status_e::unavailable, .toplevel_count = 0};
+  EXPECT_EQ(evaluate(unavailable, 0ms, k_grace), verdict_e::waiting);
+  EXPECT_EQ(evaluate(unavailable, k_grace * 2, k_grace), verdict_e::skipped);
+}
+
+TEST(PrivateSessionAttachTests, ProbingAnAbsentSocketReportsUnavailableRatherThanEmpty) {
+  const auto result = private_session_attach::probe_toplevels("polaris-no-such-socket");
+  EXPECT_EQ(result.status, probe_status_e::unavailable);
+  EXPECT_EQ(result.toplevel_count, 0);
+  EXPECT_EQ(evaluate(result, 0ms, k_grace), verdict_e::waiting);
+}
+
+TEST(PrivateSessionAttachTests, ProbingAnEmptySocketNameIsUnavailable) {
+  EXPECT_EQ(private_session_attach::probe_toplevels("").status, probe_status_e::unavailable);
+}
+
+TEST(PrivateSessionAttachTests, FlatpakLaunchersAreFlaggedForThePortalDisplayHop) {
+  EXPECT_TRUE(may_lose_display_to_flatpak_portal("flatpak run io.github.Faugus.faugus-launcher"));
+  EXPECT_TRUE(may_lose_display_to_flatpak_portal("/usr/bin/flatpak run net.lutris.Lutris"));
+  EXPECT_TRUE(may_lose_display_to_flatpak_portal("flatpak --user run com.heroicgameslauncher.hgl"));
+  EXPECT_TRUE(may_lose_display_to_flatpak_portal("env DISPLAY=:2 flatpak run com.valvesoftware.Steam"));
+  EXPECT_TRUE(may_lose_display_to_flatpak_portal("flatpak-spawn --host mygame"));
+  EXPECT_TRUE(
+    may_lose_display_to_flatpak_portal("~/.local/share/flatpak/exports/bin/net.lutris.Lutris")
+  );
+}
+
+TEST(PrivateSessionAttachTests, NonPortalCommandsAreNotFlagged) {
+  EXPECT_FALSE(may_lose_display_to_flatpak_portal(""));
+  EXPECT_FALSE(may_lose_display_to_flatpak_portal("steam steam://rungameid/870780"));
+  EXPECT_FALSE(may_lose_display_to_flatpak_portal("/usr/bin/lutris lutris:rungameid/1"));
+  // A subcommand that launches nothing must not produce a launch warning.
+  EXPECT_FALSE(may_lose_display_to_flatpak_portal("flatpak list --app"));
+}
+
+TEST(PrivateSessionAttachTests, ANativeRunnerStoredUnderAFlatpakDataDirIsNotFlagged) {
+  // The reporter's non-Flatpak A/B in issue #234 runs umu-run straight from a
+  // Flatpak app's data directory. It never touches the portal, so warning about
+  // it would point the next reader at the wrong hop entirely.
+  EXPECT_FALSE(may_lose_display_to_flatpak_portal(
+    "~/.var/app/io.github.Faugus.faugus-launcher/data/faugus-launcher/umu-run game.exe"
+  ));
+}
+
+#endif


### PR DESCRIPTION
## Summary

- watch the private labwc session for a window after launch and report when none ever appears, instead of streaming an empty compositor
- warn at launch when an app command can reach the Flatpak portal, which replaces `DISPLAY` with the host session's
- document the portal hop in `docs/troubleshooting.md`, with a one-command confirmation and the working configuration
- never turn a failed measurement into a reported failure: an unreachable or unsupported compositor stays silent

This does not fix the routing in #234, and is not meant to. It removes the reason that issue took three weeks to localize.

## Root cause

Investigated on pc-papi (Fedora, KDE Wayland, session display `:0`) against a non-session `X2` socket, which stands in for a private-session display.

| Hop | Caller sets `DISPLAY=:2` | Result |
|---|---|---|
| Steam Runtime container (`run-in-sniper`) | yes | `DISPLAY=:2`, binds `X2` only |
| `flatpak run` (direct) | yes | `DISPLAY=:2`, binds `X2` only |
| Flatpak portal `Spawn` | yes | **`DISPLAY=:0`, binds `X0` only** |
| Flatpak portal `Spawn`, explicit `--env=DISPLAY=:2` | yes | **`DISPLAY=:0`, binds `X0` only** |

The `flatpak-portal` and `xdg-desktop-portal` services both hold the login session's `DISPLAY` for the life of the session, and the portal applies its own X11 arguments after the caller's `envp`. Substituting the reporter's `:1` for this host's `:0` reproduces their observation exactly, including the flip landing between `bwrap` and `pv-adverb`.

Two corollaries worth recording, because both were load-bearing assumptions in the issue thread:

- `bwrap --args <fd>` is assembled per launch from the live caller environment. A nonexistent `WAYLAND_DISPLAY` binds no socket at all, so the blob is not a cached container-build snapshot.
- pressure-vessel is not involved in the loss. It routes correctly on its own.

Because an explicit `--env` override does not survive the portal either, no environment Polaris exports can reach the far side of that hop. Detection is the only lever available on this side.

## Implementation

`private_session_attach` binds `ext-foreign-toplevel-list-v1` against the private compositor and counts toplevels. Managed Xwayland windows are reported through it, so one probe covers native Wayland clients and the ordinary X11 windows Proton and Wine produce.

The watcher runs on a detached thread bounded by a 120s grace period, polling every 2s, and keyed to the compositor pid rather than the shared runtime pointer so it touches no state the main thread owns and stops as soon as its session ends. The verdict policy is a pure function, so every branch is testable without a compositor.

### Known blind spot, and why the guard reports rather than enforces

The probe does not see X11 override-redirect windows. wlroots treats them as unmanaged surfaces, so labwc creates no view and no toplevel handle. Measured against labwc 0.9.6:

```
baseline            -> status=ok toplevels=0
managed X11 window  -> status=ok toplevels=1
+ override-redirect -> status=ok toplevels=1     (still 1, not 2)
```

Splash screens and some fullscreen paths map exactly that kind of window, so a zero count is evidence of a problem rather than proof of one. That is the reason this reports instead of tearing the session down: enforcing on this signal would sometimes kill a stream whose app attached correctly and simply mapped a window Polaris cannot enumerate. An asynchronous check also cannot separate "rendered elsewhere" from "still loading" with enough confidence to justify killing a slow-starting title.

Adding a second signal, querying the private Xwayland root for mapped client windows, would close the blind spot. Left as a follow-up rather than folded in here.

## Validation

- `PrivateSessionAttachTests`: 10/10 passed
- full suite: 17/17 targets passed, 271 tests (serial; `ctest -j` is unsafe here because every test binary shares `/tmp/polaris-tests/test_polaris.log`, which is a pre-existing flake unrelated to this change)
- `probe_toplevels` verified against a live headless labwc 0.9.6: empty session reads `ok/0`, a mapped window reads `ok/1`, an absent socket reads `unavailable`
- override-redirect behavior measured rather than assumed, per the table above
- compiles both with and without `POLARIS_BUILD_WAYLAND`
- `git diff --check` and `scripts/check-public-surface.sh` clean

Runtime confirmation on a host that reproduces #234 is still outstanding.
