### PR TITLE
ci: run the test suites that already exist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,12 +106,18 @@ jobs:
             -DCUDA_FAIL_ON_MISSING=OFF
 
       - name: Build sanitizer unit tests
-        run: cmake --build build-sanitize --target test_polaris test_polaris_config test_polaris_http test_polaris_steam_shutdown test_polaris_stream -j"$(nproc)"
+        run: cmake --build build-sanitize --target test_polaris test_polaris_audit test_polaris_config test_polaris_http test_polaris_platform test_polaris_steam_shutdown test_polaris_stream -j"$(nproc)"
 
       - name: Run sanitizer and gamescope ownership tests
+        # Coverage here grew one target at a time, each fix adding only what it
+        # needed, so suites that existed were never run: test_polaris_audit and
+        # test_polaris_platform were built by nobody, and test_polaris_config ran
+        # a single GamescopeAttached* filter. Three tests were red on master
+        # under all-green checks because of it, including the Nova contract
+        # manifest guard whose entire job is catching that class of drift.
+        # Run the suites that exist; narrow deliberately if one earns it.
         run: |
-          ctest --test-dir build-sanitize/tests --output-on-failure -R '^(test_polaris|test_polaris_http|test_polaris_steam_shutdown|test_polaris_stream|polaris_gamescope_runtime_shell|polaris_gamescope_session_stop_shell)$'
-          build-sanitize/tests/test_polaris_config --gtest_filter='ProcessRuntimeConfigTests.GamescopeAttached*'
+          ctest --test-dir build-sanitize/tests --output-on-failure -R '^(test_polaris|test_polaris_audit|test_polaris_config|test_polaris_http|test_polaris_platform|test_polaris_steam_shutdown|test_polaris_stream|polaris_gamescope_runtime_shell|polaris_gamescope_session_stop_shell)$'
 
   arch-build:
     name: Arch build

