### PR TITLE
fix: bound peer-declared control packet lengths and undo command waits

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -8141,6 +8141,32 @@ namespace proc {
         BOOST_LOG(warning) << "System: "sv << ec.message();
       }
 
+      // An unbounded wait here holds the session lifecycle lock for as long as
+      // the undo command runs, which freezes launch, resume, stop, and every
+      // status query behind it. The app's exit_timeout bounds the app itself;
+      // bound its undo commands the same way. A configured 0 means "kill the
+      // app at once" for the process group, which would be a surprising thing
+      // to do to an undo command, so fall back to the 5s default there.
+      const auto undo_timeout = _app.exit_timeout.count() > 0 ? _app.exit_timeout : std::chrono::seconds {5};
+
+      // child::wait_for() is deprecated as unreliable, so poll like
+      // terminate_process_group() above does.
+      auto undo_remaining = undo_timeout;
+      while (child.running() && (--undo_remaining).count() >= 0) {
+        std::this_thread::sleep_for(1s);
+      }
+
+      if (child.running()) {
+        BOOST_LOG(warning) << "Undo command ["sv << cmd.undo_cmd << "] did not exit within "sv
+                           << undo_timeout.count() << "s; terminating it"sv;
+        std::error_code terminate_ec;
+        child.terminate(terminate_ec);
+        if (terminate_ec) {
+          BOOST_LOG(warning) << "Couldn't terminate undo command ["sv << cmd.undo_cmd
+                             << "]: "sv << terminate_ec.message();
+        }
+      }
+
       child.wait();
       auto ret = child.exit_code();
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -283,6 +283,54 @@ namespace stream {
     // encrypted control_header_v2 and payload data follow
   } *control_encrypted_p;
 
