### PR TITLE
fix(packaging): stop the SteamOS package from depending on labwc

### DIFF
--- a/docs/steamos.md
+++ b/docs/steamos.md
@@ -10,6 +10,8 @@ This package is built against Valve's versioned SteamOS 3.8 package repositories
 
 Initial support covers package installation and Polaris startup in SteamOS Desktop Mode only. It does not certify physical Steam Deck gameplay, Game Mode, OLED 90 Hz behavior, suspend and resume, or persistence across SteamOS updates. Those claims require separate hardware evidence.
 
+Continuous integration builds and validates this package inside a clean SteamOS 3.8 root bootstrapped from Valve's repositories. A clean root has none of the packages a shipped SteamOS image already carries, so that gate proves the package builds and its libraries resolve. It does not prove the install transaction is conflict-free on a device, and it did not catch the `libdisplay-info` conflict described under Stream Paths on SteamOS.
+
 SteamOS uses a read-only root by default. Polaris installation and `sudo -H polaris --setup-host` must run while the root is writable. Read-only mode must be restored before the user service starts.
 
 ## Install
@@ -22,6 +24,9 @@ wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.co
 set -e
 trap 'sudo steamos-readonly enable' EXIT
 sudo steamos-readonly disable || exit $?
+sudo pacman-key --init || exit $?
+sudo pacman-key --populate || exit $?
+sudo pacman -Sy || exit $?
 sudo pacman -U ./Polaris-steamos3.8-x86_64.pkg.tar.zst || exit $?
 sudo -H polaris --setup-host || exit $?
 sudo steamos-readonly enable || exit $?
@@ -32,7 +37,21 @@ systemctl --user enable --now polaris
 
 The `EXIT` trap attempts to restore read-only mode if disabling the root, package installation, host setup, or explicit restoration fails. The user service starts only after the package and setup steps succeed and read-only mode is restored.
 
+SteamOS ships without an initialized pacman keyring, so the first `pacman` transaction that has to download anything fails signature verification. `pacman-key --init` creates `/etc/pacman.d/gnupg`, and `pacman-key --populate` imports every keyring already on the image, which on SteamOS means the Arch and Holo keyrings. Both steps are one-time and idempotent, and both write to the root filesystem, so they run after `steamos-readonly disable`.
+
+`pacman -Sy` refreshes the sync databases so `pacman -U` can resolve the handful of Polaris dependencies a stock SteamOS image does not carry. Do not substitute `-Syu`. A full upgrade replaces Valve's pinned packages with rolling Arch versions and is not supported on SteamOS.
+
+Installing v1.3.9 or earlier additionally needs `--assume-installed labwc=0.9.0` on the `pacman -U` step. Those packages declared a `labwc` dependency that pulls in a library downgrade which breaks Desktop Mode. See Troubleshooting below.
+
 Open `https://localhost:47990/#/welcome`, create the web UI account, and pair Nova, Moonlight, or another GameStream-compatible client. After credentials are created, `https://localhost:47990` opens the normal console.
+
+## Stream Paths on SteamOS
+
+Polaris defaults to Mirror Desktop, which streams the visible Desktop Mode session through the portal and needs nothing beyond this package. Gamescope Stream is also available, because SteamOS ships gamescope.
+
+The Private Stream paths need `labwc` on `PATH`, and labwc cannot be installed on SteamOS 3.8 without breaking the system. labwc 0.9.0 in `extra-3.8.1x` depends on wlroots0.19, which requires `libdisplay-info.so.2` from libdisplay-info 0.2.0. SteamOS installs libdisplay-info 0.3.0 from `holo-3.8.1x`, which provides `libdisplay-info.so.3`, and KWin, Mesa, and Vulkan link against that. Installing labwc therefore downgrades a library the desktop depends on and breaks Desktop Mode.
+
+Polaris does not depend on labwc for this reason, and links nothing from it. Selecting a Private Stream path on SteamOS reports `Private Stream requires labwc on PATH.` and streams nothing. Use Mirror Desktop or Gamescope Stream instead.
 
 ## Update
 
