### PR TITLE
fix: repair the three gates master merged red

### DIFF
--- a/docs/nova-contract.json
+++ b/docs/nova-contract.json
@@ -365,6 +365,7 @@
         "reason",
         "restart_required",
         "runtime",
+        "session_overridable",
         "topology",
         "unavailable_reason",
         "value"

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -3467,7 +3467,10 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsStartedAndStoppedInsi
   const auto execute = source.substr(execute_start, execute_end - execute_start);
   const auto terminate = source.substr(terminate_start, terminate_end - terminate_start);
   const auto snapshot_guard = execute.find("snapshot_steam_big_picture_input_guard(");
-  const auto first_prep_launch = execute.find("platf::run_command(cmd.elevated, true, cmd.do_cmd");
+  // Pinned to the prep loop rather than to that call's argument list: #450
+  // reformatted the launch across lines and added a prep_output argument, which
+  // broke the old literal without changing the ordering this test guards.
+  const auto first_prep_launch = execute.find("for (; _app_prep_it != std::end(_app.prep_cmds); ++_app_prep_it)");
   const auto failed_launch_guard = execute.find("stop_guard_on_failed_launch = util::fail_guard");
   const auto failed_launch_stop = execute.find("stop_steam_big_picture_input_guard();", failed_launch_guard);
   const auto first_cage_launch = execute.find("start_cage_with_runtime_fallback(game_cmd)");
@@ -4384,7 +4387,10 @@ TEST(ProcConfiguredCommandWaitContract, CommandsRunUnderTheLifecycleLockWaitWith
   // detached thread holding no lock, where taking a long time blocks nothing.
   const auto source = read_source_file_for_contract("src/process.cpp");
 
-  const auto helper = source.find("void wait_for_configured_command(");
+  // Pinned on the helper's name alone. #450 changed it from void to bool so
+  // callers can see a timeout, and the old pin carried the return type, so
+  // reporting more about the wait read here as having removed the wait.
+  const auto helper = source.find("wait_for_configured_command(");
   ASSERT_NE(helper, std::string::npos);
 
   // The helper polls rather than calling child::wait_for(), which Boost marks


### PR DESCRIPTION
## Summary

`polaris/master` is red. Three tests across two binaries have been failing since they merged, and all three merged under green checks. This restores master to 17/17.

Found while validating an unrelated branch: my own build failed three tests I had not touched, so I removed my entire diff in the same build tree and re-ran. All three still failed on pristine `52a00651`.

## What broke

**`test_polaris_audit`, `NovaContractTests.EveryManifestObjectMatchesWhatPolarisActuallyServes`**

```
[client_settings_mode_option] serves [session_overridable] but the manifest omits it.
```

#459 added `session_overridable` to `stream_display_mode_options_json` without adding it to `docs/nova-contract.json`. `git log -S session_overridable -- src/` returns exactly that commit, and it does not touch the manifest.

It belongs in `fields` and not in `known_drift`: Nova reads it. `PolarisApiClient.parseModeOptions` parses `session_overridable` and `NovaPlaySetupModePicker` gates the entry on it, which is the `nova_reader` the manifest already names.

**`test_polaris_config`, two source-guard tests in `test_process_migration.cpp`**

Both match `src/process.cpp` as text, and #450 changed the text without changing the behaviour they guard.

- `CommandsRunUnderTheLifecycleLockWaitWithABound` pinned `"void wait_for_configured_command("`. #450 changed the helper to return `bool` so callers can see a timeout. The assertion that a bounded wait exists started reading as though the wait had been removed.
- `SteamBigPictureInputGuardIsStartedAndStoppedInsideProcessLifetime` pinned the first prep launch as a single-line call with its argument list. #450 reformatted that call across lines and gave it a `prep_output` argument.

Both invariants still hold in the code. The pins were re-expressed rather than deleted, because the ordering they assert is the reason they exist: the helper is now pinned on its name alone, and the prep launch on the prep loop itself, so neither moves when a call inside it is reformatted.

## Why all three were green on merge

One mechanism, not three accidents. In `.github/workflows/build.yml`, `cpp-sanitizer-tests`:

- `test_polaris_audit` is never built and never run, which is why a manifest drift can ship green.
- `test_polaris_platform` is never built and never run.
- `test_polaris_config` is built, but the ctest invocation runs only `ProcessRuntimeConfigTests.GamescopeAttached*` from it, so neither failing test executes.

This PR does not fix that gap. The release session owns it and is on it. Worth flagging that #459's own verification note said "CI is the gate" for exactly the test that CI does not run.

## Verification

- [x] `ctest` on this branch: 17/17 passed, 0 failed.
- [x] All three failures confirmed reproducing on pristine `52a00651` with no local changes, and confirmed passing in a build predating them, so this is a master regression and not an environment artifact.
- [x] `NovaContractTests.*` 4/4 pass, including `KnownDriftNamesFieldsThatStillExist`, which is what would object if `session_overridable` had been filed as drift instead.
- [x] `docs/nova-contract.json` re-parsed as JSON after editing; field list left alphabetically sorted.
- [x] Nova's use of the field verified against `origin/master` rather than the local clone, which is behind.
- [x] No behaviour change in `src/`. The only non-test file touched is the manifest.

## Notes

No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes. One additive manifest field and two test pins.
