### PR TITLE
fix(linux): gracefully stop private Steam before signals

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2057,6 +2057,32 @@ namespace proc {
       }
     };
 
+    using private_steam_graceful_shutdown_request_t = std::function<bool()>;
+    constexpr auto private_steam_native_shutdown_timeout = 10s;
+
+    template<typename Request, typename Wait>
+    bool attempt_session_owned_steam_graceful_shutdown(
+      Request &&request,
+      Wait &&wait_for_exact_root
+    ) {
+      return std::forward<Request>(request)() &&
+             std::forward<Wait>(wait_for_exact_root)();
+    }
+
+    bool should_request_session_owned_steam_graceful_shutdown(
+      bool ownership_capture_complete,
+      std::size_t root_count,
+      std::size_t launcher_root_count,
+      std::size_t unowned_count,
+      bool request_available
+    ) {
+      return ownership_capture_complete &&
+             root_count == 1 &&
+             launcher_root_count == 0 &&
+             unowned_count == 0 &&
+             request_available;
+    }
+
     std::optional<std::size_t> unique_top_level_steam_launcher(
       const std::vector<pidfd_handle_t> &launchers
     ) {
@@ -2294,7 +2320,8 @@ namespace proc {
     bool terminate_session_owned_steam_before_cage_stop_impl(
       const proc::ctx_t &app,
       bool session_owned_cage,
-      std::string_view session_instance_id
+      std::string_view session_instance_id,
+      private_steam_graceful_shutdown_request_t request_graceful_shutdown
     ) {
       const bool steam_context = context_uses_steam(app);
       if (!session_owned_cage || session_instance_id.empty() || !steam_context) {
@@ -2328,17 +2355,55 @@ namespace proc {
         return false;
       }
 
-      if (!ownership.unowned.empty()) {
+      const bool no_unowned_steam = ownership.unowned.empty();
+      if (!no_unowned_steam) {
         BOOST_LOG(info) << "process: leaving "sv << ownership.unowned.size()
                         << " non-session Steam client process(es) running"sv;
       }
 
-      BOOST_LOG(info) << "process: terminating the session-owned Steam client root through pidfd before "sv
-                      << ownership.helpers.size() << " helper process(es)"sv;
-      if (!terminate_pidfds(ownership.roots, 5s, 1s, "private Steam client root"sv)) {
-        BOOST_LOG(warning) << "process: session-owned Steam client root remained after bounded pidfd termination; "sv
-                           << "continuing with isolated cage fallback cleanup"sv;
-        return false;
+      bool root_exited = pidfd_has_exited(ownership.roots.front());
+      if (!root_exited &&
+          no_unowned_steam &&
+          should_request_session_owned_steam_graceful_shutdown(
+            ownership.capture_complete,
+            ownership.roots.size(),
+            ownership.launcher_roots.size(),
+            ownership.unowned.size(),
+            static_cast<bool>(request_graceful_shutdown)
+          )) {
+        BOOST_LOG(info) << "process: requesting session-owned Steam native shutdown before exact pidfd fallback"sv;
+        bool request_dispatched = false;
+        root_exited = attempt_session_owned_steam_graceful_shutdown(
+          [&]() {
+            request_dispatched = request_graceful_shutdown();
+            return request_dispatched;
+          },
+          [&]() {
+            return wait_for_pidfds_exit(
+              ownership.roots,
+              private_steam_native_shutdown_timeout
+            );
+          }
+        );
+        if (root_exited) {
+          BOOST_LOG(info) << "process: session-owned Steam client root exited after native shutdown request"sv;
+        } else if (request_dispatched) {
+          BOOST_LOG(warning) << "process: session-owned Steam native shutdown request did not stop the exact root; "sv
+                             << "falling back to PID-bound SIGTERM"sv;
+        } else {
+          BOOST_LOG(warning) << "process: session-owned Steam native shutdown request was not dispatched; "sv
+                             << "falling back to PID-bound SIGTERM"sv;
+        }
+      }
+
+      if (!root_exited) {
+        BOOST_LOG(info) << "process: terminating the session-owned Steam client root through pidfd before "sv
+                        << ownership.helpers.size() << " helper process(es)"sv;
+        if (!terminate_pidfds(ownership.roots, 5s, 1s, "private Steam client root"sv)) {
+          BOOST_LOG(warning) << "process: session-owned Steam client root remained after bounded pidfd termination; "sv
+                             << "continuing with isolated cage fallback cleanup"sv;
+          return false;
+        }
       }
 
       if (!ownership.helpers.empty()) {
@@ -4629,6 +4694,24 @@ namespace proc {
     return result;
   }
 
+  private_steam_graceful_shutdown_test_result_t run_private_steam_graceful_shutdown_scenario_for_tests(
+    bool request_dispatched,
+    bool exact_root_exited
+  ) {
+    private_steam_graceful_shutdown_test_result_t result;
+    result.root_exited = attempt_session_owned_steam_graceful_shutdown(
+      [&]() {
+        ++result.request_calls;
+        return request_dispatched;
+      },
+      [&]() {
+        ++result.wait_calls;
+        return exact_root_exited;
+      }
+    );
+    return result;
+  }
+
   std::optional<std::string> steam_instance_pipe_path_for_tests(
     const std::optional<std::string> &home_env,
     const std::optional<std::string> &account_home
@@ -4727,6 +4810,22 @@ namespace proc {
       session_owned_steam_client_active,
       unowned_steam_client_active,
       ownership_capture_complete
+    );
+  }
+
+  bool should_request_session_owned_steam_graceful_shutdown_for_tests(
+    bool ownership_capture_complete,
+    std::size_t root_count,
+    std::size_t launcher_root_count,
+    std::size_t unowned_count,
+    bool request_available
+  ) {
+    return should_request_session_owned_steam_graceful_shutdown(
+      ownership_capture_complete,
+      root_count,
+      launcher_root_count,
+      unowned_count,
+      request_available
     );
   }
 
@@ -5339,7 +5438,12 @@ namespace proc {
       forced_steam_ownership_descendants_only = previous_descendants_only;
       forced_steam_ownership_test_pids = previous_test_pids;
     });
-    return terminate_session_owned_steam_before_cage_stop();
+    return terminate_session_owned_steam_before_cage_stop_impl(
+      _app,
+      _session_used_cage_compositor,
+      _session_instance_id,
+      {}
+    );
   }
 
   bool isolated_session_capture_failure_retains_generation_for_tests(
@@ -8307,11 +8411,47 @@ namespace proc {
   }
 
 #ifdef __linux__
+  bool proc_t::request_session_owned_steam_graceful_shutdown_before_cage_stop() {
+    std::optional<std::string> session_home;
+    if (const auto home = _env.find("HOME"); home != _env.end() && !home->to_string().empty()) {
+      session_home = home->to_string();
+    }
+    const auto account_home = account_home_directory();
+    const auto pipe_path = steam_instance_pipe_path(
+      session_home,
+      account_home.empty() ? std::nullopt : std::optional<std::string> {account_home}
+    );
+    if (!pipe_path || !steam_instance_pipe_listener_active(*pipe_path)) {
+      BOOST_LOG(warning) << "process: exact private Steam FIFO listener is unavailable; refusing native shutdown request"sv;
+      return false;
+    }
+
+    const auto command = canonical_steam_shutdown_command(steam_launch_reference_command(_app));
+    BOOST_LOG(info) << "process: dispatching session-environment Steam native shutdown request ["sv << command << ']';
+    try {
+      boost::system::error_code ec;
+      boost::filesystem::path working_dir {};
+      auto child = platf::run_command(false, true, command, working_dir, _env, nullptr, ec, nullptr);
+      if (ec) {
+        BOOST_LOG(warning) << "process: session-environment Steam native shutdown command failed: "sv << ec.message();
+        return false;
+      }
+      child.detach();
+      return true;
+    } catch (const std::exception &e) {
+      BOOST_LOG(warning) << "process: session-environment Steam native shutdown command threw: "sv << e.what();
+      return false;
+    }
+  }
+
   bool proc_t::terminate_session_owned_steam_before_cage_stop() {
     return terminate_session_owned_steam_before_cage_stop_impl(
       _app,
       _session_used_cage_compositor,
-      _session_instance_id
+      _session_instance_id,
+      [this]() {
+        return request_session_owned_steam_graceful_shutdown_before_cage_stop();
+      }
     );
   }
 

--- a/src/process.h
+++ b/src/process.h
@@ -231,6 +231,17 @@ namespace proc {
     std::chrono::milliseconds timeout,
     std::chrono::milliseconds poll_interval
   );
+
+  struct private_steam_graceful_shutdown_test_result_t {
+    bool root_exited = false;
+    std::size_t request_calls = 0;
+    std::size_t wait_calls = 0;
+  };
+
+  private_steam_graceful_shutdown_test_result_t run_private_steam_graceful_shutdown_scenario_for_tests(
+    bool request_dispatched,
+    bool exact_root_exited
+  );
   std::optional<std::string> steam_instance_pipe_path_for_tests(
     const std::optional<std::string> &home_env,
     const std::optional<std::string> &account_home
@@ -265,6 +276,13 @@ namespace proc {
     bool session_owned_steam_client_active,
     bool unowned_steam_client_active,
     bool ownership_capture_complete
+  );
+  bool should_request_session_owned_steam_graceful_shutdown_for_tests(
+    bool ownership_capture_complete,
+    std::size_t root_count,
+    std::size_t launcher_root_count,
+    std::size_t unowned_count,
+    bool request_available
   );
   bool steam_shutdown_process_is_unowned_active_for_tests(
     std::string_view comm,
@@ -769,6 +787,7 @@ namespace proc {
     );
     void terminate_impl(bool immediate, bool needs_refresh);
 #ifdef __linux__
+    bool request_session_owned_steam_graceful_shutdown_before_cage_stop();
     bool terminate_session_owned_steam_before_cage_stop();
     bool cleanup_tracked_detached_children_after_launch_failure();
     void finalize_isolated_session_runtime(bool runtime_was_stopped_externally);

--- a/tests/unit/test_steam_shutdown_state_machine.cpp
+++ b/tests/unit/test_steam_shutdown_state_machine.cpp
@@ -185,6 +185,101 @@ TEST(SteamShutdownStateMachineTests, ProductionShutdownUsesSingleMonotonicQuiesc
   EXPECT_EQ(shutdown.find("for (int i = 0; i < 50; ++i)"), std::string::npos);
 }
 
+TEST(SteamShutdownStateMachineTests, PrivateCageGracefulShutdownRequiresCompleteSoloExactOwnership) {
+  EXPECT_TRUE(proc::should_request_session_owned_steam_graceful_shutdown_for_tests(
+    true, 1, 0, 0, true
+  ));
+  EXPECT_FALSE(proc::should_request_session_owned_steam_graceful_shutdown_for_tests(
+    false, 1, 0, 0, true
+  ));
+  EXPECT_FALSE(proc::should_request_session_owned_steam_graceful_shutdown_for_tests(
+    true, 0, 0, 0, true
+  ));
+  EXPECT_FALSE(proc::should_request_session_owned_steam_graceful_shutdown_for_tests(
+    true, 2, 0, 0, true
+  ));
+  EXPECT_FALSE(proc::should_request_session_owned_steam_graceful_shutdown_for_tests(
+    true, 1, 1, 0, true
+  ));
+  EXPECT_FALSE(proc::should_request_session_owned_steam_graceful_shutdown_for_tests(
+    true, 1, 0, 1, true
+  ));
+  EXPECT_FALSE(proc::should_request_session_owned_steam_graceful_shutdown_for_tests(
+    true, 1, 0, 0, false
+  ));
+}
+
+TEST(SteamShutdownStateMachineTests, GracefulAttemptDoesNotWaitWhenDispatchFails) {
+  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(false, true);
+  EXPECT_FALSE(result.root_exited);
+  EXPECT_EQ(result.request_calls, 1U);
+  EXPECT_EQ(result.wait_calls, 0U);
+}
+
+TEST(SteamShutdownStateMachineTests, GracefulAttemptFallsBackWhenExactRootDoesNotExit) {
+  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(true, false);
+  EXPECT_FALSE(result.root_exited);
+  EXPECT_EQ(result.request_calls, 1U);
+  EXPECT_EQ(result.wait_calls, 1U);
+}
+
+TEST(SteamShutdownStateMachineTests, GracefulAttemptSucceedsOnlyAfterExactRootExit) {
+  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(true, true);
+  EXPECT_TRUE(result.root_exited);
+  EXPECT_EQ(result.request_calls, 1U);
+  EXPECT_EQ(result.wait_calls, 1U);
+}
+
+TEST(SteamShutdownStateMachineTests, ProductionPrivateCageAttemptsScopedGracefulBeforePidfdFallback) {
+  const auto source = read_source_file("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto cleanup = source_between(
+    source,
+    "bool terminate_session_owned_steam_before_cage_stop_impl(",
+    "bool terminate_gamescope_attached_session_clients("
+  );
+  ASSERT_FALSE(cleanup.empty());
+
+  const auto root_cardinality_guard = cleanup.find("if (ownership.roots.size() != 1)");
+  const auto root_front_access = cleanup.find("ownership.roots.front()");
+  const auto no_unowned_guard = cleanup.find("ownership.unowned.empty()");
+  const auto graceful_request = cleanup.find("attempt_session_owned_steam_graceful_shutdown(");
+  const auto exact_pidfd_fallback = cleanup.find("terminate_pidfds(ownership.roots");
+  ASSERT_NE(root_cardinality_guard, std::string::npos);
+  ASSERT_NE(root_front_access, std::string::npos);
+  ASSERT_NE(no_unowned_guard, std::string::npos);
+  ASSERT_NE(graceful_request, std::string::npos);
+  ASSERT_NE(exact_pidfd_fallback, std::string::npos);
+  EXPECT_LT(root_cardinality_guard, root_front_access);
+  EXPECT_LT(no_unowned_guard, graceful_request);
+  EXPECT_LT(graceful_request, exact_pidfd_fallback);
+  EXPECT_NE(
+    cleanup.find("wait_for_pidfds_exit(", graceful_request),
+    std::string::npos
+  );
+  EXPECT_NE(
+    cleanup.find("private_steam_native_shutdown_timeout", graceful_request),
+    std::string::npos
+  );
+}
+
+TEST(SteamShutdownStateMachineTests, ProductionPrivateSteamRequestUsesSessionEnvironmentAndLiveFifo) {
+  const auto source = read_source_file("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto request = source_between(
+    source,
+    "bool proc_t::request_session_owned_steam_graceful_shutdown_before_cage_stop()",
+    "bool proc_t::terminate_session_owned_steam_before_cage_stop()"
+  );
+  ASSERT_FALSE(request.empty());
+  EXPECT_NE(request.find("_env.find(\"HOME\")"), std::string::npos);
+  EXPECT_NE(request.find("steam_instance_pipe_listener_active"), std::string::npos);
+  EXPECT_NE(request.find("canonical_steam_shutdown_command"), std::string::npos);
+  EXPECT_NE(request.find("platf::run_command"), std::string::npos);
+  EXPECT_NE(request.find(", _env, nullptr"), std::string::npos);
+  EXPECT_NE(request.find("child.detach()"), std::string::npos);
+}
+
 TEST(SteamShutdownStateMachineTests, PostShutdownPolicyRechecksLiveProcessState) {
   const auto source = read_source_file("src/process.cpp");
   ASSERT_FALSE(source.empty());


### PR DESCRIPTION
## Summary

- request Steam-native shutdown for the exact session-owned private Steam root before raw pidfd signaling
- permit that request only after complete ownership capture, exactly one root, zero launcher roots, zero unowned Steam, and a live Steam FIFO in the session environment
- retain exact-pidfd SIGTERM/SIGKILL fallback, helper grace, survivor recapture, PID-reuse protection, and no bare-PID fallback

## Root cause

Polaris previously sent raw SIGTERM directly to the private native Steam root during normal session teardown. That asynchronous signal can race Steam's internal Depot Download HTTP cleanup and crash a Steam worker before the existing grace period expires.

The new path asks Steam to shut down natively while the exact private session environment and FIFO are still available. If ownership is incomplete or ambiguous, an unowned/desktop Steam client exists, the request cannot be dispatched, or the exact root does not exit within the bounded wait, teardown falls back to the existing exact pidfd path.

## Validation

- regression proof: the new graceful-before-pidfd production-order contract failed on base `7f4cdb58` and passes on `0ecb8a53`
- focused Steam shutdown suite: 18/18 passed
- process/config suite: 291/291 passed
- production-equivalent Release/CUDA CTest: 18/18 passed
- deferred production-binary startup tests: 2/2 passed directly against the production-only artifact
- production-equivalent CUDA build: GCC/G++ 15, CUDA 13.2, architecture 89
- built artifact SHA-256: `32ac7e8e01123bb3702139507c17d6df50d62206073d1ed91b6e1c2a3cb872b9`
- independent exact-tree review and independent candidate read-back: PASS
- one intervening fake-labwc pre-socket fixture timeout was preserved as a test-stability caveat; the exact test then passed 10/10 and the decisive final CTest run passed 18/18

## Risk and scope

- Linux private-Steam teardown only
- no global process scan and no name-based or bare-PID termination
- native shutdown is fail-closed whenever exact ownership or FIFO state is not proven
- existing exact-pidfd fallback and post-root helper drainage remain intact
- no deployment, device validation, tag, or release is included
