### PR TITLE
Enable linear VAAPI capture on headless extcopy

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -890,8 +890,12 @@ namespace cage_display_router {
     return mode;
   }
 
-  bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type) {
-    return wlgrab_capture_policy::gpu_native_dmabuf_is_safe(hwdevice_type);
+  bool gpu_native_dmabuf_is_safe(
+    platf::mem_type_e hwdevice_type,
+    wlgrab_capture_policy::gpu_native_capture_route_e route,
+    std::optional<std::uint64_t> modifier
+  ) {
+    return wlgrab_capture_policy::gpu_native_dmabuf_is_safe(hwdevice_type, route, modifier);
   }
 
   bool should_attempt_headless_extcopy_dmabuf(
@@ -907,7 +911,10 @@ namespace cage_display_router {
       return false;
     }
 
-    return gpu_native_dmabuf_is_safe(hwdevice_type);
+    return wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
+      hwdevice_type,
+      wlgrab_capture_policy::gpu_native_capture_route_e::headless_extcopy
+    );
   }
 
   bool should_attempt_gpu_native_cage_capture(
@@ -928,7 +935,11 @@ namespace cage_display_router {
       return false;
     }
 
-    return gpu_native_dmabuf_is_safe(hwdevice_type);
+    return cage_display_router::gpu_native_dmabuf_is_safe(
+      hwdevice_type,
+      wlgrab_capture_policy::gpu_native_capture_route_e::windowed_nested,
+      std::nullopt
+    );
   }
 
   bool should_disable_headless_extcopy_after_conversion_failure(

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -8,6 +8,7 @@
 #ifdef __linux__
 
 #include "src/platform/common.h"
+#include "wlgrab_capture_policy.h"
 
 #include <optional>
 #include <string>
@@ -148,8 +149,8 @@ namespace cage_display_router {
   platf::runtime_state_t runtime_state();
 
   /**
-   * @brief Returns whether an encoder memory type has a known-safe GPU-native
-   *        DMA-BUF import/convert path.
+   * @brief Returns whether a specific encoder, route, and modifier combination
+   *        has a known-safe GPU-native DMA-BUF import/convert path.
    *
    * This is the stability policy behind every GPU-native capture route, and it
    * belongs in one place: it used to be applied only to the true-headless
@@ -157,15 +158,18 @@ namespace cage_display_router {
    * reached the same conversion boundary the headless path was refusing, and
    * segfaulted at stream start.
    */
-  bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type);
+  bool gpu_native_dmabuf_is_safe(
+    platf::mem_type_e hwdevice_type,
+    wlgrab_capture_policy::gpu_native_capture_route_e route,
+    std::optional<std::uint64_t> modifier
+  );
 
   /**
    * @brief Returns whether a headless labwc runtime should try the
    *        ext-image-copy-capture DMA-BUF path before falling back to SHM.
    *
-   * The true-headless extcopy DMA-BUF path is only enabled for encoder memory
-   * types with a known-safe import/convert path. VAAPI stacks have proven
-   * crash-prone here, so they stay on the conservative SHM path.
+   * VAAPI may probe only this private headless route. Its captured buffer still
+   * has to pass the modifier policy before it reaches the encoder.
    */
   bool should_attempt_headless_extcopy_dmabuf(
     const platf::runtime_state_t &runtime_state,

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -8,6 +8,7 @@
 
   #include "src/platform/common.h"
   #include "stream_display_policy.h"
+  #include "wlgrab_capture_policy.h"
 
   #include <optional>
   #include <string>
@@ -100,7 +101,11 @@ namespace stream_runtime {
       bool prefer_gpu_native_capture,
       bool encoder_requires_gpu_native_capture
     );
-    bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type);
+    bool gpu_native_dmabuf_is_safe(
+      platf::mem_type_e hwdevice_type,
+      wlgrab_capture_policy::gpu_native_capture_route_e route,
+      std::optional<std::uint64_t> modifier
+    );
     bool should_attempt_gpu_native_cage_capture(
       const platf::runtime_state_t &runtime_state,
       platf::mem_type_e hwdevice_type

--- a/src/platform/linux/stream_runtime_labwc.cpp
+++ b/src/platform/linux/stream_runtime_labwc.cpp
@@ -89,8 +89,12 @@ namespace stream_runtime {
       return requested_headless && prefer_gpu_native_capture && encoder_requires_gpu_native_capture;
     }
 
-    bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type) {
-      return cage_display_router::gpu_native_dmabuf_is_safe(hwdevice_type);
+    bool gpu_native_dmabuf_is_safe(
+      platf::mem_type_e hwdevice_type,
+      wlgrab_capture_policy::gpu_native_capture_route_e route,
+      std::optional<std::uint64_t> modifier
+    ) {
+      return cage_display_router::gpu_native_dmabuf_is_safe(hwdevice_type, route, modifier);
     }
 
     bool should_attempt_gpu_native_cage_capture(

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <bitset>
 #include <cstdint>
+#include <optional>
 #include <sys/types.h>
 #include <string>
 #include <string_view>
@@ -257,6 +258,14 @@ namespace wl {
 
     std::string capture_render_node() const {
       return render_node;
+    }
+
+    std::optional<std::uint64_t> capture_modifier() const {
+      if (status != READY || !current_frame || !current_frame->bo || !current_frame->buffer) {
+        return std::nullopt;
+      }
+
+      return current_frame->sd.modifier;
     }
 
     const extcopy_timing_sample_t &last_timing_sample() const {

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -749,11 +749,21 @@ namespace platf {
         try_headless_extcopy_dmabuf =
           stream_runtime::labwc::should_attempt_headless_extcopy_dmabuf(runtime_state, hwdevice_type);
         if (!try_headless_extcopy_dmabuf && hwdevice_type == platf::mem_type_e::vaapi) {
-          stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "ineligible", "policy", "vaapi_headless_dmabuf_disabled_for_stability");
+          const auto cached_result =
+            stream_runtime::labwc::cached_headless_extcopy_dmabuf_probe_result();
+          if (cached_result == std::optional<bool> {false}) {
+            stream_stats::update_gpu_native_probe_attempt(
+              "headless_extcopy",
+              "ineligible",
+              "cache",
+              "cached_unsupported",
+              true
+            );
+          }
           stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");
           if (stream_runtime::labwc::should_log_headless_ram_capture_warning()) {
             BOOST_LOG(info)
-              << "wlr: Using RAM capture path for headless labwc because true-headless ext-image-copy-capture DMA-BUF is disabled for VAAPI stability"sv;
+              << "wlr: Using RAM capture path for headless labwc because its GPU-native probe is unavailable or cached unsupported"sv;
           }
         }
       } else {
@@ -796,45 +806,71 @@ namespace platf {
 
     if (try_headless_extcopy_dmabuf && gpu_native_capture_supported) {
       bool device_pairing_failed = false;
+      bool modifier_policy_failed = false;
       auto wlr = std::make_shared<wl::wlr_extcopy_vram_t>();
       if (!wlr->init(hwdevice_type, display_name, config)) {
-        const auto capture_render_node = wlr->extcopy.capture_render_node();
-        const auto adapter_pairing = stream_stats::device_nodes_match(capture_render_node, config::video.adapter_name);
-        if (!config::video.adapter_name.empty() &&
-            !capture_render_node.empty() &&
-            (!adapter_pairing.has_value() || !*adapter_pairing)) {
-          device_pairing_failed = true;
-          const bool identity_resolved = adapter_pairing.has_value();
+        const auto capture_modifier = wlr->extcopy.capture_modifier();
+        if (!stream_runtime::labwc::gpu_native_dmabuf_is_safe(
+              hwdevice_type,
+              wlgrab_capture_policy::gpu_native_capture_route_e::headless_extcopy,
+              capture_modifier
+            )) {
+          modifier_policy_failed = true;
+          const auto failure_reason = capture_modifier.has_value() ?
+                                        "vaapi_headless_modifier_not_linear" :
+                                        "vaapi_headless_modifier_unavailable";
           BOOST_LOG(warning)
-            << "wlr: Disabling true-headless ext-image-copy-capture DMA-BUF because capture render_node=["sv
-            << capture_render_node
-            << (identity_resolved ? "] differs from encoder adapter=["sv : "] could not be identity-matched to encoder adapter=["sv)
-            << config::video.adapter_name
-            << "]; using SHM/system-memory fallback to avoid unsafe cross-GPU import"sv;
+            << "wlr: Disabling VAAPI headless ext-image-copy-capture DMA-BUF because the captured buffer modifier is "sv
+            << (capture_modifier.has_value() ? std::to_string(*capture_modifier) : "unavailable")
+            << "; only an actual linear modifier is accepted; using SHM fallback"sv;
 #ifdef __linux__
           stream_runtime::labwc::update_headless_extcopy_dmabuf_probe_result(false);
 #endif
           stream_stats::update_gpu_native_probe_attempt(
             "headless_extcopy",
             "failed",
-            "device_pairing",
-            identity_resolved ? "cross_gpu_adapter_mismatch" : "device_identity_unresolved"
+            "modifier_policy",
+            failure_reason
           );
         } else {
+          const auto capture_render_node = wlr->extcopy.capture_render_node();
+          const auto adapter_pairing = stream_stats::device_nodes_match(capture_render_node, config::video.adapter_name);
+          if (!config::video.adapter_name.empty() &&
+              !capture_render_node.empty() &&
+              (!adapter_pairing.has_value() || !*adapter_pairing)) {
+            device_pairing_failed = true;
+            const bool identity_resolved = adapter_pairing.has_value();
+            BOOST_LOG(warning)
+              << "wlr: Disabling true-headless ext-image-copy-capture DMA-BUF because capture render_node=["sv
+              << capture_render_node
+              << (identity_resolved ? "] differs from encoder adapter=["sv : "] could not be identity-matched to encoder adapter=["sv)
+              << config::video.adapter_name
+              << "]; using SHM/system-memory fallback to avoid unsafe cross-GPU import"sv;
 #ifdef __linux__
-          stream_runtime::labwc::update_headless_extcopy_dmabuf_probe_result(true);
+            stream_runtime::labwc::update_headless_extcopy_dmabuf_probe_result(false);
 #endif
-          stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "succeeded");
-          stream_stats::update_gpu_native_probe_selection("headless_extcopy_dmabuf");
-          BOOST_LOG(info) << "wlr: Using ext-image-copy-capture DMA-BUF for headless labwc"sv;
-          return wlr;
+            stream_stats::update_gpu_native_probe_attempt(
+              "headless_extcopy",
+              "failed",
+              "device_pairing",
+              identity_resolved ? "cross_gpu_adapter_mismatch" : "device_identity_unresolved"
+            );
+          } else {
+#ifdef __linux__
+            stream_runtime::labwc::update_headless_extcopy_dmabuf_probe_result(true);
+#endif
+            stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "succeeded");
+            stream_stats::update_gpu_native_probe_selection("headless_extcopy_dmabuf");
+            BOOST_LOG(info) << "wlr: Using ext-image-copy-capture DMA-BUF for headless labwc"sv;
+            return wlr;
+          }
         }
       }
 
 #ifdef __linux__
       stream_runtime::labwc::update_headless_extcopy_dmabuf_probe_result(false);
 #endif
-      if (!device_pairing_failed) {
+      if (!device_pairing_failed && !modifier_policy_failed) {
         stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "capture_init", "dmabuf_capture_not_initialized");
       }
       stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");

--- a/src/platform/linux/wlgrab_capture_policy.h
+++ b/src/platform/linux/wlgrab_capture_policy.h
@@ -6,21 +6,58 @@
 
 #include "src/platform/common.h"
 
+#include <cstdint>
+#include <drm_fourcc.h>
+#include <optional>
+
 namespace wlgrab_capture_policy {
+  enum class gpu_native_capture_route_e {
+    headless_extcopy,
+    windowed_nested,
+    direct_wayland,
+  };
+
   enum class direct_capture_path_e {
     ram,
     gpu_native,
   };
 
-  inline bool gpu_native_dmabuf_is_safe(platf::mem_type_e hwdevice_type) {
-    return hwdevice_type == platf::mem_type_e::cuda;
+  inline bool gpu_native_dmabuf_probe_is_allowed(
+    platf::mem_type_e hwdevice_type,
+    gpu_native_capture_route_e route
+  ) {
+    if (hwdevice_type == platf::mem_type_e::cuda) {
+      return true;
+    }
+
+    return hwdevice_type == platf::mem_type_e::vaapi &&
+           route == gpu_native_capture_route_e::headless_extcopy;
+  }
+
+  inline bool gpu_native_dmabuf_is_safe(
+    platf::mem_type_e hwdevice_type,
+    gpu_native_capture_route_e route,
+    std::optional<std::uint64_t> modifier
+  ) {
+    if (hwdevice_type == platf::mem_type_e::cuda) {
+      return true;
+    }
+
+    return hwdevice_type == platf::mem_type_e::vaapi &&
+           route == gpu_native_capture_route_e::headless_extcopy &&
+           modifier == DRM_FORMAT_MOD_LINEAR;
   }
 
   inline direct_capture_path_e select_direct_capture_path(
     platf::mem_type_e hwdevice_type,
     bool gpu_native_backend_available
   ) {
-    if (!gpu_native_backend_available || !gpu_native_dmabuf_is_safe(hwdevice_type)) {
+    if (!gpu_native_backend_available ||
+        !gpu_native_dmabuf_is_safe(
+          hwdevice_type,
+          gpu_native_capture_route_e::direct_wayland,
+          std::nullopt
+        )) {
       return direct_capture_path_e::ram;
     }
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7137,13 +7137,18 @@ namespace proc {
       if (!stream_runtime::labwc::headless_extcopy_dmabuf_probe_succeeded(extcopy_initialized, live_gpu_frame_converted)) {
         stream_runtime::labwc::update_headless_extcopy_dmabuf_probe_result(false);
         if (!extcopy_initialized) {
-          const auto gpu_profile = stream_stats::linux_gpu_profile_json(stream_stats::get_current());
-          if (encoder_label.find("vaapi") != std::string::npos) {
-            stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "ineligible", "policy", "vaapi_headless_dmabuf_disabled_for_stability");
-          } else if (gpu_profile.value("adapter_pairing_status", std::string {}) == "mismatched") {
-            stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "device_pairing", "cross_gpu_adapter_mismatch");
+          const auto current_stats = stream_stats::get_current();
+          const auto &headless_attempt = current_stats.gpu_native_probe.headless_extcopy;
+          if (!headless_attempt.failure_reason.empty()) {
+            BOOST_LOG(info) << "session_manager: Retaining headless extcopy failure reason ["
+                            << headless_attempt.failure_reason << "] from capture initialization";
           } else {
-            stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "capture_init", "dmabuf_capture_not_initialized");
+            const auto gpu_profile = stream_stats::linux_gpu_profile_json(current_stats);
+            if (gpu_profile.value("adapter_pairing_status", std::string {}) == "mismatched") {
+              stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "device_pairing", "cross_gpu_adapter_mismatch");
+            } else {
+              stream_stats::update_gpu_native_probe_attempt("headless_extcopy", "failed", "capture_init", "dmabuf_capture_not_initialized");
+            }
           }
           BOOST_LOG(info) << "session_manager: headless_extcopy_dmabuf probe did not initialize DMA-BUF capture"sv;
         } else {
@@ -7211,7 +7216,11 @@ namespace proc {
       // gate covers the rest, by which point the encoder is always chosen.
       const auto encoder_mem_type = video::active_encoder_mem_type();
       if (encoder_mem_type != platf::mem_type_e::unknown &&
-          !stream_runtime::labwc::gpu_native_dmabuf_is_safe(encoder_mem_type)) {
+          !stream_runtime::labwc::gpu_native_dmabuf_is_safe(
+            encoder_mem_type,
+            wlgrab_capture_policy::gpu_native_capture_route_e::windowed_nested,
+            std::nullopt
+          )) {
         stream_stats::update_gpu_native_probe_attempt("windowed", "ineligible", "policy", "vaapi_gpu_native_dmabuf_disabled_for_stability");
         BOOST_LOG(info) << "session_manager: Skipping the windowed GPU-native fallback for encoder ["
                         << (video::active_encoder_name().empty() ? "unknown" : video::active_encoder_name())

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -399,7 +399,7 @@ TEST(WaylandInterfaceTests, RemovedOutputMarksDirtyButKeepsMonitorStorageUntilRe
 // windowed_ram_fallback, headless_extcopy_probe_succeeded) live only under
 // stream_runtime::labwc as one-liners — no dual cage export / matrix tests.
 
-TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiSkipsExtcopyDmabufForShmFallback) {
+TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiMayProbeExtcopyDmabuf) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,
     .effective_headless = true,
@@ -407,7 +407,7 @@ TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiSkipsExtcopyDmabufForSh
     .backend_name = "labwc",
   };
 
-  EXPECT_FALSE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
+  EXPECT_TRUE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
     runtime_state,
     platf::mem_type_e::vaapi
   ));
@@ -486,42 +486,55 @@ TEST(CageDisplayRouterPolicyTests, GpuNativeCaptureNeedsTheOverrideRegardlessOfE
   ));
 }
 
-TEST(CageDisplayRouterPolicyTests, BothGpuNativeRoutesShareOneStabilityPolicy) {
-  // Keeping the two routes' policies independent is what let a VAAPI host
-  // crash through one while the other was refusing the same buffers, so this
-  // pins them to the same answer rather than to a literal.
-  for (const auto hwdevice_type : {
-         platf::mem_type_e::cuda,
-         platf::mem_type_e::vaapi,
-         platf::mem_type_e::system,
-         platf::mem_type_e::unknown,
-       }) {
-    const platf::runtime_state_t headless {
-      .requested_headless = true,
-      .effective_headless = true,
-      .gpu_native_override_active = false,
-      .backend_name = "labwc",
-    };
-    const platf::runtime_state_t overridden {
-      .requested_headless = true,
-      .effective_headless = false,
-      .gpu_native_override_active = true,
-      .backend_name = "labwc",
-    };
+TEST(CageDisplayRouterPolicyTests, VaapiSafetyIsLimitedToLinearHeadlessExtcopy) {
+  using route_e = wlgrab_capture_policy::gpu_native_capture_route_e;
+  constexpr std::uint64_t tiled_modifier = 0x0100000000000002ULL;
 
-    EXPECT_EQ(
-      cage_display_router::should_attempt_headless_extcopy_dmabuf(headless, hwdevice_type),
-      cage_display_router::should_attempt_gpu_native_cage_capture(overridden, hwdevice_type)
-    ) << "hwdevice_type=" << static_cast<int>(hwdevice_type);
-  }
+  EXPECT_TRUE(cage_display_router::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::headless_extcopy,
+    DRM_FORMAT_MOD_LINEAR
+  ));
+  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::headless_extcopy,
+    tiled_modifier
+  ));
+  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::headless_extcopy,
+    std::nullopt
+  ));
+  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::windowed_nested,
+    DRM_FORMAT_MOD_LINEAR
+  ));
+  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::direct_wayland,
+    DRM_FORMAT_MOD_LINEAR
+  ));
 }
 