--- a/tests/integration/test_nova_contract.cpp
+++ b/tests/integration/test_nova_contract.cpp
@@ -275,7 +275,11 @@ TEST(NovaContractTests, EveryObjectNamesTheFunctionScopingItsNovaReads) {
   // consumer (display_planner did this before papi-ux/nova#197; session_timing
   // does it now). That is a real, documented state, not something this test
   // should fail on - it only pins scope for objects that claim a reader.
-  for (const auto &[name, object] : manifest()["objects"].items()) {
+  // items() holds a proxy into the json it was called on. manifest() returns by
+  // value, so iterating its result directly walks a container that is destroyed at
+  // the end of the full expression. Bind it first, as the tests above already do.
+  const auto contract = manifest();
+  for (const auto &[name, object] : contract["objects"].items()) {
     SCOPED_TRACE(name);
     if (!object.contains("nova_reader")) {
       continue;

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -35,6 +35,31 @@
 
 namespace {
 #ifdef __linux__
+  // std::filesystem::equivalent needs both paths to exist before it will answer.
+  // A hardcoded /dev node cannot carry a pairing assertion: CI runners have no
+  // /dev/dri, equivalent fails with an error_code, and device_nodes_match then
+  // correctly reports "unknown" rather than true. The JSON field is null in that
+  // case, and EXPECT_TRUE throws type_error.302 on a null.
+  struct TempFileGuard {
+    explicit TempFileGuard(const std::string &label) {
+      static int counter = 0;
+      path = std::filesystem::temp_directory_path() /
+        ("polaris-process-migration-" + label + "-" + std::to_string(++counter));
+      std::ofstream(path).close();
+    }
+
+    ~TempFileGuard() {
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+    }
+
+    std::string string() const {
+      return path.string();
+    }
+
+    std::filesystem::path path;
+  };
+
   volatile std::sig_atomic_t sigusr1_interruptions = 0;
 
   void record_sigusr1_interrupt(int) {
@@ -960,7 +985,8 @@ TEST(ProcessRuntimeConfigTests, SessionHealthFlagsHeadlessHdrUnavailableSeparate
 #ifdef __linux__
 TEST(ProcessRuntimeConfigTests, MissionControlPolicyIncludesLinuxGpuProfileForVaapiCaptureTruth) {
   linux_cage_compositor_guard_t linux_guard;
-  config::video.adapter_name = "/dev/dri/renderD128";
+  TempFileGuard render_node("vaapi-capture-truth");
+  config::video.adapter_name = render_node.string();
   config::video.linux_display.use_cage_compositor = true;
   config::video.linux_display.prefer_gpu_native_capture = true;
 
@@ -973,7 +999,7 @@ TEST(ProcessRuntimeConfigTests, MissionControlPolicyIncludesLinuxGpuProfileForVa
   stats.capture_transport = platf::frame_transport_e::shm;
   stats.capture_residency = platf::frame_residency_e::cpu;
   stats.capture_format = platf::frame_format_e::bgra8;
-  stats.capture_device = "/dev/dri/renderD128";
+  stats.capture_device = render_node.string();
   stats.encode_target_device = "vaapi";
   stats.encode_target_residency = platf::frame_residency_e::gpu;
   stats.encode_target_format = platf::frame_format_e::nv12;
@@ -987,8 +1013,8 @@ TEST(ProcessRuntimeConfigTests, MissionControlPolicyIncludesLinuxGpuProfileForVa
   ASSERT_TRUE(policy.contains("linux_gpu_profile"));
   const auto &profile = policy.at("linux_gpu_profile");
   EXPECT_EQ(profile.at("encoder_api"), "vaapi");
-  EXPECT_EQ(profile.at("encoder_adapter"), "/dev/dri/renderD128");
-  EXPECT_EQ(profile.at("capture_device"), "/dev/dri/renderD128");
+  EXPECT_EQ(profile.at("encoder_adapter"), render_node.string());
+  EXPECT_EQ(profile.at("capture_device"), render_node.string());
   EXPECT_TRUE(profile.at("adapter_matches_capture_device"));
   EXPECT_TRUE(profile.at("gpu_native_requested"));
   EXPECT_FALSE(profile.at("gpu_native_succeeded"));


### PR DESCRIPTION
## Summary

CI builds and runs a hand-listed set of test suites. That list grew one pull request at a time, each adding the suite its own change needed, and it drifted away from the suites the repo actually builds.

Two suites were invisible to CI entirely. `test_polaris_audit` and `test_polaris_platform` were compiled by no job and run by no job. A third, `test_polaris_config`, was built but never run through ctest; it was invoked directly with a single `--gtest_filter=ProcessRuntimeConfigTests.GamescopeAttached*`, so every other test in it was dead weight.

This is one mechanism behind three tests sitting red on master while every check reported green. One of the three is the Nova contract manifest guard, which exists specifically to catch manifest drift, and it missed my own drift in #459 because it never ran. A guard that never executes is worse than no guard, since it also sells confidence it has not earned.

The change is small: build every suite, run every suite. Narrowing stays available when a suite genuinely earns it, but it should be a deliberate exclusion with a reason, not the residue of whichever pull request last touched the line.

## What turning them on immediately found

The first run of the widened job failed, which is the outcome that justifies the change. Both failures are in test code, neither is a product defect, and both are fixed here.

**A heap-use-after-free in `test_nova_contract.cpp:278`, inside the drift guard itself.** The test iterated `manifest()["objects"].items()`. `items()` holds a proxy into the container it was called on, and `manifest()` returns by value, so the loop walked memory freed at the end of the full expression. AddressSanitizer caught it the first time it ever ran. The two tests above it in the same file already bind the manifest to a local first.

That one is worth stating plainly, because it is the same shape as the bug the test was written to catch. A guard whose whole job is noticing drift had been carrying a memory error for as long as it has existed, and looked healthy the entire time, because nothing ever compiled it. The suite reported no failures because it produced no results.

**An aborted `test_polaris_config`.** `MissionControlPolicyIncludesLinuxGpuProfileForVaapiCaptureTruth` asserted a device pairing using a hardcoded `/dev/dri/renderD128`. That pairing resolves through `std::filesystem::equivalent`, which needs both paths to exist. CI runners have no `/dev/dri`, so the comparison failed with an `error_code` and `device_nodes_match` correctly answered "unknown" rather than `true`. The field is JSON null in that case, `EXPECT_TRUE` throws `type_error.302` on a null, and the uncaught exception aborted the binary. The tri-state is right; the assertion needed a real file, so it now uses the same `TempFileGuard` shape `tests/unit/test_stream_stats.cpp` already uses for exactly this reason.

`test_polaris_platform` passed on its first run.

## Verification

- `.github/workflows/build.yml` parses as YAML, and the two edited steps are the only workflow changes.
- The suite names in the ctest regex were checked against the targets CMake actually defines, so none of them silently matches nothing. That failure mode is real here: an empty ctest selection exits 0.
- The honest test is this pull request's own C++ sanitizer job.

## Known gap

`test_polaris_config` aborted partway through its 280 tests, so every test after the failing one was never reached. Fixing the abort may surface further pre-existing failures in the tail. If it does, they are the same category as these two: real results from suites that have not run in a long time, not regressions from this change.

Five suites remain unlisted (`audio`, `input`, `network`, `pairing`, `video`). They are deliberately left for a follow-up rather than widened here, so this change stays reviewable and its failures stay attributable.

