### PR TITLE
fix(video): serialize encoder probes with active capture

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
-- Prevents Nova launches from crashing when headless cage startup sees an already-counted session before encoder selection by forcing the deferred cage probe whenever no encoder is selected and stopping capture safely if that invariant is ever violated
+- Prevents Nova launches from crashing when headless cage startup sees an already-counted session before encoder selection by forcing the deferred cage probe whenever no encoder is selected, stopping capture safely if that invariant is ever violated, and keeping encoder probing or reset exclusive with active capture
 - Detects when local Steam Input settings can claim the Polaris Xbox virtual controller during strict gamepad isolation, reports the conflict and PII-free aggregate evidence in Doctor, and points to the host-wide and per-game Steam settings without changing them automatically
 
 ## v1.3.11 - 2026-08-19

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -12,7 +12,9 @@
 #include <fstream>
 #include <list>
 #include <limits>
+#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 
@@ -2045,7 +2047,10 @@ namespace video {
   };
 
   static encoder_t *chosen_encoder;
+  static std::shared_timed_mutex encoder_state_mutex;
   static thread_local bool encoder_probe_in_progress = false;
+
+  static void reset_encoder_probe_state_unlocked();
 
   bool encoder_probe_active() {
     return encoder_probe_in_progress;
@@ -3863,6 +3868,11 @@ namespace video {
     void *channel_data,
     packet_queue_t packets
   ) {
+    // A probe mutates chosen_encoder and the static encoder capability records.
+    // Hold a shared lease for the full capture lifetime so a deferred cage
+    // reprobe cannot invalidate state beneath an active video thread.
+    std::shared_lock encoder_state_lock {encoder_state_mutex};
+
     if (!chosen_encoder) {
       BOOST_LOG(error) << "Video capture refused because no encoder is selected; "sv
                        << "encoder probing must complete before a stream starts"sv;
@@ -4378,6 +4388,15 @@ namespace video {
       return -1;
     }
 
+    // Probing resets and rewrites the selected encoder and its capability
+    // fields. Keep that mutation exclusive with every capture that consumes
+    // the same process-wide state.
+    std::unique_lock encoder_state_lock {encoder_state_mutex, std::defer_lock};
+    if (!encoder_state_lock.try_lock_for(2s)) {
+      BOOST_LOG(error) << "Encoder probe refused because active video capture did not quiesce within 2 seconds"sv;
+      return -1;
+    }
+
     auto encoder_list = encoders;
 
     // If we already have a good encoder, check to see if another probe is required
@@ -4413,7 +4432,7 @@ namespace video {
       last_encoder_probe_supported_ref_frames_invalidation = previous_ref_frames_invalidation;
       last_encoder_probe_supported_yuv444_for_codec = previous_yuv444_for_codec;
     };
-    reset_encoder_probe_state();
+    reset_encoder_probe_state_unlocked();
 
     auto adjust_encoder_constraints = [&](encoder_t *encoder) {
       // If we can't satisfy both the encoder and codec requirement, prefer the encoder over codec support
@@ -4769,6 +4788,8 @@ namespace video {
   }
 
   codec_capability_state_t advertised_codec_capability_state() {
+    std::shared_lock encoder_state_lock {encoder_state_mutex};
+
     codec_capability_state_t capability_state {
       active_hevc_mode,
       active_av1_mode,
@@ -4788,6 +4809,8 @@ namespace video {
   }
 
   bool advertised_codec_capability_state_ready() {
+    std::shared_lock encoder_state_lock {encoder_state_mutex};
+
     if (chosen_encoder) {
       return true;
     }
@@ -4801,7 +4824,7 @@ namespace video {
     return false;
   }
 
-  void reset_encoder_probe_state() {
+  static void reset_encoder_probe_state_unlocked() {
     chosen_encoder = nullptr;
     active_hevc_mode = config::video.hevc_mode;
     active_av1_mode = config::video.av1_mode;
@@ -4809,7 +4832,18 @@ namespace video {
     last_encoder_probe_supported_yuv444_for_codec = {false, false, false};
   }
 
+  void reset_encoder_probe_state() {
+    std::unique_lock encoder_state_lock {encoder_state_mutex, std::defer_lock};
+    if (!encoder_state_lock.try_lock_for(2s)) {
+      BOOST_LOG(warning) << "Encoder state reset deferred because active video capture did not quiesce within 2 seconds"sv;
+      return;
+    }
+    reset_encoder_probe_state_unlocked();
+  }
+
   std::string active_encoder_name() {
+    std::shared_lock encoder_state_lock {encoder_state_mutex};
+
     if (!chosen_encoder) {
       return {};
     }
@@ -4818,6 +4852,8 @@ namespace video {
   }
 
   platf::mem_type_e active_encoder_mem_type() {
+    std::shared_lock encoder_state_lock {encoder_state_mutex};
+
     if (!chosen_encoder || !chosen_encoder->platform_formats) {
       return platf::mem_type_e::unknown;
     }
@@ -4836,6 +4872,8 @@ namespace video {
   }
 
   bool active_encoder_runtime_supports_config(const config_t &config) {
+    std::shared_lock encoder_state_lock {encoder_state_mutex};
+
     if (!chosen_encoder || !chosen_encoder->platform_formats) {
       return false;
     }
@@ -4856,6 +4894,8 @@ namespace video {
   }
 
   bool active_encoder_runtime_supports_live_gpu_capture(const config_t &config) {
+    std::shared_lock encoder_state_lock {encoder_state_mutex};
+
     if (!chosen_encoder || !chosen_encoder->platform_formats) {
       return false;
     }

--- a/tests/unit/test_video_hdr_probe_guard_source.cpp
+++ b/tests/unit/test_video_hdr_probe_guard_source.cpp
@@ -82,6 +82,49 @@ TEST(VideoCaptureGuardSource, MissingEncoderStopsBeforeCaptureDereference) {
     << "missing encoder must stop video capture rather than continue";
 }
 
+TEST(VideoCaptureGuardSource, EncoderProbeCannotMutateStateDuringCapture) {
+  const auto source = read_video_source();
+  ASSERT_FALSE(source.empty()) << "could not read src/video.cpp via POLARIS_SOURCE_DIR";
+
+  const auto probe_pos = source.find(
+    "int probe_encoders(bool strict_configured_encoder, bool save_successful_cache)"
+  );
+  ASSERT_NE(probe_pos, std::string::npos) << "encoder probe entry point not found";
+  const auto probe_prefix = source.substr(probe_pos, 1024);
+  EXPECT_NE(
+    probe_prefix.find("std::unique_lock encoder_state_lock {encoder_state_mutex, std::defer_lock};"),
+    std::string::npos
+  ) << "encoder probing must hold the encoder-state writer lock";
+  EXPECT_NE(probe_prefix.find("encoder_state_lock.try_lock_for(2s)"), std::string::npos)
+    << "encoder probing must fail closed instead of waiting indefinitely for capture";
+
+  const auto dereference_pos = source.find("if (chosen_encoder->flags & PARALLEL_ENCODING)");
+  ASSERT_NE(dereference_pos, std::string::npos) << "capture encoder dereference not found";
+  const auto capture_pos = source.rfind("void capture(", dereference_pos);
+  ASSERT_NE(capture_pos, std::string::npos) << "capture overload not found";
+  const auto capture_prefix = source.substr(capture_pos, dereference_pos - capture_pos);
+  const auto capture_lock_pos = capture_prefix.find(
+    "std::shared_lock encoder_state_lock {encoder_state_mutex};"
+  );
+  const auto missing_encoder_guard_pos = capture_prefix.find("if (!chosen_encoder)");
+  ASSERT_NE(capture_lock_pos, std::string::npos)
+    << "capture must hold an encoder-state reader lock";
+  ASSERT_NE(missing_encoder_guard_pos, std::string::npos)
+    << "capture missing-encoder guard not found";
+  EXPECT_LT(capture_lock_pos, missing_encoder_guard_pos)
+    << "the reader lock must cover the first selected-encoder read";
+
+  const auto reset_pos = source.find("void reset_encoder_probe_state()");
+  ASSERT_NE(reset_pos, std::string::npos) << "encoder state reset entry point not found";
+  const auto reset_body = source.substr(reset_pos, 512);
+  EXPECT_NE(
+    reset_body.find("std::unique_lock encoder_state_lock {encoder_state_mutex, std::defer_lock};"),
+    std::string::npos
+  ) << "external encoder-state resets must hold the writer lock";
+  EXPECT_NE(reset_body.find("encoder_state_lock.try_lock_for(2s)"), std::string::npos)
+    << "external resets must not wait indefinitely for active capture";
+}
+
 TEST(VideoHdrDiagnosticsSource, WarnsWhenAClientHdrRequestBecomesAnSdrStream) {
   const auto source = read_video_source();
   ASSERT_FALSE(source.empty()) << "could not read src/video.cpp via POLARIS_SOURCE_DIR";


### PR DESCRIPTION
## Summary

- holds a shared encoder-state lease for the full video capture lifetime
- makes encoder probe and external reset take a bounded exclusive lease
- fails closed after two seconds instead of mutating encoder state beneath capture or waiting indefinitely
- adds a source contract that pins the reader, writer, and bounded-wait invariants

## Why

The deferred cage recovery merged in #513 can reprobe when an RTSP session is already counted but no encoder is selected. The selected encoder is a process-wide raw pointer, and probing resets that pointer and rewrites static capability records while capture threads read them. Independent review identified the race, and all three retained launch crashes terminate in video::capture at the selected-encoder boundary.

## Validation

- rebased on exact master adf7397d7e79f8a67f9e59b894d5255f29c2752a
- Linux GCC 16 debug build compiled src/video.cpp
- test_polaris_video: passed
- fast suite: 363/363 passed
- capture guard contracts: 2/2 passed
- GCC 15 CUDA production build: passed
- production binary SHA-256: f571ef7ab966e9724c0095b3b68b0b70bfcea986ca90f5078f1b19be5d0399a2

## Remaining gate

Physical RP6/Nova launch validation is intentionally not claimed here. The candidate still needs a clean host window, a successful deferred cage launch, Doctor verification, and the no-new-coredump gate before this draft is ready for promotion.