### PR TITLE
fix(web): restore status surface layouts

### DIFF
--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -321,6 +321,68 @@ textarea {
   @apply xl:justify-end;
 }
 
+/* Compact context cards used beside page headings. Keep the System summary
+   visually attached to its heading instead of letting its three articles
+   collapse into an unstyled text column. */
+.system-page-header,
+.security-page-header {
+  align-items: flex-start;
+}
+
+.system-toolbar-notes {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
+}
+
+.header-support-card {
+  min-width: 0;
+  height: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--edge-raised);
+  border-radius: 0.75rem;
+  background: var(--surface-raised);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.header-support-title-row {
+  @apply flex items-center justify-between gap-2;
+}
+
+.header-support-value {
+  @apply mt-2 break-words text-base font-semibold leading-tight text-silver;
+}
+
+.header-support-copy {
+  @apply mt-1 text-xs leading-relaxed text-storm;
+}
+
+.security-header-card {
+  width: 100%;
+}
+
+@media (min-width: 40rem) {
+  .system-toolbar-notes {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 80rem) {
+  .system-page-header {
+    display: grid;
+    grid-template-columns: minmax(0, 0.8fr) minmax(36rem, 1.2fr);
+    gap: 1.5rem;
+  }
+
+  .security-header-card {
+    width: auto;
+    min-width: 20rem;
+    max-width: 24.375rem;
+  }
+}
+
 .section-title-row {
   @apply flex min-w-0 items-center gap-2;
 }

--- a/src_assets/common/assets/web/dashboard-doctor-layout.test.js
+++ b/src_assets/common/assets/web/dashboard-doctor-layout.test.js
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function webSource(relativePath) {
+  return readFileSync(join(process.cwd(), 'src_assets/common/assets/web', relativePath), 'utf8')
+}
+
+describe('Dashboard Doctor layout', () => {
+  it('separates a long diagnosis from confidence and optimizer metadata', () => {
+    const dashboard = webSource('views/DashboardView.vue')
+    const headline = dashboard.indexOf('{{ doctorHeadline }}')
+    const metadata = dashboard.indexOf('data-dashboard-doctor-meta')
+    const confidence = dashboard.indexOf('{{ doctorConfidenceLabel }}')
+    const optimizer = dashboard.indexOf('{{ autoQuality.compactLabel }}')
+
+    expect(headline).toBeGreaterThan(-1)
+    expect(metadata).toBeGreaterThan(headline)
+    expect(confidence).toBeGreaterThan(metadata)
+    expect(optimizer).toBeGreaterThan(confidence)
+    expect(dashboard).toContain('data-dashboard-doctor-meta')
+    expect(dashboard).toContain('class="mt-3 flex flex-wrap items-center gap-2"')
+  })
+})

--- a/src_assets/common/assets/web/dashboard-doctor-layout.test.js
+++ b/src_assets/common/assets/web/dashboard-doctor-layout.test.js
@@ -19,6 +19,8 @@ describe('Dashboard Doctor layout', () => {
     expect(confidence).toBeGreaterThan(metadata)
     expect(optimizer).toBeGreaterThan(confidence)
     expect(dashboard).toContain('data-dashboard-doctor-meta')
+    expect(dashboard).toContain('role="list" aria-label="Doctor confidence and Auto Quality status"')
+    expect(dashboard.match(/role="listitem"/g)).toHaveLength(3)
     expect(dashboard).toContain('class="mt-3 flex flex-wrap items-center gap-2"')
   })
 })

--- a/src_assets/common/assets/web/system-page-layout.test.js
+++ b/src_assets/common/assets/web/system-page-layout.test.js
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function webSource(relativePath) {
+  return readFileSync(join(process.cwd(), 'src_assets/common/assets/web', relativePath), 'utf8')
+}
+
+describe('System page header layout', () => {
+  it('keeps the host summary in a responsive three-card grid', () => {
+    const home = webSource('views/HomeView.vue')
+    const css = webSource('app.css')
+
+    expect(home).toContain('class="page-header system-page-header"')
+    expect(home).toContain('class="system-toolbar-notes"')
+    expect(home.match(/<article class="header-support-card">/g)).toHaveLength(3)
+    expect(css).toContain('.system-toolbar-notes')
+    expect(css).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))')
+    expect(css).toContain('grid-template-columns: minmax(0, 0.8fr) minmax(36rem, 1.2fr)')
+  })
+
+  it('styles each summary item as a bounded card', () => {
+    const css = webSource('app.css')
+
+    expect(css).toContain('.header-support-card')
+    expect(css).toContain('background: var(--surface-raised)')
+    expect(css).toContain('border: 1px solid var(--edge-raised)')
+    expect(css).toContain('.header-support-title-row')
+    expect(css).toContain('.header-support-value')
+    expect(css).toContain('.header-support-copy')
+  })
+})

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -94,9 +94,11 @@
           <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div class="min-w-0">
               <div class="section-kicker">{{ $t('dashboard.doctor') }}</div>
