### PR TITLE
fix(linux): contain VAAPI headless DMA-BUF crash

### DIFF
--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -168,8 +168,9 @@ namespace cage_display_router {
    * @brief Returns whether a headless labwc runtime should try the
    *        ext-image-copy-capture DMA-BUF path before falling back to SHM.
    *
-   * VAAPI may probe only this private headless route. Its captured buffer still
-   * has to pass the modifier policy before it reaches the encoder.
+   * VAAPI stays on the conservative SHM path even when the private headless
+   * route exports a linear buffer: modifier layout alone did not prevent the
+   * historical first-frame import crash from recurring on affected hardware.
    */
   bool should_attempt_headless_extcopy_dmabuf(
     const platf::runtime_state_t &runtime_state,

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -759,11 +759,18 @@ namespace platf {
               "cached_unsupported",
               true
             );
+          } else {
+            stream_stats::update_gpu_native_probe_attempt(
+              "headless_extcopy",
+              "ineligible",
+              "policy",
+              "vaapi_headless_dmabuf_disabled_for_stability"
+            );
           }
           stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");
           if (stream_runtime::labwc::should_log_headless_ram_capture_warning()) {
             BOOST_LOG(info)
-              << "wlr: Using RAM capture path for headless labwc because its GPU-native probe is unavailable or cached unsupported"sv;
+              << "wlr: Using RAM capture path for headless labwc because true-headless ext-image-copy-capture DMA-BUF is disabled for VAAPI stability"sv;
           }
         }
       } else {

--- a/src/platform/linux/wlgrab_capture_policy.h
+++ b/src/platform/linux/wlgrab_capture_policy.h
@@ -7,7 +7,6 @@
 #include "src/platform/common.h"
 
 #include <cstdint>
-#include <drm_fourcc.h>
 #include <optional>
 
 namespace wlgrab_capture_policy {
@@ -24,28 +23,22 @@ namespace wlgrab_capture_policy {
 
   inline bool gpu_native_dmabuf_probe_is_allowed(
     platf::mem_type_e hwdevice_type,
-    gpu_native_capture_route_e route
+    gpu_native_capture_route_e
   ) {
-    if (hwdevice_type == platf::mem_type_e::cuda) {
-      return true;
-    }
-
-    return hwdevice_type == platf::mem_type_e::vaapi &&
-           route == gpu_native_capture_route_e::headless_extcopy;
+    // A linear modifier describes layout, not whether the VAAPI import and
+    // conversion lifetime is safe on a particular driver. RDNA3 field evidence
+    // in #367 reproduced the historical first-frame crash after linear headless
+    // VAAPI capture was re-enabled, so keep every VAAPI route on SHM until the
+    // import boundary has affected-host proof.
+    return hwdevice_type == platf::mem_type_e::cuda;
   }
 
   inline bool gpu_native_dmabuf_is_safe(
     platf::mem_type_e hwdevice_type,
-    gpu_native_capture_route_e route,
-    std::optional<std::uint64_t> modifier
+    gpu_native_capture_route_e,
+    std::optional<std::uint64_t>
   ) {
-    if (hwdevice_type == platf::mem_type_e::cuda) {
-      return true;
-    }
-
-    return hwdevice_type == platf::mem_type_e::vaapi &&
-           route == gpu_native_capture_route_e::headless_extcopy &&
-           modifier == DRM_FORMAT_MOD_LINEAR;
+    return hwdevice_type == platf::mem_type_e::cuda;
   }
 
   inline direct_capture_path_e select_direct_capture_path(

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -11,6 +11,7 @@
 
   #include <cerrno>
   #include <csignal>
+  #include <drm_fourcc.h>
   #include <filesystem>
   #include <fstream>
   #include <sstream>

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -399,7 +399,7 @@ TEST(WaylandInterfaceTests, RemovedOutputMarksDirtyButKeepsMonitorStorageUntilRe
 // windowed_ram_fallback, headless_extcopy_probe_succeeded) live only under
 // stream_runtime::labwc as one-liners — no dual cage export / matrix tests.
 
-TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiMayProbeExtcopyDmabuf) {
+TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiSkipsExtcopyDmabuf) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,
     .effective_headless = true,
@@ -407,7 +407,7 @@ TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiMayProbeExtcopyDmabuf) 
     .backend_name = "labwc",
   };
 
-  EXPECT_TRUE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
+  EXPECT_FALSE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
     runtime_state,
     platf::mem_type_e::vaapi
   ));
