### PR TITLE
ci: cache Ubuntu dependencies and cancel stale PR runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   POLARIS_CHECKOUT_REF: ${{ inputs.release_tag || github.ref }}
   POLARIS_PACKAGE_REF_NAME: ${{ inputs.release_tag || github.ref_name }}
@@ -136,6 +140,14 @@ jobs:
           node-version: '22'
           cache: npm
 
+      - name: Cache Ubuntu package downloads
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/polaris-ubuntu-archives
+          key: polaris-ubuntu-apt-${{ env.UBUNTU_APT_SNAPSHOT }}-sanitizer-${{ hashFiles('.github/workflows/build.yml') }}
+          restore-keys: |
+            polaris-ubuntu-apt-${{ env.UBUNTU_APT_SNAPSHOT }}-sanitizer-
+
       - name: Install dependencies
         # This suite installs the larger dependency set; the pinned snapshot
         # completed in 18m03s on the first protected run, but the snapshot
@@ -146,7 +158,9 @@ jobs:
           snapshot_sources="$RUNNER_TEMP/polaris-ubuntu-snapshot.sources"
           snapshot_source_parts="$RUNNER_TEMP/polaris-ubuntu-source-parts"
           snapshot_lists="$RUNNER_TEMP/polaris-ubuntu-lists"
-          mkdir -p "$snapshot_source_parts" "$snapshot_lists/partial"
+          snapshot_archives="$RUNNER_TEMP/polaris-ubuntu-archives"
+          mkdir -p "$snapshot_source_parts" "$snapshot_lists/partial" "$snapshot_archives/partial"
+          sudo chown -R _apt:root "$snapshot_archives/partial"
           cat > "$snapshot_sources" <<EOF
           Types: deb
           URIs: https://snapshot.ubuntu.com/ubuntu/$UBUNTU_APT_SNAPSHOT/
@@ -158,6 +172,7 @@ jobs:
             -o "Dir::Etc::sourcelist=$snapshot_sources"
             -o "Dir::Etc::sourceparts=$snapshot_source_parts"
             -o "Dir::State::Lists=$snapshot_lists"
+            -o "Dir::Cache::archives=$snapshot_archives"
             -o APT::Update::Error-Mode=any
             -o Acquire::Retries=3
             -o Acquire::http::Timeout=30
@@ -174,7 +189,8 @@ jobs:
             libva-dev libminiupnpc-dev libnotify-dev nlohmann-json3-dev \
             libappindicator3-dev libgtk-3-dev \
             libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
-            nodejs npm wayland-protocols
+            wayland-protocols
+          sudo chmod -R a+rX "$snapshot_archives"
 
       - name: Configure sanitizer build
         run: |
@@ -839,6 +855,14 @@ jobs:
           node-version: '22'
           cache: npm
 
+      - name: Cache Ubuntu package downloads
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/polaris-ubuntu-archives
+          key: polaris-ubuntu-apt-${{ env.UBUNTU_APT_SNAPSHOT }}-build-${{ hashFiles('.github/workflows/build.yml') }}
+          restore-keys: |
+            polaris-ubuntu-apt-${{ env.UBUNTU_APT_SNAPSHOT }}-build-
+
       - name: Cache C++ compiler outputs
         uses: actions/cache@v6
         with:
@@ -860,7 +884,9 @@ jobs:
           snapshot_sources="$RUNNER_TEMP/polaris-ubuntu-snapshot.sources"
           snapshot_source_parts="$RUNNER_TEMP/polaris-ubuntu-source-parts"
           snapshot_lists="$RUNNER_TEMP/polaris-ubuntu-lists"
-          mkdir -p "$snapshot_source_parts" "$snapshot_lists/partial"
+          snapshot_archives="$RUNNER_TEMP/polaris-ubuntu-archives"
+          mkdir -p "$snapshot_source_parts" "$snapshot_lists/partial" "$snapshot_archives/partial"
+          sudo chown -R _apt:root "$snapshot_archives/partial"
           cat > "$snapshot_sources" <<EOF
           Types: deb
           URIs: https://snapshot.ubuntu.com/ubuntu/$UBUNTU_APT_SNAPSHOT/
