### PR TITLE
fix(web): redact credential fields that are not text

### DIFF
--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -1,7 +1,26 @@
 // Words that mean "secret" wherever they appear as a whole segment of a name.
 const SENSITIVE_SEGMENT_WORDS = [
   'password', 'passwd', 'token', 'secret', 'cookie', 'auth', 'authorization', 'credential',
+  // Credentials that usually arrive as something other than text. A field name is
+  // the only protection these get: sanitizeDiagnosticsValue offers strings to the
+  // text redactor and returns every other scalar untouched, so a numeric pin was
+  // exported verbatim. Polaris pairing uses a numeric PIN, so that is this
+  // project's shape rather than a hypothetical one.
+  'pin', 'passcode', 'passphrase', 'otp', 'totp', 'bearer',
 ]
+// Names raised alongside those and deliberately left off the list. `salt` and
+// `nonce` are public by design, and blanking them costs a diagnostic to protect
+// nothing. `certificate` and `pem` carry the public half of pairing, while the
+// private half is already caught as a qualified `key`. `client_id` names the
+// paired device, which is the one thing a support bundle about a paired device
+// has to be able to say.
+//
+// `session_id` is the genuinely open one. A session id is a bearer credential
+// where the Web UI is concerned, but reaching it through this list means treating
+// `id` as qualified-only, and that blanks user_id, app_id and client_id with it.
+// It needs a narrower rule than a word, so it is left for the decision about
+// non-string scalars generally rather than bolted on here.
+
 // Qualifiers that make a separator-less segment a credential name. `apikey` and
 // `authtoken` carry no separator and no camelCase hump, so there is nothing
 // structural to split on, and English gives no way to tell `apikey` from

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -957,6 +957,67 @@ describe('silent failure reporting', () => {
   })
 })
 
+describe('credentials that are not strings', () => {
+  it('redacts a numeric pairing pin', () => {
+    expect(sanitizeDiagnosticsValue({ pin: 1234 })).toEqual({ pin: REDACTED_VALUE })
+    expect(sanitizeDiagnosticsValue({ pairing_pin: 987654 })).toEqual({ pairing_pin: REDACTED_VALUE })
+    expect(sanitizeDiagnosticsValue({ pairingPin: 987654 })).toEqual({ pairingPin: REDACTED_VALUE })
+  })
+
+  it('redacts a pin whether it arrives as a number or as a string', () => {
+    // The string form leaked too, for a different reason: redactSensitiveText
+    // rewrites name=value pairs it can see inside the text, and a value sitting
+    // alone in a field carries no name for it to find.
+    expect(sanitizeDiagnosticsValue({ pin: '1234' })).toEqual({ pin: REDACTED_VALUE })
+  })
+
+  it('redacts one-time codes and passphrases', () => {
+    expect(sanitizeDiagnosticsValue({ otp: 123456, totp: 654321, passphrase: 'correct horse' }))
+      .toEqual({ otp: REDACTED_VALUE, totp: REDACTED_VALUE, passphrase: REDACTED_VALUE })
+  })
+
+  it('redacts a bearer field that holds the credential itself', () => {
+    expect(sanitizeDiagnosticsValue({ bearer: 'abc.def.ghi' })).toEqual({ bearer: REDACTED_VALUE })
+  })
+
+  it('recognises the same names in free log text', () => {
+    expect(redactSensitiveText('pairing rejected pin=1234 otp=123456'))
+      .toBe(`pairing rejected pin=${REDACTED_VALUE} otp=${REDACTED_VALUE}`)
+  })
+
+  it('agrees between a structured field and the same name in log text', () => {
+    expect(isSensitiveFieldName('pin')).toBe(true)
+    expect(redactSensitiveText('pin=1234')).toBe(`pin=${REDACTED_VALUE}`)
+  })
+
+  it('leaves numeric diagnostics alone', () => {
+    // The other half of this defect is what not to do about it. Passing every
+    // scalar through the text redactor would start rewriting the numbers a
+    // bundle exists to carry, so the field name stays the only thing that decides.
+    const measurements = { port: 47989, fps: 120, bitrate_kbps: 20000, packet_loss: 0.4, gpu_index: 0 }
+
+    expect(sanitizeDiagnosticsValue(measurements)).toEqual(measurements)
+  })
+
+  it('keeps the identifiers that say which device the bundle is about', () => {
+    // client_id and session_id were both raised with this defect and are
+    // deliberately not redacted. Reaching them through the word list means
+    // treating `id` as a credential, which blanks user_id and app_id with it, and
+    // a support bundle about a paired device has to be able to name the device.
+    const identifiers = { client_id: 'nova-rp6-01', session_id: 99887766 }
+
+    expect(sanitizeDiagnosticsValue(identifiers)).toEqual(identifiers)
+  })
+
+  it('does not treat words that merely end in a credential name as one', () => {
+    // `pin` is short and lives inside ordinary words. Only a whole segment counts,
+    // so spin and pinned stay readable.
+    const ordinary = { spin: 3, pinned_apps: 12, pinning: 'manual' }
+
+    expect(sanitizeDiagnosticsValue(ordinary)).toEqual(ordinary)
+  })
+})
+
 describe('prefilled github issue url', () => {
   const context = {
     version: '1.3.11',


### PR DESCRIPTION
## Summary

Closes #470.

`sanitizeDiagnosticsValue` hands strings to `redactSensitiveText`, recurses into objects and arrays, and returns every other scalar unchanged. A credential that is not a string is therefore protected by its field name or not at all, and several names that would carry one were missing from the list. Polaris pairing uses a numeric PIN, so `{ pin: 1234 }` surviving an export is a shape this project has rather than a hypothetical one.

This adds `pin`, `passcode`, `passphrase`, `otp`, `totp` and `bearer` as sensitive name segments. Structured fields and free log text consult the same list, so both close at once, and the string form closes with them: a bare `1234` sitting in a field carries no `name=value` pair for the text redactor to find, so it leaked for a different reason than the numeric form did.

Nothing about how values are handled changes. The field name remains the only thing that decides, which is what keeps the numbers a bundle exists to carry readable.

## What is deliberately not here

Names raised in the same report and left off the list, with the reasons recorded next to the list rather than only in review:

- `salt` and `nonce` are public by design. Blanking them costs a diagnostic and protects nothing.
- `certificate` and `pem` carry the public half of pairing. The private half is already caught as a qualified `key`.
- `client_id` names the paired device, which is the one thing a support bundle about a paired device has to be able to say.

`session_id` is the genuinely open one, and I did not close it. A session id is a bearer credential where the Web UI is concerned, but reaching it through this list means treating `id` as qualified-only, and that blanks `user_id`, `app_id` and `client_id` with it. It wants a narrower rule than a word.

## The half that stays open

Issue #470 describes two halves and this is the cheaper one. Deciding what to do about non-string scalars generally is the larger half and is not attempted here, because the obvious version of it is wrong: passing every scalar through the text redactor would start rewriting the numeric diagnostics the bundle carries. A test pins that boundary rather than leaving it as an intention.

## Verification

- `npx vitest run src_assets/common/assets/web/diagnostics-export.test.js`: 82 passed, up from 73.
- The six new assertions were run against the unfixed source first and all six failed, so they close something real rather than describing what the code already did. The three counter-tests pass on both sides, which is what a regression guard should do.
- Full web suite: `npx vitest run --config vitest.config.js`, 61 files and 478 tests passed. Adding `pin` and `bearer` to a list two code paths share is exactly the change that breaks something elsewhere, and nothing broke.
- `npm run lint` clean.
- Not covered: no C++ gate was run, since nothing outside the web assets changed.
