### PR TITLE
fix(linux): drain escaped labwc startup descendants

### DIFF
--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -68,10 +68,10 @@ namespace cage_display_router {
 #endif
 
   // The direct child tracked by cage_pid is a tiny supervisor and the immutable
-  // leader of the private labwc session/process group. The compositor and every
-  // startup descendant stay inside that anchored group, so a compositor-driven
-  // exit cannot orphan its startup client and parent fallback never has to guess
-  // whether a recycled PGID still belongs to Polaris.
+  // leader of the private labwc session/process group. Normal descendants stay
+  // inside that anchored group. The supervisor is also a child subreaper so a
+  // startup client that creates its own session is adopted and drained without
+  // any global process scan or recycled-PID guesswork.
   static volatile sig_atomic_t supervised_runtime_pid = 0;
   static volatile sig_atomic_t supervisor_stop_requested = 0;
 
@@ -199,10 +199,11 @@ namespace cage_display_router {
    * Keep a stable direct child alive as the private session/process-group anchor.
    *
    * labwc is free to exit from its own menu while its startup client remains
-   * alive. The supervisor subreaps that runtime tree, drains the anchored group,
-   * and exits cleanly once no private descendants remain. If a descendant ignores
-   * graceful teardown, the final group SIGKILL includes the supervisor itself;
-   * the parent still owns and pidfd-tracks that immutable group leader.
+   * alive. The supervisor subreaps that runtime tree, drains the anchored group
+   * plus any adopted direct children that escaped it, and exits cleanly once no
+   * private descendants remain. If a descendant ignores graceful teardown, the
+   * final SIGKILL path covers both ownership classes before the group includes
+   * the supervisor itself.
    */
   [[noreturn]] static void supervise_labwc(
     const std::string &labwc_path,
@@ -252,6 +253,23 @@ namespace cage_display_router {
 
     supervised_runtime_pid = static_cast<sig_atomic_t>(runtime_pid);
     (void) sigprocmask(SIG_SETMASK, &previous_mask, nullptr);
+
+    // A labwc startup client may call setsid() and leave the supervisor's
+    // process group. PR_SET_CHILD_SUBREAPER makes that exact runtime descendant
+    // a direct child when labwc exits. `/proc/.../children` is therefore a
+    // generation-scoped ownership source: unlike a global process scan, it
+    // cannot select an unrelated process that merely resembles the workload.
+    auto signal_direct_children = [](int signal_number) {
+      std::ifstream input {
+        "/proc/self/task/" + std::to_string(getpid()) + "/children"
+      };
+      pid_t child = 0;
+      while (input >> child) {
+        if (child > 1 && child != getpid()) {
+          (void) kill(child, signal_number);
+        }
+      }
+    };
 
     siginfo_t exit_info {};
     bool observed_exit = false;
@@ -305,6 +323,13 @@ namespace cage_display_router {
         break;
       }
 
+      if (live_children) {
+        // Catch descendants as soon as the subreaper adopts them. Repeating
+        // SIGTERM is harmless for the still-live compositor and closes the
+        // adoption race without widening ownership beyond direct children.
+        signal_direct_children(SIGTERM);
+      }
+
       if (!live_children) {
         supervised_runtime_pid = 0;
         if (runtime_reaped && WIFEXITED(runtime_status)) {
@@ -318,8 +343,10 @@ namespace cage_display_router {
       sleep_without_losing_interrupt_time(25ms);
     }
 
-    // The supervisor is the live, unreaped group leader. Killing its group is
-    // therefore generation-safe and cannot land on a recycled PGID.
+    // Separate-session descendants are outside the process group but remain
+    // exact adopted children. Kill those before killing the immutable group
+    // leader (which intentionally includes this supervisor).
+    signal_direct_children(SIGKILL);
     (void) kill(-getpgrp(), SIGKILL);
     _exit(127);
   }

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -91,11 +91,13 @@ TEST(CageDisplayRouterLifecycleTests, ExternalExitDrainsPrivateChildrenAcrossRel
     std::string original_runtime_dir;
     std::string original_pid_file;
     std::string original_compositor_pid_file;
+    std::string original_escape_child;
     bool had_path;
     bool had_home;
     bool had_runtime_dir;
     bool had_pid_file;
     bool had_compositor_pid_file;
+    bool had_escape_child;
     fs::path root;
     std::vector<pid_t> cleanup_pids;
 
@@ -120,6 +122,7 @@ TEST(CageDisplayRouterLifecycleTests, ExternalExitDrainsPrivateChildrenAcrossRel
       restore_env("XDG_RUNTIME_DIR", original_runtime_dir, had_runtime_dir);
       restore_env("FAKE_LABWC_CHILD_PID_FILE", original_pid_file, had_pid_file);
       restore_env("FAKE_LABWC_COMPOSITOR_PID_FILE", original_compositor_pid_file, had_compositor_pid_file);
+      restore_env("FAKE_LABWC_ESCAPE_CHILD", original_escape_child, had_escape_child);
       std::error_code ec;
       fs::remove_all(root, ec);
     }
@@ -130,6 +133,7 @@ TEST(CageDisplayRouterLifecycleTests, ExternalExitDrainsPrivateChildrenAcrossRel
   const auto *runtime_env = std::getenv("XDG_RUNTIME_DIR");
   const auto *pid_file_env = std::getenv("FAKE_LABWC_CHILD_PID_FILE");
   const auto *compositor_pid_file_env = std::getenv("FAKE_LABWC_COMPOSITOR_PID_FILE");
+  const auto *escape_child_env = std::getenv("FAKE_LABWC_ESCAPE_CHILD");
   cleanup_t cleanup {
     .linux_display = config::video.linux_display,
     .original_path = path_env ? path_env : "",
@@ -137,11 +141,13 @@ TEST(CageDisplayRouterLifecycleTests, ExternalExitDrainsPrivateChildrenAcrossRel
     .original_runtime_dir = runtime_env ? runtime_env : "",
     .original_pid_file = pid_file_env ? pid_file_env : "",
     .original_compositor_pid_file = compositor_pid_file_env ? compositor_pid_file_env : "",
+    .original_escape_child = escape_child_env ? escape_child_env : "",
     .had_path = path_env != nullptr,
     .had_home = home_env != nullptr,
     .had_runtime_dir = runtime_env != nullptr,
     .had_pid_file = pid_file_env != nullptr,
     .had_compositor_pid_file = compositor_pid_file_env != nullptr,
+    .had_escape_child = escape_child_env != nullptr,
     .root = fs::temp_directory_path() / ("polaris-cage-external-exit-" + std::to_string(getpid())),
   };
   auto remove_cleanup_pid = [&](pid_t pid) {
@@ -176,7 +182,15 @@ if len(sys.argv) > 1 and sys.argv[1] == "-V":
 socket_path = os.path.join(os.environ["XDG_RUNTIME_DIR"], f"wayland-{(os.getpid() % 10000) + 100}")
 wayland_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 wayland_socket.bind(socket_path)
-worker = subprocess.Popen(["sleep", "60"])
+escape_child = os.environ.get("FAKE_LABWC_ESCAPE_CHILD") == "1"
+worker_command = ["sleep", "60"]
+if escape_child:
+    worker_command = [
+        sys.executable,
+        "-c",
+        "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)",
+    ]
+worker = subprocess.Popen(worker_command, start_new_session=escape_child)
 with open(os.environ["FAKE_LABWC_COMPOSITOR_PID_FILE"], "w", encoding="utf-8") as out:
     out.write(f"{os.getpid()}\n")
 with open(os.environ["FAKE_LABWC_CHILD_PID_FILE"], "w", encoding="utf-8") as out:
@@ -275,6 +289,46 @@ exit 0
       remove_cleanup_pid(worker);
     }
   }
+
+  // labwc may launch its startup client into a separate session. The
+  // supervisor is a child subreaper, so that client becomes its direct child
+  // when labwc exits even though it is outside the anchored process group.
+  // Teardown must drain that exact adopted descendant before the supervisor
+  // exits; otherwise the client is reparented to systemd and survives.
+  ASSERT_EQ(setenv("FAKE_LABWC_ESCAPE_CHILD", "1", 1), 0);
+  std::error_code escaped_ec;
+  fs::remove(pid_file, escaped_ec);
+  fs::remove(compositor_pid_file, escaped_ec);
+  ASSERT_TRUE(cage_display_router::start(
+    1280,
+    720,
+    60,
+    "",
+    false,
+    false,
+    "escaped-startup-client"
+  ));
+  const auto escaped_supervisor_pid = cage_display_router::get_pid();
+  ASSERT_GT(escaped_supervisor_pid, 0);
+  const auto escaped_compositor_pid = wait_for_pid_file(compositor_pid_file);
+  ASSERT_GT(escaped_compositor_pid, 0);
+  const auto escaped_worker_pid = wait_for_pid_file(pid_file);
+  ASSERT_GT(escaped_worker_pid, 0);
+  cleanup.cleanup_pids.push_back(escaped_worker_pid);
+  EXPECT_EQ(getpgid(escaped_worker_pid), escaped_worker_pid);
+  EXPECT_EQ(getsid(escaped_worker_pid), escaped_worker_pid);
+  EXPECT_NE(getpgid(escaped_worker_pid), escaped_supervisor_pid);
+
+  ASSERT_EQ(kill(escaped_compositor_pid, SIGTERM), 0);
+  ASSERT_TRUE(wait_for_router_exit(std::chrono::seconds(3)));
+  cage_display_router::stop();
+  const bool escaped_worker_exited = wait_for_process_exit(escaped_worker_pid, std::chrono::seconds(2));
+  EXPECT_TRUE(escaped_worker_exited)
+    << "external labwc exit leaked separate-session startup client pid " << escaped_worker_pid;
+  if (escaped_worker_exited) {
+    remove_cleanup_pid(escaped_worker_pid);
+  }
+  ASSERT_EQ(unsetenv("FAKE_LABWC_ESCAPE_CHILD"), 0);
 
   // A compositor that cannot honor SIGTERM must still be drained by the
   // supervisor's bounded escalation, not abandoned when stop() gives up.


### PR DESCRIPTION
## Summary

- drain labwc startup clients that leave the supervisor's process group and are later adopted by its child-subreaper
- signal only exact direct children from `/proc/self/task/<supervisor>/children` during graceful teardown and before bounded SIGKILL escalation
- add a lifecycle regression where the fake startup client calls `setsid()` and ignores SIGTERM

## Root cause

The supervisor previously broadcast teardown only to its anchored process group. A startup client launched into a separate session survived that broadcast, was reparented after the supervisor exited, and remained alive after labwc was reported stopped.

`PR_SET_CHILD_SUBREAPER` already makes that escaped client an exact direct child once labwc exits. This change uses that ownership boundary rather than scanning for process names or environment markers.

## Validation

- sabotage proof: the final regression fails on base `29e54140` and passes on `a5394ff6`
- focused lifecycle regression: PASS
- platform suite: 221 passed, 1 CUDA-only test skipped in the CPU test cache
- complete CTest matrix: 18/18 passed
- production-equivalent CUDA build: GCC/G++ 15, CUDA 13.2, architecture 89
- built artifact SHA-256: `cd6606a8512f01af4fd33d8ec31ab6db5f63ad561b580e49947ef07edd27e805`
- independent read-only review: MERGE-READY PENDING CI; no Critical or Important findings

## Risk and scope

- Linux/labwc process teardown only
- no global process scan; only children owned by the subreaper are signaled
- parent fallback for an externally frozen supervisor plus a separate-session descendant remains an explicit residual case outside this focused fix
- no deployment or release is included
