### PR TITLE
feat(api): let a paired client file its half of a support report

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -120,6 +120,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/config.cpp"
         "${CMAKE_SOURCE_DIR}/src/crash_report.cpp"
         "${CMAKE_SOURCE_DIR}/src/crash_report.h"
+        "${CMAKE_SOURCE_DIR}/src/client_support_report.cpp"
+        "${CMAKE_SOURCE_DIR}/src/client_support_report.h"
         "${CMAKE_SOURCE_DIR}/src/display_device.h"
         "${CMAKE_SOURCE_DIR}/src/display_device.cpp"
         "${CMAKE_SOURCE_DIR}/src/display_planner.h"

--- a/src/client_support_report.cpp
+++ b/src/client_support_report.cpp
@@ -1,0 +1,162 @@
+/**
+ * @file src/client_support_report.cpp
+ * @brief Definitions for paired-client support report intake.
+ */
+// standard includes
+#include <algorithm>
+#include <ctime>
+#include <deque>
+#include <mutex>
+#include <unordered_map>
+
+// local includes
+#include "client_support_report.h"
+
+using namespace std::literals;
+
+namespace client_support_report {
+  namespace {
+    std::mutex state_mutex;
+    std::deque<report_t> reports;
+    std::unordered_map<std::string, std::chrono::steady_clock::time_point> last_submission;
+
+    /**
+     * @brief Take a bounded string field, tolerating a wrong JSON type.
+     *
+     * A client can send anything, so a field that is not a string is treated as
+     * absent rather than as a reason to reject the whole report: a usable report
+     * with one odd field beats no report at all.
+     */
+    std::string bounded_field(const nlohmann::json &body, const char *name) {
+      const auto found = body.find(name);
+      if (found == body.end() || !found->is_string()) {
+        return {};
+      }
+      auto value = found->get<std::string>();
+      if (value.size() > max_field_bytes) {
+        value.resize(max_field_bytes);
+        value += "\n[truncated by host]";
+      }
+      return value;
+    }
+  }  // namespace
+
+  std::string utc_timestamp_now() {
+    const std::time_t now = std::time(nullptr);
+    std::tm parts {};
+#ifdef _WIN32
+    if (gmtime_s(&parts, &now) != 0) {
+      return {};
+    }
+#else
+    if (gmtime_r(&now, &parts) == nullptr) {
+      return {};
+    }
+#endif
+    char buffer[32] = {};
+    if (std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &parts) == 0) {
+      return {};
+    }
+    return buffer;
+  }
+
+  parse_result_t parse_submission(
+    std::string_view body,
+    std::string_view client_id,
+    std::string_view received_at
+  ) {
+    parse_result_t result;
+
+    if (body.size() > max_report_bytes) {
+      result.status = accept_e::too_large;
+      result.error = "Report exceeds the accepted size.";
+      return result;
+    }
+
+    const auto document = nlohmann::json::parse(body, nullptr, false);
+    if (document.is_discarded() || !document.is_object()) {
+      result.status = accept_e::malformed;
+      result.error = "Report body must be a JSON object.";
+      return result;
+    }
+
+    report_t report;
+    // Identity comes from the verified certificate, never from the body. A
+    // client must not be able to file a report as another client.
+    report.client_id = std::string {client_id};
+    report.received_at = std::string {received_at};
+    report.device = bounded_field(document, "device");
+    report.nova_version = bounded_field(document, "nova_version");
+    report.android_release = bounded_field(document, "android_release");
+    report.occurred_at = bounded_field(document, "occurred_at");
+    report.notes = bounded_field(document, "notes");
+    report.crash = bounded_field(document, "crash");
+    report.log_tail = bounded_field(document, "log_tail");
+
+    if (report.crash.empty() && report.log_tail.empty() && report.notes.empty()) {
+      result.status = accept_e::malformed;
+      result.error = "Report carries no crash, log, or notes.";
+      return result;
+    }
+
+    result.status = accept_e::accepted;
+    result.report = std::move(report);
+    return result;
+  }
+
+  bool rate_limit_allows(std::string_view client_id, std::chrono::steady_clock::time_point now) {
+    const std::lock_guard lock {state_mutex};
+    const std::string key {client_id};
+    const auto previous = last_submission.find(key);
+    if (previous != last_submission.end() && now - previous->second < min_submission_interval) {
+      return false;
+    }
+    last_submission[key] = now;
+    return true;
+  }
+
+  void store(report_t report) {
+    const std::lock_guard lock {state_mutex};
+    // One client repeating itself must not push every other client's report out,
+    // so a new report from a client replaces that client's previous one.
+    const auto existing = std::find_if(reports.begin(), reports.end(), [&](const report_t &held) {
+      return held.client_id == report.client_id;
+    });
+    if (existing != reports.end()) {
+      reports.erase(existing);
+    }
+    reports.push_back(std::move(report));
+    while (reports.size() > max_retained_reports) {
+      reports.pop_front();
+    }
+  }
+
+  std::vector<report_t> recent() {
+    const std::lock_guard lock {state_mutex};
+    return {reports.begin(), reports.end()};
+  }
+
+  nlohmann::json to_json() {
+    auto output = nlohmann::json::array();
+    for (const auto &report : recent()) {
+      output.push_back({
+        {"client_id", report.client_id},
+        {"device", report.device},
+        {"nova_version", report.nova_version},
+        {"android_release", report.android_release},
+        {"occurred_at", report.occurred_at},
+        {"received_at", report.received_at},
+        {"notes", report.notes},
+        {"crash", report.crash},
+        {"log_tail", report.log_tail},
+      });
+    }
+    return output;
+  }
+
+  void clear() {
+    const std::lock_guard lock {state_mutex};
+    reports.clear();
+    last_submission.clear();
+  }
+}  // namespace client_support_report

