### PR TITLE
test(linux): harden VAAPI containment contracts

### DIFF
--- a/tests/unit/test_linux_platform_hardening_source.cpp
+++ b/tests/unit/test_linux_platform_hardening_source.cpp
@@ -50,6 +50,26 @@ TEST(LinuxPlatformHardeningSource, HeadlessVaapiFailsClosedBeforeDmabufInitializ
   EXPECT_NE(process.find("Retaining headless extcopy failure reason"), std::string::npos);
 }
 
+TEST(LinuxPlatformHardeningSource, HeadlessModifierGuardRemainsBehindVaapiContainment) {
+  const auto header = read_source("src/platform/linux/wayland.h");
+  const auto capture = read_source("src/platform/linux/wlgrab.cpp");
+
+  EXPECT_NE(header.find("std::optional<std::uint64_t> capture_modifier() const"), std::string::npos);
+
+  const auto headless_probe = capture.find("if (try_headless_extcopy_dmabuf && gpu_native_capture_supported)");
+  ASSERT_NE(headless_probe, std::string::npos);
+  const auto modifier = capture.find("wlr->extcopy.capture_modifier()", headless_probe);
+  const auto policy = capture.find("gpu_native_dmabuf_is_safe(", modifier);
+  const auto accepted = capture.find("update_headless_extcopy_dmabuf_probe_result(true)", policy);
+  ASSERT_NE(modifier, std::string::npos);
+  ASSERT_NE(policy, std::string::npos);
+  ASSERT_NE(accepted, std::string::npos);
+  EXPECT_LT(modifier, policy);
+  EXPECT_LT(policy, accepted);
+  EXPECT_NE(capture.find("vaapi_headless_modifier_not_linear", policy), std::string::npos);
+  EXPECT_NE(capture.find("vaapi_headless_modifier_unavailable", policy), std::string::npos);
+}
+
 TEST(LinuxPlatformHardeningSource, CudaFormatTransitionReleasesCompleteDestination) {
   const auto source = read_source("src/platform/linux/cuda.cpp");
   const auto transition = source.find("source_fourcc != descriptor.sd.fourcc");

--- a/tests/unit/test_wlgrab_capture_policy.cpp
+++ b/tests/unit/test_wlgrab_capture_policy.cpp
@@ -52,44 +52,30 @@ TEST(WlgrabCapturePolicy, VaapiNeverProbesGpuNativeDmabuf) {
   }
 }
 
-TEST(WlgrabCapturePolicy, LinearVaapiHeadlessCaptureStillUsesShmFallback) {
+TEST(WlgrabCapturePolicy, VaapiGpuNativeCaptureIsFailClosedRegardlessOfRouteOrModifier) {
   constexpr std::uint64_t tiled_modifier = 0x0100000000000002ULL;
+  const std::optional<std::uint64_t> modifiers[] = {
+    std::nullopt,
+    DRM_FORMAT_MOD_LINEAR,
+    DRM_FORMAT_MOD_INVALID,
+    tiled_modifier,
+  };
 
   // #111 and #367 both reached the first-frame failure with modifier 0, so
-  // DRM_FORMAT_MOD_LINEAR is not sufficient evidence of a safe VAAPI import.
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy,
-    DRM_FORMAT_MOD_LINEAR
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy,
-    std::nullopt
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy,
-    DRM_FORMAT_MOD_INVALID
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::headless_extcopy,
-    tiled_modifier
-  ));
-}
-
-TEST(WlgrabCapturePolicy, LinearVaapiBuffersRemainRefusedOutsideHeadlessPrivateCapture) {
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::windowed_nested,
-    DRM_FORMAT_MOD_LINEAR
-  ));
-  EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
-    platf::mem_type_e::vaapi,
-    route_e::direct_wayland,
-    DRM_FORMAT_MOD_LINEAR
-  ));
+  // every VAAPI route remains contained even when the buffer reports linear.
+  for (const auto route : {
+         route_e::headless_extcopy,
+         route_e::windowed_nested,
+         route_e::direct_wayland,
+       }) {
+    for (const auto modifier : modifiers) {
+      EXPECT_FALSE(wlgrab_capture_policy::gpu_native_dmabuf_is_safe(
+        platf::mem_type_e::vaapi,
+        route,
+        modifier
+      ));
+    }
+  }
 }
 
 TEST(WlgrabCapturePolicy, CudaSafetyDoesNotDependOnRouteOrModifier) {


### PR DESCRIPTION
## Summary

- expand the VAAPI containment contract across all three GPU-native capture routes and four modifier states
- retain the headless modifier-policy plumbing behind the current fail-closed gate
- carry forward the useful test coverage from superseded draft #449 without reopening its conflicting production implementation

## Why

#447 already restored VAAPI to SHM after the v1.3.9 first-stream crash report. Draft #449 independently reached the same production outcome but added two stronger contracts:

1. every combination of headless, windowed, and direct VAAPI routes with missing, linear, invalid, or tiled modifiers must remain unsafe;
2. the dormant modifier inspection and fallback-reason ordering must stay intact for the eventual #409 safety guard.

This PR salvages only those contracts. It does not change runtime behavior, capture selection, telemetry, packaging, or release metadata.

## Validation

- [x] `git diff --check`
- [x] Fresh exact-head protected CI on `84c35801e66491d77eb7fb1f012effeb6651a6a5`: Public Hygiene, Web checks, C++ sanitizer tests, and Arch build
- [x] CodeQL C++ and JavaScript/TypeScript analyses
- [x] Fedora 44 Clang compile, Fedora RPM build, and Ubuntu package/smoke lanes
- [x] Optional SteamOS 3.8 packaging lane

Build workflow: https://github.com/papi-ux/polaris/actions/runs/31980768297

## Scope

Refs #367, #409, #447, and #449.

No release, tag, deployment, or branch cleanup is part of this PR.