### PR TITLE
fix(doctor): quiesce active Steam before profile edits

### DIFF
--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -330,12 +330,12 @@ namespace doctor_actions {
       // Steam rewrites this file when it exits, so an edit under a live client
       // is reverted the moment that client closes. Closing Steam first is the
       // whole reason this action asks for confirmation.
-      if (proc::desktop_steam_client_active() && !proc::request_desktop_steam_shutdown_for_private_stream()) {
+      if (!proc::ensure_steam_client_quiescent_for_doctor()) {
         return {
           {"status", false},
           {"changed", false},
           {"state", "steam_still_running"},
-          {"error", "Desktop Steam did not close, so the change would be reverted when it exits. Close Steam and try again."},
+          {"error", "Steam did not close, so the change would be reverted when it exits. Close Steam and try again."},
           {"evidence", steam_input_evidence()}
         };
       }
@@ -372,7 +372,7 @@ namespace doctor_actions {
         {"status", true},
         {"changed", true},
         {"state", "watching"},
-        {"message", "Closed desktop Steam and cleared the Xbox Steam Input opt-in. Launch the game again to pick up the change."},
+        {"message", "Closed Steam and cleared the Xbox Steam Input opt-in. Launch the game again to pick up the change."},
         {"run_id", run.run_id},
         {"applied", {{"profiles_updated", static_cast<int>(run.steam_edits.size())}}},
         {"before", {{"profiles_with_xbox_support", before.profiles_with_xbox_support}, {"forced_app_count", before.forced_app_count}}},

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -4947,21 +4947,30 @@ namespace proc {
     return desktop_steam_client_active_impl();
   }
 
+  namespace {
+    bool doctor_steam_shutdown_required(
+      bool desktop_steam_active,
+      bool steam_singleton_active
+    ) {
+      return desktop_steam_active || steam_singleton_active;
+    }
+  }
+
   bool request_desktop_steam_shutdown_for_private_stream() {
     const auto pipe_path = steam_instance_pipe_path();
     if (!pipe_path) {
-      BOOST_LOG(warning) << "process: cannot determine Steam singleton path; refusing private stream shutdown handoff";
+      BOOST_LOG(warning) << "process: cannot determine Steam singleton path; refusing Steam shutdown handoff";
       return false;
     }
 
     const auto command = canonical_steam_shutdown_command("steam");
-    BOOST_LOG(info) << "process: explicit Nova request closing desktop Steam before private stream using [" << command << "]";
+    BOOST_LOG(info) << "process: explicit request closing active Steam client before protected configuration change using [" << command << "]";
     auto env = boost::this_process::environment();
     boost::system::error_code ec;
     boost::filesystem::path working_dir {};
     auto child = platf::run_command(false, true, command, working_dir, env, nullptr, ec, nullptr);
     if (ec) {
-      BOOST_LOG(warning) << "process: explicit desktop Steam shutdown command failed: " << ec.message();
+      BOOST_LOG(warning) << "process: Steam shutdown command failed: " << ec.message();
       return false;
     }
     child.detach();
@@ -4983,13 +4992,36 @@ namespace proc {
       100ms
     );
     if (!quiescent) {
-      BOOST_LOG(warning) << "process: desktop Steam did not reach process/FIFO quiescence before shutdown deadline";
+      BOOST_LOG(warning) << "process: Steam client did not reach process/FIFO quiescence before shutdown deadline";
     }
     return quiescent;
+  }
+
+  bool ensure_steam_client_quiescent_for_doctor() {
+    const auto pipe_path = steam_instance_pipe_path();
+    if (!pipe_path) {
+      BOOST_LOG(warning) << "process: cannot determine Steam singleton path; refusing Doctor Steam Input mutation";
+      return false;
+    }
+
+    const bool desktop_active = desktop_steam_client_active_impl();
+    const bool singleton_active = steam_instance_pipe_listener_active(*pipe_path);
+    if (!doctor_steam_shutdown_required(desktop_active, singleton_active)) {
+      return true;
+    }
+
+    return request_desktop_steam_shutdown_for_private_stream();
   }
 #endif
 
 #if defined(POLARIS_TESTS) && defined(__linux__)
+  bool doctor_steam_shutdown_required_for_tests(
+    bool desktop_steam_active,
+    bool steam_singleton_active
+  ) {
+    return doctor_steam_shutdown_required(desktop_steam_active, steam_singleton_active);
+  }
+
   std::optional<std::string> resolve_nested_gamescope_session_target_for_tests(
     bool gamescope_stream_session,
     const proc::ctx_t &app

--- a/src/process.h
+++ b/src/process.h
@@ -151,6 +151,7 @@ namespace proc {
   );
   bool desktop_steam_client_active();
   bool request_desktop_steam_shutdown_for_private_stream();
+  bool ensure_steam_client_quiescent_for_doctor();
 #endif
 
 #if defined(POLARIS_TESTS) && defined(__linux__)
@@ -262,6 +263,10 @@ namespace proc {
   bool desktop_steam_proc_environ_read_error_fails_closed_for_tests(pid_t forced_pid);
   bool desktop_steam_proc_scan_only_pid_for_tests(pid_t forced_pid);
   bool steam_instance_pipe_listener_active_for_tests(const std::string &pipe_path);
+  bool doctor_steam_shutdown_required_for_tests(
+    bool desktop_steam_active,
+    bool steam_singleton_active
+  );
   std::optional<std::string> resolve_nested_gamescope_session_target_for_tests(
     bool gamescope_stream_session,
     const struct ctx_t &app

--- a/tests/unit/test_steam_shutdown_state_machine.cpp
+++ b/tests/unit/test_steam_shutdown_state_machine.cpp
@@ -536,6 +536,31 @@ TEST(SteamShutdownStateMachineTests, ProductionPrivateSteamRequestUsesSessionEnv
   EXPECT_NE(request.find("child.detach()"), std::string::npos);
 }
 
+TEST(SteamShutdownStateMachineTests, DoctorShutdownIncludesPrivateSteamSingleton) {
+  EXPECT_FALSE(proc::doctor_steam_shutdown_required_for_tests(false, false));
+  EXPECT_TRUE(proc::doctor_steam_shutdown_required_for_tests(true, false));
+  EXPECT_TRUE(proc::doctor_steam_shutdown_required_for_tests(false, true));
+  EXPECT_TRUE(proc::doctor_steam_shutdown_required_for_tests(true, true));
+}
+
+TEST(SteamShutdownStateMachineTests, ProductionDoctorQuiescesSteamBeforeVdfMutation) {
+  const auto source = read_source_file("src/doctor_actions.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto action = source_between(
+    source,
+    "if (action_id == \"disable_steam_input_xbox\" ||",
+    "const auto stats = stream_stats::get_current();"
+  );
+  ASSERT_FALSE(action.empty());
+
+  const auto quiesce = action.find("ensure_steam_client_quiescent_for_doctor()");
+  const auto rewrite = action.find("rewrite_steam_profile(path, false)");
+  ASSERT_NE(quiesce, std::string::npos);
+  ASSERT_NE(rewrite, std::string::npos);
+  EXPECT_LT(quiesce, rewrite);
+  EXPECT_EQ(action.find("if (proc::desktop_steam_client_active())"), std::string::npos);
+}
+
 TEST(SteamShutdownStateMachineTests, PostShutdownPolicyRechecksLiveProcessState) {
   const auto source = read_source_file("src/process.cpp");
   ASSERT_FALSE(source.empty());


### PR DESCRIPTION
## summary

- make the confirmed Steam Input Doctor action inspect both desktop Steam and the active Steam singleton
- reuse the canonical bounded Steam shutdown and process/FIFO quiescence fence before editing `localconfig.vdf`
- fail closed when Steam identity or shutdown cannot be proven
- keep unrelated processes and sessions outside the action

## why

Polaris previously skipped shutdown whenever Steam belonged to the active private session. The live client then rewrote the VDF after Doctor changed it, leaving verification in `needs_attention`.

## verification

- intended RED: missing private-singleton shutdown planner and missing Doctor ordering contract
- focused Steam shutdown tests: 26/26
- sabotage with old production behavior: link failure on the new planner contract
- restored full CTest: 18/18
- independent blocking review: pass, zero blockers

## limits

this does not broaden process killing. it sends the existing canonical Steam shutdown request only when desktop activity or the singleton FIFO proves Steam is active, then requires quiescence before mutation.
