### PR TITLE
fix(linux): serialize nested Gamescope teardown

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Unreleased: nested Gamescope teardown now serializes helper transitions and asks session-owned Steam to exit before using the exact-generation compositor stop fallback, preventing overlapping stops from poisoning reconnect recovery.
+
 This file tracks the public Polaris release line.
 
 Older historical tags remain in the repository for continuity, but the current public product line

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -25,6 +25,37 @@ gs_refresh="${POLARIS_HDR_REFRESH:-120}"
 session_id_file="$rt/polaris-gamescope-session-id"
 session_mode_file="$rt/polaris-gamescope-session-mode"
 session_state_file="$rt/polaris-gamescope-session-state"
+session_operation_lock="$rt/polaris-gamescope-session-operation.lock"
+
+acquire_session_operation_lock() {
+  local lock_bin="${POLARIS_FLOCK_BIN:-flock}" fd_identity path_identity
+  if [ "${POLARIS_SESSION_OPERATION_LOCK_HELD:-0}" = 1 ]; then
+    fd_identity="$(stat -Lc '%d:%i' "/proc/$BASHPID/fd/7" 2>/dev/null || true)"
+    path_identity="$(stat -Lc '%d:%i' "$session_operation_lock" 2>/dev/null || true)"
+    if [ -n "$fd_identity" ] && [ "$fd_identity" = "$path_identity" ]; then
+      return 0
+    fi
+  fi
+  unset POLARIS_SESSION_OPERATION_LOCK_HELD
+  exec 7>>"$session_operation_lock" || return 1
+  "$lock_bin" -x 7 || return 1
+  export POLARIS_SESSION_OPERATION_LOCK_HELD=1
+}
+
+run_without_session_operation_lock() {
+  exec 7>&-
+  unset POLARIS_SESSION_OPERATION_LOCK_HELD
+  exec "$@"
+}
+
+wait_for_nested_gamescope_exit() {
+  local _
+  for _ in $(seq 1 "${POLARIS_NESTED_GRACE_STEPS:-20}"); do
+    polaris_validate_marker "$marker" nested || return 0
+    sleep 0.1
+  done
+  ! polaris_validate_marker "$marker" nested
+}
 
 publish_nested_claim() (
   local new_state="$1" expected_state="${2:-absent}"
@@ -223,6 +254,10 @@ steam_app_game_alive() {
 
 case "${1:-}" in
   start)
+    acquire_session_operation_lock || {
+      echo "polaris-gamescope-session: could not serialize session start" >&2
+      exit 1
+    }
     requested_session_id="${POLARIS_SESSION_INSTANCE_ID:-}"
     [ -n "$requested_session_id" ] || {
       echo "polaris-gamescope-session: missing immutable session credential" >&2
@@ -461,22 +496,22 @@ case "${1:-}" in
         echo "polaris-gamescope-session: ownership transition changed before nested launch" >&2
         exit 1
       }
-      setsid env -u WAYLAND_DISPLAY -u DISPLAY -u ENABLE_HDR_WSI \
-        "${child_env[@]}" "${POLARIS_GAMESCOPE_BIN:-gamescope}" \
-        --backend headless \
-        "${steam_flags[@]}" \
-        --xwayland-count 2 \
-        "${prefer_vk[@]}" \
-        "${hdr_flags[@]}" \
-        -W "$gs_width" -H "$gs_height" -r "$gs_refresh" \
-        -w "$gs_width" -h "$gs_height" \
-        -- "${steam_launch[@]}" \
-        >"$steam_log" 2>&1 &
+      (
+        run_without_session_operation_lock setsid env -u WAYLAND_DISPLAY -u DISPLAY -u ENABLE_HDR_WSI \
+          "${child_env[@]}" "${POLARIS_GAMESCOPE_BIN:-gamescope}" \
+          --backend headless \
+          "${steam_flags[@]}" \
+          --xwayland-count 2 \
+          "${prefer_vk[@]}" \
+          "${hdr_flags[@]}" \
+          -W "$gs_width" -H "$gs_height" -r "$gs_refresh" \
+          -w "$gs_width" -h "$gs_height" \
+          -- "${steam_launch[@]}"
+      ) >"$steam_log" 2>&1 &
       nested_launch_pid=$!
 
-      # Resolve the real headless gamescope PID. setsid/env/wrapProgram may leave
-      # $! as a launcher; preserve that PID as the private PGID/SID and pin the
-      # separately discovered compositor generation in the marker.
+      # The one explicit subshell execs setsid, so $! remains the private PGID/SID
+      # leader across env/wrapProgram execs. Resolve and pin the compositor itself.
       resolve_nested_gamescope_pid() {
         local root="$1" p
         if polaris_headless_gamescope_pid "$root" 2>/dev/null; then
@@ -611,26 +646,28 @@ case "${1:-}" in
       # captures empty gamescope → black stream (measured 2026-07-14).
       # Do not pass host WAYLAND_DISPLAY; do not enable FROG WSI here.
       echo "polaris-gamescope-session: attach Steam on DISPLAY=${DISPLAY:-:1} (X11 only, host Wayland stripped)" >&2
-      setsid -f env \
-        -u WAYLAND_DISPLAY \
-        -u CLUTTER_BACKEND \
-        -u ELECTRON_OZONE_PLATFORM_HINT \
-        -u MOZ_ENABLE_WAYLAND \
-        -u ENABLE_GAMESCOPE_WSI \
-        -u ENABLE_HDR_WSI \
-        DISPLAY="${DISPLAY:-:1}" \
-        GAMESCOPE_WAYLAND_DISPLAY=gamescope-0 \
-        PULSE_SINK="$audio_sink" \
-        PIPEWIRE_NODE="$audio_sink" \
-        POLARIS_SESSION_AUDIO_SINK="$audio_sink" \
-        STEAM_MULTIPLE_XWAYLANDS=1 \
-        QT_QPA_PLATFORM=xcb \
-        GDK_BACKEND=x11 \
-        SDL_VIDEODRIVER=x11 \
-        XDG_SESSION_TYPE=x11 \
-        "${hdr_steam_env[@]}" \
-        setpriv --inh-caps=-all --ambient-caps=-all -- \
-        "${steam_launch[@]}" >"$steam_log" 2>&1
+      (
+        run_without_session_operation_lock setsid -f env \
+          -u WAYLAND_DISPLAY \
+          -u CLUTTER_BACKEND \
+          -u ELECTRON_OZONE_PLATFORM_HINT \
+          -u MOZ_ENABLE_WAYLAND \
+          -u ENABLE_GAMESCOPE_WSI \
+          -u ENABLE_HDR_WSI \
+          DISPLAY="${DISPLAY:-:1}" \
+          GAMESCOPE_WAYLAND_DISPLAY=gamescope-0 \
+          PULSE_SINK="$audio_sink" \
+          PIPEWIRE_NODE="$audio_sink" \
+          POLARIS_SESSION_AUDIO_SINK="$audio_sink" \
+          STEAM_MULTIPLE_XWAYLANDS=1 \
+          QT_QPA_PLATFORM=xcb \
+          GDK_BACKEND=x11 \
+          SDL_VIDEODRIVER=x11 \
+          XDG_SESSION_TYPE=x11 \
+          "${hdr_steam_env[@]}" \
+          setpriv --inh-caps=-all --ambient-caps=-all -- \
+          "${steam_launch[@]}"
+      ) >"$steam_log" 2>&1
       sleep 2
     fi
     ;;
@@ -682,6 +719,21 @@ case "${1:-}" in
     done
     ;;
   stop)
+    acquire_session_operation_lock || {
+      echo "polaris-gamescope-session: could not serialize session stop" >&2
+      exit 1
+    }
+    if [ ! -e "$session_state_file" ] \
+        && [ ! -s "$session_id_file" ] \
+        && [ ! -f "$session_mode_file" ] \
+        && [ ! -f "$rt/polaris-gamescope-wsi-nested" ]; then
+      if polaris_validate_marker "$marker" nested; then
+        echo "polaris-gamescope-session: nested owner remains without a durable recovery claim" >&2
+        exit 1
+      fi
+      echo "polaris-gamescope-session: stop already complete" >&2
+      exit 0
+    fi
     load_session_instance_id || {
       echo "polaris-gamescope-session: missing or mismatched session credential during stop" >&2
       exit 1
@@ -736,10 +788,23 @@ case "${1:-}" in
           ;;
         1|nested)
           echo "polaris-gamescope-session: tearing down marked nested WSI gamescope" >&2
+          if ! kill_session_steam || ! session_steam_absent; then
+            echo "polaris-gamescope-session: exact-session Steam did not reach terminal state; retaining recovery claim" >&2
+            exit 1
+          fi
           if polaris_validate_marker "$marker" nested; then
-            if ! polaris_stop_marked_gamescope "$marker" nested "$rt"; then
-              echo "polaris-gamescope-session: nested owner did not reach terminal state; retaining recovery claim" >&2
-              exit 1
+            if wait_for_nested_gamescope_exit; then
+              echo "polaris-gamescope-session: nested gamescope exited after exact-session Steam shutdown" >&2
+              if ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+                echo "polaris-gamescope-session: nested exit left non-reclaimable sockets; retaining recovery claim" >&2
+                exit 1
+              fi
+            else
+              echo "polaris-gamescope-session: nested gamescope did not exit after child shutdown; using exact-generation fallback" >&2
+              if ! polaris_stop_marked_gamescope "$marker" nested "$rt"; then
+                echo "polaris-gamescope-session: nested owner did not reach terminal state; retaining recovery claim" >&2
+                exit 1
+              fi
             fi
           else
             # Nested generation already dead (host hang dump, gamescope crash, or
@@ -751,10 +816,6 @@ case "${1:-}" in
               exit 1
             fi
             echo "polaris-gamescope-session: nested marker invalid/dead; sockets orphan or absent — restoring idle" >&2
-          fi
-          if ! kill_session_steam || ! session_steam_absent; then
-            echo "polaris-gamescope-session: exact-session Steam did not reach terminal state; retaining recovery claim" >&2
-            exit 1
           fi
           publish_nested_claim restore-idle "$claim_state" || {
             echo "polaris-gamescope-session: transition claim changed before idle restoration" >&2

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -16,14 +16,18 @@ polaris_process_fields() {
 }
 polaris_validate_marker() {
   case "${2:-}" in
-    nested) [ "${NESTED_VALID:-0}" = 1 ] ;;
+    nested) [ "${NESTED_VALID:-0}" = 1 ] && [ ! -e "$POLARIS_ACTIONS.nested-stopped" ] ;;
     idle) [ "${IDLE_VALID:-0}" = 1 ] ;;
     *) return 1 ;;
   esac
 }
 polaris_stop_marked_gamescope() {
   printf 'stop-nested\n' >>"$POLARIS_ACTIONS"
-  [ "${STOP_OK:-0}" = 1 ]
+  if [ -n "${STOP_DELAY:-}" ]; then
+    sleep "$STOP_DELAY"
+  fi
+  [ "${STOP_OK:-0}" = 1 ] || return 1
+  : >"$POLARIS_ACTIONS.nested-stopped"
 }
 polaris_reclaim_orphan_gamescope_sockets() {
   printf 'reclaim\n' >>"$POLARIS_ACTIONS"
@@ -62,6 +66,9 @@ printf 'kill %s\n' "$*" >>"$POLARIS_ACTIONS"
 pid="${2:-}"
 case "$pid" in ''|*[!0-9]*) exit 1 ;; esac
 rm -rf "$POLARIS_PROC_ROOT/$pid"
