### PR TITLE
fix(linux): normalize same-mode session overrides

### DIFF
--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -222,6 +222,48 @@ namespace stream_display_policy {
     return true;
   }
 
+  bool selection_companion_state_matches(std::string_view selection) {
+    const auto key = to_lower_copy(selection);
+    const auto &linux_display = config::video.linux_display;
+    if (linux_display.stream_mode != key) {
+      return false;
+    }
+
+    const auto expected = legacy_booleans_for_selection(key);
+    if (linux_display.headless_mode != expected.headless_mode ||
+        linux_display.use_cage_compositor != expected.use_cage_compositor ||
+        linux_display.prefer_gpu_native_capture != expected.prefer_gpu_native_capture) {
+      return false;
+    }
+
+    if (const auto *path = stream_path::find(key)) {
+      auto expected_runtime = std::string {stream_path::runtime_kind_id(path->runtime)};
+      if (expected_runtime.empty() && expected.use_cage_compositor) {
+        expected_runtime = std::string {k_runtime_labwc};
+      }
+      if (linux_display.private_runtime != expected_runtime) {
+        return false;
+      }
+
+      if (key == stream_path::k_gamescope_stream && config::video.capture.empty()) {
+        return false;
+      }
+      if (key == stream_path::k_headless_dongle) {
+        return linux_display.auto_manage_displays &&
+               !linux_display.headless_swap_mode.empty() &&
+               !linux_display.streaming_output.empty() &&
+               !linux_display.primary_output.empty() &&
+               linux_display.streaming_output != linux_display.primary_output &&
+               config::video.capture != "auto" &&
+               !config::video.capture.empty() &&
+               !config::video.output_name.empty();
+      }
+      return true;
+    }
+
+    return key == k_desktop_display;
+  }
+
   bool apply_selection(std::string_view selection, std::string &error) {
     if (!selection_valid(selection, error)) {
       return false;

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -114,6 +114,11 @@ namespace stream_display_policy {
                                bool runtime_effective_headless);
 
   /**
+   * @brief Whether a selection ID and its deterministic companion state agree.
+   */
+  bool selection_companion_state_matches(std::string_view selection);
+
+  /**
    * @brief Apply a user/API selection into config (stream_mode + legacy bools + runtime).
    *
    * @return false and sets error on failure.

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -5845,7 +5845,7 @@ namespace proc {
       const std::string session_mode = launch_session ? launch_session->stream_mode : std::string {};
       if (!session_mode.empty() &&
           !(launch_session && launch_session->mirror_desktop) &&
-          session_mode != linux_display.stream_mode) {
+          !stream_display_policy::selection_companion_state_matches(session_mode)) {
         std::string mode_error;
         if (stream_display_policy::apply_selection(session_mode, mode_error)) {
           // Saved-state restore is armed only when a mode was actually applied,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -388,6 +388,35 @@ TEST(ProcessRuntimeConfigTests, NestedSessionPrepReceivesCredentialAndFailsLaunc
   EXPECT_NE(body.find("platf::unset_env(\"POLARIS_SESSION_INSTANCE_ID\")", app_env_loop), std::string::npos);
 }
 
+TEST(ProcessRuntimeConfigTests, ExplicitSessionModeAlwaysNormalizesCompanionState) {
+  // An explicit headless_stream request may match the current stream_mode ID
+  // while legacy companion state (for example prefer_gpu_native_capture) is
+  // stale. Skipping apply_selection in that case can resolve the session as
+  // windowed_stream even though the launch requested headless_stream.
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+
+  const auto execute_start = source.find("int proc_t::execute_impl(");
+  const auto terminate_start = source.find("void proc_t::terminate_impl(", execute_start);
+  ASSERT_NE(execute_start, std::string::npos);
+  ASSERT_NE(terminate_start, std::string::npos);
+  const auto body = source.substr(execute_start, terminate_start - execute_start);
+
+  const auto guard_start = body.find("if (!session_mode.empty()");
+  const auto apply_start = body.find("stream_display_policy::apply_selection(session_mode", guard_start);
+  ASSERT_NE(guard_start, std::string::npos);
+  ASSERT_NE(apply_start, std::string::npos);
+  const auto guard = body.substr(guard_start, apply_start - guard_start);
+
+  EXPECT_NE(guard.find("!(launch_session && launch_session->mirror_desktop)"), std::string::npos);
+  EXPECT_NE(
+    guard.find("!stream_display_policy::selection_companion_state_matches(session_mode)"),
+    std::string::npos
+  );
+  EXPECT_EQ(guard.find("session_mode != linux_display.stream_mode"), std::string::npos)
+    << "same-ID explicit overrides must still normalize companion state";
+}
+
 TEST(ProcessRuntimeConfigTests, SessionLifecycleGateOwnsLaunchRaiseAndTeardownWithoutCrossLockingRtsp) {
   const auto header = read_source_file_for_contract("src/process.h");
   const auto source = read_source_file_for_contract("src/process.cpp");

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -15,23 +15,41 @@ namespace {
         headless_mode {config::video.linux_display.headless_mode},
         use_cage_compositor {config::video.linux_display.use_cage_compositor},
         prefer_gpu_native_capture {config::video.linux_display.prefer_gpu_native_capture},
+        auto_manage_displays {config::video.linux_display.auto_manage_displays},
         stream_mode {config::video.linux_display.stream_mode},
-        private_runtime {config::video.linux_display.private_runtime} {
+        private_runtime {config::video.linux_display.private_runtime},
+        headless_swap_mode {config::video.linux_display.headless_swap_mode},
+        streaming_output {config::video.linux_display.streaming_output},
+        primary_output {config::video.linux_display.primary_output},
+        capture {config::video.capture},
+        output_name {config::video.output_name} {
     }
 
     ~LinuxDisplayPolicyGuard() {
       config::video.linux_display.headless_mode = headless_mode;
       config::video.linux_display.use_cage_compositor = use_cage_compositor;
       config::video.linux_display.prefer_gpu_native_capture = prefer_gpu_native_capture;
+      config::video.linux_display.auto_manage_displays = auto_manage_displays;
       config::video.linux_display.stream_mode = stream_mode;
       config::video.linux_display.private_runtime = private_runtime;
+      config::video.linux_display.headless_swap_mode = headless_swap_mode;
+      config::video.linux_display.streaming_output = streaming_output;
+      config::video.linux_display.primary_output = primary_output;
+      config::video.capture = capture;
+      config::video.output_name = output_name;
     }
 
     bool headless_mode;
     bool use_cage_compositor;
     bool prefer_gpu_native_capture;
+    bool auto_manage_displays;
     std::string stream_mode;
     std::string private_runtime;
+    std::string headless_swap_mode;
+    std::string streaming_output;
+    std::string primary_output;
+    std::string capture;
+    std::string output_name;
   };
 
   void configure_headless_cage(bool prefer_gpu_native_capture) {
@@ -116,6 +134,116 @@ TEST(StreamDisplayPolicyTests, ApplySelectionSyncsModeAndLegacyBooleans) {
   EXPECT_EQ(config::video.linux_display.stream_mode, "desktop_display");
   EXPECT_FALSE(config::video.linux_display.headless_mode);
   EXPECT_FALSE(config::video.linux_display.use_cage_compositor);
+}
+
+TEST(StreamDisplayPolicyTests, ReapplyingHeadlessSelectionClearsStaleCompanionState) {
+  LinuxDisplayPolicyGuard guard;
+  auto &linux_display = config::video.linux_display;
+
+  linux_display.stream_mode = "headless_stream";
+  linux_display.headless_mode = true;
+  linux_display.use_cage_compositor = true;
+  linux_display.prefer_gpu_native_capture = true;
+  linux_display.private_runtime = "labwc";
+
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("headless_stream"));
+
+  std::string error;
+  ASSERT_TRUE(stream_display_policy::apply_selection("headless_stream", error)) << error;
+  EXPECT_EQ(linux_display.stream_mode, "headless_stream");
+  EXPECT_TRUE(linux_display.headless_mode);
+  EXPECT_TRUE(linux_display.use_cage_compositor);
+  EXPECT_FALSE(linux_display.prefer_gpu_native_capture);
+  EXPECT_TRUE(stream_display_policy::selection_companion_state_matches("headless_stream"));
+  linux_display.stream_mode = "HEADLESS_STREAM";
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("headless_stream"));
+  linux_display.stream_mode = "headless_stream";
+
+  const auto resolved = stream_display_policy::resolve(stream_display_policy::input_t {});
+  EXPECT_EQ(resolved.selection, "headless_stream");
+}
+
+TEST(StreamDisplayPolicyTests, CommonModeCompanionStateMatchesAllRegisteredSelections) {
+  LinuxDisplayPolicyGuard guard;
+  auto &linux_display = config::video.linux_display;
+  struct mode_case_t {
+    const char *selection;
+    const char *runtime;
+  };
+  const mode_case_t cases[] = {
+    {"headless_stream", "labwc"},
+    {"windowed_stream", "labwc"},
+    {"desktop_display", ""},
+    {"host_virtual_display", ""},
+  };
+
+  for (const auto &test_case : cases) {
+    SCOPED_TRACE(test_case.selection);
+    const auto expected = stream_display_policy::legacy_booleans_for_selection(test_case.selection);
+    linux_display.stream_mode = test_case.selection;
+    linux_display.headless_mode = expected.headless_mode;
+    linux_display.use_cage_compositor = expected.use_cage_compositor;
+    linux_display.prefer_gpu_native_capture = expected.prefer_gpu_native_capture;
+    linux_display.private_runtime = test_case.runtime;
+    EXPECT_TRUE(stream_display_policy::selection_companion_state_matches(test_case.selection));
+
+    linux_display.prefer_gpu_native_capture = !expected.prefer_gpu_native_capture;
+    EXPECT_FALSE(stream_display_policy::selection_companion_state_matches(test_case.selection));
+  }
+}
+
+TEST(StreamDisplayPolicyTests, GamescopeCompanionStateIncludesCaptureDefault) {
+  LinuxDisplayPolicyGuard guard;
+  auto &linux_display = config::video.linux_display;
+
+  linux_display.stream_mode = "gamescope_stream";
+  linux_display.headless_mode = true;
+  linux_display.use_cage_compositor = false;
+  linux_display.prefer_gpu_native_capture = false;
+  linux_display.private_runtime = "gamescope";
+  config::video.capture.clear();
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("gamescope_stream"));
+
+  config::video.capture = "portal";
+  EXPECT_TRUE(stream_display_policy::selection_companion_state_matches("gamescope_stream"));
+}
+
+TEST(StreamDisplayPolicyTests, HeadlessDongleCompanionStateIncludesConditionalDefaults) {
+  LinuxDisplayPolicyGuard guard;
+  auto &linux_display = config::video.linux_display;
+
+  linux_display.stream_mode = "headless_dongle";
+  linux_display.headless_mode = true;
+  linux_display.use_cage_compositor = false;
+  linux_display.prefer_gpu_native_capture = false;
+  linux_display.private_runtime.clear();
+  linux_display.auto_manage_displays = true;
+  linux_display.headless_swap_mode = "privacy";
+  linux_display.streaming_output = "DP-1";
+  linux_display.primary_output = "eDP-1";
+  config::video.capture = "portal";
+  config::video.output_name = "DP-1";
+  EXPECT_TRUE(stream_display_policy::selection_companion_state_matches("headless_dongle"));
+
+  linux_display.auto_manage_displays = false;
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("headless_dongle"));
+  linux_display.auto_manage_displays = true;
+  linux_display.headless_swap_mode.clear();
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("headless_dongle"));
+  linux_display.headless_swap_mode = "privacy";
+  linux_display.streaming_output.clear();
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("headless_dongle"));
+  linux_display.streaming_output = "DP-1";
+  linux_display.primary_output.clear();
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("headless_dongle"));
+  linux_display.primary_output = "DP-1";
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("headless_dongle"));
+  linux_display.primary_output = "eDP-1";
+  config::video.capture = "auto";
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("headless_dongle"));
+  config::video.capture = "portal";
+  config::video.output_name.clear();
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("headless_dongle"));
 }
 
 TEST(StreamDisplayPolicyTests, GamescopeStreamRegisteredWithGamescopeRuntime) {


### PR DESCRIPTION
## Summary

- detect drift between an explicit session stream mode and its deterministic companion state
- reapply the requested mode when the mode ID matches but legacy booleans, runtime selection, or mode-specific defaults are stale
- preserve the existing no-op behavior when the mode and companion state already match
- retain mirror-desktop, session save/restore, and capture-source reevaluation boundaries
- add regression coverage for canonical mode identity and all six registered stream modes

## Root cause

The session launch path skipped `apply_selection()` whenever the requested mode ID matched the configured `stream_mode`.

That assumed the associated state was already consistent. If companion values such as `prefer_gpu_native_capture`, `private_runtime`, capture defaults, or display-topology defaults had drifted, an explicit same-mode request could retain contradictory state and resolve to a different effective stream path.

`selection_companion_state_matches()` now treats only an exact canonical ID plus fully matching deterministic companion state as a true no-op. Any relevant drift uses the existing application path, including its session-scoped save/restore and capture-source reevaluation.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
  - regression test failed against the original same-ID bypass
  - `test_polaris_config`: 276 passed
  - `test_polaris_stream`: 231 passed
  - production Polaris target linked successfully
  - `scripts/check-public-surface.sh`
  - `git diff --check`
  - final independent read-only review passed with no findings
- [x] I included screenshots or recordings for visible UI changes, when practical.
  - No visible UI changes.
- [x] I updated docs or release notes when user-facing behavior changed.
  - No documentation or release-note change is needed for this internal session-state normalization.

## Field validation still required

- launch an explicit same-mode private stream with intentionally drifted companion state
- confirm the effective `session_runtime` path matches the requested mode
- confirm a fully normalized same-mode launch remains a no-op
- confirm teardown restores the prior host defaults

## Notes

This does not change pairing, trusted subnets, certificates, client commands, shell hooks, packaging, privilege boundaries, or wire behavior. It does not introduce a new stream mode. It only prevents an explicit session override from being skipped when its associated in-memory state is inconsistent.