+  // Length checks for peer-supplied control packets. Free functions with
+  // external linkage so tests can drive them directly; every one is total, so
+  // a caller can hand them any value that arrived off the wire.
+
+  /**
+   * @brief Whether an ENet packet is long enough to hold the type field.
+   *
+   * Below this, `dataLength - sizeof(type)` wraps and yields a payload view
+   * claiming the whole address space.
+   */
+  bool control_packet_carries_type(std::size_t data_length) {
+    return data_length >= sizeof(std::uint16_t);
+  }
+
+  /**
+   * @brief Whether the encrypted control header itself is present.
+   *
+   * The dispatcher consumes the leading type field before the handler sees the
+   * payload, so the header starts two bytes behind it.
+   */
+  bool encrypted_control_header_present(std::size_t payload_size) {
+    return payload_size + sizeof(std::uint16_t) >= sizeof(control_encrypted_t);
+  }
+
+  /**
+   * @brief Whether a declared cipher length fits in the bytes that arrived.
+   */
+  bool encrypted_control_cipher_fits(std::size_t payload_size, std::uint16_t declared_length) {
+    if (!encrypted_control_header_present(payload_size) || declared_length < (16 + 4 + 4)) {
+      return false;
+    }
+    const auto available = payload_size + sizeof(std::uint16_t) - sizeof(control_encrypted_t);
+    return static_cast<std::size_t>(declared_length - 4) <= available;
+  }
+
+  /**
+   * @brief Whether an IDX_INPUT_DATA packet's declared cipher length is usable.
+   *
+   * The length arrives as a signed 32-bit value, so a negative one would widen
+   * to SIZE_MAX when used as a view length.
+   */
+  bool input_control_cipher_fits(std::size_t payload_size, std::int32_t declared_cipher_length) {
+    if (payload_size < sizeof(std::int32_t) || declared_cipher_length < 0) {
+      return false;
+    }
+    return static_cast<std::size_t>(declared_cipher_length) <= payload_size - sizeof(std::int32_t);
+  }
+
   struct audio_fec_packet_t {
     RTP_PACKET rtp;
     AUDIO_FEC_HEADER fecHeader;
@@ -661,6 +709,11 @@ namespace stream {
         case ENET_EVENT_TYPE_RECEIVE:
           {
             net::packet_t packet {event.packet};
+
+            if (!control_packet_carries_type(packet->dataLength)) {
+              BOOST_LOG(warning) << "Control: dropping packet too short to carry a type"sv;
+              break;
+            }
 
             auto type = *(std::uint16_t *) packet->data;
             std::string_view payload {(char *) packet->data + sizeof(type), packet->dataLength - sizeof(type)};
@@ -1110,7 +1163,21 @@ namespace stream {
     server->map(packetTypes[IDX_INPUT_DATA], [&](session_t *session, const std::string_view &payload) {
       BOOST_LOG(debug) << "type [IDX_INPUT_DATA]"sv;
 
+      if (payload.size() < sizeof(std::int32_t)) {
+        BOOST_LOG(warning) << "Control: input packet is too small to carry a cipher length"sv;
+        return;
+      }
+
       auto tagged_cipher_length = util::endian::big(*(int32_t *) payload.data());
+
+      // Signed, and straight off the wire: a negative value widens to SIZE_MAX
+      // and an overlong one runs off the end of the receive buffer.
+      if (!input_control_cipher_fits(payload.size(), tagged_cipher_length)) {
+        BOOST_LOG(warning) << "Control: input packet declares "sv << tagged_cipher_length
+                           << " cipher bytes but only "sv << payload.size() << " arrived"sv;
+        return;
+      }
+
       std::string_view tagged_cipher {payload.data() + sizeof(tagged_cipher_length), (size_t) tagged_cipher_length};
 
       std::vector<uint8_t> plaintext;
@@ -1126,7 +1193,9 @@ namespace stream {
         return;
       }
 
-      if (tagged_cipher_length >= 16 + iv.size()) {
+      // Guarded by the arrived size too: the declared length alone would let a
+      // short packet copy from before the start of the buffer.
+      if (payload.size() >= 16 && tagged_cipher_length >= 16 + static_cast<std::int32_t>(iv.size())) {
         std::copy(payload.end() - 16, payload.end(), std::begin(iv));
       }
 
@@ -1187,6 +1256,13 @@ namespace stream {
     server->map(packetTypes[IDX_ENCRYPTED], [server](session_t *session, const std::string_view &payload) {
       BOOST_LOG(verbose) << "type [IDX_ENCRYPTED]"sv;
 
+      // The header starts two bytes before the payload: the dispatcher already
+      // consumed the type field that opens it. Check it is there before reading.
+      if (!encrypted_control_header_present(payload.size())) {
+        BOOST_LOG(warning) << "Control: encrypted packet is too small for its own header"sv;
+        return;
+      }
+
       auto header = (control_encrypted_p) (payload.data() - 2);
 
       auto length = util::endian::little(header->length);
@@ -1194,6 +1270,15 @@ namespace stream {
 
       if (length < (16 + 4 + 4)) {
         BOOST_LOG(warning) << "Control: Runt packet"sv;
+        return;
+      }
+
+      // length is the peer's claim about its own packet. Without bounding it by
+      // what actually arrived, the decrypt below runs off the receive buffer
+      // before the tag check can reject anything.
+      if (!encrypted_control_cipher_fits(payload.size(), length)) {
+        BOOST_LOG(warning) << "Control: encrypted packet declares "sv << length
+                           << " bytes but only "sv << payload.size() << " arrived"sv;
         return;
       }
 

--- a/tests/unit/test_stream.cpp
+++ b/tests/unit/test_stream.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <cstdint>
+#include <limits>
 #include <functional>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -14,6 +15,10 @@
 
 namespace stream {
   void concat_and_insert_into(std::vector<uint8_t> &result, uint64_t insert_size, uint64_t slice_size, const std::string_view &data1, const std::string_view &data2);
+  bool control_packet_carries_type(std::size_t data_length);
+  bool encrypted_control_header_present(std::size_t payload_size);
+  bool encrypted_control_cipher_fits(std::size_t payload_size, std::uint16_t declared_length);
+  bool input_control_cipher_fits(std::size_t payload_size, std::int32_t declared_cipher_length);
 }
 
 namespace nvhttp {
@@ -176,4 +181,48 @@ TEST(ProcSessionLifecycleTests, AlreadyIdleTerminateDoesNotPublishDuplicateStrea
 
 TEST(ProcSessionLifecycleTests, StreamingTerminateWaitsForStreamJoinToPublishStreamEnded) {
   EXPECT_FALSE(proc::should_publish_stream_ended_after_terminate_for_tests(true, 0, "streaming"));
+}
+
+// Peer-supplied lengths on the control channel. Everything below arrives off
+// the wire from a client that has established a session, so each of these
+// bounds is the only thing standing between a declared size and a read.
+
+TEST(ControlPacketBounds, APacketShorterThanItsTypeFieldIsRejected) {
+  // dataLength - sizeof(type) wraps below 2, so the payload view would claim
+  // the entire address space.
+  EXPECT_FALSE(stream::control_packet_carries_type(0));
+  EXPECT_FALSE(stream::control_packet_carries_type(1));
+  EXPECT_TRUE(stream::control_packet_carries_type(2));
+  EXPECT_TRUE(stream::control_packet_carries_type(1024));
+}
+
+TEST(ControlPacketBounds, EncryptedHeaderMustHaveArrived) {
+  // The dispatcher consumed the 2-byte type, so 6 payload bytes complete the
+  // 8-byte header the handler reads length and seq from.
+  EXPECT_FALSE(stream::encrypted_control_header_present(0));
+  EXPECT_FALSE(stream::encrypted_control_header_present(5));
+  EXPECT_TRUE(stream::encrypted_control_header_present(6));
+}
+
+TEST(ControlPacketBounds, EncryptedCipherLengthIsBoundedByWhatArrived) {
+  // 24 is the runt floor; the cipher is length - 4 bytes past the header.
+  EXPECT_FALSE(stream::encrypted_control_cipher_fits(6, 23));  // below the floor
+  EXPECT_FALSE(stream::encrypted_control_cipher_fits(6, 24));  // declares 20, none arrived
+  EXPECT_TRUE(stream::encrypted_control_cipher_fits(26, 24));  // declares 20, 20 arrived
+  EXPECT_TRUE(stream::encrypted_control_cipher_fits(1024, 24));
+
+  // A uint16 maxes out at 65535, so the over-read was bounded but real.
+  EXPECT_FALSE(stream::encrypted_control_cipher_fits(64, 65535));
+}
+
+TEST(ControlPacketBounds, InputCipherLengthRejectsNegativeAndOverlongClaims) {
+  EXPECT_FALSE(stream::input_control_cipher_fits(3, 0));   // no room for the length itself
+  EXPECT_TRUE(stream::input_control_cipher_fits(4, 0));
+  EXPECT_TRUE(stream::input_control_cipher_fits(20, 16));
+  EXPECT_FALSE(stream::input_control_cipher_fits(20, 17));  // one byte past the buffer
+
+  // Signed off the wire: -1 would widen to SIZE_MAX as a view length.
+  EXPECT_FALSE(stream::input_control_cipher_fits(1024, -1));
+  EXPECT_FALSE(stream::input_control_cipher_fits(1024, std::numeric_limits<std::int32_t>::min()));
+  EXPECT_FALSE(stream::input_control_cipher_fits(1024, std::numeric_limits<std::int32_t>::max()));
 }


### PR DESCRIPTION
Four peer-supplied or unbounded values, found while auditing `execute_impl`/`terminate_impl` and following the control-channel entry point.

### Control channel: three lengths that arrive from the client

All three need an established stream session — a paired client that has launched — so they sit past the pairing boundary, which is exactly where a legitimate Moonlight client sits.

**`control_server_t::iterate` (`stream.cpp:665-666`)** built the payload view as `packet->dataLength - sizeof(type)`. `dataLength` is a `size_t` off the wire, so a **zero- or one-byte ENet packet** wrapped it to ~`SIZE_MAX` and handed every downstream handler a view claiming the whole address space. The two-byte type read ahead of it was already past the end. No minimum-length check existed anywhere between the socket and the handlers.

**`IDX_ENCRYPTED` (`:1192-1201`)** had a runt floor (`length < 24`) but only a floor. `length` is a `uint16` the peer chooses and it was never compared against the packet, so `cipher.decrypt` ran off the receive buffer before the GCM tag check could reject anything — bounded to ~64KB by the field width, but still a read past the end. The header holding `length` and `seq` was itself read without checking it had arrived.

*(The plaintext side was already sound: the runt floor guarantees `plaintext.size() >= 4`, so the `plaintext.size() - 4` at `:1236` cannot underflow. Left as-is.)*

**`IDX_INPUT_DATA` (`:1113-1114`, `:1130`)** took a **signed** `int32` length straight from the packet and used it as a view length, where a negative value widens to `SIZE_MAX`. The IV copy that follows was gated on the *declared* length rather than the arrived one, so a packet declaring 32 bytes with 4 present copied from 12 bytes before the start of the buffer. Reachable when `controlProtocolType != 13`, since `:628` drops unencrypted messages otherwise.

Each bound is now a free function with external linkage, so the tests drive the boundaries directly instead of asserting the source contains a guard.

### `terminate_impl` waited on undo commands forever

`process.cpp:8144` called `child.wait()` with no timeout while holding `session_lifecycle_sync().mutex` for the whole of `terminate_impl`. That mutex serializes essentially all of `proc_t`, so one undo command that never exits froze launch, resume, stop, and every Web UI status query behind it — until the host was killed.

The app's own teardown is already bounded by `exit_timeout` (`:8055`, `:8071`). Its undo commands now are too, with terminate-then-abandon if the child ignores it. A configured `0` means "kill the process group at once" for the main process, which would be a surprising thing to do to an undo command, so that case falls back to the 5s default rather than killing instantly.

### Testing

Four new `ControlPacketBounds` cases covering each boundary — including the wrap below the type field, a declared length with nothing behind it, `uint16` max against a small packet, and negative / `INT32_MIN` / `INT32_MAX` cipher lengths.

Full `ctest -j1`: 17/17 passing.
