### PR TITLE
fix(gamescope): fence wrapped compositor teardown

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ A matched Doctor-safety and stream-classification patch for Nova v1.3.9. Polaris
 - Preserves paired resolution while enforcing safe FPS, bitrate, codec, HDR, topology, and a verified fresh launch; previews never consume the one-shot record
 - Binds confirmations to exact Doctor evidence so safe-profile drift requires a new confirmation, and consumes a run only after trusted post-connect settings match
 - Keeps Steam Input recovery manual and read-only without changing VDF files, Steam state, live streams, or unrelated optimizer history
+- Prevents wrapped nested Gamescope teardown from killing Xwayland under a still-running compositor by verifying whole-group kernel stop state first, and drains separately grouped private-session helpers while the original marker remains retry authority
 - Treats OpenAI subscription Doctor explanations as a clean informational `deterministic-fallback` source while regular optimizer requests retain the Codex CLI route
 - Retains the GCC 16, Ubuntu snapshot, exact release-source, sanitizer, Arch, public-hygiene, and CodeQL gates from the protected release base
 - Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets

--- a/docs/release-notes/v1.3.14.md
+++ b/docs/release-notes/v1.3.14.md
@@ -72,6 +72,7 @@ Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite g
 ### Scope and safety
 
 - Steam Input remains manual and read-only. Apply, Undo, restart, and Resume Stream do not alter Steam VDF bytes, mode, or ownership.
+- Nested Gamescope teardown freezes the complete exact private group and verifies that both its leader and marked compositor reached kernel stop state before killing the group, avoiding an X11 I/O abort when a distro wrapper makes Gamescope a child of the private-session leader. Separately grouped private helpers are frozen, revalidated, and drained while the original marker remains retry authority.
 - Existing v1.3.13 settings remain compatible, and established safe FPS limits remain authoritative.
 - Release validation remains gated on exact-SHA CI, independent review, signed package checks, and physical host plus Retroid Pocket 6 acceptance with Nova v1.3.9.
 - CodeQL analysis remains unavailable when GitHub code scanning is disabled. A successful explicit skip path is not an analysis result.

--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -18,10 +18,15 @@ polaris_process_fields() {
   # shellcheck disable=SC2206
   local fields=( $rest )
   [ "${#fields[@]}" -ge 20 ] || return 1
+  POLARIS_PROCESS_STATE="${fields[0]}"
   POLARIS_PROCESS_PPID="${fields[1]}"
   POLARIS_PROCESS_PGID="${fields[2]}"
   POLARIS_PROCESS_SESSION_ID="${fields[3]}"
   POLARIS_PROCESS_START_TIME="${fields[19]}"
+  case "$POLARIS_PROCESS_STATE" in
+    [A-Za-z]) ;;
+    *) return 1 ;;
+  esac
   case "$POLARIS_PROCESS_PPID:$POLARIS_PROCESS_PGID:$POLARIS_PROCESS_SESSION_ID:$POLARIS_PROCESS_START_TIME" in
     *[!0-9:]*|:*|*:) return 1 ;;
   esac
