### PR TITLE
docs: note the two traps when switching to a native launcher

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,6 +102,26 @@ Heroic, Steam). The Steam Runtime container itself honors `DISPLAY` correctly, s
 portal hop is enough. A direct `flatpak run` also passes the display through correctly; it is
 specifically the portal spawn underneath a Flatpak launcher that does not.
 
+Two things commonly trip up the switch from a launcher's Flatpak build to its native one:
+
+- **Re-add the game rather than reusing its old ID.** Heroic gives sideload entries a new
+  `app_name` per install, so an identifier copied from the Flatpak install will not resolve in the
+  native one. Read the current value out of `~/.config/heroic/sideload_apps/library.json`, or your
+  launcher's equivalent.
+- **Let the launcher finish starting before handing it a launch URL.** Native Heroic given a
+  `heroic://launch?...` URL on a cold start throws
+  `Cannot read properties of undefined (reading 'getGame')` rather than queuing the request. Start
+  the launcher on its own first and send the launch as a separate command.
+
+A working app entry on the reporting host ended up as:
+
+```
+WAYLAND_DISPLAY=wayland-1 DISPLAY=:2 heroic --no-gui "heroic://launch?appName=<id>&runner=sideload"
+```
+
+Polaris exports both of those variables into the private session already, so setting them by hand
+is redundant rather than required. They are shown here because that is the entry that was verified.
+
 Polaris logs a warning at launch when an app command can reach the portal, and reports
 `never opened a window in the private session` when a launch produces no window at all, rather than
 streaming an empty compositor silently.


### PR DESCRIPTION
## Summary

Record the two things that stand between "use a native launcher" and a working stream, both of which cost the #234 reporter time after the diagnosis was already correct.

- Heroic assigns sideload entries a new `app_name` per install, so an identifier carried over from the Flatpak build resolves to nothing. The current value lives in `~/.config/heroic/sideload_apps/library.json`.
- Native Heroic given a `heroic://launch?...` URL on a cold start throws `Cannot read properties of undefined (reading 'getGame')` rather than queuing it, so the launcher has to be running before it is asked to launch anything.

Also records the app entry that was verified working, with a note that Polaris exports `WAYLAND_DISPLAY` and `DISPLAY` into the private session itself, so the ones in that entry are redundant rather than load-bearing. Worth stating explicitly, since copying it without that context invites the conclusion that setting them by hand is what fixed it.

## Context

#234 is confirmed closed by the reporter. Native Heroic, portal hop removed, `DISPLAY=:2` and `WAYLAND_DISPLAY=wayland-1` intact inside the container, and a fullscreen Proton title rendered to the client for the first time in that thread. These notes are their field report from getting there.

Docs only, no code change.

Refs #234
