### PR TITLE
feat(doctor): offer a one-click fix for the Steam Input conflict

### DIFF
--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -8,13 +8,22 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
 #include <mutex>
+#include <sstream>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
 #include "adaptive_bitrate.h"
+#include "game_library_scanner.h"
 #include "logging.h"
+
+#ifdef __linux__
+  #include "process.h"
+#endif
 
 using namespace std::literals;
 
@@ -23,13 +32,21 @@ namespace doctor_actions {
     enum class action_kind_e {
       none,
       lower_bitrate,
-      restore_quality
+      restore_quality,
+      disable_steam_input_xbox
+    };
+
+    /** One profile this run rewrote, and the value it held beforehand. */
+    struct steam_profile_edit_t {
+      std::filesystem::path path;
+      bool previously_enabled = true;
     };
 
     struct action_run_t {
       bool active = false;
       action_kind_e kind = action_kind_e::none;
       std::string run_id;
+      std::vector<steam_profile_edit_t> steam_edits;
       bool previous_adaptive_enabled = false;
       int previous_base_bitrate_kbps = 0;
       int previous_live_bitrate_kbps = 0;
@@ -62,6 +79,87 @@ namespace doctor_actions {
     bool network_stable_for_quality_retry(const stream_stats::stats_t &stats) {
       return stats.streaming && !stats.network_risk &&
         stats.packet_loss <= 2.0 && stats.latency_ms < 45.0;
+    }
+
+    /**
+     * Rewrite one profile's Xbox opt-in through a sibling temp file.
+     *
+     * A half-written localconfig.vdf is a corrupted Steam profile, so the new
+     * payload is only ever swapped in by rename, which is atomic within the
+     * directory. Returns false when nothing was written, including the case
+     * where the value already held the requested setting.
+     */
+    bool rewrite_steam_profile(const std::filesystem::path &path, bool enabled) {
+      std::ifstream input {path, std::ios::binary};
+      if (!input) {
+        return false;
+      }
+      std::ostringstream buffer;
+      buffer << input.rdbuf();
+      input.close();
+
+      const auto updated = game_library::set_steam_input_xbox_support(buffer.str(), enabled);
+      if (!updated) {
+        return false;
+      }
+
+      auto temporary = path;
+      temporary += ".polaris-doctor";
+      {
+        std::ofstream output {temporary, std::ios::binary | std::ios::trunc};
+        if (!output) {
+          return false;
+        }
+        output << *updated;
+        if (!output) {
+          return false;
+        }
+      }
+
+      std::error_code rename_ec;
+      std::filesystem::rename(temporary, path, rename_ec);
+      if (rename_ec) {
+        std::error_code discard_ec;
+        std::filesystem::remove(temporary, discard_ec);
+        return false;
+      }
+      return true;
+    }
+
+    /**
+     * Read the profiles again, deliberately bypassing the 30s snapshot cache.
+     *
+     * Verification runs seconds after the write, well inside that cache, so the
+     * cached snapshot would report the state this action just changed and call
+     * its own success a failure.
+     */
+    game_library::steam_input_snapshot_t fresh_steam_input_state() {
+      return game_library::inspect_steam_input_configs(
+        game_library::steam_localconfig_paths(
+          game_library::steam_data_roots(game_library::library_home_roots())
+        )
+      );
+    }
+
+    nlohmann::json steam_input_evidence() {
+      const auto snapshot = fresh_steam_input_state();
+      return {
+        {"steam_input_status", snapshot.status},
+        {"profiles_checked", snapshot.profiles_checked},
+        {"profiles_with_xbox_support", snapshot.profiles_with_xbox_support},
+        {"forced_app_count", snapshot.forced_app_count}
+      };
+    }
+
+    /**
+     * Whether the in-flight run is the Steam Input one.
+     *
+     * `verify` carries only a run id, so the shared verb has to ask what it is
+     * verifying before the streaming gate decides a stream is required.
+     */
+    bool steam_input_run_active() {
+      std::lock_guard<std::mutex> lock(action_mutex);
+      return action_run.active && action_run.kind == action_kind_e::disable_steam_input_xbox;
     }
 
     std::string next_run_id() {
@@ -112,6 +210,27 @@ namespace doctor_actions {
       if (!action_run.active || run_id.empty() || run_id != action_run.run_id) {
         return {{"status", false}, {"changed", false}, {"error", "This Doctor undo is no longer available."}};
       }
+
+      if (action_run.kind == action_kind_e::disable_steam_input_xbox) {
+        int restored = 0;
+        for (const auto &edit : action_run.steam_edits) {
+          if (rewrite_steam_profile(edit.path, edit.previously_enabled)) {
+            ++restored;
+          }
+        }
+        action_run.active = false;
+        BOOST_LOG(info) << "Doctor: restored Steam Input opt-in on "sv << restored
+                        << " profile(s) run=" << run_id;
+        return {
+          {"status", true},
+          {"changed", restored > 0},
+          {"state", "undone"},
+          {"message", "Restored the Steam Input setting each profile held before this Doctor run."},
+          {"restored_profiles", restored},
+          {"evidence", steam_input_evidence()}
+        };
+      }
+
       if (!adaptive_bitrate::get_state().runtime_update_supported) {
         return {
           {"status", false},
@@ -149,6 +268,113 @@ namespace doctor_actions {
         {"restored_bitrate_kbps", restore_live_bitrate_kbps},
         {"adaptive_bitrate_enabled", action_run.previous_adaptive_enabled}
       };
+    }
+
+    // Steam Input work runs ahead of the streaming gate below on purpose. Its
+    // whole point is to edit a profile Steam is not holding open, which means
+    // the fix is applied precisely when no stream is running.
+    if (action_id == "disable_steam_input_xbox" || (action_id == "verify" && steam_input_run_active())) {
+#ifndef __linux__
+      return {
+        {"status", false},
+        {"changed", false},
+        {"error", "Closing desktop Steam is only supported on Linux hosts."}
+      };
+#else
+      if (action_id == "verify") {
+        const auto run_id = request.value("run_id", std::string {});
+        std::lock_guard<std::mutex> lock(action_mutex);
+        if (!action_run.active || run_id.empty() || run_id != action_run.run_id) {
+          return {{"status", false}, {"changed", false}, {"state", "expired"}, {"error", "Doctor run not found."}};
+        }
+        const auto state = fresh_steam_input_state();
+        const bool cleared = state.profiles_with_xbox_support == 0;
+        // A per-app Force On outranks the host-wide opt-in this action owns, so
+        // clearing the opt-in while overrides remain is a real partial result,
+        // not a success and not a failure.
+        const bool overrides_remain = state.forced_app_count > 0;
+        return {
+          {"status", true},
+          {"changed", false},
+          {"run_id", run_id},
+          {"state", cleared && !overrides_remain ? "resolved" : "needs_attention"},
+          {"message", !cleared ?
+             "A Steam profile still opts the emulated controller into Steam Input." :
+             overrides_remain ?
+               "The host-wide opt-in is cleared, but per-game Force On overrides remain. Set those games to Default or Disable in their Steam controller properties." :
+               "No Steam profile opts the emulated controller into Steam Input any more."},
+          {"evidence", steam_input_evidence()},
+          {"undo", {{"available", true}, {"action_id", "undo"}, {"run_id", run_id}}}
+        };
+      }
+
+      const auto before = fresh_steam_input_state();
+      if (before.profiles_with_xbox_support == 0) {
+        return {
+          {"status", false},
+          {"changed", false},
+          {"state", "evidence_changed"},
+          {"error", before.forced_app_count > 0 ?
+             "No profile opts in host-wide. The remaining conflict is per-game Force On, which must be changed in each game's Steam controller properties." :
+             "No Steam profile opts the emulated controller into Steam Input."},
+          {"evidence", steam_input_evidence()}
+        };
+      }
+
+      // Steam rewrites this file when it exits, so an edit under a live client
+      // is reverted the moment that client closes. Closing Steam first is the
+      // whole reason this action asks for confirmation.
+      if (proc::desktop_steam_client_active() && !proc::request_desktop_steam_shutdown_for_private_stream()) {
+        return {
+          {"status", false},
+          {"changed", false},
+          {"state", "steam_still_running"},
+          {"error", "Desktop Steam did not close, so the change would be reverted when it exits. Close Steam and try again."},
+          {"evidence", steam_input_evidence()}
+        };
+      }
+
+      action_run_t run;
+      run.active = true;
+      run.kind = action_kind_e::disable_steam_input_xbox;
+      run.run_id = next_run_id();
+      run.applied_at = std::chrono::steady_clock::now();
+      for (const auto &path : game_library::steam_localconfig_paths(
+             game_library::steam_data_roots(game_library::library_home_roots()))) {
+        if (rewrite_steam_profile(path, false)) {
+          run.steam_edits.push_back({path, true});
+        }
+      }
+
+      if (run.steam_edits.empty()) {
+        return {
+          {"status", false},
+          {"changed", false},
+          {"error", "No Steam profile could be updated."},
+          {"evidence", steam_input_evidence()}
+        };
+      }
+
+      {
+        std::lock_guard<std::mutex> lock(action_mutex);
+        action_run = run;
+      }
+      BOOST_LOG(info) << "Doctor: cleared the Xbox Steam Input opt-in on "sv
+                      << run.steam_edits.size() << " profile(s) run=" << run.run_id;
+
+      return {
+        {"status", true},
+        {"changed", true},
+        {"state", "watching"},
+        {"message", "Closed desktop Steam and cleared the Xbox Steam Input opt-in. Launch the game again to pick up the change."},
+        {"run_id", run.run_id},
+        {"applied", {{"profiles_updated", static_cast<int>(run.steam_edits.size())}}},
+        {"before", {{"profiles_with_xbox_support", before.profiles_with_xbox_support}, {"forced_app_count", before.forced_app_count}}},
+        {"verification", {{"delay_seconds", 2}, {"action_id", "verify"}, {"run_id", run.run_id}}},
+        {"undo", {{"available", true}, {"action_id", "undo"}, {"run_id", run.run_id}}},
+        {"evidence", steam_input_evidence()}
+      };
+#endif
     }
 
     const auto stats = stream_stats::get_current();

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -668,6 +668,41 @@ namespace game_library {
     return cached;
   }
 
+  std::optional<std::string> set_steam_input_xbox_support(std::string_view vdf_payload, bool enabled) {
+    constexpr std::string_view key = "\"SteamController_XBoxSupport\"";
+    const auto key_at = vdf_payload.find(key);
+    if (key_at == std::string_view::npos) {
+      return std::nullopt;
+    }
+
+    // The value is the next quoted token, and it has to be on the same line: a
+    // key whose value Steam has not written yet must not consume the next
+    // setting's value and silently rewrite the wrong field.
+    const auto line_end = vdf_payload.find('\n', key_at);
+    const auto limit = line_end == std::string_view::npos ? vdf_payload.size() : line_end;
+    const auto value_open = vdf_payload.find('"', key_at + key.size());
+    if (value_open == std::string_view::npos || value_open >= limit) {
+      return std::nullopt;
+    }
+    const auto value_close = vdf_payload.find('"', value_open + 1);
+    if (value_close == std::string_view::npos || value_close >= limit) {
+      return std::nullopt;
+    }
+
+    const auto current = vdf_payload.substr(value_open + 1, value_close - value_open - 1);
+    const std::string_view desired = enabled ? "1" : "0";
+    if (current == desired) {
+      return std::nullopt;
+    }
+
+    std::string updated;
+    updated.reserve(vdf_payload.size());
+    updated.append(vdf_payload.substr(0, value_open + 1));
+    updated.append(desired);
+    updated.append(vdf_payload.substr(value_close));
+    return updated;
+  }
+
   playtime_snapshot_t steam_playtime_snapshot() {
     static std::mutex guard;
     static playtime_snapshot_t cached;

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -150,6 +150,17 @@ namespace game_library {
   /** @brief Inspect locally discovered Steam profiles, cached briefly. */
   steam_input_snapshot_t steam_input_snapshot();
 
+  /**
+   * @brief Rewrite one profile's host-wide Xbox Steam Input opt-in.
+   *
+   * Returns the whole updated payload, or nullopt when the key is absent or
+   * already holds the requested value, so a caller can skip the write entirely.
+   * Everything outside that one value is preserved byte for byte: this edits a
+   * live Steam profile, and a reformatting writer would be a far worse bug than
+   * the setting it came to change.
+   */
+  std::optional<std::string> set_steam_input_xbox_support(std::string_view vdf_payload, bool enabled);
+
   /** @brief What the launcher files said, and when we last looked. */
   struct playtime_snapshot_t {
     std::map<std::string, playtime_t> by_app_id;

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -905,7 +905,7 @@ namespace stream_stats {
         method = "POST";
         payload["action_id"] = id;
         payload["source_result_id"] = source_result_id;
-        rollback = "Undo restores the previous Steam Input opt-in for every profile this run changed.";
+        rollback = "Closing Steam ends any game running through it, including the session you are streaming now. Undo restores the previous Steam Input opt-in for every profile this run changed.";
         verification = {
           {"mode", "local_steam_config"},
           {"delay_seconds", 2},

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -894,6 +894,24 @@ namespace stream_stats {
         };
       } else if ((primary_issue == "network_jitter" || primary_issue == "quality_capped_by_history") && !live_bitrate_tunable) {
         unavailable_reason = "The active encoder does not support runtime bitrate updates.";
+      } else if (primary_issue == "steam_input_conflict") {
+        // Steam rewrites its profile on exit, so an edit made underneath a
+        // running client is reverted the moment that client closes. The action
+        // therefore closes desktop Steam first, which is why it confirms.
+        id = "disable_steam_input_xbox";
+        label = "Close Steam and fix";
+        kind = "host_setting";
+        endpoint = "/api/doctor/action";
+        method = "POST";
+        payload["action_id"] = id;
+        payload["source_result_id"] = source_result_id;
+        rollback = "Undo restores the previous Steam Input opt-in for every profile this run changed.";
+        verification = {
+          {"mode", "local_steam_config"},
+          {"delay_seconds", 2},
+          {"endpoint", "/api/doctor/action"},
+          {"success_when", nlohmann::json::array({"no Steam profile opts the emulated pad into Steam Input"})}
+        };
       } else if (primary_issue == "no_active_stream" || primary_issue == "capture_missing") {
         id = "export_support_bundle";
         label = "Export diagnostics";
@@ -911,6 +929,9 @@ namespace stream_stats {
         if (health.contains("safe_hdr")) payload["hdr"] = health["safe_hdr"];
       }
 
+      const bool undoable =
+        id == "lower_bitrate" || id == "restore_quality" || id == "disable_steam_input_xbox";
+
       return {
         {"id", id},
         {"label", label},
@@ -925,7 +946,7 @@ namespace stream_stats {
         {"payload_preview", payload},
         {"rollback", rollback},
         {"verification", verification},
-        {"undo", {{"supported", id == "lower_bitrate" || id == "restore_quality"}, {"endpoint", id == "lower_bitrate" || id == "restore_quality" ? "/api/doctor/action" : ""}}}
+        {"undo", {{"supported", undoable}, {"endpoint", undoable ? "/api/doctor/action" : ""}}}
       };
     }
   }  // namespace

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -412,6 +412,44 @@ TEST(SteamInputTests, AggregatesProfilesWithoutLeakingPathsOrAppIds) {
   EXPECT_EQ(snapshot.detail.find("555"), std::string::npos);
 }
 
+TEST(SteamInputTests, ClearsTheXboxOptInWithoutDisturbingTheRestOfTheProfile) {
+  const std::string profile =
+    "\"UserLocalConfigStore\"\n{\n"
+    "\t\"SteamController_XBoxSupport\"\t\t\"1\"\n"
+    "\t\"SteamController_GenericGamepadSupport\"\t\t\"1\"\n"
+    "}\n";
+
+  const auto updated = game_library::set_steam_input_xbox_support(profile, false);
+  ASSERT_TRUE(updated.has_value());
+  EXPECT_NE(updated->find("\"SteamController_XBoxSupport\"\t\t\"0\""), std::string::npos);
+  // Only that one value may move: this rewrites a live Steam profile.
+  EXPECT_NE(updated->find("\"SteamController_GenericGamepadSupport\"\t\t\"1\""), std::string::npos);
+  EXPECT_EQ(updated->size(), profile.size());
+
+  // Re-enabling is the undo path, and it round-trips exactly.
+  const auto restored = game_library::set_steam_input_xbox_support(*updated, true);
+  ASSERT_TRUE(restored.has_value());
+  EXPECT_EQ(*restored, profile);
+}
+
+TEST(SteamInputTests, SkipsTheWriteWhenTheOptInAlreadyHoldsTheRequestedValue) {
+  const std::string already_off =
+    "\"UserLocalConfigStore\"\n{\n\t\"SteamController_XBoxSupport\"\t\t\"0\"\n}\n";
+  EXPECT_FALSE(game_library::set_steam_input_xbox_support(already_off, false).has_value());
+
+  // A profile that never mentions the key is not ours to invent.
+  const std::string absent = "\"UserLocalConfigStore\"\n{\n\t\"Other\"\t\t\"1\"\n}\n";
+  EXPECT_FALSE(game_library::set_steam_input_xbox_support(absent, false).has_value());
+}
+
+TEST(SteamInputTests, RefusesToBorrowAValueFromTheFollowingLine) {
+  // A key Steam wrote without a value must not consume the next setting's
+  // value and silently rewrite the wrong field.
+  const std::string truncated =
+    "\"UserLocalConfigStore\"\n{\n\t\"SteamController_XBoxSupport\"\n\t\"Other\"\t\t\"1\"\n}\n";
+  EXPECT_FALSE(game_library::set_steam_input_xbox_support(truncated, false).has_value());
+}
+
 TEST(SteamInputTests, ReportsUnknownWhenNoProfileIsReadable) {
   const auto snapshot = game_library::inspect_steam_input_configs({
     lutris_test_root("steam_input_missing") / "missing.vdf"

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -664,8 +664,19 @@ TEST(StreamStatsDoctorTests, WarnsWhenSteamInputConflictsWithStrictIsolation) {
   EXPECT_EQ(doctor.at("status"), "needs_action");
   EXPECT_EQ(doctor.at("confidence").at("level"), "high");
   EXPECT_EQ(doctor.at("recommendation").at("next_step_label"), "Adjust Steam Input");
-  EXPECT_EQ(doctor.at("safe_recovery_action").at("id"), "none");
-  EXPECT_FALSE(doctor.at("safe_recovery_action").at("destructive"));
+  // This finding shipped read-only, with the action pinned to "none". It now
+  // offers one, and the invariant that replaced it is what the action must
+  // stay: reversible, never destructive, and never applied without a
+  // confirmation, because applying it closes the user's desktop Steam.
+  const auto &action = doctor.at("safe_recovery_action");
+  EXPECT_EQ(action.at("id"), "disable_steam_input_xbox");
+  EXPECT_EQ(action.at("kind"), "host_setting");
+  EXPECT_FALSE(action.at("destructive"));
+  EXPECT_TRUE(action.at("requires_confirmation"));
+  EXPECT_TRUE(action.at("requires_owner"));
+  EXPECT_TRUE(action.at("undo").at("supported"));
+  EXPECT_EQ(action.at("endpoint"), "/api/doctor/action");
+  EXPECT_EQ(action.at("payload_preview").at("action_id"), "disable_steam_input_xbox");
   EXPECT_EQ(
     doctor.at("advanced_evidence").at("controller_input").at("steam_forced_app_count"),
     2


### PR DESCRIPTION
## Summary

- Give the `steam_input_conflict` finding from #504 the guarded one-click action the rest of Doctor already has. The finding shipped read-only: it named the setting and left the user to go find it.
- Action id `disable_steam_input_xbox`, kind `host_setting`, label **"Close Steam and fix"**. It requires confirmation and owner, is never destructive, and supports undo.
- **Applying it closes desktop Steam first, which is why it confirms.** Steam holds its profile in memory and rewrites `localconfig.vdf` on exit, so an edit made underneath a running client is reverted the moment that client closes. It reuses `proc::request_desktop_steam_shutdown_for_private_stream()`, which already waits for Steam to go quiescent and reports whether it did — so a refusal to close is a refusal to apply, never a change that silently disappears later.
- **Verification reports three outcomes, not two.** Clearing the host-wide opt-in while per-game Force On overrides remain is a real partial result: those overrides outrank the setting this action owns and must be changed per game. Saying so beats claiming a success the controller will not show.
- The write is surgical and atomic: `set_steam_input_xbox_support()` replaces exactly one value and preserves the rest byte for byte, and the payload is swapped in by `rename`. A half-written `localconfig.vdf` is a corrupted Steam profile — a much worse outcome than the setting we came to change.
- Undo restores the previous value on every profile the run touched.

## Two placements worth reviewing

1. **The action runs ahead of the `!stats.streaming` gate** that every other action sits behind. Its purpose is to edit a profile Steam is not holding open, so it applies exactly when nothing is streaming — the inverse of the live bitrate steps. `verify` therefore asks which run is in flight before that gate decides a stream is required.
2. **Verification bypasses the 30-second snapshot cache** via an uncached re-inspection. Verify runs 2s after the write, well inside that cache, so the cached snapshot would report the state this action just changed and call its own success a failure.

## Re-pinned guard

`StreamStatsDoctorTests.WarnsWhenSteamInputConflictsWithStrictIsolation` pinned `safe_recovery_action.id == "none"`, asserting the finding was action-free. That intent is deliberately superseded here, so it is re-pinned in its new form rather than deleted: the action must stay reversible, never destructive, never applied without confirmation, owner-gated, and routed at `/api/doctor/action`.

## Exact candidate

- `Commit:` `667f99db6f1a240b47a41b769d6060a0157811c3`
- `Tree:` `a5805a7c11eb7829a144dc5c31415a5995fb92c2`
- `Parent:` `7d75db9e`
- `Base:` `7d75db9e` (polaris/master, carries #504 and #510)

## Verification

- [x] `ctest` full suite — 17/17 passed, 0 failed
- [x] `test_polaris --gtest_filter='SteamInputTests.*:SteamPlaytimeTests.*'` — 13/13, including three new cases for the writer
- [x] `test_polaris_stream --gtest_filter='StreamStatsDoctorTests.*'` — 16/16
- [x] The new writer tests cover: one value changes and the payload length is unchanged; undo round-trips to the original byte for byte; no write when the value already holds the request or the key is absent; and a key written without a value does **not** borrow the next line's value and rewrite the wrong field.

## Not covered

No unit test drives `doctor_actions::execute` for this action end to end. Doing so would require a real Steam client to close and real profiles to rewrite; this matches the existing pattern in that file, where the route handlers and Steam lifecycle paths are untested glue over tested pure logic. The pure parts — the payload transform and the aggregate inspection — are covered directly. The action has **not** been exercised on the live host, because the host it was written for has already had its conflict fixed by hand and no longer reproduces the finding.
