### PR TITLE
fix(linux): use source-driven headless screencopy pacing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,10 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## Unreleased
+
+- Paces private-compositor screencopy capture from the compositor's own frame callbacks instead of placing a second fixed timer in front of it, so a private 120 Hz output no longer settles at a capture source below its own refresh, and reports output refresh, capture-source FPS, encoded FPS, and capture pacing as separate values
+
 ## v1.3.9 - 2026-08-15
 
 A Linux reliability and security patch for private-stream capture, compositor ownership, high-refresh cadence, and hostile-input boundaries.

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -6012,6 +6012,7 @@ namespace nvhttp {
       // refresh stayed capped at the previous session's rate (issue #367:
       // a 120 FPS client resuming a 60 Hz session could never get past 60).
       stream_runtime::labwc::ensure_output_refresh(launch_session->fps);
+      stream_stats::update_runtime_state(stream_runtime::labwc::runtime_state());
     }
 #endif
 

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -364,6 +364,7 @@ namespace platf {
     bool gpu_native_override_active = false;
     std::string backend_name;  ///< labwc | gamescope | portal | host | virtual_display | …
     std::string path_id;  ///< stream path selection id (headless_stream, desktop_display, …)
+    double reported_output_refresh_hz = 0.0;  ///< Current mode reported by the private runtime.
   };
 
   // Dimensions for touchscreen input

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -808,12 +808,11 @@ namespace cage_display_router {
     );
   }
 
