### PR TITLE
fix(linux): keep private Steam from blocking reconnects

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -4939,6 +4939,10 @@ namespace confighttp {
           );
           const auto launch_policy_json = proc::desktop_launch_safety_policy_to_json(launch_policy);
           if (launch_policy.recommendedAction == "refuse_private_stream") {
+            BOOST_LOG(warning) << "launch_policy: refusing private stream; desktop_steam_active="sv
+                               << launch_policy.desktopSteamActive
+                               << " physical_display_risk="sv
+                               << launch_policy.physicalDisplayRisk;
             nlohmann::json error_tree;
             error_tree["status_code"] = static_cast<int>(SimpleWeb::StatusCode::client_error_conflict);
             error_tree["status"] = false;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -5825,6 +5825,10 @@ namespace nvhttp {
           put_desktop_launch_policy(tree, launch_policy);
         }
         if (launch_policy.recommendedAction == "refuse_private_stream") {
+          BOOST_LOG(warning) << "launch_policy: refusing private stream; desktop_steam_active="sv
+                             << launch_policy.desktopSteamActive
+                             << " physical_display_risk="sv
+                             << launch_policy.physicalDisplayRisk;
           tree.put("root.resume", 0);
           tree.put("root.<xmlattr>.status_code", 409);
           tree.put("root.<xmlattr>.status_message", "Unsafe private stream launch refused because desktop Steam or a desktop game is active. Quit the desktop session or retry with explicit desktop mirroring.");
@@ -7805,6 +7809,10 @@ namespace nvhttp {
           launch_policy_json = proc::desktop_launch_safety_policy_to_json(launch_policy);
         }
         if (launch_policy.recommendedAction == "refuse_private_stream") {
+          BOOST_LOG(warning) << "launch_policy: refusing private stream; desktop_steam_active="sv
+                             << launch_policy.desktopSteamActive
+                             << " physical_display_risk="sv
+                             << launch_policy.physicalDisplayRisk;
           nlohmann::json err;
           err["error"] = "Unsafe private stream launch refused because desktop Steam or a desktop game is active. Quit the desktop session or retry with explicit desktop mirroring.";
           err["error_code"] = "desktop_active_private_stream_refused";

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -1238,6 +1238,7 @@ namespace cage_display_router {
       } else {
         unsetenv("POLARIS_SESSION_INSTANCE_ID");
       }
+      setenv("POLARIS_PRIVATE_SESSION", "1", 1);
       set_labwc_process_environment(headless);
       if (headless) {
         // Headless mode: no visible window on desktop, no parent display needed.

--- a/src/platform/linux/session_launch_linux.cpp
+++ b/src/platform/linux/session_launch_linux.cpp
@@ -69,6 +69,9 @@ namespace session_launch_linux {
     if (cage_socket.empty()) {
       return;
     }
+    // Ownership marker for the desktop-Steam launch guard. This is deliberately
+    // absent from desktop-mirror launches.
+    env["POLARIS_PRIVATE_SESSION"] = "1";
     env["WAYLAND_DISPLAY"] = cage_socket;
     env["AT_SPI_BUS_ADDRESS"] = "";
     if (!cage_display.empty()) {
@@ -101,6 +104,10 @@ namespace session_launch_linux {
       // Steam base XWayland; STEAM_MULTIPLE_XWAYLANDS places games on base+1.
       cage_display = ":0";
     }
+
+    // Ownership marker for the desktop-Steam launch guard. Pressure-vessel may
+    // strip other session variables, so apply it at the final attach boundary.
+    env["POLARIS_PRIVATE_SESSION"] = "1";
 
     // Prefer XWayland into gamescope for Proton; still pin GAMESCOPE_WAYLAND_DISPLAY
     // so nested helpers and steam find the right compositor. Unset host WAYLAND_DISPLAY

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -889,6 +889,18 @@ namespace proc {
       );
     }
 
+    // This reserved marker records Polaris private-session provenance. It is
+    // not authentication against another same-user process deliberately
+    // forging its environment. Unknown or unreadable ownership still fails
+    // closed in the desktop launch guard below.
+    bool proc_environ_is_polaris_private_session(std::string_view environ) {
+      return proc_environ_contains_exact_entry(
+        environ,
+        "POLARIS_PRIVATE_SESSION"sv,
+        "1"sv
+      );
+    }
+
     std::string steam_appid_for_context(const proc::ctx_t &ctx) {
       if (!ctx.steam_appid.empty()) {
         return ctx.steam_appid;
@@ -2665,6 +2677,7 @@ namespace proc {
 #ifdef POLARIS_TESTS
     thread_local bool forced_desktop_steam_proc_open_error = false;
     thread_local pid_t forced_desktop_steam_proc_read_error_pid = -1;
+    thread_local pid_t forced_desktop_steam_proc_environ_read_error_pid = -1;
     thread_local pid_t forced_desktop_steam_scan_only_pid = -1;
 #endif
 
@@ -2842,6 +2855,25 @@ namespace proc {
           continue;
         }
         if (is_active_desktop_steam_client_process(comm, argv0, cmdline, status)) {
+          auto environ_result = read_proc_status_file_result(pid, "environ");
+#ifdef POLARIS_TESTS
+          if (pid == forced_desktop_steam_proc_environ_read_error_pid) {
+            environ_result = {{}, EACCES};
+          }
+#endif
+          if (!environ_result.ok()) {
+            if (process_vanished_during_proc_read(environ_result.error)) {
+              continue;
+            }
+            // The guard protects the physical desktop. If ownership cannot be
+            // read, keep treating this Steam process as desktop-owned.
+            return true;
+          }
+          if (proc_environ_is_polaris_private_session(environ_result.bytes)) {
+            BOOST_LOG(debug) << "process: ignoring private-session-marked Steam in desktop launch guard pid="sv
+                             << pid;
+            continue;
+          }
           return true;
         }
       }
@@ -3442,7 +3474,8 @@ namespace proc {
     }
 
     bool is_reserved_session_env_key(std::string_view key) {
-      return key == "POLARIS_SESSION_INSTANCE_ID"sv;
+      return key == "POLARIS_SESSION_INSTANCE_ID"sv ||
+             key == "POLARIS_PRIVATE_SESSION"sv;
     }
 
     void set_child_only_session_env_var(boost::process::v1::environment &env,
@@ -4570,8 +4603,10 @@ namespace proc {
   bool desktop_steam_client_process_for_tests(std::string_view comm,
                                                std::string_view argv0_path,
                                                std::string_view cmdline,
-                                               std::string_view status) {
-    return is_active_desktop_steam_client_process(comm, argv0_path, cmdline, status);
+                                               std::string_view status,
+                                               std::string_view environ) {
+    return is_active_desktop_steam_client_process(comm, argv0_path, cmdline, status) &&
+           !proc_environ_is_polaris_private_session(environ);
   }
 
   bool steam_instance_pipe_listener_active_for_tests(const std::string &pipe_path) {
@@ -4604,6 +4639,27 @@ namespace proc {
       forced_desktop_steam_scan_only_pid = previous_only_pid;
     });
     forced_desktop_steam_proc_read_error_pid = forced_pid;
+    forced_desktop_steam_scan_only_pid = forced_pid;
+    return desktop_steam_client_active_impl();
+  }
+
+  bool desktop_steam_proc_environ_read_error_fails_closed_for_tests(pid_t forced_pid) {
+    const auto previous_error_pid = forced_desktop_steam_proc_environ_read_error_pid;
+    const auto previous_only_pid = forced_desktop_steam_scan_only_pid;
+    auto restore = util::fail_guard([previous_error_pid, previous_only_pid]() {
+      forced_desktop_steam_proc_environ_read_error_pid = previous_error_pid;
+      forced_desktop_steam_scan_only_pid = previous_only_pid;
+    });
+    forced_desktop_steam_proc_environ_read_error_pid = forced_pid;
+    forced_desktop_steam_scan_only_pid = forced_pid;
+    return desktop_steam_client_active_impl();
+  }
+
+  bool desktop_steam_proc_scan_only_pid_for_tests(pid_t forced_pid) {
+    const auto previous_only_pid = forced_desktop_steam_scan_only_pid;
+    auto restore = util::fail_guard([previous_only_pid]() {
+      forced_desktop_steam_scan_only_pid = previous_only_pid;
+    });
     forced_desktop_steam_scan_only_pid = forced_pid;
     return desktop_steam_client_active_impl();
   }
@@ -6793,6 +6849,10 @@ namespace proc {
 
     _session_env_keys.clear();
 #ifdef __linux__
+    // This marker is applied only to processes launched into a Polaris-owned
+    // private compositor. Never let the daemon environment or app config leak
+    // it into a desktop-mirror launch.
+    _env.erase("POLARIS_PRIVATE_SESSION");
     // Prep commands are child processes too. Publish the immutable session
     // credential before the nested gamescope start command executes, while
     // keeping it out of the daemon's real environment.

--- a/src/process.h
+++ b/src/process.h
@@ -232,10 +232,13 @@ namespace proc {
   bool desktop_steam_client_process_for_tests(std::string_view comm,
                                                std::string_view argv0_path,
                                                std::string_view cmdline,
-                                               std::string_view status = {});
+                                               std::string_view status = {},
+                                               std::string_view environ = {});
   bool desktop_steam_proc_open_error_fails_closed_for_tests();
   bool desktop_steam_proc_enumeration_error_fails_closed_for_tests();
   bool desktop_steam_proc_read_error_fails_closed_for_tests(pid_t forced_pid);
+  bool desktop_steam_proc_environ_read_error_fails_closed_for_tests(pid_t forced_pid);
+  bool desktop_steam_proc_scan_only_pid_for_tests(pid_t forced_pid);
   bool steam_instance_pipe_listener_active_for_tests(const std::string &pipe_path);
   std::optional<std::string> resolve_nested_gamescope_session_target_for_tests(
     bool gamescope_stream_session,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -3576,6 +3576,108 @@ TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorIgnoresZombieShutdownRemnant
   ));
 }
 
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorDistinguishesPolarisPrivateSessionOwnership) {
+  const auto process_source = read_source_file_for_contract("src/process.cpp");
+  const auto launch_source = read_source_file_for_contract("src/platform/linux/session_launch_linux.cpp");
+  const auto cage_source = read_source_file_for_contract("src/platform/linux/cage_display_router.cpp");
+  ASSERT_FALSE(process_source.empty());
+  ASSERT_FALSE(launch_source.empty());
+  ASSERT_FALSE(cage_source.empty());
+
+  const auto detector_start = process_source.find("bool desktop_steam_client_active_impl()");
+  const auto detector_end = process_source.find(
+    "desktop_launch_safety_policy_t resolve_desktop_launch_safety_policy_impl(",
+    detector_start
+  );
+  ASSERT_NE(detector_start, std::string::npos);
+  ASSERT_NE(detector_end, std::string::npos);
+  const auto detector = process_source.substr(detector_start, detector_end - detector_start);
+
+  EXPECT_NE(detector.find("read_proc_status_file_result(pid, \"environ\")"), std::string::npos);
+  EXPECT_NE(detector.find("proc_environ_is_polaris_private_session"), std::string::npos);
+  EXPECT_NE(
+    launch_source.find("env[\"POLARIS_PRIVATE_SESSION\"] = \"1\""),
+    std::string::npos
+  );
+  EXPECT_NE(
+    cage_source.find("setenv(\"POLARIS_PRIVATE_SESSION\", \"1\", 1)"),
+    std::string::npos
+  );
+  EXPECT_NE(process_source.find("key == \"POLARIS_PRIVATE_SESSION\"sv"), std::string::npos);
+  EXPECT_NE(process_source.find("_env.erase(\"POLARIS_PRIVATE_SESSION\")"), std::string::npos);
+}
+
+TEST(ProcessRuntimeConfigTests, PrivateLaunchRefusalLogsTheAggregatePhysicalDisplayRisk) {
+  const auto nvhttp_source = read_source_file_for_contract("src/nvhttp.cpp");
+  const auto confighttp_source = read_source_file_for_contract("src/confighttp.cpp");
+  ASSERT_FALSE(nvhttp_source.empty());
+  ASSERT_FALSE(confighttp_source.empty());
+
+  EXPECT_EQ(nvhttp_source.find(" desktop_game_active="), std::string::npos);
+  EXPECT_EQ(confighttp_source.find(" desktop_game_active="), std::string::npos);
+  EXPECT_NE(nvhttp_source.find(" physical_display_risk="), std::string::npos);
+  EXPECT_NE(confighttp_source.find(" physical_display_risk="), std::string::npos);
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorIgnoresExactPolarisPrivateSessionMarker) {
+  const std::string running_status = "Name:\tsteam\nState:\tS (sleeping)\n";
+  const std::string private_session = std::string("POLARIS_PRIVATE_SESSION=1") + char(0);
+
+  EXPECT_FALSE(proc::desktop_steam_client_process_for_tests(
+    "steam",
+    "/opt/steam/ubuntu12_32/steam",
+    "/opt/steam/ubuntu12_32/steam",
+    running_status,
+    private_session
+  ));
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorKeepsUnmarkedAndMalformedMarkersBlocked) {
+  const std::string running_status = "Name:\tsteam\nState:\tS (sleeping)\n";
+  const std::string false_marker = std::string("POLARIS_PRIVATE_SESSION=0") + char(0);
+  const std::string unterminated_marker = "POLARIS_PRIVATE_SESSION=1";
+
+  EXPECT_TRUE(proc::desktop_steam_client_process_for_tests(
+    "steam", "/opt/steam/ubuntu12_32/steam", "/opt/steam/ubuntu12_32/steam", running_status, ""
+  ));
+  EXPECT_TRUE(proc::desktop_steam_client_process_for_tests(
+    "steam", "/opt/steam/ubuntu12_32/steam", "/opt/steam/ubuntu12_32/steam", running_status, false_marker
+  ));
+  EXPECT_TRUE(proc::desktop_steam_client_process_for_tests(
+    "steam", "/opt/steam/ubuntu12_32/steam", "/opt/steam/ubuntu12_32/steam", running_status, unterminated_marker
+  ));
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamProcScannerIgnoresMarkedPrivateSessionProcess) {
+#ifdef __linux__
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    setenv("POLARIS_PRIVATE_SESSION", "1", 1);
+    execl("/bin/sleep", "steam", "60", nullptr);
+    _exit(127);
+  }
+  linux_child_guard_t child_guard {child};
+
+  bool observed = false;
+  for (int attempt = 0; attempt < 40; ++attempt) {
+    std::ifstream cmdline("/proc/" + std::to_string(child) + "/cmdline", std::ios::binary);
+    const std::string bytes {
+      std::istreambuf_iterator<char> {cmdline}, std::istreambuf_iterator<char> {}
+    };
+    if (bytes.starts_with(std::string("steam") + char(0))) {
+      observed = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  }
+  ASSERT_TRUE(observed);
+  EXPECT_FALSE(proc::desktop_steam_proc_scan_only_pid_for_tests(child));
+#else
+  GTEST_SKIP() << "Linux-only desktop Steam proc scanner";
+#endif
+}
+
 TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorFailsClosedOnProcOpenError) {
 #ifdef __linux__
   EXPECT_TRUE(proc::desktop_steam_proc_open_error_fails_closed_for_tests());
@@ -3609,6 +3711,35 @@ TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorFailsClosedOnProcReadError) 
     std::this_thread::sleep_for(std::chrono::milliseconds(25));
   }
   EXPECT_TRUE(proc::desktop_steam_proc_read_error_fails_closed_for_tests(child));
+#else
+  GTEST_SKIP() << "Linux-only desktop Steam proc scanner";
+#endif
+}
+
+TEST(ProcessRuntimeConfigTests, DesktopSteamDetectorFailsClosedOnProcEnvironReadError) {
+#ifdef __linux__
+  const auto child = fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    execl("/bin/sleep", "steam", "60", nullptr);
+    _exit(127);
+  }
+  linux_child_guard_t child_guard {child};
+
+  bool observed = false;
+  for (int attempt = 0; attempt < 40; ++attempt) {
+    std::ifstream cmdline("/proc/" + std::to_string(child) + "/cmdline", std::ios::binary);
+    const std::string bytes {
+      std::istreambuf_iterator<char> {cmdline}, std::istreambuf_iterator<char> {}
+    };
+    if (bytes.starts_with(std::string("steam") + char(0))) {
+      observed = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  }
+  ASSERT_TRUE(observed);
+  EXPECT_TRUE(proc::desktop_steam_proc_environ_read_error_fails_closed_for_tests(child));
 #else
   GTEST_SKIP() << "Linux-only desktop Steam proc scanner";
 #endif


### PR DESCRIPTION
## Summary

- mark only Steam processes launched into a Polaris private compositor
- ignore that exact provenance marker in the desktop-Steam safety guard
- keep unmarked, malformed, and unreadable process state fail-closed
- log the aggregate physical-display risk truthfully at every private-launch refusal

## Root cause

The desktop-Steam guard classified every live Steam process as desktop-owned. A private labwc runtime can outlive a client connection, so Steam that Polaris launched into that runtime was seen on reconnect and blocked the next private launch.

Private runtime lifetime is intentionally unchanged. The fix adds a child-only `POLARIS_PRIVATE_SESSION=1` provenance marker at the labwc/gamescope attach boundaries. Desktop-mirror launches never receive it, app configuration cannot override it, and the scanner still blocks when `/proc` ownership data cannot be read.

## Security boundary

The marker records reserved same-user process provenance; it is not authentication against a same-user process deliberately forging its environment. Requiring the session-generation marker here is not viable because the pressure-vessel boundary may strip it. Missing, malformed, or unreadable provenance remains fail-closed, including a directly injected unreadable-`environ` scanner test.

Closes #483.

## Validation

RED on untouched `ddf8d213`:

- the original ownership contract failed all four expectations: no environment read, no ownership predicate, and no private marker at either launch boundary

GREEN at corrected head:

- independent review findings addressed: truthful `physical_display_risk` logging, explicit marker boundary, and injected unreadable-`environ` fail-closed coverage
- 3 focused ownership/diagnostic tests passed
- full `test_polaris_config`: 286/286 passed
- full `test_polaris_http`: 126 passed, 2 external-download dependency skips
- `git diff --check` clean
