### PR TITLE
feat(diagnostics): make silent failures loud enough to report

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -154,6 +154,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/confighttp_validation.h"
         "${CMAKE_SOURCE_DIR}/src/update_status.h"
         "${CMAKE_SOURCE_DIR}/src/update_status.cpp"
+        "${CMAKE_SOURCE_DIR}/src/verified_action.cpp"
+        "${CMAKE_SOURCE_DIR}/src/verified_action.h"
         "${CMAKE_SOURCE_DIR}/src/rtsp.cpp"
         "${CMAKE_SOURCE_DIR}/src/rtsp.h"
         "${CMAKE_SOURCE_DIR}/src/stream.cpp"

--- a/src/platform/linux/display_topology.cpp
+++ b/src/platform/linux/display_topology.cpp
@@ -11,14 +11,20 @@
   #include "src/logging.h"
   #include "src/platform/common.h"
   #include "src/platform/linux/misc.h"
+  #include "src/verified_action.h"
   #include "stream_display_policy.h"
 
   #include <algorithm>
+  #include <array>
 #include <cctype>
   #include <chrono>
+  #include <cmath>
+  #include <cstdio>
   #include <cstdlib>
   #include <filesystem>
   #include <fstream>
+  #include <memory>
+  #include <nlohmann/json.hpp>
   #include <string>
   #include <system_error>
   #include <thread>
@@ -326,6 +332,92 @@ namespace display_topology {
   }
 
 