@@ -499,6 +504,10 @@ polaris_private_session_alive() {
       return 2
     fi
     [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || continue
+    # Zombies cannot execute, fork, retain file descriptors, or own sockets.
+    # A stopped parent may not reap them until its own terminal signal, so they
+    # are terminal for teardown even while their procfs entry still exists.
+    [ "$POLARIS_PROCESS_STATE" = Z ] && continue
     # Any live member of the authorized private session keeps teardown alive,
     # including descendants that moved to a separate process group.
     found=0
@@ -507,11 +516,235 @@ polaris_private_session_alive() {
   return "$found"
 }
 
+polaris_process_group_alive() {
+  local session_id="$1" process_group="$2" proc_root process pid found=1 seen=0
+  proc_root="$(polaris_proc_root)"
+  [ -d "$proc_root" ] && [ -r "$proc_root" ] && [ -x "$proc_root" ] || return 2
+  for process in "$proc_root"/[0-9]*; do
+    [ -d "$process" ] || continue
+    seen=1
+    pid="${process##*/}"
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    if ! polaris_process_fields "$pid"; then
+      [ ! -e "$process" ] && continue
+      return 2
+    fi
+    [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || continue
+    [ "$POLARIS_PROCESS_PGID" = "$process_group" ] || continue
+    [ "$POLARIS_PROCESS_STATE" = Z ] && continue
+    found=0
+  done
+  [ "$seen" = 1 ] || return 2
+  return "$found"
+}
+
+polaris_wait_process_group_stopped() {
+  local session_id="$1" process_group="$2" proc_root process pid seen all_stopped
+  local steps="${POLARIS_FREEZE_WAIT_STEPS:-100}"
+  proc_root="$(polaris_proc_root)"
+  for _ in $(seq 1 "$steps"); do
+    [ -d "$proc_root" ] && [ -r "$proc_root" ] && [ -x "$proc_root" ] || return 1
+    seen=0
+    all_stopped=1
+    for process in "$proc_root"/[0-9]*; do
+      [ -d "$process" ] || continue
+      pid="${process##*/}"
+      case "$pid" in ''|*[!0-9]*) continue ;; esac
+      if ! polaris_process_fields "$pid"; then
+        [ ! -e "$process" ] && continue
+        return 1
+      fi
+      [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || continue
+      [ "$POLARIS_PROCESS_PGID" = "$process_group" ] || continue
+      seen=1
+      case "$POLARIS_PROCESS_STATE" in
+        T|t|Z) ;;
+        *) all_stopped=0 ;;
+      esac
+    done
+    [ "$seen" = 1 ] || return 1
+    [ "$all_stopped" = 1 ] && return 0
+    sleep 0.01
+  done
+  return 1
+}
+
+polaris_private_session_has_no_live_siblings() {
+  local session_id="$1" proc_root process pid seen=0
+  proc_root="$(polaris_proc_root)"
+  [ -d "$proc_root" ] && [ -r "$proc_root" ] && [ -x "$proc_root" ] || return 2
+  for process in "$proc_root"/[0-9]*; do
+    [ -d "$process" ] || continue
+    seen=1
+    pid="${process##*/}"
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    if ! polaris_process_fields "$pid"; then
+      [ ! -e "$process" ] && continue
+      return 2
+    fi
+    [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || continue
+    [ "$POLARIS_PROCESS_STATE" = Z ] && continue
+    [ "$POLARIS_PROCESS_PGID" = "$session_id" ] || return 1
+  done
+  [ "$seen" = 1 ] || return 2
+  return 0
+}
+
+polaris_wait_group_leader_stopped() {
+  local pid="$1" start_time="$2" session_id="$3" executable="$4"
+  local steps="${POLARIS_FREEZE_WAIT_STEPS:-100}"
+  for _ in $(seq 1 "$steps"); do
+    if ! polaris_process_fields "$pid" \
+        || [ "$POLARIS_PROCESS_START_TIME" != "$start_time" ] \
+        || [ "$POLARIS_PROCESS_PGID" != "$pid" ] \
+        || [ "$POLARIS_PROCESS_SESSION_ID" != "$session_id" ]; then
+      return 1
+    fi
+    if [ -z "$executable" ]; then
+      # A zombie leader still pins its PID/PGID against reuse but exposes no
+      # executable. It is valid authority only while its exact generation and
+      # terminal Z state remain unchanged; live group members are checked by
+      # polaris_wait_process_group_stopped before any negative KILL.
+      [ "$POLARIS_PROCESS_STATE" = Z ] && return 0
+      return 1
+    fi
+    [ "$(readlink -f "$(polaris_proc_root)/$pid/exe" 2>/dev/null)" = "$executable" ] || return 1
+    case "$POLARIS_PROCESS_STATE" in
+      T|t) return 0 ;;
+    esac
+    sleep 0.01
+  done
+  return 1
+}
+
+polaris_wait_gamescope_stopped() {
+  local pid="$1" start_time="$2" executable="$3" process_group="$4" session_id="$5"
+  local steps="${POLARIS_FREEZE_WAIT_STEPS:-100}"
+  for _ in $(seq 1 "$steps"); do
+    if ! polaris_validate_process_generation "$pid" "$start_time" "$executable" \
+        || [ "$POLARIS_PROCESS_PGID" != "$process_group" ] \
+        || [ "$POLARIS_PROCESS_SESSION_ID" != "$session_id" ]; then
+      return 1
+    fi
+    case "$POLARIS_PROCESS_STATE" in
+      T|t) return 0 ;;
+    esac
+    sleep 0.01
+  done
+  return 1
+}
+
+# Kill every remaining process group of an already-authorized private session.
+# Steam and pressure-vessel may move helpers into sibling groups while retaining
+# the original SID. Freeze and revalidate each group leader as an immutable PGID
+# reuse barrier before negative signaling. A leaderless or unreadable group
+# fails closed and keeps the durable recovery claim.
+polaris_kill_private_session_groups() {
+  local session_id="$1" kill_bin="${POLARIS_KILL_BIN:-kill}"
+  local proc_root process pid process_group group existing seen_group index
+  local group_start group_executable group_rc
+  local kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}"
+  local groups=() group_starts=() group_executables=()
+  proc_root="$(polaris_proc_root)"
+  [ -d "$proc_root" ] && [ -r "$proc_root" ] && [ -x "$proc_root" ] || return 1
+  for process in "$proc_root"/[0-9]*; do
+    [ -d "$process" ] || continue
+    pid="${process##*/}"
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    if ! polaris_process_fields "$pid"; then
+      [ ! -e "$process" ] && continue
+      return 1
+    fi
+    [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || continue
+    [ "$POLARIS_PROCESS_STATE" = Z ] && continue
+    process_group="$POLARIS_PROCESS_PGID"
+    [ "$process_group" != "$session_id" ] || continue
+    seen_group=0
+    for existing in "${groups[@]+"${groups[@]}"}"; do
+      [ "$existing" = "$process_group" ] && seen_group=1
+    done
+    [ "$seen_group" = 1 ] || groups+=("$process_group")
+  done
+  for group in "${groups[@]+"${groups[@]}"}"; do
+    polaris_process_fields "$group" || return 1
+    [ "$POLARIS_PROCESS_PGID" = "$group" ] \
+      && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
+    group_start="$POLARIS_PROCESS_START_TIME"
+    if [ "$POLARIS_PROCESS_STATE" = Z ]; then
+      # An unreaped group leader is an immutable numeric PGID barrier even
+      # though procfs no longer exposes its executable. A live sibling caused
+      # this group to be collected; all such siblings still must freeze T/t.
+      group_executable=''
+    else
+      group_executable="$(readlink -f "$proc_root/$group/exe" 2>/dev/null)" || return 1
+      [ -n "$group_executable" ] || return 1
+    fi
+    group_starts+=("$group_start")
+    group_executables+=("$group_executable")
+  done
+  for index in "${!groups[@]}"; do
+    group="${groups[$index]}"
+    # Freeze the entire validated group, not a positive PID. The live exact
+    # group leader is the PGID-reuse barrier; the post-signal identity and
+    # kernel-state checks prove that the barrier actually entered T/t.
+    "$kill_bin" -STOP "-$group" 2>/dev/null || return 1
+    polaris_wait_group_leader_stopped \
+      "$group" "${group_starts[$index]}" "$session_id" "${group_executables[$index]}" || return 1
+    polaris_wait_process_group_stopped "$session_id" "$group" || return 1
+  done
+  # The original group is already frozen, and every group found above is now
+  # frozen. A group created during enumeration is not authorized by this pass;
+  # fail with the marked compositor still alive so a retry can enumerate it.
+  for process in "$proc_root"/[0-9]*; do
+    [ -d "$process" ] || continue
+    pid="${process##*/}"
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    if ! polaris_process_fields "$pid"; then
+      [ ! -e "$process" ] && continue
+      return 1
+    fi
+    [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || continue
+    [ "$POLARIS_PROCESS_STATE" = Z ] && continue
+    process_group="$POLARIS_PROCESS_PGID"
+    [ "$process_group" != "$session_id" ] || continue
+    seen_group=0
+    for existing in "${groups[@]+"${groups[@]}"}"; do
+      [ "$existing" = "$process_group" ] && seen_group=1
+    done
+    [ "$seen_group" = 1 ] || return 1
+  done
+  for index in "${!groups[@]}"; do
+    group="${groups[$index]}"
+    polaris_wait_group_leader_stopped \
+      "$group" "${group_starts[$index]}" "$session_id" "${group_executables[$index]}" || return 1
+    polaris_wait_process_group_stopped "$session_id" "$group" || return 1
+    "$kill_bin" -KILL "-$group" 2>/dev/null || return 1
+    for _ in $(seq 1 "$kill_steps"); do
+      if polaris_process_group_alive "$session_id" "$group"; then
+        sleep 0.1
+        continue
+      else
+        group_rc=$?
+        [ "$group_rc" -eq 1 ] || return 1
+        break
+      fi
+    done
+    if polaris_process_group_alive "$session_id" "$group"; then
+      return 1
+    else
+      group_rc=$?
+      [ "$group_rc" -eq 1 ] || return 1
+    fi
+  done
+  polaris_private_session_has_no_live_siblings "$session_id"
+}
+
 polaris_stop_marked_gamescope() (
   local marker="$1" expected_role="$2" runtime_dir="$3" kill_bin="${POLARIS_KILL_BIN:-kill}"
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}"
   local marker_line pid start_time executable_path pgid session_id group_leader_start group_leader_executable socket inode entry current_inode
-  local owned_sockets=() term_steps="${POLARIS_STOP_WAIT_STEPS:-30}" kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}" leader_stopped=0
+  local owned_sockets=() kill_steps="${POLARIS_KILL_WAIT_STEPS:-20}"
+  local group_stop_requested=0 destructive_signal_armed=0 group_rc
   umask 077
   if [ "${POLARIS_GAMESCOPE_LOCK_HELD:-0}" != 1 ]; then
     exec 9>>"$runtime_dir/polaris-gamescope.lock" || return 1