@@ -872,6 +898,7 @@ jobs:
             -o "Dir::Etc::sourcelist=$snapshot_sources"
             -o "Dir::Etc::sourceparts=$snapshot_source_parts"
             -o "Dir::State::Lists=$snapshot_lists"
+            -o "Dir::Cache::archives=$snapshot_archives"
             -o APT::Update::Error-Mode=any
             -o Acquire::Retries=3
             -o Acquire::http::Timeout=30
@@ -890,6 +917,7 @@ jobs:
             libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
             golang-go \
             wayland-protocols
+          sudo chmod -R a+rX "$snapshot_archives"
 
       - name: Configure
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -587,7 +587,7 @@ jobs:
 
   arch-current-compatibility:
     name: Arch rolling compatibility
-    needs: [resolve-source, arch-build]
+    needs: [resolve-source, cpp-sanitizer-tests, arch-build]
     if: ${{ github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '' }}
     runs-on: ubuntu-24.04
     container:
@@ -646,7 +646,7 @@ jobs:
 
   fedora-clang-build:
     name: Fedora 44 Clang compile check
-    needs: [resolve-source, web-checks]
+    needs: [resolve-source, web-checks, cpp-sanitizer-tests, arch-build]
     if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
     container:
@@ -771,7 +771,7 @@ jobs:
 
   steamos-build:
     name: SteamOS 3.8 build
-    needs: [resolve-source, web-checks]
+    needs: [resolve-source, web-checks, cpp-sanitizer-tests, arch-build]
     if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
 
@@ -821,7 +821,7 @@ jobs:
 
   ubuntu-build:
     name: Ubuntu build
-    needs: [resolve-source, web-checks]
+    needs: [resolve-source, web-checks, cpp-sanitizer-tests, arch-build]
     if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
     env:
@@ -1049,7 +1049,7 @@ jobs:
 
   fedora-rpm-build:
     name: Fedora ${{ matrix.fedora }} RPM build
-    needs: [resolve-source, web-checks]
+    needs: [resolve-source, web-checks, cpp-sanitizer-tests, arch-build]
     if: needs.resolve-source.outputs.native_required == 'true'
     runs-on: ubuntu-24.04
     container:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Cache Ubuntu package downloads
         uses: actions/cache@v6
         with:
-          path: ${{ runner.temp }}/polaris-ubuntu-archives
+          path: /var/tmp/polaris-ubuntu-archives
           key: polaris-ubuntu-apt-${{ env.UBUNTU_APT_SNAPSHOT }}-sanitizer-${{ hashFiles('.github/workflows/build.yml') }}
           restore-keys: |
             polaris-ubuntu-apt-${{ env.UBUNTU_APT_SNAPSHOT }}-sanitizer-
@@ -158,7 +158,7 @@ jobs:
           snapshot_sources="$RUNNER_TEMP/polaris-ubuntu-snapshot.sources"
           snapshot_source_parts="$RUNNER_TEMP/polaris-ubuntu-source-parts"
           snapshot_lists="$RUNNER_TEMP/polaris-ubuntu-lists"
-          snapshot_archives="$RUNNER_TEMP/polaris-ubuntu-archives"
+          snapshot_archives="/var/tmp/polaris-ubuntu-archives"
           mkdir -p "$snapshot_source_parts" "$snapshot_lists/partial" "$snapshot_archives/partial"
           sudo chown -R _apt:root "$snapshot_archives/partial"
           cat > "$snapshot_sources" <<EOF
@@ -858,7 +858,7 @@ jobs:
       - name: Cache Ubuntu package downloads
         uses: actions/cache@v6
         with:
-          path: ${{ runner.temp }}/polaris-ubuntu-archives
+          path: /var/tmp/polaris-ubuntu-archives
           key: polaris-ubuntu-apt-${{ env.UBUNTU_APT_SNAPSHOT }}-build-${{ hashFiles('.github/workflows/build.yml') }}
           restore-keys: |
             polaris-ubuntu-apt-${{ env.UBUNTU_APT_SNAPSHOT }}-build-
