### PR TITLE
chore(release): prepare Polaris v1.3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
     set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
-project(Polaris VERSION 1.3.11
+project(Polaris VERSION 1.3.13
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -530,7 +530,7 @@
         "example": {
           "schema_version": 1,
           "measurement_spec_id": "measurement-spec-v1",
-          "collector_version": "1.3.11",
+          "collector_version": "1.3.13",
           "clock_domain": "CLOCK_MONOTONIC",
           "run_id": "pair-0001-control",
           "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,18 +1,34 @@
 # Changelog
 
-- Unreleased: nested Gamescope teardown now serializes helper transitions and asks session-owned Steam to exit before using the exact-generation compositor stop fallback, preventing overlapping stops from poisoning reconnect recovery.
-
 This file tracks the public Polaris release line.
 
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
-## Unreleased
+## v1.3.13 - 2026-08-22
 
-- Fixes black video with working audio when a client requests HDR on a host with no HDR output: rebuilding the encode device for the 10-bit to 8-bit demotion released the EGL context the new device had just made current, so its color-conversion shaders never compiled and the session died before the first frame
-- Sizes nested Gamescope sessions to the final negotiated render width, height, and frame rate instead of imposing the standalone 4K120 fallback on every client
-- Prevents Nova launches from crashing when headless cage startup sees an already-counted session before encoder selection by forcing the deferred cage probe whenever no encoder is selected, stopping capture safely if that invariant is ever violated, and keeping encoder probing or reset exclusive with active capture
-- Detects when local Steam Input settings can claim the Polaris Xbox virtual controller during strict gamepad isolation, reports the conflict and PII-free aggregate evidence in Doctor, and points to the host-wide and per-game Steam settings without changing them automatically
+A Linux runtime reliability and configuration patch. Polaris now stops the exact Steam app workload before asking the private Steam client to exit, keeps nested compositor teardown serialized and generation-owned, restores several capture and encoder lifecycle invariants, and lets the AI Optimizer clear a stored API key through the same strict validation contract used by the rest of Settings.
+
+- Quiesces the exact `SteamLaunch AppId=<id>` lineage, including token-stripped descendants, before requesting full private-client shutdown; requires the pinned Steam game-process stop event plus a bounded settle, and uses exact pidfd `SIGKILL` rather than entering Steam's crashing destructor when proof is incomplete
+- Prevents the observed Depot Download HTTP teardown assertion by separating game removal, recording and AutoCloud exit work from global Steam client shutdown
+- Serializes nested Gamescope stop transitions, preserves exact-generation compositor ownership, and sizes nested sessions from the final negotiated render geometry instead of imposing a standalone 4K120 fallback
+- Releases only the EGL context a teardown thread actually bound, reprobes a missing deferred cage encoder before launch, and retires the initial GPU-native conversion object without racing active capture
+- Detects Steam Input settings that can claim Polaris's isolated virtual controller, keeps the finding after a stream ends, deduplicates aliased Steam profile roots, and offers one guarded Doctor action instead of mutating settings silently
+- Redacts private-session paths from public logs and keeps CI native-build classification, sanitizer coverage, package construction, `npm audit --audit-level=high`, and snapshot dependency handling fail-closed
+- Accepts canonical boolean spellings without changing unrelated configuration parsing and explicitly allows a typed `clear_ai_api_key` operation while unsupported keys remain rejected
+- Carries forward v1.3.12's reviewed Boost 1.92.0-1 Arch package contract, exact versioned Boost SONAME dependencies, package ELF/dependency verification, and current rolling Arch installation gate
+- Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
+
+## v1.3.12 - 2026-08-22
+
+An Arch packaging compatibility hotfix. Polaris runtime and protocol behavior remain the v1.3.11 line; this release repairs the published package contract that allowed a Boost 1.91-linked binary to install on a rolling system that already provided Boost 1.92.
+
+- Rebuilds the official Arch package against reviewed Boost 1.92.0-1 inputs while keeping the immutable package snapshot and the current rolling Arch observation as separate gates
+- Declares the five linked Boost providers as exact versioned SONAME dependencies, including `libboost_locale.so=1.92.0-64`, so a future incompatible Boost transition fails during package resolution instead of at process launch
+- Inspects the finished package's ELF `NEEDED` entries and requires every Boost SONAME to have a matching package dependency
+- Installs the exact finished package against current rolling Arch, requires `ldd` to report zero unresolved libraries, and launches `polaris --version` before release publication can proceed
+- Contains no Polaris runtime-code, protocol, configuration, or Nova client change; existing v1.3.11 configuration and Nova v1.3.7 pairing remain compatible
+- Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
 
 ## v1.3.11 - 2026-08-19
 

--- a/docs/release-notes/v1.3.12.md
+++ b/docs/release-notes/v1.3.12.md
@@ -1,0 +1,60 @@
+# Polaris v1.3.12
+
+Polaris v1.3.12 is a packaging-only compatibility hotfix for Arch Linux and CachyOS. It keeps the v1.3.11 runtime and protocol behavior while correcting the Boost ABI contract in the official Arch package.
+
+The v1.3.11 Arch artifact was built against Boost 1.91, but current rolling Arch already provided Boost 1.92.0-1. Because the package declared only an unversioned `boost-libs` dependency, installation succeeded while `polaris` still required five unavailable 1.91 shared libraries at launch. Redownloading the same artifact or downgrading individual Boost packages is not an acceptable remedy.
+
+This release contains no Polaris runtime-code, protocol, configuration, or Nova client change. Existing v1.3.11 configuration remains valid, and Nova v1.3.7 pairing remains compatible.
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.12/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.12/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.12/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 users should follow the [SteamOS guide](../steamos.md), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+
+## Changes
+
+### Arch Boost ABI compatibility
+
+- Builds the Arch package with reviewed Boost 1.92.0-1 inputs instead of producing a binary tied to unavailable Boost 1.91 libraries.
+- Declares exact providers for all five linked Boost SONAMEs: `libboost_locale.so=1.92.0-64`, `libboost_log.so=1.92.0-64`, `libboost_program_options.so=1.92.0-64`, `libboost_filesystem.so=1.92.0-64`, and `libboost_thread.so=1.92.0-64`.
+- Compares the finished package's ELF `NEEDED` entries with its package metadata, so an undeclared or mismatched Boost ABI fails the package gate.
+- Keeps the immutable Arch build snapshot separate from current rolling Arch compatibility. The exact finished package is installed against the current repository state, `ldd` must contain no unresolved libraries, and `polaris --version` must launch successfully before release publication can proceed.
+- Makes the current rolling Arch compatibility result a release-publication dependency rather than an informational check.
+
+## Scope and validation limits
+
+- This hotfix does not include the later Steam teardown work from master. It does not claim the known private-Steam shutdown coredump is fixed.
+- This candidate must be rebuilt and verified from its exact source commit. A successful source contract or pull-request package is not a substitute for final exact-candidate package evidence.
+- No physical-device validation is required for the package-construction gate because there is no Nova or streaming protocol change. Any later physical-device action remains a separate authorization.
+- Publication remains blocked until the exact Arch package identity, SHA-256, versioned dependencies, payload, clean `ldd`, and `polaris --version` result are frozen and independently replayed.
+
+## Official assets
+
+- `Polaris-arch-x86_64.pkg.tar.zst`
+- `Polaris-fedora44-x86_64.rpm`
+- `Polaris-steamos3.8-x86_64.pkg.tar.zst`
+- `Polaris-ubuntu24.04-x86_64.deb`

--- a/docs/release-notes/v1.3.13.md
+++ b/docs/release-notes/v1.3.13.md
@@ -1,0 +1,80 @@
+# Polaris v1.3.13
+
+Polaris v1.3.13 is a Linux runtime reliability and configuration patch. It separates Steam game teardown from private Steam client shutdown, tightens exact-generation compositor cleanup, restores several capture and encoder lifecycle invariants, and repairs the AI Optimizer clear-key flow without weakening strict configuration validation.
+
+Existing configuration remains valid when upgrading from v1.3.11 or v1.3.12. The official Arch package retains v1.3.12's reviewed Boost 1.92.0-1 ABI contract and current rolling-repository compatibility gate.
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.13/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.13/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.13/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 users should follow the [SteamOS guide](../steamos.md), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+
+## Changes
+
+### Steam and private-runtime teardown
+
+- Stops the exact Steam app lineage before requesting global private-client shutdown. App-root matching accepts both NUL-separated and space-delimited `SteamLaunch AppId=<id>` forms with exact token boundaries.
+- Freezes and captures exact descendants with pidfds, including descendants that stripped the session token, while the cage compositor and private Steam root stay outside the app signal set.
+- Requires the pinned Steam game-process removal event plus a bounded settle before `steam -shutdown`, separating recording, compatibility-session, AutoCloud, and game-removal work from full client teardown.
+- Avoids the observed Depot Download HTTP destructor crash by using exact private-Steam pidfd `SIGKILL` whenever ownership, app quiescence, log identity, or native shutdown is incomplete. Fallback never sends Steam `SIGTERM`.
+- Serializes nested Gamescope teardown and preserves exact-generation compositor ownership so overlapping stops cannot poison reconnect recovery.
+- Drains labwc startup descendants that escape the initial parent tree without broad process-name termination.
+
+### Capture, display, and encoder reliability
+
+- Releases only the EGL context the teardown thread actually bound, preventing HDR-to-SDR demotion from discarding the replacement encode device's current context before shader compilation.
+- Sizes nested Gamescope sessions from the final negotiated render width, height, and frame rate instead of imposing the standalone 4K120 fallback.
+- Reprobes a missing deferred cage encoder before launch and stops safely if no encoder can be selected.
+- Retires the initial GPU-native conversion object without racing active capture.
+
+### Settings, Doctor, and privacy
+
+- Lets the AI Optimizer clear stored AI API key credentials through an explicitly typed `clear_ai_api_key` boolean while unrelated unsupported configuration keys remain rejected.
+- Accepts canonical boolean spellings without changing the rest of the configuration contract.
+- Detects Steam Input settings that can claim Polaris's isolated Xbox virtual controller, preserves the finding after the stream ends, deduplicates aliased Steam profile roots, and offers one guarded Doctor action instead of silently changing Steam settings.
+- Redacts each private session log path from public diagnostics.
+- Keeps the System page header usable at narrow and wide layouts.
+
+### Packaging and release gates
+
+- Carries forward the exact Boost 1.92.0-1 inputs and five versioned Boost SONAME dependencies introduced by v1.3.12.
+- Verifies the finished Arch package's ELF `NEEDED` entries against package metadata, then installs the same package against current rolling Arch, requires clean `ldd`, and launches `polaris --version`.
+- Keeps path-aware native CI classification, full sanitizer coverage, immutable package inputs, and bounded snapshot dependency operations fail-closed.
+
+## Scope and validation limits
+
+- The exact release candidate must pass source, web, native, sanitizer, package, and emulator-only stream teardown gates before the tag is created.
+- Physical Retroid Pocket 6 validation is not part of this release gate and is not implied by emulator validation.
+- SteamOS remains an experimental Desktop Mode package. This release does not claim Steam Deck Game Mode certification.
+- CodeQL analysis remains unavailable when GitHub code scanning is disabled for the repository. A successful explicit skip path is not an analysis result.
+
+## Official assets
+
+- `Polaris-arch-x86_64.pkg.tar.zst`
+- `Polaris-fedora44-x86_64.rpm`
+- `Polaris-steamos3.8-x86_64.pkg.tar.zst`
+- `Polaris-ubuntu24.04-x86_64.deb`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.3.11') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.3.13') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -643,7 +643,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.3.11.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.3.13.md").read_text(encoding="utf-8")
 )
 
 
@@ -1274,28 +1274,19 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
-    "## v1.3.11 - 2026-08-19",
-    "## v1.3.10 - 2026-08-16",
+    "## v1.3.13 - 2026-08-22",
+    "## v1.3.12 - 2026-08-22",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "Flatpak",
-    "Heroic",
-    "Lutris",
-    "headless_dongle",
-    "session_overridable",
-    "Hyprland",
-    "session_id",
-    "client report",
-    "2026/08/17",
-    "20260818T000000Z",
-    "POLARIS_PRIVATE_SESSION",
-    "polaris-gamescope-session",
-    "gamescope-0",
-    "HDR",
-    "empty pairing",
-    "POLARIS_PORTAL_DMABUF",
-    "Matrix",
+    "SteamLaunch AppId=<id>",
+    "Depot Download HTTP",
+    "SIGKILL",
+    "nested Gamescope",
+    "EGL context",
+    "Steam Input",
+    "clear_ai_api_key",
+    "Boost 1.92.0-1",
     "npm audit --audit-level=high",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
@@ -1304,7 +1295,7 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.3.11 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.3.13 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1313,7 +1304,7 @@ asset_phrase = (
     "`Polaris-steamos3.8-x86_64.pkg.tar.zst`, and "
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
-for label, section in (("v1.3.11 changelog", current_release_prose),):
+for label, section in (("v1.3.13 changelog", current_release_prose),):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
         sys.exit(1)
@@ -1331,7 +1322,7 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
     ("docs/building.md Packaging", building_packaging_prose),
-    ("v1.3.11 changelog", current_release_prose),
+    ("v1.3.13 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_assets:
@@ -1343,47 +1334,35 @@ for label, section in (
         sys.exit(1)
 
 release_notes_facts = (
-    "v1.3.10",
-    "Flatpak",
-    "Heroic",
-    "Lutris",
-    "headless_dongle",
-    "session_overridable",
-    "Hyprland",
-    "session_id",
-    "client_id",
-    "non-string scalars",
-    "Map",
-    "Set",
-    "Date",
-    "Error",
-    "2026/08/17",
-    "20260818T000000Z",
-    "POLARIS_PRIVATE_SESSION",
-    "POLARIS_PORTAL_DMABUF",
-    "Matrix",
-    "polaris-gamescope-session",
-    "gamescope-0",
-    "HDR",
-    "RX 7800 XT",
-    "share sheet",
-    "automatic paired reporting",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.11/Polaris-fedora44-x86_64.rpm &&",
+    "v1.3.11",
+    "v1.3.12",
+    "Steam app lineage",
+    "SteamLaunch AppId=<id>",
+    "Depot Download HTTP",
+    "SIGKILL",
+    "nested Gamescope",
+    "EGL context",
+    "Steam Input",
+    "clear_ai_api_key",
+    "Boost 1.92.0-1",
+    "Physical Retroid Pocket 6",
+    "CodeQL analysis remains unavailable",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.3.13/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.11/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.3.13/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.11/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.3.13/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.3.11 release notes are missing release fact: {fact}", file=sys.stderr)
+        print(f"v1.3.13 release notes are missing release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.3.11 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.3.13 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.3.11 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.3.13 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 
 release_workflow = Path(".github/workflows/build.yml").read_text(encoding="utf-8")

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.11-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.3.13-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -717,7 +717,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.3.11-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.3.13-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v1311-contract.test.js
+++ b/src_assets/common/assets/web/release-v1311-contract.test.js
@@ -7,16 +7,18 @@ const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
 const sectionBetween = (source, startHeading, endHeading) => {
   const start = source.indexOf(startHeading)
   const end = source.indexOf(endHeading, start + startHeading.length)
-  expect(start, `missing release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
-  expect(end, `missing release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  expect(start, `missing historical release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing historical release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
   return source.slice(start, end)
 }
 
-const releaseSection = () => sectionBetween(
+const historicalRelease = () => sectionBetween(
   read('docs/changelog.md'),
   '## v1.3.11 - 2026-08-19',
   '## v1.3.10 - 2026-08-16',
 )
+
+const historicalNotes = () => read('docs/release-notes/v1.3.11.md')
 
 const requiredFacts = [
   'Flatpak',
@@ -50,143 +52,47 @@ const expectedAssets = [
   'Polaris-ubuntu24.04-x86_64.deb',
 ].sort()
 
-describe('v1.3.11 release contract', () => {
-  it('moves the versioned release metadata together', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.11')
-    expect(read('README.md')).not.toMatch(/^#{1,6}\s+.*(?:release|what is new).*v\d/im)
-    expect(read('docs/changelog.md')).toContain('## v1.3.11 - 2026-08-19')
-    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.3.11"')
-  })
-
-  it('states the shipped facts in the authoritative changelog', () => {
+describe('historical v1.3.11 release contract', () => {
+  it('preserves the shipped v1.3.11 facts', () => {
+    const release = historicalRelease()
     for (const fact of requiredFacts) {
-      expect(releaseSection(), `release summary must include: ${fact}`).toContain(fact)
+      expect(release, `historical release must include: ${fact}`).toContain(fact)
     }
   })
 
-  it('aligns the public checker with the v1.3.11 release contract', () => {
-    const publicDocsGate = read('scripts/check-public-docs.sh')
-
-    expect(publicDocsGate).toContain('README must not duplicate a version-specific release section')
-    expect(publicDocsGate).toContain('"## v1.3.11 - 2026-08-19"')
-    expect(publicDocsGate).toContain('docs/release-notes/v1.3.11.md')
-    for (const asset of expectedAssets) {
-      expect(publicDocsGate, `public checker must require: ${asset}`).toContain(asset)
-    }
+  it('preserves the exact historical asset set', () => {
+    const assets = [...new Set(historicalNotes().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+    expect(assets.sort()).toEqual(expectedAssets)
   })
 
-  it('moves package-review metadata and identity to v1.3.11', () => {
-    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
-    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
-    const packagingContract = read('src_assets/common/assets/web/packaging-contracts.test.js')
-
-    expect(reviewedWarnings).toContain('usr/bin/polaris-1.3.11')
-    expect(reviewedWarnings).not.toContain('usr/bin/polaris-1.3.10')
-    expect(steamOsBuildScript).toContain("'polaris|1.3.11-1|x86_64'")
-    expect(steamOsBuildScript).not.toContain("'polaris|1.3.10-1|x86_64'")
-    expect(packagingContract).toContain("'polaris|1.3.11-1|x86_64'")
-  })
-
-  it('ships release notes whose install commands target v1.3.11', () => {
-    const notes = read('docs/release-notes/v1.3.11.md')
-    const installBlocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+  it('preserves historical install commands without owning the current version', () => {
+    const blocks = [...historicalNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
       .map((match) => match[1])
       .filter((block) => block.includes('wget --output-document='))
 
-    expect(installBlocks.length).toBe(3)
-    for (const block of installBlocks) {
+    expect(blocks).toHaveLength(3)
+    for (const block of blocks) {
       expect(block).toContain('releases/download/v1.3.11/')
-      expect(block).not.toContain('releases/download/v1.3.10/')
       expect(block).toContain('polaris --setup-host')
       expect(block).toContain('systemctl --user restart polaris')
     }
   })
 
-  it('binds curated notes and assets to one immutable release source', () => {
-    const workflow = read('.github/workflows/build.yml')
-
-    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
-    expect(workflow).toContain('- name: Check out exact release source')
-    expect(workflow).toContain('ref: ${{ needs.resolve-source.outputs.commit }}')
-    const orderedSteps = [
-      '- name: Check out exact release source',
-      '- name: Revalidate release tag against packaged source',
-      '- name: Stage curated GitHub release',
-      '- name: Upload release assets to GitHub release',
-      '- name: Verify release assets on GitHub release',
-      '- name: Publish verified draft release',
-    ]
-    const positions = orderedSteps.map((step) => workflow.indexOf(step))
-    expect(positions.every((position) => position >= 0)).toBe(true)
-    expect(positions).toEqual([...positions].sort((left, right) => left - right))
-    expect(workflow).toContain('^v[0-9]+\\.[0-9]+\\.[0-9]+$')
-    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
-    expect(workflow).toContain('if [ "$tag_commit" != "$source_commit" ]; then')
-    expect(workflow).toContain('--draft')
-    expect(workflow).toContain('--draft=true')
-    expect(workflow.match(/echo "publish_draft=true"/g)).toHaveLength(2)
-    expect(workflow).not.toContain('is_draft=')
-    expect(workflow).toContain('--verify-tag')
-    expect(workflow).toContain('--notes-file "$release_notes"')
-    expect(workflow).toContain('gh release edit "${POLARIS_PACKAGE_REF_NAME}"')
-    expect(workflow).toContain('published_notes="$(gh release view "${POLARIS_PACKAGE_REF_NAME}" --json body --jq .body)"')
-    expect(workflow).toContain('release_files=(release-assets/final/*)')
-    expect(workflow).toContain('expected_asset_names["$(basename "$release_file")"]=1')
-    expect(workflow).toContain('gh release delete-asset "${POLARIS_PACKAGE_REF_NAME}" "$published_asset" --yes')
-    expect(workflow).toContain('[ "${expected_assets[*]}" != "${published_assets[*]}" ]')
-    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
-    expect(workflow).not.toContain('Automated Fedora 44, Ubuntu, Arch, and SteamOS 3.8 release assets')
-  })
-
-  it('pins Arch build inputs and separately checks rolling compatibility', () => {
-    const workflow = read('.github/workflows/build.yml')
-
-    expect(workflow).toContain('image: archlinux@sha256:')
-    expect(workflow).toContain('ARCH_REPOSITORY_SNAPSHOT: 2026/08/19')
-    expect(workflow).toContain('ARCH_BOOST_PACKAGE_VERSION: 1.92.0-1')
-    expect(workflow).toContain('ARCH_BOOST_SHA256: 0d795c6401c8bfa16012ada7e2e7f34934fb268f9174470edac1b389056f79bb')
-    expect(workflow).toContain('ARCH_BOOST_LIBS_SHA256: 4b1392e578e46c1b23910d1c26956927d7e986d6afd5090be59045afb3c04f8d')
-    expect(workflow).toContain('archive.archlinux.org/repos/%s/$repo/os/$arch')
-    expect(workflow).toContain('- name: Install pinned Boost ABI')
-    expect(workflow).toContain('Do not add mirror retries')
-    expect(workflow).toContain('arch-current-compatibility:')
-    expect(workflow).toContain('geo.mirror.pkgbuild.com/$repo/os/$arch')
-    expect(workflow).toContain('- arch-current-compatibility')
-  })
-
-  it('records the client-report boundary without claiming automatic Nova upload', () => {
-    const notes = read('docs/release-notes/v1.3.11.md')
-
+  it('preserves the v1.3.11 support and validation boundaries', () => {
+    const notes = historicalNotes()
     expect(notes).toContain('POST /polaris/v1/support/client-report')
-    expect(notes).toContain("does not yet automatically post to this host endpoint")
+    expect(notes).toContain('does not yet automatically post to this host endpoint')
     expect(notes).toContain('must not be described as automatic paired reporting')
-  })
-
-  it('records the scalar and identifier redaction boundary', () => {
-    const notes = read('docs/release-notes/v1.3.11.md')
-
     expect(notes).toContain('session_id')
     expect(notes).toContain('client_id')
     expect(notes).toContain('user_id')
     expect(notes).toContain('app_id')
     expect(notes).toContain('non-string scalars unchanged unless their field name is sensitive')
     expect(notes).toContain('preserving measurements such as bitrate, frame rate, packet loss, port, and GPU index')
-  })
-
-  it('records the VAAPI containment and affected-host evidence boundary', () => {
-    const notes = read('docs/release-notes/v1.3.11.md')
-
     expect(notes).toContain('Keeps PipeWire VAAPI capture on SHM by default')
     expect(notes).toContain('POLARIS_PORTAL_DMABUF=1')
     expect(notes).toContain('affected RX 7800 XT has not physically tested this exact candidate')
     expect(notes).toContain('does not claim that the underlying DMA-BUF')
     expect(notes).not.toContain('containment remains in draft PR #481')
-  })
-
-  it('keeps the exact four-asset set in the release notes', () => {
-    const notes = read('docs/release-notes/v1.3.11.md')
-    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
-
-    expect(listed.sort()).toEqual(expectedAssets)
   })
 })

--- a/src_assets/common/assets/web/release-v1312-contract.test.js
+++ b/src_assets/common/assets/web/release-v1312-contract.test.js
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+
+const sectionBetween = (source, startHeading, endHeading) => {
+  const start = source.indexOf(startHeading)
+  const end = source.indexOf(endHeading, start + startHeading.length)
+  expect(start, `missing historical release heading: ${startHeading}`).toBeGreaterThanOrEqual(0)
+  expect(end, `missing historical release boundary after ${startHeading}: ${endHeading}`).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+
+const historicalRelease = () => sectionBetween(
+  read('docs/changelog.md'),
+  '## v1.3.12 - 2026-08-22',
+  '## v1.3.11 - 2026-08-19',
+)
+
+const historicalNotes = () => read('docs/release-notes/v1.3.12.md')
+
+describe('historical v1.3.12 release contract', () => {
+  it('preserves the packaging-only scope and Boost ABI facts', () => {
+    const release = historicalRelease()
+    const notes = historicalNotes()
+    for (const fact of [
+      'packaging',
+      'Boost 1.91',
+      'Boost 1.92.0-1',
+      'libboost_locale.so=1.92.0-64',
+      'no Polaris runtime-code',
+    ]) {
+      expect(`${release}\n${notes}`, `historical release must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('preserves the exact historical asset set and install identities', () => {
+    const notes = historicalNotes()
+    const assets = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+    expect(assets.sort()).toEqual(expectedAssets)
+
+    const blocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
+    expect(blocks).toHaveLength(3)
+    for (const block of blocks) {
+      expect(block).toContain('releases/download/v1.3.12/')
+      expect(block).toContain('polaris --setup-host')
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+  })
+
+  it('keeps the versioned Boost package contract active after v1.3.12', () => {
+    const pkgbuild = read('packaging/linux/Arch/PKGBUILD')
+    const verifier = read('scripts/check-release-package-dependencies.py')
+    for (const library of [
+      'libboost_filesystem.so',
+      'libboost_locale.so',
+      'libboost_log.so',
+      'libboost_program_options.so',
+      'libboost_thread.so',
+    ]) {
+      expect(pkgbuild).toContain(`'${library}'`)
+      expect(verifier).toContain(`"${library}"`)
+    }
+  })
+})

--- a/src_assets/common/assets/web/release-v1313-contract.test.js
+++ b/src_assets/common/assets/web/release-v1313-contract.test.js
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+
+describe('v1.3.13 release contract', () => {
+  it('moves every current version identity to v1.3.13', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.3.13')
+    expect(read('CMakeLists.txt')).not.toContain('project(Polaris VERSION 1.3.11')
+    expect(read('docs/changelog.md')).toContain('## v1.3.13 - 2026-08-22')
+    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.3.13"')
+
+    const reviewedWarnings = read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')
+    const steamOsBuildScript = read('scripts/ci/build-steamos-package.sh')
+    const packagingContract = read('src_assets/common/assets/web/packaging-contracts.test.js')
+    expect(reviewedWarnings).toContain('usr/bin/polaris-1.3.13')
+    expect(reviewedWarnings).not.toContain('usr/bin/polaris-1.3.11')
+    expect(steamOsBuildScript).toContain("'polaris|1.3.13-1|x86_64'")
+    expect(steamOsBuildScript).not.toContain("'polaris|1.3.11-1|x86_64'")
+    expect(packagingContract).toContain("'polaris|1.3.13-1|x86_64'")
+  })
+
+  it('keeps v1.3.11 and v1.3.12 historical while making v1.3.13 current', () => {
+    const v1311 = read('src_assets/common/assets/web/release-v1311-contract.test.js')
+    const v1312 = read('src_assets/common/assets/web/release-v1312-contract.test.js')
+    expect(v1311).toContain("describe('historical v1.3.11 release contract'")
+    expect(v1312).toContain("describe('historical v1.3.12 release contract'")
+
+    const publicDocsGate = read('scripts/check-public-docs.sh')
+    expect(publicDocsGate).toContain('docs/release-notes/v1.3.13.md')
+    expect(publicDocsGate).toContain('"## v1.3.13 - 2026-08-22"')
+  })
+
+  it('publishes exact v1.3.13 install identities and runtime scope', () => {
+    const notes = read('docs/release-notes/v1.3.13.md')
+    for (const fact of [
+      'Steam app lineage',
+      'Depot Download HTTP',
+      'clear stored AI API key',
+      'Steam Input',
+      'nested Gamescope',
+      'private session log',
+      'EGL context',
+      'Boost 1.92.0-1',
+    ]) {
+      expect(notes, `release notes must include: ${fact}`).toContain(fact)
+    }
+
+    const installBlocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
+    expect(installBlocks).toHaveLength(3)
+    for (const block of installBlocks) {
+      expect(block).toContain('releases/download/v1.3.13/')
+      expect(block).not.toContain('releases/download/v1.3.11/')
+      expect(block).not.toContain('releases/download/v1.3.12/')
+      expect(block).toContain('polaris --setup-host')
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+
+    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+    expect(listed.sort()).toEqual(expectedAssets)
+  })
+
+  it('retains exact Boost providers and immutable Arch gates', () => {
+    const pkgbuild = read('packaging/linux/Arch/PKGBUILD')
+    const workflow = read('.github/workflows/build.yml')
+    for (const library of [
+      'libboost_filesystem.so',
+      'libboost_locale.so',
+      'libboost_log.so',
+      'libboost_program_options.so',
+      'libboost_thread.so',
+    ]) {
+      expect(pkgbuild).toContain(`'${library}'`)
+    }
+    expect(workflow).toContain('image: archlinux@sha256:')
+    expect(workflow).toContain('ARCH_REPOSITORY_SNAPSHOT: 2026/08/19')
+    expect(workflow).toContain('ARCH_BOOST_PACKAGE_VERSION: 1.92.0-1')
+    expect(workflow).toContain('ARCH_BOOST_SHA256: 0d795c6401c8bfa16012ada7e2e7f34934fb268f9174470edac1b389056f79bb')
+    expect(workflow).toContain('ARCH_BOOST_LIBS_SHA256: 4b1392e578e46c1b23910d1c26956927d7e986d6afd5090be59045afb3c04f8d')
+    expect(workflow).toContain('archive.archlinux.org/repos/%s/$repo/os/$arch')
+    expect(workflow).toContain('- name: Install pinned Boost ABI')
+    expect(workflow).toContain('Do not add mirror retries')
+    expect(workflow).toContain('arch-current-compatibility:')
+    expect(workflow).toContain('geo.mirror.pkgbuild.com/$repo/os/$arch')
+    expect(workflow).toContain('- arch-current-compatibility')
+    expect(workflow).toContain('ldd "$installed_binary"')
+    expect(workflow).toContain('polaris --version')
+  })
+
+  it('binds curated notes and assets to one immutable release source', () => {
+    const workflow = read('.github/workflows/build.yml')
+
+    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
+    expect(workflow).toContain('- name: Check out exact release source')
+    expect(workflow).toContain('ref: ${{ needs.resolve-source.outputs.commit }}')
+    const orderedSteps = [
+      '- name: Check out exact release source',
+      '- name: Revalidate release tag against packaged source',
+      '- name: Stage curated GitHub release',
+      '- name: Upload release assets to GitHub release',
+      '- name: Verify release assets on GitHub release',
+      '- name: Publish verified draft release',
+    ]
+    const positions = orderedSteps.map((step) => workflow.indexOf(step))
+    expect(positions.every((position) => position >= 0)).toBe(true)
+    expect(positions).toEqual([...positions].sort((left, right) => left - right))
+    expect(workflow).toContain('^v[0-9]+\\.[0-9]+\\.[0-9]+$')
+    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
+    expect(workflow).toContain('if [ "$tag_commit" != "$source_commit" ]; then')
+    expect(workflow).toContain('--draft')
+    expect(workflow).toContain('--draft=true')
+    expect(workflow.match(/echo "publish_draft=true"/g)).toHaveLength(2)
+    expect(workflow).not.toContain('is_draft=')
+    expect(workflow).toContain('--verify-tag')
+    expect(workflow).toContain('--notes-file "$release_notes"')
+    expect(workflow).toContain('gh release edit "${POLARIS_PACKAGE_REF_NAME}"')
+    expect(workflow).toContain('published_notes="$(gh release view "${POLARIS_PACKAGE_REF_NAME}" --json body --jq .body)"')
+    expect(workflow).toContain('release_files=(release-assets/final/*)')
+    expect(workflow).toContain('expected_asset_names["$(basename "$release_file")"]=1')
+    expect(workflow).toContain('gh release delete-asset "${POLARIS_PACKAGE_REF_NAME}" "$published_asset" --yes')
+    expect(workflow).toContain('[ "${expected_assets[*]}" != "${published_assets[*]}" ]')
+    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
+    expect(workflow).not.toContain('Automated Fedora 44, Ubuntu, Arch, and SteamOS 3.8 release assets')
+  })
+})


### PR DESCRIPTION
## summary

- move every current version and SteamOS package identity to v1.3.13
- publish the merged Linux runtime, Steam teardown, capture, configuration, Doctor, privacy, and System layout work
- preserve v1.3.12 as the packaging-only Boost ABI release and carry its exact Boost 1.92.0-1 contract forward
- rotate the semantic release tests without dropping the immutable tag, asset, Arch snapshot, or rolling compatibility gates

## verification

- `npm test -- --run` - 67 files, 507 tests passed
- `npm run lint`
- `npm run build -- --logLevel warn`
- `npm audit --audit-level=high` - zero vulnerabilities
- `bash scripts/check-public-docs.sh`
- focused v1.3.11, v1.3.12, v1.3.13, and packaging contracts - 35 tests passed
- exact staged tree `fdd07cd12ba2796de82cd9754d7439961928f23a` independently reviewed and approved

## scope

- release metadata, public docs, package identities, and release contracts only
- no runtime source change in this branch
- no live install, service restart, emulator launch, or physical-device action
- the repository-unavailable CodeQL path is not being counted as an analysis result
