### PR TITLE
ci(ubuntu): allow pinned snapshot downgrades

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
             -o Acquire::https::Timeout=30
           )
           sudo apt-get "${apt_options[@]}" update
-          sudo apt-get "${apt_options[@]}" install -y \
+          sudo apt-get "${apt_options[@]}" install -y --allow-downgrades \
             build-essential cmake ninja-build \
             libboost-all-dev libssl-dev libevdev-dev \
             libpulse-dev libopus-dev libcurl4-openssl-dev \
@@ -905,7 +905,7 @@ jobs:
             -o Acquire::https::Timeout=30
           )
           sudo apt-get "${apt_options[@]}" update
-          sudo apt-get "${apt_options[@]}" install -y \
+          sudo apt-get "${apt_options[@]}" install -y --allow-downgrades \
             build-essential ccache cmake ninja-build \
             libboost-all-dev libssl-dev libevdev-dev \
             libpulse-dev libopus-dev libcurl4-openssl-dev \

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -231,6 +231,31 @@ TEST(SourceSafetyContracts, DoctorSteamVdfMutationAndUndoAreReleaseReadOnly) {
   EXPECT_EQ(action.find("disable_steam_input_xbox"), std::string::npos);
 }
 
+TEST(SourceSafetyContracts, UbuntuSnapshotInstallsMayDowngradeRunnerPackages) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / ".github/workflows/build.yml");
+  ASSERT_TRUE(input.good());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto workflow = contents.str();
+  ASSERT_FALSE(workflow.empty());
+
+  const auto count_exact = [](std::string_view haystack, std::string_view needle) {
+    std::size_t count = 0;
+    for (std::size_t offset = 0;
+         (offset = haystack.find(needle, offset)) != std::string_view::npos;
+         offset += needle.size()) {
+      ++count;
+    }
+    return count;
+  };
+
+  constexpr std::string_view unprotected_snapshot_install = R"(sudo apt-get "${apt_options[@]}" install -y \)";
+  constexpr std::string_view protected_snapshot_install = R"(sudo apt-get "${apt_options[@]}" install -y --allow-downgrades \)";
+
+  EXPECT_EQ(count_exact(workflow, unprotected_snapshot_install), 0u);
+  EXPECT_EQ(count_exact(workflow, protected_snapshot_install), 2u);
+}
+
 TEST(SourceSafetyContracts, ReadlinkResultsAreCheckedBeforeUse) {
   // readlink reports failure as -1. Widening that into a size handed a
   // string_view a length of SIZE_MAX; the other seven call sites all checked.


### PR DESCRIPTION
## what changed

- lets apt downgrade preinstalled GitHub runner packages to the pinned Ubuntu snapshot in both snapshot dependency installs
- leaves the later built `.deb` smoke install unchanged
- adds a non-vacuous source contract requiring exactly two protected snapshot installs and zero unprotected ones

## why

Polaris merge `e7b6b82a` passed every post-merge source-build row except Ubuntu. Ubuntu failed before configure because the refreshed runner already had `libcurl4t64 8.5.0-2ubuntu10.12`, while the pinned snapshot requires `.11`. apt refused that downgrade.

this keeps the snapshot authoritative instead of letting runner image drift decide dependency versions.

failed run: https://github.com/papi-ux/polaris/actions/runs/32864102796
failed job: https://github.com/papi-ux/polaris/actions/runs/32864102796/job/97860312593

## verification

- exact head: `8c59c4bf7b789ffc0417967db1b8f672d7b47098`
- exact tree: `d303d672bac07ecc9bdd800a2dd0230bce505005`
- RED: `2` unprotected snapshot installs, `0` protected
- GREEN: `0` unprotected snapshot installs, `2` protected
- focused contract: `1/1`
- Debug CTest: `7/7`
- Release WERROR CTest: `7/7`
- independent exact-scope replay: PASS

no production source, deployment, package snapshot, or release behavior changed.