### PR TITLE
fix(linux): warn when nested gamescope can stall private sessions

### DIFF
--- a/src/platform/linux/gamescope_process.cpp
+++ b/src/platform/linux/gamescope_process.cpp
@@ -419,6 +419,33 @@ namespace stream_runtime::gamescope_process {
              pid_it->second.pgid == root;
     }
 
+    std::optional<std::string> process_env_value(const fs::path &process_dir, std::string_view key) {
+      std::ifstream environ_file(process_dir / "environ", std::ios::binary);
+      if (!environ_file) {
+        return std::nullopt;
+      }
+      const std::string bytes {
+        std::istreambuf_iterator<char> {environ_file},
+        std::istreambuf_iterator<char> {},
+      };
+
+      const std::string prefix = std::string {key} + "=";
+      std::size_t offset = 0;
+      while (offset < bytes.size()) {
+        const auto end = bytes.find('\0', offset);
+        const auto length = (end == std::string::npos ? bytes.size() : end) - offset;
+        const std::string_view entry {bytes.data() + offset, length};
+        if (entry.starts_with(prefix)) {
+          return std::string {entry.substr(prefix.size())};
+        }
+        if (end == std::string::npos) {
+          break;
+        }
+        offset = end + 1;
+      }
+      return std::nullopt;
+    }
+
     std::optional<std::uint64_t> inode_for_path(
       const socket_inode_map_t &inodes,
       const fs::path &path
@@ -754,6 +781,42 @@ namespace stream_runtime::gamescope_process {
       return std::nullopt;
     }
     return ":" + std::to_string(best->display);
+  }
+
+  std::optional<int> nested_gamescope_client(
+    std::string_view wayland_socket,
+    const lookup_paths_t &paths
+  ) {
+    if (wayland_socket.empty()) {
+      return std::nullopt;
+    }
+
+    // Runs on a session watch thread every couple of seconds, so the scan reads
+    // one symlink per process and only opens environ for a gamescope.
+    std::error_code ec;
+    fs::directory_iterator iterator(paths.proc_root, fs::directory_options::skip_permission_denied, ec);
+    if (ec) {
+      return std::nullopt;
+    }
+
+    for (const auto &entry : iterator) {
+      const auto pid = parse_integer<int>(entry.path().filename().string());
+      if (!pid) {
+        continue;
+      }
+
+      std::error_code link_ec;
+      const auto executable = fs::read_symlink(entry.path() / "exe", link_ec);
+      if (link_ec || !gamescope_executable_name(executable)) {
+        continue;
+      }
+
+      if (process_env_value(entry.path(), "WAYLAND_DISPLAY") == wayland_socket) {
+        return *pid;
+      }
+    }
+
+    return std::nullopt;
   }
 
 }  // namespace stream_runtime::gamescope_process

--- a/src/platform/linux/gamescope_process.h
+++ b/src/platform/linux/gamescope_process.h
@@ -94,4 +94,23 @@ namespace stream_runtime::gamescope_process {
     const lookup_paths_t &paths = {}
   );
 