--- a/src/client_support_report.h
+++ b/src/client_support_report.h
@@ -1,0 +1,122 @@
+/**
+ * @file src/client_support_report.h
+ * @brief Intake for support reports submitted by a paired client.
+ *
+ * A streaming bug has two halves and the host only ever saw one of them. The
+ * host bundle knows the capture path, the encoder and the frame timings; the
+ * client knows what the user actually saw and whether the app fell over. Asking
+ * a user to produce both, from two devices, and keep them matched, is how a bug
+ * report turns into a conversation instead of a fix.
+ *
+ * A paired client can post its half here, and the host carries it into the same
+ * bundle. Reports are held in memory only: this is client-supplied content, and
+ * writing it to disk on the host would turn a support feature into a way for a
+ * paired device to leave files behind.
+ */
+#pragma once
+
+// standard includes
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// lib includes
+#include <nlohmann/json.hpp>
+
+namespace client_support_report {
+  /** @brief Largest submission accepted, before parsing it. */
+  inline constexpr std::size_t max_report_bytes = 256U * 1024U;
+
+  /** @brief How many clients' reports are retained. */
+  inline constexpr std::size_t max_retained_reports = 8;
+
+  /** @brief Longest field retained from a submission, to bound one client's share. */
+  inline constexpr std::size_t max_field_bytes = 64U * 1024U;
+
+  /** @brief Minimum gap between accepted submissions from one client. */
+  inline constexpr std::chrono::seconds min_submission_interval {10};
+
+  struct report_t {
+    std::string client_id;
+    std::string device;
+    std::string nova_version;
+    std::string android_release;
+    std::string occurred_at;
+    std::string received_at;
+    std::string notes;
+    std::string crash;
+    std::string log_tail;
+  };
+
+  /**
+   * @brief Outcomes of parsing a submission.
+   *
+   * Rate limiting is not here: it is decided before the body is read, so a
+   * client that is submitting too fast never gets its payload parsed at all.
+   */
+  enum class accept_e {
+    accepted,
+    too_large,
+    malformed,
+  };
+
+  struct parse_result_t {
+    accept_e status = accept_e::malformed;
+    report_t report;
+    std::string error;
+  };
+
+  /**
+   * @brief Validate and normalize a submission.
+   *
+   * Pure, so the size bound, the field bounds and the rejection reasons can be
+   * tested without a paired device or a TLS session.
+   *
+   * @param body Raw request body.
+   * @param client_id Identity the host derived from the client certificate, not
+   *                  anything the body claims about itself.
+   * @param received_at Host timestamp to record.
+   */
+  parse_result_t parse_submission(
+    std::string_view body,
+    std::string_view client_id,
+    std::string_view received_at
+  );
+
+  /**
+   * @brief Whether this client may submit again yet.
+   *
+   * Records the attempt when it allows one, so callers must only ask once per
+   * submission.
+   */
+  bool rate_limit_allows(std::string_view client_id, std::chrono::steady_clock::time_point now);
+
+  /**
+   * @brief Retain a report, evicting the oldest once full.
+   */
+  void store(report_t report);
+
+  /**
+   * @brief Retained reports, oldest first.
+   */
+  std::vector<report_t> recent();
+
+  /**
+   * @brief Render retained reports for the diagnostics API and support bundle.
+   *
+   * Values are passed through as submitted. The client redacts before sending,
+   * and the export layer redacts again on the way out, so the host does not
+   * need a third copy of those rules; what it must not do is assume the client
+   * got it right, which is why nothing here is treated as trusted text.
+   */
+  nlohmann::json to_json();
+
+  /**
+   * @brief Current host wall-clock time as UTC ISO 8601.
+   */
+  std::string utc_timestamp_now();
+
+  void clear();
+}  // namespace client_support_report

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -41,6 +41,7 @@
 #include "adaptive_bitrate.h"
 #include "browser_stream.h"
 #include "confighttp.h"
