### PR TITLE
fix(linux): size nested Gamescope to the session

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Sizes nested Gamescope sessions to the final negotiated render width, height, and frame rate instead of imposing the standalone 4K120 fallback on every client
 - Prevents Nova launches from crashing when headless cage startup sees an already-counted session before encoder selection by forcing the deferred cage probe whenever no encoder is selected, stopping capture safely if that invariant is ever violated, and keeping encoder probing or reset exclusive with active capture
 - Detects when local Steam Input settings can claim the Polaris Xbox virtual controller during strict gamepad isolation, reports the conflict and PII-free aggregate evidence in Doctor, and points to the host-wide and per-game Steam settings without changing them automatically
 

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -18,9 +18,36 @@ marker="$rt/polaris-gamescope.pid"
 export DBUS_SESSION_BUS_ADDRESS="unix:path=$rt/bus"
 # Module option services.polarisGamescopeSession.hdr — allow force-HDR path at all.
 allow_client_hdr=1
-gs_width="${POLARIS_HDR_WIDTH:-3840}"
-gs_height="${POLARIS_HDR_HEIGHT:-2160}"
-gs_refresh="${POLARIS_HDR_REFRESH:-120}"
+
+polaris_valid_dimension() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+polaris_valid_refresh() {
+  [[ "${1:-}" =~ ^[0-9]+([.][0-9]+)?$ ]] &&
+    [[ ! "${1:-}" =~ ^0+([.]0+)?$ ]]
+}
+
+polaris_first_valid_geometry_value() {
+  local validator="$1" candidate
+  shift
+  for candidate in "$@"; do
+    if "$validator" "$candidate"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Prefer the final negotiated/render geometry published by Polaris. Retain the
+# legacy HDR overrides and 4K120 defaults for standalone/manual helper use.
+gs_width="$(polaris_first_valid_geometry_value polaris_valid_dimension \
+  "${POLARIS_SESSION_TARGET_WIDTH:-}" "${POLARIS_HDR_WIDTH:-}" 3840)"
+gs_height="$(polaris_first_valid_geometry_value polaris_valid_dimension \
+  "${POLARIS_SESSION_TARGET_HEIGHT:-}" "${POLARIS_HDR_HEIGHT:-}" 2160)"
+gs_refresh="$(polaris_first_valid_geometry_value polaris_valid_refresh \
+  "${POLARIS_SESSION_TARGET_FPS:-}" "${POLARIS_HDR_REFRESH:-}" 120)"
 
 session_id_file="$rt/polaris-gamescope-session-id"
 session_mode_file="$rt/polaris-gamescope-session-mode"

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6900,6 +6900,29 @@ namespace proc {
       "POLARIS_SESSION_INSTANCE_ID",
       _session_instance_id
     );
+    if (nested_wsi_session) {
+      // Prep runs before the general session environment is published below.
+      // Give the nested compositor the final scaled render geometry before its
+      // start helper executes, without leaking it into the daemon environment.
+      set_child_only_session_env_var(
+        _env,
+        _session_env_keys,
+        "POLARIS_SESSION_TARGET_WIDTH",
+        std::to_string(launch_session->width)
+      );
+      set_child_only_session_env_var(
+        _env,
+        _session_env_keys,
+        "POLARIS_SESSION_TARGET_HEIGHT",
+        std::to_string(launch_session->height)
+      );
+      set_child_only_session_env_var(
+        _env,
+        _session_env_keys,
+        "POLARIS_SESSION_TARGET_FPS",
+        format_session_fps(launch_session->fps)
+      );
+    }
 #endif
 
     std::error_code ec;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -370,6 +370,12 @@ if (UNIX)
                 POLARIS_SOURCE_DIR=${CMAKE_SOURCE_DIR}
                 bash ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamescope_session_stop_shell.sh
     )
+    add_test(
+        NAME polaris_gamescope_session_geometry_shell
+        COMMAND ${CMAKE_COMMAND} -E env
+                POLARIS_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+                bash ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamescope_session_geometry_shell.sh
+    )
 endif()
 
 if (BUILD_FULL_TESTS)

