### PR TITLE
fix(process): take the lifecycle lock before copying the session environment

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -8642,6 +8642,14 @@ namespace proc {
   }
 
   boost::process::environment proc_t::get_env() {
+    // _env is rewritten across a session's life -- every POLARIS_* var at
+    // launch, then STATUS on resume, pause, and terminate -- always under this
+    // lock. Callers run on other threads: the server-command and undo-command
+    // runners in stream.cpp copy it while terminate_impl is writing STATUS.
+    // boost's environment owns a native block, so an unlocked copy can read
+    // pointers that operator[] just reallocated.
+    auto &sync = session_lifecycle_sync();
+    std::lock_guard<std::recursive_mutex> lifecycle_lock(sync.mutex);
     return _env;
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -182,6 +182,7 @@ set(TEST_CONFIG_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_display_device.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_entry_handler.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launcher_identity.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_proc_env_locking.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_process_migration.cpp
 )
 

--- a/tests/unit/test_proc_env_locking.cpp
+++ b/tests/unit/test_proc_env_locking.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file tests/unit/test_proc_env_locking.cpp
+ * @brief proc_t::get_env() hands out a copy of _env, which execute_impl and
+ *        terminate_impl rewrite under the session lifecycle lock. The callers
+ *        that copy it -- the server-command and undo-command runners in
+ *        stream.cpp -- are on other threads, so the copy has to take the same
+ *        lock or it can read a native environment block mid-reallocation.
+ */
+
+#include <src/process.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+TEST(ProcEnvLocking, GetEnvWaitsForTheSessionLifecycleLock) {
+  std::atomic<bool> reader_reached_call {false};
+  std::atomic<bool> reader_finished {false};
+  std::thread reader;
+
+  proc::proc.with_session_lifecycle_lock_for_tests([&]() {
+    reader = std::thread([&]() {
+      reader_reached_call.store(true, std::memory_order_release);
+      (void) proc::proc.get_env();
+      reader_finished.store(true, std::memory_order_release);
+    });
+
+    while (!reader_reached_call.load(std::memory_order_acquire)) {
+      std::this_thread::yield();
+    }
+    std::this_thread::sleep_for(200ms);
+
+    // Still inside the lock. An unlocked get_env() returns in microseconds, so
+    // observing the copy complete here is the regression this guards against.
+    // The reverse -- the reader not having reached the lock yet -- can only
+    // make this pass spuriously, never fail spuriously.
+    EXPECT_FALSE(reader_finished.load(std::memory_order_acquire));
+  });
+
+  reader.join();
+  EXPECT_TRUE(reader_finished.load(std::memory_order_acquire));
+}
+
+TEST(ProcEnvLocking, GetEnvIsReentrantFromInsideTheLock) {
+  // The lifecycle mutex is recursive, so a locked caller reaching get_env must
+  // not deadlock against itself.
+  proc::proc.with_session_lifecycle_lock_for_tests([]() {
+    EXPECT_NO_THROW((void) proc::proc.get_env());
+  });
+}


### PR DESCRIPTION
`proc_t::get_env()` returns a copy of `_env`, which is rewritten across a session's life — every `POLARIS_*` variable at launch (`process.cpp:6583-6601`), then `POLARIS_APP_STATUS` on run (`:6747`), resume (`:7647`), pause (`:7808`), and terminate (`:8077`). Every one of those writes holds `session_lifecycle_sync().mutex`.

`get_env()` did not. Of the 56 `proc_t` member functions, it was the only accessor reading lifecycle-protected state without the lock.

Its callers are on other threads:

- `stream.cpp:2270` and `:2437` — the client undo-command runners, which copy the environment while `terminate_impl` is writing `STATUS=TERMINATING`. That is the ordinary end of a session, not a rare interleaving.
- `stream.cpp:1152` — the server-command runner, so a paired client holding `PERM::server_cmd` chooses when the copy happens and can aim it at a launch or resume.
- `browser_stream.cpp:977`

`boost::process::v1::environment` owns a native environment block, so `operator[] = value` inserting a key reallocates the pointer array and its string storage. An unlocked copy can read those pointers mid-reallocation: a torn environment handed to `run_command` to `exec` a child, or a read of the freed block.

The fix takes the same lock. It is recursive, so callers already holding it are unaffected.

### Testing

`tests/unit/test_proc_env_locking.cpp` asserts mutual exclusion behaviourally rather than by grepping the source: a reader thread calls `get_env()` while the main thread holds the lifecycle lock, and the copy must not complete until the lock is released. It also covers re-entrancy from inside the lock.

Verified the test actually catches the regression — with the lock removed it fails, with the lock restored it passes. Full `ctest -j1`: 17/17.