+  /**
+   * @brief Capture stdout of a fixed command.
+   */
+  std::string exec_capture(const char *cmd) {
+    auto pipe_closer = [](FILE *pipe) {
+      if (pipe) {
+        pclose(pipe);
+      }
+    };
+    std::unique_ptr<FILE, decltype(pipe_closer)> pipe(popen(cmd, "r"), pipe_closer);
+    if (!pipe) {
+      return {};
+    }
+
+    std::array<char, 4096> buffer {};
+    std::string result;
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+      result += buffer.data();
+    }
+    return result;
+  }
+
+  /**
+   * @brief Ask kscreen what the display layout actually is right now.
+   *
+   * The argument list is fixed with no interpolation. This must not become a
+   * place where a configured output name reaches a shell.
+   */
+  std::string read_kscreen_json() {
+    return exec_capture("timeout 8 env QT_QPA_PLATFORM=wayland kscreen-doctor -j 2>/dev/null");
+  }
+
+  std::string current_output_mode(std::string_view kscreen_json, std::string_view output_name) {
+    if (kscreen_json.empty() || output_name.empty()) {
+      return {};
+    }
+
+    const auto document = nlohmann::json::parse(kscreen_json, nullptr, false);
+    if (document.is_discarded() || !document.is_object()) {
+      return {};
+    }
+    const auto outputs = document.find("outputs");
+    if (outputs == document.end() || !outputs->is_array()) {
+      return {};
+    }
+
+    for (const auto &output : *outputs) {
+      if (!output.is_object() || output.value("name", std::string {}) != output_name) {
+        continue;
+      }
+
+      const auto current_id = output.value("currentModeId", std::string {});
+      const auto modes = output.find("modes");
+      if (current_id.empty() || modes == output.end() || !modes->is_array()) {
+        return {};
+      }
+
+      for (const auto &mode : *modes) {
+        if (!mode.is_object() || mode.value("id", std::string {}) != current_id) {
+          continue;
+        }
+
+        const auto size = mode.find("size");
+        if (size == mode.end() || !size->is_object()) {
+          return {};
+        }
+        const auto width = size->value("width", 0);
+        const auto height = size->value("height", 0);
+        if (width <= 0 || height <= 0) {
+          return {};
+        }
+
+        const auto geometry = std::to_string(width) + "x" + std::to_string(height);
+        const auto refresh = mode.value("refreshRate", 0.0);
+        if (refresh <= 0.0) {
+          return geometry;
+        }
+        return geometry + "@" + std::to_string(std::llround(refresh)) + "Hz";
+      }
+
+      return {};
+    }
+
+    return {};
+  }
+
   std::string format_output_mode_arg(int width, int height, int refresh_hz) {
     if (width <= 0 || height <= 0) {
       return {};
@@ -348,15 +440,40 @@ namespace display_topology {
       return false;
     }
 
+    static constexpr auto check_id = "display_topology.output_mode";
+    static constexpr auto check_description = "Set the streaming output to the mode the session asked for";
+
     const int rc = run_kscreen({"output." + output_name + ".mode." + mode_arg});
     if (rc != 0) {
       BOOST_LOG(warning) << "display_topology: failed to request mode ["sv << mode_arg
                          << "] on output ["sv << output_name << "] code="sv << rc;
+      verified_action::confirm(check_id, check_description, mode_arg, "kscreen-doctor exited " + std::to_string(rc));
       return false;
     }
 
-    BOOST_LOG(info) << "display_topology: requested mode ["sv << mode_arg << "] on output ["
-                   << output_name << "]"sv;
+    // A zero exit means the request was accepted, not that the mode changed.
+    // Ask the compositor what it is actually running instead of believing the
+    // tool that just reported success.
+    const auto actual = current_output_mode(read_kscreen_json(), output_name);
+    if (actual.empty()) {
+      BOOST_LOG(info) << "display_topology: requested mode ["sv << mode_arg << "] on output ["sv
+                      << output_name << "]; could not read the mode back to confirm it"sv;
+      // Not recorded as a silent failure: an unreadable read-back is unknown,
+      // and claiming a mismatch we did not observe would be its own lie.
+      return true;
+    }
+
+    // A request without a refresh rate says nothing about refresh, so compare
+    // only what was actually asked for.
+    const auto comparable = mode_arg.find('@') == std::string::npos ?
+                              actual.substr(0, actual.find('@')) :
+                              actual;
+    if (!verified_action::confirm(check_id, check_description, mode_arg, comparable)) {
+      return false;
+    }
+
+    BOOST_LOG(info) << "display_topology: mode ["sv << mode_arg << "] confirmed active on output ["sv
+                    << output_name << "]"sv;
     return true;
   }
 
@@ -411,7 +528,14 @@ namespace display_topology {
   void prepare_for_stream(int width, int height, int refresh_hz) {
     if (config::video.linux_display.stream_mode == "headless_dongle" ||
         config::video.linux_display.stream_mode.empty()) {
-      ensure_dongle_outputs_configured();
+      // This step reports whether it configured anything and that answer was
+      // being dropped. A dongle setup that quietly did not run is invisible
+      // until the stream comes up on the wrong output.
+      verified_action::confirm(
+        "display_topology.dongle_outputs_configured",
+        "Configure the dongle outputs before the stream starts",
+        ensure_dongle_outputs_configured()
+      );
     }
     if (!should_manage_host_topology()) {
       return;
@@ -437,7 +561,13 @@ namespace display_topology {
       BOOST_LOG(error) << "display_topology: enable streaming output failed code="sv << ret;
     }
     // Was fixed 1500ms sleep; poll enabled state with same overall budget.
-    wait_output_state(cfg.streaming_output, true, std::chrono::milliseconds(1500), "enable_streaming");
+    // The poll reads the truth out of sysfs and its verdict was being discarded,
+    // so an output that never came up produced a warning and nothing else.
+    verified_action::confirm(
+      "display_topology.streaming_output_enabled",
+      "Bring the streaming output up before capture starts",
+      wait_output_state(cfg.streaming_output, true, std::chrono::milliseconds(1500), "enable_streaming")
+    );
     if (width > 0 && height > 0) {
       apply_requested_display_mode(cfg.streaming_output, width, height, refresh_hz);
     }

--- a/src/platform/linux/display_topology.h
+++ b/src/platform/linux/display_topology.h
@@ -67,6 +67,21 @@ namespace display_topology {
    */
   bool output_present(const std::string &name);
 
+  /**
+   * @brief Read an output's current mode out of `kscreen-doctor -j` output.
+   *
+   * Pure so the read-back can be tested without a compositor. Resolves the
+   * output's currentModeId against its mode list and renders the result in the
+   * same `WxH@RHz` form the mode request is built in, so the two are directly
+   * comparable. Refresh is rounded, because kscreen reports 59.987 for a mode
+   * it names 60.
+   *
+   * @param kscreen_json Raw stdout of `kscreen-doctor -j`.
+   * @param output_name Connector name, for example "DP-2".
+   * @return The current mode, or an empty string when it cannot be determined.
+   */
+  std::string current_output_mode(std::string_view kscreen_json, std::string_view output_name);
+
 }  // namespace display_topology
 
 #endif

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -55,6 +55,7 @@
 #include "utility.h"
 #include "video.h"
 #include "uuid.h"
+#include "verified_action.h"
 
 #ifdef _WIN32
   // from_utf8() string conversion function
@@ -6891,7 +6892,16 @@ namespace proc {
           confighttp::emit_session_event("error", "Nested gamescope session failed to start");
           return 503;
         }
-        // Non-fatal: continue session for ordinary prep commands
+        // Non-fatal: continue session for ordinary prep commands. Continuing is
+        // the right call and also the reason this needs recording: nothing
+        // downstream will mention that a setup step the app depends on did not
+        // succeed, so the session looks healthy while being half-prepared.
+        verified_action::confirm(
+          "process.prep_command",
+          "Run the app's prep commands before launching it",
+          "exit 0",
+          "exit " + std::to_string(ret)
+        );
       }
     }
 

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "logging.h"
 #include "stream_stats.h"
+#include "verified_action.h"
 #ifdef __linux__
   #include "platform/linux/stream_runtime.h"
   #include "platform/linux/stream_display_policy.h"
@@ -1115,6 +1116,11 @@ namespace stream_stats {
         {"reason", "Current debounced packet-loss and latency evidence is clean; the older health label cannot trigger a bitrate change."}
       });
     }
