### PR TITLE
feat(diagnostics): tell the user whether Polaris crashed

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -118,6 +118,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/game_artwork_provider.cpp"
         "${CMAKE_SOURCE_DIR}/src/config.h"
         "${CMAKE_SOURCE_DIR}/src/config.cpp"
+        "${CMAKE_SOURCE_DIR}/src/crash_report.cpp"
+        "${CMAKE_SOURCE_DIR}/src/crash_report.h"
         "${CMAKE_SOURCE_DIR}/src/display_device.h"
         "${CMAKE_SOURCE_DIR}/src/display_device.cpp"
         "${CMAKE_SOURCE_DIR}/src/display_planner.h"

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -43,6 +43,7 @@
 #include "confighttp.h"
 #include "confighttp_benchmark_auth.h"
 #include "confighttp_validation.h"
+#include "crash_report.h"
 #include "crypto.h"
 #include "display_device.h"
 #include "entry_handler.h"
@@ -4436,6 +4437,82 @@ namespace confighttp {
   }
 
   /**
+   * @brief Get the retained log of the run before this one.
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   *
+   * A run that crashed cannot serve its own log: by the time anyone asks, the
+   * process has restarted and the active log describes the new run. The bounded
+   * backup preserved at startup is the only copy of what the failing run said,
+   * which is what makes this the log a crash report needs.
+   *
+   * Served as plain bytes rather than the Base64 JSON of the tail endpoint,
+   * matching `/api/logs`, because this is a whole-file fetch for an export
+   * rather than an incremental reader that has to track offsets.
+   *
+   * @api_examples{/polaris/v1/diagnostics/logs/previous| GET| null}
+   */
+  void getPreviousLogs(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+    print_req(request);
+
+    const auto backup_path = logging::backup_log_path(config::sunshine.log_file);
+    std::error_code exists_error;
+    const bool present = !backup_path.empty() && std::filesystem::exists(backup_path, exists_error);
+
+    file_handler::tail_result_t tail;
+    if (present) {
+      tail = file_handler::read_file_tail(backup_path.c_str(), log_tail_api::legacy_max_bytes);
+    }
+
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    std::string contentType = "text/plain";
+  #ifdef _WIN32
+    contentType += "; charset=";
+    contentType += currentCodePageToCharset();
+  #endif
+    headers.emplace("Content-Type", contentType);
+    headers.emplace("Cache-Control", "no-store");
+    // An absent backup and an empty one are different states: the first means
+    // there was no prior run to preserve, the second that it logged nothing.
+    headers.emplace("X-Polaris-Log-Present", present ? "true" : "false");
+    headers.emplace("X-Polaris-Log-Start-Offset", std::to_string(tail.start_offset));
+    headers.emplace("X-Polaris-Log-End-Offset", std::to_string(tail.end_offset));
+    headers.emplace("X-Polaris-Log-Truncated", tail.truncated ? "true" : "false");
+    append_common_security_headers(headers);
+    response->write(SimpleWeb::StatusCode::success_ok, tail.content, headers);
+  }
+
+  /**
+   * @brief Get how the run before this one ended.
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   *
+   * Reports `clean`, `crashed`, `unclean`, or `unknown`, with the fatal signal
+   * and captured backtrace when there was one. This is what lets a support
+   * report state that Polaris crashed instead of leaving the user to work it
+   * out from `coredumpctl` by hand.
+   *
+   * @api_examples{/polaris/v1/diagnostics/last-run| GET| null}
+   */
+  void getLastRun(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+    print_req(request);
+
+    auto output = crash_report::to_json(crash_report::previous_run());
+    output["status"] = true;
+
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Cache-Control", "no-store");
+    append_json_security_headers(headers);
+    response->write(SimpleWeb::StatusCode::success_ok, output.dump(), headers);
+  }
+
+  /**
    * @brief Clear the active log file.
    * @param response The HTTP response object.
    * @param request The HTTP request object.
@@ -6526,6 +6603,8 @@ namespace confighttp {
     server.resource["^/api/games/scan$"]["GET"] = scanGames;
     server.resource["^/api/games/import$"]["POST"] = withCsrf(importGames);
     server.resource["^/polaris/v1/diagnostics/logs/tail$"]["GET"] = getLogTail;
+    server.resource["^/polaris/v1/diagnostics/logs/previous$"]["GET"] = getPreviousLogs;
+    server.resource["^/polaris/v1/diagnostics/last-run$"]["GET"] = getLastRun;
     server.resource["^/api/logs$"]["GET"] = getLogs;
     server.resource["^/api/logs/clear$"]["POST"] = withCsrf(clearLogs);
     server.resource["^/api/config$"]["GET"] = getConfig;

--- a/src/crash_report.cpp
+++ b/src/crash_report.cpp
@@ -1,0 +1,541 @@
+/**
+ * @file src/crash_report.cpp
+ * @brief Definitions for run-outcome tracking and fatal-signal evidence capture.
+ */
+// standard includes
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <exception>
+
+// local includes
+#include "crash_report.h"
+#include "logging.h"
+#include "private_state_file.h"
+
+#ifdef _WIN32
+  #include <process.h>
+#else
+  #include <csignal>
+  #include <fcntl.h>
+  #include <sys/stat.h>
+  #include <unistd.h>
+#endif
+
+#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__))
+  #define POLARIS_CRASH_HAVE_BACKTRACE 1
+  #include <execinfo.h>
+#endif
+
+using namespace std::literals;
+
+namespace crash_report {
+  namespace {
+    // Everything the signal handler is allowed to read lives here, preformatted
+    // while ordinary code is still running. A handler may not allocate, take a
+    // lock, or call into the logging framework, so the only work left at crash
+    // time is opening a file descriptor and writing bytes that already exist.
+    constexpr std::size_t max_path_bytes = 4096;
+    constexpr std::size_t max_header_bytes = 1024;
+    constexpr std::size_t max_terminate_bytes = 512;
+    constexpr int max_frames = 64;
+    // Not SIGSTKSZ: current glibc defines it as a sysconf() call rather than a
+    // constant expression, so it cannot size a static array.
+    constexpr std::size_t alternate_stack_bytes = 64U * 1024U;
+
+    char crash_path_buffer[max_path_bytes] = {};
+    char crash_header_buffer[max_header_bytes] = {};
+    std::size_t crash_header_length = 0;
+    char terminate_message_buffer[max_terminate_bytes] = {};
+    std::atomic_bool handlers_armed {false};
+
+    previous_run_t previous_run_state;
+    run_state_t current_run_state;
+    std::filesystem::path current_state_path;
+    bool run_begun = false;
+
+    struct signal_name_entry_t {
+      int number;
+      const char *name;
+    };
+
+    // Read from signal context, so it must be a table of literals and nothing else.
+    constexpr std::array<signal_name_entry_t, 6> signal_names {{
+#ifndef _WIN32
+      {SIGSEGV, "SIGSEGV"},
+      {SIGABRT, "SIGABRT"},
+      {SIGBUS, "SIGBUS"},
+      {SIGFPE, "SIGFPE"},
+      {SIGILL, "SIGILL"},
+      {SIGSYS, "SIGSYS"},
+#else
+      {0, ""},
+      {0, ""},
+      {0, ""},
+      {0, ""},
+      {0, ""},
+      {0, ""},
+#endif
+    }};
+
+    const char *signal_name_for(int number) {
+      for (const auto &entry : signal_names) {
+        if (entry.number == number && entry.name[0] != '\0') {
+          return entry.name;
+        }
+      }
+      return "UNKNOWN";
+    }
+
+    std::string utc_timestamp_now() {
+      const std::time_t now = std::time(nullptr);
+      std::tm parts {};
+#ifdef _WIN32
+      if (gmtime_s(&parts, &now) != 0) {
+        return {};
+      }
+#else
+      if (gmtime_r(&now, &parts) == nullptr) {
+        return {};
+      }
+#endif
+      char buffer[32] = {};
+      if (std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &parts) == 0) {
+        return {};
+      }
+      return buffer;
+    }
+
+    void copy_into(char *destination, std::size_t capacity, std::string_view source) {
+      const std::size_t length = std::min(source.size(), capacity - 1);
+      std::memcpy(destination, source.data(), length);
+      destination[length] = '\0';
+    }
+
+    /**
+     * @brief Extract a single-line `label: value` field from crash evidence.
+     */
+    std::string evidence_field(std::string_view evidence, std::string_view label) {
+      std::size_t cursor = 0;
+      while (cursor < evidence.size()) {
+        const auto line_end = evidence.find('\n', cursor);
+        const auto line = evidence.substr(cursor, line_end == std::string_view::npos ? std::string_view::npos : line_end - cursor);
+        if (line.size() > label.size() && line.compare(0, label.size(), label) == 0) {
+          auto value = line.substr(label.size());
+          while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) {
+            value.remove_prefix(1);
+          }
+          while (!value.empty() && (value.back() == '\r' || value.back() == ' ')) {
+            value.remove_suffix(1);
+          }
+          return std::string {value};
+        }
+        if (line_end == std::string_view::npos) {
+          break;
+        }
+        cursor = line_end + 1;
+      }
+      return {};
+    }
+
+#ifndef _WIN32
+    // Async-signal-safe primitives. ::write is on the POSIX safe list; nothing
+    // here allocates, formats through stdio, or touches a lock.
+    void write_all(int descriptor, const char *data, std::size_t length) {
+      std::size_t written = 0;
+      while (written < length) {
+        const auto result = ::write(descriptor, data + written, length - written);
+        if (result <= 0) {
+          if (result < 0 && errno == EINTR) {
+            continue;
+          }
+          return;
+        }
+        written += static_cast<std::size_t>(result);
+      }
+    }
+
+    void write_literal(int descriptor, const char *text) {
+      write_all(descriptor, text, std::strlen(text));
+    }
+
+    void write_decimal(int descriptor, long long value) {
+      char buffer[24];
+      std::size_t index = sizeof(buffer);
+      const bool negative = value < 0;
+      unsigned long long magnitude = negative ? 0ULL - static_cast<unsigned long long>(value) : static_cast<unsigned long long>(value);
+      do {
+        buffer[--index] = static_cast<char>('0' + (magnitude % 10));
+        magnitude /= 10;
+      } while (magnitude != 0 && index > 0);
+      if (negative && index > 0) {
+        buffer[--index] = '-';
+      }
+      write_all(descriptor, buffer + index, sizeof(buffer) - index);
+    }
+
+    void write_hex_pointer(int descriptor, const void *pointer) {
+      static constexpr char digits[] = "0123456789abcdef";
+      auto value = reinterpret_cast<unsigned long long>(pointer);
+      char buffer[2 + (sizeof(value) * 2)];
+      buffer[0] = '0';
+      buffer[1] = 'x';
+      for (std::size_t index = 0; index < sizeof(value) * 2; ++index) {
+        const auto shift = ((sizeof(value) * 2) - 1 - index) * 4;
+        buffer[2 + index] = digits[(value >> shift) & 0xF];
+      }
+      write_all(descriptor, buffer, sizeof(buffer));
+    }
+
+    extern "C" void fatal_signal_handler(int signal_number, siginfo_t *info, void *) {
+      // A fault inside the handler must not loop back into it.
+      static volatile sig_atomic_t already_entered = 0;
+      if (already_entered) {
+        ::_exit(128 + signal_number);
+      }
+      already_entered = 1;
+
+      const int descriptor = ::open(crash_path_buffer, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+      if (descriptor >= 0) {
+        write_all(descriptor, crash_header_buffer, crash_header_length);
+
+        write_literal(descriptor, "signal: ");
+        write_decimal(descriptor, signal_number);
+        write_literal(descriptor, " ");
+        write_literal(descriptor, signal_name_for(signal_number));
+        write_literal(descriptor, "\n");
+
+        write_literal(descriptor, "address: ");
+        write_hex_pointer(descriptor, info != nullptr ? info->si_addr : nullptr);
+        write_literal(descriptor, "\n");
+
+        if (terminate_message_buffer[0] != '\0') {
+          write_literal(descriptor, "terminate: ");
+          write_literal(descriptor, terminate_message_buffer);
+          write_literal(descriptor, "\n");
+        }
+
+        write_literal(descriptor, "backtrace:\n");
+  #ifdef POLARIS_CRASH_HAVE_BACKTRACE
+        void *frames[max_frames];
+        const int frame_count = ::backtrace(frames, max_frames);
+        ::backtrace_symbols_fd(frames, frame_count, descriptor);
+  #else
+        write_literal(descriptor, "(backtrace unavailable in this build)\n");
+  #endif
+
+        ::fsync(descriptor);
+        ::close(descriptor);
+      }
+
+      // Hand the signal back to the default disposition so the core dump still
+      // happens and coredumpctl keeps producing a symbolised backtrace.
+      struct sigaction restore {};
+      restore.sa_handler = SIG_DFL;
+      sigemptyset(&restore.sa_mask);
+      restore.sa_flags = 0;
+      ::sigaction(signal_number, &restore, nullptr);
+      ::raise(signal_number);
+    }
+#endif
+
+    void terminate_handler() {
+      // Ordinary context, so this may allocate. It runs before abort() turns
+      // into SIGABRT, and the message it leaves is picked up by that handler.
+      const char *message = "uncaught exception";
+      std::string detail;
+      if (auto pending = std::current_exception()) {
+        try {
+          std::rethrow_exception(pending);
+        } catch (const std::exception &error) {
+          detail = error.what();
+          message = detail.c_str();
+        } catch (...) {
+          message = "uncaught non-standard exception";
+        }
+      }
+      copy_into(terminate_message_buffer, sizeof(terminate_message_buffer), message);
+      std::abort();
+    }
+
+    run_state_t build_current_state(const std::string &log_path, const std::string &version) {
+      run_state_t state;
+      state.schema_version = run_state_schema_version;
+      state.version = version;
+      state.started_at = utc_timestamp_now();
+#ifdef _WIN32
+      state.pid = static_cast<long long>(::_getpid());
+#else
+      state.pid = static_cast<long long>(::getpid());
+#endif
+      state.log_path = log_path;
+      state.status = "running";
+      state.run_id = state.started_at + "-" + std::to_string(state.pid);
+      return state;
+    }
+
+    void persist(const run_state_t &state) {
+      if (current_state_path.empty()) {
+        return;
+      }
+      const auto result = private_state_file::write_atomic(current_state_path, serialize_run_state(state));
+      if (!result) {
+        BOOST_LOG(warning) << "Could not persist the run-state document; crash detection will be degraded on the next start."sv;
+      }
+    }
+  }  // namespace
+
+  std::string serialize_run_state(const run_state_t &state) {
+    nlohmann::json document;
+    document["schema_version"] = state.schema_version;
+    document["run_id"] = state.run_id;
+    document["version"] = state.version;
+    document["pid"] = state.pid;
+    document["started_at"] = state.started_at;
+    document["log_path"] = state.log_path;
+    document["status"] = state.status;
+    document["ended_at"] = state.ended_at;
+    document["shutdown_reason"] = state.shutdown_reason;
+    document["exit_code"] = state.exit_code;
+    return document.dump();
+  }
+
+  std::optional<run_state_t> parse_run_state(std::string_view payload) {
+    if (payload.empty()) {
+      return std::nullopt;
+    }
+
+    const auto document = nlohmann::json::parse(payload, nullptr, false);
+    if (document.is_discarded() || !document.is_object()) {
+      return std::nullopt;
+    }
+    if (document.value("schema_version", 0) != run_state_schema_version) {
+      return std::nullopt;
+    }
+
+    run_state_t state;
+    state.schema_version = run_state_schema_version;
+    state.run_id = document.value("run_id", std::string {});
+    state.version = document.value("version", std::string {});
+    state.pid = document.value("pid", 0LL);
+    state.started_at = document.value("started_at", std::string {});
+    state.log_path = document.value("log_path", std::string {});
+    state.status = document.value("status", std::string {});
+    state.ended_at = document.value("ended_at", std::string {});
+    state.shutdown_reason = document.value("shutdown_reason", std::string {});
+    state.exit_code = document.value("exit_code", 0);
+    return state;
+  }
+
+  previous_run_t classify_previous_run(
+    const std::optional<run_state_t> &state,
+    std::string_view crash_evidence
+  ) {
+    previous_run_t previous;
+    if (!state) {
+      return previous;
+    }
+
+    previous.version = state->version;
+    previous.run_id = state->run_id;
+    previous.started_at = state->started_at;
+    previous.ended_at = state->ended_at;
+    previous.shutdown_reason = state->shutdown_reason;
+    previous.log_path = state->log_path;
+    previous.pid = state->pid;
+    previous.exit_code = state->exit_code;
+
+    if (state->status == "clean") {
+      previous.outcome = outcome_e::clean;
+      return previous;
+    }
+
+    // The run never recorded an exit. Evidence decides whether that was a fatal
+    // signal or something that gave Polaris no chance to record anything, such
+    // as the OOM killer, SIGKILL, or power loss.
+    previous.outcome = outcome_e::unclean;
+
+    const bool evidence_is_ours =
+      crash_evidence.size() > crash_evidence_magic.size() &&
+      crash_evidence.compare(0, crash_evidence_magic.size(), crash_evidence_magic) == 0;
+    if (!evidence_is_ours) {
+      return previous;
+    }
+
+    // Evidence from an older run must not be reported against this one.
+    const auto evidence_run_id = evidence_field(crash_evidence, "run_id:");
+    if (evidence_run_id.empty() || evidence_run_id != state->run_id) {
+      return previous;
+    }
+
+    previous.outcome = outcome_e::crashed;
+    previous.evidence = std::string {crash_evidence};
+
+    const auto signal_field = evidence_field(crash_evidence, "signal:");
+    if (!signal_field.empty()) {
+      const auto separator = signal_field.find(' ');
+      const auto number_text = signal_field.substr(0, separator);
+      try {
+        previous.signal_number = std::stoi(number_text);
+      } catch (const std::exception &) {
+        previous.signal_number = 0;
+      }
+      if (separator != std::string::npos) {
+        previous.signal_name = signal_field.substr(separator + 1);
+      }
+    }
+
+    return previous;
+  }
+
+  std::string_view describe_outcome(outcome_e outcome) {
+    switch (outcome) {
+      case outcome_e::clean:
+        return "clean"sv;
+      case outcome_e::crashed:
+        return "crashed"sv;
+      case outcome_e::unclean:
+        return "unclean"sv;
+      case outcome_e::unknown:
+      default:
+        return "unknown"sv;
+    }
+  }
+
+  nlohmann::json to_json(const previous_run_t &previous) {
+    nlohmann::json document;
+    document["outcome"] = describe_outcome(previous.outcome);
+    document["recorded"] = previous.outcome != outcome_e::unknown;
+    document["version"] = previous.version;
+    document["run_id"] = previous.run_id;
+    document["started_at"] = previous.started_at;
+    document["ended_at"] = previous.ended_at;
+    document["shutdown_reason"] = previous.shutdown_reason;
+    document["log_path"] = previous.log_path;
+    document["pid"] = previous.pid;
+    document["exit_code"] = previous.exit_code;
+    document["signal_number"] = previous.signal_number;
+    document["signal_name"] = previous.signal_name;
+    document["evidence"] = previous.evidence;
+    return document;
+  }
+
+  void begin_run(
+    const std::filesystem::path &state_dir,
+    const std::string &log_path,
+    const std::string &version
+  ) {
+    if (run_begun) {
+      return;
+    }
+    run_begun = true;
+
+    std::error_code directory_error;
+    std::filesystem::create_directories(state_dir, directory_error);
+
+    current_state_path = state_dir / std::string {run_state_file_name};
+    const auto crash_path = state_dir / std::string {crash_evidence_file_name};
+
+    const auto stored = private_state_file::read_secure(current_state_path, max_run_state_bytes);
+    const auto evidence = private_state_file::read_secure(crash_path, max_crash_evidence_bytes);
+    previous_run_state = classify_previous_run(
+      stored ? parse_run_state(stored.payload) : std::nullopt,
+      evidence ? std::string_view {evidence.payload} : std::string_view {}
+    );
+
+    switch (previous_run_state.outcome) {
+      case outcome_e::crashed:
+        BOOST_LOG(error) << "The previous Polaris run crashed on "sv << previous_run_state.signal_name
+                         << ". Crash evidence is available from the Troubleshooting screen."sv;
+        break;
+      case outcome_e::unclean:
+        BOOST_LOG(warning) << "The previous Polaris run did not record an exit and left no crash evidence, "
+                              "which usually means it was killed rather than that it faulted."sv;
+        break;
+      case outcome_e::clean:
+      case outcome_e::unknown:
+      default:
+        break;
+    }
+
+    current_run_state = build_current_state(log_path, version);
+    persist(current_run_state);
+
+    // Preformat everything the signal handler may touch, while allocation is
+    // still legal.
+    copy_into(crash_path_buffer, sizeof(crash_path_buffer), crash_path.string());
+    const auto header = "polaris-crash-v1\nrun_id: " + current_run_state.run_id +
+                        "\nversion: " + current_run_state.version +
+                        "\npid: " + std::to_string(current_run_state.pid) + "\n";
+    copy_into(crash_header_buffer, sizeof(crash_header_buffer), header);
+    crash_header_length = std::strlen(crash_header_buffer);
+  }
+
+  void note_clean_exit(int exit_code, const char *shutdown_reason) {
+    if (!run_begun) {
+      return;
+    }
+    current_run_state.status = "clean";
+    current_run_state.ended_at = utc_timestamp_now();
+    current_run_state.exit_code = exit_code;
+    current_run_state.shutdown_reason = shutdown_reason != nullptr ? shutdown_reason : "";
+    persist(current_run_state);
+  }
+
+  void install_fatal_handlers() {
+    if (handlers_armed.exchange(true)) {
+      return;
+    }
+
+    std::set_terminate(terminate_handler);
+
+#ifndef _WIN32
+  #ifdef POLARIS_CRASH_HAVE_BACKTRACE
+    // backtrace() loads the unwinder lazily and that first call allocates, so
+    // force it here rather than inside a handler that may not allocate.
+    void *warmup[2];
+    (void) ::backtrace(warmup, 2);
+  #endif
+
+    // A stack-overflow SIGSEGV cannot be handled on the overflowed stack.
+    static std::array<char, alternate_stack_bytes> alternate_stack;
+    stack_t signal_stack {};
+    signal_stack.ss_sp = alternate_stack.data();
+    signal_stack.ss_size = alternate_stack.size();
+    signal_stack.ss_flags = 0;
+    (void) ::sigaltstack(&signal_stack, nullptr);
+
+    struct sigaction action {};
+    action.sa_sigaction = fatal_signal_handler;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+
+    for (const auto &entry : signal_names) {
+      if (entry.number != 0) {
+        ::sigaction(entry.number, &action, nullptr);
+      }
+    }
+#endif
+  }
+
+  const previous_run_t &previous_run() {
+    return previous_run_state;
+  }
+
+#ifdef POLARIS_TESTS
+  void reset_for_tests() {
+    previous_run_state = {};
+    current_run_state = {};
+    current_state_path.clear();
+    run_begun = false;
+    crash_path_buffer[0] = '\0';
+    crash_header_buffer[0] = '\0';
+    crash_header_length = 0;
+    terminate_message_buffer[0] = '\0';
+  }
+#endif
+}  // namespace crash_report

