### PR TITLE
fix(doctor): keep the Steam Input finding once the stream ends

### DIFF
--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -155,14 +155,17 @@ namespace doctor_actions {
     }
 
     /**
-     * Whether the in-flight run is the Steam Input one.
+     * Whether the last run was the Steam Input one, active or finished.
      *
      * `verify` carries only a run id, so the shared verb has to ask what it is
-     * verifying before the streaming gate decides a stream is required.
+     * verifying before the streaming gate decides a stream is required. The
+     * check deliberately ignores `active`: verifying a Steam Input run that has
+     * already been undone must answer "expired", not send the caller off to
+     * start a stream this action never needed.
      */
-    bool steam_input_run_active() {
+    bool steam_input_run_selected() {
       std::lock_guard<std::mutex> lock(action_mutex);
-      return action_run.active && action_run.kind == action_kind_e::disable_steam_input_xbox;
+      return action_run.kind == action_kind_e::disable_steam_input_xbox;
     }
 
     std::string next_run_id() {
@@ -276,7 +279,7 @@ namespace doctor_actions {
     // Steam Input work runs ahead of the streaming gate below on purpose. Its
     // whole point is to edit a profile Steam is not holding open, which means
     // the fix is applied precisely when no stream is running.
-    if (action_id == "disable_steam_input_xbox" || (action_id == "verify" && steam_input_run_active())) {
+    if (action_id == "disable_steam_input_xbox" || (action_id == "verify" && steam_input_run_selected())) {
 #ifndef __linux__
       return {
         {"status", false},

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -1257,10 +1257,30 @@ namespace stream_stats {
       current_stats.client_name = client_name;
       current_stats.client_ip = client_ip;
     } else {
-      // Reset all stats when stream ends
+      // Reset all stats when stream ends, but carry the controller-input facts
+      // across: they describe the host, not the stream that just ended, and the
+      // Steam Input conflict is only safe to fix while nothing is streaming.
+      // Wiping them here made the finding vanish at exactly the moment its own
+      // one-click fix became applicable.
+      const auto isolation = current_stats.input_host_controller_isolation;
+      const auto isolation_detail = current_stats.input_host_controller_isolation_detail;
+      const auto steam_status = current_stats.input_steam_input_status;
+      const auto steam_profiles = current_stats.input_steam_profiles_checked;
+      const auto steam_opt_in = current_stats.input_steam_profiles_with_xbox_support;
+      const auto steam_forced = current_stats.input_steam_forced_app_count;
+      const auto steam_detail = current_stats.input_steam_input_detail;
+
       current_stats = stats_t {};
       clear_capture_profile_buckets();
       reset_hot_fields();
+
+      current_stats.input_host_controller_isolation = isolation;
+      current_stats.input_host_controller_isolation_detail = isolation_detail;
+      current_stats.input_steam_input_status = steam_status;
+      current_stats.input_steam_profiles_checked = steam_profiles;
+      current_stats.input_steam_profiles_with_xbox_support = steam_opt_in;
+      current_stats.input_steam_forced_app_count = steam_forced;
+      current_stats.input_steam_input_detail = steam_detail;
     }
   }
 

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -639,6 +639,33 @@ TEST(StreamStatsDoctorTests, ClassifiesGpuNativeStreamAsReady) {
   EXPECT_FALSE(doctor.at("safe_recovery_action").at("destructive"));
 }
 
+TEST(StreamStatsDoctorTests, SteamInputFindingSurvivesTheEndOfTheStream) {
+  // The conflict is host state, and its one-click fix is only safe with Steam
+  // closed -- which is to say, once the stream has ended. Wiping these fields
+  // with the rest of the session made the finding disappear at exactly the
+  // moment it became actionable.
+  stream_stats::update_stream_active(true, "client", "10.0.0.5");
+  stream_stats::update_controller_input_state(true, 0, "xone", "", "strict_bwrap", "strict isolation active", true, "");
+  stream_stats::update_steam_input_state("xbox_opt_in", 1, 1, 0, "Steam Input is opted in for Xbox controllers in 1 local profile(s).");
+
+  stream_stats::update_stream_active(false, "", "");
+
+  const auto after = stream_stats::get_current();
+  EXPECT_FALSE(after.streaming);
+  EXPECT_EQ(after.input_host_controller_isolation, "strict_bwrap");
+  EXPECT_EQ(after.input_steam_input_status, "xbox_opt_in");
+  EXPECT_EQ(after.input_steam_profiles_with_xbox_support, 1);
+
+  // And the idle Doctor payload still names it, with the fix still offered.
+  const auto doctor = stream_stats::build_doctor_json(after, nlohmann::json::object());
+  EXPECT_EQ(doctor.at("primary_issue"), "steam_input_conflict");
+  EXPECT_EQ(doctor.at("safe_recovery_action").at("id"), "disable_steam_input_xbox");
+
+  // Session telemetry is still gone; only the host facts carry over.
+  EXPECT_EQ(after.client_name, "");
+  EXPECT_DOUBLE_EQ(after.encode_time_ms, 0.0);
+}
+
 TEST(StreamStatsDoctorTests, WarnsWhenSteamInputConflictsWithStrictIsolation) {
   stream_stats::stats_t stats {};
   stats.streaming = true;


### PR DESCRIPTION
## Summary

Two follow-ups to #504 and #512, both found by running the shipped action against a live host rather than by reading it.

**1. The finding no longer disappears when the stream ends.** `update_stream_active(false)` reset the whole stats struct, taking the controller and Steam Input facts with it. Those describe the host, not the session that ended — and the conflict they report is only safe to fix with Steam closed. The result was that the finding vanished at exactly the moment its own one-click fix became applicable, so the only window in which the button was reachable was the one where pressing it would close Steam under a running game. The seven controller-input fields now carry across the reset while every session measurement is still cleared.

**2. Verifying a Steam Input run no longer asks for a stream.** The pre-gate asked whether such a run was *active*, so verifying one that had already been undone fell through to the shared streaming check and answered *"Start the affected stream before Doctor applies or verifies a live fix"* — for an action that never needed a stream. It now matches on the run's kind regardless of active state, and a finished run correctly answers `expired`. This was observed directly while testing #512 against the live API.

## Known limitation, stated rather than hidden

What carries across is a snapshot from the last launch, so it can read stale if Steam settings change while nothing is streaming. That is **display only**: the action re-reads the profiles before touching anything and refuses with `evidence_changed` if the conflict is gone, and verification re-reads them too. Nothing acts on the carried value. Refreshing it while idle would mean reading the user's Steam config on a timer with no session in progress, which is a bigger behavioural change than this fix warrants.

## Exact candidate

- `Commit:` `d677182018da0c8204a4de9ab5376d890f9bdbe9`
- `Tree:` `b92bb90a217fd0cc6e85263d60d68df37bfd63bd`
- `Parent:` `7007e21e`
- `Base:` `7007e21e` (polaris/master)

## Verification

- [x] `ctest` full suite — 17/17 passed, 0 failed
- [x] `test_polaris_stream --gtest_filter='StreamStatsDoctorTests.*'` — 18/18
- [x] The new test asserts **both halves** of the invariant: the host facts carry over *and* the session telemetry is still cleared. Asserting only the first would pass just as well if the reset had stopped working altogether.
- [x] It also asserts the idle Doctor payload still reports `steam_input_conflict` and still offers `disable_steam_input_xbox`, which is the behaviour this change exists to produce.

## Note

The `verify` fix has no unit test, matching the existing treatment of `doctor_actions::execute` as untested glue over tested pure logic — driving it would require a real Steam client and real profiles. It was reproduced by hand against the live API before and after: `needs_stream` before, `expired` after.
