### PR TITLE
fix(nvhttp): tell clients which modes they may drive per session

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -438,18 +438,22 @@ namespace nvhttp {
   #if defined(__linux__)
     // Session-scoped stream-mode override gate: returns the requested mode when
     // it may drive this session, empty otherwise (the host default applies).
-    // headless_dongle swaps host output topology, so it stays host-default-only.
+    // Which modes qualify is derived from the path registry rather than listed
+    // here, and the same rule is served to clients as session_overridable so a
+    // client does not offer a choice this gate will drop.
     std::string accepted_session_stream_mode(const std::string &requested, std::string &reject_reason) {
       if (requested.empty()) {
         return {};
       }
-      if (requested == "headless_dongle") {
-        reject_reason = "headless_dongle is not supported as a per-session override";
-        return {};
-      }
+      // Validity first: an unknown or unavailable id deserves its own reason
+      // rather than being reported as a per-session restriction.
       std::string error;
       if (!stream_display_policy::selection_valid(requested, error)) {
         reject_reason = error;
+        return {};
+      }
+      if (!stream_display_policy::selection_session_overridable(requested)) {
+        reject_reason = requested + " swaps host display topology, so it is host-default only";
         return {};
       }
       return requested;
@@ -1344,6 +1348,11 @@ namespace nvhttp {
           {"runtime", option.runtime},
           {"capture", option.capture},
           {"topology", option.topology},
+          // Available and session-overridable are different questions. A dongle
+          // swap is a perfectly valid host default while still being something a
+          // single client must not switch on for one launch, and a client that
+          // cannot see the difference offers a choice the host will silently drop.
+          {"session_overridable", stream_display_policy::selection_session_overridable(option.value)},
         });
       }
 #else

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -64,6 +64,15 @@ namespace stream_display_policy {
     return false;
   }
 
+  bool selection_session_overridable(std::string_view selection) {
+    if (const auto *path = stream_path::find(selection)) {
+      // Swapping the host's primary output rearranges the machine itself, so it
+      // is a host decision rather than something one client turns on per launch.
+      return path->topology != stream_path::topology_kind_e::SWAP_PRIMARY;
+    }
+    return false;
+  }
+
   std::string selection_unavailable_reason(std::string_view selection) {
     if (const auto *path = stream_path::find(selection)) {
       // Probe-dependent reasons are not in the static registry entry; mirror

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -68,6 +68,16 @@ namespace stream_display_policy {
    */
   bool selection_available(std::string_view selection);
 
+  /**
+   * @brief Whether a client may drive this selection for one session.
+   *
+   * A path that swaps host output topology changes the machine's physical display
+   * arrangement, so it stays host-default-only rather than something a single
+   * client can turn on for one launch. Derived from the path's topology rather
+   * than an id list, so a future swapping path inherits the rule.
+   */
+  bool selection_session_overridable(std::string_view selection);
+
   std::string selection_unavailable_reason(std::string_view selection);
 
   /**

--- a/tests/unit/test_launch_mode_contract.cpp
+++ b/tests/unit/test_launch_mode_contract.cpp
@@ -92,6 +92,23 @@ TEST(SessionStreamMode, AcceptsRegistryModesItCanRunPerSession) {
   EXPECT_EQ(nvhttp::accepted_session_stream_mode_for_tests("desktop_display"), "desktop_display");
 }
 
+TEST(SessionStreamMode, DerivesSessionOverridabilityFromTopologyNotAnIdList) {
+  // The rule a client is told and the rule the gate enforces have to be the
+  // same rule, or the client offers a mode the host silently drops. It is
+  // derived from the path's topology so a future swapping path inherits it
+  // without editing a list: swapping the host's primary output rearranges the
+  // machine itself, which is a host decision rather than a per-launch one.
+  EXPECT_FALSE(stream_display_policy::selection_session_overridable("headless_dongle"));
+
+  EXPECT_TRUE(stream_display_policy::selection_session_overridable("headless_stream"));
+  EXPECT_TRUE(stream_display_policy::selection_session_overridable("windowed_stream"));
+  EXPECT_TRUE(stream_display_policy::selection_session_overridable("desktop_display"));
+
+  // Unknown ids are not "restricted", they are simply not paths. The gate
+  // checks validity first so they report as unknown rather than as reserved.
+  EXPECT_FALSE(stream_display_policy::selection_session_overridable("garbage_mode"));
+}
+
 TEST(SessionStreamMode, RejectsDongleReservedUnknownAndEmpty) {
   // headless_dongle swaps host output topology: host-default-only by design.
   EXPECT_EQ(nvhttp::accepted_session_stream_mode_for_tests("headless_dongle"), "");


### PR DESCRIPTION
## Summary

Polaris refuses `headless_dongle` as a per-session stream mode, and that refusal was invisible to clients. Nova lists Headless Dongle in its per-session picker, the user picks it, Polaris drops it and launches the host default, and the stream comes up anyway, so nothing suggests the choice did not apply.

Found while running the v1.3.10 mode matrix: the Headless Dongle row reported `streaming=True` at 120 fps on `path=headless_stream`, which is not the mode that was selected.

## Why it was invisible

The rule lived as a hardcoded id inside the launch gate:

```cpp
if (requested == "headless_dongle") {
  reject_reason = "headless_dongle is not supported as a per-session override";
```

`reject_reason` reached a host-side log line and nothing else. The served mode catalog advertised `available`, `unavailable_reason`, `group`, `runtime`, `capture` and `topology`, but nothing that answered "may a client select this for one launch".

Nova already renders an option as disabled with the host's own reason. It was never given one.

## Three changes, one rule

1. **`stream_display_policy::selection_session_overridable()`** derives the answer from the path's `topology` rather than an id list, so a future `SWAP_PRIMARY` path inherits the restriction instead of relying on someone remembering to add it.
2. **The launch gate uses that predicate**, and now runs `selection_valid` first, so an unknown or unconfigured id reports its own reason instead of being described as a per-session restriction.
3. **The served catalog gains `session_overridable`** next to `available`. They are different questions: a dongle swap is a perfectly good host default while still being something a single client must not switch on for one launch.

## Verification

- [x] Production target builds clean.
- [x] The existing contract in `test_launch_mode_contract.cpp` is unchanged in behaviour: `headless_dongle` still resolves to empty, as do reserved, unknown and absent ids, and `headless_stream`, `windowed_stream`, `desktop_display` are still accepted. This change routes those same outcomes through the shared predicate rather than a literal.
- [x] New test `DerivesSessionOverridabilityFromTopologyNotAnIdList` pins that the rule follows topology, including that unknown ids are not reported as restricted.
- [x] `session_overridable` confirmed present in the built binary.
- [ ] Test binaries not linked locally; this host hits an unrelated libstdc++ `__notify_impl` ABI failure in a different test. CI is the gate.

## Follow-up, not in this PR

Nova should read `session_overridable` and render a restricted mode as disabled with the host's reason, instead of offering it as a selectable per-session choice. The plumbing on the Nova side already exists; this PR is what gives it something to read.

Related: #458 fixes the separate problem that `headless_dongle` could not configure itself when selected as a host default.

## Notes

No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes. The added catalog field is additive.