@@ -884,7 +884,7 @@ jobs:
           snapshot_sources="$RUNNER_TEMP/polaris-ubuntu-snapshot.sources"
           snapshot_source_parts="$RUNNER_TEMP/polaris-ubuntu-source-parts"
           snapshot_lists="$RUNNER_TEMP/polaris-ubuntu-lists"
-          snapshot_archives="$RUNNER_TEMP/polaris-ubuntu-archives"
+          snapshot_archives="/var/tmp/polaris-ubuntu-archives"
           mkdir -p "$snapshot_source_parts" "$snapshot_lists/partial" "$snapshot_archives/partial"
           sudo chown -R _apt:root "$snapshot_archives/partial"
           cat > "$snapshot_sources" <<EOF

--- a/scripts/check-release-package-dependencies.py
+++ b/scripts/check-release-package-dependencies.py
@@ -648,9 +648,31 @@ for metadata_contract in (
             "Arch package smoke must bind every Boost NEEDED entry to a versioned dependency"
         )
 
-arch_current_job = workflow_job(workflow, "arch-current-compatibility")
-if arch_current_job.count("needs: [resolve-source, arch-build]") != 1:
-    raise AssertionError("current Arch compatibility must consume the exact Arch build")
+optional_native_job_needs = {
+    "arch-current-compatibility": (
+        "needs: [resolve-source, cpp-sanitizer-tests, arch-build]"
+    ),
+    "fedora-clang-build": (
+        "needs: [resolve-source, web-checks, cpp-sanitizer-tests, arch-build]"
+    ),
+    "steamos-build": (
+        "needs: [resolve-source, web-checks, cpp-sanitizer-tests, arch-build]"
+    ),
+    "ubuntu-build": (
+        "needs: [resolve-source, web-checks, cpp-sanitizer-tests, arch-build]"
+    ),
+    "fedora-rpm-build": (
+        "needs: [resolve-source, web-checks, cpp-sanitizer-tests, arch-build]"
+    ),
+}
+optional_native_jobs = {}
+for job_name, expected_needs in optional_native_job_needs.items():
+    job = workflow_job(workflow, job_name)
+    if job.count(expected_needs) != 1:
+        raise AssertionError(f"{job_name} must wait for both required native gates")
+    optional_native_jobs[job_name] = job
+
+arch_current_job = optional_native_jobs["arch-current-compatibility"]
 if arch_current_job.count(arch_package_condition) != 1:
     raise AssertionError("current Arch compatibility must run for pull requests and exact releases")
 for current_step in (


### PR DESCRIPTION
## Summary

- cancel superseded runs for the same pull request while leaving push, tag, and manual runs independent
- cache Ubuntu package archives separately for the sanitizer and Ubuntu build jobs, keyed by the pinned snapshot and dependency workflow
- rely on `actions/setup-node` instead of downloading duplicate `nodejs` and `npm` packages through APT

Fixes #520.

## Why

The required sanitizer gate and the Ubuntu build repeatedly downloaded the same pinned dependency set. Recent unrelated pull requests then timed out in `Install dependencies` before compiling any source. Superseded revisions could also continue occupying runners after a newer revision was available.

The cache remains job-specific so one job cannot publish an incomplete package set for the other. A workflow hash invalidates the exact key when dependencies change, while the snapshot-scoped restore key lets APT reuse safe archives and download only the delta.

## Verification

- `actionlint -shellcheck=`: pass for workflow syntax and expressions
- `tests/scripts/test_classify_native_build.sh`: pass
- workflow contract assertions for concurrency, two distinct caches, archive ownership, and duplicate package removal: pass
- Ubuntu 24.04 custom APT archive smoke: pass; downloaded archives remained readable for cache upload
- `git diff --check`: pass

Full `actionlint` continues to report three pre-existing shellcheck findings in untouched workflow blocks; this change adds none.