+    // Actions that reported success and did not land. These are not stream
+    // health, so they do not move status or traffic light, but they belong in
+    // the same payload: they are the evidence a user cannot see any other way,
+    // and the export path already carries this object.
+    doctor["silent_failures"] = verified_action::to_json();
     doctor["redaction"] = {{"policy", "polaris-diagnostics-redaction-v1"}, {"applied", true}, {"redacted_fields", nlohmann::json::array()}, {"notice", "Tokens, cookies, credentials, auth headers, client IPs, and sensitive config fields are redacted before export or AI explanation."}};
     doctor["ai_explanation"] = {{"enabled", false}, {"provider", "none"}, {"model", ""}, {"generated_at", nullptr}, {"input_redacted", true}, {"source_result_id", doctor["result_id"]}, {"summary", ""}, {"limits", nlohmann::json::array({"AI can explain only; deterministic Doctor owns status, evidence, and actions."})}, {"error", ""}};
     return doctor;

--- a/src/verified_action.cpp
+++ b/src/verified_action.cpp
@@ -1,0 +1,113 @@
+/**
+ * @file src/verified_action.cpp
+ * @brief Definitions for read-back confirmation of otherwise silent failures.
+ */
+// standard includes
+#include <ctime>
+#include <deque>
+#include <mutex>
+
+// local includes
+#include "logging.h"
+#include "verified_action.h"
+
+using namespace std::literals;
+
+namespace verified_action {
+  namespace {
+    std::mutex records_mutex;
+    std::deque<record_t> records;
+
+    std::string utc_timestamp_now() {
+      const std::time_t now = std::time(nullptr);
+      std::tm parts {};
+#ifdef _WIN32
+      if (gmtime_s(&parts, &now) != 0) {
+        return {};
+      }
+#else
+      if (gmtime_r(&now, &parts) == nullptr) {
+        return {};
+      }
+#endif
+      char buffer[32] = {};
+      if (std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &parts) == 0) {
+        return {};
+      }
+      return buffer;
+    }
+
+    void record_mismatch(record_t entry) {
+      // One greppable prefix for every instance of this bug class, so a support
+      // log can be searched for the whole category rather than for whichever
+      // wording the individual call site happened to use.
+      BOOST_LOG(error) << "Silent failure: "sv << entry.id << " reported success but did not land. Requested ["sv
+                       << entry.requested << "], system reports ["sv << entry.actual << "]. "sv << entry.description;
+
+      const std::lock_guard lock {records_mutex};
+      records.push_back(std::move(entry));
+      while (records.size() > max_retained_records) {
+        records.pop_front();
+      }
+    }
+  }  // namespace
+
+  bool confirm(
+    std::string_view id,
+    std::string_view description,
+    std::string_view requested,
+    std::string_view actual
+  ) {
+    if (requested == actual) {
+      return true;
+    }
+
+    record_mismatch({
+      .id = std::string {id},
+      .description = std::string {description},
+      .requested = std::string {requested},
+      .actual = std::string {actual},
+      .observed_at = utc_timestamp_now(),
+    });
+    return false;
+  }
+
+  bool confirm(std::string_view id, std::string_view description, bool landed) {
+    if (landed) {
+      return true;
+    }
+
+    record_mismatch({
+      .id = std::string {id},
+      .description = std::string {description},
+      .requested = "applied",
+      .actual = "not applied",
+      .observed_at = utc_timestamp_now(),
+    });
+    return false;
+  }
+
+  std::vector<record_t> silent_failures() {
+    const std::lock_guard lock {records_mutex};
+    return {records.begin(), records.end()};
+  }
+
+  nlohmann::json to_json() {
+    auto output = nlohmann::json::array();
+    for (const auto &entry : silent_failures()) {
+      output.push_back({
+        {"id", entry.id},
+        {"description", entry.description},
+        {"requested", entry.requested},
+        {"actual", entry.actual},
+        {"observed_at", entry.observed_at},
+      });
+    }
+    return output;
+  }
+
+  void clear() {
+    const std::lock_guard lock {records_mutex};
+    records.clear();
+  }
+}  // namespace verified_action

