### PR TITLE
fix(stream): keep static cadence out of host render blame

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2443,6 +2443,9 @@ namespace nvhttp {
         current_virtual_display &&
         (pacing_risk || capture_fallback || hdr_risk);
       const bool sustained_target_miss = meaningful_fps_shortfall;
+      // Reused frames can be intentional for static or menu content. Keep
+      // duplicate cadence as a pacing signal, but require an actual target
+      // miss or dropped frames before attributing the cause to host rendering.
       const bool host_render_limited =
         pacing_risk &&
         !network_risk &&
@@ -2452,9 +2455,7 @@ namespace nvhttp {
         !hdr_risk &&
         !decoder_risk &&
         !virtual_display_risk &&
-        (sustained_target_miss ||
-         stats.duplicate_frame_ratio >= 0.08 ||
-         stats.dropped_frame_ratio >= 0.03);
+        (sustained_target_miss || stats.dropped_frame_ratio >= 0.03);
 
       auto issues = nlohmann::json::array();
       auto recommendations = nlohmann::json::array();

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -454,6 +454,9 @@ namespace proc {
                                             (classification.pacing_risk ||
                                              classification.capture_fallback ||
                                              classification.hdr_risk);
+      // Reused frames can be intentional for static or menu content. Keep
+      // duplicate cadence as a pacing signal, but require an actual target
+      // miss or dropped frames before attributing the cause to host rendering.
       classification.host_render_limited =
         classification.pacing_risk &&
         !classification.network_risk &&
@@ -462,9 +465,7 @@ namespace proc {
         !classification.hdr_risk &&
         !classification.decoder_risk &&
         !classification.virtual_display_risk &&
-        (meaningful_fps_shortfall ||
-         stats.duplicate_frame_ratio >= 0.08 ||
-         stats.dropped_frame_ratio >= 0.03);
+        (meaningful_fps_shortfall || stats.dropped_frame_ratio >= 0.03);
 
       if (classification.network_risk) classification.primary_issue = "network_jitter";
       else if (classification.hdr_risk) classification.primary_issue = "hdr_path";

--- a/tests/unit/test_stream.cpp
+++ b/tests/unit/test_stream.cpp
@@ -144,6 +144,42 @@ TEST(NvhttpSessionHealthTests, MeaningfulTargetMissRemainsHostRenderLimited) {
   EXPECT_TRUE(health.at("host_render_limited").get<bool>());
 }
 
+TEST(NvhttpSessionHealthTests, DuplicateOnlyTargetRateDeliveryRemainsFramePacing) {
+  auto stats = stable_gpu_native_stats(60.0, 60.0);
+  stats.duplicate_frame_ratio = 0.10;
+
+  const auto health = nvhttp::build_session_health_json_for_tests(
+    stats,
+    false,
+    "Nova Client",
+    "Control"
+  );
+
+  EXPECT_EQ(health.at("grade"), "watch");
+  EXPECT_EQ(health.at("primary_issue"), "frame_pacing");
+  EXPECT_EQ(health.at("limiting_factor"), "pacing");
+  EXPECT_EQ(health.at("auto_action"), "none");
+  EXPECT_FALSE(health.at("host_render_limited").get<bool>());
+}
+
+TEST(NvhttpSessionHealthTests, DroppedFramesAtTargetRemainHostRenderLimited) {
+  auto stats = stable_gpu_native_stats(60.0, 60.0);
+  stats.dropped_frame_ratio = 0.04;
+
+  const auto health = nvhttp::build_session_health_json_for_tests(
+    stats,
+    false,
+    "Nova Client",
+    "Control"
+  );
+
+  EXPECT_EQ(health.at("grade"), "watch");
+  EXPECT_EQ(health.at("primary_issue"), "host_render_limited");
+  EXPECT_EQ(health.at("limiting_factor"), "host_render");
+  EXPECT_EQ(health.at("auto_action"), "lower_render_profile");
+  EXPECT_TRUE(health.at("host_render_limited").get<bool>());
+}
+
 TEST(StreamNetworkStatsTests, OneTransientReportDoesNotClassifyCleanStreamAsNetworkLimited) {
   constexpr auto client_ip = "203.0.113.120";
   stream_stats::update_stream_active(false);
@@ -237,6 +273,36 @@ TEST(ProcHostPauseClassificationTests, HighRefreshNearTargetDeliveryRemainsStead
 TEST(ProcHostPauseClassificationTests, MeaningfulTargetMissRemainsHostRenderLimited) {
   const auto classification = proc::classify_host_pause_session_for_tests(
     stable_gpu_native_stats(54.0, 60.0),
+    60.0,
+    false
+  );
+
+  EXPECT_EQ(classification.at("health_grade"), "watch");
+  EXPECT_EQ(classification.at("primary_issue"), "host_render_limited");
+  EXPECT_TRUE(classification.at("host_render_limited").get<bool>());
+}
+
+TEST(ProcHostPauseClassificationTests, DuplicateOnlyTargetRateDeliveryRemainsFramePacing) {
+  auto stats = stable_gpu_native_stats(60.0, 60.0);
+  stats.duplicate_frame_ratio = 0.10;
+
+  const auto classification = proc::classify_host_pause_session_for_tests(
+    stats,
+    60.0,
+    false
+  );
+
+  EXPECT_EQ(classification.at("health_grade"), "watch");
+  EXPECT_EQ(classification.at("primary_issue"), "frame_pacing");
+  EXPECT_FALSE(classification.at("host_render_limited").get<bool>());
+}
+
+TEST(ProcHostPauseClassificationTests, DroppedFramesAtTargetRemainHostRenderLimited) {
+  auto stats = stable_gpu_native_stats(60.0, 60.0);
+  stats.dropped_frame_ratio = 0.04;
+
+  const auto classification = proc::classify_host_pause_session_for_tests(
+    stats,
     60.0,
     false
   );


### PR DESCRIPTION
## what changed

- keep duplicate-only target-rate delivery classified as `frame_pacing`
- require a meaningful FPS miss or dropped frames before declaring `host_render_limited`
- keep live session health and host-pause history aligned

## why

static and menu content can intentionally reuse frames. that pacing signal should stay visible without telling Nova that host rendering failed or asking Auto Quality to lower the render profile.

## verification

- intended RED: both new duplicate-only tests failed on the old classifier
- focused classifier matrix: 8/8 passed
- sabotage RED: restoring both old clauses failed exactly the two duplicate-only tests
- restored focused GREEN: 8/8 passed
- full `test_polaris_stream`: 246/246 passed
- full CTest: 18/18 targets passed
- production target built successfully
- `git diff --check`
- added-line credential and debug-residue scan
- independent read-only review: approve, zero blocking findings

## boundaries

- no threshold change for meaningful FPS shortfall, dropped frames, jitter, capture, encoder, HDR, decoder, network, or virtual-display risk
- no release, deployment, restart, process, emulator, or physical-device action
