### PR TITLE
fix(linux): release only the EGL context this thread actually bound

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Fixes black video with working audio when a client requests HDR on a host with no HDR output: rebuilding the encode device for the 10-bit to 8-bit demotion released the EGL context the new device had just made current, so its color-conversion shaders never compiled and the session died before the first frame
 - Sizes nested Gamescope sessions to the final negotiated render width, height, and frame rate instead of imposing the standalone 4K120 fallback on every client
 - Prevents Nova launches from crashing when headless cage startup sees an already-counted session before encoder selection by forcing the deferred cage probe whenever no encoder is selected, stopping capture safely if that invariant is ever violated, and keeping encoder probing or reset exclusive with active capture
 - Detects when local Steam Input settings can claim the Polaris Xbox virtual controller during strict gamepad isolation, reports the conflict and PII-free aggregate evidence in Doctor, and points to the host-wide and per-game Steam settings without changing them automatically

--- a/src/platform/linux/graphics.cpp
+++ b/src/platform/linux/graphics.cpp
@@ -831,7 +831,18 @@ namespace egl {
         gl_drain_errors;
 
         if (compiled_source.has_right()) {
-          BOOST_LOG(error) << shader_path << ": "sv << compiled_source.right();
+          const auto &compile_error = compiled_source.right();
+          if (compile_error.empty()) {
+            // A driver that rejected the source always says why. An empty info log
+            // means the call never reached a live context, so name that instead of
+            // printing a bare colon and sending the reader after the shader files.
+            BOOST_LOG(error) << shader_path << ": compilation failed and the driver gave no reason"sv
+                             << (eglGetCurrentContext() == EGL_NO_CONTEXT ?
+                                   "; no EGL context is current on this thread"sv :
+                                   ""sv);
+          } else {
+            BOOST_LOG(error) << shader_path << ": "sv << compile_error;
+          }
           error_flag = true;
         }
       }