--- a/src/verified_action.h
+++ b/src/verified_action.h
@@ -1,0 +1,95 @@
+/**
+ * @file src/verified_action.h
+ * @brief Read-back confirmation for actions whose failure is otherwise silent.
+ *
+ * The bugs that cost the most here are not crashes. They are actions that
+ * report success and do not happen: a compositor CLI that exits 0 on a rejected
+ * mode set, a setup step that is skipped rather than run, a capture path that
+ * is requested and quietly falls back. Nothing faults, the stream comes up, and
+ * the only symptom is that the user's choice did not apply.
+ *
+ * Polaris already models one of these correctly. The Linux GPU profile records
+ * `gpu_native_requested` alongside `gpu_native_succeeded`, and the
+ * Troubleshooting screen reads the pair to tell the user that GPU-native
+ * capture was asked for and did not happen. This generalizes that shape: ask
+ * the system what it actually did, compare it against what was requested, and
+ * make the mismatch loud and reportable instead of invisible.
+ *
+ * The rule this encodes is that a return code is not evidence. Both silent
+ * failures found in the field had a truthful answer available from the system
+ * itself; the code simply never asked for it.
+ */
+#pragma once
+
+// standard includes
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// lib includes
+#include <nlohmann/json.hpp>
+
+namespace verified_action {
+  /** @brief Most mismatches retained for the support bundle. */
+  inline constexpr std::size_t max_retained_records = 32;
+
+  /**
+   * @brief One action that reported success and did not land.
+   */
+  struct record_t {
+    std::string id;           ///< Stable identifier, e.g. "display.topology.mode".
+    std::string description;  ///< What was being attempted, in a user's terms.
+    std::string requested;    ///< What the caller asked for.
+    std::string actual;       ///< What the system reported back afterwards.
+    std::string observed_at;  ///< UTC ISO 8601 timestamp.
+  };
+
+  /**
+   * @brief Confirm an action landed by comparing a read-back against the request.
+   *
+   * Call after performing the action, passing the value read back out of the
+   * system rather than anything derived from the call's own return code.
+   *
+   * @param id Stable identifier for this check.
+   * @param description What was being attempted.
+   * @param requested The value that was asked for.
+   * @param actual The value read back afterwards.
+   * @return True when the action landed, false when it silently did not.
+   */
+  bool confirm(
+    std::string_view id,
+    std::string_view description,
+    std::string_view requested,
+    std::string_view actual
+  );
+
+  /**
+   * @brief Confirm an action landed where there is no value to compare.
+   *
+   * For steps whose only observable is whether they ran at all. Prefer the
+   * value-comparing overload wherever the system can be asked what it did:
+   * "it ran" is a weaker claim than "it produced what was asked for".
+   *
+   * @param id Stable identifier for this check.
+   * @param description What was being attempted.
+   * @param landed Whether the read-back showed the action took effect.
+   * @return The value of `landed`, so callers can branch on it.
+   */
+  bool confirm(std::string_view id, std::string_view description, bool landed);
+
+  /**
+   * @brief Mismatches recorded so far, oldest first.
+   */
+  std::vector<record_t> silent_failures();
+
+  /**
+   * @brief Render recorded mismatches for the doctor payload and support bundle.
+   */
+  nlohmann::json to_json();
+
+  /**
+   * @brief Drop all recorded mismatches.
+   */
+  void clear();
+}  // namespace verified_action

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -40,6 +40,7 @@ extern "C" {
 #include "stream_stats.h"
 #include "sync.h"
 #include "video.h"
+#include "verified_action.h"
 #include "video_frame_pacing.h"
 
 #ifdef __linux__
@@ -4529,6 +4530,18 @@ namespace video {
     BOOST_LOG(info);
 
     auto &encoder = *chosen_encoder;
+
+    // A configured encoder that fails validation is quietly replaced by the
+    // fallback search above, and the stream still comes up. The user set an
+    // encoder, got a different one, and only a log line ever said so.
+    if (!config::video.encoder.empty()) {
+      verified_action::confirm(
+        "video.configured_encoder",
+        "Encode with the encoder this host is configured to use",
+        config::video.encoder,
+        encoder.name
+      );
+    }
 
     last_encoder_probe_supported_ref_frames_invalidation = (encoder.flags & REF_FRAMES_INVALIDATION);
     last_encoder_probe_supported_yuv444_for_codec[0] = encoder.h264[encoder_t::PASSED] &&

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/globals.cpp
     ${CMAKE_SOURCE_DIR}/src/logging.cpp
     ${CMAKE_SOURCE_DIR}/src/update_status.cpp
+    ${CMAKE_SOURCE_DIR}/src/verified_action.cpp
     ${CMAKE_SOURCE_DIR}/src/rswrapper.c
 )
 
@@ -112,6 +113,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_file_handler.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_log_tail_api.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_private_state_file.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_verified_action.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_web_session_store.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_beat_times.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_display_planner.cpp
@@ -159,6 +161,7 @@ set(TEST_PLATFORM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_common.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_cage_display_router.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_default_render_device.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_display_topology.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_cuda_gl_encode_device.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_graphics.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_linux_process_argv.cpp

--- a/tests/unit/platform/test_display_topology.cpp
+++ b/tests/unit/platform/test_display_topology.cpp
@@ -1,0 +1,96 @@
+/**
+ * @file tests/unit/platform/test_display_topology.cpp
+ * @brief Test the kscreen mode read-back that confirms a mode request landed.
+ */
+#include <gtest/gtest.h>
+#include <src/platform/linux/display_topology.h>
+#include <string>
+
+using namespace std::literals;
+
+namespace {
+  // Shape taken from real `kscreen-doctor -j` output, including the detail that
+  // makes the read-back non-trivial: kscreen reports 59.987 for a mode it names
+  // 60, and the current mode is named by id rather than inline.
+  constexpr auto sample = R"({
+    "features": 255,
+    "outputs": [
+      {
+        "name": "HDMI-A-1",
+        "connected": true,
+        "enabled": true,
+        "currentModeId": "7",
+        "modes": [
+          {"id": "7", "name": "1920x1080@60", "refreshRate": 59.98699951171875,
+           "size": {"height": 1080, "width": 1920}}
+        ]
+      },
+      {
+        "name": "DP-2",
+        "connected": true,
+        "enabled": true,
+        "currentModeId": "2",
+        "modes": [
+          {"id": "1", "name": "3840x2160@60", "refreshRate": 59.96799850463867,
+           "size": {"height": 2160, "width": 3840}},
+          {"id": "2", "name": "2560x1440@120", "refreshRate": 119.998,
+           "size": {"height": 1440, "width": 2560}}
+        ]
+      }
+    ]
+  })"sv;
+}  // namespace
+
+TEST(DisplayTopologyModeReadBack, ResolvesTheCurrentModeById) {
+  EXPECT_EQ(display_topology::current_output_mode(sample, "DP-2"), "2560x1440@120Hz");
+}
+
+TEST(DisplayTopologyModeReadBack, RoundsTheRefreshRateKscreenReports) {
+  // 59.987 is the same mode a user and the request string both call 60.
+  EXPECT_EQ(display_topology::current_output_mode(sample, "HDMI-A-1"), "1920x1080@60Hz");
+}
+
+TEST(DisplayTopologyModeReadBack, ReadsEachOutputSeparately) {
+  // Two outputs, different current modes. Reading the wrong one would report a
+  // mismatch that never happened, or hide one that did.
+  EXPECT_NE(
+    display_topology::current_output_mode(sample, "DP-2"),
+    display_topology::current_output_mode(sample, "HDMI-A-1")
+  );
+}
+
+TEST(DisplayTopologyModeReadBack, ReturnsNothingForAnUnknownOutput) {
+  EXPECT_TRUE(display_topology::current_output_mode(sample, "DP-9").empty());
+}
+
+TEST(DisplayTopologyModeReadBack, ReturnsNothingWhenTheModeIdDoesNotResolve) {
+  constexpr auto dangling = R"({"outputs":[{"name":"DP-1","currentModeId":"99",
+    "modes":[{"id":"1","size":{"width":1920,"height":1080},"refreshRate":60.0}]}]})"sv;
+
+  EXPECT_TRUE(display_topology::current_output_mode(dangling, "DP-1").empty());
+}
+
+TEST(DisplayTopologyModeReadBack, TreatsUnusableInputAsUnknownRatherThanAMismatch) {
+  // Every one of these must read as "could not confirm" and not as "the mode is
+  // wrong". Reporting a silent failure that was never observed would be its own
+  // false alarm.
+  EXPECT_TRUE(display_topology::current_output_mode(""sv, "DP-1").empty());
+  EXPECT_TRUE(display_topology::current_output_mode("not json"sv, "DP-1").empty());
+  EXPECT_TRUE(display_topology::current_output_mode("[]"sv, "DP-1").empty());
+  EXPECT_TRUE(display_topology::current_output_mode(R"({"outputs":"nope"})"sv, "DP-1").empty());
+  EXPECT_TRUE(display_topology::current_output_mode(sample, ""sv).empty());
+}
+
+TEST(DisplayTopologyModeReadBack, OmitsRefreshWhenKscreenDoesNotReportIt) {
+  constexpr auto no_refresh = R"({"outputs":[{"name":"DP-1","currentModeId":"1",
+    "modes":[{"id":"1","size":{"width":1920,"height":1080}}]}]})"sv;
+
+  EXPECT_EQ(display_topology::current_output_mode(no_refresh, "DP-1"), "1920x1080");
+}
+
+TEST(DisplayTopologyModeReadBack, RejectsADegenerateModeSize) {
+  constexpr auto zero_size = R"({"outputs":[{"name":"DP-1","currentModeId":"1",
+    "modes":[{"id":"1","size":{"width":0,"height":0},"refreshRate":60.0}]}]})"sv;
+
+  EXPECT_TRUE(display_topology::current_output_mode(zero_size, "DP-1").empty());
+}

