### PR TITLE
feat(web): refresh resources and add subtle sponsor link

### DIFF
--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -663,7 +663,7 @@
     "quick_troubleshoot_desc": "Use recovery tools, diagnostics, and force-close actions.",
     "quick_troubleshoot_title": "Troubleshooting",
     "recent_issues": "Recent Issues",
-    "resources_desc": "Open the Polaris docs, discussions, and stuttering clinic from one place.",
+    "resources_desc": "Official website, docs, source, releases, discussions, and tuning guides.",
     "resources_title": "Resources",
     "session_mode": "Session Mode",
     "session_mode_idle": "Idle",
@@ -1084,8 +1084,11 @@
     "warning_msg": "Only pair devices you control. A trusted client can launch apps, watch streams, or control the host depending on the permissions you give it."
   },
   "resource_card": {
+    "website": "Website",
     "documentation": "Documentation",
     "troubleshooting_guide": "Troubleshooting Guide",
+    "github": "GitHub",
+    "releases": "Releases",
     "github_discussions": "GitHub Discussions",
     "github_wiki": "GitHub WiKi",
     "github_stuttering_clinic": "Stuttering Clinic",
@@ -1094,6 +1097,8 @@
     "license": "License",
     "resources": "Resources",
     "resources_desc": "Resources for Polaris!",
+    "sponsor": "Sponsor",
+    "sponsor_desc": "Support Polaris and Nova on GitHub Sponsors",
     "third_party_notice": "Third Party Notice"
   },
   "troubleshooting": {

--- a/src_assets/common/assets/web/resource-links.js
+++ b/src_assets/common/assets/web/resource-links.js
@@ -11,12 +11,24 @@
  */
 
 export const resources = [
+  { href: 'https://papi-ux.com/', labelKey: 'resource_card.website' },
   { href: 'https://papi-ux.com/docs/', labelKey: 'resource_card.documentation' },
   { href: 'https://papi-ux.com/docs/troubleshooting/', labelKey: 'resource_card.troubleshooting_guide' },
+  { href: 'https://github.com/papi-ux/polaris', labelKey: 'resource_card.github' },
+  { href: 'https://github.com/papi-ux/polaris/releases', labelKey: 'resource_card.releases' },
   { href: 'https://github.com/papi-ux/polaris/discussions', labelKey: 'resource_card.github_discussions' },
   { href: 'https://github.com/papi-ux/polaris/wiki', labelKey: 'resource_card.github_wiki' },
   { href: 'https://github.com/papi-ux/polaris/wiki/Stuttering-Clinic', labelKey: 'resource_card.github_stuttering_clinic' }
 ]
+
+// Sponsorship is deliberately not a primary resource button. It belongs in the
+// System resource area, but should remain a quiet invitation rather than a
+// prerequisite for finding support or documentation.
+export const sponsor = {
+  href: 'https://github.com/sponsors/papi-ux',
+  labelKey: 'resource_card.sponsor',
+  ariaLabelKey: 'resource_card.sponsor_desc'
+}
 
 export const legalDocs = [
   { href: 'https://github.com/papi-ux/polaris/blob/master/LICENSE', labelKey: 'resource_card.license' },

--- a/src_assets/common/assets/web/resource-links.test.js
+++ b/src_assets/common/assets/web/resource-links.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { legalDocs, resources } from './resource-links.js'
+import { legalDocs, resources, sponsor } from './resource-links.js'
 
 const all = [...resources, ...legalDocs]
 
@@ -11,6 +11,13 @@ describe('resource links', () => {
     const hrefs = resources.map((entry) => entry.href)
     expect(hrefs).toContain('https://papi-ux.com/docs/')
     expect(hrefs).toContain('https://papi-ux.com/docs/troubleshooting/')
+  })
+
+  it('offers the canonical project entry points', () => {
+    const hrefs = resources.map((entry) => entry.href)
+    expect(hrefs).toContain('https://papi-ux.com/')
+    expect(hrefs).toContain('https://github.com/papi-ux/polaris')
+    expect(hrefs).toContain('https://github.com/papi-ux/polaris/releases')
   })
 
   it('keeps the destinations that only exist on GitHub', () => {
@@ -33,5 +40,14 @@ describe('resource links', () => {
   it('lists each destination once', () => {
     const hrefs = all.map((entry) => entry.href)
     expect(new Set(hrefs).size).toBe(hrefs.length)
+  })
+
+  it('keeps sponsorship separate from primary resources', () => {
+    expect(sponsor).toEqual({
+      href: 'https://github.com/sponsors/papi-ux',
+      labelKey: 'resource_card.sponsor',
+      ariaLabelKey: 'resource_card.sponsor_desc'
+    })
+    expect(all.map((entry) => entry.href)).not.toContain(sponsor.href)
   })
 })

--- a/src_assets/common/assets/web/resource-sponsor-view.test.js
+++ b/src_assets/common/assets/web/resource-sponsor-view.test.js
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const webSource = (relativePath) => readFileSync(
+  join(process.cwd(), 'src_assets/common/assets/web', relativePath),
+  'utf8'
+)
+
+describe('System resource sponsorship', () => {
+  it('renders the sponsor as a quiet, accessible footer link', () => {
+    const home = webSource('views/HomeView.vue')
+    const resourcesSection = home.slice(
+      home.indexOf('<div class="section-kicker">Resources</div>'),
+      home.indexOf('<div class="section-kicker">Legal</div>')
+    )
+
+    expect(resourcesSection).toContain(':href="sponsor.href"')
+    expect(resourcesSection).toContain(':aria-label="$t(sponsor.ariaLabelKey)"')
+    expect(resourcesSection).toContain('rel="noopener noreferrer"')
+    expect(resourcesSection).toContain('aria-hidden="true"')
+    expect(resourcesSection).toContain('{{ $t(sponsor.labelKey) }}')
+    expect(resourcesSection).toContain('text-xs')
+  })
+
+  it('does not repeat the sponsor prompt on onboarding and recovery cards', () => {
+    expect(webSource('ResourceCard.vue')).not.toContain('sponsor')
+  })
+})

--- a/src_assets/common/assets/web/views/HomeView.vue
+++ b/src_assets/common/assets/web/views/HomeView.vue
@@ -315,15 +315,27 @@
             </InfoHint>
           </div>
         </div>
-        <div class="flex flex-wrap gap-2">
+        <div class="flex flex-col items-start gap-2 lg:items-end">
+          <div class="flex flex-wrap gap-2 lg:justify-end">
+            <a
+              v-for="resource in resources"
+              :key="resource.href"
+              class="focus-ring inline-flex h-9 items-center justify-center rounded-lg border border-storm px-4 text-sm font-medium text-silver transition-[border-color,color,box-shadow,background-color] duration-200 hover:border-ice hover:text-ice hover:shadow-[0_0_16px_color-mix(in_srgb,var(--color-ice)_8%,transparent)] no-underline"
+              :href="resource.href"
+              target="_blank"
+            >
+              {{ $t(resource.labelKey) }}
+            </a>
+          </div>
           <a
-            v-for="resource in resources"
-            :key="resource.href"
-            class="focus-ring inline-flex h-9 items-center justify-center rounded-lg border border-storm px-4 text-sm font-medium text-silver transition-[border-color,color,box-shadow,background-color] duration-200 hover:border-ice hover:text-ice hover:shadow-[0_0_16px_color-mix(in_srgb,var(--color-ice)_8%,transparent)] no-underline"
-            :href="resource.href"
+            class="focus-ring inline-flex min-h-7 items-center rounded-md px-2 text-xs font-medium text-storm no-underline transition-colors duration-200 hover:text-silver"
+            :href="sponsor.href"
             target="_blank"
+            rel="noopener noreferrer"
+            :aria-label="$t(sponsor.ariaLabelKey)"
           >
-            {{ $t(resource.labelKey) }}
+            <span aria-hidden="true" class="mr-1.5 text-danger/80">♥</span>
+            {{ $t(sponsor.labelKey) }}
           </a>
         </div>
       </div>
@@ -381,7 +393,7 @@ const compatibilityClients = [
   { platform: 'Desktop', name: 'Coming Soon', status: 'Planned', link: '' }
 ]
 
-import { resources, legalDocs } from '../resource-links.js'
+import { resources, legalDocs, sponsor } from '../resource-links.js'
 
 const quickActions = [
   { to: '/', titleKey: 'index.quick_mission_title', descKey: 'index.quick_mission_desc' },


### PR DESCRIPTION
## What changed

- adds the official papi-ux website, Polaris repository, and releases page to the shared resource list
- keeps Documentation, Troubleshooting, Discussions, Wiki, and Stuttering Clinic destinations intact
- updates the System resource description to match the expanded destinations
- adds a compact `♥ Sponsor` link beneath the primary System resource buttons
- keeps sponsorship separate from onboarding and recovery resource cards
- pins the canonical destinations, separation, accessibility label, quiet visual treatment, and safe external-link behavior in tests

## Why

System > Resources had useful deep links but omitted the main project entry points. Sponsorship should also be discoverable without competing with support and documentation.

## User impact

Users get direct access to the project website, source, releases, support resources, and the papi-ux GitHub Sponsors page from System. The sponsor invitation is intentionally lower emphasis than the resource buttons.

## Validation

- RED: 3 new focused assertions failed before implementation
- GREEN: 8 focused resource and sponsor tests
- GREEN: full web suite, 496 tests
- GREEN: ESLint
- GREEN: production Vite build
- GREEN: web performance budget
- GREEN: public docs check
- GREEN: `git diff --check`

No backend or streaming-runtime behavior changes.