### PR TITLE
release: Polaris v1.3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
     set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
-project(Polaris VERSION 1.3.8
+project(Polaris VERSION 1.3.9
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -530,7 +530,7 @@
         "example": {
           "schema_version": 1,
           "measurement_spec_id": "measurement-spec-v1",
-          "collector_version": "1.3.8",
+          "collector_version": "1.3.9",
           "clock_domain": "CLOCK_MONOTONIC",
           "run_id": "pair-0001-control",
           "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,23 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## v1.3.9 - 2026-08-15
+
+A Linux reliability and security patch for private-stream capture, compositor ownership, high-refresh cadence, and hostile-input boundaries.
+
+- Enables VAAPI GPU-native capture only for the private headless ext-image-copy route when the captured DMA-BUF is explicitly `DRM_FORMAT_MOD_LINEAR`; tiled, invalid, missing, windowed-private, and direct-monitor modifiers remain on the SHM fallback, and Doctor preserves the exact fallback reason
+- Makes capability-enabled Polaris work with `xdg-desktop-portal` by dropping capabilities before worker threads start and restoring ordinary same-user `/proc` access; explicit DRM/KMS capture retains its required capability on a separate process start
+- Accepts capability-enabled owned Gamescope generations, warns when unsupported nested Gamescope WSI can hide a blocking dialog, and prevents owned Gamescope/Xwayland descendants from retaining Polaris listener sockets after host exit
+- Creates and owns only an exact process-scoped Hyprland virtual output, verifies it before use, and fails closed instead of silently capturing a physical display
+- Preserves high-refresh private-stream cadence, exposes launches that never attach, sees override-redirect windows during attach, and bounds preparation commands without releasing lifecycle ownership early
+- Reapplies an explicit same-mode session choice when deterministic runtime, capture, or display companion state has drifted, while retaining the normalized no-op and teardown restoration paths
+- Hardens Wayland frame ownership, VAAPI DRM PRIME descriptors, KMS render descriptors, portal/capture shutdown, session environment snapshots, and exact-generation cleanup boundaries
+- Validates every client launch key, peer-declared control length, Steam app id, artwork URL/redirect hop, pairing PIN claim, and Doctor mutation boundary before use
+- Keeps secondary-client telemetry while preventing duplicate control-channel network-risk samples
+- Keeps `npm audit --audit-level=high` mandatory
+- Retains exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
+- Records the remaining field gates without treating CI as hardware proof: linear VAAPI headless capture still needs affected AMD 4K validation, Hyprland virtual-display ownership and same-mode session normalization need affected-host confirmation, and the supported Gamescope Stream route needs an end-to-end portal retest
+
 ## v1.3.8 - 2026-08-12
 
 A safer private-stream daily driver: true-headless GPU-native capture, session-only launch choices, exact process ownership, an evidence-gated Doctor, bounded logs, benchmark controls, and a rebuilt web console.

--- a/docs/release-notes/v1.3.9.md
+++ b/docs/release-notes/v1.3.9.md
@@ -1,0 +1,75 @@
+# Polaris v1.3.9
+
+Polaris v1.3.9 is a Linux reliability and security patch for private-stream capture, Gamescope and portal ownership, high-refresh cadence, and hostile-input boundaries.
+
+## Important: upgrading from v1.3.8
+
+Nothing extra is required beyond the usual package, `--setup-host`, and restart sequence. Existing configuration remains valid.
+
+This release is especially relevant if you use Gamescope Stream, a Hyprland virtual display, high-refresh private streaming, or a VAAPI encoder on the private headless route.
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.9/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.9/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.9/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md). SteamOS remains an experimental Desktop Mode package rather than certified Game Mode support.
+
+## Changes
+
+### VAAPI and capture safety
+
+- Allows VAAPI GPU-native capture on the private headless ext-image-copy route only when the captured DMA-BUF reports `DRM_FORMAT_MOD_LINEAR`.
+- Keeps tiled, invalid, missing, windowed-private, and direct physical-monitor modifiers on SHM capture. A failed import or conversion retires the headless GPU-native probe for the process and preserves the exact reason in Doctor telemetry.
+- Hardens Wayland frame ownership, VAAPI DRM PRIME object/layer/plane validation, KMS render descriptors, capture shutdown, and high-refresh frame pacing.
+
+### Gamescope, portal, and virtual displays
+
+- Drops executable capabilities before portal-oriented worker threads start and restores ordinary same-user `/proc` access, allowing `xdg-desktop-portal` to authorize a Polaris binary installed with `cap_sys_admin=ep`. Explicit `capture=kms` remains available on a separate restart that retains the capability.
+- Accepts capability-enabled owned Gamescope generations and closes inherited Polaris descriptors before launching owned Gamescope, so Gamescope/Xwayland descendants cannot keep RTSP or HTTPS ports bound after Polaris exits.
+- Warns when unsupported nested Gamescope WSI can hide a blocking native dialog. The supported route remains Gamescope Stream through `gamescope_stream`, not a nested Gamescope client inside the private labwc session.
+- Creates, verifies, and removes only the exact process-scoped Hyprland virtual output, failing closed rather than silently streaming a physical display.
+
+### Session, API, and network hardening
+
+- Surfaces private-session launches that never attach, recognizes override-redirect windows during attach, snapshots the session environment under the lifecycle lock, and bounds preparation commands without releasing ownership early.
+- Reapplies an explicit session stream mode when its canonical ID still matches but deterministic runtime, capture, or display companion state has drifted, while preserving the normalized no-op and session-scoped restoration paths.
+- Validates client launch-key length, peer-declared control lengths, KMS descriptors, Steam app ids, artwork URL hosts and redirect hops, pairing PIN claims, and Doctor action rate limits.
+- Prevents duplicate control-channel network-risk ingestion while preserving telemetry from secondary clients.
+
+## Field-validation limits
+
+- The release is scoped to the exact-head unit, sanitizer, compile, package-build, and package-smoke matrix. No separate affected-host candidate smoke is claimed.
+- Linear VAAPI headless capture is policy-, unit-, sanitizer-, and package-build tested, but the affected AMD 4K route still needs hardware confirmation of first frame, sustained requested cadence, truthful `capture_gpu_native=true`, clean fallback, and no return of the prior AV1/startup failures.
+- Hyprland virtual-display ownership and the Gamescope Stream portal route still need affected-host end-to-end confirmation. Nested Gamescope inside the private labwc session remains unsupported.
+- Same-mode session normalization is unit- and sanitizer-tested but still needs an affected-host launch confirming that drift is corrected, an already-normalized launch stays a no-op, and teardown restores the prior host defaults.
+- Windowed-private and direct physical-monitor VAAPI GPU-native capture remain deliberately disabled pending the separate #410 and #411 hardware work.
+
+## Official assets
+
+- `Polaris-arch-x86_64.pkg.tar.zst`
+- `Polaris-fedora44-x86_64.rpm`
+- `Polaris-steamos3.8-x86_64.pkg.tar.zst`
+- `Polaris-ubuntu24.04-x86_64.deb`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.3.8') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.3.9') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -643,7 +643,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.3.8.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.3.9.md").read_text(encoding="utf-8")
 )
 
 
