### PR TITLE
test: give each test binary its own log file

### DIFF
--- a/tests/tests_main.cpp
+++ b/tests/tests_main.cpp
@@ -5,8 +5,15 @@
 #include "tests_common.h"
 #include "tests_environment.h"
 #include "tests_events.h"
+#include "tests_paths.h"
 
 int main(int argc, char **argv) {
+  // Claim a log file named after this binary before anything opens one. Every
+  // target logs into the same directory, so a shared name lets parallel ctest
+  // runs truncate each other's log (issue #414).
+  if (argc > 0 && argv[0]) {
+    test_paths::set_log_owner(argv[0]);
+  }
   testing::InitGoogleTest(&argc, argv);
   testing::AddGlobalTestEnvironment(new PolarisEnvironment);
   testing::UnitTest::GetInstance()->listeners().Append(new PolarisEventListener);

--- a/tests/tests_paths.h
+++ b/tests/tests_paths.h
@@ -3,6 +3,8 @@
 #include <filesystem>
 #include <format>
 #include <string>
+#include <string_view>
+#include <utility>
 
 namespace test_paths {
 
@@ -12,8 +14,37 @@ namespace test_paths {
     return path;
   }
 
+  namespace detail {
+    inline std::string &log_owner_storage() {
+      // Only reached by a binary that never called set_log_owner().
+      static std::string owner = "test_polaris";
+      return owner;
+    }
+  }  // namespace detail
+
+  /// Name of the binary the log file belongs to.
+  inline const std::string &log_owner() {
+    return detail::log_owner_storage();
+  }
+
+  /**
+   * @brief Scope the log file to this binary. Call once from main() with argv[0].
+   *
+   * Every test binary logs into the same directory, and one of them truncates the
+   * log through logging::clear_log_file(). While the file name was a shared
+   * constant, `ctest -j` had binaries destroying each other's log and the tests
+   * that assert on log contents failed at random, naming the code under test
+   * rather than the collision (issue #414).
+   */
+  inline void set_log_owner(std::string_view argv0) {
+    auto name = std::filesystem::path(argv0).filename().string();
+    if (!name.empty()) {
+      detail::log_owner_storage() = std::move(name);
+    }
+  }
+
   inline std::filesystem::path log_file() {
-    return root() / "test_polaris.log";
+    return root() / (log_owner() + ".log");
   }
 
   inline std::filesystem::path write_file(int file_num) {

--- a/tests/unit/test_entry_handler.cpp
+++ b/tests/unit/test_entry_handler.cpp
@@ -8,6 +8,17 @@
 
 #include <src/entry_handler.h>
 
+TEST(EntryHandlerTests, TheTestLogIsScopedToThisBinaryNotSharedAcrossTargets) {
+  // Issue #414: every test binary logged to one shared file, and test_logging.cpp
+  // truncates it through logging::clear_log_file(). Under `ctest -j` that made the
+  // assertions below fail at random, blaming the code under test for a collision
+  // in the harness. The file name has to carry the binary.
+  EXPECT_EQ(test_paths::log_file().parent_path(), test_paths::root());
+  EXPECT_FALSE(test_paths::log_owner().empty());
+  EXPECT_EQ(test_paths::log_file().filename().string(), test_paths::log_owner() + ".log");
+  EXPECT_NE(test_paths::log_file().filename().string(), "test_polaris.log");
+}
+
 TEST(EntryHandlerTests, LogPublisherDataTest) {
   // call log_publisher_data
   log_publisher_data();


### PR DESCRIPTION
## Summary

- name the test log after the running binary, claimed from `argv[0]` in `main()` before anything opens it
- pin the behavior from `test_polaris_config`, where a revert to a shared constant actually fails
- makes `ctest -j` usable, which the suite has quietly not supported

Fixes #414.

## Root cause

`test_paths::log_file()` returned `<tmp>/polaris-tests/test_polaris.log` with no per-binary component, and `tests/tests_environment.h` points every target's `logging::init()` at it. `tests/unit/test_logging.cpp` then truncates that file through `logging::clear_log_file()`.

`test_logging.cpp` builds into `test_polaris` and `test_entry_handler.cpp` builds into `test_polaris_config`. Under `ctest -j` those run concurrently and one truncates the log the other is asserting against.

## Why it was worth fixing rather than documenting

The failure named the code under test instead of the collision. A run reporting `EntryHandlerTests.LogPublisherDataTest` failing in `test_polaris_config` sends you to read your own diff, and the test passes as soon as you run it alone, which reads like a heisenbug in the change rather than a fixed bug in the harness. It cost a false alarm while gating #408.

## Validation

Measured on the same tree, `ctest -j 8`, three runs each way.

Without the change:

```
baseline run 1 -> 88% tests passed, 2 tests failed out of 17   (test_polaris, test_polaris_config)
baseline run 2 -> 88% tests passed, 2 tests failed out of 17   (test_polaris, test_polaris_config)
baseline run 3 -> 94% tests passed, 1 tests failed out of 17   (test_polaris_config)
log files on disk: test_polaris.log
```

With it:

```
run 1 -> 100% tests passed, 0 tests failed out of 17
run 2 -> 100% tests passed, 0 tests failed out of 17
run 3 -> 100% tests passed, 0 tests failed out of 17
log files on disk: 12, one per binary
```

Note that the baseline fails on both sides of the race, `test_polaris` as well as `test_polaris_config`, which is what the shared-truncation mechanism predicts.

Also: full suite serial 17/17, `scripts/check-public-surface.sh` clean, `git diff --check` clean.

## Notes

`test_game_artwork` links `gtest_main` and never initializes Polaris logging, so it is unaffected. `test_paths::write_file()` shares the same directory but is only used by `test_file_handler.cpp`, which builds into a single target, so it has no equivalent cross-binary collision.

The regression pin is in `test_entry_handler.cpp` deliberately. Its binary is `test_polaris_config`, so its log owner differs from the fallback name and a revert to the shared constant fails the assertion. The same assertion placed in `test_polaris` would still pass, since the fallback and that binary's name coincide.
