### PR TITLE
fix(process): bound the prep command wait that holds the lifecycle lock

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -5475,6 +5475,51 @@ namespace proc {
     return std::make_unique<deinit_t>();
   }
 
+  /**
+   * @brief Wait for a configured command to exit, bounded by the app's exit_timeout.
+   *
+   * Prep commands in execute_impl and undo commands in terminate_impl run
+   * synchronously on the thread that holds the session lifecycle lock, so an
+   * unbounded wait on either freezes launch, resume, stop, and every status
+   * query behind it until the host is killed. Long-running work belongs in an
+   * app's detached commands.
+   *
+   * The resume and pause state commands deliberately do not use this: they run
+   * on a detached thread holding no lock, where taking a long time is fine.
+   *
+   * A configured 0 means "kill the process group at once" for the app itself,
+   * which would be a surprising thing to do to a configured command, so that
+   * falls back to the 5s default rather than killing instantly.
+   *
+   * child::wait_for() is deprecated as unreliable, so this polls the same way
+   * terminate_process_group() below does.
+   */
+  void wait_for_configured_command(
+    boost::process::v1::child &child,
+    std::string_view command,
+    std::chrono::seconds exit_timeout
+  ) {
+    const auto timeout = exit_timeout.count() > 0 ? exit_timeout : std::chrono::seconds {5};
+
+    auto remaining = timeout;
+    while (child.running() && (--remaining).count() >= 0) {
+      std::this_thread::sleep_for(1s);
+    }
+
+    if (child.running()) {
+      BOOST_LOG(warning) << "Command ["sv << command << "] did not exit within "sv
+                         << timeout.count() << "s; terminating it"sv;
+      std::error_code terminate_ec;
+      child.terminate(terminate_ec);
+      if (terminate_ec) {
+        BOOST_LOG(warning) << "Couldn't terminate ["sv << command << "]: "sv << terminate_ec.message();
+      }
+    }
+
+    // Reaps whether it exited on its own or was just killed.
+    child.wait();
+  }
+
   void terminate_process_group(boost::process::v1::child &proc, boost::process::v1::group &group, std::chrono::seconds exit_timeout) {
     if (group.valid() && platf::process_group_running((std::uintptr_t) group.native_handle())) {
       if (exit_timeout.count() > 0) {
@@ -6728,7 +6773,7 @@ namespace proc {
         continue;
       }
 
-      child.wait();
+      wait_for_configured_command(child, cmd.do_cmd, _app.exit_timeout);
       auto ret = child.exit_code();
       if (ret != 0) {
         BOOST_LOG(warning) << '[' << cmd.do_cmd << "] returned code ["sv << ret << ']';
@@ -7753,6 +7798,8 @@ namespace proc {
             break;
           }
 
+          // Unbounded on purpose: this loop runs on a detached thread that
+          // holds no lock, so a long-running resume command blocks nothing.
           child.wait();
 
           auto ret = child.exit_code();
@@ -7914,6 +7961,8 @@ namespace proc {
             break;
           }
 
+          // Unbounded on purpose: this loop runs on a detached thread that
+          // holds no lock, so a long-running pause command blocks nothing.
           child.wait();
 
           auto ret = child.exit_code();
@@ -8226,33 +8275,7 @@ namespace proc {
         BOOST_LOG(warning) << "System: "sv << ec.message();
       }
 
-      // An unbounded wait here holds the session lifecycle lock for as long as
-      // the undo command runs, which freezes launch, resume, stop, and every
-      // status query behind it. The app's exit_timeout bounds the app itself;
-      // bound its undo commands the same way. A configured 0 means "kill the
-      // app at once" for the process group, which would be a surprising thing
-      // to do to an undo command, so fall back to the 5s default there.
-      const auto undo_timeout = _app.exit_timeout.count() > 0 ? _app.exit_timeout : std::chrono::seconds {5};
-
-      // child::wait_for() is deprecated as unreliable, so poll like
-      // terminate_process_group() above does.
-      auto undo_remaining = undo_timeout;
-      while (child.running() && (--undo_remaining).count() >= 0) {
-        std::this_thread::sleep_for(1s);
-      }
-
-      if (child.running()) {
-        BOOST_LOG(warning) << "Undo command ["sv << cmd.undo_cmd << "] did not exit within "sv
-                           << undo_timeout.count() << "s; terminating it"sv;
-        std::error_code terminate_ec;
-        child.terminate(terminate_ec);
-        if (terminate_ec) {
-          BOOST_LOG(warning) << "Couldn't terminate undo command ["sv << cmd.undo_cmd
-                             << "]: "sv << terminate_ec.message();
-        }
-      }
-
-      child.wait();
+      wait_for_configured_command(child, cmd.undo_cmd, _app.exit_timeout);
       auto ret = child.exit_code();
 
       if (ret != 0) {

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -4314,3 +4314,42 @@ TEST(ProcessMigrationTests, ParseUnwrapsPolarisHdrSessionLibraryHardwire) {
   std::filesystem::remove(file_path);
 }
 #endif
+
+TEST(ProcConfiguredCommandWaitContract, CommandsRunUnderTheLifecycleLockWaitWithABound) {
+  // Prep and undo commands run synchronously on the thread holding the session
+  // lifecycle lock, so a bare child.wait() on either freezes launch, resume,
+  // stop, and every status query behind it. Both go through a bounded helper.
+  // The resume and pause state commands deliberately do not: they run on a
+  // detached thread holding no lock, where taking a long time blocks nothing.
+  const auto source = read_source_file_for_contract("src/process.cpp");
+
+  const auto helper = source.find("void wait_for_configured_command(");
+  ASSERT_NE(helper, std::string::npos);
+
+  // The helper polls rather than calling child::wait_for(), which Boost marks
+  // deprecated as unreliable and which -Werror builds reject outright.
+  EXPECT_EQ(source.find("child.wait_for("), std::string::npos);
+  EXPECT_NE(source.find("child.running()", helper), std::string::npos);
+
+  const auto prep_loop = source.find("Executing Do Cmd:");
+  ASSERT_NE(prep_loop, std::string::npos);
+  const auto undo_loop = source.find("Executing Undo Cmd:");
+  ASSERT_NE(undo_loop, std::string::npos);
+
+  // Each locked site reaches the helper before the next command's log line.
+  const auto prep_wait = source.find("wait_for_configured_command(child, cmd.do_cmd", prep_loop);
+  ASSERT_NE(prep_wait, std::string::npos);
+  EXPECT_LT(prep_wait, source.find("Executing", prep_loop + 1));
+
+  const auto undo_wait = source.find("wait_for_configured_command(child, cmd.undo_cmd", undo_loop);
+  ASSERT_NE(undo_wait, std::string::npos);
+
+  // Every bare wait that remains is explained as deliberately unbounded.
+  for (auto at = source.find("child.wait()"); at != std::string::npos; at = source.find("child.wait()", at + 1)) {
+    const auto line_start = source.rfind('\n', at);
+    const auto preceding = source.substr(line_start > 200 ? line_start - 200 : 0, 200);
+    const bool is_helper_reap = at > helper && at < source.find("void terminate_process_group(");
+    EXPECT_TRUE(is_helper_reap || preceding.find("Unbounded on purpose") != std::string::npos)
+      << "unexplained bare child.wait() at offset " << at;
+  }
+}


### PR DESCRIPTION
Follow-up to #413, which bounded the undo-command wait in `terminate_impl`. The prep-command wait in `execute_impl` is the same bug and was left behind.

### The bug

Prep commands (`process.cpp:6772`) and undo commands (`:8270`) both run synchronously on the thread holding `session_lifecycle_sync().mutex`, and both called `child.wait()` with no bound. That mutex serializes essentially all of `proc_t`, so one configured command that never exits freezes launch, resume, stop, and every Web UI status query behind it until the host is killed.

The prep site is the worse of the two. It hangs during `/launch`, so the client's request never returns and the host is left with a half-started app — whereas the undo case at least happens while the session is already ending. Long-running work is supposed to go in an app's `detached` commands; anything in `prep_cmds` is expected to exit.

Both now go through `wait_for_configured_command()`, which polls `child.running()` the way `terminate_process_group()` does — `child::wait_for()` is marked `BOOST_DEPRECATED("wait_for is unreliable")` and `-Werror` builds reject it outright — then terminates and reaps. The `exit_timeout <= 0` fallback #413 introduced applies to both.

### What is deliberately *not* changed

The resume (`:7797`) and pause (`:7958`) state commands look like the same pattern and are not. They run inside a **detached `std::thread`** that captures `cmd_list`, `app_working_dir`, and `_env` by value; `resume()`/`pause()` spawn it and return, releasing the lock immediately. A long-running state command there blocks nothing, and bounding it would only break configurations that rely on it.

Those two waits stay unbounded, with a comment recording why. The source contract requires every remaining bare `child.wait()` to be either the helper's own reap or one carrying that explanation, so a future site cannot quietly join them without the test noticing.

### Testing

`ProcConfiguredCommandWaitContract` asserts the helper exists, that `child.wait_for(` appears nowhere, that both locked sites reach the helper, and that every surviving bare wait is accounted for.

Also compiled `process.cpp` with `-Werror=deprecated-declarations -Werror=all` against the real build flags, matching the strictness SteamOS applies. Full `ctest -j1`: 17/17.
