### PR TITLE
Separate control loss from media network pressure

### DIFF
--- a/src/ai_optimizer.cpp
+++ b/src/ai_optimizer.cpp
@@ -523,6 +523,14 @@ namespace ai_optimizer {
     return value;
   }
 
+  static bool is_legacy_host_control_loss(const session_history_t &session) {
+    return session.last_packet_loss_source.empty() &&
+      normalize_end_reason(session.last_end_reason) == "host_pause" &&
+      session.last_duration_s == 0 &&
+      session.last_sample_count == 0 &&
+      (session.last_packet_loss_pct > 0.0 || session.packet_loss_pct > 0.0);
+  }
+
   session_history_t sanitize_session_history(session_history_t session) {
     session.session_count = sanitize_session_count(session);
     session.poor_outcome_count =
@@ -532,6 +540,34 @@ namespace ai_optimizer {
         session.consecutive_poor_outcomes,
         session.poor_outcome_count
       );
+
+    if (is_legacy_host_control_loss(session)) {
+      // Pre-provenance host-pause snapshots copied ENet's reliable control
+      // channel EWMA into the media-loss field. It cannot grade video quality.
+      session.last_packet_loss_source = "legacy_control_channel";
+      session.last_packet_loss_pct = 0.0;
+      session.packet_loss_pct = 0.0;
+
+      const bool latency_confirms_network =
+        session.last_latency_ms >= stream_stats::network_risk_tracker_t::k_rtt_elevated_ms;
+      if (!latency_confirms_network) {
+        std::erase(session.last_issues, "network_jitter");
+        session.last_network_risk = "normal";
+        if (session.last_primary_issue == "network_jitter") {
+          session.last_primary_issue = session.last_issues.empty() ? "steady" : session.last_issues.front();
+        }
+        if (session.last_issues.empty()) {
+          session.last_health_grade = "good";
+          session.last_safe_bitrate_kbps = 0;
+        } else if (session.last_issues.size() == 1 &&
+                   to_lower_copy(session.last_health_grade) == "degraded") {
+          session.last_health_grade = "watch";
+        }
+      }
+
+      session.last_quality_grade = grade_session_quality(session);
+      session.quality_grade = session.last_quality_grade;
+    }
 
     if (session.last_safe_target_fps < 0.0 ||
         session.last_safe_target_fps > 240.0 ||
@@ -590,7 +626,14 @@ namespace ai_optimizer {
       before.last_relaunch_recommended != after.last_relaunch_recommended ||
       before.last_health_grade != after.last_health_grade ||
       before.last_primary_issue != after.last_primary_issue ||
-      before.last_issues != after.last_issues;
+      before.last_issues != after.last_issues ||
+      before.packet_loss_pct != after.packet_loss_pct ||
+      before.last_packet_loss_pct != after.last_packet_loss_pct ||
+      before.last_packet_loss_source != after.last_packet_loss_source ||
+      before.quality_grade != after.quality_grade ||
+      before.last_quality_grade != after.last_quality_grade ||
+      before.last_network_risk != after.last_network_risk ||
+      before.last_safe_bitrate_kbps != after.last_safe_bitrate_kbps;
   }
 
   static bool is_control_shell_app(const std::string &app_name) {
@@ -1124,6 +1167,7 @@ namespace ai_optimizer {
     merged.last_latency_ms = latest.last_latency_ms;
     merged.last_bitrate_kbps = latest.last_bitrate_kbps;
     merged.last_packet_loss_pct = latest.last_packet_loss_pct;
+    merged.last_packet_loss_source = latest.last_packet_loss_source;
     merged.last_quality_grade = latest.last_quality_grade;
     merged.last_codec = latest.last_codec;
     merged.last_duration_s = latest.last_duration_s;
@@ -1684,7 +1728,8 @@ namespace ai_optimizer {
                        << "%, latency " << static_cast<int>(std::round(prompt_history.last_latency_ms))
                        << "ms, bitrate " << prompt_history.last_bitrate_kbps
                        << "kbps, packet loss " << prompt_history.last_packet_loss_pct
-                       << "%, grade " << latest_quality_grade(prompt_history)
+                       << "% (source " << (prompt_history.last_packet_loss_source.empty() ? "unknown" : prompt_history.last_packet_loss_source) << ")"
+                       << ", grade " << latest_quality_grade(prompt_history)
                        << ", codec " << latest_codec(prompt_history) << "\n";
       }
       history_stream << "  Rolling history: " << prompt_history.session_count
@@ -2622,7 +2667,10 @@ namespace ai_optimizer {
         )
       );
 
+    const bool legacy_control_only =
+      session.last_packet_loss_source == "legacy_control_channel";
     const bool reuse_recent_success =
+      !legacy_control_only &&
       (latest_grade == "A" || latest_grade == "B") &&
       (session.last_bitrate_kbps > 0 || !session.last_codec.empty());
 
@@ -3164,6 +3212,7 @@ namespace ai_optimizer {
         h.last_latency_ms = val.value("last_latency_ms", h.avg_latency_ms);
         h.last_bitrate_kbps = val.value("last_bitrate_kbps", h.avg_bitrate_kbps);
         h.last_packet_loss_pct = val.value("last_packet_loss_pct", h.packet_loss_pct);
+        h.last_packet_loss_source = val.value("last_packet_loss_source", "");
         h.last_quality_grade = val.value("last_quality_grade", h.quality_grade);
         h.last_codec = val.value("last_codec", h.codec);
         h.last_duration_s = val.value("last_duration_s", 0);
@@ -3237,6 +3286,7 @@ namespace ai_optimizer {
         {"last_latency_ms", h.last_latency_ms},
         {"last_bitrate_kbps", h.last_bitrate_kbps},
         {"last_packet_loss_pct", h.last_packet_loss_pct},
+        {"last_packet_loss_source", h.last_packet_loss_source},
         {"last_quality_grade", h.last_quality_grade},
         {"last_codec", h.last_codec},
         {"last_duration_s", h.last_duration_s},
@@ -3345,6 +3395,7 @@ namespace ai_optimizer {
       existing.last_latency_ms = normalized_session.last_latency_ms;
       existing.last_bitrate_kbps = normalized_session.last_bitrate_kbps;
       existing.last_packet_loss_pct = normalized_session.last_packet_loss_pct;
+      existing.last_packet_loss_source = normalized_session.last_packet_loss_source;
       existing.last_quality_grade = normalized_session.last_quality_grade;
       existing.last_codec = normalized_session.last_codec;
       existing.last_duration_s = normalized_session.last_duration_s;
@@ -3542,6 +3593,7 @@ namespace ai_optimizer {
       entry["last_latency_ms"] = h.last_latency_ms;
       entry["last_bitrate_kbps"] = h.last_bitrate_kbps;
       entry["last_packet_loss_pct"] = h.last_packet_loss_pct;
+      entry["last_packet_loss_source"] = h.last_packet_loss_source;
       entry["last_quality_grade"] = h.last_quality_grade;
       entry["last_codec"] = h.last_codec;
       entry["last_duration_s"] = h.last_duration_s;

--- a/src/ai_optimizer.h
+++ b/src/ai_optimizer.h
@@ -105,6 +105,8 @@ namespace ai_optimizer {
     double last_latency_ms = 0;
     int last_bitrate_kbps = 0;
     double last_packet_loss_pct = 0;
+    /// client_media_transport, media_transport, unavailable, or legacy_control_channel.
+    std::string last_packet_loss_source;
     std::string last_quality_grade;
     std::string last_codec;
     int last_duration_s = 0;

--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -69,6 +69,9 @@ namespace doctor_actions {
         {"streaming", stats.streaming},
         {"network_risk", stats.network_risk},
         {"packet_loss_pct", stats.packet_loss},
+        {"packet_loss_available", stats.packet_loss_available},
+        {"packet_loss_source", stats.packet_loss_source},
+        {"control_channel_packet_loss_pct", stats.control_channel_packet_loss},
         {"latency_ms", stats.latency_ms},
         {"bitrate_kbps", current_live_bitrate(stats)},
         {"paired_target_bitrate_kbps", stats.paired_target_bitrate_kbps},
@@ -172,7 +175,7 @@ namespace doctor_actions {
 
   bool network_pressure_confirmed(const stream_stats::stats_t &stats) {
     return stats.streaming && stats.network_risk &&
-      (stats.packet_loss > 2.0 || stats.latency_ms >= 45.0);
+      ((stats.packet_loss_available && stats.packet_loss > 2.0) || stats.latency_ms >= 45.0);
   }
 
   int guarded_bitrate_target(int current_bitrate_kbps,

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2618,6 +2618,9 @@ namespace nvhttp {
       health["hdr_risk"] = hdr_risk ? "elevated" : "normal";
       health["hdr_source"] = hdr_source_missing ? "missing" : (stats.stream_hdr_enabled ? "metadata" : "sdr");
       health["network_risk"] = network_risk ? "elevated" : "normal";
+      health["packet_loss_available"] = stats.packet_loss_available;
+      health["packet_loss_source"] = stats.packet_loss_source;
+      health["control_channel_packet_loss_pct"] = stats.control_channel_packet_loss;
       health["host_render_limited"] = host_render_limited;
       if (auto_action != "none" || host_render_limited) {
         health["recovery_profile"] = primary_issue;
@@ -8486,6 +8489,9 @@ namespace nvhttp {
           session.last_latency_ms = avg_latency;
           session.last_bitrate_kbps = avg_bitrate;
           session.last_packet_loss_pct = packet_loss;
+          // Nova derives this value from Moonlight's client media/performance
+          // counters, independently of Polaris's ENet control channel.
+          session.last_packet_loss_source = "client_media_transport";
           session.last_codec = codec;
           session.last_duration_s = duration_s;
           session.last_sample_count = samples;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3460,14 +3460,15 @@ namespace proc {
       const double effective_target = target_fps > 0.0 ? target_fps : session_grading_target_fps(stats);
       const double fps_ratio =
         (effective_target > 0.0 && stats.fps > 0.0) ? std::clamp(stats.fps / effective_target, 0.0, 1.5) : 1.0;
+      const double media_packet_loss = stats.packet_loss_available ? stats.packet_loss : 0.0;
 
-      if (fps_ratio >= 0.95 && stats.packet_loss < 0.5 && stats.latency_ms < 20) {
+      if (fps_ratio >= 0.95 && media_packet_loss < 0.5 && stats.latency_ms < 20) {
         return "A";
       }
-      if (fps_ratio >= 0.85 && stats.packet_loss < 2.0 && stats.latency_ms < 40) {
+      if (fps_ratio >= 0.85 && media_packet_loss < 2.0 && stats.latency_ms < 40) {
         return "B";
       }
-      if (fps_ratio >= 0.70 && stats.packet_loss < 5.0) {
+      if (fps_ratio >= 0.70 && media_packet_loss < 5.0) {
         return "C";
       }
       if (fps_ratio >= 0.50) {
@@ -8123,12 +8124,13 @@ namespace proc {
         session.avg_fps = stats.fps;
         session.avg_latency_ms = stats.latency_ms;
         session.avg_bitrate_kbps = stats.bitrate_kbps;
-        session.packet_loss_pct = stats.packet_loss;
+        session.packet_loss_pct = stats.packet_loss_available ? stats.packet_loss : 0.0;
         session.last_fps = stats.fps;
         session.last_target_fps = session_grading_target_fps(stats);
         session.last_latency_ms = stats.latency_ms;
         session.last_bitrate_kbps = stats.bitrate_kbps;
-        session.last_packet_loss_pct = stats.packet_loss;
+        session.last_packet_loss_pct = session.packet_loss_pct;
+        session.last_packet_loss_source = stats.packet_loss_available ? stats.packet_loss_source : "unavailable";
         session.last_codec = stats.codec;
         session.last_end_reason = "host_pause";
         session.session_count = 1;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1068,12 +1068,12 @@ namespace stream {
 
   void record_network_stats(const std::string &client_ip,
                             double latency_ms,
-                            double packet_loss,
+                            double control_packet_loss,
                             std::uint64_t bytes_sent) {
     if (client_ip.empty()) {
-      stream_stats::update_network_stats(latency_ms, packet_loss, bytes_sent);
+      stream_stats::update_control_channel_stats(latency_ms, control_packet_loss, bytes_sent);
     } else {
-      stream_stats::update_network_stats(client_ip, latency_ms, packet_loss, bytes_sent);
+      stream_stats::update_control_channel_stats(client_ip, latency_ms, control_packet_loss, bytes_sent);
     }
   }
 
@@ -1081,9 +1081,8 @@ namespace stream {
     server->map(packetTypes[IDX_PERIODIC_PING], [](session_t *session, const std::string_view &payload) {
       BOOST_LOG(verbose) << "type [IDX_PERIODIC_PING]"sv;
 
-      // Clients on the periodic-ping protocol path never send IDX_LOSS_STATS, so this
-      // is the only packet their sessions can source network health from. ENet already
-      // maintains a smoothed mean RTT and reliable-packet loss ratio on the peer.
+      // ENet maintains RTT and a loss EWMA for its reliable, low-rate control
+      // channel. RTT is shared-path evidence; the loss EWMA is not video loss.
       if (!session->control.peer) {
         return;
       }
@@ -1094,7 +1093,7 @@ namespace stream {
         ENET_PEER_PACKET_LOSS_SCALE);
 
       if (adaptive_bitrate::is_enabled()) {
-        adaptive_bitrate::update_network_stats(loss_pct, rtt_ms);
+        adaptive_bitrate::update_network_stats(0.0, rtt_ms);
       }
 
       const auto client_ip = platf::from_sockaddr((sockaddr *) &session->control.peer->address.address);
@@ -1124,12 +1123,6 @@ namespace stream {
         << "last good frame [" << lastGoodFrame << ']' << std::endl
         << "---end stats---";
 
-      double loss_pct = 0.0;
-      if (t.count() > 0) {
-        double estimated_total_packets = t.count();
-        loss_pct = std::clamp(count * 100.0 / estimated_total_packets, 0.0, 100.0);
-      }
-
       double rtt_ms = 0.0;
       std::string client_ip;
       if (session->control.peer) {
@@ -1138,10 +1131,13 @@ namespace stream {
       }
 
       if (adaptive_bitrate::is_enabled() && t.count() > 0) {
-        adaptive_bitrate::update_network_stats(loss_pct, rtt_ms);
+        adaptive_bitrate::update_network_stats(0.0, rtt_ms);
       }
 
-      record_network_stats(client_ip, rtt_ms, loss_pct, 0);
+      // IDX_LOSS_STATS reports a lost-packet count and elapsed milliseconds,
+      // not a total-packet denominator. Dividing count by time manufactured a
+      // percentage, so retain RTT and wait for quantified media telemetry.
+      record_network_stats(client_ip, rtt_ms, 0.0, 0);
     });
 
     server->map(packetTypes[IDX_REQUEST_IDR_FRAME], [&](session_t *session, const std::string_view &payload) {

--- a/src/stream.h
+++ b/src/stream.h
@@ -30,12 +30,12 @@ namespace stream {
    *
    * A report with a client address updates that client's mirror and the
    * top-level fields when it is the primary client. An address-less report
-   * updates only the top-level fields. In either case, the network-risk
-   * debounce consumes the report exactly once.
+   * updates only the top-level fields. RTT feeds network risk; the ENet loss
+   * EWMA remains diagnostic-only control-channel context.
    */
   void record_network_stats(const std::string &client_ip,
                             double latency_ms,
-                            double packet_loss,
+                            double control_packet_loss,
                             std::uint64_t bytes_sent);
 
   struct session_profile_t {

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -75,6 +75,9 @@ namespace stream_stats {
     std::atomic<double> hot_capture_source_fps {0.0};
     std::atomic<double> hot_latency_ms {0.0};
     std::atomic<double> hot_packet_loss {0.0};
+    std::atomic<bool> hot_packet_loss_available {false};
+    std::atomic<double> hot_control_channel_packet_loss {0.0};
+    std::atomic<uint64_t> hot_control_channel_samples {0};
     std::atomic<bool> hot_network_risk {false};
     std::atomic<uint64_t> hot_bytes_sent {0};
 
@@ -122,6 +125,9 @@ namespace stream_stats {
       hot_capture_source_fps.store(0.0, std::memory_order_relaxed);
       hot_latency_ms.store(0.0, std::memory_order_relaxed);
       hot_packet_loss.store(0.0, std::memory_order_relaxed);
+      hot_packet_loss_available.store(false, std::memory_order_relaxed);
+      hot_control_channel_packet_loss.store(0.0, std::memory_order_relaxed);
+      hot_control_channel_samples.store(0, std::memory_order_relaxed);
       {
         std::lock_guard<std::mutex> risk_lock(network_risk_mutex);
         network_risk_tracker.reset();
@@ -357,6 +363,10 @@ namespace stream_stats {
     j["height"] = height;
     j["latency_ms"] = latency_ms;
     j["packet_loss"] = packet_loss;
+    j["packet_loss_available"] = packet_loss_available;
+    j["packet_loss_source"] = packet_loss_source;
+    j["control_channel_packet_loss"] = control_channel_packet_loss;
+    j["control_channel_samples"] = control_channel_samples;
     j["bytes_sent"] = bytes_sent;
     j["gpu_usage"] = gpu_usage;
     j["adaptive_target_bitrate_kbps"] = adaptive_target_bitrate_kbps;
@@ -396,6 +406,9 @@ namespace stream_stats {
       cj["height"] = c.height;
       cj["latency_ms"] = c.latency_ms;
       cj["packet_loss"] = c.packet_loss;
+      cj["packet_loss_available"] = c.packet_loss_available;
+      cj["packet_loss_source"] = c.packet_loss_source;
+      cj["control_channel_packet_loss"] = c.control_channel_packet_loss;
       cj["bytes_sent"] = c.bytes_sent;
       cj["adaptive_target_bitrate_kbps"] = c.adaptive_target_bitrate_kbps;
       clients_json.push_back(cj);
@@ -772,6 +785,11 @@ namespace stream_stats {
         body = "Doctor sees a debounced network warning, but current loss and latency do not justify reducing quality. Recheck the live path before changing bitrate.";
         next_step = "Recheck network";
         expected = "Doctor will either clear the warning or gather direct evidence before offering a bitrate change.";
+      } else if (primary_issue == "control_channel_observation") {
+        title = "Keep monitoring";
+        body = "The reliable control channel retried packets, but Polaris has no confirmed video-loss evidence and RTT remains stable. Do not lower quality from this observation alone.";
+        next_step = "Keep monitoring";
+        expected = "Visible media loss or sustained RTT pressure must appear before Doctor recommends a network recovery action.";
       } else if (primary_issue == "quality_capped_by_history") {
         if (live_bitrate_tunable) {
           body = "The current network is clean, but an older recovery profile is holding bitrate below this paired device's saved target. Doctor can retry quality gradually and verify every step.";
@@ -960,13 +978,16 @@ namespace stream_stats {
     const double target_fps = doctor_target_fps(stats);
     const double target_fps_gap = std::max(0.0, target_fps - stats.fps);
     const bool meaningful_fps_shortfall = is_meaningful_fps_shortfall(target_fps, stats.fps);
-    // The network verdict consumes the debounced flag the session status
-    // serves (network_risk_tracker_t). The raw one-sample cuts this replaced
-    // re-created the exact hair-trigger the tracker exists to prevent — the
-    // old 0.5% watch threshold sat below the control channel's steady EWMA
-    // noise, so Doctor said "network jitter" over perfect streams.
-    const bool network_fail = stats.network_risk && (stats.packet_loss > 2.0 || stats.latency_ms >= 45.0);
+    // Packet-loss actions require an explicitly confirmed media source. ENet's
+    // peer->packetLoss is a reliable control-channel EWMA: useful context, but
+    // not a measurement of video packets dropped at the client.
+    const bool confirmed_media_loss = stats.packet_loss_available && stats.packet_loss > 2.0;
+    const bool network_fail = stats.network_risk && (confirmed_media_loss || stats.latency_ms >= 45.0);
     const bool network_watch = stats.network_risk && !network_fail;
+    const bool control_channel_observation =
+      stats.streaming &&
+      stats.control_channel_samples > 0 &&
+      stats.control_channel_packet_loss >= network_risk_tracker_t::k_loss_elevated_pct;
     const int live_bitrate_kbps = stats.adaptive_runtime_update_supported && stats.adaptive_target_bitrate_kbps > 0 ?
       stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps;
     const bool history_safe_source = stats.optimization_source.find("history_safe") != std::string::npos;
@@ -1034,6 +1055,7 @@ namespace stream_stats {
       else if (!capture_known) primary_issue = "capture_missing";
       else if (pacing_watch) primary_issue = "frame_pacing";
       else if (quality_capped_by_history) primary_issue = "quality_capped_by_history";
+      else if (control_channel_observation) primary_issue = "control_channel_observation";
       else primary_issue = "none";
     }
 
@@ -1053,7 +1075,8 @@ namespace stream_stats {
       status = "needs_action";
       severity = "critical";
       simple_state = "Needs attention";
-    } else if (primary_issue != "none" || (honor_health_grade && health_grade == "watch") || capture_cpu_copy || pacing_watch) {
+    } else if ((primary_issue != "none" && primary_issue != "control_channel_observation") ||
+               (honor_health_grade && health_grade == "watch") || capture_cpu_copy || pacing_watch) {
       traffic = "amber";
       status = capture_cpu_copy ? "watch" : "needs_action";
       severity = "warning";
@@ -1066,6 +1089,7 @@ namespace stream_stats {
       primary_issue == "capture_missing" ? "Capture metadata has not arrived yet; start a stream before tuning advanced settings." :
       primary_issue == "network_jitter" ? "Sustained network pressure is affecting this stream." :
       primary_issue == "network_observation" ? "A network warning needs more live evidence before Doctor changes quality." :
+      primary_issue == "control_channel_observation" ? "Control-channel retries were observed, but video packet loss is not confirmed." :
       primary_issue == "quality_capped_by_history" ? "An older recovery profile is limiting quality even though the live network is stable." :
       primary_issue == "steam_input_conflict" ? "Local Steam Input settings conflict with strict gamepad isolation for the Polaris Xbox virtual controller." :
       primary_issue == "encoder_load" ? "Encoder load is above the low-latency budget." :
@@ -1077,7 +1101,28 @@ namespace stream_stats {
     append_doctor_evidence(evidence, "streaming", "Active stream", stats.streaming, "", stats.streaming ? "pass" : "unknown", "stream_stats", stats.streaming ? "A stream is active." : "No active stream is reporting live telemetry.");
     append_doctor_evidence(evidence, "capture_path", "Capture path", capture_path, "", !capture_known ? "unknown" : capture_latency_fail ? "fail" : capture_cpu_copy ? "watch" : capture_gpu_native ? "pass" : "watch", "stream_stats", capture_path_reason_message(capture_reason));
     append_doctor_evidence(evidence, "encoder", "Encoder", stats.encode_target_device, "", encoder_fail ? "fail" : encoder_watch ? "watch" : "pass", "stream_stats", stats.encode_time_ms > 0.0 ? "Encode timing is reported by stream telemetry." : "Encoder timing has not been reported yet.");
-    append_doctor_evidence(evidence, "packet_loss", "Packet loss", stats.packet_loss, "%", network_fail ? "fail" : network_watch ? "watch" : "pass", "stream_stats", "Packet loss reported by current stream telemetry.");
+    append_doctor_evidence(
+      evidence,
+      "packet_loss",
+      "Video packet loss",
+      stats.packet_loss_available ? nlohmann::json(stats.packet_loss) : nlohmann::json(nullptr),
+      "%",
+      !stats.packet_loss_available ? "unknown" : confirmed_media_loss ? "fail" : "pass",
+      stats.packet_loss_source,
+      stats.packet_loss_available ?
+        "Packet loss confirmed by media-path telemetry." :
+        "No confirmed media packet-loss measurement is available for this live stream."
+    );
+    append_doctor_evidence(
+      evidence,
+      "control_channel_packet_loss",
+      "Control-channel loss estimate",
+      stats.control_channel_samples > 0 ? nlohmann::json(stats.control_channel_packet_loss) : nlohmann::json(nullptr),
+      "%",
+      stats.control_channel_samples == 0 ? "unknown" : control_channel_observation ? "watch" : "pass",
+      "enet_control_channel",
+      "ENet reliable-channel EWMA. Retransmissions can make this read high even when video delivery is healthy; it cannot grade the stream or authorize a bitrate reduction."
+    );
     append_doctor_evidence(evidence, "latency", "Network latency", stats.latency_ms, "ms", stats.latency_ms >= 45.0 ? "fail" : network_watch ? "watch" : "pass", "stream_stats", "Round-trip latency reported by the active client control channel.");
     append_doctor_evidence(evidence, "bitrate", "Live bitrate", live_bitrate_kbps, "kbps", "pass", "stream_stats", stats.adaptive_runtime_update_supported ? "Current live encoder target; Doctor changes it only for confirmed pressure or a guarded recovery-profile retry." : "Applied encoder bitrate; this encoder does not expose live bitrate updates.");
     append_doctor_evidence(
@@ -1109,7 +1154,7 @@ namespace stream_stats {
     );
 
     auto advanced = nlohmann::json::object();
-    advanced["stream_stats_keys"] = nlohmann::json::array({"capture_path", "capture_path_reason", "capture_transport", "capture_residency", "capture_format", "capture_cpu_copy", "capture_gpu_native", "capture_cross_gpu_dmabuf_risk", "encode_target_device", "encode_target_residency", "fps", "encode_time_ms", "packet_loss", "frame_interval_error_ms", "frame_jitter_ms"});
+    advanced["stream_stats_keys"] = nlohmann::json::array({"capture_path", "capture_path_reason", "capture_transport", "capture_residency", "capture_format", "capture_cpu_copy", "capture_gpu_native", "capture_cross_gpu_dmabuf_risk", "encode_target_device", "encode_target_residency", "fps", "encode_time_ms", "packet_loss", "packet_loss_available", "packet_loss_source", "control_channel_packet_loss", "control_channel_samples", "frame_interval_error_ms", "frame_jitter_ms"});
     advanced["linux_gpu_profile"] = linux_gpu_profile_json(stats);
     advanced["gpu_native_probe"] = gpu_native_probe_json(stats);
     advanced["controller_input"] = {
@@ -1146,6 +1191,10 @@ namespace stream_stats {
       confidence_score = 0.68;
       confidence_level = "medium";
       basis = "live_evidence_recheck";
+    } else if (primary_issue == "control_channel_observation") {
+      confidence_score = 0.72;
+      confidence_level = "medium";
+      basis = "control_channel_only";
     } else if (health.contains("primary_issue")) {
       confidence_score = 0.92;
       confidence_level = "high";
@@ -1170,7 +1219,7 @@ namespace stream_stats {
     doctor["severity"] = severity;
     doctor["simple_state"] = simple_state;
     doctor["primary_issue"] = primary_issue;
-    doctor["confidence"] = {{"level", confidence_level}, {"score", confidence_score}, {"basis", basis}, {"sample_window", {{"samples", stats.streaming ? 1 : 0}, {"seconds", stats.streaming ? 1 : 0}}}};
+    doctor["confidence"] = {{"level", confidence_level}, {"score", confidence_score}, {"basis", basis}, {"sample_window", {{"samples", stats.control_channel_samples}, {"seconds", 0}}}};
     doctor["summary"] = summary;
     doctor["recommendation"] = doctor_recommendation(primary_issue, summary, health, stats.adaptive_runtime_update_supported);
     doctor["evidence"] = std::move(evidence);
@@ -1187,7 +1236,7 @@ namespace stream_stats {
     if (suppressed_stale_network_finding) {
       doctor["suppressed_findings"].push_back({
         {"id", "stale_network_jitter"},
-        {"reason", "Current debounced packet-loss and latency evidence is clean; the older health label cannot trigger a bitrate change."}
+        {"reason", "Confirmed media loss is unavailable and current RTT evidence is below the action threshold; the older health label cannot trigger a bitrate change."}
       });
     }
     // Actions that reported success and did not land. These are not stream
@@ -1371,6 +1420,7 @@ namespace stream_stats {
     // own lock, so stats_mutex stays out of this path.
     hot_latency_ms.store(latency_ms, std::memory_order_relaxed);
     hot_packet_loss.store(packet_loss, std::memory_order_relaxed);
+    hot_packet_loss_available.store(true, std::memory_order_relaxed);
     hot_bytes_sent.store(bytes_sent, std::memory_order_relaxed);
     ingest_network_risk(latency_ms, packet_loss);
   }
@@ -1384,16 +1434,58 @@ namespace stream_stats {
     if (it != current_stats.clients.end()) {
       it->latency_ms = latency_ms;
       it->packet_loss = packet_loss;
+      it->packet_loss_available = true;
+      it->packet_loss_source = "media_transport";
       it->bytes_sent = bytes_sent;
     }
 
-    // Also update top-level stats (use first client for backward compat)
-    if (!current_stats.clients.empty() && current_stats.clients.front().ip == client_ip) {
+    // Also update top-level stats (use first client for backward compat).
+    // Only that primary client's observation may drive the top-level risk.
+    const bool primary_client =
+      !current_stats.clients.empty() && current_stats.clients.front().ip == client_ip;
+    if (primary_client) {
       hot_latency_ms.store(latency_ms, std::memory_order_relaxed);
       hot_packet_loss.store(packet_loss, std::memory_order_relaxed);
+      hot_packet_loss_available.store(true, std::memory_order_relaxed);
       hot_bytes_sent.store(bytes_sent, std::memory_order_relaxed);
+      ingest_network_risk(latency_ms, packet_loss);
     }
-    ingest_network_risk(latency_ms, packet_loss);
+  }
+
+  void update_control_channel_stats(double latency_ms, double control_packet_loss, uint64_t bytes_sent) {
+    hot_latency_ms.store(latency_ms, std::memory_order_relaxed);
+    hot_control_channel_packet_loss.store(control_packet_loss, std::memory_order_relaxed);
+    hot_control_channel_samples.fetch_add(1, std::memory_order_relaxed);
+    hot_bytes_sent.store(bytes_sent, std::memory_order_relaxed);
+    // RTT describes the shared path. The ENet loss EWMA describes only its
+    // reliable control channel, so it cannot enter the actionable loss term.
+    ingest_network_risk(latency_ms, 0.0);
+  }
+
+  void update_control_channel_stats(const std::string &client_ip,
+                                    double latency_ms,
+                                    double control_packet_loss,
+                                    uint64_t bytes_sent) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+
+    auto it = std::find_if(current_stats.clients.begin(), current_stats.clients.end(),
+      [&client_ip](const client_stats_t &c) { return c.ip == client_ip; });
+
+    if (it != current_stats.clients.end()) {
+      it->latency_ms = latency_ms;
+      it->control_channel_packet_loss = control_packet_loss;
+      it->bytes_sent = bytes_sent;
+    }
+
+    const bool primary_client =
+      !current_stats.clients.empty() && current_stats.clients.front().ip == client_ip;
+    if (primary_client) {
+      hot_latency_ms.store(latency_ms, std::memory_order_relaxed);
+      hot_control_channel_packet_loss.store(control_packet_loss, std::memory_order_relaxed);
+      hot_control_channel_samples.fetch_add(1, std::memory_order_relaxed);
+      hot_bytes_sent.store(bytes_sent, std::memory_order_relaxed);
+      ingest_network_risk(latency_ms, 0.0);
+    }
   }
 
   void update_runtime_state(const platf::runtime_state_t &state) {
@@ -2227,6 +2319,10 @@ namespace stream_stats {
     result.capture_source_fps = hot_capture_source_fps.load(std::memory_order_relaxed);
     result.latency_ms = hot_latency_ms.load(std::memory_order_relaxed);
     result.packet_loss = hot_packet_loss.load(std::memory_order_relaxed);
+    result.packet_loss_available = hot_packet_loss_available.load(std::memory_order_relaxed);
+    result.packet_loss_source = result.packet_loss_available ? "media_transport" : "unavailable";
+    result.control_channel_packet_loss = hot_control_channel_packet_loss.load(std::memory_order_relaxed);
+    result.control_channel_samples = hot_control_channel_samples.load(std::memory_order_relaxed);
     result.network_risk = hot_network_risk.load(std::memory_order_relaxed);
     result.bytes_sent = hot_bytes_sent.load(std::memory_order_relaxed);
     result.idr_requests_total = hot_idr_requests_total.load(std::memory_order_relaxed);

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -50,7 +50,11 @@ namespace stream_stats {
 
     // Network
     double latency_ms = 0;
+    /// Confirmed media-path packet loss only. ENet control loss is kept separate.
     double packet_loss = 0;
+    bool packet_loss_available = false;
+    std::string packet_loss_source = "unavailable";
+    double control_channel_packet_loss = 0;
     uint64_t bytes_sent = 0;
 
     // Adaptive bitrate
@@ -137,7 +141,13 @@ namespace stream_stats {
 
     // Network
     double latency_ms = 0;
+    /// Confirmed media-path packet loss only. ENet control loss is kept separate.
     double packet_loss = 0;
+    bool packet_loss_available = false;
+    std::string packet_loss_source = "unavailable";
+    /// ENet reliable control-channel EWMA; diagnostic context, not video loss.
+    double control_channel_packet_loss = 0;
+    uint64_t control_channel_samples = 0;
     /// Debounced by network_risk_tracker_t; the single truth every reader serves.
     bool network_risk = false;
     uint64_t bytes_sent = 0;
@@ -358,6 +368,21 @@ namespace stream_stats {
   void update_network_stats(const std::string &client_ip, double latency_ms, double packet_loss, uint64_t bytes_sent);
 
   /**
+   * @brief Update ENet control-channel observations without treating its loss
+   *        EWMA as media packet loss.
+   *
+   * RTT remains actionable path evidence. Control loss is exposed for
+   * diagnostics only and cannot grade the stream or reduce quality.
+   */
+  void update_control_channel_stats(double latency_ms, double control_packet_loss, uint64_t bytes_sent);
+
+  /** @brief Per-client overload of update_control_channel_stats(). */
+  void update_control_channel_stats(const std::string &client_ip,
+                                    double latency_ms,
+                                    double control_packet_loss,
+                                    uint64_t bytes_sent);
+
+  /**
    * @brief Convert a scaled loss ratio (e.g. ENet's peer packetLoss against
    *        ENET_PEER_PACKET_LOSS_SCALE) to the 0-100 percentage this module stores.
    * @param scaled_loss Loss ratio numerator as reported by the transport.
@@ -369,12 +394,9 @@ namespace stream_stats {
   /**
    * @brief Debounced elevated/normal state behind the served network_risk.
    *
-   * ENet's packetLoss is an EWMA computed over the low-rate control channel,
-   * so a single retransmit reads as whole percents for a while - a 0.35%
-   * cut flagged "Network jitter" on objectively perfect streams. The 2%
-   * cut matches the session-grading "fair" line, the warm-up skips the
-   * samples computed from the fewest packets, and the two-sample debounce
-   * keeps one noisy reading from flipping the HUD either way.
+   * Confirmed media loss and RTT may feed this tracker. ENet's packetLoss is
+   * a reliable control-channel EWMA and must be passed as zero here; it is
+   * exposed separately as non-actionable diagnostic context.
    */
   struct network_risk_tracker_t {
     static constexpr double k_loss_elevated_pct = 2.0;

--- a/tests/unit/test_ai_optimizer.cpp
+++ b/tests/unit/test_ai_optimizer.cpp
@@ -266,6 +266,70 @@ TEST(AiOptimizerHistorySanitization, ClearsLowConfidenceSoftEndRecoveryBias) {
   EXPECT_EQ("host_render_limited", sanitized.last_primary_issue);
 }
 
+TEST(AiOptimizerHistorySanitization, RepairsLegacyControlLossGradeAndNetworkLimit) {
+  auto session = make_session("C", "host_pause", 0, 0);
+  session.session_count = 3;
+  session.avg_fps = 59.71;
+  session.last_fps = 59.71;
+  session.last_target_fps = 60.0;
+  session.avg_latency_ms = 4.0;
+  session.last_latency_ms = 4.0;
+  session.packet_loss_pct = 3.2;
+  session.last_packet_loss_pct = 8.72039794921875;
+  session.last_sample_confidence = "low";
+  session.last_health_grade = "watch";
+  session.last_primary_issue = "network_jitter";
+  session.last_issues = {"network_jitter"};
+  session.last_network_risk = "elevated";
+  session.last_bitrate_kbps = 16988;
+  session.last_safe_bitrate_kbps = 12741;
+
+  const auto sanitized = ai_optimizer::sanitize_session_history(session);
+
+  EXPECT_EQ(sanitized.last_packet_loss_source, "legacy_control_channel");
+  EXPECT_DOUBLE_EQ(sanitized.packet_loss_pct, 0.0);
+  EXPECT_DOUBLE_EQ(sanitized.last_packet_loss_pct, 0.0);
+  EXPECT_EQ(ai_optimizer::grade_session_quality(sanitized), "A");
+  EXPECT_EQ(sanitized.quality_grade, "A");
+  EXPECT_EQ(sanitized.last_quality_grade, "A");
+  EXPECT_EQ(sanitized.last_network_risk, "normal");
+  EXPECT_EQ(sanitized.last_primary_issue, "steady");
+  EXPECT_TRUE(sanitized.last_issues.empty());
+  EXPECT_EQ(sanitized.last_health_grade, "good");
+  EXPECT_EQ(sanitized.last_safe_bitrate_kbps, 0);
+  EXPECT_FALSE(
+    ai_optimizer::get_history_safe_fallback(
+      "RetroidPocket6",
+      "Legacy Control Loss",
+      std::optional<ai_optimizer::session_history_t> {sanitized}
+    ).has_value()
+  );
+}
+
+TEST(AiOptimizerHistorySanitization, KeepsRealRttPressureWhileDiscardingControlLoss) {
+  auto session = make_session("D", "host_pause", 0, 0);
+  session.avg_fps = 59.71;
+  session.last_fps = 59.71;
+  session.last_target_fps = 60.0;
+  session.avg_latency_ms = 52.0;
+  session.last_latency_ms = 52.0;
+  session.packet_loss_pct = 8.7;
+  session.last_packet_loss_pct = 8.7;
+  session.last_health_grade = "watch";
+  session.last_primary_issue = "network_jitter";
+  session.last_issues = {"network_jitter"};
+  session.last_network_risk = "elevated";
+
+  const auto sanitized = ai_optimizer::sanitize_session_history(session);
+
+  EXPECT_EQ(sanitized.last_packet_loss_source, "legacy_control_channel");
+  EXPECT_DOUBLE_EQ(sanitized.packet_loss_pct, 0.0);
+  EXPECT_EQ(sanitized.last_network_risk, "elevated");
+  EXPECT_EQ(sanitized.last_primary_issue, "network_jitter");
+  EXPECT_EQ(sanitized.last_health_grade, "watch");
+  EXPECT_EQ(ai_optimizer::grade_session_quality(sanitized), "C");
+}
+
 TEST(AiOptimizerHistorySanitization, KeepsSampledSoftEndRecoveryBias) {
   auto session = make_session("C", "disconnect", 180, 180);
   session.session_count = 3;

--- a/tests/unit/test_stream.cpp
+++ b/tests/unit/test_stream.cpp
@@ -177,9 +177,11 @@ TEST(StreamNetworkStatsTests, OneTransientReportDoesNotClassifyCleanStreamAsNetw
   EXPECT_EQ(health.at("primary_issue"), "steady");
   EXPECT_EQ(health.at("limiting_factor"), "none");
 
-  // A second distinct elevated report still confirms real pressure promptly.
+  // More high control-channel estimates still cannot manufacture media loss.
   stream::record_network_stats(client_ip, 3.0, 3.0, 0);
-  EXPECT_TRUE(stream_stats::get_current().network_risk);
+  EXPECT_FALSE(stream_stats::get_current().network_risk);
+  EXPECT_FALSE(stream_stats::get_current().packet_loss_available);
+  EXPECT_DOUBLE_EQ(stream_stats::get_current().control_channel_packet_loss, 3.0);
 
   stream_stats::remove_client(client_ip);
   stream_stats::update_stream_active(false);
@@ -193,19 +195,25 @@ TEST(StreamNetworkStatsTests, SecondaryClientReportDoesNotReplacePrimaryTelemetr
   stream_stats::add_client(secondary_ip, "Secondary client");
 
   stream::record_network_stats(primary_ip, 3.0, 0.0, 1000);
-  stream::record_network_stats(secondary_ip, 9.0, 1.0, 2000);
+  for (int i = 0; i < 50; ++i) {
+    stream::record_network_stats(secondary_ip, 90.0, 8.0, 2000);
+  }
 
   const auto stats = stream_stats::get_current();
   EXPECT_DOUBLE_EQ(stats.latency_ms, 3.0);
   EXPECT_DOUBLE_EQ(stats.packet_loss, 0.0);
+  EXPECT_FALSE(stats.network_risk);
+  EXPECT_EQ(stats.control_channel_samples, 1u);
   EXPECT_EQ(stats.bytes_sent, 1000u);
   EXPECT_EQ(stats.clients.size(), 2u);
   if (stats.clients.size() == 2u) {
     EXPECT_DOUBLE_EQ(stats.clients[0].latency_ms, 3.0);
     EXPECT_DOUBLE_EQ(stats.clients[0].packet_loss, 0.0);
+    EXPECT_DOUBLE_EQ(stats.clients[0].control_channel_packet_loss, 0.0);
     EXPECT_EQ(stats.clients[0].bytes_sent, 1000u);
-    EXPECT_DOUBLE_EQ(stats.clients[1].latency_ms, 9.0);
-    EXPECT_DOUBLE_EQ(stats.clients[1].packet_loss, 1.0);
+    EXPECT_DOUBLE_EQ(stats.clients[1].latency_ms, 90.0);
+    EXPECT_DOUBLE_EQ(stats.clients[1].packet_loss, 0.0);
+    EXPECT_DOUBLE_EQ(stats.clients[1].control_channel_packet_loss, 8.0);
     EXPECT_EQ(stats.clients[1].bytes_sent, 2000u);
   }
 

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -840,6 +840,55 @@ TEST(StreamStatsDoctorTests, NetworkWatchRechecksWithoutChangingBitrate) {
   EXPECT_FALSE(action.at("payload_preview").contains("target_bitrate_kbps"));
 }
 
+TEST(StreamStatsDoctorTests, ControlLossIsInformationalAndCannotReduceQuality) {
+  stream_stats::stats_t stats {};
+  stats.streaming = true;
+  stats.fps = 59.71;
+  stats.encode_target_fps = 60.0;
+  stats.bitrate_kbps = 16988;
+  stats.paired_target_bitrate_kbps = 20000;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+  stats.encode_time_ms = 0.77;
+  stats.frame_jitter_ms = 1.57;
+  stats.dropped_frame_ratio = 0.03;
+  stats.packet_loss = 0.0;
+  stats.packet_loss_available = false;
+  stats.packet_loss_source = "unavailable";
+  stats.control_channel_packet_loss = 8.72039794921875;
+  stats.control_channel_samples = 42;
+  stats.latency_ms = 4.0;
+  stats.network_risk = false;
+
+  const auto doctor = stream_stats::build_doctor_json(stats, nlohmann::json::object());
+
+  EXPECT_EQ(doctor.at("primary_issue"), "control_channel_observation");
+  EXPECT_EQ(doctor.at("status"), "ok");
+  EXPECT_EQ(doctor.at("traffic_light"), "green");
+  EXPECT_EQ(doctor.at("confidence").at("basis"), "control_channel_only");
+  EXPECT_EQ(doctor.at("confidence").at("sample_window").at("samples"), 42);
+  EXPECT_EQ(doctor.at("safe_recovery_action").at("id"), "none");
+  EXPECT_EQ(doctor.at("recommendation").at("next_step_label"), "Keep monitoring");
+
+  bool saw_unknown_media_loss = false;
+  bool saw_control_observation = false;
+  for (const auto &item : doctor.at("evidence")) {
+    if (item.at("id") == "packet_loss") {
+      saw_unknown_media_loss = true;
+      EXPECT_EQ(item.at("status"), "unknown");
+      EXPECT_TRUE(item.at("value").is_null());
+    }
+    if (item.at("id") == "control_channel_packet_loss") {
+      saw_control_observation = true;
+      EXPECT_EQ(item.at("status"), "watch");
+      EXPECT_DOUBLE_EQ(item.at("value"), 8.72039794921875);
+    }
+  }
+  EXPECT_TRUE(saw_unknown_media_loss);
+  EXPECT_TRUE(saw_control_observation);
+}
+
 TEST(StreamStatsDoctorTests, ConfirmedNetworkPressureOffersGuardedFixWithUndo) {
   stream_stats::stats_t stats {};
   stats.streaming = true;
@@ -952,9 +1001,11 @@ TEST(DoctorActionTests, RequiresCurrentNetworkEvidenceBeforeReducingQuality) {
   EXPECT_FALSE(doctor_actions::network_pressure_confirmed(stats));
 
   stats.packet_loss = 3.4;
+  stats.packet_loss_available = true;
   EXPECT_TRUE(doctor_actions::network_pressure_confirmed(stats));
 
   stats.packet_loss = 0.0;
+  stats.packet_loss_available = false;
   stats.latency_ms = 45.0;
   EXPECT_TRUE(doctor_actions::network_pressure_confirmed(stats));
 }
@@ -1297,15 +1348,35 @@ TEST(StreamStatsHotFieldTests, UpdateNetworkStatsIsVisibleThroughGetCurrent) {
 
   EXPECT_DOUBLE_EQ(stats.latency_ms, 11.5);
   EXPECT_DOUBLE_EQ(stats.packet_loss, 0.4);
+  EXPECT_TRUE(stats.packet_loss_available);
+  EXPECT_EQ(stats.packet_loss_source, "media_transport");
   EXPECT_EQ(stats.bytes_sent, 123456789ull);
 
   stream_stats::update_stream_active(false);
 }
 
-// The periodic-ping handler in stream.cpp sources loss from ENet's scaled
-// peer->packetLoss; this module stores percent (0-100), matching the readers
-// (served network_risk elevates at 2% after warm-up and debounce; session
-// grading stays at 0.5/2/5%).
+TEST(StreamStatsHotFieldTests, ControlChannelLossNeverBecomesMediaLossOrRisk) {
+  stream_stats::update_stream_active(false);
+  stream_stats::update_stream_active(true);
+  for (int i = 0; i < 50; ++i) {
+    stream_stats::update_control_channel_stats(4.0, 8.72039794921875, 0);
+  }
+
+  const auto stats = stream_stats::get_current();
+
+  EXPECT_DOUBLE_EQ(stats.latency_ms, 4.0);
+  EXPECT_DOUBLE_EQ(stats.packet_loss, 0.0);
+  EXPECT_FALSE(stats.packet_loss_available);
+  EXPECT_EQ(stats.packet_loss_source, "unavailable");
+  EXPECT_DOUBLE_EQ(stats.control_channel_packet_loss, 8.72039794921875);
+  EXPECT_EQ(stats.control_channel_samples, 50);
+  EXPECT_FALSE(stats.network_risk);
+
+  stream_stats::update_stream_active(false);
+}
+
+// The periodic-ping handler in stream.cpp converts ENet's scaled control loss
+// to percent for diagnostics, while keeping it out of media grading.
 TEST(StreamStatsHotFieldTests, RuntimeDisplayWarningIsServedAndResetWithTheStream) {
   stream_stats::update_stream_active(true);
   stream_stats::update_runtime_display_warning("Host Virtual Display could not be created");


### PR DESCRIPTION
## Summary

- keep ENet reliable control-channel loss separate from confirmed media loss
- gate Doctor actions, stream grading, and adaptive bitrate decisions on provenance-aware evidence
- repair legacy control-only host histories without erasing real RTT pressure

## Why

The 1.3.11 diagnostics exposed ENet `packetLoss` 8.72039794921875% as video loss even though RTT was 4 ms and no confirmed media-loss sample existed. This produced Network Limited or Network Jitter, a C grade, and a recovery-bitrate candidate from non-media telemetry.

## Validation

- full stacked C++ validation passed: 17/17 tests
- focused regressions passed for the exact 8.72039794921875 signal, legacy C-to-A repair and no fallback, RTT preservation, multi-client isolation, and Doctor action gating
- `git diff --check` passed after rebasing onto merged #513
- rebased head `316cda7a` has the exact same Git tree as physically tested stacked candidate `ab08a635`
- physical RP6 launch with production Nova 1.3.7 completed successfully: Doctor stayed green, reported control-channel retries without confirmed video loss, offered no bitrate-reduction action, and the completed session graded A (120.3/120)
- exact-head Build Polaris, CodeQL, and Public Hygiene completed successfully on `316cda7a`
- read-only exact-head review completed with no findings
- the host was restored to the exact pre-test Polaris baseline after validation

## Acceptance boundary

- ready for the authorized SHA-guarded merge
- physical validation covers the exact content tree now proposed by this PR
- no release, tag, or deployment is part of this PR
