### PR TITLE
fix(video): recover deferred cage encoder before capture

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Prevents Nova launches from crashing when headless cage startup sees an already-counted session before encoder selection by forcing the deferred cage probe whenever no encoder is selected and stopping capture safely if that invariant is ever violated
 - Detects when local Steam Input settings can claim the Polaris Xbox virtual controller during strict gamepad isolation, reports the conflict and PII-free aggregate evidence in Doctor, and points to the host-wide and per-game Steam settings without changing them automatically
 
 ## v1.3.11 - 2026-08-19

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3334,6 +3334,17 @@ namespace proc {
       return configured_max_bitrate > 0 || has_paired_target_bitrate || !ai_auto_quality_enabled;
     }
 
+#ifdef __linux__
+    bool should_reprobe_deferred_cage_encoder(
+      bool use_cage_compositor,
+      bool no_active_sessions_at_launch,
+      bool encoder_selected
+    ) {
+      return use_cage_compositor &&
+             (no_active_sessions_at_launch || !encoder_selected);
+    }
+#endif
+
     void apply_optimization_layer(resolved_session_optimization_t &resolved,
                                   const optimization_locks_t &locks,
                                   const device_db::optimization_t &optimization,
@@ -4073,6 +4084,18 @@ namespace proc {
 
 #if defined(POLARIS_TESTS)
 #ifdef __linux__
+  bool should_reprobe_deferred_cage_encoder_for_tests(
+    bool use_cage_compositor,
+    bool no_active_sessions_at_launch,
+    bool encoder_selected
+  ) {
+    return should_reprobe_deferred_cage_encoder(
+      use_cage_compositor,
+      no_active_sessions_at_launch,
+      encoder_selected
+    );
+  }
+
   bool steam_big_picture_input_guard_enabled_for_tests(
     const proc::ctx_t &app,
     bool use_cage_compositor,
@@ -7107,8 +7130,18 @@ namespace proc {
     bool cage_started_with_detached_client = false;
 
     auto reprobe_encoders_for_cage = [&](bool strict_configured_encoder = false, bool save_successful_cache = true) -> bool {
-      if (!config::video.linux_display.use_cage_compositor || !no_active_sessions_at_launch) {
+      const bool encoder_selected = !video::active_encoder_name().empty();
+      if (!should_reprobe_deferred_cage_encoder(
+            config::video.linux_display.use_cage_compositor,
+            no_active_sessions_at_launch,
+            encoder_selected
+          )) {
         return true;
+      }
+
+      if (!no_active_sessions_at_launch && !encoder_selected) {
+        BOOST_LOG(warning) << "session_manager: No encoder is selected after a deferred cage probe; "sv
+                           << "reprobing despite an already-counted session"sv;
       }
 
       const auto cage_socket = stream_runtime::labwc::wayland_socket();

--- a/src/process.h
+++ b/src/process.h
@@ -155,6 +155,12 @@ namespace proc {
 
 #if defined(POLARIS_TESTS) && defined(__linux__)
 
+  bool should_reprobe_deferred_cage_encoder_for_tests(
+    bool use_cage_compositor,
+    bool no_active_sessions_at_launch,
+    bool encoder_selected
+  );
+
   enum class steam_game_process_event_kind_e {
     none,
     started,

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3863,6 +3863,12 @@ namespace video {
     void *channel_data,
     packet_queue_t packets
   ) {
+    if (!chosen_encoder) {
+      BOOST_LOG(error) << "Video capture refused because no encoder is selected; "sv
+                       << "encoder probing must complete before a stream starts"sv;
+      return;
+    }
+
     auto idr_events = mail->event<bool>(mail::idr);
 
     idr_events->raise(true);

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -796,6 +796,25 @@ TEST(ProcessRuntimeConfigTests, SessionLifecycleGateOwnsLaunchRaiseAndTeardownWi
   EXPECT_NE(source.find("rtsp_snapshot.active_sessions + rtsp_snapshot.pending_sessions"), std::string::npos);
 }
 
+#ifdef __linux__
+TEST(ProcessRuntimeConfigTests, DeferredCageProbeRecoversWhenNovaLaunchAlreadyCountsASession) {
+  EXPECT_TRUE(proc::should_reprobe_deferred_cage_encoder_for_tests(true, true, false));
+  EXPECT_TRUE(proc::should_reprobe_deferred_cage_encoder_for_tests(true, false, false));
+  EXPECT_FALSE(proc::should_reprobe_deferred_cage_encoder_for_tests(true, false, true));
+  EXPECT_FALSE(proc::should_reprobe_deferred_cage_encoder_for_tests(false, true, false));
+
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto reprobe_start = source.find("auto reprobe_encoders_for_cage = [&]");
+  const auto cage_socket = source.find("const auto cage_socket", reprobe_start);
+  ASSERT_NE(reprobe_start, std::string::npos);
+  ASSERT_NE(cage_socket, std::string::npos);
+  const auto reprobe_guard = source.substr(reprobe_start, cage_socket - reprobe_start);
+  EXPECT_NE(reprobe_guard.find("should_reprobe_deferred_cage_encoder("), std::string::npos);
+  EXPECT_NE(reprobe_guard.find("!video::active_encoder_name().empty()"), std::string::npos);
+}
+#endif
+
 TEST(ProcessRuntimeConfigTests, RefreshPreservesLifecycleSynchronizationObjects) {
   const auto source = read_source_file_for_contract("src/process.cpp");
   const auto refresh_start = source.find("void refresh(const std::string &file_name, bool needs_terminate)");

--- a/tests/unit/test_video_hdr_probe_guard_source.cpp
+++ b/tests/unit/test_video_hdr_probe_guard_source.cpp
@@ -63,6 +63,25 @@ TEST(VideoHdrProbeGuardSource, HdrCapabilityProbeCannotFailTheEncoder) {
     << "HEVC profile selection must follow the actual encoder input depth";
 }
 
+TEST(VideoCaptureGuardSource, MissingEncoderStopsBeforeCaptureDereference) {
+  const auto source = read_video_source();
+  ASSERT_FALSE(source.empty()) << "could not read src/video.cpp via POLARIS_SOURCE_DIR";
+
+  const auto dereference_pos = source.find("if (chosen_encoder->flags & PARALLEL_ENCODING)");
+  ASSERT_NE(dereference_pos, std::string::npos) << "capture encoder dereference not found";
+
+  const auto capture_pos = source.rfind("void capture(", dereference_pos);
+  ASSERT_NE(capture_pos, std::string::npos) << "capture overload not found";
+
+  const auto guard_pos = source.find("if (!chosen_encoder)", capture_pos);
+  ASSERT_NE(guard_pos, std::string::npos) << "missing-encoder guard not found";
+  EXPECT_LT(guard_pos, dereference_pos) << "missing-encoder guard must run before dereference";
+
+  const auto guarded_prefix = source.substr(guard_pos, dereference_pos - guard_pos);
+  EXPECT_NE(guarded_prefix.find("return;"), std::string::npos)
+    << "missing encoder must stop video capture rather than continue";
+}
+
 TEST(VideoHdrDiagnosticsSource, WarnsWhenAClientHdrRequestBecomesAnSdrStream) {
   const auto source = read_video_source();
   ASSERT_FALSE(source.empty()) << "could not read src/video.cpp via POLARIS_SOURCE_DIR";


### PR DESCRIPTION
## Summary

- force the session-time cage encoder reprobe when no encoder is selected, even if a Nova/web launch already has a counted session
- fail closed in video capture if encoder selection is missing instead of dereferencing a null pointer
- cover the recovery policy and capture guard with regressions and document the fix

## Root cause

Headless cage mode intentionally defers encoder probing until its session runtime exists. A Nova/web launch can reach process execution with a session already counted; the existing guard then skipped the cage reprobe solely because the session count was nonzero. Video startup subsequently dereferenced the still-null selected encoder and crashed Polaris.

## Validation

- focused deferred-cage recovery regression: pass
- focused missing-encoder capture guard regression: pass
- complete local C++/shell matrix: 14/14 tests pass
- exact-head CI for `8b6647939bf5eef36ed5e1209e9281af99ed7a38`: required checks pass, including sanitizer, Arch build, web checks, public hygiene, and CodeQL
- physical Nova/RP6 test: 1920x1080@120 HEVC stream remained active; cage reprobe targeted `wayland-1` and selected NVENC
- affected-host coredump gate: no new Polaris coredump
- host restored to the exact pre-test baseline after validation

Independent review remains required before merge. This PR does not authorize a release, deployment, tag, or promotion.