--- a/src/crash_report.h
+++ b/src/crash_report.h
@@ -1,0 +1,173 @@
+/**
+ * @file src/crash_report.h
+ * @brief Run-outcome tracking and fatal-signal evidence capture.
+ *
+ * Polaris could not previously tell a user whether it had crashed. The log of a
+ * run that died is preserved as the bounded backup log, but nothing recorded
+ * that the run ended abnormally, so a support report could not distinguish a
+ * segfault from an ordinary quit.
+ *
+ * This module records one small state document per run and, when a fatal signal
+ * arrives, writes a backtrace from inside the signal handler. On the next start
+ * the two are read back together and classified.
+ */
+#pragma once
+
+// standard includes
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+
+// lib includes
+#include <nlohmann/json.hpp>
+
+namespace crash_report {
+  /** @brief Schema version of the persisted run-state document. */
+  inline constexpr int run_state_schema_version = 1;
+
+  /** @brief First line of a crash evidence file, used to reject foreign files. */
+  inline constexpr std::string_view crash_evidence_magic = "polaris-crash-v1";
+
+  /** @brief Largest crash evidence file read back on the next start. */
+  inline constexpr std::size_t max_crash_evidence_bytes = 64U * 1024U;
+
+  /** @brief Largest run-state document read back on the next start. */
+  inline constexpr std::size_t max_run_state_bytes = 8U * 1024U;
+
+  /** @brief File name of the run-state document inside the state directory. */
+  inline constexpr std::string_view run_state_file_name = "last_run.json";
+
+  /** @brief File name of the crash evidence inside the state directory. */
+  inline constexpr std::string_view crash_evidence_file_name = "last_crash.txt";
+
+  /**
+   * @brief What happened to the run before this one.
+   */
+  enum class outcome_e {
+    unknown,  ///< No usable run-state was recorded, typically a first start.
+    clean,    ///< The previous run recorded its own exit.
+    crashed,  ///< The previous run died on a fatal signal and left evidence.
+    unclean,  ///< The previous run never recorded an exit and left no evidence.
+  };
+
+  /**
+   * @brief The persisted per-run document.
+   */
+  struct run_state_t {
+    int schema_version = run_state_schema_version;
+    std::string run_id;
+    std::string version;
+    long long pid = 0;
+    std::string started_at;
+    std::string log_path;
+    std::string status;  ///< "running" while live, "clean" once an exit is recorded.
+    std::string ended_at;
+    std::string shutdown_reason;
+    int exit_code = 0;
+  };
+
+  /**
+   * @brief The classified result read back on the next start.
+   */
+  struct previous_run_t {
+    outcome_e outcome = outcome_e::unknown;
+    std::string version;
+    std::string run_id;
+    std::string started_at;
+    std::string ended_at;
+    std::string shutdown_reason;
+    std::string log_path;
+    long long pid = 0;
+    int exit_code = 0;
+    int signal_number = 0;
+    std::string signal_name;
+    std::string evidence;  ///< Raw crash evidence text; empty unless outcome is crashed.
+  };
+
+  /**
+   * @brief Serialize a run-state document.
+   */
+  std::string serialize_run_state(const run_state_t &state);
+
+  /**
+   * @brief Parse a run-state document.
+   * @return The parsed state, or nullopt when the payload is malformed or
+   *         carries a schema version this build does not understand.
+   */
+  std::optional<run_state_t> parse_run_state(std::string_view payload);
+
+  /**
+   * @brief Decide what happened to the previous run.
+   *
+   * Crash evidence is only attributed to the previous run when its recorded
+   * `run_id` matches. Evidence left by an older run is ignored rather than
+   * reported against an unrelated one, which is what makes it safe to leave the
+   * evidence file on disk instead of consuming it.
+   *
+   * @param state The previous run-state document, if one was readable.
+   * @param crash_evidence Raw contents of the crash evidence file, or empty.
+   */
+  previous_run_t classify_previous_run(
+    const std::optional<run_state_t> &state,
+    std::string_view crash_evidence
+  );
+
+  /**
+   * @brief Stable wire name for an outcome.
+   */
+  std::string_view describe_outcome(outcome_e outcome);
+
+  /**
+   * @brief Render a classified previous run for the diagnostics API.
+   */
+  nlohmann::json to_json(const previous_run_t &previous);
+
+  /**
+   * @brief Read the previous run's outcome, then record this run as running.
+   *
+   * Call once, after logging is initialized so the classification can be logged,
+   * and before anything that can crash. The state directory is passed in rather
+   * than resolved here so the module stays linkable without the platform layer.
+   *
+   * @param state_dir Directory holding the run-state and crash evidence files.
+   * @param log_path Active log path recorded for this run.
+   * @param version Polaris version recorded for this run.
+   */
+  void begin_run(
+    const std::filesystem::path &state_dir,
+    const std::string &log_path,
+    const std::string &version
+  );
+
+  /**
+   * @brief Record that this run is ending on its own terms.
+   *
+   * Must be reached by ordinary control flow. Deliberately not called from a
+   * signal handler: the write path is not async-signal-safe, and a run killed
+   * before it returns is genuinely an unclean exit.
+   */
+  void note_clean_exit(int exit_code, const char *shutdown_reason);
+
+  /**
+   * @brief Install fatal-signal handlers that write crash evidence.
+   *
+   * Requires begin_run() first, which is what preformats the buffers the
+   * handler is allowed to touch. The handler restores the default disposition
+   * and re-raises, so core dumps and `coredumpctl` keep working unchanged.
+   */
+  void install_fatal_handlers();
+
+  /**
+   * @brief The previous run as classified by begin_run().
+   */
+  const previous_run_t &previous_run();
+
+#ifdef POLARIS_TESTS
+  /**
+   * @brief Reset process-wide state so tests can drive begin_run() repeatedly.
+   */
+  void reset_for_tests();
+#endif
+}  // namespace crash_report

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -245,6 +245,13 @@ namespace logging {
   };
 #endif
 