--- a/tests/unit/platform/test_gamescope_session_geometry_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_geometry_shell.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/polaris-gamescope-session-geometry.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+script="${POLARIS_SOURCE_DIR:?}/nix/modules/polaris-gamescope-session.sh"
+prelude="$work/geometry-prelude.sh"
+runtime_stub="$work/runtime-stub.sh"
+: >"$runtime_stub"
+
+# Exercise the production resolver without entering the helper's command
+# dispatch. The geometry contract lives entirely before the first state path.
+awk '/^session_id_file=/{exit} {print}' "$script" >"$prelude"
+
+resolve_geometry() {
+  local session_width="$1" session_height="$2" session_fps="$3"
+  local legacy_width="$4" legacy_height="$5" legacy_refresh="$6"
+  local -a values=("POLARIS_GEOMETRY_TEST=1")
+
+  [ "$session_width" = unset ] || values+=("POLARIS_SESSION_TARGET_WIDTH=$session_width")
+  [ "$session_height" = unset ] || values+=("POLARIS_SESSION_TARGET_HEIGHT=$session_height")
+  [ "$session_fps" = unset ] || values+=("POLARIS_SESSION_TARGET_FPS=$session_fps")
+  [ "$legacy_width" = unset ] || values+=("POLARIS_HDR_WIDTH=$legacy_width")
+  [ "$legacy_height" = unset ] || values+=("POLARIS_HDR_HEIGHT=$legacy_height")
+  [ "$legacy_refresh" = unset ] || values+=("POLARIS_HDR_REFRESH=$legacy_refresh")
+
+  env -u POLARIS_SESSION_TARGET_WIDTH -u POLARIS_SESSION_TARGET_HEIGHT \
+    -u POLARIS_SESSION_TARGET_FPS -u POLARIS_HDR_WIDTH \
+    -u POLARIS_HDR_HEIGHT -u POLARIS_HDR_REFRESH \
+    XDG_RUNTIME_DIR="$work/run" \
+    POLARIS_GAMESCOPE_RUNTIME_LIB="$runtime_stub" \
+    "${values[@]}" \
+    bash -c '. "$1"; printf "%sx%s@%s\n" "$gs_width" "$gs_height" "$gs_refresh"' \
+    _ "$prelude"
+}
+
+[ "$(resolve_geometry 1920 1080 59.940 3840 2160 120)" = "1920x1080@59.940" ] ||
+  fail "session geometry did not take precedence"
+[ "$(resolve_geometry unset unset unset 2560 1440 144)" = "2560x1440@144" ] ||
+  fail "legacy geometry fallback was not preserved"
+[ "$(resolve_geometry unset unset unset unset unset unset)" = "3840x2160@120" ] ||
+  fail "standalone defaults were not preserved"
+[ "$(resolve_geometry bad 0 0 invalid -1 nope)" = "3840x2160@120" ] ||
+  fail "invalid geometry did not fail safely to defaults"
+
+printf 'PASS: gamescope session geometry contract\n'

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -406,10 +406,16 @@ TEST(ProcessRuntimeConfigTests, NestedSessionPrepReceivesCredentialAndFailsLaunc
   ASSERT_NE(app_env_loop, std::string::npos);
   const auto reserved_filter = body.find("is_reserved_session_env_key(key)", app_env_loop);
   ASSERT_NE(reserved_filter, std::string::npos);
-  const auto credential_reassert = body.find("set_child_only_session_env_var(", credential + 1);
+  const auto credential_reassert = body.find("set_child_only_session_env_var(", app_env_loop);
   ASSERT_NE(credential_reassert, std::string::npos);
+  const auto credential_reassert_key = body.find(
+    "\"POLARIS_SESSION_INSTANCE_ID\"",
+    credential_reassert
+  );
+  ASSERT_NE(credential_reassert_key, std::string::npos);
   EXPECT_LT(app_env_loop, reserved_filter);
   EXPECT_LT(reserved_filter, credential_reassert);
+  EXPECT_LT(credential_reassert_key, credential_reassert + 512);
   EXPECT_NE(body.find("platf::unset_env(\"POLARIS_SESSION_INSTANCE_ID\")", app_env_loop), std::string::npos);
 }
 
@@ -4683,6 +4689,27 @@ TEST(GamescopeNestedSessionContract, StartupUsesItsOwnVisibleTimeoutAndTheNixMod
   EXPECT_NE(source.find("prep_output = stderr;"), std::string::npos);
   EXPECT_NE(source.find("Nested gamescope startup timed out after "), std::string::npos);
   EXPECT_EQ(options.find("injectApps"), std::string::npos);
+}
+
+TEST(GamescopeNestedSessionContract, FinalGeometryReachesTheHelperBeforePrepStarts) {
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  const auto execute_start = source.find("int proc_t::execute_impl(");
+  const auto execute_end = source.find("int proc_t::running()", execute_start);
+  ASSERT_NE(execute_start, std::string::npos);
+  ASSERT_NE(execute_end, std::string::npos);
+  const auto execute = source.substr(execute_start, execute_end - execute_start);
+
+  const auto width = execute.find("\"POLARIS_SESSION_TARGET_WIDTH\"");
+  const auto height = execute.find("\"POLARIS_SESSION_TARGET_HEIGHT\"");
+  const auto fps = execute.find("\"POLARIS_SESSION_TARGET_FPS\"");
+  const auto prep = execute.find("for (; _app_prep_it != std::end(_app.prep_cmds);");
+  ASSERT_NE(width, std::string::npos);
+  ASSERT_NE(height, std::string::npos);
+  ASSERT_NE(fps, std::string::npos);
+  ASSERT_NE(prep, std::string::npos);
+  EXPECT_LT(width, prep);
+  EXPECT_LT(height, prep);
+  EXPECT_LT(fps, prep);
 }
 
 TEST(HeadlessDongleContract, HeadlessDongleReachesTopologyPrepareWithoutAutoManageAlreadyOn) {


### PR DESCRIPTION
## Summary

- publish the final scaled session width, height, and frame rate before nested Gamescope prep starts
- prefer that session geometry in the helper while preserving validated legacy overrides and standalone 4K120 defaults
- reject malformed or zero geometry values before they reach Gamescope
- add executable shell coverage for negotiated, legacy, default, and invalid inputs
- pin the C++ ordering contract so the helper receives geometry before launch

## Why

Nested WSI currently starts Gamescope at 3840x2160@120 for every client because the helper only sees its fallback values. That makes lower-resolution sessions pay for unnecessary compositor and capture work, especially on system-memory capture paths.

## Verification

- Gamescope nested-session contract: 3/3 passed
- full configuration suite: 287/287 passed on rerun
- unrelated process-ownership timing test: 3/3 isolated reruns passed after one transient full-suite failure
- HTTP and lifecycle suite: 128/128 passed
- helper geometry and teardown shell contracts: 2/2 passed
- public documentation, shell syntax, and diff checks passed
- committed-diff privacy scan passed

## Acceptance boundary

- draft only
- package-native affected-host confirmation should verify a lower-resolution client produces matching nested geometry and capture dimensions
- no install, deploy, service restart, physical test, merge, or release was performed

Refs #505.
