### PR TITLE
Fix Gamescope Steam session nesting for SDR and Big Picture

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,8 @@ starts at `v1.0.0`.
 ## Unreleased
 
 - Paces private-compositor screencopy capture from the compositor's own frame callbacks instead of placing a second fixed timer in front of it, so a private 120 Hz output no longer settles at a capture source below its own refresh, and reports output refresh, capture-source FPS, encoded FPS, and capture pacing as separate values
+- Gives Steam games and Steam Big Picture their own nested Gamescope session for both SDR and HDR clients, keeping the streamed picture and controller focus under the same compositor
+- Gives nested Gamescope startup a dedicated 120-second timeout with service-journal diagnostics, and removes the unused Nix `injectApps` option instead of advertising a no-op
 
 ## v1.3.9 - 2026-08-15
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,11 @@ you want to script setup, review current values, or recover from a broken UI sta
 
 If you change `port` in `polaris.conf`, the web UI moves to `https://localhost:<port + 1>`.
 
+Add installed Steam titles from the web UI's Applications library scan. The Nix modules do not
+generate or replace `apps.json`; Polaris stores each imported title with its Steam app id and applies
+the selected Linux stream runtime when that title launches. Steam Big Picture remains available as
+the browse-first entry and does not require an app id.
+
 ## Recommended first settings
 
 ```ini

--- a/nix/modules/options.nix
+++ b/nix/modules/options.nix
@@ -77,12 +77,6 @@
     description = "Optional After= ready target (null → same as desktopUserTarget).";
   };
 
-  injectApps = lib.mkOption {
-    type = lib.types.bool;
-    default = true;
-    description = "Wire Steam library launches through polaris-gamescope-session when inject is enabled.";
-  };
-
   preferVkDevice = lib.mkOption {
     type = lib.types.nullOr lib.types.str;
     default = null;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -109,6 +109,8 @@ namespace proc {
   int terminate_app_id = -1;
   std::string terminate_app_id_str;
 
+  constexpr auto nested_gamescope_start_timeout = 120s;
+
   session_stop_outcome_t evaluate_session_stop_request(
     bool can_launch,
     bool has_running_app,
@@ -890,6 +892,33 @@ namespace proc {
         if (auto appid = extract_steam_appid_from_command(cmd)) {
           return *appid;
         }
+      }
+
+      return {};
+    }
+
+    struct nested_gamescope_session_target_t {
+      bool eligible = false;
+      std::string appid;
+    };
+
+    nested_gamescope_session_target_t resolve_nested_gamescope_session_target(
+      bool gamescope_stream_session,
+      const proc::ctx_t &ctx
+    ) {
+      if (!gamescope_stream_session) {
+        return {};
+      }
+
+      if (auto appid = steam_appid_for_context(ctx); !appid.empty()) {
+        return {true, std::move(appid)};
+      }
+
+      // Big Picture is itself a valid nested-session target. The session
+      // helper intentionally accepts `start` without an app id and keeps the
+      // stream alive until the client disconnects or explicitly stops it.
+      if (is_steam_big_picture_app(ctx)) {
+        return {true, {}};
       }
 
       return {};
@@ -4444,6 +4473,17 @@ namespace proc {
 #endif
 
 #if defined(POLARIS_TESTS) && defined(__linux__)
+  std::optional<std::string> resolve_nested_gamescope_session_target_for_tests(
+    bool gamescope_stream_session,
+    const proc::ctx_t &app
+  ) {
+    auto target = resolve_nested_gamescope_session_target(gamescope_stream_session, app);
+    if (!target.eligible) {
+      return std::nullopt;
+    }
+    return target.appid;
+  }
+
   desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy_for_tests(
     bool private_stream_requested,
     bool mirror_desktop_explicit,
@@ -5476,7 +5516,7 @@ namespace proc {
   }
 
   /**
-   * @brief Wait for a configured command to exit, bounded by the app's exit_timeout.
+   * @brief Wait for a configured command to exit within a caller-selected bound.
    *
    * Prep commands in execute_impl and undo commands in terminate_impl run
    * synchronously on the thread that holds the session lifecycle lock, so an
@@ -5487,26 +5527,28 @@ namespace proc {
    * The resume and pause state commands deliberately do not use this: they run
    * on a detached thread holding no lock, where taking a long time is fine.
    *
-   * A configured 0 means "kill the process group at once" for the app itself,
-   * which would be a surprising thing to do to a configured command, so that
-   * falls back to the 5s default rather than killing instantly.
+   * A configured 0 means "kill the process group at once" for the app itself.
+   * When it reaches this helper, it falls back to the 5s configured-command
+   * default rather than killing the command instantly. Infrastructure callers
+   * may provide their own timeout instead of inheriting the app's exit policy.
    *
    * child::wait_for() is deprecated as unreliable, so this polls the same way
    * terminate_process_group() below does.
    */
-  void wait_for_configured_command(
+  bool wait_for_configured_command(
     boost::process::v1::child &child,
     std::string_view command,
-    std::chrono::seconds exit_timeout
+    std::chrono::seconds command_timeout
   ) {
-    const auto timeout = exit_timeout.count() > 0 ? exit_timeout : std::chrono::seconds {5};
+    const auto timeout = command_timeout.count() > 0 ? command_timeout : std::chrono::seconds {5};
 
     auto remaining = timeout;
     while (child.running() && (--remaining).count() >= 0) {
       std::this_thread::sleep_for(1s);
     }
 
-    if (child.running()) {
+    const bool timed_out = child.running();
+    if (timed_out) {
       BOOST_LOG(warning) << "Command ["sv << command << "] did not exit within "sv
                          << timeout.count() << "s; terminating it"sv;
       std::error_code terminate_ec;
@@ -5518,6 +5560,7 @@ namespace proc {
 
     // Reaps whether it exited on its own or was just killed.
     child.wait();
+    return timed_out;
   }
 
   void terminate_process_group(boost::process::v1::child &proc, boost::process::v1::group &group, std::chrono::seconds exit_timeout) {
@@ -5865,8 +5908,9 @@ namespace proc {
       config::video.linux_display.stream_mode == "gamescope_stream" ||
       config::video.linux_display.private_runtime == "gamescope";
     _session_used_gamescope_runtime = gamescope_stream_session;
-    // Set true after enable_hdr when rewiring to polaris-gamescope-session nested WSI.
-    bool nested_wsi_hdr_session = false;
+    // Set true when a Steam title or Big Picture is rewired to its own
+    // polaris-gamescope-session compositor.
+    bool nested_wsi_session = false;
     // Private nested runtime: labwc cage and/or owned/attach gamescope.
     const bool use_cage_compositor_for_session =
       !mirror_desktop_session &&
@@ -6141,25 +6185,22 @@ namespace proc {
       }
     }
 
-    // Nested WSI is the proven game-HDR present path (FROG layer + DXVK HDR10
-    // swapchain). SB-5 unwrapped polaris-gamescope-session into attach+X11, which
-    // cannot register Gamescope surfaces — BG3 etc. stay SDR despite stream PQ.
-    // For gamescope_stream + client HDR + Steam appid, rewire to nested session.
-    if (gamescope_stream_session && launch_session->enable_hdr) {
-      std::string appid = _app.steam_appid;
-      if (appid.empty()) {
-        if (const auto detected = extract_steam_appid_from_command(_app.cmd); detected) {
-          appid = *detected;
-        }
-      }
-      if (appid.empty()) {
-        for (const auto &cmd : _app.detached) {
-          if (const auto detected = extract_steam_appid_from_command(cmd); detected) {
-            appid = *detected;
-            break;
-          }
-        }
-      }
+    // Nested WSI gives one compositor ownership of both the visible game and
+    // its input focus. That ownership boundary is required for SDR and HDR:
+    // attaching Steam and the game to the idle compositor lets Big Picture
+    // remain focused while the game is also focusable. The session helper
+    // supports both a per-game app id and a no-id Big Picture session.
+    const auto nested_target = resolve_nested_gamescope_session_target(
+      gamescope_stream_session,
+      _app
+    );
+    if (nested_target.eligible) {
+      const auto start_arg = nested_target.appid.empty() ?
+        std::string {} :
+        " " + nested_target.appid;
+      const auto target_label = nested_target.appid.empty() ?
+        "Steam Big Picture"s :
+        "Steam appid=" + nested_target.appid;
       boost::filesystem::path session_bin;
       try {
         session_bin = boost::process::v1::search_path("polaris-gamescope-session");
@@ -6167,10 +6208,12 @@ namespace proc {
       catch (...) {
         session_bin.clear();
       }
-      if (!appid.empty() && !session_bin.empty()) {
-        nested_wsi_hdr_session = true;
-        _app.steam_appid = appid;
-        const auto start_cmd = session_bin.string() + " start " + appid;
+      if (!session_bin.empty()) {
+        nested_wsi_session = true;
+        if (!nested_target.appid.empty()) {
+          _app.steam_appid = nested_target.appid;
+        }
+        const auto start_cmd = session_bin.string() + " start" + start_arg;
         const auto wait_cmd = session_bin.string() + " wait";
         const auto stop_cmd = session_bin.string() + " stop";
         // Drop attach-era steam launches; nested session owns Steam as gamescope child.
@@ -6193,12 +6236,15 @@ namespace proc {
           proc::cmd_t {std::string {start_cmd}, std::string {stop_cmd}, false}
         );
         _app.prep_cmds = std::move(kept_prep);
-        BOOST_LOG(info) << "session_manager: nested WSI HDR path — polaris-gamescope-session start "
-                        << appid << " (Steam primary child; not attach/X11)"sv;
+        BOOST_LOG(info) << "session_manager: nested WSI "
+                        << (launch_session->enable_hdr ? "HDR"sv : "SDR"sv)
+                        << " path — polaris-gamescope-session start"
+                        << start_arg << " (" << target_label
+                        << " primary child; not attach/X11)"sv;
       }
-      else if (launch_session->enable_hdr) {
-        BOOST_LOG(warning) << "session_manager: HDR client but cannot nest WSI "
-                              "(need steam-appid + polaris-gamescope-session on PATH); using attach"sv;
+      else {
+        BOOST_LOG(warning) << "session_manager: cannot nest " << target_label
+                           << " because polaris-gamescope-session is not on PATH; using attach"sv;
       }
     }
 #endif
@@ -6750,7 +6796,7 @@ namespace proc {
 
 #ifdef __linux__
       const bool critical_nested_session_prep =
-        nested_wsi_hdr_session && command_uses_polaris_gamescope_session(cmd.do_cmd);
+        nested_wsi_session && command_uses_polaris_gamescope_session(cmd.do_cmd);
 #else
       const bool critical_nested_session_prep = false;
 #endif
@@ -6759,7 +6805,25 @@ namespace proc {
                                               find_working_directory(cmd.do_cmd, _env) :
                                               boost::filesystem::path(_app.working_dir);
       BOOST_LOG(info) << "Executing Do Cmd: ["sv << cmd.do_cmd << "] elevated: " << cmd.elevated;
-      auto child = platf::run_command(cmd.elevated, true, cmd.do_cmd, working_dir, _env, _pipe.get(), ec, nullptr);
+      FILE *prep_output = _pipe.get();
+#ifdef __linux__
+      // Session-helper diagnostics are infrastructure logs, not app output.
+      // Keep them visible in the Polaris service journal even when the app has
+      // no output file configured.
+      if (critical_nested_session_prep) {
+        prep_output = stderr;
+      }
+#endif
+      auto child = platf::run_command(
+        cmd.elevated,
+        true,
+        cmd.do_cmd,
+        working_dir,
+        _env,
+        prep_output,
+        ec,
+        nullptr
+      );
 
       if (ec) {
         BOOST_LOG(warning) << "Couldn't run ["sv << cmd.do_cmd << "]: System: "sv << ec.message();
@@ -6773,7 +6837,27 @@ namespace proc {
         continue;
       }
 
-      wait_for_configured_command(child, cmd.do_cmd, _app.exit_timeout);
+      const auto prep_timeout = critical_nested_session_prep ?
+        nested_gamescope_start_timeout :
+        _app.exit_timeout;
+      if (critical_nested_session_prep) {
+        BOOST_LOG(info) << "session_manager: waiting up to "sv
+                        << prep_timeout.count() << "s for nested gamescope startup"sv;
+      }
+      const bool prep_timed_out = wait_for_configured_command(child, cmd.do_cmd, prep_timeout);
+      if (prep_timed_out && critical_nested_session_prep) {
+        // The command may have published durable recovery state before timing
+        // out. Mark its undo as eligible so terminate_impl drives stop.
+        ++_app_prep_it;
+        BOOST_LOG(error) << "session_manager: nested gamescope startup timed out after "sv
+                         << prep_timeout.count() << "s"sv;
+        confighttp::emit_session_event(
+          "warning",
+          "Nested gamescope startup timed out after " + std::to_string(prep_timeout.count()) + "s"
+        );
+        confighttp::emit_session_event("error", "Nested gamescope session failed to start");
+        return 503;
+      }
       auto ret = child.exit_code();
       if (ret != 0) {
         BOOST_LOG(warning) << '[' << cmd.do_cmd << "] returned code ["sv << ret << ']';
@@ -7007,9 +7091,9 @@ namespace proc {
       false
     );
     // Nested WSI owns gamescope-0 (Steam as primary child). Do not attach/spawn a
-    // second idle compositor — that was the SB-5 path that lost FROG HDR present.
+    // second idle compositor; that loses the game surface and input-focus boundary.
     const bool need_private_runtime =
-      use_cage_compositor_for_session && !nested_wsi_hdr_session;
+      use_cage_compositor_for_session && !nested_wsi_session;
     const bool prefer_gamescope =
       path_policy.runtime == stream_path::runtime_kind_e::GAMESCOPE ||
       gamescope_stream_session;
@@ -7465,14 +7549,14 @@ namespace proc {
           spawn_detached_into_runtime(_app.detached[i]);
         }
       }
-    } else if (use_cage_compositor_for_session && !nested_wsi_hdr_session) {
+    } else if (use_cage_compositor_for_session && !nested_wsi_session) {
       // No detached commands — start cage empty, game will use _app.cmd
       if (!start_cage_with_runtime_fallback("")) {
         BOOST_LOG(error) << "session_manager: Failed to start cage compositor"sv;
         return 503;
       }
       _session_used_cage_compositor = true;
-    } else if (nested_wsi_hdr_session) {
+    } else if (nested_wsi_session) {
       // polaris-gamescope-session start already owns nested gamescope + Steam (prep-cmd).
       // _app.cmd is "wait"; do not attach idle or spawn a second compositor.
       _session_used_cage_compositor = false;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -111,6 +111,15 @@ namespace proc {
 
   constexpr auto nested_gamescope_start_timeout = 120s;
 
+  // Teardown gets its own, much shorter budget than startup. The stop path in
+  // polaris-gamescope-session.sh waits up to about 15s of its own accord
+  // (POLARIS_IDLE_WAIT_STEPS and POLARIS_PORTAL_WAIT_STEPS, both at 0.1s), so a
+  // 5s caller can terminate it mid-drain. This leaves headroom over that budget
+  // while staying far below the startup timeout, because undo runs while the
+  // session lifecycle lock is held and a two-minute teardown would be worse than
+  // the stall it prevents.
+  constexpr auto nested_gamescope_stop_timeout = 30s;
+
   session_stop_outcome_t evaluate_session_stop_request(
     bool can_launch,
     bool has_running_app,
@@ -8390,13 +8399,41 @@ namespace proc {
                                               find_working_directory(cmd.undo_cmd, _env) :
                                               boost::filesystem::path(_app.working_dir);
       BOOST_LOG(info) << "Executing Undo Cmd: ["sv << cmd.undo_cmd << ']';
-      auto child = platf::run_command(cmd.elevated, true, cmd.undo_cmd, working_dir, _env, _pipe.get(), ec, nullptr);
+#ifdef __linux__
+      const bool critical_nested_session_undo = command_uses_polaris_gamescope_session(cmd.undo_cmd);
+#else
+      const bool critical_nested_session_undo = false;
+#endif
+      FILE *undo_output = _pipe.get();
+#ifdef __linux__
+      // Same reasoning as the prep side: session-helper diagnostics are
+      // infrastructure logs, not app output. Without this a failed teardown is
+      // silent even though a failed startup is not.
+      if (critical_nested_session_undo) {
+        undo_output = stderr;
+      }
+#endif
+      auto child = platf::run_command(cmd.elevated, true, cmd.undo_cmd, working_dir, _env, undo_output, ec, nullptr);
 
       if (ec) {
         BOOST_LOG(warning) << "System: "sv << ec.message();
       }
 
-      wait_for_configured_command(child, cmd.undo_cmd, _app.exit_timeout);
+      const auto undo_timeout = critical_nested_session_undo ?
+        nested_gamescope_stop_timeout :
+        _app.exit_timeout;
+      if (critical_nested_session_undo) {
+        BOOST_LOG(info) << "session_manager: waiting up to "sv
+                        << undo_timeout.count() << "s for nested gamescope teardown"sv;
+      }
+      const bool undo_timed_out = wait_for_configured_command(child, cmd.undo_cmd, undo_timeout);
+      if (undo_timed_out && critical_nested_session_undo) {
+        // The stop path is written to fail into a recoverable state, so this is
+        // reported rather than escalated: the durable claim files are published
+        // before the risky operations precisely so a retry can resume.
+        BOOST_LOG(error) << "session_manager: nested gamescope teardown timed out after "sv
+                         << undo_timeout.count() << "s; session may need manual recovery"sv;
+      }
       auto ret = child.exit_code();
 
       if (ret != 0) {

--- a/src/process.h
+++ b/src/process.h
@@ -237,6 +237,10 @@ namespace proc {
   bool desktop_steam_proc_enumeration_error_fails_closed_for_tests();
   bool desktop_steam_proc_read_error_fails_closed_for_tests(pid_t forced_pid);
   bool steam_instance_pipe_listener_active_for_tests(const std::string &pipe_path);
+  std::optional<std::string> resolve_nested_gamescope_session_target_for_tests(
+    bool gamescope_stream_session,
+    const struct ctx_t &app
+  );
 
   bool cage_mangohud_allowed_for_session_for_tests(const struct ctx_t &app,
                                                    bool use_cage_compositor,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -4435,3 +4435,31 @@ TEST(GamescopeNestedSessionContract, StartupUsesItsOwnVisibleTimeoutAndTheNixMod
   EXPECT_NE(source.find("Nested gamescope startup timed out after "), std::string::npos);
   EXPECT_EQ(options.find("injectApps"), std::string::npos);
 }
+
+TEST(GamescopeNestedSessionContract, TeardownGetsTheSameBudgetAndVisibilityAsStartup) {
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  const auto collapsed_source = collapse_whitespace(source);
+
+  // Startup got a dedicated budget. Teardown was left on the app's exit-timeout,
+  // which defaults to 5s, while the stop path in polaris-gamescope-session.sh
+  // waits up to about 15s of its own accord (POLARIS_IDLE_WAIT_STEPS plus
+  // POLARIS_PORTAL_WAIT_STEPS). A 5s caller could terminate it mid-drain and
+  // leave the session needing manual recovery. Both halves of the lifecycle get
+  // their own visible budget, or neither should.
+  EXPECT_NE(source.find("constexpr auto nested_gamescope_stop_timeout = 30s;"), std::string::npos);
+  EXPECT_NE(
+    collapsed_source.find(
+      "const auto undo_timeout = critical_nested_session_undo ? nested_gamescope_stop_timeout : _app.exit_timeout;"
+    ),
+    std::string::npos
+  );
+  EXPECT_NE(
+    collapsed_source.find("wait_for_configured_command(child, cmd.undo_cmd, undo_timeout)"),
+    std::string::npos
+  );
+
+  // A failed teardown must be as diagnosable as a failed startup. Without this
+  // the undo inherits the app's output pipe and a nested stop failure is silent.
+  EXPECT_NE(source.find("undo_output = stderr;"), std::string::npos);
+  EXPECT_NE(source.find("nested gamescope teardown timed out after "), std::string::npos);
+}

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1059,6 +1059,38 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsScopedToPrivateCompat
   EXPECT_FALSE(proc::steam_big_picture_input_guard_enabled_for_tests(compatibility_game, true, false));
 }
 
+TEST(ProcessRuntimeConfigTests, GamescopeNestedSessionTargetsSteamGamesAndBigPictureWithoutAnHdrGate) {
+  proc::ctx_t steam_game {};
+  steam_game.name = "Palworld";
+  steam_game.source = "steam";
+  steam_game.steam_appid = "1623730";
+  steam_game.detached = {"setsid steam steam://rungameid/1623730"};
+
+  const auto game_target = proc::resolve_nested_gamescope_session_target_for_tests(
+    true,
+    steam_game
+  );
+  ASSERT_TRUE(game_target.has_value());
+  EXPECT_EQ(*game_target, "1623730");
+
+  proc::ctx_t big_picture {};
+  big_picture.name = "Steam Big Picture";
+  big_picture.detached = {"setsid steam -gamepadui"};
+
+  const auto big_picture_target = proc::resolve_nested_gamescope_session_target_for_tests(
+    true,
+    big_picture
+  );
+  ASSERT_TRUE(big_picture_target.has_value());
+  EXPECT_TRUE(big_picture_target->empty())
+    << "an empty appid selects the helper's supported Big Picture start mode";
+
+  proc::ctx_t non_steam {};
+  non_steam.name = "Desktop";
+  EXPECT_FALSE(proc::resolve_nested_gamescope_session_target_for_tests(true, non_steam).has_value());
+  EXPECT_FALSE(proc::resolve_nested_gamescope_session_target_for_tests(false, steam_game).has_value());
+}
+
 TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardUsesAppHomeForLogPath) {
   proc::ctx_t app {};
   app.env_vars["HOME"] = "/tmp/polaris-app-home";
@@ -4381,4 +4413,25 @@ TEST(ProcConfiguredCommandWaitContract, CommandsRunUnderTheLifecycleLockWaitWith
     EXPECT_TRUE(is_helper_reap || preceding.find("Unbounded on purpose") != std::string::npos)
       << "unexplained bare child.wait() at offset " << at;
   }
+}
+
+TEST(GamescopeNestedSessionContract, StartupUsesItsOwnVisibleTimeoutAndTheNixModuleExposesNoDeadOption) {
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  const auto collapsed_source = collapse_whitespace(source);
+  const auto options = read_source_file_for_contract("nix/modules/options.nix");
+
+  EXPECT_EQ(
+    source.find("if (gamescope_stream_session && launch_session->enable_hdr)"),
+    std::string::npos
+  );
+  EXPECT_NE(source.find("constexpr auto nested_gamescope_start_timeout = 120s;"), std::string::npos);
+  EXPECT_NE(
+    collapsed_source.find(
+      "const auto prep_timeout = critical_nested_session_prep ? nested_gamescope_start_timeout : _app.exit_timeout;"
+    ),
+    std::string::npos
+  );
+  EXPECT_NE(source.find("prep_output = stderr;"), std::string::npos);
+  EXPECT_NE(source.find("Nested gamescope startup timed out after "), std::string::npos);
+  EXPECT_EQ(options.find("injectApps"), std::string::npos);
 }


### PR DESCRIPTION
## Summary

- make `gamescope_stream` choose the nested Steam session for SDR as well as HDR clients
- support nested Steam Big Picture sessions without requiring a Steam app id up front
- give nested Gamescope startup a dedicated 120-second timeout and surface helper diagnostics in the Polaris service journal
- remove the unused Nix `injectApps` option and document Applications-library importing
- add regression coverage for per-game, Big Picture, timeout, logging, and removed-option contracts

## Root cause

Nested Gamescope selection was gated on `launch_session->enable_hdr`, even though nesting owns both the visible surface and input focus. SDR sessions therefore attached Steam and the game to the idle compositor, where Big Picture could remain focused and be streamed instead of the game.

The nested helper also inherited the app's default five-second `exit-timeout`, so valid compositor startup was terminated mid-launch. Big Picture was excluded because the runtime required a Steam app id even though `polaris-gamescope-session start` already supports a no-id browse-first session.

Separately, the Nix `injectApps` option had never been consumed and advertised behavior it did not provide.

## User impact

SDR Steam games and browse-first Steam Big Picture sessions now use the same nested ownership path as HDR games, keeping picture and controller focus under one compositor. Slow but valid nested startup has up to 120 seconds and reports a specific timeout instead of an opaque return code.

## Validation

- `git diff --check`
- shell syntax validation for `polaris-gamescope-session.sh`
- compiled the modified `test_process_migration.cpp` test object
- verified source contracts for removal of the HDR gate, the dedicated startup timeout, journal output, and removal of `injectApps`

Linux/Nix CI remains required. The local macOS full test target stops in unrelated baseline macOS build failures, and the Gamescope process tests require Linux semantics. Physical acceptance should verify both an SDR per-game launch and a Big Picture browse-to-game launch, including controller focus and teardown.

Fixes #445
Fixes #446

---

## Added after review: teardown parity

Rebased onto `16f9726f` (picks up #441 and #455; the `docs/changelog.md` conflict was resolved by keeping both Unreleased bullets).

A review pass on the lifecycle seam found that this PR fixed startup and left teardown behind, and papi-9f confirmed it independently on the branch.

`wait_for_configured_command(child, cmd.undo_cmd, _app.exit_timeout)` bounds undo at the app's exit-timeout, default 5 for every generated entry, while the stop path in `polaris-gamescope-session.sh` waits up to about 15s of its own accord (`POLARIS_IDLE_WAIT_STEPS` 100 and `POLARIS_PORTAL_WAIT_STEPS` 50, both at 0.1s). A 5s caller can terminate the stop mid-drain. Teardown also inherited `_pipe.get()` instead of stderr, so a nested stop failure was silent while a nested start failure was not.

Severity, stated accurately: the stop path is deliberately written to fail into a recoverable state, publishing its durable force and claim files before the risky operations so a retry does not repeat nested signaling, and orphan-reclaim machinery sits upstream. The consequence is a session that **may need manual recovery**, not a dead next launch.

This is pre-existing rather than a regression from this PR: `master` carries the identical call. Fixing startup is what made the asymmetry visible, and shipping half a symmetric lifecycle is how the follow-up issue gets generated.

Changes: a dedicated `nested_gamescope_stop_timeout = 30s`, undo stderr routed to the journal, a timeout report, and a source-contract test pinning both halves. 30s rather than 120s because undo runs while the session lifecycle lock is held, so a two-minute teardown would be worse than the stall it prevents.

### Verification of the added commit

- [x] Production `polaris` target compiles and links with the change; `process.cpp.o` builds with no new errors or warnings.
- [x] Every assertion the new source-contract test makes was checked directly against the patched source, including the pre-existing startup pins and the existing lifecycle test's `wait_for_configured_command(child, cmd.undo_cmd` call shape, which this change preserves.
- [ ] Full test binaries did not link locally. A freshly configured worktree on this host hits an unrelated libstdc++ ABI failure (`std::__detail::__notify_impl` undefined) in `PidfdSteamTerminationDeadlineSurvivesRepeatedEintr`, which this change does not touch. **CI is the gate for the test binaries.**