@@ -545,29 +778,55 @@ polaris_stop_marked_gamescope() (
   polaris_validate_process_generation "$pid" "$start_time" "$executable_path" || return 1
   [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
     && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
-  # Inline EXIT trap (not a nested function) so SC2329 does not flag a
-  # "never invoked" helper. CONT only if we STOPped the leader and authorize it.
+  # Freeze the complete private process group and prove that both the immutable
+  # group leader and the exact marked compositor reached kernel stop state.
+  # This removes the Xwayland-disappears-while-Gamescope-runs failure mode even
+  # when setsid owns a wrapper and Gamescope is its child. Before teardown is
+  # committed, a failure resumes only the still-exact group. Once committed,
+  # every failure leaves the marker generation stopped for a safe retry.
   trap '
-    if [ "$leader_stopped" = 1 ] \
+    if [ "$destructive_signal_armed" = 0 ] \
+        && [ "$group_stop_requested" = 1 ] \
         && polaris_process_fields "$pgid" \
         && [ "$POLARIS_PROCESS_START_TIME" = "$group_leader_start" ] \
         && [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
         && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] \
         && [ "$(readlink -f "$(polaris_proc_root)/$pgid/exe" 2>/dev/null)" = "$group_leader_executable" ]; then
-      "$kill_bin" -CONT "$pgid" 2>/dev/null || true
+      "$kill_bin" -CONT "-$pgid" 2>/dev/null || true
     fi
   ' EXIT
-  "$kill_bin" -STOP "$pgid" 2>/dev/null || return 1
-  leader_stopped=1
+  # Revalidate the leader immediately before the negative-PGID freeze. Keeping
+  # that exact leader alive prevents the numeric process group from being
+  # recycled while stop state is established.
   polaris_process_fields "$pgid" || return 1
   [ "$POLARIS_PROCESS_START_TIME" = "$group_leader_start" ] \
     && [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
     && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
   [ "$(readlink -f "$(polaris_proc_root)/$pgid/exe" 2>/dev/null)" = "$group_leader_executable" ] || return 1
-  "$kill_bin" -TERM "-$pgid" 2>/dev/null || return 1
-  group_rc=0
-  for _ in $(seq 1 "$term_steps"); do
-    [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
+  group_stop_requested=1
+  "$kill_bin" -STOP "-$pgid" 2>/dev/null || return 1
+  polaris_wait_group_leader_stopped "$pgid" "$group_leader_start" "$session_id" "$group_leader_executable" || return 1
+  polaris_wait_gamescope_stopped "$pid" "$start_time" "$executable_path" "$pgid" "$session_id" || return 1
+  polaris_wait_process_group_stopped "$session_id" "$pgid" || return 1
+  [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
+  # Commit before the first helper that may send SIGKILL. An interruption after
+  # this assignment can never resume Gamescope over a partially removed group.
+  destructive_signal_armed=1
+  polaris_kill_private_session_groups "$pgid" || return 1
+  # All escaped groups must be terminal while the exact original marker and
+  # frozen leader still provide retry authority. Only then kill the original.
+  polaris_process_fields "$pgid" || return 1
+  [ "$POLARIS_PROCESS_STATE" = T ] || [ "$POLARIS_PROCESS_STATE" = t ] || return 1
+  [ "$POLARIS_PROCESS_START_TIME" = "$group_leader_start" ] \
+    && [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
+    && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
+  [ "$(readlink -f "$(polaris_proc_root)/$pgid/exe" 2>/dev/null)" = "$group_leader_executable" ] || return 1
+  polaris_wait_gamescope_stopped "$pid" "$start_time" "$executable_path" "$pgid" "$session_id" || return 1
+  polaris_wait_process_group_stopped "$session_id" "$pgid" || return 1
+  polaris_private_session_has_no_live_siblings "$session_id" || return 1
+  [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
+  "$kill_bin" -KILL "-$pgid" 2>/dev/null || return 1
+  for _ in $(seq 1 "$kill_steps"); do
     if polaris_private_session_alive "$pgid"; then
       sleep 0.1
       continue
@@ -577,34 +836,6 @@ polaris_stop_marked_gamescope() (
       break
     fi
   done
-  if polaris_private_session_alive "$pgid"; then
-    [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-    # Keep the exact private-session leader allocation as an immutable PGID-reuse
-    # barrier through the last negative-PGID operation. The marked compositor may
-    # be a launcher child and may exit after TERM; only the retained leader can
-    # authorize safe escalation.
-    polaris_process_fields "$pgid" || return 1
-    [ "$POLARIS_PROCESS_START_TIME" = "$group_leader_start" ] \
-      && [ "$POLARIS_PROCESS_PGID" = "$pgid" ] \
-      && [ "$POLARIS_PROCESS_SESSION_ID" = "$session_id" ] || return 1
-    [ "$(readlink -f "$(polaris_proc_root)/$pgid/exe" 2>/dev/null)" = "$group_leader_executable" ] || return 1
-    [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-    "$kill_bin" -KILL "-$pgid" 2>/dev/null || return 1
-    for _ in $(seq 1 "$kill_steps"); do
-      [ -f "$marker" ] && [ "$(<"$marker")" = "$marker_line" ] || return 1
-      if polaris_private_session_alive "$pgid"; then
-        sleep 0.1
-        continue
-      else
-        group_rc=$?
-        [ "$group_rc" -eq 1 ] || return 1
-        break
-      fi
-    done
-  else
-    group_rc=$?
-    [ "$group_rc" -eq 1 ] || return 1
-  fi
   if polaris_private_session_alive "$pgid"; then
     return 1
   else

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -17,6 +17,7 @@ export POLARIS_PROC_ROOT="$work/proc"
 export POLARIS_PROC_NET_UNIX="$work/proc/net/unix"
 export POLARIS_X11_SOCKET_DIR="$work/tmp/.X11-unix"
 export POLARIS_STOP_WAIT_STEPS=2
+export POLARIS_FREEZE_WAIT_STEPS=2
 mkdir -p "$POLARIS_PROC_ROOT/net" "$POLARIS_X11_SOCKET_DIR" "$work/run" "$work/bin"
 cat >"$work/bin/flock" <<'EOF'
 #!/usr/bin/env bash
@@ -54,6 +55,49 @@ write_unix_header() {
   printf 'Num RefCount Protocol Flags Type St Inode Path\n' >"$POLARIS_PROC_NET_UNIX"
 }
 
+# Model Linux's asynchronous group stop becoming visible in /proc. Production
+# waits for the exact leader and marked compositor to report T/t; a signal-call
+# ordering assertion alone would not exercise that contract.
+cat >"$work/bin/fake-stop-state" <<'EOF'
+#!/usr/bin/env python3
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+target = sys.argv[2]
+if not target.startswith("-"):
+    raise SystemExit(0)
+group = int(target[1:])
+for stat_path in root.glob("[0-9]*/stat"):
+    line = stat_path.read_text()
+    marker = line.rfind(") ")
+    if marker < 0:
+        continue
+    fields = line[marker + 2 :].split()
+    if len(fields) < 4 or int(fields[2]) != group:
+        continue
+    if fields[0] == "Z":
+        continue
+    fields[0] = "T"
+    stat_path.write_text(line[: marker + 2] + " ".join(fields) + "\n")
+EOF
+chmod +x "$work/bin/fake-stop-state"
+cat >"$work/bin/fake-pid-state" <<'EOF'
+#!/usr/bin/env python3
+import pathlib
+import sys
+
+stat_path = pathlib.Path(sys.argv[1]) / sys.argv[2] / "stat"
+line = stat_path.read_text()
+marker = line.rfind(") ")
+if marker < 0:
+    raise SystemExit(1)
+fields = line[marker + 2 :].split()
+fields[0] = sys.argv[3]
+stat_path.write_text(line[: marker + 2] + " ".join(fields) + "\n")
+EOF
+chmod +x "$work/bin/fake-pid-state"
+
 # Rename failure must fail marker publication and leave neither authority nor
 # a stale temporary file behind.
 write_process 410 1 9001 /usr/bin/gamescope --backend headless
@@ -84,7 +128,9 @@ printf 'DISPLAY=:9\nPOLARIS_GAMESCOPE_PID=410\nPOLARIS_GAMESCOPE_START_TIME=9000
 cat >"$work/bin/kill" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >>"$work/kills"
-if [ "\${1:-}" = -TERM ] && [ "\${2:-}" = -410 ]; then
+if [ "\${1:-}" = -STOP ]; then
+  "$work/bin/fake-stop-state" "$POLARIS_PROC_ROOT" "\${2:-}"
+elif [ "\${1:-}" = -KILL ] && [ "\${2:-}" = -410 ]; then
   rm -rf "$POLARIS_PROC_ROOT/410" "$POLARIS_PROC_ROOT/411"
   rm -f "$work/run/gamescope-0"
 fi
@@ -118,27 +164,76 @@ cp "$work/bin/kill" "$work/bin/kill.default"
 cat >"$work/bin/kill" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >>"$work/kills"
-if [ "\${1:-}" = -TERM ] && [ "\${2:-}" = -400 ]; then
-  rm -rf "$POLARIS_PROC_ROOT/410"
-  rm -f "$work/run/gamescope-0"
+if [ "\${1:-}" = -STOP ]; then
+  "$work/bin/fake-stop-state" "$POLARIS_PROC_ROOT" "\${2:-}"
 elif [ "\${1:-}" = -KILL ] && [ "\${2:-}" = -400 ]; then
-  rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/411"
+  if [ "\$(awk '{ print \$3 }' "$POLARIS_PROC_ROOT/410/stat")" != T ]; then
+    : >"$work/gamescope-abort"
+  fi
+  rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410" "$POLARIS_PROC_ROOT/411"
+  rm -f "$work/run/gamescope-0"
 fi
 EOF
 chmod +x "$work/bin/kill"
 polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run" ||
   fail "private child compositor group did not stop"
-grep -qx -- '-STOP 400' "$work/kills" || fail "private-session leader was not pinned before TERM"
-grep -qx -- '-TERM -400' "$work/kills" || fail "validated PGID was not signalled"
-grep -qx -- '-KILL -400' "$work/kills" || fail "TERM-resistant group sibling was not escalated"
+grep -qx -- '-STOP -400' "$work/kills" || fail "private process group was not frozen"
+grep -qx -- '-KILL -400' "$work/kills" || fail "validated frozen PGID was not killed"
+[ ! -e "$work/gamescope-abort" ] || fail "group teardown reached a running wrapped Gamescope"
 if grep -q -- '-410' "$work/kills"; then
   fail "compositor PID was used as a process group"
 fi
 mv "$work/bin/kill.default" "$work/bin/kill"
 chmod +x "$work/bin/kill"
 
-# A descendant that moved to another PGID but retained the private SID must
-# prevent marker/environment deletion after the original group is drained.
+# Signal delivery is not the freeze boundary. If the exact leader/compositor do
+# not actually report T/t, fail before KILL and resume only the validated group.
+write_process_with_group 400 1 400 400 9150 /usr/bin/sleep infinity
+write_process_with_group 410 400 400 400 9151 /usr/bin/gamescope --backend headless
+printf '410 9151 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
+cat >"$work/bin/kill-no-freeze" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >>"$work/kills"
+EOF
+chmod +x "$work/bin/kill-no-freeze"
+: >"$work/kills"
+if POLARIS_KILL_BIN="$work/bin/kill-no-freeze" POLARIS_FREEZE_WAIT_STEPS=1 \
+    polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run"; then
+  fail "unobserved group stop advanced to destructive teardown"
+fi
+grep -qx -- '-STOP -400' "$work/kills" || fail "freeze-timeout fixture did not request group stop"
+! grep -q -- '-KILL' "$work/kills" || fail "unobserved group stop sent a destructive signal"
+grep -qx -- '-CONT -400' "$work/kills" || fail "pre-commit freeze failure did not resume the exact group"
+[ -e "$work/run/polaris-gamescope.pid" ] || fail "freeze-timeout failure cleared marker authority"
+rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410"
+
+# Seeing only the leader and marked compositor stop is insufficient: every
+# live group member must reach T/t before the commit boundary.
+write_process_with_group 400 1 400 400 9170 /usr/bin/sleep infinity
+write_process_with_group 410 400 400 400 9171 /usr/bin/gamescope --backend headless
+write_process_with_group 411 410 400 400 9172 /usr/bin/Xwayland :2
+printf '410 9171 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
+cat >"$work/bin/kill-partial-freeze" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >>"$work/kills"
+if [ "\${1:-}" = -STOP ] && [ "\${2:-}" = -400 ]; then
+  "$work/bin/fake-pid-state" "$POLARIS_PROC_ROOT" 400 T
+  "$work/bin/fake-pid-state" "$POLARIS_PROC_ROOT" 410 T
+fi
+EOF
+chmod +x "$work/bin/kill-partial-freeze"
+: >"$work/kills"
+if POLARIS_KILL_BIN="$work/bin/kill-partial-freeze" POLARIS_FREEZE_WAIT_STEPS=1 \
+    polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run"; then
+  fail "running group member advanced to destructive teardown"
+fi
+! grep -q -- '-KILL' "$work/kills" || fail "running group member was present before KILL"
+grep -qx -- '-CONT -400' "$work/kills" || fail "partial pre-commit freeze did not resume the exact group"
+[ -e "$work/run/polaris-gamescope.pid" ] || fail "partial freeze cleared marker authority"
+rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410" "$POLARIS_PROC_ROOT/411"
+
+# A descendant that moved to another PGID but retained the private SID must be
+# drained through its separately frozen and revalidated group leader.
 write_process_with_group 400 1 400 400 9200 /usr/bin/sleep infinity
 write_process_with_group 410 400 400 400 9201 /usr/bin/gamescope --backend headless
 write_process_with_group 420 410 420 400 9202 /usr/bin/sleep infinity
@@ -150,23 +245,99 @@ printf '410 9201 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
 printf 'DISPLAY=:2\n' >"$work/run/polaris-gamescope.env"
 cat >"$work/bin/kill-escaped-sid" <<EOF
 #!/usr/bin/env bash
-if [ "\${1:-}" = -TERM ]; then
-  rm -rf "$POLARIS_PROC_ROOT/410"
-elif [ "\${1:-}" = -KILL ]; then
+echo "\$*" >>"$work/kills"
+if [ "\${1:-}" = -STOP ]; then
+  "$work/bin/fake-stop-state" "$POLARIS_PROC_ROOT" "\${2:-}"
+elif [ "\${1:-}" = -KILL ] && [ "\${2:-}" = -400 ]; then
   rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410"
+  rm -f "$work/run/gamescope-0"
+elif [ "\${1:-}" = -KILL ] && [ "\${2:-}" = -420 ]; then
+  "$work/bin/fake-pid-state" "$POLARIS_PROC_ROOT" 420 Z
 fi
 EOF
 chmod +x "$work/bin/kill-escaped-sid"
-if POLARIS_KILL_BIN="$work/bin/kill-escaped-sid" POLARIS_STOP_WAIT_STEPS=1 POLARIS_KILL_WAIT_STEPS=1 \
-    polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run"; then
-  fail "separate-PGID private-session descendant was reported drained"
-fi
-[ -e "$work/run/polaris-gamescope.pid" ] || fail "escaped SID descendant allowed marker deletion"
-[ -e "$work/run/polaris-gamescope.env" ] || fail "escaped SID descendant allowed env deletion"
+: >"$work/kills"
+POLARIS_KILL_BIN="$work/bin/kill-escaped-sid" POLARIS_STOP_WAIT_STEPS=1 POLARIS_KILL_WAIT_STEPS=1 \
+  polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run" ||
+  fail "separate-PGID private-session descendant did not drain"
+grep -qx -- '-STOP -420' "$work/kills" || fail "escaped SID process group was not frozen"
+grep -qx -- '-KILL -420' "$work/kills" || fail "escaped SID process group was not killed"
+[ "$(awk '{ print $3 }' "$POLARIS_PROC_ROOT/420/stat")" = Z ] || fail "zombie fixture was not retained for terminal-state proof"
+[ ! -e "$work/run/polaris-gamescope.pid" ] || fail "drained escaped SID retained marker authority"
 rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410" "$POLARIS_PROC_ROOT/420"
 
-# If the private-session leader generation changes after TERM, numeric PGID
-# escalation loses its immutable reuse barrier and must fail closed.
+# A zombie group leader still pins its numeric PGID even though /proc/<pid>/exe
+# is unavailable. Freeze and kill a live member through that exact Z leader;
+# the stopped original parent must not make this state permanently unretryable.
+write_process_with_group 400 1 400 400 9230 /usr/bin/sleep infinity
+write_process_with_group 410 400 400 400 9231 /usr/bin/gamescope --backend headless
+write_process_with_group 420 410 420 400 9232 /usr/bin/sleep infinity
+write_process_with_group 421 420 420 400 9233 /usr/bin/sleep infinity
+"$work/bin/fake-pid-state" "$POLARIS_PROC_ROOT" 420 Z
+rm -f "$POLARIS_PROC_ROOT/420/exe"
+printf '410 9231 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
+cat >"$work/bin/kill-zombie-leader-sid" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >>"$work/kills"
+if [ "\${1:-}" = -STOP ]; then
+  "$work/bin/fake-stop-state" "$POLARIS_PROC_ROOT" "\${2:-}"
+elif [ "\${1:-}" = -KILL ] && [ "\${2:-}" = -420 ]; then
+  rm -rf "$POLARIS_PROC_ROOT/421"
+elif [ "\${1:-}" = -KILL ] && [ "\${2:-}" = -400 ]; then
+  rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410"
+fi
+EOF
+chmod +x "$work/bin/kill-zombie-leader-sid"
+: >"$work/kills"
+POLARIS_KILL_BIN="$work/bin/kill-zombie-leader-sid" POLARIS_FREEZE_WAIT_STEPS=1 POLARIS_KILL_WAIT_STEPS=1 \
+  polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run" ||
+  fail "zombie-led escaped process group did not drain"
+grep -qx -- '-STOP -420' "$work/kills" || fail "zombie-led group was not frozen"
+grep -qx -- '-KILL -420' "$work/kills" || fail "zombie-led group was not killed"
+[ -e "$POLARIS_PROC_ROOT/420/stat" ] || fail "zombie leader fixture did not remain unreaped"
+[ ! -e "$work/run/polaris-gamescope.pid" ] || fail "zombie-led drain retained marker authority"
+rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410" "$POLARIS_PROC_ROOT/420" "$POLARIS_PROC_ROOT/421"
+
+# A sibling process group without its leader has no immutable PGID reuse
+# barrier. Keep the marker rather than signal that ambiguous numeric group.
+write_process_with_group 400 1 400 400 9250 /usr/bin/sleep infinity
+write_process_with_group 410 400 400 400 9251 /usr/bin/gamescope --backend headless
+write_process_with_group 421 410 420 400 9252 /usr/bin/sleep infinity
+: >"$work/run/gamescope-0"
+write_unix_header
+printf 'row row row row row row 803 %s\n' "$work/run/gamescope-0" >>"$POLARIS_PROC_NET_UNIX"
+ln -sfn 'socket:[803]' "$POLARIS_PROC_ROOT/410/fd/3"
+printf '410 9251 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
+cat >"$work/bin/kill-leaderless-sid" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >>"$work/kills"
+if [ "\${1:-}" = -STOP ]; then
+  "$work/bin/fake-stop-state" "$POLARIS_PROC_ROOT" "\${2:-}"
+elif [ "\${1:-}" = -KILL ] && [ "\${2:-}" = -400 ]; then
+  rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410"
+  rm -f "$work/run/gamescope-0"
+fi
+EOF
+chmod +x "$work/bin/kill-leaderless-sid"
+: >"$work/kills"
+if POLARIS_KILL_BIN="$work/bin/kill-leaderless-sid" POLARIS_STOP_WAIT_STEPS=1 POLARIS_KILL_WAIT_STEPS=1 \
+    polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run"; then
+  fail "leaderless escaped SID process group was reported drained"
+fi
+! grep -qx -- '-KILL -420' "$work/kills" || fail "leaderless escaped SID process group was signalled"
+[ -e "$work/run/polaris-gamescope.pid" ] || fail "leaderless escaped SID failure cleared marker authority"
+! grep -qx -- '-KILL -400' "$work/kills" || fail "leaderless sibling failure destroyed retry authority"
+rm -rf "$POLARIS_PROC_ROOT/421"
+: >"$work/kills"
+POLARIS_KILL_BIN="$work/bin/kill-leaderless-sid" POLARIS_FREEZE_WAIT_STEPS=1 POLARIS_KILL_WAIT_STEPS=1 \
+  polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run" ||
+  fail "leaderless escaped SID cleanup did not recover after the survivor exited"
+grep -qx -- '-KILL -400' "$work/kills" || fail "retry did not terminate the retained exact group"
+[ ! -e "$work/run/polaris-gamescope.pid" ] || fail "successful retry retained marker authority"
+rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410"
+
+# If the private-session leader generation changes after the destructive group
+# signal, numeric PGID authority is lost and cleanup must fail closed.
 write_process_with_group 400 1 400 400 9300 /usr/bin/sleep infinity
 write_process_with_group 410 400 400 400 9301 /usr/bin/gamescope --backend headless
 write_process_with_group 411 410 400 400 9302 /usr/bin/tail -f /dev/null
@@ -179,7 +350,9 @@ printf '410 9301 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
 cat >"$work/bin/kill-reused-leader" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >>"$work/kills"
-if [ "\${1:-}" = -TERM ]; then
+if [ "\${1:-}" = -STOP ]; then
+  "$work/bin/fake-stop-state" "$POLARIS_PROC_ROOT" "\${2:-}"
+elif [ "\${1:-}" = -KILL ]; then
   printf '400 (sleep) S 1 400 400 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 9400\n' >"$POLARIS_PROC_ROOT/400/stat"
   rm -rf "$POLARIS_PROC_ROOT/410"
 fi
@@ -189,7 +362,8 @@ if POLARIS_KILL_BIN="$work/bin/kill-reused-leader" \
     polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" nested "$work/run"; then
   fail "recycled private-session leader authorized PGID escalation"
 fi
-! grep -q -- '-KILL' "$work/kills" || fail "recycled PGID received KILL"
+grep -qx -- '-KILL -400' "$work/kills" || fail "ambiguous destructive signal was not exercised"
+! grep -q -- '-CONT' "$work/kills" || fail "ambiguous destructive signal resumed a partial generation"
 [ -e "$work/run/polaris-gamescope.pid" ] || fail "leader-reuse failure cleared marker authority"
 rm -rf "$POLARIS_PROC_ROOT/400" "$POLARIS_PROC_ROOT/410" "$POLARIS_PROC_ROOT/411"
 
@@ -310,13 +484,13 @@ mv "$work/unix.unique" "$POLARIS_PROC_NET_UNIX"
 # metadata/socket are removed. The unrelated host X display survives.
 polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" idle "$work/run" ||
   fail "valid marked generation did not stop"
-grep -qx -- '-TERM -410' "$work/kills" || fail "exact marked process group was not signalled"
+grep -qx -- '-KILL -410' "$work/kills" || fail "exact frozen process group was not killed"
 [ ! -e "$work/run/polaris-gamescope.pid" ] || fail "owned marker survived terminal stop"
 [ ! -e "$work/run/polaris-gamescope.env" ] || fail "owned runtime env survived terminal stop"
 [ -e "$POLARIS_X11_SOCKET_DIR/X0" ] || fail "host X0 was removed during owned stop"
 
-# A same-role successor replacing the PID generation during TERM must never
-# receive the predecessor's escalation or lose its socket/marker.
+# A same-role successor replacing the PID generation during an ambiguous KILL
+# result must never receive a repeated signal or lose its socket/marker.
 write_process 410 1 9100 /usr/bin/gamescope --backend headless
 : >"$work/run/gamescope-0"
 ln -s 'socket:[700]' "$POLARIS_PROC_ROOT/410/fd/3"
@@ -328,7 +502,9 @@ printf '410 9100 idle /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
 cat >"$work/bin/kill-successor" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >>"$work/kills"
-if [ "\${1:-}" = -TERM ]; then
+if [ "\${1:-}" = -STOP ]; then
+  "$work/bin/fake-stop-state" "$POLARIS_PROC_ROOT" "\${2:-}"
+elif [ "\${1:-}" = -KILL ]; then
   printf '410 (gamescope) S 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 9101\n' \
     >"$POLARIS_PROC_ROOT/410/stat"
   printf '410 9101 idle /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
@@ -339,9 +515,8 @@ if POLARIS_KILL_BIN="$work/bin/kill-successor" \
     polaris_stop_marked_gamescope "$work/run/polaris-gamescope.pid" idle "$work/run"; then
   fail "predecessor stop accepted a replacement marker as terminal cleanup authority"
 fi
-if grep -q -- '-KILL' "$work/kills"; then
-  fail "same-role successor received predecessor escalation"
-fi
+[ "$(grep -cFx -- '-KILL -410' "$work/kills")" = 1 ] || fail "predecessor teardown repeated destructive signaling"
+! grep -q -- '-CONT' "$work/kills" || fail "predecessor teardown resumed a successor group"
 [ "$(<"$work/run/polaris-gamescope.pid")" = '410 9101 idle /usr/bin/gamescope' ] ||
   fail "same-role successor marker was removed"
 [ -e "$work/run/gamescope-0" ] || fail "same-role successor socket was removed"
@@ -354,7 +529,7 @@ if polaris_marker_owns_socket "$work/run/polaris-gamescope.pid" "$work/run/games
   fail "duplicate socket pathname was accepted as owned"
 fi
 
-# A marker removed after TERM also revokes all cleanup authority. Environment
+# A marker removed after KILL also revokes all cleanup authority. Environment
 # and socket state must remain untouched because no exact generation is current.
 write_process 410 1 9200 /usr/bin/gamescope --backend headless
 rm -f "$POLARIS_PROC_ROOT/410/fd/3"
@@ -369,7 +544,9 @@ printf 'POLARIS_GAMESCOPE_PID=410\nPOLARIS_GAMESCOPE_START_TIME=9200\nPOLARIS_GA
 cat >"$work/bin/kill-missing-marker" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >>"$work/kills"
-if [ "\${1:-}" = -TERM ]; then
+if [ "\${1:-}" = -STOP ]; then
+  "$work/bin/fake-stop-state" "$POLARIS_PROC_ROOT" "\${2:-}"
+elif [ "\${1:-}" = -KILL ]; then
   rm -f "$work/run/polaris-gamescope.pid"
 fi
 EOF

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -321,6 +321,63 @@ TEST(SessionStopContractTests, UnclassifiedNestedLaunchHasNoNumericGroupKillFall
   ASSERT_NE(recover, std::string::npos);
 }
 
+TEST(SessionStopContractTests, WrappedGamescopeIsFrozenBeforeXwaylandGroupTeardown) {
+  const auto source = read_source_for_contract("nix/modules/polaris-gamescope-runtime-lib.sh");
+  ASSERT_FALSE(source.empty());
+  const auto stop_start = source.find("polaris_stop_marked_gamescope() (");
+  ASSERT_NE(stop_start, std::string::npos);
+  const auto body = source.substr(stop_start);
+  const auto freeze_group = body.find("\"$kill_bin\" -STOP \"-$pgid\"");
+  const auto leader_stopped = body.find("polaris_wait_group_leader_stopped", freeze_group);
+  const auto compositor_stopped = body.find("polaris_wait_gamescope_stopped", leader_stopped);
+  const auto all_original_stopped = body.find("polaris_wait_process_group_stopped", compositor_stopped);
+  const auto arm_destructive = body.find("destructive_signal_armed=1", all_original_stopped);
+  const auto drain_siblings = body.find("polaris_kill_private_session_groups \"$pgid\"", arm_destructive);
+  const auto final_sibling_scan = body.find("polaris_private_session_has_no_live_siblings", drain_siblings);
+  const auto kill_group = body.find("\"$kill_bin\" -KILL \"-$pgid\"", drain_siblings);
+  const auto clear_marker = body.rfind("rm -f \"$marker\"");
+  ASSERT_NE(freeze_group, std::string::npos);
+  ASSERT_NE(leader_stopped, std::string::npos);
+  ASSERT_NE(compositor_stopped, std::string::npos);
+  ASSERT_NE(all_original_stopped, std::string::npos);
+  ASSERT_NE(arm_destructive, std::string::npos);
+  ASSERT_NE(drain_siblings, std::string::npos);
+  ASSERT_NE(final_sibling_scan, std::string::npos);
+  ASSERT_NE(kill_group, std::string::npos);
+  ASSERT_NE(clear_marker, std::string::npos);
+  EXPECT_LT(freeze_group, leader_stopped);
+  EXPECT_LT(leader_stopped, compositor_stopped);
+  EXPECT_LT(compositor_stopped, all_original_stopped);
+  EXPECT_LT(all_original_stopped, arm_destructive);
+  EXPECT_LT(arm_destructive, drain_siblings);
+  EXPECT_LT(drain_siblings, final_sibling_scan);
+  EXPECT_LT(final_sibling_scan, kill_group);
+  EXPECT_LT(drain_siblings, kill_group);
+  EXPECT_LT(kill_group, clear_marker);
+  EXPECT_EQ(body.find("-TERM \"-$pgid\""), std::string::npos);
+  EXPECT_NE(body.find("[ \"$destructive_signal_armed\" = 0 ]"), std::string::npos);
+
+  const auto sibling_start = source.find("polaris_kill_private_session_groups() {");
+  ASSERT_NE(sibling_start, std::string::npos);
+  const auto sibling_end = source.find("polaris_stop_marked_gamescope() (", sibling_start);
+  ASSERT_NE(sibling_end, std::string::npos);
+  const auto sibling_body = source.substr(sibling_start, sibling_end - sibling_start);
+  const auto sibling_freeze = sibling_body.find("\"$kill_bin\" -STOP \"-$group\"");
+  const auto sibling_stopped = sibling_body.find("polaris_wait_group_leader_stopped", sibling_freeze);
+  const auto all_siblings_stopped = sibling_body.find("polaris_wait_process_group_stopped", sibling_stopped);
+  const auto sibling_kill = sibling_body.find("\"$kill_bin\" -KILL \"-$group\"", sibling_freeze);
+  ASSERT_NE(sibling_freeze, std::string::npos);
+  ASSERT_NE(sibling_stopped, std::string::npos);
+  ASSERT_NE(all_siblings_stopped, std::string::npos);
+  ASSERT_NE(sibling_kill, std::string::npos);
+  EXPECT_LT(sibling_freeze, sibling_stopped);
+  EXPECT_LT(sibling_stopped, all_siblings_stopped);
+  EXPECT_LT(all_siblings_stopped, sibling_kill);
+  EXPECT_NE(sibling_body.find("[ \"$POLARIS_PROCESS_STATE\" = Z ] && continue"), std::string::npos);
+  EXPECT_NE(sibling_body.find("if [ \"$POLARIS_PROCESS_STATE\" = Z ]; then"), std::string::npos);
+  EXPECT_NE(source.find("[ -z \"$executable\" ]"), std::string::npos);
+}
+
 TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebind) {
   const auto recovery = read_source_for_contract("nix/modules/session-lib.nix");
   const auto session = read_source_for_contract("nix/modules/polaris-gamescope-session.sh");


### PR DESCRIPTION
## Summary

- Freeze the complete exact private process group and require its leader, marked Gamescope compositor, and every live member to report kernel stop state before teardown. This closes the wrapper-child ordering that let Xwayland exit under a running compositor and produced the physical-gate X11 I/O `SIGABRT`.
- Drain separately grouped private-session helpers while the original marked group remains frozen and valid retry authority. Every live sibling must stop before signaling; zombies are terminal, and a zombie leader authorizes its numeric PGID only through exact start-time/PGID/SID/`Z` proof.
- Arm destructive state before the first `SIGKILL`, kill escaped groups before the original marker generation, and fail closed across interruption, leaderless groups, generation changes, or incomplete procfs evidence.
- Update the pending v1.3.14 changelog and release notes.

## Verification

- Exact-head Linux shell tests pass: `polaris_gamescope_runtime_shell` and `polaris_gamescope_session_stop_shell`.
- Focused Linux CTest passes: both shell tests plus `test_polaris_http`.
- Fixtures cover an unobserved stop, a still-running nonleader, ambiguous destructive delivery, escaped groups, leaderless retry, zombie-only completion, and a zombie leader with a live sibling.
- `bash -n`, production-helper ShellCheck, diff hygiene, and the public documentation contract pass.
- Independent release-blocking review is clean at exact head `33606739c6aadf2a2278710b4be57c6430d889fa`.
- Full exact-head CI and renewed exact-merge-SHA physical acceptance remain required before release approval.

## Scope

This pull request changes the Gamescope ownership helper, focused tests, and v1.3.14 documentation only. It does not tag, publish, deploy, or alter the protected release branch.
