### PR TITLE
fix(video): warn when HDR requests fall back to SDR

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3429,6 +3429,7 @@ namespace video {
         << " display_hdr="sv << (hdr_probe.display_hdr ? "true" : "false")
         << " hdr_metadata_available="sv << (hdr_probe.metadata ? "true" : "false")
         << " stream_hdr_enabled="sv << (colorspace_is_hdr(colorspace) ? "true" : "false");
+
     }
 
     if (dynamic_cast<const encoder_platform_formats_avcodec *>(encoder.platform_formats.get())) {
@@ -3515,6 +3516,11 @@ namespace video {
         colorspace_is_hdr(colorspace),
         std::string {color_coding_label(colorspace)}
       );
+      if (!encoder_probe_in_progress && config.dynamicRange > 0 && !colorspace_is_hdr(colorspace)) {
+        BOOST_LOG(warning)
+          << "Client requested HDR, but Polaris is streaming SDR because the active display or capture path could not produce a usable HDR stream. "
+             "Some clients may show black video with working audio; disable HDR on the client or use an HDR-capable display path."sv;
+      }
     }
 
     return result;

--- a/tests/unit/test_video_hdr_probe_guard_source.cpp
+++ b/tests/unit/test_video_hdr_probe_guard_source.cpp
@@ -62,3 +62,99 @@ TEST(VideoHdrProbeGuardSource, HdrCapabilityProbeCannotFailTheEncoder) {
   EXPECT_NE(source.find("hevc_profile_for_input(colorspace.bit_depth"), std::string::npos)
     << "HEVC profile selection must follow the actual encoder input depth";
 }
+
+TEST(VideoHdrDiagnosticsSource, WarnsWhenAClientHdrRequestBecomesAnSdrStream) {
+  const auto source = read_video_source();
+  ASSERT_FALSE(source.empty()) << "could not read src/video.cpp via POLARIS_SOURCE_DIR";
+
+  const auto encode_device_pos = source.find(
+    "std::unique_ptr<platf::encode_device_t> make_encode_device("
+  );
+  ASSERT_NE(encode_device_pos, std::string::npos) << "make_encode_device not found";
+
+  const auto decision = source.substr(encode_device_pos, 8192);
+  const auto result_pos = decision.find(
+    "if (result) {\n      result->colorspace = colorspace;"
+  );
+  ASSERT_NE(result_pos, std::string::npos)
+    << "successful encode-device finalization and final colorspace assignment not found";
+
+  const auto colorspace_assignment_pos = decision.find(
+    "result->colorspace = colorspace;",
+    result_pos
+  );
+  ASSERT_NE(colorspace_assignment_pos, std::string::npos)
+    << "final encode-device colorspace assignment not found";
+
+  const auto find_matching_brace = [&](const std::size_t open_brace_pos) {
+    if (open_brace_pos == std::string::npos || decision[open_brace_pos] != '{') {
+      return std::string::npos;
+    }
+
+    std::size_t depth = 0;
+    for (auto pos = open_brace_pos; pos < decision.size(); ++pos) {
+      if (decision[pos] == '{') {
+        ++depth;
+      } else if (decision[pos] == '}' && --depth == 0) {
+        return pos;
+      }
+    }
+    return std::string::npos;
+  };
+
+  const auto result_open_brace_pos = decision.find('{', result_pos);
+  const auto result_block_end_pos = find_matching_brace(result_open_brace_pos);
+  ASSERT_NE(result_block_end_pos, std::string::npos)
+    << "successful encode-device finalization block is malformed";
+
+  const auto return_pos = decision.find("return result;", result_block_end_pos);
+  ASSERT_NE(return_pos, std::string::npos) << "make_encode_device return not found";
+  const auto after_finalization = decision.substr(
+    result_block_end_pos + 1,
+    return_pos - result_block_end_pos - 1
+  );
+  EXPECT_EQ(after_finalization.find_first_not_of(" \t\r\n"), std::string::npos)
+    << "successful result finalization must remain the last operation before return";
+
+  const auto warning_guard_pos = decision.find(
+    "!encoder_probe_in_progress && config.dynamicRange > 0 && !colorspace_is_hdr(colorspace)",
+    colorspace_assignment_pos
+  );
+  ASSERT_NE(warning_guard_pos, std::string::npos)
+    << "the warning must be limited to live requested HDR that was downgraded to SDR";
+  EXPECT_GT(warning_guard_pos, colorspace_assignment_pos)
+    << "the warning must use the final encode-device colorspace";
+  EXPECT_LT(warning_guard_pos, result_block_end_pos)
+    << "the warning must not escape successful encode-device finalization";
+  const auto later_colorspace_assignment_pos = decision.find("colorspace =", warning_guard_pos);
+  EXPECT_TRUE(
+    later_colorspace_assignment_pos == std::string::npos ||
+    later_colorspace_assignment_pos > result_block_end_pos
+  ) << "the warning must follow the final colorspace mutation";
+  const auto later_colorspace_member_pos = decision.find("colorspace.", warning_guard_pos);
+  EXPECT_TRUE(
+    later_colorspace_member_pos == std::string::npos ||
+    later_colorspace_member_pos > result_block_end_pos
+  ) << "the warning must follow final colorspace member mutations";
+
+  const auto warning_open_brace_pos = decision.find('{', warning_guard_pos);
+  const auto warning_block_end_pos = find_matching_brace(warning_open_brace_pos);
+  ASSERT_NE(warning_block_end_pos, std::string::npos)
+    << "the diagnostic warning block is malformed";
+  EXPECT_LT(warning_block_end_pos, result_block_end_pos)
+    << "the warning guard itself must remain inside successful encode-device finalization";
+
+  const auto warning_log_pos = decision.find("BOOST_LOG(warning)", warning_guard_pos);
+  ASSERT_NE(warning_log_pos, std::string::npos)
+    << "an HDR-to-SDR downgrade must be visible at warning severity";
+  EXPECT_LT(warning_log_pos, warning_block_end_pos)
+    << "the diagnostic warning must be controlled by the live HDR-to-SDR guard";
+
+  const auto warning = decision.substr(warning_log_pos, warning_block_end_pos - warning_log_pos);
+  EXPECT_NE(warning.find("display or capture path"), std::string::npos)
+    << "the warning must cover both metadata and 8-bit capture demotions";
+  EXPECT_NE(warning.find("black video with working audio"), std::string::npos)
+    << "the warning must identify the distinctive client symptom";
+  EXPECT_NE(warning.find("disable HDR on the client"), std::string::npos)
+    << "the warning must include the immediate recovery action";
+}


