### PR TITLE
fix(linux): unblock gamescope portal capture

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -228,6 +228,7 @@ if(GIO_FOUND AND GIO_UNIX_FOUND AND PIPEWIRE_FOUND)
     add_compile_definitions(POLARIS_BUILD_PORTAL)
     list(APPEND PLATFORM_TARGET_FILES
             "${CMAKE_SOURCE_DIR}/src/platform/linux/portal_grab.cpp"
+            "${CMAKE_SOURCE_DIR}/src/platform/linux/portal_capability.cpp"
             "${CMAKE_SOURCE_DIR}/src/platform/linux/portal_session.cpp"
             "${CMAKE_SOURCE_DIR}/src/platform/linux/pipewire_capture.cpp")
     message(STATUS "XDG Desktop Portal capture support enabled")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,9 @@
 #elif __linux__
   #include "platform/linux/session_manager.h"
   #include "platform/linux/stream_display_policy.h"
+  #ifdef POLARIS_BUILD_PORTAL
+    #include "platform/linux/portal_capability.h"
+  #endif
 #endif
 
 #define PROBE_DISPLAY_UUID "38F72B96-B00C-4F21-8B6C-E1BFF1602B0E"
@@ -248,6 +251,16 @@ int main(int argc, char *argv[]) {
     BOOST_LOG(info) << "config: '"sv << name << "' = "sv << config::redact_config_value(name, val);
   }
   config::modified_config_settings.clear();
+
+#if defined(__linux__) && defined(POLARIS_BUILD_PORTAL)
+  // File capabilities are inherited by every thread. Drop capabilities that
+  // portal-oriented capture paths cannot use before any workers are started,
+  // then restore ordinary same-user /proc access for portal authorization.
+  (void) portal_capability::prepare_process_for_capture(
+    config::video.capture,
+    config::video.linux_display.stream_mode
+  );
+#endif
 
   // Initialize stream recorder from config
   stream_recorder::load_config();

--- a/src/platform/linux/portal_capability.cpp
+++ b/src/platform/linux/portal_capability.cpp
@@ -1,0 +1,113 @@
+/**
+ * @file src/platform/linux/portal_capability.cpp
+ * @brief Process capability policy for XDG Desktop Portal capture.
+ */
+
+#include "portal_capability.h"
+
+#ifdef __linux__
+
+  #include "src/logging.h"
+
+  #include <algorithm>
+  #include <array>
+  #include <cctype>
+  #include <cerrno>
+  #include <cstring>
+  #include <string>
+
+  #include <linux/capability.h>
+  #include <sys/prctl.h>
+  #include <sys/syscall.h>
+  #include <unistd.h>
+
+using namespace std::literals;
+
+namespace portal_capability {
+
+  namespace {
+    std::string lower_copy(std::string_view value) {
+      std::string result(value);
+      std::transform(result.begin(), result.end(), result.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+      });
+      return result;
+    }
+  }  // namespace
+
+  bool requires_unprivileged_process(
+    std::string_view configured_capture,
+    std::string_view stream_mode
+  ) {
+    const auto capture = lower_copy(configured_capture);
+    if (!capture.empty() && capture != "auto") {
+      return capture == "portal";
+    }
+
+    const auto mode = lower_copy(stream_mode);
+    return mode == "desktop_display" ||
+           mode == "gamescope_stream" ||
+           mode == "headless_dongle";
+  }
+
+  prepare_result_e prepare_process_for_capture(
+    std::string_view configured_capture,
+    std::string_view stream_mode
+  ) {
+    if (!requires_unprivileged_process(configured_capture, stream_mode)) {
+      return prepare_result_e::not_needed;
+    }
+
+    if (geteuid() == 0) {
+      BOOST_LOG(error) << "portal: refusing to alter capabilities for a root Polaris process; run Polaris as the desktop user"sv;
+      return prepare_result_e::failed;
+    }
+
+    __user_cap_header_struct header {
+      .version = _LINUX_CAPABILITY_VERSION_3,
+      .pid = 0,
+    };
+    std::array<__user_cap_data_struct, _LINUX_CAPABILITY_U32S_3> capabilities {};
+    if (syscall(SYS_capget, &header, capabilities.data()) != 0) {
+      BOOST_LOG(error) << "portal: could not inspect process capabilities before ScreenCast setup: "sv
+                       << std::strerror(errno);
+      return prepare_result_e::failed;
+    }
+
+    const bool has_capabilities = std::any_of(
+      capabilities.begin(),
+      capabilities.end(),
+      [](const auto &entry) {
+        return entry.effective != 0 || entry.permitted != 0 || entry.inheritable != 0;
+      }
+    );
+    if (!has_capabilities) {
+      return prepare_result_e::unchanged;
+    }
+
+    // Portal capture needs no Linux capability. Clearing every set also covers
+    // locally-added capabilities such as CAP_SYS_NICE: any capability that is
+    // not available to the portal daemon can make its /proc caller check fail.
+    capabilities = {};
+    if (syscall(SYS_capset, &header, capabilities.data()) != 0) {
+      BOOST_LOG(error) << "portal: could not drop inherited executable capabilities before ScreenCast setup: "sv
+                       << std::strerror(errno);
+      return prepare_result_e::failed;
+    }
+
+    // Executing a file-capability-enabled binary resets dumpability. capset()
+    // does not restore it after the privilege has been discarded, so do that
+    // explicitly before xdg-desktop-portal opens /proc/<pid>/root.
+    if (prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) != 0) {
+      BOOST_LOG(error) << "portal: dropped inherited capabilities but could not restore normal process dumpability: "sv
+                       << std::strerror(errno);
+      return prepare_result_e::failed;
+    }
+
+    BOOST_LOG(info) << "portal: dropped inherited executable capabilities and restored normal process access for ScreenCast; DRM/KMS capture remains available after a restart with capture=kms"sv;
+    return prepare_result_e::dropped;
+  }
+
+}  // namespace portal_capability
+
+#endif  // __linux__

