### PR TITLE
fix(web): redact Web UI session identifiers

### DIFF
--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -13,13 +13,15 @@ const SENSITIVE_SEGMENT_WORDS = [
 // nothing. `certificate` and `pem` carry the public half of pairing, while the
 // private half is already caught as a qualified `key`. `client_id` names the
 // paired device, which is the one thing a support bundle about a paired device
-// has to be able to say.
+// has to be able to say. Non-string scalars also stay unchanged unless their
+// field name is sensitive, preserving numeric diagnostics such as bitrate and
+// packet loss.
 //
-// `session_id` is the genuinely open one. A session id is a bearer credential
-// where the Web UI is concerned, but reaching it through this list means treating
-// `id` as qualified-only, and that blanks user_id, app_id and client_id with it.
-// It needs a narrower rule than a word, so it is left for the decision about
-// non-string scalars generally rather than bolted on here.
+// Exact multi-word identifiers cover credentials whose individual words are too
+// broad to classify. `session_id` is a Web UI bearer credential, but making `id`
+// sensitive would also blank client_id, user_id and app_id. Normalize separators
+// and camel case so the same exact name cannot evade the rule by changing style.
+const SENSITIVE_EXACT_IDENTIFIERS = ['session_id']
 
 // Qualifiers that make a separator-less segment a credential name. `apikey` and
 // `authtoken` carry no separator and no camelCase hump, so there is nothing
@@ -196,6 +198,7 @@ function segmentIsSensitive(segment) {
 function isSensitiveIdentifier(name, bareQualifiedCounts) {
   const segments = identifierSegments(name)
   if (segments.length === 0) return false
+  if (SENSITIVE_EXACT_IDENTIFIERS.includes(segments.join('_'))) return true
   if (segments.some(segmentIsSensitive)) return true
   if (bareQualifiedCounts && segments.length === 1) {
     return segmentMatches(segments[0], QUALIFIED_ONLY_WORDS)
@@ -1109,7 +1112,8 @@ export function buildAnonymizedDiagnosticsBundle(input = {}) {
       'Values are redacted client-side before export when their name reads as a credential.',
       'Whole words such as password, passwd, token, secret, cookie, auth, authorization and',
       'credential count, as do run-together forms such as apikey. The word key counts only when',
-      'something qualifies it, as in api_key or apiKey. Names that merely contain one of those,',
+      'something qualifies it, as in api_key or apiKey. The exact name session_id also counts',
+      'because Web UI access depends on keeping it private. Names that merely contain one of those,',
       'such as keyboard or monkey, stay readable so the bundle remains useful. In raw log text a',
       'bare key assignment is also redacted, because a log line carries no surrounding context to',
       'say whether it names a label or a secret.',

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -935,6 +935,7 @@ describe('the redaction notice describes what the code does', () => {
     expect(notice).not.toContain('Fields containing')
     expect(notice).toContain('Whole words')
     expect(notice).toContain('qualifies it')
+    expect(notice).toContain('session_id')
   })
 
   it('survives its own rules', () => {
@@ -1085,12 +1086,33 @@ describe('credentials that are not strings', () => {
     expect(sanitizeDiagnosticsValue(measurements)).toEqual(measurements)
   })
 
-  it('keeps the identifiers that say which device the bundle is about', () => {
-    // client_id and session_id were both raised with this defect and are
-    // deliberately not redacted. Reaching them through the word list means
-    // treating `id` as a credential, which blanks user_id and app_id with it, and
-    // a support bundle about a paired device has to be able to name the device.
-    const identifiers = { client_id: 'nova-rp6-01', session_id: 99887766 }
+  it('redacts the Web UI session bearer id in structured diagnostics', () => {
+    expect(sanitizeDiagnosticsValue({
+      session_id: 99887766,
+      sessionId: 'session-secret',
+      'session-id': 'another-secret',
+    })).toEqual({
+      session_id: REDACTED_VALUE,
+      sessionId: REDACTED_VALUE,
+      'session-id': REDACTED_VALUE,
+    })
+  })
+
+  it('redacts the Web UI session bearer id in free log text', () => {
+    expect(redactSensitiveText('session_id=99887766 sessionId=session-secret'))
+      .toBe(`session_id=${REDACTED_VALUE} sessionId=${REDACTED_VALUE}`)
+  })
+
+  it('keeps non-secret identifiers and nearby session names readable', () => {
+    // `id` cannot become sensitive generally: these identifiers carry useful
+    // diagnostic identity, while only session_id is the Web UI bearer credential.
+    const identifiers = {
+      client_id: 'nova-rp6-01',
+      user_id: 42,
+      app_id: 1091500,
+      session_idle: false,
+      session_identifier: 'display-session-2',
+    }
 
     expect(sanitizeDiagnosticsValue(identifiers)).toEqual(identifiers)
   })


### PR DESCRIPTION
## What changed

- Treat the exact normalized identifier `session_id` as sensitive in structured diagnostics and free log text.
- Cover snake case, camel case, and hyphenated forms without making the generic word `id` sensitive.
- Update the user-facing redaction notice to describe the new rule.
- Keep non-string scalars unchanged unless their field name is sensitive.

## Why

The Web UI session id is a bearer credential, but adding `id` to the general sensitive-word list would also erase useful `client_id`, `user_id`, and `app_id` diagnostics. The exact multi-word rule closes that gap while preserving device identity and numeric measurements.

## Validation

- RED: with tests applied and source unchanged, the diagnostics file reported 3 failures and 92 passes. The failures covered the redaction notice, structured session ids, and free-text session ids.
- GREEN: `diagnostics-export.test.js` passed 95/95.
- Full web suite passed: 61 files, 491 tests.
- `npm run lint`
- `git diff --check`

Counter-tests preserve `client_id`, `user_id`, `app_id`, `session_idle`, `session_identifier`, and ordinary numeric diagnostics.