+#include "client_support_report.h"
 #include "confighttp_benchmark_auth.h"
 #include "confighttp_validation.h"
 #include "crash_report.h"
@@ -4513,6 +4514,38 @@ namespace confighttp {
   }
 
   /**
+   * @brief Get support reports submitted by paired clients.
+   * @param response The HTTP response object.
+   * @param request The HTTP request object.
+   *
+   * Held in memory only and never written to host disk: this is content a paired
+   * device supplied, and a support feature should not double as a way for one to
+   * leave files behind.
+   *
+   * Values are passed through as the client sent them. The client redacts before
+   * sending and the export layer redacts again on the way out, so this is not the
+   * place for a third copy of those rules; it is the place that must not assume
+   * the client got it right.
+   *
+   * @api_examples{/polaris/v1/diagnostics/client-reports| GET| null}
+   */
+  void getClientSupportReports(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+    print_req(request);
+
+    nlohmann::json output;
+    output["status"] = true;
+    output["reports"] = client_support_report::to_json();
+
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Cache-Control", "no-store");
+    append_json_security_headers(headers);
+    response->write(SimpleWeb::StatusCode::success_ok, output.dump(), headers);
+  }
+
+  /**
    * @brief Clear the active log file.
    * @param response The HTTP response object.
    * @param request The HTTP request object.
@@ -6605,6 +6638,7 @@ namespace confighttp {
     server.resource["^/polaris/v1/diagnostics/logs/tail$"]["GET"] = getLogTail;
     server.resource["^/polaris/v1/diagnostics/logs/previous$"]["GET"] = getPreviousLogs;
     server.resource["^/polaris/v1/diagnostics/last-run$"]["GET"] = getLastRun;
+    server.resource["^/polaris/v1/diagnostics/client-reports$"]["GET"] = getClientSupportReports;
     server.resource["^/api/logs$"]["GET"] = getLogs;
     server.resource["^/api/logs/clear$"]["POST"] = withCsrf(clearLogs);
     server.resource["^/api/config$"]["GET"] = getConfig;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -78,6 +78,7 @@
 #include "ai_optimizer.h"
 #include "device_db.h"
 #include "doctor_actions.h"
+#include "client_support_report.h"
 #include "confighttp.h"
 #include "stream_stats.h"
 #include "video.h"
@@ -6469,6 +6470,7 @@ namespace nvhttp {
       features["artwork_manifest_v1"] = true;
       features["artwork_manual_match_v1"] = nonblank_artwork_api_key(
         config::sunshine.steamgriddb_api_key);
+      features["support_client_report_v1"] = true;
       features["session_lifecycle"] = true;
       features["session_stop_v1"] = true;
       features["device_profiles"] = true;
@@ -8844,7 +8846,65 @@ namespace nvhttp {
       response->write(output.dump(), headers);
     };
 
+    // Support report from a paired client. A streaming bug has a host half and a
+    // client half, and only the host can hold both. Asking a user to export from
+    // two devices and keep the two matched is how a bug report turns into a
+    // conversation instead of a fix.
+    auto polarisClientSupportReport = [](resp_https_t response, req_https_t request) {
+      print_req<PolarisHTTPS>(request);
+      const auto named_cert = get_verified_cert(request);
+      if (!named_cert) {
+        response->write(SimpleWeb::StatusCode::client_error_unauthorized);
+        return;
+      }
+
+      const auto reply = [&response](SimpleWeb::StatusCode code, const std::string &error) {
+        nlohmann::json output;
+        output["status"] = error.empty();
+        if (!error.empty()) {
+          output["error"] = error;
+        }
+        SimpleWeb::CaseInsensitiveMultimap headers;
+        headers.emplace("Content-Type", "application/json");
+        response->write(code, output.dump(), headers);
+      };
+
+      // Checked before the body is read: a client submitting too fast should not
+      // be able to make the host parse a quarter megabyte to find that out.
+      if (!client_support_report::rate_limit_allows(named_cert->uuid, std::chrono::steady_clock::now())) {
+        reply(SimpleWeb::StatusCode::client_error_too_many_requests, "Wait before submitting another report.");
+        return;
+      }
+
+      const std::string body {std::istreambuf_iterator<char>(request->content), std::istreambuf_iterator<char>()};
+      auto parsed = client_support_report::parse_submission(
+        body,
+        named_cert->uuid,
+        client_support_report::utc_timestamp_now()
+      );
+
+      if (parsed.status == client_support_report::accept_e::too_large) {
+        reply(SimpleWeb::StatusCode::client_error_payload_too_large, parsed.error);
+        return;
+      }
+      if (parsed.status != client_support_report::accept_e::accepted) {
+        reply(SimpleWeb::StatusCode::client_error_bad_request, parsed.error);
+        return;
+      }
+
+      // The paired name is the host's own record of this device, so it is a
+      // better answer than whatever the body claimed.
+      if (parsed.report.device.empty()) {
+        parsed.report.device = named_cert->name;
+      }
+
+      BOOST_LOG(info) << "Support report received from client ["sv << named_cert->name << "]"sv;
+      client_support_report::store(std::move(parsed.report));
+      reply(SimpleWeb::StatusCode::success_ok, {});
+    };
+
     https_server.resource["^/polaris/v1/session/report$"]["POST"] = polarisSessionReport;
+    https_server.resource["^/polaris/v1/support/client-report$"]["POST"] = polarisClientSupportReport;
     https_server.resource["^/polaris/v1/optimizer/profile/clear$"]["POST"] = polarisClearOptimizerProfile;
     https_server.resource["^/polaris/v1/optimizer/profiles$"]["GET"] = polarisOptimizerProfiles;
     https_server.resource["^/polaris/v1/optimizer/profiles/clear$"]["POST"] = polarisClearOptimizerProfiles;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/confighttp_benchmark_auth.cpp
     ${CMAKE_SOURCE_DIR}/src/browser_stream_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/crash_report.cpp
+    ${CMAKE_SOURCE_DIR}/src/client_support_report.cpp
     ${CMAKE_SOURCE_DIR}/src/file_handler.cpp
     ${CMAKE_SOURCE_DIR}/src/log_tail_api.cpp
     ${CMAKE_SOURCE_DIR}/src/private_state_file.cpp
@@ -109,6 +110,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_client_settings_advertisement.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_browser_stream_protocol.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_crash_report.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_client_support_report.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_cursor_visibility.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_file_handler.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_log_tail_api.cpp

--- a/tests/integration/test_nova_contract.cpp
+++ b/tests/integration/test_nova_contract.cpp
@@ -223,7 +223,7 @@ TEST(NovaContractTests, NewLibraryFeaturesAreDeclaredInCapabilities) {
   // expected to render conditionally has to be announced rather than inferred.
   const auto source = read_source_file("src/nvhttp.cpp");
 
-  for (const auto flag : {"library_playtime_v1", "library_beat_times_v1", "display_planner_v1"}) {
+  for (const auto flag : {"library_playtime_v1", "library_beat_times_v1", "display_planner_v1", "support_client_report_v1"}) {
     SCOPED_TRACE(flag);
     EXPECT_NE(source.find(std::string {"features[\""} + flag + "\"]"), std::string::npos);
   }

--- a/tests/unit/test_client_support_report.cpp
+++ b/tests/unit/test_client_support_report.cpp
@@ -1,0 +1,157 @@
+/**
+ * @file tests/unit/test_client_support_report.cpp
+ * @brief Test paired-client support report intake.
+ */
+#include <chrono>
+#include <gtest/gtest.h>
+#include <src/client_support_report.h>
+#include <string>
+
+using namespace std::literals;
+
+namespace {
+  class ClientSupportReport: public ::testing::Test {
+  protected:
+    void SetUp() override {
+      client_support_report::clear();
+    }
+
+    void TearDown() override {
+      client_support_report::clear();
+    }
+  };
+
+  std::string submission(const std::string &extra = R"("notes":"stream froze")") {
+    return "{" + extra + R"(,"device":"Retroid Pocket 6","nova_version":"1.1.3","android_release":"13"})";
+  }
+}  // namespace
+
+TEST_F(ClientSupportReport, AcceptsAReportAndRecordsHostSideFacts) {
+  const auto parsed = client_support_report::parse_submission(
+    submission(),
+    "client-uuid-1",
+    "2026-08-17T12:00:00Z"
+  );
+
+  ASSERT_EQ(parsed.status, client_support_report::accept_e::accepted);
+  EXPECT_EQ(parsed.report.client_id, "client-uuid-1");
+  EXPECT_EQ(parsed.report.received_at, "2026-08-17T12:00:00Z");
+  EXPECT_EQ(parsed.report.device, "Retroid Pocket 6");
+  EXPECT_EQ(parsed.report.notes, "stream froze");
+}
+
+TEST_F(ClientSupportReport, TakesIdentityFromTheCertificateAndNotTheBody) {
+  // A paired client must not be able to file a report as a different client.
+  const auto parsed = client_support_report::parse_submission(
+    R"({"client_id":"someone-else","notes":"n"})",
+    "client-uuid-1",
+    "2026-08-17T12:00:00Z"
+  );
+
+  ASSERT_EQ(parsed.status, client_support_report::accept_e::accepted);
+  EXPECT_EQ(parsed.report.client_id, "client-uuid-1");
+}
+
+TEST_F(ClientSupportReport, RejectsASubmissionOverTheSizeBound) {
+  const std::string oversized = "{\"notes\":\"" + std::string(client_support_report::max_report_bytes + 10, 'x') + "\"}";
+
+  const auto parsed = client_support_report::parse_submission(oversized, "c1", "t");
+
+  EXPECT_EQ(parsed.status, client_support_report::accept_e::too_large);
+  EXPECT_FALSE(parsed.error.empty());
+}
+
+TEST_F(ClientSupportReport, RejectsMalformedOrEmptySubmissions) {
+  for (const auto body : {""sv, "not json"sv, "[]"sv, R"({"device":"RP6"})"sv}) {
+    const auto parsed = client_support_report::parse_submission(body, "c1", "t");
+    EXPECT_EQ(parsed.status, client_support_report::accept_e::malformed) << body;
+  }
+}
+
+TEST_F(ClientSupportReport, TreatsAWronglyTypedFieldAsAbsentRatherThanFatal) {
+  // A usable report with one odd field beats no report at all.
+  const auto parsed = client_support_report::parse_submission(
+    R"({"notes":"real note","device":12345,"crash":null})",
+    "c1",
+    "t"
+  );
+
+  ASSERT_EQ(parsed.status, client_support_report::accept_e::accepted);
+  EXPECT_EQ(parsed.report.notes, "real note");
+  EXPECT_TRUE(parsed.report.device.empty());
+}
+
+TEST_F(ClientSupportReport, BoundsAnOversizedFieldInsideAnAcceptedReport) {
+  const std::string big = R"({"log_tail":")" + std::string(client_support_report::max_field_bytes + 500, 'y') + R"("})";
+
+  const auto parsed = client_support_report::parse_submission(big, "c1", "t");
+
+  ASSERT_EQ(parsed.status, client_support_report::accept_e::accepted);
+  EXPECT_LT(parsed.report.log_tail.size(), client_support_report::max_field_bytes + 100);
+  EXPECT_NE(parsed.report.log_tail.find("truncated by host"), std::string::npos);
+}
+
+TEST_F(ClientSupportReport, RateLimitsRepeatSubmissionsFromOneClient) {
+  const auto now = std::chrono::steady_clock::now();
+
+  EXPECT_TRUE(client_support_report::rate_limit_allows("c1", now));
+  EXPECT_FALSE(client_support_report::rate_limit_allows("c1", now + 1s));
+  // A different client is not punished for the first one's behaviour.
+  EXPECT_TRUE(client_support_report::rate_limit_allows("c2", now + 1s));
+  EXPECT_TRUE(client_support_report::rate_limit_allows("c1", now + client_support_report::min_submission_interval + 1s));
+}
+
+TEST_F(ClientSupportReport, ReplacesAClientsPreviousReportRatherThanStackingThem) {
+  // One client repeating itself must not push every other client's report out.
+  client_support_report::store({.client_id = "c1", .notes = "first"});
+  client_support_report::store({.client_id = "c2", .notes = "other client"});
+  client_support_report::store({.client_id = "c1", .notes = "second"});
+
+  const auto held = client_support_report::recent();
+  ASSERT_EQ(held.size(), 2);
+  EXPECT_EQ(held[0].client_id, "c2");
+  EXPECT_EQ(held[1].notes, "second");
+}
+
+TEST_F(ClientSupportReport, EvictsTheOldestOnceFull) {
+  for (std::size_t index = 0; index < client_support_report::max_retained_reports + 3; ++index) {
+    client_support_report::store({.client_id = "client-" + std::to_string(index), .notes = "n"});
+  }
+
+  const auto held = client_support_report::recent();
+  ASSERT_EQ(held.size(), client_support_report::max_retained_reports);
+  EXPECT_EQ(held.front().client_id, "client-3");
+}
+
+TEST_F(ClientSupportReport, RendersReportsForTheDiagnosticsApi) {
+  client_support_report::store({
+    .client_id = "c1",
+    .device = "RP6",
+    .nova_version = "1.1.3",
+    .received_at = "2026-08-17T12:00:00Z",
+    .notes = "stream froze",
+  });
+
+  const auto document = client_support_report::to_json();
+
+  ASSERT_TRUE(document.is_array());
+  ASSERT_EQ(document.size(), 1);
+  EXPECT_EQ(document[0]["client_id"], "c1");
+  EXPECT_EQ(document[0]["device"], "RP6");
+  EXPECT_EQ(document[0]["notes"], "stream froze");
+}
+
+TEST_F(ClientSupportReport, RendersAnEmptyArrayWithNothingSubmitted) {
+  const auto document = client_support_report::to_json();
+
+  ASSERT_TRUE(document.is_array());
+  EXPECT_TRUE(document.empty());
+}
+
+TEST_F(ClientSupportReport, StampsAUsableHostTimestamp) {
+  const auto stamp = client_support_report::utc_timestamp_now();
+
+  ASSERT_EQ(stamp.size(), 20);
+  EXPECT_EQ(stamp.back(), 'Z');
+  EXPECT_EQ(stamp[10], 'T');
+}