+if [ "${NESTED_DIES_WITH_STEAM:-0}" = 1 ]; then
+  : >"$POLARIS_ACTIONS.nested-stopped"
+fi
 EOF
 chmod +x "$work/bin/"*
 
@@ -78,7 +85,9 @@ run_stop() {
     POLARIS_PGREP_OUTPUT="${POLARIS_PGREP_OUTPUT:-}" \
     POLARIS_PGREP_STATUS="${POLARIS_PGREP_STATUS:-0}" \
     POLARIS_IDLE_WAIT_STEPS=2 POLARIS_PORTAL_WAIT_STEPS=2 \
+    POLARIS_NESTED_GRACE_STEPS=1 \
     NESTED_VALID="${NESTED_VALID:-0}" STOP_OK="${STOP_OK:-0}" \
+    STOP_DELAY="${STOP_DELAY:-}" NESTED_DIES_WITH_STEAM="${NESTED_DIES_WITH_STEAM:-0}" \
     RECLAIM_OK="${RECLAIM_OK:-0}" IDLE_VALID="${IDLE_VALID:-0}" \
     IDLE_OWNS_SOCKET="${IDLE_OWNS_SOCKET:-0}" WRITE_ENV_OK="${WRITE_ENV_OK:-0}" \
     IDLE_START_OK="${IDLE_START_OK:-1}" PORTAL_RESTART_OK="${PORTAL_RESTART_OK:-1}" \
@@ -87,6 +96,7 @@ run_stop() {
 }
 reset_state() {
   rm -rf "$work/run"/*
+  rm -f "$actions".*
   mkdir -p "$work/run"
   printf '1\n' >"$work/run/polaris-gamescope-wsi-nested"
   printf 'nested\n' >"$work/run/polaris-gamescope-session-mode"
@@ -176,6 +186,44 @@ POLARIS_SESSION_INSTANCE_ID=session-A POLARIS_PGREP_OUTPUT=$'100\n101' \
 grep -qx 'kill -TERM 101' "$actions" || fail "exact-session Steam was not signalled"
 ! grep -q 'kill .*100' "$actions" || fail "desktop Steam was signalled"
 [ -d "$work/proc/100" ] || fail "desktop Steam process was removed"
+steam_line="$(grep -nFx 'kill -TERM 101' "$actions" | head -n1 | cut -d: -f1)"
+stop_line="$(grep -nFx 'stop-nested' "$actions" | head -n1 | cut -d: -f1)"
+[ -n "$steam_line" ] && [ -n "$stop_line" ] && [ "$steam_line" -lt "$stop_line" ] ||
+  fail "nested compositor fallback ran before exact-session Steam shutdown"
+
+# A primary-child exit may terminate gamescope naturally. Reclaim its orphaned
+# endpoints and never signal the compositor group in that case.
+reset_state
+mkdir -p "$work/proc/101"
+printf '11\n' >"$work/proc/101/start"
+printf 'POLARIS_SESSION_INSTANCE_ID=session-A\0' >"$work/proc/101/environ"
+POLARIS_SESSION_INSTANCE_ID=session-A POLARIS_PGREP_OUTPUT=101 \
+  NESTED_VALID=1 STOP_OK=1 NESTED_DIES_WITH_STEAM=1 RECLAIM_OK=1 \
+  IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 PORTAL_READY=1 \
+  run_stop >/dev/null 2>&1 || fail "natural nested exit handoff failed"
+grep -qx 'kill -TERM 101' "$actions" || fail "natural exit did not request exact-session Steam shutdown"
+! grep -qx 'stop-nested' "$actions" || fail "natural exit still signalled the compositor group"
+grep -qx 'reclaim' "$actions" || fail "natural exit did not reclaim orphaned endpoints"
+
+# Overlapping stop attempts serialize on one lifecycle lock. The first consumes
+# the durable state; the waiter then observes an idempotently completed stop.
+reset_state
+NESTED_VALID=1 STOP_OK=1 STOP_DELAY=0.3 RECLAIM_OK=1 \
+  IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 PORTAL_READY=1 \
+  run_stop >/dev/null 2>&1 &
+first_stop=$!
+for _ in $(seq 1 100); do
+  grep -qx 'stop-nested' "$actions" 2>/dev/null && break
+  sleep 0.01
+done
+grep -qx 'stop-nested' "$actions" || fail "first overlapping stop never entered teardown"
+NESTED_VALID=1 STOP_OK=1 RECLAIM_OK=1 \
+  IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 PORTAL_READY=1 \
+  run_stop >/dev/null 2>&1 &
+second_stop=$!
+wait "$first_stop" || fail "first overlapping stop failed"
+wait "$second_stop" || fail "serialized overlapping stop was not idempotent"
+[ "$(grep -cx 'stop-nested' "$actions")" = 1 ] || fail "overlapping stops repeated compositor teardown"
 
 # Recovery may run in a fresh process environment; the immutable credential is
 # persisted until the full idle/portal handoff completes.
@@ -227,6 +275,75 @@ while IFS= read -r line; do
   [ "$line" = 'case "${1:-}" in' ] && break
   printf '%s\n' "$line" >>"$prefix"
 done <"$script"
+
+# The lifecycle lock belongs to the short-lived start/stop operation. The single
+# launch subshell must exec the detached target with fd 7 closed while preserving
+# $! as that target's PID, process-group leader, and session leader.
+(
+  export XDG_RUNTIME_DIR="$work/run"
+  export POLARIS_GAMESCOPE_RUNTIME_LIB="$work/runtime-stub.sh"
+  export POLARIS_FLOCK_BIN="$(command -v flock)"
+  # shellcheck source=/dev/null
+  . "$prefix"
+  acquire_session_operation_lock || fail "could not acquire operation lock for inheritance test"
+  parent_identity="$(stat -Lc '%d:%i' "/proc/$BASHPID/fd/7")"
+  path_identity="$(stat -Lc '%d:%i' "$session_operation_lock")"
+  [ "$parent_identity" = "$path_identity" ] || fail "parent does not hold operation lock"
+  child_result="$work/child-operation-lock"
+  child_pid=
+  cleanup_operation_lock_child() {
+    if [ -n "${child_pid:-}" ] && kill -0 "$child_pid" 2>/dev/null; then
+      kill -TERM "$child_pid" 2>/dev/null || true
+      wait "$child_pid" 2>/dev/null || true
+    fi
+  }
+  trap cleanup_operation_lock_child EXIT
+  (
+    run_without_session_operation_lock setsid bash -c '
+      if [ -e "/proc/$BASHPID/fd/7" ]; then fd7=inherited; else fd7=closed; fi
+      process_stat="$(<"/proc/$BASHPID/stat")"
+      process_fields="${process_stat#*) }"
+      set -- $process_fields
+      pgid="$3"
+      sid="$4"
+      printf "fd7=%s\npid=%s\npgid=%s\nsid=%s\n" "$fd7" "$BASHPID" "$pgid" "$sid"
+      trap "exit 0" TERM
+      while :; do sleep 1; done
+    '
+  ) >"$child_result" &
+  child_pid=$!
+  child_ready=0
+  for _ in $(seq 1 100); do
+    if [ "$(wc -l <"$child_result")" -ge 4 ]; then
+      child_ready=1
+      break
+    fi
+    kill -0 "$child_pid" 2>/dev/null || fail "session child exited before topology capture"
+    sleep 0.02
+  done
+  [ "$child_ready" = 1 ] || fail "session child topology capture timed out"
+  [ "$(sed -n '1p' "$child_result")" = fd7=closed ] ||
+    fail "session child inherited operation lock fd"
+  [ "$(sed -n '2p' "$child_result")" = "pid=$child_pid" ] ||
+    fail "launch pid does not identify the session child"
+  [ "$(sed -n '3p' "$child_result")" = "pgid=$child_pid" ] ||
+    fail "launch pid is not the child process-group leader"
+  [ "$(sed -n '4p' "$child_result")" = "sid=$child_pid" ] ||
+    fail "launch pid is not the child session leader"
+  child_exe="$(readlink -f "/proc/$child_pid/exe")"
+  bash_exe="$(readlink -f "$(command -v bash)")"
+  [ "$child_exe" = "$bash_exe" ] || fail "launch pid does not identify the target executable"
+  kill -TERM "$child_pid"
+  wait "$child_pid" || true
+  child_pid=
+  trap - EXIT
+)
+grep -Fq 'run_without_session_operation_lock() {' "$script" ||
+  fail "operation-lock helper adds an extra subshell"
+grep -Fq 'run_without_session_operation_lock setsid env' "$script" ||
+  fail "nested Gamescope launch does not drop the operation lock"
+grep -Fq 'run_without_session_operation_lock setsid -f env' "$script" ||
+  fail "attach Steam launch does not drop the operation lock"
 (
   export XDG_RUNTIME_DIR="$work/run"
   export POLARIS_GAMESCOPE_RUNTIME_LIB="$work/runtime-stub.sh"
@@ -293,5 +410,9 @@ grep -Fq 'POLARIS_SESSION_STATE_BEFORE_COMMIT_HOOK' "$script" ||
   fail "atomic publication interruption hook is missing"
 grep -Fq 'export POLARIS_GAMESCOPE_LOCK_HELD=1' "$script" ||
   fail "portal handoff is not finalized under the ownership lock"
+grep -Fq 'acquire_session_operation_lock' "$script" ||
+  fail "nested lifecycle operations are not serialized"
+grep -Fq 'wait_for_nested_gamescope_exit' "$script" ||
+  fail "nested stop has no graceful compositor-exit window"
 
 echo "PASS: gamescope session stop state machine"


### PR DESCRIPTION
## Summary

- serialize each nested Gamescope start or stop transition with one helper lifecycle lock
- make a repeated stop idempotent after the first caller completes recovery
- terminate exact-session Steam before signaling the compositor process group
- allow a bounded natural Gamescope exit before using the existing exact-generation stop fallback
- retain durable claims whenever identity, child shutdown, endpoint reclaim, or idle handoff remains uncertain
- add regressions for child-first ordering, natural compositor exit, and overlapping stop attempts

## Why

Package-native validation showed that endpoint cleanup works, but nested teardown can still abort Gamescope and retain a recovery claim that blocks reconnect. The observed reaper and Xwayland sequence is consistent with signaling the compositor group before its primary Steam child has exited. The same run also observed overlapping helper stop processes.

This patch changes that ordering without weakening the existing PID, process-group, marker, socket, or lock identity checks.

## Verification

- focused helper state machine passed repeatedly, including 10 overlap stress runs
- 48/48 session ownership contract tests passed
- full HTTP and lifecycle suite: 127 passed, 1 skipped because an external download fixture was unavailable
- public documentation check passed
- shell syntax and diff checks passed
- committed-diff privacy scan passed

## Acceptance boundary

- draft only
- package-native affected-host disconnect and reconnect validation is still required
- no install, deploy, service restart, physical test, merge, or release was performed

Refs #507.