### PR TITLE
fix(linux): verify Hyprland applied the mode instead of trusting hyprctl

### DIFF
--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -325,6 +325,44 @@ namespace virtual_display {
     return false;
   }
 
+  std::optional<hyprland_mode_t> hyprland_monitor_mode(
+    std::string_view monitors_json,
+    std::string_view output_name
+  ) {
+    const auto monitors = nlohmann::json::parse(monitors_json, nullptr, false);
+    if (!monitors.is_array()) {
+      return std::nullopt;
+    }
+
+    for (const auto &monitor : monitors) {
+      if (!monitor.is_object() ||
+          !monitor.contains("name") ||
+          !monitor["name"].is_string() ||
+          monitor["name"].get_ref<const std::string &>() != output_name) {
+        continue;
+      }
+
+      hyprland_mode_t mode;
+      if (monitor.contains("width") && monitor["width"].is_number()) {
+        mode.width = monitor["width"].get<int>();
+      }
+      if (monitor.contains("height") && monitor["height"].is_number()) {
+        mode.height = monitor["height"].get<int>();
+      }
+      if (monitor.contains("refreshRate") && monitor["refreshRate"].is_number()) {
+        mode.refresh_hz = monitor["refreshRate"].get<double>();
+      }
+
+      // A named output with no usable geometry is not an answer, it is a gap.
+      if (mode.width <= 0 || mode.height <= 0) {
+        return std::nullopt;
+      }
+      return mode;
+    }
+
+    return std::nullopt;
+  }
+
   bool hyprland_output_is_polaris_owned(std::string_view output_name) {
     constexpr std::string_view prefix = "POLARIS-HEADLESS-";
     if (!output_name.starts_with(prefix)) {
@@ -1133,13 +1171,63 @@ namespace virtual_display {
           return std::nullopt;
         }
 
-        // Set resolution and refresh rate
-        std::string mode_cmd = "hyprctl keyword monitor " + output_name + "," +
-                               std::to_string(width) + "x" + std::to_string(height) +
-                               "@" + std::to_string(fps) + ",auto,1";
-        int rc = exec_cmd_rc(mode_cmd);
-        if (rc != 0) {
-          BOOST_LOG(warning) << "Virtual display: failed to set Hyprland monitor mode (rc="sv << rc << ")"sv;
+        // Set resolution and refresh rate.
+        //
+        // hyprctl's exit status does not mean the request was honored. Hyprland
+        // 0.56 answers `hyprctl keyword` with "unknown request" and still exits
+        // 0 (#444), so trusting rc left Polaris logging the client's geometry
+        // while the output stayed at the compositor's default. Capture then ran
+        // at the wrong size and was silently scaled, with nothing in the log to
+        // explain the wrong-aspect stream. Read the mode back and believe that.
+        const std::string mode_spec = std::to_string(width) + "x" + std::to_string(height) +
+                                      "@" + std::to_string(fps);
+
+        const auto mode_landed = [&]() {
+          // The set is not always instant; give it the same short settle budget
+          // the output-creation poll above uses.
+          const auto settle = std::chrono::steady_clock::now() + 1s;
+          do {
+            const auto actual = hyprland_monitor_mode(
+              exec_cmd("hyprctl monitors -j 2>/dev/null"),
+              output_name
+            );
+            if (actual && actual->width == width && actual->height == height) {
+              return true;
+            }
+            std::this_thread::sleep_for(50ms);
+          } while (std::chrono::steady_clock::now() < settle);
+          return false;
+        };
+
+        const std::string keyword_result = exec_cmd(
+          "hyprctl keyword monitor " + output_name + "," + mode_spec + ",auto,1 2>&1"
+        );
+
+        if (!mode_landed()) {
+          BOOST_LOG(info) << "Virtual display: hyprctl keyword did not apply the mode ["sv
+                          << keyword_result << "]; trying the Lua monitor form"sv;
+
+          // Hyprland 0.56 moved config/IPC to Lua. hl.monitor takes a table and
+          // the field is `output`, not `name`.
+          const std::string eval_result = exec_cmd(
+            "hyprctl eval 'hl.monitor({output=\"" + output_name + "\", mode=\"" + mode_spec +
+            "\", position=\"auto\", scale=1})' 2>&1"
+          );
+
+          if (!mode_landed()) {
+            const auto actual = hyprland_monitor_mode(
+              exec_cmd("hyprctl monitors -j 2>/dev/null"),
+              output_name
+            );
+            BOOST_LOG(warning) << "Virtual display: Hyprland did not apply mode ["sv << mode_spec
+                               << "] on ["sv << output_name << "]; it reports ["sv
+                               << (actual ? std::to_string(actual->width) + "x" + std::to_string(actual->height) : std::string {"unknown"})
+                               << "]. The stream will be captured at that size and scaled. keyword=["sv
+                               << keyword_result << "] eval=["sv << eval_result << ']';
+          } else {
+            BOOST_LOG(info) << "Virtual display: Lua monitor form applied ["sv << mode_spec
+                            << "] on ["sv << output_name << ']';
+          }
         }
       }
       else if (compositor == "sway") {

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -118,6 +118,26 @@ namespace virtual_display {
    */
   bool hyprland_monitors_contain_output(std::string_view monitors_json, std::string_view output_name);
 
+  /// An output's active mode as the compositor reports it.
+  struct hyprland_mode_t {
+    int width = 0;
+    int height = 0;
+    double refresh_hz = 0.0;
+  };
+
+  /**
+   * @brief Read an output's active mode out of `hyprctl monitors -j`.
+   *
+   * The compositor's own answer is the only trustworthy signal that a mode set
+   * landed: `hyprctl keyword` exits 0 on Hyprland 0.56 even when it rejects the
+   * request outright (#444). Returns nullopt when the output is absent or its
+   * geometry is unusable.
+   */
+  std::optional<hyprland_mode_t> hyprland_monitor_mode(
+    std::string_view monitors_json,
+    std::string_view output_name
+  );
+
   /**
    * @brief Return whether an output name belongs to Polaris's Hyprland namespace.
    */

--- a/tests/unit/platform/test_virtual_display.cpp
+++ b/tests/unit/platform/test_virtual_display.cpp
@@ -11,6 +11,51 @@
 #ifdef __linux__
   #include <src/platform/linux/virtual_display.h>
 
+TEST(VirtualDisplayTests, HyprlandMonitorModeReadsBackTheGeometryTheCompositorActuallyHas) {
+  // The whole point of reading this back is that hyprctl's exit status lies:
+  // Hyprland 0.56 answers `hyprctl keyword` with "unknown request" and still
+  // exits 0, so a rejected mode set looked like success and the stream was
+  // captured at the compositor default and scaled (#444).
+  constexpr std::string_view monitors = R"([
+    {"name":"DP-1","width":3440,"height":1440,"refreshRate":99.982},
+    {"name":"POLARIS-HEADLESS-4242-0","width":1920,"height":1080,"refreshRate":60.0}
+  ])";
+
+  const auto actual = virtual_display::hyprland_monitor_mode(monitors, "POLARIS-HEADLESS-4242-0");
+  ASSERT_TRUE(actual.has_value());
+  EXPECT_EQ(actual->width, 1920);
+  EXPECT_EQ(actual->height, 1080);
+  EXPECT_NEAR(actual->refresh_hz, 60.0, 0.001);
+
+  // This is the reported failure in miniature: 2400x1080 was requested and the
+  // output is still 1920x1080, which the caller must be able to notice.
+  EXPECT_NE(actual->width, 2400);
+
+  const auto other = virtual_display::hyprland_monitor_mode(monitors, "DP-1");
+  ASSERT_TRUE(other.has_value());
+  EXPECT_EQ(other->width, 3440);
+}
+
+TEST(VirtualDisplayTests, HyprlandMonitorModeRefusesAbsentOutputsAndUnusableGeometry) {
+  constexpr std::string_view monitors = R"([{"name":"DP-1","width":3440,"height":1440}])";
+
+  // Absent output: no answer, not a zero-sized one.
+  EXPECT_FALSE(virtual_display::hyprland_monitor_mode(monitors, "POLARIS-HEADLESS-4242-0").has_value());
+
+  // Present but unusable geometry must not read as a successful mode set.
+  EXPECT_FALSE(
+    virtual_display::hyprland_monitor_mode(R"([{"name":"X","width":0,"height":0}])", "X").has_value()
+  );
+  EXPECT_FALSE(
+    virtual_display::hyprland_monitor_mode(R"([{"name":"X"}])", "X").has_value()
+  );
+
+  // Malformed or non-array input is a gap, not a match.
+  EXPECT_FALSE(virtual_display::hyprland_monitor_mode("not json", "X").has_value());
+  EXPECT_FALSE(virtual_display::hyprland_monitor_mode("{}", "X").has_value());
+  EXPECT_FALSE(virtual_display::hyprland_monitor_mode("", "X").has_value());
+}
+
 TEST(VirtualDisplayTests, BackendDetectionLogCacheOnlySignalsOnFirstObservationAndChanges) {
   virtual_display::backend_detection_log_cache_t cache;
 


### PR DESCRIPTION
Fixes #444.

## Summary

`hyprctl`'s exit status does not mean the request was honored. On Hyprland 0.56, `hyprctl keyword monitor ...` answers `unknown request` and **still exits 0**, so the mode set silently did nothing while Polaris logged the client's geometry as applied:

```
Virtual display: hyprctl output create headless: ok
Virtual display: Wayland headless display created [POLARIS-HEADLESS-287728-0] 2400x1080@60Hz
```

while the output stayed at `1920x1080`. Capture then ran at the compositor default and was scaled to the client's size, giving a wrong-aspect flickering stream with nothing in the log to explain it. The log actively asserted the correct geometry.

@harveywuk reported it with an exact repro, including that `hyprctl keyword` is non-functional for **any** option on that version, verified against `general:gaps_in`.

## Approach

The durable half is not version detection, it is refusing to believe the CLI.

After setting the mode, read it back out of `hyprctl monitors -j` and compare against what was requested. That is compositor-reported truth, and it does not care which Hyprland release is underneath or which one decides to return 0 on a rejected request next. As the reporter put it, this is not Hyprland-specific in nature: any backend whose CLI returns 0 on a rejected request behaves the same way.

When the read-back does not match, try the form they verified on 0.56:

```
hyprctl eval 'hl.monitor({output="NAME", mode="WxH@R", position="auto", scale=1})'
```

`hl.monitor` takes a table and the field is `output`, not `name`. If that also fails to land, warn with requested versus actual and state that the stream will be captured at that size and scaled, instead of reporting success.

On a version where `keyword` works, the read-back passes on the first check and the Lua path never runs.

## Verification

`hyprland_monitor_mode()` is a pure parser beside the existing `hyprland_monitors_contain_output()`, so the detection logic is fully testable without a Hyprland host:

```
test_polaris_platform --gtest_filter=*HyprlandMonitorMode*
  2 tests from VirtualDisplayTests
  PASSED 2 tests
```

Covers geometry read-back, the reported shape (2400x1080 requested, 1920x1080 actual, and the caller must be able to notice), absent outputs, zero and missing geometry, and malformed or non-array input.

Full platform suite as a regression check: **212 tests, 212 passed**.

- [x] Linux production target builds clean, no new warnings in `virtual_display`.
- [ ] **The compositor call itself is reporter-gated.** There is no Hyprland host on the maintainer side; pc-papi runs KWin. The read-back logic is tested, the live `hyprctl eval` invocation is reasoned from the reporter's verified command.

@harveywuk if you get a chance on this branch: an SDR `host_virtual_display` launch at a non-1080p size. Pass looks like the stream arriving at the size you asked for, and either silence or a Lua-form line in the journal. Failure now looks like an explicit warning naming requested versus actual instead of a clean log and a bad picture.

## Not addressed here

The `sway` branch a few lines below ignores its return code entirely, same class. Left alone rather than changed blind, since I cannot test it either.

The issue also raises two `host_virtual_display` items that are separate from the mode set: the generic portal retry waiting on `gamescope-0` on a path with no gamescope, and the per-session output name invalidating the portal restore token on every reconnect. Both deserve their own issue rather than riding along here.

## Notes

No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes.