-TEST(CageDisplayRouterPolicyTests, OnlyCudaHasASafeGpuNativeDmabufPath) {
-  EXPECT_TRUE(cage_display_router::gpu_native_dmabuf_is_safe(platf::mem_type_e::cuda));
-  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(platf::mem_type_e::vaapi));
-  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(platf::mem_type_e::system));
-  // An encoder that has not resolved yet must not read as safe.
-  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(platf::mem_type_e::unknown));
+TEST(CageDisplayRouterPolicyTests, CudaRemainsSafeWithoutAModifier) {
+  using route_e = wlgrab_capture_policy::gpu_native_capture_route_e;
+
+  EXPECT_TRUE(cage_display_router::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::cuda,
+    route_e::headless_extcopy,
+    std::nullopt
+  ));
+  EXPECT_TRUE(cage_display_router::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::cuda,
+    route_e::windowed_nested,
+    std::nullopt
+  ));
+  EXPECT_TRUE(cage_display_router::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::cuda,
+    route_e::direct_wayland,
+    std::nullopt
+  ));
 }
 
 TEST(CageDisplayRouterPolicyTests, HeadlessDmabufGpuConversionFailureDisablesExtcopyFallback) {

--- a/tests/unit/test_linux_platform_hardening_source.cpp
+++ b/tests/unit/test_linux_platform_hardening_source.cpp
@@ -37,6 +37,30 @@ TEST(LinuxPlatformHardeningSource, TimedOutWlrCaptureCancelsItsRequest) {
   EXPECT_NE(capture.find("dmabuf.cancel()"), std::string::npos);
 }
 
+TEST(LinuxPlatformHardeningSource, HeadlessVaapiChecksActualModifierBeforeGpuNativeSelection) {
+  const auto header = read_source("src/platform/linux/wayland.h");
+  const auto capture = read_source("src/platform/linux/wlgrab.cpp");
+  const auto process = read_source("src/process.cpp");
+
+  EXPECT_NE(header.find("std::optional<std::uint64_t> capture_modifier() const"), std::string::npos);
+
+  const auto headless_probe = capture.find("if (try_headless_extcopy_dmabuf && gpu_native_capture_supported)");
+  ASSERT_NE(headless_probe, std::string::npos);
+  const auto modifier = capture.find("wlr->extcopy.capture_modifier()", headless_probe);
+  const auto policy = capture.find("gpu_native_dmabuf_is_safe(", modifier);
+  const auto accepted = capture.find("update_headless_extcopy_dmabuf_probe_result(true)", policy);
+  ASSERT_NE(modifier, std::string::npos);
+  ASSERT_NE(policy, std::string::npos);
+  ASSERT_NE(accepted, std::string::npos);
+  EXPECT_LT(modifier, policy);
+  EXPECT_LT(policy, accepted);
+  EXPECT_NE(capture.find("vaapi_headless_modifier_not_linear", policy), std::string::npos);
+  EXPECT_NE(capture.find("vaapi_headless_modifier_unavailable", policy), std::string::npos);
+  EXPECT_NE(process.find("if (!headless_attempt.failure_reason.empty())"), std::string::npos);
+  EXPECT_NE(process.find("Retaining headless extcopy failure reason"), std::string::npos);
+  EXPECT_EQ(process.find("vaapi_headless_dmabuf_disabled_for_stability"), std::string::npos);
+}
+
 TEST(LinuxPlatformHardeningSource, CudaFormatTransitionReleasesCompleteDestination) {
   const auto source = read_source("src/platform/linux/cuda.cpp");
   const auto transition = source.find("source_fourcc != descriptor.sd.fourcc");

--- a/tests/unit/test_wlgrab_capture_policy.cpp
+++ b/tests/unit/test_wlgrab_capture_policy.cpp
@@ -3,8 +3,13 @@
  * @brief Regression tests for direct wlroots capture-path selection.
  */
 #include <gtest/gtest.h>
+#include <drm_fourcc.h>
 
 #include "src/platform/linux/wlgrab_capture_policy.h"
+
+namespace {
+  using route_e = wlgrab_capture_policy::gpu_native_capture_route_e;
+}
 
 TEST(WlgrabCapturePolicy, DirectVaapiCaptureUsesRamFallback) {
   EXPECT_EQ(
@@ -32,4 +37,84 @@ TEST(WlgrabCapturePolicy, SystemMemoryEncoderUsesRamCapture) {
     wlgrab_capture_policy::select_direct_capture_path(platf::mem_type_e::system, true),
     wlgrab_capture_policy::direct_capture_path_e::ram
   );
+}
+
+TEST(WlgrabCapturePolicy, VaapiMayProbeOnlyTheHeadlessPrivateRoute) {
+  EXPECT_TRUE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
+    platf::mem_type_e::vaapi,
+    route_e::headless_extcopy
+  ));
+  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
+    platf::mem_type_e::vaapi,
+    route_e::windowed_nested
+  ));
+  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
+    platf::mem_type_e::vaapi,
+    route_e::direct_wayland
+  ));
+}
+
+TEST(WlgrabCapturePolicy, VaapiHeadlessCaptureRequiresAnActualLinearModifier) {
+  constexpr std::uint64_t tiled_modifier = 0x0100000000000002ULL;
+
+  EXPECT_TRUE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::headless_extcopy,
+    DRM_FORMAT_MOD_LINEAR
+  ));
+  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::headless_extcopy,
+    std::nullopt
+  ));
+  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::headless_extcopy,
+    DRM_FORMAT_MOD_INVALID
+  ));
+  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::headless_extcopy,
+    tiled_modifier
+  ));
+}
+
+TEST(WlgrabCapturePolicy, LinearVaapiBuffersRemainRefusedOutsideHeadlessPrivateCapture) {
+  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::windowed_nested,
+    DRM_FORMAT_MOD_LINEAR
+  ));
+  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+    platf::mem_type_e::vaapi,
+    route_e::direct_wayland,
+    DRM_FORMAT_MOD_LINEAR
+  ));
+}
+
+TEST(WlgrabCapturePolicy, CudaSafetyDoesNotDependOnRouteOrModifier) {
+  for (const auto route : {
+         route_e::headless_extcopy,
+         route_e::windowed_nested,
+         route_e::direct_wayland,
+       }) {
+    EXPECT_TRUE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+      platf::mem_type_e::cuda,
+      route,
+      std::nullopt
+    ));
+  }
+}
+
+TEST(WlgrabCapturePolicy, UnsupportedEncoderTypesAreNeverGpuNativeSafe) {
+  for (const auto hwdevice_type : {
+         platf::mem_type_e::system,
+         platf::mem_type_e::unknown,
+       }) {
+    EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+      hwdevice_type,
+      route_e::headless_extcopy,
+      DRM_FORMAT_MOD_LINEAR
+    ));
+  }
 }


