### PR TITLE
feat(web): point the app at papi-ux.com where the docs actually live

### DIFF
--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -1,7 +1,7 @@
 # Publisher Metadata
 set(POLARIS_PUBLISHER_NAME "Polaris Project"
         CACHE STRING "The name of the publisher (or fork developer) of the application.")
-set(POLARIS_PUBLISHER_WEBSITE "https://github.com/papi-ux/polaris"
+set(POLARIS_PUBLISHER_WEBSITE "https://papi-ux.com/polaris/"
         CACHE STRING "The URL of the publisher's website.")
 set(POLARIS_PUBLISHER_ISSUE_URL "https://github.com/papi-ux/polaris/issues"
         CACHE STRING "The URL of the publisher's support site or issue tracker.

--- a/src_assets/common/assets/web/ResourceCard.vue
+++ b/src_assets/common/assets/web/ResourceCard.vue
@@ -45,14 +45,5 @@
 </template>
 
 <script setup>
-const resources = [
-  { href: 'https://github.com/papi-ux/polaris/discussions', labelKey: 'resource_card.github_discussions' },
-  { href: 'https://github.com/papi-ux/polaris/wiki', labelKey: 'resource_card.github_wiki' },
-  { href: 'https://github.com/papi-ux/polaris/wiki/Stuttering-Clinic', labelKey: 'resource_card.github_stuttering_clinic' }
-]
-
-const legalDocs = [
-  { href: 'https://github.com/papi-ux/polaris/blob/master/LICENSE', labelKey: 'resource_card.license' },
-  { href: 'https://github.com/papi-ux/polaris/blob/master/NOTICE', labelKey: 'resource_card.third_party_notice' }
-]
+import { resources, legalDocs } from './resource-links.js'
 </script>

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -1084,6 +1084,8 @@
     "warning_msg": "Only pair devices you control. A trusted client can launch apps, watch streams, or control the host depending on the permissions you give it."
   },
   "resource_card": {
+    "documentation": "Documentation",
+    "troubleshooting_guide": "Troubleshooting Guide",
     "github_discussions": "GitHub Discussions",
     "github_wiki": "GitHub WiKi",
     "github_stuttering_clinic": "Stuttering Clinic",

--- a/src_assets/common/assets/web/resource-links.js
+++ b/src_assets/common/assets/web/resource-links.js
@@ -1,0 +1,24 @@
+/**
+ * The outbound links the web UI offers, defined once.
+ *
+ * ResourceCard.vue and HomeView.vue previously carried byte-identical copies of
+ * both lists, so every edit had to be made twice or the two drifted.
+ *
+ * Where a link points is a judgement, not a preference. papi-ux.com renders the
+ * repository's own docs/, so it is the better destination for the pages that
+ * exist there. The wiki keeps the pages that live only in the wiki, and
+ * Discussions stays on GitHub because that is where the discussion is.
+ */
+
+export const resources = [
+  { href: 'https://papi-ux.com/docs/', labelKey: 'resource_card.documentation' },
+  { href: 'https://papi-ux.com/docs/troubleshooting/', labelKey: 'resource_card.troubleshooting_guide' },
+  { href: 'https://github.com/papi-ux/polaris/discussions', labelKey: 'resource_card.github_discussions' },
+  { href: 'https://github.com/papi-ux/polaris/wiki', labelKey: 'resource_card.github_wiki' },
+  { href: 'https://github.com/papi-ux/polaris/wiki/Stuttering-Clinic', labelKey: 'resource_card.github_stuttering_clinic' }
+]
+
+export const legalDocs = [
+  { href: 'https://github.com/papi-ux/polaris/blob/master/LICENSE', labelKey: 'resource_card.license' },
+  { href: 'https://github.com/papi-ux/polaris/blob/master/NOTICE', labelKey: 'resource_card.third_party_notice' }
+]

--- a/src_assets/common/assets/web/resource-links.test.js
+++ b/src_assets/common/assets/web/resource-links.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { legalDocs, resources } from './resource-links.js'
+
+const all = [...resources, ...legalDocs]
+
+describe('resource links', () => {
+  it('offers the docs site for the pages it actually renders', () => {
+    // papi-ux.com renders the repository's own docs/, so these two are the
+    // better destination than the wiki for the same subjects.
+    const hrefs = resources.map((entry) => entry.href)
+    expect(hrefs).toContain('https://papi-ux.com/docs/')
+    expect(hrefs).toContain('https://papi-ux.com/docs/troubleshooting/')
+  })
+
+  it('keeps the destinations that only exist on GitHub', () => {
+    // Discussions is where the discussion is, and these wiki pages have no
+    // equivalent on the docs site. Repointing them would break them, so this
+    // pins that a future sweep does not "modernise" them into 404s.
+    const hrefs = resources.map((entry) => entry.href)
+    expect(hrefs).toContain('https://github.com/papi-ux/polaris/discussions')
+    expect(hrefs).toContain('https://github.com/papi-ux/polaris/wiki')
+    expect(hrefs).toContain('https://github.com/papi-ux/polaris/wiki/Stuttering-Clinic')
+  })
+
+  it('gives every link a label key and an absolute https target', () => {
+    for (const entry of all) {
+      expect(entry.labelKey, JSON.stringify(entry)).toMatch(/^resource_card\./)
+      expect(entry.href, JSON.stringify(entry)).toMatch(/^https:\/\//)
+    }
+  })
+
+  it('lists each destination once', () => {
+    const hrefs = all.map((entry) => entry.href)
+    expect(new Set(hrefs).size).toBe(hrefs.length)
+  })
+})

--- a/src_assets/common/assets/web/views/HomeView.vue
+++ b/src_assets/common/assets/web/views/HomeView.vue
@@ -381,16 +381,7 @@ const compatibilityClients = [
   { platform: 'Desktop', name: 'Coming Soon', status: 'Planned', link: '' }
 ]
 
-const resources = [
-  { href: 'https://github.com/papi-ux/polaris/discussions', labelKey: 'resource_card.github_discussions' },
-  { href: 'https://github.com/papi-ux/polaris/wiki', labelKey: 'resource_card.github_wiki' },
-  { href: 'https://github.com/papi-ux/polaris/wiki/Stuttering-Clinic', labelKey: 'resource_card.github_stuttering_clinic' }
-]
-
-const legalDocs = [
-  { href: 'https://github.com/papi-ux/polaris/blob/master/LICENSE', labelKey: 'resource_card.license' },
-  { href: 'https://github.com/papi-ux/polaris/blob/master/NOTICE', labelKey: 'resource_card.third_party_notice' }
-]
+import { resources, legalDocs } from '../resource-links.js'
 
 const quickActions = [
   { to: '/', titleKey: 'index.quick_mission_title', descKey: 'index.quick_mission_desc' },


### PR DESCRIPTION
## Summary

papi-ux.com renders this repository's own `docs/`, and the app never linked to it. The Resources card sent people to the GitHub wiki for help while a rendered Troubleshooting page sat on the docs site unlinked.

- Adds **Documentation** (`https://papi-ux.com/docs/`) and **Troubleshooting Guide** (`https://papi-ux.com/docs/troubleshooting/`) to the Resources list.
- Points `POLARIS_PUBLISHER_WEBSITE` at `https://papi-ux.com/polaris/` instead of the GitHub repository. It is the product's front door, and it is what `entry_handler.cpp` prints as Publisher Website at startup.

## Deliberately not a sweep

Every destination added was checked live for a 200 first. Every destination kept was kept for a reason:

- **GitHub Discussions stays.** That is where the discussion is; the site has no equivalent.
- **The wiki links stay.** Display-Mode-Override, Client-Commands and the Stuttering Clinic exist only in the wiki. Repointing them at papi-ux.com would turn working links into 404s.

## One source of truth

`ResourceCard.vue` and `HomeView.vue` carried byte-identical copies of both link lists. Adding two entries would have meant adding them twice and leaving the next editor the same trap, so the lists move to `resource-links.js` and both files import them.

The built bundle confirms it deduplicated into one shared chunk (`resource-links-*.js`) rather than two copies. Net 20 lines removed even after the additions.

`ResourceCard.vue` is used by `WelcomeView.vue` and `RecoveryView.vue`; `HomeView.vue` rendered its own copy inline. Both now read the same list, and `HomeView`'s layout is untouched.

## Verification

- [x] `npx vitest run` — 60 files, 340 tests, all passing (up from 59/336; the new spec adds 4).
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [x] Checked the **built** bundle rather than the source: both papi-ux.com URLs present, the GitHub destinations retained, and the two new locale keys shipped in `assets/locale/en.json`.
- [x] All target pages verified 200 live before linking: `/`, `/polaris/`, `/docs/`, `/docs/troubleshooting/`.

`resource-links.test.js` pins the parts that are judgement rather than preference: the docs links exist, the GitHub-only destinations are still GitHub, every entry has a label key and an absolute `https` target, and no destination appears twice. The wiki assertion exists specifically so a later "modernise the links" pass cannot quietly turn them into 404s.

## Notes

Only `en.json` gains keys; other locales fall back as they already do for untranslated strings. The locale edit is a two-line insert rather than a reserialise, so the file's hand-grouped key order is unchanged.

No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes.
