### PR TITLE
fix(pairing): normalize subnets and reject empty ids

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3491,12 +3491,37 @@ namespace nvhttp {
    * @brief Check if an IP address falls within any configured trusted subnet.
    * Used for TOFU (Trust-on-First-Use) LAN pairing.
    */
+  namespace {
+    std::string_view normalize_trusted_subnet(std::string_view subnet) {
+      const auto first = subnet.find_first_not_of(" \t\r\n");
+      if (first == std::string_view::npos) {
+        return {};
+      }
+
+      subnet.remove_prefix(first);
+      subnet.remove_suffix(subnet.size() - subnet.find_last_not_of(" \t\r\n") - 1);
+      if (subnet.size() >= 2 &&
+          ((subnet.front() == '"' && subnet.back() == '"') ||
+           (subnet.front() == '\'' && subnet.back() == '\''))) {
+        subnet.remove_prefix(1);
+        subnet.remove_suffix(1);
+      }
+
+      return subnet;
+    }
+
+    bool pairing_unique_id_valid(std::string_view unique_id) {
+      return !unique_id.empty();
+    }
+  }  // namespace
+
   bool is_in_trusted_subnet(const boost::asio::ip::address &addr) {
     if (config::nvhttp.trusted_subnets.empty()) {
       return false;
     }
 
-    for (const auto &subnet_str : config::nvhttp.trusted_subnets) {
+    for (const auto &configured_subnet : config::nvhttp.trusted_subnets) {
+      const std::string subnet_str {normalize_trusted_subnet(configured_subnet)};
       auto slash = subnet_str.find('/');
       if (slash == std::string::npos) {
         continue;
@@ -3545,7 +3570,7 @@ namespace nvhttp {
         }
       }
       catch (...) {
-        BOOST_LOG(warning) << "TOFU: Failed to parse trusted subnet: " << subnet_str;
+        BOOST_LOG(warning) << "TOFU: Failed to parse trusted subnet: " << configured_subnet;
         continue;
       }
     }
@@ -5082,6 +5107,12 @@ namespace nvhttp {
     }
 
     auto uniqID {get_arg(args, "uniqueid")};
+    if (!pairing_unique_id_valid(uniqID)) {
+      tree.put("root.<xmlattr>.status_code", 400);
+      tree.put("root.<xmlattr>.status_message", "Invalid uniqueid");
+
+      return;
+    }
 
     args_t::const_iterator it;
     if (it = args.find("phrase"); it != std::end(args)) {
@@ -5113,7 +5144,7 @@ namespace nvhttp {
         auto ptr = map_id_sess.emplace(sess.client.uniqueID, std::move(sess)).first;
 
         ptr->second.async_insert_pin.salt = std::move(get_arg(args, "salt"));
-        BOOST_LOG(info) << "pair: getservercert uniqueid="sv << uniqID
+        BOOST_LOG(info) << "pair: getservercert uniqueid="sv << ptr->second.client.uniqueID
                         << " device=\""sv << ptr->second.client.name << "\""
                         << " remote="sv << remote_addr_str
                         << " trustedpair="sv << trusted_pair_requested
@@ -9010,6 +9041,14 @@ namespace nvhttp {
   }
 
 #ifdef POLARIS_TESTS
+  bool is_in_trusted_subnet_for_tests(const boost::asio::ip::address &addr) {
+    return is_in_trusted_subnet(addr);
+  }
+
+  bool pairing_unique_id_valid_for_tests(std::string_view unique_id) {
+    return pairing_unique_id_valid(unique_id);
+  }
+
   void reset_pairing_state_for_tests() {
     std::lock_guard lock(client_state_mutex);
     map_id_sess.clear();

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -390,6 +390,8 @@ namespace nvhttp {
   );
 
 #ifdef POLARIS_TESTS
+  bool is_in_trusted_subnet_for_tests(const boost::asio::ip::address &addr);
+  bool pairing_unique_id_valid_for_tests(std::string_view unique_id);
   enum class pairing_state_write_fault_t {
     none,
     open,

--- a/tests/unit/test_http_pairing.cpp
+++ b/tests/unit/test_http_pairing.cpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <thread>
 #include <vector>
 
@@ -23,6 +24,63 @@
 
 using namespace nvhttp;
 using namespace std::literals;
+
+struct TrustedSubnetTest: testing::Test {
+  void SetUp() override {
+    previous_trusted_subnets = config::nvhttp.trusted_subnets;
+  }
+
+  void TearDown() override {
+    config::nvhttp.trusted_subnets = std::move(previous_trusted_subnets);
+  }
+
+  bool matches(std::initializer_list<std::string> subnets) {
+    config::nvhttp.trusted_subnets = subnets;
+    return is_in_trusted_subnet_for_tests(boost::asio::ip::make_address("192.168.18.248"));
+  }
+
+  std::vector<std::string> previous_trusted_subnets;
+};
+
+TEST_F(TrustedSubnetTest, AcceptsQuotedIpv4CidrsFromListStyleConfig) {
+  EXPECT_TRUE(matches({R"("192.168.18.0/24")"}));
+  EXPECT_TRUE(matches({"  '192.168.18.0/24'  "}));
+}
+
+TEST_F(TrustedSubnetTest, PreservesBareCidrsAndRejectsNonMatchingOrMalformedEntries) {
+  EXPECT_TRUE(matches({"192.168.18.0/24"}));
+  EXPECT_FALSE(matches({"192.168.19.0/24"}));
+  EXPECT_FALSE(matches({R"("not-a-subnet")"}));
+}
+
+TEST(PairingRequestValidationTest, RejectsOnlyEmptyUniqueIdsAtThisBoundary) {
+  EXPECT_FALSE(pairing_unique_id_valid_for_tests(""));
+  EXPECT_TRUE(pairing_unique_id_valid_for_tests("0123456789ABCDEF"));
+
+  // Existing clients own the identifier format. Keep this change scoped to the
+  // observed empty value instead of inventing a new protocol restriction.
+  EXPECT_TRUE(pairing_unique_id_valid_for_tests("client-defined-id"));
+}
+
+TEST(PairingRequestValidationTest, LogsTheStoredUniqueIdAfterMovingTheRequestValue) {
+  const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / "src/nvhttp.cpp";
+  std::ifstream file {path};
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  const auto source = buffer.str();
+  ASSERT_FALSE(source.empty()) << "could not read src/nvhttp.cpp via POLARIS_SOURCE_DIR";
+
+  const auto move_pos = source.find("sess.client.uniqueID = std::move(uniqID)");
+  ASSERT_NE(move_pos, std::string::npos) << "pairing uniqueid move not found";
+
+  const auto log_pos = source.find("pair: getservercert uniqueid=", move_pos);
+  ASSERT_NE(log_pos, std::string::npos) << "getservercert diagnostic not found";
+  const auto diagnostic = source.substr(log_pos, 512);
+  EXPECT_NE(diagnostic.find("ptr->second.client.uniqueID"), std::string::npos)
+    << "the diagnostic must read the stored id, not the moved-from request value";
+  EXPECT_EQ(diagnostic.find("<< uniqID"), std::string::npos)
+    << "logging the moved-from request value makes valid clients appear to have an empty id";
+}
 
 namespace confighttp {
   bool config_request_authorized_for_tests(


### PR DESCRIPTION
## Summary

- normalize whitespace and one matching layer of quotes around configured trusted subnet CIDRs before parsing
- reject an actually empty `uniqueid` before any pairing session can be created
- log the stored pairing identifier rather than the moved-from request value
- preserve bare CIDRs, client-defined non-empty identifiers, and the existing PIN validation boundary

Refs #484.

## Evidence

Issue #484 established that `trusted_subnets = ["192.168.18.0/24"]` retained quotes around the CIDR, so both observed LAN clients logged `trusted_subnet_match=false`.

The apparently empty `getservercert uniqueid` diagnostic did not prove that the client sent an empty identifier: Polaris moved `uniqID` into the session and then logged the moved-from string. This patch fixes that diagnostic and separately rejects an actually empty request value before session creation.

The remaining VoidLink-specific handshake stall is not claimed fixed here. Empty-PIN behavior also remains unchanged: the current server and Web UI already reject an empty PIN, and there is no raw request/response evidence identifying another boundary.

## Verification

On Fedora 44 at corrected rebased head `d06267af`:

- RED for the review regression: with only the test added, the old source logged `uniqID` after its move and failed the stored-ID contract
- prior RED for the request behavior: reverting only the new source behavior failed the quoted-CIDR and empty-identifier tests while the bare/nonmatching counter-test passed
- GREEN: `test_polaris_pairing` — 50/50
- GREEN: `test_polaris_http` — 127 passed, 1 unrelated external-download dependency skip
- `git diff --check` clean
