### PR TITLE
Fix durable next-launch recovery profiles

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -80,6 +80,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/adaptive_bitrate.cpp"
         "${CMAKE_SOURCE_DIR}/src/doctor_actions.h"
         "${CMAKE_SOURCE_DIR}/src/doctor_actions.cpp"
+        "${CMAKE_SOURCE_DIR}/src/recovery_profile.h"
+        "${CMAKE_SOURCE_DIR}/src/recovery_profile.cpp"
         "${CMAKE_SOURCE_DIR}/src/browser_stream_protocol.h"
         "${CMAKE_SOURCE_DIR}/src/bounded_log_file.cpp"
         "${CMAKE_SOURCE_DIR}/src/bounded_log_file.h"

--- a/src/ai_optimizer.cpp
+++ b/src/ai_optimizer.cpp
@@ -2368,7 +2368,8 @@ namespace ai_optimizer {
   }
 
   static nlohmann::json doctor_explanation_fallback(const std::string &reason,
-                                                      const nlohmann::json &evidence = nlohmann::json::object()) {
+                                                      const nlohmann::json &evidence = nlohmann::json::object(),
+                                                      bool expected_subscription_fallback = false) {
     nlohmann::json explanation;
     const auto doctor = evidence.value("doctor", nlohmann::json::object());
     const auto checklist = evidence.value("fix_my_stream_checklist", nlohmann::json::array());
@@ -2415,8 +2416,14 @@ namespace ai_optimizer {
     explanation["destructive_action_allowed"] = false;
 
     return {
-      {"status", false},
-      {"provider_error", reason},
+      {"status", expected_subscription_fallback},
+      {"fallback", true},
+      {"provider_error", expected_subscription_fallback ? "" : reason},
+      {"source", {
+        {"kind", expected_subscription_fallback ? "deterministic-fallback" : "provider-failure"},
+        {"mode", expected_subscription_fallback ? "openai-subscription" : "error-fallback"},
+        {"informational", expected_subscription_fallback}
+      }},
       {"explanation", explanation},
     };
   }
@@ -2528,6 +2535,12 @@ namespace ai_optimizer {
     auto active_cfg = resolved_config(config);
     if (!is_config_enabled(active_cfg)) {
       return doctor_explanation_fallback("AI explanations are disabled or not fully configured.", evidence).dump();
+    }
+    if (active_cfg.provider == PROVIDER_OPENAI && active_cfg.auth_mode == AUTH_SUBSCRIPTION) {
+      // Codex CLI remains the ordinary optimizer route. Doctor explanations
+      // intentionally stay deterministic in subscription mode so an expected
+      // unsupported explanation transport is informational, not provider noise.
+      return doctor_explanation_fallback(std::string {}, evidence, true).dump();
     }
 
     try {

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3619,7 +3619,35 @@ namespace confighttp {
       std::stringstream ss;
       ss << request->content.rdbuf();
       const auto body = nlohmann::json::parse(ss.str());
-      send_response(response, doctor_actions::execute(body));
+      const auto stats = stream_stats::get_current();
+      const auto owner_uuid = proc::proc.get_session_owner_unique_id();
+      const auto device_name = proc::proc.get_session_owner_device_name();
+      const auto app_uuid = proc::proc.get_running_app_uuid();
+      const auto app_name = proc::proc.get_last_run_app_name();
+      const bool virtual_display = proc::proc.session_uses_virtual_display();
+      const auto timing = stream_stats::get_session_timing(owner_uuid);
+      const auto health = nvhttp::build_session_health_for_action(
+        stats, virtual_display, device_name, app_name
+      );
+      doctor_actions::recovery_action_context_t recovery_context {
+        .active_owner = !owner_uuid.empty() && proc::proc.is_session_owner(owner_uuid),
+        .host_tuning_allowed = stats.streaming && !proc::proc.session_shutdown_requested(),
+        .caller_is_viewer = false,
+        .require_owner_scope = false,
+        .owner_uuid = owner_uuid,
+        .device_name = device_name,
+        .app_uuid = app_uuid,
+        .app_name = app_name,
+        .launch_instance_id = proc::proc.get_session_token(),
+        .session_generation = timing.session_generation,
+        .effective_stream_display_mode = nvhttp::effective_stream_display_mode_for_action(
+          stats, virtual_display
+        ),
+        .state_path = platf::appdata() / "recovery_profiles.json",
+        .stats = stats,
+        .health = health,
+      };
+      send_response(response, doctor_actions::execute(body, recovery_context));
     } catch (const std::exception &e) {
       send_response(response, {{"status", false}, {"changed", false}, {"error", e.what()}});
     }

--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -350,7 +350,9 @@ namespace doctor_actions {
       if (receipt.value("status", false)) {
         receipt["action_id"] = "apply_recovery_profile_next_launch";
         receipt["kind"] = "next_launch_profile";
-        receipt["message"] =
+        const auto recovery_state = receipt.value("recovery_state", std::string {});
+        receipt["message"] = recovery_state == "applied" ?
+          "This confirmed recovery action was already applied by its matching one-shot launch." :
           "The current stream is unchanged. The safer profile is queued only for the next launch of this game on this paired device.";
         receipt["verification"] = {
           {"mode", "post_connect"},
@@ -371,8 +373,11 @@ namespace doctor_actions {
   bool paired_route_allowed(std::string_view action_id,
                             bool active_owner_present,
                             bool caller_is_active_owner) {
+    static_cast<void>(active_owner_present);
     if (caller_is_active_owner) return true;
-    return action_id == "undo" && !active_owner_present;
+    // The core action resolves Undo under the caller certificate's owner UUID,
+    // so this cannot remove the active owner's or another client's record.
+    return action_id == "undo";
   }
 
   int guarded_bitrate_target(int current_bitrate_kbps,

--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -6,11 +6,13 @@
 #include "doctor_actions.h"
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -20,6 +22,7 @@
 #include "adaptive_bitrate.h"
 #include "game_library_scanner.h"
 #include "logging.h"
+#include "recovery_profile.h"
 
 #ifdef __linux__
   #include "process.h"
@@ -174,11 +177,202 @@ namespace doctor_actions {
       ).count();
       return "doctor-run-" + std::to_string(ticks);
     }
+
+    std::string normalized_codec_family(std::string codec) {
+      std::transform(codec.begin(), codec.end(), codec.begin(), [](unsigned char value) {
+        return static_cast<char>(std::tolower(value));
+      });
+      if (codec.find("av1") != std::string::npos) return "av1";
+      if (codec.find("hevc") != std::string::npos || codec.find("h265") != std::string::npos ||
+          codec.find("h.265") != std::string::npos) return "hevc";
+      if (codec.find("h264") != std::string::npos || codec.find("h.264") != std::string::npos ||
+          codec.find("avc") != std::string::npos) return "h264";
+      return {};
+    }
+
+    int trusted_target_fps(const stream_stats::stats_t &stats) {
+      const double fps =
+        stats.encode_target_fps > 0.0 ? stats.encode_target_fps :
+        stats.session_target_fps > 0.0 ? stats.session_target_fps :
+        stats.requested_client_fps > 0.0 ? stats.requested_client_fps :
+        stats.fps;
+      return static_cast<int>(std::round(fps));
+    }
+
+    int trusted_bitrate(const stream_stats::stats_t &stats) {
+      return stats.adaptive_target_bitrate_kbps > 0 ?
+        stats.adaptive_target_bitrate_kbps : stats.bitrate_kbps;
+    }
+
+    std::optional<recovery_profile::safe_profile_t> derive_safe_recovery_profile(
+      const recovery_action_context_t &context
+    ) {
+      recovery_profile::safe_profile_t profile;
+      const auto safe_mode = context.health.value("safe_display_mode", std::string {});
+      profile.stream_display_mode = safe_mode == "virtual_display" ? "host_virtual_display" :
+        safe_mode == "headless" ? "headless_stream" : context.effective_stream_display_mode;
+      profile.width = context.stats.width;
+      profile.height = context.stats.height;
+      profile.target_fps = context.health.value("safe_target_fps", trusted_target_fps(context.stats));
+      profile.target_bitrate_kbps = context.health.value("safe_bitrate_kbps", trusted_bitrate(context.stats));
+      profile.preferred_codec = normalized_codec_family(
+        context.health.value("safe_codec", context.stats.codec)
+      );
+      if (profile.preferred_codec.empty()) profile.preferred_codec = "h264";
+      profile.hdr = context.health.value("safe_hdr", false);
+
+      if (profile.width <= 0 || profile.height <= 0 || profile.target_fps <= 0 ||
+          profile.target_bitrate_kbps <= 0 || profile.stream_display_mode.empty()) {
+        return std::nullopt;
+      }
+      return profile;
+    }
+
+    nlohmann::json recovery_rejected(std::string error, std::string state = "rejected") {
+      return {
+        {"status", false},
+        {"changed", false},
+        {"state", state},
+        {"recovery_state", state},
+        {"error", std::move(error)}
+      };
+    }
+
+    nlohmann::json execute_recovery_action(const nlohmann::json &request,
+                                            const recovery_action_context_t &context) {
+      const auto action_id = request.value("action_id", std::string {});
+      if (action_id != "apply_recovery_profile_next_launch" &&
+          action_id != "verify_recovery_profile_next_launch" &&
+          action_id != "undo") {
+        return nlohmann::json();
+      }
+
+      const auto run_id = request.value("run_id", std::string {});
+      if (action_id == "undo") {
+        if (context.caller_is_viewer || context.state_path.empty() ||
+            (context.require_owner_scope && context.owner_uuid.empty())) {
+          return recovery_rejected(
+            "Only the paired owner or authenticated host can undo this recovery run.",
+            "evidence_changed"
+          );
+        }
+        const std::optional<std::string> owner_scope = context.require_owner_scope ?
+          std::optional<std::string> {context.owner_uuid} : std::nullopt;
+        auto result = recovery_profile::undo_run(
+          context.state_path, run_id, owner_scope
+        );
+        if (!result.value("status", false) &&
+            result.value("error", std::string {}).find("no longer available") != std::string::npos) {
+          // This was not an owned queued recovery run. Preserve the existing
+          // live-action Undo namespace for its own run identifiers.
+          return nlohmann::json();
+        }
+        return result;
+      }
+
+      if (!context.active_owner || !context.host_tuning_allowed || context.owner_uuid.empty() ||
+          context.app_uuid.empty() || context.state_path.empty() || !context.stats.streaming) {
+        return recovery_rejected(
+          "A matching active owner and game stream are required for this recovery action.",
+          "evidence_changed"
+        );
+      }
+
+      if (action_id == "verify_recovery_profile_next_launch") {
+        if (run_id.empty()) {
+          return recovery_rejected("Recovery verification requires a run_id.");
+        }
+        recovery_profile::observed_launch_t observed {
+          .streaming = context.stats.streaming,
+          .owner_uuid = context.owner_uuid,
+          .app_uuid = context.app_uuid,
+          .stream_display_mode = context.effective_stream_display_mode,
+          .width = context.stats.width,
+          .height = context.stats.height,
+          .target_fps = trusted_target_fps(context.stats),
+          .bitrate_kbps = trusted_bitrate(context.stats),
+          .codec = normalized_codec_family(context.stats.codec),
+          .hdr = context.stats.stream_hdr_enabled,
+          .launch_instance_id = context.launch_instance_id,
+          .session_generation = context.session_generation,
+        };
+        return recovery_profile::verify(
+          context.state_path, context.owner_uuid, context.app_uuid, run_id, observed
+        );
+      }
+
+      if (!request.value("confirmed", false)) {
+        return recovery_rejected(
+          "Confirm that the current stream stays unchanged and the safer profile applies only to the next launch of this game on this paired device.",
+          "confirmation_required"
+        );
+      }
+
+      const auto doctor = context.health.value("doctor", nlohmann::json::object());
+      const auto current_action = doctor.value("safe_recovery_action", nlohmann::json::object());
+      const auto source_result_id = doctor.value("result_id", std::string {});
+      const auto requested_result_id = request.value("source_result_id", std::string {});
+      const auto requested_app_uuid = request.value("app_uuid", std::string {});
+      const auto preview = current_action.value("payload_preview", nlohmann::json::object());
+      const bool exact_current_action =
+        context.health.value("relaunch_recommended", false) &&
+        current_action.value("id", std::string {}) == "apply_recovery_profile_next_launch" &&
+        current_action.value("kind", std::string {}) == "next_launch_profile" &&
+        current_action.value("requires_confirmation", false) &&
+        current_action.value("requires_owner", false) &&
+        current_action.value("owner_tuning_allowed", false) &&
+        current_action.value("undo", nlohmann::json::object()).value("supported", false) &&
+        !source_result_id.empty() && requested_result_id == source_result_id &&
+        preview.value("source_result_id", std::string {}) == source_result_id &&
+        !requested_app_uuid.empty() && requested_app_uuid == context.app_uuid &&
+        preview.value("app_uuid", std::string {}) == context.app_uuid &&
+        !context.launch_instance_id.empty() && context.session_generation > 0;
+      if (!exact_current_action) {
+        return recovery_rejected(
+          "Current Doctor evidence no longer authorizes this next-launch recovery profile.",
+          "evidence_changed"
+        );
+      }
+
+      const auto profile = derive_safe_recovery_profile(context);
+      if (!profile) {
+        return recovery_rejected("Current host evidence cannot produce a complete safe profile.");
+      }
+      auto receipt = recovery_profile::queue(
+        context.state_path,
+        context.owner_uuid,
+        context.app_uuid,
+        source_result_id,
+        *profile,
+        context.launch_instance_id,
+        context.session_generation
+      );
+      if (receipt.value("status", false)) {
+        receipt["action_id"] = "apply_recovery_profile_next_launch";
+        receipt["kind"] = "next_launch_profile";
+        receipt["message"] =
+          "The current stream is unchanged. The safer profile is queued only for the next launch of this game on this paired device.";
+        receipt["verification"] = {
+          {"mode", "post_connect"},
+          {"action_id", "verify_recovery_profile_next_launch"},
+          {"endpoint", "/polaris/v1/doctor/action"},
+          {"run_id", receipt.value("run_id", std::string {})}
+        };
+      }
+      return receipt;
+    }
   }  // namespace
 
   bool network_pressure_confirmed(const stream_stats::stats_t &stats) {
     return stats.streaming && stats.network_risk &&
       ((stats.packet_loss_available && stats.packet_loss > 2.0) || stats.latency_ms >= 45.0);
+  }
+
+  bool paired_route_allowed(std::string_view action_id,
+                            bool active_owner_present,
+                            bool caller_is_active_owner) {
+    if (caller_is_active_owner) return true;
+    return action_id == "undo" && !active_owner_present;
   }
 
   int guarded_bitrate_target(int current_bitrate_kbps,
@@ -645,6 +839,15 @@ namespace doctor_actions {
       {"undo", {{"available", true}, {"action_id", "undo"}, {"run_id", run.run_id}}},
       {"evidence", evidence}
     };
+  }
+
+  nlohmann::json execute(const nlohmann::json &request,
+                         const recovery_action_context_t &recovery_context) {
+    auto recovery_result = execute_recovery_action(request, recovery_context);
+    if (!recovery_result.is_null()) {
+      return recovery_result;
+    }
+    return execute(request);
   }
 
 }  // namespace doctor_actions

--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -249,7 +249,7 @@ namespace doctor_actions {
 
       const auto run_id = request.value("run_id", std::string {});
       if (action_id == "undo") {
-        if (context.caller_is_viewer || context.state_path.empty() ||
+        if (context.state_path.empty() ||
             (context.require_owner_scope && context.owner_uuid.empty())) {
           return recovery_rejected(
             "Only the paired owner or authenticated host can undo this recovery run.",

--- a/src/doctor_actions.h
+++ b/src/doctor_actions.h
@@ -4,14 +4,41 @@
  */
 #pragma once
 
-#include <nlohmann/json_fwd.hpp>
+#include <filesystem>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include <nlohmann/json.hpp>
 
 #include "stream_stats.h"
 
 namespace doctor_actions {
 
+  struct recovery_action_context_t {
+    bool active_owner = false;
+    bool host_tuning_allowed = false;
+    bool caller_is_viewer = false;
+    bool require_owner_scope = true;
+    std::string owner_uuid;
+    std::string device_name;
+    std::string app_uuid;
+    std::string app_name;
+    std::string launch_instance_id;
+    std::uint64_t session_generation = 0;
+    std::string effective_stream_display_mode;
+    std::filesystem::path state_path;
+    stream_stats::stats_t stats;
+    nlohmann::json health;
+  };
+
   /** Current telemetry must pass this guard before Doctor may reduce quality. */
   bool network_pressure_confirmed(const stream_stats::stats_t &stats);
+
+  /** Paired-route authorization, including owner-scoped Undo after disconnect. */
+  bool paired_route_allowed(std::string_view action_id,
+                            bool active_owner_present,
+                            bool caller_is_active_owner);
 
   /** Clamp a proposed bitrate to one guarded reduction step. */
   int guarded_bitrate_target(int current_bitrate_kbps,
@@ -24,5 +51,9 @@ namespace doctor_actions {
 
   /** Execute recheck, apply, verify, or undo and return the Doctor action result contract. */
   nlohmann::json execute(const nlohmann::json &request);
+
+  /** Execute with trusted current owner/app/telemetry for durable recovery actions. */
+  nlohmann::json execute(const nlohmann::json &request,
+                         const recovery_action_context_t &recovery_context);
 
 }  // namespace doctor_actions

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -78,6 +78,7 @@
 #include "ai_optimizer.h"
 #include "device_db.h"
 #include "doctor_actions.h"
+#include "recovery_profile.h"
 #include "client_support_report.h"
 #include "confighttp.h"
 #include "stream_stats.h"
@@ -2401,7 +2402,8 @@ namespace nvhttp {
     nlohmann::json build_session_health_json(const stream_stats::stats_t &stats,
                                              bool current_virtual_display,
                                              const std::string &device_name,
-                                             const std::string &app_name) {
+                                             const std::string &app_name,
+                                             std::string_view app_uuid = {}) {
       const auto device_profile = device_db::get_device(device_name);
       const bool mobile_client = is_mobile_client_type(device_profile);
       const std::string active_codec_family = codec_family(stats.codec);
@@ -2646,10 +2648,28 @@ namespace nvhttp {
         adaptive_bitrate::get_state(),
         stats.bitrate_kbps
       );
-      health["doctor"] = stream_stats::build_doctor_json(stats, health);
+      health["doctor"] = stream_stats::build_doctor_json(stats, health, app_uuid);
       return health;
     }
   }  // namespace
+
+  nlohmann::json build_session_health_for_action(const stream_stats::stats_t &stats,
+                                                 bool current_virtual_display,
+                                                 const std::string &device_name,
+                                                 const std::string &app_name) {
+    return build_session_health_json(
+      stats,
+      current_virtual_display,
+      device_name,
+      app_name,
+      proc::proc.get_running_app_uuid()
+    );
+  }
+
+  std::string effective_stream_display_mode_for_action(const stream_stats::stats_t &stats,
+                                                       bool current_virtual_display) {
+    return effective_stream_display_mode_selection(stats, current_virtual_display);
+  }
 
 #ifdef POLARIS_TESTS
   std::optional<int> select_paired_client_launch_bitrate_for_tests(
@@ -6523,6 +6543,7 @@ namespace nvhttp {
       features["disconnect_resume_v1"] = true;
       features["diagnostics_doctor_v1"] = true;
       features["doctor_actions_v1"] = true;
+      features["recovery_profile_next_launch_v1"] = true;
       features["doctor_ai_explanation_v1"] = false;
       features["cursor_visibility_control"] = true;
       features["lock_screen_control"] = false;
@@ -6765,10 +6786,32 @@ namespace nvhttp {
         stats,
         status_snapshot.virtual_display,
         named_cert_p->name,
-        status_snapshot.game
+        status_snapshot.game,
+        status_snapshot.game_uuid
       );
       output["health"] = health;
       output["doctor"] = health.value("doctor", nlohmann::json::object());
+      const auto recovery_records = client_role == "viewer" ? nlohmann::json::array() :
+        recovery_profile::statuses_for_owner(
+          platf::appdata() / "recovery_profiles.json", named_cert_p->uuid
+        );
+      output["recovery_records"] = recovery_records;
+      if (client_role != "viewer" && !status_snapshot.game_uuid.empty()) {
+        output["recovery"] = recovery_profile::status(
+          platf::appdata() / "recovery_profiles.json",
+          named_cert_p->uuid,
+          status_snapshot.game_uuid
+        );
+      } else if (recovery_records.size() == 1) {
+        output["recovery"] = recovery_records.front();
+      } else {
+        output["recovery"] = {
+          {"status", true},
+          {"changed", false},
+          {"state", "none"},
+          {"recovery_state", "none"}
+        };
+      }
       output["auto_quality"] = health.value("recovery_policy", nlohmann::json::object());
       output["profile_state"] = build_live_profile_state_json(
         health,
@@ -6882,7 +6925,8 @@ namespace nvhttp {
           stats,
           proc::proc.session_uses_virtual_display(),
           response_client->name,
-          app_name
+          app_name,
+          proc::proc.get_running_app_uuid()
         );
 
         nlohmann::json output;
@@ -7108,7 +7152,8 @@ namespace nvhttp {
           stats,
           proc::proc.session_uses_virtual_display(),
           response_client->name,
-          proc::proc.get_last_run_app_name()
+          proc::proc.get_last_run_app_name(),
+          proc::proc.get_running_app_uuid()
         );
 
         nlohmann::json output;
@@ -8060,19 +8105,50 @@ namespace nvhttp {
         response->write(SimpleWeb::StatusCode::client_error_unauthorized);
         return;
       }
-      if (!proc::proc.is_session_owner(named_cert_p->uuid)) {
-        nlohmann::json err;
-        err["error"] = "Only the active session owner can run Doctor actions";
-        SimpleWeb::CaseInsensitiveMultimap headers;
-        headers.emplace("Content-Type", "application/json");
-        response->write(SimpleWeb::StatusCode::client_error_forbidden, err.dump(), headers);
-        return;
-      }
 
       try {
         std::string body_str(std::istreambuf_iterator<char>(request->content), {});
         const auto body = body_str.empty() ? nlohmann::json::object() : nlohmann::json::parse(body_str);
-        const auto output = doctor_actions::execute(body);
+        const bool active_owner_present = !proc::proc.get_session_owner_unique_id().empty();
+        const bool active_owner =
+          active_owner_present && proc::proc.is_session_owner(named_cert_p->uuid);
+        if (!doctor_actions::paired_route_allowed(
+              body.value("action_id", std::string {}),
+              active_owner_present,
+              active_owner
+            )) {
+          nlohmann::json err;
+          err["error"] = "Only the active session owner can run Doctor actions; a disconnected owner may only undo its own queued recovery run.";
+          SimpleWeb::CaseInsensitiveMultimap headers;
+          headers.emplace("Content-Type", "application/json");
+          response->write(SimpleWeb::StatusCode::client_error_forbidden, err.dump(), headers);
+          return;
+        }
+        const auto stats = stream_stats::get_current();
+        const auto app_uuid = proc::proc.get_running_app_uuid();
+        const auto app_name = proc::proc.get_last_run_app_name();
+        const bool virtual_display = proc::proc.session_uses_virtual_display();
+        const auto timing = stream_stats::get_session_timing(named_cert_p->uuid);
+        const auto health = build_session_health_json(
+          stats, virtual_display, named_cert_p->name, app_name, app_uuid
+        );
+        doctor_actions::recovery_action_context_t recovery_context {
+          .active_owner = active_owner,
+          .host_tuning_allowed = stats.streaming && !proc::proc.session_shutdown_requested(),
+          .caller_is_viewer = !active_owner && active_owner_present,
+          .require_owner_scope = true,
+          .owner_uuid = named_cert_p->uuid,
+          .device_name = named_cert_p->name,
+          .app_uuid = app_uuid,
+          .app_name = app_name,
+          .launch_instance_id = proc::proc.get_session_token(),
+          .session_generation = timing.session_generation,
+          .effective_stream_display_mode = effective_stream_display_mode_selection(stats, virtual_display),
+          .state_path = platf::appdata() / "recovery_profiles.json",
+          .stats = stats,
+          .health = health,
+        };
+        const auto output = doctor_actions::execute(body, recovery_context);
         SimpleWeb::CaseInsensitiveMultimap headers;
         headers.emplace("Content-Type", "application/json");
         response->write(output.dump(), headers);
@@ -8117,7 +8193,8 @@ namespace nvhttp {
           stats,
           proc::proc.session_uses_virtual_display(),
           named_cert_p->name,
-          proc::proc.get_last_run_app_name()
+          proc::proc.get_last_run_app_name(),
+          proc::proc.get_running_app_uuid()
         );
         output["client_settings"] = build_client_settings_json(*named_cert_p, stats, health);
         output["sync_status"] = output["client_settings"]["sync_status"];
@@ -8179,7 +8256,8 @@ namespace nvhttp {
           stats,
           proc::proc.session_uses_virtual_display(),
           named_cert_p->name,
-          proc::proc.get_last_run_app_name()
+          proc::proc.get_last_run_app_name(),
+          proc::proc.get_running_app_uuid()
         );
         output["client_settings"] = build_client_settings_json(*named_cert_p, stats, health);
         output["sync_status"] = output["client_settings"]["sync_status"];
@@ -8240,7 +8318,8 @@ namespace nvhttp {
           stats,
           proc::proc.session_uses_virtual_display(),
           named_cert_p->name,
-          proc::proc.get_last_run_app_name()
+          proc::proc.get_last_run_app_name(),
+          proc::proc.get_running_app_uuid()
         );
         output["client_settings"] = build_client_settings_json(*named_cert_p, stats, health);
         output["sync_status"] = output["client_settings"]["sync_status"];
@@ -8875,6 +8954,62 @@ namespace nvhttp {
         }
         output["last_invalidated_at"] = session_history->last_invalidated_at;
       }
+      std::optional<std::string> canonical_app_uuid;
+      if (!game.empty()) {
+        const auto apps = proc::proc.get_apps();
+        std::vector<recovery_profile::app_identity_t> identities;
+        identities.reserve(apps.size());
+        for (const auto &app : apps) {
+          identities.push_back({.uuid = app.uuid, .id = app.id, .name = app.name});
+        }
+        canonical_app_uuid = recovery_profile::resolve_canonical_app_uuid(game, identities);
+      }
+      if (canonical_app_uuid) {
+        double paired_mode_fps = 0.0;
+        int paired_width = 0;
+        int paired_height = 0;
+        (void) (!named_cert_p->display_mode.empty() &&
+          parse_stream_policy_display_mode(
+            named_cert_p->display_mode, paired_width, paired_height, paired_mode_fps
+          ));
+        recovery_profile::optimizer_constraints_t recovery_constraints;
+        recovery_constraints.paired_width = paired_width;
+        recovery_constraints.paired_height = paired_height;
+        const auto codec_support = advertised_codec_support_for_http(true);
+        recovery_constraints.supported_codecs.push_back("h264");
+        if (codec_support.hevc_mode > 1) recovery_constraints.supported_codecs.push_back("hevc");
+        if (codec_support.av1_mode > 1) recovery_constraints.supported_codecs.push_back("av1");
+        recovery_constraints.hdr_supported =
+          codec_support.hevc_mode == 3 && device_profile && device_profile->hdr_capable;
+#ifdef __linux__
+        recovery_constraints.allowed_stream_display_modes =
+          stream_display_policy::allowed_launch_modes(host_virtual_display_available(), false);
+#else
+        recovery_constraints.allowed_stream_display_modes = {
+          "headless_stream", "desktop_display", "windowed_stream"
+        };
+        if (host_virtual_display_available()) {
+          recovery_constraints.allowed_stream_display_modes.push_back("host_virtual_display");
+        }
+#endif
+        const auto recovery = recovery_profile::prepare_for_optimizer(
+          platf::appdata() / "recovery_profiles.json",
+          named_cert_p->uuid,
+          *canonical_app_uuid,
+          recovery_constraints
+        );
+        if (recovery) {
+          output = recovery_profile::overlay_optimization(
+            std::move(output), *recovery
+          );
+          effective_optimization.display_mode = output.value("display_mode", std::string {});
+          effective_optimization.target_bitrate_kbps = output.value("target_bitrate_kbps", 0);
+          effective_optimization.preferred_codec = output.value("preferred_codec", std::string {});
+          effective_optimization.hdr = output.value("hdr", false);
+          effective_optimization.virtual_display = output.value("virtual_display", false);
+        }
+      }
+
       output["profile_state"] = build_optimizer_profile_state_json(
         device,
         game,
@@ -8885,6 +9020,10 @@ namespace nvhttp {
         output.value("recovery_policy", nlohmann::json::object()),
         applied_history_safe
       );
+      if (output.contains("recovery_run_id")) {
+        output["profile_state"]["recovery_run_id"] = output["recovery_run_id"];
+        output["profile_state"]["recovery_state"] = output["recovery_state"];
+      }
 
 #ifdef __linux__
       put_optimization_launch_policy(output, args, game);

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -26,11 +26,9 @@
 
 using namespace std::chrono_literals;
 
-#ifdef POLARIS_TESTS
 namespace stream_stats {
   struct stats_t;
 }
-#endif
 
 #if defined(__linux__)
 namespace proc {
@@ -388,6 +386,14 @@ namespace nvhttp {
     const bool allow_client_commands,
     const bool always_use_virtual_display
   );
+
+  /** Shared trusted evidence used by both authenticated Doctor action routes. */
+  nlohmann::json build_session_health_for_action(const stream_stats::stats_t &stats,
+                                                 bool current_virtual_display,
+                                                 const std::string &device_name,
+                                                 const std::string &app_name);
+  std::string effective_stream_display_mode_for_action(const stream_stats::stats_t &stats,
+                                                       bool current_virtual_display);
 
 #ifdef POLARIS_TESTS
   bool is_in_trusted_subnet_for_tests(const boost::asio::ip::address &addr);

--- a/src/recovery_profile.cpp
+++ b/src/recovery_profile.cpp
@@ -1,0 +1,628 @@
+/**
+ * @file src/recovery_profile.cpp
+ * @brief Durable, owner-and-game-scoped next-launch recovery profiles.
+ */
+
+#include "recovery_profile.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <mutex>
+#include <random>
+#include <string_view>
+#include <vector>
+
+#include <boost/algorithm/string/predicate.hpp>
+
+#include "private_state_file.h"
+
+using namespace std::literals;
+
+namespace recovery_profile {
+  namespace {
+    constexpr std::size_t maximum_store_bytes = 256 * 1024;
+    constexpr int schema_version = 2;
+    std::mutex store_mutex;
+
+    struct store_t {
+      std::vector<record_t> records;
+    };
+
+    bool nonblank(std::string_view value, std::size_t maximum = 256) {
+      return !value.empty() && value.size() <= maximum &&
+        std::all_of(value.begin(), value.end(), [](unsigned char byte) {
+          return byte >= 0x20 && byte != 0x7f;
+        });
+    }
+
+    bool valid_profile(const safe_profile_t &profile) {
+      const bool valid_mode =
+        profile.stream_display_mode == "headless_stream" ||
+        profile.stream_display_mode == "host_virtual_display" ||
+        profile.stream_display_mode == "gamescope_stream" ||
+        profile.stream_display_mode == "windowed_stream" ||
+        profile.stream_display_mode == "desktop_display";
+      const bool valid_codec =
+        profile.preferred_codec == "h264" ||
+        profile.preferred_codec == "hevc" ||
+        profile.preferred_codec == "av1";
+      return valid_mode && valid_codec &&
+        profile.width >= 320 && profile.width <= 16384 &&
+        profile.height >= 240 && profile.height <= 16384 &&
+        profile.target_fps >= 15 && profile.target_fps <= 240 &&
+        profile.target_bitrate_kbps >= 1000 && profile.target_bitrate_kbps <= 300000;
+    }
+
+    nlohmann::json record_json(const record_t &record) {
+      return {
+        {"run_id", record.run_id},
+        {"owner_uuid", record.owner_uuid},
+        {"app_uuid", record.app_uuid},
+        {"source_result_id", record.source_result_id},
+        {"state", record.state},
+        {"created_at", record.created_at},
+        {"expires_at", record.expires_at},
+        {"queued_launch_instance_id", record.queued_launch_instance_id},
+        {"queued_session_generation", record.queued_session_generation},
+        {"optimizer_prepared", record.optimizer_prepared},
+        {"profile", profile_json(record.profile)}
+      };
+    }
+
+    std::optional<safe_profile_t> parse_profile(const nlohmann::json &value) {
+      if (!value.is_object()) return std::nullopt;
+      safe_profile_t profile;
+      profile.stream_display_mode = value.value("stream_display_mode", std::string {});
+      profile.width = value.value("width", 0);
+      profile.height = value.value("height", 0);
+      profile.target_fps = value.value("target_fps", 0);
+      profile.target_bitrate_kbps = value.value("target_bitrate_kbps", 0);
+      profile.preferred_codec = value.value("preferred_codec", std::string {});
+      profile.hdr = value.value("hdr", false);
+      if (!valid_profile(profile)) return std::nullopt;
+      return profile;
+    }
+
+    std::optional<record_t> parse_record(const nlohmann::json &value) {
+      if (!value.is_object()) return std::nullopt;
+      record_t record;
+      record.run_id = value.value("run_id", std::string {});
+      record.owner_uuid = value.value("owner_uuid", std::string {});
+      record.app_uuid = value.value("app_uuid", std::string {});
+      record.source_result_id = value.value("source_result_id", std::string {});
+      record.state = value.value("state", std::string {});
+      record.created_at = value.value("created_at", std::int64_t {0});
+      record.expires_at = value.value("expires_at", std::int64_t {0});
+      record.queued_launch_instance_id = value.value("queued_launch_instance_id", std::string {});
+      record.queued_session_generation = value.value("queued_session_generation", std::uint64_t {0});
+      record.optimizer_prepared = value.value("optimizer_prepared", false);
+      const auto profile = parse_profile(value.value("profile", nlohmann::json::object()));
+      const bool valid_state = record.state == "queued" || record.state == "applied" || record.state == "expired";
+      if (!nonblank(record.run_id) || !nonblank(record.owner_uuid) ||
+          !nonblank(record.app_uuid) || !nonblank(record.source_result_id) ||
+          !nonblank(record.queued_launch_instance_id) || record.queued_session_generation == 0 ||
+          !valid_state || record.created_at <= 0 ||
+          record.expires_at <= record.created_at || !profile) {
+        return std::nullopt;
+      }
+      record.profile = *profile;
+      return record;
+    }
+
+    enum class load_status_e { ok, rejected, io_error };
+
+    struct load_result_t {
+      load_status_e status = load_status_e::io_error;
+      store_t store;
+    };
+
+    load_result_t load(const std::filesystem::path &path) {
+      const auto stored = private_state_file::read_secure(path, maximum_store_bytes);
+      if (stored.status == private_state_file::read_status_e::missing) {
+        return {load_status_e::ok, {}};
+      }
+      if (stored.status == private_state_file::read_status_e::rejected) {
+        return {load_status_e::rejected, {}};
+      }
+      if (stored.status != private_state_file::read_status_e::ok) {
+        return {load_status_e::io_error, {}};
+      }
+
+      try {
+        const auto root = nlohmann::json::parse(stored.payload);
+        if (!root.is_object() || root.value("version", 0) != schema_version ||
+            !root.contains("records") || !root["records"].is_array() ||
+            root["records"].size() > 1024) {
+          return {load_status_e::rejected, {}};
+        }
+        store_t result;
+        for (const auto &value : root["records"]) {
+          const auto record = parse_record(value);
+          if (!record) return {load_status_e::rejected, {}};
+          const auto duplicate = std::find_if(result.records.begin(), result.records.end(), [&](const record_t &existing) {
+            return existing.run_id == record->run_id ||
+              (existing.owner_uuid == record->owner_uuid && existing.app_uuid == record->app_uuid);
+          });
+          if (duplicate != result.records.end()) return {load_status_e::rejected, {}};
+          result.records.push_back(*record);
+        }
+        return {load_status_e::ok, std::move(result)};
+      } catch (...) {
+        return {load_status_e::rejected, {}};
+      }
+    }
+
+    bool persist(const std::filesystem::path &path, const store_t &store) {
+      nlohmann::json root;
+      root["version"] = schema_version;
+      root["records"] = nlohmann::json::array();
+      for (const auto &record : store.records) {
+        root["records"].push_back(record_json(record));
+      }
+      return static_cast<bool>(private_state_file::write_atomic(path, root.dump()));
+    }
+
+    bool expire_and_prune(store_t &store, std::int64_t now) {
+      bool changed = false;
+      for (auto &record : store.records) {
+        if (record.state == "queued" && now >= record.expires_at) {
+          record.state = "expired";
+          changed = true;
+        }
+      }
+      const auto old_size = store.records.size();
+      std::erase_if(store.records, [now](const record_t &record) {
+        // Terminal receipts remain for one additional day so a reconnect can
+        // reconstruct applied/expired state without keeping unbounded history.
+        return record.state != "queued" && now >= record.expires_at + lifetime_seconds;
+      });
+      return changed || old_size != store.records.size();
+    }
+
+    bool contains(const std::vector<std::string> &values, const std::string &candidate) {
+      return std::find(values.begin(), values.end(), candidate) != values.end();
+    }
+
+    std::optional<std::string> safest_allowed_mode(const std::vector<std::string> &allowed) {
+      for (const auto candidate : {
+             "headless_stream"sv,
+             "host_virtual_display"sv,
+             "gamescope_stream"sv,
+             "windowed_stream"sv,
+             "desktop_display"sv,
+           }) {
+        if (contains(allowed, std::string {candidate})) return std::string {candidate};
+      }
+      return std::nullopt;
+    }
+
+    std::string next_run_id() {
+      std::array<unsigned char, 16> bytes {};
+      std::random_device random;
+      for (auto &byte : bytes) byte = static_cast<unsigned char>(random());
+      constexpr char hex[] = "0123456789abcdef";
+      std::string id = "recovery-run-";
+      id.reserve(id.size() + bytes.size() * 2);
+      for (const auto byte : bytes) {
+        id.push_back(hex[(byte >> 4) & 0x0f]);
+        id.push_back(hex[byte & 0x0f]);
+      }
+      return id;
+    }
+
+    nlohmann::json unavailable(load_status_e status) {
+      return {
+        {"status", false},
+        {"changed", false},
+        {"state", "rejected"},
+        {"error", status == load_status_e::rejected ?
+          "Recovery profile state failed secure validation." :
+          "Recovery profile state is unavailable."}
+      };
+    }
+
+    auto find_key(store_t &store, const std::string &owner_uuid, const std::string &app_uuid) {
+      return std::find_if(store.records.begin(), store.records.end(), [&](const record_t &record) {
+        return record.owner_uuid == owner_uuid && record.app_uuid == app_uuid;
+      });
+    }
+
+    auto find_run(store_t &store,
+                  const std::string &run_id,
+                  const std::optional<std::string> &owner_scope) {
+      return std::find_if(store.records.begin(), store.records.end(), [&](const record_t &record) {
+        return record.run_id == run_id &&
+          (!owner_scope || record.owner_uuid == *owner_scope);
+      });
+    }
+
+    bool launch_matches(const record_t &record,
+                        const observed_launch_t &observed,
+                        nlohmann::json &mismatches) {
+      const auto &profile = record.profile;
+      const auto mismatch = [&mismatches](std::string_view field) {
+        mismatches.push_back(field);
+      };
+      if (!observed.streaming) mismatch("streaming");
+      if (observed.owner_uuid != record.owner_uuid) mismatch("owner");
+      if (observed.app_uuid != record.app_uuid) mismatch("app");
+      if (observed.stream_display_mode != profile.stream_display_mode) mismatch("stream_display_mode");
+      if (observed.width != profile.width || observed.height != profile.height) mismatch("resolution");
+      if (observed.target_fps != profile.target_fps) mismatch("target_fps");
+      if (observed.bitrate_kbps != profile.target_bitrate_kbps) mismatch("target_bitrate_kbps");
+      if (observed.codec != profile.preferred_codec) mismatch("preferred_codec");
+      if (observed.hdr != profile.hdr) mismatch("hdr");
+      if (observed.launch_instance_id.empty() ||
+          observed.launch_instance_id == record.queued_launch_instance_id) {
+        mismatch("fresh_launch");
+      }
+      if (observed.session_generation == 0) mismatch("session_generation");
+      return mismatches.empty();
+    }
+  }  // namespace
+
+  std::int64_t now_epoch_seconds() {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::system_clock::now().time_since_epoch()
+    ).count();
+  }
+
+  std::optional<std::string> resolve_canonical_app_uuid(
+    std::string_view query,
+    const std::vector<app_identity_t> &apps
+  ) {
+    if (query.empty()) return std::nullopt;
+    const auto unique_match = [&](const auto &member) -> std::optional<std::string> {
+      std::optional<std::string> result;
+      for (const auto &app : apps) {
+        const auto &candidate = app.*member;
+        if (candidate.empty() || !boost::iequals(candidate, query)) continue;
+        if (result) return std::nullopt;
+        result = app.uuid;
+      }
+      return result;
+    };
+    if (const auto uuid = unique_match(&app_identity_t::uuid)) return uuid;
+    if (const auto id = unique_match(&app_identity_t::id)) return id;
+    return unique_match(&app_identity_t::name);
+  }
+
+  nlohmann::json profile_json(const safe_profile_t &profile) {
+    return {
+      {"stream_display_mode", profile.stream_display_mode},
+      {"width", profile.width},
+      {"height", profile.height},
+      {"target_fps", profile.target_fps},
+      {"target_bitrate_kbps", profile.target_bitrate_kbps},
+      {"preferred_codec", profile.preferred_codec},
+      {"hdr", profile.hdr},
+      {"preserve_paired_resolution", true},
+      {"requires_fresh_launch", true}
+    };
+  }
+
+  nlohmann::json receipt_json(const record_t &record) {
+    return {
+      {"status", true},
+      {"changed", false},
+      {"state", record.state},
+      {"recovery_state", record.state},
+      {"run_id", record.run_id},
+      {"source_result_id", record.source_result_id},
+      {"app_uuid", record.app_uuid},
+      {"expires_at", record.expires_at},
+      {"safe_profile", profile_json(record.profile)},
+      {"undo", {
+        {"supported", record.state == "queued"},
+        {"available", record.state == "queued"},
+        {"action_id", "undo"},
+        {"run_id", record.run_id},
+        {"endpoint", "/api/doctor/action"},
+        {"paired_endpoint", "/polaris/v1/doctor/action"}
+      }}
+    };
+  }
+
+  nlohmann::json overlay_optimization(nlohmann::json normalized,
+                                      const record_t &record) {
+    if (record.state != "queued" || !record.optimizer_prepared ||
+        !valid_profile(record.profile)) return normalized;
+
+    const auto &effective_profile = record.profile;
+    const auto display_mode =
+      std::to_string(effective_profile.width) + "x" +
+      std::to_string(effective_profile.height) + "x" +
+      std::to_string(effective_profile.target_fps);
+
+    normalized["display_mode"] = display_mode;
+    normalized["target_bitrate_kbps"] = effective_profile.target_bitrate_kbps;
+    normalized["preferred_codec"] = effective_profile.preferred_codec;
+    normalized["hdr"] = effective_profile.hdr;
+    normalized["virtual_display"] = effective_profile.stream_display_mode == "host_virtual_display";
+    normalized["stream_display_mode"] = effective_profile.stream_display_mode;
+    normalized["requires_fresh_launch"] = true;
+    normalized["recovery_run_id"] = record.run_id;
+    normalized["recovery_state"] = record.state;
+    normalized["recovery_profile"] = profile_json(effective_profile);
+    normalized["auto_action"] = "apply_recovery";
+
+    if (!normalized.contains("stability") || !normalized["stability"].is_object()) {
+      normalized["stability"] = nlohmann::json::object();
+    }
+    normalized["stability"]["relaunch_required"] = true;
+    normalized["stability"]["auto_action"] = "apply_recovery";
+    normalized["stability"]["safe_profile"] = normalized["recovery_profile"];
+    if (!normalized.contains("recovery_policy") || !normalized["recovery_policy"].is_object()) {
+      normalized["recovery_policy"] = nlohmann::json::object();
+    }
+    normalized["recovery_policy"]["state"] = "recovery_queued";
+    normalized["recovery_policy"]["relaunch_required"] = true;
+    return normalized;
+  }
+
+  nlohmann::json queue(const std::filesystem::path &path,
+                       const std::string &owner_uuid,
+                       const std::string &app_uuid,
+                       const std::string &source_result_id,
+                       const safe_profile_t &profile,
+                       const std::string &current_launch_instance_id,
+                       std::uint64_t current_session_generation,
+                       std::int64_t now) {
+    if (!nonblank(owner_uuid) || !nonblank(app_uuid) ||
+        !nonblank(source_result_id) || !valid_profile(profile) ||
+        !nonblank(current_launch_instance_id) || current_session_generation == 0 || now <= 0) {
+      return {{"status", false}, {"changed", false}, {"state", "rejected"},
+              {"error", "Current Doctor evidence cannot produce a safe next-launch profile."}};
+    }
+    std::lock_guard<std::mutex> lock(store_mutex);
+    auto loaded = load(path);
+    if (loaded.status != load_status_e::ok) return unavailable(loaded.status);
+    const bool expired_records_changed = expire_and_prune(loaded.store, now);
+
+    auto existing = find_key(loaded.store, owner_uuid, app_uuid);
+    if (existing != loaded.store.records.end() && existing->state == "queued" &&
+        existing->source_result_id == source_result_id) {
+      auto receipt = receipt_json(*existing);
+      receipt["state"] = "queued";
+      receipt["recovery_state"] = "queued";
+      receipt["idempotent"] = true;
+      if (expired_records_changed && !persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+      return receipt;
+    }
+
+    record_t record;
+    record.run_id = next_run_id();
+    record.owner_uuid = owner_uuid;
+    record.app_uuid = app_uuid;
+    record.source_result_id = source_result_id;
+    record.state = "queued";
+    record.created_at = now;
+    record.expires_at = now + lifetime_seconds;
+    record.queued_launch_instance_id = current_launch_instance_id;
+    record.queued_session_generation = current_session_generation;
+    record.optimizer_prepared = false;
+    record.profile = profile;
+    if (existing == loaded.store.records.end()) {
+      loaded.store.records.push_back(record);
+    } else {
+      *existing = record;
+    }
+    if (!persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+    auto receipt = receipt_json(record);
+    receipt["changed"] = true;
+    receipt["idempotent"] = false;
+    return receipt;
+  }
+
+  nlohmann::json status(const std::filesystem::path &path,
+                        const std::string &owner_uuid,
+                        const std::string &app_uuid,
+                        std::int64_t now) {
+    if (owner_uuid.empty() || app_uuid.empty()) {
+      return {{"status", true}, {"changed", false}, {"state", "none"}, {"recovery_state", "none"}};
+    }
+    std::lock_guard<std::mutex> lock(store_mutex);
+    auto loaded = load(path);
+    if (loaded.status != load_status_e::ok) return unavailable(loaded.status);
+    const bool changed = expire_and_prune(loaded.store, now);
+    if (changed && !persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+    const auto record = find_key(loaded.store, owner_uuid, app_uuid);
+    if (record == loaded.store.records.end()) {
+      return {{"status", true}, {"changed", false}, {"state", "none"}, {"recovery_state", "none"}};
+    }
+    return receipt_json(*record);
+  }
+
+  std::optional<record_t> queued(const std::filesystem::path &path,
+                                 const std::string &owner_uuid,
+                                 const std::string &app_uuid,
+                                 std::int64_t now) {
+    if (owner_uuid.empty() || app_uuid.empty()) return std::nullopt;
+    std::lock_guard<std::mutex> lock(store_mutex);
+    auto loaded = load(path);
+    if (loaded.status != load_status_e::ok) return std::nullopt;
+    const bool changed = expire_and_prune(loaded.store, now);
+    if (changed && !persist(path, loaded.store)) return std::nullopt;
+    const auto record = find_key(loaded.store, owner_uuid, app_uuid);
+    if (record == loaded.store.records.end() || record->state != "queued") return std::nullopt;
+    return *record;
+  }
+
+  std::optional<record_t> prepare_for_optimizer(const std::filesystem::path &path,
+                                                const std::string &owner_uuid,
+                                                const std::string &app_uuid,
+                                                const optimizer_constraints_t &constraints,
+                                                std::int64_t now) {
+    if (owner_uuid.empty() || app_uuid.empty()) return std::nullopt;
+    std::lock_guard<std::mutex> lock(store_mutex);
+    auto loaded = load(path);
+    if (loaded.status != load_status_e::ok) return std::nullopt;
+    bool changed = expire_and_prune(loaded.store, now);
+    const auto record = find_key(loaded.store, owner_uuid, app_uuid);
+    if (record == loaded.store.records.end() || record->state != "queued") {
+      if (changed && !persist(path, loaded.store)) return std::nullopt;
+      return std::nullopt;
+    }
+
+    const bool valid_paired_resolution =
+      constraints.paired_width >= 320 && constraints.paired_width <= 16384 &&
+      constraints.paired_height >= 240 && constraints.paired_height <= 16384;
+    if (valid_paired_resolution &&
+        (record->profile.width != constraints.paired_width ||
+         record->profile.height != constraints.paired_height)) {
+      record->profile.width = constraints.paired_width;
+      record->profile.height = constraints.paired_height;
+      changed = true;
+    }
+
+    if (!contains(constraints.supported_codecs, "h264") ||
+        constraints.allowed_stream_display_modes.empty()) {
+      if (changed && !persist(path, loaded.store)) return std::nullopt;
+      return std::nullopt;
+    }
+    if (!contains(constraints.supported_codecs, record->profile.preferred_codec)) {
+      record->profile.preferred_codec =
+        record->profile.hdr && contains(constraints.supported_codecs, "hevc") ? "hevc" : "h264";
+      changed = true;
+    }
+    if (record->profile.hdr &&
+        (!constraints.hdr_supported || record->profile.preferred_codec == "h264")) {
+      record->profile.hdr = false;
+      changed = true;
+    }
+    if (!contains(constraints.allowed_stream_display_modes, record->profile.stream_display_mode)) {
+      const auto fallback_mode = safest_allowed_mode(constraints.allowed_stream_display_modes);
+      if (!fallback_mode) {
+        if (changed && !persist(path, loaded.store)) return std::nullopt;
+        return std::nullopt;
+      }
+      record->profile.stream_display_mode = *fallback_mode;
+      changed = true;
+    }
+    if (!record->optimizer_prepared) {
+      record->optimizer_prepared = true;
+      changed = true;
+    }
+    if (changed && !persist(path, loaded.store)) return std::nullopt;
+    return *record;
+  }
+
+  nlohmann::json statuses_for_owner(const std::filesystem::path &path,
+                                    const std::string &owner_uuid,
+                                    std::int64_t now) {
+    auto receipts = nlohmann::json::array();
+    if (owner_uuid.empty()) return receipts;
+    std::lock_guard<std::mutex> lock(store_mutex);
+    auto loaded = load(path);
+    if (loaded.status != load_status_e::ok) return receipts;
+    const bool changed = expire_and_prune(loaded.store, now);
+    if (changed && !persist(path, loaded.store)) return nlohmann::json::array();
+    for (const auto &record : loaded.store.records) {
+      if (record.owner_uuid == owner_uuid) receipts.push_back(receipt_json(record));
+    }
+    return receipts;
+  }
+
+  nlohmann::json undo(const std::filesystem::path &path,
+                      const std::string &owner_uuid,
+                      const std::string &app_uuid,
+                      const std::string &run_id,
+                      std::int64_t now) {
+    std::lock_guard<std::mutex> lock(store_mutex);
+    auto loaded = load(path);
+    if (loaded.status != load_status_e::ok) return unavailable(loaded.status);
+    const bool expired_records_changed = expire_and_prune(loaded.store, now);
+    const auto record = find_key(loaded.store, owner_uuid, app_uuid);
+    if (record == loaded.store.records.end() || record->run_id != run_id || record->state != "queued") {
+      if (expired_records_changed && !persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+      return {{"status", false}, {"changed", false}, {"state", "rejected"},
+              {"error", "This queued recovery profile is no longer available to undo."}};
+    }
+    loaded.store.records.erase(record);
+    if (!persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+    return {{"status", true}, {"changed", true}, {"state", "undone"},
+            {"recovery_state", "undone"}, {"run_id", run_id}, {"app_uuid", app_uuid},
+            {"undo", {{"supported", false}, {"available", false}}}};
+  }
+
+  nlohmann::json undo_run(const std::filesystem::path &path,
+                          const std::string &run_id,
+                          const std::optional<std::string> &owner_scope,
+                          std::int64_t now) {
+    if (!nonblank(run_id) || (owner_scope && !nonblank(*owner_scope))) {
+      return {{"status", false}, {"changed", false}, {"state", "rejected"},
+              {"error", "A valid queued recovery run is required for Undo."}};
+    }
+    std::lock_guard<std::mutex> lock(store_mutex);
+    auto loaded = load(path);
+    if (loaded.status != load_status_e::ok) return unavailable(loaded.status);
+    const bool expired_records_changed = expire_and_prune(loaded.store, now);
+    const auto record = find_run(loaded.store, run_id, owner_scope);
+    if (record == loaded.store.records.end() || record->state != "queued") {
+      if (expired_records_changed && !persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+      return {{"status", false}, {"changed", false}, {"state", "rejected"},
+              {"error", "This queued recovery profile is no longer available to undo."}};
+    }
+    const auto app_uuid = record->app_uuid;
+    loaded.store.records.erase(record);
+    if (!persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+    return {{"status", true}, {"changed", true}, {"state", "undone"},
+            {"recovery_state", "undone"}, {"run_id", run_id}, {"app_uuid", app_uuid},
+            {"undo", {{"supported", false}, {"available", false}}}};
+  }
+
+  nlohmann::json verify(const std::filesystem::path &path,
+                        const std::string &owner_uuid,
+                        const std::string &app_uuid,
+                        const std::string &run_id,
+                        const observed_launch_t &observed,
+                        std::int64_t now) {
+    std::lock_guard<std::mutex> lock(store_mutex);
+    auto loaded = load(path);
+    if (loaded.status != load_status_e::ok) return unavailable(loaded.status);
+    const bool changed = expire_and_prune(loaded.store, now);
+    auto record = find_key(loaded.store, owner_uuid, app_uuid);
+    if (record == loaded.store.records.end() || record->run_id != run_id) {
+      if (changed && !persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+      return {{"status", false}, {"changed", false}, {"state", "expired"},
+              {"recovery_state", "expired"}, {"error", "Recovery run not found or expired."}};
+    }
+    if (record->state == "applied") {
+      if (changed && !persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+      auto receipt = receipt_json(*record);
+      receipt["idempotent"] = true;
+      return receipt;
+    }
+    if (record->state == "expired") {
+      if (changed && !persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+      auto receipt = receipt_json(*record);
+      receipt["status"] = false;
+      receipt["changed"] = false;
+      receipt["idempotent"] = true;
+      receipt["error"] = "Recovery run expired before a matching launch was verified.";
+      return receipt;
+    }
+
+    auto mismatches = nlohmann::json::array();
+    if (!launch_matches(*record, observed, mismatches)) {
+      if (changed && !persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+      auto receipt = receipt_json(*record);
+      receipt["status"] = false;
+      receipt["changed"] = false;
+      receipt["state"] = "rejected";
+      receipt["recovery_state"] = "queued";
+      receipt["mismatches"] = std::move(mismatches);
+      receipt["error"] = "The connected stream does not match the queued recovery profile; it remains queued.";
+      return receipt;
+    }
+
+    record->state = "applied";
+    if (!persist(path, loaded.store)) return unavailable(load_status_e::io_error);
+    auto receipt = receipt_json(*record);
+    receipt["changed"] = true;
+    receipt["idempotent"] = false;
+    return receipt;
+  }
+}  // namespace recovery_profile

--- a/src/recovery_profile.cpp
+++ b/src/recovery_profile.cpp
@@ -382,11 +382,10 @@ namespace recovery_profile {
     const bool expired_records_changed = expire_and_prune(loaded.store, now);
 
     auto existing = find_key(loaded.store, owner_uuid, app_uuid);
-    if (existing != loaded.store.records.end() && existing->state == "queued" &&
+    if (existing != loaded.store.records.end() &&
+        (existing->state == "queued" || existing->state == "applied") &&
         existing->source_result_id == source_result_id) {
       auto receipt = receipt_json(*existing);
-      receipt["state"] = "queued";
-      receipt["recovery_state"] = "queued";
       receipt["idempotent"] = true;
       if (expired_records_changed && !persist(path, loaded.store)) return unavailable(load_status_e::io_error);
       return receipt;

--- a/src/recovery_profile.h
+++ b/src/recovery_profile.h
@@ -1,0 +1,146 @@
+/**
+ * @file src/recovery_profile.h
+ * @brief Durable, owner-and-game-scoped next-launch recovery profiles.
+ */
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace recovery_profile {
+  inline constexpr std::int64_t lifetime_seconds = 24 * 60 * 60;
+
+  struct safe_profile_t {
+    std::string stream_display_mode;
+    int width = 0;
+    int height = 0;
+    int target_fps = 0;
+    int target_bitrate_kbps = 0;
+    std::string preferred_codec;
+    bool hdr = false;
+  };
+
+  struct record_t {
+    std::string run_id;
+    std::string owner_uuid;
+    std::string app_uuid;
+    std::string source_result_id;
+    std::string state;
+    std::int64_t created_at = 0;
+    std::int64_t expires_at = 0;
+    std::string queued_launch_instance_id;
+    std::uint64_t queued_session_generation = 0;
+    bool optimizer_prepared = false;
+    safe_profile_t profile;
+  };
+
+  struct observed_launch_t {
+    bool streaming = false;
+    std::string owner_uuid;
+    std::string app_uuid;
+    std::string stream_display_mode;
+    int width = 0;
+    int height = 0;
+    int target_fps = 0;
+    int bitrate_kbps = 0;
+    std::string codec;
+    bool hdr = false;
+    std::string launch_instance_id;
+    std::uint64_t session_generation = 0;
+  };
+
+  struct optimizer_constraints_t {
+    int paired_width = 0;
+    int paired_height = 0;
+    std::vector<std::string> supported_codecs;
+    bool hdr_supported = false;
+    std::vector<std::string> allowed_stream_display_modes;
+  };
+
+  struct app_identity_t {
+    std::string uuid;
+    std::string id;
+    std::string name;
+  };
+
+  /** Prefer exact UUID/id; accept a display name only when it is unambiguous. */
+  std::optional<std::string> resolve_canonical_app_uuid(
+    std::string_view query,
+    const std::vector<app_identity_t> &apps
+  );
+
+  std::int64_t now_epoch_seconds();
+
+  /** Queue a host-derived profile. Same key + result id is idempotent. */
+  nlohmann::json queue(const std::filesystem::path &path,
+                       const std::string &owner_uuid,
+                       const std::string &app_uuid,
+                       const std::string &source_result_id,
+                       const safe_profile_t &profile,
+                       const std::string &current_launch_instance_id,
+                       std::uint64_t current_session_generation,
+                       std::int64_t now = now_epoch_seconds());
+
+  /** Return only the matching owner's matching game's record. */
+  nlohmann::json status(const std::filesystem::path &path,
+                        const std::string &owner_uuid,
+                        const std::string &app_uuid,
+                        std::int64_t now = now_epoch_seconds());
+
+  /** Read a queued record without consuming it (optimizer previews use this). */
+  std::optional<record_t> queued(const std::filesystem::path &path,
+                                 const std::string &owner_uuid,
+                                 const std::string &app_uuid,
+                                 std::int64_t now = now_epoch_seconds());
+
+  /**
+   * Read a queued record for optimizer launch preflight and atomically bind
+   * its resolution to the authenticated paired client's preserved mode.
+   */
+  std::optional<record_t> prepare_for_optimizer(const std::filesystem::path &path,
+                                                const std::string &owner_uuid,
+                                                const std::string &app_uuid,
+                                                const optimizer_constraints_t &constraints,
+                                                std::int64_t now = now_epoch_seconds());
+
+  /** Return terminal and queued receipts visible to only one paired owner. */
+  nlohmann::json statuses_for_owner(const std::filesystem::path &path,
+                                    const std::string &owner_uuid,
+                                    std::int64_t now = now_epoch_seconds());
+
+  /** Remove only the exact matching unconsumed record. */
+  nlohmann::json undo(const std::filesystem::path &path,
+                      const std::string &owner_uuid,
+                      const std::string &app_uuid,
+                      const std::string &run_id,
+                      std::int64_t now = now_epoch_seconds());
+
+  /**
+   * Remove an exact queued run. Paired routes provide owner_scope; the
+   * authenticated host route may omit it while still requiring the run id.
+   */
+  nlohmann::json undo_run(const std::filesystem::path &path,
+                          const std::string &run_id,
+                          const std::optional<std::string> &owner_scope,
+                          std::int64_t now = now_epoch_seconds());
+
+  /** Consume exactly once after a trusted host-side effective-settings match. */
+  nlohmann::json verify(const std::filesystem::path &path,
+                        const std::string &owner_uuid,
+                        const std::string &app_uuid,
+                        const std::string &run_id,
+                        const observed_launch_t &observed,
+                        std::int64_t now = now_epoch_seconds());
+
+  nlohmann::json profile_json(const safe_profile_t &profile);
+  nlohmann::json receipt_json(const record_t &record);
+
+  /** Overlay a queued profile after ordinary optimizer normalization. */
+  nlohmann::json overlay_optimization(nlohmann::json normalized,
+                                      const record_t &record);
+}  // namespace recovery_profile

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -8,6 +8,7 @@
 // standard includes
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cmath>
 #include <filesystem>
 #include <mutex>
@@ -19,8 +20,10 @@
 // local includes
 #include "adaptive_bitrate.h"
 #include "config.h"
+#include "crypto.h"
 #include "logging.h"
 #include "stream_stats.h"
+#include "utility.h"
 #include "verified_action.h"
 #ifdef __linux__
   #include "platform/linux/stream_runtime.h"
@@ -109,6 +112,42 @@ namespace stream_stats {
         case 2: return "av1";
         default: return {};
       }
+    }
+
+    std::string doctor_codec_family(std::string codec) {
+      std::transform(codec.begin(), codec.end(), codec.begin(), [](unsigned char byte) {
+        return static_cast<char>(std::tolower(byte));
+      });
+      if (codec.find("av1") != std::string::npos) return "av1";
+      if (codec.find("hevc") != std::string::npos || codec.find("h265") != std::string::npos ||
+          codec.find("h.265") != std::string::npos) return "hevc";
+      if (codec.find("h264") != std::string::npos || codec.find("h.264") != std::string::npos ||
+          codec.find("avc") != std::string::npos) return "h264";
+      return {};
+    }
+
+    std::string recovery_evidence_result_id(std::string base,
+                                            const stats_t &stats,
+                                            const nlohmann::json &health,
+                                            std::string_view app_uuid,
+                                            double target_fps,
+                                            int live_bitrate_kbps) {
+      if (!health.value("relaunch_recommended", false)) return base;
+
+      auto codec = health.value("safe_codec", doctor_codec_family(stats.codec));
+      if (codec.empty()) codec = "h264";
+      const nlohmann::json evidence = {
+        {"app_uuid", app_uuid},
+        {"stream_display_mode", health.value("safe_display_mode", std::string {})},
+        {"width", stats.width},
+        {"height", stats.height},
+        {"target_fps", health.value("safe_target_fps", static_cast<int>(std::round(target_fps)))},
+        {"target_bitrate_kbps", health.value("safe_bitrate_kbps", live_bitrate_kbps)},
+        {"preferred_codec", codec},
+        {"hdr", health.value("safe_hdr", false)}
+      };
+      const auto fingerprint = util::hex(crypto::hash(evidence.dump())).to_string();
+      return base + "-" + fingerprint.substr(0, 32);
     }
 
     void reset_hot_fields() {
@@ -1219,7 +1258,14 @@ namespace stream_stats {
 
     nlohmann::json doctor;
     doctor["version"] = 2;
-    doctor["result_id"] = "doctor-v2-" + status + "-" + primary_issue + "-" + capture_reason;
+    doctor["result_id"] = recovery_evidence_result_id(
+      "doctor-v2-" + status + "-" + primary_issue + "-" + capture_reason,
+      stats,
+      health,
+      app_uuid,
+      target_fps,
+      live_bitrate_kbps
+    );
     doctor["scope"] = "stream";
     doctor["status"] = status;
     doctor["traffic_light"] = traffic;

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -843,7 +843,8 @@ namespace stream_stats {
                                       int current_bitrate_kbps,
                                       int paired_target_bitrate_kbps,
                                       bool live_bitrate_tunable,
-                                      const std::string &source_result_id) {
+                                      const std::string &source_result_id,
+                                      std::string_view app_uuid) {
       std::string id = "none";
       std::string label = "No automatic action";
       std::string kind = "none";
@@ -934,15 +935,23 @@ namespace stream_stats {
         id = "apply_recovery_profile_next_launch";
         label = "Use safer next launch";
         kind = "next_launch_profile";
-        rollback = "Restore the previous display, HDR, codec, FPS, or bitrate settings before launching again.";
-        if (health.contains("safe_display_mode")) payload["display_mode"] = health["safe_display_mode"];
-        if (health.contains("safe_bitrate_kbps")) payload["target_bitrate_kbps"] = health["safe_bitrate_kbps"];
-        if (health.contains("safe_target_fps")) payload["target_fps"] = health["safe_target_fps"];
-        if (health.contains("safe_codec")) payload["preferred_codec"] = health["safe_codec"];
-        if (health.contains("safe_hdr")) payload["hdr"] = health["safe_hdr"];
+        endpoint = "/api/doctor/action";
+        method = "POST";
+        payload["action_id"] = id;
+        payload["source_result_id"] = source_result_id;
+        if (!app_uuid.empty()) payload["app_uuid"] = app_uuid;
+        rollback = "Undo cancels only the queued, unconsumed next-launch profile. The current stream and saved host settings remain unchanged.";
+        verification = {
+          {"mode", "post_connect"},
+          {"delay_seconds", 0},
+          {"action_id", "verify_recovery_profile_next_launch"},
+          {"endpoint", "/polaris/v1/doctor/action"},
+          {"success_when", nlohmann::json::array({"matching owner and game are connected", "effective topology, resolution, FPS, bitrate, codec, and HDR match the queued safe profile"})}
+        };
       }
 
-      const bool undoable = id == "lower_bitrate" || id == "restore_quality";
+      const bool undoable = id == "lower_bitrate" || id == "restore_quality" ||
+        id == "apply_recovery_profile_next_launch";
 
       return {
         {"id", id},
@@ -958,12 +967,17 @@ namespace stream_stats {
         {"payload_preview", payload},
         {"rollback", rollback},
         {"verification", verification},
-        {"undo", {{"supported", undoable}, {"endpoint", undoable ? "/api/doctor/action" : ""}}}
+        {"paired_endpoint", id == "apply_recovery_profile_next_launch" ? "/polaris/v1/doctor/action" : ""},
+        {"owner_tuning_allowed", id == "apply_recovery_profile_next_launch"},
+        {"undo", {{"supported", undoable}, {"endpoint", undoable ? "/api/doctor/action" : ""},
+          {"paired_endpoint", id == "apply_recovery_profile_next_launch" ? "/polaris/v1/doctor/action" : ""}}}
       };
     }
   }  // namespace
 
-  nlohmann::json build_doctor_json(const stats_t &stats, const nlohmann::json &health) {
+  nlohmann::json build_doctor_json(const stats_t &stats,
+                                   const nlohmann::json &health,
+                                   std::string_view app_uuid) {
     const auto capture_reason = capture_path_reason(stats);
     const auto capture_path = capture_path_summary(stats);
     const bool capture_cpu_copy = capture_path_uses_cpu_copy(stats);
@@ -1224,7 +1238,8 @@ namespace stream_stats {
       live_bitrate_kbps,
       stats.paired_target_bitrate_kbps,
       stats.adaptive_runtime_update_supported,
-      doctor["result_id"].get<std::string>()
+      doctor["result_id"].get<std::string>(),
+      app_uuid
     );
     doctor["suppressed_findings"] = nlohmann::json::array();
     if (suppressed_stale_network_finding) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -248,7 +248,9 @@ namespace stream_stats {
    * @param stats Current stream statistics snapshot.
    * @param health Existing deterministic health JSON, when available.
    */
-  nlohmann::json build_doctor_json(const stats_t &stats, const nlohmann::json &health);
+  nlohmann::json build_doctor_json(const stats_t &stats,
+                                   const nlohmann::json &health,
+                                   std::string_view app_uuid = {});
 
   /**
    * @brief Effective dynamic range mode Polaris is advertising for the stream.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/file_handler.cpp
     ${CMAKE_SOURCE_DIR}/src/log_tail_api.cpp
     ${CMAKE_SOURCE_DIR}/src/private_state_file.cpp
+    ${CMAKE_SOURCE_DIR}/src/recovery_profile.cpp
     ${CMAKE_SOURCE_DIR}/src/web_session_store.cpp
     ${CMAKE_SOURCE_DIR}/src/beat_times.cpp
     ${CMAKE_SOURCE_DIR}/src/display_planner.cpp
@@ -115,6 +116,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_file_handler.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_log_tail_api.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_private_state_file.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_recovery_profile.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_verified_action.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_web_session_store.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_beat_times.cpp
@@ -225,6 +227,7 @@ set(TEST_STREAM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_ai_optimizer.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_stream.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_stream_display_policy.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_recovery_doctor_actions.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_stream_stats.cpp
 )
 

--- a/tests/unit/test_ai_optimizer.cpp
+++ b/tests/unit/test_ai_optimizer.cpp
@@ -835,6 +835,27 @@ TEST(AiOptimizerDoctorExplanation, DisabledConfigFallsBackToDeterministicEvidenc
   EXPECT_FALSE(result.at("explanation").value("destructive_action_allowed", true));
 }
 
+TEST(AiOptimizerDoctorExplanation, OpenAiSubscriptionUsesCleanExpectedDeterministicFallback) {
+  ai_optimizer::config_t config;
+  config.enabled = true;
+  config.provider = "openai";
+  config.model = "gpt-5";
+  config.auth_mode = "subscription";
+
+  const auto result = nlohmann::json::parse(ai_optimizer::explain_doctor_json_with_config(config, R"({
+    "doctor":{"simple_state":"Frame pacing","primary_issue":"frame_pacing"}
+  })"));
+
+  EXPECT_TRUE(result.value("status", false));
+  EXPECT_TRUE(result.value("fallback", false));
+  EXPECT_TRUE(result.value("provider_error", "not-empty").empty());
+  EXPECT_EQ("deterministic-fallback", result.at("source").value("kind", ""));
+  EXPECT_EQ("openai-subscription", result.at("source").value("mode", ""));
+  EXPECT_TRUE(result.at("source").value("informational", false));
+  EXPECT_EQ("deterministic-fallback", result.at("explanation").value("confidence", ""));
+  EXPECT_EQ("Frame pacing", result.at("explanation").value("likely_cause", ""));
+}
+
 TEST(AiOptimizerModeAwareCache, LegacyRequestsKeepTheirBucketAndModesGetTheirOwn) {
   const auto legacy = ai_optimizer::cache_key_for_tests(
     "anthropic", "model", "url", "RetroidPocket6", "Control Ultimate Edition", "");

--- a/tests/unit/test_recovery_doctor_actions.cpp
+++ b/tests/unit/test_recovery_doctor_actions.cpp
@@ -211,9 +211,25 @@ TEST_F(RecoveryDoctorActionTest, UndoCancelsOnlyTheMatchingQueuedRun) {
     context.state_path, context.owner_uuid, context.app_uuid
   ));
 
-  context.stats.streaming = false;
-  context.host_tuning_allowed = false;
-  context.app_uuid.clear();
+  auto other_owner = context;
+  other_owner.active_owner = false;
+  other_owner.caller_is_viewer = true;
+  other_owner.owner_uuid = "client-b";
+  const auto cross_owner = doctor_actions::execute({
+    {"action_id", "undo"}, {"run_id", run_id}
+  }, other_owner);
+  EXPECT_FALSE(cross_owner.value("status", true));
+  EXPECT_TRUE(recovery_profile::queued(
+    context.state_path, context.owner_uuid, context.app_uuid
+  ));
+
+  // The queued owner may be disconnected while another paired client owns the
+  // live stream. Exact owner scoping still lets A cancel only A's record.
+  context.active_owner = false;
+  context.caller_is_viewer = true;
+  context.stats.streaming = true;
+  context.host_tuning_allowed = true;
+  context.app_uuid = "game-b";
   const auto undone = doctor_actions::execute({
     {"action_id", "undo"}, {"run_id", run_id}
   }, context);

--- a/tests/unit/test_recovery_doctor_actions.cpp
+++ b/tests/unit/test_recovery_doctor_actions.cpp
@@ -1,0 +1,237 @@
+/**
+ * @file tests/unit/test_recovery_doctor_actions.cpp
+ * @brief Trusted Doctor execution tests for next-launch recovery profiles.
+ */
+#include "../tests_common.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+
+#include <src/doctor_actions.h>
+#include <src/recovery_profile.h>
+
+namespace {
+  std::atomic_uint64_t recovery_action_counter {0};
+
+  class RecoveryDoctorActionTest: public testing::Test {
+  protected:
+    void SetUp() override {
+      const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+      directory = std::filesystem::temp_directory_path() /
+        ("polaris-recovery-doctor-" + std::to_string(nonce) + "-" +
+         std::to_string(recovery_action_counter.fetch_add(1)));
+      std::filesystem::create_directories(directory);
+
+      context.active_owner = true;
+      context.host_tuning_allowed = true;
+      context.owner_uuid = "client-a";
+      context.device_name = "RetroidPocket6";
+      context.app_uuid = "game-a";
+      context.app_name = "Control Ultimate Edition";
+      context.launch_instance_id = "launch-a";
+      context.session_generation = 1;
+      context.effective_stream_display_mode = "host_virtual_display";
+      context.state_path = directory / "recovery_profiles.json";
+      context.stats.streaming = true;
+      context.stats.width = 1920;
+      context.stats.height = 1080;
+      context.stats.encode_target_fps = 60;
+      context.stats.bitrate_kbps = 30000;
+      context.stats.codec = "AV1";
+      context.stats.stream_hdr_enabled = true;
+      context.health = {
+        {"relaunch_recommended", true},
+        {"safe_display_mode", "headless"},
+        {"safe_target_fps", 40},
+        {"safe_bitrate_kbps", 18000},
+        {"safe_codec", "hevc"},
+        {"safe_hdr", false},
+        {"doctor", {
+          {"result_id", source_result_id},
+          {"safe_recovery_action", {
+            {"id", "apply_recovery_profile_next_launch"},
+            {"kind", "next_launch_profile"},
+            {"requires_confirmation", true},
+            {"requires_owner", true},
+            {"owner_tuning_allowed", true},
+            {"payload_preview", {
+              {"source_result_id", source_result_id},
+              {"app_uuid", "game-a"}
+            }},
+            {"undo", {{"supported", true}}}
+          }}
+        }}
+      };
+    }
+
+    void TearDown() override {
+      std::error_code error;
+      std::filesystem::remove_all(directory, error);
+    }
+
+    nlohmann::json apply_request() const {
+      return {
+        {"action_id", "apply_recovery_profile_next_launch"},
+        {"source_result_id", source_result_id},
+        {"app_uuid", "game-a"},
+        {"confirmed", true},
+        // All of these are attacker-controlled and must be ignored.
+        {"display_mode", "desktop_display"},
+        {"target_fps", 240},
+        {"target_bitrate_kbps", 300000},
+        {"preferred_codec", "arbitrary"},
+        {"hdr", true}
+      };
+    }
+
+    std::filesystem::path directory;
+    doctor_actions::recovery_action_context_t context;
+    const std::string source_result_id = "doctor-v2-watch-frame_pacing-none";
+  };
+}
+
+TEST_F(RecoveryDoctorActionTest, RequiresConfirmationCurrentEvidenceAndOwnerTuning) {
+  auto unconfirmed = apply_request();
+  unconfirmed["confirmed"] = false;
+  EXPECT_EQ(
+    doctor_actions::execute(unconfirmed, context).value("state", ""),
+    "confirmation_required"
+  );
+
+  auto stale = apply_request();
+  stale["source_result_id"] = "doctor-v2-stale";
+  EXPECT_EQ(doctor_actions::execute(stale, context).value("state", ""), "evidence_changed");
+
+  auto viewer = context;
+  viewer.active_owner = false;
+  EXPECT_EQ(doctor_actions::execute(apply_request(), viewer).value("state", ""), "evidence_changed");
+}
+
+TEST_F(RecoveryDoctorActionTest, RejectsConfirmationReplayedForAnotherGame) {
+  auto game_b = context;
+  game_b.app_uuid = "game-b";
+  game_b.app_name = "Another Game";
+
+  EXPECT_EQ(
+    doctor_actions::execute(apply_request(), game_b).value("state", ""),
+    "evidence_changed"
+  );
+
+  auto forged_for_b = apply_request();
+  forged_for_b["app_uuid"] = "game-b";
+  EXPECT_EQ(
+    doctor_actions::execute(forged_for_b, game_b).value("state", ""),
+    "evidence_changed"
+  );
+  EXPECT_FALSE(recovery_profile::queued(
+    context.state_path, context.owner_uuid, "game-b"
+  ));
+}
+
+TEST_F(RecoveryDoctorActionTest, QueuesOnlyHostDerivedProfileAndIsIdempotent) {
+  const auto first = doctor_actions::execute(apply_request(), context);
+  ASSERT_TRUE(first.value("status", false));
+  EXPECT_TRUE(first.value("changed", false));
+  EXPECT_EQ(first.value("recovery_state", ""), "queued");
+  const auto profile = first.at("safe_profile");
+  EXPECT_EQ(profile.value("stream_display_mode", ""), "headless_stream");
+  EXPECT_EQ(profile.value("width", 0), 1920);
+  EXPECT_EQ(profile.value("height", 0), 1080);
+  EXPECT_EQ(profile.value("target_fps", 0), 40);
+  EXPECT_EQ(profile.value("target_bitrate_kbps", 0), 18000);
+  EXPECT_EQ(profile.value("preferred_codec", ""), "hevc");
+  EXPECT_FALSE(profile.value("hdr", true));
+  EXPECT_TRUE(profile.value("requires_fresh_launch", false));
+
+  const auto repeated = doctor_actions::execute(apply_request(), context);
+  EXPECT_EQ(repeated.value("run_id", ""), first.value("run_id", ""));
+  EXPECT_TRUE(repeated.value("idempotent", false));
+  EXPECT_FALSE(repeated.value("changed", true));
+}
+
+TEST_F(RecoveryDoctorActionTest, VerifiesTrustedEffectiveSettingsAfterConnectAndConsumesOnce) {
+  const auto queued = doctor_actions::execute(apply_request(), context);
+  const auto run_id = queued.value("run_id", "");
+  ASSERT_FALSE(run_id.empty());
+
+  const auto rejected = doctor_actions::execute({
+    {"action_id", "verify_recovery_profile_next_launch"},
+    {"run_id", run_id},
+    {"target_fps", 40}
+  }, context);
+  EXPECT_EQ(rejected.value("state", ""), "rejected");
+  EXPECT_EQ(rejected.value("recovery_state", ""), "queued");
+
+  context.stats.encode_target_fps = 40;
+  context.stats.bitrate_kbps = 18000;
+  context.stats.codec = "HEVC";
+  context.stats.stream_hdr_enabled = false;
+  context.effective_stream_display_mode = "headless_stream";
+  const auto same_launch = doctor_actions::execute({
+    {"action_id", "verify_recovery_profile_next_launch"},
+    {"run_id", run_id}
+  }, context);
+  EXPECT_FALSE(same_launch.value("status", true));
+  EXPECT_EQ(same_launch.value("recovery_state", ""), "queued");
+  EXPECT_NE(
+    std::find(same_launch.at("mismatches").begin(), same_launch.at("mismatches").end(), "fresh_launch"),
+    same_launch.at("mismatches").end()
+  );
+
+  context.launch_instance_id = "launch-b";
+  context.session_generation = 2;
+  const auto applied = doctor_actions::execute({
+    {"action_id", "verify_recovery_profile_next_launch"},
+    {"run_id", run_id}
+  }, context);
+  EXPECT_TRUE(applied.value("status", false));
+  EXPECT_TRUE(applied.value("changed", false));
+  EXPECT_EQ(applied.value("recovery_state", ""), "applied");
+
+  const auto repeated = doctor_actions::execute({
+    {"action_id", "verify_recovery_profile_next_launch"},
+    {"run_id", run_id}
+  }, context);
+  EXPECT_TRUE(repeated.value("status", false));
+  EXPECT_TRUE(repeated.value("idempotent", false));
+  EXPECT_FALSE(repeated.value("changed", true));
+}
+
+TEST_F(RecoveryDoctorActionTest, UndoCancelsOnlyTheMatchingQueuedRun) {
+  const auto queued = doctor_actions::execute(apply_request(), context);
+  const auto run_id = queued.value("run_id", "");
+
+  const auto wrong = doctor_actions::execute({
+    {"action_id", "undo"}, {"run_id", "recovery-run-imposter"}
+  }, context);
+  EXPECT_FALSE(wrong.value("status", true));
+  EXPECT_TRUE(recovery_profile::queued(
+    context.state_path, context.owner_uuid, context.app_uuid
+  ));
+
+  context.stats.streaming = false;
+  context.host_tuning_allowed = false;
+  context.app_uuid.clear();
+  const auto undone = doctor_actions::execute({
+    {"action_id", "undo"}, {"run_id", run_id}
+  }, context);
+  EXPECT_TRUE(undone.value("status", false));
+  EXPECT_EQ(undone.value("recovery_state", ""), "undone");
+  EXPECT_FALSE(recovery_profile::queued(
+    context.state_path, context.owner_uuid, "game-a"
+  ));
+}
+
+TEST(PairedDoctorRoutePolicyTests, AllowsDisconnectedOwnerUndoButRejectsViewerAndOtherActions) {
+  EXPECT_TRUE(doctor_actions::paired_route_allowed("undo", false, false));
+  EXPECT_TRUE(doctor_actions::paired_route_allowed("undo", true, true));
+  EXPECT_FALSE(doctor_actions::paired_route_allowed("undo", true, false));
+  EXPECT_FALSE(doctor_actions::paired_route_allowed(
+    "apply_recovery_profile_next_launch", false, false
+  ));
+  EXPECT_TRUE(doctor_actions::paired_route_allowed(
+    "apply_recovery_profile_next_launch", true, true
+  ));
+}

--- a/tests/unit/test_recovery_doctor_actions.cpp
+++ b/tests/unit/test_recovery_doctor_actions.cpp
@@ -227,7 +227,7 @@ TEST_F(RecoveryDoctorActionTest, UndoCancelsOnlyTheMatchingQueuedRun) {
 TEST(PairedDoctorRoutePolicyTests, AllowsDisconnectedOwnerUndoButRejectsViewerAndOtherActions) {
   EXPECT_TRUE(doctor_actions::paired_route_allowed("undo", false, false));
   EXPECT_TRUE(doctor_actions::paired_route_allowed("undo", true, true));
-  EXPECT_FALSE(doctor_actions::paired_route_allowed("undo", true, false));
+  EXPECT_TRUE(doctor_actions::paired_route_allowed("undo", true, false));
   EXPECT_FALSE(doctor_actions::paired_route_allowed(
     "apply_recovery_profile_next_launch", false, false
   ));

--- a/tests/unit/test_recovery_profile.cpp
+++ b/tests/unit/test_recovery_profile.cpp
@@ -135,6 +135,35 @@ TEST_F(RecoveryProfileTest, QueuesPrivateDurableProfileAndRepeatsIdempotently) {
   EXPECT_EQ(resumed.value("recovery_state", ""), "queued");
 }
 
+TEST_F(RecoveryProfileTest, RepeatingConsumedConfirmedActionReturnsAppliedRun) {
+  const auto first = queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none-a", safe_profile(), now
+  );
+  ASSERT_TRUE(first.value("status", false));
+  const auto run_id = first.value("run_id", "");
+  auto launched = matching_launch();
+  ASSERT_TRUE(recovery_profile::verify(
+    target, "client-a", "game-a", run_id, launched, now + 1
+  ).value("status", false));
+
+  auto changed_profile = safe_profile();
+  changed_profile.target_fps = 30;
+  const auto repeated = queue_profile(
+    target,
+    "client-a",
+    "game-a",
+    "doctor-v2-watch-frame_pacing-none-a",
+    changed_profile,
+    now + 2
+  );
+  EXPECT_TRUE(repeated.value("status", false));
+  EXPECT_FALSE(repeated.value("changed", true));
+  EXPECT_TRUE(repeated.value("idempotent", false));
+  EXPECT_EQ(repeated.value("recovery_state", ""), "applied");
+  EXPECT_EQ(repeated.value("run_id", ""), run_id);
+  EXPECT_EQ(repeated.at("safe_profile").value("target_fps", 0), safe_profile().target_fps);
+}
+
 TEST_F(RecoveryProfileTest, IsolatesOwnerAndCanonicalGame) {
   ASSERT_TRUE(queue_profile(
     target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now

--- a/tests/unit/test_recovery_profile.cpp
+++ b/tests/unit/test_recovery_profile.cpp
@@ -1,0 +1,398 @@
+/**
+ * @file tests/unit/test_recovery_profile.cpp
+ * @brief Durable next-launch recovery profile contract tests.
+ */
+#include "../tests_common.h"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <utility>
+
+#if defined(__linux__)
+  #include <sys/stat.h>
+#endif
+
+#include <src/recovery_profile.h>
+
+namespace {
+  std::atomic_uint64_t path_counter {0};
+
+  recovery_profile::safe_profile_t safe_profile() {
+    return {
+      .stream_display_mode = "headless_stream",
+      .width = 1920,
+      .height = 1080,
+      .target_fps = 40,
+      .target_bitrate_kbps = 18000,
+      .preferred_codec = "hevc",
+      .hdr = false,
+    };
+  }
+
+  recovery_profile::optimizer_constraints_t optimizer_constraints(
+    int width = 1920,
+    int height = 1080
+  ) {
+    return {
+      .paired_width = width,
+      .paired_height = height,
+      .supported_codecs = {"h264", "hevc", "av1"},
+      .hdr_supported = true,
+      .allowed_stream_display_modes = {"headless_stream", "host_virtual_display"},
+    };
+  }
+
+  nlohmann::json queue_profile(const std::filesystem::path &target,
+                               const std::string &owner,
+                               const std::string &app,
+                               const std::string &result_id,
+                               const recovery_profile::safe_profile_t &profile,
+                               std::int64_t now,
+                               const std::string &launch_instance_id = "launch-a",
+                               std::uint64_t session_generation = 1) {
+    return recovery_profile::queue(
+      target,
+      owner,
+      app,
+      result_id,
+      profile,
+      launch_instance_id,
+      session_generation,
+      now
+    );
+  }
+
+  recovery_profile::observed_launch_t matching_launch(std::string owner = "client-a",
+                                                        std::string app = "game-a") {
+    return {
+      .streaming = true,
+      .owner_uuid = std::move(owner),
+      .app_uuid = std::move(app),
+      .stream_display_mode = "headless_stream",
+      .width = 1920,
+      .height = 1080,
+      .target_fps = 40,
+      .bitrate_kbps = 18000,
+      .codec = "hevc",
+      .hdr = false,
+      .launch_instance_id = "launch-b",
+      .session_generation = 2,
+    };
+  }
+
+  class RecoveryProfileTest: public testing::Test {
+  protected:
+    void SetUp() override {
+      const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+      directory = std::filesystem::temp_directory_path() /
+                  ("polaris-recovery-profile-" + std::to_string(nonce) + "-" +
+                   std::to_string(path_counter.fetch_add(1)));
+      std::filesystem::create_directories(directory);
+      target = directory / "recovery_profiles.json";
+    }
+
+    void TearDown() override {
+      std::error_code error;
+      std::filesystem::remove_all(directory, error);
+    }
+
+    std::filesystem::path directory;
+    std::filesystem::path target;
+    static constexpr std::int64_t now = 1'800'000'000;
+  };
+}
+
+TEST_F(RecoveryProfileTest, QueuesPrivateDurableProfileAndRepeatsIdempotently) {
+  const auto first = queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  );
+  ASSERT_TRUE(first.value("status", false));
+  EXPECT_TRUE(first.value("changed", false));
+  EXPECT_EQ(first.value("state", ""), "queued");
+  EXPECT_EQ(first.value("expires_at", 0LL), now + recovery_profile::lifetime_seconds);
+  const auto run_id = first.value("run_id", "");
+  ASSERT_FALSE(run_id.empty());
+
+  const auto repeated = queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now + 5
+  );
+  EXPECT_TRUE(repeated.value("status", false));
+  EXPECT_FALSE(repeated.value("changed", true));
+  EXPECT_TRUE(repeated.value("idempotent", false));
+  EXPECT_EQ(repeated.value("run_id", ""), run_id);
+
+#if defined(__linux__)
+  struct stat metadata {};
+  ASSERT_EQ(::stat(target.c_str(), &metadata), 0);
+  EXPECT_EQ(metadata.st_mode & 0777, 0600);
+#endif
+
+  // A fresh load through the public API proves the record does not depend on
+  // process memory and therefore survives a Polaris restart.
+  const auto resumed = recovery_profile::status(target, "client-a", "game-a", now + 10);
+  EXPECT_EQ(resumed.value("run_id", ""), run_id);
+  EXPECT_EQ(resumed.value("recovery_state", ""), "queued");
+}
+
+TEST_F(RecoveryProfileTest, IsolatesOwnerAndCanonicalGame) {
+  ASSERT_TRUE(queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  ).value("status", false));
+
+  EXPECT_EQ(recovery_profile::status(target, "client-b", "game-a", now).value("state", ""), "none");
+  EXPECT_EQ(recovery_profile::status(target, "client-a", "game-b", now).value("state", ""), "none");
+  EXPECT_FALSE(recovery_profile::queued(target, "client-b", "game-a", now));
+  EXPECT_FALSE(recovery_profile::queued(target, "client-a", "game-b", now));
+}
+
+TEST_F(RecoveryProfileTest, PreviewDoesNotConsumeAndUndoOnlyRemovesExactQueuedRun) {
+  const auto queued = queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  );
+  const auto run_id = queued.value("run_id", "");
+  ASSERT_TRUE(recovery_profile::queued(target, "client-a", "game-a", now + 1));
+  ASSERT_TRUE(recovery_profile::queued(target, "client-a", "game-a", now + 2));
+
+  const auto wrong_owner = recovery_profile::undo(target, "client-b", "game-a", run_id, now + 3);
+  EXPECT_FALSE(wrong_owner.value("status", true));
+  EXPECT_TRUE(recovery_profile::queued(target, "client-a", "game-a", now + 4));
+
+  const auto undone = recovery_profile::undo(target, "client-a", "game-a", run_id, now + 5);
+  EXPECT_TRUE(undone.value("status", false));
+  EXPECT_EQ(undone.value("recovery_state", ""), "undone");
+  EXPECT_FALSE(recovery_profile::queued(target, "client-a", "game-a", now + 6));
+  EXPECT_EQ(recovery_profile::status(target, "client-a", "game-a", now + 6).value("state", ""), "none");
+}
+
+TEST_F(RecoveryProfileTest, OptimizerOverlayPreservesExistingFieldsAndPairedResolution) {
+  ASSERT_TRUE(queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  ).value("status", false));
+  const auto record = recovery_profile::prepare_for_optimizer(
+    target, "client-a", "game-a", optimizer_constraints(2560, 1440), now + 1
+  );
+  ASSERT_TRUE(record);
+
+  const auto optimized = recovery_profile::overlay_optimization(
+    {{"nvenc_tune", "p4"}, {"normalization_reason", "paired profile applied"}},
+    *record
+  );
+  EXPECT_EQ(optimized.value("nvenc_tune", ""), "p4");
+  EXPECT_EQ(optimized.value("normalization_reason", ""), "paired profile applied");
+  EXPECT_EQ(optimized.value("display_mode", ""), "2560x1440x40");
+  EXPECT_EQ(optimized.value("target_bitrate_kbps", 0), 18000);
+  EXPECT_EQ(optimized.value("preferred_codec", ""), "hevc");
+  EXPECT_FALSE(optimized.value("hdr", true));
+  EXPECT_EQ(optimized.value("stream_display_mode", ""), "headless_stream");
+  EXPECT_TRUE(optimized.value("requires_fresh_launch", false));
+  EXPECT_EQ(optimized.value("recovery_run_id", ""), record->run_id);
+  EXPECT_EQ(optimized.value("recovery_state", ""), "queued");
+  EXPECT_EQ(optimized.at("recovery_profile").value("width", 0), 2560);
+  EXPECT_EQ(optimized.at("recovery_profile").value("height", 0), 1440);
+  EXPECT_TRUE(optimized.at("stability").value("relaunch_required", false));
+  EXPECT_EQ(optimized.at("recovery_policy").value("state", ""), "recovery_queued");
+  EXPECT_TRUE(recovery_profile::queued(target, "client-a", "game-a", now + 2));
+}
+
+TEST_F(RecoveryProfileTest, OptimizerPersistsPairedResolutionForTrustedVerification) {
+  const auto queued = queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  );
+  const auto run_id = queued.value("run_id", "");
+
+  const auto prepared = recovery_profile::prepare_for_optimizer(
+    target, "client-a", "game-a", optimizer_constraints(2560, 1440), now + 1
+  );
+  ASSERT_TRUE(prepared);
+  EXPECT_EQ(prepared->profile.width, 2560);
+  EXPECT_EQ(prepared->profile.height, 1440);
+  auto observed = matching_launch();
+  observed.width = 2560;
+  observed.height = 1440;
+  EXPECT_TRUE(recovery_profile::verify(
+    target, "client-a", "game-a", run_id, observed, now + 2
+  ).value("status", false));
+}
+
+TEST_F(RecoveryProfileTest, RepeatApplyAfterOptimizerPreparationKeepsRunAndPreparedProfile) {
+  const auto first = queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  );
+  const auto run_id = first.value("run_id", "");
+  ASSERT_FALSE(run_id.empty());
+  ASSERT_TRUE(recovery_profile::prepare_for_optimizer(
+    target, "client-a", "game-a", optimizer_constraints(2560, 1440), now + 1
+  ));
+
+  const auto repeated = queue_profile(
+    target,
+    "client-a",
+    "game-a",
+    "doctor-v2-watch-frame_pacing-none",
+    safe_profile(),
+    now + 2
+  );
+  EXPECT_TRUE(repeated.value("idempotent", false));
+  EXPECT_EQ(repeated.value("run_id", ""), run_id);
+  EXPECT_EQ(repeated.at("safe_profile").value("width", 0), 2560);
+  EXPECT_EQ(repeated.at("safe_profile").value("height", 0), 1440);
+
+  const auto stored = recovery_profile::queued(target, "client-a", "game-a", now + 3);
+  ASSERT_TRUE(stored);
+  EXPECT_TRUE(stored->optimizer_prepared);
+  EXPECT_EQ(stored->profile.width, 2560);
+  EXPECT_EQ(stored->profile.height, 1440);
+}
+
+TEST_F(RecoveryProfileTest, RevalidatesQueuedCodecHdrAndTopologyAgainstCurrentCapabilities) {
+  auto originally_safe = safe_profile();
+  originally_safe.stream_display_mode = "host_virtual_display";
+  originally_safe.preferred_codec = "av1";
+  originally_safe.hdr = true;
+  const auto queued = queue_profile(
+    target,
+    "client-a",
+    "game-a",
+    "doctor-v2-watch-frame_pacing-none",
+    originally_safe,
+    now
+  );
+  const auto run_id = queued.value("run_id", "");
+
+  auto drifted = optimizer_constraints();
+  drifted.supported_codecs = {"h264"};
+  drifted.hdr_supported = false;
+  drifted.allowed_stream_display_modes = {"headless_stream"};
+  const auto prepared = recovery_profile::prepare_for_optimizer(
+    target, "client-a", "game-a", drifted, now + 1
+  );
+  ASSERT_TRUE(prepared);
+  EXPECT_EQ(prepared->run_id, run_id);
+  EXPECT_EQ(prepared->profile.preferred_codec, "h264");
+  EXPECT_FALSE(prepared->profile.hdr);
+  EXPECT_EQ(prepared->profile.stream_display_mode, "headless_stream");
+
+  const auto optimized = recovery_profile::overlay_optimization(
+    {{"preferred_codec", "hevc"}, {"hdr", true}, {"stream_display_mode", "host_virtual_display"}},
+    *prepared
+  );
+  EXPECT_EQ(optimized.value("preferred_codec", ""), "h264");
+  EXPECT_FALSE(optimized.value("hdr", true));
+  EXPECT_EQ(optimized.value("stream_display_mode", ""), "headless_stream");
+}
+
+TEST_F(RecoveryProfileTest, OwnerStatusReconstructsQueueWithoutAnActiveGame) {
+  ASSERT_TRUE(queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  ).value("status", false));
+  ASSERT_TRUE(queue_profile(
+    target, "client-b", "game-b", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  ).value("status", false));
+
+  const auto owner_records = recovery_profile::statuses_for_owner(target, "client-a", now + 1);
+  ASSERT_EQ(owner_records.size(), 1);
+  EXPECT_EQ(owner_records.front().value("app_uuid", ""), "game-a");
+  EXPECT_EQ(owner_records.front().value("recovery_state", ""), "queued");
+}
+
+TEST_F(RecoveryProfileTest, MismatchedLaunchStaysQueuedAndMatchingLaunchConsumesExactlyOnce) {
+  const auto queued = queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  );
+  const auto run_id = queued.value("run_id", "");
+
+  auto wrong = matching_launch();
+  wrong.target_fps = 60;
+  const auto rejected = recovery_profile::verify(
+    target, "client-a", "game-a", run_id, wrong, now + 1
+  );
+  EXPECT_FALSE(rejected.value("status", true));
+  EXPECT_EQ(rejected.value("state", ""), "rejected");
+  EXPECT_EQ(rejected.value("recovery_state", ""), "queued");
+  EXPECT_TRUE(recovery_profile::queued(target, "client-a", "game-a", now + 2));
+
+  const auto applied = recovery_profile::verify(
+    target, "client-a", "game-a", run_id, matching_launch(), now + 3
+  );
+  EXPECT_TRUE(applied.value("status", false));
+  EXPECT_TRUE(applied.value("changed", false));
+  EXPECT_EQ(applied.value("recovery_state", ""), "applied");
+  EXPECT_FALSE(recovery_profile::queued(target, "client-a", "game-a", now + 4));
+
+  const auto repeated = recovery_profile::verify(
+    target, "client-a", "game-a", run_id, matching_launch(), now + 5
+  );
+  EXPECT_TRUE(repeated.value("status", false));
+  EXPECT_FALSE(repeated.value("changed", true));
+  EXPECT_TRUE(repeated.value("idempotent", false));
+  EXPECT_EQ(repeated.value("recovery_state", ""), "applied");
+}
+
+TEST_F(RecoveryProfileTest, MatchingSettingsOnTheQueuedLaunchCannotConsume) {
+  const auto queued = queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  );
+  auto same_launch = matching_launch();
+  same_launch.launch_instance_id = "launch-a";
+  same_launch.session_generation = 1;
+  const auto rejected = recovery_profile::verify(
+    target,
+    "client-a",
+    "game-a",
+    queued.value("run_id", ""),
+    same_launch,
+    now + 1
+  );
+  EXPECT_FALSE(rejected.value("status", true));
+  EXPECT_EQ(rejected.value("recovery_state", ""), "queued");
+  EXPECT_TRUE(recovery_profile::queued(target, "client-a", "game-a", now + 2));
+}
+
+TEST(RecoveryProfileCanonicalAppTests, RejectsAmbiguousNamesAndPrefersExactIdentifiers) {
+  const std::vector<recovery_profile::app_identity_t> apps {
+    {.uuid = "uuid-a", .id = "101", .name = "Control"},
+    {.uuid = "uuid-b", .id = "202", .name = "Control"},
+    {.uuid = "uuid-c", .id = "303", .name = "Another Game"},
+  };
+
+  EXPECT_FALSE(recovery_profile::resolve_canonical_app_uuid("Control", apps));
+  EXPECT_EQ(recovery_profile::resolve_canonical_app_uuid("UUID-B", apps), "uuid-b");
+  EXPECT_EQ(recovery_profile::resolve_canonical_app_uuid("303", apps), "uuid-c");
+  EXPECT_EQ(recovery_profile::resolve_canonical_app_uuid("another game", apps), "uuid-c");
+}
+
+TEST_F(RecoveryProfileTest, ExpiresAtTwentyFourHoursAndCannotBeConsumed) {
+  const auto queued = queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  );
+  const auto run_id = queued.value("run_id", "");
+  const auto expiry = now + recovery_profile::lifetime_seconds;
+
+  const auto expired = recovery_profile::status(target, "client-a", "game-a", expiry);
+  EXPECT_EQ(expired.value("recovery_state", ""), "expired");
+  EXPECT_FALSE(expired.at("undo").value("available", true));
+  EXPECT_FALSE(recovery_profile::queued(target, "client-a", "game-a", expiry));
+
+  const auto verify = recovery_profile::verify(
+    target, "client-a", "game-a", run_id, matching_launch(), expiry + 1
+  );
+  EXPECT_FALSE(verify.value("status", true));
+  EXPECT_EQ(verify.value("recovery_state", ""), "expired");
+}
+
+TEST_F(RecoveryProfileTest, RejectsInvalidHostProfilesAndInsecureState) {
+  auto invalid = safe_profile();
+  invalid.preferred_codec = "arbitrary-client-codec";
+  EXPECT_FALSE(queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", invalid, now
+  ).value("status", true));
+
+  ASSERT_TRUE(queue_profile(
+    target, "client-a", "game-a", "doctor-v2-watch-frame_pacing-none", safe_profile(), now
+  ).value("status", false));
+  std::filesystem::permissions(target, std::filesystem::perms::group_read, std::filesystem::perm_options::add);
+  const auto rejected = recovery_profile::status(target, "client-a", "game-a", now + 1);
+  EXPECT_FALSE(rejected.value("status", true));
+  EXPECT_EQ(rejected.value("state", ""), "rejected");
+}

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -1069,6 +1069,37 @@ TEST(StreamStatsDoctorTests, RelaunchFindingOffersExactDurableNextLaunchContract
     action.at("verification").at("action_id"),
     "verify_recovery_profile_next_launch"
   );
+
+  const auto identical = stream_stats::build_doctor_json(
+    stats,
+    {
+      {"primary_issue", "frame_pacing"},
+      {"grade", "watch"},
+      {"relaunch_recommended", true},
+      {"safe_display_mode", "headless"},
+      {"safe_target_fps", 40},
+      {"safe_bitrate_kbps", 18000},
+      {"safe_codec", "hevc"},
+      {"safe_hdr", false}
+    },
+    "game-a"
+  );
+  const auto changed_profile = stream_stats::build_doctor_json(
+    stats,
+    {
+      {"primary_issue", "frame_pacing"},
+      {"grade", "watch"},
+      {"relaunch_recommended", true},
+      {"safe_display_mode", "headless"},
+      {"safe_target_fps", 30},
+      {"safe_bitrate_kbps", 14000},
+      {"safe_codec", "hevc"},
+      {"safe_hdr", false}
+    },
+    "game-a"
+  );
+  EXPECT_EQ(identical.at("result_id"), doctor.at("result_id"));
+  EXPECT_NE(changed_profile.at("result_id"), doctor.at("result_id"));
 }
 
 TEST(DoctorActionTests, RequiresCurrentNetworkEvidenceBeforeReducingQuality) {

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -1024,6 +1024,53 @@ TEST(StreamStatsDoctorTests, CleanHistorySafeCapOffersGraduatedQualityRestore) {
   ASSERT_EQ(doctor.at("suppressed_findings").size(), 1);
 }
 
+TEST(StreamStatsDoctorTests, RelaunchFindingOffersExactDurableNextLaunchContract) {
+  stream_stats::stats_t stats {};
+  stats.streaming = true;
+  stats.fps = 54.0;
+  stats.encode_target_fps = 60.0;
+  stats.bitrate_kbps = 30000;
+  stats.codec = "AV1";
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+
+  const auto doctor = stream_stats::build_doctor_json(
+    stats,
+    {
+      {"primary_issue", "frame_pacing"},
+      {"grade", "watch"},
+      {"relaunch_recommended", true},
+      {"safe_display_mode", "headless"},
+      {"safe_target_fps", 40},
+      {"safe_bitrate_kbps", 18000},
+      {"safe_codec", "hevc"},
+      {"safe_hdr", false}
+    },
+    "game-a"
+  );
+  const auto &action = doctor.at("safe_recovery_action");
+
+  EXPECT_EQ(action.at("id"), "apply_recovery_profile_next_launch");
+  EXPECT_EQ(action.at("kind"), "next_launch_profile");
+  EXPECT_EQ(action.at("endpoint"), "/api/doctor/action");
+  EXPECT_EQ(action.at("paired_endpoint"), "/polaris/v1/doctor/action");
+  EXPECT_EQ(action.at("method"), "POST");
+  EXPECT_TRUE(action.at("requires_confirmation"));
+  EXPECT_TRUE(action.at("requires_owner"));
+  EXPECT_TRUE(action.at("owner_tuning_allowed"));
+  EXPECT_TRUE(action.at("undo").at("supported"));
+  EXPECT_EQ(action.at("payload_preview").size(), 3);
+  EXPECT_EQ(action.at("payload_preview").at("action_id"), action.at("id"));
+  EXPECT_EQ(action.at("payload_preview").at("source_result_id"), doctor.at("result_id"));
+  EXPECT_EQ(action.at("payload_preview").at("app_uuid"), "game-a");
+  EXPECT_EQ(action.at("verification").at("mode"), "post_connect");
+  EXPECT_EQ(
+    action.at("verification").at("action_id"),
+    "verify_recovery_profile_next_launch"
+  );
+}
+
 TEST(DoctorActionTests, RequiresCurrentNetworkEvidenceBeforeReducingQuality) {
   stream_stats::stats_t stats {};
   stats.streaming = true;


### PR DESCRIPTION
## Summary
- execute the authenticated next-launch recovery contract with owner/game isolation, 24-hour private persistence, idempotent Apply, restart-safe status, and exact Undo
- overlay only the queued paired profile during launch optimization and consume it only after a fresh matching stream is verified
- return OpenAI subscription Doctor explanations as a clean deterministic informational fallback while retaining Codex CLI for ordinary optimization

## Validation
- Linux native: 388 core tests and 255 stream/runtime tests
- Web: 512 Vitest tests, ESLint, production build, and performance budgets
- Focused recovery/action/optimizer/authentication/persistence/capability-drift coverage included

## Release gates still required
- independent review and exact PR-head CI
- merge approval, exact-merge-SHA CI, and physical pc-papi/RP6 acceptance
- release approval before v1.3.14 tagging