### PR TITLE
fix(doctor): flag Steam Input isolation conflicts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,10 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## Unreleased
+
+- Detects when local Steam Input settings can claim the Polaris Xbox virtual controller during strict gamepad isolation, reports the conflict and PII-free aggregate evidence in Doctor, and points to the host-wide and per-game Steam settings without changing them automatically
+
 ## v1.3.11 - 2026-08-19
 
 A support, private-runtime recovery, display-truth, and reproducibility patch. Polaris can now preserve the evidence around crashes and silent failures, accept a bounded report from an authenticated paired client, recover private Steam and owned Gamescope reconnects, find Flatpak Heroic and Lutris libraries, keep PipeWire VAAPI capture on the safe SHM path by default, and stop describing requested display state as applied until the compositor reports it back.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,6 +160,25 @@ own virtual devices enabled. This needs no configuration and applies to every pr
 Writing your own `rc.xml` there takes over completely: a file without Polaris' generated marker
 comment is never overwritten, and Polaris then stops managing input isolation for that session.
 
+### Steam Input and virtual controllers
+
+Strict host-controller isolation exposes the Polaris virtual gamepad to the streamed app while hiding
+physical controllers connected to the host. Local Steam Input settings can still claim that virtual
+Xbox controller.
+For Proton games, Steam then tries to hand the game a replacement controller through `/dev/uinput`,
+but the strict sandbox deliberately does not expose that device or dynamically created input nodes.
+The result is a controller that works in host-side event tests but is completely dead in the game.
+
+When Doctor reports `steam_input_conflict`, open Steam Settings > Controller and disable Steam Input
+for Xbox controllers. Also review the affected game's Controller properties: use Default after
+disabling the host-wide Xbox setting, or Disable Steam Input for that game. A per-game Force On
+override still triggers the conflict.
+
+This Doctor check is read-only. It reports only aggregate status and counts; it does not expose Steam
+account ids, installed app ids, profile filenames, or filesystem paths, and it does not edit Steam
+configuration. Close Steam before changing the setting through Steam or by another supported tool so
+the running client cannot overwrite the update.
+
 ## Linux HDR and Main10
 
 On Linux, treat sessions that log `stream_hdr_enabled=false` as SDR even if the client requests HDR.

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -509,6 +509,165 @@ namespace game_library {
     return roots;
   }
 
