### PR TITLE
ci(nix): give the polaris-stream build its submodules

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -153,6 +153,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # third-party/* are git submodules that cmake's wayland-scanner step
+          # needs. Checking them out puts them on disk; the ?submodules=1 flake
+          # ref below is what actually carries them into the nix build, because
+          # the flake source is `self` and nix does not descend into submodules
+          # on its own even when the files are present.
+          submodules: recursive
 
       - name: Free runner disk space
         # A CUDA-enabled closure does not fit next to the runner's preinstalled
@@ -170,4 +177,4 @@ jobs:
       - name: Build polaris-stream
         # npmDepsHash pins the npm dependency set by content, so this is also
         # what catches package-lock.json moving without the flake following.
-        run: nix build --print-build-logs .#polaris-stream
+        run: nix build --print-build-logs '.?submodules=1#polaris-stream'


### PR DESCRIPTION
## Summary

Gives the `Build polaris-stream` nix job the git submodules it needs, on disk and in the flake source. The job has never passed, and it fails identically on `master`.

## Root cause

Three runs exist. The 2026-08-10 cron failed on the stale `npmDepsHash` that #392 fixed on 08-13. A 2026-08-13 dispatch was cancelled. A 2026-08-16 dispatch reached the real failure:

```
wayland-scanner private-code .../third-party/wayland-protocols/unstable/xdg-output/xdg-output-unstable-v1.xml
Could not open input file: No such file or directory
CMake Error at cmake/macros/linux.cmake:25 (message): wayland-scanner failed
```

The hash failure was masking this one, so #392 fixing the hash only exposed the next layer.

`third-party/wayland-protocols` is a git submodule, and none of the five `actions/checkout@v7` steps in `nix.yml` requested submodules. The job therefore configured against an empty `third-party/`, and cmake's `GEN_WAYLAND` step died.

## Why both halves are needed

`submodules: recursive` puts the content on disk. `.?submodules=1#polaris-stream` is what carries it into the build: the flake source is `polarisSrc = cleanSourceWith { src = self; }`, and nix does not descend into submodules when resolving `self` even when the files are present in the working tree. Either change alone leaves the build failing.

The existing source filter already permits `third-party/`, so nothing there changes.

## Scope

Scoped to the `polaris-stream` job. The other four checkouts build gamescope patches, evaluate the flake, or build the web UI. None reach the C++ tree and all four are currently green.

## Verification

- [x] Confirmed pre-existing on `master`, not branch-specific: dispatched `nix.yml` on `master` as a control (run `31981751549`) and it failed on `Build polaris-stream` with `Patch stacks`, `Flake eval`, `npm deps` and `gamescope-polaris` all green, matching the failing dispatch on an unrelated branch (run `31980394700`).
- [x] `yaml.safe_load` parses the edited workflow and still reports all five jobs.
- [x] Dispatch on this branch green. Run `31984036265`: `Build polaris-stream=success`, alongside `Patch stacks`, `Flake eval`, `npm deps` and `gamescope-polaris`. **This is the first time this job has ever passed.** A dispatch-only job cannot prove itself from a PR check, so this run is the evidence.

## Consequence worth stating

No v1.3.x has had a verified Nix package build. This does not affect the released artifacts, which are the Arch, Fedora, SteamOS and Ubuntu packages built by their own jobs, all currently green.

## Notes

No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes. CI configuration only.
