### PR TITLE
fix(library): find Heroic and Lutris games installed as Flatpaks

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2656,61 +2656,11 @@ namespace confighttp {
    * @brief Scan for installed Steam, Lutris, and Heroic games.
    */
   std::vector<fs::path> lutris_game_config_dirs() {
-    std::vector<fs::path> dirs;
-    std::set<fs::path> seen_dirs;
-    auto append_dir = [&](fs::path path) {
-      if (path.empty()) {
-        return;
-      }
-      path = path.lexically_normal();
-      if (seen_dirs.insert(path).second) {
-        dirs.push_back(std::move(path));
-      }
-    };
-
-    const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
-    const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
-    if (xdg_config_home && *xdg_config_home) {
-      append_dir(fs::path(xdg_config_home) / "lutris/games");
-    }
-    if (xdg_data_home && *xdg_data_home) {
-      append_dir(fs::path(xdg_data_home) / "lutris/games");
-    }
-    for (const auto &home : game_library::library_home_roots()) {
-      append_dir(home / ".config/lutris/games");
-      append_dir(home / ".local/share/lutris/games");
-    }
-
-    return dirs;
+    return game_library::lutris_game_config_dirs(game_library::library_home_roots());
   }
 
   std::vector<fs::path> lutris_art_roots() {
-    std::vector<fs::path> roots;
-    std::set<fs::path> seen_roots;
-    auto append_root = [&](fs::path path) {
-      if (path.empty()) {
-        return;
-      }
-      path = path.lexically_normal();
-      if (seen_roots.insert(path).second) {
-        roots.push_back(std::move(path));
-      }
-    };
-
-    const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
-    const char *xdg_cache_home = std::getenv("XDG_CACHE_HOME");
-    if (xdg_data_home && *xdg_data_home) {
-      append_root(fs::path(xdg_data_home) / "lutris");
-    }
-    if (xdg_cache_home && *xdg_cache_home) {
-      append_root(fs::path(xdg_cache_home) / "lutris");
-    }
-    for (const auto &home : game_library::library_home_roots()) {
-      append_root(home / ".local/share/lutris");
-      append_root(home / ".cache/lutris");
-    }
-
-    return roots;
+    return game_library::lutris_art_roots(game_library::library_home_roots());
   }
 
   std::string lutris_image_path_for_app_node(const nlohmann::json &app) {
@@ -2958,19 +2908,26 @@ namespace confighttp {
       }
     }
 
-    // Scan Heroic Games Launcher (GOG + Epic via Legendary)
+    // Scan Heroic Games Launcher (GOG + Epic via Legendary), native and Flatpak installs
     nlohmann::json heroic_games = nlohmann::json::array();
-    if (!home_roots.empty()) {
-      std::vector<std::pair<std::string, std::string>> heroic_paths;
-      for (const auto &home : home_roots) {
-        heroic_paths.emplace_back((home / ".config/heroic/gog_store/installed.json").string(), "gog");
-        heroic_paths.emplace_back((home / ".config/heroic/legendaryConfig/legendary/installed.json").string(), "epic");
+    std::set<std::string> seen_heroic_keys;
+    const auto heroic_already_imported = [&existing_cmds](const std::string &store, const std::string &app_name) {
+      // A title can already be published under either install's command form, including one
+      // a user typed by hand before this scan could find their Flatpak.
+      for (const auto &candidate : game_library::heroic_launch_commands(store, app_name)) {
+        if (existing_cmds.count(candidate) > 0) {
+          return true;
+        }
       }
 
-      for (const auto &[path, store] : heroic_paths) {
-        if (!std::filesystem::exists(path)) continue;
+      return false;
+    };
+
+    if (!home_roots.empty()) {
+      for (const auto &[library_path, store, install] : game_library::heroic_installed_files(home_roots)) {
+        if (!std::filesystem::exists(library_path)) continue;
         try {
-          std::ifstream f(path);
+          std::ifstream f(library_path);
           auto data = nlohmann::json::parse(f);
 
           // Heroic installed.json: { "installed": [ { "app_name": "...", "title": "...", ... } ] }
@@ -2993,8 +2950,15 @@ namespace confighttp {
             // Skip DLC / tools
             if (entry.contains("is_dlc") && entry["is_dlc"].get<bool>()) continue;
 
-            std::string launch_cmd = "setsid heroic heroic://launch/" + store + "/" + app_name;
-            bool already = existing_cmds.count(launch_cmd) > 0;
+            // Both installs can hold the same title, and the launch command follows the
+            // install this entry came from.
+            if (!seen_heroic_keys.insert(store + "/" + app_name).second) continue;
+
+            std::string launch_cmd = game_library::heroic_launch_command(store, app_name, install);
+            if (launch_cmd.empty()) {
+              BOOST_LOG(warning) << "Skipped Heroic title [" << title << "]: app name is not safe to launch";
+              continue;
+            }
 
             nlohmann::json game;
             game["name"] = title;
@@ -3002,24 +2966,19 @@ namespace confighttp {
             game["store"] = store;
             game["cmd"] = launch_cmd;
             game["source"] = "heroic";
-            game["already_imported"] = already;
+            game["already_imported"] = heroic_already_imported(store, app_name);
             heroic_games.push_back(game);
           }
         } catch (const std::exception &e) {
-          BOOST_LOG(warning) << "Failed to parse Heroic library at " << path << ": " << e.what();
+          BOOST_LOG(warning) << "Failed to parse Heroic library at " << library_path.string() << ": " << e.what();
         }
       }
 
       // Also check Heroic library.json (a combined library cache)
-      std::vector<std::pair<std::string, std::string>> heroic_cache_paths;
-      for (const auto &home : home_roots) {
-        heroic_cache_paths.emplace_back((home / ".config/heroic/store_cache/gog_library.json").string(), "gog");
-        heroic_cache_paths.emplace_back((home / ".config/heroic/store_cache/egs_library.json").string(), "epic");
-      }
-      for (const auto &[path, store] : heroic_cache_paths) {
-        if (!std::filesystem::exists(path)) continue;
+      for (const auto &[library_path, store, install] : game_library::heroic_cache_files(home_roots)) {
+        if (!std::filesystem::exists(library_path)) continue;
         try {
-          std::ifstream f(path);
+          std::ifstream f(library_path);
           auto data = nlohmann::json::parse(f);
           auto &lib = data.contains("library") ? data["library"] : data;
           if (!lib.is_array()) continue;
@@ -3027,16 +2986,15 @@ namespace confighttp {
             std::string app_name = entry.value("app_name", "");
             std::string title = entry.value("title", entry.value("app_name", ""));
             if (title.empty() || app_name.empty()) continue;
-            // Skip if already found from installed.json
-            bool dup = false;
-            for (const auto &existing : heroic_games) {
-              if (existing["app_name"] == app_name) { dup = true; break; }
-            }
-            if (dup) continue;
             if (!entry.value("is_installed", false)) continue;
+            // Skip what installed.json or the other install already provided
+            if (!seen_heroic_keys.insert(store + "/" + app_name).second) continue;
 
-            std::string launch_cmd = "setsid heroic heroic://launch/" + store + "/" + app_name;
-            bool already = existing_cmds.count(launch_cmd) > 0;
+            std::string launch_cmd = game_library::heroic_launch_command(store, app_name, install);
+            if (launch_cmd.empty()) {
+              BOOST_LOG(warning) << "Skipped Heroic title [" << title << "]: app name is not safe to launch";
+              continue;
+            }
 
             nlohmann::json game;
             game["name"] = title;
@@ -3044,7 +3002,7 @@ namespace confighttp {
             game["store"] = store;
             game["cmd"] = launch_cmd;
             game["source"] = "heroic";
-            game["already_imported"] = already;
+            game["already_imported"] = heroic_already_imported(store, app_name);
             heroic_games.push_back(game);
           }
         } catch (...) {}

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -191,8 +191,87 @@ namespace game_library {
       }
     }
 
+    constexpr std::string_view heroic_flatpak_app_id = "com.heroicgameslauncher.hgl";
+    constexpr std::string_view lutris_flatpak_app_id = "net.lutris.Lutris";
+
+    /**
+     * @brief Whether PATH holds an executable by this name.
+     *
+     * A Flatpak-only host has the launcher installed and no such binary, and asking before
+     * spawning keeps the scan from paying for a shell that can only fail.
+     */
+    bool binary_on_path(std::string_view name) {
+    #if defined(_WIN32)
+      (void) name;
+      return false;
+    #else
+      const char *path_env = std::getenv("PATH");
+      if (!path_env || !*path_env) {
+        return false;
+      }
+
+      std::string_view remaining(path_env);
+      while (true) {
+        const auto separator = remaining.find(':');
+        const auto entry = remaining.substr(0, separator);
+        if (!entry.empty()) {
+          const auto candidate = (std::filesystem::path(entry) / name).string();
+          if (::access(candidate.c_str(), X_OK) == 0) {
+            return true;
+          }
+        }
+
+        if (separator == std::string_view::npos) {
+          return false;
+        }
+        remaining.remove_prefix(separator + 1);
+      }
+    #endif
+    }
+
+    struct heroic_config_root_t {
+      std::filesystem::path path;
+      launcher_install_t install = launcher_install_t::native;
+    };
+
+    /** @brief Heroic's config directory for every install we can see, native first. */
+    std::vector<heroic_config_root_t> heroic_config_roots(const std::vector<std::filesystem::path> &home_roots) {
+      std::vector<heroic_config_root_t> roots;
+      std::set<std::filesystem::path> seen;
+      const auto append = [&roots, &seen](std::filesystem::path path, launcher_install_t install) {
+        if (path.empty()) {
+          return;
+        }
+
+        path = path.lexically_normal();
+        if (seen.insert(path).second) {
+          roots.push_back(heroic_config_root_t {std::move(path), install});
+        }
+      };
+
+      for (const auto &home : home_roots) {
+        if (home.empty()) {
+          continue;
+        }
+
+        append(home / ".config" / "heroic", launcher_install_t::native);
+        append(
+          home / ".var" / "app" / std::filesystem::path(heroic_flatpak_app_id) / "config" / "heroic",
+          launcher_install_t::flatpak
+        );
+      }
+
+      return roots;
+    }
+
     std::string read_lutris_list_games_json() {
     #ifdef __linux__
+      // Flatpak-only hosts have no lutris binary. Their games come from the directory scan,
+      // which reads the same YAML out of the Flatpak home instead of shelling out.
+      if (!binary_on_path("lutris")) {
+        return {};
+      }
+
       std::string output;
       std::array<char, 4096> buffer {};
       FILE *pipe = popen("lutris --list-games --json 2>/dev/null", "r");
@@ -234,7 +313,156 @@ namespace game_library {
   }
 
   std::string lutris_launch_command(const std::string &slug) {
-    return "setsid lutris lutris:rungame/" + slug;
+    return lutris_launch_command(slug, launcher_install_t::native);
+  }
+
+  std::string lutris_launch_command(const std::string &slug, launcher_install_t install) {
+    const auto uri = "lutris:rungame/" + slug;
+    if (install == launcher_install_t::flatpak) {
+      return "setsid flatpak run " + std::string(lutris_flatpak_app_id) + " " + uri;
+    }
+
+    return "setsid lutris " + uri;
+  }
+
+  std::vector<std::filesystem::path> lutris_game_config_dirs(const std::vector<std::filesystem::path> &home_roots) {
+    std::vector<std::filesystem::path> dirs;
+    const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+    const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
+    if (xdg_config_home && *xdg_config_home) {
+      append_unique_path(dirs, std::filesystem::path(xdg_config_home) / "lutris" / "games");
+    }
+    if (xdg_data_home && *xdg_data_home) {
+      append_unique_path(dirs, std::filesystem::path(xdg_data_home) / "lutris" / "games");
+    }
+
+    for (const auto &home : home_roots) {
+      if (home.empty()) {
+        continue;
+      }
+
+      append_unique_path(dirs, home / ".config" / "lutris" / "games");
+      append_unique_path(dirs, home / ".local" / "share" / "lutris" / "games");
+
+      const auto flatpak_home = home / ".var" / "app" / std::filesystem::path(lutris_flatpak_app_id);
+      append_unique_path(dirs, flatpak_home / "config" / "lutris" / "games");
+      append_unique_path(dirs, flatpak_home / "data" / "lutris" / "games");
+    }
+
+    return dirs;
+  }
+
+  std::vector<std::filesystem::path> lutris_art_roots(const std::vector<std::filesystem::path> &home_roots) {
+    std::vector<std::filesystem::path> roots;
+    const char *xdg_data_home = std::getenv("XDG_DATA_HOME");
+    const char *xdg_cache_home = std::getenv("XDG_CACHE_HOME");
+    if (xdg_data_home && *xdg_data_home) {
+      append_unique_path(roots, std::filesystem::path(xdg_data_home) / "lutris");
+    }
+    if (xdg_cache_home && *xdg_cache_home) {
+      append_unique_path(roots, std::filesystem::path(xdg_cache_home) / "lutris");
+    }
+
+    for (const auto &home : home_roots) {
+      if (home.empty()) {
+        continue;
+      }
+
+      append_unique_path(roots, home / ".local" / "share" / "lutris");
+      append_unique_path(roots, home / ".cache" / "lutris");
+
+      const auto flatpak_home = home / ".var" / "app" / std::filesystem::path(lutris_flatpak_app_id);
+      append_unique_path(roots, flatpak_home / "data" / "lutris");
+      append_unique_path(roots, flatpak_home / "cache" / "lutris");
+    }
+
+    return roots;
+  }
+
+  bool path_is_under_flatpak_app(const std::filesystem::path &path, std::string_view app_id) {
+    if (app_id.empty()) {
+      return false;
+    }
+
+    const auto normalized = path.lexically_normal();
+    for (auto part = normalized.begin(); part != normalized.end(); ++part) {
+      if (part->string() != ".var") {
+        continue;
+      }
+
+      const auto app_dir = std::next(part);
+      if (app_dir == normalized.end() || app_dir->string() != "app") {
+        continue;
+      }
+
+      const auto id = std::next(app_dir);
+      if (id != normalized.end() && id->string() == app_id) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  std::vector<heroic_library_file_t> heroic_installed_files(const std::vector<std::filesystem::path> &home_roots) {
+    std::vector<heroic_library_file_t> files;
+    for (const auto &root : heroic_config_roots(home_roots)) {
+      files.push_back(heroic_library_file_t {root.path / "gog_store" / "installed.json", "gog", root.install});
+      files.push_back(heroic_library_file_t {
+        root.path / "legendaryConfig" / "legendary" / "installed.json",
+        "epic",
+        root.install
+      });
+    }
+
+    return files;
+  }
+
+  std::vector<heroic_library_file_t> heroic_cache_files(const std::vector<std::filesystem::path> &home_roots) {
+    std::vector<heroic_library_file_t> files;
+    for (const auto &root : heroic_config_roots(home_roots)) {
+      files.push_back(heroic_library_file_t {root.path / "store_cache" / "gog_library.json", "gog", root.install});
+      files.push_back(heroic_library_file_t {root.path / "store_cache" / "egs_library.json", "epic", root.install});
+    }
+
+    return files;
+  }
+
+  bool is_heroic_app_name_safe(const std::string &app_name) {
+    if (app_name.empty()) {
+      return false;
+    }
+
+    return std::all_of(app_name.begin(), app_name.end(), [](unsigned char ch) {
+      return std::isalnum(ch) || ch == '-' || ch == '_' || ch == '.';
+    });
+  }
+
+  std::string heroic_launch_command(const std::string &store, const std::string &app_name, launcher_install_t install) {
+    // Both halves reach a shell through the app's launch command, the same exposure the
+    // Steam app id and the Lutris slug are already checked for.
+    if (!is_heroic_app_name_safe(store) || !is_heroic_app_name_safe(app_name)) {
+      return {};
+    }
+
+    const auto uri = "heroic://launch/" + store + "/" + app_name;
+    if (install == launcher_install_t::flatpak) {
+      return "setsid flatpak run " + std::string(heroic_flatpak_app_id) + " " + uri;
+    }
+
+    return "setsid heroic " + uri;
+  }
+
+  std::vector<std::string> heroic_launch_commands(const std::string &store, const std::string &app_name) {
+    std::vector<std::string> commands;
+    for (const auto install : {launcher_install_t::native, launcher_install_t::flatpak}) {
+      auto command = heroic_launch_command(store, app_name, install);
+      if (!command.empty()) {
+        commands.push_back(std::move(command));
+      }
+    }
+
+    return commands;
   }
 
   std::string find_lutris_image_path(const std::string &slug, const std::vector<std::filesystem::path> &lutris_roots) {
@@ -537,11 +765,17 @@ namespace game_library {
       name = slug_to_name(slug);
     }
 
+    // Where the config was found is what says how to launch it: a config under
+    // ~/.var/app/net.lutris.Lutris belongs to a Flatpak install that has no lutris on PATH.
+    const auto install = path_is_under_flatpak_app(path, lutris_flatpak_app_id) ?
+      launcher_install_t::flatpak :
+      launcher_install_t::native;
+
     return lutris_game_t {
       .name = name,
       .slug = slug,
       .runner = runner,
-      .command = lutris_launch_command(slug),
+      .command = lutris_launch_command(slug, install),
     };
   }
 

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -14,6 +14,18 @@
 
 namespace game_library {
 
+  /**
+   * @brief Which packaging of a launcher a library entry was discovered through.
+   *
+   * The launch command has to follow the install that produced the entry: a Flatpak-only
+   * host has no `heroic` or `lutris` on PATH, and a native host should keep the command it
+   * already has.
+   */
+  enum class launcher_install_t {
+    native,
+    flatpak,
+  };
+
   struct lutris_game_t {
     std::string name;
     std::string slug;
@@ -39,11 +51,53 @@ namespace game_library {
   std::vector<std::filesystem::path> library_home_roots();
   std::string find_lutris_image_path(const std::string &slug, const std::vector<std::filesystem::path> &lutris_roots);
   std::string lutris_launch_command(const std::string &slug);
+  std::string lutris_launch_command(const std::string &slug, launcher_install_t install);
   std::vector<lutris_game_t> parse_lutris_list_games_json(std::string_view json_payload);
   std::optional<lutris_game_t> parse_lutris_game_config(const std::filesystem::path &path);
   std::vector<lutris_game_t> scan_lutris_games(const std::filesystem::path &games_dir);
   std::vector<lutris_game_t> scan_lutris_games(const std::vector<std::filesystem::path> &games_dirs);
   std::vector<lutris_game_t> scan_lutris_library(const std::vector<std::filesystem::path> &games_dirs);
+
+  /** @brief Where Lutris keeps its per-game YAML, for each install we can see. */
+  std::vector<std::filesystem::path> lutris_game_config_dirs(const std::vector<std::filesystem::path> &home_roots);
+
+  /** @brief Where Lutris keeps its artwork, for each install we can see. */
+  std::vector<std::filesystem::path> lutris_art_roots(const std::vector<std::filesystem::path> &home_roots);
+
+  /**
+   * @brief True when the path lives inside a Flatpak application's per-app home.
+   *
+   * Flatpak maps `XDG_CONFIG_HOME` and friends into `~/.var/app/<app-id>/`, so where a
+   * library file was found is what tells us how to launch it.
+   */
+  bool path_is_under_flatpak_app(const std::filesystem::path &path, std::string_view app_id);
+
+  /** @brief One Heroic library file, and the install it belongs to. */
+  struct heroic_library_file_t {
+    std::filesystem::path path;
+    std::string store;  // the segment Heroic expects in heroic://launch/<store>/<app_name>
+    launcher_install_t install = launcher_install_t::native;
+  };
+
+  /** @brief Heroic's installed-games manifests, native install first. */
+  std::vector<heroic_library_file_t> heroic_installed_files(const std::vector<std::filesystem::path> &home_roots);
+
+  /** @brief Heroic's cached store libraries, used when a manifest is missing. */
+  std::vector<heroic_library_file_t> heroic_cache_files(const std::vector<std::filesystem::path> &home_roots);
+
+  /**
+   * @brief True when a Heroic app name or store is safe to place in a launch command.
+   *
+   * Both come out of a file on disk and end up in a shell command, the same exposure the
+   * Steam app id and the Lutris slug are already checked for.
+   */
+  bool is_heroic_app_name_safe(const std::string &app_name);
+
+  /** @brief The `heroic://launch` command for one title, for the install that has it. */
+  std::string heroic_launch_command(const std::string &store, const std::string &app_name, launcher_install_t install);
+
+  /** @brief Every command form that could launch one Heroic title, for import dedup. */
+  std::vector<std::string> heroic_launch_commands(const std::string &store, const std::string &app_name);
 
   /**
    * @brief Steam app id to playtime, read from one localconfig.vdf payload.

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -3,6 +3,7 @@
 
 #include <src/game_library_scanner.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 
@@ -297,4 +298,109 @@ TEST(LutrisLibraryScannerTests, CarriesPlaytimeSecondsFromTheListingJson) {
 
   ASSERT_EQ(games.size(), 1u);
   EXPECT_EQ(games.front().playtime_seconds, 73);
+}
+
+TEST(FlatpakLibraryTests, RecognisesPathsInsideAFlatpakApplicationHome) {
+  EXPECT_TRUE(game_library::path_is_under_flatpak_app(
+    "/tmp/library-home/.var/app/net.lutris.Lutris/config/lutris/games/game.yml",
+    "net.lutris.Lutris"));
+  EXPECT_TRUE(game_library::path_is_under_flatpak_app(
+    "/tmp/library-home/.var/app/com.heroicgameslauncher.hgl/config/heroic",
+    "com.heroicgameslauncher.hgl"));
+
+  // A different application's home, the native home, and a lookalike prefix are not it.
+  EXPECT_FALSE(game_library::path_is_under_flatpak_app(
+    "/tmp/library-home/.var/app/com.valvesoftware.Steam/config/lutris/games/game.yml",
+    "net.lutris.Lutris"));
+  EXPECT_FALSE(game_library::path_is_under_flatpak_app(
+    "/tmp/library-home/.config/lutris/games/game.yml",
+    "net.lutris.Lutris"));
+  EXPECT_FALSE(game_library::path_is_under_flatpak_app(
+    "/tmp/library-home/.var/app/net.lutris.Lutris.backup/config/lutris/games/game.yml",
+    "net.lutris.Lutris"));
+}
+
+TEST(LutrisLibraryScannerTests, IncludesFlatpakGameAndArtDirectories) {
+  const std::filesystem::path home = "/tmp/library-home";
+  const auto dirs = game_library::lutris_game_config_dirs({home});
+  const auto roots = game_library::lutris_art_roots({home});
+
+  const auto contains = [](const auto &haystack, const std::filesystem::path &needle) {
+    return std::find(haystack.begin(), haystack.end(), needle) != haystack.end();
+  };
+
+  EXPECT_TRUE(contains(dirs, home / ".config/lutris/games"));
+  EXPECT_TRUE(contains(dirs, home / ".local/share/lutris/games"));
+  EXPECT_TRUE(contains(dirs, home / ".var/app/net.lutris.Lutris/config/lutris/games"));
+  EXPECT_TRUE(contains(dirs, home / ".var/app/net.lutris.Lutris/data/lutris/games"));
+
+  EXPECT_TRUE(contains(roots, home / ".local/share/lutris"));
+  EXPECT_TRUE(contains(roots, home / ".cache/lutris"));
+  EXPECT_TRUE(contains(roots, home / ".var/app/net.lutris.Lutris/data/lutris"));
+  EXPECT_TRUE(contains(roots, home / ".var/app/net.lutris.Lutris/cache/lutris"));
+}
+
+TEST(LutrisLibraryScannerTests, LaunchesAFlatpakConfigThroughFlatpak) {
+  const auto root = lutris_test_root("flatpak_config");
+  const auto games_dir = root / ".var/app/net.lutris.Lutris/config/lutris/games";
+  std::filesystem::create_directories(games_dir);
+  write_text(games_dir / "vintage-story.yml",
+    "name: Vintage Story\n"
+    "slug: vintage-story\n"
+    "runner: linux\n");
+
+  const auto game = game_library::parse_lutris_game_config(games_dir / "vintage-story.yml");
+  ASSERT_TRUE(game.has_value());
+  EXPECT_EQ(game->command, "setsid flatpak run net.lutris.Lutris lutris:rungame/vintage-story");
+
+  // The same slug from a native install keeps the command it already had.
+  EXPECT_EQ(game_library::lutris_launch_command("vintage-story"), "setsid lutris lutris:rungame/vintage-story");
+}
+
+TEST(HeroicLibraryScannerTests, ListsBothInstallsForEveryStoreFile) {
+  const std::filesystem::path home = "/tmp/library-home";
+  const auto installed = game_library::heroic_installed_files({home});
+  const auto cached = game_library::heroic_cache_files({home});
+
+  ASSERT_EQ(installed.size(), 4u);
+  EXPECT_EQ(installed[0].path, home / ".config/heroic/gog_store/installed.json");
+  EXPECT_EQ(installed[0].store, "gog");
+  EXPECT_EQ(installed[0].install, game_library::launcher_install_t::native);
+  EXPECT_EQ(installed[1].path, home / ".config/heroic/legendaryConfig/legendary/installed.json");
+  EXPECT_EQ(installed[1].store, "epic");
+  EXPECT_EQ(installed[2].path, home / ".var/app/com.heroicgameslauncher.hgl/config/heroic/gog_store/installed.json");
+  EXPECT_EQ(installed[2].install, game_library::launcher_install_t::flatpak);
+  EXPECT_EQ(installed[3].path,
+    home / ".var/app/com.heroicgameslauncher.hgl/config/heroic/legendaryConfig/legendary/installed.json");
+
+  ASSERT_EQ(cached.size(), 4u);
+  EXPECT_EQ(cached[0].path, home / ".config/heroic/store_cache/gog_library.json");
+  EXPECT_EQ(cached[1].path, home / ".config/heroic/store_cache/egs_library.json");
+  EXPECT_EQ(cached[2].path, home / ".var/app/com.heroicgameslauncher.hgl/config/heroic/store_cache/gog_library.json");
+  EXPECT_EQ(cached[2].install, game_library::launcher_install_t::flatpak);
+}
+
+TEST(HeroicLibraryScannerTests, BuildsTheCommandForTheInstallThatHasTheTitle) {
+  EXPECT_EQ(
+    game_library::heroic_launch_command("gog", "1207658930", game_library::launcher_install_t::native),
+    "setsid heroic heroic://launch/gog/1207658930");
+  EXPECT_EQ(
+    game_library::heroic_launch_command("gog", "1207658930", game_library::launcher_install_t::flatpak),
+    "setsid flatpak run com.heroicgameslauncher.hgl heroic://launch/gog/1207658930");
+
+  const auto both = game_library::heroic_launch_commands("epic", "Snow");
+  ASSERT_EQ(both.size(), 2u);
+  EXPECT_EQ(both[0], "setsid heroic heroic://launch/epic/Snow");
+  EXPECT_EQ(both[1], "setsid flatpak run com.heroicgameslauncher.hgl heroic://launch/epic/Snow");
+}
+
+TEST(HeroicLibraryScannerTests, RefusesAppNamesThatWouldReachTheShell) {
+  EXPECT_TRUE(game_library::is_heroic_app_name_safe("Grimoire.Manastone_1207658930"));
+  EXPECT_FALSE(game_library::is_heroic_app_name_safe(""));
+  EXPECT_FALSE(game_library::is_heroic_app_name_safe("app; rm -rf ~"));
+  EXPECT_FALSE(game_library::is_heroic_app_name_safe("app$(id)"));
+
+  EXPECT_TRUE(game_library::heroic_launch_command("gog", "app; rm -rf ~", game_library::launcher_install_t::native).empty());
+  EXPECT_TRUE(game_library::heroic_launch_command("gog && id", "1207658930", game_library::launcher_install_t::native).empty());
+  EXPECT_TRUE(game_library::heroic_launch_commands("gog", "app; rm -rf ~").empty());
 }


### PR DESCRIPTION
## Summary

Closes #451.

- Discovers Heroic under `~/.var/app/com.heroicgameslauncher.hgl/config/heroic/`, for all four files the scan already reads: both `installed.json` manifests and both `store_cache` libraries.
- Discovers Lutris under `~/.var/app/net.lutris.Lutris/{config,data,cache}/lutris`, for per-game YAML and for artwork.
- Builds the launch command from the install that produced the entry: `setsid flatpak run com.heroicgameslauncher.hgl "heroic://launch/<store>/<app_name>"` and `setsid flatpak run net.lutris.Lutris lutris:rungame/<slug>` for Flatpak installs, unchanged commands for native ones. A Lutris config's install is inferred from where the config was found, so a host with both installs gets the right command per game.
- Deduplicates Heroic entries on store and app name across both installs and both manifest passes, replacing an app-name-only scan of the results so far.
- Reports a title as already imported when any known command form for it is already published, so a re-scan after this change does not offer a duplicate of a title imported under the other form, including one a user added by hand.
- Checks the Heroic app name and store before they reach a launch command, the same guard `is_valid_steam_appid` and `is_lutris_slug_safe` already provide, and logs a skipped title instead of dropping it silently.
- Skips the `lutris --list-games --json` probe when no `lutris` binary is on PATH. The popen previously ran and failed on every scan of a host without it, and a Flatpak-only host is served by the directory scan instead.

Moves `lutris_game_config_dirs` and `lutris_art_roots` out of `confighttp.cpp` into `game_library_scanner`, beside `steam_data_roots`, so root derivation lives in one place and is unit testable.

### Known boundary

On a host with both a native and a Flatpak Lutris where the native CLI answers, `scan_lutris_library` still returns the CLI result alone, so games that exist only in the Flatpak install are not listed. That early return is existing behavior. Removing it would merge the directory scan into every native host's results, which can resurrect YAML for games that were uninstalled, so it is left alone here.

Heroic artwork, playtime, runtime metadata, a stable import key, and a Heroic launcher entry are #452, deliberately not in this change.

## Exact candidate

`Commit: 8022bc8fe8128f1fada1d8ee89d5da6744de5273`
`Tree:   254945c9ac5bdab76fcf4b68e92d8a69867e326e`
`Parent: 46e6fed3b562414af5e3c6041ebb01b1ae0b2fe4`
`Base:   46e6fed3b562414af5e3c6041ebb01b1ae0b2fe4 (master)`

## Verification

Built and run on Fedora, pc-papi, from a clean worktree at this exact commit.

- [x] `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DPOLARIS_ENABLE_CUDA=OFF -DPOLARIS_ALLOW_CUDA_DISABLED_ON_NVIDIA=ON -DBOOST_USE_STATIC=OFF -DBUILD_TESTS=ON -DBUILD_TESTING=ON -DBUILD_FULL_TESTS=ON`, then `ninja`, exit 0
- [x] `ctest --output-on-failure -j$(nproc)`: 17/17 suites passed
- [x] `./tests/test_polaris --gtest_filter='*Heroic*:*Flatpak*:*Lutris*'`: 14 tests passed, 6 of them new
- [x] `bash scripts/check-public-surface.sh`, `bash scripts/check-public-docs.sh`, `python3 scripts/check-release-package-dependencies.py`, `python3 scripts/check-nix-patches.py`: all exit 0

New coverage: Flatpak application home detection including a lookalike app id, Flatpak game and art directories in both root lists, a Lutris config under the Flatpak home producing the Flatpak command while a native slug keeps its own, both installs listed for every Heroic store file with the right install tag, both Heroic command forms, and app names and stores that would reach a shell being refused.

Not covered: no host with a real Flatpak Heroic or Flatpak Lutris install was available to run an end-to-end scan against, so discovery is proven against the path contract and the unit tests rather than against a live Flatpak library. The reporter in #443 runs Flatpak Heroic on Bazzite and is the natural confirmation.