+  /**
+   * @brief PID of a gamescope running as a client of @p wayland_socket.
+   *
+   * Polaris' own gamescope owns a display; a gamescope nested inside the
+   * private compositor connects to one, so its WAYLAND_DISPLAY names that
+   * socket. That difference is what separates the supported arrangement from
+   * the unsupported one, and it holds however the nesting was launched -- from
+   * the app's command directly or from a wrapper script that never mentions
+   * gamescope, which is why this reads the running process rather than config.
+   *
+   * Identifies gamescope by its executable, so a nix-wrapped
+   * .gamescope-wrapped counts, and reads environ only for the processes that
+   * clear that check.
+   */
+  std::optional<int> nested_gamescope_client(
+    std::string_view wayland_socket,
+    const lookup_paths_t &paths = {}
+  );
+
 }  // namespace stream_runtime::gamescope_process

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7610,6 +7610,7 @@ namespace proc {
            compositor_pid = private_compositor_pid,
            app_name = _app.name]() {
             const auto started = std::chrono::steady_clock::now();
+            bool reported_nested_gamescope = false;
             for (;;) {
               std::this_thread::sleep_for(private_session_attach::k_default_attach_poll);
               // Watching a pid rather than the shared runtime keeps this thread
@@ -7617,6 +7618,26 @@ namespace proc {
               // once the session it was launched for is gone.
               if (kill(compositor_pid, 0) != 0) {
                 return;
+              }
+
+              // Checked before the attach verdict below, which returns as soon
+              // as a window exists -- and a nested gamescope is what maps that
+              // window, so its presence is observable on the same poll.
+              if (!reported_nested_gamescope) {
+                if (const auto nested = stream_runtime::gamescope_process::nested_gamescope_client(socket)) {
+                  reported_nested_gamescope = true;
+                  BOOST_LOG(error) << "private_session: a gamescope (pid "sv << *nested
+                                   << ") is running as a client of the private compositor for ["sv
+                                   << app_name << "]. Input does not reach games launched inside a "sv
+                                   << "nested gamescope, so the stream will render but the keyboard "sv
+                                   << "and controller will appear dead. Launch the app without "sv
+                                   << "gamescope, or switch the session to the gamescope stream mode "sv
+                                   << "so Polaris owns the gamescope instead of nesting one."sv;
+                  confighttp::emit_session_event(
+                    "warning",
+                    app_name + " is running inside a nested gamescope; keyboard and controller input will not reach it"
+                  );
+                }
               }
               const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - started

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7628,14 +7628,14 @@ namespace proc {
                   reported_nested_gamescope = true;
                   BOOST_LOG(error) << "private_session: a gamescope (pid "sv << *nested
                                    << ") is running as a client of the private compositor for ["sv
-                                   << app_name << "]. Input does not reach games launched inside a "sv
-                                   << "nested gamescope, so the stream will render but the keyboard "sv
-                                   << "and controller will appear dead. Launch the app without "sv
-                                   << "gamescope, or switch the session to the gamescope stream mode "sv
-                                   << "so Polaris owns the gamescope instead of nesting one."sv;
+                                   << app_name << "]. This unsupported nesting can leave games blocked "sv
+                                   << "behind Gamescope WSI errors or native dialogs that are not visible "sv
+                                   << "in the stream. Launch the app without gamescope, or switch the "sv
+                                   << "session to the gamescope stream mode so Polaris owns the gamescope "sv
+                                   << "instead of nesting one."sv;
                   confighttp::emit_session_event(
                     "warning",
-                    app_name + " is running inside a nested gamescope; keyboard and controller input will not reach it"
+                    app_name + " is using an unsupported nested gamescope; games may stall behind an invisible Gamescope WSI error"
                   );
                 }
               }

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -448,10 +448,11 @@ TEST(GamescopeProcessOwnershipTests, RefusesLiveUnownedSocketReclaim) {
 #endif
 
 // Nested gamescope detection for issue #422. A gamescope launched inside the
-// private compositor connects to it as a client, and games launched inside that
-// nesting receive no keyboard or controller input. Detection reads the running
-// process because the app's configured command may be a wrapper script that
-// never mentions gamescope.
+// private compositor connects to it as a client. The reported game then stalled
+// behind a Gamescope WSI dialog that was outside the captured surface, making
+// the session look alive but unresponsive. Detection reads the running process
+// because the app's configured command may be a wrapper script that never
+// mentions gamescope.
 
 TEST(GamescopeProcessNestingTests, FindsAGamescopeClientOfThePrivateCompositor) {
   fake_proc_tree_t tree;

--- a/tests/unit/platform/test_gamescope_process.cpp
+++ b/tests/unit/platform/test_gamescope_process.cpp
@@ -47,7 +47,8 @@ namespace {
       const std::vector<std::uint64_t> &socket_inodes = {},
       const fs::path &executable_override = {},
       int pgid = -1,
-      int session = -1
+      int session = -1,
+      const std::vector<std::pair<std::string, std::string>> &environment = {}
     ) {
       const auto dir = proc / std::to_string(pid);
       fs::remove_all(dir);
@@ -78,6 +79,15 @@ namespace {
       for (const auto &arg : argv) {
         cmdline.write(arg.data(), static_cast<std::streamsize>(arg.size()));
         cmdline.put('\0');
+      }
+
+      if (!environment.empty()) {
+        std::ofstream environ_file(dir / "environ", std::ios::binary);
+        for (const auto &[key, value] : environment) {
+          const auto entry = key + "=" + value;
+          environ_file.write(entry.data(), static_cast<std::streamsize>(entry.size()));
+          environ_file.put('\0');
+        }
       }
 
       int fd = 3;
@@ -436,3 +446,62 @@ TEST(GamescopeProcessOwnershipTests, RefusesLiveUnownedSocketReclaim) {
   EXPECT_TRUE(fs::exists(gamescope_socket));
 }
 #endif
+
+// Nested gamescope detection for issue #422. A gamescope launched inside the
+// private compositor connects to it as a client, and games launched inside that
+// nesting receive no keyboard or controller input. Detection reads the running
+// process because the app's configured command may be a wrapper script that
+// never mentions gamescope.
+
+TEST(GamescopeProcessNestingTests, FindsAGamescopeClientOfThePrivateCompositor) {
+  fake_proc_tree_t tree;
+  tree.add_process(4242, 1, 100, {"gamescope", "--steam", "-W", "1920", "-H", "1080"}, {}, {}, -1, -1,
+                   {{"WAYLAND_DISPLAY", "wayland-1"}});
+
+  const auto nested = gp::nested_gamescope_client("wayland-1", paths_for(tree));
+  ASSERT_TRUE(nested.has_value());
+  EXPECT_EQ(*nested, 4242);
+}
+
+TEST(GamescopeProcessNestingTests, IgnoresAGamescopeOnADifferentDisplay) {
+  fake_proc_tree_t tree;
+  // Polaris' own gamescope owns its display rather than connecting to the
+  // private compositor's, which is what makes the supported case distinguishable.
+  tree.add_process(4242, 1, 100, {"gamescope", "--backend=headless"}, {}, {}, -1, -1,
+                   {{"WAYLAND_DISPLAY", "gamescope-0"}});
+
+  EXPECT_FALSE(gp::nested_gamescope_client("wayland-1", paths_for(tree)).has_value());
+}
+
+TEST(GamescopeProcessNestingTests, IgnoresNonGamescopeClientsOfTheSameDisplay) {
+  fake_proc_tree_t tree;
+  tree.add_process(4242, 1, 100, {"steam", "-gamepadui"}, {}, {}, -1, -1,
+                   {{"WAYLAND_DISPLAY", "wayland-1"}});
+
+  EXPECT_FALSE(gp::nested_gamescope_client("wayland-1", paths_for(tree)).has_value());
+}
+
+TEST(GamescopeProcessNestingTests, FindsAWrapperLaunchedNixWrappedGamescope) {
+  fake_proc_tree_t tree;
+  // The reported configuration pointed the app's detached command at a shell
+  // script, so argv carries the script rather than gamescope. Identifying by
+  // executable is what makes that case visible.
+  tree.add_process(4242, 1, 100, {"/opt/launchers/big-picture.sh"}, {},
+                   "/nix/store/abc/bin/.gamescope-wrapped", -1, -1,
+                   {{"WAYLAND_DISPLAY", "wayland-1"}});
+
+  const auto nested = gp::nested_gamescope_client("wayland-1", paths_for(tree));
+  ASSERT_TRUE(nested.has_value());
+  EXPECT_EQ(*nested, 4242);
+}
+
+TEST(GamescopeProcessNestingTests, ReportsNothingWithoutASocketOrProcTree) {
+  fake_proc_tree_t tree;
+  tree.add_process(4242, 1, 100, {"gamescope"}, {}, {}, -1, -1, {{"WAYLAND_DISPLAY", "wayland-1"}});
+
+  EXPECT_FALSE(gp::nested_gamescope_client("", paths_for(tree)).has_value());
+
+  auto missing = paths_for(tree);
+  missing.proc_root = tree.root / "missing-proc";
+  EXPECT_FALSE(gp::nested_gamescope_client("wayland-1", missing).has_value());
+}


### PR DESCRIPTION
Addresses part 1 of #422.

A gamescope launched as a Wayland client inside a Private Stream session can leave the session looking healthy while the game never becomes usable. The reporter first observed this as dead keyboard/controller input, then found the concrete failure: the game was blocked behind a native Gamescope WSI error dialog that was not part of the captured surface.

## Why the attach guard cannot cover this

`private_session_attach` concludes from the private compositor's toplevel list. A nested gamescope maps a window like any other Wayland client, so the verdict is `attached` and the guard correctly stays quiet. The failure occurs later inside the unsupported nested Gamescope/WSI arrangement.

## Why this reads the process rather than the config

The reported setup pointed the app's `detached` command at a wrapper script, so `gamescope` appeared nowhere in the stored command.

`nested_gamescope_client()` instead finds a gamescope whose `WAYLAND_DISPLAY` names the private compositor's socket. Polaris' supported owned gamescope creates a display; the unsupported nested one connects to the private compositor's display. The executable check also recognizes Nix's `.gamescope-wrapped` form.

The scan reads one executable symlink per process and opens `environ` only for candidates that are actually gamescope. It runs on the existing two-second private-session watch thread.

## Report, not block

The detector emits one session warning explaining that this unsupported nesting can leave games blocked behind an off-stream Gamescope WSI error or native dialog. It directs the user to launch without gamescope or switch to the Gamescope stream mode so Polaris owns gamescope itself.

It does not tear down the session or claim that every nested Gamescope launch fails identically.

## What this does not fix

This does not make nested Gamescope-in-Private-Stream supported. The supported `gamescope_stream` route is separately blocked on the reporter's host by the exact-generation failure first recorded in a comment on #395 and repeated in #422.

Parts 2 and 3 of #422 remain separate:

- making the supported owned-Gamescope route usable on the affected host
- investigating classic Steam Overlay scaling and intermittently dropped virtual-keyboard input

## Testing

Five cases use a fake `/proc` tree:

- direct nested-gamescope client
- gamescope connected to a different display
- non-gamescope client on the private display
- wrapper-launched Nix `.gamescope-wrapped`
- empty socket and missing `/proc`

The first CI run was fully green. After updating onto current `master`, the warning and test commentary were corrected to match the reporter's WSI-dialog finding; fresh CI is required for that final head.
