### PR TITLE
fix(http): validate every download redirect hop

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -724,6 +724,19 @@ namespace confighttp {
       std::string background_raw;
     };
 
+    bool steam_artwork_url_allowed(std::string_view url) {
+      return game_artwork::is_allowed_provider_url(game_artwork::provider_e::steam, url);
+    }
+
+    bool cover_download_url_allowed(std::string_view url) {
+      return steam_artwork_url_allowed(url) ||
+             game_artwork::is_allowed_provider_url(game_artwork::provider_e::steamgriddb, url);
+    }
+
+    bool igdb_image_url_allowed(std::string_view url) {
+      return http::url_is_https_host(url, "images.igdb.com");
+    }
+
     std::optional<steam_store_assets_t> fetch_steam_store_assets(const std::string &appid) {
       const std::string url = "https://store.steampowered.com/api/appdetails?appids=" + appid;
       CURL *curl = curl_easy_init();
@@ -732,18 +745,41 @@ namespace confighttp {
       }
 
       std::string response;
-      curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-      curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+      curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
       curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, append_string_curl_write_cb);
       curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
       curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
       curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
       curl_easy_setopt(curl, CURLOPT_USERAGENT, "Polaris/1.0");
+#if LIBCURL_VERSION_NUM >= 0x075500
+      curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "https");
+#else
+      curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
+#endif
 
-      const CURLcode res = curl_easy_perform(curl);
+      const bool downloaded = http::redirect::follow(
+        url,
+        steam_artwork_url_allowed,
+        [&](const std::string &current_url) {
+          response.clear();
+          curl_easy_setopt(curl, CURLOPT_URL, current_url.c_str());
+          const CURLcode result = curl_easy_perform(curl);
+          long response_code = 0;
+          char *redirect_url = nullptr;
+          if (result == CURLE_OK) {
+            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+            curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &redirect_url);
+          }
+          return http::redirect::hop_result_t {
+            result == CURLE_OK,
+            response_code,
+            redirect_url && *redirect_url ? std::optional<std::string> {redirect_url} : std::nullopt,
+          };
+        }
+      );
       curl_easy_cleanup(curl);
 
