### PR TITLE
fix(linux): close virtual display ownership gaps

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Fixed Gamescope session recovery on distro-package hosts by restoring their empty compositor baseline without requiring Nix-only idle/portal units, and made failed prior-session recovery retain its exact claim instead of forcing unsafe socket cleanup.
+- Fixed Linux host-virtual-display capture so each launch is bound to the exact output it created, while Desktop mirror launches stay on the desktop path even when an app or optimizer prefers a virtual display. Capture now fails closed instead of silently selecting another monitor.
 
 This file tracks the public Polaris release line.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 - Fixed Gamescope session recovery on distro-package hosts by restoring their empty compositor baseline without requiring Nix-only idle/portal units, and made failed prior-session recovery retain its exact claim instead of forcing unsafe socket cleanup.
-- Fixed Linux host-virtual-display capture so each launch is bound to the exact output it created, while Desktop mirror launches stay on the desktop path even when an app or optimizer prefers a virtual display. Capture now fails closed instead of silently selecting another monitor.
+- Fixed Linux host-virtual-display ownership across launch, capture reinitialization, and teardown. The bundled legacy Desktop entry is migrated to an explicit mirror semantic that overrides paired virtual-display preferences; wlroots capture remains bound to the immutable private-compositor generation; and failed output removal retains durable retry state. KScreen restores and reads back the exact pre-launch output state instead of assuming that disable succeeded.
 
 This file tracks the public Polaris release line.
 

--- a/docs/release-notes/v1.3.14.md
+++ b/docs/release-notes/v1.3.14.md
@@ -1,7 +1,7 @@
 # Polaris v1.3.14
 
 - Distro-package Gamescope sessions now return to an empty compositor baseline when the Nix-only idle and private-portal services are absent. Failed prior-session recovery remains fenced instead of deleting ownership state and launching a replacement generation.
-- Linux Host Virtual Display now captures the exact output created for that launch, and Desktop mirror no longer inherits a virtual-display default. If exact output ownership cannot be proved, Polaris stops instead of streaming a different monitor.
+- Linux Host Virtual Display now stays bound to the exact output and private compositor generation created for that launch. The bundled legacy Desktop entry is migrated to an explicit mirror semantic, so paired virtual-display preferences cannot turn Desktop mirroring into a private output. If exact ownership, capture provenance, or teardown cannot be verified, Polaris fails closed and retains recovery state; KScreen restores and reads back the exact pre-launch topology.
 
 Polaris v1.3.14 is a matched Doctor-safety and stream-classification patch for Nova v1.3.9. It shows frame-pacing evidence without contradictory Stable state, adds a durable next-launch recovery profile scoped to one paired client and game, and keeps OpenAI subscription Doctor explanations deterministic without changing the ordinary Codex CLI optimizer route.
 
@@ -74,6 +74,9 @@ Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite g
 
 ### Scope and safety
 
+- Keeps the bundled and narrowly matched legacy Desktop app on the desktop-mirror path even when paired-device or optimizer settings prefer a virtual display; user-created apps named Desktop are not rewritten.
+- Keeps wlroots socket, adapter, capture-policy, and reinitialization decisions bound to the immutable launch generation, and refuses to enumerate the host compositor when a private compositor generation is unavailable.
+- Removes durable virtual-display recovery state only after backend teardown is verified. Failed Hyprland, EVDI, or KScreen teardown remains retryable, while KScreen snapshots, restores, and reads back the exact managed-output and primary-output state.
 - Steam Input remains manual and read-only. Apply, Undo, restart, and Resume Stream do not alter Steam VDF bytes, mode, or ownership.
 - Nested Gamescope teardown freezes the complete exact private group and verifies that both its leader and marked compositor reached kernel stop state before killing the group, avoiding an X11 I/O abort when a distro wrapper makes Gamescope a child of the private-session leader. Separately grouped private helpers are frozen, revalidated, and drained while the original marker remains retry authority.
 - Existing v1.3.13 settings remain compatible, and established safe FPS limits remain authoritative.

--- a/docs/release-notes/v1.3.14.md
+++ b/docs/release-notes/v1.3.14.md
@@ -1,6 +1,7 @@
 # Polaris v1.3.14
 
 - Distro-package Gamescope sessions now return to an empty compositor baseline when the Nix-only idle and private-portal services are absent. Failed prior-session recovery remains fenced instead of deleting ownership state and launching a replacement generation.
+- Linux Host Virtual Display now captures the exact output created for that launch, and Desktop mirror no longer inherits a virtual-display default. If exact output ownership cannot be proved, Polaris stops instead of streaming a different monitor.
 
 Polaris v1.3.14 is a matched Doctor-safety and stream-classification patch for Nova v1.3.9. It shows frame-pacing evidence without contradictory Stable state, adds a durable next-launch recovery profile scoped to one paired client and game, and keeps OpenAI subscription Doctor explanations deterministic without changing the ordinary Codex CLI optimizer route.
 

--- a/src/capture_generation.h
+++ b/src/capture_generation.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace capture_generation {
+
+  // Immutable source-selection authority for one capture generation.
+  struct identity_t {
+    std::uint64_t generation_id = 0;
+    std::string exact_display_name;
+    std::string requested_output_name;
+    std::string stream_mode;
+    std::string capture_backend;
+    std::string private_runtime;
+    std::string adapter_name;
+    bool headless_mode = false;
+    bool use_cage_compositor = false;
+
+    [[nodiscard]] bool empty() const {
+      return generation_id == 0 &&
+             exact_display_name.empty() &&
+             requested_output_name.empty() &&
+             stream_mode.empty() &&
+             capture_backend.empty() &&
+             private_runtime.empty() &&
+             adapter_name.empty() &&
+             !headless_mode &&
+             !use_cage_compositor;
+    }
+
+    bool operator==(const identity_t &) const = default;
+  };
+
+}  // namespace capture_generation

--- a/src/capture_generation.h
+++ b/src/capture_generation.h
@@ -13,6 +13,8 @@ namespace capture_generation {
     std::string stream_mode;
     std::string capture_backend;
     std::string private_runtime;
+    std::string private_wayland_socket;
+    std::string private_runtime_instance_id;
     std::string adapter_name;
     bool headless_mode = false;
     bool use_cage_compositor = false;
@@ -24,6 +26,8 @@ namespace capture_generation {
              stream_mode.empty() &&
              capture_backend.empty() &&
              private_runtime.empty() &&
+             private_wayland_socket.empty() &&
+             private_runtime_instance_id.empty() &&
              adapter_name.empty() &&
              !headless_mode &&
              !use_cage_compositor;

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -5762,10 +5762,13 @@ namespace confighttp {
       return;
     }
 
-    virtual_display::destroy(*ui_vdisplay);
-    ui_vdisplay.reset();
-
-    output_tree["status"] = true;
+    if (virtual_display::destroy(*ui_vdisplay)) {
+      ui_vdisplay.reset();
+      output_tree["status"] = true;
+    } else {
+      output_tree["status"] = false;
+      output_tree["error"] = "Virtual display teardown could not be verified; recovery state was retained";
+    }
     send_response(response, output_tree);
   }
 #endif  // __linux__

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -402,6 +402,7 @@ namespace confighttp::validation {
       "per-client-app-identity"sv,
       "terminate-on-pause"sv,
       "use-app-identity"sv,
+      "desktop-mirror"sv,
       "virtual-display"sv,
       "virtual-display-primary"sv,
       "wait-all"sv,

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -487,6 +487,8 @@ namespace nvhttp {
       const proc::ctx_t &app,
       bool active_desktop_game
     ) {
+      const bool mirror_desktop_requested =
+        explicit_mirror_desktop_requested(args) || app.desktop_mirror;
       bool private_stream_requested =
         proc::streaming_launch_requests_private_family(
           config::video.linux_display.headless_mode,
@@ -498,7 +500,7 @@ namespace nvhttp {
       // A per-session override changes which family this launch actually is.
       std::string session_mode_reject_reason;
       const auto session_mode = accepted_session_stream_mode(session_stream_mode_requested(args), session_mode_reject_reason);
-      if (!session_mode.empty() && !explicit_mirror_desktop_requested(args)) {
+      if (!session_mode.empty() && !mirror_desktop_requested) {
         const auto session_booleans = stream_display_policy::legacy_booleans_for_selection(session_mode);
         private_stream_requested = proc::streaming_launch_requests_private_family(
           session_booleans.headless_mode,
@@ -510,7 +512,7 @@ namespace nvhttp {
 #endif
       return proc::resolve_desktop_launch_safety_policy(
         private_stream_requested,
-        explicit_mirror_desktop_requested(args),
+        mirror_desktop_requested,
         force_private_after_desktop_steam_shutdown_requested(args),
         app,
         proc::desktop_steam_client_active(),
@@ -523,6 +525,8 @@ namespace nvhttp {
       const proc::ctx_t &app,
       bool active_desktop_game
     ) {
+      const bool mirror_desktop_requested =
+        explicit_mirror_desktop_requested(body) || app.desktop_mirror;
       bool private_stream_requested =
         proc::streaming_launch_requests_private_family(
           config::video.linux_display.headless_mode,
@@ -534,7 +538,7 @@ namespace nvhttp {
       // A per-session override changes which family this launch actually is.
       std::string session_mode_reject_reason;
       const auto session_mode = accepted_session_stream_mode(session_stream_mode_requested(body), session_mode_reject_reason);
-      if (!session_mode.empty() && !explicit_mirror_desktop_requested(body)) {
+      if (!session_mode.empty() && !mirror_desktop_requested) {
         const auto session_booleans = stream_display_policy::legacy_booleans_for_selection(session_mode);
         private_stream_requested = proc::streaming_launch_requests_private_family(
           session_booleans.headless_mode,
@@ -546,7 +550,7 @@ namespace nvhttp {
 #endif
       return proc::resolve_desktop_launch_safety_policy(
         private_stream_requested,
-        explicit_mirror_desktop_requested(body),
+        mirror_desktop_requested,
         force_private_after_desktop_steam_shutdown_requested(body),
         app,
         proc::desktop_steam_client_active(),
@@ -5858,6 +5862,7 @@ namespace nvhttp {
         }
 
 #ifdef __linux__
+        proc::apply_app_display_semantics(*app_iter, *launch_session);
         auto launch_policy = resolve_streaming_launch_safety_policy(
           args,
           *app_iter,

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -745,6 +745,14 @@ namespace platf {
 
   // A list of names of displays accepted as display_name with the mem_type_e
   std::vector<std::string> display_names(mem_type_e hwdevice_type);
+#ifdef __linux__
+  // Session capture must enumerate through the immutable launch generation;
+  // global display configuration may change while a stream is reinitializing.
+  std::vector<std::string> display_names(
+    mem_type_e hwdevice_type,
+    const video::config_t &config
+  );
+#endif
 
   /**
    * @brief Check if GPUs/drivers have changed since the last call to this function.

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -77,6 +77,7 @@ namespace cage_display_router {
 
   static std::string cage_wayland_socket;  // e.g., "wayland-5"
   static std::string cage_x11_display;  // e.g., ":1"
+  static std::string cage_session_instance_id;
 
   // The output mode most recently requested of the running compositor. A
   // resume can carry a different refresh than the launch that started the
@@ -1122,6 +1123,7 @@ namespace cage_display_router {
     cage_pid = 0;
     cage_wayland_socket.clear();
     cage_x11_display.clear();
+    cage_session_instance_id.clear();
     // The mode is unrecorded until this startup settles: a resume racing the
     // launch must see "no recorded mode" and report failure, not silently
     // claim the refresh was applied.
@@ -1390,6 +1392,7 @@ namespace cage_display_router {
                     << std::chrono::duration_cast<std::chrono::milliseconds>(
                          std::chrono::steady_clock::now() - startup_begin
                        ).count();
+    cage_session_instance_id = session_instance_id;
     return true;
   }
 
@@ -1505,6 +1508,7 @@ namespace cage_display_router {
       cage_pid = 0;
       cage_wayland_socket.clear();
       cage_x11_display.clear();
+      cage_session_instance_id.clear();
       cage_runtime_state = {
         .requested_headless = false,
         .effective_headless = false,
@@ -1551,6 +1555,7 @@ namespace cage_display_router {
     cage_pid = 0;
     cage_wayland_socket.clear();
     cage_x11_display.clear();
+    cage_session_instance_id.clear();
     cage_runtime_state = {
       .requested_headless = false,
       .effective_headless = false,
@@ -1568,6 +1573,7 @@ namespace cage_display_router {
     cage_pid = 0;
     cage_wayland_socket.clear();
     cage_x11_display.clear();
+    cage_session_instance_id.clear();
     cage_runtime_state = {
       .requested_headless = false,
       .effective_headless = false,
@@ -1601,6 +1607,10 @@ namespace cage_display_router {
 
   std::string get_wayland_socket() {
     return cage_wayland_socket;
+  }
+
+  std::string get_session_instance_id() {
+    return cage_session_instance_id;
   }
 
   std::string get_x11_display() {

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -136,6 +136,7 @@ namespace cage_display_router {
    * Empty string if cage is not running.
    */
   std::string get_wayland_socket();
+  std::string get_session_instance_id();
 
   /**
    * @brief Returns the XWayland display exposed by cage (e.g., ":1").

--- a/src/platform/linux/kwingrab.cpp
+++ b/src/platform/linux/kwingrab.cpp
@@ -8,7 +8,6 @@
 
 #include "kwingrab.h"
 
-#include "src/config.h"
 #include "src/logging.h"
 
 #include <algorithm>
@@ -234,19 +233,6 @@ namespace kwingrab {
                              << "] not found; refusing another output"sv;
             if (!output_selection_can_fallback(output_name)) {
               return -1;
-            }
-          }
-        }
-        if (!output) {
-          // Prefer config streaming_output when set (dongle path).
-          const auto &want = config::video.linux_display.streaming_output;
-          if (!want.empty()) {
-            for (const auto &[o, p] : outputs_) {
-              if (p->name == want) {
-                output = o;
-                params = p;
-                break;
-              }
             }
           }
         }
@@ -517,32 +503,27 @@ namespace kwingrab {
     return session;
   }
 
-  bool prefer_for_current_stream_mode() {
-    const auto &mode = config::video.linux_display.stream_mode;
+  bool prefer_for_generation(const capture_generation::identity_t &generation) {
+    const auto &mode = generation.stream_mode;
     // Host KDE paths only. gamescope_stream / labwc private runtimes stay on
     // gamescopegrab / portal / wlroots — never kwingrab.
-    // host_virtual_display belongs here too: its EVDI output is composited by
-    // KWin, and only this path can pin capture to that output by name — the
-    // portal ScreenCast picker cannot select a specific monitor, so falling
-    // through to it captures whatever output the restore token last granted
-    // (observed live: the 7680x2160 primary desktop instead of DVI-I-1).
     if (mode == "desktop_display" || mode == "headless_dongle" ||
         mode == "host_virtual_display") {
       return true;
     }
     // Empty mode historically maps to desktop-ish host on some configs; only
-    // when not using a private runtime.
+    // when the immutable generation did not select a private runtime.
     if (mode.empty() &&
-        !config::video.linux_display.use_cage_compositor &&
-        config::video.linux_display.private_runtime != "gamescope" &&
-        config::video.linux_display.private_runtime != "labwc") {
+        !generation.use_cage_compositor &&
+        generation.private_runtime != "gamescope" &&
+        generation.private_runtime != "labwc") {
       return true;
     }
     return false;
   }
 
-  bool require_for_current_stream_mode() {
-    return config::video.linux_display.stream_mode == "host_virtual_display";
+  bool require_for_generation(const capture_generation::identity_t &generation) {
+    return generation.stream_mode == "host_virtual_display";
   }
 
 }  // namespace kwingrab

--- a/src/platform/linux/kwingrab.cpp
+++ b/src/platform/linux/kwingrab.cpp
@@ -230,12 +230,11 @@ namespace kwingrab {
             }
           }
           if (!output) {
-            // A requested output that is not in KWin's registry (e.g. a virtual
-            // display that failed to attach) silently streaming some other
-            // output is exactly the wrong-output bug this pinning exists to
-            // prevent — make the miss visible before falling back.
-            BOOST_LOG(warning) << "kwingrab: requested output ["sv << output_name
-                               << "] not found; falling back to configured/first output"sv;
+            BOOST_LOG(error) << "kwingrab: requested output ["sv << output_name
+                             << "] not found; refusing another output"sv;
+            if (!output_selection_can_fallback(output_name)) {
+              return -1;
+            }
           }
         }
         if (!output) {
@@ -498,6 +497,10 @@ namespace kwingrab {
     return impl_->cast->source_;
   }
 
+  bool output_selection_can_fallback(std::string_view requested_output_name) {
+    return requested_output_name.empty();
+  }
+
   std::unique_ptr<session_t> start_output_session(std::string_view output_name) {
     auto session = std::make_unique<session_t>();
     session->impl_->cast = std::make_unique<screencast_t>();
@@ -536,6 +539,10 @@ namespace kwingrab {
       return true;
     }
     return false;
+  }
+
+  bool require_for_current_stream_mode() {
+    return config::video.linux_display.stream_mode == "host_virtual_display";
   }
 
 }  // namespace kwingrab

--- a/src/platform/linux/kwingrab.h
+++ b/src/platform/linux/kwingrab.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <string_view>
 
+#include "src/capture_generation.h"
+
 namespace kwingrab {
 
   struct stream_source_t {
@@ -56,10 +58,10 @@ namespace kwingrab {
   /// True when an absent requested output may use configured/first output.
   bool output_selection_can_fallback(std::string_view requested_output_name);
 
-  /// True when current stream_mode is a host KDE path that may prefer kwingrab.
-  bool prefer_for_current_stream_mode();
+  /// True when the immutable generation is a host KDE path that may prefer kwingrab.
+  bool prefer_for_generation(const capture_generation::identity_t &generation);
 
-  /// True when host virtual capture must not fall through to generic portal.
-  bool require_for_current_stream_mode();
+  /// True when this generation must not fall through to generic portal.
+  bool require_for_generation(const capture_generation::identity_t &generation);
 
 }  // namespace kwingrab

--- a/src/platform/linux/kwingrab.h
+++ b/src/platform/linux/kwingrab.h
@@ -53,7 +53,13 @@ namespace kwingrab {
    */
   std::unique_ptr<session_t> start_output_session(std::string_view output_name = {});
 
+  /// True when an absent requested output may use configured/first output.
+  bool output_selection_can_fallback(std::string_view requested_output_name);
+
   /// True when current stream_mode is a host KDE path that may prefer kwingrab.
   bool prefer_for_current_stream_mode();
+
+  /// True when host virtual capture must not fall through to generic portal.
+  bool require_for_current_stream_mode();
 
 }  // namespace kwingrab

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 
 // platform includes
 #include <arpa/inet.h>
@@ -57,6 +58,7 @@
 #include "src/logging.h"
 #include "src/platform/common.h"
 #include "vaapi.h"
+#include "virtual_display.h"
 
 #include <linux/rtnetlink.h>
 
@@ -1363,19 +1365,28 @@ std::string get_local_ip_for_gateway() {
     return std::make_unique<linux_deinit_t>();
   }
 
-  // host_virtual_display is composited by KWin: its EVDI output is an ordinary
-  // KWin monitor, not a private cage. Capture must reach portal_grab, which
-  // routes it to kwingrab's output-pinned KWin ScreenCast (see PR #351). The
-  // auto-selected direct wlr/wlgrab path below would instead bind the desktop
-  // wayland-0, which does not advertise wlr-export-dmabuf — observed live to
-  // hard-fail every encoder (nvenc/vaapi/software) and produce no stream. So
-  // this mode must be kept off the auto WAYLAND source, letting PORTAL be
-  // chosen. An explicit capture=wlr still forces wlr (operator's call);
-  // cage-compositor modes (windowed/headless_stream) are unaffected because
-  // they set use_cage and are not host_virtual_display.
+  // host_virtual_display can be backed by two different compositor contracts.
+  // KWin/EVDI exposes an ordinary KWin monitor, so capture must reach
+  // portal_grab and kwingrab's output-pinned KWin ScreenCast (PR #351/#352).
+  // Hyprland/Sway WAYLAND_WLR creates a native wlroots headless output, which
+  // wlgrab can capture directly by its exact POLARIS-HEADLESS output name.
+  // Cage-compositor modes own their own capture source and never enter here.
+  bool host_virtual_display_needs_portal_for_backend(
+    std::string_view stream_mode,
+    bool use_cage_compositor,
+    virtual_display::backend_e backend
+  ) {
+    return stream_mode == "host_virtual_display" &&
+           !use_cage_compositor &&
+           backend != virtual_display::backend_e::WAYLAND_WLR;
+  }
+
   bool host_virtual_display_needs_portal() {
-    return !config::video.linux_display.use_cage_compositor
-        && config::video.linux_display.stream_mode == "host_virtual_display";
+    return host_virtual_display_needs_portal_for_backend(
+      config::video.linux_display.stream_mode,
+      config::video.linux_display.use_cage_compositor,
+      virtual_display::detect_backend()
+    );
   }
 
   void reevaluate_capture_sources() {

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -1362,6 +1362,7 @@ std::string get_local_ip_for_gateway() {
 
 #ifdef POLARIS_BUILD_WAYLAND
   std::vector<std::string> wl_display_names();
+  std::vector<std::string> wl_display_names(const capture_generation::identity_t &generation);
   std::shared_ptr<display_t> wl_display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config);
 
   bool verify_wl() {
@@ -1423,6 +1424,74 @@ std::string get_local_ip_for_gateway() {
       return x11_display_names();
     }
 #endif
+    return {};
+  }
+
+  std::vector<std::string> display_names(
+    mem_type_e hwdevice_type,
+    const video::config_t &config
+  ) {
+    bool nvfbc_available = false;
+    bool wayland_available = false;
+    bool portal_available = false;
+    bool kms_available = false;
+    bool x11_available = false;
+#ifdef POLARIS_BUILD_CUDA
+    nvfbc_available = sources[source::NVFBC];
+#endif
+#ifdef POLARIS_BUILD_WAYLAND
+    wayland_available = sources[source::WAYLAND];
+#endif
+#ifdef POLARIS_BUILD_PORTAL
+    portal_available = sources[source::PORTAL];
+#endif
+#ifdef POLARIS_BUILD_DRM
+    kms_available = sources[source::KMS];
+#endif
+#ifdef POLARIS_BUILD_X11
+    x11_available = sources[source::X11];
+#endif
+
+    const auto &generation = config.capture_generation;
+    const auto backend = choose_display_backend(
+      generation.capture_backend,
+      !generation.exact_display_name.empty(),
+      nvfbc_available,
+      wayland_available,
+      portal_available,
+      kms_available,
+      x11_available,
+      hwdevice_type == mem_type_e::cuda
+    );
+    switch (backend) {
+      case display_backend_e::nvfbc:
+#ifdef POLARIS_BUILD_CUDA
+        return nvfbc_display_names();
+#endif
+        break;
+      case display_backend_e::wayland:
+#ifdef POLARIS_BUILD_WAYLAND
+        return wl_display_names(generation);
+#endif
+        break;
+      case display_backend_e::portal:
+#ifdef POLARIS_BUILD_PORTAL
+        return portal_display_names();
+#endif
+        break;
+      case display_backend_e::kms:
+#ifdef POLARIS_BUILD_DRM
+        return kms_display_names(hwdevice_type);
+#endif
+        break;
+      case display_backend_e::x11:
+#ifdef POLARIS_BUILD_X11
+        return x11_display_names();
+#endif
+        break;
+      default:
+        break;
+    }
     return {};
   }
 

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -57,6 +57,7 @@
 #include "src/entry_handler.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
+#include "src/video.h"
 #include "vaapi.h"
 #include "virtual_display.h"
 
@@ -1233,6 +1234,123 @@ std::string get_local_ip_for_gateway() {
 
   static std::bitset<source::MAX_FLAGS> sources;
 
+  enum class display_backend_e {
+    none,
+    nvfbc,
+    wayland,
+    portal,
+    kms,
+    x11,
+  };
+
+  static display_backend_e choose_display_backend(
+    std::string_view requested,
+    bool exact_output_owned,
+    bool nvfbc_available,
+    bool wayland_available,
+    bool portal_available,
+    bool kms_available,
+    bool x11_available,
+    bool cuda_memory
+  ) {
+    if (exact_output_owned && (requested.empty() || requested == "auto")) {
+      return display_backend_e::none;
+    }
+    if (requested == "wlr") {
+      return wayland_available ? display_backend_e::wayland : display_backend_e::none;
+    }
+    if (requested == "portal" || requested == "kwin") {
+      return portal_available ? display_backend_e::portal : display_backend_e::none;
+    }
+    if (requested == "kms" || requested == "drm") {
+      return kms_available ? display_backend_e::kms : display_backend_e::none;
+    }
+    if (requested == "x11") {
+      return x11_available ? display_backend_e::x11 : display_backend_e::none;
+    }
+    if (requested == "nvfbc") {
+      return nvfbc_available && cuda_memory ? display_backend_e::nvfbc : display_backend_e::none;
+    }
+    if (!requested.empty() && requested != "auto") {
+      return display_backend_e::none;
+    }
+    if (nvfbc_available && cuda_memory) {
+      return display_backend_e::nvfbc;
+    }
+    if (wayland_available) {
+      return display_backend_e::wayland;
+    }
+    if (portal_available) {
+      return display_backend_e::portal;
+    }
+    if (kms_available) {
+      return display_backend_e::kms;
+    }
+    if (x11_available) {
+      return display_backend_e::x11;
+    }
+    return display_backend_e::none;
+  }
+
+#ifdef POLARIS_TESTS
+  std::string capture_backend_dispatch_for_tests(
+    std::string_view requested,
+    bool nvfbc_available,
+    bool wayland_available,
+    bool portal_available,
+    bool kms_available,
+    bool x11_available,
+    bool cuda_memory
+  ) {
+    switch (choose_display_backend(
+      requested,
+      false,
+      nvfbc_available,
+      wayland_available,
+      portal_available,
+      kms_available,
+      x11_available,
+      cuda_memory
+    )) {
+      case display_backend_e::nvfbc: return "nvfbc";
+      case display_backend_e::wayland: return "wayland";
+      case display_backend_e::portal: return "portal";
+      case display_backend_e::kms: return "kms";
+      case display_backend_e::x11: return "x11";
+      default: return "none";
+    }
+  }
+
+  std::string exact_capture_backend_dispatch_for_tests(
+    std::string_view requested,
+    bool exact_output_owned,
+    bool nvfbc_available,
+    bool wayland_available,
+    bool portal_available,
+    bool kms_available,
+    bool x11_available,
+    bool cuda_memory
+  ) {
+    switch (choose_display_backend(
+      requested,
+      exact_output_owned,
+      nvfbc_available,
+      wayland_available,
+      portal_available,
+      kms_available,
+      x11_available,
+      cuda_memory
+    )) {
+      case display_backend_e::nvfbc: return "nvfbc";
+      case display_backend_e::wayland: return "wayland";
+      case display_backend_e::portal: return "portal";
+      case display_backend_e::kms: return "kms";
+      case display_backend_e::x11: return "x11";
+      default: return "none";
+    }
+  }
+#endif
+
 #ifdef POLARIS_BUILD_CUDA
   std::vector<std::string> nvfbc_display_names();
   std::shared_ptr<display_t> nvfbc_display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config);
@@ -1318,37 +1436,81 @@ std::string get_local_ip_for_gateway() {
   }
 
   std::shared_ptr<display_t> display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config) {
+    bool nvfbc_available = false;
+    bool wayland_available = false;
+    bool portal_available = false;
+    bool kms_available = false;
+    bool x11_available = false;
 #ifdef POLARIS_BUILD_CUDA
-    if (sources[source::NVFBC] && hwdevice_type == mem_type_e::cuda) {
-      BOOST_LOG(info) << "Screencasting with NvFBC"sv;
-      return nvfbc_display(hwdevice_type, display_name, config);
-    }
+    nvfbc_available = sources[source::NVFBC];
 #endif
 #ifdef POLARIS_BUILD_WAYLAND
-    if (sources[source::WAYLAND]) {
-      BOOST_LOG(info) << "Screencasting with Wayland's protocol"sv;
-      return wl_display(hwdevice_type, display_name, config);
-    }
+    wayland_available = sources[source::WAYLAND];
 #endif
 #ifdef POLARIS_BUILD_PORTAL
-    if (sources[source::PORTAL]) {
-      BOOST_LOG(info) << "Screencasting with XDG Desktop Portal"sv;
-      return portal_display(hwdevice_type, display_name, config);
-    }
+    portal_available = sources[source::PORTAL];
 #endif
 #ifdef POLARIS_BUILD_DRM
-    if (sources[source::KMS]) {
-      BOOST_LOG(info) << "Screencasting with KMS"sv;
-      return kms_display(hwdevice_type, display_name, config);
-    }
+    kms_available = sources[source::KMS];
 #endif
 #ifdef POLARIS_BUILD_X11
-    if (sources[source::X11]) {
-      BOOST_LOG(info) << "Screencasting with X11"sv;
-      return x11_display(hwdevice_type, display_name, config);
-    }
+    x11_available = sources[source::X11];
 #endif
 
+    const auto requested_backend = config.capture_generation.capture_backend;
+    const bool exact_output_owned = !config.capture_generation.exact_display_name.empty();
+    const auto backend = choose_display_backend(
+      requested_backend,
+      exact_output_owned,
+      nvfbc_available,
+      wayland_available,
+      portal_available,
+      kms_available,
+      x11_available,
+      hwdevice_type == mem_type_e::cuda
+    );
+    switch (backend) {
+      case display_backend_e::nvfbc:
+#ifdef POLARIS_BUILD_CUDA
+        BOOST_LOG(info) << "Screencasting with NvFBC"sv;
+        return nvfbc_display(hwdevice_type, display_name, config);
+#else
+        break;
+#endif
+      case display_backend_e::wayland:
+#ifdef POLARIS_BUILD_WAYLAND
+        BOOST_LOG(info) << "Screencasting with Wayland's protocol"sv;
+        return wl_display(hwdevice_type, display_name, config);
+#else
+        break;
+#endif
+      case display_backend_e::portal:
+#ifdef POLARIS_BUILD_PORTAL
+        BOOST_LOG(info) << "Screencasting with XDG Desktop Portal"sv;
+        return portal_display(hwdevice_type, display_name, config);
+#else
+        break;
+#endif
+      case display_backend_e::kms:
+#ifdef POLARIS_BUILD_DRM
+        BOOST_LOG(info) << "Screencasting with KMS"sv;
+        return kms_display(hwdevice_type, display_name, config);
+#else
+        break;
+#endif
+      case display_backend_e::x11:
+#ifdef POLARIS_BUILD_X11
+        BOOST_LOG(info) << "Screencasting with X11"sv;
+        return x11_display(hwdevice_type, display_name, config);
+#else
+        break;
+#endif
+      default:
+        break;
+    }
+
+    BOOST_LOG(error) << "No available capture backend satisfies generation request ["sv
+                     << requested_backend << "]"sv;
     return nullptr;
   }
 

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -452,14 +452,6 @@ namespace portal {
     return true;
   }
 
-  static bool ensure_global_session() {
-    std::lock_guard transition_lock(g_capture_transition_mu);
-    auto start = session_media::begin_start();
-    reap_portal_cleanup();
-    std::lock_guard lock(g_media_mu);
-    return ensure_session_unlocked();
-  }
-
   static std::shared_ptr<pipewire_capture::capture_t> ensure_global_capture(
     int width,
     int height,
@@ -504,29 +496,16 @@ namespace portal {
 
         BOOST_LOG(info) << "portal: capture configuration changed; retiring PipeWire generation before reconnect"sv;
         auto retired_capture = std::move(g_media.capture);
+        auto retired_portal = std::move(g_media.portal);
         auto retired_kwin = std::move(g_media.kwin);
         g_media.clear_meta();
         lock.unlock();
         retired_capture->stop();
         retired_capture->shutdown();
         retired_capture.reset();
+        retired_portal.reset();
         retired_kwin.reset();
         lock.lock();
-
-        // A PipeWire remote FD is a protocol connection, not a reusable device
-        // handle. Request a fresh remote only after the old producer is fully
-        // quiescent; the transition mutex prevents a concurrent replacement.
-        if (g_media.portal && g_media.portal->conn && !g_media.portal->session_handle.empty()) {
-          if (g_media.portal->pw_remote_fd >= 0) {
-            close(g_media.portal->pw_remote_fd);
-            g_media.portal->pw_remote_fd = -1;
-          }
-          g_media.portal->pw_remote_fd =
-            open_pipewire_remote_fd(g_media.portal->conn, g_media.portal->session_handle);
-        }
-        if (!g_media.portal || g_media.portal->pw_remote_fd < 0) {
-          g_media.portal.reset();
-        }
       } else if (g_media.capture) {
         // A dead stream invalidates the node on this private remote. Explicitly
         // retire it outside g_media_mu before replacing portal/session state.
@@ -855,11 +834,6 @@ namespace portal {
         cage_configured = config::video.linux_display.use_cage_compositor;
 #endif
         if (!cage_configured) {
-          if (!ensure_global_session()) {
-            return -1;
-          }
-
-
           auto cap = ensure_global_capture(requested_width, requested_height, mem_type, client_dynamic_range);
           if (!cap) {
             return -1;
@@ -979,13 +953,7 @@ namespace portal {
       }
 #endif
 
-      // Fallback: portal D-Bus capture (only when cage is NOT configured)
-      if (!ensure_global_session()) {
-        BOOST_LOG(warning) << "portal: No capture session available"sv;
-        return platf::capture_e::reinit;
-      }
-
-
+      // Fallback: source-owned portal/KWin capture (only when cage is NOT configured)
       auto cap = ensure_global_capture(requested_width, requested_height, mem_type, client_dynamic_range);
       if (!cap) {
         BOOST_LOG(warning) << "portal: No capture available"sv;

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -73,6 +73,32 @@ namespace portal {
   //     move the cache out while display threads still hold a ref.
   // -----------------------------------------------------------------------
 
+  bool capture_identity_matches(
+    std::string_view cached_stream_mode,
+    std::string_view cached_output_name,
+    std::string_view requested_stream_mode,
+    std::string_view requested_output_name
+  ) {
+    return cached_stream_mode == requested_stream_mode &&
+           cached_output_name == requested_output_name;
+  }
+
+#ifdef POLARIS_TESTS
+  bool portal_capture_identity_matches_for_tests(
+    std::string_view cached_stream_mode,
+    std::string_view cached_output_name,
+    std::string_view requested_stream_mode,
+    std::string_view requested_output_name
+  ) {
+    return capture_identity_matches(
+      cached_stream_mode,
+      cached_output_name,
+      requested_stream_mode,
+      requested_output_name
+    );
+  }
+#endif
+
   struct media_cache_t {
     std::unique_ptr<portal_session_t> portal;
     // Opaque lifetime guard for a Wayland-only kwingrab session. Keeping the
@@ -83,6 +109,8 @@ namespace portal {
     int requested_height = 0;
     platf::mem_type_e mem_type = platf::mem_type_e::system;
     std::string adapter;
+    std::string stream_mode;
+    std::string output_name;
     // Last EnumFormat preference: prefer_hdr (force ∧ dynamicRange>0) or
     // prefer_sdr (dynamicRange<=0). Reuse only when both match.
     bool prefer_hdr = false;
@@ -93,6 +121,8 @@ namespace portal {
       requested_height = 0;
       mem_type = platf::mem_type_e::system;
       adapter.clear();
+      stream_mode.clear();
+      output_name.clear();
       prefer_hdr = false;
       prefer_sdr = false;
     }
@@ -450,11 +480,22 @@ namespace portal {
       std::unique_lock lock(g_media_mu);
 
       const auto requested_adapter = config::video.adapter_name;
+      const auto requested_stream_mode = config::video.linux_display.stream_mode;
+      const auto requested_output_name =
+        config::video.output_name.empty() ?
+          config::video.linux_display.streaming_output :
+          config::video.output_name;
       if (g_media.capture && g_media.capture->running()) {
         const auto compatible = g_media.requested_width == width &&
                                 g_media.requested_height == height &&
                                 g_media.mem_type == mem_type &&
                                 g_media.adapter == requested_adapter &&
+                                capture_identity_matches(
+                                  g_media.stream_mode,
+                                  g_media.output_name,
+                                  requested_stream_mode,
+                                  requested_output_name
+                                ) &&
                                 g_media.prefer_hdr == want_prefer_hdr &&
                                 g_media.prefer_sdr == want_prefer_sdr;
         if (compatible) {
@@ -504,9 +545,8 @@ namespace portal {
       // W3/W5 gamescopegrab: prefer session-graph Video/Source (media.name=gamescope)
       // without private portal ScreenCast when linux_stream_mode=gamescope_stream.
       // Falls through to portal if the node is missing (idle unit not exporting yet).
-      const auto &stream_mode = config::video.linux_display.stream_mode;
       if ((!g_media.capture || !g_media.capture->running()) &&
-          (stream_mode == "gamescope_stream" || stream_mode.empty()) &&
+          (requested_stream_mode == "gamescope_stream" || requested_stream_mode.empty()) &&
           config::video.linux_display.private_runtime == "gamescope") {
         if (auto gs = pipewire_capture::find_gamescope_video_source()) {
           if (auto local = start_local_pw_capture(
@@ -519,6 +559,8 @@ namespace portal {
             g_media.requested_height = height;
             g_media.mem_type = mem_type;
             g_media.adapter = requested_adapter;
+            g_media.stream_mode = requested_stream_mode;
+            g_media.output_name = requested_output_name;
             g_media.prefer_hdr = want_prefer_hdr;
             g_media.prefer_sdr = want_prefer_sdr;
             capture = g_media.capture;
@@ -543,10 +585,7 @@ namespace portal {
           portal_like_capture &&
           kwingrab::prefer_for_current_stream_mode()) {
         g_media.kwin.reset();
-        if (auto kwin_session = kwingrab::start_output_session(
-              config::video.output_name.empty() ? config::video.linux_display.streaming_output :
-                                                  config::video.output_name
-            )) {
+        if (auto kwin_session = kwingrab::start_output_session(requested_output_name)) {
           const auto &src = kwin_session->source();
           if (auto local = start_local_pw_capture(
                 src.node_id,
@@ -565,17 +604,29 @@ namespace portal {
             g_media.requested_height = height;
             g_media.mem_type = mem_type;
             g_media.adapter = requested_adapter;
+            g_media.stream_mode = requested_stream_mode;
+            g_media.output_name = requested_output_name;
             g_media.prefer_hdr = want_prefer_hdr;
             g_media.prefer_sdr = want_prefer_sdr;
             capture = g_media.capture;
           }
           else {
-            BOOST_LOG(info) << "portal: kwingrab PipeWire start failed; falling back to portal ScreenCast"sv;
+            BOOST_LOG(error) << "portal: kwingrab PipeWire start failed"sv;
             kwin_session.reset();
+            if (kwingrab::require_for_current_stream_mode()) {
+              BOOST_LOG(error) << "portal: host virtual capture requires output-pinned KWin capture; refusing generic portal fallback"sv;
+              return nullptr;
+            }
+            BOOST_LOG(info) << "portal: falling back to portal ScreenCast"sv;
           }
         }
         else {
-          BOOST_LOG(info) << "portal: kwingrab unavailable; falling back to portal ScreenCast"sv;
+          BOOST_LOG(error) << "portal: kwingrab unavailable"sv;
+          if (kwingrab::require_for_current_stream_mode()) {
+            BOOST_LOG(error) << "portal: host virtual capture requires output-pinned KWin capture; refusing generic portal fallback"sv;
+            return nullptr;
+          }
+          BOOST_LOG(info) << "portal: falling back to portal ScreenCast"sv;
         }
       }
 #endif
@@ -717,6 +768,8 @@ namespace portal {
         g_media.requested_height = height;
         g_media.mem_type = mem_type;
         g_media.adapter = requested_adapter;
+        g_media.stream_mode = requested_stream_mode;
+        g_media.output_name = requested_output_name;
         g_media.prefer_hdr = want_prefer_hdr;
         g_media.prefer_sdr = want_prefer_sdr;
         g_media.capture = new_capture;

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -81,7 +81,18 @@ namespace portal {
     return cached == requested;
   }
 
+  bool portal_capture_backend_allowed(std::string_view capture_backend) {
+    return capture_backend.empty() ||
+           capture_backend == "auto" ||
+           capture_backend == "portal" ||
+           capture_backend == "kwin";
+  }
+
 #ifdef POLARIS_TESTS
+  bool portal_capture_backend_allowed_for_tests(std::string_view capture_backend) {
+    return portal_capture_backend_allowed(capture_backend);
+  }
+
   bool portal_capture_generation_matches_for_tests(
     const capture_generation::identity_t &cached,
     const capture_generation::identity_t &requested
@@ -449,6 +460,11 @@ namespace portal {
     int client_dynamic_range,
     const capture_generation::identity_t &generation
   ) {
+    if (!portal_capture_backend_allowed(generation.capture_backend)) {
+      BOOST_LOG(error) << "portal: capture generation backend ["sv << generation.capture_backend
+                       << "] is not portal-authoritative; refusing acquisition"sv;
+      return nullptr;
+    }
     // Only one configuration transition may retire/publish a capture generation.
     std::lock_guard transition_lock(g_capture_transition_mu);
     auto start = session_media::begin_start();
@@ -539,11 +555,7 @@ namespace portal {
       // W4/P1 kwingrab: host KDE desktop_display / headless_dongle — try KWin
       // zkde screencast before portal picker. Fail cleanly when not on KWin.
       // capture=portal/auto/empty only; explicit wlr/kms unchanged.
-      const bool portal_like_capture =
-        generation.capture_backend.empty() ||
-        generation.capture_backend == "auto" ||
-        generation.capture_backend == "portal" ||
-        generation.capture_backend == "kwin";
+      const bool portal_like_capture = portal_capture_backend_allowed(generation.capture_backend);
       if ((!g_media.capture || !g_media.capture->running()) &&
           portal_like_capture &&
           kwingrab::prefer_for_generation(generation)) {
@@ -790,6 +802,11 @@ namespace portal {
     int
     init(platf::mem_type_e hwdevice_type, const std::string &display_name, const ::video::config_t &config) {
       generation_ = config.capture_generation;
+      if (!portal_capture_backend_allowed(generation_.capture_backend)) {
+        BOOST_LOG(error) << "portal: capture generation backend ["sv << generation_.capture_backend
+                         << "] is not portal-authoritative; refusing initialization"sv;
+        return -1;
+      }
       if (!generation_.exact_display_name.empty() &&
           (display_name != generation_.exact_display_name ||
            generation_.requested_output_name != generation_.exact_display_name)) {

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -572,6 +572,13 @@ namespace portal {
         }
       }
 
+#ifndef POLARIS_BUILD_WAYLAND
+      if (requested_stream_mode == "host_virtual_display") {
+        BOOST_LOG(error) << "portal: host virtual capture requires KWin output pinning, but Wayland support is not built"sv;
+        return nullptr;
+      }
+#endif
+
 #ifdef POLARIS_BUILD_WAYLAND
       // W4/P1 kwingrab: host KDE desktop_display / headless_dongle — try KWin
       // zkde screencast before portal picker. Fail cleanly when not on KWin.

--- a/src/platform/linux/portal_grab.cpp
+++ b/src/platform/linux/portal_grab.cpp
@@ -26,6 +26,7 @@
 #include <spa/param/video/raw.h>
 #include <unistd.h>
 
+#include "src/capture_generation.h"
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
@@ -73,29 +74,19 @@ namespace portal {
   //     move the cache out while display threads still hold a ref.
   // -----------------------------------------------------------------------
 
-  bool capture_identity_matches(
-    std::string_view cached_stream_mode,
-    std::string_view cached_output_name,
-    std::string_view requested_stream_mode,
-    std::string_view requested_output_name
+  bool capture_generation_matches(
+    const capture_generation::identity_t &cached,
+    const capture_generation::identity_t &requested
   ) {
-    return cached_stream_mode == requested_stream_mode &&
-           cached_output_name == requested_output_name;
+    return cached == requested;
   }
 
 #ifdef POLARIS_TESTS
-  bool portal_capture_identity_matches_for_tests(
-    std::string_view cached_stream_mode,
-    std::string_view cached_output_name,
-    std::string_view requested_stream_mode,
-    std::string_view requested_output_name
+  bool portal_capture_generation_matches_for_tests(
+    const capture_generation::identity_t &cached,
+    const capture_generation::identity_t &requested
   ) {
-    return capture_identity_matches(
-      cached_stream_mode,
-      cached_output_name,
-      requested_stream_mode,
-      requested_output_name
-    );
+    return capture_generation_matches(cached, requested);
   }
 #endif
 
@@ -108,9 +99,7 @@ namespace portal {
     int requested_width = 0;
     int requested_height = 0;
     platf::mem_type_e mem_type = platf::mem_type_e::system;
-    std::string adapter;
-    std::string stream_mode;
-    std::string output_name;
+    capture_generation::identity_t generation;
     // Last EnumFormat preference: prefer_hdr (force ∧ dynamicRange>0) or
     // prefer_sdr (dynamicRange<=0). Reuse only when both match.
     bool prefer_hdr = false;
@@ -120,9 +109,7 @@ namespace portal {
       requested_width = 0;
       requested_height = 0;
       mem_type = platf::mem_type_e::system;
-      adapter.clear();
-      stream_mode.clear();
-      output_name.clear();
+      generation = {};
       prefer_hdr = false;
       prefer_sdr = false;
     }
@@ -194,12 +181,14 @@ namespace portal {
   // Exclusive 10-bit PQ EnumFormat only when gamescope is in HDR mode *and* the
   // client stream will encode HDR (dynamicRange > 0). Host KDE ScreenCast is
   // 8-bit-only; never restrict EnumFormat to PQ outside gamescope_stream.
-  static bool portal_prefer_hdr_formats(int client_dynamic_range) {
+  static bool portal_prefer_hdr_formats(
+    int client_dynamic_range,
+    std::string_view stream_mode
+  ) {
     if (client_dynamic_range <= 0 || !portal_force_hdr_enabled()) {
       return false;
     }
-    const auto &mode = config::video.linux_display.stream_mode;
-    return mode.empty() || mode == "gamescope_stream";
+    return stream_mode.empty() || stream_mode == "gamescope_stream";
   }
 
   // Exclusive 8-bit EnumFormat when the stream encodes SDR. Mixed offers still
@@ -235,8 +224,8 @@ namespace portal {
   // when it names a canonical render node, else the host's sole render node.
   // Single-GPU hosts get zero-copy without configuration; multi-GPU hosts stay
   // fail-closed so DMA-BUF never imports across GPUs by guess.
-  static std::optional<std::string> encoder_render_node_for_dmabuf() {
-    if (auto configured = pipewire_capture::canonical_render_node(config::video.adapter_name)) {
+  static std::optional<std::string> encoder_render_node_for_dmabuf(std::string_view adapter_name) {
+    if (auto configured = pipewire_capture::canonical_render_node(adapter_name)) {
       return configured;
     }
     std::vector<std::string> nodes;
@@ -265,12 +254,13 @@ namespace portal {
     int width,
     int height,
     platf::mem_type_e mem_type,
-    int client_dynamic_range
+    int client_dynamic_range,
+    const capture_generation::identity_t &generation
   ) {
-    const auto encoder_render_node = encoder_render_node_for_dmabuf();
+    const auto encoder_render_node = encoder_render_node_for_dmabuf(generation.adapter_name);
     std::vector<pipewire_capture::dmabuf_format_modifier_t> dmabuf_formats;
     bool may_use_dmabuf = false;
-    const bool prefer_hdr = portal_prefer_hdr_formats(client_dynamic_range);
+    const bool prefer_hdr = portal_prefer_hdr_formats(client_dynamic_range, generation.stream_mode);
     const bool prefer_sdr = portal_prefer_sdr_formats(client_dynamic_range);
     const auto dmabuf_override = portal_dmabuf_override();
     if (encoder_render_node) {
@@ -411,14 +401,14 @@ namespace portal {
   }
 
   // Caller must hold g_media_mu.
-  static bool ensure_session_unlocked() {
+  static bool ensure_session_unlocked(const capture_generation::identity_t &generation) {
     if (!g_media.portal || !g_media.portal->ready || g_media.portal->pw_node_id == 0) {
       g_media.portal.reset();
-      auto try_create = []() {
+      auto try_create = [&generation]() {
         return create_portal_session(capture_type_for_stream_display(
-          config::video.linux_display.headless_mode,
-          config::video.linux_display.use_cage_compositor,
-          config::video.linux_display.stream_mode));
+          generation.headless_mode,
+          generation.use_cage_compositor,
+          generation.stream_mode));
       };
       g_media.portal = try_create();
       // Nested↔idle gamescope handoff: portal-gamescope may briefly fail Start with
@@ -456,7 +446,8 @@ namespace portal {
     int width,
     int height,
     platf::mem_type_e mem_type,
-    int client_dynamic_range
+    int client_dynamic_range,
+    const capture_generation::identity_t &generation
   ) {
     // Only one configuration transition may retire/publish a capture generation.
     std::lock_guard transition_lock(g_capture_transition_mu);
@@ -465,29 +456,17 @@ namespace portal {
     // Lock contract (SB-2 + S4 single mutex):
     // 1) Under g_media_mu: ensure session + start PipeWire (no dual-mutex nesting).
     // 2) Wait for negotiation OUTSIDE the lock so release_global_capture can progress.
-    const bool want_prefer_hdr = portal_prefer_hdr_formats(client_dynamic_range);
+    const bool want_prefer_hdr = portal_prefer_hdr_formats(client_dynamic_range, generation.stream_mode);
     const bool want_prefer_sdr = portal_prefer_sdr_formats(client_dynamic_range);
     std::shared_ptr<pipewire_capture::capture_t> capture;
     {
       std::unique_lock lock(g_media_mu);
 
-      const auto requested_adapter = config::video.adapter_name;
-      const auto requested_stream_mode = config::video.linux_display.stream_mode;
-      const auto requested_output_name =
-        config::video.output_name.empty() ?
-          config::video.linux_display.streaming_output :
-          config::video.output_name;
       if (g_media.capture && g_media.capture->running()) {
         const auto compatible = g_media.requested_width == width &&
                                 g_media.requested_height == height &&
                                 g_media.mem_type == mem_type &&
-                                g_media.adapter == requested_adapter &&
-                                capture_identity_matches(
-                                  g_media.stream_mode,
-                                  g_media.output_name,
-                                  requested_stream_mode,
-                                  requested_output_name
-                                ) &&
+                                g_media.generation == generation &&
                                 g_media.prefer_hdr == want_prefer_hdr &&
                                 g_media.prefer_sdr == want_prefer_sdr;
         if (compatible) {
@@ -525,11 +504,11 @@ namespace portal {
       // without private portal ScreenCast when linux_stream_mode=gamescope_stream.
       // Falls through to portal if the node is missing (idle unit not exporting yet).
       if ((!g_media.capture || !g_media.capture->running()) &&
-          (requested_stream_mode == "gamescope_stream" || requested_stream_mode.empty()) &&
-          config::video.linux_display.private_runtime == "gamescope") {
+          (generation.stream_mode == "gamescope_stream" || generation.stream_mode.empty()) &&
+          generation.private_runtime == "gamescope") {
         if (auto gs = pipewire_capture::find_gamescope_video_source()) {
           if (auto local = start_local_pw_capture(
-                gs->node_id, gs->object_serial, width, height, mem_type, client_dynamic_range)) {
+                gs->node_id, gs->object_serial, width, height, mem_type, client_dynamic_range, generation)) {
             BOOST_LOG(info) << "portal: gamescopegrab local Video/Source node="sv << gs->node_id
                             << " name="sv << gs->node_name << " (no private ScreenCast)"sv;
             g_media.kwin.reset();
@@ -537,9 +516,7 @@ namespace portal {
             g_media.requested_width = width;
             g_media.requested_height = height;
             g_media.mem_type = mem_type;
-            g_media.adapter = requested_adapter;
-            g_media.stream_mode = requested_stream_mode;
-            g_media.output_name = requested_output_name;
+            g_media.generation = generation;
             g_media.prefer_hdr = want_prefer_hdr;
             g_media.prefer_sdr = want_prefer_sdr;
             capture = g_media.capture;
@@ -552,7 +529,7 @@ namespace portal {
       }
 
 #ifndef POLARIS_BUILD_WAYLAND
-      if (requested_stream_mode == "host_virtual_display") {
+      if (generation.stream_mode == "host_virtual_display") {
         BOOST_LOG(error) << "portal: host virtual capture requires KWin output pinning, but Wayland support is not built"sv;
         return nullptr;
       }
@@ -563,15 +540,15 @@ namespace portal {
       // zkde screencast before portal picker. Fail cleanly when not on KWin.
       // capture=portal/auto/empty only; explicit wlr/kms unchanged.
       const bool portal_like_capture =
-        config::video.capture.empty() ||
-        config::video.capture == "auto" ||
-        config::video.capture == "portal" ||
-        config::video.capture == "kwin";
+        generation.capture_backend.empty() ||
+        generation.capture_backend == "auto" ||
+        generation.capture_backend == "portal" ||
+        generation.capture_backend == "kwin";
       if ((!g_media.capture || !g_media.capture->running()) &&
           portal_like_capture &&
-          kwingrab::prefer_for_current_stream_mode()) {
+          kwingrab::prefer_for_generation(generation)) {
         g_media.kwin.reset();
-        if (auto kwin_session = kwingrab::start_output_session(requested_output_name)) {
+        if (auto kwin_session = kwingrab::start_output_session(generation.requested_output_name)) {
           const auto &src = kwin_session->source();
           if (auto local = start_local_pw_capture(
                 src.node_id,
@@ -579,7 +556,8 @@ namespace portal {
                 width > 0 ? width : src.width,
                 height > 0 ? height : src.height,
                 mem_type,
-                client_dynamic_range)) {
+                client_dynamic_range,
+                generation)) {
             BOOST_LOG(info) << "portal: kwingrab local PW node="sv << src.node_id
                             << " output="sv << src.output_name
                             << " (no xdg-desktop-portal picker)"sv;
@@ -589,9 +567,7 @@ namespace portal {
             g_media.requested_width = width;
             g_media.requested_height = height;
             g_media.mem_type = mem_type;
-            g_media.adapter = requested_adapter;
-            g_media.stream_mode = requested_stream_mode;
-            g_media.output_name = requested_output_name;
+            g_media.generation = generation;
             g_media.prefer_hdr = want_prefer_hdr;
             g_media.prefer_sdr = want_prefer_sdr;
             capture = g_media.capture;
@@ -599,7 +575,7 @@ namespace portal {
           else {
             BOOST_LOG(error) << "portal: kwingrab PipeWire start failed"sv;
             kwin_session.reset();
-            if (kwingrab::require_for_current_stream_mode()) {
+            if (kwingrab::require_for_generation(generation)) {
               BOOST_LOG(error) << "portal: host virtual capture requires output-pinned KWin capture; refusing generic portal fallback"sv;
               return nullptr;
             }
@@ -608,7 +584,7 @@ namespace portal {
         }
         else {
           BOOST_LOG(error) << "portal: kwingrab unavailable"sv;
-          if (kwingrab::require_for_current_stream_mode()) {
+          if (kwingrab::require_for_generation(generation)) {
             BOOST_LOG(error) << "portal: host virtual capture requires output-pinned KWin capture; refusing generic portal fallback"sv;
             return nullptr;
           }
@@ -621,12 +597,12 @@ namespace portal {
       if (capture && capture->running()) {
         // fall through to negotiation wait outside lock
       }
-      else if (!ensure_session_unlocked()) {
+      else if (!ensure_session_unlocked(generation)) {
         return nullptr;
       }
       else {
         auto *session = g_media.portal.get();
-        const auto encoder_render_node = encoder_render_node_for_dmabuf();
+        const auto encoder_render_node = encoder_render_node_for_dmabuf(generation.adapter_name);
         // Headless gamescope often omits SPA capture.device / render_node. If the
         // operator set adapter_name to a render node (same GPU as NVENC), assume it.
         if (!session->capture_render_node) {
@@ -648,7 +624,7 @@ namespace portal {
         } else if (!session->capture_render_node) {
           BOOST_LOG(info) << "portal: DMA-BUF disabled because the portal stream did not provide an explicit capture render node"sv;
         } else if (!encoder_render_node) {
-          BOOST_LOG(info) << "portal: DMA-BUF disabled because config::video.adapter_name is not an explicit canonical render node"sv;
+          BOOST_LOG(info) << "portal: DMA-BUF disabled because the capture generation adapter is not an explicit canonical render node"sv;
         } else if (*session->capture_render_node != *encoder_render_node) {
           BOOST_LOG(info) << "portal: DMA-BUF disabled because capture render node ["sv << *session->capture_render_node
                           << "] does not match encoder adapter ["sv << *encoder_render_node << ']';
@@ -753,9 +729,7 @@ namespace portal {
         g_media.requested_width = width;
         g_media.requested_height = height;
         g_media.mem_type = mem_type;
-        g_media.adapter = requested_adapter;
-        g_media.stream_mode = requested_stream_mode;
-        g_media.output_name = requested_output_name;
+        g_media.generation = generation;
         g_media.prefer_hdr = want_prefer_hdr;
         g_media.prefer_sdr = want_prefer_sdr;
         g_media.capture = new_capture;
@@ -773,7 +747,7 @@ namespace portal {
     {
       std::lock_guard lock(g_media_mu);
       // If release_global_capture raced us, drop the orphan (caller must not use it).
-      if (g_media.capture != capture) {
+      if (g_media.capture != capture || g_media.generation != generation) {
         return nullptr;
       }
       if (!capture || !capture->negotiated()) {
@@ -811,9 +785,17 @@ namespace portal {
     std::uint32_t capture_spa_format = 0;
 
     bool probe_only = false;  // true during encoder probe (skip portal session)
+    capture_generation::identity_t generation_;
 
     int
     init(platf::mem_type_e hwdevice_type, const std::string &display_name, const ::video::config_t &config) {
+      generation_ = config.capture_generation;
+      if (!generation_.exact_display_name.empty() &&
+          (display_name != generation_.exact_display_name ||
+           generation_.requested_output_name != generation_.exact_display_name)) {
+        BOOST_LOG(error) << "portal: exact capture generation identity mismatch; refusing initialization"sv;
+        return -1;
+      }
       requested_width = config.width;
       requested_height = config.height;
       cfg_width = requested_width;
@@ -831,10 +813,10 @@ namespace portal {
         // Check config, not runtime state — cage may not be running yet at init time.
         bool cage_configured = false;
 #ifdef POLARIS_BUILD_WAYLAND
-        cage_configured = config::video.linux_display.use_cage_compositor;
+        cage_configured = generation_.use_cage_compositor;
 #endif
         if (!cage_configured) {
-          auto cap = ensure_global_capture(requested_width, requested_height, mem_type, client_dynamic_range);
+          auto cap = ensure_global_capture(requested_width, requested_height, mem_type, client_dynamic_range, generation_);
           if (!cap) {
             return -1;
           }
@@ -926,7 +908,7 @@ namespace portal {
 
       // If cage/labwc is configured, use direct wlr-screencopy (no portal, no picker)
 #ifdef POLARIS_BUILD_WAYLAND
-      if (config::video.linux_display.use_cage_compositor) {
+      if (generation_.use_cage_compositor) {
         // Wait for labwc to be running (it may still be starting up)
         for (int wait = 0; wait < 50 && !stream_runtime::labwc::is_running(); ++wait) {
           std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -954,7 +936,7 @@ namespace portal {
 #endif
 
       // Fallback: source-owned portal/KWin capture (only when cage is NOT configured)
-      auto cap = ensure_global_capture(requested_width, requested_height, mem_type, client_dynamic_range);
+      auto cap = ensure_global_capture(requested_width, requested_height, mem_type, client_dynamic_range, generation_);
       if (!cap) {
         BOOST_LOG(warning) << "portal: No capture available"sv;
         return platf::capture_e::reinit;

--- a/src/platform/linux/portal_session.cpp
+++ b/src/platform/linux/portal_session.cpp
@@ -406,7 +406,7 @@ namespace portal {
     // never an app window — it sets headless_mode too, so without this entry it
     // fell through to portal_source_window: the same hang-prone combination, and
     // a source type that cannot name the virtual output at all.
-    const auto mode = stream_mode.empty() ? std::string_view {config::video.linux_display.stream_mode} : stream_mode;
+    const auto mode = stream_mode;
     if (mode == "headless_dongle" || mode == "desktop_display" || mode == "headless_evdi" ||
         mode == "host_virtual_display") {
       return portal_source_monitor;

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -147,7 +147,7 @@ namespace stream_display_policy {
     bool virtual_display_user_locked
   ) {
     if (mirror_desktop) {
-      return {};
+      return std::string {k_desktop_display};
     }
     if (!requested_selection.empty()) {
       return std::string {requested_selection};

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -173,9 +173,8 @@ namespace stream_display_policy {
       return "wlr";
     }
 
-    if ((backend == virtual_display::backend_e::EVDI ||
-         backend == virtual_display::backend_e::KSCREEN_DOCTOR) &&
-        (current_capture.empty() || current_capture == "auto")) {
+    if (backend == virtual_display::backend_e::EVDI ||
+        backend == virtual_display::backend_e::KSCREEN_DOCTOR) {
       return "portal";
     }
 

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -139,6 +139,49 @@ namespace stream_display_policy {
     return booleans;
   }
 
+  std::string effective_session_selection_for_launch(
+    std::string_view requested_selection,
+    bool mirror_desktop,
+    bool launch_virtual_display,
+    bool app_virtual_display,
+    bool virtual_display_user_locked
+  ) {
+    if (mirror_desktop) {
+      return {};
+    }
+    if (!requested_selection.empty()) {
+      return std::string {requested_selection};
+    }
+    if (launch_virtual_display || (app_virtual_display && !virtual_display_user_locked)) {
+      return std::string {k_host_virtual_display};
+    }
+    return {};
+  }
+
+  std::string capture_output_name_for_virtual_display(
+    std::string_view created_output_name,
+    std::string_view mapped_output_name
+  ) {
+    return std::string {mapped_output_name.empty() ? created_output_name : mapped_output_name};
+  }
+
+  std::string capture_for_host_virtual_display_backend(
+    virtual_display::backend_e backend,
+    std::string_view current_capture
+  ) {
+    if (backend == virtual_display::backend_e::WAYLAND_WLR) {
+      return "wlr";
+    }
+
+    if ((backend == virtual_display::backend_e::EVDI ||
+         backend == virtual_display::backend_e::KSCREEN_DOCTOR) &&
+        (current_capture.empty() || current_capture == "auto")) {
+      return "portal";
+    }
+
+    return std::string {current_capture};
+  }
+
   resolved_t resolve(const input_t &input) {
     const auto selection = configured_selection_id();
     const auto *path = stream_path::find(selection);
@@ -254,6 +297,13 @@ namespace stream_display_policy {
         return false;
       }
 
+      if (key == k_host_virtual_display &&
+          config::video.capture != capture_for_host_virtual_display_backend(
+                                     virtual_display::detect_backend(),
+                                     config::video.capture
+                                   )) {
+        return false;
+      }
       if (key == stream_path::k_gamescope_stream && config::video.capture.empty()) {
         return false;
       }
@@ -280,6 +330,13 @@ namespace stream_display_policy {
     const auto key = to_lower_copy(selection);
 
     auto &linux_display = config::video.linux_display;
+
+    if (key == k_host_virtual_display) {
+      config::video.capture = capture_for_host_virtual_display_backend(
+        virtual_display::detect_backend(),
+        config::video.capture
+      );
+    }
 
     if (key == stream_path::k_gamescope_stream) {
       auto caps = stream_path::probe_host_capabilities();
@@ -351,6 +408,12 @@ namespace stream_display_policy {
         }
         else if (path->runtime == stream_path::runtime_kind_e::GAMESCOPE) {
           linux_display.private_runtime = std::string {k_runtime_gamescope};
+        }
+        if (path->id == k_host_virtual_display) {
+          config::video.capture = capture_for_host_virtual_display_backend(
+            virtual_display::detect_backend(),
+            config::video.capture
+          );
         }
         // headless_dongle: default to portal (host desktop after topology swap).
         // Do not force KMS — without CAP_SYS_ADMIN encoder probe fails empty.

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -297,6 +297,9 @@ namespace stream_display_policy {
         return false;
       }
 
+      if (key == k_host_virtual_display && linux_display.auto_manage_displays) {
+        return false;
+      }
       if (key == k_host_virtual_display &&
           config::video.capture != capture_for_host_virtual_display_backend(
                                      virtual_display::detect_backend(),
@@ -332,6 +335,7 @@ namespace stream_display_policy {
     auto &linux_display = config::video.linux_display;
 
     if (key == k_host_virtual_display) {
+      linux_display.auto_manage_displays = false;
       config::video.capture = capture_for_host_virtual_display_backend(
         virtual_display::detect_backend(),
         config::video.capture

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -153,7 +153,8 @@ namespace stream_display_policy {
     bool mirror_desktop,
     bool launch_virtual_display,
     bool app_virtual_display,
-    bool virtual_display_user_locked
+    bool virtual_display_user_locked,
+    bool virtual_display_optimization_present
   ) {
     if (mirror_desktop) {
       return std::string {k_desktop_display};
@@ -161,7 +162,12 @@ namespace stream_display_policy {
     if (!requested_selection.empty()) {
       return std::string {requested_selection};
     }
-    if (launch_virtual_display || (app_virtual_display && !virtual_display_user_locked)) {
+    if (launch_virtual_display) {
+      return std::string {k_host_virtual_display};
+    }
+    if (!virtual_display_optimization_present &&
+        app_virtual_display &&
+        !virtual_display_user_locked) {
       return std::string {k_host_virtual_display};
     }
     return {};
@@ -411,11 +417,11 @@ namespace stream_display_policy {
         linux_display.headless_mode = booleans.headless_mode;
         linux_display.use_cage_compositor = booleans.use_cage_compositor;
         linux_display.prefer_gpu_native_capture = booleans.prefer_gpu_native_capture;
-        if (path->runtime == stream_path::runtime_kind_e::LABWC) {
+        linux_display.private_runtime = std::string {
+          stream_path::runtime_kind_id(path->runtime)
+        };
+        if (linux_display.private_runtime.empty() && booleans.use_cage_compositor) {
           linux_display.private_runtime = std::string {k_runtime_labwc};
-        }
-        else if (path->runtime == stream_path::runtime_kind_e::GAMESCOPE) {
-          linux_display.private_runtime = std::string {k_runtime_gamescope};
         }
         if (path->id == k_host_virtual_display) {
           normalize_host_virtual_display_state();
@@ -441,8 +447,13 @@ namespace stream_display_policy {
       normalize_host_virtual_display_state();
     }
 
-    if (linux_display.private_runtime.empty()) {
-      linux_display.private_runtime = std::string {k_runtime_labwc};
+    if (const auto *path = stream_path::find(linux_display.stream_mode)) {
+      linux_display.private_runtime = std::string {
+        stream_path::runtime_kind_id(path->runtime)
+      };
+      if (linux_display.private_runtime.empty() && linux_display.use_cage_compositor) {
+        linux_display.private_runtime = std::string {k_runtime_labwc};
+      }
     }
   }
 

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -32,6 +32,15 @@ namespace stream_display_policy {
       });
     }
 
+    void normalize_host_virtual_display_state() {
+      auto &linux_display = config::video.linux_display;
+      linux_display.auto_manage_displays = false;
+      config::video.capture = capture_for_host_virtual_display_backend(
+        virtual_display::detect_backend(),
+        config::video.capture
+      );
+    }
+
   }  // namespace
 
   std::string label_for_selection(std::string_view selection) {
@@ -334,11 +343,7 @@ namespace stream_display_policy {
     auto &linux_display = config::video.linux_display;
 
     if (key == k_host_virtual_display) {
-      linux_display.auto_manage_displays = false;
-      config::video.capture = capture_for_host_virtual_display_backend(
-        virtual_display::detect_backend(),
-        config::video.capture
-      );
+      normalize_host_virtual_display_state();
     }
 
     if (key == stream_path::k_gamescope_stream) {
@@ -413,10 +418,7 @@ namespace stream_display_policy {
           linux_display.private_runtime = std::string {k_runtime_gamescope};
         }
         if (path->id == k_host_virtual_display) {
-          config::video.capture = capture_for_host_virtual_display_backend(
-            virtual_display::detect_backend(),
-            config::video.capture
-          );
+          normalize_host_virtual_display_state();
         }
         // headless_dongle: default to portal (host desktop after topology swap).
         // Do not force KMS — without CAP_SYS_ADMIN encoder probe fails empty.
@@ -435,6 +437,9 @@ namespace stream_display_policy {
       linux_display.use_cage_compositor,
       linux_display.prefer_gpu_native_capture,
     });
+    if (linux_display.stream_mode == k_host_virtual_display) {
+      normalize_host_virtual_display_state();
+    }
 
     if (linux_display.private_runtime.empty()) {
       linux_display.private_runtime = std::string {k_runtime_labwc};

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -58,7 +58,8 @@ namespace stream_display_policy {
     bool mirror_desktop,
     bool launch_virtual_display,
     bool app_virtual_display,
-    bool virtual_display_user_locked
+    bool virtual_display_user_locked,
+    bool virtual_display_optimization_present = false
   );
 
   /**

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -13,6 +13,10 @@
 #include <string_view>
 #include <vector>
 
+namespace virtual_display {
+  enum class backend_e;
+}
+
 namespace stream_display_policy {
 
   struct input_t {
@@ -41,6 +45,42 @@ namespace stream_display_policy {
     bool use_cage_compositor = false;
     bool prefer_gpu_native_capture = false;
   };
+
+  /**
+   * @brief Derive a session mode for legacy Virtual Display launches.
+   *
+   * Explicit accepted streamMode and mirrorDesktop remain authoritative. An
+   * app default is used only when the client did not explicitly lock the
+   * virtual-display choice.
+   */
+  std::string effective_session_selection_for_launch(
+    std::string_view requested_selection,
+    bool mirror_desktop,
+    bool launch_virtual_display,
+    bool app_virtual_display,
+    bool virtual_display_user_locked
+  );
+
+  /**
+   * @brief Keep the created virtual connector name when display mapping cannot
+   *        produce a backend-specific identifier.
+   */
+  std::string capture_output_name_for_virtual_display(
+    std::string_view created_output_name,
+    std::string_view mapped_output_name
+  );
+
+  /**
+   * @brief Resolve the capture backend required by a host virtual display.
+   *
+   * Native wlroots headless outputs are capturable directly by output name.
+   * EVDI/KScreen outputs remain on the portal/KWin path unless an operator
+   * explicitly selected another backend.
+   */
+  std::string capture_for_host_virtual_display_backend(
+    virtual_display::backend_e backend,
+    std::string_view current_capture
+  );
 
   /** Stable selection ids — SoT is stream_path (no dual string tables). */
   constexpr std::string_view k_headless_stream = stream_path::k_headless_stream;

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -86,6 +86,7 @@ namespace stream_runtime {
     void stop();
     void reset_after_external_stop();
     std::string wayland_socket();
+    std::string session_instance_id();
     std::string x11_display();
     platf::runtime_state_t runtime_state();
 

--- a/src/platform/linux/stream_runtime_labwc.cpp
+++ b/src/platform/linux/stream_runtime_labwc.cpp
@@ -68,6 +68,10 @@ namespace stream_runtime {
       return cage_display_router::get_wayland_socket();
     }
 
+    std::string session_instance_id() {
+      return cage_display_router::get_session_instance_id();
+    }
+
     std::string x11_display() {
       return cage_display_router::get_x11_display();
     }

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -363,6 +363,60 @@ namespace virtual_display {
     return std::nullopt;
   }
 
+  bool sway_create_output_succeeded(std::string_view response_json) {
+    const auto response = nlohmann::json::parse(response_json, nullptr, false);
+    if (!response.is_array() || response.empty()) {
+      return false;
+    }
+    for (const auto &entry : response) {
+      if (!entry.is_object() ||
+          !entry.contains("success") ||
+          !entry["success"].is_boolean() ||
+          !entry["success"].get<bool>()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  std::optional<std::string> sway_new_headless_output(
+    std::string_view before_outputs_json,
+    std::string_view after_outputs_json
+  ) {
+    const auto before = nlohmann::json::parse(before_outputs_json, nullptr, false);
+    const auto after = nlohmann::json::parse(after_outputs_json, nullptr, false);
+    if (!before.is_array() || !after.is_array()) {
+      return std::nullopt;
+    }
+
+    std::set<std::string> previous_names;
+    for (const auto &output : before) {
+      if (output.is_object() && output.contains("name") && output["name"].is_string()) {
+        previous_names.insert(output["name"].get<std::string>());
+      }
+    }
+
+    std::optional<std::string> owned_output;
+    for (const auto &output : after) {
+      if (!output.is_object() || !output.contains("name") || !output["name"].is_string()) {
+        continue;
+      }
+      const auto name = output["name"].get<std::string>();
+      if (previous_names.contains(name) || !std::string_view {name}.starts_with("HEADLESS-")) {
+        continue;
+      }
+      if (owned_output) {
+        return std::nullopt;
+      }
+      owned_output = name;
+    }
+    return owned_output;
+  }
+
+  bool evdi_output_name_is_proven(std::string_view output_name) {
+    return !output_name.empty();
+  }
+
   bool hyprland_output_is_polaris_owned(std::string_view output_name) {
     constexpr std::string_view prefix = "POLARIS-HEADLESS-";
     if (!output_name.starts_with(prefix)) {
@@ -960,11 +1014,11 @@ namespace virtual_display {
         output_name = find_evdi_output(new_device_path);
       }
 
-      if (output_name.empty()) {
-        // Fallback: use a generic name that downstream code can try to match
-        output_name = "VIRTUAL-1";
-        BOOST_LOG(warning) << "Virtual display: could not determine EVDI output name, using fallback ["sv
-                           << output_name << "]"sv;
+      if (!evdi_output_name_is_proven(output_name)) {
+        BOOST_LOG(error) << "Virtual display: could not prove the EVDI output connector; refusing to publish a guessed name"sv;
+        fn_disconnect(handle);
+        fn_close(handle);
+        return std::nullopt;
       }
 
       vdisplay_t display;
@@ -1231,20 +1285,39 @@ namespace virtual_display {
         }
       }
       else if (compositor == "sway") {
-        // Sway: create a headless output
-        std::string result = exec_cmd("swaymsg create_output 2>&1");
-        BOOST_LOG(info) << "Virtual display: swaymsg create_output: "sv << result;
+        const std::string sway_outputs_before = exec_cmd("swaymsg -t get_outputs -r 2>/dev/null");
+        const std::string create_result = exec_cmd("swaymsg -r create_output 2>&1");
+        BOOST_LOG(info) << "Virtual display: swaymsg create_output: "sv << create_result;
+        if (!sway_create_output_succeeded(create_result)) {
+          BOOST_LOG(error) << "Virtual display: Sway rejected headless output creation"sv;
+          return std::nullopt;
+        }
 
-        std::this_thread::sleep_for(500ms);
+        const auto deadline = std::chrono::steady_clock::now() + 2s;
+        do {
+          output_name = sway_new_headless_output(
+            sway_outputs_before,
+            exec_cmd("swaymsg -t get_outputs -r 2>/dev/null")
+          ).value_or("");
+          if (!output_name.empty()) {
+            break;
+          }
+          std::this_thread::sleep_for(50ms);
+        } while (std::chrono::steady_clock::now() < deadline);
 
-        // Sway names headless outputs as HEADLESS-N
-        output_name = "HEADLESS-1";
+        if (output_name.empty()) {
+          BOOST_LOG(error) << "Virtual display: could not prove ownership of the newly created Sway output"sv;
+          return std::nullopt;
+        }
 
-        // Set the resolution
         std::string mode_str = std::to_string(width) + "x" + std::to_string(height) +
                                "@" + std::to_string(fps) + "Hz";
         std::string mode_cmd = "swaymsg output " + output_name + " mode " + mode_str;
-        exec_cmd_rc(mode_cmd);
+        if (exec_cmd_rc(mode_cmd) != 0) {
+          BOOST_LOG(error) << "Virtual display: failed to configure owned Sway output ["sv << output_name << ']';
+          exec_cmd_rc("swaymsg output " + output_name + " disable >/dev/null 2>&1");
+          return std::nullopt;
+        }
       }
       else {
         // Generic wlr-randr approach

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -237,6 +237,10 @@ namespace virtual_display {
     }
   }  // namespace
 
+  bool wayland_compositor_supports_exact_output_creation(std::string_view compositor) {
+    return compositor == "hyprland"sv;
+  }
+
   std::vector<persisted_display_t> parse_persisted_displays(std::string_view state_json) {
     std::vector<persisted_display_t> entries;
 
@@ -365,87 +369,6 @@ namespace virtual_display {
     }
 
     return std::nullopt;
-  }
-
-  static bool sway_output_snapshot_is_valid(std::string_view snapshot) {
-    const auto outputs = nlohmann::json::parse(snapshot, nullptr, false);
-    if (!outputs.is_array()) return false;
-    for (const auto &output : outputs) {
-      if (!output.is_object() || !output.contains("name") || !output["name"].is_string()) return false;
-    }
-    return true;
-  }
-
-  static bool with_valid_sway_before_snapshot(
-    std::string_view snapshot,
-    const std::function<void()> &create_callback
-  ) {
-    if (!sway_output_snapshot_is_valid(snapshot)) return false;
-    create_callback();
-    return true;
-  }
-
-#ifdef POLARIS_TESTS
-  bool with_valid_sway_before_snapshot_for_tests(
-    std::string_view snapshot,
-    const std::function<void()> &create_callback
-  ) {
-    return with_valid_sway_before_snapshot(snapshot, create_callback);
-  }
-#endif
-
-  bool sway_create_output_succeeded(std::string_view response_json) {
-    const auto response = nlohmann::json::parse(response_json, nullptr, false);
-    if (!response.is_array() || response.empty()) {
-      return false;
-    }
-    for (const auto &entry : response) {
-      if (!entry.is_object() ||
-          !entry.contains("success") ||
-          !entry["success"].is_boolean() ||
-          !entry["success"].get<bool>()) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  std::optional<std::string> sway_new_headless_output(
-    std::string_view before_outputs_json,
-    std::string_view after_outputs_json
-  ) {
-    if (!sway_output_snapshot_is_valid(before_outputs_json) ||
-        !sway_output_snapshot_is_valid(after_outputs_json)) {
-      return std::nullopt;
-    }
-    const auto before = nlohmann::json::parse(before_outputs_json, nullptr, false);
-    const auto after = nlohmann::json::parse(after_outputs_json, nullptr, false);
-    if (!before.is_array() || !after.is_array()) {
-      return std::nullopt;
-    }
-
-    std::set<std::string> previous_names;
-    for (const auto &output : before) {
-      if (output.is_object() && output.contains("name") && output["name"].is_string()) {
-        previous_names.insert(output["name"].get<std::string>());
-      }
-    }
-
-    std::optional<std::string> owned_output;
-    for (const auto &output : after) {
-      if (!output.is_object() || !output.contains("name") || !output["name"].is_string()) {
-        continue;
-      }
-      const auto name = output["name"].get<std::string>();
-      if (previous_names.contains(name) || !std::string_view {name}.starts_with("HEADLESS-")) {
-        continue;
-      }
-      if (owned_output) {
-        return std::nullopt;
-      }
-      owned_output = name;
-    }
-    return owned_output;
   }
 
   bool evdi_output_name_is_proven(std::string_view output_name) {
@@ -1165,24 +1088,12 @@ namespace virtual_display {
       }
 
       std::string compositor = detect_compositor();
-      if (compositor == "hyprland") {
-        // hyprctl is the control interface for Hyprland
-        return exec_cmd_rc("which hyprctl >/dev/null 2>&1") == 0;
-      }
-      if (compositor == "sway") {
-        // swaymsg can create outputs
-        return exec_cmd_rc("which swaymsg >/dev/null 2>&1") == 0;
-      }
-      if (compositor == "kwin") {
-        // KWin supports virtual outputs via DBus or kscreen-doctor
-        // (handled by kscreen fallback)
+      if (!wayland_compositor_supports_exact_output_creation(compositor)) {
         return false;
       }
 
-      // No supported compositor identified. wlr-randr alone cannot create an
-      // output (create() refuses the generic branch), so reporting available
-      // here would advertise a display that can never appear.
-      return false;
+      // hyprctl is the control interface for Hyprland and accepts a caller-owned name.
+      return exec_cmd_rc("which hyprctl >/dev/null 2>&1") == 0;
     }
 
     /**
@@ -1190,6 +1101,12 @@ namespace virtual_display {
      */
     static std::optional<vdisplay_t> create(int width, int height, int fps) {
       std::string compositor = detect_compositor();
+      if (!wayland_compositor_supports_exact_output_creation(compositor)) {
+        BOOST_LOG(warning) << "Virtual display: compositor ["sv << compositor
+                           << "] cannot create a caller-named output; refusing before mutation"sv;
+        return std::nullopt;
+      }
+
       std::string output_name;
 
       if (compositor == "hyprland") {
@@ -1319,50 +1236,8 @@ namespace virtual_display {
           }
         }
       }
-      else if (compositor == "sway") {
-        const std::string sway_outputs_before = exec_cmd("swaymsg -t get_outputs -r 2>/dev/null");
-        std::string create_result;
-        if (!with_valid_sway_before_snapshot(sway_outputs_before, [&] {
-              create_result = exec_cmd("swaymsg -r create_output 2>&1");
-            })) {
-          BOOST_LOG(error) << "Virtual display: refusing Sway creation without a valid before snapshot"sv;
-          return std::nullopt;
-        }
-        BOOST_LOG(info) << "Virtual display: swaymsg create_output: "sv << create_result;
-        if (!sway_create_output_succeeded(create_result)) {
-          BOOST_LOG(error) << "Virtual display: Sway rejected headless output creation"sv;
-          return std::nullopt;
-        }
-
-        const auto deadline = std::chrono::steady_clock::now() + 2s;
-        do {
-          output_name = sway_new_headless_output(
-            sway_outputs_before,
-            exec_cmd("swaymsg -t get_outputs -r 2>/dev/null")
-          ).value_or("");
-          if (!output_name.empty()) {
-            break;
-          }
-          std::this_thread::sleep_for(50ms);
-        } while (std::chrono::steady_clock::now() < deadline);
-
-        if (output_name.empty()) {
-          BOOST_LOG(error) << "Virtual display: could not prove ownership of the newly created Sway output"sv;
-          return std::nullopt;
-        }
-
-        std::string mode_str = std::to_string(width) + "x" + std::to_string(height) +
-                               "@" + std::to_string(fps) + "Hz";
-        std::string mode_cmd = "swaymsg output " + output_name + " mode " + mode_str;
-        if (exec_cmd_rc(mode_cmd) != 0) {
-          BOOST_LOG(error) << "Virtual display: failed to configure owned Sway output ["sv << output_name << ']';
-          exec_cmd_rc("swaymsg output " + output_name + " disable >/dev/null 2>&1");
-          return std::nullopt;
-        }
-      }
       else {
-        // Generic wlr-randr approach
-        BOOST_LOG(warning) << "Virtual display: no supported Wayland compositor detected for headless output creation"sv;
+        BOOST_LOG(warning) << "Virtual display: no supported Wayland compositor detected for named output creation"sv;
         return std::nullopt;
       }
 

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -414,6 +414,10 @@ namespace virtual_display {
     std::string_view before_outputs_json,
     std::string_view after_outputs_json
   ) {
+    if (!sway_output_snapshot_is_valid(before_outputs_json) ||
+        !sway_output_snapshot_is_valid(after_outputs_json)) {
+      return std::nullopt;
+    }
     const auto before = nlohmann::json::parse(before_outputs_json, nullptr, false);
     const auto after = nlohmann::json::parse(after_outputs_json, nullptr, false);
     if (!before.is_array() || !after.is_array()) {

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -367,6 +367,33 @@ namespace virtual_display {
     return std::nullopt;
   }
 
+  static bool sway_output_snapshot_is_valid(std::string_view snapshot) {
+    const auto outputs = nlohmann::json::parse(snapshot, nullptr, false);
+    if (!outputs.is_array()) return false;
+    for (const auto &output : outputs) {
+      if (!output.is_object() || !output.contains("name") || !output["name"].is_string()) return false;
+    }
+    return true;
+  }
+
+  static bool with_valid_sway_before_snapshot(
+    std::string_view snapshot,
+    const std::function<void()> &create_callback
+  ) {
+    if (!sway_output_snapshot_is_valid(snapshot)) return false;
+    create_callback();
+    return true;
+  }
+
+#ifdef POLARIS_TESTS
+  bool with_valid_sway_before_snapshot_for_tests(
+    std::string_view snapshot,
+    const std::function<void()> &create_callback
+  ) {
+    return with_valid_sway_before_snapshot(snapshot, create_callback);
+  }
+#endif
+
   bool sway_create_output_succeeded(std::string_view response_json) {
     const auto response = nlohmann::json::parse(response_json, nullptr, false);
     if (!response.is_array() || response.empty()) {
@@ -1290,7 +1317,13 @@ namespace virtual_display {
       }
       else if (compositor == "sway") {
         const std::string sway_outputs_before = exec_cmd("swaymsg -t get_outputs -r 2>/dev/null");
-        const std::string create_result = exec_cmd("swaymsg -r create_output 2>&1");
+        std::string create_result;
+        if (!with_valid_sway_before_snapshot(sway_outputs_before, [&] {
+              create_result = exec_cmd("swaymsg -r create_output 2>&1");
+            })) {
+          BOOST_LOG(error) << "Virtual display: refusing Sway creation without a valid before snapshot"sv;
+          return std::nullopt;
+        }
         BOOST_LOG(info) << "Virtual display: swaymsg create_output: "sv << create_result;
         if (!sway_create_output_succeeded(create_result)) {
           BOOST_LOG(error) << "Virtual display: Sway rejected headless output creation"sv;

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -70,6 +70,10 @@ namespace virtual_display {
     }
 
     std::mutex persisted_state_mutex;
+    // One creation transaction across stream and web UI callers. The lock is
+    // held through output discovery/configuration and persisted ownership
+    // publication so Sway before/after attribution cannot overlap in-process.
+    static std::mutex creation_mutex;
 
     const char *backend_persist_name(backend_e backend) {
       switch (backend) {
@@ -1581,7 +1585,9 @@ namespace virtual_display {
     return unavailable_reason_for(backend, evdi_blocked, !config::video.linux_display.streaming_output.empty());
   }
 
-  bool cleanup_stale() {
+  static void destroy_unlocked(vdisplay_t &display);
+
+  static bool cleanup_stale_unlocked() {
     const pid_t self = getpid();
     std::vector<persisted_display_t> stale;
 
@@ -1613,14 +1619,27 @@ namespace virtual_display {
     for (auto &entry : stale) {
       BOOST_LOG(info) << "Virtual display: cleaning up stale persisted display ["sv
                       << entry.display.output_name << "] from pid "sv << entry.owner_pid;
-      destroy(entry.display);
+      destroy_unlocked(entry.display);
     }
 
     return !stale.empty();
   }
 
+  bool cleanup_stale() {
+    std::lock_guard creation_lock {creation_mutex};
+    return cleanup_stale_unlocked();
+  }
+
+#ifdef POLARIS_TESTS
+  void with_creation_lock_for_tests(const std::function<void()> &callback) {
+    std::lock_guard creation_lock {creation_mutex};
+    callback();
+  }
+#endif
+
   std::optional<vdisplay_t> create(int width, int height, int fps) {
-    cleanup_stale();
+    std::lock_guard creation_lock {creation_mutex};
+    cleanup_stale_unlocked();
 
     backend_e backend = detect_backend();
 
@@ -1656,7 +1675,7 @@ namespace virtual_display {
     }
   }
 
-  void destroy(vdisplay_t &display) {
+  static void destroy_unlocked(vdisplay_t &display) {
     if (!display.active) {
       return;
     }
@@ -1685,6 +1704,11 @@ namespace virtual_display {
     // Drop only this display's record. Clearing the whole file here used to
     // strand a sibling display that was still live.
     forget_persisted_display(display);
+  }
+
+  void destroy(vdisplay_t &display) {
+    std::lock_guard creation_lock {creation_mutex};
+    destroy_unlocked(display);
   }
 
 }  // namespace virtual_display

--- a/src/platform/linux/virtual_display.cpp
+++ b/src/platform/linux/virtual_display.cpp
@@ -13,6 +13,7 @@
  */
 
 // standard includes
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstdint>
@@ -22,6 +23,7 @@
 #include <errno.h>
 #include <filesystem>
 #include <fstream>
+#include <fcntl.h>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -35,6 +37,7 @@
 #include <dlfcn.h>
 #include <nlohmann/json.hpp>
 #include <sys/wait.h>
+#include <sys/stat.h>
 
 // local includes
 #include "misc.h"
@@ -102,6 +105,36 @@ namespace virtual_display {
       return backend_e::NONE;
     }
 
+    std::optional<kscreen_output_state_t> parse_kscreen_state(const nlohmann::json &node) {
+      if (!node.is_object() ||
+          !node.contains("name") || !node["name"].is_string() ||
+          !node.contains("enabled") || !node["enabled"].is_boolean() ||
+          !node.contains("current_mode_id") || !node["current_mode_id"].is_string() ||
+          !node.contains("priority") || !node["priority"].is_number_integer()) {
+        return std::nullopt;
+      }
+      const int priority = node["priority"].get<int>();
+      const auto name = node["name"].get<std::string>();
+      if (name.empty() || priority < 0 || priority > 100) {
+        return std::nullopt;
+      }
+      return kscreen_output_state_t {
+        .name = name,
+        .enabled = node["enabled"].get<bool>(),
+        .current_mode_id = node["current_mode_id"].get<std::string>(),
+        .priority = priority,
+      };
+    }
+
+    nlohmann::json serialize_kscreen_state(const kscreen_output_state_t &state) {
+      return {
+        {"name", state.name},
+        {"enabled", state.enabled},
+        {"current_mode_id", state.current_mode_id},
+        {"priority", state.priority},
+      };
+    }
+
     std::optional<persisted_display_t> parse_persisted_entry(const nlohmann::json &node) {
       if (!node.is_object()) {
         return std::nullopt;
@@ -116,6 +149,12 @@ namespace virtual_display {
       entry.display.fps = node.value("fps", 0);
       entry.display.active = node.value("active", false);
       entry.display.backend = backend_from_persist_name(node.value("backend", "none"));
+      if (node.contains("kscreen_output_before")) {
+        entry.display.kscreen_output_before = parse_kscreen_state(node["kscreen_output_before"]);
+      }
+      if (node.contains("kscreen_primary_before")) {
+        entry.display.kscreen_primary_before = parse_kscreen_state(node["kscreen_primary_before"]);
+      }
 
       if (!entry.display.active || entry.display.backend == backend_e::NONE || entry.display.output_name.empty()) {
         return std::nullopt;
@@ -134,36 +173,82 @@ namespace virtual_display {
       node["fps"] = entry.display.fps;
       node["active"] = entry.display.active;
       node["backend"] = backend_persist_name(entry.display.backend);
+      if (entry.display.kscreen_output_before) {
+        node["kscreen_output_before"] = serialize_kscreen_state(*entry.display.kscreen_output_before);
+      }
+      if (entry.display.kscreen_primary_before) {
+        node["kscreen_primary_before"] = serialize_kscreen_state(*entry.display.kscreen_primary_before);
+      }
       return node;
     }
 
     /**
      * @brief Read every persisted display. Callers must hold persisted_state_mutex.
      */
-    std::vector<persisted_display_t> load_persisted_entries() {
-      std::ifstream file(persisted_state_path());
+    std::optional<std::vector<persisted_display_t>> load_persisted_entries() {
+      const auto path = persisted_state_path();
+      std::ifstream file(path);
       if (!file.is_open()) {
-        return {};
+        std::error_code ec;
+        if (!fs::exists(path, ec) && !ec) {
+          return std::vector<persisted_display_t> {};
+        }
+        BOOST_LOG(error) << "Virtual display: persisted recovery state is unreadable at "sv << path.string();
+        return std::nullopt;
       }
 
       std::ostringstream buffer;
       buffer << file.rdbuf();
-      return parse_persisted_displays(buffer.str());
+      const auto serialized = buffer.str();
+      const auto root = nlohmann::json::parse(serialized, nullptr, false);
+      if (!root.is_object()) {
+        BOOST_LOG(error) << "Virtual display: persisted recovery state is malformed; refusing to replace it"sv;
+        return std::nullopt;
+      }
+
+      auto entries = parse_persisted_displays(serialized);
+      const std::size_t expected_entries =
+        root.contains("displays") && root["displays"].is_array() ?
+          root["displays"].size() :
+          1;
+      if (entries.size() != expected_entries) {
+        BOOST_LOG(error) << "Virtual display: persisted recovery state contains an unusable entry; refusing to replace it"sv;
+        return std::nullopt;
+      }
+      return entries;
     }
 
     /**
      * @brief Replace the persisted state with these displays. Callers must hold persisted_state_mutex.
      */
-    void write_persisted_entries(const std::vector<persisted_display_t> &entries) {
+    bool write_persisted_entries(const std::vector<persisted_display_t> &entries) {
       const auto path = persisted_state_path();
       std::error_code ec;
 
+      const auto sync_parent = [&]() {
+        const int dir_fd = ::open(path.parent_path().c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+        if (dir_fd < 0) {
+          return false;
+        }
+        const bool synced = ::fsync(dir_fd) == 0;
+        ::close(dir_fd);
+        return synced;
+      };
+
       if (entries.empty()) {
-        fs::remove(path, ec);
-        return;
+        const bool removed = fs::remove(path, ec);
+        if (ec) {
+          BOOST_LOG(error) << "Virtual display: failed to remove persisted recovery state: "sv << ec.message();
+          return false;
+        }
+        return !removed || sync_parent();
       }
 
       fs::create_directories(path.parent_path(), ec);
+      if (ec) {
+        BOOST_LOG(error) << "Virtual display: failed to create recovery state directory: "sv << ec.message();
+        return false;
+      }
 
       nlohmann::json root;
       root["displays"] = nlohmann::json::array();
@@ -175,43 +260,99 @@ namespace virtual_display {
       // through a write would otherwise strand every display it was tracking.
       auto temp_path = path;
       temp_path += ".tmp";
-      {
-        std::ofstream file(temp_path, std::ios::trunc);
-        if (!file.is_open()) {
-          BOOST_LOG(warning) << "Virtual display: failed to persist state at "sv << path.string();
-          return;
+      const auto serialized = root.dump(2);
+      const int fd = ::open(
+        temp_path.c_str(),
+        O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC,
+        S_IRUSR | S_IWUSR
+      );
+      if (fd < 0 || ::fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
+        if (fd >= 0) {
+          ::close(fd);
         }
-        file << root.dump(2);
+        BOOST_LOG(error) << "Virtual display: failed to open private recovery state at "sv << temp_path.string();
+        return false;
+      }
+      std::size_t offset = 0;
+      bool wrote = true;
+      while (offset < serialized.size()) {
+        const auto result = ::write(fd, serialized.data() + offset, serialized.size() - offset);
+        if (result < 0 && errno == EINTR) {
+          continue;
+        }
+        if (result <= 0) {
+          wrote = false;
+          break;
+        }
+        offset += static_cast<std::size_t>(result);
+      }
+      const bool synced = wrote && ::fsync(fd) == 0;
+      const bool closed = ::close(fd) == 0;
+      if (!synced || !closed) {
+        BOOST_LOG(error) << "Virtual display: failed to durably write recovery state at "sv << temp_path.string();
+        fs::remove(temp_path, ec);
+        return false;
       }
 
       fs::rename(temp_path, path, ec);
       if (ec) {
-        BOOST_LOG(warning) << "Virtual display: failed to persist state at "sv << path.string()
+        BOOST_LOG(error) << "Virtual display: failed to persist state at "sv << path.string()
                            << ": "sv << ec.message();
         fs::remove(temp_path, ec);
+        return false;
       }
+      if (!sync_parent()) {
+        BOOST_LOG(error) << "Virtual display: recovery state rename was not durably committed"sv;
+        return false;
+      }
+      return true;
     }
 
-    void record_persisted_display(const vdisplay_t &display) {
-      const pid_t self = getpid();
+    bool record_persisted_display(const vdisplay_t &display, pid_t owner_pid = getpid()) {
       std::lock_guard lock {persisted_state_mutex};
 
-      auto entries = load_persisted_entries();
-      std::erase_if(entries, [&](const persisted_display_t &entry) {
-        return entry.owner_pid == self && entry.display.output_name == display.output_name;
+      auto loaded = load_persisted_entries();
+      if (!loaded) {
+        return false;
+      }
+      auto &entries = *loaded;
+      const auto incoming = persisted_display_t {owner_pid, display};
+      const auto existing = std::find_if(entries.begin(), entries.end(), [&](const persisted_display_t &entry) {
+        return entry.display.output_name == display.output_name;
       });
-      entries.push_back({self, display});
-      write_persisted_entries(entries);
+      if (existing != entries.end()) {
+        auto existing_display = serialize_persisted_entry(*existing);
+        auto incoming_display = serialize_persisted_entry(incoming);
+        existing_display.erase("pid");
+        incoming_display.erase("pid");
+        const bool same_display = existing_display == incoming_display;
+        if (!same_display || (existing->owner_pid != owner_pid && existing->owner_pid != 0)) {
+          BOOST_LOG(error) << "Virtual display: refusing to replace existing recovery authority for ["sv
+                           << display.output_name << ']';
+          return false;
+        }
+        if (existing->owner_pid == owner_pid) {
+          return true;
+        }
+        *existing = incoming;  // Promote a durable pre-mutation intent to its live owner.
+      } else {
+        entries.push_back(incoming);
+      }
+      return write_persisted_entries(entries);
     }
 
-    void forget_persisted_display(const vdisplay_t &display) {
+    bool forget_persisted_display(const vdisplay_t &display) {
       std::lock_guard lock {persisted_state_mutex};
 
-      auto entries = load_persisted_entries();
+      auto loaded = load_persisted_entries();
+      if (!loaded) {
+        return false;
+      }
+      auto &entries = *loaded;
       std::erase_if(entries, [&](const persisted_display_t &entry) {
         return entry.display.output_name == display.output_name;
       });
-      write_persisted_entries(entries);
+      return write_persisted_entries(entries);
     }
 
     void log_detected_backend(backend_e backend) {
@@ -315,22 +456,40 @@ namespace virtual_display {
     return "POLARIS-HEADLESS-" + std::to_string(pid) + "-" + std::to_string(slot);
   }
 
-  bool hyprland_monitors_contain_output(std::string_view monitors_json, std::string_view output_name) {
+  std::optional<bool> hyprland_monitors_contain_output(
+    std::string_view monitors_json,
+    std::string_view output_name
+  ) {
+    if (output_name.empty()) {
+      return std::nullopt;
+    }
     const auto monitors = nlohmann::json::parse(monitors_json, nullptr, false);
     if (!monitors.is_array()) {
-      return false;
+      return std::nullopt;
     }
 
     for (const auto &monitor : monitors) {
-      if (monitor.is_object() &&
-          monitor.contains("name") &&
-          monitor["name"].is_string() &&
-          monitor["name"].get_ref<const std::string &>() == output_name) {
+      if (!monitor.is_object() ||
+          !monitor.contains("name") ||
+          !monitor["name"].is_string()) {
+        return std::nullopt;
+      }
+      if (monitor["name"].get_ref<const std::string &>() == output_name) {
         return true;
       }
     }
 
     return false;
+  }
+
+  std::optional<bool> evdi_connector_status_is_connected(std::string_view status) {
+    if (status == "connected"sv) {
+      return true;
+    }
+    if (status == "disconnected"sv) {
+      return false;
+    }
+    return std::nullopt;
   }
 
   std::optional<hyprland_mode_t> hyprland_monitor_mode(
@@ -368,6 +527,39 @@ namespace virtual_display {
       return mode;
     }
 
+    return std::nullopt;
+  }
+
+  std::optional<kscreen_output_state_t> kscreen_output_state_from_json(
+    std::string_view output_json,
+    std::string_view output_name
+  ) {
+    const auto root = nlohmann::json::parse(output_json, nullptr, false);
+    if (!root.is_object() || !root.contains("outputs") || !root["outputs"].is_array()) {
+      return std::nullopt;
+    }
+
+    for (const auto &output : root["outputs"]) {
+      if (!output.is_object() ||
+          !output.contains("name") || !output["name"].is_string() ||
+          output["name"].get_ref<const std::string &>() != output_name ||
+          !output.contains("enabled") || !output["enabled"].is_boolean() ||
+          !output.contains("currentModeId") || !output["currentModeId"].is_string() ||
+          !output.contains("priority") || !output["priority"].is_number_integer()) {
+        continue;
+      }
+
+      const int priority = output["priority"].get<int>();
+      if (priority < 0 || priority > 100) {
+        return std::nullopt;
+      }
+      return kscreen_output_state_t {
+        .name = std::string {output_name},
+        .enabled = output["enabled"].get<bool>(),
+        .current_mode_id = output["currentModeId"].get<std::string>(),
+        .priority = priority,
+      };
+    }
     return std::nullopt;
   }
 
@@ -784,6 +976,33 @@ namespace virtual_display {
       return {};
     }
 
+    static std::optional<bool> output_is_connected(const vdisplay_t &display) {
+      const auto card_name = fs::path {display.device_path}.filename().string();
+      if (card_name.empty() || display.output_name.empty()) {
+        return std::nullopt;
+      }
+      const auto status_path = fs::path {"/sys/class/drm"} /
+                               (card_name + "-" + display.output_name) /
+                               "status";
+      std::error_code ec;
+      const bool exists = fs::exists(status_path, ec);
+      if (ec) {
+        return std::nullopt;
+      }
+      if (!exists) {
+        return false;
+      }
+      std::ifstream status(status_path);
+      if (!status.is_open()) {
+        return std::nullopt;
+      }
+      std::string value;
+      if (!(status >> value)) {
+        return std::nullopt;
+      }
+      return evdi_connector_status_is_connected(value);
+    }
+
     static bool supported_gpu_driver(const std::string &driver) {
       return driver == "nvidia" || driver == "amdgpu" || driver == "i915";
     }
@@ -998,9 +1217,15 @@ namespace virtual_display {
     /**
      * @brief Destroy an EVDI virtual display.
      */
-    static void destroy(vdisplay_t &display) {
+    static bool destroy(vdisplay_t &display) {
       if (!display.evdi_handle) {
-        return;
+        const auto connected = output_is_connected(display);
+        if (connected && !*connected) {
+          display.active = false;
+          return true;
+        }
+        BOOST_LOG(error) << "Virtual display: EVDI absence could not be verified without a disconnect handle; retaining recovery authority"sv;
+        return false;
       }
 
       BOOST_LOG(info) << "Virtual display: disconnecting EVDI display ["sv << display.output_name << "]"sv;
@@ -1013,9 +1238,19 @@ namespace virtual_display {
       fn_close((evdi_handle_t)display.evdi_handle);
 
       display.evdi_handle = nullptr;
-      display.active = false;
+      const auto deadline = std::chrono::steady_clock::now() + 2s;
+      do {
+        const auto connected = output_is_connected(display);
+        if (connected && !*connected) {
+          display.active = false;
+          BOOST_LOG(info) << "Virtual display: EVDI disconnect verified"sv;
+          return true;
+        }
+        std::this_thread::sleep_for(50ms);
+      } while (std::chrono::steady_clock::now() < deadline);
 
-      BOOST_LOG(info) << "Virtual display: EVDI display destroyed"sv;
+      BOOST_LOG(error) << "Virtual display: EVDI connector remains connected; retaining recovery authority"sv;
+      return false;
     }
 
   }  // namespace evdi
@@ -1124,14 +1359,16 @@ namespace virtual_display {
             continue;
           }
 
-          if (hyprland_monitors_contain_output(monitors_before, candidate)) {
-            // In the compositor but reserved by nothing: an orphan from an
-            // earlier create of ours that materialized after we gave up on it.
-            // The name is ours by construction, so removing it is safe. Take the
-            // next slot either way — removal may not land before we need a name.
-            BOOST_LOG(info) << "Virtual display: removing orphaned Hyprland output ["sv
-                            << candidate << "]"sv;
-            exec_cmd_rc("hyprctl output remove " + candidate + " >/dev/null 2>&1");
+          const auto present = hyprland_monitors_contain_output(monitors_before, candidate);
+          if (!present) {
+            BOOST_LOG(error) << "Virtual display: Hyprland monitor inventory was not valid; refusing named-output creation"sv;
+            hyprland_release_output_name(candidate);
+            return std::nullopt;
+          }
+          if (*present) {
+            // Never mutate an untracked orphan during selection. A durable
+            // recovery record, if one exists, is handled by stale cleanup;
+            // otherwise occupying this slot is safer than guessing ownership.
             hyprland_release_output_name(candidate);
             continue;
           }
@@ -1144,11 +1381,24 @@ namespace virtual_display {
           return std::nullopt;
         }
 
+        vdisplay_t intent;
+        intent.output_name = output_name;
+        intent.width = width;
+        intent.height = height;
+        intent.fps = fps;
+        intent.active = true;
+        intent.backend = backend_e::WAYLAND_WLR;
+        if (!record_persisted_display(intent, 0)) {
+          BOOST_LOG(error) << "Virtual display: refusing Hyprland mutation because durable recovery intent could not be committed"sv;
+          hyprland_release_output_name(output_name);
+          return std::nullopt;
+        }
+
         std::string result = exec_cmd("hyprctl output create headless " + output_name + " 2>&1");
         BOOST_LOG(info) << "Virtual display: hyprctl output create headless: "sv << result;
         if (result != "ok") {
           BOOST_LOG(warning) << "Virtual display: Hyprland rejected headless output creation for ["sv
-                             << output_name << "]"sv;
+                             << output_name << "]; retaining recovery intent until serialized cleanup verifies stable absence"sv;
           hyprland_release_output_name(output_name);
           return std::nullopt;
         }
@@ -1156,10 +1406,11 @@ namespace virtual_display {
         const auto deadline = std::chrono::steady_clock::now() + 2s;
         bool output_appeared = false;
         do {
-          if (hyprland_monitors_contain_output(
-                exec_cmd("hyprctl monitors -j 2>/dev/null"),
-                output_name
-              )) {
+          const auto present = hyprland_monitors_contain_output(
+            exec_cmd("hyprctl monitors -j 2>/dev/null"),
+            output_name
+          );
+          if (present && *present) {
             output_appeared = true;
             break;
           }
@@ -1169,9 +1420,9 @@ namespace virtual_display {
         if (!output_appeared) {
           BOOST_LOG(warning) << "Virtual display: created Hyprland output did not appear ["sv
                              << output_name << "]"sv;
-          // Best effort: the output may still materialize after this removal
-          // runs. Releasing the reservation lets the next create recognize it as
-          // an orphan and clear it rather than inheriting a name it cannot use.
+          // The output may still materialize after this removal runs. Keep the
+          // owner-zero recovery intent even if one immediate query says absent;
+          // serialized stale cleanup must verify removal before another create.
           exec_cmd_rc("hyprctl output remove " + output_name + " >/dev/null 2>&1");
           hyprland_release_output_name(output_name);
           return std::nullopt;
@@ -1262,32 +1513,57 @@ namespace virtual_display {
     /**
      * @brief Destroy a Wayland headless output.
      */
-    static void destroy(vdisplay_t &display) {
+    static bool destroy(vdisplay_t &display) {
       std::string compositor = detect_compositor();
 
       if (compositor == "hyprland") {
         if (!hyprland_output_is_polaris_owned(display.output_name)) {
           BOOST_LOG(warning) << "Virtual display: refusing to remove unowned Hyprland output ["sv
                              << display.output_name << "]"sv;
-          display.active = false;
-          return;
+          return false;
         }
         std::string cmd = "hyprctl output remove " + display.output_name;
         int rc = exec_cmd_rc(cmd);
         if (rc != 0) {
           BOOST_LOG(warning) << "Virtual display: hyprctl output remove failed (rc="sv << rc << ")"sv;
         }
-        hyprland_release_output_name(display.output_name);
-      }
-      else if (compositor == "sway") {
-        // Sway doesn't have a direct "remove output" command for headless outputs,
-        // but we can disable it
-        std::string cmd = "swaymsg output " + display.output_name + " disable";
-        exec_cmd_rc(cmd);
+
+        const auto deadline = std::chrono::steady_clock::now() + 2s;
+        std::optional<std::chrono::steady_clock::time_point> absent_since;
+        do {
+          const auto now = std::chrono::steady_clock::now();
+          const auto present = hyprland_monitors_contain_output(
+            exec_cmd("hyprctl monitors -j 2>/dev/null"),
+            display.output_name
+          );
+          if (present && !*present) {
+            if (!absent_since) {
+              absent_since = now;
+            }
+            if (now - *absent_since >= 500ms) {
+              hyprland_release_output_name(display.output_name);
+              display.active = false;
+              BOOST_LOG(info) << "Virtual display: Wayland headless display removal verified after stable absence ["sv
+                              << display.output_name << "]"sv;
+              return true;
+            }
+          } else {
+            // Presence or an invalid query breaks the proof window. This also
+            // covers a create request that materializes after its caller timed out.
+            absent_since.reset();
+          }
+          std::this_thread::sleep_for(50ms);
+        } while (std::chrono::steady_clock::now() < deadline);
+
+        BOOST_LOG(error) << "Virtual display: Hyprland output remains after removal attempt ["sv
+                         << display.output_name << "]; retaining recovery authority"sv;
+        return false;
       }
 
-      display.active = false;
-      BOOST_LOG(info) << "Virtual display: Wayland headless display destroyed ["sv << display.output_name << "]"sv;
+      BOOST_LOG(error) << "Virtual display: cannot verify removal for compositor ["sv
+                       << compositor << "]; retaining recovery authority for ["sv
+                       << display.output_name << "]"sv;
+      return false;
     }
 
   }  // namespace wayland_wlr
@@ -1302,6 +1578,65 @@ namespace virtual_display {
         return false;
       }
       return exec_cmd_rc("which kscreen-doctor >/dev/null 2>&1") == 0;
+    }
+
+    static std::optional<kscreen_output_state_t> current_output_state(
+      const std::string &output_name
+    ) {
+      return kscreen_output_state_from_json(
+        exec_cmd("kscreen-doctor --json 2>/dev/null"),
+        output_name
+      );
+    }
+
+    static void append_restore_args(
+      std::vector<std::string> &args,
+      const kscreen_output_state_t &state
+    ) {
+      const auto prefix = "output." + state.name;
+      if (state.enabled) {
+        args.push_back(prefix + ".enable");
+      }
+      if (!state.current_mode_id.empty()) {
+        args.push_back(prefix + ".mode." + state.current_mode_id);
+      }
+      args.push_back(prefix + ".priority." + std::to_string(state.priority));
+      if (!state.enabled) {
+        args.push_back(prefix + ".disable");
+      }
+    }
+
+    static bool restore_exact(vdisplay_t &display) {
+      if (!display.kscreen_output_before) {
+        BOOST_LOG(error) << "Virtual display: KScreen teardown has no exact pre-launch output state; retaining recovery authority"sv;
+        return false;
+      }
+
+      std::vector<std::string> args {"kscreen-doctor"};
+      append_restore_args(args, *display.kscreen_output_before);
+      if (display.kscreen_primary_before &&
+          display.kscreen_primary_before->name != display.kscreen_output_before->name) {
+        append_restore_args(args, *display.kscreen_primary_before);
+      }
+
+      const int rc = platf::run_process_argv(args);
+      const auto output_after = current_output_state(display.kscreen_output_before->name);
+      const auto primary_after = display.kscreen_primary_before ?
+        current_output_state(display.kscreen_primary_before->name) :
+        std::optional<kscreen_output_state_t> {};
+      const bool output_restored = output_after && *output_after == *display.kscreen_output_before;
+      const bool primary_restored = !display.kscreen_primary_before ||
+        (primary_after && *primary_after == *display.kscreen_primary_before);
+      if (!output_restored || !primary_restored) {
+        BOOST_LOG(error) << "Virtual display: KScreen exact topology restore did not read back"
+                         << " rc="sv << rc << "; retaining recovery authority"sv;
+        return false;
+      }
+
+      display.active = false;
+      BOOST_LOG(info) << "Virtual display: KScreen topology restored exactly for ["sv
+                      << display.output_name << ']';
+      return true;
     }
 
     /**
@@ -1322,6 +1657,39 @@ namespace virtual_display {
       }
 
       std::string output = cfg.streaming_output;
+      const auto output_before = current_output_state(output);
+      const auto primary_before =
+        !cfg.primary_output.empty() && cfg.primary_output != output ?
+          current_output_state(cfg.primary_output) :
+          std::optional<kscreen_output_state_t> {};
+      if (!output_before ||
+          (!cfg.primary_output.empty() && cfg.primary_output != output && !primary_before)) {
+        BOOST_LOG(error) << "Virtual display: refusing KScreen mutation because exact pre-launch topology could not be read"sv;
+        return std::nullopt;
+      }
+
+      vdisplay_t display;
+      display.output_name = output;
+      display.width = width;
+      display.height = height;
+      display.fps = fps;
+      display.active = true;
+      display.backend = backend_e::KSCREEN_DOCTOR;
+      display.kscreen_output_before = output_before;
+      display.kscreen_primary_before = primary_before;
+      if (!record_persisted_display(display, 0)) {
+        BOOST_LOG(error) << "Virtual display: refusing KScreen mutation because durable pre-launch recovery state could not be committed"sv;
+        return std::nullopt;
+      }
+      const auto restore_or_retain = [&]() {
+        if (restore_exact(display)) {
+          if (!forget_persisted_display(display)) {
+            BOOST_LOG(error) << "Virtual display: KScreen topology was restored but its recovery record could not be retired"sv;
+          }
+        } else {
+          display.active = true;
+        }
+      };
 
       // Set mode and enable the output
       std::string mode_str = std::to_string(width) + "x" + std::to_string(height) +
@@ -1355,17 +1723,17 @@ namespace virtual_display {
         rc = platf::run_process_argv(args);
         if (rc != 0) {
           BOOST_LOG(error) << "Virtual display: kscreen-doctor fallback enable also failed (rc="sv << rc << ")"sv;
+          restore_or_retain();
           return std::nullopt;
         }
       }
 
-      vdisplay_t display;
-      display.output_name = output;
-      display.width = width;
-      display.height = height;
-      display.fps = fps;
-      display.active = true;
-      display.backend = backend_e::KSCREEN_DOCTOR;
+      const auto output_after = current_output_state(output);
+      if (!output_after || !output_after->enabled) {
+        BOOST_LOG(error) << "Virtual display: KScreen enable did not read back; restoring exact pre-launch topology"sv;
+        restore_or_retain();
+        return std::nullopt;
+      }
 
       BOOST_LOG(info) << "Virtual display: kscreen-doctor display enabled ["sv
                       << output << "] "sv << width << "x"sv << height << "@"sv << fps << "Hz"sv;
@@ -1376,24 +1744,9 @@ namespace virtual_display {
     /**
      * @brief Disable the display managed by kscreen-doctor.
      */
-    static void destroy(vdisplay_t &display) {
-      const auto &cfg = config::video.linux_display;
-
-      std::vector<std::string> args {"kscreen-doctor"};
-      if (!cfg.primary_output.empty()) {
-        args.push_back("output." + cfg.primary_output + ".priority.1");
-      }
-      args.push_back("output." + display.output_name + ".priority.2");
-      args.push_back("output." + display.output_name + ".disable");
-
-      BOOST_LOG(info) << "Virtual display: running kscreen-doctor disable with "sv << args.size() - 1 << " argument(s)"sv;
-      int rc = platf::run_process_argv(args);
-      if (rc != 0) {
-        BOOST_LOG(warning) << "Virtual display: kscreen-doctor disable failed (rc="sv << rc << ")"sv;
-      }
-
-      display.active = false;
-      BOOST_LOG(info) << "Virtual display: kscreen-doctor display disabled ["sv << display.output_name << "]"sv;
+    static bool destroy(vdisplay_t &display) {
+      BOOST_LOG(info) << "Virtual display: restoring exact pre-launch KScreen topology"sv;
+      return restore_exact(display);
     }
 
   }  // namespace kscreen
@@ -1497,19 +1850,26 @@ namespace virtual_display {
     return unavailable_reason_for(backend, evdi_blocked, !config::video.linux_display.streaming_output.empty());
   }
 
-  static void destroy_unlocked(vdisplay_t &display);
+  static bool destroy_unlocked(vdisplay_t &display);
 
-  static bool cleanup_stale_unlocked() {
+  struct stale_cleanup_result_t {
+    bool found = false;
+    bool succeeded = true;
+  };
+
+  static stale_cleanup_result_t cleanup_stale_unlocked() {
     const pid_t self = getpid();
     std::vector<persisted_display_t> stale;
 
     {
       std::lock_guard lock {persisted_state_mutex};
-      auto entries = load_persisted_entries();
+      auto loaded = load_persisted_entries();
+      if (!loaded) {
+        return {.found = false, .succeeded = false};
+      }
+      const auto &entries = *loaded;
       if (entries.empty()) {
-        // Nothing usable in the file, so drop whatever is left of it.
-        write_persisted_entries({});
-        return false;
+        return {};
       }
 
       for (const auto &entry : entries) {
@@ -1528,18 +1888,22 @@ namespace virtual_display {
 
     // destroy() drops each entry from the file itself, so the lock is released
     // before it runs.
+    bool succeeded = true;
     for (auto &entry : stale) {
       BOOST_LOG(info) << "Virtual display: cleaning up stale persisted display ["sv
                       << entry.display.output_name << "] from pid "sv << entry.owner_pid;
-      destroy_unlocked(entry.display);
+      if (!destroy_unlocked(entry.display)) {
+        succeeded = false;
+      }
     }
 
-    return !stale.empty();
+    return {.found = !stale.empty(), .succeeded = succeeded};
   }
 
   bool cleanup_stale() {
     std::lock_guard creation_lock {creation_mutex};
-    return cleanup_stale_unlocked();
+    const auto result = cleanup_stale_unlocked();
+    return result.found && result.succeeded;
   }
 
 #ifdef POLARIS_TESTS
@@ -1551,34 +1915,40 @@ namespace virtual_display {
 
   std::optional<vdisplay_t> create(int width, int height, int fps) {
     std::lock_guard creation_lock {creation_mutex};
-    cleanup_stale_unlocked();
+    const auto cleanup = cleanup_stale_unlocked();
+    if (!cleanup.succeeded) {
+      BOOST_LOG(error) << "Virtual display: stale recovery cleanup failed; refusing a replacement display"sv;
+      return std::nullopt;
+    }
 
     backend_e backend = detect_backend();
 
     BOOST_LOG(info) << "Virtual display: creating "sv << width << "x"sv << height
                     << "@"sv << fps << "Hz using backend: "sv << backend_name(backend);
 
+    const auto publish = [&](std::optional<vdisplay_t> display) -> std::optional<vdisplay_t> {
+      if (!display) {
+        return std::nullopt;
+      }
+      if (record_persisted_display(*display)) {
+        return display;
+      }
+      BOOST_LOG(error) << "Virtual display: live output could not be bound to durable recovery authority; tearing it down"sv;
+      if (!destroy_unlocked(*display)) {
+        BOOST_LOG(error) << "Virtual display: emergency teardown was not verified after persistence failure"sv;
+      }
+      return std::nullopt;
+    };
+
     switch (backend) {
       case backend_e::EVDI:
-        if (auto display = evdi::create(width, height, fps)) {
-          record_persisted_display(*display);
-          return display;
-        }
-        return std::nullopt;
+        return publish(evdi::create(width, height, fps));
 
       case backend_e::WAYLAND_WLR:
-        if (auto display = wayland_wlr::create(width, height, fps)) {
-          record_persisted_display(*display);
-          return display;
-        }
-        return std::nullopt;
+        return publish(wayland_wlr::create(width, height, fps));
 
       case backend_e::KSCREEN_DOCTOR:
-        if (auto display = kscreen::create(width, height, fps)) {
-          record_persisted_display(*display);
-          return display;
-        }
-        return std::nullopt;
+        return publish(kscreen::create(width, height, fps));
 
       case backend_e::NONE:
       default:
@@ -1587,25 +1957,26 @@ namespace virtual_display {
     }
   }
 
-  static void destroy_unlocked(vdisplay_t &display) {
+  static bool destroy_unlocked(vdisplay_t &display) {
     if (!display.active) {
-      return;
+      return forget_persisted_display(display);
     }
 
     BOOST_LOG(info) << "Virtual display: destroying ["sv << display.output_name
                     << "] via "sv << backend_name(display.backend);
 
+    bool destroyed = false;
     switch (display.backend) {
       case backend_e::EVDI:
-        evdi::destroy(display);
+        destroyed = evdi::destroy(display);
         break;
 
       case backend_e::WAYLAND_WLR:
-        wayland_wlr::destroy(display);
+        destroyed = wayland_wlr::destroy(display);
         break;
 
       case backend_e::KSCREEN_DOCTOR:
-        kscreen::destroy(display);
+        destroyed = kscreen::destroy(display);
         break;
 
       case backend_e::NONE:
@@ -1613,14 +1984,25 @@ namespace virtual_display {
         break;
     }
 
-    // Drop only this display's record. Clearing the whole file here used to
-    // strand a sibling display that was still live.
-    forget_persisted_display(display);
+    if (!teardown_is_verified(destroyed, display.active)) {
+      BOOST_LOG(error) << "Virtual display: teardown was not verified; persisted recovery record retained for ["sv
+                       << display.output_name << "]"sv;
+      return false;
+    }
+
+    // Drop only this display's record after verified teardown. Clearing the
+    // whole file here used to strand a sibling display that was still live.
+    if (!forget_persisted_display(display)) {
+      BOOST_LOG(error) << "Virtual display: teardown was verified but persisted recovery retirement failed for ["sv
+                       << display.output_name << ']';
+      return false;
+    }
+    return true;
   }
 
-  void destroy(vdisplay_t &display) {
+  bool destroy(vdisplay_t &display) {
     std::lock_guard creation_lock {creation_mutex};
-    destroy_unlocked(display);
+    return destroy_unlocked(display);
   }
 
 }  // namespace virtual_display

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -29,6 +29,15 @@ namespace virtual_display {
     KSCREEN_DOCTOR,  ///< KDE kscreen-doctor (manages existing outputs)
   };
 
+  struct kscreen_output_state_t {
+    std::string name;
+    bool enabled = false;
+    std::string current_mode_id;
+    int priority = 0;
+
+    bool operator==(const kscreen_output_state_t &) const = default;
+  };
+
   /**
    * @brief Tracks whether a backend observation should be logged.
    *
@@ -58,6 +67,11 @@ namespace virtual_display {
     int fps = 0;                 ///< Refresh rate (Hz)
     bool active = false;         ///< Whether the display is currently active
     backend_e backend = backend_e::NONE;  ///< Which backend created this display
+
+    // KScreen mutates an existing output rather than creating one. Exact
+    // pre-launch state is therefore part of the durable teardown authority.
+    std::optional<kscreen_output_state_t> kscreen_output_before;
+    std::optional<kscreen_output_state_t> kscreen_primary_before;
 
     // EVDI-specific state (opaque handle, managed internally)
     void *evdi_handle = nullptr;
@@ -118,9 +132,11 @@ namespace virtual_display {
   std::string hyprland_output_name_for_pid(int pid, int slot);
 
   /**
-   * @brief Return whether a Hyprland monitor JSON response contains an exact output name.
+   * @brief Return exact presence from a valid Hyprland monitor response.
+   *
+   * `nullopt` means the response cannot prove either presence or absence.
    */
-  bool hyprland_monitors_contain_output(std::string_view monitors_json, std::string_view output_name);
+  std::optional<bool> hyprland_monitors_contain_output(std::string_view monitors_json, std::string_view output_name);
 
   /// An output's active mode as the compositor reports it.
   struct hyprland_mode_t {
@@ -142,8 +158,17 @@ namespace virtual_display {
     std::string_view output_name
   );
 
+  /** @brief Parse one exact output from `kscreen-doctor --json`. */
+  std::optional<kscreen_output_state_t> kscreen_output_state_from_json(
+    std::string_view output_json,
+    std::string_view output_name
+  );
+
   /** @brief EVDI output identity is proven only by non-empty connector discovery. */
   bool evdi_output_name_is_proven(std::string_view output_name);
+
+  /** @brief Parse a DRM connector status; unknown values are not absence proof. */
+  std::optional<bool> evdi_connector_status_is_connected(std::string_view status);
 
   /**
    * @brief Return whether an output name belongs to Polaris's Hyprland namespace.
@@ -167,6 +192,11 @@ namespace virtual_display {
    * and the web UI each own one, and neither can see the other's.
    */
   bool persisted_display_is_stale(int owner_pid, int self_pid, bool owner_alive);
+
+  /** @brief Persistence may be cleared only after backend success and inactive readback. */
+  inline bool teardown_is_verified(bool backend_succeeded, bool display_active) {
+    return backend_succeeded && !display_active;
+  }
 
   /**
    * @brief Human-readable reason a virtual display cannot be created right now.
@@ -209,7 +239,7 @@ namespace virtual_display {
    * For Wayland, removes the headless output.
    * For kscreen-doctor, disables the managed output.
    */
-  void destroy(vdisplay_t &display);
+  [[nodiscard]] bool destroy(vdisplay_t &display);
 
   /**
    * @brief Clean up a persisted virtual display from a dead Polaris process.

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -105,6 +105,9 @@ namespace virtual_display {
    */
   bool wayland_backend_probe_allowed(bool platform_reports_wayland, std::string_view wayland_display);
 
+  /** @brief Return true only when the compositor can create a caller-named output. */
+  bool wayland_compositor_supports_exact_output_creation(std::string_view compositor);
+
   /**
    * @brief Build the connector name requested from Hyprland for one virtual display.
    *
@@ -137,18 +140,6 @@ namespace virtual_display {
   std::optional<hyprland_mode_t> hyprland_monitor_mode(
     std::string_view monitors_json,
     std::string_view output_name
-  );
-
-  /** @brief Return true only when swaymsg reports create_output success. */
-  bool sway_create_output_succeeded(std::string_view response_json);
-
-  /**
-   * @brief Return the one newly appeared HEADLESS-N output, or nullopt when
-   *        ownership cannot be proved from before/after Sway snapshots.
-   */
-  std::optional<std::string> sway_new_headless_output(
-    std::string_view before_outputs_json,
-    std::string_view after_outputs_json
   );
 
   /** @brief EVDI output identity is proven only by non-empty connector discovery. */
@@ -208,10 +199,6 @@ namespace virtual_display {
 #ifdef POLARIS_TESTS
   /** @brief Execute a callback under the production virtual-display creation mutex. */
   void with_creation_lock_for_tests(const std::function<void()> &callback);
-  bool with_valid_sway_before_snapshot_for_tests(
-    std::string_view snapshot,
-    const std::function<void()> &create_callback
-  );
 #endif
 
   /**

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -208,6 +208,10 @@ namespace virtual_display {
 #ifdef POLARIS_TESTS
   /** @brief Execute a callback under the production virtual-display creation mutex. */
   void with_creation_lock_for_tests(const std::function<void()> &callback);
+  bool with_valid_sway_before_snapshot_for_tests(
+    std::string_view snapshot,
+    const std::function<void()> &create_callback
+  );
 #endif
 
   /**

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -138,6 +138,21 @@ namespace virtual_display {
     std::string_view output_name
   );
 
+  /** @brief Return true only when swaymsg reports create_output success. */
+  bool sway_create_output_succeeded(std::string_view response_json);
+
+  /**
+   * @brief Return the one newly appeared HEADLESS-N output, or nullopt when
+   *        ownership cannot be proved from before/after Sway snapshots.
+   */
+  std::optional<std::string> sway_new_headless_output(
+    std::string_view before_outputs_json,
+    std::string_view after_outputs_json
+  );
+
+  /** @brief EVDI output identity is proven only by non-empty connector discovery. */
+  bool evdi_output_name_is_proven(std::string_view output_name);
+
   /**
    * @brief Return whether an output name belongs to Polaris's Hyprland namespace.
    */

--- a/src/platform/linux/virtual_display.h
+++ b/src/platform/linux/virtual_display.h
@@ -11,6 +11,7 @@
 #pragma once
 
 // standard includes
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -203,6 +204,11 @@ namespace virtual_display {
    * For kscreen-doctor, enables/configures an existing output.
    */
   std::optional<vdisplay_t> create(int width, int height, int fps);
+
+#ifdef POLARIS_TESTS
+  /** @brief Execute a callback under the production virtual-display creation mutex. */
+  void with_creation_lock_for_tests(const std::function<void()> &callback);
+#endif
 
   /**
    * @brief Destroy a previously created virtual display.

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -77,19 +77,45 @@ namespace wl {
     int init(platf::mem_type_e hwdevice_type, const std::string &display_name, const ::video::config_t &config) {
       delay = std::chrono::nanoseconds {1s} / config.framerate;
       mem_type = hwdevice_type;
+      const auto generation_policy = wlgrab_capture_policy::resolve_generation_policy(
+        config.capture_generation,
+        config::video.linux_display.use_cage_compositor,
+        config::video.adapter_name
+      );
+      const bool generation_owned = generation_policy.owned;
+      const bool use_private_compositor = generation_policy.use_private_compositor;
 
       // If cage compositor is running, connect to cage's Wayland socket
       // for direct wlr-screencopy capture (no portal, no picker).
       const char *wayland_target = nullptr;
+      std::string wayland_socket;
 #ifdef __linux__
-      if (config::video.linux_display.use_cage_compositor && stream_runtime::labwc::is_running()) {
-        static std::string cached_socket;
-        cached_socket = stream_runtime::labwc::wayland_socket();
-        if (!cached_socket.empty()) {
-          wayland_target = cached_socket.c_str();
-          private_compositor_capture = true;
-          BOOST_LOG(info) << "wlr: Targeting cage compositor on "sv << cached_socket;
+      if (use_private_compositor) {
+        if (generation_owned) {
+          const auto live_socket = stream_runtime::labwc::wayland_socket();
+          const auto live_instance = stream_runtime::labwc::session_instance_id();
+          if (!stream_runtime::labwc::is_running() ||
+              !wlgrab_capture_policy::private_runtime_matches_generation(
+                generation_policy,
+                live_socket,
+                live_instance
+              )) {
+            BOOST_LOG(error) << "wlr: Immutable private capture generation does not match the live labwc instance; refusing host or replacement-compositor fallback"sv;
+            return -1;
+          }
+          wayland_socket = generation_policy.private_wayland_socket;
+        } else if (stream_runtime::labwc::is_running()) {
+          wayland_socket = stream_runtime::labwc::wayland_socket();
         }
+        if (!wayland_socket.empty()) {
+          wayland_target = wayland_socket.c_str();
+          private_compositor_capture = true;
+          BOOST_LOG(info) << "wlr: Targeting cage compositor on "sv << wayland_socket;
+        }
+      }
+      if (generation_owned && use_private_compositor && wayland_target == nullptr) {
+        BOOST_LOG(error) << "wlr: Immutable private capture generation has no exact labwc target; refusing host compositor fallback"sv;
+        return -1;
       }
 #endif
 
@@ -103,7 +129,7 @@ namespace wl {
       display.roundtrip();
 
       if (!interface[wl::interface_t::XDG_OUTPUT]) {
-        if (!config::video.linux_display.use_cage_compositor) {
+        if (!use_private_compositor) {
           BOOST_LOG(error) << "Missing Wayland wire for xdg_output"sv;
           return -1;
         }
@@ -113,7 +139,7 @@ namespace wl {
       if (!interface[wl::interface_t::WLR_EXPORT_DMABUF]) {
         // wlr-export-dmabuf is optional when using cage — screencopy handles frame capture.
         // Only fail if we're NOT targeting cage (i.e., capturing the desktop directly).
-        if (!config::video.linux_display.use_cage_compositor) {
+        if (!use_private_compositor) {
           BOOST_LOG(error) << "Missing Wayland wire for wlr-export-dmabuf"sv;
           return -1;
         }
@@ -756,6 +782,14 @@ namespace platf {
       return nullptr;
     }
 
+    const auto generation_policy = wlgrab_capture_policy::resolve_generation_policy(
+      config.capture_generation,
+      config::video.linux_display.use_cage_compositor,
+      config::video.adapter_name
+    );
+    const bool use_private_compositor = generation_policy.use_private_compositor;
+    const auto &adapter_name = generation_policy.adapter_name;
+
     bool prefer_ram_capture = (hwdevice_type == platf::mem_type_e::system);
     const bool gpu_native_capture_supported = wl::supports_gpu_native_capture(hwdevice_type);
     const auto direct_capture_path = wlgrab_capture_policy::select_direct_capture_path(
@@ -767,7 +801,7 @@ namespace platf {
     bool try_headless_extcopy_dmabuf = false;
 #ifdef __linux__
     if (!prefer_ram_capture &&
-        config::video.linux_display.use_cage_compositor &&
+        use_private_compositor &&
         stream_runtime::labwc::is_running()) {
       auto runtime_state = stream_runtime::labwc::runtime_state();
       if (stream_runtime::labwc::should_attempt_gpu_native_cage_capture(runtime_state, hwdevice_type)) {
@@ -835,7 +869,7 @@ namespace platf {
 
     if (!prefer_ram_capture &&
         gpu_native_capture_supported &&
-        (!config::video.linux_display.use_cage_compositor || !stream_runtime::labwc::is_running()) &&
+        (!use_private_compositor || !stream_runtime::labwc::is_running()) &&
         direct_capture_path == wlgrab_capture_policy::direct_capture_path_e::ram) {
       prefer_ram_capture = true;
       BOOST_LOG(warning)
@@ -889,8 +923,8 @@ namespace platf {
           );
         } else {
           const auto capture_render_node = wlr->extcopy.capture_render_node();
-          const auto adapter_pairing = stream_stats::device_nodes_match(capture_render_node, config::video.adapter_name);
-          if (!config::video.adapter_name.empty() &&
+          const auto adapter_pairing = stream_stats::device_nodes_match(capture_render_node, adapter_name);
+          if (!adapter_name.empty() &&
               !capture_render_node.empty() &&
               (!adapter_pairing.has_value() || !*adapter_pairing)) {
             device_pairing_failed = true;
@@ -899,7 +933,7 @@ namespace platf {
               << "wlr: Disabling true-headless ext-image-copy-capture DMA-BUF because capture render_node=["sv
               << capture_render_node
               << (identity_resolved ? "] differs from encoder adapter=["sv : "] could not be identity-matched to encoder adapter=["sv)
-              << config::video.adapter_name
+              << adapter_name
               << "]; using SHM/system-memory fallback to avoid unsafe cross-GPU import"sv;
 #ifdef __linux__
             stream_runtime::labwc::update_headless_extcopy_dmabuf_probe_result(false);
@@ -945,19 +979,47 @@ namespace platf {
     return wlr;
   }
 
-  std::vector<std::string> wl_display_names() {
+  static std::vector<std::string> wl_display_names_for_generation(
+    const capture_generation::identity_t *generation
+  ) {
     std::vector<std::string> display_names;
+    const auto generation_policy = wlgrab_capture_policy::resolve_generation_policy(
+      generation == nullptr ? capture_generation::identity_t {} : *generation,
+      config::video.linux_display.use_cage_compositor,
+      config::video.adapter_name
+    );
+    const bool generation_owned = generation_policy.owned;
+    const bool use_private_compositor = generation_policy.use_private_compositor;
 
     // If cage is running, enumerate from cage. Otherwise use default display.
     const char *wayland_target = nullptr;
+    std::string wayland_socket;
 #ifdef __linux__
-    if (config::video.linux_display.use_cage_compositor && stream_runtime::labwc::is_running()) {
-      static std::string cached_socket;
-      cached_socket = stream_runtime::labwc::wayland_socket();
-      if (!cached_socket.empty()) {
-        wayland_target = cached_socket.c_str();
-        BOOST_LOG(info) << "wlr: Enumerating displays from cage on "sv << cached_socket;
+    if (use_private_compositor) {
+      if (generation_owned) {
+        const auto live_socket = stream_runtime::labwc::wayland_socket();
+        const auto live_instance = stream_runtime::labwc::session_instance_id();
+        if (!stream_runtime::labwc::is_running() ||
+            !wlgrab_capture_policy::private_runtime_matches_generation(
+              generation_policy,
+              live_socket,
+              live_instance
+            )) {
+          BOOST_LOG(error) << "wlr: Immutable private capture generation cannot enumerate a replacement labwc instance"sv;
+          return {};
+        }
+        wayland_socket = generation_policy.private_wayland_socket;
+      } else if (stream_runtime::labwc::is_running()) {
+        wayland_socket = stream_runtime::labwc::wayland_socket();
       }
+      if (!wayland_socket.empty()) {
+        wayland_target = wayland_socket.c_str();
+        BOOST_LOG(info) << "wlr: Enumerating displays from cage on "sv << wayland_socket;
+      }
+    }
+    if (generation_owned && use_private_compositor && wayland_target == nullptr) {
+      BOOST_LOG(error) << "wlr: Immutable private capture generation cannot enumerate without its exact labwc target"sv;
+      return {};
     }
 #endif
 
@@ -1009,6 +1071,16 @@ namespace platf {
     BOOST_LOG(info) << "--------- End of Wayland monitor list ---------"sv;
 
     return display_names;
+  }
+
+  std::vector<std::string> wl_display_names() {
+    return wl_display_names_for_generation(nullptr);
+  }
+
+  std::vector<std::string> wl_display_names(
+    const capture_generation::identity_t &generation
+  ) {
+    return wl_display_names_for_generation(&generation);
   }
 
 }  // namespace platf

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -1000,7 +1000,10 @@ namespace platf {
 
       BOOST_LOG(info) << "Monitor " << x << " is "sv << monitor->name << ": "sv << monitor->description;
 
-      display_names.emplace_back(std::to_string(x));
+      display_names.emplace_back(wlgrab_capture_policy::enumerated_monitor_identity(
+        static_cast<std::size_t>(x),
+        monitor->name
+      ));
     }
 
     BOOST_LOG(info) << "--------- End of Wayland monitor list ---------"sv;

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -3,7 +3,9 @@
  * @brief Definitions for wlgrab capture.
  */
 // standard includes
+#include <string>
 #include <thread>
+#include <vector>
 
 // local includes
 #include "stream_runtime.h"
@@ -118,19 +120,33 @@ namespace wl {
         BOOST_LOG(info) << "wlr: wlr-export-dmabuf not available (cage mode — using screencopy only)"sv;
       }
 
-      auto monitor = interface.monitors[0].get();
-
-      if (!display_name.empty()) {
-        auto streamedMonitor = util::from_view(display_name);
-
-        if (streamedMonitor >= 0 && streamedMonitor < interface.monitors.size()) {
-          monitor = interface.monitors[streamedMonitor].get();
-        }
+      if (interface.monitors.empty()) {
+        BOOST_LOG(error) << "Wayland compositor advertised no capturable outputs"sv;
+        return -1;
       }
 
-      monitor->listen(interface.output_manager);
-
+      for (const auto &candidate : interface.monitors) {
+        candidate->listen(interface.output_manager);
+      }
       display.roundtrip();
+
+      std::vector<std::string> monitor_names;
+      monitor_names.reserve(interface.monitors.size());
+      for (const auto &candidate : interface.monitors) {
+        monitor_names.emplace_back(candidate->name);
+      }
+
+      const auto monitor_index = wlgrab_capture_policy::select_monitor_index(
+        display_name,
+        monitor_names
+      );
+      if (!monitor_index) {
+        BOOST_LOG(error) << "Requested Wayland output ["sv << display_name
+                         << "] was not found; refusing to capture another output"sv;
+        return -1;
+      }
+
+      auto monitor = interface.monitors[*monitor_index].get();
       reported_wayland_main_device = interface.dmabuf_feedback.main_device_path;
       stream_stats::update_wayland_main_device(reported_wayland_main_device);
       interface.consume_output_topology_dirty();

--- a/src/platform/linux/wlgrab_capture_policy.h
+++ b/src/platform/linux/wlgrab_capture_policy.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include "src/capture_generation.h"
 #include "src/platform/common.h"
 
 #include <charconv>
@@ -15,6 +16,48 @@
 #include <vector>
 
 namespace wlgrab_capture_policy {
+  struct generation_policy_t {
+    bool owned = false;
+    bool use_private_compositor = false;
+    std::string adapter_name;
+    std::string private_wayland_socket;
+    std::string private_runtime_instance_id;
+  };
+
+  inline generation_policy_t resolve_generation_policy(
+    const capture_generation::identity_t &generation,
+    bool global_use_private_compositor,
+    std::string_view global_adapter_name
+  ) {
+    if (!generation.empty()) {
+      return {
+        .owned = true,
+        .use_private_compositor = generation.use_cage_compositor,
+        .adapter_name = generation.adapter_name,
+        .private_wayland_socket = generation.private_wayland_socket,
+        .private_runtime_instance_id = generation.private_runtime_instance_id,
+      };
+    }
+    return {
+      .owned = false,
+      .use_private_compositor = global_use_private_compositor,
+      .adapter_name = std::string {global_adapter_name},
+    };
+  }
+
+  inline bool private_runtime_matches_generation(
+    const generation_policy_t &policy,
+    std::string_view live_socket,
+    std::string_view live_instance_id
+  ) {
+    return policy.owned &&
+           policy.use_private_compositor &&
+           !policy.private_wayland_socket.empty() &&
+           !policy.private_runtime_instance_id.empty() &&
+           policy.private_wayland_socket == live_socket &&
+           policy.private_runtime_instance_id == live_instance_id;
+  }
+
   enum class gpu_native_capture_route_e {
     headless_extcopy,
     windowed_nested,

--- a/src/platform/linux/wlgrab_capture_policy.h
+++ b/src/platform/linux/wlgrab_capture_policy.h
@@ -6,8 +6,13 @@
 
 #include "src/platform/common.h"
 
+#include <charconv>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace wlgrab_capture_policy {
   enum class gpu_native_capture_route_e {
@@ -20,6 +25,35 @@ namespace wlgrab_capture_policy {
     ram,
     gpu_native,
   };
+
+  inline std::optional<std::size_t> select_monitor_index(
+    std::string_view requested_display,
+    const std::vector<std::string> &monitor_names
+  ) {
+    if (monitor_names.empty()) {
+      return std::nullopt;
+    }
+    if (requested_display.empty()) {
+      return 0;
+    }
+
+    std::size_t requested_index = 0;
+    const auto *begin = requested_display.data();
+    const auto *end = begin + requested_display.size();
+    const auto parsed = std::from_chars(begin, end, requested_index);
+    if (parsed.ec == std::errc {} && parsed.ptr == end) {
+      return requested_index < monitor_names.size() ?
+               std::optional<std::size_t> {requested_index} :
+               std::nullopt;
+    }
+
+    for (std::size_t index = 0; index < monitor_names.size(); ++index) {
+      if (monitor_names[index] == requested_display) {
+        return index;
+      }
+    }
+    return std::nullopt;
+  }
 
   inline bool gpu_native_dmabuf_probe_is_allowed(
     platf::mem_type_e hwdevice_type,

--- a/src/platform/linux/wlgrab_capture_policy.h
+++ b/src/platform/linux/wlgrab_capture_policy.h
@@ -26,6 +26,13 @@ namespace wlgrab_capture_policy {
     gpu_native,
   };
 
+  inline std::string enumerated_monitor_identity(
+    std::size_t monitor_index,
+    std::string_view connector_name
+  ) {
+    return connector_name.empty() ? std::to_string(monitor_index) : std::string {connector_name};
+  }
+
   inline std::optional<std::size_t> select_monitor_index(
     std::string_view requested_display,
     const std::vector<std::string> &monitor_names

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7190,10 +7190,7 @@ namespace proc {
     const bool using_headless_cage =
       display_policy.requested_headless &&
       display_policy.uses_labwc();
-    const bool should_use_linux_virtual_display =
-      display_policy.use_host_virtual_display ||
-      launch_session->virtual_display ||
-      (!launch_session->user_locked_virtual_display && _app.virtual_display);
+    const bool should_use_linux_virtual_display = display_policy.use_host_virtual_display;
 
     if (
       !display_policy.uses_labwc() &&

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6522,7 +6522,13 @@ namespace proc {
       this->initial_use_cage_compositor = linux_display.use_cage_compositor;
       this->initial_prefer_gpu_native_capture = linux_display.prefer_gpu_native_capture;
       this->initial_auto_manage_displays = linux_display.auto_manage_displays;
-      const std::string session_mode = launch_session ? launch_session->stream_mode : std::string {};
+      const std::string session_mode = stream_display_policy::effective_session_selection_for_launch(
+        launch_session ? std::string_view {launch_session->stream_mode} : std::string_view {},
+        launch_session && launch_session->mirror_desktop,
+        launch_session && launch_session->virtual_display,
+        _app.virtual_display,
+        launch_session && launch_session->user_locked_virtual_display
+      );
       if (!session_mode.empty() &&
           !(launch_session && launch_session->mirror_desktop) &&
           !stream_display_policy::selection_companion_state_matches(session_mode)) {
@@ -7221,8 +7227,13 @@ namespace proc {
                           << virtual_display::backend_name(linux_vdisplay->backend);
 
           // Set output_name to the newly created virtual display so the
-          // capture pipeline uses the correct output
-          config::video.output_name = display_device::map_display_name(this->display_name);
+          // capture pipeline uses the correct output. If platform mapping is
+          // unavailable, keep the connector name rather than falling back.
+          const auto mapped_output_name = display_device::map_display_name(this->display_name);
+          config::video.output_name = stream_display_policy::capture_output_name_for_virtual_display(
+            this->display_name,
+            mapped_output_name
+          );
         } else {
           BOOST_LOG(warning) << "Virtual Display creation failed on Linux"sv;
           launch_session->virtual_display = false;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6530,7 +6530,6 @@ namespace proc {
         launch_session && launch_session->user_locked_virtual_display
       );
       if (!session_mode.empty() &&
-          !(launch_session && launch_session->mirror_desktop) &&
           !stream_display_policy::selection_companion_state_matches(session_mode)) {
         std::string mode_error;
         if (stream_display_policy::apply_selection(session_mode, mode_error)) {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6784,7 +6784,8 @@ namespace proc {
       launch_session && launch_session->mirror_desktop,
       launch_session && launch_session->virtual_display,
       _app.virtual_display,
-      launch_session && launch_session->user_locked_virtual_display
+      launch_session && launch_session->user_locked_virtual_display,
+      resolved_optimization.virtual_display.has_value()
     );
     if (!session_mode.empty()) {
       launch_session->virtual_display = session_mode == stream_display_policy::k_host_virtual_display;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7161,6 +7161,7 @@ namespace proc {
           // Set virtual_display to true when everything went fine
           this->virtual_display = true;
           this->display_name = platf::to_utf8(vdisplayName);
+          this->exact_display_name = this->display_name;
 
           // When using virtual display, we don't care which display user configured to use.
           // So we always set output_name to the newly created virtual display as a workaround for
@@ -7223,6 +7224,7 @@ namespace proc {
           launch_session->virtual_display = true;
           this->virtual_display = true;
           this->display_name = linux_vdisplay->output_name;
+          this->exact_display_name = this->display_name;
 
           BOOST_LOG(info) << "Virtual Display created: "sv << linux_vdisplay->output_name
                           << " ("sv << render_width << "x"sv << render_height
@@ -9342,6 +9344,7 @@ namespace proc {
     _app_name.clear();
     _app = {};
     display_name.clear();
+    exact_display_name.clear();
     initial_display.clear();
     initial_color_range = 0;
     initial_nvenc_tune = 0;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6507,11 +6507,9 @@ namespace proc {
     allow_client_commands = app.allow_client_commands;
 
 #ifdef __linux__
-    // Session-scoped stream-mode override (/launch streamMode): apply the mode
-    // to the IN-MEMORY config for this session only. Nothing here persists to
-    // disk; terminate_impl restores the saved values after teardown, so the
-    // host default survives every launch. Without an override this block only
-    // snapshots current values and behavior is identical to before.
+    // Snapshot the host display policy before any session-scoped override.
+    // Final mode derivation is intentionally deferred until device/AI
+    // optimization has settled launch_session->virtual_display.
     {
       auto &linux_display = config::video.linux_display;
       this->initial_stream_mode = linux_display.stream_mode;
@@ -6522,44 +6520,7 @@ namespace proc {
       this->initial_use_cage_compositor = linux_display.use_cage_compositor;
       this->initial_prefer_gpu_native_capture = linux_display.prefer_gpu_native_capture;
       this->initial_auto_manage_displays = linux_display.auto_manage_displays;
-      const std::string session_mode = stream_display_policy::effective_session_selection_for_launch(
-        launch_session ? std::string_view {launch_session->stream_mode} : std::string_view {},
-        launch_session && launch_session->mirror_desktop,
-        launch_session && launch_session->virtual_display,
-        _app.virtual_display,
-        launch_session && launch_session->user_locked_virtual_display
-      );
-      if (!session_mode.empty() &&
-          !stream_display_policy::selection_companion_state_matches(session_mode)) {
-        std::string mode_error;
-        if (stream_display_policy::apply_selection(session_mode, mode_error)) {
-          // Saved-state restore is armed only when a mode was actually applied,
-          // so a no-override session touches nothing at save or teardown.
-          this->initial_linux_display_saved = true;
-          BOOST_LOG(info) << "process: session stream mode override ["sv << session_mode
-                          << "] applied in-memory for this session; host default restored at teardown"sv;
-          platf::reevaluate_capture_sources();
-        } else {
-          BOOST_LOG(warning) << "process: session stream mode override ["sv << session_mode
-                             << "] rejected: "sv << mode_error << "; using the host default"sv;
-        }
-      }
     }
-    const bool mirror_desktop_session = launch_session && launch_session->mirror_desktop;
-    const bool gamescope_stream_session =
-      config::video.linux_display.stream_mode == "gamescope_stream" ||
-      config::video.linux_display.private_runtime == "gamescope";
-    _session_used_gamescope_runtime = gamescope_stream_session;
-    // Set true when a Steam title or Big Picture is rewired to its own
-    // polaris-gamescope-session compositor.
-    bool nested_wsi_session = false;
-    // Private nested runtime: labwc cage and/or owned/attach gamescope.
-    const bool use_cage_compositor_for_session =
-      !mirror_desktop_session &&
-      (config::video.linux_display.use_cage_compositor || gamescope_stream_session);
-    const bool requested_headless_for_session =
-      !mirror_desktop_session &&
-      (config::video.linux_display.headless_mode || gamescope_stream_session);
 #endif
 
     this->initial_display = config::video.output_name;
@@ -6807,7 +6768,57 @@ namespace proc {
                       << (launch_session->enable_hdr ? "true"sv : "false"sv);
     }
 
+    if (resolved_optimization.virtual_display.has_value()) {
+      launch_session->virtual_display = *resolved_optimization.virtual_display;
+    }
+
 #ifdef __linux__
+    // Apply the session display policy only after device/AI optimization has
+    // finalized virtual_display. This generation then owns runtime topology,
+    // capture policy, and the creation decision together.
+    const bool virtual_display_requested_before_mode =
+      launch_session->virtual_display ||
+      (_app.virtual_display && !launch_session->user_locked_virtual_display);
+    const std::string session_mode = stream_display_policy::effective_session_selection_for_launch(
+      launch_session ? std::string_view {launch_session->stream_mode} : std::string_view {},
+      launch_session && launch_session->mirror_desktop,
+      launch_session && launch_session->virtual_display,
+      _app.virtual_display,
+      launch_session && launch_session->user_locked_virtual_display
+    );
+    if (!session_mode.empty()) {
+      launch_session->virtual_display = session_mode == stream_display_policy::k_host_virtual_display;
+    }
+    if (!session_mode.empty() &&
+        !stream_display_policy::selection_companion_state_matches(session_mode)) {
+      std::string mode_error;
+      if (stream_display_policy::apply_selection(session_mode, mode_error)) {
+        this->initial_linux_display_saved = true;
+        BOOST_LOG(info) << "process: final session stream mode override ["sv << session_mode
+                        << "] applied in-memory after optimization; host default restored at teardown"sv;
+        platf::reevaluate_capture_sources();
+      } else {
+        BOOST_LOG(warning) << "process: final session stream mode override ["sv << session_mode
+                           << "] rejected: "sv << mode_error << "; using the host default"sv;
+      }
+    }
+
+    const bool mirror_desktop_session = launch_session && launch_session->mirror_desktop;
+    const bool gamescope_stream_session =
+      config::video.linux_display.stream_mode == "gamescope_stream" ||
+      config::video.linux_display.private_runtime == "gamescope";
+    _session_used_gamescope_runtime = gamescope_stream_session;
+    // Set true when a Steam title or Big Picture is rewired to its own
+    // polaris-gamescope-session compositor.
+    bool nested_wsi_session = false;
+    // Private nested runtime: labwc cage and/or owned/attach gamescope.
+    const bool use_cage_compositor_for_session =
+      !mirror_desktop_session &&
+      (config::video.linux_display.use_cage_compositor || gamescope_stream_session);
+    const bool requested_headless_for_session =
+      !mirror_desktop_session &&
+      (config::video.linux_display.headless_mode || gamescope_stream_session);
+
     // Portal is_hdr reads this file. Write from final enable_hdr only.
     // Never restart gamescope or rewrite from encoder probe. Session owns restart.
     {
@@ -6892,10 +6903,6 @@ namespace proc {
     );
 #endif
 
-    if (resolved_optimization.virtual_display.has_value()) {
-      launch_session->virtual_display = *resolved_optimization.virtual_display;
-    }
-
     if (resolved_optimization.target_bitrate_kbps.has_value()) {
       launch_session->target_bitrate_kbps = *resolved_optimization.target_bitrate_kbps;
       config::video.max_bitrate = *resolved_optimization.target_bitrate_kbps;
@@ -6943,9 +6950,8 @@ namespace proc {
     const bool using_headless_cage_runtime =
       requested_headless_for_session &&
       use_cage_compositor_for_session;
-    if (using_headless_cage_runtime && launch_session->virtual_display) {
+    if (using_headless_cage_runtime && virtual_display_requested_before_mode) {
       BOOST_LOG(info) << "session_optimization: normalized virtual_display from true to false for headless cage runtime"sv;
-      launch_session->virtual_display = false;
       stream_stats::update_runtime_display_warning(
         "Virtual display request skipped: the private stream runtime provides this session's display."
       );

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6488,6 +6488,7 @@ namespace proc {
 #endif
 
     ++_session_generation;
+    capture_generation.generation_id = _session_generation;
 #ifdef __linux__
     _session_instance_id = generate_session_token();
     _session_used_cage_compositor = false;
@@ -7161,7 +7162,7 @@ namespace proc {
           // Set virtual_display to true when everything went fine
           this->virtual_display = true;
           this->display_name = platf::to_utf8(vdisplayName);
-          this->exact_display_name = this->display_name;
+          this->capture_generation.exact_display_name = this->display_name;
 
           // When using virtual display, we don't care which display user configured to use.
           // So we always set output_name to the newly created virtual display as a workaround for
@@ -7224,7 +7225,7 @@ namespace proc {
           launch_session->virtual_display = true;
           this->virtual_display = true;
           this->display_name = linux_vdisplay->output_name;
-          this->exact_display_name = this->display_name;
+          this->capture_generation.exact_display_name = this->display_name;
 
           BOOST_LOG(info) << "Virtual Display created: "sv << linux_vdisplay->output_name
                           << " ("sv << render_width << "x"sv << render_height
@@ -7309,6 +7310,23 @@ namespace proc {
       }
       linux_display::enable_streaming_display(render_width, render_height, target_fps);
     }
+
+    const auto generation_id = capture_generation.generation_id;
+    const auto exact_output_name = capture_generation.exact_display_name;
+    const auto configured_output_name = !config::video.output_name.empty() ?
+                                          config::video.output_name :
+                                          config::video.linux_display.streaming_output;
+    capture_generation = capture_generation::identity_t {
+      .generation_id = generation_id,
+      .exact_display_name = exact_output_name,
+      .requested_output_name = exact_output_name.empty() ? configured_output_name : exact_output_name,
+      .stream_mode = config::video.linux_display.stream_mode,
+      .capture_backend = config::video.capture,
+      .private_runtime = config::video.linux_display.private_runtime,
+      .adapter_name = config::video.adapter_name,
+      .headless_mode = config::video.linux_display.headless_mode,
+      .use_cage_compositor = config::video.linux_display.use_cage_compositor,
+    };
 #endif
 
     // Probe encoders again before streaming to ensure our chosen
@@ -9344,7 +9362,7 @@ namespace proc {
     _app_name.clear();
     _app = {};
     display_name.clear();
-    exact_display_name.clear();
+    capture_generation = {};
     initial_display.clear();
     initial_color_range = 0;
     initial_nvenc_tune = 0;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -4859,6 +4859,17 @@ namespace proc {
 #endif
 
 #if defined(__linux__)
+  void apply_app_display_semantics(
+    const proc::ctx_t &app,
+    rtsp_stream::launch_session_t &launch_session
+  ) {
+    if (!app.desktop_mirror) {
+      return;
+    }
+    launch_session.mirror_desktop = true;
+    launch_session.virtual_display = false;
+  }
+
   bool streaming_launch_requests_private_family(
     bool headless_mode,
     bool use_cage_compositor,
@@ -6774,6 +6785,14 @@ namespace proc {
     }
 
 #ifdef __linux__
+    if (_app.desktop_mirror) {
+      if (!launch_session->mirror_desktop || launch_session->virtual_display) {
+        BOOST_LOG(info) << "process: app launch semantic selects desktop mirroring for ["sv
+                        << _app.name << "]; ignoring virtual-display preference for this session"sv;
+      }
+      apply_app_display_semantics(_app, *launch_session);
+    }
+
     // Apply the session display policy only after device/AI optimization has
     // finalized virtual_display. This generation then owns runtime topology,
     // capture policy, and the creation decision together.
@@ -7885,6 +7904,20 @@ namespace proc {
       };
       if (!private_runtime->start(start_params)) {
         return false;
+      }
+
+      if (private_runtime->backend_id() == stream_display_policy::k_runtime_labwc) {
+        capture_generation.private_wayland_socket = private_runtime->wayland_socket();
+        capture_generation.private_runtime_instance_id = _session_instance_id;
+        if (capture_generation.private_wayland_socket.empty() ||
+            stream_runtime::labwc::session_instance_id() != _session_instance_id) {
+          BOOST_LOG(error) << "session_manager: Private labwc generation identity was not published exactly"sv;
+          private_runtime->stop();
+          return false;
+        }
+      } else {
+        capture_generation.private_wayland_socket.clear();
+        capture_generation.private_runtime_instance_id.clear();
       }
 
       if (!reprobe_encoders_for_cage(strict_configured_encoder, save_successful_cache)) {
@@ -9301,16 +9334,23 @@ namespace proc {
       }
 #elif __linux__
     // Destroy Linux virtual display if one was created
-    bool used_linux_vdisplay = linux_vdisplay.has_value() && linux_vdisplay->active;
-    if (used_linux_vdisplay) {
-      virtual_display::destroy(*linux_vdisplay);
-      linux_vdisplay.reset();
-      BOOST_LOG(info) << "Linux Virtual Display removed successfully"sv;
+    const bool had_linux_vdisplay = linux_vdisplay.has_value();
+    if (had_linux_vdisplay) {
+      if (virtual_display::destroy(*linux_vdisplay)) {
+        linux_vdisplay.reset();
+        BOOST_LOG(info) << "Linux Virtual Display teardown verified"sv;
+      } else {
+        BOOST_LOG(error) << "Linux Virtual Display teardown not verified; retaining handle for retry"sv;
+      }
     }
 
     if (proc::proc.get_last_run_app_name().length() > 0 && has_run) {
-      if (used_linux_vdisplay) {
-        display_device::reset_persistence();
+      if (had_linux_vdisplay) {
+        if (!linux_vdisplay.has_value()) {
+          display_device::reset_persistence();
+        } else {
+          BOOST_LOG(error) << "Linux Virtual Display recovery remains pending; skipping unrelated display reconfiguration"sv;
+        }
       } else {
         display_device::revert_configuration();
       }
@@ -9974,7 +10014,7 @@ namespace proc {
    * Legacy versions of Sunshine/Apollo stored boolean and integer values as strings.
    * The following keys are converted:
    *   - Boolean keys: "exclude-global-prep-cmd", "elevated", "auto-detach", "wait-all",
-   *                     "use-app-identity", "per-client-app-identity", "virtual-display"
+   *                     "use-app-identity", "per-client-app-identity", "desktop-mirror", "virtual-display"
    *   - Integer keys: "exit-timeout"
    *
    * A migration version is stored in the file tree (under "version") so that future changes can be applied.
@@ -10063,6 +10103,7 @@ namespace proc {
         {"wait-all", true},
         {"use-app-identity", false},
         {"per-client-app-identity", false},
+        {"desktop-mirror", false},
         {"virtual-display", false},
         {"virtual-display-primary", false},
         {"terminate-on-pause", false}
@@ -10429,8 +10470,64 @@ namespace proc {
     }
   }
 
+  void migration_v6(nlohmann::json &fileTree) {
+    // The bundled Desktop app predates an explicit launch semantic. Preserve
+    // that exact legacy entry as a desktop mirror without inferring behavior
+    // from the display name alone: a user app is allowed to be named Desktop.
+    static const int this_version = 10;
+    const int file_version = json_int_member_or(fileTree, "version", 0);
+    if (file_version >= this_version) {
+      return;
+    }
+
+    if (!fileTree.contains("apps") || !fileTree["apps"].is_array()) {
+      fileTree["version"] = this_version;
+      return;
+    }
+
+    for (auto &app : fileTree["apps"]) {
+      if (!app.is_object() || app.contains("desktop-mirror")) {
+        continue;
+      }
+
+      const auto name = json_string_member_or(app, "name");
+      const auto image_path = json_string_member_or(app, "image-path");
+      const auto source = json_string_member_or(app, "source", "manual");
+      const auto cmd = json_string_member_or(app, "cmd");
+      const auto steam_appid = json_string_member_or(app, "steam-appid");
+      const bool no_detached = !app.contains("detached") ||
+                               (app["detached"].is_array() && app["detached"].empty());
+      const bool no_prep = !app.contains("prep-cmd") ||
+                           (app["prep-cmd"].is_array() && app["prep-cmd"].empty());
+      const bool no_state = !app.contains("state-cmd") ||
+                            (app["state-cmd"].is_array() && app["state-cmd"].empty());
+      const bool virtual_display = app.contains("virtual-display") &&
+                                   coerce_json_bool(app["virtual-display"], false);
+      const bool client_commands = !app.contains("allow-client-commands") ||
+                                   coerce_json_bool(app["allow-client-commands"], true);
+
+      const bool exact_legacy_desktop =
+        name == "Desktop" &&
+        image_path == "desktop.png" &&
+        boost::iequals(source, "manual") &&
+        cmd.empty() &&
+        steam_appid.empty() &&
+        no_detached &&
+        no_prep &&
+        no_state &&
+        !virtual_display &&
+        !client_commands;
+      if (exact_legacy_desktop) {
+        app["desktop-mirror"] = true;
+        BOOST_LOG(info) << "Migrated the bundled legacy Desktop app to explicit desktop-mirror launch semantics.";
+      }
+    }
+
+    fileTree["version"] = this_version;
+  }
+
   void migrate(nlohmann::json& fileTree, const std::string& fileName) {
-    int last_version = 9;
+    int last_version = 10;
 
     int file_version = json_int_member_or(fileTree, "version", 0);
     if (fileTree.contains("version") && !coerce_json_int(fileTree["version"]).has_value()) {
@@ -10442,6 +10539,7 @@ namespace proc {
       migration_v3(fileTree);
       migration_v4(fileTree);
       migration_v5(fileTree);
+      migration_v6(fileTree);
       file_handler::write_file(fileName.c_str(), fileTree.dump(4));
     }
   }
@@ -10574,6 +10672,7 @@ namespace proc {
           ctx.wait_all = app_node.value("wait-all", true);
           ctx.exit_timeout = std::chrono::seconds { app_node.value("exit-timeout", 5) };
           ctx.virtual_display = app_node.value("virtual-display", false);
+          ctx.desktop_mirror = app_node.value("desktop-mirror", false);
           ctx.scale_factor = app_node.value("scale-factor", 100);
           ctx.use_app_identity = app_node.value("use-app-identity", false);
           ctx.per_client_app_identity = app_node.value("per-client-app-identity", false);
@@ -10659,6 +10758,7 @@ namespace proc {
       ctx.name = "Desktop (fallback)";
       ctx.image_path = parse_env_val(this_env, "desktop-alt.png");
       ctx.virtual_display = false;
+      ctx.desktop_mirror = true;
       ctx.scale_factor = 100;
       ctx.use_app_identity = false;
       ctx.per_client_app_identity = false;

--- a/src/process.h
+++ b/src/process.h
@@ -682,6 +682,9 @@ namespace proc {
     KITTY_DEFAULT_CONSTR_MOVE_THROW(proc_t)
 
     std::string display_name;
+    // Connector identity owned by this launch generation. Unlike display_name,
+    // this is never rewritten by legacy display enumeration.
+    std::string exact_display_name;
     std::string initial_display;
     std::string mode_changed_display;
     bool initial_hdr = false;

--- a/src/process.h
+++ b/src/process.h
@@ -42,6 +42,7 @@
 #include <nlohmann/json.hpp>
 
 // local includes
+#include "capture_generation.h"
 #include "config.h"
 #include "audio.h"
 #include "platform/common.h"
@@ -682,9 +683,7 @@ namespace proc {
     KITTY_DEFAULT_CONSTR_MOVE_THROW(proc_t)
 
     std::string display_name;
-    // Connector identity owned by this launch generation. Unlike display_name,
-    // this is never rewritten by legacy display enumeration.
-    std::string exact_display_name;
+    capture_generation::identity_t capture_generation;
     std::string initial_display;
     std::string mode_changed_display;
     bool initial_hdr = false;

--- a/src/process.h
+++ b/src/process.h
@@ -153,6 +153,10 @@ namespace proc {
   bool desktop_steam_client_active();
   bool request_desktop_steam_shutdown_for_private_stream();
   bool ensure_steam_client_quiescent_for_doctor();
+  void apply_app_display_semantics(
+    const struct ctx_t &app,
+    rtsp_stream::launch_session_t &launch_session
+  );
 #endif
 
 #if defined(POLARIS_TESTS) && defined(__linux__)
@@ -543,6 +547,7 @@ namespace proc {
     bool wait_all;
     bool virtual_display;
     bool virtual_display_primary;
+    bool desktop_mirror = false;
     bool use_app_identity;
     bool per_client_app_identity;
     bool allow_client_commands;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1457,6 +1457,7 @@ namespace video {
     config_t config;
     int frame_nr;
     void *channel_data;
+    std::string exact_display_name;
   };
 
   struct sync_session_t {
@@ -1471,6 +1472,7 @@ namespace video {
     img_event_t images;
     config_t config;
     void *channel_data;
+    std::string exact_display_name;
   };
 
   struct capture_thread_async_ctx_t {
@@ -2098,6 +2100,13 @@ namespace video {
     return exact_display_name.empty();
   }
 
+  bool exact_display_generations_match(
+    std::string_view active_exact_display_name,
+    std::string_view incoming_exact_display_name
+  ) {
+    return active_exact_display_name == incoming_exact_display_name;
+  }
+
   std::optional<int> find_display_index(
     const std::vector<std::string> &display_names,
     std::string_view requested_display_name
@@ -2240,7 +2249,7 @@ namespace video {
     std::vector<std::string> display_names;
     int display_p = -1;
     std::shared_ptr<platf::display_t> disp;
-    const auto exact_display_name = proc::proc.display_name;
+    const auto exact_display_name = capture_ctxs.front().exact_display_name;
     {
 #ifdef __linux__
     session_media::pending_start_owner_scope_t initial_owner_scope {
@@ -2397,7 +2406,21 @@ namespace video {
         }
 
         while (capture_ctx_queue->peek()) {
-          capture_ctxs.emplace_back(std::move(*capture_ctx_queue->pop()));
+          auto incoming_capture_ctx = capture_ctx_queue->pop();
+          if (!incoming_capture_ctx) {
+            return false;
+          }
+          if (!exact_display_generations_match(
+                exact_display_name,
+                incoming_capture_ctx->exact_display_name
+              )) {
+            BOOST_LOG(error) << "Rejecting capture context with exact display provenance ["sv
+                             << incoming_capture_ctx->exact_display_name
+                             << "] while generation ["sv << exact_display_name << "] is active"sv;
+            incoming_capture_ctx->images->stop();
+            continue;
+          }
+          capture_ctxs.emplace_back(std::move(*incoming_capture_ctx));
         }
 
         if (switch_display_event->peek()) {
@@ -3692,7 +3715,6 @@ namespace video {
     int &display_p
   ) {
     const auto &encoder = *chosen_encoder;
-    const auto exact_display_name = proc::proc.display_name;
 
     std::shared_ptr<platf::display_t> disp;
 
@@ -3706,6 +3728,8 @@ namespace video {
 
       synced_session_ctxs.emplace_back(std::make_unique<sync_session_ctx_t>(std::move(*ctx)));
     }
+
+    const auto exact_display_name = synced_session_ctxs.front()->exact_display_name;
 
     while (encode_session_ctx_queue.running()) {
       if (!exact_display_name.empty()) {
@@ -3800,12 +3824,23 @@ namespace video {
         auto frame = make_frame(std::move(img));
 
         while (encode_session_ctx_queue.peek()) {
-          auto encode_session_ctx = encode_session_ctx_queue.pop();
-          if (!encode_session_ctx) {
+          auto incoming_sync_ctx = encode_session_ctx_queue.pop();
+          if (!incoming_sync_ctx) {
             return false;
           }
+          if (!exact_display_generations_match(
+                exact_display_name,
+                incoming_sync_ctx->exact_display_name
+              )) {
+            BOOST_LOG(error) << "Rejecting synchronized capture context with exact display provenance ["sv
+                             << incoming_sync_ctx->exact_display_name
+                             << "] while generation ["sv << exact_display_name << "] is active"sv;
+            incoming_sync_ctx->shutdown_event->raise(true);
+            incoming_sync_ctx->join_event->raise(true);
+            continue;
+          }
 
-          synced_session_ctxs.emplace_back(std::make_unique<sync_session_ctx_t>(std::move(*encode_session_ctx)));
+          synced_session_ctxs.emplace_back(std::make_unique<sync_session_ctx_t>(std::move(*incoming_sync_ctx)));
 
           bool retired_gpu_native_route = false;
           auto encode_session = make_synced_session(disp.get(), encoder, frame, *synced_session_ctxs.back(), retired_gpu_native_route);
@@ -3937,7 +3972,8 @@ namespace video {
     safe::mail_t mail,
     config_t &config,
     void *channel_data,
-    packet_queue_t packets
+    packet_queue_t packets,
+    std::string exact_display_name
   ) {
     auto shutdown_event = mail->event<bool>(mail::shutdown);
 
@@ -3952,7 +3988,12 @@ namespace video {
       return;
     }
 
-    ref->capture_ctx_queue->raise(capture_ctx_t {images, config, channel_data});
+    ref->capture_ctx_queue->raise(capture_ctx_t {
+      images,
+      config,
+      channel_data,
+      std::move(exact_display_name),
+    });
 
     if (!ref->capture_ctx_queue->running()) {
       return;
@@ -4040,8 +4081,15 @@ namespace video {
     auto idr_events = mail->event<bool>(mail::idr);
 
     idr_events->raise(true);
+    const auto exact_display_name = proc::proc.exact_display_name;
     if (chosen_encoder->flags & PARALLEL_ENCODING) {
-      capture_async(std::move(mail), config, channel_data, std::move(packets));
+      capture_async(
+        std::move(mail),
+        config,
+        channel_data,
+        std::move(packets),
+        exact_display_name
+      );
     } else {
       safe::signal_t join_event;
       auto ref = capture_thread_sync.ref();
@@ -4055,6 +4103,7 @@ namespace video {
         config,
         1,
         channel_data,
+        exact_display_name,
       });
 
       // Wait for join signal
@@ -5212,6 +5261,13 @@ namespace video {
 
   bool display_switch_allowed_for_exact_capture_for_tests(std::string_view exact_display_name) {
     return display_switch_allowed_for_exact_capture(exact_display_name);
+  }
+
+  bool exact_display_generations_match_for_tests(
+    std::string_view active_exact_display_name,
+    std::string_view incoming_exact_display_name
+  ) {
+    return exact_display_generations_match(active_exact_display_name, incoming_exact_display_name);
   }
 
   std::optional<int> find_display_index_for_tests(

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <atomic>
 #include <bitset>
+#include <charconv>
 #include <cmath>
 #include <filesystem>
 #include <fcntl.h>
@@ -2100,6 +2101,17 @@ namespace video {
     if (requested_display_name.empty()) {
       return std::nullopt;
     }
+
+    std::size_t requested_index = 0;
+    const auto *begin = requested_display_name.data();
+    const auto *end = begin + requested_display_name.size();
+    const auto parsed = std::from_chars(begin, end, requested_index);
+    if (parsed.ec == std::errc {} && parsed.ptr == end) {
+      return requested_index < display_names.size() ?
+               std::optional<int> {static_cast<int>(requested_index)} :
+               std::nullopt;
+    }
+
     for (int index = 0; index < display_names.size(); ++index) {
       if (display_names[index] == requested_display_name) {
         return index;
@@ -2444,17 +2456,31 @@ namespace video {
               // only support a single display session per device/application.
               disp.reset();
 
-              // Reenumeration must preserve the exact active connector. A
-              // missing named output cannot reset capture to display 0.
-              if (!refresh_displays(
+              const auto exact_display_name = proc::proc.display_name;
+              if (!switch_display_event->peek() && !exact_display_name.empty()) {
+                {
+#ifdef __linux__
+                  session_media::pending_start_owner_scope_t owner_scope {
+                    capture_ctxs.front().channel_data
+                  };
+#endif
+                  reset_display(
+                    disp,
                     encoder.platform_formats->dev_type,
-                    display_names,
-                    display_p,
-                    proc::proc.display_name
-                  )) {
-                BOOST_LOG(error) << "Active display identity could not be preserved during reinitialization"sv;
-                return;
+                    exact_display_name,
+                    capture_ctxs.front().config
+                  );
+                }
+                if (!disp) {
+                  BOOST_LOG(error) << "Exact active display ["sv << exact_display_name
+                                   << "] could not be reopened; refusing another output"sv;
+                  return;
+                }
+                break;
               }
+
+              // Only an explicit switch or an unnamed legacy session may enumerate.
+              refresh_displays(encoder.platform_formats->dev_type, display_names, display_p);
 
               // Process any pending display switch with the new list of displays
               if (switch_display_event->peek()) {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1457,7 +1457,6 @@ namespace video {
     config_t config;
     int frame_nr;
     void *channel_data;
-    std::string exact_display_name;
   };
 
   struct sync_session_t {
@@ -1472,7 +1471,6 @@ namespace video {
     img_event_t images;
     config_t config;
     void *channel_data;
-    std::string exact_display_name;
   };
 
   struct capture_thread_async_ctx_t {
@@ -2100,11 +2098,32 @@ namespace video {
     return exact_display_name.empty();
   }
 
-  bool exact_display_generations_match(
-    std::string_view active_exact_display_name,
-    std::string_view incoming_exact_display_name
+  bool capture_generations_match(
+    const capture_generation::identity_t &active,
+    const capture_generation::identity_t &incoming
   ) {
-    return active_exact_display_name == incoming_exact_display_name;
+    return active == incoming;
+  }
+
+  capture_generation::identity_t current_capture_generation_identity() {
+    auto configured_output_name = config::video.output_name;
+#ifdef __linux__
+    if (configured_output_name.empty()) {
+      configured_output_name = config::video.linux_display.streaming_output;
+    }
+#endif
+    capture_generation::identity_t generation {
+      .requested_output_name = configured_output_name,
+      .capture_backend = config::video.capture,
+      .adapter_name = config::video.adapter_name,
+    };
+#ifdef __linux__
+    generation.stream_mode = config::video.linux_display.stream_mode;
+    generation.private_runtime = config::video.linux_display.private_runtime;
+    generation.headless_mode = config::video.linux_display.headless_mode;
+    generation.use_cage_compositor = config::video.linux_display.use_cage_compositor;
+#endif
+    return generation;
   }
 
   std::optional<int> find_display_index(
@@ -2249,7 +2268,8 @@ namespace video {
     std::vector<std::string> display_names;
     int display_p = -1;
     std::shared_ptr<platf::display_t> disp;
-    const auto exact_display_name = capture_ctxs.front().exact_display_name;
+    const auto active_generation = capture_ctxs.front().config.capture_generation;
+    const auto &exact_display_name = active_generation.exact_display_name;
     {
 #ifdef __linux__
     session_media::pending_start_owner_scope_t initial_owner_scope {
@@ -2410,13 +2430,15 @@ namespace video {
           if (!incoming_capture_ctx) {
             return false;
           }
-          if (!exact_display_generations_match(
-                exact_display_name,
-                incoming_capture_ctx->exact_display_name
+          if (!capture_generations_match(
+                active_generation,
+                incoming_capture_ctx->config.capture_generation
               )) {
-            BOOST_LOG(error) << "Rejecting capture context with exact display provenance ["sv
-                             << incoming_capture_ctx->exact_display_name
-                             << "] while generation ["sv << exact_display_name << "] is active"sv;
+            BOOST_LOG(error) << "Rejecting capture context from generation ["sv
+                             << incoming_capture_ctx->config.capture_generation.exact_display_name
+                             << "/"sv << incoming_capture_ctx->config.capture_generation.stream_mode
+                             << "] while generation ["sv << exact_display_name
+                             << "/"sv << active_generation.stream_mode << "] is active"sv;
             incoming_capture_ctx->images->stop();
             continue;
           }
@@ -3729,7 +3751,8 @@ namespace video {
       synced_session_ctxs.emplace_back(std::make_unique<sync_session_ctx_t>(std::move(*ctx)));
     }
 
-    const auto exact_display_name = synced_session_ctxs.front()->exact_display_name;
+    const auto active_generation = synced_session_ctxs.front()->config.capture_generation;
+    const auto &exact_display_name = active_generation.exact_display_name;
 
     while (encode_session_ctx_queue.running()) {
       if (!exact_display_name.empty()) {
@@ -3828,13 +3851,15 @@ namespace video {
           if (!incoming_sync_ctx) {
             return false;
           }
-          if (!exact_display_generations_match(
-                exact_display_name,
-                incoming_sync_ctx->exact_display_name
+          if (!capture_generations_match(
+                active_generation,
+                incoming_sync_ctx->config.capture_generation
               )) {
-            BOOST_LOG(error) << "Rejecting synchronized capture context with exact display provenance ["sv
-                             << incoming_sync_ctx->exact_display_name
-                             << "] while generation ["sv << exact_display_name << "] is active"sv;
+            BOOST_LOG(error) << "Rejecting synchronized capture context from generation ["sv
+                             << incoming_sync_ctx->config.capture_generation.exact_display_name
+                             << "/"sv << incoming_sync_ctx->config.capture_generation.stream_mode
+                             << "] while generation ["sv << exact_display_name
+                             << "/"sv << active_generation.stream_mode << "] is active"sv;
             incoming_sync_ctx->shutdown_event->raise(true);
             incoming_sync_ctx->join_event->raise(true);
             continue;
@@ -3972,8 +3997,7 @@ namespace video {
     safe::mail_t mail,
     config_t &config,
     void *channel_data,
-    packet_queue_t packets,
-    std::string exact_display_name
+    packet_queue_t packets
   ) {
     auto shutdown_event = mail->event<bool>(mail::shutdown);
 
@@ -3992,7 +4016,6 @@ namespace video {
       images,
       config,
       channel_data,
-      std::move(exact_display_name),
     });
 
     if (!ref->capture_ctx_queue->running()) {
@@ -4081,14 +4104,16 @@ namespace video {
     auto idr_events = mail->event<bool>(mail::idr);
 
     idr_events->raise(true);
-    const auto exact_display_name = proc::proc.exact_display_name;
+    config.capture_generation = proc::proc.capture_generation;
+    if (config.capture_generation.empty()) {
+      config.capture_generation = current_capture_generation_identity();
+    }
     if (chosen_encoder->flags & PARALLEL_ENCODING) {
       capture_async(
         std::move(mail),
         config,
         channel_data,
-        std::move(packets),
-        exact_display_name
+        std::move(packets)
       );
     } else {
       safe::signal_t join_event;
@@ -4103,7 +4128,6 @@ namespace video {
         config,
         1,
         channel_data,
-        exact_display_name,
       });
 
       // Wait for join signal
@@ -5263,11 +5287,11 @@ namespace video {
     return display_switch_allowed_for_exact_capture(exact_display_name);
   }
 
-  bool exact_display_generations_match_for_tests(
-    std::string_view active_exact_display_name,
-    std::string_view incoming_exact_display_name
+  bool capture_generations_match_for_tests(
+    const capture_generation::identity_t &active,
+    const capture_generation::identity_t &incoming
   ) {
-    return exact_display_generations_match(active_exact_display_name, incoming_exact_display_name);
+    return capture_generations_match(active, incoming);
   }
 
   std::optional<int> find_display_index_for_tests(

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2178,9 +2178,17 @@ namespace video {
    * @param current_display_index The current display index or -1 if not yet known.
    * @return true when the current/preferred identity remains selectable.
    */
-  bool refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index, std::string &preferred_display_name) {
+  bool refresh_displays(
+    platf::mem_type_e dev_type,
+    std::vector<std::string> &display_names,
+    int &current_display_index,
+    std::string &preferred_display_name,
+    const config_t *capture_config
+  ) {
     // It is possible that the output name may be empty even if it wasn't before (device disconnected) or vice-versa
-    const auto output_name { display_device::map_output_name(config::video.output_name) };
+    const auto output_name = capture_config != nullptr ?
+      capture_config->capture_generation.requested_output_name :
+      display_device::map_output_name(config::video.output_name);
     std::string current_display_name = preferred_display_name;
 
     // If we have a current display index, let's start with that
@@ -2190,7 +2198,13 @@ namespace video {
 
     // Refresh the display names
     auto old_display_names = std::move(display_names);
+#ifdef __linux__
+    display_names = capture_config != nullptr ?
+      platf::display_names(dev_type, *capture_config) :
+      platf::display_names(dev_type);
+#else
     display_names = platf::display_names(dev_type);
+#endif
 
     // If we now have no displays, let's put the old display array back and fail
     if (display_names.empty() && !old_display_names.empty()) {
@@ -2206,7 +2220,7 @@ namespace video {
     current_display_index = 0;
 
     if (current_display_name.empty()) {
-      current_display_name = display_device::map_output_name(config::video.output_name);
+      current_display_name = output_name;
     }
 
     // Exact prior identity is authoritative. A miss cannot become display 0.
@@ -2228,9 +2242,14 @@ namespace video {
     return !display_names.empty();
   }
 
-  void refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index) {
+  void refresh_displays(
+    platf::mem_type_e dev_type,
+    std::vector<std::string> &display_names,
+    int &current_display_index,
+    const config_t *capture_config = nullptr
+  ) {
     static std::string empty_str = "";
-    if (!refresh_displays(dev_type, display_names, current_display_index, empty_str)) {
+    if (!refresh_displays(dev_type, display_names, current_display_index, empty_str, capture_config)) {
       current_display_index = display_names.empty() ? -1 : 0;
     }
   }
@@ -2287,7 +2306,12 @@ namespace video {
     if (!disp) {
       // Get all the monitor names now, rather than at boot, to
       // get the most up-to-date list available monitors
-      refresh_displays(encoder.platform_formats->dev_type, display_names, display_p);
+      refresh_displays(
+        encoder.platform_formats->dev_type,
+        display_names,
+        display_p,
+        &capture_ctxs.front().config
+      );
       if (display_names.empty()) {
         BOOST_LOG(error) << "No displays were found for initial capture setup"sv;
         return;
@@ -2542,7 +2566,12 @@ namespace video {
               }
 
               // Only an explicit switch or an unnamed legacy session may enumerate.
-              refresh_displays(encoder.platform_formats->dev_type, display_names, display_p);
+              refresh_displays(
+                encoder.platform_formats->dev_type,
+                display_names,
+                display_p,
+                &capture_ctxs.front().config
+              );
 
               // Process any pending display switch with the new list of displays
               if (switch_display_event->peek()) {
@@ -3785,7 +3814,12 @@ namespace video {
       }
 
       // Refresh display names since a display removal might have caused the reinitialization
-      refresh_displays(encoder.platform_formats->dev_type, display_names, display_p);
+      refresh_displays(
+        encoder.platform_formats->dev_type,
+        display_names,
+        display_p,
+        &synced_session_ctxs.front()->config
+      );
 
       // Process any pending display switch with the new list of displays
       if (switch_display_event->peek()) {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2094,6 +2094,10 @@ namespace video {
     return requested_display_name.empty();
   }
 
+  bool display_switch_allowed_for_exact_capture(std::string_view exact_display_name) {
+    return exact_display_name.empty();
+  }
+
   std::optional<int> find_display_index(
     const std::vector<std::string> &display_names,
     std::string_view requested_display_name
@@ -2236,18 +2240,18 @@ namespace video {
     std::vector<std::string> display_names;
     int display_p = -1;
     std::shared_ptr<platf::display_t> disp;
+    const auto exact_display_name = proc::proc.display_name;
     {
 #ifdef __linux__
     session_media::pending_start_owner_scope_t initial_owner_scope {
       capture_ctxs.front().channel_data
     };
 #endif
-    const auto requested_display_name = proc::proc.display_name;
-    if (!requested_display_name.empty()) {
-      disp = platf::display(encoder.platform_formats->dev_type, requested_display_name, capture_ctxs.front().config);
+    if (!exact_display_name.empty()) {
+      disp = platf::display(encoder.platform_formats->dev_type, exact_display_name, capture_ctxs.front().config);
     }
-    if (!disp && !capture_fallback_allowed(requested_display_name)) {
-      BOOST_LOG(error) << "Requested display ["sv << requested_display_name
+    if (!disp && !capture_fallback_allowed(exact_display_name)) {
+      BOOST_LOG(error) << "Requested display ["sv << exact_display_name
                        << "] could not be initialized; refusing another output"sv;
       return;
     }
@@ -2397,8 +2401,15 @@ namespace video {
         }
 
         if (switch_display_event->peek()) {
-          artificial_reinit = true;
-          return false;
+          if (!display_switch_allowed_for_exact_capture(exact_display_name)) {
+            const auto requested_display = *switch_display_event->pop();
+            BOOST_LOG(warning) << "Ignoring display switch request ["sv
+                               << requested_display << "] while exact display ["sv
+                               << exact_display_name << "] is owned"sv;
+          } else {
+            artificial_reinit = true;
+            return false;
+          }
         }
 
         if (reinit_request_event.peek()) {
@@ -2456,8 +2467,14 @@ namespace video {
               // only support a single display session per device/application.
               disp.reset();
 
-              const auto exact_display_name = proc::proc.display_name;
-              if (!switch_display_event->peek() && !exact_display_name.empty()) {
+              if (!exact_display_name.empty()) {
+                if (switch_display_event->peek() &&
+                    !display_switch_allowed_for_exact_capture(exact_display_name)) {
+                  const auto requested_display = *switch_display_event->pop();
+                  BOOST_LOG(warning) << "Ignoring display switch request ["sv
+                                     << requested_display << "] while exact display ["sv
+                                     << exact_display_name << "] is owned"sv;
+                }
                 {
 #ifdef __linux__
                   session_media::pending_start_owner_scope_t owner_scope {
@@ -3675,6 +3692,7 @@ namespace video {
     int &display_p
   ) {
     const auto &encoder = *chosen_encoder;
+    const auto exact_display_name = proc::proc.display_name;
 
     std::shared_ptr<platf::display_t> disp;
 
@@ -3690,6 +3708,35 @@ namespace video {
     }
 
     while (encode_session_ctx_queue.running()) {
+      if (!exact_display_name.empty()) {
+        if (switch_display_event->peek() &&
+            !display_switch_allowed_for_exact_capture(exact_display_name)) {
+          const auto requested_display = *switch_display_event->pop();
+          BOOST_LOG(warning) << "Ignoring display switch request ["sv
+                             << requested_display << "] while exact display ["sv
+                             << exact_display_name << "] is owned"sv;
+        }
+        {
+#ifdef __linux__
+          session_media::pending_start_owner_scope_t owner_scope {
+            synced_session_ctxs.front()->channel_data
+          };
+#endif
+          reset_display(
+            disp,
+            encoder.platform_formats->dev_type,
+            exact_display_name,
+            synced_session_ctxs.front()->config
+          );
+        }
+        if (!disp) {
+          BOOST_LOG(error) << "Exact active display ["sv << exact_display_name
+                           << "] could not be opened; refusing another output"sv;
+          return encode_e::error;
+        }
+        break;
+      }
+
       // Refresh display names since a display removal might have caused the reinitialization
       refresh_displays(encoder.platform_formats->dev_type, display_names, display_p);
 
@@ -3824,8 +3871,15 @@ namespace video {
         })
 
         if (switch_display_event->peek()) {
-          ec = platf::capture_e::reinit;
-          return false;
+          if (!display_switch_allowed_for_exact_capture(exact_display_name)) {
+            const auto requested_display = *switch_display_event->pop();
+            BOOST_LOG(warning) << "Ignoring display switch request ["sv
+                               << requested_display << "] while exact display ["sv
+                               << exact_display_name << "] is owned"sv;
+          } else {
+            ec = platf::capture_e::reinit;
+            return false;
+          }
         }
 
         return true;
@@ -5154,6 +5208,10 @@ namespace video {
 
   bool capture_fallback_allowed_for_tests(std::string_view requested_display_name) {
     return capture_fallback_allowed(requested_display_name);
+  }
+
+  bool display_switch_allowed_for_exact_capture_for_tests(std::string_view exact_display_name) {
+    return display_switch_allowed_for_exact_capture(exact_display_name);
   }
 
   std::optional<int> find_display_index_for_tests(

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2089,6 +2089,25 @@ namespace video {
     false
   };
 
+  bool capture_fallback_allowed(std::string_view requested_display_name) {
+    return requested_display_name.empty();
+  }
+
+  std::optional<int> find_display_index(
+    const std::vector<std::string> &display_names,
+    std::string_view requested_display_name
+  ) {
+    if (requested_display_name.empty()) {
+      return std::nullopt;
+    }
+    for (int index = 0; index < display_names.size(); ++index) {
+      if (display_names[index] == requested_display_name) {
+        return index;
+      }
+    }
+    return std::nullopt;
+  }
+
   void reset_display(std::shared_ptr<platf::display_t> &disp, const platf::mem_type_e &type, const std::string &display_name, const config_t &config) {
     constexpr int max_attempts = 3;
 
@@ -2113,8 +2132,9 @@ namespace video {
    * @param dev_type The encoder device type used for display lookup.
    * @param display_names The list of display names to repopulate.
    * @param current_display_index The current display index or -1 if not yet known.
+   * @return true when the current/preferred identity remains selectable.
    */
-  void refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index, std::string &preferred_display_name) {
+  bool refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index, std::string &preferred_display_name) {
     // It is possible that the output name may be empty even if it wasn't before (device disconnected) or vice-versa
     const auto output_name { display_device::map_output_name(config::video.output_name) };
     std::string current_display_name = preferred_display_name;
@@ -2132,7 +2152,8 @@ namespace video {
     if (display_names.empty() && !old_display_names.empty()) {
       BOOST_LOG(error) << "No displays were found after reenumeration!"sv;
       display_names = std::move(old_display_names);
-      return;
+      current_display_index = -1;
+      return false;
     } else if (display_names.empty()) {
       display_names.emplace_back(output_name);
     }
@@ -2144,30 +2165,30 @@ namespace video {
       current_display_name = display_device::map_output_name(config::video.output_name);
     }
 
-    // If we had a name previously, let's try to find it in the new list
+    // Exact prior identity is authoritative. A miss cannot become display 0.
     if (!current_display_name.empty()) {
-      for (int x = 0; x < display_names.size(); ++x) {
-        if (display_names[x] == current_display_name) {
-          current_display_index = x;
-          return;
-        }
+      if (const auto index = find_display_index(display_names, current_display_name)) {
+        current_display_index = *index;
+        return true;
       }
 
-      // The old display was removed, so we'll start back at the first display again
-      BOOST_LOG(warning) << "Previous active display ["sv << current_display_name << "] is no longer present"sv;
-    } else {
-      for (int x = 0; x < display_names.size(); ++x) {
-        if (display_names[x] == output_name) {
-          current_display_index = x;
-          return;
-        }
-      }
+      current_display_index = -1;
+      BOOST_LOG(error) << "Previous active display ["sv << current_display_name
+                       << "] is no longer present; refusing another output"sv;
+      return false;
     }
+
+    if (const auto index = find_display_index(display_names, output_name)) {
+      current_display_index = *index;
+    }
+    return !display_names.empty();
   }
 
   void refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index) {
     static std::string empty_str = "";
-    refresh_displays(dev_type, display_names, current_display_index, empty_str);
+    if (!refresh_displays(dev_type, display_names, current_display_index, empty_str)) {
+      current_display_index = display_names.empty() ? -1 : 0;
+    }
   }
 
   void captureThread(
@@ -2209,8 +2230,14 @@ namespace video {
       capture_ctxs.front().channel_data
     };
 #endif
-    if (!proc::proc.display_name.empty()) {
-      disp = platf::display(encoder.platform_formats->dev_type, proc::proc.display_name, capture_ctxs.front().config);
+    const auto requested_display_name = proc::proc.display_name;
+    if (!requested_display_name.empty()) {
+      disp = platf::display(encoder.platform_formats->dev_type, requested_display_name, capture_ctxs.front().config);
+    }
+    if (!disp && !capture_fallback_allowed(requested_display_name)) {
+      BOOST_LOG(error) << "Requested display ["sv << requested_display_name
+                       << "] could not be initialized; refusing another output"sv;
+      return;
     }
     if (!disp) {
       // Get all the monitor names now, rather than at boot, to
@@ -2417,8 +2444,17 @@ namespace video {
               // only support a single display session per device/application.
               disp.reset();
 
-              // Refresh display names since a display removal might have caused the reinitialization
-              refresh_displays(encoder.platform_formats->dev_type, display_names, display_p, proc::proc.display_name);
+              // Reenumeration must preserve the exact active connector. A
+              // missing named output cannot reset capture to display 0.
+              if (!refresh_displays(
+                    encoder.platform_formats->dev_type,
+                    display_names,
+                    display_p,
+                    proc::proc.display_name
+                  )) {
+                BOOST_LOG(error) << "Active display identity could not be preserved during reinitialization"sv;
+                return;
+              }
 
               // Process any pending display switch with the new list of displays
               if (switch_display_event->peek()) {
@@ -5088,6 +5124,17 @@ namespace video {
 
   std::chrono::milliseconds reset_display_retry_delay_for_tests(int attempt) {
     return reset_display_retry_delay(attempt);
+  }
+
+  bool capture_fallback_allowed_for_tests(std::string_view requested_display_name) {
+    return capture_fallback_allowed(requested_display_name);
+  }
+
+  std::optional<int> find_display_index_for_tests(
+    const std::vector<std::string> &display_names,
+    std::string_view requested_display_name
+  ) {
+    return find_display_index(display_names, requested_display_name);
   }
 
   std::optional<int> clamp_display_index_for_tests(int requested_index, std::size_t display_count) {

--- a/src/video.h
+++ b/src/video.h
@@ -594,6 +594,11 @@ namespace video {
 
   bool display_switch_allowed_for_exact_capture_for_tests(std::string_view exact_display_name);
 
+  bool exact_display_generations_match_for_tests(
+    std::string_view active_exact_display_name,
+    std::string_view incoming_exact_display_name
+  );
+
   std::optional<int> find_display_index_for_tests(
     const std::vector<std::string> &display_names,
     std::string_view requested_display_name

--- a/src/video.h
+++ b/src/video.h
@@ -5,6 +5,7 @@
 #pragma once
 
 // local includes
+#include "capture_generation.h"
 #include "input.h"
 #include "nvenc/nvenc_config.h"
 #include "platform/common.h"
@@ -52,6 +53,7 @@ namespace video {
 
     int encodingFramerate; // Requested display framerate
     bool input_only;
+    capture_generation::identity_t capture_generation;
   };
 
   platf::mem_type_e map_base_dev_type(AVHWDeviceType type);
@@ -594,9 +596,9 @@ namespace video {
 
   bool display_switch_allowed_for_exact_capture_for_tests(std::string_view exact_display_name);
 
-  bool exact_display_generations_match_for_tests(
-    std::string_view active_exact_display_name,
-    std::string_view incoming_exact_display_name
+  bool capture_generations_match_for_tests(
+    const capture_generation::identity_t &active,
+    const capture_generation::identity_t &incoming
   );
 
   std::optional<int> find_display_index_for_tests(

--- a/src/video.h
+++ b/src/video.h
@@ -592,6 +592,8 @@ namespace video {
 
   bool capture_fallback_allowed_for_tests(std::string_view requested_display_name);
 
+  bool display_switch_allowed_for_exact_capture_for_tests(std::string_view exact_display_name);
+
   std::optional<int> find_display_index_for_tests(
     const std::vector<std::string> &display_names,
     std::string_view requested_display_name

--- a/src/video.h
+++ b/src/video.h
@@ -590,6 +590,13 @@ namespace video {
 
   std::chrono::milliseconds reset_display_retry_delay_for_tests(int attempt);
 
+  bool capture_fallback_allowed_for_tests(std::string_view requested_display_name);
+
+  std::optional<int> find_display_index_for_tests(
+    const std::vector<std::string> &display_names,
+    std::string_view requested_display_name
+  );
+
   std::optional<int> clamp_display_index_for_tests(int requested_index, std::size_t display_count);
 
   bool hdr_metadata_is_usable_for_tests(const SS_HDR_METADATA &metadata);

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -229,7 +229,8 @@ describe('Linux packaging contracts', () => {
       /#ifdef POLARIS_BUILD_WAYLAND\s+#include "src\/platform\/linux\/cage_screencopy\.h"\s+#include "src\/platform\/linux\/kwingrab\.h"\s+#endif/,
     )
     expect(portalGrab).toContain('std::shared_ptr<void> kwin;')
-    expect(portalGrab).toMatch(/#ifdef POLARIS_BUILD_WAYLAND[\s\S]*?kwingrab::prefer_for_current_stream_mode\(\)[\s\S]*?#endif/)
+    expect(portalGrab).toMatch(/#ifdef POLARIS_BUILD_WAYLAND[\s\S]*?kwingrab::prefer_for_generation\(generation\)[\s\S]*?#endif/)
+    expect(portalGrab).toContain('kwingrab::require_for_generation(generation)')
     expect(portalGrab).toMatch(/#ifdef POLARIS_BUILD_WAYLAND[\s\S]*?cage_screencopy::capture\([\s\S]*?#endif/)
   })
 

--- a/src_assets/linux/assets/apps.json
+++ b/src_assets/linux/assets/apps.json
@@ -6,6 +6,7 @@
     {
       "name": "Desktop",
       "image-path": "desktop.png",
+      "desktop-mirror": true,
       "allow-client-commands": false
     },
     {

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -42,9 +42,33 @@ namespace portal {
   bool portal_cancel_pending_request_for_tests();
   bool portal_cancel_request_owner_for_tests();
   bool portal_cancel_source_wakes_wait_for_tests();
+  bool portal_capture_backend_allowed_for_tests(std::string_view capture_backend);
   bool portal_capture_generation_matches_for_tests(
     const capture_generation::identity_t &cached,
     const capture_generation::identity_t &requested
+  );
+}
+
+namespace platf {
+  std::string capture_backend_dispatch_for_tests(
+    std::string_view capture_backend,
+    bool nvfbc_available,
+    bool wayland_available,
+    bool portal_available,
+    bool kms_available,
+    bool x11_available,
+    bool cuda_memory
+  );
+
+  std::string exact_capture_backend_dispatch_for_tests(
+    std::string_view capture_backend,
+    bool exact_output_owned,
+    bool nvfbc_available,
+    bool wayland_available,
+    bool portal_available,
+    bool kms_available,
+    bool x11_available,
+    bool cuda_memory
   );
 }
 
@@ -106,6 +130,37 @@ TEST(PortalGrabPolicyTests, HostVirtualDisplayRequestsMonitorSourceDespiteHeadle
   // exact window+restore_token combination the dongle comment above warns
   // hangs KDE ScreenCast.
   EXPECT_EQ(portal::capture_type_for_stream_display(true, false, "host_virtual_display"), 1u);
+}
+
+TEST(PortalGrabPolicyTests, EmptyModeSourcePolicyDoesNotReadMutableGlobalMode) {
+  const auto original_mode = config::video.linux_display.stream_mode;
+  config::video.linux_display.stream_mode = "host_virtual_display";
+  EXPECT_EQ(portal::capture_type_for_stream_display(true, false, ""), 2u);
+  config::video.linux_display.stream_mode = original_mode;
+}
+
+TEST(PortalGrabPolicyTests, ExplicitBackendDispatchNeverFallsThrough) {
+  EXPECT_EQ(platf::capture_backend_dispatch_for_tests("wlr", false, false, true, false, false, false), "none");
+  EXPECT_EQ(platf::capture_backend_dispatch_for_tests("wlr", false, true, true, false, false, false), "wayland");
+  EXPECT_EQ(platf::capture_backend_dispatch_for_tests("portal", false, true, true, true, true, false), "portal");
+  EXPECT_EQ(platf::capture_backend_dispatch_for_tests("kms", false, true, true, false, true, false), "none");
+  EXPECT_EQ(platf::capture_backend_dispatch_for_tests("auto", false, true, true, true, true, false), "wayland");
+  EXPECT_EQ(platf::capture_backend_dispatch_for_tests("bogus", true, true, true, true, true, true), "none");
+}
+
+TEST(PortalGrabPolicyTests, ExactOwnedBackendMustBeConcrete) {
+  EXPECT_EQ(platf::exact_capture_backend_dispatch_for_tests("", true, false, false, true, false, false, false), "none");
+  EXPECT_EQ(platf::exact_capture_backend_dispatch_for_tests("auto", true, false, true, true, false, false, false), "none");
+  EXPECT_EQ(platf::exact_capture_backend_dispatch_for_tests("", false, false, false, true, false, false, false), "portal");
+}
+
+TEST(PortalGrabPolicyTests, PortalAcceptsOnlyPortalAuthority) {
+  for (const auto backend : {"", "auto", "portal", "kwin"}) {
+    EXPECT_TRUE(portal::portal_capture_backend_allowed_for_tests(backend)) << backend;
+  }
+  for (const auto backend : {"wlr", "kms", "drm", "x11", "nvfbc"}) {
+    EXPECT_FALSE(portal::portal_capture_backend_allowed_for_tests(backend)) << backend;
+  }
 }
 
 TEST(PortalGrabPolicyTests, CaptureCacheReuseRequiresTheWholeImmutableGeneration) {

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -24,6 +24,7 @@
 #include <drm_fourcc.h>
 #include <spa/param/video/raw.h>
 
+#include "src/capture_generation.h"
 #include "src/config.h"
 #include "src/platform/common.h"
 #include "src/platform/linux/pipewire_capture.h"
@@ -41,11 +42,9 @@ namespace portal {
   bool portal_cancel_pending_request_for_tests();
   bool portal_cancel_request_owner_for_tests();
   bool portal_cancel_source_wakes_wait_for_tests();
-  bool portal_capture_identity_matches_for_tests(
-    std::string_view cached_stream_mode,
-    std::string_view cached_output_name,
-    std::string_view requested_stream_mode,
-    std::string_view requested_output_name
+  bool portal_capture_generation_matches_for_tests(
+    const capture_generation::identity_t &cached,
+    const capture_generation::identity_t &requested
   );
 }
 
@@ -109,60 +108,65 @@ TEST(PortalGrabPolicyTests, HostVirtualDisplayRequestsMonitorSourceDespiteHeadle
   EXPECT_EQ(portal::capture_type_for_stream_display(true, false, "host_virtual_display"), 1u);
 }
 
-TEST(PortalGrabPolicyTests, CaptureCacheReuseIsBoundToStreamAndOutputIdentity) {
-  EXPECT_TRUE(portal::portal_capture_identity_matches_for_tests(
-    "host_virtual_display", "DVI-I-1", "host_virtual_display", "DVI-I-1"
-  ));
-  EXPECT_FALSE(portal::portal_capture_identity_matches_for_tests(
-    "desktop_display", "HDMI-A-1", "host_virtual_display", "DVI-I-1"
-  ));
-  EXPECT_FALSE(portal::portal_capture_identity_matches_for_tests(
-    "host_virtual_display", "HDMI-A-1", "host_virtual_display", "DVI-I-1"
-  ));
+TEST(PortalGrabPolicyTests, CaptureCacheReuseRequiresTheWholeImmutableGeneration) {
+  const capture_generation::identity_t generation {
+    .generation_id = 42,
+    .exact_display_name = "DVI-I-1",
+    .requested_output_name = "DVI-I-1",
+    .stream_mode = "host_virtual_display",
+    .capture_backend = "portal",
+    .private_runtime = "",
+    .adapter_name = "/dev/dri/renderD128",
+    .headless_mode = true,
+    .use_cage_compositor = false,
+  };
+  EXPECT_TRUE(portal::portal_capture_generation_matches_for_tests(generation, generation));
+
+  std::vector<capture_generation::identity_t> mismatches(9, generation);
+  mismatches[0].generation_id = 43;
+  mismatches[1].exact_display_name = "DVI-I-2";
+  mismatches[2].requested_output_name = "HDMI-A-1";
+  mismatches[3].stream_mode = "desktop_display";
+  mismatches[4].capture_backend = "wlr";
+  mismatches[5].private_runtime = "gamescope";
+  mismatches[6].adapter_name = "/dev/dri/renderD129";
+  mismatches[7].headless_mode = false;
+  mismatches[8].use_cage_compositor = true;
+  for (const auto &mismatch : mismatches) {
+    EXPECT_FALSE(portal::portal_capture_generation_matches_for_tests(generation, mismatch));
+  }
 }
 
 #ifdef POLARIS_BUILD_WAYLAND
-TEST(PortalGrabPolicyTests, KwingrabPreferredForHostKdeModesIncludingVirtualDisplay) {
-  struct config_guard_t {
-    config::video_t::linux_display_t linux_display = config::video.linux_display;
-
-    ~config_guard_t() {
-      config::video.linux_display = linux_display;
-    }
-  } guard;
-
-  auto &ld = config::video.linux_display;
-
-  // Host KDE paths pin capture through kwingrab. host_virtual_display must be
-  // one of them: its EVDI output is composited by KWin, and kwingrab is the
-  // only path that can select that output by name — the portal picker cannot.
+TEST(PortalGrabPolicyTests, KwingrabPreferenceUsesImmutableGenerationPolicy) {
+  capture_generation::identity_t generation;
   for (const char *mode : {"desktop_display", "headless_dongle", "host_virtual_display"}) {
-    ld.stream_mode = mode;
-    EXPECT_TRUE(kwingrab::prefer_for_current_stream_mode()) << mode;
+    generation.stream_mode = mode;
+    EXPECT_TRUE(kwingrab::prefer_for_generation(generation)) << mode;
   }
-
-  // Private compositor runtimes stay on gamescopegrab / portal / wlroots.
   for (const char *mode : {"windowed_stream", "headless_stream", "gamescope_stream"}) {
-    ld.stream_mode = mode;
-    EXPECT_FALSE(kwingrab::prefer_for_current_stream_mode()) << mode;
+    generation.stream_mode = mode;
+    EXPECT_FALSE(kwingrab::prefer_for_generation(generation)) << mode;
   }
+
+  generation.stream_mode.clear();
+  generation.use_cage_compositor = false;
+  generation.private_runtime.clear();
+  EXPECT_TRUE(kwingrab::prefer_for_generation(generation));
+  generation.private_runtime = "gamescope";
+  EXPECT_FALSE(kwingrab::prefer_for_generation(generation));
+  generation.private_runtime.clear();
+  generation.use_cage_compositor = true;
+  EXPECT_FALSE(kwingrab::prefer_for_generation(generation));
 }
-TEST(PortalGrabPolicyTests, KwingrabRequiredOnlyForPinnedHostVirtualDisplay) {
-  struct config_guard_t {
-    config::video_t::linux_display_t linux_display = config::video.linux_display;
-
-    ~config_guard_t() {
-      config::video.linux_display = linux_display;
-    }
-  } guard;
-
-  auto &mode = config::video.linux_display.stream_mode;
-  mode = "host_virtual_display";
-  EXPECT_TRUE(kwingrab::require_for_current_stream_mode());
+TEST(PortalGrabPolicyTests, KwingrabRequirementUsesImmutableGenerationPolicy) {
+  capture_generation::identity_t generation;
+  generation.stream_mode = "host_virtual_display";
+  EXPECT_TRUE(kwingrab::require_for_generation(generation));
 
   for (const char *unrequired : {"desktop_display", "headless_dongle", "windowed_stream", ""}) {
-    mode = unrequired;
-    EXPECT_FALSE(kwingrab::require_for_current_stream_mode()) << unrequired;
+    generation.stream_mode = unrequired;
+    EXPECT_FALSE(kwingrab::require_for_generation(generation)) << unrequired;
   }
 }
 
@@ -363,7 +367,7 @@ TEST(PortalGrabPolicyTests, TeardownCancellationCoversRemoteReopenAndRetryLoop) 
   EXPECT_NE(open_body.find("&out_fd_list,\n      cancellable,"), std::string::npos)
     << "OpenPipeWireRemote must receive the registered cancellable";
 
-  const auto ensure_begin = grab_source.find("static bool ensure_session_unlocked()");
+  const auto ensure_begin = grab_source.find("static bool ensure_session_unlocked(const capture_generation::identity_t &generation)");
   const auto ensure_end = grab_source.find(
     "static std::shared_ptr<pipewire_capture::capture_t> ensure_global_capture(",
     ensure_begin
@@ -456,7 +460,7 @@ TEST(PortalGrabPolicyTests, EnsureGlobalCaptureLockContractAndUniqueTokens) {
   EXPECT_NE(grab.find("g_media_mu"), std::string::npos);
   EXPECT_EQ(grab.find("g_portal_mu"), std::string::npos);
   EXPECT_EQ(grab.find("g_capture_mtx"), std::string::npos);
-  EXPECT_NE(grab.find("ensure_session_unlocked()"), std::string::npos);
+  EXPECT_NE(grab.find("ensure_session_unlocked(generation)"), std::string::npos);
   EXPECT_NE(grab.find("Wait outside g_media_mu"), std::string::npos);
   EXPECT_NE(grab.find("pipewire_capture::capture_t"), std::string::npos);
   EXPECT_NE(grab.find("polaris-gamescope-force"), std::string::npos);
@@ -475,7 +479,7 @@ TEST(PortalGrabPolicyTests, EnsureGlobalCaptureLockContractAndUniqueTokens) {
   const auto fn_end = grab.find("class portal_display_t", fn_start);
   ASSERT_NE(fn_end, std::string::npos);
   const auto fn = grab.substr(fn_start, fn_end - fn_start);
-  EXPECT_NE(fn.find("ensure_session_unlocked()"), std::string::npos);
+  EXPECT_NE(fn.find("ensure_session_unlocked(generation)"), std::string::npos);
   EXPECT_NE(fn.find("Wait outside g_media_mu"), std::string::npos);
   auto stripped = fn;
   for (;;) {

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -364,7 +364,10 @@ TEST(PortalGrabPolicyTests, TeardownCancellationCoversRemoteReopenAndRetryLoop) 
     << "OpenPipeWireRemote must receive the registered cancellable";
 
   const auto ensure_begin = grab_source.find("static bool ensure_session_unlocked()");
-  const auto ensure_end = grab_source.find("static bool ensure_global_session()", ensure_begin);
+  const auto ensure_end = grab_source.find(
+    "static std::shared_ptr<pipewire_capture::capture_t> ensure_global_capture(",
+    ensure_begin
+  );
   ASSERT_NE(ensure_begin, std::string::npos);
   ASSERT_NE(ensure_end, std::string::npos);
   const auto ensure_body = grab_source.substr(ensure_begin, ensure_end - ensure_begin);

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -41,6 +41,12 @@ namespace portal {
   bool portal_cancel_pending_request_for_tests();
   bool portal_cancel_request_owner_for_tests();
   bool portal_cancel_source_wakes_wait_for_tests();
+  bool portal_capture_identity_matches_for_tests(
+    std::string_view cached_stream_mode,
+    std::string_view cached_output_name,
+    std::string_view requested_stream_mode,
+    std::string_view requested_output_name
+  );
 }
 
 TEST(PortalCapabilityPolicyTests, ExplicitCaptureSelectionWinsOverStreamModeDefault) {
@@ -103,6 +109,18 @@ TEST(PortalGrabPolicyTests, HostVirtualDisplayRequestsMonitorSourceDespiteHeadle
   EXPECT_EQ(portal::capture_type_for_stream_display(true, false, "host_virtual_display"), 1u);
 }
 
+TEST(PortalGrabPolicyTests, CaptureCacheReuseIsBoundToStreamAndOutputIdentity) {
+  EXPECT_TRUE(portal::portal_capture_identity_matches_for_tests(
+    "host_virtual_display", "DVI-I-1", "host_virtual_display", "DVI-I-1"
+  ));
+  EXPECT_FALSE(portal::portal_capture_identity_matches_for_tests(
+    "desktop_display", "HDMI-A-1", "host_virtual_display", "DVI-I-1"
+  ));
+  EXPECT_FALSE(portal::portal_capture_identity_matches_for_tests(
+    "host_virtual_display", "HDMI-A-1", "host_virtual_display", "DVI-I-1"
+  ));
+}
+
 #ifdef POLARIS_BUILD_WAYLAND
 TEST(PortalGrabPolicyTests, KwingrabPreferredForHostKdeModesIncludingVirtualDisplay) {
   struct config_guard_t {
@@ -128,6 +146,29 @@ TEST(PortalGrabPolicyTests, KwingrabPreferredForHostKdeModesIncludingVirtualDisp
     ld.stream_mode = mode;
     EXPECT_FALSE(kwingrab::prefer_for_current_stream_mode()) << mode;
   }
+}
+TEST(PortalGrabPolicyTests, KwingrabRequiredOnlyForPinnedHostVirtualDisplay) {
+  struct config_guard_t {
+    config::video_t::linux_display_t linux_display = config::video.linux_display;
+
+    ~config_guard_t() {
+      config::video.linux_display = linux_display;
+    }
+  } guard;
+
+  auto &mode = config::video.linux_display.stream_mode;
+  mode = "host_virtual_display";
+  EXPECT_TRUE(kwingrab::require_for_current_stream_mode());
+
+  for (const char *unrequired : {"desktop_display", "headless_dongle", "windowed_stream", ""}) {
+    mode = unrequired;
+    EXPECT_FALSE(kwingrab::require_for_current_stream_mode()) << unrequired;
+  }
+}
+
+TEST(PortalGrabPolicyTests, KwingrabNamedOutputMissCannotFallback) {
+  EXPECT_TRUE(kwingrab::output_selection_can_fallback(""));
+  EXPECT_FALSE(kwingrab::output_selection_can_fallback("DVI-I-1"));
 }
 #endif
 

--- a/tests/unit/platform/test_portal_grab_policy.cpp
+++ b/tests/unit/platform/test_portal_grab_policy.cpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <unistd.h>
@@ -29,6 +30,7 @@
 #include "src/platform/linux/portal_capability.h"
 #include "src/platform/linux/portal_session.h"
 #include "src/platform/linux/session_media.h"
+#include "src/platform/linux/virtual_display.h"
 
 #ifdef POLARIS_BUILD_WAYLAND
   #include "src/platform/linux/kwingrab.h"
@@ -130,45 +132,36 @@ TEST(PortalGrabPolicyTests, KwingrabPreferredForHostKdeModesIncludingVirtualDisp
 #endif
 
 namespace platf {
-  bool host_virtual_display_needs_portal();
+  bool host_virtual_display_needs_portal_for_backend(
+    std::string_view stream_mode,
+    bool use_cage_compositor,
+    virtual_display::backend_e backend
+  );
 }
 
-TEST(PortalGrabPolicyTests, HostVirtualDisplayIsKeptOffTheAutoWlrSource) {
-  // Companion to PR #351's kwingrab routing: even with the right kwingrab
-  // preference, host_virtual_display only reaches portal_grab (hence kwingrab)
-  // if reevaluate_capture_sources does NOT auto-select the direct WAYLAND/wlr
-  // source first — which binds the desktop wayland-0 (no wlr-export-dmabuf) and
-  // hard-fails every encoder. This guards the source-selection half of that fix.
-  struct config_guard_t {
-    config::video_t::linux_display_t linux_display = config::video.linux_display;
-    std::string capture = config::video.capture;
+TEST(PortalGrabPolicyTests, HostVirtualDisplayCaptureRoutingDependsOnBackend) {
+  using virtual_display::backend_e;
 
-    ~config_guard_t() {
-      config::video.linux_display = linux_display;
-      config::video.capture = capture;
+  for (const auto backend : {backend_e::EVDI, backend_e::KSCREEN_DOCTOR, backend_e::NONE}) {
+    EXPECT_TRUE(platf::host_virtual_display_needs_portal_for_backend(
+      "host_virtual_display", false, backend
+    ));
+  }
+
+  EXPECT_FALSE(platf::host_virtual_display_needs_portal_for_backend(
+    "host_virtual_display", false, backend_e::WAYLAND_WLR
+  )) << "a native wlroots headless output must be captured directly by name";
+
+  for (const auto backend : {backend_e::EVDI, backend_e::WAYLAND_WLR, backend_e::KSCREEN_DOCTOR, backend_e::NONE}) {
+    EXPECT_FALSE(platf::host_virtual_display_needs_portal_for_backend(
+      "host_virtual_display", true, backend
+    )) << "a cage compositor owns its own capture source";
+
+    for (const auto mode :
+         {"windowed_stream", "headless_stream", "gamescope_stream", "desktop_display", "headless_dongle", ""}) {
+      EXPECT_FALSE(platf::host_virtual_display_needs_portal_for_backend(mode, false, backend))
+        << mode;
     }
-  } guard;
-
-  auto &ld = config::video.linux_display;
-  config::video.capture.clear();  // the auto path is where the bug lived
-
-  // host_virtual_display composites through KWin (use_cage stays false): must
-  // be kept off the auto wlr source so PORTAL (→ kwingrab) is chosen.
-  ld.stream_mode = "host_virtual_display";
-  ld.use_cage_compositor = false;
-  EXPECT_TRUE(platf::host_virtual_display_needs_portal());
-
-  // A cage-compositor session (the booleans HVD never carries) streams through
-  // labwc's own wlr socket, not portal — must NOT be diverted.
-  ld.use_cage_compositor = true;
-  EXPECT_FALSE(platf::host_virtual_display_needs_portal());
-
-  // Every other mode keeps its existing source selection untouched.
-  ld.use_cage_compositor = false;
-  for (const char *mode :
-       {"windowed_stream", "headless_stream", "gamescope_stream", "desktop_display", "headless_dongle", ""}) {
-    ld.stream_mode = mode;
-    EXPECT_FALSE(platf::host_virtual_display_needs_portal()) << mode;
   }
 }
 

--- a/tests/unit/platform/test_virtual_display.cpp
+++ b/tests/unit/platform/test_virtual_display.cpp
@@ -86,6 +86,13 @@ TEST(VirtualDisplayTests, SwayCreationRequiresCommandSuccessAndOneNewHeadlessOut
   ).has_value());
 }
 
+TEST(VirtualDisplayTests, SwayMalformedAfterCannotProveOwnership) {
+  EXPECT_FALSE(virtual_display::sway_new_headless_output(
+    R"([{"name":"DP-1"}])",
+    R"([{"name":"DP-1"},{"bad":true},{"name":"HEADLESS-2"}])"
+  ));
+}
+
 TEST(VirtualDisplayTests, SwayInvalidBeforeSnapshotDoesNotCreate) {
   int create_calls = 0;
   const auto create = [&] { ++create_calls; };

--- a/tests/unit/platform/test_virtual_display.cpp
+++ b/tests/unit/platform/test_virtual_display.cpp
@@ -4,9 +4,12 @@
  */
 #include "../../tests_common.h"
 
+#include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <thread>
 
 #ifdef __linux__
   #include <src/platform/linux/virtual_display.h>
@@ -86,6 +89,34 @@ TEST(VirtualDisplayTests, SwayCreationRequiresCommandSuccessAndOneNewHeadlessOut
 TEST(VirtualDisplayTests, EvdiConnectorIdentityMustBeDiscovered) {
   EXPECT_FALSE(virtual_display::evdi_output_name_is_proven(""));
   EXPECT_TRUE(virtual_display::evdi_output_name_is_proven("DVI-I-1"));
+}
+
+TEST(VirtualDisplayTests, CreationMutexSerializesIndependentCallers) {
+  std::atomic<int> active {0};
+  std::atomic<int> maximum_active {0};
+  std::atomic<int> completed {0};
+
+  const auto callback = [&] {
+    const int now = active.fetch_add(1) + 1;
+    int observed = maximum_active.load();
+    while (observed < now && !maximum_active.compare_exchange_weak(observed, now)) {
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    active.fetch_sub(1);
+    completed.fetch_add(1);
+  };
+
+  std::thread first {[&] {
+    virtual_display::with_creation_lock_for_tests(callback);
+  }};
+  std::thread second {[&] {
+    virtual_display::with_creation_lock_for_tests(callback);
+  }};
+  first.join();
+  second.join();
+
+  EXPECT_EQ(completed.load(), 2);
+  EXPECT_EQ(maximum_active.load(), 1);
 }
 
 TEST(VirtualDisplayTests, BackendDetectionLogCacheOnlySignalsOnFirstObservationAndChanges) {

--- a/tests/unit/platform/test_virtual_display.cpp
+++ b/tests/unit/platform/test_virtual_display.cpp
@@ -56,6 +56,38 @@ TEST(VirtualDisplayTests, HyprlandMonitorModeRefusesAbsentOutputsAndUnusableGeom
   EXPECT_FALSE(virtual_display::hyprland_monitor_mode("", "X").has_value());
 }
 
+TEST(VirtualDisplayTests, SwayCreationRequiresCommandSuccessAndOneNewHeadlessOutput) {
+  constexpr std::string_view before = R"json([
+    {"name":"DP-1"},
+    {"name":"HEADLESS-1"}
+  ])json";
+  constexpr std::string_view after = R"json([
+    {"name":"DP-1"},
+    {"name":"HEADLESS-1"},
+    {"name":"HEADLESS-2"}
+  ])json";
+
+  EXPECT_TRUE(virtual_display::sway_create_output_succeeded(R"json([{"success":true}])json"));
+  EXPECT_FALSE(virtual_display::sway_create_output_succeeded(R"json([{"success":false}])json"));
+  EXPECT_FALSE(virtual_display::sway_create_output_succeeded("not json"));
+
+  EXPECT_EQ(virtual_display::sway_new_headless_output(before, after), "HEADLESS-2");
+  EXPECT_FALSE(virtual_display::sway_new_headless_output(before, before).has_value());
+  EXPECT_FALSE(virtual_display::sway_new_headless_output(
+    before,
+    R"json([{"name":"DP-1"},{"name":"HEADLESS-1"},{"name":"DP-2"}])json"
+  ).has_value());
+  EXPECT_FALSE(virtual_display::sway_new_headless_output(
+    before,
+    R"json([{"name":"DP-1"},{"name":"HEADLESS-1"},{"name":"HEADLESS-2"},{"name":"HEADLESS-3"}])json"
+  ).has_value());
+}
+
+TEST(VirtualDisplayTests, EvdiConnectorIdentityMustBeDiscovered) {
+  EXPECT_FALSE(virtual_display::evdi_output_name_is_proven(""));
+  EXPECT_TRUE(virtual_display::evdi_output_name_is_proven("DVI-I-1"));
+}
+
 TEST(VirtualDisplayTests, BackendDetectionLogCacheOnlySignalsOnFirstObservationAndChanges) {
   virtual_display::backend_detection_log_cache_t cache;
 

--- a/tests/unit/platform/test_virtual_display.cpp
+++ b/tests/unit/platform/test_virtual_display.cpp
@@ -59,6 +59,31 @@ TEST(VirtualDisplayTests, HyprlandMonitorModeRefusesAbsentOutputsAndUnusableGeom
   EXPECT_FALSE(virtual_display::hyprland_monitor_mode("", "X").has_value());
 }
 
+TEST(VirtualDisplayTests, KscreenJsonSnapshotCarriesExactRestoreFields) {
+  constexpr auto output_json = R"json({
+    "outputs": [
+      {"name":"DP-1","enabled":true,"currentModeId":"7","priority":1},
+      {"name":"HDMI-A-1","enabled":false,"currentModeId":"12","priority":0}
+    ]
+  })json";
+
+  const auto state = virtual_display::kscreen_output_state_from_json(output_json, "HDMI-A-1");
+  ASSERT_TRUE(state.has_value());
+  EXPECT_EQ(state->name, "HDMI-A-1");
+  EXPECT_FALSE(state->enabled);
+  EXPECT_EQ(state->current_mode_id, "12");
+  EXPECT_EQ(state->priority, 0);
+  EXPECT_FALSE(virtual_display::kscreen_output_state_from_json(output_json, "DP-9").has_value());
+  EXPECT_FALSE(virtual_display::kscreen_output_state_from_json("not json", "DP-1").has_value());
+}
+
+TEST(VirtualDisplayTests, FailedOrStillActiveTeardownRetainsRecoveryAuthority) {
+  EXPECT_TRUE(virtual_display::teardown_is_verified(true, false));
+  EXPECT_FALSE(virtual_display::teardown_is_verified(false, false));
+  EXPECT_FALSE(virtual_display::teardown_is_verified(true, true));
+  EXPECT_FALSE(virtual_display::teardown_is_verified(false, true));
+}
+
 TEST(VirtualDisplayTests, OnlyNamedWaylandCreationIsAdvertised) {
   EXPECT_TRUE(virtual_display::wayland_compositor_supports_exact_output_creation("hyprland"));
   EXPECT_FALSE(virtual_display::wayland_compositor_supports_exact_output_creation("sway"));
@@ -189,22 +214,39 @@ TEST(VirtualDisplayTests, HyprlandMonitorLookupDoesNotSelectExistingHeadlessOutp
     {"name":"POLARIS-HEADLESS-4242-0"}
   ])json";
 
-  EXPECT_TRUE(virtual_display::hyprland_monitors_contain_output(
-    monitors,
-    "POLARIS-HEADLESS-4242-0"
-  ));
-  EXPECT_FALSE(virtual_display::hyprland_monitors_contain_output(
-    monitors,
-    "POLARIS-HEADLESS-4242-1"
-  ));
-  EXPECT_FALSE(virtual_display::hyprland_monitors_contain_output(
-    monitors,
-    "POLARIS-HEADLESS-9999-0"
-  ));
+  EXPECT_EQ(
+    virtual_display::hyprland_monitors_contain_output(monitors, "POLARIS-HEADLESS-4242-0"),
+    std::optional<bool> {true}
+  );
+  EXPECT_EQ(
+    virtual_display::hyprland_monitors_contain_output(monitors, "POLARIS-HEADLESS-4242-1"),
+    std::optional<bool> {false}
+  );
+  EXPECT_EQ(
+    virtual_display::hyprland_monitors_contain_output(monitors, "POLARIS-HEADLESS-9999-0"),
+    std::optional<bool> {false}
+  );
   EXPECT_FALSE(virtual_display::hyprland_monitors_contain_output(
     "not json",
     "POLARIS-HEADLESS-4242-0"
-  ));
+  ).has_value());
+  EXPECT_FALSE(virtual_display::hyprland_monitors_contain_output(
+    R"json([{"description":"missing name"}])json",
+    "POLARIS-HEADLESS-4242-0"
+  ).has_value());
+}
+
+TEST(VirtualDisplayTests, EvdiConnectorStatusRequiresPositiveAbsenceProof) {
+  EXPECT_EQ(
+    virtual_display::evdi_connector_status_is_connected("connected"),
+    std::optional<bool> {true}
+  );
+  EXPECT_EQ(
+    virtual_display::evdi_connector_status_is_connected("disconnected"),
+    std::optional<bool> {false}
+  );
+  EXPECT_FALSE(virtual_display::evdi_connector_status_is_connected("").has_value());
+  EXPECT_FALSE(virtual_display::evdi_connector_status_is_connected("unknown").has_value());
 }
 
 TEST(VirtualDisplayTests, PersistedStateTracksEveryConcurrentDisplay) {
@@ -214,8 +256,10 @@ TEST(VirtualDisplayTests, PersistedStateTracksEveryConcurrentDisplay) {
     "displays": [
       {"pid":4242,"output_name":"POLARIS-HEADLESS-4242-0","width":1920,"height":1080,
        "fps":60,"active":true,"backend":"wayland_wlr","device_path":""},
-      {"pid":4242,"output_name":"POLARIS-HEADLESS-4242-1","width":2560,"height":1440,
-       "fps":120,"active":true,"backend":"wayland_wlr","device_path":""}
+      {"pid":4242,"output_name":"HDMI-A-1","width":2560,"height":1440,
+       "fps":120,"active":true,"backend":"kscreen_doctor","device_path":"",
+       "kscreen_output_before":{"name":"HDMI-A-1","enabled":false,"current_mode_id":"12","priority":0},
+       "kscreen_primary_before":{"name":"DP-1","enabled":true,"current_mode_id":"7","priority":1}}
     ]
   })json";
 
@@ -225,8 +269,13 @@ TEST(VirtualDisplayTests, PersistedStateTracksEveryConcurrentDisplay) {
   EXPECT_EQ(displays[0].display.output_name, "POLARIS-HEADLESS-4242-0");
   EXPECT_EQ(displays[0].display.width, 1920);
   EXPECT_EQ(displays[0].display.backend, virtual_display::backend_e::WAYLAND_WLR);
-  EXPECT_EQ(displays[1].display.output_name, "POLARIS-HEADLESS-4242-1");
+  EXPECT_EQ(displays[1].display.output_name, "HDMI-A-1");
   EXPECT_EQ(displays[1].display.fps, 120);
+  ASSERT_TRUE(displays[1].display.kscreen_output_before.has_value());
+  EXPECT_FALSE(displays[1].display.kscreen_output_before->enabled);
+  EXPECT_EQ(displays[1].display.kscreen_output_before->current_mode_id, "12");
+  ASSERT_TRUE(displays[1].display.kscreen_primary_before.has_value());
+  EXPECT_EQ(displays[1].display.kscreen_primary_before->priority, 1);
 }
 
 TEST(VirtualDisplayTests, PersistedStateStillReadsPreListSingleDisplayDocument) {

--- a/tests/unit/platform/test_virtual_display.cpp
+++ b/tests/unit/platform/test_virtual_display.cpp
@@ -86,6 +86,16 @@ TEST(VirtualDisplayTests, SwayCreationRequiresCommandSuccessAndOneNewHeadlessOut
   ).has_value());
 }
 
+TEST(VirtualDisplayTests, SwayInvalidBeforeSnapshotDoesNotCreate) {
+  int create_calls = 0;
+  const auto create = [&] { ++create_calls; };
+  EXPECT_FALSE(virtual_display::with_valid_sway_before_snapshot_for_tests("not json", create));
+  EXPECT_EQ(create_calls, 0);
+  EXPECT_TRUE(virtual_display::with_valid_sway_before_snapshot_for_tests(
+    R"([{"name":"DP-1"},{"name":"HEADLESS-1"}])", create));
+  EXPECT_EQ(create_calls, 1);
+}
+
 TEST(VirtualDisplayTests, EvdiConnectorIdentityMustBeDiscovered) {
   EXPECT_FALSE(virtual_display::evdi_output_name_is_proven(""));
   EXPECT_TRUE(virtual_display::evdi_output_name_is_proven("DVI-I-1"));

--- a/tests/unit/platform/test_virtual_display.cpp
+++ b/tests/unit/platform/test_virtual_display.cpp
@@ -59,48 +59,11 @@ TEST(VirtualDisplayTests, HyprlandMonitorModeRefusesAbsentOutputsAndUnusableGeom
   EXPECT_FALSE(virtual_display::hyprland_monitor_mode("", "X").has_value());
 }
 
-TEST(VirtualDisplayTests, SwayCreationRequiresCommandSuccessAndOneNewHeadlessOutput) {
-  constexpr std::string_view before = R"json([
-    {"name":"DP-1"},
-    {"name":"HEADLESS-1"}
-  ])json";
-  constexpr std::string_view after = R"json([
-    {"name":"DP-1"},
-    {"name":"HEADLESS-1"},
-    {"name":"HEADLESS-2"}
-  ])json";
-
-  EXPECT_TRUE(virtual_display::sway_create_output_succeeded(R"json([{"success":true}])json"));
-  EXPECT_FALSE(virtual_display::sway_create_output_succeeded(R"json([{"success":false}])json"));
-  EXPECT_FALSE(virtual_display::sway_create_output_succeeded("not json"));
-
-  EXPECT_EQ(virtual_display::sway_new_headless_output(before, after), "HEADLESS-2");
-  EXPECT_FALSE(virtual_display::sway_new_headless_output(before, before).has_value());
-  EXPECT_FALSE(virtual_display::sway_new_headless_output(
-    before,
-    R"json([{"name":"DP-1"},{"name":"HEADLESS-1"},{"name":"DP-2"}])json"
-  ).has_value());
-  EXPECT_FALSE(virtual_display::sway_new_headless_output(
-    before,
-    R"json([{"name":"DP-1"},{"name":"HEADLESS-1"},{"name":"HEADLESS-2"},{"name":"HEADLESS-3"}])json"
-  ).has_value());
-}
-
-TEST(VirtualDisplayTests, SwayMalformedAfterCannotProveOwnership) {
-  EXPECT_FALSE(virtual_display::sway_new_headless_output(
-    R"([{"name":"DP-1"}])",
-    R"([{"name":"DP-1"},{"bad":true},{"name":"HEADLESS-2"}])"
-  ));
-}
-
-TEST(VirtualDisplayTests, SwayInvalidBeforeSnapshotDoesNotCreate) {
-  int create_calls = 0;
-  const auto create = [&] { ++create_calls; };
-  EXPECT_FALSE(virtual_display::with_valid_sway_before_snapshot_for_tests("not json", create));
-  EXPECT_EQ(create_calls, 0);
-  EXPECT_TRUE(virtual_display::with_valid_sway_before_snapshot_for_tests(
-    R"([{"name":"DP-1"},{"name":"HEADLESS-1"}])", create));
-  EXPECT_EQ(create_calls, 1);
+TEST(VirtualDisplayTests, OnlyNamedWaylandCreationIsAdvertised) {
+  EXPECT_TRUE(virtual_display::wayland_compositor_supports_exact_output_creation("hyprland"));
+  EXPECT_FALSE(virtual_display::wayland_compositor_supports_exact_output_creation("sway"));
+  EXPECT_FALSE(virtual_display::wayland_compositor_supports_exact_output_creation("kwin"));
+  EXPECT_FALSE(virtual_display::wayland_compositor_supports_exact_output_creation(""));
 }
 
 TEST(VirtualDisplayTests, EvdiConnectorIdentityMustBeDiscovered) {

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -449,6 +449,57 @@ TEST(ProcessRuntimeConfigTests, ExplicitSessionModeAlwaysNormalizesCompanionStat
     << "same-ID explicit overrides must still normalize companion state";
 }
 
+TEST(ProcessRuntimeConfigTests, FinalOptimizedVirtualDisplayChoicePrecedesLinuxModeDerivation) {
+  const auto source = read_source_file_for_contract("src/process.cpp");
+  ASSERT_FALSE(source.empty());
+
+  const auto execute_start = source.find("int proc_t::execute_impl(");
+  const auto terminate_start = source.find("void proc_t::terminate_impl(", execute_start);
+  ASSERT_NE(execute_start, std::string::npos);
+  ASSERT_NE(terminate_start, std::string::npos);
+  const auto body = source.substr(execute_start, terminate_start - execute_start);
+
+  const auto optimization_guard = body.find("if (resolved_optimization.virtual_display.has_value())");
+  const auto optimization_write = body.find(
+    "launch_session->virtual_display = *resolved_optimization.virtual_display",
+    optimization_guard
+  );
+  const auto mode_derivation = body.find(
+    "stream_display_policy::effective_session_selection_for_launch(",
+    optimization_write
+  );
+  const auto mode_apply = body.find(
+    "stream_display_policy::apply_selection(session_mode",
+    mode_derivation
+  );
+  const auto runtime_derivation = body.find(
+    "const bool gamescope_stream_session",
+    mode_apply
+  );
+  const auto capture_policy = body.find(
+    "stream_display_policy::resolve_current(",
+    runtime_derivation
+  );
+
+  ASSERT_NE(optimization_guard, std::string::npos);
+  ASSERT_NE(optimization_write, std::string::npos);
+  ASSERT_NE(mode_derivation, std::string::npos);
+  ASSERT_NE(mode_apply, std::string::npos);
+  ASSERT_NE(runtime_derivation, std::string::npos);
+  ASSERT_NE(capture_policy, std::string::npos);
+  EXPECT_LT(optimization_guard, optimization_write);
+  EXPECT_LT(optimization_write, mode_derivation)
+    << "final device/AI virtual-display intent must own session mode derivation";
+  EXPECT_LT(mode_derivation, mode_apply);
+  EXPECT_LT(mode_apply, runtime_derivation)
+    << "gamescope/headless decisions must consume the final session mode";
+  EXPECT_LT(runtime_derivation, capture_policy);
+  EXPECT_EQ(
+    body.find("stream_display_policy::effective_session_selection_for_launch(", mode_derivation + 1),
+    std::string::npos
+  ) << "one final derivation must own mode, capture, and reported runtime behavior";
+}
+
 TEST(ProcessRuntimeConfigTests, SessionLifecycleGateOwnsLaunchRaiseAndTeardownWithoutCrossLockingRtsp) {
   const auto header = read_source_file_for_contract("src/process.h");
   const auto source = read_source_file_for_contract("src/process.cpp");
@@ -3048,8 +3099,12 @@ TEST(ProcessRuntimeConfigTests, ExactGenerationOwnedCandidateSurvivesAnotherCand
   const bool transient_exited = wait_for_pidfd_exit(transient_pidfd.fd, std::chrono::seconds(2));
   EXPECT_TRUE(owned_exited) << "a previously proven owned pidfd must survive another candidate's retry";
   EXPECT_TRUE(transient_exited);
-  if (owned_exited) EXPECT_EQ(owned_guard.wait(nullptr, 0), owned);
-  if (transient_exited) EXPECT_EQ(transient_guard.wait(nullptr, 0), transient);
+  if (owned_exited) {
+    EXPECT_EQ(owned_guard.wait(nullptr, 0), owned);
+  }
+  if (transient_exited) {
+    EXPECT_EQ(transient_guard.wait(nullptr, 0), transient);
+  }
 #else
   GTEST_SKIP() << "Linux-only exact-generation owned pidfd retention";
 #endif

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -420,10 +420,10 @@ TEST(ProcessRuntimeConfigTests, NestedSessionPrepReceivesCredentialAndFailsLaunc
 }
 
 TEST(ProcessRuntimeConfigTests, ExplicitSessionModeAlwaysNormalizesCompanionState) {
-  // An explicit headless_stream request may match the current stream_mode ID
-  // while legacy companion state (for example prefer_gpu_native_capture) is
-  // stale. Skipping apply_selection in that case can resolve the session as
-  // windowed_stream even though the launch requested headless_stream.
+  // Explicit session modes must always normalize companion state. Mirror is
+  // derived as a session-scoped desktop_display override, so bypassing
+  // apply_selection would preserve a host_virtual_display default and could
+  // create or capture the wrong output.
   const auto source = read_source_file_for_contract("src/process.cpp");
   ASSERT_FALSE(source.empty());
 
@@ -439,7 +439,8 @@ TEST(ProcessRuntimeConfigTests, ExplicitSessionModeAlwaysNormalizesCompanionStat
   ASSERT_NE(apply_start, std::string::npos);
   const auto guard = body.substr(guard_start, apply_start - guard_start);
 
-  EXPECT_NE(guard.find("!(launch_session && launch_session->mirror_desktop)"), std::string::npos);
+  EXPECT_EQ(guard.find("!(launch_session && launch_session->mirror_desktop)"), std::string::npos)
+    << "mirror must normalize to the session-scoped desktop_display override";
   EXPECT_NE(
     guard.find("!stream_display_policy::selection_companion_state_matches(session_mode)"),
     std::string::npos

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -464,6 +464,10 @@ TEST(ProcessRuntimeConfigTests, FinalOptimizedVirtualDisplayChoicePrecedesLinuxM
     "launch_session->virtual_display = *resolved_optimization.virtual_display",
     optimization_guard
   );
+  const auto desktop_mirror_semantic = body.find(
+    "if (_app.desktop_mirror)",
+    optimization_write
+  );
   const auto mode_derivation = body.find(
     "stream_display_policy::effective_session_selection_for_launch(",
     optimization_write
@@ -483,12 +487,14 @@ TEST(ProcessRuntimeConfigTests, FinalOptimizedVirtualDisplayChoicePrecedesLinuxM
 
   ASSERT_NE(optimization_guard, std::string::npos);
   ASSERT_NE(optimization_write, std::string::npos);
+  ASSERT_NE(desktop_mirror_semantic, std::string::npos);
   ASSERT_NE(mode_derivation, std::string::npos);
   ASSERT_NE(mode_apply, std::string::npos);
   ASSERT_NE(runtime_derivation, std::string::npos);
   ASSERT_NE(capture_policy, std::string::npos);
   EXPECT_LT(optimization_guard, optimization_write);
-  EXPECT_LT(optimization_write, mode_derivation)
+  EXPECT_LT(optimization_write, desktop_mirror_semantic);
+  EXPECT_LT(desktop_mirror_semantic, mode_derivation)
     << "final device/AI virtual-display intent must own session mode derivation";
   EXPECT_LT(mode_derivation, mode_apply);
   EXPECT_LT(mode_apply, runtime_derivation)
@@ -4060,6 +4066,24 @@ TEST(ProcessRuntimeConfigTests, ClearPrivateSteamLaunchIsAllowed) {
   EXPECT_TRUE(policy.canMirrorDesktop);
   EXPECT_EQ(policy.recommendedAction, "launch_private_stream");
 }
+
+TEST(ProcessRuntimeConfigTests, DesktopMirrorAppOverridesPairedVirtualDisplayPreference) {
+  proc::ctx_t desktop;
+  desktop.name = "Desktop";
+  desktop.desktop_mirror = true;
+
+  rtsp_stream::launch_session_t launch_session;
+  launch_session.virtual_display = true;
+  launch_session.user_locked_virtual_display = true;
+  launch_session.mirror_desktop = false;
+
+  proc::apply_app_display_semantics(desktop, launch_session);
+
+  EXPECT_TRUE(launch_session.mirror_desktop);
+  EXPECT_FALSE(launch_session.virtual_display);
+  EXPECT_TRUE(launch_session.user_locked_virtual_display)
+    << "the semantic overrides this launch without mutating paired settings";
+}
 #endif
 
 TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {
@@ -4096,7 +4120,7 @@ TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
   ASSERT_TRUE(migrated_tree.contains("version"));
-  EXPECT_EQ(migrated_tree["version"], 9);
+  EXPECT_EQ(migrated_tree["version"], 10);
   ASSERT_TRUE(migrated_tree.contains("apps"));
   ASSERT_TRUE(migrated_tree["apps"].is_array());
   ASSERT_EQ(migrated_tree["apps"].size(), 1);
@@ -4131,6 +4155,51 @@ TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {
   EXPECT_EQ(migrated_ctx->scale_factor, 125);
   EXPECT_EQ(migrated_ctx->exit_timeout, std::chrono::seconds(5));
   EXPECT_EQ(migrated_ctx->last_launched, 1710000000);
+
+  std::filesystem::remove(file_path);
+}
+
+TEST(ProcessMigrationTests, LegacyBundledDesktopGetsExplicitMirrorSemanticOnlyForExactStockShape) {
+  const auto file_path = test_paths::root() / "legacy_desktop_mirror_migration.json";
+  const nlohmann::json legacy_apps = {
+    {"version", 9},
+    {"apps", {
+      {
+        {"name", "Desktop"},
+        {"uuid", "11111111-1111-4111-8111-111111111111"},
+        {"image-path", "desktop.png"},
+        {"allow-client-commands", false}
+      },
+      {
+        {"name", "Desktop"},
+        {"uuid", "22222222-2222-4222-8222-222222222222"},
+        {"image-path", "custom-desktop.png"},
+        {"cmd", "launch-custom-desktop"},
+        {"allow-client-commands", false}
+      }
+    }}
+  };
+
+  ASSERT_EQ(file_handler::write_file(file_path.string().c_str(), legacy_apps.dump(2)), 0);
+  auto parsed_proc = proc::parse(file_path.string());
+  ASSERT_TRUE(parsed_proc.has_value());
+
+  const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
+  EXPECT_EQ(migrated_tree["version"], 10);
+  EXPECT_TRUE(migrated_tree["apps"][0].value("desktop-mirror", false));
+  EXPECT_FALSE(migrated_tree["apps"][1].contains("desktop-mirror"));
+
+  const auto &apps = parsed_proc->get_apps();
+  const auto stock = std::find_if(apps.begin(), apps.end(), [](const auto &app) {
+    return app.uuid == "11111111-1111-4111-8111-111111111111";
+  });
+  const auto custom = std::find_if(apps.begin(), apps.end(), [](const auto &app) {
+    return app.uuid == "22222222-2222-4222-8222-222222222222";
+  });
+  ASSERT_NE(stock, apps.end());
+  ASSERT_NE(custom, apps.end());
+  EXPECT_TRUE(stock->desktop_mirror);
+  EXPECT_FALSE(custom->desktop_mirror);
 
   std::filesystem::remove(file_path);
 }
@@ -4312,7 +4381,7 @@ TEST(ProcessMigrationTests, ParseNormalizesSteamLibraryLaunchAndAddsShutdownUndo
   EXPECT_EQ(steam_ctx->source, "steam");
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(migrated_tree["version"], 9);
+  EXPECT_EQ(migrated_tree["version"], 10);
 
   std::filesystem::remove(file_path);
 }
@@ -4363,7 +4432,7 @@ TEST(ProcessMigrationTests, ParseNormalizesCurrentSteamLibraryLaunchWithoutBigPi
   EXPECT_EQ(steam_ctx->prep_cmds.front().undo_cmd, expected_steam_shutdown_command());
 
   const auto parsed_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(parsed_tree["version"], 9);
+  EXPECT_EQ(parsed_tree["version"], 10);
 
   std::filesystem::remove(file_path);
 }
@@ -4576,7 +4645,7 @@ TEST(ProcessMigrationTests, ParseAddsLutrisLauncherWhenLutrisGamesExist) {
   ASSERT_TRUE(parsed_proc.has_value());
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(migrated_tree["version"], 9);
+  EXPECT_EQ(migrated_tree["version"], 10);
   ASSERT_TRUE(migrated_tree.contains("apps"));
 
   const auto &migrated_apps = migrated_tree["apps"];
@@ -4642,7 +4711,7 @@ TEST(ProcessMigrationTests, ParseUnwrapsPolarisHdrSessionLibraryHardwire) {
   ASSERT_TRUE(parsed_proc.has_value());
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(migrated_tree["version"], 9);
+  EXPECT_EQ(migrated_tree["version"], 10);
 
   const auto &migrated_apps = migrated_tree["apps"];
   const auto lib_app = std::find_if(migrated_apps.begin(), migrated_apps.end(), [](const auto &app) {

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -663,6 +663,75 @@ TEST(SourceSafetyContracts, PortalSourceSelectionAndPublicationUseOneCaptureGene
   EXPECT_NE(kwin_header.find("require_for_generation(const capture_generation::identity_t &generation)"), std::string::npos);
 }
 
+TEST(SourceSafetyContracts, LinuxBackendDispatchUsesCaptureGenerationAuthority) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/misc.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto planner = source.find("static display_backend_e choose_display_backend(");
+  const auto display = source.find("std::shared_ptr<display_t> display(", planner);
+  const auto display_end = source.find("class linux_deinit_t", display);
+  ASSERT_NE(planner, std::string::npos);
+  ASSERT_NE(display, std::string::npos);
+  ASSERT_NE(display_end, std::string::npos);
+  const auto planner_body = source.substr(planner, display - planner);
+  const auto display_body = source.substr(display, display_end - display);
+  EXPECT_NE(planner_body.find("exact_output_owned && (requested.empty() || requested == \"auto\")"), std::string::npos);
+  EXPECT_NE(planner_body.find("requested == \"wlr\""), std::string::npos);
+  EXPECT_NE(planner_body.find("requested == \"portal\""), std::string::npos);
+  const auto requested = display_body.find("config.capture_generation.capture_backend");
+  const auto exact_owned = display_body.find("config.capture_generation.exact_display_name.empty()", requested);
+  const auto choose = display_body.find("choose_display_backend(", exact_owned);
+  const auto dispatch = display_body.find("switch (backend)", choose);
+  ASSERT_NE(requested, std::string::npos);
+  ASSERT_NE(exact_owned, std::string::npos);
+  ASSERT_NE(choose, std::string::npos);
+  ASSERT_NE(dispatch, std::string::npos);
+  EXPECT_LT(requested, exact_owned);
+  EXPECT_LT(exact_owned, choose);
+  EXPECT_LT(choose, dispatch);
+  EXPECT_EQ(display_body.find("if (sources[source::"), std::string::npos);
+}
+
+TEST(SourceSafetyContracts, PortalRejectsForeignBackendBeforeMutationAndUsesPureMode) {
+  const auto root = fs::path {POLARIS_SOURCE_DIR};
+  std::ifstream portal_in(root / "src/platform/linux/portal_grab.cpp");
+  std::ifstream session_in(root / "src/platform/linux/portal_session.cpp");
+  ASSERT_TRUE(portal_in.is_open());
+  ASSERT_TRUE(session_in.is_open());
+  std::ostringstream portal_out, session_out;
+  portal_out << portal_in.rdbuf();
+  session_out << session_in.rdbuf();
+  const auto portal = portal_out.str();
+  const auto session = session_out.str();
+
+  const auto policy = session.find("uint32_t capture_type_for_stream_display(");
+  const auto policy_end = session.find("// Helper: call a portal method", policy);
+  ASSERT_NE(policy, std::string::npos);
+  ASSERT_NE(policy_end, std::string::npos);
+  const auto policy_body = session.substr(policy, policy_end - policy);
+  EXPECT_NE(policy_body.find("const auto mode = stream_mode;"), std::string::npos);
+  EXPECT_EQ(policy_body.find("config::video"), std::string::npos);
+
+  const auto ensure = portal.find("static std::shared_ptr<pipewire_capture::capture_t> ensure_global_capture(");
+  const auto transition = portal.find("std::lock_guard transition_lock", ensure);
+  const auto ensure_guard = portal.find("portal_capture_backend_allowed(generation.capture_backend)", ensure);
+  ASSERT_NE(ensure, std::string::npos);
+  ASSERT_NE(transition, std::string::npos);
+  ASSERT_NE(ensure_guard, std::string::npos);
+  EXPECT_LT(ensure_guard, transition);
+
+  const auto init = portal.find("init(platf::mem_type_e");
+  const auto init_guard = portal.find("portal_capture_backend_allowed(generation_.capture_backend)", init);
+  const auto exact_guard = portal.find("generation_.exact_display_name.empty()", init_guard);
+  ASSERT_NE(init, std::string::npos);
+  ASSERT_NE(init_guard, std::string::npos);
+  ASSERT_NE(exact_guard, std::string::npos);
+  EXPECT_LT(init_guard, exact_guard);
+}
+
 TEST(SourceSafetyContracts, SwayVirtualOutputCreationIsRejectedBeforeMutation) {
   std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/virtual_display.cpp");
   ASSERT_TRUE(input.is_open());

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -379,7 +379,7 @@ TEST(SourceSafetyContracts, ExactDisplayCaptureCannotFallBackDuringInitOrReinit)
   EXPECT_LT(reinit_reject, fallback_refresh);
 
   const auto generic_refresh = source.find(
-    "void refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index)"
+    "void refresh_displays(\n    platf::mem_type_e dev_type"
   );
   const auto capture_thread = source.find("void captureThread(", generic_refresh);
   ASSERT_NE(generic_refresh, std::string::npos);
@@ -589,7 +589,8 @@ TEST(SourceSafetyContracts, CaptureGenerationIdentityIsOwnedFromLaunchThroughVid
 
   EXPECT_NE(identity.find("struct identity_t"), std::string::npos);
   for (const auto field : {"generation_id", "exact_display_name", "requested_output_name", "stream_mode",
-                           "capture_backend", "private_runtime", "adapter_name",
+                           "capture_backend", "private_runtime", "private_wayland_socket",
+                           "private_runtime_instance_id", "adapter_name",
                            "headless_mode", "use_cage_compositor"}) {
     EXPECT_NE(identity.find(field), std::string::npos) << field;
   }
@@ -597,6 +598,8 @@ TEST(SourceSafetyContracts, CaptureGenerationIdentityIsOwnedFromLaunchThroughVid
   EXPECT_EQ(process_header.find("std::string exact_display_name;"), std::string::npos);
   EXPECT_NE(process.find("capture_generation.generation_id = _session_generation;"), std::string::npos);
   EXPECT_NE(process.find("capture_generation = capture_generation::identity_t {"), std::string::npos);
+  EXPECT_NE(process.find("capture_generation.private_wayland_socket = private_runtime->wayland_socket()"), std::string::npos);
+  EXPECT_NE(process.find("capture_generation.private_runtime_instance_id = _session_instance_id"), std::string::npos);
   EXPECT_NE(video_header.find("capture_generation::identity_t capture_generation;"), std::string::npos);
   EXPECT_NE(video.find("config.capture_generation = proc::proc.capture_generation;"), std::string::npos);
 }
@@ -910,7 +913,7 @@ TEST(SourceSafetyContracts, VirtualDisplayCreateSerializesCleanupCreationAndPers
   const auto cleanup_body = source.substr(cleanup_entry, cleanup_end - cleanup_entry);
   const auto cleanup_lock = cleanup_body.find("std::lock_guard creation_lock {creation_mutex}");
   const auto create = source.find("std::optional<vdisplay_t> create(int width, int height, int fps)", cleanup_entry);
-  const auto create_end = source.find("void destroy(vdisplay_t &display)", create);
+  const auto create_end = source.find("bool destroy(vdisplay_t &display)", create);
   const auto destroy_lock = source.find("std::lock_guard creation_lock {creation_mutex}", create_end);
   ASSERT_NE(mutex, std::string::npos);
   ASSERT_NE(cleanup_entry, std::string::npos);
@@ -922,13 +925,17 @@ TEST(SourceSafetyContracts, VirtualDisplayCreateSerializesCleanupCreationAndPers
   const auto body = source.substr(create, create_end - create);
   const auto lock = body.find("std::lock_guard creation_lock {creation_mutex}");
   const auto cleanup = body.find("cleanup_stale_unlocked()");
+  const auto cleanup_refusal = body.find("if (!cleanup.succeeded)", cleanup);
   const auto backend = body.find("detect_backend()");
   const auto persistence = body.find("record_persisted_display(");
   ASSERT_NE(lock, std::string::npos);
   ASSERT_NE(cleanup, std::string::npos);
+  ASSERT_NE(cleanup_refusal, std::string::npos);
   ASSERT_NE(backend, std::string::npos);
   ASSERT_NE(persistence, std::string::npos);
   EXPECT_LT(lock, cleanup);
+  EXPECT_LT(cleanup, cleanup_refusal);
+  EXPECT_LT(cleanup_refusal, backend);
   EXPECT_LT(cleanup, backend);
   EXPECT_LT(backend, persistence);
 
@@ -942,6 +949,106 @@ TEST(SourceSafetyContracts, VirtualDisplayCreateSerializesCleanupCreationAndPers
   confighttp_contents << confighttp_input.rdbuf();
   EXPECT_NE(process_contents.str().find("virtual_display::create("), std::string::npos);
   EXPECT_NE(confighttp_contents.str().find("virtual_display::create("), std::string::npos);
+}
+
+TEST(SourceSafetyContracts, VirtualDisplayTeardownKeepsRecoveryUntilExactReadback) {
+  const auto root = fs::path {POLARIS_SOURCE_DIR};
+  std::ifstream virtual_display_in(root / "src/platform/linux/virtual_display.cpp");
+  std::ifstream process_in(root / "src/process.cpp");
+  ASSERT_TRUE(virtual_display_in.is_open());
+  ASSERT_TRUE(process_in.is_open());
+  std::ostringstream virtual_display_out, process_out;
+  virtual_display_out << virtual_display_in.rdbuf();
+  process_out << process_in.rdbuf();
+  const auto source = virtual_display_out.str();
+  const auto process = process_out.str();
+
+  const auto destroy = source.find("static bool destroy_unlocked(vdisplay_t &display)");
+  const auto public_destroy = source.find("bool destroy(vdisplay_t &display)", destroy);
+  ASSERT_NE(destroy, std::string::npos);
+  ASSERT_NE(public_destroy, std::string::npos);
+  const auto body = source.substr(destroy, public_destroy - destroy);
+  const auto verify = body.find("teardown_is_verified(destroyed, display.active)");
+  const auto retain = body.find("persisted recovery record retained", verify);
+  const auto forget = body.find("forget_persisted_display(display)", retain);
+  ASSERT_NE(verify, std::string::npos);
+  ASSERT_NE(retain, std::string::npos);
+  ASSERT_NE(forget, std::string::npos);
+  EXPECT_LT(verify, retain);
+  EXPECT_LT(retain, forget);
+
+  const auto kscreen = source.find("namespace kscreen");
+  const auto kscreen_end = source.find("}  // namespace kscreen", kscreen);
+  ASSERT_NE(kscreen, std::string::npos);
+  ASSERT_NE(kscreen_end, std::string::npos);
+  const auto kscreen_body = source.substr(kscreen, kscreen_end - kscreen);
+  EXPECT_NE(kscreen_body.find("kscreen-doctor --json"), std::string::npos);
+  EXPECT_NE(kscreen_body.find("kscreen_output_before"), std::string::npos);
+  EXPECT_NE(kscreen_body.find("kscreen_primary_before"), std::string::npos);
+  EXPECT_NE(kscreen_body.find("*output_after == *display.kscreen_output_before"), std::string::npos);
+  EXPECT_NE(kscreen_body.find("*primary_after == *display.kscreen_primary_before"), std::string::npos);
+  const auto kscreen_record = kscreen_body.find("record_persisted_display(display, 0)");
+  const auto kscreen_mutation = kscreen_body.find("platf::run_process_argv(args)", kscreen_record);
+  ASSERT_NE(kscreen_record, std::string::npos);
+  ASSERT_NE(kscreen_mutation, std::string::npos);
+  EXPECT_LT(kscreen_record, kscreen_mutation);
+
+  const auto durable_write = source.find("bool write_persisted_entries(");
+  const auto file_sync = source.find("::fsync(fd)", durable_write);
+  const auto rename = source.find("fs::rename(temp_path, path", file_sync);
+  const auto directory_sync = source.find("sync_parent()", rename);
+  ASSERT_NE(durable_write, std::string::npos);
+  ASSERT_NE(file_sync, std::string::npos);
+  ASSERT_NE(rename, std::string::npos);
+  ASSERT_NE(directory_sync, std::string::npos);
+  EXPECT_LT(file_sync, rename);
+  EXPECT_LT(rename, directory_sync);
+
+  EXPECT_NE(source.find("const auto connected = output_is_connected(display)"), std::string::npos);
+  EXPECT_NE(source.find("if (connected && !*connected)"), std::string::npos);
+  EXPECT_NE(source.find("if (present && !*present)"), std::string::npos);
+  const auto hypr_destroy = source.find("static bool destroy(vdisplay_t &display)", source.find("namespace wayland_wlr"));
+  const auto stable_absence = source.find("std::optional<std::chrono::steady_clock::time_point> absent_since", hypr_destroy);
+  const auto stable_window = source.find("now - *absent_since >= 500ms", stable_absence);
+  const auto mark_inactive = source.find("display.active = false", stable_window);
+  ASSERT_NE(hypr_destroy, std::string::npos);
+  ASSERT_NE(stable_absence, std::string::npos);
+  ASSERT_NE(stable_window, std::string::npos);
+  ASSERT_NE(mark_inactive, std::string::npos);
+  EXPECT_LT(stable_absence, stable_window);
+  EXPECT_LT(stable_window, mark_inactive);
+
+  const auto process_destroy = process.find("if (virtual_display::destroy(*linux_vdisplay))");
+  const auto process_reset = process.find("linux_vdisplay.reset()", process_destroy);
+  ASSERT_NE(process_destroy, std::string::npos);
+  ASSERT_NE(process_reset, std::string::npos);
+  EXPECT_LT(process_destroy, process_reset);
+}
+
+TEST(SourceSafetyContracts, WlgrabReinitEnumeratesFromImmutableCaptureGeneration) {
+  const auto root = fs::path {POLARIS_SOURCE_DIR};
+  std::ifstream wlgrab_in(root / "src/platform/linux/wlgrab.cpp");
+  std::ifstream linux_misc_in(root / "src/platform/linux/misc.cpp");
+  std::ifstream video_in(root / "src/video.cpp");
+  ASSERT_TRUE(wlgrab_in.is_open());
+  ASSERT_TRUE(linux_misc_in.is_open());
+  ASSERT_TRUE(video_in.is_open());
+  std::ostringstream wlgrab_out, linux_misc_out, video_out;
+  wlgrab_out << wlgrab_in.rdbuf();
+  linux_misc_out << linux_misc_in.rdbuf();
+  video_out << video_in.rdbuf();
+  const auto wlgrab = wlgrab_out.str();
+  const auto linux_misc = linux_misc_out.str();
+  const auto video = video_out.str();
+
+  EXPECT_NE(wlgrab.find("resolve_generation_policy("), std::string::npos);
+  EXPECT_NE(wlgrab.find("private_runtime_matches_generation("), std::string::npos);
+  EXPECT_NE(wlgrab.find("wl_display_names_for_generation("), std::string::npos);
+  EXPECT_NE(wlgrab.find("Immutable private capture generation cannot enumerate a replacement labwc instance"), std::string::npos);
+  EXPECT_NE(linux_misc.find("wl_display_names(generation)"), std::string::npos);
+  EXPECT_NE(video.find("platf::display_names(dev_type, *capture_config)"), std::string::npos);
+  EXPECT_NE(video.find("&capture_ctxs.front().config"), std::string::npos);
+  EXPECT_NE(video.find("&synced_session_ctxs.front()->config"), std::string::npos);
 }
 
 TEST(SourceSafetyContracts, WlgrabRequestedOutputSelectionFailsClosed) {

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -294,6 +294,24 @@ TEST(SourceSafetyContracts, LegacyVirtualDisplayPromotionPrecedesCaptureReevalua
   EXPECT_NE(teardown.find("config::video.capture = initial_capture"), std::string::npos);
 }
 
+TEST(SourceSafetyContracts, LinuxVirtualDisplayCreationUsesOnlyTheEffectiveMode) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/process.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto decision = source.find("const bool should_use_linux_virtual_display");
+  const auto launch = source.find("if (", decision);
+  ASSERT_NE(decision, std::string::npos);
+  ASSERT_NE(launch, std::string::npos);
+  const auto body = source.substr(decision, launch - decision);
+
+  EXPECT_NE(body.find("display_policy.use_host_virtual_display"), std::string::npos);
+  EXPECT_EQ(body.find("launch_session->virtual_display"), std::string::npos);
+  EXPECT_EQ(body.find("_app.virtual_display"), std::string::npos);
+}
+
 TEST(SourceSafetyContracts, VirtualDisplayCreatedNameSurvivesMappingFailureBeforeCapture) {
   std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/process.cpp");
   ASSERT_TRUE(input.is_open());
@@ -313,6 +331,115 @@ TEST(SourceSafetyContracts, VirtualDisplayCreatedNameSurvivesMappingFailureBefor
   ASSERT_NE(preserve, std::string::npos);
   EXPECT_LT(map, preserve);
   EXPECT_NE(launch.find("this->display_name", preserve), std::string::npos);
+}
+
+TEST(SourceSafetyContracts, ExactDisplayCaptureCannotFallBackDuringInitOrReinit) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/video.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto initial = source.find("const auto requested_display_name = proc::proc.display_name;");
+  const auto initial_end = source.find("display_wp = disp", initial);
+  ASSERT_NE(initial, std::string::npos);
+  ASSERT_NE(initial_end, std::string::npos);
+  const auto initial_body = source.substr(initial, initial_end - initial);
+  const auto initial_policy = initial_body.find("capture_fallback_allowed(");
+  const auto initial_reject = initial_body.find("return;", initial_policy);
+  const auto initial_refresh = initial_body.find("refresh_displays(");
+  ASSERT_NE(initial_policy, std::string::npos);
+  ASSERT_NE(initial_reject, std::string::npos);
+  ASSERT_NE(initial_refresh, std::string::npos);
+  EXPECT_LT(initial_policy, initial_reject);
+  EXPECT_LT(initial_reject, initial_refresh);
+
+  const auto reinit = source.find("while (capture_ctx_queue->running())", initial_end);
+  const auto reinit_end = source.find("display_wp = disp", reinit);
+  ASSERT_NE(reinit, std::string::npos);
+  ASSERT_NE(reinit_end, std::string::npos);
+  const auto reinit_body = source.substr(reinit, reinit_end - reinit);
+  const auto exact_refresh = reinit_body.find("if (!refresh_displays(");
+  const auto identity = reinit_body.find("proc::proc.display_name", exact_refresh);
+  const auto reinit_reject = reinit_body.find("return;", exact_refresh);
+  const auto reset = reinit_body.find("reset_display(", exact_refresh);
+  ASSERT_NE(exact_refresh, std::string::npos);
+  ASSERT_NE(identity, std::string::npos);
+  ASSERT_NE(reinit_reject, std::string::npos);
+  ASSERT_NE(reset, std::string::npos);
+  EXPECT_LT(exact_refresh, identity);
+  EXPECT_LT(identity, reinit_reject);
+  EXPECT_LT(reinit_reject, reset);
+
+  const auto generic_refresh = source.find(
+    "void refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index)"
+  );
+  const auto capture_thread = source.find("void captureThread(", generic_refresh);
+  ASSERT_NE(generic_refresh, std::string::npos);
+  ASSERT_NE(capture_thread, std::string::npos);
+  const auto wrapper = source.substr(generic_refresh, capture_thread - generic_refresh);
+  EXPECT_NE(wrapper.find("if (!refresh_displays("), std::string::npos);
+  EXPECT_NE(
+    wrapper.find("current_display_index = display_names.empty() ? -1 : 0"),
+    std::string::npos
+  );
+}
+
+TEST(SourceSafetyContracts, RequiredKwinVirtualCaptureCannotFallThroughToAnotherOutputOrPortal) {
+  std::ifstream kwin_input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/kwingrab.cpp");
+  ASSERT_TRUE(kwin_input.is_open());
+  std::ostringstream kwin_contents;
+  kwin_contents << kwin_input.rdbuf();
+  const auto kwin = kwin_contents.str();
+
+  const auto requested = kwin.find("if (!output_name.empty())");
+  const auto exact_policy = kwin.find("output_selection_can_fallback(output_name)", requested);
+  const auto reject = kwin.find("return -1;", exact_policy);
+  const auto configured_fallback = kwin.find("config::video.linux_display.streaming_output", requested);
+  ASSERT_NE(requested, std::string::npos);
+  ASSERT_NE(exact_policy, std::string::npos);
+  ASSERT_NE(reject, std::string::npos);
+  ASSERT_NE(configured_fallback, std::string::npos);
+  EXPECT_LT(exact_policy, reject);
+  EXPECT_LT(reject, configured_fallback);
+
+  std::ifstream portal_input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/portal_grab.cpp");
+  ASSERT_TRUE(portal_input.is_open());
+  std::ostringstream portal_contents;
+  portal_contents << portal_input.rdbuf();
+  const auto portal = portal_contents.str();
+
+  const auto compatible = portal.find("const auto compatible");
+  const auto identity = portal.find("capture_identity_matches(", compatible);
+  const auto identity_mode = portal.find("g_media.stream_mode", identity);
+  const auto identity_output = portal.find("g_media.output_name", identity_mode);
+  const auto requested_mode = portal.find("requested_stream_mode", identity_output);
+  const auto requested_output = portal.find("requested_output_name", requested_mode);
+  const auto reuse = portal.find("return g_media.capture;", requested_output);
+  const auto kwin_start = portal.find("kwingrab::start_output_session(", reuse);
+  const auto required = portal.find("kwingrab::require_for_current_stream_mode()", kwin_start);
+  const auto fail_closed = portal.find("return nullptr;", required);
+  const auto generic_portal = portal.find("ensure_session_unlocked()", kwin_start);
+  ASSERT_NE(compatible, std::string::npos);
+  ASSERT_NE(identity, std::string::npos);
+  ASSERT_NE(identity_mode, std::string::npos);
+  ASSERT_NE(identity_output, std::string::npos);
+  ASSERT_NE(requested_mode, std::string::npos);
+  ASSERT_NE(requested_output, std::string::npos);
+  ASSERT_NE(reuse, std::string::npos);
+  ASSERT_NE(kwin_start, std::string::npos);
+  ASSERT_NE(required, std::string::npos);
+  ASSERT_NE(fail_closed, std::string::npos);
+  ASSERT_NE(generic_portal, std::string::npos);
+  EXPECT_LT(compatible, identity);
+  EXPECT_LT(identity, identity_mode);
+  EXPECT_LT(identity_mode, identity_output);
+  EXPECT_LT(identity_output, requested_mode);
+  EXPECT_LT(requested_mode, requested_output);
+  EXPECT_LT(requested_output, reuse);
+  EXPECT_LT(reuse, kwin_start);
+  EXPECT_LT(required, fail_closed);
+  EXPECT_LT(fail_closed, generic_portal);
 }
 
 TEST(SourceSafetyContracts, WlgrabRequestedOutputSelectionFailsClosed) {

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -344,7 +344,7 @@ TEST(SourceSafetyContracts, ExactDisplayCaptureCannotFallBackDuringInitOrReinit)
   contents << input.rdbuf();
   const auto source = contents.str();
 
-  const auto initial = source.find("const auto requested_display_name = proc::proc.display_name;");
+  const auto initial = source.find("const auto exact_display_name = proc::proc.display_name;");
   const auto initial_end = source.find("display_wp = disp", initial);
   ASSERT_NE(initial, std::string::npos);
   ASSERT_NE(initial_end, std::string::npos);
@@ -363,17 +363,17 @@ TEST(SourceSafetyContracts, ExactDisplayCaptureCannotFallBackDuringInitOrReinit)
   ASSERT_NE(reinit, std::string::npos);
   ASSERT_NE(reinit_end, std::string::npos);
   const auto reinit_body = source.substr(reinit, reinit_end - reinit);
-  const auto exact_name = reinit_body.find("const auto exact_display_name = proc::proc.display_name");
-  const auto exact_reset = reinit_body.find("reset_display(", exact_name);
+  const auto exact_branch = reinit_body.find("if (!exact_display_name.empty())");
+  const auto exact_reset = reinit_body.find("reset_display(", exact_branch);
   const auto identity = reinit_body.find("exact_display_name", exact_reset);
   const auto reinit_reject = reinit_body.find("return;", identity);
   const auto fallback_refresh = reinit_body.find("refresh_displays(", reinit_reject);
-  ASSERT_NE(exact_name, std::string::npos);
+  ASSERT_NE(exact_branch, std::string::npos);
   ASSERT_NE(exact_reset, std::string::npos);
   ASSERT_NE(identity, std::string::npos);
   ASSERT_NE(reinit_reject, std::string::npos);
   ASSERT_NE(fallback_refresh, std::string::npos);
-  EXPECT_LT(exact_name, exact_reset);
+  EXPECT_LT(exact_branch, exact_reset);
   EXPECT_LT(exact_reset, identity);
   EXPECT_LT(identity, reinit_reject);
   EXPECT_LT(reinit_reject, fallback_refresh);
@@ -390,6 +390,85 @@ TEST(SourceSafetyContracts, ExactDisplayCaptureCannotFallBackDuringInitOrReinit)
     wrapper.find("current_display_index = display_names.empty() ? -1 : 0"),
     std::string::npos
   );
+}
+
+TEST(SourceSafetyContracts, ExactOwnedCaptureRejectsDisplaySwitchesInBothCapturePipelines) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/video.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto async_begin = source.find("void captureThread(");
+  const auto sync_begin = source.find("encode_e encode_run_sync(", async_begin);
+  const auto sync_end = source.find("void captureThreadSync()", sync_begin);
+  ASSERT_NE(async_begin, std::string::npos);
+  ASSERT_NE(sync_begin, std::string::npos);
+  ASSERT_NE(sync_end, std::string::npos);
+
+  const auto async_body = source.substr(async_begin, sync_begin - async_begin);
+  const auto async_exact = async_body.find("const auto exact_display_name = proc::proc.display_name;");
+  const auto async_policy = async_body.find("display_switch_allowed_for_exact_capture(exact_display_name)");
+  const auto async_reinit_loop = async_body.find("while (capture_ctx_queue->running())", async_policy);
+  const auto async_exact_reopen = async_body.find("if (!exact_display_name.empty())", async_reinit_loop);
+  const auto async_reset = async_body.find("reset_display(", async_exact_reopen);
+  const auto async_identity = async_body.find("exact_display_name", async_reset);
+  const auto async_generic_refresh = async_body.find("refresh_displays(", async_identity);
+  ASSERT_NE(async_exact, std::string::npos);
+  ASSERT_NE(async_policy, std::string::npos);
+  ASSERT_NE(async_reinit_loop, std::string::npos);
+  ASSERT_NE(async_exact_reopen, std::string::npos);
+  ASSERT_NE(async_reset, std::string::npos);
+  ASSERT_NE(async_identity, std::string::npos);
+  ASSERT_NE(async_generic_refresh, std::string::npos);
+  EXPECT_LT(async_exact, async_policy);
+  EXPECT_LT(async_exact_reopen, async_reset);
+  EXPECT_LT(async_reset, async_identity);
+  EXPECT_LT(async_identity, async_generic_refresh);
+  EXPECT_EQ(
+    async_body.find("!switch_display_event->peek() && !exact_display_name.empty()"),
+    std::string::npos
+  );
+
+  const auto sync_body = source.substr(sync_begin, sync_end - sync_begin);
+  const auto sync_exact = sync_body.find("const auto exact_display_name = proc::proc.display_name;");
+  const auto sync_exact_branch = sync_body.find("if (!exact_display_name.empty())", sync_exact);
+  const auto sync_reset = sync_body.find("reset_display(", sync_exact_branch);
+  const auto sync_identity = sync_body.find("exact_display_name", sync_reset);
+  const auto sync_generic_refresh = sync_body.find("refresh_displays(", sync_identity);
+  const auto sync_policy = sync_body.find("display_switch_allowed_for_exact_capture(exact_display_name)");
+  ASSERT_NE(sync_exact, std::string::npos);
+  ASSERT_NE(sync_exact_branch, std::string::npos);
+  ASSERT_NE(sync_reset, std::string::npos);
+  ASSERT_NE(sync_identity, std::string::npos);
+  ASSERT_NE(sync_generic_refresh, std::string::npos);
+  ASSERT_NE(sync_policy, std::string::npos);
+  EXPECT_LT(sync_exact_branch, sync_reset);
+  EXPECT_LT(sync_reset, sync_identity);
+  EXPECT_LT(sync_identity, sync_generic_refresh);
+}
+
+TEST(SourceSafetyContracts, SwayVirtualOutputCreationIsRejectedBeforeMutation) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/virtual_display.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto wayland = source.find("namespace wayland_wlr");
+  const auto available = source.find("static bool is_available()", wayland);
+  const auto create = source.find("static std::optional<vdisplay_t> create(", available);
+  ASSERT_NE(wayland, std::string::npos);
+  ASSERT_NE(available, std::string::npos);
+  ASSERT_NE(create, std::string::npos);
+  const auto availability_body = source.substr(available, create - available);
+  const auto exact_capability = availability_body.find(
+    "wayland_compositor_supports_exact_output_creation(compositor)"
+  );
+  const auto reject = availability_body.find("return false", exact_capability);
+  ASSERT_NE(exact_capability, std::string::npos);
+  ASSERT_NE(reject, std::string::npos);
+  EXPECT_EQ(source.find("swaymsg -r create_output"), std::string::npos);
 }
 
 TEST(SourceSafetyContracts, RequiredKwinVirtualCaptureCannotFallThroughToAnotherOutputOrPortal) {
@@ -518,28 +597,27 @@ TEST(SourceSafetyContracts, VirtualDisplayCreationPublishesOnlyProvenOwnedConnec
   EXPECT_LT(evdi_close, evdi_reject);
   EXPECT_LT(evdi_reject, evdi_publish);
 
-  const auto sway = source.find("else if (compositor == \"sway\")");
-  const auto before = source.find("sway_outputs_before", sway);
-  const auto snapshot_gate = source.find("if (!with_valid_sway_before_snapshot(", before);
-  const auto create = source.find("swaymsg -r create_output", snapshot_gate);
-  const auto command_proof = source.find("sway_create_output_succeeded(", create);
-  const auto ownership = source.find("sway_new_headless_output(", command_proof);
-  const auto sway_reject = source.find("return std::nullopt;", ownership);
-  const auto mode = source.find("std::string mode_str", sway_reject);
-  ASSERT_NE(sway, std::string::npos);
-  ASSERT_NE(before, std::string::npos);
-  ASSERT_NE(snapshot_gate, std::string::npos);
+  const auto wayland = source.find("namespace wayland_wlr");
+  const auto create_entry = source.find("static std::optional<vdisplay_t> create(", wayland);
+  const auto hyprland = source.find("if (compositor == \"hyprland\")", create_entry);
+  const auto requested_name = source.find("std::string candidate = hyprland_output_name_for_pid(", hyprland);
+  const auto create = source.find("hyprctl output create headless", requested_name);
+  const auto ownership = source.find("hyprland_monitors_contain_output(", create);
+  const auto reject = source.find("return std::nullopt;", ownership);
+  const auto publish = source.find("display.backend = backend_e::WAYLAND_WLR", reject);
+  ASSERT_NE(wayland, std::string::npos);
+  ASSERT_NE(create_entry, std::string::npos);
+  ASSERT_NE(hyprland, std::string::npos);
+  ASSERT_NE(requested_name, std::string::npos);
   ASSERT_NE(create, std::string::npos);
-  ASSERT_NE(command_proof, std::string::npos);
   ASSERT_NE(ownership, std::string::npos);
-  ASSERT_NE(sway_reject, std::string::npos);
-  ASSERT_NE(mode, std::string::npos);
-  EXPECT_LT(before, snapshot_gate);
-  EXPECT_LT(snapshot_gate, create);
-  EXPECT_LT(create, command_proof);
-  EXPECT_LT(command_proof, ownership);
-  EXPECT_LT(ownership, sway_reject);
-  EXPECT_LT(sway_reject, mode);
+  ASSERT_NE(reject, std::string::npos);
+  ASSERT_NE(publish, std::string::npos);
+  EXPECT_LT(requested_name, create);
+  EXPECT_LT(create, ownership);
+  EXPECT_LT(ownership, reject);
+  EXPECT_LT(reject, publish);
+  EXPECT_EQ(source.find("swaymsg -r create_output"), std::string::npos);
 }
 
 TEST(SourceSafetyContracts, VirtualDisplayCreateSerializesCleanupCreationAndPersistence) {

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -461,6 +461,41 @@ TEST(SourceSafetyContracts, RequiredKwinVirtualCaptureCannotFallThroughToAnother
   EXPECT_LT(fail_closed, generic_portal);
 }
 
+TEST(SourceSafetyContracts, PortalSourceSelectionAndIdentityTransitionOwnOneGeneration) {
+  std::ifstream portal_input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/portal_grab.cpp");
+  ASSERT_TRUE(portal_input.is_open());
+  std::ostringstream portal_contents;
+  portal_contents << portal_input.rdbuf();
+  const auto portal = portal_contents.str();
+
+  EXPECT_EQ(portal.find("static bool ensure_global_session()"), std::string::npos);
+  const auto init = portal.find("if (!cage_configured)");
+  const auto init_capture = portal.find("ensure_global_capture(", init);
+  ASSERT_NE(init, std::string::npos);
+  ASSERT_NE(init_capture, std::string::npos);
+  EXPECT_EQ(portal.substr(init, init_capture - init).find("ensure_global_session()"), std::string::npos);
+
+  const auto capture_fallback = portal.find("// Fallback: source-owned portal/KWin capture");
+  const auto capture_owner = portal.find("ensure_global_capture(", capture_fallback);
+  ASSERT_NE(capture_fallback, std::string::npos);
+  ASSERT_NE(capture_owner, std::string::npos);
+  EXPECT_EQ(portal.substr(capture_fallback, capture_owner - capture_fallback).find("ensure_global_session()"), std::string::npos);
+
+  const auto transition = portal.find("capture configuration changed");
+  const auto retired_portal = portal.find("auto retired_portal = std::move(g_media.portal)", transition);
+  const auto unlock = portal.find("lock.unlock()", transition);
+  const auto destroy_portal = portal.find("retired_portal.reset()", unlock);
+  const auto relock = portal.find("lock.lock()", destroy_portal);
+  ASSERT_NE(transition, std::string::npos);
+  ASSERT_NE(retired_portal, std::string::npos);
+  ASSERT_NE(unlock, std::string::npos);
+  ASSERT_NE(destroy_portal, std::string::npos);
+  ASSERT_NE(relock, std::string::npos);
+  EXPECT_LT(retired_portal, unlock);
+  EXPECT_LT(unlock, destroy_portal);
+  EXPECT_LT(destroy_portal, relock);
+}
+
 TEST(SourceSafetyContracts, VirtualDisplayCreationPublishesOnlyProvenOwnedConnectors) {
   std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/virtual_display.cpp");
   ASSERT_TRUE(input.is_open());
@@ -499,6 +534,53 @@ TEST(SourceSafetyContracts, VirtualDisplayCreationPublishesOnlyProvenOwnedConnec
   EXPECT_LT(command_proof, ownership);
   EXPECT_LT(ownership, sway_reject);
   EXPECT_LT(sway_reject, mode);
+}
+
+TEST(SourceSafetyContracts, VirtualDisplayCreateSerializesCleanupCreationAndPersistence) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/virtual_display.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto mutex = source.find("static std::mutex creation_mutex");
+  const auto cleanup_entry = source.find("bool cleanup_stale()");
+  const auto cleanup_end = source.find("#ifdef POLARIS_TESTS", cleanup_entry);
+  const auto cleanup_body = source.substr(cleanup_entry, cleanup_end - cleanup_entry);
+  const auto cleanup_lock = cleanup_body.find("std::lock_guard creation_lock {creation_mutex}");
+  const auto create = source.find("std::optional<vdisplay_t> create(int width, int height, int fps)", cleanup_entry);
+  const auto create_end = source.find("void destroy(vdisplay_t &display)", create);
+  const auto destroy_lock = source.find("std::lock_guard creation_lock {creation_mutex}", create_end);
+  ASSERT_NE(mutex, std::string::npos);
+  ASSERT_NE(cleanup_entry, std::string::npos);
+  ASSERT_NE(cleanup_end, std::string::npos);
+  ASSERT_NE(cleanup_lock, std::string::npos);
+  ASSERT_NE(create, std::string::npos);
+  ASSERT_NE(create_end, std::string::npos);
+  ASSERT_NE(destroy_lock, std::string::npos);
+  const auto body = source.substr(create, create_end - create);
+  const auto lock = body.find("std::lock_guard creation_lock {creation_mutex}");
+  const auto cleanup = body.find("cleanup_stale_unlocked()");
+  const auto backend = body.find("detect_backend()");
+  const auto persistence = body.find("record_persisted_display(");
+  ASSERT_NE(lock, std::string::npos);
+  ASSERT_NE(cleanup, std::string::npos);
+  ASSERT_NE(backend, std::string::npos);
+  ASSERT_NE(persistence, std::string::npos);
+  EXPECT_LT(lock, cleanup);
+  EXPECT_LT(cleanup, backend);
+  EXPECT_LT(backend, persistence);
+
+  std::ifstream process_input(fs::path {POLARIS_SOURCE_DIR} / "src/process.cpp");
+  std::ifstream confighttp_input(fs::path {POLARIS_SOURCE_DIR} / "src/confighttp.cpp");
+  ASSERT_TRUE(process_input.is_open());
+  ASSERT_TRUE(confighttp_input.is_open());
+  std::ostringstream process_contents;
+  std::ostringstream confighttp_contents;
+  process_contents << process_input.rdbuf();
+  confighttp_contents << confighttp_input.rdbuf();
+  EXPECT_NE(process_contents.str().find("virtual_display::create("), std::string::npos);
+  EXPECT_NE(confighttp_contents.str().find("virtual_display::create("), std::string::npos);
 }
 
 TEST(SourceSafetyContracts, WlgrabRequestedOutputSelectionFailsClosed) {

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -263,6 +263,85 @@ TEST(SourceSafetyContracts, UbuntuSnapshotInstallsMayDowngradeRunnerPackages) {
   EXPECT_EQ(count_exact(workflow, curl_dev_pin), 2u);
 }
 
+TEST(SourceSafetyContracts, LegacyVirtualDisplayPromotionPrecedesCaptureReevaluationAndRestoresHostState) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/process.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto execute = source.find("int proc_t::execute_impl(");
+  const auto terminate = source.find("void proc_t::terminate_impl(", execute);
+  ASSERT_NE(execute, std::string::npos);
+  ASSERT_NE(terminate, std::string::npos);
+  const auto launch = source.substr(execute, terminate - execute);
+
+  const auto derive = launch.find("effective_session_selection_for_launch(");
+  const auto apply = launch.find("stream_display_policy::apply_selection(session_mode");
+  const auto reevaluate = launch.find("platf::reevaluate_capture_sources()", apply);
+  ASSERT_NE(derive, std::string::npos);
+  ASSERT_NE(apply, std::string::npos);
+  ASSERT_NE(reevaluate, std::string::npos);
+  EXPECT_LT(derive, apply);
+  EXPECT_LT(apply, reevaluate);
+  EXPECT_NE(launch.find("_app.virtual_display", derive), std::string::npos);
+  EXPECT_NE(launch.find("launch_session->user_locked_virtual_display", derive), std::string::npos);
+
+  const auto terminate_end = source.find("bool proc_t::reload_configuration_from_file", terminate);
+  ASSERT_NE(terminate_end, std::string::npos);
+  const auto teardown = source.substr(terminate, terminate_end - terminate);
+  EXPECT_NE(teardown.find("linux_display.stream_mode = initial_stream_mode"), std::string::npos);
+  EXPECT_NE(teardown.find("config::video.capture = initial_capture"), std::string::npos);
+}
+
+TEST(SourceSafetyContracts, VirtualDisplayCreatedNameSurvivesMappingFailureBeforeCapture) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/process.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto created = source.find("Virtual Display created: ");
+  const auto terminate = source.find("void proc_t::terminate_impl(", created);
+  ASSERT_NE(created, std::string::npos);
+  ASSERT_NE(terminate, std::string::npos);
+  const auto launch = source.substr(created, terminate - created);
+
+  const auto map = launch.find("display_device::map_display_name(this->display_name)");
+  const auto preserve = launch.find("capture_output_name_for_virtual_display(", map);
+  ASSERT_NE(map, std::string::npos);
+  ASSERT_NE(preserve, std::string::npos);
+  EXPECT_LT(map, preserve);
+  EXPECT_NE(launch.find("this->display_name", preserve), std::string::npos);
+}
+
+TEST(SourceSafetyContracts, WlgrabRequestedOutputSelectionFailsClosed) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/wlgrab.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+  const auto init = source.find("int init(platf::mem_type_e hwdevice_type");
+  const auto next_method = source.find("std::shared_ptr<platf::img_t> alloc_img()", init);
+  ASSERT_NE(init, std::string::npos);
+  ASSERT_NE(next_method, std::string::npos);
+  const auto body = source.substr(init, next_method - init);
+
+  const auto select = body.find("wlgrab_capture_policy::select_monitor_index(");
+  const auto reject = body.find("if (!monitor_index)", select);
+  const auto refuse = body.find("refusing to capture another output", reject);
+  const auto return_failure = body.find("return -1;", reject);
+  const auto dereference = body.find("interface.monitors[*monitor_index]", select);
+  ASSERT_NE(select, std::string::npos);
+  ASSERT_NE(reject, std::string::npos);
+  ASSERT_NE(refuse, std::string::npos);
+  ASSERT_NE(return_failure, std::string::npos);
+  ASSERT_NE(dereference, std::string::npos);
+  EXPECT_LT(reject, return_failure);
+  EXPECT_LT(return_failure, dereference);
+  EXPECT_EQ(body.find("interface.monitors[0].get()"), std::string::npos);
+}
+
 TEST(SourceSafetyContracts, ReadlinkResultsAreCheckedBeforeUse) {
   // readlink reports failure as -1. Widening that into a size handed a
   // string_view a length of SIZE_MAX; the other seven call sites all checked.

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -344,7 +344,7 @@ TEST(SourceSafetyContracts, ExactDisplayCaptureCannotFallBackDuringInitOrReinit)
   contents << input.rdbuf();
   const auto source = contents.str();
 
-  const auto initial = source.find("const auto exact_display_name = capture_ctxs.front().exact_display_name;");
+  const auto initial = source.find("const auto active_generation = capture_ctxs.front().config.capture_generation;");
   const auto initial_end = source.find("display_wp = disp", initial);
   ASSERT_NE(initial, std::string::npos);
   ASSERT_NE(initial_end, std::string::npos);
@@ -410,17 +410,16 @@ TEST(SourceSafetyContracts, ExactOutputProvenanceLivesInLaunchAndCaptureGenerati
   const auto process_source = process_contents.str();
   const auto process_header = process_header_contents.str();
 
-  EXPECT_NE(process_header.find("std::string exact_display_name;"), std::string::npos);
-  const auto first_publish = process_source.find("this->exact_display_name = this->display_name;");
-  const auto second_publish = process_source.find("this->exact_display_name = this->display_name;", first_publish + 1);
-  const auto third_publish = process_source.find(
-    "this->exact_display_name = this->display_name;",
-    second_publish + 1
+  EXPECT_NE(process_header.find("capture_generation::identity_t capture_generation;"), std::string::npos);
+  EXPECT_EQ(process_header.find("std::string exact_display_name;"), std::string::npos);
+  const auto first_publish = process_source.find("this->capture_generation.exact_display_name = this->display_name;");
+  const auto second_publish = process_source.find(
+    "this->capture_generation.exact_display_name = this->display_name;",
+    first_publish + 1
   );
-  const auto clear = process_source.find("exact_display_name.clear()", second_publish);
+  const auto clear = process_source.find("capture_generation = {};", second_publish);
   ASSERT_NE(first_publish, std::string::npos);
   ASSERT_NE(second_publish, std::string::npos);
-  EXPECT_EQ(third_publish, std::string::npos);
   ASSERT_NE(clear, std::string::npos);
 
   const auto sync_ctx = source.find("struct sync_session_ctx_t");
@@ -431,20 +430,22 @@ TEST(SourceSafetyContracts, ExactOutputProvenanceLivesInLaunchAndCaptureGenerati
   ASSERT_NE(sync_ctx_end, std::string::npos);
   ASSERT_NE(async_ctx, std::string::npos);
   ASSERT_NE(async_ctx_end, std::string::npos);
-  EXPECT_NE(source.substr(sync_ctx, sync_ctx_end - sync_ctx).find("std::string exact_display_name;"), std::string::npos);
-  EXPECT_NE(source.substr(async_ctx, async_ctx_end - async_ctx).find("std::string exact_display_name;"), std::string::npos);
+  EXPECT_NE(source.substr(sync_ctx, sync_ctx_end - sync_ctx).find("config_t config;"), std::string::npos);
+  EXPECT_NE(source.substr(async_ctx, async_ctx_end - async_ctx).find("config_t config;"), std::string::npos);
+  EXPECT_EQ(source.substr(sync_ctx, sync_ctx_end - sync_ctx).find("std::string exact_display_name;"), std::string::npos);
+  EXPECT_EQ(source.substr(async_ctx, async_ctx_end - async_ctx).find("std::string exact_display_name;"), std::string::npos);
   const auto capture_admission = source.find(
-    "const auto exact_display_name = proc::proc.exact_display_name;"
+    "config.capture_generation = proc::proc.capture_generation;"
   );
   const auto async_entry = source.find("void capture_async(");
   const auto async_publish = source.find("ref->capture_ctx_queue->raise(capture_ctx_t", async_entry);
-  const auto async_provenance = source.find("std::move(exact_display_name)", async_publish);
+  const auto async_provenance = source.find("config,", async_publish);
   const auto async_publish_end = source.find("});", async_publish);
   const auto async_call = source.find("capture_async(", capture_admission);
-  const auto async_call_provenance = source.find("exact_display_name", async_call);
+  const auto async_call_provenance = source.find("config,", async_call);
   const auto async_call_end = source.find(");", async_call);
   const auto sync_publish = source.find("ref->encode_session_ctx_queue.raise(sync_session_ctx_t", capture_admission);
-  const auto sync_provenance = source.find("exact_display_name,", sync_publish);
+  const auto sync_provenance = source.find("config,", sync_publish);
   const auto sync_publish_end = source.find("});", sync_publish);
   ASSERT_NE(capture_admission, std::string::npos);
   ASSERT_NE(async_entry, std::string::npos);
@@ -469,7 +470,7 @@ TEST(SourceSafetyContracts, ExactOutputProvenanceLivesInLaunchAndCaptureGenerati
   ASSERT_NE(sync_end, std::string::npos);
 
   const auto async_body = source.substr(async_begin, sync_begin - async_begin);
-  const auto async_exact = async_body.find("const auto exact_display_name = capture_ctxs.front().exact_display_name;");
+  const auto async_exact = async_body.find("const auto active_generation = capture_ctxs.front().config.capture_generation;");
   const auto async_policy = async_body.find("display_switch_allowed_for_exact_capture(exact_display_name)");
   const auto async_reinit_loop = async_body.find("while (capture_ctx_queue->running())", async_policy);
   const auto async_exact_reopen = async_body.find("if (!exact_display_name.empty())", async_reinit_loop);
@@ -501,7 +502,7 @@ TEST(SourceSafetyContracts, ExactOutputProvenanceLivesInLaunchAndCaptureGenerati
   );
 
   const auto sync_body = source.substr(sync_begin, sync_end - sync_begin);
-  const auto sync_exact = sync_body.find("const auto exact_display_name = synced_session_ctxs.front()->exact_display_name;");
+  const auto sync_exact = sync_body.find("const auto active_generation = synced_session_ctxs.front()->config.capture_generation;");
   const auto sync_exact_branch = sync_body.find("if (!exact_display_name.empty())", sync_exact);
   const auto sync_reset = sync_body.find("reset_display(", sync_exact_branch);
   const auto sync_identity = sync_body.find("exact_display_name", sync_reset);
@@ -541,7 +542,7 @@ TEST(SourceSafetyContracts, CaptureGenerationMismatchIsRejectedBeforePublication
   ASSERT_NE(sync_end, std::string::npos);
 
   const auto async_body = source.substr(async_begin, sync_begin - async_begin);
-  const auto async_match = async_body.find("exact_display_generations_match(");
+  const auto async_match = async_body.find("capture_generations_match(");
   const auto async_reject = async_body.find("incoming_capture_ctx->images->stop()", async_match);
   const auto async_publish = async_body.find("capture_ctxs.emplace_back", async_reject);
   ASSERT_NE(async_match, std::string::npos);
@@ -551,7 +552,7 @@ TEST(SourceSafetyContracts, CaptureGenerationMismatchIsRejectedBeforePublication
   EXPECT_LT(async_reject, async_publish);
 
   const auto sync_body = source.substr(sync_begin, sync_end - sync_begin);
-  const auto sync_match = sync_body.find("exact_display_generations_match(");
+  const auto sync_match = sync_body.find("capture_generations_match(");
   const auto sync_reject = sync_body.find("incoming_sync_ctx->join_event->raise(true)", sync_match);
   const auto sync_publish = sync_body.find("synced_session_ctxs.emplace_back", sync_reject);
   ASSERT_NE(sync_match, std::string::npos);
@@ -559,6 +560,107 @@ TEST(SourceSafetyContracts, CaptureGenerationMismatchIsRejectedBeforePublication
   ASSERT_NE(sync_publish, std::string::npos);
   EXPECT_LT(sync_match, sync_reject);
   EXPECT_LT(sync_reject, sync_publish);
+}
+
+TEST(SourceSafetyContracts, CaptureGenerationIdentityIsOwnedFromLaunchThroughVideo) {
+  const auto root = fs::path {POLARIS_SOURCE_DIR};
+  std::ifstream identity_in(root / "src/capture_generation.h");
+  std::ifstream process_header_in(root / "src/process.h");
+  std::ifstream process_in(root / "src/process.cpp");
+  std::ifstream video_header_in(root / "src/video.h");
+  std::ifstream video_in(root / "src/video.cpp");
+  ASSERT_TRUE(identity_in.is_open());
+  ASSERT_TRUE(process_header_in.is_open());
+  ASSERT_TRUE(process_in.is_open());
+  ASSERT_TRUE(video_header_in.is_open());
+  ASSERT_TRUE(video_in.is_open());
+
+  std::ostringstream identity_out, process_header_out, process_out, video_header_out, video_out;
+  identity_out << identity_in.rdbuf();
+  process_header_out << process_header_in.rdbuf();
+  process_out << process_in.rdbuf();
+  video_header_out << video_header_in.rdbuf();
+  video_out << video_in.rdbuf();
+  const auto identity = identity_out.str();
+  const auto process_header = process_header_out.str();
+  const auto process = process_out.str();
+  const auto video_header = video_header_out.str();
+  const auto video = video_out.str();
+
+  EXPECT_NE(identity.find("struct identity_t"), std::string::npos);
+  for (const auto field : {"generation_id", "exact_display_name", "requested_output_name", "stream_mode",
+                           "capture_backend", "private_runtime", "adapter_name",
+                           "headless_mode", "use_cage_compositor"}) {
+    EXPECT_NE(identity.find(field), std::string::npos) << field;
+  }
+  EXPECT_NE(process_header.find("capture_generation::identity_t capture_generation;"), std::string::npos);
+  EXPECT_EQ(process_header.find("std::string exact_display_name;"), std::string::npos);
+  EXPECT_NE(process.find("capture_generation.generation_id = _session_generation;"), std::string::npos);
+  EXPECT_NE(process.find("capture_generation = capture_generation::identity_t {"), std::string::npos);
+  EXPECT_NE(video_header.find("capture_generation::identity_t capture_generation;"), std::string::npos);
+  EXPECT_NE(video.find("config.capture_generation = proc::proc.capture_generation;"), std::string::npos);
+}
+
+TEST(SourceSafetyContracts, PortalSourceSelectionAndPublicationUseOneCaptureGeneration) {
+  const auto root = fs::path {POLARIS_SOURCE_DIR};
+  std::ifstream portal_in(root / "src/platform/linux/portal_grab.cpp");
+  std::ifstream kwin_header_in(root / "src/platform/linux/kwingrab.h");
+  ASSERT_TRUE(portal_in.is_open());
+  ASSERT_TRUE(kwin_header_in.is_open());
+  std::ostringstream portal_out, kwin_header_out;
+  portal_out << portal_in.rdbuf();
+  kwin_header_out << kwin_header_in.rdbuf();
+  const auto portal = portal_out.str();
+  const auto kwin_header = kwin_header_out.str();
+
+  const auto ensure = portal.find("static std::shared_ptr<pipewire_capture::capture_t> ensure_global_capture(");
+  const auto display = portal.find("class portal_display_t", ensure);
+  ASSERT_NE(ensure, std::string::npos);
+  ASSERT_NE(display, std::string::npos);
+  const auto ensure_body = portal.substr(ensure, display - ensure);
+  EXPECT_NE(ensure_body.find("const capture_generation::identity_t &generation"), std::string::npos);
+  EXPECT_NE(ensure_body.find("g_media.generation == generation"), std::string::npos);
+  const auto first_publication = ensure_body.find("g_media.generation = generation");
+  const auto second_publication = ensure_body.find("g_media.generation = generation", first_publication + 1);
+  const auto third_publication = ensure_body.find("g_media.generation = generation", second_publication + 1);
+  const auto fourth_publication = ensure_body.find("g_media.generation = generation", third_publication + 1);
+  ASSERT_NE(first_publication, std::string::npos);
+  ASSERT_NE(second_publication, std::string::npos);
+  ASSERT_NE(third_publication, std::string::npos);
+  EXPECT_EQ(fourth_publication, std::string::npos);
+  EXPECT_NE(
+    ensure_body.find("g_media.capture != capture || g_media.generation != generation"),
+    std::string::npos
+  );
+  EXPECT_NE(ensure_body.find("ensure_session_unlocked(generation)"), std::string::npos);
+  EXPECT_NE(ensure_body.find("kwingrab::prefer_for_generation(generation)"), std::string::npos);
+  EXPECT_NE(ensure_body.find("kwingrab::require_for_generation(generation)"), std::string::npos);
+  EXPECT_NE(ensure_body.find("start_output_session(generation.requested_output_name)"), std::string::npos);
+  for (const auto forbidden : {"config::video.adapter_name", "config::video.output_name",
+                               "config::video.capture", "config::video.linux_display"}) {
+    EXPECT_EQ(ensure_body.find(forbidden), std::string::npos) << forbidden;
+  }
+
+  const auto init = portal.find("init(platf::mem_type_e", display);
+  const auto capture = portal.find("capture(const push_captured_image_cb_t", init);
+  ASSERT_NE(init, std::string::npos);
+  ASSERT_NE(capture, std::string::npos);
+  const auto init_body = portal.substr(init, capture - init);
+  const auto exact_validation = init_body.find("display_name != generation_.exact_display_name");
+  const auto requested_validation = init_body.find("generation_.requested_output_name != generation_.exact_display_name");
+  const auto exact_reject = init_body.find("return -1;", requested_validation);
+  const auto init_capture = init_body.find("ensure_global_capture(", exact_reject);
+  ASSERT_NE(exact_validation, std::string::npos);
+  ASSERT_NE(requested_validation, std::string::npos);
+  ASSERT_NE(exact_reject, std::string::npos);
+  ASSERT_NE(init_capture, std::string::npos);
+  EXPECT_LT(exact_validation, requested_validation);
+  EXPECT_LT(requested_validation, exact_reject);
+  EXPECT_LT(exact_reject, init_capture);
+  EXPECT_NE(init_body.find("generation_ = config.capture_generation;"), std::string::npos);
+  EXPECT_NE(init_body.find("generation_"), std::string::npos);
+  EXPECT_NE(kwin_header.find("prefer_for_generation(const capture_generation::identity_t &generation)"), std::string::npos);
+  EXPECT_NE(kwin_header.find("require_for_generation(const capture_generation::identity_t &generation)"), std::string::npos);
 }
 
 TEST(SourceSafetyContracts, SwayVirtualOutputCreationIsRejectedBeforeMutation) {
@@ -595,12 +697,14 @@ TEST(SourceSafetyContracts, RequiredKwinVirtualCaptureCannotFallThroughToAnother
   const auto exact_policy = kwin.find("output_selection_can_fallback(output_name)", requested);
   const auto reject = kwin.find("return -1;", exact_policy);
   const auto configured_fallback = kwin.find("config::video.linux_display.streaming_output", requested);
+  const auto first_output_fallback = kwin.find("output = outputs_.begin()->first", reject);
   ASSERT_NE(requested, std::string::npos);
   ASSERT_NE(exact_policy, std::string::npos);
   ASSERT_NE(reject, std::string::npos);
-  ASSERT_NE(configured_fallback, std::string::npos);
+  EXPECT_EQ(configured_fallback, std::string::npos);
+  ASSERT_NE(first_output_fallback, std::string::npos);
   EXPECT_LT(exact_policy, reject);
-  EXPECT_LT(reject, configured_fallback);
+  EXPECT_LT(reject, first_output_fallback);
 
   std::ifstream portal_input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/portal_grab.cpp");
   ASSERT_TRUE(portal_input.is_open());
@@ -609,26 +713,21 @@ TEST(SourceSafetyContracts, RequiredKwinVirtualCaptureCannotFallThroughToAnother
   const auto portal = portal_contents.str();
 
   const auto compatible = portal.find("const auto compatible");
-  const auto identity = portal.find("capture_identity_matches(", compatible);
-  const auto identity_mode = portal.find("g_media.stream_mode", identity);
-  const auto identity_output = portal.find("g_media.output_name", identity_mode);
-  const auto requested_mode = portal.find("requested_stream_mode", identity_output);
-  const auto requested_output = portal.find("requested_output_name", requested_mode);
-  const auto reuse = portal.find("return g_media.capture;", requested_output);
+  const auto identity = portal.find("g_media.generation == generation", compatible);
+  const auto reuse = portal.find("return g_media.capture;", identity);
   const auto no_wayland = portal.find("#ifndef POLARIS_BUILD_WAYLAND", reuse);
-  const auto no_wayland_mode = portal.find("requested_stream_mode == \"host_virtual_display\"", no_wayland);
+  const auto no_wayland_mode = portal.find("generation.stream_mode == \"host_virtual_display\"", no_wayland);
   const auto no_wayland_reject = portal.find("return nullptr;", no_wayland_mode);
   const auto wayland_guard = portal.find("#ifdef POLARIS_BUILD_WAYLAND", no_wayland_reject);
-  const auto kwin_start = portal.find("kwingrab::start_output_session(", wayland_guard);
-  const auto required = portal.find("kwingrab::require_for_current_stream_mode()", kwin_start);
+  const auto kwin_start = portal.find(
+    "kwingrab::start_output_session(generation.requested_output_name)",
+    wayland_guard
+  );
+  const auto required = portal.find("kwingrab::require_for_generation(generation)", kwin_start);
   const auto fail_closed = portal.find("return nullptr;", required);
-  const auto generic_portal = portal.find("ensure_session_unlocked()", kwin_start);
+  const auto generic_portal = portal.find("ensure_session_unlocked(generation)", kwin_start);
   ASSERT_NE(compatible, std::string::npos);
   ASSERT_NE(identity, std::string::npos);
-  ASSERT_NE(identity_mode, std::string::npos);
-  ASSERT_NE(identity_output, std::string::npos);
-  ASSERT_NE(requested_mode, std::string::npos);
-  ASSERT_NE(requested_output, std::string::npos);
   ASSERT_NE(reuse, std::string::npos);
   ASSERT_NE(no_wayland, std::string::npos);
   ASSERT_NE(no_wayland_mode, std::string::npos);
@@ -639,11 +738,7 @@ TEST(SourceSafetyContracts, RequiredKwinVirtualCaptureCannotFallThroughToAnother
   ASSERT_NE(fail_closed, std::string::npos);
   ASSERT_NE(generic_portal, std::string::npos);
   EXPECT_LT(compatible, identity);
-  EXPECT_LT(identity, identity_mode);
-  EXPECT_LT(identity_mode, identity_output);
-  EXPECT_LT(identity_output, requested_mode);
-  EXPECT_LT(requested_mode, requested_output);
-  EXPECT_LT(requested_output, reuse);
+  EXPECT_LT(identity, reuse);
   EXPECT_LT(reuse, no_wayland);
   EXPECT_LT(no_wayland, no_wayland_mode);
   EXPECT_LT(no_wayland_mode, no_wayland_reject);

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -286,6 +286,10 @@ TEST(SourceSafetyContracts, LegacyVirtualDisplayPromotionPrecedesCaptureReevalua
   EXPECT_LT(apply, reevaluate);
   EXPECT_NE(launch.find("_app.virtual_display", derive), std::string::npos);
   EXPECT_NE(launch.find("launch_session->user_locked_virtual_display", derive), std::string::npos);
+  EXPECT_EQ(
+    launch.find("!(launch_session && launch_session->mirror_desktop)", derive),
+    std::string::npos
+  ) << "derived desktop_display must actually be applied for mirror sessions";
 
   const auto terminate_end = source.find("bool proc_t::reload_configuration_from_file", terminate);
   ASSERT_NE(terminate_end, std::string::npos);
@@ -359,17 +363,20 @@ TEST(SourceSafetyContracts, ExactDisplayCaptureCannotFallBackDuringInitOrReinit)
   ASSERT_NE(reinit, std::string::npos);
   ASSERT_NE(reinit_end, std::string::npos);
   const auto reinit_body = source.substr(reinit, reinit_end - reinit);
-  const auto exact_refresh = reinit_body.find("if (!refresh_displays(");
-  const auto identity = reinit_body.find("proc::proc.display_name", exact_refresh);
-  const auto reinit_reject = reinit_body.find("return;", exact_refresh);
-  const auto reset = reinit_body.find("reset_display(", exact_refresh);
-  ASSERT_NE(exact_refresh, std::string::npos);
+  const auto exact_name = reinit_body.find("const auto exact_display_name = proc::proc.display_name");
+  const auto exact_reset = reinit_body.find("reset_display(", exact_name);
+  const auto identity = reinit_body.find("exact_display_name", exact_reset);
+  const auto reinit_reject = reinit_body.find("return;", identity);
+  const auto fallback_refresh = reinit_body.find("refresh_displays(", reinit_reject);
+  ASSERT_NE(exact_name, std::string::npos);
+  ASSERT_NE(exact_reset, std::string::npos);
   ASSERT_NE(identity, std::string::npos);
   ASSERT_NE(reinit_reject, std::string::npos);
-  ASSERT_NE(reset, std::string::npos);
-  EXPECT_LT(exact_refresh, identity);
+  ASSERT_NE(fallback_refresh, std::string::npos);
+  EXPECT_LT(exact_name, exact_reset);
+  EXPECT_LT(exact_reset, identity);
   EXPECT_LT(identity, reinit_reject);
-  EXPECT_LT(reinit_reject, reset);
+  EXPECT_LT(reinit_reject, fallback_refresh);
 
   const auto generic_refresh = source.find(
     "void refresh_displays(platf::mem_type_e dev_type, std::vector<std::string> &display_names, int &current_display_index)"
@@ -416,7 +423,11 @@ TEST(SourceSafetyContracts, RequiredKwinVirtualCaptureCannotFallThroughToAnother
   const auto requested_mode = portal.find("requested_stream_mode", identity_output);
   const auto requested_output = portal.find("requested_output_name", requested_mode);
   const auto reuse = portal.find("return g_media.capture;", requested_output);
-  const auto kwin_start = portal.find("kwingrab::start_output_session(", reuse);
+  const auto no_wayland = portal.find("#ifndef POLARIS_BUILD_WAYLAND", reuse);
+  const auto no_wayland_mode = portal.find("requested_stream_mode == \"host_virtual_display\"", no_wayland);
+  const auto no_wayland_reject = portal.find("return nullptr;", no_wayland_mode);
+  const auto wayland_guard = portal.find("#ifdef POLARIS_BUILD_WAYLAND", no_wayland_reject);
+  const auto kwin_start = portal.find("kwingrab::start_output_session(", wayland_guard);
   const auto required = portal.find("kwingrab::require_for_current_stream_mode()", kwin_start);
   const auto fail_closed = portal.find("return nullptr;", required);
   const auto generic_portal = portal.find("ensure_session_unlocked()", kwin_start);
@@ -427,6 +438,10 @@ TEST(SourceSafetyContracts, RequiredKwinVirtualCaptureCannotFallThroughToAnother
   ASSERT_NE(requested_mode, std::string::npos);
   ASSERT_NE(requested_output, std::string::npos);
   ASSERT_NE(reuse, std::string::npos);
+  ASSERT_NE(no_wayland, std::string::npos);
+  ASSERT_NE(no_wayland_mode, std::string::npos);
+  ASSERT_NE(no_wayland_reject, std::string::npos);
+  ASSERT_NE(wayland_guard, std::string::npos);
   ASSERT_NE(kwin_start, std::string::npos);
   ASSERT_NE(required, std::string::npos);
   ASSERT_NE(fail_closed, std::string::npos);
@@ -437,9 +452,53 @@ TEST(SourceSafetyContracts, RequiredKwinVirtualCaptureCannotFallThroughToAnother
   EXPECT_LT(identity_output, requested_mode);
   EXPECT_LT(requested_mode, requested_output);
   EXPECT_LT(requested_output, reuse);
-  EXPECT_LT(reuse, kwin_start);
+  EXPECT_LT(reuse, no_wayland);
+  EXPECT_LT(no_wayland, no_wayland_mode);
+  EXPECT_LT(no_wayland_mode, no_wayland_reject);
+  EXPECT_LT(no_wayland_reject, wayland_guard);
+  EXPECT_LT(wayland_guard, kwin_start);
   EXPECT_LT(required, fail_closed);
   EXPECT_LT(fail_closed, generic_portal);
+}
+
+TEST(SourceSafetyContracts, VirtualDisplayCreationPublishesOnlyProvenOwnedConnectors) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/virtual_display.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto evdi_proof = source.find("if (!evdi_output_name_is_proven(output_name))");
+  const auto evdi_disconnect = source.find("fn_disconnect(handle)", evdi_proof);
+  const auto evdi_close = source.find("fn_close(handle)", evdi_disconnect);
+  const auto evdi_reject = source.find("return std::nullopt;", evdi_close);
+  const auto evdi_publish = source.find("vdisplay_t display", evdi_reject);
+  ASSERT_NE(evdi_proof, std::string::npos);
+  ASSERT_NE(evdi_disconnect, std::string::npos);
+  ASSERT_NE(evdi_close, std::string::npos);
+  ASSERT_NE(evdi_reject, std::string::npos);
+  ASSERT_NE(evdi_publish, std::string::npos);
+  EXPECT_LT(evdi_proof, evdi_disconnect);
+  EXPECT_LT(evdi_disconnect, evdi_close);
+  EXPECT_LT(evdi_close, evdi_reject);
+  EXPECT_LT(evdi_reject, evdi_publish);
+
+  const auto sway = source.find("else if (compositor == \"sway\")");
+  const auto before = source.find("sway_outputs_before", sway);
+  const auto command_proof = source.find("sway_create_output_succeeded(", before);
+  const auto ownership = source.find("sway_new_headless_output(", command_proof);
+  const auto sway_reject = source.find("return std::nullopt;", ownership);
+  const auto mode = source.find("std::string mode_str", sway_reject);
+  ASSERT_NE(sway, std::string::npos);
+  ASSERT_NE(before, std::string::npos);
+  ASSERT_NE(command_proof, std::string::npos);
+  ASSERT_NE(ownership, std::string::npos);
+  ASSERT_NE(sway_reject, std::string::npos);
+  ASSERT_NE(mode, std::string::npos);
+  EXPECT_LT(before, command_proof);
+  EXPECT_LT(command_proof, ownership);
+  EXPECT_LT(ownership, sway_reject);
+  EXPECT_LT(sway_reject, mode);
 }
 
 TEST(SourceSafetyContracts, WlgrabRequestedOutputSelectionFailsClosed) {

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -344,7 +344,7 @@ TEST(SourceSafetyContracts, ExactDisplayCaptureCannotFallBackDuringInitOrReinit)
   contents << input.rdbuf();
   const auto source = contents.str();
 
-  const auto initial = source.find("const auto exact_display_name = proc::proc.display_name;");
+  const auto initial = source.find("const auto exact_display_name = capture_ctxs.front().exact_display_name;");
   const auto initial_end = source.find("display_wp = disp", initial);
   ASSERT_NE(initial, std::string::npos);
   ASSERT_NE(initial_end, std::string::npos);
@@ -392,12 +392,74 @@ TEST(SourceSafetyContracts, ExactDisplayCaptureCannotFallBackDuringInitOrReinit)
   );
 }
 
-TEST(SourceSafetyContracts, ExactOwnedCaptureRejectsDisplaySwitchesInBothCapturePipelines) {
+TEST(SourceSafetyContracts, ExactOutputProvenanceLivesInLaunchAndCaptureGenerations) {
   std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/video.cpp");
   ASSERT_TRUE(input.is_open());
   std::ostringstream contents;
   contents << input.rdbuf();
   const auto source = contents.str();
+
+  std::ifstream process_input(fs::path {POLARIS_SOURCE_DIR} / "src/process.cpp");
+  std::ifstream process_header_input(fs::path {POLARIS_SOURCE_DIR} / "src/process.h");
+  ASSERT_TRUE(process_input.is_open());
+  ASSERT_TRUE(process_header_input.is_open());
+  std::ostringstream process_contents;
+  std::ostringstream process_header_contents;
+  process_contents << process_input.rdbuf();
+  process_header_contents << process_header_input.rdbuf();
+  const auto process_source = process_contents.str();
+  const auto process_header = process_header_contents.str();
+
+  EXPECT_NE(process_header.find("std::string exact_display_name;"), std::string::npos);
+  const auto first_publish = process_source.find("this->exact_display_name = this->display_name;");
+  const auto second_publish = process_source.find("this->exact_display_name = this->display_name;", first_publish + 1);
+  const auto third_publish = process_source.find(
+    "this->exact_display_name = this->display_name;",
+    second_publish + 1
+  );
+  const auto clear = process_source.find("exact_display_name.clear()", second_publish);
+  ASSERT_NE(first_publish, std::string::npos);
+  ASSERT_NE(second_publish, std::string::npos);
+  EXPECT_EQ(third_publish, std::string::npos);
+  ASSERT_NE(clear, std::string::npos);
+
+  const auto sync_ctx = source.find("struct sync_session_ctx_t");
+  const auto sync_ctx_end = source.find("};", sync_ctx);
+  const auto async_ctx = source.find("struct capture_ctx_t");
+  const auto async_ctx_end = source.find("};", async_ctx);
+  ASSERT_NE(sync_ctx, std::string::npos);
+  ASSERT_NE(sync_ctx_end, std::string::npos);
+  ASSERT_NE(async_ctx, std::string::npos);
+  ASSERT_NE(async_ctx_end, std::string::npos);
+  EXPECT_NE(source.substr(sync_ctx, sync_ctx_end - sync_ctx).find("std::string exact_display_name;"), std::string::npos);
+  EXPECT_NE(source.substr(async_ctx, async_ctx_end - async_ctx).find("std::string exact_display_name;"), std::string::npos);
+  const auto capture_admission = source.find(
+    "const auto exact_display_name = proc::proc.exact_display_name;"
+  );
+  const auto async_entry = source.find("void capture_async(");
+  const auto async_publish = source.find("ref->capture_ctx_queue->raise(capture_ctx_t", async_entry);
+  const auto async_provenance = source.find("std::move(exact_display_name)", async_publish);
+  const auto async_publish_end = source.find("});", async_publish);
+  const auto async_call = source.find("capture_async(", capture_admission);
+  const auto async_call_provenance = source.find("exact_display_name", async_call);
+  const auto async_call_end = source.find(");", async_call);
+  const auto sync_publish = source.find("ref->encode_session_ctx_queue.raise(sync_session_ctx_t", capture_admission);
+  const auto sync_provenance = source.find("exact_display_name,", sync_publish);
+  const auto sync_publish_end = source.find("});", sync_publish);
+  ASSERT_NE(capture_admission, std::string::npos);
+  ASSERT_NE(async_entry, std::string::npos);
+  ASSERT_NE(async_publish, std::string::npos);
+  ASSERT_NE(async_provenance, std::string::npos);
+  ASSERT_NE(async_publish_end, std::string::npos);
+  ASSERT_NE(async_call, std::string::npos);
+  ASSERT_NE(async_call_provenance, std::string::npos);
+  ASSERT_NE(async_call_end, std::string::npos);
+  ASSERT_NE(sync_publish, std::string::npos);
+  ASSERT_NE(sync_provenance, std::string::npos);
+  ASSERT_NE(sync_publish_end, std::string::npos);
+  EXPECT_LT(async_provenance, async_publish_end);
+  EXPECT_LT(async_call_provenance, async_call_end);
+  EXPECT_LT(sync_provenance, sync_publish_end);
 
   const auto async_begin = source.find("void captureThread(");
   const auto sync_begin = source.find("encode_e encode_run_sync(", async_begin);
@@ -407,7 +469,7 @@ TEST(SourceSafetyContracts, ExactOwnedCaptureRejectsDisplaySwitchesInBothCapture
   ASSERT_NE(sync_end, std::string::npos);
 
   const auto async_body = source.substr(async_begin, sync_begin - async_begin);
-  const auto async_exact = async_body.find("const auto exact_display_name = proc::proc.display_name;");
+  const auto async_exact = async_body.find("const auto exact_display_name = capture_ctxs.front().exact_display_name;");
   const auto async_policy = async_body.find("display_switch_allowed_for_exact_capture(exact_display_name)");
   const auto async_reinit_loop = async_body.find("while (capture_ctx_queue->running())", async_policy);
   const auto async_exact_reopen = async_body.find("if (!exact_display_name.empty())", async_reinit_loop);
@@ -426,12 +488,20 @@ TEST(SourceSafetyContracts, ExactOwnedCaptureRejectsDisplaySwitchesInBothCapture
   EXPECT_LT(async_reset, async_identity);
   EXPECT_LT(async_identity, async_generic_refresh);
   EXPECT_EQ(
+    async_body.find("const auto exact_display_name = proc::proc.display_name"),
+    std::string::npos
+  );
+  EXPECT_EQ(
+    async_body.find("const auto exact_display_name = proc::proc.exact_display_name"),
+    std::string::npos
+  );
+  EXPECT_EQ(
     async_body.find("!switch_display_event->peek() && !exact_display_name.empty()"),
     std::string::npos
   );
 
   const auto sync_body = source.substr(sync_begin, sync_end - sync_begin);
-  const auto sync_exact = sync_body.find("const auto exact_display_name = proc::proc.display_name;");
+  const auto sync_exact = sync_body.find("const auto exact_display_name = synced_session_ctxs.front()->exact_display_name;");
   const auto sync_exact_branch = sync_body.find("if (!exact_display_name.empty())", sync_exact);
   const auto sync_reset = sync_body.find("reset_display(", sync_exact_branch);
   const auto sync_identity = sync_body.find("exact_display_name", sync_reset);
@@ -446,6 +516,49 @@ TEST(SourceSafetyContracts, ExactOwnedCaptureRejectsDisplaySwitchesInBothCapture
   EXPECT_LT(sync_exact_branch, sync_reset);
   EXPECT_LT(sync_reset, sync_identity);
   EXPECT_LT(sync_identity, sync_generic_refresh);
+  EXPECT_EQ(
+    sync_body.find("const auto exact_display_name = proc::proc.display_name"),
+    std::string::npos
+  );
+  EXPECT_EQ(
+    sync_body.find("const auto exact_display_name = proc::proc.exact_display_name"),
+    std::string::npos
+  );
+}
+
+TEST(SourceSafetyContracts, CaptureGenerationMismatchIsRejectedBeforePublication) {
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/video.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto async_begin = source.find("void captureThread(");
+  const auto sync_begin = source.find("encode_e encode_run_sync(", async_begin);
+  const auto sync_end = source.find("void captureThreadSync()", sync_begin);
+  ASSERT_NE(async_begin, std::string::npos);
+  ASSERT_NE(sync_begin, std::string::npos);
+  ASSERT_NE(sync_end, std::string::npos);
+
+  const auto async_body = source.substr(async_begin, sync_begin - async_begin);
+  const auto async_match = async_body.find("exact_display_generations_match(");
+  const auto async_reject = async_body.find("incoming_capture_ctx->images->stop()", async_match);
+  const auto async_publish = async_body.find("capture_ctxs.emplace_back", async_reject);
+  ASSERT_NE(async_match, std::string::npos);
+  ASSERT_NE(async_reject, std::string::npos);
+  ASSERT_NE(async_publish, std::string::npos);
+  EXPECT_LT(async_match, async_reject);
+  EXPECT_LT(async_reject, async_publish);
+
+  const auto sync_body = source.substr(sync_begin, sync_end - sync_begin);
+  const auto sync_match = sync_body.find("exact_display_generations_match(");
+  const auto sync_reject = sync_body.find("incoming_sync_ctx->join_event->raise(true)", sync_match);
+  const auto sync_publish = sync_body.find("synced_session_ctxs.emplace_back", sync_reject);
+  ASSERT_NE(sync_match, std::string::npos);
+  ASSERT_NE(sync_reject, std::string::npos);
+  ASSERT_NE(sync_publish, std::string::npos);
+  EXPECT_LT(sync_match, sync_reject);
+  EXPECT_LT(sync_reject, sync_publish);
 }
 
 TEST(SourceSafetyContracts, SwayVirtualOutputCreationIsRejectedBeforeMutation) {

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -520,17 +520,23 @@ TEST(SourceSafetyContracts, VirtualDisplayCreationPublishesOnlyProvenOwnedConnec
 
   const auto sway = source.find("else if (compositor == \"sway\")");
   const auto before = source.find("sway_outputs_before", sway);
-  const auto command_proof = source.find("sway_create_output_succeeded(", before);
+  const auto snapshot_gate = source.find("if (!with_valid_sway_before_snapshot(", before);
+  const auto create = source.find("swaymsg -r create_output", snapshot_gate);
+  const auto command_proof = source.find("sway_create_output_succeeded(", create);
   const auto ownership = source.find("sway_new_headless_output(", command_proof);
   const auto sway_reject = source.find("return std::nullopt;", ownership);
   const auto mode = source.find("std::string mode_str", sway_reject);
   ASSERT_NE(sway, std::string::npos);
   ASSERT_NE(before, std::string::npos);
+  ASSERT_NE(snapshot_gate, std::string::npos);
+  ASSERT_NE(create, std::string::npos);
   ASSERT_NE(command_proof, std::string::npos);
   ASSERT_NE(ownership, std::string::npos);
   ASSERT_NE(sway_reject, std::string::npos);
   ASSERT_NE(mode, std::string::npos);
-  EXPECT_LT(before, command_proof);
+  EXPECT_LT(before, snapshot_gate);
+  EXPECT_LT(snapshot_gate, create);
+  EXPECT_LT(create, command_proof);
   EXPECT_LT(command_proof, ownership);
   EXPECT_LT(ownership, sway_reject);
   EXPECT_LT(sway_reject, mode);

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -136,6 +136,14 @@ TEST(StreamDisplayPolicyTests, LegacyVirtualDisplayLaunchPromotesOnlyWhenTheClie
     ""
   ) << "an explicit client virtual-display choice must beat the app default";
   EXPECT_EQ(
+    effective_session_selection_for_launch("", false, false, true, false, true),
+    ""
+  ) << "optimizer false must suppress an unlocked legacy app default";
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", false, true, true, false, true),
+    "host_virtual_display"
+  );
+  EXPECT_EQ(
     effective_session_selection_for_launch("", true, true, true, false),
     "desktop_display"
   ) << "mirrorDesktop must override a host_virtual_display default for this session";
@@ -345,6 +353,17 @@ TEST(StreamDisplayPolicyTests, ExplicitStreamModeWinsOverBooleans) {
   EXPECT_EQ(resolved.selection, "host_virtual_display");
   EXPECT_TRUE(resolved.use_host_virtual_display);
   EXPECT_FALSE(resolved.use_private_runtime);
+}
+
+TEST(StreamDisplayPolicyTests, NormalizeConfigClearsStaleGamescopeRuntime) {
+  LinuxDisplayPolicyGuard guard;
+  auto &d = config::video.linux_display;
+  for (const auto mode : {"desktop_display", "host_virtual_display", "headless_dongle"}) {
+    d.stream_mode = mode;
+    d.private_runtime = "gamescope";
+    stream_display_policy::normalize_config_from_load();
+    EXPECT_TRUE(d.private_runtime.empty()) << mode;
+  }
 }
 
 TEST(StreamDisplayPolicyTests, NormalizeConfigRepairsHostVirtualState) {

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <src/platform/linux/stream_display_policy.h>
+#include <src/platform/linux/virtual_display.h>
 #include <src/config.h>
 
 #include <algorithm>
@@ -119,6 +120,64 @@ TEST(StreamDisplayPolicyTests, LegacyBooleansMapToSelections) {
   EXPECT_EQ(selection_from_legacy_booleans({false, false, false}), "desktop_display");
 }
 
+TEST(StreamDisplayPolicyTests, LegacyVirtualDisplayLaunchPromotesOnlyWhenTheClientDidNotChoose) {
+  using stream_display_policy::effective_session_selection_for_launch;
+
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", false, false, true, false),
+    "host_virtual_display"
+  );
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", false, true, false, true),
+    "host_virtual_display"
+  );
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", false, false, true, true),
+    ""
+  ) << "an explicit client virtual-display choice must beat the app default";
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", true, true, true, false),
+    ""
+  ) << "mirrorDesktop remains authoritative";
+  EXPECT_EQ(
+    effective_session_selection_for_launch("headless_stream", false, true, true, false),
+    "headless_stream"
+  ) << "an explicit accepted streamMode remains authoritative";
+}
+
+TEST(StreamDisplayPolicyTests, VirtualCaptureOutputNameNeverLosesTheCreatedConnector) {
+  using stream_display_policy::capture_output_name_for_virtual_display;
+
+  EXPECT_EQ(
+    capture_output_name_for_virtual_display("POLARIS-HEADLESS-512536-0", ""),
+    "POLARIS-HEADLESS-512536-0"
+  );
+  EXPECT_EQ(
+    capture_output_name_for_virtual_display("POLARIS-HEADLESS-512536-0", "1"),
+    "1"
+  );
+}
+
+TEST(StreamDisplayPolicyTests, HostVirtualCaptureFollowsTheVirtualDisplayBackend) {
+  using stream_display_policy::capture_for_host_virtual_display_backend;
+  using virtual_display::backend_e;
+
+  for (const auto current : {"", "auto", "portal", "kms"}) {
+    EXPECT_EQ(capture_for_host_virtual_display_backend(backend_e::WAYLAND_WLR, current), "wlr")
+      << current;
+  }
+
+  for (const auto backend : {backend_e::EVDI, backend_e::KSCREEN_DOCTOR}) {
+    EXPECT_EQ(capture_for_host_virtual_display_backend(backend, ""), "portal");
+    EXPECT_EQ(capture_for_host_virtual_display_backend(backend, "auto"), "portal");
+    EXPECT_EQ(capture_for_host_virtual_display_backend(backend, "portal"), "portal");
+    EXPECT_EQ(capture_for_host_virtual_display_backend(backend, "wlr"), "wlr")
+      << "the existing explicit EVDI/KScreen operator override stays intact";
+  }
+
+  EXPECT_EQ(capture_for_host_virtual_display_backend(backend_e::NONE, "portal"), "portal");
+}
+
 TEST(StreamDisplayPolicyTests, ApplySelectionSyncsModeAndLegacyBooleans) {
   LinuxDisplayPolicyGuard guard;
   std::string error;
@@ -185,6 +244,12 @@ TEST(StreamDisplayPolicyTests, CommonModeCompanionStateMatchesAllRegisteredSelec
     linux_display.use_cage_compositor = expected.use_cage_compositor;
     linux_display.prefer_gpu_native_capture = expected.prefer_gpu_native_capture;
     linux_display.private_runtime = test_case.runtime;
+    config::video.capture = test_case.selection == std::string_view {"host_virtual_display"} ?
+                              stream_display_policy::capture_for_host_virtual_display_backend(
+                                virtual_display::detect_backend(),
+                                ""
+                              ) :
+                              std::string {};
     EXPECT_TRUE(stream_display_policy::selection_companion_state_matches(test_case.selection));
 
     linux_display.prefer_gpu_native_capture = !expected.prefer_gpu_native_capture;

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -347,6 +347,23 @@ TEST(StreamDisplayPolicyTests, ExplicitStreamModeWinsOverBooleans) {
   EXPECT_FALSE(resolved.use_private_runtime);
 }
 
+TEST(StreamDisplayPolicyTests, NormalizeConfigRepairsHostVirtualState) {
+  LinuxDisplayPolicyGuard guard;
+  auto &d = config::video.linux_display;
+  d.stream_mode = "host_virtual_display";
+  d.auto_manage_displays = true;
+  stream_display_policy::normalize_config_from_load();
+  EXPECT_FALSE(d.auto_manage_displays);
+
+  d.stream_mode.clear();
+  d.headless_mode = true;
+  d.use_cage_compositor = false;
+  d.auto_manage_displays = true;
+  stream_display_policy::normalize_config_from_load();
+  EXPECT_EQ(d.stream_mode, "host_virtual_display");
+  EXPECT_FALSE(d.auto_manage_displays);
+}
+
 TEST(StreamDisplayPolicyTests, NormalizeConfigDerivesStreamModeFromLegacyBooleans) {
   LinuxDisplayPolicyGuard guard;
   config::video.linux_display.stream_mode.clear();

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -181,8 +181,8 @@ TEST(StreamDisplayPolicyTests, HostVirtualCaptureFollowsTheVirtualDisplayBackend
     EXPECT_EQ(capture_for_host_virtual_display_backend(backend, ""), "portal");
     EXPECT_EQ(capture_for_host_virtual_display_backend(backend, "auto"), "portal");
     EXPECT_EQ(capture_for_host_virtual_display_backend(backend, "portal"), "portal");
-    EXPECT_EQ(capture_for_host_virtual_display_backend(backend, "wlr"), "wlr")
-      << "the existing explicit EVDI/KScreen operator override stays intact";
+    EXPECT_EQ(capture_for_host_virtual_display_backend(backend, "wlr"), "portal");
+    EXPECT_EQ(capture_for_host_virtual_display_backend(backend, "kms"), "portal");
   }
 
   EXPECT_EQ(capture_for_host_virtual_display_backend(backend_e::NONE, "portal"), "portal");

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -137,8 +137,8 @@ TEST(StreamDisplayPolicyTests, LegacyVirtualDisplayLaunchPromotesOnlyWhenTheClie
   ) << "an explicit client virtual-display choice must beat the app default";
   EXPECT_EQ(
     effective_session_selection_for_launch("", true, true, true, false),
-    ""
-  ) << "mirrorDesktop remains authoritative";
+    "desktop_display"
+  ) << "mirrorDesktop must override a host_virtual_display default for this session";
   EXPECT_EQ(
     effective_session_selection_for_launch("headless_stream", false, true, true, false),
     "headless_stream"

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -145,6 +145,16 @@ TEST(StreamDisplayPolicyTests, LegacyVirtualDisplayLaunchPromotesOnlyWhenTheClie
   ) << "an explicit accepted streamMode remains authoritative";
 }
 
+TEST(StreamDisplayPolicyTests, HostVirtualClearsStaleAutoManage) {
+  LinuxDisplayPolicyGuard guard;
+  std::string error;
+  ASSERT_TRUE(stream_display_policy::apply_selection("host_virtual_display", error)) << error;
+  config::video.linux_display.auto_manage_displays = true;
+  EXPECT_FALSE(stream_display_policy::selection_companion_state_matches("host_virtual_display"));
+  ASSERT_TRUE(stream_display_policy::apply_selection("host_virtual_display", error)) << error;
+  EXPECT_FALSE(config::video.linux_display.auto_manage_displays);
+}
+
 TEST(StreamDisplayPolicyTests, VirtualCaptureOutputNameNeverLosesTheCreatedConnector) {
   using stream_display_policy::capture_output_name_for_virtual_display;
 

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -175,6 +175,9 @@ TEST(VideoDisplaySelectionTests, ExactDisplayIdentityMustRemainPresentAcrossRein
 
   EXPECT_EQ(video::find_display_index_for_tests(displays, "POLARIS-HEADLESS-512536-0"), 0);
   EXPECT_EQ(video::find_display_index_for_tests(displays, "HDMI-A-1"), 1);
+  EXPECT_EQ(video::find_display_index_for_tests(displays, "1"), 1)
+    << "legacy numeric WLR selection must retain its index after connector-name enumeration";
+  EXPECT_EQ(video::find_display_index_for_tests(displays, "2"), std::nullopt);
   EXPECT_EQ(video::find_display_index_for_tests(displays, "missing-output"), std::nullopt);
 }
 

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -194,6 +194,8 @@ TEST(VideoDisplaySelectionTests, CaptureContextsMustShareTheWholeGeneration) {
     .requested_output_name = "POLARIS-HEADLESS-512536-0",
     .stream_mode = "host_virtual_display",
     .capture_backend = "portal",
+    .private_wayland_socket = "wayland-polaris-42",
+    .private_runtime_instance_id = "session-42",
     .adapter_name = "/dev/dri/renderD128",
     .headless_mode = true,
   };
@@ -204,6 +206,12 @@ TEST(VideoDisplaySelectionTests, CaptureContextsMustShareTheWholeGeneration) {
   EXPECT_FALSE(video::capture_generations_match_for_tests(generation, changed));
   changed = generation;
   changed.stream_mode = "desktop_display";
+  EXPECT_FALSE(video::capture_generations_match_for_tests(generation, changed));
+  changed = generation;
+  changed.private_wayland_socket = "wayland-polaris-43";
+  EXPECT_FALSE(video::capture_generations_match_for_tests(generation, changed));
+  changed = generation;
+  changed.private_runtime_instance_id = "session-43";
   EXPECT_FALSE(video::capture_generations_match_for_tests(generation, changed));
   changed = generation;
   changed.adapter_name = "/dev/dri/renderD129";

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -187,6 +187,20 @@ TEST(VideoDisplaySelectionTests, ExactOwnedCaptureRejectsDisplaySwitches) {
   EXPECT_FALSE(video::display_switch_allowed_for_exact_capture_for_tests("HDMI-A-1"));
 }
 
+TEST(VideoDisplaySelectionTests, CaptureContextsMustShareExactGenerationProvenance) {
+  EXPECT_TRUE(video::exact_display_generations_match_for_tests("", ""));
+  EXPECT_TRUE(video::exact_display_generations_match_for_tests(
+    "POLARIS-HEADLESS-512536-0",
+    "POLARIS-HEADLESS-512536-0"
+  ));
+  EXPECT_FALSE(video::exact_display_generations_match_for_tests("", "POLARIS-HEADLESS-512536-0"));
+  EXPECT_FALSE(video::exact_display_generations_match_for_tests("POLARIS-HEADLESS-512536-0", ""));
+  EXPECT_FALSE(video::exact_display_generations_match_for_tests(
+    "POLARIS-HEADLESS-512536-0",
+    "POLARIS-HEADLESS-512536-1"
+  ));
+}
+
 TEST(VideoDisplaySelectionTests, RejectsDisplaySwitchWhenDisplayListIsEmpty) {
   EXPECT_EQ(video::clamp_display_index_for_tests(1, 0), std::nullopt);
 }

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -162,6 +162,22 @@ TEST(VideoCacheTests, ResetDisplayRetryDelayBackoffCapsAtTwoHundredMilliseconds)
   EXPECT_EQ(video::reset_display_retry_delay_for_tests(3), std::chrono::milliseconds(200));
 }
 
+TEST(VideoDisplaySelectionTests, ExactNamedCaptureDoesNotAllowGenericFallback) {
+  EXPECT_TRUE(video::capture_fallback_allowed_for_tests(""));
+  EXPECT_FALSE(video::capture_fallback_allowed_for_tests("POLARIS-HEADLESS-512536-0"));
+}
+
+TEST(VideoDisplaySelectionTests, ExactDisplayIdentityMustRemainPresentAcrossReinit) {
+  const std::vector<std::string> displays {
+    "POLARIS-HEADLESS-512536-0",
+    "HDMI-A-1",
+  };
+
+  EXPECT_EQ(video::find_display_index_for_tests(displays, "POLARIS-HEADLESS-512536-0"), 0);
+  EXPECT_EQ(video::find_display_index_for_tests(displays, "HDMI-A-1"), 1);
+  EXPECT_EQ(video::find_display_index_for_tests(displays, "missing-output"), std::nullopt);
+}
+
 TEST(VideoDisplaySelectionTests, RejectsDisplaySwitchWhenDisplayListIsEmpty) {
   EXPECT_EQ(video::clamp_display_index_for_tests(1, 0), std::nullopt);
 }

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -187,18 +187,30 @@ TEST(VideoDisplaySelectionTests, ExactOwnedCaptureRejectsDisplaySwitches) {
   EXPECT_FALSE(video::display_switch_allowed_for_exact_capture_for_tests("HDMI-A-1"));
 }
 
-TEST(VideoDisplaySelectionTests, CaptureContextsMustShareExactGenerationProvenance) {
-  EXPECT_TRUE(video::exact_display_generations_match_for_tests("", ""));
-  EXPECT_TRUE(video::exact_display_generations_match_for_tests(
-    "POLARIS-HEADLESS-512536-0",
-    "POLARIS-HEADLESS-512536-0"
-  ));
-  EXPECT_FALSE(video::exact_display_generations_match_for_tests("", "POLARIS-HEADLESS-512536-0"));
-  EXPECT_FALSE(video::exact_display_generations_match_for_tests("POLARIS-HEADLESS-512536-0", ""));
-  EXPECT_FALSE(video::exact_display_generations_match_for_tests(
-    "POLARIS-HEADLESS-512536-0",
-    "POLARIS-HEADLESS-512536-1"
-  ));
+TEST(VideoDisplaySelectionTests, CaptureContextsMustShareTheWholeGeneration) {
+  capture_generation::identity_t generation {
+    .generation_id = 42,
+    .exact_display_name = "POLARIS-HEADLESS-512536-0",
+    .requested_output_name = "POLARIS-HEADLESS-512536-0",
+    .stream_mode = "host_virtual_display",
+    .capture_backend = "portal",
+    .adapter_name = "/dev/dri/renderD128",
+    .headless_mode = true,
+  };
+  EXPECT_TRUE(video::capture_generations_match_for_tests(generation, generation));
+
+  auto changed = generation;
+  changed.generation_id = 43;
+  EXPECT_FALSE(video::capture_generations_match_for_tests(generation, changed));
+  changed = generation;
+  changed.stream_mode = "desktop_display";
+  EXPECT_FALSE(video::capture_generations_match_for_tests(generation, changed));
+  changed = generation;
+  changed.adapter_name = "/dev/dri/renderD129";
+  EXPECT_FALSE(video::capture_generations_match_for_tests(generation, changed));
+  changed = generation;
+  changed.exact_display_name.clear();
+  EXPECT_FALSE(video::capture_generations_match_for_tests(generation, changed));
 }
 
 TEST(VideoDisplaySelectionTests, RejectsDisplaySwitchWhenDisplayListIsEmpty) {

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -181,6 +181,12 @@ TEST(VideoDisplaySelectionTests, ExactDisplayIdentityMustRemainPresentAcrossRein
   EXPECT_EQ(video::find_display_index_for_tests(displays, "missing-output"), std::nullopt);
 }
 
+TEST(VideoDisplaySelectionTests, ExactOwnedCaptureRejectsDisplaySwitches) {
+  EXPECT_TRUE(video::display_switch_allowed_for_exact_capture_for_tests(""));
+  EXPECT_FALSE(video::display_switch_allowed_for_exact_capture_for_tests("POLARIS-HEADLESS-512536-0"));
+  EXPECT_FALSE(video::display_switch_allowed_for_exact_capture_for_tests("HDMI-A-1"));
+}
+
 TEST(VideoDisplaySelectionTests, RejectsDisplaySwitchWhenDisplayListIsEmpty) {
   EXPECT_EQ(video::clamp_display_index_for_tests(1, 0), std::nullopt);
 }

--- a/tests/unit/test_wlgrab_capture_policy.cpp
+++ b/tests/unit/test_wlgrab_capture_policy.cpp
@@ -11,6 +11,14 @@ namespace {
   using route_e = wlgrab_capture_policy::gpu_native_capture_route_e;
 }
 
+TEST(WlgrabCapturePolicy, EnumeratedOutputsPreferStableConnectorIdentity) {
+  EXPECT_EQ(
+    wlgrab_capture_policy::enumerated_monitor_identity(0, "POLARIS-HEADLESS-512536-0"),
+    "POLARIS-HEADLESS-512536-0"
+  );
+  EXPECT_EQ(wlgrab_capture_policy::enumerated_monitor_identity(1, ""), "1");
+}
+
 TEST(WlgrabCapturePolicy, RequestedMonitorSelectionIsExactAndFailClosed) {
   const std::vector<std::string> monitors {
     "POLARIS-HEADLESS-512536-0",

--- a/tests/unit/test_wlgrab_capture_policy.cpp
+++ b/tests/unit/test_wlgrab_capture_policy.cpp
@@ -19,6 +19,46 @@ TEST(WlgrabCapturePolicy, EnumeratedOutputsPreferStableConnectorIdentity) {
   EXPECT_EQ(wlgrab_capture_policy::enumerated_monitor_identity(1, ""), "1");
 }
 
+TEST(WlgrabCapturePolicy, ImmutableGenerationWinsAfterGlobalConfigDrift) {
+  const capture_generation::identity_t generation {
+    .generation_id = 41,
+    .stream_mode = "headless_stream",
+    .capture_backend = "wlr",
+    .private_wayland_socket = "wayland-polaris-41",
+    .private_runtime_instance_id = "session-41",
+    .adapter_name = "/dev/dri/renderD128",
+    .headless_mode = true,
+    .use_cage_compositor = true,
+  };
+
+  const auto policy = wlgrab_capture_policy::resolve_generation_policy(
+    generation,
+    false,
+    "/dev/dri/renderD129"
+  );
+
+  EXPECT_TRUE(policy.owned);
+  EXPECT_TRUE(policy.use_private_compositor);
+  EXPECT_EQ(policy.adapter_name, "/dev/dri/renderD128");
+  EXPECT_EQ(policy.private_wayland_socket, "wayland-polaris-41");
+  EXPECT_EQ(policy.private_runtime_instance_id, "session-41");
+  EXPECT_TRUE(wlgrab_capture_policy::private_runtime_matches_generation(
+    policy,
+    "wayland-polaris-41",
+    "session-41"
+  ));
+  EXPECT_FALSE(wlgrab_capture_policy::private_runtime_matches_generation(
+    policy,
+    "wayland-polaris-42",
+    "session-41"
+  ));
+  EXPECT_FALSE(wlgrab_capture_policy::private_runtime_matches_generation(
+    policy,
+    "wayland-polaris-41",
+    "session-42"
+  ));
+}
+
 TEST(WlgrabCapturePolicy, RequestedMonitorSelectionIsExactAndFailClosed) {
   const std::vector<std::string> monitors {
     "POLARIS-HEADLESS-512536-0",

--- a/tests/unit/test_wlgrab_capture_policy.cpp
+++ b/tests/unit/test_wlgrab_capture_policy.cpp
@@ -11,6 +11,24 @@ namespace {
   using route_e = wlgrab_capture_policy::gpu_native_capture_route_e;
 }
 
+TEST(WlgrabCapturePolicy, RequestedMonitorSelectionIsExactAndFailClosed) {
+  const std::vector<std::string> monitors {
+    "POLARIS-HEADLESS-512536-0",
+    "HDMI-A-1",
+  };
+
+  EXPECT_EQ(wlgrab_capture_policy::select_monitor_index("", monitors), 0u);
+  EXPECT_EQ(wlgrab_capture_policy::select_monitor_index("1", monitors), 1u);
+  EXPECT_EQ(
+    wlgrab_capture_policy::select_monitor_index("POLARIS-HEADLESS-512536-0", monitors),
+    0u
+  );
+  EXPECT_EQ(wlgrab_capture_policy::select_monitor_index("HDMI-A-1", monitors), 1u);
+  EXPECT_FALSE(wlgrab_capture_policy::select_monitor_index("2", monitors).has_value());
+  EXPECT_FALSE(wlgrab_capture_policy::select_monitor_index("DP-9", monitors).has_value());
+  EXPECT_FALSE(wlgrab_capture_policy::select_monitor_index("", {}).has_value());
+}
+
 TEST(WlgrabCapturePolicy, DirectVaapiCaptureUsesRamFallback) {
   EXPECT_EQ(
     wlgrab_capture_policy::select_direct_capture_path(platf::mem_type_e::vaapi, true),


### PR DESCRIPTION
## Summary

- make bundled and narrowly matched legacy Desktop launches explicitly mirror the desktop even when paired settings prefer a virtual display
- bind portal, KWin, and wlroots capture plus reinitialization to the exact launch generation, output, private Wayland socket, and runtime instance
- make Linux virtual-display creation and teardown transactional: durable pre-mutation intent, tri-state readback, stable Hyprland absence, exact KScreen topology restoration, and fail-closed stale cleanup

## Exact scope

- base: 6738b2e60a213aceb6434c77e164bcbda48b6b2d
- head: dd8aca8a51411100da44d0dfcad79b4dfdd3d5dd

## Validation

- exact-head Linux build completed
- full configured native suite passed 18/18
- focused Desktop migration, virtual-display, capture-generation, source-safety, stream, platform, config, and video coverage passed
- independent exact-head review: CLEAN

Fixes #532