### PR TITLE
fix(confighttp): parse the cover URL host and resolve the app before writing

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -47,6 +47,7 @@
 #include "display_device.h"
 #include "entry_handler.h"
 #include "file_handler.h"
+#include "game_artwork.h"
 #include "globals.h"
 #include "httpcommon.h"
 #include "logging.h"
@@ -4238,18 +4239,36 @@ namespace confighttp {
         return;
       }
 
-      // Only allow SteamGridDB URLs
-      if (url.find("steamgriddb.com") == std::string::npos &&
-          url.find("steamcdn") == std::string::npos) {
+      // Only allow SteamGridDB / Steam CDN URLs. A substring match let anything
+      // through that merely contained the name -- "http://10.0.0.1/?x=steamgriddb.com"
+      // passed, and download_file follows redirects. game_artwork already keeps
+      // the parsed, exact-host allowlist for these two providers.
+      if (!game_artwork::is_allowed_provider_url(game_artwork::provider_e::steamgriddb, url) &&
+          !game_artwork::is_allowed_provider_url(game_artwork::provider_e::steam, url)) {
         output["status"] = false;
         output["error"] = "Only SteamGridDB/Steam CDN URLs allowed";
         send_response(response, output);
         return;
       }
 
+      // The uuid becomes part of a filesystem path, so resolve it against the
+      // app list and build from the stored value rather than the request's.
+      // uploadCover escapes its key for this reason; this handler pasted the
+      // request body straight in, so "../.." escaped the covers directory.
+      const auto apps = proc::proc.get_apps();
+      const auto app_entry = std::find_if(apps.begin(), apps.end(), [&](const proc::ctx_t &candidate) {
+        return boost::iequals(candidate.uuid, app_uuid);
+      });
+      if (app_entry == apps.end()) {
+        output["status"] = false;
+        output["error"] = "Unknown app_uuid";
+        send_response(response, output);
+        return;
+      }
+
       const std::string coverdir = platf::appdata().string() + "/covers/";
       file_handler::make_directory(coverdir);
-      std::string cover_path = coverdir + app_uuid + safe_cover_extension_from_url(url);
+      std::string cover_path = coverdir + http::url_escape(app_entry->uuid) + safe_cover_extension_from_url(url);
 
       if (!http::download_file(url, cover_path)) {
         output["status"] = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_benchmark_control_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_validation.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_benchmark_auth.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_cover_download_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_client_settings_advertisement.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_browser_stream_protocol.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_cursor_visibility.cpp

--- a/tests/unit/test_cover_download_contract.cpp
+++ b/tests/unit/test_cover_download_contract.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file tests/unit/test_cover_download_contract.cpp
+ * @brief POST /api/covers/download takes a URL to fetch and a uuid that lands
+ *        in a filesystem path. Both come from the request body, so the handler
+ *        has to check the URL against a parsed host allowlist rather than by
+ *        substring, and build the path from an app it actually resolved.
+ *
+ *        The allowlist itself is covered behaviourally by GameArtworkAllowlist;
+ *        what these assert is that the handler reaches for it.
+ */
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+  std::string read_source(const std::filesystem::path &relative_path) {
+    std::ifstream input(std::filesystem::path {POLARIS_SOURCE_DIR} / relative_path);
+    EXPECT_TRUE(input.good()) << relative_path;
+    std::ostringstream contents;
+    contents << input.rdbuf();
+    return contents.str();
+  }
+
+  std::string download_cover_body() {
+    const auto source = read_source("src/confighttp.cpp");
+    const auto handler = source.find("void downloadCover(");
+    EXPECT_NE(handler, std::string::npos);
+    if (handler == std::string::npos) {
+      return {};
+    }
+    const auto next_handler = source.find("\n  void ", handler + 1);
+    return source.substr(handler, next_handler - handler);
+  }
+
+}  // namespace
+
+TEST(CoverDownloadContract, TheUrlIsCheckedAgainstAParsedHostAllowlist) {
+  const auto body = download_cover_body();
+  ASSERT_FALSE(body.empty());
+
+  // A substring match passed anything merely containing the name, including
+  // "http://10.0.0.1/?x=steamgriddb.com", and download_file follows redirects.
+  EXPECT_EQ(body.find(R"(url.find("steamgriddb.com"))"), std::string::npos);
+  EXPECT_EQ(body.find(R"(url.find("steamcdn"))"), std::string::npos);
+
+  EXPECT_NE(body.find("game_artwork::is_allowed_provider_url"), std::string::npos);
+}
+
+TEST(CoverDownloadContract, TheCoverPathIsBuiltFromAResolvedApp) {
+  const auto body = download_cover_body();
+  ASSERT_FALSE(body.empty());
+
+  // The request's uuid must not reach the path: "../.." escaped the covers
+  // directory, and download_file creates parent directories on the way.
+  EXPECT_EQ(body.find("coverdir + app_uuid"), std::string::npos);
+
+  EXPECT_NE(body.find("proc::proc.get_apps()"), std::string::npos);
+  EXPECT_NE(body.find("http::url_escape(app_entry->uuid)"), std::string::npos);
+}
+
+TEST(CoverDownloadContract, TheUploadHandlerStillEscapesItsKey) {
+  // uploadCover was already correct; keep it that way, since it is the sibling
+  // this handler should have matched in the first place.
+  const auto source = read_source("src/confighttp.cpp");
+  const auto handler = source.find("void uploadCover(");
+  ASSERT_NE(handler, std::string::npos);
+  const auto body = source.substr(handler, source.find("\n  void ", handler + 1) - handler);
+
+  EXPECT_NE(body.find("http::url_escape(key)"), std::string::npos);
+  EXPECT_NE(body.find("http::url_get_host(url)"), std::string::npos);
+}


### PR DESCRIPTION
`POST /api/covers/download` takes a URL to fetch and a uuid that becomes part of a filesystem path, both straight from the request body. Neither was checked properly.

### The URL allowlist was a substring search

```cpp
if (url.find("steamgriddb.com") == std::string::npos &&
    url.find("steamcdn") == std::string::npos) { … reject … }
```

`find` matches anywhere in the string, so all of these passed:

- `http://10.0.0.169/?x=steamgriddb.com`
- `http://steamgriddb.com.evil.example/payload`
- `http://evil.example/steamcdn`

`http::download_file` then fetches that URL and writes the response body to disk, following redirects (`CURLOPT_FOLLOWLOCATION`, `httpcommon.cpp:312`).

It now goes through `game_artwork::is_allowed_provider_url`, which parses the URL, requires `https`, rejects userinfo / ports / IPv6 literals / credential-bearing query params, and matches the host exactly against the set these two providers actually serve from. That function already existed for the artwork path and is covered by `GameArtworkAllowlist`, which rejects precisely the suffix-domain, prefix-domain, userinfo and port bypasses.

### The uuid was concatenated into the path unescaped

```cpp
std::string cover_path = coverdir + app_uuid + safe_cover_extension_from_url(url);
```

`app_uuid` was checked only for `empty()`. `../../../../tmp/x` escaped the covers directory, and `download_file` creates parent directories on the way (`httpcommon.cpp:294`). The extension is constrained to `.jpg/.jpeg/.png/.webp`, so this is an arbitrary-path write of attacker-chosen remote bytes with an image extension rather than a route to dropping a script.

The handler now resolves the uuid against `proc::proc.get_apps()`, returns "Unknown app_uuid" if it does not match, and builds the path from the stored value, escaped.

### Both fixes already had precedent in this file

`uploadCover`, two hundred lines earlier, checks `http::url_get_host(url) != "images.igdb.com"` and builds its path with `coverdir + http::url_escape(key)`. `downloadCover` simply did neither. A regression test pins `uploadCover`'s behaviour too, since it is the sibling this handler should have matched from the start.

Both paths require an authenticated session — the same trust level as any other settings write. A settings write is not supposed to reach arbitrary hosts or arbitrary paths.

### Not changed

`download_file` follows redirects without re-validating the target, so an allowlisted host that redirects is still followed. That affects every caller and deserves its own decision rather than riding along here.

### Testing

`CoverDownloadContract` asserts the handler reaches for the parsed allowlist and the resolved app, and that the substring checks and raw concatenation are gone. Compiled with `-Werror=deprecated-declarations -Werror=all` against the real build flags. Full `ctest -j1`: 17/17.
