### PR TITLE
fix(stream): honor explicit High FPS launch preference

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -4596,6 +4596,9 @@ namespace nvhttp {
     launch_session->requested_width = launch_session->width;
     launch_session->requested_height = launch_session->height;
     launch_session->requested_fps = launch_session->fps;
+    launch_session->profile_preference = normalize_profile_preference(
+      get_arg(args, "profilePreference", "auto")
+    );
 
     launch_session->device_name = named_cert_p->name.empty() ? "PolarisDisplay"s : named_cert_p->name;
     launch_session->unique_id = named_cert_p->uuid;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -101,6 +101,19 @@
 #define DEFAULT_APP_IMAGE_PATH POLARIS_ASSETS_DIR "/box.png"
 
 namespace proc {
+  namespace {
+    bool should_apply_history_safe_fps_cap(
+      bool history_available,
+      double safe_target_fps,
+      bool relax_safe_target,
+      std::string_view preference
+    ) {
+      return history_available &&
+             safe_target_fps > 0.0 &&
+             !relax_safe_target &&
+             preference != "high_fps";
+    }
+  }
   using namespace std::literals;
   namespace pt = boost::property_tree;
 
@@ -5022,6 +5035,20 @@ namespace proc {
     return doctor_steam_shutdown_required(desktop_steam_active, steam_singleton_active);
   }
 
+  bool should_apply_history_safe_fps_cap_for_tests(
+    bool history_available,
+    double safe_target_fps,
+    bool relax_safe_target,
+    std::string_view preference
+  ) {
+    return should_apply_history_safe_fps_cap(
+      history_available,
+      safe_target_fps,
+      relax_safe_target,
+      preference
+    );
+  }
+
   std::optional<std::string> resolve_nested_gamescope_session_target_for_tests(
     bool gamescope_stream_session,
     const proc::ctx_t &app
@@ -6715,8 +6742,15 @@ namespace proc {
 
     const double effective_history_safe_target_fps =
       history ? ai_optimizer::effective_history_safe_target_fps(launch_session->device_name, *history) : 0.0;
-    if (history && effective_history_safe_target_fps > 0.0 &&
-        !ai_optimizer::should_relax_history_safe_target_fps(*history)) {
+    const bool relax_history_safe_target =
+      history && ai_optimizer::should_relax_history_safe_target_fps(*history);
+    const bool apply_history_safe_cap = should_apply_history_safe_fps_cap(
+      static_cast<bool>(history),
+      effective_history_safe_target_fps,
+      relax_history_safe_target,
+      launch_session->profile_preference
+    );
+    if (apply_history_safe_cap) {
       const int safe_fps =
         static_cast<int>(std::round(effective_history_safe_target_fps * 1000.0));
       if (safe_fps > 0 && launch_session->fps > safe_fps) {
@@ -6741,6 +6775,12 @@ namespace proc {
           "History-safe pacing overrode the paired display-mode FPS ceiling."
         );
       }
+    } else if (history && effective_history_safe_target_fps > 0.0 &&
+               launch_session->profile_preference == "high_fps") {
+      BOOST_LOG(info) << "session_optimization: explicit high_fps preference bypassed the soft history-safe "
+                      << static_cast<int>(std::round(effective_history_safe_target_fps))
+                      << " FPS cap for \""sv << launch_session->device_name << "\" + \""sv
+                      << _app.name << '"';
     } else if (history && effective_history_safe_target_fps > 0.0) {
       BOOST_LOG(info) << "session_optimization: relaxing history-safe "
                       << static_cast<int>(std::round(effective_history_safe_target_fps))

--- a/src/process.h
+++ b/src/process.h
@@ -232,6 +232,12 @@ namespace proc {
     std::chrono::milliseconds timeout,
     std::chrono::milliseconds poll_interval
   );
+  bool should_apply_history_safe_fps_cap_for_tests(
+    bool history_available,
+    double safe_target_fps,
+    bool relax_safe_target,
+    std::string_view preference
+  );
 
   struct private_steam_graceful_shutdown_test_result_t {
     bool root_exited = false;

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -125,6 +125,10 @@ namespace rtsp_stream {
     // Empty = host default. Validated in make_launch_session; applied to the
     // in-memory config by proc_t::execute and restored at teardown.
     std::string stream_mode;
+    // Normalized Nova Play Setup preference from /launch profilePreference.
+    // Only high_fps may bypass the soft historical safe-FPS cap. Hard client,
+    // device, and encoder constraints remain authoritative.
+    std::string profile_preference = "auto";
     bool user_locked_display_mode;
     bool user_locked_virtual_display;
     uint32_t scale_factor;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -205,6 +205,7 @@ set(TEST_PAIRING_SOURCES
 set(TEST_HTTP_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_httpcommon.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_mode_contract.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_preference.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_response_status.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_session_key.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_otp_claim.cpp

--- a/tests/unit/test_launch_preference.cpp
+++ b/tests/unit/test_launch_preference.cpp
@@ -1,0 +1,106 @@
+#include <src/crypto.h>
+#include <src/nvhttp.h>
+#include <src/process.h>
+#include <src/rtsp.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace {
+  std::unique_ptr<crypto::named_cert_t> client_cert() {
+    auto cert = std::make_unique<crypto::named_cert_t>();
+    cert->name = "test-client";
+    cert->uuid = "remote-client";
+    cert->perm = crypto::PERM::_game_control;
+    return cert;
+  }
+
+  nvhttp::args_t launch_args(std::string preference = {}) {
+    nvhttp::args_t args;
+    args.emplace("rikey", std::string(crypto::cipher::key_size * 2, '0'));
+    args.emplace("rikeyid", "1");
+    args.emplace("mode", "1920x1080x120");
+    if (!preference.empty()) {
+      args.emplace("profilePreference", std::move(preference));
+    }
+    return args;
+  }
+}
+
+TEST(LaunchPreference, MissingPreferenceDefaultsToAuto) {
+  auto cert = client_cert();
+  const auto session = nvhttp::make_launch_session(true, false, launch_args(), cert.get());
+
+  ASSERT_NE(session, nullptr);
+  EXPECT_EQ(session->profile_preference, "auto");
+  EXPECT_EQ(session->requested_fps, 120000);
+}
+
+TEST(LaunchPreference, CamelCaseHighFpsPropagatesToLaunchSession) {
+  auto cert = client_cert();
+  const auto session = nvhttp::make_launch_session(
+    true,
+    false,
+    launch_args("HIGH_FPS"),
+    cert.get()
+  );
+
+  ASSERT_NE(session, nullptr);
+  EXPECT_EQ(session->profile_preference, "high_fps");
+  EXPECT_EQ(session->requested_fps, 120000);
+}
+
+TEST(LaunchPreference, KnownNonTrialPreferencesRemainDistinct) {
+  for (const auto *preference : {"quality", "stability"}) {
+    auto cert = client_cert();
+    const auto session = nvhttp::make_launch_session(
+      true,
+      false,
+      launch_args(preference),
+      cert.get()
+    );
+
+    ASSERT_NE(session, nullptr);
+    EXPECT_EQ(session->profile_preference, preference);
+  }
+}
+
+TEST(LaunchPreference, UnknownPreferenceFailsSafeToAuto) {
+  auto cert = client_cert();
+  const auto session = nvhttp::make_launch_session(
+    true,
+    false,
+    launch_args("turbo"),
+    cert.get()
+  );
+
+  ASSERT_NE(session, nullptr);
+  EXPECT_EQ(session->profile_preference, "auto");
+}
+
+TEST(LaunchPreference, HighFpsBypassesOnlySoftActiveHistoryCap) {
+  EXPECT_FALSE(proc::should_apply_history_safe_fps_cap_for_tests(
+    true, 60.0, false, "high_fps"
+  ));
+
+  for (const auto *preference : {"auto", "quality", "stability"}) {
+    EXPECT_TRUE(proc::should_apply_history_safe_fps_cap_for_tests(
+      true, 60.0, false, preference
+    )) << preference;
+  }
+
+  EXPECT_FALSE(proc::should_apply_history_safe_fps_cap_for_tests(
+    false, 60.0, false, "auto"
+  ));
+  EXPECT_FALSE(proc::should_apply_history_safe_fps_cap_for_tests(
+    true, 0.0, false, "auto"
+  ));
+  EXPECT_FALSE(proc::should_apply_history_safe_fps_cap_for_tests(
+    true, 60.0, true, "auto"
+  ));
+  EXPECT_TRUE(proc::should_apply_history_safe_fps_cap_for_tests(
+    true, 60.0, false, "HIGH_FPS"
+  ));
+}

--- a/tests/unit/test_steam_shutdown_state_machine.cpp
+++ b/tests/unit/test_steam_shutdown_state_machine.cpp
@@ -1,5 +1,6 @@
 #include "../tests_common.h"
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -360,10 +361,12 @@ TEST(SteamShutdownStateMachineTests, EmptySteamAppRootStillUsesPinnedStopBarrier
 
 TEST(SteamShutdownStateMachineTests, PrivateSteamAppQuiescenceTerminatesOnlyExactAppLineage) {
   const std::string token = "private-steam-app-quiescence";
+  const std::string appid = "4242" + std::to_string(getpid());
+  const std::string launch_marker = "AppId=" + appid;
   proc::ctx_t steam_app {};
   steam_app.name = "Control";
   steam_app.source = "steam";
-  steam_app.steam_appid = "4242";
+  steam_app.steam_appid = appid;
 
   const auto spawn_owned = [&](const char *argv0) {
     const auto child = fork();
@@ -407,7 +410,7 @@ TEST(SteamShutdownStateMachineTests, PrivateSteamAppQuiescenceTerminatesOnlyExac
       "-c",
       "trap 'exit 0' TERM; sleep 60 & wait",
       "SteamLaunch",
-      "AppId=4242",
+      launch_marker.c_str(),
       nullptr
     );
     _exit(127);
@@ -435,12 +438,38 @@ TEST(SteamShutdownStateMachineTests, PrivateSteamAppQuiescenceTerminatesOnlyExac
       (std::istreambuf_iterator<char>(cmdline_file)),
       std::istreambuf_iterator<char>()
     );
-    marker_visible = proc::steam_launch_cmdline_matches_appid_for_tests(cmdline, "4242");
+    marker_visible = proc::steam_launch_cmdline_matches_appid_for_tests(cmdline, appid);
     if (!marker_visible) {
       std::this_thread::sleep_for(std::chrono::milliseconds(25));
     }
   }
   ASSERT_TRUE(marker_visible);
+
+  bool single_marker_root = false;
+  for (int attempt = 0; attempt < 40 && !single_marker_root; ++attempt) {
+    std::size_t matching_roots = 0;
+    std::error_code ec;
+    for (const auto &entry : std::filesystem::directory_iterator("/proc", ec)) {
+      const auto name = entry.path().filename().string();
+      if (ec || name.empty() ||
+          !std::all_of(name.begin(), name.end(), [](unsigned char ch) { return std::isdigit(ch); })) {
+        continue;
+      }
+      std::ifstream cmdline_file(entry.path() / "cmdline", std::ios::binary);
+      const std::string cmdline(
+        (std::istreambuf_iterator<char>(cmdline_file)),
+        std::istreambuf_iterator<char>()
+      );
+      if (proc::steam_launch_cmdline_matches_appid_for_tests(cmdline, appid)) {
+        ++matching_roots;
+      }
+    }
+    single_marker_root = matching_roots == 1;
+    if (!single_marker_root) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+  }
+  ASSERT_TRUE(single_marker_root);
 
   ASSERT_TRUE(proc::terminate_session_owned_steam_app_lineage_for_tests(steam_app, token));
   ASSERT_TRUE(wait_pidfd_exit(app_root_pidfd, std::chrono::seconds(2)))


### PR DESCRIPTION
## summary

- parse Nova's signed `profilePreference` launch field into the session
- normalize unknown values to `auto`
- let explicit `high_fps` trials bypass only the soft historical safe-FPS cap
- preserve auto, quality, stability, client bounds, device limits, and encoder safety

## why

Play Setup could say `120 FPS pinned`, while Polaris silently reapplied a historical 60 FPS cap during the real launch. Preview and execution therefore contradicted each other.

## verification

- intended RED: launch session had no preference field
- focused launch-preference tests: 5/5
- full HTTP/launch target: 133/133
- full stream target: 246/246
- sabotage with old production behavior: compile RED on the missing session contract
- restored full CTest: 18/18
- independent blocking review: pass, zero blockers

## limits

this bypasses only `history_safe`. explicit client ceilings and hard runtime constraints remain authoritative.