@@ -57,6 +76,32 @@ trap - EXIT
 ```
 
 Package removal does not automatically delete user configuration under `~/.config/polaris`. Keep that directory if you plan to reinstall, or remove it separately only after backing up any settings you need.
+
+## Troubleshooting
+
+### `keyring is not writable` or `required key missing from keyring`
+
+```
+warning: Public keyring not found; have you run 'pacman-key --init'?
+downloading required keys...
+error: keyring is not writable
+error: required key missing from keyring
+error: failed to commit transaction (unexpected error)
+```
+
+The pacman keyring was never initialized, or the root filesystem is still read-only. Run `sudo steamos-readonly disable`, then `sudo pacman-key --init` and `sudo pacman-key --populate`, then retry. Nothing was installed when this error appears, so it is safe to rerun the whole install block.
+
+### pacman offers to downgrade `libdisplay-info`
+
+Answer no and let the transaction abort. A downgrade from 0.3.0 to 0.2.0 breaks KWin, Mesa, and Vulkan, which takes Desktop Mode with it. It means labwc or another wlroots0.19 consumer entered the transaction.
+
+Polaris no longer declares that dependency. If you are installing v1.3.9 or earlier, add `--assume-installed labwc=0.9.0` to the package step so pacman treats it as already satisfied:
+
+```bash
+sudo pacman -U --assume-installed labwc=0.9.0 ./Polaris-steamos3.8-x86_64.pkg.tar.zst
+```
+
+Polaris does not use labwc on SteamOS either way, so nothing is lost by skipping it.
 
 ## Reporting SteamOS Results
 

--- a/packaging/linux/SteamOS/PKGBUILD
+++ b/packaging/linux/SteamOS/PKGBUILD
@@ -14,6 +14,10 @@ install=polaris.install
 # Split a polaris-debug package so crash reports from this build are debuggable.
 options=('debug' 'strip')
 
+# labwc is deliberately absent. Polaris links nothing from it, and on SteamOS 3.8 it
+# resolves to labwc 0.9.0 -> wlroots0.19 -> libdisplay-info.so=2, which downgrades the
+# libdisplay-info 0.3.0 that holo-3.8.1x ships and KWin, Mesa, and Vulkan link against.
+# It is an optdepend instead; see docs/steamos.md.
 depends=(
   'avahi'
   'boost-libs'
@@ -24,7 +28,6 @@ depends=(
   'grim'
   'gtk3'
   'hicolor-icon-theme'
-  'labwc'
   'libayatana-appindicator'
   'libcap'
   'libdrm'
@@ -73,6 +76,7 @@ makedepends=(
 )
 
 optdepends=(
+  'labwc: Private Stream paths; not installable on SteamOS 3.8, see docs/steamos.md'
   'libva-mesa-driver: AMD GPU encoding support'
 )
 

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -3,7 +3,6 @@ polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')
 polaris W: Dependency included, but may not be needed ('grim')
-polaris W: Dependency included, but may not be needed ('labwc')
 polaris W: Dependency included, but may not be needed ('libmfx')
 polaris W: Dependency included, but may not be needed ('libx11')
 polaris W: Dependency included, but may not be needed ('libxfixes')

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -685,9 +685,13 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain('namcap emitted unreviewed warnings or a reviewed warning disappeared')
     expect(buildScript).not.toContain('namcap "$PACKAGE_PATH" > "$OUTPUT_ROOT/steamos3.8-namcap-all.txt" || true')
     const reviewedWarnings = reviewedNamcap.trim().split('\n')
-    // 19 since the attach guard started linking libxcb for real: namcap stopped
-    // calling that dependency unneeded, so its reviewed line was retired (#415).
-    expect(reviewedWarnings).toHaveLength(19)
+    // 18 since labwc left depends for optdepends: it pulled wlroots0.19, which pins
+    // libdisplay-info.so=2 and downgraded the libdisplay-info 0.3.0 that SteamOS runs
+    // KWin, Mesa, and Vulkan on, so no install could succeed. With the dependency gone
+    // namcap has nothing unneeded to report and its reviewed line retired with it (#442).
+    // It was 19 after the attach guard started linking libxcb for real, which retired
+    // that dependency's line the same way (#415).
+    expect(reviewedWarnings).toHaveLength(18)
     expect(new Set(reviewedWarnings).size).toBe(reviewedWarnings.length)
     expect(reviewedWarnings.every((warning) => warning.startsWith('polaris W: '))).toBe(true)
     expect(buildScript).toContain('"$RECEIPT_ROOT/usr/bin/polaris-browser-stream-helper"')


### PR DESCRIPTION
## Summary

- Removes `labwc` from the SteamOS 3.8 package's `depends` and moves it to `optdepends`. It made the package uninstallable on real hardware: `labwc 0.9.0` in `extra-3.8.1x` depends on `wlroots0.19`, which requires `libdisplay-info.so=2-64`, while SteamOS installs `libdisplay-info 0.3.0` (`.so.3`) from `holo-3.8.1x` for KWin, Mesa, and Vulkan. Every install had to downgrade that library or abort.
- Drops the matching reviewed namcap warning, since the exact-match gate fails in both directions when a listed warning disappears.
- Adds the pacman keyring bootstrap the install guide never had. SteamOS ships with `/etc/pacman.d/gnupg` uninitialized, so the first transaction that downloads a dependency dies on `keyring is not writable` before installing anything.
- Documents which stream paths actually work on SteamOS, and adds troubleshooting for both failures including the `--assume-installed` workaround for already-released packages.

Reported on Reddit against v1.3.9 on SteamOS 3.8.16 (build 20260716.1), by two separate users hitting the two failures in sequence.

### Why this is safe

Polaris links nothing from labwc. `objdump -p` on the released `usr/bin/polaris-1.3.9` shows 34 `NEEDED` entries and none are wlroots or libdisplay-info. labwc is a runtime command dependency of the Private Stream paths only, and `stream_path.cpp` already handles its absence honestly rather than failing:

```cpp
// Soft availability: labwc path without binary stays selectable but truthfully notes it.
if (path.runtime == runtime_kind_e::LABWC && path.available && !caps.labwc_present) {
  out.reason = "Private Stream requires labwc on PATH.";
}
```

The shipped configuration defaults to `use_cage_compositor = false` and `headless_mode = false`, which `selection_from_legacy_booleans` resolves to `desktop_display` (Mirror Desktop). Private Stream is opt-in, so out-of-box behavior on every platform is unchanged. Gamescope Stream also stays available on SteamOS, which ships gamescope.

Scoped to the SteamOS PKGBUILD deliberately. Rolling Arch rebuilds `wlroots0.19` against its current libdisplay-info, so there is no conflict there and no reason to change what Arch users already get.

## Exact candidate

`Commit: 418c35709d3b3676030b452bc2c38a2ded44f14c`
`Tree: 63193a826802775d2af0f0c3ce195c0a266f008f`
`Parent: 5e998d01db09149e6141dc266b04ab980716413d`
`Base: 5e998d01db09149e6141dc266b04ab980716413d`

## Verification

- [x] Traced the conflict from the shipped artifact, not from the source tree: pulled `Polaris-steamos3.8-x86_64.pkg.tar.zst` from the v1.3.9 release and read `depend = labwc` out of its `.PKGINFO`.
- [x] Confirmed the chain against Valve's mirror: `labwc 0.9.0-1` → `libwlroots-0.19.so`, `wlroots0.19 0.19.0-1` → `depend = libdisplay-info.so=2-64`, `extra-3.8.1x` carrying only `libdisplay-info 0.2.0-2` while `holo-3.8.1x` ships `0.3.0-1`.
- [x] Confirmed the binary does not link it: `objdump -p usr/bin/polaris-1.3.9 | grep NEEDED`, 34 entries, no wlroots, no libdisplay-info. Boost is `1.88.0` and glibc symbols resolve, so the v1.3.2 mismatch stays fixed.
- [x] Checked the rest of the install set for the same hazard by extracting the full `extra-3.8.1x` package database and dumping soname pins for grim, wlr-randr, xorg-xdpyinfo, miniupnpc, libayatana-appindicator, ayatana-ido, libdbusmenu-glib, libmfx, numactl, boost-libs, libevdev, libnotify, opus, vulkan-icd-loader, seatd, librsvg, and libsfdo. `wlroots0.19` is the only package in the set with any soname pins, so this removes the hazard class rather than one case.
- [x] `python3 scripts/check-release-package-dependencies.py` passes (it reads the Arch PKGBUILD, not the SteamOS one, so this change is outside its contract).
- [x] `bash -n packaging/linux/SteamOS/PKGBUILD` parses.

Not covered: no Steam Deck was used. The end-to-end install, the keyring bootstrap, and the stream-path behavior are all reasoned from repository metadata and the released artifact, not run on hardware. The `steamos-build` job in this PR rebuilds the package and re-runs the namcap gate, which is what confirms the reviewed-warning removal is correct, but that job builds in a clean SteamOS root and by construction cannot reproduce a conflict against an already-populated image. Confirmation has to come from the reporters or a device.

## Follow-ups not in this PR

- The CI gate builds in a clean bootstrapped root, which is exactly why this shipped. A `pacman -U --print` dry run against a package set resembling a real SteamOS image would have caught it.
- Even fixed, the install layers ~10 packages from a pinned snapshot into an immutable OS that wipes them on update. Bundling the few libraries SteamOS does not ship (`libminiupnpc.so.21`, `libayatana-appindicator3.so.1` and its ayatana dependencies) under `/usr/lib/polaris` with an `$ORIGIN` RPATH would make the install a self-contained transaction with no repository resolution, no keyring, and no downgrade risk.
