### PR TITLE
fix(linux): quiesce Steam app before client shutdown

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2059,6 +2059,17 @@ namespace proc {
 
     using private_steam_graceful_shutdown_request_t = std::function<bool()>;
     constexpr auto private_steam_native_shutdown_timeout = 10s;
+    constexpr auto private_steam_app_exit_timeout = 5s;
+    constexpr auto private_steam_app_settle_time = 5s;
+    constexpr auto private_steam_app_capture_timeout = 500ms;
+    constexpr auto private_steam_app_sigterm_timeout = 2s;
+    constexpr auto private_steam_app_sigkill_timeout = 1s;
+
+    bool quiesce_session_owned_steam_app_before_native_shutdown(
+      const proc::ctx_t &app,
+      std::string_view session_instance_id,
+      const boost::process::v1::environment &env
+    );
 
     template<typename Request, typename Wait>
     bool attempt_session_owned_steam_graceful_shutdown(
@@ -2153,7 +2164,22 @@ namespace proc {
       for (auto &handle : snapshot.helpers) {
         handles.emplace_back(std::move(handle));
       }
+      snapshot.roots.clear();
+      snapshot.launcher_roots.clear();
+      snapshot.helpers.clear();
       return handles;
+    }
+
+    bool kill_private_steam_pidfds_immediately(steam_client_ownership_snapshot_t &snapshot) {
+      auto handles = take_owned_steam_handles(snapshot);
+      for (const auto &handle : handles) {
+        if (!send_pidfd_signal(handle, SIGKILL)) {
+          BOOST_LOG(error) << "process: exact private Steam pidfd SIGKILL failed pid="sv
+                           << handle.pid << " error="sv << std::strerror(errno);
+          return false;
+        }
+      }
+      return wait_for_pidfds_exit(handles, private_steam_app_sigkill_timeout);
     }
 
     steam_client_ownership_snapshot_t steam_client_ownership_snapshot(std::string_view session_instance_id) {
@@ -2317,10 +2343,279 @@ namespace proc {
       return snapshot;
     }
 
+    bool steam_launch_cmdline_matches_appid(std::string_view cmdline, std::string_view appid) {
+      if (appid.empty() || !std::all_of(appid.begin(), appid.end(), [](unsigned char value) {
+            return std::isdigit(value) != 0;
+          })) {
+        return false;
+      }
+
+      const auto expected_appid = "AppId="s + std::string {appid};
+      const auto is_separator = [](unsigned char value) {
+        return value == '\0' || std::isspace(value) != 0;
+      };
+      std::string_view previous;
+      std::size_t cursor = 0;
+      while (cursor < cmdline.size()) {
+        while (cursor < cmdline.size() &&
+               is_separator(static_cast<unsigned char>(cmdline[cursor]))) {
+          ++cursor;
+        }
+        const auto begin = cursor;
+        while (cursor < cmdline.size() &&
+               !is_separator(static_cast<unsigned char>(cmdline[cursor]))) {
+          ++cursor;
+        }
+        if (begin == cursor) {
+          break;
+        }
+        const auto token = cmdline.substr(begin, cursor - begin);
+        if (previous == "SteamLaunch"sv && token == expected_appid) {
+          return true;
+        }
+        previous = token;
+      }
+      return false;
+    }
+
+    struct private_steam_app_root_snapshot_t {
+      std::vector<pidfd_handle_t> roots;
+      bool capture_complete = true;
+    };
+
+    private_steam_app_root_snapshot_t private_steam_app_root_snapshot(
+      std::string_view session_instance_id,
+      std::string_view appid
+    ) {
+      private_steam_app_root_snapshot_t snapshot;
+      DIR *dir = opendir("/proc");
+      if (!dir) {
+        snapshot.capture_complete = false;
+        return snapshot;
+      }
+      for (;;) {
+        auto *entry = read_next_proc_entry(dir);
+        if (entry == nullptr) {
+          if (errno != 0) {
+            snapshot.capture_complete = false;
+          }
+          break;
+        }
+        const std::string name = entry->d_name;
+        if (!proc_pid_dir_name(name)) {
+          continue;
+        }
+        const auto pid = static_cast<pid_t>(std::strtol(name.c_str(), nullptr, 10));
+        if (pid <= 1 || pid == getpid()) {
+          continue;
+        }
+        const auto cmdline_before = read_proc_status_file_result(pid, "cmdline");
+        if (!cmdline_before.ok()) {
+          if (!process_vanished_during_proc_read(cmdline_before.error)) {
+            const auto status = read_proc_status_file(pid, "status");
+            if (!proc_status_is_zombie(status)) {
+              snapshot.capture_complete = false;
+            }
+          }
+          continue;
+        }
+        if (!steam_launch_cmdline_matches_appid(cmdline_before.bytes, appid)) {
+          continue;
+        }
+        const auto environ_before = read_proc_status_file_result(pid, "environ");
+        const auto identity_before = proc_start_time_ticks(pid);
+        if (!environ_before.ok() ||
+            !proc_environ_matches_isolated_session(environ_before.bytes, session_instance_id) ||
+            !identity_before) {
+          snapshot.capture_complete = false;
+          continue;
+        }
+        int open_error = 0;
+        auto handle = open_process_pidfd(pid, open_error);
+        if (!handle) {
+          if (!process_vanished_during_proc_read(open_error)) {
+            snapshot.capture_complete = false;
+          }
+          continue;
+        }
+        const auto cmdline_after = read_proc_status_file_result(pid, "cmdline");
+        const auto environ_after = read_proc_status_file_result(pid, "environ");
+        const auto identity_after = proc_start_time_ticks(pid);
+        if (!cmdline_after.ok() || !environ_after.ok() ||
+            !steam_launch_cmdline_matches_appid(cmdline_after.bytes, appid) ||
+            !proc_environ_matches_isolated_session(environ_after.bytes, session_instance_id) ||
+            !steam_pidfd_capture_identity_matches(identity_before, identity_after)) {
+          snapshot.capture_complete = false;
+          continue;
+        }
+        snapshot.roots.emplace_back(std::move(*handle));
+      }
+      closedir(dir);
+      return snapshot;
+    }
+
+    bool resume_or_kill_frozen_pidfds(const std::vector<pidfd_handle_t> &frozen) {
+      bool all_safe = true;
+      for (const auto &handle : frozen) {
+        if (pidfd_has_exited(handle) || send_pidfd_signal(handle, SIGCONT)) {
+          continue;
+        }
+        const auto resume_error = errno;
+        if (resume_error == ESRCH || pidfd_has_exited(handle)) {
+          continue;
+        }
+        BOOST_LOG(warning) << "process: exact private Steam app pidfd could not resume; sending SIGKILL pid="sv
+                           << handle.pid << " error="sv << std::strerror(resume_error);
+        if (!send_pidfd_signal(handle, SIGKILL) && errno != ESRCH && !pidfd_has_exited(handle)) {
+          BOOST_LOG(error) << "process: exact private Steam app pidfd remained stopped after SIGCONT and SIGKILL failures pid="sv
+                           << handle.pid << " error="sv << std::strerror(errno);
+          all_safe = false;
+        }
+      }
+      return all_safe;
+    }
+
+    bool terminate_session_owned_steam_app_lineage(
+      const proc::ctx_t &app,
+      std::string_view session_instance_id
+    ) {
+      const auto appid = steam_appid_for_context(app);
+      if (appid.empty()) {
+        return true;
+      }
+      auto roots = private_steam_app_root_snapshot(session_instance_id, appid);
+      if (!roots.capture_complete || roots.roots.size() > 1) {
+        BOOST_LOG(error) << "process: refusing private Steam app quiescence because exact AppID root capture was ambiguous appid="sv
+                         << appid << " roots="sv << roots.roots.size();
+        return false;
+      }
+      if (roots.roots.empty()) {
+        BOOST_LOG(info) << "process: private Steam app is already quiescent appid="sv << appid;
+        return true;
+      }
+
+      const auto app_root_pid = roots.roots.front().pid;
+      std::vector<pidfd_handle_t> frozen;
+      std::set<pid_t> captured;
+      for (auto &root : roots.roots) {
+        if (!send_pidfd_signal(root, SIGSTOP)) {
+          return false;
+        }
+        captured.emplace(root.pid);
+        frozen.emplace_back(std::move(root));
+      }
+      auto resume_on_failure = util::fail_guard([&frozen]() {
+        (void) resume_or_kill_frozen_pidfds(frozen);
+      });
+
+      const auto capture_deadline = std::chrono::steady_clock::now() + private_steam_app_capture_timeout;
+      bool closure_complete = false;
+      while (std::chrono::steady_clock::now() < capture_deadline) {
+        bool added = false;
+        bool capture_failed = false;
+        DIR *dir = opendir("/proc");
+        if (!dir) {
+          return false;
+        }
+        for (;;) {
+          auto *entry = read_next_proc_entry(dir);
+          if (entry == nullptr) {
+            if (errno != 0) {
+              capture_failed = true;
+            }
+            break;
+          }
+          const std::string name = entry->d_name;
+          if (!proc_pid_dir_name(name)) {
+            continue;
+          }
+          const auto pid = static_cast<pid_t>(std::strtol(name.c_str(), nullptr, 10));
+          if (pid <= 1 || pid == getpid() || captured.contains(pid)) {
+            continue;
+          }
+          const auto status = read_proc_status_file(pid, "status");
+          if (proc_status_is_zombie(status)) {
+            continue;
+          }
+          const auto real_uid = proc_status_real_uid(status);
+          if (!real_uid || *real_uid != getuid()) {
+            continue;
+          }
+          const auto descends_before = proc_pid_descends_from(pid, app_root_pid);
+          if (!descends_before) {
+            capture_failed = true;
+            continue;
+          }
+          if (!*descends_before) {
+            continue;
+          }
+          const auto identity_before = proc_start_time_ticks(pid);
+          int open_error = 0;
+          auto handle = open_process_pidfd(pid, open_error);
+          if (!handle) {
+            if (!process_vanished_during_proc_read(open_error)) {
+              capture_failed = true;
+            }
+            continue;
+          }
+          const auto identity_after = proc_start_time_ticks(pid);
+          const auto descends_after = proc_pid_descends_from(pid, app_root_pid);
+          if (!steam_pidfd_capture_identity_matches(identity_before, identity_after) ||
+              !descends_after || !*descends_after ||
+              !send_pidfd_signal(*handle, SIGSTOP)) {
+            capture_failed = true;
+            continue;
+          }
+          captured.emplace(pid);
+          frozen.emplace_back(std::move(*handle));
+          added = true;
+        }
+        closedir(dir);
+        if (capture_failed) {
+          return false;
+        }
+        if (!added) {
+          closure_complete = true;
+          break;
+        }
+        std::this_thread::sleep_for(10ms);
+      }
+      if (!closure_complete) {
+        BOOST_LOG(error) << "process: private Steam app lineage did not quiesce during exact pidfd capture appid="sv << appid;
+        return false;
+      }
+
+      for (const auto &handle : frozen) {
+        if (!send_pidfd_signal(handle, SIGTERM)) {
+          return false;
+        }
+      }
+      if (!resume_or_kill_frozen_pidfds(frozen)) {
+        return false;
+      }
+      resume_on_failure.disable();
+      if (!wait_for_pidfds_exit(frozen, private_steam_app_sigterm_timeout)) {
+        BOOST_LOG(warning) << "process: exact private Steam app lineage did not exit after SIGTERM; sending pidfd SIGKILL appid="sv
+                           << appid;
+        for (const auto &handle : frozen) {
+          if (!send_pidfd_signal(handle, SIGKILL)) {
+            return false;
+          }
+        }
+        if (!wait_for_pidfds_exit(frozen, private_steam_app_sigkill_timeout)) {
+          return false;
+        }
+      }
+      BOOST_LOG(info) << "process: exact private Steam app lineage drained before native shutdown appid="sv
+                      << appid << " processes="sv << frozen.size();
+      return true;
+    }
+
     bool terminate_session_owned_steam_before_cage_stop_impl(
       const proc::ctx_t &app,
       bool session_owned_cage,
       std::string_view session_instance_id,
+      const boost::process::v1::environment &env,
       private_steam_graceful_shutdown_request_t request_graceful_shutdown
     ) {
       const bool steam_context = context_uses_steam(app);
@@ -2371,49 +2666,49 @@ namespace proc {
             ownership.unowned.size(),
             static_cast<bool>(request_graceful_shutdown)
           )) {
-        BOOST_LOG(info) << "process: requesting session-owned Steam native shutdown before exact pidfd fallback"sv;
-        bool request_dispatched = false;
-        root_exited = attempt_session_owned_steam_graceful_shutdown(
-          [&]() {
-            request_dispatched = request_graceful_shutdown();
-            return request_dispatched;
-          },
-          [&]() {
-            return wait_for_pidfds_exit(
-              ownership.roots,
-              private_steam_native_shutdown_timeout
-            );
-          }
+        const bool app_quiescent = quiesce_session_owned_steam_app_before_native_shutdown(
+          app,
+          session_instance_id,
+          env
         );
-        if (root_exited) {
-          BOOST_LOG(info) << "process: session-owned Steam client root exited after native shutdown request"sv;
-        } else if (request_dispatched) {
-          BOOST_LOG(warning) << "process: session-owned Steam native shutdown request did not stop the exact root; "sv
-                             << "falling back to PID-bound SIGTERM"sv;
+        if (app_quiescent) {
+          BOOST_LOG(info) << "process: requesting session-owned Steam native shutdown after exact app quiescence"sv;
+          bool request_dispatched = false;
+          root_exited = attempt_session_owned_steam_graceful_shutdown(
+            [&]() {
+              request_dispatched = request_graceful_shutdown();
+              return request_dispatched;
+            },
+            [&]() {
+              return wait_for_pidfds_exit(
+                ownership.roots,
+                private_steam_native_shutdown_timeout
+              );
+            }
+          );
+          if (root_exited) {
+            BOOST_LOG(info) << "process: session-owned Steam client root exited after native shutdown request"sv;
+          } else if (request_dispatched) {
+            BOOST_LOG(warning) << "process: session-owned Steam native shutdown request did not stop the exact root; "sv
+                               << "falling back to exact pidfd SIGKILL"sv;
+          } else {
+            BOOST_LOG(warning) << "process: session-owned Steam native shutdown request was not dispatched; "sv
+                               << "falling back to exact pidfd SIGKILL"sv;
+          }
         } else {
-          BOOST_LOG(warning) << "process: session-owned Steam native shutdown request was not dispatched; "sv
-                             << "falling back to PID-bound SIGTERM"sv;
+          BOOST_LOG(warning) << "process: private Steam app did not reach verified quiescence; "sv
+                             << "skipping native shutdown and falling back to exact pidfd SIGKILL"sv;
         }
       }
 
       if (!root_exited) {
-        BOOST_LOG(info) << "process: terminating the session-owned Steam client root through pidfd before "sv
-                        << ownership.helpers.size() << " helper process(es)"sv;
-        if (!terminate_pidfds(ownership.roots, 5s, 1s, "private Steam client root"sv)) {
-          BOOST_LOG(warning) << "process: session-owned Steam client root remained after bounded pidfd termination; "sv
+        BOOST_LOG(info) << "process: terminating the exact private Steam set with pidfd SIGKILL to avoid Steam's crashing shutdown destructor"sv;
+        if (!kill_private_steam_pidfds_immediately(ownership)) {
+          BOOST_LOG(warning) << "process: session-owned Steam remained after exact pidfd SIGKILL; "sv
                              << "continuing with isolated cage fallback cleanup"sv;
           return false;
         }
-      }
-
-      if (!ownership.helpers.empty()) {
-        BOOST_LOG(info) << "process: allowing "sv << ownership.helpers.size()
-                        << " session-owned Steam helper process(es) to drain after client-root exit"sv;
-        if (wait_for_pidfds_exit(ownership.helpers, 2s)) {
-          BOOST_LOG(info) << "process: session-owned Steam helpers drained without direct signaling"sv;
-        } else {
-          BOOST_LOG(info) << "process: session-owned Steam helper drain grace elapsed; capturing exact survivors"sv;
-        }
+        root_exited = true;
       }
 
       auto survivors = steam_client_ownership_snapshot(session_instance_id);
@@ -2431,15 +2726,15 @@ namespace proc {
         return true;
       }
 
-      auto survivor_handles = take_owned_steam_handles(survivors);
-      BOOST_LOG(info) << "process: terminating "sv << survivor_handles.size()
+      const auto survivor_count = survivors.owned_count();
+      BOOST_LOG(info) << "process: terminating "sv << survivor_count
                       << " session-owned Steam survivor process(es) after client-root drain"sv;
-      if (terminate_pidfds(survivor_handles, 2s, 1s, "private Steam survivor"sv)) {
+      if (kill_private_steam_pidfds_immediately(survivors)) {
         BOOST_LOG(info) << "process: session-owned Steam exited before isolated cage stop"sv;
         return true;
       }
 
-      BOOST_LOG(warning) << "process: session-owned Steam survivors remained after bounded pidfd termination; "sv
+      BOOST_LOG(warning) << "process: session-owned Steam survivors remained after exact pidfd SIGKILL; "sv
                          << "continuing with isolated cage fallback cleanup"sv;
       return false;
     }
@@ -3878,6 +4173,83 @@ namespace proc {
       return candidates.front();
     }
 
+    bool wait_for_steam_app_stopped_event(
+      const std::filesystem::path &path,
+      const steam_game_process_log_snapshot_result_t &snapshot,
+      std::string_view appid
+    ) {
+      if (snapshot.status != steam_game_process_log_snapshot_status_e::captured ||
+          !snapshot.identity) {
+        return false;
+      }
+      auto cursor = snapshot.offset;
+      const auto deadline = std::chrono::steady_clock::now() + private_steam_app_exit_timeout;
+      while (std::chrono::steady_clock::now() < deadline) {
+        const auto current_identity = steam_game_process_log_identity(path);
+        if (!current_identity || *current_identity != *snapshot.identity) {
+          BOOST_LOG(warning) << "process: Steam gameprocess log changed identity while waiting for app stop appid="sv
+                             << appid;
+          return false;
+        }
+        std::ifstream log(path, std::ios::binary);
+        if (!log) {
+          return false;
+        }
+        log.seekg(static_cast<std::streamoff>(cursor), std::ios::beg);
+        if (!log) {
+          return false;
+        }
+        std::string line;
+        while (std::getline(log, line)) {
+          cursor += line.size() + 1;
+          const auto event = parse_steam_game_process_event(line);
+          if (event.kind == steam_game_process_event_kind_internal_e::stopped &&
+              event.appid == appid) {
+            std::this_thread::sleep_for(private_steam_app_settle_time);
+            return true;
+          }
+        }
+        if (log.bad()) {
+          return false;
+        }
+        std::this_thread::sleep_for(50ms);
+      }
+      return false;
+    }
+
+    bool quiesce_session_owned_steam_app_before_native_shutdown(
+      const proc::ctx_t &app,
+      std::string_view session_instance_id,
+      const boost::process::v1::environment &env
+    ) {
+      const auto appid = steam_appid_for_context(app);
+      if (appid.empty()) {
+        return true;
+      }
+      const auto log_path = steam_game_process_log_path(app, env);
+      const auto log_snapshot = snapshot_steam_game_process_log(log_path);
+      if (log_snapshot.status != steam_game_process_log_snapshot_status_e::captured) {
+        BOOST_LOG(warning) << "process: cannot prove private Steam app stop because gameprocess log snapshot failed appid="sv
+                           << appid;
+        return false;
+      }
+      const auto roots_before = private_steam_app_root_snapshot(session_instance_id, appid);
+      if (!roots_before.capture_complete || roots_before.roots.size() > 1) {
+        return false;
+      }
+      if (!roots_before.roots.empty() &&
+          !terminate_session_owned_steam_app_lineage(app, session_instance_id)) {
+        return false;
+      }
+      if (!wait_for_steam_app_stopped_event(log_path, log_snapshot, appid)) {
+        BOOST_LOG(warning) << "process: exact Steam app-stopped event did not arrive before native shutdown appid="sv
+                           << appid;
+        return false;
+      }
+      BOOST_LOG(info) << "process: verified private Steam app quiescence before native shutdown appid="sv << appid;
+      return true;
+    }
+
     bool dispatch_steam_big_picture_action(
       const std::string &reference_command,
       std::string_view action,
@@ -4695,10 +5067,20 @@ namespace proc {
   }
 
   private_steam_graceful_shutdown_test_result_t run_private_steam_graceful_shutdown_scenario_for_tests(
+    bool app_stop_dispatched,
+    bool app_quiescent,
     bool request_dispatched,
     bool exact_root_exited
   ) {
     private_steam_graceful_shutdown_test_result_t result;
+    ++result.app_stop_calls;
+    if (!app_stop_dispatched) {
+      return result;
+    }
+    ++result.app_wait_calls;
+    if (!app_quiescent) {
+      return result;
+    }
     result.root_exited = attempt_session_owned_steam_graceful_shutdown(
       [&]() {
         ++result.request_calls;
@@ -4710,6 +5092,20 @@ namespace proc {
       }
     );
     return result;
+  }
+
+  bool terminate_session_owned_steam_app_lineage_for_tests(
+    const ctx_t &app,
+    std::string_view session_instance_id
+  ) {
+    return terminate_session_owned_steam_app_lineage(app, session_instance_id);
+  }
+
+  bool steam_launch_cmdline_matches_appid_for_tests(
+    std::string_view cmdline,
+    std::string_view appid
+  ) {
+    return steam_launch_cmdline_matches_appid(cmdline, appid);
   }
 
   std::optional<std::string> steam_instance_pipe_path_for_tests(
@@ -5442,6 +5838,7 @@ namespace proc {
       _app,
       _session_used_cage_compositor,
       _session_instance_id,
+      boost::this_process::environment(),
       {}
     );
   }
@@ -8449,6 +8846,7 @@ namespace proc {
       _app,
       _session_used_cage_compositor,
       _session_instance_id,
+      _env,
       [this]() {
         return request_session_owned_steam_graceful_shutdown_before_cage_stop();
       }

--- a/src/process.h
+++ b/src/process.h
@@ -234,11 +234,15 @@ namespace proc {
 
   struct private_steam_graceful_shutdown_test_result_t {
     bool root_exited = false;
+    std::size_t app_stop_calls = 0;
+    std::size_t app_wait_calls = 0;
     std::size_t request_calls = 0;
     std::size_t wait_calls = 0;
   };
 
   private_steam_graceful_shutdown_test_result_t run_private_steam_graceful_shutdown_scenario_for_tests(
+    bool app_stop_dispatched,
+    bool app_quiescent,
     bool request_dispatched,
     bool exact_root_exited
   );
@@ -283,6 +287,14 @@ namespace proc {
     std::size_t launcher_root_count,
     std::size_t unowned_count,
     bool request_available
+  );
+  bool terminate_session_owned_steam_app_lineage_for_tests(
+    const struct ctx_t &app,
+    std::string_view session_instance_id
+  );
+  bool steam_launch_cmdline_matches_appid_for_tests(
+    std::string_view cmdline,
+    std::string_view appid
   );
   bool steam_shutdown_process_is_unowned_active_for_tests(
     std::string_view comm,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -1943,7 +1943,7 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownUsesImmutableExact
 #endif
 }
 
-TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownDrainsHelpersBeforeFallbackSignals) {
+TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownHardKillsExactFallbackSetWithoutDestructorSignals) {
 #ifdef __linux__
   linux_cage_compositor_guard_t config_guard;
   const std::string token = "steam-root-first-generation";
@@ -2037,8 +2037,8 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownDrainsHelpersBefor
 
   int root_status = 0;
   ASSERT_EQ(root_guard.wait(&root_status, 0), root);
-  ASSERT_TRUE(WIFEXITED(root_status));
-  EXPECT_EQ(WEXITSTATUS(root_status), 0);
+  ASSERT_TRUE(WIFSIGNALED(root_status));
+  EXPECT_EQ(WTERMSIG(root_status), SIGKILL);
 
   std::string shutdown_events;
   for (;;) {
@@ -2053,12 +2053,12 @@ TEST(ProcessRuntimeConfigTests, ProductionPreCageSteamTeardownDrainsHelpersBefor
   }
   close(event_pipe[0]);
 
-  EXPECT_NE(shutdown_events.find('R'), std::string::npos)
-    << "the Steam client root must receive the initial graceful signal";
-  EXPECT_NE(shutdown_events.find('G'), std::string::npos)
-    << "the Steam helper must drain through the client root";
+  EXPECT_EQ(shutdown_events.find('R'), std::string::npos)
+    << "fallback must not invoke the Steam client root destructor through SIGTERM";
+  EXPECT_EQ(shutdown_events.find('G'), std::string::npos)
+    << "fallback must not ask Steam helpers to drain through the crashing destructor path";
   EXPECT_EQ(shutdown_events.find('H'), std::string::npos)
-    << "Steam helpers must not receive fallback SIGTERM before the client root can drain them";
+    << "fallback must not deliver SIGTERM to exact private Steam helpers";
 #else
   GTEST_SKIP() << "Linux-only private Steam process-graph teardown ordering";
 #endif
@@ -3246,7 +3246,7 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   const auto generation_gate = implementation.find("session_instance_id.empty()");
   const auto capture_gate = implementation.find("ownership.capture_complete");
   const auto mixed_ownership_gate = implementation.find("ownership.unowned.empty()");
-  const auto pidfd_termination = implementation.find("terminate_pidfds(");
+  const auto pidfd_termination = implementation.find("kill_private_steam_pidfds_immediately(");
   ASSERT_NE(ownership_scan, std::string::npos);
   ASSERT_NE(immutable_cage_gate, std::string::npos);
   ASSERT_NE(generation_gate, std::string::npos);
@@ -3256,6 +3256,7 @@ TEST(ProcessRuntimeConfigTests, SessionOwnedSteamUsesExactGenerationPidfdsBefore
   EXPECT_LT(ownership_scan, capture_gate);
   EXPECT_LT(capture_gate, pidfd_termination);
   EXPECT_LT(mixed_ownership_gate, pidfd_termination);
+  EXPECT_EQ(implementation.find("terminate_pidfds(ownership"), std::string::npos);
   EXPECT_EQ(implementation.find("config::video.linux_display.use_cage_compositor"), std::string::npos);
   EXPECT_EQ(implementation.find("cage_display_router::is_running()"), std::string::npos);
   EXPECT_EQ(implementation.find("platf::run_command("), std::string::npos);

--- a/tests/unit/test_steam_shutdown_state_machine.cpp
+++ b/tests/unit/test_steam_shutdown_state_machine.cpp
@@ -12,11 +12,57 @@
 
 #if defined(__linux__)
   #include <fcntl.h>
+  #include <poll.h>
+  #include <signal.h>
   #include <sys/stat.h>
+  #include <sys/syscall.h>
+  #include <sys/wait.h>
   #include <unistd.h>
 #endif
 
 namespace {
+#if defined(__linux__)
+  struct child_guard_t {
+    pid_t pid = -1;
+    bool reaped = false;
+
+    ~child_guard_t() {
+      if (pid <= 0 || reaped) {
+        return;
+      }
+      (void) kill(pid, SIGKILL);
+      int status = 0;
+      while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
+    }
+
+    pid_t wait(int *status, int options) {
+      const auto result = waitpid(pid, status, options);
+      if (result == pid) {
+        reaped = true;
+      }
+      return result;
+    }
+  };
+
+  struct fd_guard_t {
+    int fd = -1;
+    ~fd_guard_t() {
+      if (fd >= 0) {
+        close(fd);
+      }
+    }
+  };
+
+  bool wait_pidfd_exit(int fd, std::chrono::milliseconds timeout) {
+    pollfd descriptor {fd, POLLIN, 0};
+    int result = -1;
+    do {
+      result = poll(&descriptor, 1, static_cast<int>(timeout.count()));
+    } while (result < 0 && errno == EINTR);
+    return result == 1 && (descriptor.revents & POLLIN) != 0;
+  }
+#endif
+
   std::string read_source_file(const char *relative_path) {
     const auto path = std::filesystem::path(POLARIS_SOURCE_DIR) / relative_path;
     std::ifstream in(path);
@@ -209,28 +255,211 @@ TEST(SteamShutdownStateMachineTests, PrivateCageGracefulShutdownRequiresComplete
   ));
 }
 
-TEST(SteamShutdownStateMachineTests, GracefulAttemptDoesNotWaitWhenDispatchFails) {
-  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(false, true);
+TEST(SteamShutdownStateMachineTests, GracefulAttemptDoesNotRequestShutdownWhenAppStopFails) {
+  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(
+    false, true, true, true
+  );
   EXPECT_FALSE(result.root_exited);
+  EXPECT_EQ(result.app_stop_calls, 1U);
+  EXPECT_EQ(result.app_wait_calls, 0U);
+  EXPECT_EQ(result.request_calls, 0U);
+  EXPECT_EQ(result.wait_calls, 0U);
+}
+
+TEST(SteamShutdownStateMachineTests, GracefulAttemptDoesNotRequestShutdownBeforeAppQuiesces) {
+  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(
+    true, false, true, true
+  );
+  EXPECT_FALSE(result.root_exited);
+  EXPECT_EQ(result.app_stop_calls, 1U);
+  EXPECT_EQ(result.app_wait_calls, 1U);
+  EXPECT_EQ(result.request_calls, 0U);
+  EXPECT_EQ(result.wait_calls, 0U);
+}
+
+TEST(SteamShutdownStateMachineTests, GracefulAttemptDoesNotWaitWhenDispatchFails) {
+  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(
+    true, true, false, true
+  );
+  EXPECT_FALSE(result.root_exited);
+  EXPECT_EQ(result.app_stop_calls, 1U);
+  EXPECT_EQ(result.app_wait_calls, 1U);
   EXPECT_EQ(result.request_calls, 1U);
   EXPECT_EQ(result.wait_calls, 0U);
 }
 
 TEST(SteamShutdownStateMachineTests, GracefulAttemptFallsBackWhenExactRootDoesNotExit) {
-  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(true, false);
+  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(
+    true, true, true, false
+  );
   EXPECT_FALSE(result.root_exited);
+  EXPECT_EQ(result.app_stop_calls, 1U);
+  EXPECT_EQ(result.app_wait_calls, 1U);
   EXPECT_EQ(result.request_calls, 1U);
   EXPECT_EQ(result.wait_calls, 1U);
 }
 
-TEST(SteamShutdownStateMachineTests, GracefulAttemptSucceedsOnlyAfterExactRootExit) {
-  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(true, true);
+TEST(SteamShutdownStateMachineTests, GracefulAttemptSucceedsOnlyAfterAppQuiescenceAndExactRootExit) {
+  const auto result = proc::run_private_steam_graceful_shutdown_scenario_for_tests(
+    true, true, true, true
+  );
   EXPECT_TRUE(result.root_exited);
+  EXPECT_EQ(result.app_stop_calls, 1U);
+  EXPECT_EQ(result.app_wait_calls, 1U);
   EXPECT_EQ(result.request_calls, 1U);
   EXPECT_EQ(result.wait_calls, 1U);
 }
 
-TEST(SteamShutdownStateMachineTests, ProductionPrivateCageAttemptsScopedGracefulBeforePidfdFallback) {
+TEST(SteamShutdownStateMachineTests, SteamLaunchMarkerMatchesSplitArgvWithExactBoundaries) {
+  static constexpr char split_cmdline[] =
+    "reaper\0SteamLaunch\0AppId=4242\0--\0";
+  const std::string_view split_view {split_cmdline, sizeof(split_cmdline) - 1};
+
+  EXPECT_TRUE(proc::steam_launch_cmdline_matches_appid_for_tests(split_view, "4242"));
+  EXPECT_TRUE(proc::steam_launch_cmdline_matches_appid_for_tests(
+    "reaper SteamLaunch AppId=4242 --",
+    "4242"
+  ));
+  EXPECT_FALSE(proc::steam_launch_cmdline_matches_appid_for_tests(
+    "reaper NotSteamLaunch AppId=4242 --",
+    "4242"
+  ));
+  EXPECT_FALSE(proc::steam_launch_cmdline_matches_appid_for_tests(
+    "reaper SteamLaunch AppId=42420 --",
+    "4242"
+  ));
+  EXPECT_FALSE(proc::steam_launch_cmdline_matches_appid_for_tests(split_view, ""));
+  EXPECT_FALSE(proc::steam_launch_cmdline_matches_appid_for_tests(split_view, "42x2"));
+}
+
+TEST(SteamShutdownStateMachineTests, EmptySteamAppRootStillUsesPinnedStopBarrier) {
+  const auto source = read_source_file("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto quiescence = source_between(
+    source,
+    "bool quiesce_session_owned_steam_app_before_native_shutdown(\n"
+    "      const proc::ctx_t &app,\n"
+    "      std::string_view session_instance_id,\n"
+    "      const boost::process::v1::environment &env\n"
+    "    ) {\n"
+    "      const auto appid",
+    "bool dispatch_steam_big_picture_action("
+  );
+  ASSERT_FALSE(quiescence.empty());
+
+  const auto log_snapshot = quiescence.find("snapshot_steam_game_process_log(");
+  const auto roots_snapshot = quiescence.find("private_steam_app_root_snapshot(");
+  const auto stopped_barrier = quiescence.find("wait_for_steam_app_stopped_event(");
+  ASSERT_NE(log_snapshot, std::string::npos);
+  ASSERT_NE(roots_snapshot, std::string::npos);
+  ASSERT_NE(stopped_barrier, std::string::npos);
+  EXPECT_LT(log_snapshot, roots_snapshot);
+  EXPECT_LT(roots_snapshot, stopped_barrier);
+  EXPECT_EQ(quiescence.find("if (roots_before.roots.empty())"), std::string::npos);
+}
+
+TEST(SteamShutdownStateMachineTests, PrivateSteamAppQuiescenceTerminatesOnlyExactAppLineage) {
+  const std::string token = "private-steam-app-quiescence";
+  proc::ctx_t steam_app {};
+  steam_app.name = "Control";
+  steam_app.source = "steam";
+  steam_app.steam_appid = "4242";
+
+  const auto spawn_owned = [&](const char *argv0) {
+    const auto child = fork();
+    EXPECT_GE(child, 0);
+    if (child == 0) {
+      setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+      execl("/bin/sleep", argv0, "60", nullptr);
+      _exit(127);
+    }
+    return child;
+  };
+
+  const auto cage = spawn_owned("labwc");
+  child_guard_t cage_guard {cage};
+  const auto steam = spawn_owned("/tmp/ubuntu12_32/steam");
+  child_guard_t steam_guard {steam};
+  ASSERT_GT(cage, 0);
+  ASSERT_GT(steam, 0);
+
+  int lineage_pipe[2] {-1, -1};
+  ASSERT_EQ(pipe(lineage_pipe), 0);
+  const auto app_root = fork();
+  ASSERT_GE(app_root, 0);
+  child_guard_t app_root_guard {app_root};
+  if (app_root == 0) {
+    close(lineage_pipe[0]);
+    setenv("POLARIS_SESSION_INSTANCE_ID", token.c_str(), 1);
+    const auto descendant = fork();
+    if (descendant < 0) _exit(124);
+    if (descendant == 0) {
+      close(lineage_pipe[1]);
+      unsetenv("POLARIS_SESSION_INSTANCE_ID");
+      execl("/bin/sleep", "Control.exe", "60", nullptr);
+      _exit(127);
+    }
+    if (write(lineage_pipe[1], &descendant, sizeof(descendant)) != sizeof(descendant)) _exit(125);
+    close(lineage_pipe[1]);
+    execl(
+      "/bin/bash",
+      "reaper",
+      "-c",
+      "trap 'exit 0' TERM; sleep 60 & wait",
+      "SteamLaunch",
+      "AppId=4242",
+      nullptr
+    );
+    _exit(127);
+  }
+
+  close(lineage_pipe[1]);
+  fd_guard_t lineage_read {lineage_pipe[0]};
+  pid_t descendant = -1;
+  ASSERT_EQ(read(lineage_read.fd, &descendant, sizeof(descendant)), sizeof(descendant));
+  ASSERT_GT(descendant, 0);
+  const int app_root_pidfd = static_cast<int>(syscall(SYS_pidfd_open, app_root, 0));
+  ASSERT_GE(app_root_pidfd, 0);
+  fd_guard_t app_root_pidfd_guard {app_root_pidfd};
+  const int descendant_pidfd = static_cast<int>(syscall(SYS_pidfd_open, descendant, 0));
+  ASSERT_GE(descendant_pidfd, 0);
+  fd_guard_t descendant_guard {descendant_pidfd};
+  auto terminate_descendant = util::fail_guard([descendant_pidfd]() {
+    (void) syscall(SYS_pidfd_send_signal, descendant_pidfd, SIGKILL, nullptr, 0);
+  });
+
+  bool marker_visible = false;
+  for (int attempt = 0; attempt < 40 && !marker_visible; ++attempt) {
+    std::ifstream cmdline_file("/proc/" + std::to_string(app_root) + "/cmdline", std::ios::binary);
+    const std::string cmdline(
+      (std::istreambuf_iterator<char>(cmdline_file)),
+      std::istreambuf_iterator<char>()
+    );
+    marker_visible = proc::steam_launch_cmdline_matches_appid_for_tests(cmdline, "4242");
+    if (!marker_visible) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+  }
+  ASSERT_TRUE(marker_visible);
+
+  ASSERT_TRUE(proc::terminate_session_owned_steam_app_lineage_for_tests(steam_app, token));
+  ASSERT_TRUE(wait_pidfd_exit(app_root_pidfd, std::chrono::seconds(2)))
+    << "the split-argv Steam app root must be terminated";
+
+  int app_status = 0;
+  EXPECT_EQ(app_root_guard.wait(&app_status, 0), app_root);
+  EXPECT_TRUE(WIFEXITED(app_status) || WIFSIGNALED(app_status));
+  EXPECT_TRUE(wait_pidfd_exit(descendant_pidfd, std::chrono::seconds(2)))
+    << "a token-stripped descendant of the exact Steam app root must be terminated";
+
+  int survivor_status = 0;
+  EXPECT_EQ(cage_guard.wait(&survivor_status, WNOHANG), 0)
+    << "the cage compositor must remain alive until cage teardown";
+  EXPECT_EQ(steam_guard.wait(&survivor_status, WNOHANG), 0)
+    << "the Steam root must remain alive until native shutdown is dispatched";
+}
+
+TEST(SteamShutdownStateMachineTests, ProductionPrivateCageQuiescesSteamAppBeforeNativeShutdown) {
   const auto source = read_source_file("src/process.cpp");
   ASSERT_FALSE(source.empty());
   const auto cleanup = source_between(
@@ -243,16 +472,21 @@ TEST(SteamShutdownStateMachineTests, ProductionPrivateCageAttemptsScopedGraceful
   const auto root_cardinality_guard = cleanup.find("if (ownership.roots.size() != 1)");
   const auto root_front_access = cleanup.find("ownership.roots.front()");
   const auto no_unowned_guard = cleanup.find("ownership.unowned.empty()");
+  const auto app_quiescence = cleanup.find("quiesce_session_owned_steam_app_before_native_shutdown(");
   const auto graceful_request = cleanup.find("attempt_session_owned_steam_graceful_shutdown(");
-  const auto exact_pidfd_fallback = cleanup.find("terminate_pidfds(ownership.roots");
+  const auto exact_pidfd_fallback = cleanup.find("kill_private_steam_pidfds_immediately(ownership");
   ASSERT_NE(root_cardinality_guard, std::string::npos);
   ASSERT_NE(root_front_access, std::string::npos);
   ASSERT_NE(no_unowned_guard, std::string::npos);
+  ASSERT_NE(app_quiescence, std::string::npos);
   ASSERT_NE(graceful_request, std::string::npos);
   ASSERT_NE(exact_pidfd_fallback, std::string::npos);
   EXPECT_LT(root_cardinality_guard, root_front_access);
-  EXPECT_LT(no_unowned_guard, graceful_request);
+  EXPECT_LT(no_unowned_guard, app_quiescence);
+  EXPECT_LT(app_quiescence, graceful_request);
   EXPECT_LT(graceful_request, exact_pidfd_fallback);
+  EXPECT_EQ(cleanup.find("terminate_pidfds(ownership.roots"), std::string::npos);
+  EXPECT_EQ(cleanup.find("wait_for_pidfds_exit(ownership.helpers"), std::string::npos);
   EXPECT_NE(
     cleanup.find("wait_for_pidfds_exit(", graceful_request),
     std::string::npos
@@ -261,6 +495,28 @@ TEST(SteamShutdownStateMachineTests, ProductionPrivateCageAttemptsScopedGraceful
     cleanup.find("private_steam_native_shutdown_timeout", graceful_request),
     std::string::npos
   );
+}
+
+TEST(SteamShutdownStateMachineTests, ProductionAppLineageCaptureIsBoundedAndCannotLeakStoppedProcesses) {
+  const auto source = read_source_file("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto resume_helper = source_between(
+    source,
+    "bool resume_or_kill_frozen_pidfds(",
+    "bool terminate_session_owned_steam_app_lineage("
+  );
+  const auto app_termination = source_between(
+    source,
+    "bool terminate_session_owned_steam_app_lineage(",
+    "bool terminate_session_owned_steam_before_cage_stop_impl("
+  );
+  ASSERT_FALSE(resume_helper.empty());
+  ASSERT_FALSE(app_termination.empty());
+  EXPECT_NE(resume_helper.find("SIGCONT"), std::string::npos);
+  EXPECT_NE(resume_helper.find("SIGKILL"), std::string::npos);
+  EXPECT_NE(app_termination.find("resume_or_kill_frozen_pidfds("), std::string::npos);
+  EXPECT_NE(app_termination.find("private_steam_app_capture_timeout"), std::string::npos);
+  EXPECT_EQ(app_termination.find("max_capture_passes"), std::string::npos);
 }
 
 TEST(SteamShutdownStateMachineTests, ProductionPrivateSteamRequestUsesSessionEnvironmentAndLiveFifo) {


### PR DESCRIPTION
## summary

- stop the exact session-owned Steam app lineage before requesting full client shutdown
- require the pinned `gameprocess_log.txt` stop event plus a five-second settle before `steam -shutdown`
- hard-kill only captured private Steam pidfds when ownership, app quiescence, log identity, or native shutdown is incomplete
- keep Steam `SIGTERM` out of fallback teardown so it cannot re-enter the crashing destructor path

## why

this is a follow-up to #525. the guarded native shutdown path fixed the raw pidfd `SIGTERM` race, but a later smoke exposed a second failure inside Steam itself.

Polaris requested `steam -shutdown` while Steam was still removing the game process graph, stopping recording, releasing compatibility state, and running AutoCloud exit work. Steam then asserted in its Depot Download HTTP client and crashed before the client root exited.

this change makes app teardown and client teardown separate ordered phases. it matches both NUL-separated and space-delimited `SteamLaunch AppId=<id>` forms, revalidates `/proc` identity around pidfd capture, freezes and drains token-stripped descendants, and fails closed on every ambiguous boundary.

## verification

- regression RED against the old ordering
- focused GREEN after implementation
- sabotage RED with app quiescence removed, then restored GREEN
- reviewer-remediation RED for split argv, prefix boundaries, empty-root barrier bypass, moved-helper waits, and frozen-process recovery
- second sabotage RED with split matching disabled and the empty-root bypass restored
- Steam shutdown tests: 24/24
- full CTest: 18/18
- web tests: 506/506
- lint: pass
- production web build: pass
- npm audit: zero vulnerabilities
- production non-test binary build and version probe: pass
- independent exact-diff review: approved

exact-head CI, including the sanitizer lane, is still required before merge.

## boundaries

no deployment, service restart, device work, tag, release, or branch cleanup is included here.