@@ -486,11 +486,11 @@ TEST(CageDisplayRouterPolicyTests, GpuNativeCaptureNeedsTheOverrideRegardlessOfE
   ));
 }
 
-TEST(CageDisplayRouterPolicyTests, VaapiSafetyIsLimitedToLinearHeadlessExtcopy) {
+TEST(CageDisplayRouterPolicyTests, LinearHeadlessVaapiRemainsUnsafeAfterFieldCrash) {
   using route_e = wlgrab_capture_policy::gpu_native_capture_route_e;
   constexpr std::uint64_t tiled_modifier = 0x0100000000000002ULL;
 
-  EXPECT_TRUE(cage_display_router::gpu_native_dmabuf_is_safe(
+  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(
     platf::mem_type_e::vaapi,
     route_e::headless_extcopy,
     DRM_FORMAT_MOD_LINEAR

--- a/tests/unit/test_linux_platform_hardening_source.cpp
+++ b/tests/unit/test_linux_platform_hardening_source.cpp
@@ -37,28 +37,17 @@ TEST(LinuxPlatformHardeningSource, TimedOutWlrCaptureCancelsItsRequest) {
   EXPECT_NE(capture.find("dmabuf.cancel()"), std::string::npos);
 }
 
-TEST(LinuxPlatformHardeningSource, HeadlessVaapiChecksActualModifierBeforeGpuNativeSelection) {
-  const auto header = read_source("src/platform/linux/wayland.h");
+TEST(LinuxPlatformHardeningSource, HeadlessVaapiFailsClosedBeforeDmabufInitialization) {
+  const auto policy = read_source("src/platform/linux/wlgrab_capture_policy.h");
   const auto capture = read_source("src/platform/linux/wlgrab.cpp");
   const auto process = read_source("src/process.cpp");
 
-  EXPECT_NE(header.find("std::optional<std::uint64_t> capture_modifier() const"), std::string::npos);
-
-  const auto headless_probe = capture.find("if (try_headless_extcopy_dmabuf && gpu_native_capture_supported)");
-  ASSERT_NE(headless_probe, std::string::npos);
-  const auto modifier = capture.find("wlr->extcopy.capture_modifier()", headless_probe);
-  const auto policy = capture.find("gpu_native_dmabuf_is_safe(", modifier);
-  const auto accepted = capture.find("update_headless_extcopy_dmabuf_probe_result(true)", policy);
-  ASSERT_NE(modifier, std::string::npos);
-  ASSERT_NE(policy, std::string::npos);
-  ASSERT_NE(accepted, std::string::npos);
-  EXPECT_LT(modifier, policy);
-  EXPECT_LT(policy, accepted);
-  EXPECT_NE(capture.find("vaapi_headless_modifier_not_linear", policy), std::string::npos);
-  EXPECT_NE(capture.find("vaapi_headless_modifier_unavailable", policy), std::string::npos);
+  EXPECT_NE(policy.find("return hwdevice_type == platf::mem_type_e::cuda;"), std::string::npos);
+  EXPECT_EQ(policy.find("hwdevice_type == platf::mem_type_e::vaapi"), std::string::npos);
+  EXPECT_NE(capture.find("vaapi_headless_dmabuf_disabled_for_stability"), std::string::npos);
+  EXPECT_NE(capture.find("true-headless ext-image-copy-capture DMA-BUF is disabled for VAAPI stability"), std::string::npos);
   EXPECT_NE(process.find("if (!headless_attempt.failure_reason.empty())"), std::string::npos);
   EXPECT_NE(process.find("Retaining headless extcopy failure reason"), std::string::npos);
-  EXPECT_EQ(process.find("vaapi_headless_dmabuf_disabled_for_stability"), std::string::npos);
 }
 
 TEST(LinuxPlatformHardeningSource, CudaFormatTransitionReleasesCompleteDestination) {

--- a/tests/unit/test_wlgrab_capture_policy.cpp
+++ b/tests/unit/test_wlgrab_capture_policy.cpp
@@ -39,25 +39,25 @@ TEST(WlgrabCapturePolicy, SystemMemoryEncoderUsesRamCapture) {
   );
 }
 
-TEST(WlgrabCapturePolicy, VaapiMayProbeOnlyTheHeadlessPrivateRoute) {
-  EXPECT_TRUE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
-    platf::mem_type_e::vaapi,
-    route_e::windowed_nested
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
-    platf::mem_type_e::vaapi,
-    route_e::direct_wayland
-  ));
+TEST(WlgrabCapturePolicy, VaapiNeverProbesGpuNativeDmabuf) {
+  for (const auto route : {
+         route_e::headless_extcopy,
+         route_e::windowed_nested,
+         route_e::direct_wayland,
+       }) {
+    EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
+      platf::mem_type_e::vaapi,
+      route
+    ));
+  }
 }
 
-TEST(WlgrabCapturePolicy, VaapiHeadlessCaptureRequiresAnActualLinearModifier) {
+TEST(WlgrabCapturePolicy, LinearVaapiHeadlessCaptureStillUsesShmFallback) {
   constexpr std::uint64_t tiled_modifier = 0x0100000000000002ULL;
 
-  EXPECT_TRUE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+  // #111 and #367 both reached the first-frame failure with modifier 0, so
+  // DRM_FORMAT_MOD_LINEAR is not sufficient evidence of a safe VAAPI import.
+  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
     platf::mem_type_e::vaapi,
     route_e::headless_extcopy,
     DRM_FORMAT_MOD_LINEAR


### PR DESCRIPTION
## Summary

- fail closed for every VAAPI GPU-native DMA-BUF route, including private headless buffers that report `DRM_FORMAT_MOD_LINEAR`
- keep CUDA GPU-native capture unchanged
- restore the established `vaapi_headless_dmabuf_disabled_for_stability` telemetry and SHM fallback log
- pin the linear-modifier regression in policy, compositor-routing, and source-contract tests

Refs #367 and #409.

## Root cause

v1.3.9 re-enabled VAAPI on the private headless ext-image-copy route when the captured buffer reported a linear modifier. That predicate was not sufficient: the historical #111 field log had already reached its first-frame crash with modifier `0` (`DRM_FORMAT_MOD_LINEAR`), and the RDNA3 reporter in #367 now reports a Polaris `SIGSEGV` immediately after upgrading from the stable v1.3.8 SHM path to v1.3.9.

The latest support bundle was captured without an active stream and contains no Polaris log window, so it cannot provide a stack trace. The release-to-crash attribution is therefore a strong field-evidence inference, not a symbolized root-cause claim. Containment should not wait for the backtrace because the newly enabled path re-enters a boundary already known to crash affected AMD hosts.

## Impact

VAAPI private-headless capture returns to the conservative SHM/system-memory path. This restores the v1.3.8 safety posture but also restores its 4K copy/cadence ceiling. The GPU-native VAAPI optimization remains follow-up work under #409 and requires affected-host proof before it can be enabled again.

CUDA/NVENC routing is unchanged.

## Testing

- [x] I tested the affected install, build, stream, or UI path.
  - exact candidate: `50d82781762ba5b94e5d7f4bf7da3b81ada5a121`
  - Linux production `polaris` target: built successfully
  - `test_polaris`: 306/306 passed
  - `test_polaris_platform`: 207 passed, 1 expected CUDA-only skip
  - focused VAAPI policy/source tests: 10/10 passed
  - focused compositor-routing policy tests: 35/35 passed
  - `git diff --check`: passed
- [x] I included screenshots or recordings for visible UI changes, when practical. No visible UI change.
- [x] I updated docs or release notes when user-facing behavior changed. No documentation change: this restores the prior fail-closed behavior, while the v1.3.9 notes remain historical.

## Draft gate

Keep this draft until the #367 reporter verifies on the affected RDNA3/CachyOS host that:

1. Polaris no longer coredumps when the Ally starts the same Private Stream case.
2. Logs report the VAAPI policy refusal and `capture_transport=shm frame_residency=cpu`.
3. No new Polaris coredump appears in `coredumpctl`.

A symbolized backtrace from the v1.3.9 crash is still useful for the root fix, but it is not required to validate this containment.

## Notes

No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes. No release or deployment is part of this PR.