### PR TITLE
ci(arch): sync the package database in the transaction that installs from it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,8 +172,15 @@ jobs:
             polaris-arch-gomod-
 
       - name: Install dependencies
+        # -Syu, not -S: the bootstrap sync happens before checkout, submodules
+        # and cache restore, so by the time this runs the package database can
+        # be minutes stale against rolling mirrors. That gap produced repeated
+        # 404s for packages the database still believed in (elfutils-0.195-8 on
+        # 2026-08-17), failing the job on unrelated PRs. Refresh and upgrade in
+        # the same transaction that installs, and never -Sy alone, which would
+        # leave a partial upgrade.
         run: |
-          pacman -S --noconfirm --needed \
+          pacman -Syu --noconfirm --needed \
             appstream appstream-glib avahi base-devel boost boost-libs ccache cmake curl \
             desktop-file-utils ffmpeg gtk3 libayatana-appindicator libcap \
             gcc go libdrm libevdev libmfx libnotify libpulse libva libx11 libxcb \
@@ -249,7 +256,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '' }}
         run: |
           useradd -m builder
-          pacman -S --noconfirm --needed cuda
+          pacman -Syu --noconfirm --needed cuda
 
           # CUDA 13 supports GCC up to 15.x. Arch rolling moved to GCC 16,
           # so use Arch's cuda-provided gcc15 toolchain when present. Older


### PR DESCRIPTION
## Summary

The Arch build failed on **four separate runs** on 2026-08-17, every one identical:

```
error: failed retrieving file 'elfutils-0.195-8-x86_64.pkg.tar.zst'
  from fastly.mirror.pkgbuild.com : The requested URL returned error: 404
error: failed retrieving file 'elfutils-0.195-8-x86_64.pkg.tar.zst'
  from geo.mirror.pkgbuild.com : The requested URL returned error: 404
error: failed to commit transaction (failed to retrieve some files)
```

Both mirrors, so not a mirror outage, and not a flake.

## Cause

The container bootstraps with `pacman -Syu` (line 128). Then checkout, submodule init and three cache restores run. Only then does the dependency step install with `pacman -S` (no `-y`).

By that point the package database is minutes old against a rolling repository. It still names `elfutils-0.195-8` while the mirrors have moved to the next build, so the download 404s. Nothing about it is specific to elfutils or to any branch: it hit unrelated PRs all day and cost a rerun each time.

A release tag build would pay the same toll at the worst possible moment.

## Fix

Refresh in the same transaction that installs, on the dependency step and on the tag-only CUDA step.

`-Syu` rather than `-Sy`: a bare `-Sy` followed by an install is exactly the partial-upgrade pattern Arch warns about, resolving new dependencies against packages that were never upgraded. In a throwaway CI container a full upgrade costs nothing.

The apt-based jobs are untouched. They do not have this failure mode, because `apt-get update` already runs immediately before `apt-get install` there.

## Verification

- [x] `yaml.safe_load` parses the workflow and still reports all eight jobs.
- [x] Self-verifying by nature: this PR's own Arch build either stops 404ing or it does not.
