### PR TITLE
fix(linux): keep PipeWire VAAPI capture safe by default

### DIFF
--- a/src/platform/linux/pipewire_capture.cpp
+++ b/src/platform/linux/pipewire_capture.cpp
@@ -78,10 +78,6 @@ namespace pipewire_capture {
              spa_format == SPA_VIDEO_FORMAT_RGBA;
     }
 
-    bool gpu_encoder_mem_type(platf::mem_type_e mem_type) {
-      return mem_type == platf::mem_type_e::vaapi || mem_type == platf::mem_type_e::cuda;
-    }
-
     bool contains_modifier(const std::vector<std::uint64_t> &modifiers, std::uint64_t modifier) {
       return std::find(modifiers.begin(), modifiers.end(), modifier) != modifiers.end();
     }
@@ -147,7 +143,28 @@ namespace pipewire_capture {
     return canonical_render_node(nodes.front());
   }
 
-  bool may_offer_dmabuf(const dmabuf_eligibility_t &eligibility) {
+  dmabuf_override_e dmabuf_override_from_env(const char *value) {
+    if (value && std::strcmp(value, "0") == 0) {
+      return dmabuf_override_e::force_cpu;
+    }
+    if (value && std::strcmp(value, "1") == 0) {
+      return dmabuf_override_e::allow_vaapi;
+    }
+    return dmabuf_override_e::default_safe;
+  }
+
+  bool may_offer_dmabuf(const dmabuf_eligibility_t &eligibility, dmabuf_override_e override) {
+    // #367 and #480 reached the first-frame VAAPI failure boundary on different
+    // capture backends. A matching render node and importable modifier prove
+    // layout compatibility, not driver-safe import/conversion lifetime. Keep
+    // every unproven VAAPI PipeWire route on SHM by default. CUDA remains the
+    // validated GPU-native path; VAAPI is available only as an explicit field-
+    // testing opt-in on hosts where the operator has already proved it works.
+    const bool supported_encoder = eligibility.mem_type == platf::mem_type_e::cuda ||
+                                   (override == dmabuf_override_e::allow_vaapi && eligibility.mem_type == platf::mem_type_e::vaapi);
+    if (override == dmabuf_override_e::force_cpu || !supported_encoder) {
+      return false;
+    }
     if (!eligibility.capture_render_node) {
       return false;
     }
@@ -155,7 +172,6 @@ namespace pipewire_capture {
     const auto encoder_node = canonical_render_node(eligibility.encoder_render_node);
     return capture_node && encoder_node &&
            *capture_node == *encoder_node &&
-           gpu_encoder_mem_type(eligibility.mem_type) &&
            eligibility.egl_import_supported;
   }
 
@@ -1064,8 +1080,8 @@ namespace pipewire_capture {
       cap->set_terminal(wait_result_e::reinit);
       return;
     }
-    const char *dmabuf_env = std::getenv("POLARIS_PORTAL_DMABUF");
-    const bool force_cpu = dmabuf_env && dmabuf_env[0] == '0' && dmabuf_env[1] == '\0';
+    const auto dmabuf_override = dmabuf_override_from_env(std::getenv("POLARIS_PORTAL_DMABUF"));
+    const bool force_cpu = dmabuf_override == dmabuf_override_e::force_cpu;
     const bool want_dmabuf = cap->options_.may_use_dmabuf && !force_cpu;
     const auto has_modifier = (raw_info.flags & SPA_VIDEO_FLAG_MODIFIER) &&
                               raw_info.modifier != DRM_FORMAT_MOD_INVALID;

--- a/src/platform/linux/pipewire_capture.h
+++ b/src/platform/linux/pipewire_capture.h
@@ -77,6 +77,12 @@ namespace pipewire_capture {
     bool egl_import_supported = false;
   };
 
+  enum class dmabuf_override_e {
+    default_safe,
+    force_cpu,
+    allow_vaapi,
+  };
+
   struct dmabuf_plane_t {
     int fd = -1;
     std::uint32_t chunk_offset = 0;
@@ -111,7 +117,16 @@ namespace pipewire_capture {
     const std::optional<std::string> &portal_capture_render_node,
     const std::optional<std::string> &encoder_render_node
   );
-  bool may_offer_dmabuf(const dmabuf_eligibility_t &eligibility);
+  // Only exact "0" and "1" values carry authority. Everything else, including
+  // a missing variable, retains the fail-closed default.
+  dmabuf_override_e dmabuf_override_from_env(const char *value);
+  // VAAPI stays fail-closed unless the operator explicitly opts into the
+  // unvalidated route. The typed override prevents contradictory force/allow
+  // flags from reaching this boundary.
+  bool may_offer_dmabuf(
+    const dmabuf_eligibility_t &eligibility,
+    dmabuf_override_e override = dmabuf_override_e::default_safe
+  );
   std::vector<dmabuf_format_modifier_t> task1_packed_dmabuf_formats(std::vector<std::uint64_t> modifiers);
   std::vector<dmabuf_format_modifier_t> filter_importable_dmabuf_formats(
     const std::vector<dmabuf_format_modifier_t> &portal_formats,

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -178,6 +178,29 @@ namespace portal {
     return client_dynamic_range <= 0;
   }
 
+  static pipewire_capture::dmabuf_override_e portal_dmabuf_override() {
+    return pipewire_capture::dmabuf_override_from_env(std::getenv("POLARIS_PORTAL_DMABUF"));
+  }
+
+  static void log_dmabuf_policy(
+    platf::mem_type_e mem_type,
+    pipewire_capture::dmabuf_override_e override,
+    std::string_view source
+  ) {
+    if (override == pipewire_capture::dmabuf_override_e::force_cpu) {
+      BOOST_LOG(info) << "portal: portal_dmabuf_forced_off source="sv << source
+                      << "; offering SHM only"sv;
+    }
+    else if (mem_type == platf::mem_type_e::vaapi && override == pipewire_capture::dmabuf_override_e::allow_vaapi) {
+      BOOST_LOG(warning) << "portal: vaapi_pipewire_dmabuf_explicitly_enabled source="sv << source
+                         << "; operator opted into an unvalidated path with no automatic stall fallback"sv;
+    }
+    else if (mem_type == platf::mem_type_e::vaapi) {
+      BOOST_LOG(info) << "portal: vaapi_pipewire_dmabuf_disabled_for_stability source="sv << source
+                      << "; offering SHM by default; set POLARIS_PORTAL_DMABUF=1 only on a host where this path is known to work"sv;
+    }
+  }
+
   // Encoder render node for DMA-BUF eligibility: the configured adapter_name
   // when it names a canonical render node, else the host's sole render node.
   // Single-GPU hosts get zero-copy without configuration; multi-GPU hosts stay
@@ -219,7 +242,18 @@ namespace portal {
     bool may_use_dmabuf = false;
     const bool prefer_hdr = portal_prefer_hdr_formats(client_dynamic_range);
     const bool prefer_sdr = portal_prefer_sdr_formats(client_dynamic_range);
+    const auto dmabuf_override = portal_dmabuf_override();
     if (encoder_render_node) {
+      const pipewire_capture::dmabuf_eligibility_t eligibility {
+        .capture_render_node = encoder_render_node,
+        .encoder_render_node = *encoder_render_node,
+        .mem_type = mem_type,
+        .egl_import_supported = true,
+      };
+      may_use_dmabuf = pipewire_capture::may_offer_dmabuf(eligibility, dmabuf_override);
+    }
+    log_dmabuf_policy(mem_type, dmabuf_override, "local_graph"sv);
+    if (may_use_dmabuf) {
       // LINEAR always for gamescope (only allocates LINEAR on PW node).
       dmabuf_formats = pipewire_capture::task1_packed_dmabuf_formats({DRM_FORMAT_MOD_LINEAR});
       // Ensure 10-bit LINEAR is present for HDR streams even if EGL skipped it.
@@ -247,7 +281,6 @@ namespace portal {
                  format.spa_format == SPA_VIDEO_FORMAT_xRGB_210LE;
         });
       }
-      may_use_dmabuf = !dmabuf_formats.empty();
     }
     auto local = std::make_shared<pipewire_capture::capture_t>(pipewire_capture::capture_options_t {
       .remote_fd = -1,
@@ -568,15 +601,23 @@ namespace portal {
         }
         std::vector<pipewire_capture::dmabuf_format_modifier_t> dmabuf_formats;
         bool may_use_dmabuf = false;
-        if (!session->capture_render_node) {
+        const auto dmabuf_override = portal_dmabuf_override();
+        const bool allow_vaapi = dmabuf_override == pipewire_capture::dmabuf_override_e::allow_vaapi;
+        log_dmabuf_policy(mem_type, dmabuf_override, "portal_remote"sv);
+        if (dmabuf_override == pipewire_capture::dmabuf_override_e::force_cpu ||
+            (mem_type == platf::mem_type_e::vaapi && !allow_vaapi)) {
+          // The policy log above records whether this is an operator-forced or
+          // default stability containment decision.
+        } else if (!session->capture_render_node) {
           BOOST_LOG(info) << "portal: DMA-BUF disabled because the portal stream did not provide an explicit capture render node"sv;
         } else if (!encoder_render_node) {
           BOOST_LOG(info) << "portal: DMA-BUF disabled because config::video.adapter_name is not an explicit canonical render node"sv;
         } else if (*session->capture_render_node != *encoder_render_node) {
           BOOST_LOG(info) << "portal: DMA-BUF disabled because capture render node ["sv << *session->capture_render_node
                           << "] does not match encoder adapter ["sv << *encoder_render_node << ']';
-        } else if (mem_type != platf::mem_type_e::vaapi && mem_type != platf::mem_type_e::cuda) {
-          BOOST_LOG(info) << "portal: DMA-BUF disabled because encoder memory type is not VAAPI or CUDA"sv;
+        } else if (mem_type != platf::mem_type_e::cuda &&
+                   !(allow_vaapi && mem_type == platf::mem_type_e::vaapi)) {
+          BOOST_LOG(info) << "portal: DMA-BUF disabled because encoder memory type is neither CUDA nor explicitly enabled VAAPI"sv;
         } else {
           if (mem_type == platf::mem_type_e::cuda) {
             // LINEAR one-plane packed RGB: 8-bit BGRx/BGRA + 10-bit xBGR_210LE (HDR).
@@ -633,7 +674,7 @@ namespace portal {
             .mem_type = mem_type,
             .egl_import_supported = !dmabuf_formats.empty(),
           };
-          may_use_dmabuf = pipewire_capture::may_offer_dmabuf(eligibility);
+          may_use_dmabuf = pipewire_capture::may_offer_dmabuf(eligibility, dmabuf_override);
           if (!may_use_dmabuf) {
             BOOST_LOG(info) << "portal: DMA-BUF disabled because no compatible packed-RGB modifier is available for encoder render node ["sv
                             << *encoder_render_node << ']';
@@ -646,6 +687,7 @@ namespace portal {
                         << " prefer_hdr="sv << (want_prefer_hdr ? "true"sv : "false"sv)
                         << " prefer_sdr="sv << (want_prefer_sdr ? "true"sv : "false"sv)
                         << " force_hdr="sv << (portal_force_hdr_enabled() ? "true"sv : "false"sv)
+                        << " vaapi_opt_in="sv << (allow_vaapi ? "true"sv : "false"sv)
                         << " client_dynamic_range="sv << client_dynamic_range
                         << " capture_node="sv << session->capture_render_node.value_or("none")
                         << " encoder_node="sv << encoder_render_node.value_or("none")

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -628,15 +628,34 @@ TEST(PipeWireCapturePolicyTests, RenderNodeValidationAcceptsOnlyCanonicalRenderN
   EXPECT_EQ(pipewire_capture::canonical_render_node("/dev/dri/renderDabc"), std::nullopt);
 }
 
-TEST(PipeWireCapturePolicyTests, SameRenderNodeEligibilityRequiresExplicitMatchingGpuPathAndEglSupport) {
+TEST(PipeWireCapturePolicyTests, DmaBufEligibilityRequiresSupportedEncoderAndExplicitMatchingGpuPath) {
   const pipewire_capture::dmabuf_eligibility_t eligible {
     .capture_render_node = "/dev/dri/renderD128",
     .encoder_render_node = "/dev/dri/renderD128",
-    .mem_type = platf::mem_type_e::vaapi,
+    .mem_type = platf::mem_type_e::cuda,
     .egl_import_supported = true,
   };
 
   EXPECT_TRUE(pipewire_capture::may_offer_dmabuf(eligible));
+  EXPECT_FALSE(pipewire_capture::may_offer_dmabuf(eligible, pipewire_capture::dmabuf_override_e::force_cpu));
+
+  auto vaapi = eligible;
+  vaapi.mem_type = platf::mem_type_e::vaapi;
+  EXPECT_FALSE(pipewire_capture::may_offer_dmabuf(vaapi));
+  EXPECT_TRUE(pipewire_capture::may_offer_dmabuf(vaapi, pipewire_capture::dmabuf_override_e::allow_vaapi));
+  EXPECT_FALSE(pipewire_capture::may_offer_dmabuf(vaapi, pipewire_capture::dmabuf_override_e::force_cpu));
+
+  auto vaapi_missing_capture = vaapi;
+  vaapi_missing_capture.capture_render_node.reset();
+  EXPECT_FALSE(pipewire_capture::may_offer_dmabuf(vaapi_missing_capture, pipewire_capture::dmabuf_override_e::allow_vaapi));
+
+  auto vaapi_mismatched = vaapi;
+  vaapi_mismatched.encoder_render_node = "/dev/dri/renderD129";
+  EXPECT_FALSE(pipewire_capture::may_offer_dmabuf(vaapi_mismatched, pipewire_capture::dmabuf_override_e::allow_vaapi));
+
+  auto vaapi_no_egl = vaapi;
+  vaapi_no_egl.egl_import_supported = false;
+  EXPECT_FALSE(pipewire_capture::may_offer_dmabuf(vaapi_no_egl, pipewire_capture::dmabuf_override_e::allow_vaapi));
 
   auto missing_capture = eligible;
   missing_capture.capture_render_node.reset();
@@ -649,6 +668,7 @@ TEST(PipeWireCapturePolicyTests, SameRenderNodeEligibilityRequiresExplicitMatchi
   auto system_memory = eligible;
   system_memory.mem_type = platf::mem_type_e::system;
   EXPECT_FALSE(pipewire_capture::may_offer_dmabuf(system_memory));
+  EXPECT_FALSE(pipewire_capture::may_offer_dmabuf(system_memory, pipewire_capture::dmabuf_override_e::allow_vaapi));
 
   auto no_egl = eligible;
   no_egl.egl_import_supported = false;
@@ -658,6 +678,19 @@ TEST(PipeWireCapturePolicyTests, SameRenderNodeEligibilityRequiresExplicitMatchi
   noncanonical.capture_render_node = "renderD128";
   noncanonical.encoder_render_node = "renderD128";
   EXPECT_FALSE(pipewire_capture::may_offer_dmabuf(noncanonical));
+}
+
+TEST(PipeWireCapturePolicyTests, DmaBufEnvironmentOverrideRequiresAnExactZeroOrOne) {
+  using enum pipewire_capture::dmabuf_override_e;
+
+  EXPECT_EQ(pipewire_capture::dmabuf_override_from_env(nullptr), default_safe);
+  EXPECT_EQ(pipewire_capture::dmabuf_override_from_env(""), default_safe);
+  EXPECT_EQ(pipewire_capture::dmabuf_override_from_env("0"), force_cpu);
+  EXPECT_EQ(pipewire_capture::dmabuf_override_from_env("1"), allow_vaapi);
+  EXPECT_EQ(pipewire_capture::dmabuf_override_from_env("00"), default_safe);
+  EXPECT_EQ(pipewire_capture::dmabuf_override_from_env("01"), default_safe);
+  EXPECT_EQ(pipewire_capture::dmabuf_override_from_env("true"), default_safe);
+  EXPECT_EQ(pipewire_capture::dmabuf_override_from_env(" 1"), default_safe);
 }
 
 TEST(PipeWireCapturePolicyTests, DmaBufCapabilityFilteringKeepsOnlyPackedRgbImportableNonExternalFormats) {

--- a/tests/unit/test_linux_platform_hardening_source.cpp
+++ b/tests/unit/test_linux_platform_hardening_source.cpp
@@ -50,6 +50,26 @@ TEST(LinuxPlatformHardeningSource, HeadlessVaapiFailsClosedBeforeDmabufInitializ
   EXPECT_NE(process.find("Retaining headless extcopy failure reason"), std::string::npos);
 }
 
+TEST(LinuxPlatformHardeningSource, PipeWireVaapiDefaultsToShmWithExplicitOptInAndForcedCpuPrecedence) {
+  const auto policy = read_source("src/platform/linux/pipewire_capture.cpp");
+  const auto capture = read_source("src/platform/linux/portal_grab.cpp");
+
+  EXPECT_NE(policy.find("override == dmabuf_override_e::allow_vaapi && eligibility.mem_type == platf::mem_type_e::vaapi"), std::string::npos);
+  EXPECT_NE(policy.find("dmabuf_override_from_env(std::getenv(\"POLARIS_PORTAL_DMABUF\"))"), std::string::npos);
+  EXPECT_NE(capture.find("portal_dmabuf_override"), std::string::npos);
+  EXPECT_NE(capture.find("vaapi_pipewire_dmabuf_disabled_for_stability"), std::string::npos);
+  EXPECT_NE(capture.find("vaapi_pipewire_dmabuf_explicitly_enabled"), std::string::npos);
+
+  const std::string offer_call = "may_offer_dmabuf(eligibility, dmabuf_override)";
+  const auto local_offer = capture.find(offer_call);
+  ASSERT_NE(local_offer, std::string::npos);
+  EXPECT_NE(capture.find(offer_call, local_offer + offer_call.size()), std::string::npos)
+    << "both local-graph and portal-remote capture must apply the same explicit policy";
+
+  EXPECT_NE(capture.find("query_egl_dmabuf_import_formats(*encoder_render_node)"), std::string::npos)
+    << "the explicit VAAPI opt-in must retain the existing EGL modifier capability gate";
+}
+
 TEST(LinuxPlatformHardeningSource, HeadlessModifierGuardRemainsBehindVaapiContainment) {
   const auto header = read_source("src/platform/linux/wayland.h");
   const auto capture = read_source("src/platform/linux/wlgrab.cpp");


### PR DESCRIPTION
## What

- Fail closed to SHM before PipeWire format advertisement for VAAPI capture on both local gamescope/KWin graphs and portal-remoted streams.
- Preserve CUDA DMA-BUF behavior.
- Treat `POLARIS_PORTAL_DMABUF` as a narrow typed override:
  - unset or any value other than exact `0`/`1`: safe default, so VAAPI stays on SHM
  - exact `0`: force SHM, including a second check at final PipeWire negotiation
  - exact `1`: explicitly opt VAAPI back into DMA-BUF for field-proven hosts
- Keep the opt-in behind the existing local-graph LINEAR route and the portal-remote canonical render-node/EGL modifier checks.
- Emit a warning that the opt-in is unvalidated and has no automatic stall fallback.

## Why

The affected RX 7800 XT report on v1.3.10 negotiates `capture_transport=dmabuf frame_residency=gpu`, then produces a black/no-media session that requires `kill -9`. The trace proves that one frame reached the capture-to-encode handoff; it does not distinguish a later import, conversion, encode, buffer-lifetime, or producer stall.

The old eligibility check proved matching render nodes and an importable layout, but that is not proof of driver-safe VAAPI import/conversion lifetime. Defaulting VAAPI to SHM is the bounded containment.

A second AMD host also proved that a permanent blanket block would be too broad: RX 9070 XT / RDNA4 / Mesa 26.1.6 / KWin streamed correctly through the unpatched local DMA-BUF path, while the same hardware still hit the separate zero-frame failure on headless ext-image-copy. Exact `POLARIS_PORTAL_DMABUF=1` therefore exposes the already-existing PipeWire VAAPI route only to operators who have proved it on their host; it is not an allowlist or a claim that AMD VAAPI is generally safe.

A generic no-frame timeout remains intentionally out of scope: a static Gamescope scene can legitimately stop producing frames, so a watchdog would create false reconnect loops.

## Validation

RED before the opt-in implementation:

- with the final tests kept and only the production files restored to the original #481 source, the build failed because `dmabuf_override_e`, its exact-value parser, and the typed policy overload did not exist

GREEN on Linux after the implementation:

- focused default/force/opt-in policy and source-boundary tests
- exact environment parser counter-tests (`00`, `01`, `true`, whitespace, unset)
- `test_polaris`: 353/353
- `test_polaris_platform`: 218 passed, 1 expected CUDA-only skip
- full production `polaris` executable build
- `git diff --check`

Protected exact-head CI is required after this rebase.

## Release gate

Keep this PR draft until the affected RX 7800 XT / VAAPI host proves on the exact head:

- default `gamescope_stream` produces changing media through the SHM containment
- exact `POLARIS_PORTAL_DMABUF=0` behaves the same way from initial negotiation
- session stop/cleanup completes without a coredump, residue, or forced kill

The RDNA4 host may separately test exact `POLARIS_PORTAL_DMABUF=1`; that is useful opt-in evidence but does not replace the affected-host default-containment gate.

Closes #480. Refs #409. Original affected report: https://github.com/papi-ux/polaris/issues/422#issuecomment-5326544071. RDNA4 local-graph evidence: https://github.com/papi-ux/polaris/pull/481#issuecomment-5334129897.
