### PR TITLE
fix(linux): let headless_dongle configure itself from polaris.conf

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6641,8 +6641,20 @@ namespace proc {
 #endif
 
 #ifdef __linux__
-    // Enable streaming display BEFORE encoder probe so HDMI-A-1 is available
-    if (config::video.linux_display.auto_manage_displays) {
+    // Enable streaming display BEFORE encoder probe so the dongle is available.
+    //
+    // headless_dongle has to reach prepare_for_stream() even while
+    // auto_manage_displays is still false, because that path self-configures
+    // through ensure_dongle_outputs_configured(): it auto-detects the connectors,
+    // sets output_name, and is what turns auto_manage_displays on in the first
+    // place. Gating solely on the flag made the mode unconfigurable from
+    // polaris.conf, since apply_selection() is the only other place that sets it
+    // and headless_dongle is refused as a per-session override. The result was a
+    // session that streamed whatever the portal happened to grab, performed no
+    // topology swap, and never blanked the panel the mode promises to blank,
+    // without logging why.
+    if (config::video.linux_display.auto_manage_displays ||
+        config::video.linux_display.stream_mode == "headless_dongle") {
       int target_fps = launch_session->fps ? launch_session->fps : 60000;
       if (target_fps >= 1000) {
         target_fps /= 1000;

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -4436,6 +4436,29 @@ TEST(GamescopeNestedSessionContract, StartupUsesItsOwnVisibleTimeoutAndTheNixMod
   EXPECT_EQ(options.find("injectApps"), std::string::npos);
 }
 
+TEST(HeadlessDongleContract, HeadlessDongleReachesTopologyPrepareWithoutAutoManageAlreadyOn) {
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  const auto collapsed_source = collapse_whitespace(source);
+
+  // headless_dongle self-configures inside prepare_for_stream(): that path calls
+  // ensure_dongle_outputs_configured(), which auto-detects the connectors and is
+  // what sets auto_manage_displays. Gating the call solely on auto_manage_displays
+  // therefore made the mode unconfigurable from polaris.conf, because
+  // apply_selection() is the only other place that sets the flag and the mode is
+  // refused as a per-session override. The session still streamed, so the failure
+  // was silent: no topology swap and no blanked panel.
+  const auto guard = collapsed_source.find(
+    "if (config::video.linux_display.auto_manage_displays || "
+    "config::video.linux_display.stream_mode == \"headless_dongle\") {"
+  );
+  EXPECT_NE(guard, std::string::npos)
+    << "headless_dongle must reach enable_streaming_display even when "
+       "auto_manage_displays is still false, or the mode cannot self-configure";
+
+  const auto call = collapsed_source.find("linux_display::enable_streaming_display(", guard);
+  EXPECT_NE(call, std::string::npos);
+}
+
 TEST(GamescopeNestedSessionContract, TeardownGetsTheSameBudgetAndVisibilityAsStartup) {
   const auto source = read_source_file_for_contract("src/process.cpp");
   const auto collapsed_source = collapse_whitespace(source);


### PR DESCRIPTION
## Summary

`linux_stream_mode = headless_dongle` in `polaris.conf` produced a session that streamed, reported `path=headless_dongle`, and did none of what the mode promises: no topology swap, no panel blank, no output selection, and no log line explaining why.

Found while running the v1.3.10 mode matrix on a physical dummy plug. The session looked successful, which is what makes it worth fixing: the stream came up, so nothing suggested the mode was half-applied.

## Root cause: a chicken-and-egg

`prepare_for_stream()` is where the dongle path self-configures. It calls `ensure_dongle_outputs_configured()`, which auto-detects connectors from sysfs, sets `output_name`, and is itself what turns `auto_manage_displays` on.

But the call into it was gated behind `auto_manage_displays` already being true:

```cpp
if (config::video.linux_display.auto_manage_displays) {
  linux_display::enable_streaming_display(render_width, render_height, target_fps);
}
```

So the function that enables the flag could only run once the flag was enabled.

The only other place that sets it is `apply_selection()`, reached from the web UI (`nvhttp.cpp`) and from the per-session override path (`process.cpp`). `headless_dongle` is deliberately refused as a per-session override, because it swaps host output topology. **A config-file selection therefore could never configure the mode, and nothing said so.**

## The fix

One condition: also enter the block when the configured stream mode is `headless_dongle`. Everything downstream already exists and already handles this correctly, including the "dongle auto-detect incomplete" warning that until now could not fire.

## Verification

Run on a host configured exactly the way that failed: `linux_auto_manage_displays = disabled`, `linux_streaming_output` and `linux_primary_output` both unset. Real hardware, a WOIEYEK 4K dummy plug on HDMI-A-2 alongside a physical monitor on DP-2.

**Before**, the launch logged **zero** `display_topology` lines. Session topology was `output=;auto_manage=0`. DP-2 stayed on the whole time.

**After**, same config, same launch:

```
display_topology: auto-selected primary_output=[DP-2]
display_topology: auto-enabling auto_manage_displays (dongle outputs ready)
display_topology: requested mode [1920x1080@60Hz] on output [HDMI-A-2]
display_topology: settle ok early for priority_streaming [HDMI-A-2] want_enabled=true
display_topology: settle ok early for disable_primary [DP-2] want_enabled=false
```

Session topology became `output=HDMI-A-2;auto_manage=1`. `/sys/class/drm` confirmed `card2-DP-2 enabled=disabled dpms=Off` during the session, so the panel genuinely blanked, which is the whole point of `headless_swap_mode=privacy`.

Teardown restored DP-2 to `enabled=enabled dpms=On` without intervention.

- [x] Linux production target builds.
- [x] Live before/after on affected hardware, above.
- [x] Contract assertions checked directly against the patched source.
- [ ] Test binaries not linked locally; this host hits an unrelated libstdc++ `__notify_impl` ABI failure in a different test. CI is the gate.

## Not fixed here

Capture on this path runs `capture_transport=shm` and the dongle is captured at its native mode, so a 4K-only dummy plug pays a 4K CPU copy to feed a 1080p client. That is a separate performance question and wants its own issue rather than being folded into a correctness fix.

## Notes

No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes.
