### PR TITLE
fix(doctor): keep Steam VDF guidance read only

### DIFF
--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -207,6 +207,15 @@ namespace doctor_actions {
     return std::min(one_step_ceiling_kbps, paired_target_bitrate_kbps);
   }
 
+  nlohmann::json steam_vdf_read_only_response() {
+    return {
+      {"status", false},
+      {"changed", false},
+      {"state", "read_only"},
+      {"error", "Automatic Steam profile changes and their Undo are disabled in this release. Review Steam Input settings manually."}
+    };
+  }
+
   nlohmann::json execute(const nlohmann::json &request) {
     const auto action_id = request.value("action_id", std::string {});
 
@@ -218,6 +227,7 @@ namespace doctor_actions {
       }
 
       if (action_run.kind == action_kind_e::disable_steam_input_xbox) {
+        return steam_vdf_read_only_response();
         int restored = 0;
         for (const auto &edit : action_run.steam_edits) {
           if (rewrite_steam_profile(edit.path, edit.previously_enabled)) {
@@ -276,10 +286,10 @@ namespace doctor_actions {
       };
     }
 
-    // Steam Input work runs ahead of the streaming gate below on purpose. Its
-    // whole point is to edit a profile Steam is not holding open, which means
-    // the fix is applied precisely when no stream is running.
+    // Legacy Steam VDF action IDs remain recognized only so stale clients and
+    // receipts fail closed before Steam shutdown or filesystem work.
     if (action_id == "disable_steam_input_xbox" || (action_id == "verify" && steam_input_run_selected())) {
+      return steam_vdf_read_only_response();
 #ifndef __linux__
       return {
         {"status", false},

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -913,22 +913,17 @@ namespace stream_stats {
       } else if ((primary_issue == "network_jitter" || primary_issue == "quality_capped_by_history") && !live_bitrate_tunable) {
         unavailable_reason = "The active encoder does not support runtime bitrate updates.";
       } else if (primary_issue == "steam_input_conflict") {
-        // Steam rewrites its profile on exit, so an edit made underneath a
-        // running client is reverted the moment that client closes. The action
-        // therefore closes desktop Steam first, which is why it confirms.
-        id = "disable_steam_input_xbox";
-        label = "Close Steam and fix";
-        kind = "host_setting";
-        endpoint = "/api/doctor/action";
-        method = "POST";
-        payload["action_id"] = id;
-        payload["source_result_id"] = source_result_id;
-        rollback = "Closing Steam ends any game running through it, including the session you are streaming now. Undo restores the previous Steam Input opt-in for every profile this run changed.";
+        id = "none";
+        label = "Review Steam Input";
+        kind = "manual_guidance";
+        unavailable_reason =
+          "Automatic Steam profile changes are disabled in this release. Review the host-wide Xbox opt-in and per-game overrides in Steam controller settings.";
+        rollback = "Read-only guidance; Doctor does not close Steam or change any profile.";
         verification = {
-          {"mode", "local_steam_config"},
-          {"delay_seconds", 2},
-          {"endpoint", "/api/doctor/action"},
-          {"success_when", nlohmann::json::array({"no Steam profile opts the emulated pad into Steam Input"})}
+          {"mode", "manual_steam_config"},
+          {"delay_seconds", 0},
+          {"endpoint", ""},
+          {"success_when", nlohmann::json::array({"Steam Input host opt-in and per-game overrides are reviewed manually"})}
         };
       } else if (primary_issue == "no_active_stream" || primary_issue == "capture_missing") {
         id = "export_support_bundle";
@@ -947,8 +942,7 @@ namespace stream_stats {
         if (health.contains("safe_hdr")) payload["hdr"] = health["safe_hdr"];
       }
 
-      const bool undoable =
-        id == "lower_bitrate" || id == "restore_quality" || id == "disable_steam_input_xbox";
+      const bool undoable = id == "lower_bitrate" || id == "restore_quality";
 
       return {
         {"id", id},

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -192,6 +192,45 @@ TEST(SourceSafetyContracts, GamescopePreviewConsumesBestEffortRepaintResult) {
   EXPECT_NE(window.find("BOOST_LOG(debug)"), std::string::npos);
 }
 
+TEST(SourceSafetyContracts, DoctorSteamVdfMutationAndUndoAreReleaseReadOnly) {
+  const auto read = [](const fs::path &path) {
+    std::ifstream input(path);
+    std::ostringstream out;
+    out << input.rdbuf();
+    return out.str();
+  };
+  const auto root = fs::path {POLARIS_SOURCE_DIR};
+  const auto doctor = read(root / "src/doctor_actions.cpp");
+  const auto stream = read(root / "src/stream_stats.cpp");
+
+  const auto apply = doctor.find("if (action_id == \"disable_steam_input_xbox\"");
+  const auto apply_guard = doctor.find("return steam_vdf_read_only_response()", apply);
+  const auto shutdown = doctor.find("ensure_steam_client_quiescent_for_doctor()", apply);
+  ASSERT_NE(apply, std::string::npos);
+  ASSERT_NE(apply_guard, std::string::npos);
+  ASSERT_NE(shutdown, std::string::npos);
+  EXPECT_LT(apply_guard, shutdown);
+
+  const auto undo = doctor.find("if (action_run.kind == action_kind_e::disable_steam_input_xbox)");
+  const auto undo_guard = doctor.find("return steam_vdf_read_only_response()", undo);
+  const auto restore = doctor.find("rewrite_steam_profile(edit.path", undo);
+  ASSERT_NE(undo, std::string::npos);
+  ASSERT_NE(undo_guard, std::string::npos);
+  ASSERT_NE(restore, std::string::npos);
+  EXPECT_LT(undo_guard, restore);
+
+  const auto builder = stream.find("nlohmann::json doctor_safe_action(");
+  const auto branch = stream.find("else if (primary_issue == \"steam_input_conflict\")", builder);
+  const auto branch_end = stream.find("} else if", branch + 1);
+  ASSERT_NE(builder, std::string::npos);
+  ASSERT_NE(branch, std::string::npos);
+  ASSERT_NE(branch_end, std::string::npos);
+  const auto action = stream.substr(branch, branch_end - branch);
+  EXPECT_NE(action.find("id = \"none\""), std::string::npos);
+  EXPECT_NE(action.find("kind = \"manual_guidance\""), std::string::npos);
+  EXPECT_EQ(action.find("disable_steam_input_xbox"), std::string::npos);
+}
+
 TEST(SourceSafetyContracts, ReadlinkResultsAreCheckedBeforeUse) {
   // readlink reports failure as -1. Widening that into a size handed a
   // string_view a length of SIZE_MAX; the other seven call sites all checked.

--- a/tests/unit/test_steam_shutdown_state_machine.cpp
+++ b/tests/unit/test_steam_shutdown_state_machine.cpp
@@ -572,7 +572,7 @@ TEST(SteamShutdownStateMachineTests, DoctorShutdownIncludesPrivateSteamSingleton
   EXPECT_TRUE(proc::doctor_steam_shutdown_required_for_tests(true, true));
 }
 
-TEST(SteamShutdownStateMachineTests, ProductionDoctorQuiescesSteamBeforeVdfMutation) {
+TEST(SteamShutdownStateMachineTests, ProductionDoctorSteamVdfMutationFailsClosedBeforeAnyWork) {
   const auto source = read_source_file("src/doctor_actions.cpp");
   ASSERT_FALSE(source.empty());
   const auto action = source_between(
@@ -581,13 +581,30 @@ TEST(SteamShutdownStateMachineTests, ProductionDoctorQuiescesSteamBeforeVdfMutat
     "const auto stats = stream_stats::get_current();"
   );
   ASSERT_FALSE(action.empty());
-
-  const auto quiesce = action.find("ensure_steam_client_quiescent_for_doctor()");
+  const auto guard = action.find("return steam_vdf_read_only_response()");
+  const auto shutdown = action.find("ensure_steam_client_quiescent_for_doctor()");
   const auto rewrite = action.find("rewrite_steam_profile(path, false)");
-  ASSERT_NE(quiesce, std::string::npos);
+  ASSERT_NE(guard, std::string::npos);
+  ASSERT_NE(shutdown, std::string::npos);
   ASSERT_NE(rewrite, std::string::npos);
-  EXPECT_LT(quiesce, rewrite);
-  EXPECT_EQ(action.find("if (proc::desktop_steam_client_active())"), std::string::npos);
+  EXPECT_LT(guard, shutdown);
+  EXPECT_LT(guard, rewrite);
+}
+
+TEST(SteamShutdownStateMachineTests, DoctorSteamVdfUndoFailsClosedBeforeAnyRestore) {
+  const auto source = read_source_file("src/doctor_actions.cpp");
+  ASSERT_FALSE(source.empty());
+  const auto undo = source_between(
+    source,
+    "if (action_run.kind == action_kind_e::disable_steam_input_xbox)",
+    "if (!adaptive_bitrate::get_state().runtime_update_supported)"
+  );
+  ASSERT_FALSE(undo.empty());
+  const auto guard = undo.find("return steam_vdf_read_only_response()");
+  const auto restore = undo.find("rewrite_steam_profile(edit.path");
+  ASSERT_NE(guard, std::string::npos);
+  ASSERT_NE(restore, std::string::npos);
+  EXPECT_LT(guard, restore);
 }
 
 TEST(SteamShutdownStateMachineTests, PostShutdownPolicyRechecksLiveProcessState) {

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -656,14 +656,23 @@ TEST(StreamStatsDoctorTests, SteamInputFindingSurvivesTheEndOfTheStream) {
   EXPECT_EQ(after.input_steam_input_status, "xbox_opt_in");
   EXPECT_EQ(after.input_steam_profiles_with_xbox_support, 1);
 
-  // And the idle Doctor payload still names it, with the fix still offered.
+  // The idle Doctor payload still reports the finding, but this release exposes
+  // read-only manual guidance rather than a host mutation.
   const auto doctor = stream_stats::build_doctor_json(after, nlohmann::json::object());
   EXPECT_EQ(doctor.at("primary_issue"), "steam_input_conflict");
-  EXPECT_EQ(doctor.at("safe_recovery_action").at("id"), "disable_steam_input_xbox");
+  EXPECT_EQ(doctor.at("safe_recovery_action").at("id"), "none");
+  EXPECT_EQ(doctor.at("safe_recovery_action").at("kind"), "manual_guidance");
 
   // Session telemetry is still gone; only the host facts carry over.
   EXPECT_EQ(after.client_name, "");
   EXPECT_DOUBLE_EQ(after.encode_time_ms, 0.0);
+}
+
+TEST(StreamStatsDoctorTests, LegacySteamVdfActionFailsClosedReadOnly) {
+  const auto result = doctor_actions::execute({{"action_id", "disable_steam_input_xbox"}});
+  EXPECT_FALSE(result.at("status").get<bool>());
+  EXPECT_FALSE(result.at("changed").get<bool>());
+  EXPECT_EQ(result.at("state"), "read_only");
 }
 
 TEST(StreamStatsDoctorTests, WarnsWhenSteamInputConflictsWithStrictIsolation) {
@@ -691,19 +700,16 @@ TEST(StreamStatsDoctorTests, WarnsWhenSteamInputConflictsWithStrictIsolation) {
   EXPECT_EQ(doctor.at("status"), "needs_action");
   EXPECT_EQ(doctor.at("confidence").at("level"), "high");
   EXPECT_EQ(doctor.at("recommendation").at("next_step_label"), "Adjust Steam Input");
-  // This finding shipped read-only, with the action pinned to "none". It now
-  // offers one, and the invariant that replaced it is what the action must
-  // stay: reversible, never destructive, and never applied without a
-  // confirmation, because applying it closes the user's desktop Steam.
+  // High-confidence evidence remains, but the release action is manual only.
   const auto &action = doctor.at("safe_recovery_action");
-  EXPECT_EQ(action.at("id"), "disable_steam_input_xbox");
-  EXPECT_EQ(action.at("kind"), "host_setting");
+  EXPECT_EQ(action.at("id"), "none");
+  EXPECT_EQ(action.at("kind"), "manual_guidance");
   EXPECT_FALSE(action.at("destructive"));
-  EXPECT_TRUE(action.at("requires_confirmation"));
-  EXPECT_TRUE(action.at("requires_owner"));
-  EXPECT_TRUE(action.at("undo").at("supported"));
-  EXPECT_EQ(action.at("endpoint"), "/api/doctor/action");
-  EXPECT_EQ(action.at("payload_preview").at("action_id"), "disable_steam_input_xbox");
+  EXPECT_FALSE(action.at("requires_confirmation"));
+  EXPECT_FALSE(action.at("requires_owner"));
+  EXPECT_FALSE(action.at("undo").at("supported"));
+  EXPECT_EQ(action.at("endpoint"), "");
+  EXPECT_FALSE(action.at("payload_preview").contains("action_id"));
   EXPECT_EQ(
     doctor.at("advanced_evidence").at("controller_input").at("steam_forced_app_count"),
     2


### PR DESCRIPTION
## summary

this keeps the Steam Input conflict visible in Doctor while making the release behavior honestly read-only.

- replaces the automatic Steam profile action with manual guidance
- keeps the existing host evidence and recommendation visible
- makes stale Apply, verify, and Steam VDF Undo requests return `read_only` before Steam shutdown or filesystem work
- leaves non-Steam Doctor actions unchanged

## why

the automatic VDF transaction and Undo path needs more hardening than this release should absorb. this deliberately removes it from the release surface instead of hiding the finding or shipping a path we dont trust yet.

#532 is not included in this PR and is deferred outside the next release.

## verification

- exact head: `2ce0c4d2dbef71ce410072994bc63b4265108562`
- exact tree: `4d9030eda94d5e88a1809c56bc5b5df53f9e8d5d`
- Release WERROR CTest: `7/7`
- Debug CTest: `18/18`
- read-only action and recommendation: `3/3`
- source guard contract: `1/1`
- shutdown-before-work guards: `2/2`
- exact detached review: APPROVE, zero blockers
- all GitHub checks: successful or intentionally skipped
- RP6 exact-candidate smoke: Control streamed, Command Center Doctor rendered guidance with no Steam Input finding and no Fix, Apply, or Undo control
- pc-papi rollback: exact production binary restored, capability intact, HTTP `200`, zero stream sockets

RP6 evidence is captured and the PR is ready for merge.