--- a/tests/unit/test_verified_action.cpp
+++ b/tests/unit/test_verified_action.cpp
@@ -1,0 +1,90 @@
+/**
+ * @file tests/unit/test_verified_action.cpp
+ * @brief Test read-back confirmation of otherwise silent failures.
+ */
+#include <gtest/gtest.h>
+#include <src/verified_action.h>
+#include <string>
+
+using namespace std::literals;
+
+namespace {
+  class VerifiedAction: public ::testing::Test {
+  protected:
+    void SetUp() override {
+      verified_action::clear();
+    }
+
+    void TearDown() override {
+      verified_action::clear();
+    }
+  };
+}  // namespace
+
+TEST_F(VerifiedAction, RecordsNothingWhenTheReadBackMatchesTheRequest) {
+  EXPECT_TRUE(verified_action::confirm("display.mode", "Apply the requested display mode", "2560x1440@120", "2560x1440@120"));
+
+  EXPECT_TRUE(verified_action::silent_failures().empty());
+}
+
+TEST_F(VerifiedAction, RecordsBothValuesWhenTheReadBackDisagrees) {
+  // The whole point of the read-back: the caller asked for 120 Hz, the system
+  // says 60, and nothing in the return code of the request would have said so.
+  EXPECT_FALSE(verified_action::confirm("display.mode", "Apply the requested display mode", "2560x1440@120", "2560x1440@60"));
+
+  const auto recorded = verified_action::silent_failures();
+  ASSERT_EQ(recorded.size(), 1);
+  EXPECT_EQ(recorded.front().id, "display.mode");
+  EXPECT_EQ(recorded.front().requested, "2560x1440@120");
+  EXPECT_EQ(recorded.front().actual, "2560x1440@60");
+  EXPECT_EQ(recorded.front().description, "Apply the requested display mode");
+  EXPECT_FALSE(recorded.front().observed_at.empty());
+}
+
+TEST_F(VerifiedAction, ReturnsTheVerdictSoCallersCanBranchOnIt) {
+  // A caller that wants to fall back needs the answer, not just the record.
+  EXPECT_FALSE(verified_action::confirm("step.ran", "Run the topology step", false));
+  EXPECT_TRUE(verified_action::confirm("step.ran", "Run the topology step", true));
+}
+
+TEST_F(VerifiedAction, RecordsAStepThatNeverRan) {
+  EXPECT_FALSE(verified_action::confirm("topology.step", "Run the headless topology step", false));
+
+  const auto recorded = verified_action::silent_failures();
+  ASSERT_EQ(recorded.size(), 1);
+  EXPECT_EQ(recorded.front().id, "topology.step");
+  EXPECT_EQ(recorded.front().requested, "applied");
+  EXPECT_EQ(recorded.front().actual, "not applied");
+}
+
+TEST_F(VerifiedAction, KeepsTheNewestMismatchesWithinItsBound) {
+  // A failure repeating every frame must not be able to grow without limit, and
+  // the entries worth keeping are the most recent ones.
+  for (std::size_t index = 0; index < verified_action::max_retained_records + 10; ++index) {
+    verified_action::confirm("capture.path", "Use the requested capture path", "dmabuf", "shm" + std::to_string(index));
+  }
+
+  const auto recorded = verified_action::silent_failures();
+  ASSERT_EQ(recorded.size(), verified_action::max_retained_records);
+  EXPECT_EQ(recorded.back().actual, "shm" + std::to_string(verified_action::max_retained_records + 9));
+  EXPECT_EQ(recorded.front().actual, "shm10");
+}
+
+TEST_F(VerifiedAction, RendersRecordsForTheSupportBundle) {
+  verified_action::confirm("capture.path", "Use the requested capture path", "dmabuf", "shm");
+
+  const auto document = verified_action::to_json();
+  ASSERT_TRUE(document.is_array());
+  ASSERT_EQ(document.size(), 1);
+  EXPECT_EQ(document[0]["id"], "capture.path");
+  EXPECT_EQ(document[0]["requested"], "dmabuf");
+  EXPECT_EQ(document[0]["actual"], "shm");
+  EXPECT_FALSE(document[0]["observed_at"].get<std::string>().empty());
+}
+
+TEST_F(VerifiedAction, RendersAnEmptyArrayWhenNothingFailedSilently) {
+  const auto document = verified_action::to_json();
+
+  ASSERT_TRUE(document.is_array());
+  EXPECT_TRUE(document.empty());
+}


