### PR TITLE
ci: skip native matrix for web-only pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,7 @@ jobs:
           native_required=true
           if [ "$EVENT_NAME" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "$BASE_COMMIT"
-            native_required="$(
-              git diff --name-only --no-renames -z "$BASE_COMMIT" "$source_commit" |
-                scripts/ci/classify-native-build.sh
-            )"
+            native_required="$(git diff --name-only --no-renames -z "$BASE_COMMIT" "$source_commit" | scripts/ci/classify-native-build.sh)"
           fi
 
           if [ "$IS_RELEASE" = "true" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,20 +27,35 @@ jobs:
       contents: read
     outputs:
       commit: ${{ steps.source.outputs.commit }}
+      native_required: ${{ steps.source.outputs.native_required }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ env.POLARIS_CHECKOUT_REF }}
 
+      - name: Verify build scope classifier
+        run: tests/scripts/test_classify_native_build.sh
+
       - name: Bind release tag to source commit
         id: source
         env:
+          BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
           IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '' }}
         run: |
           set -euo pipefail
 
           source_commit="$(git rev-parse HEAD)"
+          native_required=true
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_COMMIT"
+            native_required="$(
+              git diff --name-only --no-renames -z "$BASE_COMMIT" "$source_commit" |
+                scripts/ci/classify-native-build.sh
+            )"
+          fi
+
           if [ "$IS_RELEASE" = "true" ]; then
             release_tag="${POLARIS_PACKAGE_REF_NAME}"
             if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -59,6 +74,7 @@ jobs:
           fi
 
           echo "commit=$source_commit" >> "$GITHUB_OUTPUT"
+          echo "native_required=$native_required" >> "$GITHUB_OUTPUT"
 
   web-checks:
     name: Web checks
@@ -105,6 +121,7 @@ jobs:
   cpp-sanitizer-tests:
     name: C++ sanitizer tests
     needs: resolve-source
+    if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
     env:
       ASAN_OPTIONS: detect_leaks=0:halt_on_error=1:strict_string_checks=1
@@ -124,9 +141,10 @@ jobs:
 
       - name: Install dependencies
         # This suite installs the larger dependency set; the pinned snapshot
-        # completed in 18m03s on the first protected run, so retain margin while
-        # still turning a mirror stall into a bounded failure.
-        timeout-minutes: 30
+        # completed in 18m03s on the first protected run, but the snapshot
+        # service can exceed 30 minutes. Keep the stall bounded without turning
+        # transient mirror pressure into a false source failure.
+        timeout-minutes: 60
         run: |
           snapshot_sources="$RUNNER_TEMP/polaris-ubuntu-snapshot.sources"
           snapshot_source_parts="$RUNNER_TEMP/polaris-ubuntu-source-parts"
@@ -193,6 +211,7 @@ jobs:
   arch-build:
     name: Arch build
     needs: [resolve-source, web-checks]
+    if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
     container:
       # Match the package snapshot below. Keeping both immutable prevents a
@@ -525,6 +544,7 @@ jobs:
   fedora-clang-build:
     name: Fedora 44 Clang compile check
     needs: [resolve-source, web-checks]
+    if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
     container:
       image: fedora:44
@@ -649,6 +669,7 @@ jobs:
   steamos-build:
     name: SteamOS 3.8 build
     needs: [resolve-source, web-checks]
+    if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
 
     steps:
@@ -698,6 +719,7 @@ jobs:
   ubuntu-build:
     name: Ubuntu build
     needs: [resolve-source, web-checks]
+    if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
     env:
       CCACHE_DIR: ~/.cache/ccache
@@ -746,7 +768,7 @@ jobs:
             polaris-ubuntu-gomod-
 
       - name: Install dependencies
-        timeout-minutes: 20
+        timeout-minutes: 40
         run: |
           snapshot_sources="$RUNNER_TEMP/polaris-ubuntu-snapshot.sources"
           snapshot_source_parts="$RUNNER_TEMP/polaris-ubuntu-source-parts"
@@ -913,6 +935,7 @@ jobs:
   fedora-rpm-build:
     name: Fedora ${{ matrix.fedora }} RPM build
     needs: [resolve-source, web-checks]
+    if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
     container:
       image: fedora:${{ matrix.fedora }}

--- a/scripts/ci/classify-native-build.sh
+++ b/scripts/ci/classify-native-build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 0 ]; then
+  echo "Usage: provide NUL-delimited changed paths on stdin" >&2
+  exit 2
+fi
+
+native_required=false
+path_count=0
+
+while IFS= read -r -d '' changed_path; do
+  path_count=$((path_count + 1))
+  case "$changed_path" in
+    src_assets/common/assets/web/*)
+      ;;
+    *)
+      native_required=true
+      ;;
+  esac
+done
+
+# An empty diff is unexpected for a pull request. Fail closed so a broken
+# comparison cannot silently bypass native validation.
+if [ "$path_count" -eq 0 ]; then
+  native_required=true
+fi
+
+printf '%s\n' "$native_required"

--- a/tests/scripts/test_classify_native_build.sh
+++ b/tests/scripts/test_classify_native_build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+classifier="$repo_root/scripts/ci/classify-native-build.sh"
+
+assert_scope() {
+  local expected="$1"
+  shift
+
+  local actual
+  actual="$(printf '%s\0' "$@" | "$classifier")"
+  if [ "$actual" != "$expected" ]; then
+    echo "Expected native_required=$expected, got $actual for: $*" >&2
+    exit 1
+  fi
+}
+
+assert_scope false \
+  src_assets/common/assets/web/app.css
+assert_scope false \
+  src_assets/common/assets/web/views/DashboardView.vue \
+  'src_assets/common/assets/web/tests/layout with spaces.test.js'
+assert_scope true \
+  src/video.cpp
+assert_scope true \
+  src_assets/common/assets/web/app.css \
+  tests/unit/test_video.cpp
+assert_scope true \
+  package-lock.json
+
+empty_scope="$(printf '' | "$classifier")"
+if [ "$empty_scope" != true ]; then
+  echo "Expected an empty diff to require native validation" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- classify pull requests as web-only only when every changed path is under the web asset tree
- skip the native sanitizer, Arch, Fedora, SteamOS, and Ubuntu jobs for that narrow case while preserving the existing required check names
- keep the complete native matrix for mixed or native pull requests, pushes, tags, and manual runs
- extend the bounded Ubuntu snapshot install windows to tolerate current mirror pressure

## Safety
- fail closed when the changed-path comparison is empty or includes any path outside the web asset tree
- retain exact source binding and unchanged release behavior
- avoid branch-protection setting changes

## Validation
- actionlint v1.7.12
- shellcheck
- classifier unit tests
- public surface and public documentation checks
- real-diff classification: web layout change skips native work; logging and packaging changes retain it
- added-line privacy and attribution scan