--- a/src/platform/linux/graphics.h
+++ b/src/platform/linux/graphics.h
@@ -222,7 +222,18 @@ namespace egl {
   KITTY_USING_MOVE_T(ctx_t, (std::tuple<display_t::pointer, EGLContext>), , {
     TUPLE_2D_REF(disp, ctx, el);
     if (ctx) {
-      eglMakeCurrent(disp, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+      // Releasing with EGL_NO_CONTEXT unbinds whatever context is current on the
+      // calling thread, and the display argument does not scope it: EGL 1.5 3.7.3
+      // treats the release as thread-wide, and Mesa's _eglBindContext unbinds the
+      // thread's context whichever display it came from. video::make_encode_device
+      // builds a replacement encode device before destroying the original when it
+      // demotes 10-bit to 8-bit, so releasing unconditionally here unbound the
+      // context the replacement had just made current. Every later GL call then
+      // silently no-opped and all five conversion shaders reported a compile
+      // failure with an empty driver info log. Release only what we bound.
+      if (eglGetCurrentContext() == ctx) {
+        eglMakeCurrent(disp, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+      }
       eglDestroyContext(disp, ctx);
     }
   });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_game_library_scanner.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_kmsgrab_logging_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_video_hdr_probe_guard_source.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_egl_ctx_release_guard_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_labwc_render_device_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_linux_platform_hardening_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_logging.cpp

--- a/tests/unit/test_egl_ctx_release_guard_source.cpp
+++ b/tests/unit/test_egl_ctx_release_guard_source.cpp
@@ -24,10 +24,12 @@
  */
 #include <gtest/gtest.h>
 
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 namespace {
 
@@ -39,40 +41,138 @@ namespace {
     return buffer.str();
   }
 
+  std::string strip_cpp_comments(std::string_view source) {
+    enum class state_e {
+      code,
+      line_comment,
+      block_comment,
+      string_literal,
+      char_literal,
+    };
+
+    std::string code;
+    code.reserve(source.size());
+    auto state = state_e::code;
+    bool escaped = false;
+
+    for (std::size_t i = 0; i < source.size(); ++i) {
+      const auto ch = source[i];
+      const auto next = i + 1 < source.size() ? source[i + 1] : '\0';
+
+      switch (state) {
+        case state_e::code:
+          if (ch == '/' && next == '/') {
+            code.push_back(' ');
+            ++i;
+            state = state_e::line_comment;
+          } else if (ch == '/' && next == '*') {
+            code.push_back(' ');
+            ++i;
+            state = state_e::block_comment;
+          } else {
+            code.push_back(ch);
+            if (ch == '"') {
+              state = state_e::string_literal;
+              escaped = false;
+            } else if (ch == '\'') {
+              state = state_e::char_literal;
+              escaped = false;
+            }
+          }
+          break;
+
+        case state_e::line_comment:
+          if (ch == '\n') {
+            code.push_back(ch);
+            state = state_e::code;
+          }
+          break;
+
+        case state_e::block_comment:
+          if (ch == '*' && next == '/') {
+            code.push_back(' ');
+            ++i;
+            state = state_e::code;
+          }
+          break;
+
+        case state_e::string_literal:
+        case state_e::char_literal: {
+          code.push_back(ch);
+          const auto terminator = state == state_e::string_literal ? '"' : '\'';
+          if (escaped) {
+            escaped = false;
+          } else if (ch == '\\') {
+            escaped = true;
+          } else if (ch == terminator) {
+            state = state_e::code;
+          }
+          break;
+        }
+      }
+    }
+
+    return code;
+  }
+
+  std::string normalize_code(std::string_view source) {
+    const auto uncommented = strip_cpp_comments(source);
+    std::string normalized;
+    normalized.reserve(uncommented.size());
+    bool pending_space = false;
+
+    for (const auto ch : uncommented) {
+      if (std::isspace(static_cast<unsigned char>(ch))) {
+        pending_space = !normalized.empty();
+        continue;
+      }
+      if (pending_space) {
+        normalized.push_back(' ');
+        pending_space = false;
+      }
+      normalized.push_back(ch);
+    }
+
+    return normalized;
+  }
+
+  std::size_t count_occurrences(std::string_view source, std::string_view needle) {
+    std::size_t count = 0;
+    std::size_t position = 0;
+    while ((position = source.find(needle, position)) != std::string_view::npos) {
+      ++count;
+      position += needle.size();
+    }
+    return count;
+  }
+
+  bool ctx_release_contract_holds(std::string_view source) {
+    const auto code = normalize_code(source);
+    constexpr std::string_view contract =
+      "if (eglGetCurrentContext() == ctx) { "
+      "eglMakeCurrent(disp, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT); "
+      "} eglDestroyContext(disp, ctx);";
+    return count_occurrences(code, "KITTY_USING_MOVE_T(ctx_t,") == 1 &&
+           count_occurrences(code, contract) == 1;
+  }
+
+  bool missing_context_diagnostic_contract_holds(std::string_view source) {
+    const auto code = normalize_code(source);
+    constexpr std::string_view condition =
+      "eglGetCurrentContext() == EGL_NO_CONTEXT ? "
+      "\"; no EGL context is current on this thread\"sv : \"\"sv";
+    return count_occurrences(code, "if (compile_error.empty()) {") == 1 &&
+           count_occurrences(code, "compilation failed and the driver gave no reason") == 1 &&
+           count_occurrences(code, condition) == 1;
+  }
+
 }  // namespace
 
 TEST(EglCtxReleaseGuardSource, ContextReleaseIsScopedToTheContextWeBound) {
   const auto source = read_source("src/platform/linux/graphics.h");
   ASSERT_FALSE(source.empty()) << "could not read src/platform/linux/graphics.h via POLARIS_SOURCE_DIR";
-
-  const auto ctx_pos = source.find("KITTY_USING_MOVE_T(ctx_t,");
-  ASSERT_NE(ctx_pos, std::string::npos) << "egl::ctx_t declaration not found";
-
-  const auto body_end = source.find("});", ctx_pos);
-  ASSERT_NE(body_end, std::string::npos) << "egl::ctx_t destructor body not found";
-  const auto body = source.substr(ctx_pos, body_end - ctx_pos);
-
-  const auto guard_pos = body.find("if (eglGetCurrentContext() == ctx)");
-  EXPECT_NE(guard_pos, std::string::npos)
-    << "~egl::ctx_t must release only when this context is the one bound to the calling "
-       "thread: eglMakeCurrent with EGL_NO_CONTEXT is a thread-wide release and would "
-       "otherwise unbind a live context belonging to a replacement encode device";
-
-  const auto release_pos = body.find("eglMakeCurrent(disp, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)");
-  ASSERT_NE(release_pos, std::string::npos) << "the context release call is missing entirely";
-  EXPECT_LT(guard_pos, release_pos)
-    << "the release must sit inside the eglGetCurrentContext() guard, not before it";
-
-  // Destruction itself must stay unconditional. A context that is current on some
-  // other thread still has to be destroyed here; EGL defers the delete until it is
-  // no longer current, which is exactly the behaviour we want.
-  const auto destroy_pos = body.find("eglDestroyContext(disp, ctx)");
-  ASSERT_NE(destroy_pos, std::string::npos) << "eglDestroyContext call not found";
-  EXPECT_LT(release_pos, destroy_pos) << "release must precede destroy";
-  const auto guard_close = body.find("}", release_pos);
-  ASSERT_NE(guard_close, std::string::npos) << "guard block is unterminated";
-  EXPECT_LT(guard_close, destroy_pos)
-    << "eglDestroyContext must run unconditionally, outside the eglGetCurrentContext guard";
+  EXPECT_TRUE(ctx_release_contract_holds(source))
+    << "~egl::ctx_t must guard the thread-wide release and keep destruction unconditional";
 }
 
 TEST(EglCtxReleaseGuardSource, EmptyShaderInfoLogNamesTheMissingContext) {
@@ -82,8 +182,40 @@ TEST(EglCtxReleaseGuardSource, EmptyShaderInfoLogNamesTheMissingContext) {
   // An empty compile info log means the GL call never reached a live context. Saying
   // so is what separates this failure from a missing or unreadable shader file; the
   // bare "<path>: " line it used to print sent two reporters after their asset paths.
-  EXPECT_NE(source.find("compilation failed and the driver gave no reason"), std::string::npos)
-    << "an empty shader info log must report that the driver gave no reason, not print a bare colon";
-  EXPECT_NE(source.find("no EGL context is current on this thread"), std::string::npos)
-    << "an empty shader info log must name a missing current EGL context as the likely cause";
+  EXPECT_TRUE(missing_context_diagnostic_contract_holds(source))
+    << "an empty shader info log must report the missing-current-context condition";
+}
+
+TEST(EglCtxReleaseGuardMatcher, RejectsCommentedOutGuard) {
+  constexpr std::string_view source = R"cpp(
+    KITTY_USING_MOVE_T(ctx_t, tuple_t, , {
+      // if (eglGetCurrentContext() == ctx)
+      eglMakeCurrent(disp, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+      }
+      eglDestroyContext(disp, ctx);
+    });
+  )cpp";
+  EXPECT_FALSE(ctx_release_contract_holds(source));
+}
+
+TEST(EglCtxReleaseGuardMatcher, RejectsDestroyHiddenInsideOuterGuard) {
+  constexpr std::string_view source = R"cpp(
+    KITTY_USING_MOVE_T(ctx_t, tuple_t, , {
+      if (eglGetCurrentContext() == ctx) {
+        eglMakeCurrent(disp, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        if (cleanup_enabled) {}
+        eglDestroyContext(disp, ctx);
+      }
+    });
+  )cpp";
+  EXPECT_FALSE(ctx_release_contract_holds(source));
+}
+
+TEST(EglCtxReleaseGuardMatcher, RejectsInvertedMissingContextDiagnostic) {
+  constexpr std::string_view source = R"cpp(
+    eglGetCurrentContext() != EGL_NO_CONTEXT ?
+      "; no EGL context is current on this thread"sv : ""sv;
+    "compilation failed and the driver gave no reason"sv;
+  )cpp";
+  EXPECT_FALSE(missing_context_diagnostic_contract_holds(source));
 }

--- a/tests/unit/test_egl_ctx_release_guard_source.cpp
+++ b/tests/unit/test_egl_ctx_release_guard_source.cpp
@@ -1,0 +1,89 @@
+/**
+ * @file tests/unit/test_egl_ctx_release_guard_source.cpp
+ * @brief Source guard: ~egl::ctx_t must release the EGL context only when that
+ *        context is the one currently bound to the calling thread.
+ *
+ * eglMakeCurrent with EGL_NO_CONTEXT is a thread-wide release. The display
+ * argument does not scope it (EGL 1.5 3.7.3; Mesa's _eglBindContext unbinds the
+ * thread's context whichever display it came from), so releasing unconditionally
+ * in the destructor unbinds a *different*, live context that some other object
+ * made current first.
+ *
+ * That is not theoretical. video::make_encode_device builds a replacement encode
+ * device and only then destroys the original when it demotes a 10-bit request to
+ * 8-bit, which is the ordinary path for any client that asks for HDR on a host
+ * with no HDR output. va_t owns an egl::ctx_t, so the old device's destructor
+ * unbound the context the new device had just made current. Every subsequent GL
+ * call no-opped, all five conversion shaders reported a compile failure with an
+ * empty driver info log, set_frame returned -1, and the session died before its
+ * first frame: black video, working audio, no useful error (issues #516, #482).
+ *
+ * Reproducing that needs a VAAPI host taking the demotion, which no unit test and
+ * no CI runner has, so the invariant is pinned at the source level the same way
+ * test_video_hdr_probe_guard_source.cpp pins its probe contract.
+ */
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+  std::string read_source(const std::string &relative_path) {
+    const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / relative_path;
+    std::ifstream file {path};
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+  }
+
+}  // namespace
+
+TEST(EglCtxReleaseGuardSource, ContextReleaseIsScopedToTheContextWeBound) {
+  const auto source = read_source("src/platform/linux/graphics.h");
+  ASSERT_FALSE(source.empty()) << "could not read src/platform/linux/graphics.h via POLARIS_SOURCE_DIR";
+
+  const auto ctx_pos = source.find("KITTY_USING_MOVE_T(ctx_t,");
+  ASSERT_NE(ctx_pos, std::string::npos) << "egl::ctx_t declaration not found";
+
+  const auto body_end = source.find("});", ctx_pos);
+  ASSERT_NE(body_end, std::string::npos) << "egl::ctx_t destructor body not found";
+  const auto body = source.substr(ctx_pos, body_end - ctx_pos);
+
+  const auto guard_pos = body.find("if (eglGetCurrentContext() == ctx)");
+  EXPECT_NE(guard_pos, std::string::npos)
+    << "~egl::ctx_t must release only when this context is the one bound to the calling "
+       "thread: eglMakeCurrent with EGL_NO_CONTEXT is a thread-wide release and would "
+       "otherwise unbind a live context belonging to a replacement encode device";
+
+  const auto release_pos = body.find("eglMakeCurrent(disp, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)");
+  ASSERT_NE(release_pos, std::string::npos) << "the context release call is missing entirely";
+  EXPECT_LT(guard_pos, release_pos)
+    << "the release must sit inside the eglGetCurrentContext() guard, not before it";
+
+  // Destruction itself must stay unconditional. A context that is current on some
+  // other thread still has to be destroyed here; EGL defers the delete until it is
+  // no longer current, which is exactly the behaviour we want.
+  const auto destroy_pos = body.find("eglDestroyContext(disp, ctx)");
+  ASSERT_NE(destroy_pos, std::string::npos) << "eglDestroyContext call not found";
+  EXPECT_LT(release_pos, destroy_pos) << "release must precede destroy";
+  const auto guard_close = body.find("}", release_pos);
+  ASSERT_NE(guard_close, std::string::npos) << "guard block is unterminated";
+  EXPECT_LT(guard_close, destroy_pos)
+    << "eglDestroyContext must run unconditionally, outside the eglGetCurrentContext guard";
+}
+
+TEST(EglCtxReleaseGuardSource, EmptyShaderInfoLogNamesTheMissingContext) {
+  const auto source = read_source("src/platform/linux/graphics.cpp");
+  ASSERT_FALSE(source.empty()) << "could not read src/platform/linux/graphics.cpp via POLARIS_SOURCE_DIR";
+
+  // An empty compile info log means the GL call never reached a live context. Saying
+  // so is what separates this failure from a missing or unreadable shader file; the
+  // bare "<path>: " line it used to print sent two reporters after their asset paths.
+  EXPECT_NE(source.find("compilation failed and the driver gave no reason"), std::string::npos)
+    << "an empty shader info log must report that the driver gave no reason, not print a bare colon";
+  EXPECT_NE(source.find("no EGL context is current on this thread"), std::string::npos)
+    << "an empty shader info log must name a missing current EGL context as the likely cause";
+}


### PR DESCRIPTION
## Summary

- releases the EGL context in `~egl::ctx_t` only when that context is the one bound to the calling thread
- keeps `eglDestroyContext` unconditional, so a context current on another thread is still destroyed and EGL defers the delete as it should
- reports an empty shader compile info log as a dead context instead of printing the shader path followed by nothing
- adds a source guard pinning both invariants

## Why

`eglMakeCurrent` with `EGL_NO_CONTEXT` is a thread-wide release. The display argument does not scope it: EGL 1.5 section 3.7.3 defines the release against the calling thread, and Mesa's `_eglBindContext` unbinds whatever context the thread holds regardless of which display it came from. `~egl::ctx_t` released unconditionally, so destroying a stale context unbound a live one belonging to a different object.

That ordering is the ordinary path rather than a corner case. When a client requests HDR on a host with no HDR output, `video::make_encode_device` demotes the 10-bit request to 8-bit by building a second encode device, and `unique_ptr` assignment destroys the original only after the replacement has already made its own context current. `va_t` owns an `egl::ctx_t`, so the old device's destructor unbound the new device's context. Every following GL call no-opped against a dead dispatch, all five conversion shaders reported a compile failure with an empty driver info log, `set_frame` returned -1, and the session died before its first frame. The host looked healthy, audio played, and video stayed black until the client timed out.

Both `va_ram_t` and `va_vram_t` are affected, because `set_frame` and the shader compile live in the shared `va_t` base and the subclasses override only `convert`. `gl_cuda_vram_t` owns a context on the same terms. The plain `cuda_t` family is not exposed, because its `sws_t` holds no EGL context.

The diagnostics change matters as much as the fix here. An empty compile info log meant the call never reached a live context, but the log printed the shader path followed by nothing, which reads as a missing or unreadable asset. Both reporters chased their shader files instead; #516 sent in the installed files, which turned out to be byte-identical to the repository copies.

## Validation

- based on exact master `6c739bf7d2c3c55a87c08fa1e9e5987cdc0cf99f`, candidate `e6dc66450b904bee8d0c9c66bba0c5e70734a0e3`
- mechanism reproduced standalone: a two-display, two-context program mirroring `make_ctx` and `shader_t::compile` shows `compile_status=0 info_log_length=0 glGetError=0x0` after a stale context's destructor runs, and `compile_status=1` with the guard applied
- Mesa side confirmed by source: `_eglCheckMakeCurrent` short-circuits before any display comparison when `ctx`, `draw`, and `read` are all null, and `_eglBindContextToThread` then clears `t->CurrentContext`
- reporter's installed shaders in #516 compared byte for byte against `src_assets/linux/assets/shaders/opengl`: all five identical, ASCII, no BOM, world readable, which rules out the asset explanation the old message implied
- `ninja polaris` compiled `src/platform/linux/graphics.cpp` and linked clean
- matcher hardening RED: commented-out guard, nested-brace destroy, and inverted missing-context diagnostic all false-passed the original source guard; GREEN after comment stripping, whitespace normalization, exact-contract matching, and unique-occurrence checks (5/5 focused matcher tests)
- `test_polaris`, `test_polaris_platform`, `test_polaris_video`: 3 of 3 focused CTest targets passed on the final local head
- widened local CTest ran 18 targets: 17 passed; `test_polaris_config` retains a pre-existing source-order assertion failure whose source/test files and exact offsets are identical on base `6c739bf7` and this PR head; exact-head CI remains the merge gate
- teardown member order checked for `va_t` and `gl_cuda_vram_t`: `ctx` is declared before their GL-owning resources, so reverse destruction releases those resources before the context

## Remaining gate

No end-to-end reproduction is claimed. The symptom needs a VAAPI host taking the 10-bit to 8-bit demotion, and this host is NVIDIA, where the NVENC path never reaches that code. The mechanism is reproduced directly and the invariant is pinned at the source level, but affected-host confirmation from #516 or #482 on a build carrying this commit is the last piece.

Fixes #516.
Refs #482.
