### PR TITLE
fix(web): redact credentials in every naming convention, stop redacting labels

### DIFF
--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -1,22 +1,253 @@
-const SENSITIVE_FIELD_PATTERN = /(password|token|secret|key|cookie|auth|credential)/i
-const SENSITIVE_ASSIGNMENT_PATTERN = /\b(password|token|secret|key|cookie|auth|credential)(\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;})\]]+)/gi
+// Words that mean "secret" wherever they appear as a whole segment of a name.
+const SENSITIVE_SEGMENT_WORDS = [
+  'password', 'passwd', 'token', 'secret', 'cookie', 'auth', 'authorization', 'credential',
+]
+// Qualifiers that make a separator-less segment a credential name. `apikey` and
+// `authtoken` carry no separator and no camelCase hump, so there is nothing
+// structural to split on, and English gives no way to tell `apikey` from
+// `monkey`: both are a qualifier followed by "key". The list is explicit because
+// the distinction is semantic, not structural.
+//
+// Polaris already made this call for the same string. The artwork request
+// sanitiser in src/game_artwork_manual.cpp treats a bare "apikey" header as
+// sensitive, so the redactor agreeing with it is the point.
+const CREDENTIAL_QUALIFIERS = [
+  'api', 'app', 'access', 'auth', 'bearer', 'client', 'db', 'master', 'oauth',
+  'private', 'public', 'refresh', 'secret', 'session', 'user',
+]
+// "key" is different. On its own it is a map key or a label far more often than
+// a credential, and treating it as secret blanked the diagnostic labels the
+// bundle exists to carry. It counts only when something qualifies it and that
+// qualifier comes first: api_key and apiKey are credentials, keyName and keyCode
+// are labels.
+const QUALIFIED_ONLY_WORDS = ['key']
+// Any `name = value` or `name: value` pair. Which names are sensitive is decided
+// by isSensitiveIdentifier rather than by a second list encoded in this regex.
+// Two independent definitions is what let apiKey= leak from log text while a
+// field named apiKey was correctly redacted.
+//
+// Built fresh per call rather than kept as one global regex, because the scan
+// recurses into values and a shared /g regex carries lastIndex between them.
+// A name immediately followed by a separator. The value is deliberately NOT part
+// of this pattern: consuming it made an innocent pair swallow a sensitive one,
+// and truncating it at a `]` left a stray bracket behind that accumulated on
+// every pass. The scan below reads the value without consuming it instead.
+// A closing delimiter may sit between the name and its separator, which is
+// what every quoted JSON key looks like. Requiring the name to reach its
+// separator directly meant {"api_key": "..."} was never recognised at all,
+// and JSON always quotes its keys.
+const NAME_BEFORE_SEPARATOR_SOURCE = String.raw`\b([A-Za-z][\w.-]*)["')\]]?\s*[:=]\s*`
+// A value that is not a quoted string or a structure. Structures are measured by
+// balancing rather than by pattern, because a regex cannot see where a nested
+// object ends and stopping early is worse than not matching at all: it replaces
+// the opening fragment and leaves the secret behind, while reading as though the
+// whole subtree was handled.
+const BARE_VALUE_AT_START = /^[^\s,;})\]]+/
+const STRUCTURE_CLOSERS = { '{': '}', '[': ']' }
+
+/**
+ * Length of a quoted string starting at `start`, or 0 if it never closes.
+ */
+function quotedExtent(source, start) {
+  const quote = source[start]
+  for (let index = start + 1; index < source.length; index += 1) {
+    if (source[index] === '\\') {
+      index += 1
+      continue
+    }
+    if (source[index] === quote) return index - start + 1
+  }
+  return 0
+}
+
+/**
+ * Length of a balanced object or array starting at `start`, or 0 if unbalanced.
+ *
+ * Quoted spans are skipped so a brace inside a string cannot unbalance it.
+ */
+function structuredExtent(source, start) {
+  const stack = []
+  let quote = ''
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index]
+    if (quote) {
+      if (character === '\\') index += 1
+      else if (character === quote) quote = ''
+      continue
+    }
+    if (character === '"' || character === "'") {
+      quote = character
+      continue
+    }
+    if (STRUCTURE_CLOSERS[character]) {
+      stack.push(STRUCTURE_CLOSERS[character])
+      continue
+    }
+    if (character === stack[stack.length - 1]) {
+      stack.pop()
+      if (stack.length === 0) return index - start + 1
+    }
+  }
+  return 0
+}
+
+/**
+ * The value that follows a separator, as text.
+ *
+ * A value that opens a quote or a structure and never closes it is taken to run
+ * to the end of the line. That is deliberate: the usual cause is a truncated log
+ * line, where everything after the opener is still part of the value, and
+ * stopping at the first bare token would leave most of the secret in place.
+ * Over-redacting a malformed line is the safe direction.
+ */
+function valueAt(source, start) {
+  const first = source[start]
+  if (first === undefined) return ''
+
+  const opensSomething = first === '"' || first === "'" || Boolean(STRUCTURE_CLOSERS[first])
+  if (opensSomething) {
+    const extent = first === '"' || first === "'"
+      ? quotedExtent(source, start)
+      : structuredExtent(source, start)
+    if (extent > 0) return source.slice(start, start + extent)
+
+    const lineEnd = source.indexOf('\n', start)
+    return source.slice(start, lineEnd === -1 ? source.length : lineEnd)
+  }
+
+  const bare = BARE_VALUE_AT_START.exec(source.slice(start))
+  return bare ? bare[0] : ''
+}
 const AUTH_HEADER_PATTERN = /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi
+const AUTH_SCHEME_VALUE_PATTERN = /^(Bearer|Basic)$/i
 const COOKIE_HEADER_PATTERN = /\b(cookie|set-cookie)(\s*[:=]\s*)[^\n;]+/gi
 const URL_CREDENTIAL_PATTERN = /(https?:\/\/)([^\s/@:]+):([^\s/@]+)@/gi
 
 export const REDACTED_VALUE = '[redacted]'
 
