### PR TITLE
Fix Linux packages to ship Gamescope session helper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,6 +378,13 @@ jobs:
             echo "Packaged Browser Stream helper was not found" >&2
             exit 1
           fi
+          for gamescope_payload in polaris-gamescope-session polaris-gamescope-runtime-lib.sh; do
+            if [ ! -x "$extract_dir/usr/bin/$gamescope_payload" ]; then
+              echo "Packaged Gamescope payload was not found: $gamescope_payload" >&2
+              exit 1
+            fi
+            bash -n "$extract_dir/usr/bin/$gamescope_payload"
+          done
 
           strings "$binary" > arch-pkgbuild/package-strings.txt
           if ! grep -Fq "Couldn't initialize cuda" arch-pkgbuild/package-strings.txt; then
@@ -410,6 +417,13 @@ jobs:
             echo "Installed Arch package is missing the Browser Stream helper" >&2
             exit 1
           fi
+          for gamescope_payload in /usr/bin/polaris-gamescope-session /usr/bin/polaris-gamescope-runtime-lib.sh; do
+            if [ ! -x "$gamescope_payload" ]; then
+              echo "Installed Arch package is missing a Gamescope payload: $gamescope_payload" >&2
+              exit 1
+            fi
+            bash -n "$gamescope_payload"
+          done
 
           ldd "$installed_binary" | tee arch-pkgbuild/package-ldd.txt
           if grep -Fq "not found" arch-pkgbuild/package-ldd.txt; then
@@ -800,6 +814,13 @@ jobs:
             echo "Installed Ubuntu DEB is missing the Browser Stream helper" >&2
             exit 1
           fi
+          for gamescope_payload in /usr/bin/polaris-gamescope-session /usr/bin/polaris-gamescope-runtime-lib.sh; do
+            if ! dpkg -L "$package_name" | grep -Fxq "$gamescope_payload" || [ ! -x "$gamescope_payload" ]; then
+              echo "Installed Ubuntu DEB is missing a Gamescope payload: $gamescope_payload" >&2
+              exit 1
+            fi
+            bash -n "$gamescope_payload"
+          done
 
           readelf -d "$binary" | tee build/cpack_artifacts/package-needed.txt
           ldd "$binary" | tee build/cpack_artifacts/package-ldd.txt
@@ -1099,6 +1120,13 @@ jobs:
             echo "Installed Fedora RPM is missing the Browser Stream helper" >&2
             exit 1
           fi
+          for gamescope_payload in /usr/bin/polaris-gamescope-session /usr/bin/polaris-gamescope-runtime-lib.sh; do
+            if ! grep -Fxq "$gamescope_payload" build/cpack_artifacts/package-files.txt || [ ! -x "$gamescope_payload" ]; then
+              echo "Installed Fedora RPM is missing a Gamescope payload: $gamescope_payload" >&2
+              exit 1
+            fi
+            bash -n "$gamescope_payload"
+          done
 
           readelf -d "$binary" | tee build/cpack_artifacts/package-needed.txt
           ldd "$binary" | tee build/cpack_artifacts/package-ldd.txt

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -20,6 +20,15 @@ if(NOT ${POLARIS_BUILD_APPIMAGE})
             DESTINATION "${POLARIS_UDEV_RULES_DIR}")
     install(FILES "${POLARIS_SOURCE_ASSETS_DIR}/linux/misc/60-polaris.conf"
             DESTINATION "${POLARIS_MODULES_LOAD_DIR}")
+
+    # gamescope_stream resolves this launcher by name at runtime. Keep the
+    # shared ownership library beside it so the launcher's default lookup is
+    # package-owned on DEB, RPM, Arch, and SteamOS installs.
+    install(PROGRAMS "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-session.sh"
+            DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            RENAME "polaris-gamescope-session")
+    install(PROGRAMS "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-runtime-lib.sh"
+            DESTINATION "${CMAKE_INSTALL_BINDIR}")
 endif()
 
 # copy assets (excluding shaders) to build directory, for running without install

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -62,6 +62,7 @@ set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${POLARIS_SOURCE_ASSETS_DIR}/linux/misc/
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
             ${CPACK_DEB_PLATFORM_PACKAGE_DEPENDS} \