+  steam_input_config_t parse_steam_input_vdf(std::string_view vdf_payload) {
+    steam_input_config_t result;
+    if (vdf_payload.empty()) {
+      return result;
+    }
+
+    std::vector<std::string> section;
+    std::string pending_section;
+    std::set<std::string> forced_apps;
+    std::istringstream stream {std::string(vdf_payload)};
+    std::string line;
+    bool saw_vdf_entry = false;
+
+    const auto quoted = [](const std::string &text, std::size_t from, std::string &out) -> std::size_t {
+      const auto open = text.find('"', from);
+      if (open == std::string::npos) {
+        return std::string::npos;
+      }
+      const auto close = text.find('"', open + 1);
+      if (close == std::string::npos) {
+        return std::string::npos;
+      }
+      out = text.substr(open + 1, close - open - 1);
+      return close + 1;
+    };
+
+    while (std::getline(stream, line)) {
+      const auto begin = line.find_first_not_of(" \t\r");
+      if (begin == std::string::npos) {
+        continue;
+      }
+      line = line.substr(begin);
+      while (!line.empty() && (line.back() == '\r' || line.back() == ' ' || line.back() == '\t')) {
+        line.pop_back();
+      }
+
+      if (line == "{") {
+        section.push_back(pending_section);
+        pending_section.clear();
+        continue;
+      }
+      if (line == "}") {
+        if (!section.empty()) {
+          section.pop_back();
+        }
+        continue;
+      }
+      if (line.empty() || line.front() != '"') {
+        continue;
+      }
+
+      std::string key;
+      const auto after_key = quoted(line, 0, key);
+      if (after_key == std::string::npos) {
+        continue;
+      }
+
+      std::string value;
+      if (quoted(line, after_key, value) == std::string::npos) {
+        pending_section = key;
+        saw_vdf_entry = true;
+        continue;
+      }
+      saw_vdf_entry = true;
+
+      if (key == "SteamController_XBoxSupport") {
+        result.xbox_support_enabled = value == "1";
+        continue;
+      }
+
+      if (key != "UseSteamControllerConfig" ||
+          section.size() < 2 ||
+          section[section.size() - 2] != "apps") {
+        continue;
+      }
+
+      const auto &app_id = section.back();
+      if (app_id.empty() || app_id.find_first_not_of("0123456789") != std::string::npos) {
+        continue;
+      }
+      if (value == "2") {
+        forced_apps.insert(app_id);
+      } else {
+        forced_apps.erase(app_id);
+      }
+    }
+
+    result.parsed = saw_vdf_entry;
+    result.forced_app_count = static_cast<int>(forced_apps.size());
+    return result;
+  }
+
+  steam_input_snapshot_t inspect_steam_input_configs(const std::vector<std::filesystem::path> &paths) {
+    steam_input_snapshot_t result;
+    for (const auto &path : paths) {
+      std::ifstream file(path);
+      if (!file.is_open()) {
+        continue;
+      }
+
+      const std::string payload {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+      const auto profile = parse_steam_input_vdf(payload);
+      if (!profile.parsed) {
+        continue;
+      }
+      ++result.profiles_checked;
+      if (profile.xbox_support_enabled) {
+        ++result.profiles_with_xbox_support;
+      }
+      result.forced_app_count += profile.forced_app_count;
+    }
+
+    if (result.profiles_checked == 0) {
+      result.detail = "No readable Steam local profile was found.";
+    } else if (result.profiles_with_xbox_support > 0 && result.forced_app_count > 0) {
+      result.status = "xbox_opt_in_and_per_app_forced";
+      result.detail =
+        "Steam Input is opted in for Xbox controllers in " +
+        std::to_string(result.profiles_with_xbox_support) +
+        " local profile(s), and " +
+        std::to_string(result.forced_app_count) +
+        " app override(s) force Steam Input on.";
+    } else if (result.profiles_with_xbox_support > 0) {
+      result.status = "xbox_opt_in";
+      result.detail =
+        "Steam Input is opted in for Xbox controllers in " +
+        std::to_string(result.profiles_with_xbox_support) +
+        " local profile(s).";
+    } else if (result.forced_app_count > 0) {
+      result.status = "per_app_forced";
+      result.detail =
+        std::to_string(result.forced_app_count) +
+        " app override(s) force Steam Input on.";
+    } else {
+      result.status = "clear";
+      result.detail = "Steam Input is not opted in for Xbox controllers, and no app override forces it on.";
+    }
+
+    return result;
+  }
+
+  steam_input_snapshot_t steam_input_snapshot() {
+    static std::mutex guard;
+    static steam_input_snapshot_t cached;
+    static std::chrono::steady_clock::time_point read_at {};
+
+    const std::lock_guard<std::mutex> lock {guard};
+    const auto now = std::chrono::steady_clock::now();
+    if (read_at != std::chrono::steady_clock::time_point {} && now - read_at < std::chrono::seconds(30)) {
+      return cached;
+    }
+
+    cached = inspect_steam_input_configs(
+      steam_localconfig_paths(steam_data_roots(library_home_roots()))
+    );
+    read_at = now;
+    return cached;
+  }
+
   playtime_snapshot_t steam_playtime_snapshot() {
     static std::mutex guard;
     static playtime_snapshot_t cached;

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -113,6 +113,43 @@ namespace game_library {
   /** @brief Where Steam keeps its data, for each home directory we know about. */
   std::vector<std::filesystem::path> steam_data_roots(const std::vector<std::filesystem::path> &home_roots);
 
+  /**
+   * @brief Steam Input settings relevant to Polaris' emulated Xbox controller.
+   *
+   * App ids and profile paths deliberately do not leave the parser. Doctor only
+   * needs the aggregate conflict state, and diagnostics exports must not reveal
+   * which local account owns a profile or which games are installed.
+   */
+  struct steam_input_config_t {
+    bool parsed = false;
+    bool xbox_support_enabled = false;
+    int forced_app_count = 0;
+  };
+
+  /** @brief Read the relevant settings from one localconfig.vdf payload. */
+  steam_input_config_t parse_steam_input_vdf(std::string_view vdf_payload);
+
+  /**
+   * @brief PII-free aggregate of the Steam profiles Polaris could inspect.
+   */
+  struct steam_input_snapshot_t {
+    std::string status = "unknown";
+    int profiles_checked = 0;
+    int profiles_with_xbox_support = 0;
+    int forced_app_count = 0;
+    std::string detail;
+
+    bool conflict() const {
+      return profiles_with_xbox_support > 0 || forced_app_count > 0;
+    }
+  };
+
+  /** @brief Inspect an explicit set of profile files without caching. */
+  steam_input_snapshot_t inspect_steam_input_configs(const std::vector<std::filesystem::path> &paths);
+
+  /** @brief Inspect locally discovered Steam profiles, cached briefly. */
+  steam_input_snapshot_t steam_input_snapshot();
+
   /** @brief What the launcher files said, and when we last looked. */
   struct playtime_snapshot_t {
     std::map<std::string, playtime_t> by_app_id;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -96,6 +96,7 @@
 #include "browser_stream.h"
 #include "stream_stats.h"
 #include "game_classifier.h"
+#include "game_library_scanner.h"
 
 #define DEFAULT_APP_IMAGE_PATH POLARIS_ASSETS_DIR "/box.png"
 
@@ -7506,6 +7507,27 @@ namespace proc {
         stats.input_haptics_supported,
         stats.input_haptics_detail
       );
+
+      if (gamepad_isolation_plan.strict_applied() && context_uses_steam(_app)) {
+        const auto steam_input = game_library::steam_input_snapshot();
+        stream_stats::update_steam_input_state(
+          steam_input.status,
+          steam_input.profiles_checked,
+          steam_input.profiles_with_xbox_support,
+          steam_input.forced_app_count,
+          steam_input.detail
+        );
+      } else {
+        stream_stats::update_steam_input_state(
+          "not_applicable",
+          0,
+          0,
+          0,
+          gamepad_isolation_plan.strict_applied() ?
+            "The active launch does not use Steam." :
+            "Strict gamepad isolation is not active."
+        );
+      }
     };
 
     auto apply_gamepad_sdl_env = [&](auto &env) {

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -373,6 +373,11 @@ namespace stream_stats {
       {"virtual_controller_error", input_virtual_controller_error},
       {"host_controller_isolation", input_host_controller_isolation},
       {"host_controller_isolation_detail", input_host_controller_isolation_detail},
+      {"steam_input_status", input_steam_input_status},
+      {"steam_profiles_checked", input_steam_profiles_checked},
+      {"steam_profiles_with_xbox_support", input_steam_profiles_with_xbox_support},
+      {"steam_forced_app_count", input_steam_forced_app_count},
+      {"steam_input_detail", input_steam_input_detail},
       {"haptics_supported", input_haptics_supported},
       {"haptics_detail", input_haptics_detail}
     };
@@ -777,6 +782,10 @@ namespace stream_stats {
           next_step = "Relaunch with paired target";
           expected = "The next stream should start at the saved paired bitrate.";
         }
+      } else if (primary_issue == "steam_input_conflict") {
+        body = "Local Steam Input settings can claim the Polaris Xbox virtual controller while strict isolation prevents Steam from creating its replacement controller. Disable Steam Input for Xbox controllers in Steam Settings, and set any per-game Force On overrides to Default or Disable.";
+        next_step = "Adjust Steam Input";
+        expected = "Proton games should read the Polaris virtual controller directly without a per-game workaround.";
       } else if (primary_issue == "encoder_load") {
         body = "Trim bitrate, resolution, or FPS to give the active encoder more frame time.";
         next_step = "Lower stream load";
@@ -961,6 +970,15 @@ namespace stream_stats {
       stats.duplicate_frame_ratio >= 0.10 ||
       stats.dropped_frame_ratio >= 0.04 ||
       meaningful_fps_shortfall;
+    const bool strict_gamepad_isolation =
+      stats.input_host_controller_isolation == "strict_bwrap";
+    const bool steam_input_known =
+      stats.input_steam_input_status != "unknown" &&
+      stats.input_steam_input_status != "not_applicable";
+    const bool steam_input_conflict =
+      strict_gamepad_isolation &&
+      (stats.input_steam_profiles_with_xbox_support > 0 ||
+       stats.input_steam_forced_app_count > 0);
 
     std::string primary_issue = health.value("primary_issue", std::string {});
     if (primary_issue == "steady" || primary_issue == "none") primary_issue.clear();
@@ -973,6 +991,13 @@ namespace stream_stats {
       // bitrate reduction without current debounced network evidence. A live
       // debounced watch can request another check, never a quality change.
       primary_issue = network_watch ? "network_observation" : std::string {};
+    }
+    if (steam_input_conflict && !network_fail && !encoder_fail && !capture_latency_fail) {
+      // This is a deterministic host-state conflict, not an inference from a
+      // missing controller event. Keep critical live stream failures ahead of
+      // it, but do not let a generic pacing or capture watch hide why the
+      // controller is structurally dead inside the strict sandbox.
+      primary_issue = "steam_input_conflict";
     }
     if (primary_issue.empty()) {
       if (!stats.streaming) primary_issue = "no_active_stream";
@@ -1021,6 +1046,7 @@ namespace stream_stats {
       primary_issue == "network_jitter" ? "Sustained network pressure is affecting this stream." :
       primary_issue == "network_observation" ? "A network warning needs more live evidence before Doctor changes quality." :
       primary_issue == "quality_capped_by_history" ? "An older recovery profile is limiting quality even though the live network is stable." :
+      primary_issue == "steam_input_conflict" ? "Local Steam Input settings conflict with strict gamepad isolation for the Polaris Xbox virtual controller." :
       primary_issue == "encoder_load" ? "Encoder load is above the low-latency budget." :
       primary_issue == "frame_pacing" ? "Frame pacing telemetry needs attention." :
       health.contains("summary") && !suppressed_stale_network_finding ? health.value("summary", std::string {}) :
@@ -1048,19 +1074,46 @@ namespace stream_stats {
     append_doctor_evidence(evidence, "paired_bitrate_target", "Paired quality target", stats.paired_target_bitrate_kbps, "kbps", quality_capped_by_history ? "watch" : stats.paired_target_bitrate_kbps > 0 ? "pass" : "unknown", "session_profile", quality_capped_by_history ? "A history-safe recovery layer is keeping the live bitrate below the paired target." : "Saved bitrate preference for the active paired client.");
     append_doctor_evidence(evidence, "target_fps_gap", "Target FPS gap", target_fps_gap, "FPS", meaningful_fps_shortfall ? "watch" : "pass", "stream_stats", "Encoded FPS below the requested cadence is a source or compositor pacing gap, not network jitter by itself.");
     append_doctor_evidence(evidence, "frame_pacing", "Mean target interval error", stats.frame_jitter_ms, "ms", pacing_watch ? "watch" : "pass", "stream_stats", "Mean absolute distance between actual source-frame intervals and the requested interval; this is not statistical network jitter.");
+    append_doctor_evidence(
+      evidence,
+      "steam_input_compatibility",
+      "Steam Input compatibility",
+      stats.input_steam_input_status,
+      "",
+      steam_input_conflict ? "fail" : strict_gamepad_isolation && steam_input_known ? "pass" : "unknown",
+      "local_steam_config",
+      stats.input_steam_input_detail.empty() ?
+        (strict_gamepad_isolation ? "Steam Input compatibility has not been inspected yet." : "Strict gamepad isolation is not active.") :
+        stats.input_steam_input_detail
+    );
 
     auto advanced = nlohmann::json::object();
     advanced["stream_stats_keys"] = nlohmann::json::array({"capture_path", "capture_path_reason", "capture_transport", "capture_residency", "capture_format", "capture_cpu_copy", "capture_gpu_native", "capture_cross_gpu_dmabuf_risk", "encode_target_device", "encode_target_residency", "fps", "encode_time_ms", "packet_loss", "frame_interval_error_ms", "frame_jitter_ms"});
     advanced["linux_gpu_profile"] = linux_gpu_profile_json(stats);
     advanced["gpu_native_probe"] = gpu_native_probe_json(stats);
+    advanced["controller_input"] = {
+      {"host_controller_isolation", stats.input_host_controller_isolation},
+      {"steam_input_status", stats.input_steam_input_status},
+      {"steam_profiles_checked", stats.input_steam_profiles_checked},
+      {"steam_profiles_with_xbox_support", stats.input_steam_profiles_with_xbox_support},
+      {"steam_forced_app_count", stats.input_steam_forced_app_count},
+      {"steam_input_detail", stats.input_steam_input_detail}
+    };
     advanced["health"] = health;
     advanced["recent_issue_codes"] = nlohmann::json::array();
+    if (steam_input_conflict) {
+      advanced["recent_issue_codes"].push_back("steam_input_conflict");
+    }
     advanced["raw_fields_redacted"] = true;
 
     double confidence_score = 0.35;
     std::string confidence_level = "low";
     std::string basis = "insufficient_data";
-    if (primary_issue == "quality_capped_by_history") {
+    if (primary_issue == "steam_input_conflict") {
+      confidence_score = 0.98;
+      confidence_level = "high";
+      basis = "local_steam_config_and_isolation_plan";
+    } else if (primary_issue == "quality_capped_by_history") {
       confidence_score = 0.96;
       confidence_level = "high";
       basis = "session_policy_and_live_telemetry";
@@ -1449,6 +1502,19 @@ namespace stream_stats {
     current_stats.input_host_controller_isolation_detail = host_controller_isolation_detail;
     current_stats.input_haptics_supported = haptics_supported;
     current_stats.input_haptics_detail = haptics_detail;
+  }
+
+  void update_steam_input_state(const std::string &status,
+                                int profiles_checked,
+                                int profiles_with_xbox_support,
+                                int forced_app_count,
+                                const std::string &detail) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.input_steam_input_status = status.empty() ? "unknown" : status;
+    current_stats.input_steam_profiles_checked = std::max(0, profiles_checked);
+    current_stats.input_steam_profiles_with_xbox_support = std::max(0, profiles_with_xbox_support);
+    current_stats.input_steam_forced_app_count = std::max(0, forced_app_count);
+    current_stats.input_steam_input_detail = detail;
   }
 
   void update_capture_profile(const capture_profile_sample_t &sample) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -157,6 +157,11 @@ namespace stream_stats {
     std::string input_virtual_controller_error;
     std::string input_host_controller_isolation = "unknown";
     std::string input_host_controller_isolation_detail;
+    std::string input_steam_input_status = "unknown";
+    int input_steam_profiles_checked = 0;
+    int input_steam_profiles_with_xbox_support = 0;
+    int input_steam_forced_app_count = 0;
+    std::string input_steam_input_detail;
     bool input_haptics_supported = false;
     std::string input_haptics_detail;
 
@@ -517,6 +522,15 @@ namespace stream_stats {
                                      const std::string &host_controller_isolation_detail,
                                      bool haptics_supported,
                                      const std::string &haptics_detail);
+
+  /**
+   * @brief Update the PII-free Steam Input compatibility snapshot for Doctor.
+   */
+  void update_steam_input_state(const std::string &status,
+                                int profiles_checked,
+                                int profiles_with_xbox_support,
+                                int forced_app_count,
+                                const std::string &detail);
 
   /**
    * @brief Record a single capture timing sample into the shared telemetry sink.

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -292,6 +292,110 @@ TEST(SteamPlaytimeTests, FindsLocalconfigForEveryUserUnderARoot) {
   EXPECT_EQ(found.front(), user / "localconfig.vdf");
 }
 
+TEST(SteamInputTests, ReadsXboxOptInAndOnlyCountsForcedApps) {
+  constexpr const char *config = R"vdf(
+"UserLocalConfigStore"
+{
+  "system"
+  {
+    "SteamController_XBoxSupport"  "1"
+  }
+  "Software"
+  {
+    "Valve"
+    {
+      "Steam"
+      {
+        "apps"
+        {
+          "111"
+          {
+            "UseSteamControllerConfig"  "2"
+          }
+          "222"
+          {
+            "UseSteamControllerConfig"  "0"
+          }
+        }
+        "somethingelse"
+        {
+          "333"
+          {
+            "UseSteamControllerConfig"  "2"
+          }
+        }
+      }
+    }
+  }
+}
+)vdf";
+
+  const auto parsed = game_library::parse_steam_input_vdf(config);
+  EXPECT_TRUE(parsed.parsed);
+  EXPECT_TRUE(parsed.xbox_support_enabled);
+  EXPECT_EQ(parsed.forced_app_count, 1);
+}
+
+TEST(SteamInputTests, LastSettingWinsAndMalformedInputStaysUnknown) {
+  constexpr const char *config = R"vdf(
+"SteamController_XBoxSupport"  "1"
+"SteamController_XBoxSupport"  "0"
+"apps"
+{
+  "444"
+  {
+    "UseSteamControllerConfig"  "2"
+    "UseSteamControllerConfig"  "1"
+  }
+}
+)vdf";
+
+  const auto parsed = game_library::parse_steam_input_vdf(config);
+  EXPECT_TRUE(parsed.parsed);
+  EXPECT_FALSE(parsed.xbox_support_enabled);
+  EXPECT_EQ(parsed.forced_app_count, 0);
+
+  const auto malformed = game_library::parse_steam_input_vdf("not a vdf payload");
+  EXPECT_FALSE(malformed.parsed);
+  EXPECT_FALSE(malformed.xbox_support_enabled);
+  EXPECT_EQ(malformed.forced_app_count, 0);
+}
+
+TEST(SteamInputTests, AggregatesProfilesWithoutLeakingPathsOrAppIds) {
+  const auto root = lutris_test_root("steam_input_profiles");
+  const auto first = root / "profile-a.vdf";
+  const auto second = root / "profile-b.vdf";
+  write_text(first,
+    "\"SteamController_XBoxSupport\"  \"1\"\n"
+    "\"apps\"\n"
+    "{\n"
+    "  \"555\"\n"
+    "  {\n"
+    "    \"UseSteamControllerConfig\"  \"2\"\n"
+    "  }\n"
+    "}\n");
+  write_text(second, "\"SteamController_XBoxSupport\"  \"0\"\n");
+
+  const auto snapshot = game_library::inspect_steam_input_configs({first, second});
+  EXPECT_EQ(snapshot.status, "xbox_opt_in_and_per_app_forced");
+  EXPECT_EQ(snapshot.profiles_checked, 2);
+  EXPECT_EQ(snapshot.profiles_with_xbox_support, 1);
+  EXPECT_EQ(snapshot.forced_app_count, 1);
+  EXPECT_TRUE(snapshot.conflict());
+  EXPECT_EQ(snapshot.detail.find(root.string()), std::string::npos);
+  EXPECT_EQ(snapshot.detail.find("555"), std::string::npos);
+}
+
+TEST(SteamInputTests, ReportsUnknownWhenNoProfileIsReadable) {
+  const auto snapshot = game_library::inspect_steam_input_configs({
+    lutris_test_root("steam_input_missing") / "missing.vdf"
+  });
+
+  EXPECT_EQ(snapshot.status, "unknown");
+  EXPECT_EQ(snapshot.profiles_checked, 0);
+  EXPECT_FALSE(snapshot.conflict());
+}
+
 TEST(LutrisLibraryScannerTests, CarriesPlaytimeSecondsFromTheListingJson) {
   const auto games = game_library::parse_lutris_list_games_json(
     R"json([{"name":"3DMark","slug":"3dmark","runner":"steam","playtimeSeconds":73.152428}])json");

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -278,6 +278,11 @@ TEST(StreamStatsControllerInputTests, SerializesNativeControllerDiagnostics) {
   stats.input_virtual_controller_error = "";
   stats.input_host_controller_isolation = "strict_bwrap";
   stats.input_host_controller_isolation_detail = "2 virtual nodes allowed; host pads masked";
+  stats.input_steam_input_status = "xbox_opt_in";
+  stats.input_steam_profiles_checked = 2;
+  stats.input_steam_profiles_with_xbox_support = 1;
+  stats.input_steam_forced_app_count = 0;
+  stats.input_steam_input_detail = "Steam Input is opted in for Xbox controllers in 1 local profile(s).";
   stats.input_haptics_supported = true;
   stats.input_haptics_detail = "rumble callbacks registered for client pad 2";
 
@@ -290,6 +295,11 @@ TEST(StreamStatsControllerInputTests, SerializesNativeControllerDiagnostics) {
   EXPECT_EQ(input.at("virtual_controller_kind"), "xone");
   EXPECT_EQ(input.at("host_controller_isolation"), "strict_bwrap");
   EXPECT_EQ(input.at("host_controller_isolation_detail"), "2 virtual nodes allowed; host pads masked");
+  EXPECT_EQ(input.at("steam_input_status"), "xbox_opt_in");
+  EXPECT_EQ(input.at("steam_profiles_checked"), 2);
+  EXPECT_EQ(input.at("steam_profiles_with_xbox_support"), 1);
+  EXPECT_EQ(input.at("steam_forced_app_count"), 0);
+  EXPECT_EQ(input.at("steam_input_detail"), "Steam Input is opted in for Xbox controllers in 1 local profile(s).");
   EXPECT_TRUE(input.at("haptics_supported"));
   EXPECT_EQ(input.at("haptics_detail"), "rumble callbacks registered for client pad 2");
 }
@@ -627,6 +637,76 @@ TEST(StreamStatsDoctorTests, ClassifiesGpuNativeStreamAsReady) {
   EXPECT_EQ(doctor.at("primary_issue"), "none");
   EXPECT_EQ(doctor.at("safe_recovery_action").at("id"), "none");
   EXPECT_FALSE(doctor.at("safe_recovery_action").at("destructive"));
+}
+
+TEST(StreamStatsDoctorTests, WarnsWhenSteamInputConflictsWithStrictIsolation) {
+  stream_stats::stats_t stats {};
+  stats.streaming = true;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+  stats.encode_time_ms = 4.0;
+  stats.input_host_controller_isolation = "strict_bwrap";
+  stats.input_steam_input_status = "xbox_opt_in_and_per_app_forced";
+  stats.input_steam_profiles_checked = 2;
+  stats.input_steam_profiles_with_xbox_support = 1;
+  stats.input_steam_forced_app_count = 2;
+  stats.input_steam_input_detail =
+    "Steam Input is opted in for Xbox controllers in 1 local profile(s), and 2 app override(s) force Steam Input on.";
+
+  const auto doctor = stream_stats::build_doctor_json(
+    stats,
+    {{"primary_issue", "steady"}, {"grade", "good"}}
+  );
+
+  EXPECT_EQ(doctor.at("primary_issue"), "steam_input_conflict");
+  EXPECT_EQ(doctor.at("traffic_light"), "amber");
+  EXPECT_EQ(doctor.at("status"), "needs_action");
+  EXPECT_EQ(doctor.at("confidence").at("level"), "high");
+  EXPECT_EQ(doctor.at("recommendation").at("next_step_label"), "Adjust Steam Input");
+  EXPECT_EQ(doctor.at("safe_recovery_action").at("id"), "none");
+  EXPECT_FALSE(doctor.at("safe_recovery_action").at("destructive"));
+  EXPECT_EQ(
+    doctor.at("advanced_evidence").at("controller_input").at("steam_forced_app_count"),
+    2
+  );
+  ASSERT_EQ(doctor.at("advanced_evidence").at("recent_issue_codes").size(), 1);
+  EXPECT_EQ(
+    doctor.at("advanced_evidence").at("recent_issue_codes").at(0),
+    "steam_input_conflict"
+  );
+
+  bool saw_conflict = false;
+  for (const auto &item : doctor.at("evidence")) {
+    if (item.at("id") == "steam_input_compatibility") {
+      saw_conflict = true;
+      EXPECT_EQ(item.at("status"), "fail");
+      EXPECT_EQ(item.at("source"), "local_steam_config");
+      EXPECT_EQ(item.at("value"), "xbox_opt_in_and_per_app_forced");
+    }
+  }
+  EXPECT_TRUE(saw_conflict);
+}
+
+TEST(StreamStatsDoctorTests, IgnoresSteamInputSettingsWithoutStrictIsolation) {
+  stream_stats::stats_t stats {};
+  stats.streaming = true;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+  stats.encode_time_ms = 4.0;
+  stats.input_host_controller_isolation = "disabled";
+  stats.input_steam_input_status = "xbox_opt_in";
+  stats.input_steam_profiles_checked = 1;
+  stats.input_steam_profiles_with_xbox_support = 1;
+
+  const auto doctor = stream_stats::build_doctor_json(
+    stats,
+    {{"primary_issue", "steady"}, {"grade", "good"}}
+  );
+
+  EXPECT_EQ(doctor.at("primary_issue"), "none");
+  EXPECT_EQ(doctor.at("traffic_light"), "green");
 }
 
 TEST(StreamStatsDoctorTests, KeepsNearTargetHighRefreshPacingGreen) {


### PR DESCRIPTION
## Summary

- inspect local Steam profiles only when strict gamepad isolation is prepared for a Steam launch
- detect the host-wide Xbox Steam Input opt-in and per-app Force On overrides
- expose only aggregate status and counts in controller diagnostics and Doctor
- surface a high-confidence `steam_input_conflict` finding with read-only recovery guidance
- document the Proton failure mode and the host-wide/per-game Steam settings

## Verification

- focused Steam parser coverage: 4/4 passed
- focused controller serialization and Doctor coverage: 3/3 passed
- `test_polaris`: 357/357 passed
- `test_polaris_stream`: 237/237 passed
- `bash scripts/check-public-docs.sh`
- `git diff --check`

## Privacy and scope

- diagnostics do not expose Steam account ids, app ids, profile filenames, or filesystem paths
- no raw host logs, usernames, email addresses, IP addresses, credentials, or private paths are included
- the added-line and committed-diff PII scans are clean
- this is a read-only Doctor check; it does not edit Steam configuration or add a one-click action
- draft only; no merge, release, deploy, review request, Nova change, or physical acceptance is included

Refs #503.