### PR DESCRIPTION
## Summary

A streaming bug has two halves and the host only ever saw one.

The host bundle knows the capture path, the encoder and the frame timings. The client knows what the user actually saw, and whether the app fell over. Diagnosing from one half is how a report becomes a conversation instead of a fix, and asking a user to export from two devices and keep the two matched is not a reasonable thing to ask.

A paired client can now POST its half to `/polaris/v1/support/client-report`, and the host carries it into the same bundle its own evidence goes into. Nova is the first caller; there is nothing Nova-specific in the endpoint.

## Authentication and identity

The existing verified client certificate, the same gate the rest of the `/polaris/v1` surface uses, so only a paired device can submit.

**The client's identity is taken from that certificate and never from the body.** A paired client must not be able to file a report as a different client, and a test pins that a body claiming another `client_id` does not get one.

## Bounds

This is the first endpoint that accepts substantial content *from* a client rather than sending it, so the limits are the design rather than an afterthought.

| bound | value | why |
|---|---|---|
| submission size | 256 KB, rejected before parsing | a client should not be able to make the host parse a quarter megabyte to find out it was rejected |
| per field | 64 KB | one client cannot spend the whole budget on a single runaway log |
| rate | 1 per client per 10s, checked before the body is read | same reason as above |
| retained | 8 clients, newest per client replaces | one repeating client cannot push every other client's report out |