+            bash, \
             debianutils, \
             grim, \
             labwc, \
@@ -84,6 +85,7 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "\
             xwayland")
 set(CPACK_RPM_PACKAGE_REQUIRES "\
             ${CPACK_RPM_PLATFORM_PACKAGE_REQUIRES} \
+            bash, \
             grim, \
             labwc, \
             libcap >= 2.22, \

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Shared gamescope exact-generation ownership helpers.
 # Callers must set POLARIS_PROC_ROOT/POLARIS_PROC_NET_UNIX/POLARIS_X11_SOCKET_DIR
 # only in tests; production defaults are Linux procfs and the X11 socket directory.

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+# Kept executable as a standalone script so distro packages can install this
+# shared body directly. Nix and the manual installer prepend their own wrapper;
+# this shebang is then an inert comment.
 export PATH="${POLARIS_SESSION_PATH:-$PATH}"
 
 set -euo pipefail
@@ -860,4 +864,3 @@ case "${1:-}" in
     exit 2
     ;;
 esac
-

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Kept executable as a standalone script so distro packages can install this
 # shared body directly. Nix and the manual installer prepend their own wrapper;
 # this shebang is then an inert comment.

--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -24,6 +24,7 @@ options=('debug' 'strip')
 
 depends=(
   'avahi'
+  'bash'
   'boost-libs'
   'curl'
   'grim'

--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -255,4 +255,8 @@ package() {
     # privileged setup step that should not be necessary.
     test -f "$pkgdir/usr/lib/udev/rules.d/60-polaris.rules"
     test -f "$pkgdir/usr/lib/modules-load.d/60-polaris.conf"
+    test -x "$pkgdir/usr/bin/polaris-gamescope-session"
+    test -x "$pkgdir/usr/bin/polaris-gamescope-runtime-lib.sh"
+    bash -n "$pkgdir/usr/bin/polaris-gamescope-session"
+    bash -n "$pkgdir/usr/bin/polaris-gamescope-runtime-lib.sh"
 }

--- a/packaging/linux/SteamOS/PKGBUILD
+++ b/packaging/linux/SteamOS/PKGBUILD
@@ -159,4 +159,8 @@ package() {
   test "$(readlink "$pkgdir/usr/bin/polaris")" = "polaris-$pkgver"
   test -f "$pkgdir/usr/lib/udev/rules.d/60-polaris.rules"
   test -f "$pkgdir/usr/lib/modules-load.d/60-polaris.conf"
+  test -x "$pkgdir/usr/bin/polaris-gamescope-session"
+  test -x "$pkgdir/usr/bin/polaris-gamescope-runtime-lib.sh"
+  bash -n "$pkgdir/usr/bin/polaris-gamescope-session"
+  bash -n "$pkgdir/usr/bin/polaris-gamescope-runtime-lib.sh"
 }

--- a/packaging/linux/SteamOS/PKGBUILD
+++ b/packaging/linux/SteamOS/PKGBUILD
@@ -20,6 +20,7 @@ options=('debug' 'strip')
 # It is an optdepend instead; see docs/steamos.md.
 depends=(
   'avahi'
+  'bash'
   'boost-libs'
   'curl'
   'gcc-libs'

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -97,6 +97,8 @@ if [ ! -L "$RECEIPT_ROOT/usr/bin/polaris" ] && [ ! -x "$RECEIPT_ROOT/usr/bin/pol
   exit 1
 fi
 test -x "$RECEIPT_ROOT/usr/bin/polaris-browser-stream-helper"
+test -x "$RECEIPT_ROOT/usr/bin/polaris-gamescope-session"
+test -x "$RECEIPT_ROOT/usr/bin/polaris-gamescope-runtime-lib.sh"
 test -d "$RECEIPT_ROOT/usr/share/polaris"
 test -f "$RECEIPT_ROOT/usr/share/applications/dev.polaris-stream.app.Polaris.desktop"
 test -f "$RECEIPT_ROOT/usr/share/applications/dev.polaris-stream.app.Polaris.terminal.desktop"

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -119,7 +119,14 @@ objdump -p "$BINARY_PATH" >> "$OUTPUT_ROOT/steamos3.8-binary-needed.txt"
 NAMCAP_ACTUAL="$BUILD_ROOT/namcap-actual.sorted"
 NAMCAP_ALLOWED="$BUILD_ROOT/namcap-allowed.sorted"
 NAMCAP_MISSING="$BUILD_ROOT/namcap-reviewed-missing.txt"
-namcap "$PACKAGE_PATH" > "$OUTPUT_ROOT/steamos3.8-namcap-all.txt"
+# Namcap 3.6 resolves shebang basenames through PATH, then compares the
+# unresolved lexical result with pacman's owned paths. SteamOS inherits a root
+# PATH that prefers /usr/sbin (a symlink to /usr/bin), so Bash is found as
+# /usr/sbin/bash even though the package database owns /usr/bin/bash. That
+# produces the contradictory "dependency not needed" and "uninstalled
+# dependency" warnings for valid Bash scripts. Use the canonical user binary
+# paths so interpreter ownership remains deterministic and reviewable.
+PATH=/usr/bin:/bin namcap "$PACKAGE_PATH" > "$OUTPUT_ROOT/steamos3.8-namcap-all.txt"
 LC_ALL=C sort -u "$OUTPUT_ROOT/steamos3.8-namcap-all.txt" > "$NAMCAP_ACTUAL"
 LC_ALL=C sort -u "$SOURCE_ROOT/packaging/linux/SteamOS/namcap-reviewed-warnings.txt" > "$NAMCAP_ALLOWED"
 comm -23 "$NAMCAP_ACTUAL" "$NAMCAP_ALLOWED" > "$OUTPUT_ROOT/steamos3.8-namcap.txt"

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -406,6 +406,7 @@ describe('Linux packaging contracts', () => {
     expect(packageInstall.match(/DESTINATION "\$\{CMAKE_INSTALL_BINDIR\}"/g)).toHaveLength(2)
 
     for (const pkgbuild of [archPkgbuild, steamOsPkgbuild]) {
+      expect(pkgbuild).toMatch(/depends=\([\s\S]*?\n\s+'bash'\n[\s\S]*?\n\)/)
       expect(pkgbuild).toContain('test -x "$pkgdir/usr/bin/polaris-gamescope-session"')
       expect(pkgbuild).toContain('test -x "$pkgdir/usr/bin/polaris-gamescope-runtime-lib.sh"')
       expect(pkgbuild).toContain('bash -n "$pkgdir/usr/bin/polaris-gamescope-session"')

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -728,7 +728,7 @@ describe('Linux packaging contracts', () => {
     for (const dependency of ['gcc-libs', 'glib2', 'glibc', 'gtk3', 'hicolor-icon-theme', 'libpipewire', 'libxkbcommon']) {
       expect(pkgbuild).toContain(`'${dependency}'`)
     }
-    expect(buildScript).toContain('namcap "$PACKAGE_PATH" > "$OUTPUT_ROOT/steamos3.8-namcap-all.txt"')
+    expect(buildScript).toContain('PATH=/usr/bin:/bin namcap "$PACKAGE_PATH" > "$OUTPUT_ROOT/steamos3.8-namcap-all.txt"')
     expect(buildScript).toContain('comm -23 "$NAMCAP_ACTUAL" "$NAMCAP_ALLOWED"')
     expect(buildScript).toContain('comm -13 "$NAMCAP_ACTUAL" "$NAMCAP_ALLOWED"')
     expect(buildScript).toContain('if [ -s "$OUTPUT_ROOT/steamos3.8-namcap.txt" ]; then')

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -398,12 +398,16 @@ describe('Linux packaging contracts', () => {
     const ubuntuJob = section(workflow, '  ubuntu-build:', '  fedora-rpm-build:')
     const fedoraJob = section(workflow, '  fedora-rpm-build:', '  release-assets:')
     const packageInstall = section(cmake, 'if(NOT ${POLARIS_BUILD_APPIMAGE})', 'endif()')
+    const debDependencies = section(cmake, 'set(CPACK_DEBIAN_PACKAGE_DEPENDS', 'set(CPACK_RPM_PACKAGE_REQUIRES')
+    const rpmDependencies = section(cmake, 'set(CPACK_RPM_PACKAGE_REQUIRES', 'if(NOT BOOST_USE_STATIC)')
 
     expect(session.startsWith('#!/usr/bin/env bash\n')).toBe(true)
     expect(packageInstall).toContain('"${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-session.sh"')
     expect(packageInstall).toContain('RENAME "polaris-gamescope-session"')
     expect(packageInstall).toContain('"${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-runtime-lib.sh"')
     expect(packageInstall.match(/DESTINATION "\$\{CMAKE_INSTALL_BINDIR\}"/g)).toHaveLength(2)
+    expect(debDependencies).toContain('bash, \\')
+    expect(rpmDependencies).toContain('bash, \\')
 
     for (const pkgbuild of [archPkgbuild, steamOsPkgbuild]) {
       expect(pkgbuild).toMatch(/depends=\([\s\S]*?\n\s+'bash'\n[\s\S]*?\n\)/)

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -387,6 +387,49 @@ describe('Linux packaging contracts', () => {
     }
   })
 
+  it('ships the gamescope stream launcher and runtime library in every Linux package', () => {
+    const cmake = readSource('cmake/packaging/linux.cmake')
+    const session = readSource('nix/modules/polaris-gamescope-session.sh')
+    const archPkgbuild = readSource('packaging/linux/Arch/PKGBUILD')
+    const steamOsPkgbuild = readSource('packaging/linux/SteamOS/PKGBUILD')
+    const steamOsBuild = readSource('scripts/ci/build-steamos-package.sh')
+    const workflow = readSource('.github/workflows/build.yml')
+    const archJob = section(workflow, '  arch-build:', '  fedora-clang-build:')
+    const ubuntuJob = section(workflow, '  ubuntu-build:', '  fedora-rpm-build:')
+    const fedoraJob = section(workflow, '  fedora-rpm-build:', '  release-assets:')
+    const packageInstall = section(cmake, 'if(NOT ${POLARIS_BUILD_APPIMAGE})', 'endif()')
+
+    expect(session.startsWith('#!/usr/bin/env bash\n')).toBe(true)
+    expect(packageInstall).toContain('"${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-session.sh"')
+    expect(packageInstall).toContain('RENAME "polaris-gamescope-session"')
+    expect(packageInstall).toContain('"${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-runtime-lib.sh"')
+    expect(packageInstall.match(/DESTINATION "\$\{CMAKE_INSTALL_BINDIR\}"/g)).toHaveLength(2)
+
+    for (const pkgbuild of [archPkgbuild, steamOsPkgbuild]) {
+      expect(pkgbuild).toContain('test -x "$pkgdir/usr/bin/polaris-gamescope-session"')
+      expect(pkgbuild).toContain('test -x "$pkgdir/usr/bin/polaris-gamescope-runtime-lib.sh"')
+      expect(pkgbuild).toContain('bash -n "$pkgdir/usr/bin/polaris-gamescope-session"')
+      expect(pkgbuild).toContain('bash -n "$pkgdir/usr/bin/polaris-gamescope-runtime-lib.sh"')
+    }
+
+    for (const packagedPath of [
+      '$RECEIPT_ROOT/usr/bin/polaris-gamescope-session',
+      '$RECEIPT_ROOT/usr/bin/polaris-gamescope-runtime-lib.sh',
+    ]) {
+      expect(steamOsBuild).toContain(`test -x "${packagedPath}"`)
+    }
+
+    for (const [job, packageKind] of [
+      [archJob, 'Arch package'],
+      [ubuntuJob, 'Ubuntu DEB'],
+      [fedoraJob, 'Fedora RPM'],
+    ]) {
+      expect(job, `${packageKind} must check the installed gamescope launcher`).toContain('/usr/bin/polaris-gamescope-session')
+      expect(job, `${packageKind} must check the installed gamescope runtime library`).toContain('/usr/bin/polaris-gamescope-runtime-lib.sh')
+      expect(job, `${packageKind} must syntax-check its gamescope payload`).toContain('bash -n "$gamescope_payload"')
+    }
+  })
+
   it('defines a distinct SteamOS 3.8 build lane', () => {
     const workflow = readSource('.github/workflows/build.yml')
     const steamOs = section(workflow, '  steamos-build:', '  ubuntu-build:')

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -390,6 +390,7 @@ describe('Linux packaging contracts', () => {
   it('ships the gamescope stream launcher and runtime library in every Linux package', () => {
     const cmake = readSource('cmake/packaging/linux.cmake')
     const session = readSource('nix/modules/polaris-gamescope-session.sh')
+    const runtimeLibrary = readSource('nix/modules/polaris-gamescope-runtime-lib.sh')
     const archPkgbuild = readSource('packaging/linux/Arch/PKGBUILD')
     const steamOsPkgbuild = readSource('packaging/linux/SteamOS/PKGBUILD')
     const steamOsBuild = readSource('scripts/ci/build-steamos-package.sh')
@@ -401,7 +402,8 @@ describe('Linux packaging contracts', () => {
     const debDependencies = section(cmake, 'set(CPACK_DEBIAN_PACKAGE_DEPENDS', 'set(CPACK_RPM_PACKAGE_REQUIRES')
     const rpmDependencies = section(cmake, 'set(CPACK_RPM_PACKAGE_REQUIRES', 'if(NOT BOOST_USE_STATIC)')
 
-    expect(session.startsWith('#!/usr/bin/env bash\n')).toBe(true)
+    expect(session.startsWith('#!/bin/bash\n')).toBe(true)
+    expect(runtimeLibrary.startsWith('#!/bin/bash\n')).toBe(true)
     expect(packageInstall).toContain('"${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-session.sh"')
     expect(packageInstall).toContain('RENAME "polaris-gamescope-session"')
     expect(packageInstall).toContain('"${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-runtime-lib.sh"')


### PR DESCRIPTION
## Summary

- install `polaris-gamescope-session` and its shared runtime library in non-AppImage Linux packages
- make both shared scripts directly executable with an explicit `/bin/bash` interpreter while preserving the existing Nix and manual-installer composition
- declare the scripts' Bash runtime dependency in Arch, SteamOS, DEB, and RPM manifests
- fail package creation or smoke validation when the launcher/runtime library is absent or syntactically invalid in Arch, SteamOS, Ubuntu DEB, or Fedora RPM payloads
- make SteamOS namcap shebang ownership deterministic by restricting its lookup PATH to canonical user binary directories

This is packaging-only. It does not change Gamescope ownership, teardown, capture policy, or runtime selection.

Closes #490

## Verification

- RED: the new packaging contract failed before the source/install changes because the shared session body was not standalone and no distro package owned either payload
- CI RED: SteamOS `namcap` rejected the first candidate because the new scripts referenced undeclared Bash
- CI RED: after declaring Bash, namcap emitted contradictory missing/unneeded Bash findings for both `#!/usr/bin/env bash` and `#!/bin/bash`
- disposable vanilla-Arch reproduction: namcap 3.6 resolved all `/bin/bash`, `/usr/bin/bash`, and `/usr/bin/env bash` fixtures through inherited root PATH as `/usr/sbin/bash`, while `pacman -Qo` proved Bash owns `/usr/bin/bash`; `PATH=/usr/bin:/bin namcap ...` removed both false warnings
- RED→GREEN: the strengthened dependency/interpreter contracts failed before each correction, then passed with explicit Bash dependencies and `#!/bin/bash`
- focused packaging contracts — 20/20
- full web suite — 492/492
- web lint — clean
- `bash -n` — shared launcher/runtime library and package scripts
- workflow YAML parse — clean
- `git diff --check` — clean

Final exact-head CI is green: sanitizer, Nix, CodeQL, public hygiene, Arch, Ubuntu DEB, Fedora compile, Fedora RPM, and SteamOS package build/install/receipts all passed. Release-only Arch package validation remains a tag gate.

Base: `468b6ba7fcee631bd8cd52ef8ac583ff5dce1512`
Head: `0e6907c957c12dfbfef0ef408e76a265a567f1ff`