--- a/src/platform/linux/portal_capability.h
+++ b/src/platform/linux/portal_capability.h
@@ -1,0 +1,45 @@
+/**
+ * @file src/platform/linux/portal_capability.h
+ * @brief Process capability policy for XDG Desktop Portal capture.
+ */
+#pragma once
+
+#ifdef __linux__
+
+  #include <string_view>
+
+namespace portal_capability {
+
+  enum class prepare_result_e {
+    not_needed,
+    unchanged,
+    dropped,
+    failed,
+  };
+
+  /**
+   * Return whether the configured capture path may need the desktop portal.
+   * Explicit non-portal capture selections always win over the stream-mode
+   * default.
+   */
+  bool requires_unprivileged_process(
+    std::string_view configured_capture,
+    std::string_view stream_mode
+  );
+
+  /**
+   * Drop inherited executable capabilities before worker threads are created.
+   *
+   * A file-capability-enabled process is non-dumpable. xdg-desktop-portal
+   * consequently cannot inspect /proc/<pid>/root to authorize ScreenCast. A
+   * portal capture path does not need Polaris' KMS capability, so make the
+   * process equivalent to an ordinary unprivileged Polaris invocation.
+   */
+  prepare_result_e prepare_process_for_capture(
+    std::string_view configured_capture,
+    std::string_view stream_mode
+  );
+
+}  // namespace portal_capability
+
+#endif  // __linux__

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -61,6 +61,7 @@ namespace stream_runtime {
   bool drain_gamescope_private_group_for_tests(pid_t pgid);
   bool rollback_gamescope_spawn_for_tests(pid_t pgid, int leader_pidfd);
   bool gamescope_runtime_acquisition_allowed_for_tests();
+  bool gamescope_runtime_closes_inherited_descriptors_for_tests();
 
   /**
    * Labwc-only free functions — only stream_runtime_labwc.cpp may include

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -49,6 +49,21 @@ namespace stream_runtime {
 
     std::string xdg_runtime_dir();
 
+    void close_inherited_descriptors(long fallback_limit) {
+#ifdef SYS_close_range
+      // No descriptor is intentionally passed to an owned gamescope. Use the
+      // kernel primitive when available so a high RLIMIT_NOFILE does not turn
+      // every launch into a million close(2) calls.
+      if (syscall(SYS_close_range, static_cast<unsigned int>(STDERR_FILENO + 1), ~0U, 0) == 0) {
+        return;
+      }
+#endif
+      const auto limit = fallback_limit > STDERR_FILENO ? fallback_limit : 1024;
+      for (long fd = STDERR_FILENO + 1; fd < limit; ++fd) {
+        (void) close(static_cast<int>(fd));
+      }
+    }
+
     class owner_transition_lock_t {
     public:
       explicit owner_transition_lock_t(bool acquire = true) {
@@ -482,6 +497,7 @@ namespace stream_runtime {
         }
         argv.push_back(nullptr);
 
+        const long inherited_fd_limit = sysconf(_SC_OPEN_MAX);
         const pid_t child = fork();
         if (child < 0) {
           BOOST_LOG(error) << "gamescope_runtime: fork failed: "sv << std::strerror(errno);
@@ -496,6 +512,10 @@ namespace stream_runtime {
           unsetenv("ENABLE_HDR_WSI");
           // Prefer gamescope-0 naming when the compositor honors it.
           setenv("GAMESCOPE_WAYLAND_DISPLAY", "gamescope-0", 1);
+          // The owned runtime is forked after Polaris starts its RTSP/HTTPS
+          // listeners. Without this boundary, gamescope and its Xwayland
+          // children keep those sockets bound after Polaris is killed.
+          close_inherited_descriptors(inherited_fd_limit);
           execv(gamescope_executable.c_str(), argv.data());
           _exit(127);
         }
@@ -1021,6 +1041,36 @@ namespace stream_runtime {
   bool gamescope_runtime_acquisition_allowed_for_tests() {
     owner_transition_lock_t owner_lock;
     return owner_lock && runtime_acquisition_allowed_locked();
+  }
+
+  bool gamescope_runtime_closes_inherited_descriptors_for_tests() {
+    int descriptors[2] = {-1, -1};
+    if (pipe2(descriptors, O_CLOEXEC) != 0) {
+      return false;
+    }
+    const long fallback_limit = sysconf(_SC_OPEN_MAX);
+    const pid_t child = fork();
+    if (child < 0) {
+      close(descriptors[0]);
+      close(descriptors[1]);
+      return false;
+    }
+    if (child == 0) {
+      const int probe_fd = descriptors[0];
+      close_inherited_descriptors(fallback_limit);
+      const bool closed = fcntl(probe_fd, F_GETFD) == -1 && errno == EBADF;
+      _exit(closed ? 0 : 1);
+    }
+
+    close(descriptors[0]);
+    close(descriptors[1]);
+    int status = 0;
+    while (waitpid(child, &status, 0) < 0) {
+      if (errno != EINTR) {
+        return false;
+      }
+    }
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
   }
 
   stream_runtime_t *gamescope_runtime_instance() {

--- a/tests/unit/platform/test_linux_process_argv.cpp
+++ b/tests/unit/platform/test_linux_process_argv.cpp
@@ -7,6 +7,7 @@
 #ifdef __linux__
 
 #include "src/platform/linux/misc.h"
+#include "src/platform/linux/stream_runtime.h"
 
 TEST(LinuxProcessArgv, PreservesShellMetacharactersAsLiteralArguments) {
   constexpr auto value = "output.HDMI-A-1; exit 99";
@@ -19,6 +20,10 @@ TEST(LinuxProcessArgv, ReturnsChildExitStatus) {
 
 TEST(LinuxProcessArgv, ReportsMissingExecutable) {
   EXPECT_EQ(platf::run_process_argv({"polaris-command-that-does-not-exist"}), 127);
+}
+
+TEST(GamescopeRuntime, ClosesInheritedDescriptorsBeforeExec) {
+  EXPECT_TRUE(stream_runtime::gamescope_runtime_closes_inherited_descriptors_for_tests());
 }
 
 #endif

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -16,12 +16,17 @@
 
 #include <unistd.h>
 
+#include <fcntl.h>
+#include <sys/prctl.h>
+#include <sys/wait.h>
+
 #include <drm_fourcc.h>
 #include <spa/param/video/raw.h>
 
 #include "src/config.h"
 #include "src/platform/common.h"
 #include "src/platform/linux/pipewire_capture.h"
+#include "src/platform/linux/portal_capability.h"
 #include "src/platform/linux/portal_session.h"
 #include "src/platform/linux/session_media.h"
 
@@ -34,6 +39,47 @@ namespace portal {
   bool portal_cancel_pending_request_for_tests();
   bool portal_cancel_request_owner_for_tests();
   bool portal_cancel_source_wakes_wait_for_tests();
+}
+
+TEST(PortalCapabilityPolicyTests, ExplicitCaptureSelectionWinsOverStreamModeDefault) {
+  EXPECT_TRUE(portal_capability::requires_unprivileged_process("portal", "headless_stream"));
+  EXPECT_TRUE(portal_capability::requires_unprivileged_process("PoRtAl", "headless_stream"));
+  EXPECT_FALSE(portal_capability::requires_unprivileged_process("kms", "gamescope_stream"));
+  EXPECT_FALSE(portal_capability::requires_unprivileged_process("wlr", "gamescope_stream"));
+}
+
+TEST(PortalCapabilityPolicyTests, PortalOrientedModesDropCapabilitiesForImplicitCapture) {
+  for (const char *mode : {"desktop_display", "gamescope_stream", "headless_dongle"}) {
+    EXPECT_TRUE(portal_capability::requires_unprivileged_process("", mode)) << mode;
+    EXPECT_TRUE(portal_capability::requires_unprivileged_process("auto", mode)) << mode;
+  }
+
+  EXPECT_FALSE(portal_capability::requires_unprivileged_process("", "headless_stream"));
+  EXPECT_FALSE(portal_capability::requires_unprivileged_process("auto", "windowed_stream"));
+}
+
+TEST(PortalCapabilityPolicyTests, PreparationLeavesProcRootReadableToSameUserPortalPeer) {
+  const auto result = portal_capability::prepare_process_for_capture("portal", "gamescope_stream");
+  ASSERT_NE(result, portal_capability::prepare_result_e::failed);
+  EXPECT_EQ(prctl(PR_GET_DUMPABLE, 0, 0, 0, 0), 1);
+
+  const auto parent = getpid();
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    const auto path = "/proc/" + std::to_string(parent) + "/root";
+    const int fd = open(path.c_str(), O_PATH | O_CLOEXEC);
+    if (fd >= 0) {
+      close(fd);
+      _exit(0);
+    }
+    _exit(1);
+  }
+
+  int status = 0;
+  ASSERT_EQ(waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0);
 }
 
 TEST(PortalGrabPolicyTests, DesktopDisplayRequestsMonitorSource) {

--- a/tests/unit/test_linux_stream_contract.cpp
+++ b/tests/unit/test_linux_stream_contract.cpp
@@ -64,6 +64,12 @@ TEST(LinuxStreamContractTests, GamescopeOwnershipTransitionsUseOneCrossProcessLo
   EXPECT_NE(runtime.find("owner_transition_lock_t"), std::string::npos);
   EXPECT_NE(runtime.find("polaris-gamescope.lock"), std::string::npos);
   EXPECT_NE(runtime.find("POLARIS_GAMESCOPE_EXECUTABLE"), std::string::npos);
+  const auto child_branch = runtime.find("if (child == 0)");
+  const auto child_exec = runtime.find("execv(gamescope_executable.c_str()", child_branch);
+  ASSERT_NE(child_branch, std::string::npos);
+  ASSERT_NE(child_exec, std::string::npos);
+  const auto child_body = runtime.substr(child_branch, child_exec - child_branch);
+  EXPECT_NE(child_body.find("close_inherited_descriptors(inherited_fd_limit)"), std::string::npos);
 
   const auto marker_failure = runtime.find("if (!marker_written)");
   ASSERT_NE(marker_failure, std::string::npos);
@@ -75,6 +81,16 @@ TEST(LinuxStreamContractTests, GamescopeOwnershipTransitionsUseOneCrossProcessLo
   EXPECT_LT(rollback, clear_state);
   EXPECT_NE(runtime.find("drain_private_process_group(child"), std::string::npos);
   EXPECT_NE(failure_body.find("preserving state"), std::string::npos);
+}
+
+TEST(LinuxStreamContractTests, PortalCapabilityDropRunsBeforeWorkerThreads) {
+  const auto main = read_source("src/main.cpp");
+  ASSERT_FALSE(main.empty());
+  const auto prepare = main.find("portal_capability::prepare_process_for_capture(");
+  const auto workers = main.find("task_pool.start(1)");
+  ASSERT_NE(prepare, std::string::npos);
+  ASSERT_NE(workers, std::string::npos);
+  EXPECT_LT(prepare, workers);
 }
 
 TEST(LinuxStreamContractTests, PipeWireLoopCallbacksNeverTakeShutdownMutex) {


### PR DESCRIPTION
## Summary

- drop executable capabilities before portal-oriented capture starts worker threads
- restore ordinary same-user `/proc` access required by xdg-desktop-portal caller verification
- close inherited Polaris listener descriptors before launching an owned Gamescope runtime
- add capability-policy, `/proc` accessibility, startup-order, and descriptor-cleanup regressions

## Root cause

A Polaris binary carrying `cap_sys_admin=ep` starts non-dumpable, so xdg-desktop-portal cannot open `/proc/<polaris-pid>/root` while authorizing ScreenCast. Separately, the owned Gamescope/Xwayland process tree inherited Polaris listener descriptors and could keep RTSP/HTTPS ports bound after Polaris exited.

## Validation

- full Polaris build
- `ctest --test-dir build-issue-422 --output-on-failure -j8` (17/17 passed)
- portal `/proc` regression passed with the test executable carrying `cap_sys_admin=ep`
- behavioral inherited-descriptor regression passed
- `git diff --check`

Fixes #422