### PR DESCRIPTION
## Summary

The bugs that cost the most here do not crash. They are actions that report success and do not happen.

Two shipped this month: a headless topology step that never ran (#458), and a compositor mode set that was rejected while `hyprctl` exited 0 (#444). Neither faulted, both streams came up, and the only symptom was that the user's choice did not apply. Crash reporting cannot see this class at all, which is why this exists alongside it rather than inside it.

## Polaris already models this correctly, once

The Linux GPU profile records `gpu_native_requested` next to `gpu_native_succeeded`, and the Troubleshooting screen reads the pair to tell the user that GPU-native capture was asked for and did not happen. `verified_action` generalises that shape.

The rule it encodes is that **a return code is not evidence**. Both silent failures had a truthful answer available from the system itself and the code simply never asked for it, so `confirm()` takes a value read back out of the system rather than a predicate over the call's own result. Every mismatch logs one greppable `Silent failure:` prefix, so the class can be searched for as a whole instead of depending on whichever wording each site invented.

## Four call sites, each an answer that already existed and was being dropped

**`display_topology` reads the active mode back out of `kscreen-doctor`** after setting it, because a zero exit means the request was *accepted*, not that the mode changed. This is the KDE twin of the hyprctl bug, in the same file the headless topology bug lived in.

The parser is pure and unit tested against output I sampled from the real tool rather than guessed at — including the detail that kscreen reports `59.987` for a mode it names 60. Both sides are rounded before comparing, so that cannot manufacture a mismatch.

**An unreadable read-back is recorded as unknown, not as a mismatch.** Claiming a failure that was not observed is its own false alarm, and a report full of those is one nobody reads.

**`display_topology` also confirms two results it was discarding outright:** whether the dongle outputs were configured, and whether the streaming output actually came up. The sysfs poll behind the second already knew and threw the answer away, so an output that never enabled produced a warning and nothing else.

**`video` confirms the encoder in use is the one the host was configured to use.** A configured encoder that fails validation is replaced by the fallback search and the stream still comes up, so the setting can be overridden with only a log line to say so.

**`process` records an ordinary prep command that exited non-zero and was continued past.** Continuing is the right call and also the reason it needs recording: nothing downstream mentions that a setup step the app depends on did not succeed, so the session looks healthy while being half-prepared.

## Deliberately not wired

Confirming a launched app is still alive shortly after spawn, which was in the original plan.

A Steam launcher exiting immediately is normal behaviour, so that check would manufacture false silent-failure reports. The cost of that is not one bad row: it is that nobody trusts the rest of the rows, in exactly the report a user sends when something is actually wrong.

## Where they surface

The records reach the doctor payload as `silent_failures`, which puts them in the support bundle and the issue draft with no further work. They deliberately do **not** move doctor status or the traffic light: they are not stream health, they are evidence the user cannot otherwise see.

## Verification

- [x] `ctest`: **17/17 passed, 0 failed**, rebased onto master at `2567e72b`.
- [x] 7 unit tests for the mechanism: records both values on mismatch, records nothing on match, returns the verdict so callers can branch, bounds its retained records and keeps the newest, renders for the bundle.
- [x] 8 unit tests for the kscreen read-back parser, including refresh rounding against the real `59.987` value, per-output resolution, a dangling mode id, and that every unusable input reads as unknown rather than as a mismatch.
- [x] Verified the `process.cpp` edit does not break the source-guard tests that match that file as text, by applying #464's pins on top and re-running: 17/17.

## Notes

New source file registered in both `POLARIS_TARGET_FILES` and `tests/CMakeLists.txt`. No pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes. `virtual_display.cpp` is untouched; now that #461 has landed, moving its bespoke wording onto the shared `Silent failure:` prefix is a follow-up its author has already agreed to.