@@ -1274,17 +1274,17 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.3.9 - 2026-08-15",
     "## v1.3.8 - 2026-08-12",
-    "## v1.3.7 - 2026-08-07",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "true-headless",
-    "GPU-native",
-    "streamMode",
-    "PIDFD",
+    "DRM_FORMAT_MOD_LINEAR",
+    "xdg-desktop-portal",
+    "Gamescope",
+    "Hyprland",
     "Doctor",
-    "8 MiB",
+    "high-refresh",
     "npm audit --audit-level=high",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
@@ -1293,7 +1293,7 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.3.8 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.3.9 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1302,7 +1302,7 @@ asset_phrase = (
     "`Polaris-steamos3.8-x86_64.pkg.tar.zst`, and "
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
-for label, section in (("v1.3.8 changelog", current_release_prose),):
+for label, section in (("v1.3.9 changelog", current_release_prose),):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
         sys.exit(1)
@@ -1320,7 +1320,7 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
     ("docs/building.md Packaging", building_packaging_prose),
-    ("v1.3.8 changelog", current_release_prose),
+    ("v1.3.9 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_assets:
@@ -1332,28 +1332,28 @@ for label, section in (
         sys.exit(1)
 
 release_notes_facts = (
-    "v1.3.7",
-    "true-headless",
-    "streamMode",
-    "PIDFD",
+    "v1.3.8",
+    "DRM_FORMAT_MOD_LINEAR",
+    "xdg-desktop-portal",
+    "Gamescope",
+    "Hyprland",
     "Doctor",
-    "8 MiB",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.8/Polaris-fedora44-x86_64.rpm &&",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.9/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.8/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.9/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.8/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.9/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.3.8 release notes are missing bootstrap fact: {fact}", file=sys.stderr)
+        print(f"v1.3.9 release notes are missing bootstrap fact: {fact}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.3.8 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.3.9 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.3.8 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.3.9 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 
 if "bash scripts/check-public-docs.sh" not in contributing:

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.8-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.9-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -667,7 +667,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.3.8-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.3.9-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v138-contract.test.js
+++ b/src_assets/common/assets/web/release-v138-contract.test.js
@@ -7,15 +7,20 @@ const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
 const sectionBetween = (source, startHeading, endHeading) => {
   const start = source.indexOf(startHeading)
   const end = source.indexOf(endHeading, start + startHeading.length)
-  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
-  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  expect(start, `missing historical release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing historical release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
   return source.slice(start, end)
 }
 
-const releaseSection = () =>
-  sectionBetween(read('docs/changelog.md'), '## v1.3.8 - 2026-08-12', '## v1.3.7')
+const historicalRelease = () => sectionBetween(
+  read('docs/changelog.md'),
+  '## v1.3.8 - 2026-08-12',
+  '## v1.3.7 - 2026-08-07',
+)
 
-const requiredFacts = [
+const historicalReleaseNotes = () => read('docs/release-notes/v1.3.8.md')
+
+const requiredFixFacts = [
   'true-headless',
   'GPU-native',
   'streamMode',
@@ -32,70 +37,35 @@ const expectedAssets = [
   'Polaris-ubuntu24.04-x86_64.deb',
 ].sort()
 
-describe('v1.3.8 release contract', () => {
-  it('moves the CMake version and authoritative changelog heading together', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.8')
-    expect(read('README.md')).not.toMatch(/^#{1,6}\s+.*(?:release|what is new).*v\d/im)
-    expect(read('docs/changelog.md')).toContain('## v1.3.8 - 2026-08-12')
-    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.3.8"')
-  })
+describe('historical v1.3.8 release contract', () => {
+  it('preserves the v1.3.8 release facts', () => {
+    const release = historicalRelease()
 
-  it('states release facts in the authoritative changelog', () => {
-    for (const fact of requiredFacts) {
-      expect(releaseSection(), `release summary must include: ${fact}`).toContain(fact)
+    for (const fact of requiredFixFacts) {
+      expect(release, `historical release must include: ${fact}`).toContain(fact)
     }
   })
 
-  it('aligns the public checker with the v1.3.8 release contract', () => {
-    const publicDocsGate = read('scripts/check-public-docs.sh')
+  it('preserves the exact historical four-asset set', () => {
+    const actualAssets = historicalRelease().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? []
 
-    expect(publicDocsGate).toContain('README must not duplicate a version-specific release section')
-    expect(publicDocsGate).not.toContain('"## What is New in v1.3.8"')
-    expect(publicDocsGate).toContain('"## v1.3.8 - 2026-08-12"')
-    for (const asset of expectedAssets) {
-      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
-    }
+    expect(actualAssets.sort()).toEqual(expectedAssets)
   })
 
-  it('moves versioned package-review metadata to v1.3.8', () => {
-    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
-    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
-    const packagingContract = read('src_assets/common/assets/web/packaging-contracts.test.js')
-
-    expect(reviewedWarnings).toContain('usr/bin/polaris-1.3.8')
-    expect(reviewedWarnings).not.toContain('usr/bin/polaris-1.3.7')
-    expect(steamOsBuildScript).toContain("'polaris|1.3.8-1|x86_64'")
-    expect(steamOsBuildScript).not.toContain("'polaris|1.3.7-1|x86_64'")
-    expect(packagingContract).toContain("'polaris|1.3.8-1|x86_64'")
-  })
-
-  it('ships release notes whose install commands target v1.3.8', () => {
-    const releaseNotes = read('docs/release-notes/v1.3.8.md')
-    const benchmarkOpenApi = read('docs/benchmark-control-openapi.json')
-
-    expect(benchmarkOpenApi).toContain('"collector_version": "1.3.8"')
-    expect(benchmarkOpenApi).not.toContain('"collector_version": "1.3.7"')
-    for (const fact of ['v1.3.7', 'true-headless', 'streamMode', 'PIDFD', 'Doctor', '8 MiB']) {
-      expect(releaseNotes, `release notes must include: ${fact}`).toContain(fact)
-    }
-
-    const installBlocks = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+  it('preserves the v1.3.8 install commands and lifecycle steps', () => {
+    const notes = historicalReleaseNotes()
+    const installBlocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
       .map((match) => match[1])
       .filter((block) => block.includes('wget --output-document='))
 
     expect(installBlocks.length).toBe(3)
     for (const block of installBlocks) {
       expect(block).toContain('releases/download/v1.3.8/')
-      expect(block).not.toContain('releases/download/v1.3.7/')
       expect(block).toContain('polaris --setup-host')
       expect(block).toContain('systemctl --user restart polaris')
     }
-  })
-
-  it('keeps the exact four-asset set in the release notes', () => {
-    const notes = read('docs/release-notes/v1.3.8.md')
-    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
-
-    expect(listed.sort()).toEqual(expectedAssets)
+    for (const asset of expectedAssets.filter((asset) => !asset.includes('steamos'))) {
+      expect(notes).toContain(asset)
+    }
   })
 })

--- a/src_assets/common/assets/web/release-v139-contract.test.js
+++ b/src_assets/common/assets/web/release-v139-contract.test.js
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+
+const sectionBetween = (source, startHeading, endHeading) => {
+  const start = source.indexOf(startHeading)
+  const end = source.indexOf(endHeading, start + startHeading.length)
+  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+const releaseSection = () =>
+  sectionBetween(read('docs/changelog.md'), '## v1.3.9 - 2026-08-15', '## v1.3.8')
+
+const requiredFacts = [
+  'DRM_FORMAT_MOD_LINEAR',
+  'xdg-desktop-portal',
+  'Gamescope',
+  'Hyprland',
+  'Doctor',
+  'high-refresh',
+  'npm audit --audit-level=high',
+]
+
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+
+describe('v1.3.9 release contract', () => {
+  it('moves the CMake version and authoritative changelog heading together', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.9')
+    expect(read('README.md')).not.toMatch(/^#{1,6}\s+.*(?:release|what is new).*v\d/im)
+    expect(read('docs/changelog.md')).toContain('## v1.3.9 - 2026-08-15')
+    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.3.9"')
+  })
+
+  it('states release facts in the authoritative changelog', () => {
+    for (const fact of requiredFacts) {
+      expect(releaseSection(), `release summary must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('aligns the public checker with the v1.3.9 release contract', () => {
+    const publicDocsGate = read('scripts/check-public-docs.sh')
+
+    expect(publicDocsGate).toContain('README must not duplicate a version-specific release section')
+    expect(publicDocsGate).not.toContain('"## What is New in v1.3.9"')
+    expect(publicDocsGate).toContain('"## v1.3.9 - 2026-08-15"')
+    for (const asset of expectedAssets) {
+      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
+    }
+  })
+
+  it('moves versioned package-review metadata to v1.3.9', () => {
+    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
+    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
+    const packagingContract = read('src_assets/common/assets/web/packaging-contracts.test.js')
+
+    expect(reviewedWarnings).toContain('usr/bin/polaris-1.3.9')
+    expect(reviewedWarnings).not.toContain('usr/bin/polaris-1.3.8')
+    expect(steamOsBuildScript).toContain("'polaris|1.3.9-1|x86_64'")
+    expect(steamOsBuildScript).not.toContain("'polaris|1.3.8-1|x86_64'")
+    expect(packagingContract).toContain("'polaris|1.3.9-1|x86_64'")
+  })
+
+  it('ships release notes whose install commands target v1.3.9', () => {
+    const releaseNotes = read('docs/release-notes/v1.3.9.md')
+    const benchmarkOpenApi = read('docs/benchmark-control-openapi.json')
+
+    expect(benchmarkOpenApi).toContain('"collector_version": "1.3.9"')
+    expect(benchmarkOpenApi).not.toContain('"collector_version": "1.3.8"')
+    for (const fact of ['v1.3.8', 'DRM_FORMAT_MOD_LINEAR', 'xdg-desktop-portal', 'Gamescope', 'Hyprland', 'Doctor']) {
+      expect(releaseNotes, `release notes must include: ${fact}`).toContain(fact)
+    }
+
+    const installBlocks = [...releaseNotes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
+
+    expect(installBlocks.length).toBe(3)
+    for (const block of installBlocks) {
+      expect(block).toContain('releases/download/v1.3.9/')
+      expect(block).not.toContain('releases/download/v1.3.8/')
+      expect(block).toContain('polaris --setup-host')
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+  })
+
+  it('keeps the exact four-asset set in the release notes', () => {
+    const notes = read('docs/release-notes/v1.3.9.md')
+    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+
+    expect(listed.sort()).toEqual(expectedAssets)
+  })
+})


### PR DESCRIPTION
## Summary

- bump Polaris and package identities to v1.3.9
- publish the v1.3.9 changelog and release notes
- move the release/public-documentation contracts from v1.3.8 to v1.3.9 while retaining historical v1.3.8 coverage
- record the exact four supported release assets and the remaining affected-host validation limits

## Release scope

v1.3.9 is a Linux reliability and security patch for private-stream capture, Gamescope and portal ownership, high-refresh cadence, and hostile-input boundaries. It includes the merged #430, #431, and #432 work.

No separate affected-host candidate smoke is claimed. The release notes explicitly retain the AMD 4K linear-VAAPI, Hyprland virtual-display, Gamescope portal, and same-mode normalization field limits; windowed and direct-monitor GPU-native VAAPI remain disabled pending #410 and #411.

## Validation

- `bash scripts/check-public-docs.sh`
- `bash scripts/check-public-surface.sh`
- `python3 scripts/check-release-package-dependencies.py`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm run lint`
- `npm test` — 56 files, 323 tests
- `npm run build-clean`
- `npm run budget:web`
- `git diff --check`

The exact current master also passed the full Fedora, Ubuntu, Arch, SteamOS, sanitizer, Clang, web, CodeQL, and public-hygiene matrix before this version-only release commit.