### PR TITLE
fix(linux): keep nested Steam in Big Picture

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3678,10 +3678,15 @@ namespace proc {
     bool steam_big_picture_input_guard_enabled(
       const proc::ctx_t &app,
       bool use_cage_compositor,
-      bool mirror_desktop
+      bool mirror_desktop,
+      bool nested_wsi_session
     ) {
+      // Nested Gamescope owns Steam as its primary child. Closing Big Picture
+      // there can surface desktop Steam above the game instead of protecting a
+      // separate background client, which is the labwc compatibility case.
       return use_cage_compositor &&
              !mirror_desktop &&
+             !nested_wsi_session &&
              (is_steam_big_picture_app(app) ||
               proc::steam_launch_mode_is_big_picture(app.steam_launch_mode));
     }
@@ -4070,9 +4075,15 @@ namespace proc {
   bool steam_big_picture_input_guard_enabled_for_tests(
     const proc::ctx_t &app,
     bool use_cage_compositor,
-    bool mirror_desktop
+    bool mirror_desktop,
+    bool nested_wsi_session
   ) {
-    return steam_big_picture_input_guard_enabled(app, use_cage_compositor, mirror_desktop);
+    return steam_big_picture_input_guard_enabled(
+      app,
+      use_cage_compositor,
+      mirror_desktop,
+      nested_wsi_session
+    );
   }
 
   std::string steam_big_picture_log_path_for_tests(
@@ -5798,9 +5809,10 @@ namespace proc {
 
   std::shared_ptr<const steam_big_picture_guard_snapshot_t> proc_t::snapshot_steam_big_picture_input_guard(
     bool use_cage_compositor,
-    bool mirror_desktop
+    bool mirror_desktop,
+    bool nested_wsi_session
   ) const {
-    if (!steam_big_picture_input_guard_enabled(_app, use_cage_compositor, mirror_desktop)) {
+    if (!steam_big_picture_input_guard_enabled(_app, use_cage_compositor, mirror_desktop, nested_wsi_session)) {
       return {};
     }
 
@@ -5984,10 +5996,6 @@ namespace proc {
     const bool requested_headless_for_session =
       !mirror_desktop_session &&
       (config::video.linux_display.headless_mode || gamescope_stream_session);
-    const auto steam_guard_snapshot = snapshot_steam_big_picture_input_guard(
-      use_cage_compositor_for_session,
-      launch_session && launch_session->mirror_desktop
-    );
 #endif
 
     this->initial_display = config::video.output_name;
@@ -6313,6 +6321,11 @@ namespace proc {
                            << " because polaris-gamescope-session is not on PATH; using attach"sv;
       }
     }
+    const auto steam_guard_snapshot = snapshot_steam_big_picture_input_guard(
+      use_cage_compositor_for_session,
+      mirror_desktop_session,
+      nested_wsi_session
+    );
 #endif
 
     if (resolved_optimization.virtual_display.has_value()) {

--- a/src/process.h
+++ b/src/process.h
@@ -185,7 +185,8 @@ namespace proc {
   bool steam_big_picture_input_guard_enabled_for_tests(
     const struct ctx_t &app,
     bool use_cage_compositor,
-    bool mirror_desktop
+    bool mirror_desktop,
+    bool nested_wsi_session
   );
   std::string steam_big_picture_log_path_for_tests(
     const struct ctx_t &app,
@@ -769,7 +770,8 @@ namespace proc {
     void finish_isolated_session_generation_cleanup();
     std::shared_ptr<const steam_big_picture_guard_snapshot_t> snapshot_steam_big_picture_input_guard(
       bool use_cage_compositor,
-      bool mirror_desktop
+      bool mirror_desktop,
+      bool nested_wsi_session
     ) const;
     void start_steam_big_picture_input_guard(
       const boost::process::v1::environment &launch_env,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1065,9 +1065,10 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsScopedToPrivateCompat
   big_picture.name = "Steam Big Picture";
   big_picture.detached = {"setsid steam -gamepadui"};
 
-  EXPECT_TRUE(proc::steam_big_picture_input_guard_enabled_for_tests(big_picture, true, false));
-  EXPECT_FALSE(proc::steam_big_picture_input_guard_enabled_for_tests(big_picture, false, false));
-  EXPECT_FALSE(proc::steam_big_picture_input_guard_enabled_for_tests(big_picture, true, true));
+  EXPECT_TRUE(proc::steam_big_picture_input_guard_enabled_for_tests(big_picture, true, false, false));
+  EXPECT_FALSE(proc::steam_big_picture_input_guard_enabled_for_tests(big_picture, false, false, false));
+  EXPECT_FALSE(proc::steam_big_picture_input_guard_enabled_for_tests(big_picture, true, true, false));
+  EXPECT_FALSE(proc::steam_big_picture_input_guard_enabled_for_tests(big_picture, true, false, true));
 
   proc::ctx_t compatibility_game {};
   compatibility_game.name = "MOUSE";
@@ -1078,11 +1079,12 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsScopedToPrivateCompat
     "setsid steam -gamepadui",
     "setsid steam steam://rungameid/2416450",
   };
-  EXPECT_TRUE(proc::steam_big_picture_input_guard_enabled_for_tests(compatibility_game, true, false));
+  EXPECT_TRUE(proc::steam_big_picture_input_guard_enabled_for_tests(compatibility_game, true, false, false));
+  EXPECT_FALSE(proc::steam_big_picture_input_guard_enabled_for_tests(compatibility_game, true, false, true));
 
   compatibility_game.steam_launch_mode = "direct";
   compatibility_game.detached = {"setsid steam steam://rungameid/2416450"};
-  EXPECT_FALSE(proc::steam_big_picture_input_guard_enabled_for_tests(compatibility_game, true, false));
+  EXPECT_FALSE(proc::steam_big_picture_input_guard_enabled_for_tests(compatibility_game, true, false, false));
 }
 
 TEST(ProcessRuntimeConfigTests, GamescopeNestedSessionTargetsSteamGamesAndBigPictureWithoutAnHdrGate) {
@@ -3550,6 +3552,9 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsStartedAndStoppedInsi
   const auto execute = source.substr(execute_start, execute_end - execute_start);
   const auto terminate = source.substr(terminate_start, terminate_end - terminate_start);
   const auto snapshot_guard = execute.find("snapshot_steam_big_picture_input_guard(");
+  const auto nested_wsi_selected = execute.find("nested_wsi_session = true");
+  const auto snapshot_guard_end = execute.find(");", snapshot_guard);
+  const auto snapshot_guard_call = execute.substr(snapshot_guard, snapshot_guard_end - snapshot_guard);
   // Pinned to the prep loop rather than to that call's argument list: #450
   // reformatted the launch across lines and added a prep_output argument, which
   // broke the old literal without changing the ordering this test guards.
@@ -3561,6 +3566,8 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsStartedAndStoppedInsi
   const auto start_guard = execute.find("start_steam_big_picture_input_guard(");
   const auto launch_committed = execute.find("stop_guard_on_failed_launch.disable()");
   ASSERT_NE(snapshot_guard, std::string::npos);
+  ASSERT_NE(nested_wsi_selected, std::string::npos);
+  ASSERT_NE(snapshot_guard_end, std::string::npos);
   ASSERT_NE(first_prep_launch, std::string::npos);
   ASSERT_NE(failed_launch_guard, std::string::npos);
   ASSERT_NE(failed_launch_stop, std::string::npos);
@@ -3568,6 +3575,9 @@ TEST(ProcessRuntimeConfigTests, SteamBigPictureInputGuardIsStartedAndStoppedInsi
   ASSERT_NE(first_main_launch, std::string::npos);
   ASSERT_NE(start_guard, std::string::npos);
   ASSERT_NE(launch_committed, std::string::npos);
+  EXPECT_LT(nested_wsi_selected, snapshot_guard);
+  EXPECT_NE(snapshot_guard_call.find("nested_wsi_session"), std::string::npos)
+    << "nested WSI selection must disable the labwc Big Picture compatibility guard";
   EXPECT_LT(snapshot_guard, first_prep_launch);
   EXPECT_LT(snapshot_guard, start_guard);
   EXPECT_LT(failed_launch_guard, failed_launch_stop);


### PR DESCRIPTION
Closes #495.

## Summary

- exclude packaged nested Gamescope WSI sessions from the labwc Big Picture compatibility guard
- keep the existing guard unchanged for private labwc compatibility sessions
- defer the guard snapshot until nested WSI selection is known, while keeping it before any prep command can launch Steam
- pin both the eligibility boundary and snapshot ordering in executable tests

## Root cause

The Big Picture input guard predates nested Gamescope WSI. It correctly closes a separate background Big Picture client in labwc compatibility sessions so one controller event is not consumed by both Big Picture and the game.

In nested WSI, Steam Big Picture is Gamescope's primary child and owns the session focus boundary. Dispatching `steam://close/bigpicture` changes that primary child into desktop Steam while the game is running, which can place the desktop Steam window above the game.

## Impact and boundaries

Only sessions that actually select the packaged nested WSI helper are excluded. Labwc compatibility sessions, Mirror Desktop, and direct Steam launches retain their existing policy.

This is a source-level containment for the reproduced command path. It does not claim physical focus acceptance, change input isolation, alter Gamescope startup timing, merge another release blocker, or authorize a release.

## Validation

RED with the final test changes and unchanged production source:

- `test_polaris_config` failed to compile because the nested-session eligibility argument and production exclusion did not exist

GREEN:

- focused guard eligibility and lifecycle/source-order contracts: 2/2
- full `test_polaris_config`: 286/286
- fast `test_polaris`: 352/352
- production `polaris` executable build: pass
- `git diff --check`: clean

Physical nested Gamescope verification remains required before release promotion.