-              <div class="mt-2 flex flex-wrap items-center gap-2">
-                <span class="inline-block h-2.5 w-2.5 shrink-0 rounded-full" :class="doctorLightClass" aria-hidden="true"></span>
+              <div class="mt-2 flex min-w-0 items-start gap-2">
+                <span class="mt-1.5 inline-block h-2.5 w-2.5 shrink-0 rounded-full" :class="doctorLightClass" aria-hidden="true"></span>
                 <h3 class="text-xl font-semibold leading-tight text-silver">{{ doctorHeadline }}</h3>
+              </div>
+              <div class="mt-3 flex flex-wrap items-center gap-2" data-dashboard-doctor-meta>
                 <span v-if="doctorConfidenceLabel" class="control-chip">{{ doctorConfidenceLabel }}</span>
                 <span class="meta-pill" :class="autoQuality.toneClass">{{ autoQuality.compactLabel }}</span>
                 <InfoHint size="sm" label="Auto Quality details">{{ autoQuality.detail }}</InfoHint>

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -98,10 +98,12 @@
                 <span class="mt-1.5 inline-block h-2.5 w-2.5 shrink-0 rounded-full" :class="doctorLightClass" aria-hidden="true"></span>
                 <h3 class="text-xl font-semibold leading-tight text-silver">{{ doctorHeadline }}</h3>
               </div>
-              <div class="mt-3 flex flex-wrap items-center gap-2" data-dashboard-doctor-meta>
-                <span v-if="doctorConfidenceLabel" class="control-chip">{{ doctorConfidenceLabel }}</span>
-                <span class="meta-pill" :class="autoQuality.toneClass">{{ autoQuality.compactLabel }}</span>
-                <InfoHint size="sm" label="Auto Quality details">{{ autoQuality.detail }}</InfoHint>
+              <div class="mt-3 flex flex-wrap items-center gap-2" data-dashboard-doctor-meta role="list" aria-label="Doctor confidence and Auto Quality status">
+                <div v-if="doctorConfidenceLabel" class="control-chip" role="listitem">{{ doctorConfidenceLabel }}</div>
+                <div class="meta-pill" :class="autoQuality.toneClass" role="listitem">{{ autoQuality.compactLabel }}</div>
+                <div class="inline-flex" role="listitem">
+                  <InfoHint size="sm" label="Auto Quality details">{{ autoQuality.detail }}</InfoHint>
+                </div>
               </div>
               <p v-if="doctorRecommendation" class="mt-2 max-w-3xl text-sm leading-relaxed text-storm">{{ doctorRecommendation }}</p>
               <p v-if="doctorExplanation" class="mt-3 max-w-3xl rounded-lg border border-accent/20 bg-accent/5 px-3 py-2 text-sm leading-relaxed text-silver">


### PR DESCRIPTION
## Summary

- restore the missing shared styles for System header support cards
- present Version, Update, and Issues as a balanced three-card summary on wider viewports and a single-column stack on phones
- move Doctor confidence and optimizer metadata below long diagnosis headlines so labels no longer run together
- add source contracts for both responsive layouts

## Verification

- `npm run test -- --run src_assets/common/assets/web/system-page-layout.test.js src_assets/common/assets/web/dashboard-doctor-layout.test.js src_assets/common/assets/web/dashboard-live-hierarchy.test.js`
- `npm run lint`
- `npm run build -- --logLevel warn`
- synthetic 1440x900 and 390x844 browser renders inspected locally
- `git diff --check`

## Privacy and scope

- the reporter screenshot and raw host logs are not committed or attached
- the diff contains no private host paths, usernames, email addresses, IP addresses, credentials, or raw logs
- draft only; no merge, release, deploy, or physical acceptance is included
