### PR TITLE
fix(web): stop dropping shared references and container contents

### DIFF
--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -268,21 +268,75 @@ export function redactSensitiveText(value) {
 
 
 
+/**
+ * Sanitise `entries` into a plain object, applying the field-name rule to keys.
+ *
+ * Keys are stringified because a Map may key on anything, and an exported bundle
+ * is JSON either way. Which names count as credentials stays with
+ * isSensitiveFieldName rather than becoming a second definition here.
+ */
+function sanitizeEntries(entries, seen) {
+  return Object.fromEntries(entries.map(([key, item]) => [
+    String(key),
+    isSensitiveFieldName(String(key)) ? REDACTED_VALUE : sanitizeDiagnosticsValue(item, seen),
+  ]))
+}
+
+/**
+ * An error as diagnostics rather than as an empty object.
+ *
+ * `message` and `name` are non-enumerable, so Object.entries cannot see them and
+ * the whole error collapsed to `{}` on the way into a bundle. The message is
+ * usually the most useful line in a support report, so it is named explicitly
+ * and redacted like any other text. Enumerable own fields are kept after it,
+ * since that is where a code or an errno rides along.
+ *
+ * The stack is deliberately not carried. The bundle already ships log text, and
+ * a stack adds host paths without adding much a maintainer cannot get there.
+ */
+function sanitizeError(error, seen) {
+  return {
+    name: String(error.name || 'Error'),
+    message: redactSensitiveText(error.message || ''),
+    ...sanitizeEntries(Object.entries(error), seen),
+  }
+}
+
+/**
+ * Sanitise a value that is known to be an object, by what kind of object it is.
+ *
+ * Map, Set, Date and Error all have their contents somewhere Object.entries
+ * cannot reach, so the generic path turned each of them into `{}`. That is the
+ * safe direction and the useless one: the bundle still opened and still read as
+ * complete while carrying nothing.
+ */
+function sanitizeObjectLike(value, seen) {
+  if (Array.isArray(value)) return value.map((item) => sanitizeDiagnosticsValue(item, seen))
+  // An invalid date has no ISO form and toISOString throws on it, which would
+  // take the whole export down over one bad field.
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value.toISOString() : null
+  if (value instanceof Error) return sanitizeError(value, seen)
+  if (value instanceof Map) return sanitizeEntries([...value.entries()], seen)
+  if (value instanceof Set) return [...value].map((item) => sanitizeDiagnosticsValue(item, seen))
+  return sanitizeEntries(Object.entries(value), seen)
+}
+
 export function sanitizeDiagnosticsValue(value, seen = new WeakSet()) {
   if (value === null || value === undefined) return value
   if (typeof value === 'string') return redactSensitiveText(value)
   if (typeof value !== 'object') return value
+  // Only an ancestor is a cycle. `seen` used to keep every object the walk had
+  // ever visited, so the second reference to a shared object was reported as
+  // circular and whichever branch happened to be walked second lost its
+  // contents. Genuine cycles still terminate, because an ancestor is still in
+  // the set while its own subtree is being walked.
   if (seen.has(value)) return '[circular]'
   seen.add(value)
-
-  if (Array.isArray(value)) {
-    return value.map((item) => sanitizeDiagnosticsValue(item, seen))
+  try {
+    return sanitizeObjectLike(value, seen)
+  } finally {
+    seen.delete(value)
   }
-
-  return Object.fromEntries(Object.entries(value).map(([key, item]) => [
-    key,
-    isSensitiveFieldName(key) ? REDACTED_VALUE : sanitizeDiagnosticsValue(item, seen),
-  ]))
 }
 
 function issueTermPattern(term) {

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -624,6 +624,92 @@ describe('redaction defects closed', () => {
   })
 })
 
+describe('container shapes the walk used to drop', () => {
+  it('reports a second reference to the same object as the object, not as a cycle', () => {
+    const shared = { capture_path: 'dmabuf', frame_residency: 'gpu' }
+
+    expect(sanitizeDiagnosticsValue({ first: shared, second: shared })).toEqual({
+      first: { capture_path: 'dmabuf', frame_residency: 'gpu' },
+      second: { capture_path: 'dmabuf', frame_residency: 'gpu' },
+    })
+  })
+
+  it('reports the same shared value at any depth and in arrays', () => {
+    const shared = { encoder: 'nvenc' }
+
+    expect(sanitizeDiagnosticsValue({ a: { deep: shared }, b: [shared, shared] })).toEqual({
+      a: { deep: { encoder: 'nvenc' } },
+      b: [{ encoder: 'nvenc' }, { encoder: 'nvenc' }],
+    })
+  })
+
+  it('still terminates on a genuine self-reference', () => {
+    const cyclic = { name: 'session' }
+    cyclic.self = cyclic
+
+    expect(sanitizeDiagnosticsValue(cyclic)).toEqual({ name: 'session', self: '[circular]' })
+  })
+
+  it('still terminates on a cycle that runs through several objects', () => {
+    const first = { label: 'first' }
+    const second = { label: 'second', back: first }
+    first.forward = second
+
+    expect(sanitizeDiagnosticsValue(first)).toEqual({
+      label: 'first',
+      forward: { label: 'second', back: '[circular]' },
+    })
+  })
+
+  it('carries the contents of a Map instead of an empty object', () => {
+    const value = { limits: new Map([['fps', 120], ['bitrate_kbps', 20000]]) }
+
+    expect(sanitizeDiagnosticsValue(value)).toEqual({ limits: { fps: 120, bitrate_kbps: 20000 } })
+  })
+
+  it('applies the field-name rule to Map keys', () => {
+    const value = { headers: new Map([['authorization', 'Bearer abc'], ['accept', 'application/json']]) }
+
+    expect(sanitizeDiagnosticsValue(value)).toEqual({
+      headers: { authorization: REDACTED_VALUE, accept: 'application/json' },
+    })
+  })
+
+  it('carries the contents of a Set as a list', () => {
+    const value = { codecs: new Set(['h264', 'hevc', 'av1']) }
+
+    expect(sanitizeDiagnosticsValue(value)).toEqual({ codecs: ['h264', 'hevc', 'av1'] })
+  })
+
+  it('carries a Date as an ISO timestamp', () => {
+    expect(sanitizeDiagnosticsValue({ started_at: new Date(0) }))
+      .toEqual({ started_at: '1970-01-01T00:00:00.000Z' })
+  })
+
+  it('survives an invalid Date rather than throwing the export away', () => {
+    // toISOString throws on an invalid date, which would take the whole bundle
+    // down over one bad field.
+    expect(sanitizeDiagnosticsValue({ started_at: new Date('nonsense') })).toEqual({ started_at: null })
+  })
+
+  it('keeps the error message, which is the line a support bundle needs most', () => {
+    const value = { failure: new Error('capture failed on /dev/dri/renderD128') }
+
+    expect(sanitizeDiagnosticsValue(value)).toEqual({
+      failure: { name: 'Error', message: 'capture failed on /dev/dri/renderD128' },
+    })
+  })
+
+  it('redacts an error message and keeps the fields riding along with it', () => {
+    const failure = new Error('pairing rejected auth_token=hunter2')
+    failure.code = 'EAUTH'
+
+    expect(sanitizeDiagnosticsValue({ failure })).toEqual({
+      failure: { name: 'Error', message: `pairing rejected auth_token=${REDACTED_VALUE}`, code: 'EAUTH' },
+    })
+  })
+})
+
 describe('redaction across naming conventions', () => {
   it('redacts camelCase credential names in free text', () => {
     // The first fix handled snake and kebab and missed camelCase entirely, which


### PR DESCRIPTION
## Summary

Closes #469.

Two container shapes lost diagnostics on the way into a bundle. Neither is a credential leak, and both are the harder kind of failure to notice, because the bundle still opens and still reads as complete.

**A shared reference was reported as a cycle.** The `seen` WeakSet held every object the traversal had ever visited rather than the current ancestor path, so the second appearance of the same object became `[circular]` and whichever branch happened to be walked second lost its contents. Only an ancestor is a cycle. Each object is now removed from the set once its own subtree is done, which restores that meaning while genuine cycles still terminate, since an ancestor is still in the set while its subtree is being walked.

**Map, Set, Date and Error collapsed to `{}`.** Their contents live somewhere `Object.entries` cannot reach. Each is now handled by what it is: a Map becomes an object with the field-name rule applied to its keys, a Set becomes a list, a Date becomes an ISO timestamp, and an Error keeps its `name` and `message`. The message is the one that matters most, since it is non-enumerable and an error message is usually the most valuable line in a support report.

## Decisions inside that

- An error message is redacted like any other text, and the enumerable fields that ride along with an error, such as a `code` or an `errno`, are kept after it.
- An error stack is deliberately not carried. The bundle already ships log text, and a stack adds host paths without adding much a maintainer cannot get there.
- An invalid Date becomes `null` rather than throwing. `toISOString` throws on one, which would take the whole export down over a single bad field.
- Map keys are stringified, because a Map may key on anything and the bundle is JSON either way. Which key names count as credentials stays with `isSensitiveFieldName` rather than becoming a second definition.

## Consequence worth naming

A value referenced from several places is now expanded at each reference rather than once, so a heavily shared structure serialises larger than it did before. Cycles stay bounded, which is what the guard is for, and a diagnostics bundle is small enough that reporting a shared value faithfully is the better trade. If a bundle ever does carry a wide DAG, this is the change to look at first.

## Verification

- `npx vitest run src_assets/common/assets/web/diagnostics-export.test.js`: 84 passed, up from 73.
- The eleven new assertions were run against the unfixed source first. Nine failed. The two that passed on both sides are the cycle-termination guards, which is the point of them: the fix must not buy shared-reference fidelity by letting a real cycle run away.
- Full web suite: `npx vitest run --config vitest.config.js`, 61 files and 480 tests passed.
- `npm run lint` clean.
- Not covered: no C++ gate was run, since nothing outside the web assets changed. The reachability question the issue raises about whether the capability descriptors in `browser-stream-support.js` alias in practice is still unconfirmed, and this change makes it moot rather than answering it.
