### PR TITLE
ci: pin Ubuntu package snapshot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ on:
 env:
   POLARIS_CHECKOUT_REF: ${{ inputs.release_tag || github.ref }}
   POLARIS_PACKAGE_REF_NAME: ${{ inputs.release_tag || github.ref_name }}
+  # Advance deliberately only after the full matrix proves a newer snapshot.
+  UBUNTU_APT_SNAPSHOT: 20260818T000000Z
 
 jobs:
   web-checks:
@@ -78,9 +80,33 @@ jobs:
           cache: npm
 
       - name: Install dependencies
+        # This suite installs the larger dependency set; the pinned snapshot
+        # completed in 18m03s on the first protected run, so retain margin while
+        # still turning a mirror stall into a bounded failure.
+        timeout-minutes: 30
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          snapshot_sources="$RUNNER_TEMP/polaris-ubuntu-snapshot.sources"
+          snapshot_source_parts="$RUNNER_TEMP/polaris-ubuntu-source-parts"
+          snapshot_lists="$RUNNER_TEMP/polaris-ubuntu-lists"
+          mkdir -p "$snapshot_source_parts" "$snapshot_lists/partial"
+          cat > "$snapshot_sources" <<EOF
+          Types: deb
+          URIs: https://snapshot.ubuntu.com/ubuntu/$UBUNTU_APT_SNAPSHOT/
+          Suites: noble noble-updates noble-backports noble-security
+          Components: main universe restricted multiverse
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
+          apt_options=(
+            -o "Dir::Etc::sourcelist=$snapshot_sources"
+            -o "Dir::Etc::sourceparts=$snapshot_source_parts"
+            -o "Dir::State::Lists=$snapshot_lists"
+            -o APT::Update::Error-Mode=any
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=30
+            -o Acquire::https::Timeout=30
+          )
+          sudo apt-get "${apt_options[@]}" update
+          sudo apt-get "${apt_options[@]}" install -y \
             build-essential cmake ninja-build \
             libboost-all-dev libssl-dev libevdev-dev \
             libpulse-dev libopus-dev libcurl4-openssl-dev \
@@ -661,9 +687,30 @@ jobs:
             polaris-ubuntu-gomod-
 
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          snapshot_sources="$RUNNER_TEMP/polaris-ubuntu-snapshot.sources"
+          snapshot_source_parts="$RUNNER_TEMP/polaris-ubuntu-source-parts"
+          snapshot_lists="$RUNNER_TEMP/polaris-ubuntu-lists"
+          mkdir -p "$snapshot_source_parts" "$snapshot_lists/partial"
+          cat > "$snapshot_sources" <<EOF
+          Types: deb
+          URIs: https://snapshot.ubuntu.com/ubuntu/$UBUNTU_APT_SNAPSHOT/
+          Suites: noble noble-updates noble-backports noble-security
+          Components: main universe restricted multiverse
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
+          apt_options=(
+            -o "Dir::Etc::sourcelist=$snapshot_sources"
+            -o "Dir::Etc::sourceparts=$snapshot_source_parts"
+            -o "Dir::State::Lists=$snapshot_lists"
+            -o APT::Update::Error-Mode=any
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=30
+            -o Acquire::https::Timeout=30
+          )
+          sudo apt-get "${apt_options[@]}" update
+          sudo apt-get "${apt_options[@]}" install -y \
             build-essential ccache cmake ninja-build \
             libboost-all-dev libssl-dev libevdev-dev \
             libpulse-dev libopus-dev libcurl4-openssl-dev \
@@ -714,6 +761,7 @@ jobs:
         run: cpack -G DEB --config ./build/CPackConfig.cmake
 
       - name: Smoke test Ubuntu DEB package
+        timeout-minutes: 5
         run: |
           set -euo pipefail
 
@@ -727,7 +775,21 @@ jobs:
           dpkg-deb --field "$deb_path" Depends | tee build/cpack_artifacts/package-depends.txt
           dpkg-deb --contents "$deb_path" | tee build/cpack_artifacts/package-files.txt
 