### PR DESCRIPTION
## Summary

- let VAAPI probe GPU-native DMA-BUF capture on the private headless extcopy route
- make the shared safety decision depend on encoder, route, and the actual captured modifier
- accept VAAPI only when the headless buffer is confirmed `DRM_FORMAT_MOD_LINEAR`
- fall back to SHM and cache the failed path for tiled, invalid, or unavailable modifiers
- preserve the exact modifier failure reason in Doctor telemetry
- keep windowed and direct VAAPI capture on SHM for #410 and #411

This replaces the blanket encoder-only refusal with the smallest route-specific policy that addresses the 4K capture bottleneck without reopening the tiled physical-monitor crash path.

Refs #409

## Testing

- [x] I tested the affected install, build, stream, or UI path.
  - full local build
  - `ctest --test-dir build -j1 --output-on-failure`, 17/17 passed
  - 9 focused capture-policy tests passed
  - all 35 cage display router policy tests passed
  - source contract confirms the actual modifier is checked before GPU-native selection and the exact fallback reason survives the probe handoff
  - deliberate regression accepting any known modifier failed on invalid and tiled modifiers
  - `bash scripts/check-public-surface.sh`
- [x] I included screenshots or recordings for visible UI changes, when practical. No visible UI changes.
- [x] I updated docs or release notes when user-facing behavior changed. No documentation or release-note change is needed for this internal capture-path policy.

## Field validation still required

- AMD/VAAPI headless capture reports `capture_gpu_native=true` and does not report `shm_cpu_capture`
- the affected 4K route holds the requested frame rate
- no return of the AV1 slice errors or headless startup failures tracked by #124 and #111

## Notes

This does not change pairing, trusted subnets, certificates, client commands, shell hooks, packaging, or privilege boundaries. A failed modifier or conversion still retires GPU-native headless capture for the process and falls back to SHM.
