### PR TITLE
fix(doctor): clarify inactive diagnostics and probe noise

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -5381,7 +5381,11 @@ namespace confighttp {
     nlohmann::json output_tree;
     output_tree["status"] = true;
 
-    bool available = cached_backend != virtual_display::backend_e::NONE;
+    const bool backend_detected = cached_backend != virtual_display::backend_e::NONE;
+    const bool available = virtual_display::backend_has_required_configuration(
+      cached_backend,
+      config::video.linux_display.streaming_output
+    );
     output_tree["available"] = available;
     const auto labwc = snapshot_labwc();
     const auto display_policy = stream_display_policy::resolve(stream_display_policy::input_t {
@@ -5391,6 +5395,9 @@ namespace confighttp {
     });
     output_tree["backend"] = virtual_display::backend_name(cached_backend);
     output_tree["backend_id"] = static_cast<int>(cached_backend);
+    output_tree["backend_detected"] = backend_detected;
+    output_tree["configuration_ready"] = available;
+    output_tree["unavailable_reason"] = available ? "" : virtual_display::unavailable_reason();
     output_tree["configured_adapter"] = config::video.adapter_name;
     output_tree["policy_mode"] = display_policy.selection;
     output_tree["policy_label"] = display_policy.label;

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -333,6 +333,10 @@ namespace stream_stats {
     j["duplicate_frame_ratio"] = duplicate_frame_ratio;
     j["dropped_frame_ratio"] = dropped_frame_ratio;
     j["avg_frame_age_ms"] = avg_frame_age_ms;
+    // Compatibility: frame_jitter_ms predates the metric's precise name. The
+    // value is mean absolute error from the requested frame interval, not the
+    // variance of otherwise on-target delivery intervals.
+    j["frame_interval_error_ms"] = frame_jitter_ms;
     j["frame_jitter_ms"] = frame_jitter_ms;
     j["codec"] = codec;
     j["pacing_policy"] = pacing_policy;
@@ -898,6 +902,7 @@ namespace stream_stats {
     const bool capture_gpu_native = capture_path_is_gpu_native(stats);
     const bool capture_known = doctor_has_capture_metadata(stats);
     const double target_fps = doctor_target_fps(stats);
+    const double target_fps_gap = std::max(0.0, target_fps - stats.fps);
     const bool meaningful_fps_shortfall = is_meaningful_fps_shortfall(target_fps, stats.fps);
     // The network verdict consumes the debounced flag the session status
     // serves (network_risk_tracker_t). The raw one-sample cuts this replaced
@@ -1003,10 +1008,11 @@ namespace stream_stats {
     append_doctor_evidence(evidence, "latency", "Network latency", stats.latency_ms, "ms", stats.latency_ms >= 45.0 ? "fail" : network_watch ? "watch" : "pass", "stream_stats", "Round-trip latency reported by the active client control channel.");
     append_doctor_evidence(evidence, "bitrate", "Live bitrate", stats.adaptive_target_bitrate_kbps > 0 ? stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps, "kbps", "pass", "stream_stats", "Current live encoder target; Doctor changes it only for confirmed pressure or a guarded recovery-profile retry.");
     append_doctor_evidence(evidence, "paired_bitrate_target", "Paired quality target", stats.paired_target_bitrate_kbps, "kbps", quality_capped_by_history ? "watch" : stats.paired_target_bitrate_kbps > 0 ? "pass" : "unknown", "session_profile", quality_capped_by_history ? "A history-safe recovery layer is keeping the live bitrate below the paired target." : "Saved bitrate preference for the active paired client.");
-    append_doctor_evidence(evidence, "frame_pacing", "Frame pacing", stats.frame_jitter_ms, "ms jitter", pacing_watch ? "watch" : "pass", "stream_stats", "Frame jitter, duplicate/drop ratios, and target FPS gap classify pacing risk.");
+    append_doctor_evidence(evidence, "target_fps_gap", "Target FPS gap", target_fps_gap, "FPS", meaningful_fps_shortfall ? "watch" : "pass", "stream_stats", "Encoded FPS below the requested cadence is a source or compositor pacing gap, not network jitter by itself.");
+    append_doctor_evidence(evidence, "frame_pacing", "Mean target interval error", stats.frame_jitter_ms, "ms", pacing_watch ? "watch" : "pass", "stream_stats", "Mean absolute distance between actual source-frame intervals and the requested interval; this is not statistical network jitter.");
 
     auto advanced = nlohmann::json::object();
-    advanced["stream_stats_keys"] = nlohmann::json::array({"capture_path", "capture_path_reason", "capture_transport", "capture_residency", "capture_format", "capture_cpu_copy", "capture_gpu_native", "capture_cross_gpu_dmabuf_risk", "encode_target_device", "encode_target_residency", "fps", "encode_time_ms", "packet_loss", "frame_jitter_ms"});
+    advanced["stream_stats_keys"] = nlohmann::json::array({"capture_path", "capture_path_reason", "capture_transport", "capture_residency", "capture_format", "capture_cpu_copy", "capture_gpu_native", "capture_cross_gpu_dmabuf_risk", "encode_target_device", "encode_target_residency", "fps", "encode_time_ms", "packet_loss", "frame_interval_error_ms", "frame_jitter_ms"});
     advanced["linux_gpu_profile"] = linux_gpu_profile_json(stats);
     advanced["gpu_native_probe"] = gpu_native_probe_json(stats);
     advanced["health"] = health;

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/VirtualDisplayStatus.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/VirtualDisplayStatus.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { presentVirtualDisplayStatus } from '../../../virtual-display-status.js'
 
 defineProps({
   platform: String,
@@ -10,6 +11,7 @@ const loading = ref(true)
 const error = ref(null)
 const vdStatus = ref(null)
 const backends = ref([])
+const presentation = computed(() => presentVirtualDisplayStatus(vdStatus.value || {}))
 
 async function fetchStatus() {
   try {
@@ -63,15 +65,23 @@ onMounted(async () => {
         <div class="flex items-center gap-2">
           <span
             class="w-2 h-2 rounded-full"
-            :class="vdStatus.available ? 'bg-success' : 'bg-danger'"
+            :class="presentation.kind === 'available'
+              ? 'bg-success'
+              : presentation.kind === 'missing'
+                ? 'bg-danger'
+                : 'bg-warning'"
           ></span>
           <span class="text-sm text-storm">
-            {{ vdStatus.available ? 'Available' : 'Not available' }}
+            {{ presentation.label }}
           </span>
         </div>
 
-        <div v-if="vdStatus.available" class="text-sm text-storm">
-          Active backend: <span class="text-silver font-medium">{{ vdStatus.backend }}</span>
+        <div class="text-sm text-storm">
+          {{ presentation.detail }}
+        </div>
+
+        <div v-if="vdStatus.backend_detected" class="text-sm text-storm">
+          Detected backend: <span class="text-silver font-medium">{{ vdStatus.backend }}</span>
         </div>
 
         <div v-if="backends.length > 0" class="mt-2 space-y-1">
@@ -86,28 +96,27 @@ onMounted(async () => {
               :class="b.detected ? 'bg-success' : 'bg-storm/70'"
             ></span>
             <span :class="b.detected ? 'text-silver' : 'text-storm/60'">{{ b.name }}</span>
-            <span v-if="b.detected" class="text-xs text-ice">(active)</span>
+            <span v-if="b.detected" class="text-xs text-ice">(detected)</span>
           </div>
         </div>
 
         <div
-          v-if="vdStatus.backend === 'kscreen-doctor'"
+          v-if="presentation.kind === 'unconfigured' && vdStatus.backend === 'kscreen-doctor'"
           class="mt-3 rounded-xl border border-storm/20 bg-deep/40 p-3 text-sm text-storm space-y-2"
         >
           <div class="text-silver font-medium text-xs uppercase tracking-wide">kscreen-doctor Configuration</div>
           <p>
-            This backend manages existing physical displays. Make sure
-            <code class="text-ice bg-void/50 px-1 rounded">linux_streaming_output</code> and
-            <code class="text-ice bg-void/50 px-1 rounded">linux_primary_output</code>
-            are configured in the Audio/Video settings above (Output Name field) or in the config file.
+            This backend manages an existing output instead of creating one. Set
+            <code class="text-ice bg-void/50 px-1 rounded">linux_streaming_output</code>
+            in the Audio/Video settings above (Output Name) or in the config file so Polaris knows which output it may reconfigure.
           </p>
         </div>
 
         <div
-          v-if="!vdStatus.available"
+          v-if="presentation.kind === 'missing'"
           class="mt-2 rounded-xl border border-storm/20 bg-deep/40 p-3 text-sm text-storm"
         >
-          No virtual display backend was detected. Install one of the following:
+          No virtual display backend was detected. Install one of the following only if you want to use Host Virtual Display:
           <ul class="list-disc list-inside mt-1 space-y-0.5">
             <li><span class="text-silver">EVDI</span> - kernel module + libevdi for true virtual connectors</li>
             <li><span class="text-silver">Wayland compositor</span> - Hyprland, Sway, or wlroots-based with headless output support</li>

--- a/src_assets/common/assets/web/recent-issues.js
+++ b/src_assets/common/assets/web/recent-issues.js
@@ -1,0 +1,66 @@
+const ENCODER_PROBE_START = 'Testing for available encoders, this may generate errors. You can safely ignore those errors.'
+const ENCODER_PROBE_END = 'Ignore any errors mentioned above, they are not relevant.'
+
+function probeBoundary(line) {
+  if (line.includes(ENCODER_PROBE_START)) return 'start'
+  if (line.includes(ENCODER_PROBE_END)) return 'end'
+  return null
+}
+
+function parseIssueLine(line) {
+  const match = line.match(/^(\[[^\]]+\]):\s*(Fatal|Warning|Error):\s*(.*)$/)
+  if (!match) return null
+
+  return {
+    timestamp: match[1],
+    level: match[2],
+    message: match[3].replace(/\s+/g, ' ').trim(),
+  }
+}
+
+/**
+ * Group recent warning/error log lines while excluding capability-probe noise.
+ *
+ * Encoder probing intentionally tries unsupported codec/profile combinations.
+ * Polaris brackets those attempts with stable start/end banners. Filtering by
+ * that context keeps an identical codec failure visible when it occurs during
+ * a real stream. If a bounded log tail begins inside a probe, the first end
+ * banner also lets us infer that the leading lines belong to the probe window.
+ */
+export function groupRecentIssueLogs(logText, {
+  maxSourceLines = 300,
+  maxGroups = Number.POSITIVE_INFINITY,
+} = {}) {
+  const lines = String(logText || '').split('\n').slice(-maxSourceLines)
+  const firstStart = lines.findIndex((line) => probeBoundary(line) === 'start')
+  const firstEnd = lines.findIndex((line) => probeBoundary(line) === 'end')
+  let insideEncoderProbe = firstEnd >= 0 && (firstStart < 0 || firstEnd < firstStart)
+  const visibleIssues = []
+
+  for (const line of lines) {
+    const boundary = probeBoundary(line)
+    if (boundary === 'start') {
+      insideEncoderProbe = true
+      continue
+    }
+    if (boundary === 'end') {
+      insideEncoderProbe = false
+      continue
+    }
+
+    const issue = parseIssueLine(line)
+    if (issue && !insideEncoderProbe) visibleIssues.push(issue)
+  }
+
+  const grouped = new Map()
+  visibleIssues.reverse().forEach((entry) => {
+    const key = `${entry.level}:${entry.message}`
+    if (!grouped.has(key)) {
+      grouped.set(key, { ...entry, count: 1 })
+      return
+    }
+    grouped.get(key).count += 1
+  })
+
+  return Array.from(grouped.values()).slice(0, maxGroups)
+}

--- a/src_assets/common/assets/web/recent-issues.test.js
+++ b/src_assets/common/assets/web/recent-issues.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { groupRecentIssueLogs } from './recent-issues.js'
+
+const start = '[2026-08-16 10:00:00.000]: Info: // Testing for available encoders, this may generate errors. You can safely ignore those errors. //'
+const end = '[2026-08-16 10:00:01.000]: Info: // Ignore any errors mentioned above, they are not relevant. //'
+
+describe('recent issue log grouping', () => {
+  it('suppresses expected errors only inside encoder probe windows', () => {
+    const codecError = 'Error: Could not open codec [hevc_vaapi]'
+    const grouped = groupRecentIssueLogs([
+      '[2026-08-16 09:59:59.000]: Warning: real warning before probe',
+      start,
+      `[2026-08-16 10:00:00.100]: ${codecError}`,
+      '[2026-08-16 10:00:00.200]: Error: shader probe failed',
+      end,
+      `[2026-08-16 10:00:02.000]: ${codecError}`,
+    ].join('\n'))
+
+    expect(grouped).toEqual([
+      expect.objectContaining({ level: 'Error', message: 'Could not open codec [hevc_vaapi]', count: 1 }),
+      expect.objectContaining({ level: 'Warning', message: 'real warning before probe', count: 1 }),
+    ])
+    expect(grouped.some((entry) => entry.message === 'shader probe failed')).toBe(false)
+  })
+
+  it('recognizes a bounded tail that begins inside a probe window', () => {
+    const grouped = groupRecentIssueLogs([
+      '[2026-08-16 10:00:00.100]: Error: expected leading probe failure',
+      end,
+      '[2026-08-16 10:00:02.000]: Error: live stream failure',
+    ].join('\n'))
+
+    expect(grouped).toEqual([
+      expect.objectContaining({ message: 'live stream failure' }),
+    ])
+  })
+
+  it('groups matching non-probe issues and keeps the newest timestamp', () => {
+    const grouped = groupRecentIssueLogs([
+      '[2026-08-16 10:00:00.000]: Warning: connection stalled',
+      '[2026-08-16 10:00:01.000]: Warning: connection   stalled',
+    ].join('\n'))
+
+    expect(grouped).toEqual([
+      {
+        timestamp: '[2026-08-16 10:00:01.000]',
+        level: 'Warning',
+        message: 'connection stalled',
+        count: 2,
+      },
+    ])
+  })
+})

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -82,7 +82,7 @@
             <div class="flex flex-wrap justify-end gap-1.5">
               <span class="data-pill" :class="frameHealth.droppedTone">{{ frameHealth.dropped }} dropped</span>
               <span class="data-pill" :class="frameHealth.duplicateTone">{{ frameHealth.duplicate }} duped</span>
-              <span class="data-pill" :class="frameHealth.jitterTone">{{ frameHealth.jitter }} jitter</span>
+              <span class="data-pill" :class="frameHealth.intervalErrorTone">{{ frameHealth.intervalError }} target interval error</span>
             </div>
             <span v-if="prefersReducedMotion" class="font-mono text-[10px] text-storm">Live charts are paused while reduced motion is enabled.</span>
           </div>
@@ -1148,21 +1148,21 @@ const previewStatusText = computed(() => {
 
 
 
-// Frame health: dropped/duplicate ratios and jitter arrive on every SSE tick
-// but were never surfaced; they explain stutter that FPS alone hides.
+// Frame health: dropped/duplicate ratios and mean target-interval error arrive
+// on every SSE tick. The interval metric is not statistical network jitter.
 const frameHealth = computed(() => {
   const s = stats.value || {}
   const dropped = Number(s.dropped_frame_ratio)
   const duplicate = Number(s.duplicate_frame_ratio)
-  const jitter = Number(s.frame_jitter_ms)
+  const intervalError = Number(s.frame_interval_error_ms ?? s.frame_jitter_ms)
   const pct = (v) => (Number.isFinite(v) ? `${(v * 100).toFixed(1)}%` : '--')
   return {
     dropped: pct(dropped),
     droppedTone: Number.isFinite(dropped) && dropped > 0.02 ? 'text-danger' : Number.isFinite(dropped) && dropped > 0.005 ? 'text-warning' : '',
     duplicate: pct(duplicate),
     duplicateTone: Number.isFinite(duplicate) && duplicate > 0.05 ? 'text-warning' : '',
-    jitter: Number.isFinite(jitter) ? `${jitter.toFixed(1)} ms` : '--',
-    jitterTone: Number.isFinite(jitter) && jitter > 4 ? 'text-warning' : '',
+    intervalError: Number.isFinite(intervalError) ? `${intervalError.toFixed(1)} ms` : '--',
+    intervalErrorTone: Number.isFinite(intervalError) && intervalError > 4 ? 'text-warning' : '',
   }
 })
 

--- a/src_assets/common/assets/web/views/HomeView.vue
+++ b/src_assets/common/assets/web/views/HomeView.vue
@@ -358,6 +358,7 @@ import PolarisVersion from '../polaris_version'
 import { buildUpdateCenterState, updateStatusLightClass } from '../update-center.js'
 import InfoHint from '../components/InfoHint.vue'
 import { createLogTailState, fetchLogTail } from '../log-tail-state.js'
+import { groupRecentIssueLogs } from '../recent-issues.js'
 
 const { gpu, displays, audio, sessionType, displaySession, loading: systemLoading } = useSystemStats(3000)
 
@@ -418,48 +419,7 @@ const buildVersionIsDirty = computed(() => {
     version.value.version.includes('dirty')
 })
 
-const fancyLogs = computed(() => {
-  if (!logs.value) return []
-  const regex = /(\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}]):\s/g
-  const rawLogLines = logs.value.split(regex).splice(1)
-  const logLines = []
-  for (let i = 0; i < rawLogLines.length; i += 2) {
-    logLines.push({ timestamp: rawLogLines[i], level: rawLogLines[i + 1].split(':')[0], value: rawLogLines[i + 1] })
-  }
-  return logLines
-})
-
-const issueLogs = computed(() => {
-  return fancyLogs.value.filter((entry) => ['Fatal', 'Warning', 'Error'].includes(entry.level))
-})
-
-function normalizeIssueMessage(value) {
-  return value.trim().replace(/^\w+:\s*/, '').replace(/\s+/g, ' ')
-}
-
-const groupedIssueLogs = computed(() => {
-  const grouped = new Map()
-
-  issueLogs.value
-    .slice(-200)
-    .reverse()
-    .forEach((entry) => {
-      const message = normalizeIssueMessage(entry.value)
-      const key = `${entry.level}:${message}`
-      if (!grouped.has(key)) {
-        grouped.set(key, {
-          ...entry,
-          message,
-          count: 1
-        })
-        return
-      }
-
-      grouped.get(key).count += 1
-    })
-
-  return Array.from(grouped.values())
-})
+const groupedIssueLogs = computed(() => groupRecentIssueLogs(logs.value, { maxSourceLines: 200 }))
 
 const fatalCount = computed(() => groupedIssueLogs.value.filter((entry) => entry.level === 'Fatal').length)
 const warningCount = computed(() => groupedIssueLogs.value.filter((entry) => entry.level === 'Warning').length)

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -446,6 +446,7 @@ import {
 } from '../diagnostics-export.js'
 import { AI_DOCTOR_EXPLANATION_CATEGORIES, explainDoctorWithAi } from '../ai-doctor-explanation.js'
 import { createLogTailState, fetchLogTail } from '../log-tail-state.js'
+import { groupRecentIssueLogs } from '../recent-issues.js'
 
 const { toast: showToast } = useToast()
 const i18n = inject('i18n')
@@ -631,49 +632,10 @@ function fpsTargetGapDescription(s) {
   return `${formatFps(encoded)} encoded against ${formatFps(target)} target`
 }
 
-function normalizeIssueLine(line) {
-  return line.replace(/^\[[^\]]+\]:\s*/, '').replace(/^\w+:\s*/, '').replace(/\s+/g, ' ').trim()
-}
-
-function lineLevel(line) {
-  if (line.includes('Fatal:')) return 'Fatal'
-  if (line.includes('Warning:')) return 'Warning'
-  return 'Error'
-}
-
-function lineTimestamp(line) {
-  const match = line.match(/^\[([^\]]+)\]/)
-  return match ? `[${match[1]}]` : ''
-}
-
-const groupedRecentIssues = computed(() => {
-  const grouped = new Map()
-
-  ;(logs.value || '')
-    .split('\n')
-    .filter(line => /(Error|Warning|Fatal):/.test(line))
-    .slice(-300)
-    .reverse()
-    .forEach((line) => {
-      const level = lineLevel(line)
-      const message = normalizeIssueLine(line)
-      const key = `${level}:${message}`
-
-      if (!grouped.has(key)) {
-        grouped.set(key, {
-          level,
-          message,
-          timestamp: lineTimestamp(line),
-          count: 1
-        })
-        return
-      }
-
-      grouped.get(key).count += 1
-    })
-
-  return Array.from(grouped.values()).slice(0, 8)
-})
+const groupedRecentIssues = computed(() => groupRecentIssueLogs(logs.value, {
+  maxSourceLines: 300,
+  maxGroups: 8,
+}))
 
 const recentIssueSummaryText = computed(() => groupedRecentIssues.value
   .map((entry) => `${entry.timestamp} ${entry.level}: ${entry.message}${entry.count > 1 ? ` (${entry.count}x)` : ''}`.trim())
@@ -876,7 +838,7 @@ const sessionSnapshotItems = computed(() => {
     { label: 'Optimization Source', value: s.optimization_source || 'default' },
     { label: 'Network', value: `${formatNumber(s.latency_ms, 1)} ms latency / ${formatNumber(s.packet_loss, 2)}% loss` },
     { label: 'Frame Delivery', value: `${formatNumber((s.duplicate_frame_ratio || 0) * 100, 2)}% duplicate / ${formatNumber((s.dropped_frame_ratio || 0) * 100, 2)}% dropped` },
-    { label: 'Frame Timing', value: `${formatNumber(s.avg_frame_age_ms, 2)} ms age / ${formatNumber(s.frame_jitter_ms, 2)} ms jitter` }
+    { label: 'Frame Timing', value: `${formatNumber(s.avg_frame_age_ms, 2)} ms age / ${formatNumber(s.frame_interval_error_ms ?? s.frame_jitter_ms, 2)} ms target interval error` }
   ]
 })
 

--- a/src_assets/common/assets/web/virtual-display-status.js
+++ b/src_assets/common/assets/web/virtual-display-status.js
@@ -1,0 +1,33 @@
+const PRIVATE_STREAM_MODES = new Set(['headless_stream', 'windowed_stream'])
+
+export function presentVirtualDisplayStatus(status = {}) {
+  if (PRIVATE_STREAM_MODES.has(status.policy_mode)) {
+    return {
+      kind: 'unused',
+      label: 'Not needed for Private Stream',
+      detail: 'Private Stream creates its own compositor output, so host virtual-display creation is intentionally skipped.',
+    }
+  }
+
+  if (status.available) {
+    return {
+      kind: 'available',
+      label: 'Available',
+      detail: `${status.backend || 'The detected backend'} is ready to create or manage the stream output.`,
+    }
+  }
+
+  if (status.backend_detected) {
+    return {
+      kind: 'unconfigured',
+      label: 'Configuration required',
+      detail: status.unavailable_reason || `${status.backend || 'The detected backend'} needs additional configuration.`,
+    }
+  }
+
+  return {
+    kind: 'missing',
+    label: 'Not available',
+    detail: status.unavailable_reason || 'No supported host virtual-display backend was detected.',
+  }
+}

--- a/src_assets/common/assets/web/virtual-display-status.test.js
+++ b/src_assets/common/assets/web/virtual-display-status.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { presentVirtualDisplayStatus } from './virtual-display-status.js'
+
+describe('virtual display status presentation', () => {
+  it('explains that Private Stream intentionally bypasses host virtual displays', () => {
+    const state = presentVirtualDisplayStatus({
+      policy_mode: 'headless_stream',
+      available: false,
+      backend_detected: false,
+    })
+
+    expect(state.kind).toBe('unused')
+    expect(state.label).toBe('Not needed for Private Stream')
+  })
+
+  it('shows backend-specific configuration guidance when kscreen-doctor is detected', () => {
+    const state = presentVirtualDisplayStatus({
+      policy_mode: 'host_virtual_display',
+      available: false,
+      backend_detected: true,
+      backend: 'kscreen-doctor',
+      unavailable_reason: 'kscreen-doctor backend needs linux_streaming_output set to the output it may reconfigure.',
+    })
+
+    expect(state.kind).toBe('unconfigured')
+    expect(state.detail).toContain('linux_streaming_output')
+  })
+
+  it('reserves dependency guidance for a genuinely missing backend', () => {
+    expect(presentVirtualDisplayStatus({
+      policy_mode: 'host_virtual_display',
+      available: false,
+      backend_detected: false,
+    }).kind).toBe('missing')
+  })
+})

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -644,6 +644,51 @@ TEST(StreamStatsDoctorTests, KeepsNearTargetHighRefreshPacingGreen) {
   EXPECT_EQ(doctor.at("primary_issue"), "none");
 }
 
+TEST(StreamStatsDoctorTests, ClassifiesMetronomicHalfRateAsPacingWithoutNetworkEvidence) {
+  stream_stats::stats_t stats {};
+  stats.streaming = true;
+  stats.fps = 60.0;
+  stats.encode_target_fps = 120.0;
+  stats.frame_jitter_ms = 8.3333;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+  stats.encode_time_ms = 2.0;
+  stats.packet_loss = 0.0;
+  stats.latency_ms = 4.0;
+  stats.network_risk = false;
+
+  const auto doctor = stream_stats::build_doctor_json(
+    stats,
+    {{"primary_issue", "network_jitter"}, {"grade", "degraded"}}
+  );
+
+  EXPECT_EQ(doctor.at("primary_issue"), "frame_pacing");
+  EXPECT_EQ(doctor.at("summary"), "Frame pacing telemetry needs attention.");
+  EXPECT_NE(doctor.at("safe_recovery_action").at("id"), "lower_bitrate");
+
+  bool saw_fps_gap = false;
+  bool saw_interval_error = false;
+  for (const auto &item : doctor.at("evidence")) {
+    if (item.at("id") == "target_fps_gap") {
+      saw_fps_gap = true;
+      EXPECT_DOUBLE_EQ(item.at("value"), 60.0);
+      EXPECT_EQ(item.at("status"), "watch");
+    }
+    if (item.at("id") == "frame_pacing") {
+      saw_interval_error = true;
+      EXPECT_EQ(item.at("label"), "Mean target interval error");
+      EXPECT_EQ(item.at("unit"), "ms");
+    }
+  }
+  EXPECT_TRUE(saw_fps_gap);
+  EXPECT_TRUE(saw_interval_error);
+
+  const auto serialized = nlohmann::json::parse(stats.to_json());
+  EXPECT_DOUBLE_EQ(serialized.at("frame_interval_error_ms"), 8.3333);
+  EXPECT_DOUBLE_EQ(serialized.at("frame_jitter_ms"), 8.3333);
+}
+
 TEST(StreamStatsDoctorTests, SuppressesStaleNetworkFindingWhenLiveEvidenceIsClean) {
   stream_stats::stats_t stats {};
   stats.streaming = true;


### PR DESCRIPTION
## Summary

Doctor and the Virtual Display panel conflated several different states: a detected but unconfigured KDE backend looked like missing software, Private Stream looked like it needed a virtual display, expected encoder-probe failures appeared as recent errors, and a steady half-rate source was labeled network jitter.

This change:

- separates backend detection from configuration readiness
- explains that Private Stream does not require the Virtual Display path
- gives backend-specific configuration guidance
- filters errors only inside the explicitly safe encoder-probe window
- reports target interval error and target FPS gap separately from network jitter

Fixes #437.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
- [ ] I included screenshots or recordings for visible UI changes, when practical.
- [ ] I updated docs or release notes when user-facing behavior changed.

- web tests: 58 files and 329 tests passed
- production Vite build passed
- test_polaris_stream: 232 passed
- test_polaris: 306 passed
- focused final-copy test: 3 passed
- lint and git diff --check passed

## Notes

No pairing, trusted subnet, certificate, command, packaging, or privilege-boundary changes.