-          sudo apt-get install -y "./$deb_path"
+          snapshot_sources="$RUNNER_TEMP/polaris-ubuntu-snapshot.sources"
+          snapshot_source_parts="$RUNNER_TEMP/polaris-ubuntu-source-parts"
+          snapshot_lists="$RUNNER_TEMP/polaris-ubuntu-lists"
+          test -s "$snapshot_sources"
+          test -d "$snapshot_source_parts"
+          test -d "$snapshot_lists/partial"
+          apt_options=(
+            -o "Dir::Etc::sourcelist=$snapshot_sources"
+            -o "Dir::Etc::sourceparts=$snapshot_source_parts"
+            -o "Dir::State::Lists=$snapshot_lists"
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=30
+            -o Acquire::https::Timeout=30
+          )
+          sudo apt-get "${apt_options[@]}" install -y "./$deb_path"
           package_name="$(dpkg-deb --field "$deb_path" Package)"
           binary="$(dpkg -L "$package_name" | awk '$0 == "/usr/bin/polaris" || /\/usr\/bin\/polaris-[0-9][^/]*$/ { print; exit }')"
           if [ -z "$binary" ]; then


### PR DESCRIPTION
## Summary

- pin the sanitizer and Ubuntu package jobs to Ubuntu snapshot `20260818T000000Z`
- isolate APT source and package-list state from GitHub runner mirror configuration and stale indexes
- fail closed on any partial index update
- bound sanitizer dependency installation to 30 minutes and Ubuntu to 20 minutes
- run the Ubuntu DEB smoke against the identical isolated snapshot state, with a 5-minute deadline
- bound each APT request with three retries and 30-second HTTP/HTTPS timeouts

## Why

Exact-master Build Polaris run `32166294964` at `9c16b61e` spent about 2 hours 40 minutes in the Ubuntu dependency step. Its completed log showed repeated ignores from `azure.archive.ubuntu.com`, a fallback that fetched three InRelease files from `archive.ubuntu.com`, and then no package-index progress until cancellation.

Rerunning only Ubuntu on the same merge SHA completed dependency installation quickly and passed the build, tests, DEB smoke, and artifact steps. That isolates the delay to external mirror selection rather than Polaris.

The snapshot source and its list directory are explicit and isolated. `APT::Update::Error-Mode=any` makes a partial index set fatal, so an unavailable snapshot cannot silently reuse the runner's current or stale Ubuntu package indexes. The DEB smoke deliberately reconstructs the same APT configuration rather than escaping to runner defaults.

## Validation

- Ubuntu 24.04 container fetched only `https://snapshot.ubuntu.com/ubuntu/20260818T000000Z`
- the complete sanitizer/Ubuntu package set resolved successfully in an APT install simulation
- an intentionally invalid snapshot suite failed `apt-get update` nonzero, demonstrating the fail-closed boundary
- protected PR run `32184150592` passed every test/build job at prior candidate `72da4906`; release assets skipped as expected
- that run fetched Ubuntu indexes and packages only from the pinned snapshot; no `azure.archive.ubuntu.com` or `archive.ubuntu.com` access appeared
- observed install times were 18m03s for sanitizer and 9m56s for Ubuntu; the sanitizer ceiling was therefore widened from 20 to 30 minutes with Ubuntu retained at 20
- Ubuntu DEB smoke passed in 54 seconds using the isolated snapshot state
- actionlint `v1.7.7` clean with only the pre-existing Arch `SC2016` notice ignored
- Ruby YAML parse and `git diff --check` clean
- independent review findings about partial updates, whole-step deadlines, and the DEB smoke's APT state were corrected; current exact head is `8f88abb0fd14150f609d03eab7012247fc3a093a`

This changes CI dependency resolution only; it does not alter Polaris runtime behavior or release assets.