### PR TITLE
fix(linux): finalize owned Gamescope runtime

### DIFF
--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -364,7 +364,7 @@ namespace stream_runtime {
       bool start(const start_params_t &params) override {
         std::lock_guard lock(mu_);
         const bool retained_state =
-          owned_ || pid_ > 0 || leader_pidfd_ >= 0 || marker_ ||
+          owned_ || owned_group_drained_ || pid_ > 0 || leader_pidfd_ >= 0 || marker_ ||
           !socket_name_.empty() || !x11_display_.empty();
         if (retained_state) {
           owner_transition_lock_t retained_lock;
@@ -529,6 +529,7 @@ namespace stream_runtime {
         }
         pid_ = child;
         owned_ = true;
+        owned_group_drained_ = false;
         socket_name_ = "gamescope-0";
 
         // Capture the exact PID generation only after exec has exposed the
@@ -569,6 +570,7 @@ namespace stream_runtime {
           close_leader_pidfd();
           pid_ = 0;
           owned_ = false;
+          owned_group_drained_ = false;
           marker_.reset();
           socket_name_.clear();
           return false;
@@ -599,6 +601,7 @@ namespace stream_runtime {
             close_leader_pidfd();
             pid_ = 0;
             owned_ = false;
+            owned_group_drained_ = false;
             marker_.reset();
             socket_name_.clear();
             return false;
@@ -646,6 +649,7 @@ namespace stream_runtime {
         close_leader_pidfd();
         pid_ = 0;
         owned_ = false;
+        owned_group_drained_ = false;
         marker_.reset();
         socket_name_.clear();
         x11_display_.clear();
@@ -696,6 +700,11 @@ namespace stream_runtime {
       pid_t pid_ = 0;
       int leader_pidfd_ = -1;
       bool owned_ = false;
+      // A successful drain consumes live process identity, but socket removal
+      // can still fail closed on a lock/holder race. Keep that progress so a
+      // later stop retries exact socket/file cleanup without trying to signal a
+      // process group that has already been proven empty.
+      bool owned_group_drained_ = false;
       std::optional<gp::marker_t> marker_;
       std::string socket_name_;
       std::string x11_display_;
@@ -778,32 +787,71 @@ namespace stream_runtime {
         return fs::remove(marker_path(), ec) && !ec;
       }
 
+      bool reclaim_owned_gamescope_sockets_after_drain_unlocked() const {
+        if (!owned_group_drained_ || socket_name_ != "gamescope-0") {
+          BOOST_LOG(error) << "gamescope_runtime: refusing post-drain cleanup without exact gamescope-0 ownership"sv;
+          return false;
+        }
+
+        if (!gp::remove_orphan_socket(socket_path("gamescope-0"))) {
+          BOOST_LOG(error) << "gamescope_runtime: gamescope-0 socket remains live or ambiguous after owned drain"sv;
+          return false;
+        }
+        if (!gp::remove_orphan_socket(socket_path("gamescope-0-ei"))) {
+          BOOST_LOG(error) << "gamescope_runtime: gamescope-0-ei socket remains live or ambiguous after owned drain"sv;
+          return false;
+        }
+        return true;
+      }
+
       void stop_unlocked() {
+        if (owned_ && !marker_) {
+          BOOST_LOG(error) << "gamescope_runtime: owned runtime lacks immutable marker authority; preserving state"sv;
+          return;
+        }
         if (owned_ && marker_) {
           owner_transition_lock_t owner_lock;
           if (!owner_lock) {
             BOOST_LOG(error) << "gamescope_runtime: could not acquire ownership transition lock; refusing teardown"sv;
             return;
           }
-          const auto current = gp::validated_marker(marker_path(), "runtime");
-          if (!current || *current != *marker_ || !is_private_group_leader(marker_->pid)) {
-            BOOST_LOG(warning) << "gamescope_runtime: refusing to signal stale or unverified group="sv
+          // The durable marker remains authoritative across a retry after the
+          // live group has drained. Re-read it under the transition lock before
+          // either signaling or consuming socket/file ownership.
+          const auto marker_on_disk = gp::read_marker(marker_path());
+          if (!marker_on_disk || *marker_on_disk != *marker_) {
+            BOOST_LOG(warning) << "gamescope_runtime: refusing teardown with stale or replaced marker group="sv
                                << marker_->pid;
             return;
           }
-          // The pidfd keeps the unreaped leader allocation as the PGID barrier.
-          // After TERM the leader may be a zombie, so this callback deliberately
-          // fences only the immutable marker record instead of requiring live
-          // cmdline/exe/socket validation before SIGKILL escalation.
-          const auto authority_still_current = [this]() {
-            const auto marker_on_disk = gp::read_marker(marker_path());
-            return marker_on_disk && *marker_on_disk == *marker_;
-          };
-          if (!drain_private_process_group(marker_->pid, leader_pidfd_, authority_still_current)) {
-            BOOST_LOG(error) << "gamescope_runtime: private group did not drain; preserving ownership state"sv;
+
+          if (!owned_group_drained_) {
+            const auto current = gp::validated_marker(marker_path(), "runtime");
+            if (!current || *current != *marker_ || !is_private_group_leader(marker_->pid)) {
+              BOOST_LOG(warning) << "gamescope_runtime: refusing to signal stale or unverified group="sv
+                                 << marker_->pid;
+              return;
+            }
+            // The pidfd keeps the unreaped leader allocation as the PGID
+            // barrier. After TERM the leader may be a zombie, so escalation
+            // fences the immutable marker instead of requiring live socket
+            // ownership that teardown is intentionally consuming.
+            const auto authority_still_current = [this]() {
+              const auto marker_on_disk = gp::read_marker(marker_path());
+              return marker_on_disk && *marker_on_disk == *marker_;
+            };
+            if (!drain_private_process_group(marker_->pid, leader_pidfd_, authority_still_current)) {
+              BOOST_LOG(error) << "gamescope_runtime: private group did not drain; preserving ownership state"sv;
+              return;
+            }
+            owned_group_drained_ = true;
+            BOOST_LOG(info) << "gamescope_runtime: drained owned gamescope group="sv << marker_->pid;
+          }
+
+          if (!reclaim_owned_gamescope_sockets_after_drain_unlocked()) {
+            BOOST_LOG(error) << "gamescope_runtime: failed to reclaim drained generation sockets; preserving state"sv;
             return;
           }
-          BOOST_LOG(info) << "gamescope_runtime: drained owned gamescope group="sv << marker_->pid;
           if (!remove_owned_files_if_current_unlocked()) {
             BOOST_LOG(error) << "gamescope_runtime: failed to clear drained ownership files; preserving state"sv;
             return;
@@ -816,6 +864,7 @@ namespace stream_runtime {
         close_leader_pidfd();
         pid_ = 0;
         owned_ = false;
+        owned_group_drained_ = false;
         marker_.reset();
         socket_name_.clear();
         x11_display_.clear();
@@ -835,6 +884,7 @@ namespace stream_runtime {
         close_leader_pidfd();
         marker_.reset();
         owned_ = false;
+        owned_group_drained_ = false;
         pid_ = 0;
         socket_name_.clear();
         x11_display_.clear();
@@ -898,6 +948,7 @@ namespace stream_runtime {
         close_leader_pidfd();
         marker_ = marker;
         owned_ = false;
+        owned_group_drained_ = false;
         pid_ = marker->pid;
         socket_name_ = "gamescope-0";
         x11_display_ = display;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -5902,7 +5902,7 @@ namespace proc {
       }
       BOOST_LOG(warning) << "process: reaped a retained isolated session generation at launch"sv;
       if (retained_session_owned_cage) {
-        stream_runtime::labwc::reset_after_external_stop();
+        finalize_isolated_session_runtime(true);
       }
       _session_instance_id.clear();
       _session_used_cage_compositor = false;
@@ -8244,6 +8244,32 @@ namespace proc {
     return complete;
   }
 
+  void proc_t::finalize_isolated_session_runtime(bool runtime_was_stopped_externally) {
+    // Runtime selection is immutable launch-generation state. Mutable config
+    // may already have been restored by the time retained cleanup runs, so it
+    // cannot safely choose which singleton owns teardown.
+    if (_session_used_gamescope_runtime) {
+      auto *gamescope_runtime = stream_runtime::acquire(
+        stream_path::runtime_kind_e::GAMESCOPE
+      );
+      if (!gamescope_runtime) {
+        BOOST_LOG(error) << "process: Gamescope launch generation has no runtime owner; refusing fallback teardown"sv;
+        return;
+      }
+      // Owned runtimes drain through their pidfd/marker authority. Attached
+      // idle runtimes detach here without signaling their external owner.
+      gamescope_runtime->stop();
+      return;
+    }
+
+    if (runtime_was_stopped_externally) {
+      stream_runtime::labwc::reset_after_external_stop();
+    }
+    else {
+      stream_runtime::labwc::stop();
+    }
+  }
+
   void proc_t::terminate_isolated_session_generation() {
     const bool prior_cleanup_complete = _exact_generation_cleanup_complete;
     const bool detached_only = !_app.detached.empty() && _app.cmd.empty();
@@ -8282,7 +8308,7 @@ namespace proc {
           !_session_instance_id.empty(),
           _exact_generation_cleanup_complete
         )) {
-      stream_runtime::labwc::reset_after_external_stop();
+      finalize_isolated_session_runtime(true);
     } else {
       BOOST_LOG(error) << "process: retaining immutable cage generation because exact-generation cleanup was incomplete"sv;
       // The generation stays retained for whatever the snapshot could not
@@ -8296,7 +8322,7 @@ namespace proc {
       // reaps the supervisor's private group, and fails closed on its own
       // ownership proof, so it cannot touch anything this session did not
       // spawn.
-      stream_runtime::labwc::stop();
+      finalize_isolated_session_runtime(false);
     }
   }
 

--- a/src/process.h
+++ b/src/process.h
@@ -764,6 +764,7 @@ namespace proc {
 #ifdef __linux__
     bool terminate_session_owned_steam_before_cage_stop();
     bool cleanup_tracked_detached_children_after_launch_failure();
+    void finalize_isolated_session_runtime(bool runtime_was_stopped_externally);
     void terminate_isolated_session_generation();
     void finish_isolated_session_generation_cleanup();
     std::shared_ptr<const steam_big_picture_guard_snapshot_t> snapshot_steam_big_picture_input_guard(

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -3411,11 +3411,19 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
     << "terminate_impl must not be able to replace captured completeness with a literal";
 
   const auto generation_cleanup_start = source.find("void proc_t::terminate_isolated_session_generation()");
+  const auto runtime_finalize_start = source.find("void proc_t::finalize_isolated_session_runtime(");
   const auto generation_finish_start = source.find("void proc_t::finish_isolated_session_generation_cleanup()");
   const auto generation_finish_end = source.find("#endif", generation_finish_start);
+  ASSERT_NE(runtime_finalize_start, std::string::npos);
   ASSERT_NE(generation_cleanup_start, std::string::npos);
   ASSERT_NE(generation_finish_start, std::string::npos);
   ASSERT_NE(generation_finish_end, std::string::npos);
+  ASSERT_LT(runtime_finalize_start, generation_cleanup_start);
+  const auto runtime_finalize = source.substr(
+    runtime_finalize_start,
+    generation_cleanup_start - runtime_finalize_start
+  );
+  const auto normalized_runtime_finalize = collapse_whitespace(runtime_finalize);
   const auto generation_cleanup = source.substr(
     generation_cleanup_start,
     generation_finish_start - generation_cleanup_start
@@ -3428,37 +3436,86 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
     "const bool isolated_cleanup_complete = terminate_isolated_session_processes("
   );
   const auto cleanup_success_gate = generation_cleanup.find("isolated_session_cleanup_resets_router(");
-  // The router reset goes through the labwc stream-runtime facade rather than
-  // naming cage_display_router directly.
-  const auto reset_cage = generation_cleanup.find("stream_runtime::labwc::reset_after_external_stop()");
+  const auto reset_runtime = generation_cleanup.find("finalize_isolated_session_runtime(true)");
   const auto retain_generation = generation_cleanup.find(
     "retaining immutable cage generation because exact-generation cleanup was incomplete"
   );
+  const auto stop_runtime = generation_cleanup.find("finalize_isolated_session_runtime(false)");
   const auto cleanup_clear_gate = generation_finish.find("isolated_session_cleanup_clears_state(");
   const auto clear_generation = generation_finish.find("_session_instance_id.clear()");
-  // Retention must not orphan the cage: the supervisor is polaris's own
-  // pidfd-bound child and always provable, so even when the wider generation
-  // snapshot is incomplete the retention branch has to stop the session cage
-  // (via the labwc facade, whose stop() carries its own ownership proof).
-  // Without this, an incompletely attributable teardown leaves labwc running
-  // as an orphan compositor and its supervisor as a zombie until restart.
-  const auto retention_stops_cage = generation_cleanup.find("stream_runtime::labwc::stop()");
   ASSERT_NE(cleanup_result, std::string::npos);
   ASSERT_NE(cleanup_success_gate, std::string::npos);
-  ASSERT_NE(reset_cage, std::string::npos);
+  ASSERT_NE(reset_runtime, std::string::npos);
   ASSERT_NE(retain_generation, std::string::npos);
-  ASSERT_NE(retention_stops_cage, std::string::npos)
-    << "the retention branch of terminate_isolated_session_generation must stop "
-       "the session cage rather than orphan it";
+  ASSERT_NE(stop_runtime, std::string::npos)
+    << "the retention branch must stop the immutable launch runtime rather than orphan it";
   ASSERT_NE(cleanup_clear_gate, std::string::npos);
   ASSERT_NE(clear_generation, std::string::npos);
   EXPECT_LT(cleanup_result, cleanup_success_gate);
-  EXPECT_LT(cleanup_success_gate, reset_cage);
-  EXPECT_LT(reset_cage, retain_generation);
-  EXPECT_LT(retain_generation, retention_stops_cage)
-    << "the cage stop belongs on the retention branch, after the retention "
+  EXPECT_LT(cleanup_success_gate, reset_runtime);
+  EXPECT_LT(reset_runtime, retain_generation);
+  EXPECT_LT(retain_generation, stop_runtime)
+    << "the runtime stop belongs on the retention branch, after the retention "
        "decision is logged";
   EXPECT_LT(cleanup_clear_gate, clear_generation);
+
+  const auto gamescope_branch = normalized_runtime_finalize.find("if (_session_used_gamescope_runtime)");
+  const auto gamescope_acquire = normalized_runtime_finalize.find(
+    "stream_runtime::acquire(",
+    gamescope_branch
+  );
+  const auto gamescope_kind = normalized_runtime_finalize.find(
+    "stream_path::runtime_kind_e::GAMESCOPE",
+    gamescope_acquire
+  );
+  const auto gamescope_acquire_end = normalized_runtime_finalize.find(");", gamescope_kind);
+  const auto gamescope_stop = normalized_runtime_finalize.find(
+    "gamescope_runtime->stop()",
+    gamescope_acquire_end
+  );
+  const auto gamescope_return = normalized_runtime_finalize.find("return;", gamescope_stop);
+  const auto reset_labwc = normalized_runtime_finalize.find(
+    "stream_runtime::labwc::reset_after_external_stop()",
+    gamescope_return
+  );
+  const auto stop_labwc = normalized_runtime_finalize.find("stream_runtime::labwc::stop()", reset_labwc);
+  ASSERT_NE(gamescope_branch, std::string::npos);
+  ASSERT_NE(gamescope_acquire, std::string::npos);
+  ASSERT_NE(gamescope_kind, std::string::npos);
+  ASSERT_NE(gamescope_acquire_end, std::string::npos);
+  ASSERT_NE(gamescope_stop, std::string::npos);
+  ASSERT_NE(gamescope_return, std::string::npos);
+  ASSERT_NE(reset_labwc, std::string::npos);
+  ASSERT_NE(stop_labwc, std::string::npos);
+  EXPECT_LT(gamescope_branch, gamescope_acquire);
+  EXPECT_LT(gamescope_acquire, gamescope_kind);
+  EXPECT_LT(gamescope_kind, gamescope_acquire_end);
+  EXPECT_LT(gamescope_acquire_end, gamescope_stop);
+  EXPECT_LT(gamescope_stop, gamescope_return);
+  EXPECT_LT(gamescope_return, reset_labwc)
+    << "the Gamescope branch must return before any labwc lifecycle call";
+  EXPECT_LT(reset_labwc, stop_labwc);
+
+  const auto retained_generation_reaped = execute.find(
+    "process: reaped a retained isolated session generation at launch"
+  );
+  const auto retained_runtime_finalize = execute.find(
+    "finalize_isolated_session_runtime(true)",
+    retained_generation_reaped
+  );
+  const auto retained_runtime_flag_clear = execute.find(
+    "_session_used_gamescope_runtime = false",
+    retained_runtime_finalize
+  );
+  ASSERT_NE(retained_generation_reaped, std::string::npos);
+  ASSERT_NE(retained_runtime_finalize, std::string::npos);
+  ASSERT_NE(retained_runtime_flag_clear, std::string::npos);
+  EXPECT_LT(retained_generation_reaped, retained_runtime_finalize);
+  EXPECT_LT(retained_runtime_finalize, retained_runtime_flag_clear)
+    << "retained cleanup must dispatch through immutable runtime identity before clearing it";
+
+  EXPECT_EQ(generation_cleanup.find("stream_runtime::labwc::reset_after_external_stop()"), std::string::npos);
+  EXPECT_EQ(generation_cleanup.find("stream_runtime::labwc::stop()"), std::string::npos);
   EXPECT_EQ(terminate.find("config::video.linux_display.use_cage_compositor"), std::string::npos);
   EXPECT_EQ(terminate.find("cage_display_router::stop()"), std::string::npos);
   EXPECT_EQ(terminate.find("terminate_steam_app_processes("), std::string::npos);

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -371,8 +371,93 @@ TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState
   ASSERT_NE(stop_start, std::string::npos);
   ASSERT_NE(refresh_start, std::string::npos);
   const auto stop_body = source.substr(stop_start, refresh_start - stop_start);
-  EXPECT_NE(stop_body.find("gp::read_marker(marker_path())"), std::string::npos);
+  EXPECT_NE(source.find("bool owned_group_drained_ = false"), std::string::npos);
+
+  const auto owned_socket_reclaim_start = source.find(
+    "bool reclaim_owned_gamescope_sockets_after_drain_unlocked()"
+  );
+  ASSERT_NE(owned_socket_reclaim_start, std::string::npos);
+  ASSERT_LT(owned_socket_reclaim_start, stop_start);
+  const auto owned_socket_reclaim = source.substr(
+    owned_socket_reclaim_start,
+    stop_start - owned_socket_reclaim_start
+  );
+  EXPECT_NE(
+    owned_socket_reclaim.find("!owned_group_drained_ || socket_name_ != \"gamescope-0\""),
+    std::string::npos
+  );
+  const auto reclaim_wayland = owned_socket_reclaim.find(
+    "gp::remove_orphan_socket(socket_path(\"gamescope-0\"))"
+  );
+  const auto reclaim_ei = owned_socket_reclaim.find(
+    "gp::remove_orphan_socket(socket_path(\"gamescope-0-ei\"))"
+  );
+  ASSERT_NE(reclaim_wayland, std::string::npos);
+  ASSERT_NE(reclaim_ei, std::string::npos);
+  EXPECT_LT(reclaim_wayland, reclaim_ei);
+  EXPECT_EQ(owned_socket_reclaim.find("gamescope-1"), std::string::npos)
+    << "post-drain cleanup may reclaim only the exact owned runtime socket pair";
+
+  const auto missing_marker_guard = stop_body.find("if (owned_ && !marker_)");
+  const auto missing_marker_return = stop_body.find("return;", missing_marker_guard);
+  const auto owned_marker_branch = stop_body.find("if (owned_ && marker_)", missing_marker_return);
+  const auto raw_marker = stop_body.find(
+    "const auto marker_on_disk = gp::read_marker(marker_path())",
+    owned_marker_branch
+  );
+  const auto retry_gate = stop_body.find("if (!owned_group_drained_)", raw_marker);
+  const auto live_marker = stop_body.find("gp::validated_marker(marker_path(), \"runtime\")", retry_gate);
+  const auto drain_group = stop_body.find("drain_private_process_group(", live_marker);
+  const auto mark_drained = stop_body.find("owned_group_drained_ = true", drain_group);
+  const auto reclaim_sockets = stop_body.find(
+    "reclaim_owned_gamescope_sockets_after_drain_unlocked()",
+    mark_drained
+  );
+  const auto clear_files = stop_body.find("remove_owned_files_if_current_unlocked()", reclaim_sockets);
+  const auto clear_retry_state = stop_body.find("owned_group_drained_ = false", clear_files);
+  ASSERT_NE(missing_marker_guard, std::string::npos);
+  ASSERT_NE(missing_marker_return, std::string::npos);
+  ASSERT_NE(owned_marker_branch, std::string::npos);
+  ASSERT_NE(raw_marker, std::string::npos);
+  ASSERT_NE(retry_gate, std::string::npos);
+  ASSERT_NE(live_marker, std::string::npos);
+  ASSERT_NE(drain_group, std::string::npos);
+  ASSERT_NE(mark_drained, std::string::npos);
+  ASSERT_NE(reclaim_sockets, std::string::npos);
+  ASSERT_NE(clear_files, std::string::npos);
+  ASSERT_NE(clear_retry_state, std::string::npos);
+  EXPECT_LT(missing_marker_guard, missing_marker_return);
+  EXPECT_LT(missing_marker_return, owned_marker_branch)
+    << "an owned runtime without immutable marker authority must retain its state";
+  EXPECT_LT(owned_marker_branch, raw_marker);
+  EXPECT_LT(raw_marker, retry_gate)
+    << "every retry must revalidate the raw immutable marker before cleanup";
+  EXPECT_LT(retry_gate, live_marker);
+  EXPECT_LT(live_marker, drain_group);
+  EXPECT_LT(drain_group, mark_drained);
+  EXPECT_LT(mark_drained, reclaim_sockets);
+  EXPECT_LT(reclaim_sockets, clear_files)
+    << "socket authority must be consumed before marker/environment authority";
+  EXPECT_LT(clear_files, clear_retry_state);
   EXPECT_EQ(stop_body.find("validated_marker_for_socket"), std::string::npos);
+
+  const auto reset_start = source.find("void reset_after_external_stop() override");
+  const auto reset_end = source.find("bool is_running() const override", reset_start);
+  ASSERT_NE(reset_start, std::string::npos);
+  ASSERT_NE(reset_end, std::string::npos);
+  const auto reset_body = source.substr(reset_start, reset_end - reset_start);
+  EXPECT_NE(reset_body.find("owned_group_drained_ = false"), std::string::npos);
+
+  const auto clear_state_start = source.find("void clear_runtime_state_unlocked()");
+  const auto clear_state_end = source.find("bool revalidate_running_unlocked(", clear_state_start);
+  ASSERT_NE(clear_state_start, std::string::npos);
+  ASSERT_NE(clear_state_end, std::string::npos);
+  const auto clear_state_body = source.substr(
+    clear_state_start,
+    clear_state_end - clear_state_start
+  );
+  EXPECT_NE(clear_state_body.find("owned_group_drained_ = false"), std::string::npos);
+
   const auto runtime_start = source.find("bool start(const start_params_t &params) override");
   const auto runtime_stop = source.find("void stop() override", runtime_start);
   ASSERT_NE(runtime_start, std::string::npos);
@@ -389,8 +474,20 @@ TEST(SessionStopContractTests, OwnedRuntimeDrainsPrivateGroupBeforeClearingState
   EXPECT_LT(acquisition, reclaim);
   EXPECT_LT(reclaim, spawn);
   EXPECT_LT(spawn, marker_write);
+  const auto owned_spawn = start_body.find("owned_ = true", spawn);
+  const auto reset_spawn_retry_state = start_body.find("owned_group_drained_ = false", owned_spawn);
+  ASSERT_NE(owned_spawn, std::string::npos);
+  ASSERT_NE(reset_spawn_retry_state, std::string::npos);
+  EXPECT_LT(owned_spawn, reset_spawn_retry_state);
   EXPECT_NE(start_body.find("runtime_acquisition_allowed_locked()"), std::string::npos);
   EXPECT_NE(source.find("try_attach_gamescope0(params, true)"), std::string::npos);
+
+  const auto attach_start = source.find("bool try_attach_gamescope0(");
+  const auto attach_end = source.find("static bool idle_hdr_flags_match_force()", attach_start);
+  ASSERT_NE(attach_start, std::string::npos);
+  ASSERT_NE(attach_end, std::string::npos);
+  const auto attach_body = source.substr(attach_start, attach_end - attach_start);
+  EXPECT_NE(attach_body.find("owned_group_drained_ = false"), std::string::npos);
   const auto drain_start = source.find("bool drain_private_process_group(");
   const auto rollback_start = source.find("bool rollback_spawned_private_group(", drain_start);
   ASSERT_NE(drain_start, std::string::npos);


### PR DESCRIPTION
Closes #489.

## Summary

- dispatch isolated-session teardown through the immutable runtime selected by the launch generation, so Gamescope sessions no longer fall through the labwc lifecycle path
- drain Polaris-owned Gamescope through its existing pidfd/marker authority while leaving validated idle/attached Gamescope running
- reclaim only the owned `gamescope-0` / `gamescope-0-ei` pair after the private group is proven drained, under the existing transition lock plus Wayland lock/live-holder checks
- retain drained progress, marker authority, and runtime state when socket or ownership cleanup is ambiguous so a later stop retries without re-signalling a proven-empty group
- fail closed when an owned runtime has no immutable marker authority

## Regression coverage

The source contracts now pin:

- Gamescope-vs-labwc teardown dispatch from immutable launch state, including retained-generation cleanup before the runtime identity is cleared
- attached detach versus owned stop behavior through the runtime singleton
- marker revalidation, drain, socket cleanup, marker/environment cleanup, and state-clear ordering
- exact socket-pair scope and the absence of `gamescope-1*` cleanup in the owned path
- retry state across spawn, attach, reset, and stale-state transitions
- missing-marker ownership failure preserving state

RED verification against unchanged source:

- `SessionStopContractTests.OwnedRuntimeDrainsPrivateGroupBeforeClearingState` failed before the teardown/socket implementation
- `ProcessRuntimeConfigTests.SessionOwnedSteamUsesExactGenerationPidfdsBeforeImmutableCageCleanup` failed before immutable runtime dispatch
- the added missing-marker assertion independently failed before its fail-closed guard

GREEN verification on Linux:

- focused regressions: pass
- `test_polaris_http`: 128/128
- `test_polaris_config`: 286/286
- fast C++ suite: 352/352
- Gamescope process ownership/lock subset: 24/24
- Gamescope runtime and session-stop shell contracts: pass
- Web suite: 492/492
- Web lint: clean

## Boundaries

This changes teardown ownership and stale-socket reclamation only. It does not enable VAAPI DMA-BUF, alter #481's containment policy, claim affected-host acceptance, or cut a release.
