### PR TITLE
fix(linux): contain VAAPI headless DMA-BUF after v1.3.9 crash

### DIFF
--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -168,8 +168,8 @@ namespace cage_display_router {
    * @brief Returns whether a headless labwc runtime should try the
    *        ext-image-copy-capture DMA-BUF path before falling back to SHM.
    *
-   * VAAPI may probe only this private headless route. Its captured buffer still
-   * has to pass the modifier policy before it reaches the encoder.
+   * CUDA may probe this private headless route. VAAPI remains fail-closed while
+   * the affected-host crash at its first live import is under containment.
    */
   bool should_attempt_headless_extcopy_dmabuf(
     const platf::runtime_state_t &runtime_state,

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -759,6 +759,13 @@ namespace platf {
               "cached_unsupported",
               true
             );
+          } else {
+            stream_stats::update_gpu_native_probe_attempt(
+              "headless_extcopy",
+              "ineligible",
+              "policy",
+              "vaapi_headless_dmabuf_disabled_for_stability"
+            );
           }
           stream_stats::update_gpu_native_probe_selection("headless_shm", "headless_shm");
           if (stream_runtime::labwc::should_log_headless_ram_capture_warning()) {

--- a/src/platform/linux/wlgrab_capture_policy.h
+++ b/src/platform/linux/wlgrab_capture_policy.h
@@ -24,28 +24,21 @@ namespace wlgrab_capture_policy {
 
   inline bool gpu_native_dmabuf_probe_is_allowed(
     platf::mem_type_e hwdevice_type,
-    gpu_native_capture_route_e route
+    gpu_native_capture_route_e
   ) {
-    if (hwdevice_type == platf::mem_type_e::cuda) {
-      return true;
-    }
-
-    return hwdevice_type == platf::mem_type_e::vaapi &&
-           route == gpu_native_capture_route_e::headless_extcopy;
+    // Release containment: the linear-modifier policy alone did not prevent a
+    // VAAPI host from crashing while the headless probe imported its first
+    // live DMA-BUF. Keep VAAPI fail-closed on every route until affected AMD
+    // hardware proves a stronger import/conversion guard.
+    return hwdevice_type == platf::mem_type_e::cuda;
   }
 
   inline bool gpu_native_dmabuf_is_safe(
     platf::mem_type_e hwdevice_type,
-    gpu_native_capture_route_e route,
-    std::optional<std::uint64_t> modifier
+    gpu_native_capture_route_e,
+    std::optional<std::uint64_t>
   ) {
-    if (hwdevice_type == platf::mem_type_e::cuda) {
-      return true;
-    }
-
-    return hwdevice_type == platf::mem_type_e::vaapi &&
-           route == gpu_native_capture_route_e::headless_extcopy &&
-           modifier == DRM_FORMAT_MOD_LINEAR;
+    return hwdevice_type == platf::mem_type_e::cuda;
   }
 
   inline direct_capture_path_e select_direct_capture_path(

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -399,7 +399,7 @@ TEST(WaylandInterfaceTests, RemovedOutputMarksDirtyButKeepsMonitorStorageUntilRe
 // windowed_ram_fallback, headless_extcopy_probe_succeeded) live only under
 // stream_runtime::labwc as one-liners — no dual cage export / matrix tests.
 
-TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiMayProbeExtcopyDmabuf) {
+TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiExtcopyProbeIsFailClosed) {
   const platf::runtime_state_t runtime_state {
     .requested_headless = true,
     .effective_headless = true,
@@ -407,7 +407,7 @@ TEST(CageDisplayRouterPolicyTests, EffectiveHeadlessVaapiMayProbeExtcopyDmabuf) 
     .backend_name = "labwc",
   };
 
-  EXPECT_TRUE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
+  EXPECT_FALSE(cage_display_router::should_attempt_headless_extcopy_dmabuf(
     runtime_state,
     platf::mem_type_e::vaapi
   ));
@@ -486,11 +486,11 @@ TEST(CageDisplayRouterPolicyTests, GpuNativeCaptureNeedsTheOverrideRegardlessOfE
   ));
 }
 
-TEST(CageDisplayRouterPolicyTests, VaapiSafetyIsLimitedToLinearHeadlessExtcopy) {
+TEST(CageDisplayRouterPolicyTests, VaapiSafetyIsFailClosedDuringContainment) {
   using route_e = wlgrab_capture_policy::gpu_native_capture_route_e;
   constexpr std::uint64_t tiled_modifier = 0x0100000000000002ULL;
 
-  EXPECT_TRUE(cage_display_router::gpu_native_dmabuf_is_safe(
+  EXPECT_FALSE(cage_display_router::gpu_native_dmabuf_is_safe(
     platf::mem_type_e::vaapi,
     route_e::headless_extcopy,
     DRM_FORMAT_MOD_LINEAR

--- a/tests/unit/test_linux_platform_hardening_source.cpp
+++ b/tests/unit/test_linux_platform_hardening_source.cpp
@@ -37,7 +37,7 @@ TEST(LinuxPlatformHardeningSource, TimedOutWlrCaptureCancelsItsRequest) {
   EXPECT_NE(capture.find("dmabuf.cancel()"), std::string::npos);
 }
 
-TEST(LinuxPlatformHardeningSource, HeadlessVaapiChecksActualModifierBeforeGpuNativeSelection) {
+TEST(LinuxPlatformHardeningSource, HeadlessGpuNativeRetainsModifierGuardBehindVaapiContainment) {
   const auto header = read_source("src/platform/linux/wayland.h");
   const auto capture = read_source("src/platform/linux/wlgrab.cpp");
   const auto process = read_source("src/process.cpp");
@@ -58,7 +58,7 @@ TEST(LinuxPlatformHardeningSource, HeadlessVaapiChecksActualModifierBeforeGpuNat
   EXPECT_NE(capture.find("vaapi_headless_modifier_unavailable", policy), std::string::npos);
   EXPECT_NE(process.find("if (!headless_attempt.failure_reason.empty())"), std::string::npos);
   EXPECT_NE(process.find("Retaining headless extcopy failure reason"), std::string::npos);
-  EXPECT_EQ(process.find("vaapi_headless_dmabuf_disabled_for_stability"), std::string::npos);
+  EXPECT_NE(capture.find("vaapi_headless_dmabuf_disabled_for_stability"), std::string::npos);
 }
 
 TEST(LinuxPlatformHardeningSource, CudaFormatTransitionReleasesCompleteDestination) {

--- a/tests/unit/test_wlgrab_capture_policy.cpp
+++ b/tests/unit/test_wlgrab_capture_policy.cpp
@@ -39,57 +39,41 @@ TEST(WlgrabCapturePolicy, SystemMemoryEncoderUsesRamCapture) {
   );
 }
 
-TEST(WlgrabCapturePolicy, VaapiMayProbeOnlyTheHeadlessPrivateRoute) {
-  EXPECT_TRUE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
-    platf::mem_type_e::vaapi,
-    route_e::windowed_nested
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
-    platf::mem_type_e::vaapi,
-    route_e::direct_wayland
-  ));
+TEST(WlgrabCapturePolicy, VaapiGpuNativeProbeIsFailClosedAcrossAllRoutes) {
+  for (const auto route : {
+         route_e::headless_extcopy,
+         route_e::windowed_nested,
+         route_e::direct_wayland,
+       }) {
+    EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_probe_is_allowed(
+      platf::mem_type_e::vaapi,
+      route
+    ));
+  }
 }
 
-TEST(WlgrabCapturePolicy, VaapiHeadlessCaptureRequiresAnActualLinearModifier) {
+TEST(WlgrabCapturePolicy, VaapiGpuNativeCaptureIsFailClosedRegardlessOfModifier) {
   constexpr std::uint64_t tiled_modifier = 0x0100000000000002ULL;
+  const std::optional<std::uint64_t> modifiers[] = {
+    std::nullopt,
+    DRM_FORMAT_MOD_LINEAR,
+    DRM_FORMAT_MOD_INVALID,
+    tiled_modifier,
+  };
 
-  EXPECT_TRUE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy,
-    DRM_FORMAT_MOD_LINEAR
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy,
-    std::nullopt
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy,
-    DRM_FORMAT_MOD_INVALID
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy,
-    tiled_modifier
-  ));
-}
-
-TEST(WlgrabCapturePolicy, LinearVaapiBuffersRemainRefusedOutsideHeadlessPrivateCapture) {
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::windowed_nested,
-    DRM_FORMAT_MOD_LINEAR
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::direct_wayland,
-    DRM_FORMAT_MOD_LINEAR
-  ));
+  for (const auto route : {
+         route_e::headless_extcopy,
+         route_e::windowed_nested,
+         route_e::direct_wayland,
+       }) {
+    for (const auto modifier : modifiers) {
+      EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+        platf::mem_type_e::vaapi,
+        route,
+        modifier
+      ));
+    }
+  }
 }
 
 TEST(WlgrabCapturePolicy, CudaSafetyDoesNotDependOnRouteOrModifier) {


### PR DESCRIPTION
## Summary

- restore fail-closed GPU-native DMA-BUF eligibility for VAAPI on every wlroots route
- retain the route/modifier plumbing so a hardware-proven guard can replace the containment later
- preserve CUDA GPU-native behavior
- report `vaapi_headless_dmabuf_disabled_for_stability` when the headless VAAPI path falls back to SHM

## Why

An affected AMD/CachyOS host from #367 began dumping `SIGSEGV` at stream start after updating to v1.3.9. The diagnostics bundle was exported after the backend died and contains no crash stack, so the exact faulting function still needs the coredump. The leading regression boundary is the VAAPI headless DMA-BUF import/conversion path enabled by #430 without its affected-host field gate.

This PR contains that path while the crash is diagnosed. A linear modifier is not sufficient evidence that the first live VAAPI import/conversion is safe on the reporter's stack.

## Impact

VAAPI private-headless capture returns to the SHM/system-memory path used before v1.3.9. The 4K performance optimization from #430 is temporarily disabled. CUDA/NVENC GPU-native capture is unchanged, and direct/windowed VAAPI routes remain on their existing SHM containment.

## Validation

- full local build
- focused capture policy and source-contract tests: 9 passed
- cage display router policy tests: 35 passed
- `ctest --test-dir build -j1 --output-on-failure`: 17/17 passed
- `bash scripts/check-public-surface.sh`
- `git diff --check`

## Follow-up

- collect the matching v1.3.9 `coredumpctl` output and final Polaris log from #367
- validate this containment on the affected AMD host
- reopen VAAPI headless GPU-native eligibility only with AMD/Intel first-frame, sustained-cadence, fallback, and crash evidence

Refs #367
Refs #409
