### PR TITLE
fix(steam): report each Steam profile once when roots alias

### DIFF
--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -805,6 +805,11 @@ namespace game_library {
 
   std::vector<std::filesystem::path> steam_localconfig_paths(const std::vector<std::filesystem::path> &roots) {
     std::vector<std::filesystem::path> found;
+    // A stock Linux install symlinks ~/.steam/steam at ~/.local/share/Steam, and both
+    // are probed as roots, so the same profile arrives twice. Callers that merge by
+    // app id never noticed; callers that count -- Doctor reports "N app override(s)"
+    // -- reported double. Identity is the resolved file, not the path used to reach it.
+    std::set<std::filesystem::path> seen;
     for (const auto &root : roots) {
       // A fresh code per query: one shared across the walk stays set after the first
       // user directory that has no localconfig, and silently swallows every later one.
@@ -828,6 +833,17 @@ namespace game_library {
         auto candidate = user.path() / "config" / "localconfig.vdf";
         std::error_code file_ec;
         if (std::filesystem::is_regular_file(candidate, file_ec) && !file_ec) {
+          // Deduplicate on the resolved target, but report the path we walked: the
+          // raw path is what a caller can act on, and a file we cannot resolve is
+          // still worth reading once.
+          std::error_code canonical_ec;
+          auto identity = std::filesystem::weakly_canonical(candidate, canonical_ec);
+          if (canonical_ec) {
+            identity = candidate;
+          }
+          if (!seen.insert(std::move(identity)).second) {
+            continue;
+          }
           found.push_back(std::move(candidate));
         }
       }

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -292,6 +292,32 @@ TEST(SteamPlaytimeTests, FindsLocalconfigForEveryUserUnderARoot) {
   EXPECT_EQ(found.front(), user / "localconfig.vdf");
 }
 
+TEST(SteamPlaytimeTests, ReportsEachProfileOnceWhenTwoRootsResolveToTheSameDirectory) {
+  const auto root = lutris_test_root("steam_userdata_aliased");
+  const auto user = root / "userdata" / "11324806" / "config";
+  std::filesystem::create_directories(user);
+  write_text(user / "localconfig.vdf", kLocalConfig);
+
+  // A stock install symlinks ~/.steam/steam at ~/.local/share/Steam, and both are
+  // probed, so this profile is reachable twice. Counting callers must still see one.
+  const auto alias = root.parent_path() / "steam_userdata_aliased_link";
+  std::filesystem::remove_all(alias);
+  std::error_code link_ec;
+  std::filesystem::create_directory_symlink(root, alias, link_ec);
+  if (link_ec) {
+    GTEST_SKIP() << "symlinks are unavailable on this filesystem";
+  }
+
+  const auto found = game_library::steam_localconfig_paths({root, alias});
+  ASSERT_EQ(found.size(), 1u);
+
+  // Reached through the alias alone, the profile is still reported once, by the
+  // path the caller actually walked rather than the resolved target.
+  const auto through_alias = game_library::steam_localconfig_paths({alias});
+  ASSERT_EQ(through_alias.size(), 1u);
+  EXPECT_EQ(through_alias.front(), alias / "userdata" / "11324806" / "config" / "localconfig.vdf");
+}
+
 TEST(SteamInputTests, ReadsXboxOptInAndOnlyCountsForcedApps) {
   constexpr const char *config = R"vdf(
 "UserLocalConfigStore"


### PR DESCRIPTION
## Summary

- Deduplicate Steam profiles in `steam_localconfig_paths()` so a profile reachable through two roots is reported once.
- Found by live verification of #504 on pc-papi, not by a test: a stock Linux install symlinks `~/.steam/steam` at `~/.local/share/Steam`, and `steam_data_roots()` probes both, so the identical `localconfig.vdf` was walked twice. Doctor reported **"4 app override(s) force Steam Input on"** on a host that has exactly two, and `steam_profiles_checked` read `2` for a single profile.
- The conflict verdict itself was never wrong (`conflict()` only tests `> 0`), so this is a reporting-accuracy fix, not a false-positive fix. It matters because those counts are what the Doctor evidence detail shows the user.
- `steam_playtime_snapshot()` was double-reading the same file too. It merges into a map keyed by app id, so the duplicate collapsed silently and nothing surfaced — fixed here as a side effect of putting the dedupe at the path layer, which is the one place every consumer shares.
- Identity is the resolved file (`weakly_canonical`), but the **walked** path is what gets reported: that is the path a caller can act on, and a file whose target cannot be resolved is still worth reading once rather than dropped.

## Exact candidate

- `Commit:` `3699c98608976a960aa18cfe1aa6a8db6f3920cf`
- `Tree:` `371583778d8020bf0d0c47f33fc6cc36a60346a0`
- `Parent:` `d7dd072e`
- `Base:` `d7dd072e` (polaris/master, carries #504)

## Verification

- [x] `test_polaris --gtest_filter='SteamPlaytimeTests.*:SteamInputTests.*'` — 10/10 passed
- [x] **Negative check**: with the `game_library_scanner.cpp` change reverted and the test kept, `ReportsEachProfileOnceWhenTwoRootsResolveToTheSameDirectory` **fails**; with the fix restored it passes. The test catches the defect rather than merely passing beside it.
- [x] `ctest` full suite — 17/17 passed, 0 failed (64.9s)
- [x] Reproduced on the live host before fixing: `steam_forced_app_count: 4` / `steam_profiles_checked: 2` against a single real profile holding two forced-on apps.

## Notes

The new regression test covers both shapes: two roots where one is a symlink of the other, and reaching the profile through the alias alone (asserting the alias path is what comes back, not the resolved target). It skips rather than fails where symlinks are unavailable.
