### PR TITLE
ci: cache the Go modules the browser-stream helper needs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,6 +163,13 @@ jobs:
           key: polaris-arch-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             polaris-arch-npm-
+      - name: Cache Go module downloads
+        uses: actions/cache@v6
+        with:
+          path: /github/home/go/pkg/mod
+          key: polaris-arch-gomod-${{ hashFiles('browser_stream_helper/go.sum') }}
+          restore-keys: |
+            polaris-arch-gomod-
 
       - name: Install dependencies
         run: |
@@ -466,6 +473,13 @@ jobs:
           key: polaris-fedora-44-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             polaris-fedora-44-npm-
+      - name: Cache Go module downloads
+        uses: actions/cache@v6
+        with:
+          path: /github/home/go/pkg/mod
+          key: polaris-fedora-44-clang-gomod-${{ hashFiles('browser_stream_helper/go.sum') }}
+          restore-keys: |
+            polaris-fedora-44-clang-gomod-
 
       - name: Install Fedora build dependencies
         run: |
@@ -613,6 +627,13 @@ jobs:
           key: polaris-ubuntu-ccache-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'src/**/*', 'tests/**/*') }}
           restore-keys: |
             polaris-ubuntu-ccache-
+      - name: Cache Go module downloads
+        uses: actions/cache@v6
+        with:
+          path: ~/go/pkg/mod
+          key: polaris-ubuntu-gomod-${{ hashFiles('browser_stream_helper/go.sum') }}
+          restore-keys: |
+            polaris-ubuntu-gomod-
 
       - name: Install dependencies
         run: |
@@ -803,6 +824,13 @@ jobs:
           key: polaris-fedora-${{ matrix.fedora }}-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             polaris-fedora-${{ matrix.fedora }}-npm-
+      - name: Cache Go module downloads
+        uses: actions/cache@v6
+        with:
+          path: /github/home/go/pkg/mod
+          key: polaris-fedora-${{ matrix.fedora }}-gomod-${{ hashFiles('browser_stream_helper/go.sum') }}
+          restore-keys: |
+            polaris-fedora-${{ matrix.fedora }}-gomod-
 
       - name: Install Fedora build dependencies
         run: |


### PR DESCRIPTION
## Summary

Cache the Go module set that `polaris-browser-stream-helper` needs, in the four jobs that build it.

Every build job installs Go and builds the helper, and none of them cache its modules, so all eight are fetched from `proxy.golang.org` on every run of every job. `ccache` and npm downloads are already cached beside them; this one was simply missed.

## Why now

It came due on #421. A C++ test-only branch failed the Fedora Clang job on:

```
golang.org/x/text@v0.40.0: read "https://proxy.golang.org/golang.org/x/text/@v/v0.40.0.zip":
stream error: stream ID 29; INTERNAL_ERROR; received from peer
```

An unrelated network service resolving an indirect dependency is currently able to fail any change in the repository.

## Shape

One step per job, mirroring the npm cache already next to it, keyed on `browser_stream_helper/go.sum` so the cache turns over exactly when the module set does.

| Job | Path |
|---|---|
| Arch build | `/github/home/go/pkg/mod` |
| Fedora 44 Clang compile check | `/github/home/go/pkg/mod` |
| Ubuntu build | `~/go/pkg/mod` |
| Fedora RPM build (matrix) | `/github/home/go/pkg/mod` |

Container jobs use the same `/github/home` prefix as their existing caches, and the ubuntu job the same `~` prefix as its own, so a mismatched path cannot silently cache nothing.

## Deliberately not included

**Vendoring.** `go mod vendor` would remove the network dependency outright rather than only on a warm cache, at the cost of committing the vendor tree, `golang.org/x/text` included. That is a real tradeoff about repository size and review noise, and it should be decided on its own rather than folded into a cache change.

**The SteamOS job.** It builds through a nested container in `run-steamos-build.sh` and caches nothing at all today, so a module cache there is a differently shaped change.

## Validation

- `.github/workflows/build.yml` parses as YAML, and the Go cache step resolves into exactly the four intended jobs, checked by loading the file rather than by reading the diff
- web test suite 320/320 across 55 files, including `packaging-contracts.test.js`, which reads this workflow and asserts on its structure
