### PR TITLE
fix(stream): report only applied adaptive bitrate targets

### DIFF
--- a/src/adaptive_bitrate.cpp
+++ b/src/adaptive_bitrate.cpp
@@ -24,6 +24,7 @@ namespace adaptive_bitrate {
 
   static config_t current_config;
   static std::atomic<bool> enabled {false};
+  static std::atomic<bool> runtime_update_supported {false};
   static std::atomic<int> base_bitrate_kbps {0};
   static std::atomic<int> target_bitrate_kbps {0};
 
@@ -41,6 +42,7 @@ namespace adaptive_bitrate {
   static bool initialized = false;
   static std::string controller_state = "disabled";
   static std::string controller_reason = "disabled";
+  static std::string runtime_update_reason = "encoder_not_initialized";
 
   static void set_controller_status(const std::string &state, const std::string &reason) {
     controller_state = state;
@@ -73,7 +75,7 @@ namespace adaptive_bitrate {
   }
 
   void update_network_stats(double packet_loss_percent, double rtt_ms) {
-    if (!enabled.load(std::memory_order_relaxed)) {
+    if (!is_active()) {
       return;
     }
 
@@ -185,7 +187,7 @@ namespace adaptive_bitrate {
                             double frame_jitter_ms,
                             double encode_time_ms,
                             double avg_frame_age_ms) {
-    if (!enabled.load(std::memory_order_relaxed)) {
+    if (!is_active()) {
       return;
     }
 
@@ -239,7 +241,7 @@ namespace adaptive_bitrate {
   }
 
   int get_target_bitrate_kbps() {
-    if (!enabled.load(std::memory_order_relaxed)) {
+    if (!is_active()) {
       return 0;
     }
     return target_bitrate_kbps.load(std::memory_order_relaxed);
@@ -249,14 +251,16 @@ namespace adaptive_bitrate {
     std::lock_guard<std::mutex> lock(state_mutex);
     state_t state;
     state.enabled = enabled.load(std::memory_order_relaxed);
+    state.runtime_update_supported = runtime_update_supported.load(std::memory_order_relaxed);
+    state.active = state.enabled && state.runtime_update_supported;
     state.base_bitrate_kbps = base_bitrate_kbps.load(std::memory_order_relaxed);
-    state.target_bitrate_kbps = state.enabled ? target_bitrate_kbps.load(std::memory_order_relaxed) : 0;
+    state.target_bitrate_kbps = state.active ? target_bitrate_kbps.load(std::memory_order_relaxed) : 0;
     state.min_bitrate_kbps = current_config.min_bitrate_kbps;
     state.max_bitrate_kbps = current_config.max_bitrate_kbps;
     state.ewma_packet_loss = ewma_packet_loss;
     state.ewma_rtt_ms = ewma_rtt;
-    state.state = state.enabled ? controller_state : "disabled";
-    state.reason = state.enabled ? controller_reason : "disabled";
+    state.state = !state.enabled ? "disabled" : state.active ? controller_state : "unavailable";
+    state.reason = !state.enabled ? "disabled" : state.active ? controller_reason : runtime_update_reason;
     return state;
   }
 
@@ -306,6 +310,21 @@ namespace adaptive_bitrate {
     return enabled.load(std::memory_order_relaxed);
   }
 
+  void set_runtime_update_supported(bool supported, const std::string &reason) {
+    std::lock_guard<std::mutex> lock(state_mutex);
+    runtime_update_supported.store(supported, std::memory_order_relaxed);
+    runtime_update_reason = supported ? "supported" :
+      (reason.empty() ? "encoder_runtime_update_unsupported" : reason);
+    if (supported) {
+      set_controller_status("steady", "encoder_ready");
+    }
+  }
+
+  bool is_active() {
+    return enabled.load(std::memory_order_relaxed) &&
+      runtime_update_supported.load(std::memory_order_relaxed);
+  }
+
   void load_config() {
     std::lock_guard<std::mutex> lock(state_mutex);
 
@@ -331,6 +350,8 @@ namespace adaptive_bitrate {
     avg_rtt = 0.0;
     rtt_sample_count = 0;
     initialized = false;
+    runtime_update_supported.store(false, std::memory_order_relaxed);
+    runtime_update_reason = "encoder_not_initialized";
     set_controller_status(enabled.load(std::memory_order_relaxed) ? "steady" : "disabled",
                           enabled.load(std::memory_order_relaxed) ? "reset" : "disabled");
 

--- a/src/adaptive_bitrate.h
+++ b/src/adaptive_bitrate.h
@@ -25,6 +25,8 @@ namespace adaptive_bitrate {
 
   struct state_t {
     bool enabled = false;
+    bool active = false;
+    bool runtime_update_supported = false;
     int base_bitrate_kbps = 0;
     int target_bitrate_kbps = 0;
     int min_bitrate_kbps = 0;
@@ -97,6 +99,19 @@ namespace adaptive_bitrate {
    * @return True if enabled.
    */
   bool is_enabled();
+
+  /**
+   * @brief Report whether the active encoder can apply bitrate changes live.
+   *
+   * The controller remains configured when this is false, but it must not
+   * consume telemetry or publish an encoder target that was never applied.
+   */
+  void set_runtime_update_supported(bool supported, const std::string &reason = {});
+
+  /**
+   * @brief Check whether adaptive bitrate is configured and usable live.
+   */
+  bool is_active();
 
   /**
    * @brief Load configuration from polaris config system.

--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -42,13 +42,18 @@ namespace doctor_actions {
     std::mutex action_mutex;
     action_run_t action_run;
 
+    int current_live_bitrate(const stream_stats::stats_t &stats) {
+      return stats.adaptive_runtime_update_supported && stats.adaptive_target_bitrate_kbps > 0 ?
+        stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps;
+    }
+
     nlohmann::json network_evidence(const stream_stats::stats_t &stats) {
       return {
         {"streaming", stats.streaming},
         {"network_risk", stats.network_risk},
         {"packet_loss_pct", stats.packet_loss},
         {"latency_ms", stats.latency_ms},
-        {"bitrate_kbps", stats.adaptive_target_bitrate_kbps > 0 ? stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps},
+        {"bitrate_kbps", current_live_bitrate(stats)},
         {"paired_target_bitrate_kbps", stats.paired_target_bitrate_kbps},
         {"optimization_source", stats.optimization_source}
       };
@@ -106,6 +111,14 @@ namespace doctor_actions {
       std::lock_guard<std::mutex> lock(action_mutex);
       if (!action_run.active || run_id.empty() || run_id != action_run.run_id) {
         return {{"status", false}, {"changed", false}, {"error", "This Doctor undo is no longer available."}};
+      }
+      if (!adaptive_bitrate::get_state().runtime_update_supported) {
+        return {
+          {"status", false},
+          {"changed", false},
+          {"state", "runtime_update_unavailable"},
+          {"error", "The active encoder cannot apply a live bitrate change."}
+        };
       }
 
       const int restore_live_bitrate_kbps = action_run.previous_live_bitrate_kbps > 0 ?
@@ -169,6 +182,16 @@ namespace doctor_actions {
       std::lock_guard<std::mutex> lock(action_mutex);
       if (!action_run.active || run_id.empty() || run_id != action_run.run_id) {
         return {{"status", false}, {"changed", false}, {"state", "expired"}, {"error", "Doctor run not found."}};
+      }
+      if (!adaptive_bitrate::get_state().runtime_update_supported) {
+        return {
+          {"status", false},
+          {"changed", false},
+          {"run_id", run_id},
+          {"state", "runtime_update_unavailable"},
+          {"error", "The active encoder can no longer apply live bitrate changes."},
+          {"evidence", evidence}
+        };
       }
       const auto elapsed_seconds = std::chrono::duration_cast<std::chrono::seconds>(
         std::chrono::steady_clock::now() - action_run.applied_at
@@ -250,8 +273,16 @@ namespace doctor_actions {
       }
 
       const auto adaptive_state = adaptive_bitrate::get_state();
-      const int current_bitrate_kbps = stats.adaptive_target_bitrate_kbps > 0 ?
-        stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps;
+      if (!adaptive_state.runtime_update_supported) {
+        return {
+          {"status", false},
+          {"changed", false},
+          {"state", "runtime_update_unavailable"},
+          {"error", "The active encoder cannot restore bitrate during a live stream."},
+          {"evidence", evidence}
+        };
+      }
+      const int current_bitrate_kbps = current_live_bitrate(stats);
       const int goal_bitrate_kbps = stats.paired_target_bitrate_kbps;
       const int target_bitrate_kbps = guarded_quality_retry_target(
         current_bitrate_kbps,
@@ -320,8 +351,16 @@ namespace doctor_actions {
     }
 
     const auto adaptive_state = adaptive_bitrate::get_state();
-    const int current_bitrate_kbps = stats.adaptive_target_bitrate_kbps > 0 ?
-      stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps;
+    if (!adaptive_state.runtime_update_supported) {
+      return {
+        {"status", false},
+        {"changed", false},
+        {"state", "runtime_update_unavailable"},
+        {"error", "The active encoder cannot lower bitrate during a live stream."},
+        {"evidence", evidence}
+      };
+    }
+    const int current_bitrate_kbps = current_live_bitrate(stats);
     const int target_bitrate_kbps = guarded_bitrate_target(
       current_bitrate_kbps,
       request.value("target_bitrate_kbps", 0),

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -769,7 +769,7 @@ namespace nvhttp {
       policy["detail"] = health.value("summary", summary);
       policy["components"] = {
         {"optimizer_active", ai_optimizer::is_enabled()},
-        {"adaptive_bitrate_active", adaptive_bitrate::is_enabled()},
+        {"adaptive_bitrate_active", adaptive_bitrate::is_active()},
         {"adaptive_state", adaptive_state.state},
         {"adaptive_reason", adaptive_state.reason},
         {"target_bitrate_kbps", live_bitrate_kbps}
@@ -6609,6 +6609,8 @@ namespace nvhttp {
       hdr["downgrade_reason"] = stream_stats::hdr_downgrade_reason(stats);
       hdr["downgrade_message"] = stream_stats::hdr_downgrade_message(stats);
       output["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
+      output["adaptive_bitrate_active"] = adaptive_state.active;
+      output["adaptive_runtime_update_supported"] = adaptive_state.runtime_update_supported;
       output["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
       output["adaptive_bitrate_state"] = adaptive_state.state;
       output["adaptive_bitrate_reason"] = adaptive_state.reason;
@@ -6627,6 +6629,8 @@ namespace nvhttp {
 
       auto &tuning = output["tuning"];
       tuning["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
+      tuning["adaptive_bitrate_active"] = adaptive_state.active;
+      tuning["adaptive_runtime_update_supported"] = adaptive_state.runtime_update_supported;
       tuning["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
       tuning["adaptive_base_bitrate_kbps"] = adaptive_state.base_bitrate_kbps;
       tuning["adaptive_min_bitrate_kbps"] = adaptive_state.min_bitrate_kbps;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2453,15 +2453,17 @@ namespace stream {
 
       session.pingTimeout = std::chrono::steady_clock::now() + config::stream.ping_timeout;
 
+      // Initialize controller state before the encoder thread publishes its
+      // runtime-update capability. Resetting after the thread starts can erase
+      // that capability and silently leave a supported encoder inactive.
+      adaptive_bitrate::load_config();
+      adaptive_bitrate::reset();
+      adaptive_bitrate::set_base_bitrate(session.config.monitor.bitrate);
+
       session.audioThread = std::thread {audioThread, &session};
       session.videoThread = std::thread {videoThread, &session};
 
       session.state.store(state_e::RUNNING, std::memory_order_relaxed);
-
-      // Initialize adaptive bitrate for this session
-      adaptive_bitrate::load_config();
-      adaptive_bitrate::reset();
-      adaptive_bitrate::set_base_bitrate(session.config.monitor.bitrate);
 
       auto codec_name = session.config.monitor.videoFormat == 2 ? "av1" :
                          session.config.monitor.videoFormat == 1 ? "hevc" : "h264";

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -354,6 +354,8 @@ namespace stream_stats {
     j["bytes_sent"] = bytes_sent;
     j["gpu_usage"] = gpu_usage;
     j["adaptive_target_bitrate_kbps"] = adaptive_target_bitrate_kbps;
+    j["adaptive_bitrate_active"] = adaptive_bitrate_active;
+    j["adaptive_runtime_update_supported"] = adaptive_runtime_update_supported;
     j["idr_requests_total"] = idr_requests_total;
     j["invalidate_ref_frames_requests_total"] = invalidate_ref_frames_requests_total;
     j["headless_mode"] = config::video.linux_display.headless_mode;
@@ -733,7 +735,8 @@ namespace stream_stats {
 
     nlohmann::json doctor_recommendation(const std::string &primary_issue,
                                          const std::string &summary,
-                                         const nlohmann::json &health) {
+                                         const nlohmann::json &health,
+                                         bool live_bitrate_tunable) {
       std::string title = "Try this first";
       std::string body = "Start a stream, reproduce the issue, then export diagnostics with this Doctor result attached.";
       std::string next_step = "Export diagnostics";
@@ -745,17 +748,29 @@ namespace stream_stats {
         next_step = "Keep monitoring";
         expected = "No recovery action should be needed right now.";
       } else if (primary_issue == "network_jitter") {
-        body = "Current sustained loss or latency evidence confirms network pressure. Doctor can lower bitrate one guarded step and watch the same telemetry for recovery.";
-        next_step = "Fix and verify";
-        expected = "Packet loss and latency should return to the stable range without changing encoder or display settings.";
+        if (live_bitrate_tunable) {
+          body = "Current sustained loss or latency evidence confirms network pressure. Doctor can lower bitrate one guarded step and watch the same telemetry for recovery.";
+          next_step = "Fix and verify";
+          expected = "Packet loss and latency should return to the stable range without changing encoder or display settings.";
+        } else {
+          body = "Current sustained loss or latency evidence confirms network pressure, but this encoder cannot change bitrate during a live stream. Lower the paired or client bitrate for the next launch.";
+          next_step = "Lower next-stream bitrate";
+          expected = "The next stream should start at a bitrate the network can sustain.";
+        }
       } else if (primary_issue == "network_observation") {
         body = "Doctor sees a debounced network warning, but current loss and latency do not justify reducing quality. Recheck the live path before changing bitrate.";
         next_step = "Recheck network";
         expected = "Doctor will either clear the warning or gather direct evidence before offering a bitrate change.";
       } else if (primary_issue == "quality_capped_by_history") {
-        body = "The current network is clean, but an older recovery profile is holding bitrate below this paired device's saved target. Doctor can retry quality gradually and verify every step.";
-        next_step = "Restore and verify";
-        expected = "Bitrate should climb toward the paired target while Doctor stops immediately if live loss or latency returns.";
+        if (live_bitrate_tunable) {
+          body = "The current network is clean, but an older recovery profile is holding bitrate below this paired device's saved target. Doctor can retry quality gradually and verify every step.";
+          next_step = "Restore and verify";
+          expected = "Bitrate should climb toward the paired target while Doctor stops immediately if live loss or latency returns.";
+        } else {
+          body = "The current network is clean, but this encoder cannot restore bitrate during a live stream. Relaunch to apply the paired quality target.";
+          next_step = "Relaunch with paired target";
+          expected = "The next stream should start at the saved paired bitrate.";
+        }
       } else if (primary_issue == "encoder_load") {
         body = "Trim bitrate, resolution, or FPS to give the active encoder more frame time.";
         next_step = "Lower stream load";
@@ -794,6 +809,7 @@ namespace stream_stats {
                                       const nlohmann::json &health,
                                       int current_bitrate_kbps,
                                       int paired_target_bitrate_kbps,
+                                      bool live_bitrate_tunable,
                                       const std::string &source_result_id) {
       std::string id = "none";
       std::string label = "No automatic action";
@@ -802,6 +818,7 @@ namespace stream_stats {
       std::string method;
       nlohmann::json payload = nlohmann::json::object();
       std::string rollback = "No change is applied by Doctor.";
+      std::string unavailable_reason;
 
       nlohmann::json verification = {
         {"mode", "none"},
@@ -810,7 +827,7 @@ namespace stream_stats {
         {"success_when", nlohmann::json::array()}
       };
 
-      if (primary_issue == "network_jitter") {
+      if (primary_issue == "network_jitter" && live_bitrate_tunable) {
         id = "lower_bitrate";
         label = "Fix and verify";
         kind = "live_tuning";
@@ -844,7 +861,7 @@ namespace stream_stats {
           {"endpoint", "/api/doctor/action"},
           {"success_when", nlohmann::json::array({"current network evidence remains below the action threshold"})}
         };
-      } else if (primary_issue == "quality_capped_by_history") {
+      } else if (primary_issue == "quality_capped_by_history" && live_bitrate_tunable) {
         id = "restore_quality";
         label = "Restore and verify";
         kind = "live_tuning";
@@ -860,6 +877,8 @@ namespace stream_stats {
           {"endpoint", "/api/doctor/action"},
           {"success_when", nlohmann::json::array({"network_risk stays clear", "packet_loss_pct <= 2", "latency_ms < 45", "paired bitrate target is reached"})}
         };
+      } else if ((primary_issue == "network_jitter" || primary_issue == "quality_capped_by_history") && !live_bitrate_tunable) {
+        unavailable_reason = "The active encoder does not support runtime bitrate updates.";
       } else if (primary_issue == "no_active_stream" || primary_issue == "capture_missing") {
         id = "export_support_bundle";
         label = "Export diagnostics";
@@ -887,6 +906,7 @@ namespace stream_stats {
         {"allowed_in_viewer_mode", id == "export_support_bundle"},
         {"endpoint", endpoint},
         {"method", method},
+        {"unavailable_reason", unavailable_reason},
         {"payload_preview", payload},
         {"rollback", rollback},
         {"verification", verification},
@@ -911,7 +931,7 @@ namespace stream_stats {
     // noise, so Doctor said "network jitter" over perfect streams.
     const bool network_fail = stats.network_risk && (stats.packet_loss > 2.0 || stats.latency_ms >= 45.0);
     const bool network_watch = stats.network_risk && !network_fail;
-    const int live_bitrate_kbps = stats.adaptive_target_bitrate_kbps > 0 ?
+    const int live_bitrate_kbps = stats.adaptive_runtime_update_supported && stats.adaptive_target_bitrate_kbps > 0 ?
       stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps;
     const bool history_safe_source = stats.optimization_source.find("history_safe") != std::string::npos;
     const bool quality_capped_by_history =
@@ -1006,7 +1026,19 @@ namespace stream_stats {
     append_doctor_evidence(evidence, "encoder", "Encoder", stats.encode_target_device, "", encoder_fail ? "fail" : encoder_watch ? "watch" : "pass", "stream_stats", stats.encode_time_ms > 0.0 ? "Encode timing is reported by stream telemetry." : "Encoder timing has not been reported yet.");
     append_doctor_evidence(evidence, "packet_loss", "Packet loss", stats.packet_loss, "%", network_fail ? "fail" : network_watch ? "watch" : "pass", "stream_stats", "Packet loss reported by current stream telemetry.");
     append_doctor_evidence(evidence, "latency", "Network latency", stats.latency_ms, "ms", stats.latency_ms >= 45.0 ? "fail" : network_watch ? "watch" : "pass", "stream_stats", "Round-trip latency reported by the active client control channel.");
-    append_doctor_evidence(evidence, "bitrate", "Live bitrate", stats.adaptive_target_bitrate_kbps > 0 ? stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps, "kbps", "pass", "stream_stats", "Current live encoder target; Doctor changes it only for confirmed pressure or a guarded recovery-profile retry.");
+    append_doctor_evidence(evidence, "bitrate", "Live bitrate", live_bitrate_kbps, "kbps", "pass", "stream_stats", stats.adaptive_runtime_update_supported ? "Current live encoder target; Doctor changes it only for confirmed pressure or a guarded recovery-profile retry." : "Applied encoder bitrate; this encoder does not expose live bitrate updates.");
+    append_doctor_evidence(
+      evidence,
+      "live_bitrate_control",
+      "Live bitrate control",
+      stats.adaptive_runtime_update_supported,
+      "",
+      !stats.streaming ? "unknown" : stats.adaptive_runtime_update_supported ? "pass" : "watch",
+      "encoder_capability",
+      !stats.streaming ? "Start a stream before checking encoder bitrate controls." :
+      stats.adaptive_runtime_update_supported ? "The active encoder accepts runtime bitrate updates." :
+                                                "The active encoder does not support runtime bitrate updates; bitrate changes require a new stream."
+    );
     append_doctor_evidence(evidence, "paired_bitrate_target", "Paired quality target", stats.paired_target_bitrate_kbps, "kbps", quality_capped_by_history ? "watch" : stats.paired_target_bitrate_kbps > 0 ? "pass" : "unknown", "session_profile", quality_capped_by_history ? "A history-safe recovery layer is keeping the live bitrate below the paired target." : "Saved bitrate preference for the active paired client.");
     append_doctor_evidence(evidence, "target_fps_gap", "Target FPS gap", target_fps_gap, "FPS", meaningful_fps_shortfall ? "watch" : "pass", "stream_stats", "Encoded FPS below the requested cadence is a source or compositor pacing gap, not network jitter by itself.");
     append_doctor_evidence(evidence, "frame_pacing", "Mean target interval error", stats.frame_jitter_ms, "ms", pacing_watch ? "watch" : "pass", "stream_stats", "Mean absolute distance between actual source-frame intervals and the requested interval; this is not statistical network jitter.");
@@ -1060,14 +1092,15 @@ namespace stream_stats {
     doctor["primary_issue"] = primary_issue;
     doctor["confidence"] = {{"level", confidence_level}, {"score", confidence_score}, {"basis", basis}, {"sample_window", {{"samples", stats.streaming ? 1 : 0}, {"seconds", stats.streaming ? 1 : 0}}}};
     doctor["summary"] = summary;
-    doctor["recommendation"] = doctor_recommendation(primary_issue, summary, health);
+    doctor["recommendation"] = doctor_recommendation(primary_issue, summary, health, stats.adaptive_runtime_update_supported);
     doctor["evidence"] = std::move(evidence);
     doctor["advanced_evidence"] = std::move(advanced);
     doctor["safe_recovery_action"] = doctor_safe_action(
       primary_issue,
       health,
-      stats.adaptive_target_bitrate_kbps > 0 ? stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps,
+      live_bitrate_kbps,
       stats.paired_target_bitrate_kbps,
+      stats.adaptive_runtime_update_supported,
       doctor["result_id"].get<std::string>()
     );
     doctor["suppressed_findings"] = nlohmann::json::array();
@@ -2055,10 +2088,13 @@ namespace stream_stats {
 
   stats_t get_current() {
     stats_t result;
+    const auto adaptive_state = adaptive_bitrate::get_state();
     {
       std::lock_guard<std::mutex> lock(stats_mutex);
-      auto target_bitrate = adaptive_bitrate::get_target_bitrate_kbps();
+      const auto target_bitrate = adaptive_state.target_bitrate_kbps;
       current_stats.adaptive_target_bitrate_kbps = target_bitrate;
+      current_stats.adaptive_bitrate_active = adaptive_state.active;
+      current_stats.adaptive_runtime_update_supported = adaptive_state.runtime_update_supported;
 
       // Also update adaptive bitrate for all clients
       for (auto &c : current_stats.clients) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -141,6 +141,8 @@ namespace stream_stats {
 
     // Adaptive bitrate
     int adaptive_target_bitrate_kbps = 0;
+    bool adaptive_bitrate_active = false;
+    bool adaptive_runtime_update_supported = false;
 
     // System
     double gpu_usage = 0;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1408,6 +1408,10 @@ namespace video {
       return encode_device->nvenc->update_bitrate(new_bitrate_kbps);
     }
 
+    bool supports_runtime_bitrate_update() const override {
+      return true;
+    }
+
   private:
     std::unique_ptr<encode_device_frame_converter_t<platf::nvenc_encode_device_t>> converter;
     conversion_request_t conversion_request;
@@ -3070,6 +3074,11 @@ namespace video {
       return;
     }
 
+    adaptive_bitrate::set_runtime_update_supported(session->supports_runtime_bitrate_update());
+    auto runtime_bitrate_guard = util::fail_guard([] {
+      adaptive_bitrate::set_runtime_update_supported(false, "encoder_session_ended");
+    });
+
     // As a workaround for NVENC hangs and to generally speed up encoder reinit,
     // we will complete the encoder teardown in a separate thread if supported.
     // This will move expensive processing off the encoder thread to allow us
@@ -3330,6 +3339,9 @@ namespace video {
               if (session->update_bitrate(target)) {
                 applied_adaptive_bitrate = target;
                 effective_bitrate = target;
+              } else {
+                BOOST_LOG(warning) << "Encoder rejected a runtime bitrate update; disabling live adaptive bitrate for this session"sv;
+                adaptive_bitrate::set_runtime_update_supported(false, "runtime_bitrate_update_failed");
               }
             } else if (target > 0) {
               effective_bitrate = applied_adaptive_bitrate;

--- a/src/video.h
+++ b/src/video.h
@@ -315,6 +315,13 @@ namespace video {
     virtual void invalidate_ref_frames(int64_t first_frame, int64_t last_frame) = 0;
 
     /**
+     * @brief Whether this encoder session can apply bitrate changes at runtime.
+     */
+    virtual bool supports_runtime_bitrate_update() const {
+      return false;
+    }
+
+    /**
      * @brief Dynamically update the encoder bitrate at runtime.
      * @param new_bitrate_kbps New target bitrate in kilobits per second.
      * @return `true` if the encoder supports runtime bitrate update and it succeeded.

--- a/tests/unit/test_adaptive_bitrate.cpp
+++ b/tests/unit/test_adaptive_bitrate.cpp
@@ -20,6 +20,7 @@ namespace {
     config::video.adaptive_bitrate.max_bitrate_kbps = 50000;
     adaptive_bitrate::load_config();
     adaptive_bitrate::reset();
+    adaptive_bitrate::set_runtime_update_supported(true);
     adaptive_bitrate::set_base_bitrate(base_bitrate_kbps);
   }
 }
@@ -82,6 +83,22 @@ TEST(AdaptiveBitrateController, ExplicitLiveRetryCanRaiseSessionCeilingAndTarget
   EXPECT_EQ(state.base_bitrate_kbps, 9475);
   EXPECT_EQ(state.target_bitrate_kbps, 9475);
   EXPECT_EQ(state.reason, "doctor_action");
+}
+
+TEST(AdaptiveBitrateController, HidesTargetsWhenEncoderCannotApplyRuntimeUpdates) {
+  enable_controller(26000);
+  adaptive_bitrate::set_runtime_update_supported(false);
+
+  adaptive_bitrate::update_network_stats(21.8, 12.0);
+
+  const auto state = adaptive_bitrate::get_state();
+  EXPECT_TRUE(state.enabled);
+  EXPECT_FALSE(state.active);
+  EXPECT_FALSE(state.runtime_update_supported);
+  EXPECT_EQ(0, state.target_bitrate_kbps);
+  EXPECT_EQ(0, adaptive_bitrate::get_target_bitrate_kbps());
+  EXPECT_EQ("unavailable", state.state);
+  EXPECT_EQ("encoder_runtime_update_unsupported", state.reason);
 }
 
 TEST(AdaptiveBitrateController, NormalizesMaxBelowMinBeforeClampingBase) {

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -755,6 +755,7 @@ TEST(StreamStatsDoctorTests, ConfirmedNetworkPressureOffersGuardedFixWithUndo) {
   stats.network_risk = true;
   stats.packet_loss = 3.4;
   stats.latency_ms = 52.0;
+  stats.adaptive_runtime_update_supported = true;
 
   const auto doctor = stream_stats::build_doctor_json(
     stats,
@@ -769,6 +770,45 @@ TEST(StreamStatsDoctorTests, ConfirmedNetworkPressureOffersGuardedFixWithUndo) {
   EXPECT_EQ(action.at("payload_preview").at("source_result_id"), doctor.at("result_id"));
   EXPECT_FALSE(action.at("requires_confirmation"));
   EXPECT_TRUE(action.at("undo").at("supported"));
+}
+
+TEST(StreamStatsDoctorTests, UnsupportedRuntimeBitrateUsesAppliedRateAndOffersNoLiveFix) {
+  stream_stats::stats_t stats {};
+  stats.streaming = true;
+  stats.fps = 60.0;
+  stats.encode_target_fps = 120.0;
+  stats.bitrate_kbps = 26000;
+  stats.adaptive_target_bitrate_kbps = 2000;
+  stats.adaptive_bitrate_active = false;
+  stats.adaptive_runtime_update_supported = false;
+  stats.capture_transport = platf::frame_transport_e::shm;
+  stats.capture_residency = platf::frame_residency_e::cpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+  stats.network_risk = true;
+  stats.packet_loss = 21.8;
+  stats.latency_ms = 52.0;
+
+  const auto doctor = stream_stats::build_doctor_json(
+    stats,
+    {{"primary_issue", "network_jitter"}, {"grade", "degraded"}}
+  );
+
+  EXPECT_EQ(doctor.at("primary_issue"), "network_jitter");
+  EXPECT_EQ(doctor.at("safe_recovery_action").at("id"), "none");
+  EXPECT_EQ(
+    doctor.at("safe_recovery_action").at("unavailable_reason"),
+    "The active encoder does not support runtime bitrate updates."
+  );
+  EXPECT_EQ(doctor.at("recommendation").at("next_step_label"), "Lower next-stream bitrate");
+
+  for (const auto &item : doctor.at("evidence")) {
+    if (item.at("id") == "bitrate") {
+      EXPECT_EQ(item.at("value"), 26000);
+    }
+    if (item.at("id") == "live_bitrate_control") {
+      EXPECT_FALSE(item.at("value").get<bool>());
+    }
+  }
 }
 
 TEST(StreamStatsDoctorTests, CleanHistorySafeCapOffersGraduatedQualityRestore) {
@@ -787,6 +827,7 @@ TEST(StreamStatsDoctorTests, CleanHistorySafeCapOffersGraduatedQualityRestore) {
   stats.packet_loss = 0.0;
   stats.latency_ms = 3.8;
   stats.network_risk = false;
+  stats.adaptive_runtime_update_supported = true;
 
   const auto doctor = stream_stats::build_doctor_json(
     stats,
@@ -854,6 +895,7 @@ TEST(DoctorActionTests, ExecuteAppliesVerifiesAndUndoesOneGuardedStepEndToEnd) {
   // the two pieces this arc depends on before seeding telemetry.
   adaptive_bitrate::set_max_bitrate(100000);
   adaptive_bitrate::set_enabled(false);
+  adaptive_bitrate::set_runtime_update_supported(true);
 
   stream_stats::update_stream_active(true, "DoctorContractTest", "203.0.113.7");
   stream_stats::update_video_stats(60.0, 20000, 5.0, "hevc", 1920, 1080);
@@ -875,6 +917,14 @@ TEST(DoctorActionTests, ExecuteAppliesVerifiesAndUndoesOneGuardedStepEndToEnd) {
     stream_stats::update_network_stats(52.0, 3.4, 1000);
   }
   ASSERT_TRUE(stream_stats::get_current().network_risk);
+
+  adaptive_bitrate::set_runtime_update_supported(false);
+  const auto unavailable = doctor_actions::execute({{"action_id", "lower_bitrate"}});
+  EXPECT_FALSE(unavailable.at("status").get<bool>());
+  EXPECT_FALSE(unavailable.at("changed").get<bool>());
+  EXPECT_EQ(unavailable.at("state"), "runtime_update_unavailable");
+
+  adaptive_bitrate::set_runtime_update_supported(true);
 
   const auto applied = doctor_actions::execute({{"action_id", "lower_bitrate"}});
   ASSERT_TRUE(applied.at("status").get<bool>());


### PR DESCRIPTION
## Summary

Adaptive bitrate treated every requested runtime bitrate as applied even when the encoder rejected the update. VAAPI therefore walked an internal target down to the 2000 kbps floor while continuing to encode at the session bitrate, and Doctor reported that phantom value as live state.

This change:

- exposes whether an encoder supports runtime bitrate updates
- enables live adaptive control only for an encoder that can apply it
- disables the live controller if an update is rejected
- keeps Doctor evidence and fixes aligned with the bitrate the encoder actually uses

Fixes #436.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [ ] I included screenshots or recordings for visible UI changes, when practical.
- [ ] I updated docs or release notes when user-facing behavior changed.

- test_polaris_stream: 233 passed
- git diff --check

## Notes

No pairing, trusted subnet, certificate, command, packaging, or privilege-boundary changes.