### PR TITLE
fix(config): allow clearing stored AI API keys

### DIFF
--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -105,6 +105,7 @@ namespace confighttp::validation {
       "browser_streaming"sv,
       "capture"sv,
       "cert"sv,
+      "clear_ai_api_key"sv,
       "color_range"sv,
       "client_gamepad_seat_isolation"sv,
       "client_keyboard_mouse_seat_isolation"sv,
@@ -359,6 +360,11 @@ namespace confighttp::validation {
 
       if (!contains(allowed_config_keys, std::string_view {key})) {
         error = "Unsupported config key: " + key;
+        return false;
+      }
+
+      if (key == "clear_ai_api_key" && !value.is_boolean()) {
+        error = "clear_ai_api_key must be a boolean";
         return false;
       }
 

--- a/tests/unit/test_confighttp_validation.cpp
+++ b/tests/unit/test_confighttp_validation.cpp
@@ -37,6 +37,26 @@ TEST(ConfigValidationTests, RejectsUnsupportedConfigKeys) {
   EXPECT_NE(error.find("Unsupported config key"), std::string::npos);
 }
 
+TEST(ConfigValidationTests, AcceptsAiApiKeyClearForPersistence) {
+  nlohmann::json payload = {
+    {"ai_api_key", ""},
+    {"clear_ai_api_key", true}
+  };
+
+  std::string error;
+  EXPECT_TRUE(confighttp::validation::validate_config_payload(payload, error)) << error;
+}
+
+TEST(ConfigValidationTests, RejectsNonBooleanAiApiKeyClearFlag) {
+  nlohmann::json payload = {
+    {"clear_ai_api_key", "true"}
+  };
+
+  std::string error;
+  EXPECT_FALSE(confighttp::validation::validate_config_payload(payload, error));
+  EXPECT_NE(error.find("clear_ai_api_key must be a boolean"), std::string::npos);
+}
+
 TEST(ConfigValidationTests, AcceptsBrowserStreamPrimaryAndDeprecatedAliasKeys) {
   nlohmann::json payload = {
     {"browser_streaming", "enabled"},


### PR DESCRIPTION
## what

- allows the intentional `clear_ai_api_key` request flag through strict config validation
- rejects non-boolean clear flags before the typed save handler reads them
- adds focused acceptance and malformed-type regression tests

## why

The AI settings UI already sends `clear_ai_api_key: true`, and the save handler already persists an empty key when that flag is set. Strict config validation omitted the synthetic key, so the request returned HTTP 400 before the handler could run.

This is intentionally different from the SteamGridDB clear flag, which is UI-only and stripped before save.

Fixes #528.

## verification

- baseline config validation: 6/6
- expected RED: both new tests fail on the old validator
- focused GREEN: 8/8
- sabotage RED: both tests fail after restoring the old validator
- final focused GREEN: 8/8
- full native unit suite: 370/370
- CTest: 18/18
- web tests: 506/506
- web lint: pass
- npm audit: zero vulnerabilities
- production web build: pass
- independent review: approved
- `git diff --check`: pass

## scope

Two files only. No UI behavior, secret logging, release-branch, packaging, protocol, deployment, or device change. This targets `master` and is not backported into the packaging-only v1.3.12 release.