### PR DESCRIPTION
## Summary

- raise an actionable host warning when a client requests HDR but the negotiated stream is SDR
- emit it only for a successful live encode device, after final colorspace selection
- suppress it during encoder capability probes
- cover both display-metadata and 8-bit capture-path demotions without misdiagnosing the cause
- name the distinctive black-video/working-audio symptom and immediate recovery
- leave request acceptance, colorspace selection, and GameStream protocol behavior unchanged

Refs #482.

## Scope

This is the diagnostics-only boundary for the release. Polaris already records the downgrade in stream statistics, Doctor, and support-policy JSON. It does not yet have enough client-specific protocol evidence to safely refuse or renegotiate VoidLink's request, so this PR does not claim to fix the black frame itself.

## Verification

Published exact head `5f3de7db5291806b66d6f25cc8feb17f58d24bdd`, rebased onto master `428f463d116acf8a24f3f6b1d332a23ad4cb1ace`.

On Fedora 44 for the same production change before the conflict-free rebase:

- RED with the source change reverted: the HDR downgrade predicate, symptom, and recovery-action assertions failed
- GREEN: focused HDR diagnostic contract — 1/1
- GREEN: `test_polaris` — 352/352
- GREEN: `test_polaris_video` — 24 passed, one expected VAAPI hardware skip

Independent review: no material findings at the exact published head after corrections:

- accurate display/capture wording for missing metadata and 8-bit capture demotion
- final result block and nested warning guard structurally matched
- final `result->colorspace` assignment ordered before the warning
- finalization required to be the last operation before `return result`
- later whole-object or member colorspace mutations rejected
- severity, symptom, recovery, and cause wording scoped to the guard block

Exact-head protected CI is green:

- Build Polaris [32192000629](https://github.com/papi-ux/polaris/actions/runs/32192000629): Web, sanitizer, Arch, Ubuntu, Fedora Clang/RPM, and SteamOS all passed; release assets skipped as expected
- CodeQL [32192000634](https://github.com/papi-ux/polaris/actions/runs/32192000634): C++ and JavaScript/TypeScript passed
- Public Hygiene [32192000612](https://github.com/papi-ux/polaris/actions/runs/32192000612): passed
- `git diff --check` clean