**Reports are held in memory and never written to host disk.** This is content a paired device supplied, and a support feature should not double as a way for one to leave files on the host. Losing them on restart is the right trade: they exist to be exported alongside a host bundle in the same sitting.

## Tolerant of a client that disagrees with it

A wrongly typed field is treated as absent rather than as a reason to reject the whole submission. A usable report with one odd field beats no report at all, and the client and host version independently, so a field changing shape is a thing that will happen.

## Redaction is not re-implemented here

The client redacts before sending and the export layer redacts again on the way out. A third copy of those rules in C++ would be a third place for them to drift.

What the host does instead is treat everything in the body as untrusted: bounded, typed, and attributed to the certificate rather than to its own claims.

## Contract

`support_client_report_v1` is announced in capabilities so a client can feature-detect instead of probing, and the contract test that pins announced flags now covers it.

`docs/nova-contract.json` is **unchanged on purpose**. It describes what Polaris serves *to* Nova, and this is the first contract in the other direction. Whether that manifest should grow a request section is a decision worth making deliberately rather than as a side effect of this change, so the request body's field names are documented at the endpoint instead.

## Verification

- [x] `ctest`: **17/17 passed, 0 failed**, rebased onto master at `2567e72b`.
- [x] 12 unit tests: identity comes from the certificate and not the body, size rejection before parsing, per-field bounding inside an accepted report, malformed and empty rejection, a wrongly typed field treated as absent, rate limiting per client with a second client unaffected, replace-not-stack, oldest-evicted-once-full, and the rendered payload.
- [x] The parse path is pure and takes the identity and timestamp as arguments, so all of that is tested without a paired device or a TLS session.

## Notes

New source file registered in both `POLARIS_TARGET_FILES` and `tests/CMakeLists.txt`. The new endpoint is certificate-gated like its neighbours; no pairing, trusted-subnet, certificate, client-command, shell-hook, dependency, packaging, or privilege-boundary changes. The read-back endpoint for the Web UI requires the same authentication as the rest of `/polaris/v1/diagnostics/`.
