### PR TITLE
fix(linux): restore GCC 16 package builds

### DIFF
--- a/packaging/linux/Arch/PKGBUILD
+++ b/packaging/linux/Arch/PKGBUILD
@@ -139,9 +139,13 @@ build() {
     export CFLAGS="${CFLAGS/-Werror=format-security/}"
     export CXXFLAGS="${CXXFLAGS/-Werror=format-security/}"
 
-    # GCC 15 plus Polaris' current Release workaround can conflict with Arch's
-    # injected fortify defines during makepkg validation rebuilds.
-    if [[ "$("${CXX}" -dumpfullversion | cut -d. -f1)" == "15" ]]; then
+    # Polaris' GNU Release workaround disables optimization for two translation
+    # units, so makepkg's injected fortify defines must not reach that compile.
+    # Clang defines __GNUC__ for compatibility but does not use the workaround.
+    local _compiler_macros
+    _compiler_macros="$("${CXX}" -dM -E -x c++ /dev/null)"
+    if [[ "${_compiler_macros}" == *"#define __GNUC__ "* &&
+          "${_compiler_macros}" != *"#define __clang__ "* ]]; then
       local _filtered_cppflags=()
       local _filtered_cflags=()
       local _filtered_cxxflags=()

--- a/packaging/linux/SteamOS/PKGBUILD
+++ b/packaging/linux/SteamOS/PKGBUILD
@@ -98,7 +98,12 @@ build() {
   export CFLAGS="${CFLAGS/-Werror=format-security/}"
   export CXXFLAGS="${CXXFLAGS/-Werror=format-security/}"
 
-  if [[ "$("${CXX}" -dumpfullversion | cut -d. -f1)" == "15" ]]; then
+  # Match the GNU-only Release workaround without aging out on compiler bumps.
+  # Clang defines __GNUC__ for compatibility but does not use the workaround.
+  local _compiler_macros
+  _compiler_macros="$("${CXX}" -dM -E -x c++ /dev/null)"
+  if [[ "${_compiler_macros}" == *"#define __GNUC__ "* &&
+        "${_compiler_macros}" != *"#define __clang__ "* ]]; then
     local _filtered_cppflags=()
     local _filtered_cflags=()
     local _filtered_cxxflags=()

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -523,7 +523,12 @@ namespace confighttp {
         // Nudge a frame then screenshot (async write inside gamescope).
         // shell-escape-checked: env is built above from shell_escape'd values,
         // and everything concatenated here is a literal.
-        std::system((env + "gamescopectl debug_force_repaint >/dev/null 2>&1").c_str());
+        const int repaint_result = std::system(
+          (env + "gamescopectl debug_force_repaint >/dev/null 2>&1").c_str()
+        );
+        if (repaint_result != 0) {
+          BOOST_LOG(debug) << "ConfigUI: gamescope repaint request failed with exit code " << repaint_result;
+        }
         std::ostringstream cmd;
         cmd << env << "gamescopectl screenshot " << shell_escape(outfile)
             << " >/dev/null 2>&1";

--- a/src/private_state_file.cpp
+++ b/src/private_state_file.cpp
@@ -172,7 +172,9 @@ namespace private_state_file {
           return;
         }
 
+#ifdef POLARIS_TESTS
         std::size_t created_parent_index = 0;
+#endif
         for (std::size_t index = 0; index < components.size(); ++index) {
           const auto &component = components[index];
           const bool final_parent = index + 1 == components.size();
@@ -235,9 +237,11 @@ namespace private_state_file {
             return;
           }
           descriptor_ = next;
+#ifdef POLARIS_TESTS
           if (parent_entry_needs_sync) {
             ++created_parent_index;
           }
+#endif
         }
       }
 

--- a/tests/unit/test_private_state_file.cpp
+++ b/tests/unit/test_private_state_file.cpp
@@ -102,6 +102,26 @@ TEST_F(PrivateStateFileTest, DoesNotCarryUnsupportedWindowsSecurityImplementatio
   EXPECT_EQ(session_contents.str().find("std::filesystem::create_directories("), std::string::npos);
 }
 
+TEST_F(PrivateStateFileTest, ParentFaultCounterExistsOnlyInTestBuilds) {
+  std::ifstream source(std::string {POLARIS_SOURCE_DIR} + "/src/private_state_file.cpp");
+  ASSERT_TRUE(source.is_open());
+  std::ostringstream contents;
+  contents << source.rdbuf();
+  const auto source_text = contents.str();
+
+  const auto expect_test_guarded = [&](std::string_view needle) {
+    const auto position = source_text.find(needle);
+    ASSERT_NE(position, std::string::npos);
+    const auto guard = source_text.rfind("#ifdef POLARIS_TESTS", position);
+    const auto guard_end = source_text.rfind("#endif", position);
+    ASSERT_NE(guard, std::string::npos);
+    EXPECT_GT(guard, guard_end) << needle;
+  };
+
+  expect_test_guarded("std::size_t created_parent_index = 0");
+  expect_test_guarded("++created_parent_index");
+}
+
 TEST_F(PrivateStateFileTest, SyncsCreatedParentEntryBeforeDescending) {
   std::ifstream source(std::string {POLARIS_SOURCE_DIR} + "/src/private_state_file.cpp");
   ASSERT_TRUE(source.is_open());

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -158,6 +158,40 @@ TEST(SourceSafetyContracts, ShellCommandsBuiltByConcatenationAreEscaped) {
   }();
 }
 
+TEST(SourceSafetyContracts, PackageFortifyFilterFollowsTheGnuCompilerIdentity) {
+  for (const auto *relative_path : {
+         "packaging/linux/Arch/PKGBUILD",
+         "packaging/linux/SteamOS/PKGBUILD"
+       }) {
+    std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / relative_path);
+    ASSERT_TRUE(input.is_open()) << relative_path;
+    std::ostringstream contents;
+    contents << input.rdbuf();
+    const auto text = contents.str();
+
+    EXPECT_NE(text.find("-dM -E -x c++ /dev/null"), std::string::npos) << relative_path;
+    EXPECT_NE(text.find("#define __GNUC__"), std::string::npos) << relative_path;
+    EXPECT_NE(text.find("#define __clang__"), std::string::npos) << relative_path;
+    EXPECT_EQ(text.find("-dumpfullversion"), std::string::npos) << relative_path;
+  }
+}
+
+TEST(SourceSafetyContracts, GamescopePreviewConsumesBestEffortRepaintResult) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/confighttp.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto text = contents.str();
+  const auto command = text.find("gamescopectl debug_force_repaint");
+  ASSERT_NE(command, std::string::npos);
+  const auto window_start = command > 300 ? command - 300 : 0;
+  const auto window = text.substr(window_start, 700);
+
+  EXPECT_NE(window.find("const int repaint_result = std::system("), std::string::npos);
+  EXPECT_NE(window.find("if (repaint_result != 0)"), std::string::npos);
+  EXPECT_NE(window.find("BOOST_LOG(debug)"), std::string::npos);
+}
+
 TEST(SourceSafetyContracts, ReadlinkResultsAreCheckedBeforeUse) {
   // readlink reports failure as -1. Widening that into a size handed a
   // string_view a length of SIZE_MAX; the other seven call sites all checked.


### PR DESCRIPTION
fixes #537

## what changed

- keep the private-state parent fault counter entirely inside `POLARIS_TESTS`
- make the Arch and SteamOS fortify filter follow the actual GNU compiler identity instead of aging out at GCC 15
- keep Clang fortify flags unchanged
- consume and debug-log the best-effort gamescope repaint result
- add source-contract coverage for the counter, package filters, and repaint result

## why

GCC 16 exposed three separate `BUILD_WERROR=ON` failures in the current CachyOS `makepkg` path: the production-only unused counter, Arch's injected fortify define colliding with Polaris's GNU Release `-O0` workaround, and the discarded `std::system` result.

removing the counter outright would break indexed parent fault injection in test builds. disabling `BUILD_WERROR` would only hide the failures. this keeps the test seam intact and fixes the package/compiler boundaries instead.

## verified

- reproduced all three GCC 16.2.1 Release failures before the fixes
- full GCC 16.2.1 Release build with `BUILD_WERROR=ON`: passed `214/214` build steps
- complete CTest suite: passed `7/7`
- private-state suite: passed `35/35`
- GNU/Clang package-filter harness passed for both PKGBUILDs
- package syntax and release dependency contracts passed
- regression contracts were confirmed RED before implementation and GREEN after

no fortify workaround was removed, no warning was suppressed, and the rolling compatibility lane remains install/runtime validation rather than a rolling `makepkg` rebuild.