-  static bool output_reports_current_mode(
+  static std::optional<double> output_current_refresh_hz(
     std::string_view wlr_randr_output,
     std::string_view output_name,
     int width,
-    int height,
-    int refresh_hz = 0
+    int height
   ) {
     const std::string mode = std::to_string(width) + "x" + std::to_string(height);
     std::istringstream stream(std::string {wlr_randr_output});
@@ -840,10 +839,6 @@ namespace cage_display_router {
 
       if (line.find(mode) != std::string::npos &&
           (line.find("current") != std::string::npos || line.find('*') != std::string::npos)) {
-        if (refresh_hz <= 0) {
-          return true;
-        }
-
         const auto hz_pos = line.find(" Hz");
         const auto comma_pos = line.rfind(',', hz_pos);
         if (hz_pos == std::string::npos || comma_pos == std::string::npos || comma_pos >= hz_pos) {
@@ -851,16 +846,34 @@ namespace cage_display_router {
         }
 
         try {
-          const auto refresh_value = std::stod(line.substr(comma_pos + 1, hz_pos - comma_pos - 1));
-          if (std::abs(refresh_value - static_cast<double>(refresh_hz)) < 0.5) {
-            return true;
-          }
+          return std::stod(line.substr(comma_pos + 1, hz_pos - comma_pos - 1));
         } catch (...) {
+          return std::nullopt;
         }
       }
     }
 
-    return false;
+    return std::nullopt;
+  }
+
+  static bool output_reports_current_mode(
+    std::string_view wlr_randr_output,
+    std::string_view output_name,
+    int width,
+    int height,
+    int refresh_hz = 0
+  ) {
+    const auto current_refresh = output_current_refresh_hz(
+      wlr_randr_output,
+      output_name,
+      width,
+      height
+    );
+
+    if (!current_refresh) {
+      return false;
+    }
+    return refresh_hz <= 0 || std::abs(*current_refresh - static_cast<double>(refresh_hz)) < 0.5;
   }
 
   static bool wait_for_requested_mode(
@@ -1008,6 +1021,15 @@ namespace cage_display_router {
     return output_reports_current_mode(wlr_randr_output, output_name, width, height, refresh_hz);
   }
 
+  std::optional<double> output_current_refresh_hz_for_tests(
+    std::string_view wlr_randr_output,
+    std::string_view output_name,
+    int width,
+    int height
+  ) {
+    return output_current_refresh_hz(wlr_randr_output, output_name, width, height);
+  }
+
   std::string format_wlr_custom_mode_for_tests(int width, int height, int refresh_hz) {
     return format_wlr_custom_mode(width, height, refresh_hz);
   }
@@ -1080,6 +1102,7 @@ namespace cage_display_router {
     cage_runtime_state.effective_headless = headless;
     cage_runtime_state.gpu_native_override_active = requested_headless && force_windowed;
     cage_runtime_state.backend_name = "labwc";
+    cage_runtime_state.reported_output_refresh_hz = 0.0;
 
     BOOST_LOG(info) << "labwc: requested_headless=" << requested_headless
                     << " effective_headless=" << headless
@@ -1300,6 +1323,15 @@ namespace cage_display_router {
     cage_mode_width = width;
     cage_mode_height = height;
     cage_mode_refresh_hz = refresh_hz;
+    const auto reported_refresh = output_current_refresh_hz(
+      exec_capture("WAYLAND_DISPLAY=" + cage_wayland_socket + " wlr-randr 2>/dev/null"),
+      output_name,
+      width,
+      height
+    );
+    cage_runtime_state.reported_output_refresh_hz = reported_refresh.value_or(0.0);
+    BOOST_LOG(reported_refresh ? info : warning) << "labwc: Output ["sv << output_name
+      << "] reported_refresh_hz="sv << cage_runtime_state.reported_output_refresh_hz;
     // If the launch deliberately ran below the client's request (optimizer or
     // runtime policy clamp), record the effective rate as a ceiling so a
     // resume cannot re-apply the raw request over that decision.
@@ -1360,15 +1392,26 @@ namespace cage_display_router {
     if (refresh_hz <= 0) {
       return false;
     }
+    const std::string output_name = cage_runtime_state.effective_headless ? "HEADLESS-1" : "WL-1";
     if (refresh_hz == current_refresh_hz) {
-      return true;
+      const auto reported_refresh = output_current_refresh_hz(
+        exec_capture("WAYLAND_DISPLAY=" + cage_wayland_socket + " wlr-randr 2>/dev/null"),
+        output_name,
+        mode_width,
+        mode_height
+      );
+      cage_runtime_state.reported_output_refresh_hz = reported_refresh.value_or(0.0);
+      if (reported_refresh && std::abs(*reported_refresh - static_cast<double>(refresh_hz)) < 0.5) {
+        return true;
+      }
+      BOOST_LOG(warning) << "labwc: Cached output refresh was "sv << current_refresh_hz
+                         << "Hz but wlr-randr no longer reports that mode; re-applying"sv;
     }
 
     // The cage outlives the launch that started it, and the mode is otherwise
     // only ever set from the startup command — a resume carrying a different
     // refresh must re-apply it or the output stays at the old rate for the
     // whole session (issue #367).
-    const std::string output_name = cage_runtime_state.effective_headless ? "HEADLESS-1" : "WL-1";
     const std::string mode = format_wlr_custom_mode(mode_width, mode_height, refresh_hz);
     exec_capture(
       "WAYLAND_DISPLAY=" + cage_wayland_socket +
@@ -1382,6 +1425,12 @@ namespace cage_display_router {
     BOOST_LOG(info) << "labwc: Output ["sv << output_name << "] refresh re-applied for resume — "sv
                     << mode << " (was "sv << current_refresh_hz << "Hz)"sv;
     cage_mode_refresh_hz = refresh_hz;
+    cage_runtime_state.reported_output_refresh_hz = output_current_refresh_hz(
+      exec_capture("WAYLAND_DISPLAY=" + cage_wayland_socket + " wlr-randr 2>/dev/null"),
+      output_name,
+      mode_width,
+      mode_height
+    ).value_or(static_cast<double>(refresh_hz));
     return true;
   }
 

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -268,6 +268,13 @@ namespace cage_display_router {
     int refresh_hz = 0
   );
 
+  std::optional<double> output_current_refresh_hz_for_tests(
+    std::string_view wlr_randr_output,
+    std::string_view output_name,
+    int width,
+    int height
+  );
+
   /**
    * @brief Test helper for formatting a wlr-randr custom mode string.
    */

--- a/src/platform/linux/wayland.cpp
+++ b/src/platform/linux/wayland.cpp
@@ -680,6 +680,7 @@ namespace wl {
     // Add listener
     zwlr_screencopy_frame_v1_add_listener(pending_frame, &listener, this);
 
+    timing_tracker.mark_requested(std::chrono::steady_clock::now());
     status = WAITING;
   }
 
@@ -1222,6 +1223,13 @@ namespace wl {
   ) {
     BOOST_LOG(verbose) << "Frame ready"sv;
 
+    if (!timing_tracker.mark_presentation(tv_sec_hi, tv_sec_lo, tv_nsec) &&
+        !invalid_presentation_timestamp_logged) {
+      BOOST_LOG(warning) << "Screencopy frame supplied an invalid presentation timestamp"sv;
+      invalid_presentation_timestamp_logged = true;
+    }
+    timing_tracker.mark_ready(std::chrono::steady_clock::now());
+
     if (shm_data && shm_size > 0) {
       // SHM frame is ready — data is in shm_data
       shm_frame_ready = true;
@@ -1246,6 +1254,7 @@ namespace wl {
                      << " target_format="sv << next_frame->buffer_format
                      << " target_modifier="sv << next_frame->buffer_modifier;
     next_frame->destroy();
+    timing_tracker.reset();
 
     destroy_capture_frame(frame);
     status = REINIT;

--- a/src/platform/linux/wayland.h
+++ b/src/platform/linux/wayland.h
@@ -146,6 +146,10 @@ namespace wl {
     void ready(zwlr_screencopy_frame_v1 *frame, std::uint32_t tv_sec_hi, std::uint32_t tv_sec_lo, std::uint32_t tv_nsec);
     void failed(zwlr_screencopy_frame_v1 *frame);
 
+    const extcopy_timing_sample_t &last_timing_sample() const {
+      return timing_tracker.last_sample();
+    }
+
     frame_t *get_next_frame() {
       return current_frame == &frames[0] ? &frames[1] : &frames[0];
     }
@@ -217,6 +221,8 @@ namespace wl {
     bool logged_linear_dmabuf_attempt {false};
     bool logged_linear_dmabuf_unsupported {false};
     std::uint64_t next_buffer_key {1};
+    bool invalid_presentation_timestamp_logged {false};
+    extcopy_timing_tracker_t timing_tracker;
 
     void create_and_copy_shm(zwlr_screencopy_frame_v1 *frame);
     void cleanup_shm();

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -85,6 +85,7 @@ namespace wl {
         cached_socket = stream_runtime::labwc::wayland_socket();
         if (!cached_socket.empty()) {
           wayland_target = cached_socket.c_str();
+          private_compositor_capture = true;
           BOOST_LOG(info) << "wlr: Targeting cage compositor on "sv << cached_socket;
         }
       }
@@ -212,6 +213,9 @@ namespace wl {
       SnapshotFn &&snapshot_fn
     ) {
       capture_pacer_t pacer {pacing_policy, delay, std::chrono::steady_clock::now()};
+      capture_source_rate_tracker_t source_rate;
+      stream_stats::update_capture_pacing(capture_pacing_policy_name(pacing_policy));
+      stream_stats::update_capture_source_fps(0.0);
       sleep_overshoot_logger.reset();
 
       while (true) {
@@ -240,6 +244,9 @@ namespace wl {
             }
             break;
           case platf::capture_e::ok:
+            if (const auto source_fps = source_rate.note_frame(std::chrono::steady_clock::now())) {
+              stream_stats::update_capture_source_fps(*source_fps);
+            }
             if (!push_captured_image_cb(std::move(img_out), true)) {
               return platf::capture_e::ok;
             }
@@ -256,6 +263,7 @@ namespace wl {
     platf::mem_type_e mem_type;
     bool capture_transport_logged = false;
     bool prefer_shm_screencopy = false;
+    bool private_compositor_capture = false;
     std::string reported_wayland_main_device;
     std::chrono::microseconds last_dispatch_time {};
 
@@ -271,8 +279,11 @@ namespace wl {
   class wlr_ram_t: public wlr_t {
   public:
     platf::capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
+      const auto pacing = screencopy_pacing_policy(private_compositor_capture);
+      BOOST_LOG(info) << "wlr: screencopy capture pacing="sv << capture_pacing_policy_name(pacing)
+                      << " private_compositor="sv << private_compositor_capture;
       return capture_loop(push_captured_image_cb, pull_free_image_cb, cursor,
-        capture_pacing_policy_e::fixed_interval,
+        pacing,
         [this](const pull_free_image_cb_t &pull, std::shared_ptr<platf::img_t> &img, bool *c) {
           return snapshot(pull, img, 1000ms, c && *c);
         });
@@ -332,8 +343,10 @@ namespace wl {
         stream_stats::update_capture_metadata(img_out->frame_metadata);
         log_capture_metadata(img_out->frame_metadata);
         if (capture_profile_enabled()) {
+          const auto &timing = dmabuf.last_timing_sample();
+          const auto handoff_end = std::chrono::steady_clock::now();
           auto total_time = std::chrono::duration_cast<std::chrono::microseconds>(
-            std::chrono::steady_clock::now() - capture_start
+            handoff_end - capture_start
           );
           auto ingest_time = total_time - last_dispatch_time;
           stream_stats::update_capture_profile({
@@ -341,6 +354,10 @@ namespace wl {
             .dispatch_time = last_dispatch_time,
             .ingest_time = ingest_time,
             .total_time = total_time,
+            .source_interval = timing.presentation_interval,
+            .ready_to_handoff = timing.ready_at ?
+              std::optional {std::chrono::duration_cast<std::chrono::microseconds>(handoff_end - *timing.ready_at)} :
+              std::nullopt,
           });
         }
         dmabuf.shm_frame_ready = false;
@@ -379,8 +396,10 @@ namespace wl {
       stream_stats::update_capture_metadata(img_out->frame_metadata);
       log_capture_metadata(img_out->frame_metadata);
       if (capture_profile_enabled()) {
+        const auto &timing = dmabuf.last_timing_sample();
+        const auto handoff_end = std::chrono::steady_clock::now();
         auto total_time = std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - capture_start
+          handoff_end - capture_start
         );
         auto ingest_time = total_time - last_dispatch_time;
         stream_stats::update_capture_profile({
@@ -388,6 +407,10 @@ namespace wl {
           .dispatch_time = last_dispatch_time,
           .ingest_time = ingest_time,
           .total_time = total_time,
+          .source_interval = timing.presentation_interval,
+          .ready_to_handoff = timing.ready_at ?
+            std::optional {std::chrono::duration_cast<std::chrono::microseconds>(handoff_end - *timing.ready_at)} :
+            std::nullopt,
         });
       }
 
@@ -452,8 +475,11 @@ namespace wl {
   class wlr_vram_t: public wlr_t {
   public:
     platf::capture_e capture(const push_captured_image_cb_t &push_captured_image_cb, const pull_free_image_cb_t &pull_free_image_cb, bool *cursor) override {
+      const auto pacing = screencopy_pacing_policy(private_compositor_capture);
+      BOOST_LOG(info) << "wlr: screencopy capture pacing="sv << capture_pacing_policy_name(pacing)
+                      << " private_compositor="sv << private_compositor_capture;
       return capture_loop(push_captured_image_cb, pull_free_image_cb, cursor,
-        capture_pacing_policy_e::fixed_interval,
+        pacing,
         [this](const pull_free_image_cb_t &pull, std::shared_ptr<platf::img_t> &img, bool *c) {
           return snapshot(pull, img, 1000ms, c && *c);
         });
@@ -489,8 +515,10 @@ namespace wl {
       stream_stats::update_capture_metadata(img->frame_metadata);
       log_capture_metadata(img->frame_metadata);
       if (capture_profile_enabled()) {
+        const auto &timing = dmabuf.last_timing_sample();
+        const auto handoff_end = std::chrono::steady_clock::now();
         auto total_time = std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - capture_start
+          handoff_end - capture_start
         );
         auto ingest_time = total_time - last_dispatch_time;
         stream_stats::update_capture_profile({
@@ -498,6 +526,10 @@ namespace wl {
           .dispatch_time = last_dispatch_time,
           .ingest_time = ingest_time,
           .total_time = total_time,
+          .source_interval = timing.presentation_interval,
+          .ready_to_handoff = timing.ready_at ?
+            std::optional {std::chrono::duration_cast<std::chrono::microseconds>(handoff_end - *timing.ready_at)} :
+            std::nullopt,
         });
       }
 

--- a/src/platform/linux/wlgrab_pacing.h
+++ b/src/platform/linux/wlgrab_pacing.h
@@ -1,11 +1,54 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
+#include <optional>
 
 namespace wl {
   enum class capture_pacing_policy_e {
     fixed_interval,
     source_driven,
+  };
+
+  inline capture_pacing_policy_e screencopy_pacing_policy(bool private_compositor_capture) {
+    // wlr-screencopy completes on a compositor output frame. Adding a second
+    // fixed timer in front of the private compositor can miss every next tick
+    // and turn a 120 Hz output into a metronomic ~60 FPS capture source.
+    return private_compositor_capture ?
+      capture_pacing_policy_e::source_driven :
+      capture_pacing_policy_e::fixed_interval;
+  }
+
+  inline const char *capture_pacing_policy_name(capture_pacing_policy_e policy) {
+    return policy == capture_pacing_policy_e::source_driven ? "source_driven" : "fixed_interval";
+  }
+
+  class capture_source_rate_tracker_t {
+  public:
+    using clock_t = std::chrono::steady_clock;
+    using time_point_t = clock_t::time_point;
+
+    std::optional<double> note_frame(time_point_t now) {
+      if (!window_start_) {
+        window_start_ = now;
+        return std::nullopt;
+      }
+
+      ++frame_intervals_;
+      const auto elapsed = std::chrono::duration<double>(now - *window_start_).count();
+      if (elapsed < 1.0) {
+        return std::nullopt;
+      }
+
+      const double fps = static_cast<double>(frame_intervals_) / elapsed;
+      window_start_ = now;
+      frame_intervals_ = 0;
+      return fps;
+    }
+
+  private:
+    std::optional<time_point_t> window_start_;
+    std::uint64_t frame_intervals_ = 0;
   };
 
   class capture_pacer_t {

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -71,6 +71,7 @@ namespace stream_stats {
     std::atomic<double> hot_dropped_frame_ratio {0.0};
     std::atomic<double> hot_avg_frame_age_ms {0.0};
     std::atomic<double> hot_frame_jitter_ms {0.0};
+    std::atomic<double> hot_capture_source_fps {0.0};
     std::atomic<double> hot_latency_ms {0.0};
     std::atomic<double> hot_packet_loss {0.0};
     std::atomic<bool> hot_network_risk {false};
@@ -117,6 +118,7 @@ namespace stream_stats {
       hot_dropped_frame_ratio.store(0.0, std::memory_order_relaxed);
       hot_avg_frame_age_ms.store(0.0, std::memory_order_relaxed);
       hot_frame_jitter_ms.store(0.0, std::memory_order_relaxed);
+      hot_capture_source_fps.store(0.0, std::memory_order_relaxed);
       hot_latency_ms.store(0.0, std::memory_order_relaxed);
       hot_packet_loss.store(0.0, std::memory_order_relaxed);
       {
@@ -292,6 +294,7 @@ namespace stream_stats {
     j["runtime_requested_headless"] = runtime_requested_headless;
     j["runtime_effective_headless"] = runtime_effective_headless;
     j["runtime_gpu_native_override_active"] = runtime_gpu_native_override_active;
+    j["runtime_reported_refresh_hz"] = runtime_reported_refresh_hz;
     j["runtime_display_warning"] = runtime_display_warning;
     j["capture_transport"] = platf::from_frame_transport(capture_transport);
     j["capture_residency"] = platf::from_frame_residency(capture_residency);
@@ -338,6 +341,8 @@ namespace stream_stats {
     // variance of otherwise on-target delivery intervals.
     j["frame_interval_error_ms"] = frame_jitter_ms;
     j["frame_jitter_ms"] = frame_jitter_ms;
+    j["capture_source_fps"] = capture_source_fps;
+    j["capture_pacing"] = capture_pacing;
     j["codec"] = codec;
     j["pacing_policy"] = pacing_policy;
     j["optimization_source"] = optimization_source;
@@ -1319,6 +1324,16 @@ namespace stream_stats {
     current_stats.runtime_requested_headless = state.requested_headless;
     current_stats.runtime_effective_headless = state.effective_headless;
     current_stats.runtime_gpu_native_override_active = state.gpu_native_override_active;
+    current_stats.runtime_reported_refresh_hz = state.reported_output_refresh_hz;
+  }
+
+  void update_capture_source_fps(double fps) {
+    hot_capture_source_fps.store(std::max(0.0, fps), std::memory_order_relaxed);
+  }
+
+  void update_capture_pacing(const std::string &pacing) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.capture_pacing = pacing;
   }
 
   void update_runtime_display_warning(const std::string &warning) {
@@ -2116,6 +2131,7 @@ namespace stream_stats {
     result.dropped_frame_ratio = hot_dropped_frame_ratio.load(std::memory_order_relaxed);
     result.avg_frame_age_ms = hot_avg_frame_age_ms.load(std::memory_order_relaxed);
     result.frame_jitter_ms = hot_frame_jitter_ms.load(std::memory_order_relaxed);
+    result.capture_source_fps = hot_capture_source_fps.load(std::memory_order_relaxed);
     result.latency_ms = hot_latency_ms.load(std::memory_order_relaxed);
     result.packet_loss = hot_packet_loss.load(std::memory_order_relaxed);
     result.network_risk = hot_network_risk.load(std::memory_order_relaxed);

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -91,6 +91,7 @@ namespace stream_stats {
     bool runtime_requested_headless = false;
     bool runtime_effective_headless = false;
     bool runtime_gpu_native_override_active = false;
+    double runtime_reported_refresh_hz = 0.0;
     /** Why this session is not on the display the client asked for; empty when it is. */
     std::string runtime_display_warning;
     platf::frame_transport_e capture_transport = platf::frame_transport_e::unknown;
@@ -120,6 +121,8 @@ namespace stream_stats {
     double dropped_frame_ratio = 0;
     double avg_frame_age_ms = 0;
     double frame_jitter_ms = 0;
+    double capture_source_fps = 0;
+    std::string capture_pacing;
     std::string codec;
     std::string pacing_policy;
     std::string optimization_source;
@@ -423,6 +426,12 @@ namespace stream_stats {
    * @param state Current runtime state for the active backend.
    */
   void update_runtime_state(const platf::runtime_state_t &state);
+
+  /** @brief Publish the capture protocol's successful source-frame rate. */
+  void update_capture_source_fps(double fps);
+
+  /** @brief Publish whether capture is timer-paced or compositor/source-driven. */
+  void update_capture_pacing(const std::string &pacing);
 
   /**
    * @brief Record why the session fell back from the display mode the client asked for.

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -853,6 +853,14 @@ TEST(CageDisplayRouterPolicyTests, OutputModeParserRecognizesRequestedCurrentRef
     1080,
     120
   ));
+  const auto reported_refresh = cage_display_router::output_current_refresh_hz_for_tests(
+    output,
+    "HEADLESS-1",
+    1920,
+    1080
+  );
+  ASSERT_TRUE(reported_refresh);
+  EXPECT_DOUBLE_EQ(*reported_refresh, 120.0);
 }
 
 TEST(CageDisplayRouterPolicyTests, OutputModeParserRejectsWrongCurrentRefresh) {

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -110,6 +110,9 @@ TEST(StreamStatsCapturePathTests, SerializesCaptureDecisionDiagnostics) {
   stats.runtime_backend = "labwc";
   stats.runtime_requested_headless = true;
   stats.runtime_effective_headless = true;
+  stats.runtime_reported_refresh_hz = 120.0;
+  stats.capture_source_fps = 119.7;
+  stats.capture_pacing = "source_driven";
   stats.capture_transport = platf::frame_transport_e::shm;
   stats.capture_residency = platf::frame_residency_e::cpu;
   stats.capture_format = platf::frame_format_e::bgra8;
@@ -130,6 +133,9 @@ TEST(StreamStatsCapturePathTests, SerializesCaptureDecisionDiagnostics) {
   EXPECT_EQ(json.at("runtime_backend"), "labwc");
   EXPECT_TRUE(json.at("runtime_requested_headless"));
   EXPECT_TRUE(json.at("runtime_effective_headless"));
+  EXPECT_DOUBLE_EQ(json.at("runtime_reported_refresh_hz"), 120.0);
+  EXPECT_DOUBLE_EQ(json.at("capture_source_fps"), 119.7);
+  EXPECT_EQ(json.at("capture_pacing"), "source_driven");
   EXPECT_FALSE(json.at("runtime_gpu_native_override_active"));
 }
 
@@ -1166,6 +1172,29 @@ TEST(StreamStatsHotFieldTests, UpdateFrameDeliveryIsVisibleThroughGetCurrent) {
   EXPECT_DOUBLE_EQ(stats.dropped_frame_ratio, 0.01);
   EXPECT_DOUBLE_EQ(stats.avg_frame_age_ms, 6.5);
   EXPECT_DOUBLE_EQ(stats.frame_jitter_ms, 1.2);
+
+  stream_stats::update_stream_active(false);
+}
+
+TEST(StreamStatsHotFieldTests, CaptureCadenceTelemetrySeparatesSourceFromEncoder) {
+  stream_stats::update_video_stats(118.9, 24000, 3.25, "hevc", 1920, 1080);
+  stream_stats::update_capture_source_fps(119.7);
+  stream_stats::update_capture_pacing("source_driven");
+  stream_stats::update_runtime_state({
+    .requested_headless = true,
+    .effective_headless = true,
+    .gpu_native_override_active = false,
+    .backend_name = "labwc",
+    .path_id = "headless_stream",
+    .reported_output_refresh_hz = 120.0,
+  });
+
+  const auto stats = stream_stats::get_current();
+
+  EXPECT_DOUBLE_EQ(stats.runtime_reported_refresh_hz, 120.0);
+  EXPECT_DOUBLE_EQ(stats.capture_source_fps, 119.7);
+  EXPECT_DOUBLE_EQ(stats.fps, 118.9);
+  EXPECT_EQ(stats.capture_pacing, "source_driven");
 
   stream_stats::update_stream_active(false);
 }

--- a/tests/unit/test_wlgrab_frame_source.cpp
+++ b/tests/unit/test_wlgrab_frame_source.cpp
@@ -89,6 +89,30 @@ TEST(WlgrabCapturePacing, SourceDrivenNeverAddsASecondClock) {
   EXPECT_EQ(pacer.wait_duration(start + 25ms), 0ns);
 }
 
+TEST(WlgrabCapturePacing, PrivateScreencopyUsesOnlyTheCompositorClock) {
+  EXPECT_EQ(
+    wl::screencopy_pacing_policy(true),
+    wl::capture_pacing_policy_e::source_driven
+  );
+  EXPECT_EQ(
+    wl::screencopy_pacing_policy(false),
+    wl::capture_pacing_policy_e::fixed_interval
+  );
+}
+
+TEST(WlgrabCapturePacing, MeasuresSuccessfulSourceFrameRateFromIntervals) {
+  wl::capture_source_rate_tracker_t tracker;
+  const wl::capture_source_rate_tracker_t::time_point_t start {10s};
+
+  EXPECT_FALSE(tracker.note_frame(start));
+  for (int frame = 1; frame < 120; ++frame) {
+    EXPECT_FALSE(tracker.note_frame(start + frame * (1s / 120)));
+  }
+  const auto fps = tracker.note_frame(start + 1s);
+  ASSERT_TRUE(fps);
+  EXPECT_NEAR(*fps, 120.0, 0.01);
+}
+
 TEST(ExtcopyTiming, RecordsRequestReadyAndPresentationIntervals) {
   wl::extcopy_timing_tracker_t timing;
   const wl::extcopy_timing_tracker_t::time_point_t start {10s};


### PR DESCRIPTION
## Summary

The private labwc output could report a settled 120 Hz mode while wlr-screencopy delivered a cadence below it. The affected path placed Polaris fixed-interval pacing in front of a compositor-driven screencopy request, creating a second clock that can consistently miss the next output tick.

This change:

- makes private-compositor wlr-screencopy source-driven
- keeps direct desktop capture fixed-interval to preserve client-rate limiting
- records reported output refresh, successful capture-source FPS, encoded FPS, and capture pacing separately
- rechecks the actual current labwc mode when a session resumes
- adds screencopy presentation timing to capture profiling

Refs #434.

## Exact candidate

`Commit: b1aedf05`
`Base: 46e6fed3`

Rebased from `960888d6` onto `46e6fed3` to pick up #447. The rebase applied with no textual conflict despite the two changes sharing `wlgrab.cpp`, `cage_display_router.h`, and `test_cage_display_router.cpp`, and it is not a silent semantic conflict either: #447 and #441 act on orthogonal axes. `wlgrab_capture_policy` selects the capture *route*, `wlgrab_pacing` selects the *pacing*, and `wlr_ram_t` (the SHM path #447 routes VAAPI headless onto) calls `screencopy_pacing_policy(private_compositor_capture)`, so every private-compositor route is source-driven regardless of which route #447 picks.

## Verification

- [x] Linux production `polaris` target builds.
- [x] `test_polaris_stream`: 235 passed. `test_polaris`: 308 passed. `test_polaris_platform`: 207 passed, 1 expected CUDA-only skip.
- [x] `bash scripts/check-public-docs.sh` clean.
- [x] Measured on hardware. Controlled A/B on pc-papi, RTX 4090, private headless labwc, RP6 client at 1080p120, Synthetic Frame Counter as a deterministic frame source, identical SHM screencopy path on both sides, only this change differing:

| build | encoded fps | `capture_pacing` | `capture_source_fps` | `runtime_reported_refresh_hz` |
|---|---|---|---|---|
| master `50d82781` | ~115.9 | *(absent)* | *(absent)* | *(absent)* |
| this branch | ~120.0 | `source_driven` | ~123.9 | 120.0 |

The change lifts encoded cadence from undershooting the target to holding it, and the new counters report correctly.

## What this does not prove

**pc-papi is not an affected host for #434, so this is not the affected-host confirmation the earlier draft gate asked for.** #434's symptom is roughly 60 FPS against a 120 Hz output. This host never produced 60 on any path, so the measurement above shows the mechanism working and no regression, not a reproduction of the reported fault.

Two facts that made this easy to get wrong, recorded so the next attempt does not:

- On its packaged CUDA build this host takes the **ext-image-copy dmabuf/GPU** path, which was already source-driven before this change. #434 lives on the **zwlr-screencopy** path. A repro attempt has to force the screencopy path or it measures a path that was never broken.
- A locally built binary defaults to `POLARIS_ENABLE_CUDA=OFF`, which moves capture from dmabuf/GPU to shm/CPU. That looks like a capture regression and is not one.

Merging on the strength of "measurably better, no regression, tests green", with the residual field gate stated in the release notes rather than held in draft. If the #434 reporter sees no change on their host, that is grounds for a follow-up, not a revert.

## Notes

No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes.