-      if (res != CURLE_OK) {
+      if (!downloaded) {
         return std::nullopt;
       }
 
@@ -812,7 +848,7 @@ namespace confighttp {
 
       const std::string portrait_url = "https://steamcdn-a.akamaihd.net/steam/apps/" + appid + "/library_600x900_2x.jpg";
       const fs::path portrait_path = coverdir / (stem + safe_cover_extension_from_url(portrait_url));
-      if (http::download_file(portrait_url, portrait_path.string())) {
+      if (http::download_file(portrait_url, portrait_path.string(), steam_artwork_url_allowed)) {
         return portrait_path.string();
       }
 
@@ -824,7 +860,7 @@ namespace confighttp {
       if (!assets->header_image.empty()) {
         const auto tmp_stem = "steam_header_" + appid + "_" + uuid_util::uuid_t::generate().string();
         const fs::path header_tmp_path = fs::temp_directory_path() / (tmp_stem + safe_cover_extension_from_url(assets->header_image));
-        if (http::download_file(assets->header_image, header_tmp_path.string())) {
+        if (http::download_file(assets->header_image, header_tmp_path.string(), steam_artwork_url_allowed)) {
           const fs::path generated_path = coverdir / (stem + ".jpg");
           if (synthesize_steam_cover_from_header(header_tmp_path, generated_path)) {
             std::error_code ec;
@@ -850,7 +886,7 @@ namespace confighttp {
         }
 
         const fs::path candidate_path = coverdir / (stem + safe_cover_extension_from_url(candidate_url));
-        if (http::download_file(candidate_url, candidate_path.string())) {
+        if (http::download_file(candidate_url, candidate_path.string(), steam_artwork_url_allowed)) {
           BOOST_LOG(info) << "Fell back to Steam capsule art for [" << appid << "]";
           return candidate_path.string();
         }
@@ -4032,11 +4068,11 @@ namespace confighttp {
       file_handler::make_directory(coverdir);
       std::string path = coverdir + http::url_escape(key) + ".png";
       if (!url.empty()) {
-        if (http::url_get_host(url) != "images.igdb.com") {
+        if (!igdb_image_url_allowed(url)) {
           bad_request(response, request, "Only images.igdb.com is allowed");
           return;
         }
-        if (!http::download_file(url, path)) {
+        if (!http::download_file(url, path, igdb_image_url_allowed)) {
           bad_request(response, request, "Failed to download cover");
           return;
         }
@@ -4291,7 +4327,7 @@ namespace confighttp {
       file_handler::make_directory(coverdir);
       std::string cover_path = coverdir + http::url_escape(app_entry->uuid) + safe_cover_extension_from_url(url);
 
-      if (!http::download_file(url, cover_path)) {
+      if (!http::download_file(url, cover_path, cover_download_url_allowed)) {
         output["status"] = false;
         output["error"] = "Failed to download cover";
         send_response(response, output);

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -283,7 +283,58 @@ namespace http {
     return 0;
   }
 
-  bool download_file(const std::string &url, const std::string &file, long ssl_version) {
+  namespace redirect {
+    bool follow(
+      const std::string &initial_url,
+      const download_url_validator_t &url_allowed,
+      const request_t &request
+    ) {
+      constexpr std::size_t maximum_redirects = 5;
+      if (!url_allowed || !request || !url_allowed(initial_url)) {
+        return false;
+      }
+
+      std::string current_url = initial_url;
+      std::size_t redirect_count = 0;
+      while (true) {
+        const auto result = request(current_url);
+        if (!result.transport_ok) {
+          return false;
+        }
+        if (result.response_code >= 200 && result.response_code < 300) {
+          return true;
+        }
+        if (result.response_code < 300 || result.response_code >= 400 ||
+            !result.redirect_url || result.redirect_url->empty()) {
+          return false;
+        }
+        if (redirect_count >= maximum_redirects) {
+          BOOST_LOG(warning) << "Download exceeded the five-redirect limit";
+          return false;
+        }
+        if (!url_allowed(*result.redirect_url)) {
+          BOOST_LOG(warning) << "Refused download redirect to non-allowlisted host ["sv
+                             << url_get_host(*result.redirect_url) << ']';
+          return false;
+        }
+
+        current_url = *result.redirect_url;
+        ++redirect_count;
+      }
+    }
+  }  // namespace redirect
+
+  bool download_file(
+    const std::string &url,
+    const std::string &file,
+    const download_url_validator_t &url_allowed,
+    long ssl_version
+  ) {
+    if (!url_allowed || !url_allowed(url)) {
+      BOOST_LOG(warning) << "Refused non-allowlisted download URL host ["sv << url_get_host(url) << ']';
+      return false;
+    }
+
     // sonar complains about weak ssl and tls versions; however sonar cannot detect the fix
     CURL *curl = curl_easy_init();  // NOSONAR
     if (!curl) {
@@ -297,46 +348,53 @@ namespace http {
       return false;
     }
 
-    FILE *fp = fopen(file.c_str(), "wb");
-    if (!fp) {
-      BOOST_LOG(error) << "Couldn't open ["sv << file << ']';
-      curl_easy_cleanup(curl);
-      return false;
-    }
-
     curl_easy_setopt(curl, CURLOPT_SSLVERSION, ssl_version);  // NOSONAR
-    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
-    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-
-    // Callers vet the host of the URL they pass, but a redirect is a second
-    // URL nobody vetted. Steam's CDNs do redirect, so following is kept -- but
-    // only over https and only a few hops, so a redirect cannot drop to
-    // plaintext, reach a non-http scheme, or loop.
-    // CURLOPT_REDIR_PROTOCOLS is deprecated in 7.85; the _STR form replaces it.
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
 #if LIBCURL_VERSION_NUM >= 0x075500
-    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "https");
+#else
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
 #endif
-    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
 #ifdef _WIN32
     curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
 #endif
-    CURLcode result = curl_easy_perform(curl);
-    long response_code = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-    if (result != CURLE_OK) {
-      BOOST_LOG(error) << "Couldn't download ["sv << url << ", code:" << result << ']';
-    }
-    curl_easy_cleanup(curl);
-    fclose(fp);
 
-    const bool http_ok = response_code >= 200 && response_code < 300;
-    if (result != CURLE_OK || !http_ok) {
-      if (!http_ok) {
-        BOOST_LOG(error) << "Download returned unexpected HTTP status for ["sv << url << "]: "sv << response_code;
+    const bool downloaded = redirect::follow(
+      url,
+      url_allowed,
+      [&](const std::string &current_url) {
+        FILE *fp = fopen(file.c_str(), "wb");
+        if (!fp) {
+          BOOST_LOG(error) << "Couldn't open ["sv << file << ']';
+          return redirect::hop_result_t {false, 0, std::nullopt};
+        }
+
+        curl_easy_setopt(curl, CURLOPT_URL, current_url.c_str());
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
+        const CURLcode result = curl_easy_perform(curl);
+        long response_code = 0;
+        char *redirect_url = nullptr;
+        if (result == CURLE_OK) {
+          curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+          curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &redirect_url);
+        }
+        fclose(fp);
+
+        if (result != CURLE_OK) {
+          BOOST_LOG(error) << "Couldn't download from host ["sv << url_get_host(current_url)
+                           << "], code:"sv << result;
+        }
+        return redirect::hop_result_t {
+          result == CURLE_OK,
+          response_code,
+          redirect_url && *redirect_url ? std::optional<std::string> {redirect_url} : std::nullopt,
+        };
       }
+    );
+    curl_easy_cleanup(curl);
+
+    if (!downloaded) {
       std::error_code err_code;
       fs::remove(file, err_code);
       if (err_code) {
@@ -357,8 +415,11 @@ namespace http {
 
   std::string url_get_host(const std::string &url) {
     CURLU *curlu = curl_url();
-    curl_url_set(curlu, CURLUPART_URL, url.c_str(), static_cast<unsigned int>(url.length()));
-    char *host;
+    if (!curlu || curl_url_set(curlu, CURLUPART_URL, url.c_str(), 0) != CURLUE_OK) {
+      if (curlu) curl_url_cleanup(curlu);
+      return "";
+    }
+    char *host = nullptr;
     if (curl_url_get(curlu, CURLUPART_HOST, &host, 0) != CURLUE_OK) {
       curl_url_cleanup(curlu);
       return "";
@@ -367,5 +428,35 @@ namespace http {
     curl_free(host);
     curl_url_cleanup(curlu);
     return result;
+  }
+
+  bool url_is_https_host(std::string_view url, std::string_view expected_host) {
+    if (url.empty() || expected_host.empty()) {
+      return false;
+    }
+
+    CURLU *curlu = curl_url();
+    const std::string owned_url {url};
+    if (!curlu || curl_url_set(curlu, CURLUPART_URL, owned_url.c_str(), 0) != CURLUE_OK) {
+      if (curlu) curl_url_cleanup(curlu);
+      return false;
+    }
+
+    char *scheme = nullptr;
+    char *host = nullptr;
+    char *forbidden = nullptr;
+    const bool valid =
+      curl_url_get(curlu, CURLUPART_SCHEME, &scheme, 0) == CURLUE_OK &&
+      curl_url_get(curlu, CURLUPART_HOST, &host, 0) == CURLUE_OK &&
+      boost::iequals(scheme, "https") && boost::iequals(host, expected_host) &&
+      curl_url_get(curlu, CURLUPART_PORT, &forbidden, 0) != CURLUE_OK &&
+      curl_url_get(curlu, CURLUPART_USER, &forbidden, 0) != CURLUE_OK &&
+      curl_url_get(curlu, CURLUPART_PASSWORD, &forbidden, 0) != CURLUE_OK;
+
+    if (scheme) curl_free(scheme);
+    if (host) curl_free(host);
+    if (forbidden) curl_free(forbidden);
+    curl_url_cleanup(curlu);
+    return valid;
   }
 }  // namespace http

--- a/src/httpcommon.h
+++ b/src/httpcommon.h
@@ -7,12 +7,39 @@
 // lib includes
 #include <curl/curl.h>
 
+// standard includes
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+
 // local includes
 #include "network.h"
 #include "thread_safe.h"
 #include "uuid.h"
 
 namespace http {
+
+  using download_url_validator_t = std::function<bool(std::string_view)>;
+
+  namespace redirect {
+    struct hop_result_t {
+      bool transport_ok;
+      long response_code;
+      std::optional<std::string> redirect_url;
+    };
+
+    using request_t = std::function<hop_result_t(const std::string &url)>;
+
+    /**
+     * Follow at most five redirects, validating each target before requesting it.
+     */
+    bool follow(
+      const std::string &initial_url,
+      const download_url_validator_t &url_allowed,
+      const request_t &request
+    );
+  }  // namespace redirect
 
   int init();
   int create_creds(const std::string &pkey, const std::string &cert);
@@ -41,9 +68,15 @@ namespace http {
 #ifdef POLARIS_TESTS
   void set_credential_upgrade_reload_failure_for_tests(bool enabled);
 #endif
-  bool download_file(const std::string &url, const std::string &file, long ssl_version = CURL_SSLVERSION_TLSv1_2);
+  bool download_file(
+    const std::string &url,
+    const std::string &file,
+    const download_url_validator_t &url_allowed,
+    long ssl_version = CURL_SSLVERSION_TLSv1_2
+  );
   std::string url_escape(const std::string &url);
   std::string url_get_host(const std::string &url);
+  bool url_is_https_host(std::string_view url, std::string_view expected_host);
 
   extern std::string unique_id;
   extern uuid_util::uuid_t uuid;

--- a/tests/unit/test_cover_download_contract.cpp
+++ b/tests/unit/test_cover_download_contract.cpp
@@ -71,5 +71,6 @@ TEST(CoverDownloadContract, TheUploadHandlerStillEscapesItsKey) {
   const auto body = source.substr(handler, source.find("\n  void ", handler + 1) - handler);
 
   EXPECT_NE(body.find("http::url_escape(key)"), std::string::npos);
-  EXPECT_NE(body.find("http::url_get_host(url)"), std::string::npos);
+  EXPECT_NE(source.find(R"(return http::url_is_https_host(url, "images.igdb.com");)"), std::string::npos);
+  EXPECT_NE(body.find("http::download_file(url, path, igdb_image_url_allowed)"), std::string::npos);
 }

--- a/tests/unit/test_httpcommon.cpp
+++ b/tests/unit/test_httpcommon.cpp
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <vector>
 
 // local imports
 #include <src/config.h>
@@ -50,13 +51,140 @@ INSTANTIATE_TEST_SUITE_P(
   )
 );
 
+struct UrlIsHttpsHostTest: testing::TestWithParam<std::tuple<std::string, std::string, bool>> {};
+
+TEST_P(UrlIsHttpsHostTest, Run) {
+  const auto &[url, host, expected] = GetParam();
+  EXPECT_EQ(http::url_is_https_host(url, host), expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  UrlIsHttpsHostTests,
+  UrlIsHttpsHostTest,
+  testing::Values(
+    std::make_tuple("https://images.igdb.com/cover.png", "images.igdb.com", true),
+    std::make_tuple("HTTPS://IMAGES.IGDB.COM/cover.png", "images.igdb.com", true),
+    std::make_tuple("http://images.igdb.com/cover.png", "images.igdb.com", false),
+    std::make_tuple("https://images.igdb.com.evil.example/cover.png", "images.igdb.com", false),
+    std::make_tuple("https://user@images.igdb.com/cover.png", "images.igdb.com", false),
+    std::make_tuple("https://images.igdb.com:8443/cover.png", "images.igdb.com", false),
+    std::make_tuple("not a URL", "images.igdb.com", false)
+  )
+);
+
+TEST(HttpCommonRedirectPolicy, RejectsInitialUrlBeforeRequestingIt) {
+  int request_count = 0;
+  const auto allowed = [](std::string_view url) {
+    return http::url_is_https_host(url, "cdn.example");
+  };
+
+  EXPECT_FALSE(http::redirect::follow(
+    "http://cdn.example/asset.jpg",
+    allowed,
+    [&](const std::string &) {
+      ++request_count;
+      return http::redirect::hop_result_t {true, 200, std::nullopt};
+    }
+  ));
+  EXPECT_EQ(request_count, 0);
+}
+
+TEST(HttpCommonRedirectPolicy, RejectsRedirectBeforeRequestingDisallowedHost) {
+  std::vector<std::string> requested;
+  const auto allowed = [](std::string_view url) {
+    return http::url_is_https_host(url, "cdn.example");
+  };
+
+  EXPECT_FALSE(http::redirect::follow(
+    "https://cdn.example/asset.jpg",
+    allowed,
+    [&](const std::string &url) {
+      requested.push_back(url);
+      return http::redirect::hop_result_t {
+        true,
+        302,
+        "https://metadata.internal/latest",
+      };
+    }
+  ));
+  EXPECT_EQ(requested, (std::vector<std::string> {"https://cdn.example/asset.jpg"}));
+}
+
+TEST(HttpCommonRedirectPolicy, AllowsFiveValidatedRedirects) {
+  std::vector<std::string> requested;
+  const auto allowed = [](std::string_view url) {
+    return http::url_is_https_host(url, "cdn.example");
+  };
+
+  EXPECT_TRUE(http::redirect::follow(
+    "https://cdn.example/0",
+    allowed,
+    [&](const std::string &url) {
+      requested.push_back(url);
+      if (requested.size() == 6) {
+        return http::redirect::hop_result_t {true, 200, std::nullopt};
+      }
+      return http::redirect::hop_result_t {
+        true,
+        302,
+        "https://cdn.example/" + std::to_string(requested.size()),
+      };
+    }
+  ));
+  EXPECT_EQ(requested.size(), 6);
+}
+
+TEST(HttpCommonRedirectPolicy, RejectsTheSixthRedirectWithoutRequestingItsTarget) {
+  std::vector<std::string> requested;
+  const auto allowed = [](std::string_view url) {
+    return http::url_is_https_host(url, "cdn.example");
+  };
+
+  EXPECT_FALSE(http::redirect::follow(
+    "https://cdn.example/0",
+    allowed,
+    [&](const std::string &url) {
+      requested.push_back(url);
+      return http::redirect::hop_result_t {
+        true,
+        302,
+        "https://cdn.example/" + std::to_string(requested.size()),
+      };
+    }
+  ));
+  EXPECT_EQ(requested.size(), 6);
+}
+
+TEST(HttpCommonRedirectPolicy, RejectsTransportErrorsAndNonSuccessResponses) {
+  const auto allowed = [](std::string_view url) {
+    return http::url_is_https_host(url, "cdn.example");
+  };
+  EXPECT_FALSE(http::redirect::follow(
+    "https://cdn.example/asset.jpg",
+    allowed,
+    [](const std::string &) {
+      return http::redirect::hop_result_t {false, 0, std::nullopt};
+    }
+  ));
+  EXPECT_FALSE(http::redirect::follow(
+    "https://cdn.example/asset.jpg",
+    allowed,
+    [](const std::string &) {
+      return http::redirect::hop_result_t {true, 404, std::nullopt};
+    }
+  ));
+}
+
 struct DownloadFileTest: testing::TestWithParam<std::tuple<std::string, std::string>> {};
 
 TEST_P(DownloadFileTest, Run) {
   const auto &[url, filename] = GetParam();
   const std::string test_dir = platf::appdata().string() + "/tests/";
   std::string path = test_dir + filename;
-  if (!http::download_file(url, path, CURL_SSLVERSION_TLSv1_0)) {
+  const auto allowed = [](std::string_view candidate) {
+    return http::url_is_https_host(candidate, "httpbin.org");
+  };
+  if (!http::download_file(url, path, allowed, CURL_SSLVERSION_TLSv1_0)) {
     GTEST_SKIP() << "External download dependency unavailable for " << url;
   }
 }


### PR DESCRIPTION
## Summary

- require each download caller to supply an exact provider URL validator
- replace libcurl automatic redirects with a five-hop loop that validates every target before requesting it
- restrict Steam, SteamGridDB, and IGDB artwork downloads to HTTPS on approved hosts
- harden shared URL parsing and preserve the cover upload source contract

## Why

The first download URL was checked, but libcurl followed its redirects automatically. A redirect target therefore bypassed the caller's host allowlist and could reintroduce SSRF through an otherwise approved provider.

The new redirect loop stops before requesting a disallowed target. It also rejects transport errors, non-success responses, missing redirect locations, and more than five redirects.

This is the deferred per-hop validation noted in #426.

## Validation

- full build completed successfully
- `test_polaris_http`: 127/127 passed
- `ctest --test-dir build -j1 --output-on-failure`: 17/17 passed
- `scripts/check-public-surface.sh`: passed
- `git diff --check`: passed
- deliberate RED check proved the redirect regression test requests the disallowed host when the per-hop validation guard is removed