+  std::string backup_log_path(const std::string &log_file) {
+    if (log_file.empty()) {
+      return {};
+    }
+    return log_file + ".backup";
+  }
+
   [[nodiscard]] std::unique_ptr<deinit_t> init(int min_log_level, const std::string &log_file) {
     if (sink || file_sink) {
       // Deinitialize the logging system before reinitializing it. This can probably only ever be hit in tests.
@@ -253,10 +260,7 @@ namespace logging {
 
     // Check if the log file exists and handle backup. An empty path requests
     // console-only logging for commands that must not initialize user state.
-    std::string backup_log_file;
-    if (!log_file.empty()) {
-      backup_log_file = log_file + ".backup";
-    }
+    const std::string backup_log_file = backup_log_path(log_file);
     auto file_logging_ready = !log_file.empty();
     if (file_logging_ready) {
       // Single owner per config directory: a second Polaris reaching this init

--- a/src/logging.h
+++ b/src/logging.h
@@ -103,6 +103,18 @@ namespace logging {
   bool clear_log_file();
 
   /**
+   * @brief Path of the retained bounded backup of the prior run's log.
+   *
+   * The backup is what survives a run that crashed, so readers outside the
+   * logging system need to name it. Deriving it in one place keeps the suffix
+   * from drifting between the writer and its readers.
+   *
+   * @param log_file Active log path, or empty for console-only logging.
+   * @return The backup path, or an empty string when there is no file logging.
+   */
+  std::string backup_log_path(const std::string &log_file);
+
+  /**
    * @brief Print help to stdout.
    * @param name The name of the program.
    * @examples

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include "beat_times.h"
 #include "client_profiles.h"
 #include "confighttp.h"
+#include "crash_report.h"
 #include "display_device.h"
 #include "entry_handler.h"
 #include "globals.h"
@@ -234,6 +235,14 @@ int main(int argc, char *argv[]) {
   // if anything is logged prior to this point, it will appear in stdout, but not in the log viewer in the UI
   // the version should be printed to the log before anything else
   BOOST_LOG(info) << PROJECT_NAME << " version: " << PROJECT_VERSION << " commit: " << PROJECT_VERSION_COMMIT;
+
+  // Classify how the previous run ended and record that this one is live, then
+  // arm the handlers that leave evidence if it is not. This has to happen after
+  // logging is up, so the verdict on the previous run reaches the log, and
+  // before anything that can fault.
+  crash_report::begin_run(platf::appdata(), config::sunshine.log_file, PROJECT_VERSION);
+  crash_report::install_fatal_handlers();
+
 #ifdef __linux__
   #ifdef POLARIS_BUILD_CUDA
   constexpr auto linux_cuda_build_feature = "enabled"sv;
@@ -597,6 +606,10 @@ int main(int argc, char *argv[]) {
     system_tray::end_tray_threaded();
   }
 #endif
+
+  // Reached only by ordinary control flow, which is exactly what makes it
+  // meaningful: a run killed before this point is recorded as unclean.
+  crash_report::note_clean_exit(lifetime::desired_exit_code, lifetime::shutdown_reason());
 
   return lifetime::desired_exit_code;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/confighttp_validation.cpp
     ${CMAKE_SOURCE_DIR}/src/confighttp_benchmark_auth.cpp
     ${CMAKE_SOURCE_DIR}/src/browser_stream_protocol.cpp
+    ${CMAKE_SOURCE_DIR}/src/crash_report.cpp
     ${CMAKE_SOURCE_DIR}/src/file_handler.cpp
     ${CMAKE_SOURCE_DIR}/src/log_tail_api.cpp
     ${CMAKE_SOURCE_DIR}/src/private_state_file.cpp
@@ -106,6 +107,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_cover_download_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_client_settings_advertisement.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_browser_stream_protocol.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_crash_report.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_cursor_visibility.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_file_handler.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_log_tail_api.cpp

--- a/tests/unit/test_crash_report.cpp
+++ b/tests/unit/test_crash_report.cpp
@@ -1,0 +1,270 @@
+/**
+ * @file tests/unit/test_crash_report.cpp
+ * @brief Test run-outcome classification and its persisted contract.
+ */
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <src/crash_report.h>
+#include <src/logging.h>
+#include <string>
+
+#ifndef _WIN32
+  #include <csignal>
+  #include <sys/resource.h>
+  #include <sys/wait.h>
+  #include <unistd.h>
+#endif
+
+using namespace std::literals;
+
+namespace {
+  namespace fs = std::filesystem;
+
+  crash_report::run_state_t running_state() {
+    crash_report::run_state_t state;
+    state.run_id = "2026-08-17T10:00:00Z-4242";
+    state.version = "1.3.11";
+    state.pid = 4242;
+    state.started_at = "2026-08-17T10:00:00Z";
+    state.log_path = "/var/log/polaris/polaris.log";
+    state.status = "running";
+    return state;
+  }
+
+  std::string evidence_for(const std::string &run_id, const std::string &signal_line = "signal: 11 SIGSEGV") {
+    return std::string {crash_report::crash_evidence_magic} +
+           "\nrun_id: " + run_id +
+           "\nversion: 1.3.11\npid: 4242\n" + signal_line +
+           "\naddress: 0x0000000000000000\nbacktrace:\npolaris(+0x1234)\n";
+  }
+
+  class CrashReportStateDir: public ::testing::Test {
+  protected:
+    void SetUp() override {
+      root_ = fs::temp_directory_path() / ("polaris-crash-report-" + std::to_string(counter_++));
+      fs::remove_all(root_);
+      crash_report::reset_for_tests();
+    }
+
+    void TearDown() override {
+      crash_report::reset_for_tests();
+      std::error_code error;
+      fs::remove_all(root_, error);
+    }
+
+    fs::path root_;
+
+  private:
+    static int counter_;
+  };
+
+  int CrashReportStateDir::counter_ = 0;
+}  // namespace
+
+TEST(CrashReportRunStateTests, SerializesAndParsesRoundTrip) {
+  auto state = running_state();
+  state.status = "clean";
+  state.ended_at = "2026-08-17T11:00:00Z";
+  state.shutdown_reason = "SIGTERM received";
+  state.exit_code = 3;
+
+  const auto parsed = crash_report::parse_run_state(crash_report::serialize_run_state(state));
+
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(parsed->run_id, state.run_id);
+  EXPECT_EQ(parsed->version, state.version);
+  EXPECT_EQ(parsed->pid, state.pid);
+  EXPECT_EQ(parsed->started_at, state.started_at);
+  EXPECT_EQ(parsed->log_path, state.log_path);
+  EXPECT_EQ(parsed->status, state.status);
+  EXPECT_EQ(parsed->ended_at, state.ended_at);
+  EXPECT_EQ(parsed->shutdown_reason, state.shutdown_reason);
+  EXPECT_EQ(parsed->exit_code, state.exit_code);
+}
+
+TEST(CrashReportRunStateTests, RejectsUnusablePayloads) {
+  EXPECT_FALSE(crash_report::parse_run_state(""sv).has_value());
+  EXPECT_FALSE(crash_report::parse_run_state("not json"sv).has_value());
+  EXPECT_FALSE(crash_report::parse_run_state("[]"sv).has_value());
+  // A document from a schema this build does not understand must not be read
+  // field by field on the assumption the names still mean the same thing.
+  EXPECT_FALSE(crash_report::parse_run_state(R"({"schema_version":99,"status":"clean"})"sv).has_value());
+}
+
+TEST(CrashReportClassifyTests, ReportsUnknownWithoutAPreviousRun) {
+  const auto previous = crash_report::classify_previous_run(std::nullopt, ""sv);
+
+  EXPECT_EQ(previous.outcome, crash_report::outcome_e::unknown);
+  EXPECT_TRUE(previous.evidence.empty());
+}
+
+TEST(CrashReportClassifyTests, ReportsCleanWhenTheRunRecordedItsExit) {
+  auto state = running_state();
+  state.status = "clean";
+  state.shutdown_reason = "SIGINT received";
+  state.exit_code = 0;
+
+  const auto previous = crash_report::classify_previous_run(state, ""sv);
+
+  EXPECT_EQ(previous.outcome, crash_report::outcome_e::clean);
+  EXPECT_EQ(previous.shutdown_reason, "SIGINT received");
+}
+
+TEST(CrashReportClassifyTests, ReportsUncleanWhenNoExitAndNoEvidence) {
+  // SIGKILL, the OOM killer, and power loss all land here: the run never got to
+  // record an exit and never got to write evidence either.
+  const auto previous = crash_report::classify_previous_run(running_state(), ""sv);
+
+  EXPECT_EQ(previous.outcome, crash_report::outcome_e::unclean);
+  EXPECT_EQ(previous.signal_number, 0);
+  EXPECT_TRUE(previous.evidence.empty());
+}
+
+TEST(CrashReportClassifyTests, ReportsCrashedWithTheSignalItDiedOn) {
+  const auto state = running_state();
+
+  const auto previous = crash_report::classify_previous_run(state, evidence_for(state.run_id));
+
+  EXPECT_EQ(previous.outcome, crash_report::outcome_e::crashed);
+  EXPECT_EQ(previous.signal_number, 11);
+  EXPECT_EQ(previous.signal_name, "SIGSEGV");
+  EXPECT_NE(previous.evidence.find("backtrace:"), std::string::npos);
+  EXPECT_EQ(previous.log_path, state.log_path);
+}
+
+TEST(CrashReportClassifyTests, IgnoresEvidenceLeftByAnEarlierRun) {
+  // The evidence file is deliberately not consumed on read, so a crash from
+  // three runs ago is still on disk. Attributing it to an unrelated run would
+  // report a crash that did not happen.
+  const auto previous = crash_report::classify_previous_run(
+    running_state(),
+    evidence_for("2026-08-01T09:00:00Z-1111")
+  );
+
+  EXPECT_EQ(previous.outcome, crash_report::outcome_e::unclean);
+  EXPECT_TRUE(previous.evidence.empty());
+  EXPECT_EQ(previous.signal_number, 0);
+}
+
+TEST(CrashReportClassifyTests, IgnoresEvidenceThatIsNotOurs) {
+  const auto state = running_state();
+  const auto foreign = "some other tool's crash file\nrun_id: " + state.run_id + "\n";
+
+  const auto previous = crash_report::classify_previous_run(state, foreign);
+
+  EXPECT_EQ(previous.outcome, crash_report::outcome_e::unclean);
+  EXPECT_TRUE(previous.evidence.empty());
+}
+
+TEST(CrashReportClassifyTests, SurvivesEvidenceWithoutAParsableSignal) {
+  const auto state = running_state();
+
+  const auto previous = crash_report::classify_previous_run(state, evidence_for(state.run_id, "signal: not-a-number"));
+
+  EXPECT_EQ(previous.outcome, crash_report::outcome_e::crashed);
+  EXPECT_EQ(previous.signal_number, 0);
+}
+
+TEST(CrashReportClassifyTests, DescribesOutcomesWithStableWireNames) {
+  EXPECT_EQ(crash_report::describe_outcome(crash_report::outcome_e::unknown), "unknown"sv);
+  EXPECT_EQ(crash_report::describe_outcome(crash_report::outcome_e::clean), "clean"sv);
+  EXPECT_EQ(crash_report::describe_outcome(crash_report::outcome_e::crashed), "crashed"sv);
+  EXPECT_EQ(crash_report::describe_outcome(crash_report::outcome_e::unclean), "unclean"sv);
+}
+
+TEST(CrashReportClassifyTests, RendersTheDiagnosticsPayload) {
+  const auto state = running_state();
+
+  const auto document = crash_report::to_json(crash_report::classify_previous_run(state, evidence_for(state.run_id)));
+
+  EXPECT_EQ(document["outcome"], "crashed");
+  EXPECT_TRUE(document["recorded"].get<bool>());
+  EXPECT_EQ(document["signal_name"], "SIGSEGV");
+  EXPECT_EQ(document["version"], "1.3.11");
+  EXPECT_FALSE(document["evidence"].get<std::string>().empty());
+}
+
+TEST(CrashReportClassifyTests, MarksAnAbsentPreviousRunAsNotRecorded) {
+  const auto document = crash_report::to_json(crash_report::classify_previous_run(std::nullopt, ""sv));
+
+  EXPECT_EQ(document["outcome"], "unknown");
+  EXPECT_FALSE(document["recorded"].get<bool>());
+}
+
+TEST_F(CrashReportStateDir, FirstRunHasNoPreviousOutcome) {
+  crash_report::begin_run(root_, (root_ / "polaris.log").string(), "1.3.11");
+
+  EXPECT_EQ(crash_report::previous_run().outcome, crash_report::outcome_e::unknown);
+  EXPECT_TRUE(fs::exists(root_ / std::string {crash_report::run_state_file_name}));
+}
+
+TEST_F(CrashReportStateDir, ARecordedExitIsReadBackAsClean) {
+  crash_report::begin_run(root_, (root_ / "polaris.log").string(), "1.3.11");
+  crash_report::note_clean_exit(0, "SIGTERM received");
+
+  crash_report::reset_for_tests();
+  crash_report::begin_run(root_, (root_ / "polaris.log").string(), "1.3.11");
+
+  const auto &previous = crash_report::previous_run();
+  EXPECT_EQ(previous.outcome, crash_report::outcome_e::clean);
+  EXPECT_EQ(previous.shutdown_reason, "SIGTERM received");
+  EXPECT_EQ(previous.version, "1.3.11");
+}
+
+TEST_F(CrashReportStateDir, AMissingExitIsReadBackAsUnclean) {
+  crash_report::begin_run(root_, (root_ / "polaris.log").string(), "1.3.11");
+  // No note_clean_exit(): this is what a killed process leaves behind.
+
+  crash_report::reset_for_tests();
+  crash_report::begin_run(root_, (root_ / "polaris.log").string(), "1.3.11");
+
+  EXPECT_EQ(crash_report::previous_run().outcome, crash_report::outcome_e::unclean);
+}
+
+#ifndef _WIN32
+TEST_F(CrashReportStateDir, AFatalSignalLeavesEvidenceTheNextRunReadsBack) {
+  // The handler cannot be exercised in-process: it re-raises so the default
+  // disposition still dumps core, which would take the test runner with it.
+  // A forked child dies for real, exactly as Polaris would, and the parent then
+  // plays the part of the next start.
+  const auto child = ::fork();
+  ASSERT_NE(child, -1);
+
+  if (child == 0) {
+    // Do not litter the developer's machine or CI with core files just to prove
+    // the handler ran.
+    const rlimit no_core {0, 0};
+    (void) ::setrlimit(RLIMIT_CORE, &no_core);
+
+    crash_report::begin_run(root_, (root_ / "polaris.log").string(), "1.3.11");
+    crash_report::install_fatal_handlers();
+    std::raise(SIGSEGV);
+    ::_exit(0);  // Only reached if the handler swallowed the signal, which is a bug.
+  }
+
+  int status = 0;
+  ASSERT_EQ(::waitpid(child, &status, 0), child);
+  // Re-raising rather than exiting is what keeps coredumpctl working, so assert
+  // the child really did die of the original signal.
+  ASSERT_TRUE(WIFSIGNALED(status)) << "child exited instead of dying on the signal";
+  EXPECT_EQ(WTERMSIG(status), SIGSEGV);
+
+  crash_report::reset_for_tests();
+  crash_report::begin_run(root_, (root_ / "polaris.log").string(), "1.3.11");
+
+  const auto &previous = crash_report::previous_run();
+  EXPECT_EQ(previous.outcome, crash_report::outcome_e::crashed);
+  EXPECT_EQ(previous.signal_number, SIGSEGV);
+  EXPECT_EQ(previous.signal_name, "SIGSEGV");
+  EXPECT_EQ(previous.version, "1.3.11");
+  EXPECT_NE(previous.evidence.find("backtrace:"), std::string::npos);
+}
+#endif
+
+TEST(BackupLogPathTests, NamesTheBackupBesideTheActiveLog) {
+  EXPECT_EQ(logging::backup_log_path("/var/log/polaris.log"), "/var/log/polaris.log.backup");
+}
+
+TEST(BackupLogPathTests, HasNoBackupWhenLoggingIsConsoleOnly) {
+  EXPECT_TRUE(logging::backup_log_path("").empty());
+}


### PR DESCRIPTION
## Summary

Polaris could not say how its own last run ended. If it died, the user got nothing, and the answer `docs/troubleshooting.md` gives today is to install a debug package and read `coredumpctl` by hand. That is a reasonable ask of a developer and not of a user filing a bug.

It now records one small state document per run and, when a fatal signal arrives, writes a backtrace from inside the signal handler. The next start reads the two back together and classifies the previous run.

First of a small series adding crash and troubleshooting reporting across Polaris and Nova. This one is the host-side evidence; the Web UI that surfaces it follows separately.

## The evidence already existed and was unreachable

`logging.cpp` already renames the previous run's log to `<log>.backup` on every start, so the log of a run that crashed survives. Nothing in the codebase ever read it back, and `/api/logs` serves only the active log — which, after a crash and a restart, describes the *new* run. The only copy of what the failing run said was on disk and unreachable from the UI.

## Four verdicts, not two

| verdict | meaning |
|---|---|
| `clean` | the run recorded its own exit |
| `crashed` | it died on a fatal signal and left evidence |
| `unclean` | it never recorded an exit and left no evidence |
| `unknown` | nothing was recorded, typically a first start |

`unclean` is a real answer rather than a fallback. It separates a fault from a SIGKILL, an OOM kill, or power loss, which is exactly the distinction a support report needs and the one users currently have to guess at.

## The handler

It allocates nothing, takes no lock, and never enters the logging framework. Every string it writes is preformatted during `begin_run`, while ordinary code is still running. It restores the default disposition and re-raises, so **core dumps and `coredumpctl` keep working exactly as they do today**.

Crash evidence is matched to the run that wrote it by `run_id`, so the evidence file is deliberately *not* consumed on read. A crash from three runs ago stays on disk as forensics and is still never reported against an unrelated run.

## Endpoints

Both authenticated, both under the existing `/polaris/v1/diagnostics/` namespace that `logs/tail` established.

- `last-run` for the verdict, signal and backtrace.
- `logs/previous` for the retained log of the run that failed. It serves plain bytes like `/api/logs` rather than the Base64 JSON of `logs/tail`, because it is a whole-file fetch for an export rather than an incremental reader tracking offsets, and it distinguishes an absent backup from an empty one.

`logging::backup_log_path()` gives the `.backup` suffix one definition now that something outside the logging system reads it.

## Known gap, left deliberately

`lifetime::debug_trap()` raises `SIGTRAP` before `abort()`, so the ten-second forced-shutdown path is recorded as `unclean` rather than `crashed`. Handling SIGTRAP would interfere with debuggers, and that path already logs a `fatal` line and flushes before trapping, so its evidence reaches the backup log regardless.

## Verification

- [x] `ctest`: **17/17 passed, 0 failed**, on this branch rebased onto master at `2567e72b`.
- [x] 18 new unit tests covering run-state round trip, schema rejection, all four verdicts, and the `.backup` path helper.
- [x] **The signal handler is tested end to end**, not just the classification: a forked child installs the handlers, raises SIGSEGV, and the test asserts via `WTERMSIG` that it really died of the original signal rather than exiting, then the parent plays the part of the next start and classifies the evidence. That runs in CI rather than needing a manual `kill -SEGV` against a shared host.
- [x] A test pins that evidence from an earlier run is *not* misreported against a later one.
- [x] `RLIMIT_CORE` is set to 0 in the forked child so proving the handler ran does not litter the machine with core files.

## Notes

New source files are registered in both `POLARIS_TARGET_FILES` and `tests/CMakeLists.txt`. No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes. The two added endpoints require the same authentication as the rest of the surface.
