### PR TITLE
fix(linux): report effective private stream path

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -127,7 +127,6 @@ namespace cage_display_router {
     .effective_headless = false,
     .gpu_native_override_active = false,
     .backend_name = "labwc",
-    .path_id = "headless_stream",
   };
 
   // -----------------------------------------------------------------------
@@ -1102,6 +1101,7 @@ namespace cage_display_router {
     cage_runtime_state.effective_headless = headless;
     cage_runtime_state.gpu_native_override_active = requested_headless && force_windowed;
     cage_runtime_state.backend_name = "labwc";
+    cage_runtime_state.path_id = headless ? "headless_stream" : "windowed_stream";
     cage_runtime_state.reported_output_refresh_hz = 0.0;
 
     BOOST_LOG(info) << "labwc: requested_headless=" << requested_headless

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -205,6 +205,10 @@ HEADLESS-1 "Fake headless output"
   Enabled: yes
   Modes:
     1280x720 px, 60.000000 Hz (current)
+WL-1 "Fake windowed output"
+  Enabled: yes
+  Modes:
+    1280x720 px, 60.000000 Hz (current)
 EOF
 fi
 exit 0
@@ -239,6 +243,13 @@ exit 0
       false,
       "external-exit-cycle-" + std::to_string(cycle)
     ));
+
+    const auto runtime_state = cage_display_router::runtime_state();
+    EXPECT_TRUE(runtime_state.requested_headless);
+    EXPECT_TRUE(runtime_state.effective_headless);
+    EXPECT_FALSE(runtime_state.gpu_native_override_active);
+    EXPECT_EQ(runtime_state.backend_name, "labwc");
+    EXPECT_EQ(runtime_state.path_id, "headless_stream");
 
     const auto router_pid = cage_display_router::get_pid();
     ASSERT_GT(router_pid, 0);
@@ -275,10 +286,16 @@ exit 0
     720,
     60,
     "",
-    false,
+    true,
     false,
     "explicit-stop-escalation"
   ));
+  const auto forced_windowed_runtime_state = cage_display_router::runtime_state();
+  EXPECT_TRUE(forced_windowed_runtime_state.requested_headless);
+  EXPECT_FALSE(forced_windowed_runtime_state.effective_headless);
+  EXPECT_TRUE(forced_windowed_runtime_state.gpu_native_override_active);
+  EXPECT_EQ(forced_windowed_runtime_state.backend_name, "labwc");
+  EXPECT_EQ(forced_windowed_runtime_state.path_id, "windowed_stream");
   const auto stopped_compositor_pid = wait_for_pid_file(compositor_pid_file);
   ASSERT_GT(stopped_compositor_pid, 0);
   const auto stopped_worker_pid = wait_for_pid_file(pid_file);


### PR DESCRIPTION
## Summary

- publish the labwc runtime path ID from the effective topology on every start
- leave the path ID unset before startup instead of advertising a path that is not active
- cover repeated headless relaunches and the forced-windowed fallback in the lifecycle regression

## Why

The labwc runtime state initialized `path_id` once, but teardown resets the state and startup did not repopulate the field. It also could not truthfully represent the forced-windowed path. As a result, runtime telemetry could report a missing or stale path identity even though capture was operating through a different effective topology.

Assigning the path ID next to the existing effective-headless state keeps telemetry aligned with the topology that was actually selected.

## Verification

- focused lifecycle regression: passed
- complete `test_polaris_platform`: 210/210 passed
- CUDA-enabled Release `polaris` target: built successfully
- `git diff --check`: passed
- independent exact-tree review: approved with no blockers

Local `clang-format` was not run because the formatter was unavailable; hosted CI remains authoritative for that gate.