+/**
+ * Split an identifier into lowercase words across camelCase and . _ - breaks.
+ */
+function identifierSegments(name) {
+  return String(name || '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((segment) => segment.toLowerCase())
+}
+
+/**
+ * Whether a segment is one of `words`, tolerating a plural.
+ *
+ * Field names in the wild are as often `credentials` and `tokens` as they are
+ * singular, and a stem match would drag in `keyboard` again.
+ */
+function segmentMatches(segment, words) {
+  return words.some((word) => segment === word || segment === `${word}s`)
+}
+
+/**
+ * Whether a separator-less segment is a qualifier glued to a sensitive word.
+ *
+ * Deliberately requires a known qualifier rather than any prefix, so `apikey`
+ * is a credential and `monkey` is not.
+ */
+function isConcatenatedCredential(segment) {
+  return [...SENSITIVE_SEGMENT_WORDS, ...QUALIFIED_ONLY_WORDS].some((word) => (
+    [word, `${word}s`].some((ending) => (
+      segment.length > ending.length &&
+      segment.endsWith(ending) &&
+      CREDENTIAL_QUALIFIERS.includes(segment.slice(0, segment.length - ending.length))
+    ))
+  ))
+}
+
+function segmentIsSensitive(segment) {
+  return segmentMatches(segment, SENSITIVE_SEGMENT_WORDS) || isConcatenatedCredential(segment)
+}
+
+/**
+ * Whether an identifier names something secret.
+ *
+ * @param name Identifier to classify.
+ * @param bareQualifiedCounts Whether a lone qualified-only word such as `key`
+ *   counts on its own. Structured field names say no, free log text says yes;
+ *   see isSensitiveFieldName and redactSensitiveText for why they differ.
+ */
+function isSensitiveIdentifier(name, bareQualifiedCounts) {
+  const segments = identifierSegments(name)
+  if (segments.length === 0) return false
+  if (segments.some(segmentIsSensitive)) return true
+  if (bareQualifiedCounts && segments.length === 1) {
+    return segmentMatches(segments[0], QUALIFIED_ONLY_WORDS)
+  }
+  // Qualified, and never as the leading segment: `apiKey` is a credential,
+  // `keyName` names one.
+  return segments.slice(1).some((segment) => segmentMatches(segment, QUALIFIED_ONLY_WORDS))
+}
+
+/**
+ * Whether an object field should have its value replaced.
+ *
+ * A bare `key` is a label here. Both checklistItem() and the network probe emit
+ * a `key` field as a plain identifier, and blanking those removed the labels
+ * that make a bundle readable while protecting nothing.
+ */
 export function isSensitiveFieldName(key) {
-  return SENSITIVE_FIELD_PATTERN.test(String(key || ''))
+  return isSensitiveIdentifier(key, false)
+}
+
+/**
+ * Redact the value of every `name = value` pair whose name reads as a credential.
+ *
+ * Walks names without consuming their values, so an innocent pair cannot swallow
+ * a sensitive one that follows it: `Error: auth_token=abc` is the ordinary shape
+ * of a log line, and the credential has to still be visible to the scan after
+ * the label in front of it has been considered and skipped.
+ *
+ * Leaving values unconsumed also makes this idempotent. Nova redacts before it
+ * posts a report and the host redacts again on export, so two passes over the
+ * same bytes is the normal path rather than an edge case, and a user should not
+ * be able to tell how many times it ran by counting brackets.
+ *
+ * Free text is the one place a bare `key=` counts as a credential. In a
+ * structured payload the surrounding object says what a `key` field is; in a log
+ * line nothing does, and losing one diagnostic line costs far less than
+ * exporting a secret.
+ */
+function redactAssignments(text) {
+  const source = String(text)
+  const scanner = new RegExp(NAME_BEFORE_SEPARATOR_SOURCE, 'g')
+  let output = ''
+  let cursor = 0
+  let match
+
+  while ((match = scanner.exec(source)) !== null) {
+    const [whole, label] = match
+    const valueStart = match.index + whole.length
+    const value = valueAt(source, valueStart)
+    if (!value) continue
+    // Already redacted, or an auth scheme whose credential the header pattern
+    // has already taken. Both are left exactly as found.
+    if (value === REDACTED_VALUE || AUTH_SCHEME_VALUE_PATTERN.test(value)) continue
+    if (!isSensitiveIdentifier(label, true)) continue
+
+    output += source.slice(cursor, valueStart) + REDACTED_VALUE
+    cursor = valueStart + value.length
+    scanner.lastIndex = cursor
+  }
+
+  return output + source.slice(cursor)
 }
 
 export function redactSensitiveText(value) {
-  return String(value || '')
+  return redactAssignments(String(value || '')
     .replace(URL_CREDENTIAL_PATTERN, `$1${REDACTED_VALUE}:${REDACTED_VALUE}@`)
     .replace(AUTH_HEADER_PATTERN, (_, scheme) => `${scheme} ${REDACTED_VALUE}`)
-    .replace(COOKIE_HEADER_PATTERN, (_, label, separator) => `${label}${separator}${REDACTED_VALUE}`)
-    .replace(SENSITIVE_ASSIGNMENT_PATTERN, (_, label, separator) => `${label}${separator}${REDACTED_VALUE}`)
+    .replace(COOKIE_HEADER_PATTERN, (_, label, separator) => `${label}${separator}${REDACTED_VALUE}`))
 }
+
+
 
 export function sanitizeDiagnosticsValue(value, seen = new WeakSet()) {
   if (value === null || value === undefined) return value
@@ -666,7 +897,19 @@ export function buildAnonymizedDiagnosticsBundle(input = {}) {
   return sanitizeDiagnosticsValue({
     generated_at: input.generated_at || new Date().toISOString(),
     export_kind: 'polaris-anonymized-diagnostics',
-    redaction_notice: 'Fields containing password, token, secret, key, cookie, auth, or credential are redacted client-side before export.',
+    // The user-facing promise, and the thing someone reads before posting a
+    // bundle publicly. It has to describe what the code does rather than what an
+    // earlier version did: this is whole-word matching, not substring matching,
+    // and `key` alone is a label here.
+    redaction_notice: [
+      'Values are redacted client-side before export when their name reads as a credential.',
+      'Whole words such as password, passwd, token, secret, cookie, auth, authorization and',
+      'credential count, as do run-together forms such as apikey. The word key counts only when',
+      'something qualifies it, as in api_key or apiKey. Names that merely contain one of those,',
+      'such as keyboard or monkey, stay readable so the bundle remains useful. In raw log text a',
+      'bare key assignment is also redacted, because a log line carries no surrounding context to',
+      'say whether it names a label or a secret.',
+    ].join(' '),
     support_bundle_version: 2,
     ...input,
     stream_evidence: streamEvidence,

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -9,6 +9,7 @@ import {
   buildPostSessionStreamReport,
   buildSupportSelfTestCopy,
   describeLinuxGpuProfile,
+  isSensitiveFieldName,
   redactSensitiveText,
   sanitizeDiagnosticsValue,
 } from './diagnostics-export.js'
@@ -547,5 +548,310 @@ describe('support self-service reports', () => {
     expect(copy).toContain('Post-session Stream Report')
     expect(copy).toContain(`token=${REDACTED_VALUE}`)
     expect(copy).not.toContain('abc123')
+  })
+})
+
+describe('redaction defects closed', () => {
+  it('redacts a credential whose name carries a prefix', () => {
+    // A word-boundary anchor matched token= and missed auth_token=, because an
+    // underscore is a word character. Prefixed names are the common shape in a
+    // log line, so every one of them was exported verbatim.
+    const redacted = redactSensitiveText(
+      'auth_token=hunter2 api-key=abc123 session.secret=xyz789 X-Auth-Token: qqq111'
+    )
+
+    expect(redacted).not.toContain('hunter2')
+    expect(redacted).not.toContain('abc123')
+    expect(redacted).not.toContain('xyz789')
+    expect(redacted).not.toContain('qqq111')
+    expect(redacted).toContain(`auth_token=${REDACTED_VALUE}`)
+  })
+
+  it('leaves ordinary words that merely contain a keyword alone', () => {
+    // Over-redaction is not free: it eats the diagnostics the bundle exists for.
+    const redacted = redactSensitiveText('keyboard=us monkey=banana capture_path=dmabuf packet_loss=2.5')
+
+    expect(redacted).toBe('keyboard=us monkey=banana capture_path=dmabuf packet_loss=2.5')
+  })
+
+  it('treats a field named exactly key as a label, not a credential', () => {
+    // checklistItem() and the network probe both use a `key` field as an
+    // identifier. Blanking those removed the labels that make a bundle readable
+    // while protecting nothing.
+    expect(isSensitiveFieldName('key')).toBe(false)
+    expect(isSensitiveFieldName('monkey')).toBe(false)
+    expect(isSensitiveFieldName('keyboard')).toBe(false)
+  })
+
+  it('still treats a qualified key as a credential', () => {
+    expect(isSensitiveFieldName('api_key')).toBe(true)
+    expect(isSensitiveFieldName('apiKey')).toBe(true)
+    expect(isSensitiveFieldName('private-key')).toBe(true)
+  })
+
+  it('still redacts every field name it protected before', () => {
+    for (const name of ['password', 'token', 'api_token', 'accessToken', 'secret', 'cookie', 'auth', 'credential']) {
+      expect(isSensitiveFieldName(name)).toBe(true)
+    }
+    for (const name of ['bitrate', 'capture_path', 'client_ip', 'fps', '']) {
+      expect(isSensitiveFieldName(name)).toBe(false)
+    }
+  })
+
+  it('keeps checklist labels readable through a real export', () => {
+    const bundle = buildAnonymizedDiagnosticsBundle({
+      fix_my_stream_checklist: [
+        { key: 'capture-path', label: 'Capture path', status: 'warning', detail: 'fell back to SHM' },
+      ],
+      config: { api_key: 'tok_live_secret' },
+    })
+
+    expect(bundle.fix_my_stream_checklist[0].key).toBe('capture-path')
+    expect(bundle.config.api_key).toBe(REDACTED_VALUE)
+  })
+})
+
+describe('redaction across naming conventions', () => {
+  it('redacts camelCase credential names in free text', () => {
+    // The first fix handled snake and kebab and missed camelCase entirely, which
+    // is the house style of this codebase's own JavaScript.
+    const redacted = redactSensitiveText(
+      'apiKey=abc123 authToken=tok_1 accessToken: at_2 clientSecret=cs_3 userPassword=pw_5'
+    )
+
+    for (const leaked of ['abc123', 'tok_1', 'at_2', 'cs_3', 'pw_5']) {
+      expect(redacted).not.toContain(leaked)
+    }
+  })
+
+  it('redacts plural and spelled-out credential names', () => {
+    const redacted = redactSensitiveText('credentials=zzz tokens=ttt authorization=xyz passwd=ppp')
+
+    for (const leaked of ['zzz', 'ttt', 'xyz', 'ppp']) {
+      expect(redacted).not.toContain(leaked)
+    }
+  })
+
+  it('agrees between a structured field and the same name in log text', () => {
+    // Two independent definitions is what let apiKey= leak from a log line while
+    // a field named apiKey was correctly redacted.
+    for (const name of ['apiKey', 'auth_token', 'accessToken', 'credentials', 'authorization']) {
+      expect(isSensitiveFieldName(name)).toBe(true)
+      expect(redactSensitiveText(`${name}=zzz999`)).not.toContain('zzz999')
+    }
+    for (const name of ['keyboard', 'monkey', 'capture_path', 'keyName']) {
+      expect(isSensitiveFieldName(name)).toBe(false)
+      expect(redactSensitiveText(`${name}=zzz999`)).toContain('zzz999')
+    }
+  })
+
+  it('treats a bare key as a label in a field and as a credential in free text', () => {
+    // The one place the two paths differ, on purpose. A surrounding object says
+    // what a `key` field is; a log line says nothing, so free text stays
+    // conservative.
+    expect(isSensitiveFieldName('key')).toBe(false)
+    expect(redactSensitiveText('key=barevalue')).not.toContain('barevalue')
+  })
+
+  it('does not treat key as a credential when it leads the name', () => {
+    expect(isSensitiveFieldName('keyName')).toBe(false)
+    expect(isSensitiveFieldName('keyCode')).toBe(false)
+    expect(isSensitiveFieldName('apiKey')).toBe(true)
+    expect(isSensitiveFieldName('publicKey')).toBe(true)
+  })
+})
+
+describe('separator-less credential names', () => {
+  it('redacts a qualifier glued to a sensitive word', () => {
+    // apikey has no separator and no camelCase hump, so segmentation alone
+    // cannot see it. Polaris already treats a bare "apikey" header as sensitive
+    // in the artwork request sanitiser; the redactor now agrees with it.
+    const redacted = redactSensitiveText(
+      'apikey=aaa111 apisecret=bbb222 authtoken=ccc333 accesstoken=ddd444 clientsecret=eee555 privatekey=fff666'
+    )
+
+    for (const leaked of ['aaa111', 'bbb222', 'ccc333', 'ddd444', 'eee555', 'fff666']) {
+      expect(redacted).not.toContain(leaked)
+    }
+  })
+
+  it('recognises the same names as fields', () => {
+    for (const name of ['apikey', 'apisecret', 'authtoken', 'accesstoken', 'dbpassword', 'apikeys']) {
+      expect(isSensitiveFieldName(name)).toBe(true)
+    }
+  })
+
+  it('still leaves words that merely end in a sensitive word alone', () => {
+    // monkey and apikey are structurally identical: a prefix followed by "key".
+    // Only a known qualifier makes the difference, which is why the list is
+    // explicit rather than a substring test.
+    for (const name of ['monkey', 'keyboard', 'turnkey', 'passwordless']) {
+      expect(isSensitiveFieldName(name)).toBe(false)
+      expect(redactSensitiveText(`${name}=zzz999`)).toContain('zzz999')
+    }
+  })
+})
+
+describe('credentials inside another pair', () => {
+  it('redacts a credential that follows an innocent label', () => {
+    // The ordinary shape of a log line is "Something: detail". Matching the
+    // outer pair and stopping consumed the credential as someone else's value
+    // and left it in the output, which made this the most common leak of all.
+    const redacted = redactSensitiveText([
+      'java.io.IOException: auth_token=hunter2',
+      'Error at Foo.bar: apikey=abc123',
+      'WARN [stream]: clientSecret=cs9',
+      'a: b: c: token=deep',
+    ].join('\n'))
+
+    for (const leaked of ['hunter2', 'abc123', 'cs9', 'deep']) {
+      expect(redacted).not.toContain(leaked)
+    }
+  })
+
+  it('leaves an innocent pair intact when nothing inside it is sensitive', () => {
+    const survives = 'Info: capture_path=dmabuf\nWarning: packet_loss=2.5\nlevel: info'
+
+    expect(redactSensitiveText(survives)).toBe(survives)
+  })
+
+  it('still keeps the auth scheme when the header follows a label', () => {
+    expect(redactSensitiveText('Request failed, Authorization: Bearer ey.secret'))
+      .toContain(`Bearer ${REDACTED_VALUE}`)
+  })
+})
+
+describe('redaction is idempotent', () => {
+  it('does not accumulate on repeated passes', () => {
+    // Nova redacts before it posts a report and the host redacts again on
+    // export, so two passes over the same bytes is the normal path. A user
+    // should not be able to tell how many times it ran by counting brackets.
+    let text = 'Warning: auth_token=hunter2 apiKey=abc123'
+    const passes = []
+    for (let index = 0; index < 5; index += 1) {
+      text = redactSensitiveText(text)
+      passes.push(text)
+    }
+
+    expect(new Set(passes).size).toBe(1)
+    expect(passes[0]).not.toContain('hunter2')
+    expect(passes[0]).not.toContain(']]')
+  })
+
+  it('captures a bracketed value whole instead of leaving the bracket behind', () => {
+    expect(redactSensitiveText('token=[abc]')).toBe(`token=${REDACTED_VALUE}`)
+    expect(redactSensitiveText('note=[abc]')).toBe('note=[abc]')
+  })
+
+  it('leaves an already redacted document untouched', () => {
+    const already = 'Info: capture_path=dmabuf\nWarning: auth_token=[redacted]\nlevel: info'
+
+    expect(redactSensitiveText(already)).toBe(already)
+  })
+})
+
+describe('quoted and delimited names', () => {
+  it('redacts a credential behind a quoted JSON key', () => {
+    // JSON always quotes its keys, and Polaris logs JSON response bodies, so
+    // requiring the name to reach its separator directly missed every one of
+    // them. This is the same family as the two defects above: the scan failing
+    // to see a name that is right there.
+    const redacted = redactSensitiveText([
+      '{"api_key": "abc123"}',
+      "{'apiKey': 'x9'}",
+      '{"auth_token":"t1"}',
+      '"client_secret": cs9',
+    ].join('\n'))
+
+    for (const leaked of ['abc123', 'x9', 't1', 'cs9']) {
+      expect(redacted).not.toContain(leaked)
+    }
+  })
+
+  it('redacts through a closing paren or bracket before the separator', () => {
+    expect(redactSensitiveText('(api_key): abc123')).not.toContain('abc123')
+    expect(redactSensitiveText('[auth_token]: t1')).not.toContain('t1')
+  })
+
+  it('leaves innocent quoted keys and their values alone', () => {
+    const survives = '{"level": "info", "capture_path": "dmabuf", "keyName": "readable"}'
+
+    expect(redactSensitiveText(survives)).toBe(survives)
+  })
+
+  it('stays idempotent on a redacted json document', () => {
+    const once = redactSensitiveText('{"api_key": "abc123"}')
+
+    expect(redactSensitiveText(once)).toBe(once)
+  })
+})
+
+describe('a sensitive name whose value is a structure', () => {
+  it('redacts the whole object, not its opening fragment', () => {
+    // Stopping early is worse than not matching: it leaves the secret behind
+    // while "auth": [redacted] reads as though the subtree was handled, so a
+    // human skimming the bundle would sign it off.
+    expect(redactSensitiveText('{"auth": {"api_key": "abc123"}}')).toBe(`{"auth": ${REDACTED_VALUE}}`)
+    expect(redactSensitiveText('{"secret": {"inner": "s1"}}')).toBe(`{"secret": ${REDACTED_VALUE}}`)
+    expect(redactSensitiveText('{auth: {api_key: "a1"}}')).toBe(`{auth: ${REDACTED_VALUE}}`)
+  })
+
+  it('redacts an arbitrarily nested structure whole', () => {
+    expect(redactSensitiveText('{"cfg": {"auth": {"api_key": "x9"}}}')).not.toContain('x9')
+  })
+
+  it('redacts an array value whole', () => {
+    expect(redactSensitiveText('{"tokens": ["t1", "t2"]}')).toBe(`{"tokens": ${REDACTED_VALUE}}`)
+  })
+
+  it('still reaches a credential nested under an innocent name', () => {
+    expect(redactSensitiveText('{"cfg": {"api_key": "x"}}')).toBe(`{"cfg": {"api_key": ${REDACTED_VALUE}}}`)
+  })
+
+  it('is not confused by a brace inside a quoted string', () => {
+    expect(redactSensitiveText('{"auth": {"note": "a } brace", "api_key": "k1"}}'))
+      .toBe(`{"auth": ${REDACTED_VALUE}}`)
+  })
+
+  it('still redacts when the structure never closes', () => {
+    // Degenerate input must not become a reason to leave a secret alone.
+    expect(redactSensitiveText('api_key={"a": "b"')).not.toContain('"b"')
+    expect(redactSensitiveText('token=[')).toBe(`token=${REDACTED_VALUE}`)
+  })
+
+  it('stays idempotent over a redacted structure', () => {
+    const once = redactSensitiveText('{"auth": {"api_key": "a"}}')
+
+    expect(redactSensitiveText(once)).toBe(once)
+  })
+})
+
+describe('the redaction notice describes what the code does', () => {
+  it('does not promise substring matching the code no longer does', () => {
+    const notice = buildAnonymizedDiagnosticsBundle({}).redaction_notice
+
+    // It used to say "fields containing ... key", which claimed keyboard and
+    // monkey were redacted and that a bare key field was. Neither is true, and
+    // this is the promise someone reads before posting a bundle publicly.
+    expect(notice).not.toContain('Fields containing')
+    expect(notice).toContain('Whole words')
+    expect(notice).toContain('qualifies it')
+  })
+
+  it('survives its own rules', () => {
+    // The first attempt at rewording tripped them: "credential: password" and
+    // "key=" inside the notice were themselves redacted.
+    expect(buildAnonymizedDiagnosticsBundle({}).redaction_notice).not.toContain(REDACTED_VALUE)
+  })
+
+  it('keeps discriminator keys readable in a real bundle', () => {
+    // browser-stream-support.js uses key: 'touch', key: 'keyboard' and seven
+    // more as capability discriminators. Redacting those destroyed the table.
+    const bundle = buildAnonymizedDiagnosticsBundle({
+      capabilities: [{ key: 'keyboard', supported: true }, { key: 'gamepad', supported: false }],
+    })
+
+    expect(bundle.capabilities[0].key).toBe('keyboard')
+    expect(bundle.capabilities[1].key).toBe('gamepad')
   })
 })

--- a/src_assets/common/assets/web/redaction-shape-cases.test.js
+++ b/src_assets/common/assets/web/redaction-shape-cases.test.js
@@ -1,0 +1,179 @@
+// Shape cases for the diagnostics redactor.
+//
+// Every defect found in this file so far has been the same failure: the scan not
+// seeing a name that is there, or not agreeing with a human about where that
+// name's value ends. None of them were found by reading the code. They were
+// found by running a shape nobody had written a case for.
+//
+// So these are organised by shape rather than by name. When adding to this file,
+// prefer a case that violates an assumption every existing case shares over
+// another instance of a shape already covered.
+//
+// Place beside diagnostics-export.js and adjust the import if it moves.
+import { describe, expect, it } from 'vitest'
+import { redactSensitiveText, REDACTED_VALUE } from './diagnostics-export.js'
+
+const SECRET = 'abc123'
+const leaks = (input) => redactSensitiveText(input).includes(SECRET)
+
+describe('redactSensitiveText: value quoting', () => {
+  it.each([
+    ['double-quoted value', 'auth_token="abc123"'],
+    ['single-quoted value', "api_key='abc123'"],
+    ['yaml', 'api_key: "abc123"'],
+    ['bracketed value', 'token=[abc123]'],
+    ['bracketed value behind a prefix', 'Warning: token=[abc123]'],
+    ['value containing the separator', 'api_key=a=b=c=abc123'],
+    ['value containing a colon', 'auth_token=abc123:extra'],
+    ['url as the value', 'api_key=https://x.test/?q=abc123'],
+  ])('redacts %s', (_label, input) => {
+    expect(leaks(input)).toBe(false)
+  })
+})
+
+describe('redactSensitiveText: separator spacing', () => {
+  it.each([
+    ['spaces around equals', 'api_key  =  abc123'],
+    ['tabs around equals', 'api_key\t=\tabc123'],
+    ['colon with no space', 'api_key:abc123'],
+  ])('redacts %s', (_label, input) => {
+    expect(leaks(input)).toBe(false)
+  })
+})
+
+// A closing delimiter used to sit between the name and its separator and hide
+// the name from the scan. That is every JSON key there is, since JSON quotes
+// them all.
+describe('redactSensitiveText: delimiters between the name and its separator', () => {
+  it.each([
+    ['quoted key', '{"api_key": "abc123"}'],
+    ['quoted key, bare value', '"api_key": abc123'],
+    ['quoted key with equals', '"api_key"=abc123'],
+    ['single-quoted key', "{'api_key': 'abc123'}"],
+    ['parenthesised name', '(api_key): abc123'],
+    ['bracketed name', '[api_key]: abc123'],
+    ['nested objects', '{"a": {"b": {"api_key": "abc123"}}}'],
+    ['sibling keys', '{"a": "x", "api_key": "abc123"}'],
+    ['realistic config shape', '{"root": {"api_key": "abc123", "port": 47990}}'],
+  ])('redacts %s', (_label, input) => {
+    expect(leaks(input)).toBe(false)
+  })
+})
+
+// The inverse failure: the name is seen, but the value is taken to end at the
+// nested name rather than at the end of the object, so only the opening
+// fragment is replaced and the secret survives one level down. Worse than a
+// plain miss, because "auth": [redacted] reads as if the subtree was handled.
+describe('redactSensitiveText: a sensitive name whose value is a structure', () => {
+  it.each([
+    ['object value', '{"auth": {"api_key": "abc123"}}'],
+    ['object value, nested', '{"cfg": {"auth": {"api_key": "abc123"}}}'],
+    ['object value, bare names', '{auth: {api_key: "abc123"}}'],
+    ['object value, no braces around the pair', 'auth: {api_key: "abc123"}'],
+    ['object value under a different name', '{"secret": {"inner": "abc123"}}'],
+    ['array value', '{"tokens": ["abc123", "x"]}'],
+  ])('redacts %s', (_label, input) => {
+    expect(leaks(input)).toBe(false)
+  })
+})
+
+// An innocent pair must not consume a sensitive one that follows it.
+describe('redactSensitiveText: ordering', () => {
+  it.each([
+    ['innocent then sensitive', 'keyboard=us auth_token=abc123'],
+    ['two innocent then sensitive', 'monkey=banana keyboard=us api_key=abc123'],
+    ['sensitive between innocents', 'keyboard=us api_key=abc123 monkey=banana'],
+    ['innocent-sounding name first', 'keyName=capture_path client_secret=abc123'],
+    ['repeated on one line', 'first=ok auth_token=abc123 second=ok apikey=abc123'],
+  ])('redacts %s', (_label, input) => {
+    expect(leaks(input)).toBe(false)
+  })
+})
+
+describe('redactSensitiveText: log framing', () => {
+  it.each([
+    ['timestamped', '[2026-08-17 20:31:02.123]: Info: config: api_key = abc123'],
+    ['syslog style', 'polaris[591466]: Warning: request failed apiKey=abc123'],
+    ['java stack frame', 'at com.papi.nova.Foo.bar(Foo.kt:42): client_secret=abc123'],
+    ['exception chain', 'Caused by: java.lang.RuntimeException: db-password=abc123'],
+    ['http request line', 'GET /api/config?apikey=abc123 HTTP/1.1'],
+    ['header', 'curl -H "Authorization: Bearer abc123" https://host/x'],
+    ['set-cookie', 'set-cookie: session=abc123; Path=/'],
+    ['logfmt', 'msg="auth failed" auth_token=abc123 status=401'],
+    ['multi-line block', 'Info: start\nWarning: auth_token=abc123\nInfo: done'],
+    ['crlf block', 'Info: start\r\nWarning: api_key=abc123\r\nInfo: end'],
+  ])('redacts %s', (_label, input) => {
+    expect(leaks(input)).toBe(false)
+  })
+})
+
+// Real Polaris journal lines. Redaction that eats these makes the bundle
+// useless, which is the failure mode nobody reports because the bundle still
+// looks fine.
+describe('redactSensitiveText: diagnostics survive byte for byte', () => {
+  it.each([
+    'Info: wlr: capture_transport=dmabuf frame_residency=gpu frame_format=bgra8',
+    'Info: wlr: screencopy capture pacing=source_driven private_compositor=true',
+    'Info: session_runtime: path=headless_dongle backend=portal requested_headless=true',
+    'Info: display_topology: auto-selected primary_output=[DP-2]',
+    'Info: display_topology: requested mode [1920x1080@60Hz] on output [HDMI-A-2]',
+    'Info: kwingrab: stream ready node=161 serial=8154 output=HDMI-A-2 3840x2160',
+    'Info: Session stream mode override requested: [headless_stream]',
+    'Info: config: linux_stream_mode = headless_dongle',
+    'Info: capture_path=dmabuf',
+    'level: info',
+    'session_overridable=false',
+    'encode_time_ms=3.28',
+    'keyboard=us monkey=banana turnkey=yes passwordless=true',
+    'keyName=capture_path',
+    // quoted innocent keys: recognising quoted names must not start eating these
+    '{"level": "info"}',
+    '{"keyName": "capture_path"}',
+    '{"capture_path": "dmabuf", "frame_residency": "gpu"}',
+    '{"keyboard": "us", "monkey": "banana"}',
+  ])('leaves %s unchanged', (line) => {
+    expect(redactSensitiveText(line)).toBe(line)
+  })
+
+  it('leaves the redaction marker itself alone when it is an innocent value', () => {
+    const line = `capture_path=${REDACTED_VALUE}`
+    expect(redactSensitiveText(line)).toBe(line)
+  })
+})
+
+describe('redactSensitiveText: redacting an already-redacted document is a no-op', () => {
+  it.each([
+    'auth_token=abc123',
+    'Warning: token=[abc123]',
+    '{"api_key": "abc123"}',
+    `auth_token=${REDACTED_VALUE} api_key=abc123`,
+    `api_key=abc123 auth_token=${REDACTED_VALUE}`,
+    'Info: start\nWarning: auth_token=abc123\nInfo: done',
+  ])('is stable across three passes: %s', (input) => {
+    const once = redactSensitiveText(input)
+    const twice = redactSensitiveText(once)
+    expect(twice).toBe(once)
+    expect(redactSensitiveText(twice)).toBe(once)
+  })
+})
+
+describe('redactSensitiveText: degenerate input', () => {
+  it.each([
+    'api_key=', 'api_key', '=abc123', '', '   ', 'a'.repeat(5000),
+    '{"api_key":', 'token=[', 'token=]', '[[[[[[', 'api_key=[[[[',
+  ])('does not throw on %j', (input) => {
+    expect(() => redactSensitiveText(input)).not.toThrow()
+  })
+})
+
+describe('redactSensitiveText: cost', () => {
+  it('stays linear on a bundle-sized input and still catches a secret at the end', () => {
+    const big = `${Array.from({ length: 20000 }, (_, i) =>
+      `Info: frame=${i} capture_path=dmabuf keyboard=us encode_time_ms=3.28`).join('\n')
+    }\nWarning: api_key=abc123\n`
+    const started = Date.now()
+    const out = redactSensitiveText(big)
+    expect(Date.now() - started).toBeLessThan(3000)
+    expect(out.includes(SECRET)).toBe(false)
+  })
+})

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -443,6 +443,7 @@ import {
   buildNetworkPathTestReport,
   buildPostSessionStreamReport,
   buildSupportSelfTestCopy,
+  redactSensitiveText,
 } from '../diagnostics-export.js'
 import { AI_DOCTOR_EXPLANATION_CATEGORIES, explainDoctorWithAi } from '../ai-doctor-explanation.js'
 import { createLogTailState, fetchLogTail } from '../log-tail-state.js'
@@ -964,7 +965,10 @@ function copyLogs() {
     showToast(i18n.t('troubleshooting.copy_logs_empty') || 'No visible logs to copy.', 'info')
     return
   }
-  navigator.clipboard.writeText(actualLogs.value)
+  // Every other export path redacts. This one did not, so a log line
+  // holding a credential went to the clipboard intact and straight into
+  // wherever it was pasted.
+  navigator.clipboard.writeText(redactSensitiveText(actualLogs.value))
   showToast(i18n.t('troubleshooting.copy_logs_success') || 'Visible log lines copied.', 'success')
 }
 


### PR DESCRIPTION
## Summary

The support-bundle redactor had defects pointing in opposite directions: it let credentials through, and it blanked the diagnostics a bundle exists to carry. Both live in `redactSensitiveText` / `isSensitiveFieldName`, which every export path depends on.

**Root cause of the leaks: "which names are secret" was written twice** — once as a regex inside the free-text pattern, once as a field-name test. The two disagreed, so a field named `apiKey` was correctly redacted while the identical string in a log line was exported verbatim. Both now come from one function, so they cannot drift apart again.

## Under-redaction, free text

The original pattern anchored on `\b`, and `_` is a word character, so `token=value` matched and `auth_token=value` did not.

A first pass at this fixed separator-delimited names and **still missed camelCase entirely**, which is this repo's own house style for JavaScript:

```
apiKey=abc123        -> apiKey=abc123        (leaked)
authToken=tok_1      -> authToken=tok_1      (leaked)
accessToken: at_2    -> accessToken: at_2    (leaked)
clientSecret=cs_3    -> clientSecret=cs_3    (leaked)
```

Plurals and spelled-out forms leaked too: `credentials=`, `tokens=`, `authorization=`.

Names are now split into segments across camelCase and separators, matched by whole segment, with a plural tolerated.

## Separator-less names

`apikey` has no separator and no camelCase hump, so segmentation cannot see it at all:

```
apikey=alllower  -> apikey=alllower  (leaked)
apisecret=x      -> apisecret=x      (leaked)
authtoken=x      -> authtoken=x      (leaked)
```

English gives no structural way to tell `apikey` from `monkey` — both are a prefix followed by `key`. The distinction is semantic, so a known-qualifier list settles it, and the list is explicit by necessity rather than by preference.

**Polaris had already made this exact call for this exact string.** `src/game_artwork_manual.cpp` treats a bare `apikey` header as sensitive in its artwork request sanitiser, alongside `authorization`, `proxy_authorization`, and an `_token` suffix rule. The redactor now agrees with it instead of contradicting it, which is the same drift this restructure exists to end.

## Idempotence

Redaction ran twice over the same bytes and accumulated:

```
pass 1: Warning: auth_token=[redacted]
pass 2: Warning: auth_token=[redacted]]
pass 3: Warning: auth_token=[redacted]]]
```

The value pattern stopped at a closing bracket, so an already-redacted value was captured as `[redacted` and the replacement wrote `[redacted]` in front of the original bracket. The same cause corrupted a legitimate bracketed value on a single pass: `token=[abc]` became `token=[redacted]]`.

**This is not academic, and Slice 5 is why.** Nova redacts before it posts a support report, and the host redacts again on export, so two passes over the same bytes is the normal path for a real report rather than an edge case.

Both this and the swallowing bug had one cause: the pattern consumed the value. The scan now reads a value **without consuming it**, so an innocent pair cannot swallow a sensitive one, and re-running is a no-op. Both properties are now structural rather than a consequence of the regex happening to hold, and an idempotence test is pinned permanently.

## Quoted JSON keys

A closing delimiter between the name and its separator defeated the scan entirely:

```
{api_key: "abc123"}     -> {api_key: [redacted]}   ok
{"api_key": "abc123"}   -> unchanged               LEAK
"api_key": abc123       -> unchanged               LEAK
(api_key): abc123       -> unchanged               LEAK
```

It was never about the value being quoted, which was handled. The *name* had to reach its separator directly, so **every quoted JSON key was invisible** — and JSON always quotes its keys.

Reachability, stated precisely: `redactSensitiveText` is applied to raw log text, and Polaris does log JSON response bodies (`ai_optimizer.cpp` logs up to 200 characters of a provider HTTP response). So the path from quoted-key JSON to the redactor exists. No log line actually carrying a credential through it has been demonstrated, and pc-papi's current `polaris.log` contains no quoted JSON keys at all. **Fixed on the strength of the mechanism, not on a claim of a proven leak.**

This matters more on the Nova side, which parses API responses, and the same gap was present and is fixed in the Kotlin port.

## A sensitive name whose value is a structure

The value pattern stopped at the nested name, so only the opening fragment was replaced:

```
{"auth": {"api_key": "abc123"}}   ->  {"auth": [redacted] "abc123"}}
{"secret": {"inner": "abc123"}}   ->  {"secret": [redacted] "abc123"}}
```

**This is worse than a plain miss.** The secret survives, the structure is mangled, and `"auth": [redacted]` reads as though the whole subtree was handled, so a human skimming the bundle would sign it off.

Structures are now measured by **balancing** rather than by pattern, since a regex cannot see where a nested object ends. A structure that never closes is redacted to end of line: the usual cause is a truncated log line, and over-redacting a malformed one is the safe direction.

**The over-redaction is bounded to its own line.** Later lines survive untouched, and a balanced structure does not eat trailing diagnostics on its own line either:

```
Warning: api_key={"a"          ->  Warning: api_key=[redacted]
Info: capture_path=dmabuf      ->  Info: capture_path=dmabuf      (survives)
Info: auth={"a": 1} capture_path=dmabuf
                               ->  Info: auth=[redacted] capture_path=dmabuf
```

The only cost is a same-line tail after an opener that never closes. "Redacted to end of line" reads scarier than it behaves.

Verified not a regression from the quoted-key fix: all four forms leak identically at the commit before it, including the bare-name form that predates quoted keys being recognised at all.

## Over-redaction, field names

`isSensitiveFieldName` was a bare substring test, so a field named exactly `key` was treated as a credential. Both `checklistItem()` and the network path probe use `key` as a plain identifier, so **every Fix My Stream row and every probed port reached support with its label replaced by `[redacted]`**. The same test matched `monkey` and `keyboard`.

## The failure mode this file has

Seven defects have been found here, and every one was found by running a shape nobody had written a case for. None was found by reading the code.

All seven are the same thing: **the scan and a human reader disagreeing about where a name starts or where its value ends.** The first several were the scan failing to see a name that was there (prefixed, camelCase, run-together, quoted). The last was the scan seeing the name and stopping the value too early. That sentence is a better guide for the next change than any individual case, and the tests are organised to keep aiming at it.

## The one word that is judged, not matched

`key` is deliberately treated differently in the two paths:

| | bare `key` | `apiKey` / `api_key` | `keyName` / `keyCode` |
|---|---|---|---|
| structured field | label, kept | credential, redacted | label, kept |
| free log text | credential, redacted | credential, redacted | label, kept |

In a payload the surrounding object says what a `key` field is. In a log line nothing does, and losing one diagnostic line costs far less than exporting a secret. `key` never counts when it leads the name, so `keyName` and `keyCode` stay readable.

This asymmetry is the one place the two paths differ, it is one flag on one shared function, and it is commented at both call sites.

## Authorization headers keep their scheme

The generic rule would otherwise eat `Bearer` after the header pattern had already redacted the credential. `Bearer` and `Basic` fail for different reasons, so the scheme is worth reading. Four pre-existing tests pin this, and they are what caught it.

## Copy logs

It wrote the visible log to the clipboard with **no redaction at all**, while every other export path redacted. It now uses the same function.

## Scope of the exposure

**This is a latent leak, not an incident, and it should not be described as one.**

The one support bundle known to be public, attached to #367, was scanned for `auth_token=`, `api_key=`, `access_token=`, any `*_token=`, `password=`, `secret=`, `Authorization`, and `Bearer` values. There are no matches. Redaction did run there: 34 markers present, remaining opaque strings benign.

No credential is known to have escaped. The defect was real and reachable, and it did not bite.

That same scan is where the `key` blanking surfaced: all 34 redactions in that bundle were on label fields, which is also why it was less useful than it should have been.

## The notice was a false promise

The bundle's `redaction_notice` still read *"Fields containing password, token, secret, key, cookie, auth, or credential are redacted client-side before export."* Two ways that is no longer true: it describes substring matching where the code does whole-word matching, so it promised `keyboard`, `monkey` and `turnkey` were redacted when they correctly are not; and it lists `key`, which this change deliberately stops treating as sensitive in a structured field.

That notice is the promise a user reads **before posting a bundle publicly**, so leaving it describing an earlier version would be its own kind of wrong. It is rewritten to match behaviour.

That the `key` change is right rather than a regression is visible in `browser-stream-support.js`, which uses `key` as a capability discriminator **nine times** — including `key: 'keyboard'` and `key: 'gamepad'`. Before this change every one came out `[redacted]` and the capability table was destroyed.

The notice is also worded to survive its own rules. The first rewrite contained a credential word followed by a colon and a bare `key` assignment, and the redactor duly redacted the sentence explaining redaction.

## A permanent shape suite

`redaction-shape-cases.test.js` is added alongside: 78 cases organised **by shape rather than by name**, because shape is what kept finding defects. Its header asks the next person to add a case that violates an assumption every existing case shares, rather than another instance of a shape already covered.

It covers value quoting, separator spacing, delimiters between a name and its separator, structured values, ordering, real log framing (syslog, java stack frames, logfmt, CRLF), 18 real Polaris journal lines that must survive byte for byte, idempotence, degenerate input, and cost on a bundle-sized document.

## Verification

- [x] `npx vitest run` full suite: **452 passed, 61 files, 0 failures**.
- [x] Four independent adversarial probe rounds run clean against the live branch, covering realistic log shapes, 12 real Polaris journal lines surviving byte for byte, idempotence, degenerate inputs, and a 1.3MB linear-time scan.
- [x] New tests pin camelCase, plurals, `authorization`, the field/free-text asymmetry, and that `key` leading a name is not a credential.
- [x] A regression test asserts every field name protected before is still protected, and that a real export keeps checklist labels readable while redacting `config.api_key`.
- [x] `npx eslint` clean; `npm run build` succeeds.

## Notes

Split out of a larger crash-reporting branch so it can land on its own; no feature work. No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes.
