### PR TITLE
fix(video): probe VAAPI HEVC Main10 with 10-bit input

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -426,6 +426,15 @@ namespace video {
                encoder.platform_formats->pix_fmt_8bit;
     }
 
+    int hevc_profile_for_input(int bit_depth, int chroma_sampling_type) {
+      if (chroma_sampling_type == 1) {
+        // HEVC uses the same RExt profile for both 8- and 10-bit YUV 4:4:4.
+        return AV_PROFILE_HEVC_REXT;
+      }
+
+      return bit_depth == 10 ? AV_PROFILE_HEVC_MAIN_10 : AV_PROFILE_HEVC_MAIN;
+    }
+
     std::optional<conversion_request_t> make_conversion_request(const encoder_t &encoder, const config_t &config, const sunshine_colorspace_t &colorspace, platf::mem_type_e target_device) {
       auto pix_fmt = select_encoder_output_pix_fmt(encoder, config, colorspace);
       if (!pix_fmt) {
@@ -2620,12 +2629,10 @@ namespace video {
           break;
 
         case 1:
-          if (config.chromaSamplingType == 1) {
-            // HEVC uses the same RExt profile for both 8 and 10 bit YUV 4:4:4 encoding
-            ctx->profile = AV_PROFILE_HEVC_REXT;
-          } else {
-            ctx->profile = config.dynamicRange ? AV_PROFILE_HEVC_MAIN_10 : AV_PROFILE_HEVC_MAIN;
-          }
+          // The client flag describes its request, but the capture path can
+          // legitimately demote a live SDR session to 8-bit. Keep the codec
+          // profile consistent with the frames the encoder actually receives.
+          ctx->profile = hevc_profile_for_input(colorspace.bit_depth, config.chromaSamplingType);
           break;
 
         case 2:
@@ -3419,44 +3426,50 @@ namespace video {
       // If the capture path is 8-bit-only but colorspace is still HDR PQ, demote to
       // full SDR — bit_depth=8 alone still attaches Rec.2020+PQ metadata and the
       // client shows dark/red "HDR garbage" over SDR pixels.
-      if (result && result->prefer_8bit_encode && colorspace_is_hdr(colorspace)) {
-        // Probe / host-portal SHM paths demote often; gamescope_stream still gets real
-        // 10-bit later via dmabuf — keep that path at info to avoid session spam.
-        const bool gamescope_stream =
-          config::video.linux_display.stream_mode == "gamescope_stream";
-        if (gamescope_stream) {
-          BOOST_LOG(info)
-            << "Forcing SDR colorspace for this encode device: capture path reported "
-               "8-bit-only frames (common during portal probe); gamescope_stream HDR "
-               "may still negotiate 10-bit on the live capture path."sv;
-        } else {
-          BOOST_LOG(warning)
-            << "Forcing SDR colorspace: capture path cannot produce 10-bit HDR frames "
-               "(host portal SHM/MemFd is 8-bit BGRx). Use gamescope_stream for real HDR."sv;
-        }
-        colorspace = colorspace_from_client_config(config, /*hdr_metadata_available=*/false);
-        colorspace.bit_depth = 8;
-        if (auto pix8 = select_encoder_output_pix_fmt(encoder, config, colorspace)) {
-          result = disp.make_avcodec_encode_device(*pix8);
-          if (result) {
-            result->prefer_8bit_encode = true;
+      // Capability probes must exercise the requested 10-bit path. Applying
+      // the live-session SDR optimization here turns the HEVC Main10 probe
+      // into Main10-over-NV12 (or, if the profile follows NV12, a false-positive
+      // 8-bit "HDR" probe). Let a genuinely unsupported P010 path fail the
+      // trial encode and be recorded as unsupported instead.
+      if (result && !encoder_probe_in_progress) {
+        if (result->prefer_8bit_encode && colorspace_is_hdr(colorspace)) {
+          // Probe / host-portal SHM paths demote often; gamescope_stream still gets real
+          // 10-bit later via dmabuf — keep that path at info to avoid session spam.
+          const bool gamescope_stream =
+            config::video.linux_display.stream_mode == "gamescope_stream";
+          if (gamescope_stream) {
+            BOOST_LOG(info)
+              << "Forcing SDR colorspace for this encode device: capture path reported "
+                 "8-bit-only frames (common during portal probe); gamescope_stream HDR "
+                 "may still negotiate 10-bit on the live capture path."sv;
+          } else {
+            BOOST_LOG(warning)
+              << "Forcing SDR colorspace: capture path cannot produce 10-bit HDR frames "
+                 "(host portal SHM/MemFd is 8-bit BGRx). Use gamescope_stream for real HDR."sv;
           }
-        }
-        BOOST_LOG(info) << "Color coding (after 8-bit capture demote): " << color_coding_label(colorspace);
-        BOOST_LOG(info) << "HDR decision (after 8-bit capture demote): stream_hdr_enabled=false";
-      }
-      else if (result && colorspace.bit_depth == 10 &&
-               (result->prefer_8bit_encode || !colorspace_is_hdr(colorspace))) {
-        if (result->prefer_8bit_encode) {
-          BOOST_LOG(info) << "Using 8-bit NV12 CUDA upload for capture path that cannot do 10-bit GPU frames"sv;
-        } else {
-          BOOST_LOG(info) << "Using 8-bit NV12 encode for non-HDR stream (avoid p010 cost for 10-bit SDR)"sv;
-        }
-        colorspace.bit_depth = 8;
-        if (auto pix8 = select_encoder_output_pix_fmt(encoder, config, colorspace)) {
-          result = disp.make_avcodec_encode_device(*pix8);
-          if (result) {
-            result->prefer_8bit_encode = true;
+          colorspace = colorspace_from_client_config(config, /*hdr_metadata_available=*/false);
+          colorspace.bit_depth = 8;
+          if (auto pix8 = select_encoder_output_pix_fmt(encoder, config, colorspace)) {
+            result = disp.make_avcodec_encode_device(*pix8);
+            if (result) {
+              result->prefer_8bit_encode = true;
+            }
+          }
+          BOOST_LOG(info) << "Color coding (after 8-bit capture demote): " << color_coding_label(colorspace);
+          BOOST_LOG(info) << "HDR decision (after 8-bit capture demote): stream_hdr_enabled=false";
+        } else if (colorspace.bit_depth == 10 &&
+                   (result->prefer_8bit_encode || !colorspace_is_hdr(colorspace))) {
+          if (result->prefer_8bit_encode) {
+            BOOST_LOG(info) << "Using 8-bit NV12 CUDA upload for capture path that cannot do 10-bit GPU frames"sv;
+          } else {
+            BOOST_LOG(info) << "Using 8-bit NV12 encode for non-HDR stream (avoid p010 cost for 10-bit SDR)"sv;
+          }
+          colorspace.bit_depth = 8;
+          if (auto pix8 = select_encoder_output_pix_fmt(encoder, config, colorspace)) {
+            result = disp.make_avcodec_encode_device(*pix8);
+            if (result) {
+              result->prefer_8bit_encode = true;
+            }
           }
         }
       }
@@ -4906,6 +4919,10 @@ namespace video {
   }
 
 #ifdef POLARIS_TESTS
+  int hevc_profile_for_input_for_tests(int bit_depth, int chroma_sampling_type) {
+    return hevc_profile_for_input(bit_depth, chroma_sampling_type);
+  }
+
   bool write_driver_version_cache_for_tests(
     const std::filesystem::path &cache_path,
     const std::filesystem::path &binary_path,

--- a/src/video.h
+++ b/src/video.h
@@ -544,6 +544,8 @@ namespace video {
   bool active_encoder_runtime_supports_live_gpu_capture(const config_t &config);
 
 #ifdef POLARIS_TESTS
+  int hevc_profile_for_input_for_tests(int bit_depth, int chroma_sampling_type);
+
   struct encoder_probe_cache_snapshot_t {
     std::string encoder_name;
     codec_capability_state_t capability_state {};

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -94,6 +94,13 @@ TEST(VideoColorSpaceTests, ClientHdrRequestWithDisplayMetadataEnablesTrueHdr) {
   EXPECT_EQ(colorspace.bit_depth, 10);
 }
 
+TEST(VideoCodecProfileTests, HevcProfileFollowsActualEncoderInputDepth) {
+  EXPECT_EQ(video::hevc_profile_for_input_for_tests(8, 0), AV_PROFILE_HEVC_MAIN);
+  EXPECT_EQ(video::hevc_profile_for_input_for_tests(10, 0), AV_PROFILE_HEVC_MAIN_10);
+  EXPECT_EQ(video::hevc_profile_for_input_for_tests(8, 1), AV_PROFILE_HEVC_REXT);
+  EXPECT_EQ(video::hevc_profile_for_input_for_tests(10, 1), AV_PROFILE_HEVC_REXT);
+}
+
 namespace {
   SS_HDR_METADATA usable_hdr_metadata() {
     SS_HDR_METADATA metadata {};

--- a/tests/unit/test_video_hdr_probe_guard_source.cpp
+++ b/tests/unit/test_video_hdr_probe_guard_source.cpp
@@ -56,4 +56,9 @@ TEST(VideoHdrProbeGuardSource, HdrCapabilityProbeCannotFailTheEncoder) {
   // The H.264 YUV444 capability probe (outside the lambda) must be guarded too.
   EXPECT_NE(source.find("H.264 YUV444 capability probe raised"), std::string::npos)
     << "the H.264 YUV444 capability probe must catch and downgrade a raised exception";
+
+  EXPECT_NE(source.find("if (result && !encoder_probe_in_progress)"), std::string::npos)
+    << "capability probes must not demote their requested 10-bit input to the live-session 8-bit path";
+  EXPECT_NE(source.find("hevc_profile_for_input(colorspace.bit_depth"), std::string::npos)
+    << "HEVC profile selection must follow the actual encoder input depth";
 }


### PR DESCRIPTION
## Summary

The VAAPI HEVC Main10 capability probe selected the Main10 profile while feeding the encoder an 8-bit input surface. That invalid pairing caused capable Mesa hosts to fail the probe and suppress HDR advertisement.

This change:

- preserves the requested 10-bit P010 input during capability probes
- selects HEVC Main, Main10, or RExt from the actual input format
- keeps live-session fallback behavior separate from capability detection

Fixes #435.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [ ] I included screenshots or recordings for visible UI changes, when practical.
- [ ] I updated docs or release notes when user-facing behavior changed.

- test_polaris: 306 passed
- test_polaris_video: 24 passed, 1 expected hardware skip
- focused HEVC probe tests: 4 passed
- git diff --check

## Notes

No pairing, trusted subnet, certificate, command, packaging, or privilege-boundary changes.