### PR TITLE
fix(gamescope): preserve distro-package recovery coherence

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fixed Gamescope session recovery on distro-package hosts by restoring their empty compositor baseline without requiring Nix-only idle/portal units, and made failed prior-session recovery retain its exact claim instead of forcing unsafe socket cleanup.
+
 This file tracks the public Polaris release line.
 
 Older historical tags remain in the repository for continuity, but the current public product line

--- a/docs/release-notes/v1.3.14.md
+++ b/docs/release-notes/v1.3.14.md
@@ -1,5 +1,7 @@
 # Polaris v1.3.14
 
+- Distro-package Gamescope sessions now return to an empty compositor baseline when the Nix-only idle and private-portal services are absent. Failed prior-session recovery remains fenced instead of deleting ownership state and launching a replacement generation.
+
 Polaris v1.3.14 is a matched Doctor-safety and stream-classification patch for Nova v1.3.9. It shows frame-pacing evidence without contradictory Stable state, adds a durable next-launch recovery profile scoped to one paired client and game, and keeps OpenAI subscription Doctor explanations deterministic without changing the ordinary Codex CLI optimizer route.
 
 Existing v1.3.13 configuration remains valid. Steam Input profile mutation remains unavailable: Doctor reports read-only evidence and manual guidance, and the recovery action changes no live stream, global setting, Steam configuration, or unrelated game profile.

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -54,6 +54,27 @@ session_mode_file="$rt/polaris-gamescope-session-mode"
 session_state_file="$rt/polaris-gamescope-session-state"
 session_operation_lock="$rt/polaris-gamescope-session-operation.lock"
 
+polaris_gamescope_service_mode() {
+  local idle_state portal_state
+  idle_state="$(systemctl --user show -p LoadState --value polaris-gamescope-idle.service 2>/dev/null || true)"
+  portal_state="$(systemctl --user show -p LoadState --value polaris-portal-gamescope.service 2>/dev/null || true)"
+  case "$idle_state:$portal_state" in
+    loaded:loaded)
+      printf 'managed\n'
+      ;;
+    not-found:not-found)
+      # Distro packages install the nested-session helper without the Nix-only
+      # idle compositor/private portal units. Their safe baseline is no
+      # gamescope generation at all, not an impossible idle-unit restoration.
+      printf 'standalone\n'
+      ;;
+    *)
+      echo "polaris-gamescope-session: inconsistent gamescope services idle=$idle_state portal=$portal_state" >&2
+      return 1
+      ;;
+  esac
+}
+
 acquire_session_operation_lock() {
   local lock_bin="${POLARIS_FLOCK_BIN:-flock}" fd_identity path_identity
   if [ "${POLARIS_SESSION_OPERATION_LOCK_HELD:-0}" = 1 ]; then
@@ -99,8 +120,9 @@ publish_nested_claim() (
 )
 
 publish_session_mode() (
-  local mode="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp
+  local mode="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp service_mode
   case "$mode" in attach|nested) ;; *) return 1 ;; esac
+  service_mode="$(polaris_gamescope_service_mode)" || return 1
   exec 9>>"$rt/polaris-gamescope.lock" || return 1
   "$lock_bin" -x 9 || return 1
   [ ! -e "$session_state_file" ] \
@@ -108,23 +130,51 @@ publish_session_mode() (
     && [ ! -e "$session_mode_file" ] || return 1
   tmp="$session_state_file.tmp.$$"
   trap 'rm -f -- "$tmp"' EXIT
-  printf '%s %s\n' "$POLARIS_SESSION_INSTANCE_ID" "$mode" >"$tmp" || return 1
+  printf '%s %s %s\n' "$POLARIS_SESSION_INSTANCE_ID" "$mode" "$service_mode" >"$tmp" || return 1
   if [ -n "${POLARIS_SESSION_STATE_BEFORE_COMMIT_HOOK:-}" ]; then
     eval "$POLARIS_SESSION_STATE_BEFORE_COMMIT_HOOK" || return 1
   fi
   mv -f -- "$tmp" "$session_state_file"
+  echo "polaris-gamescope-session: runtime services=$service_mode" >&2
+)
+
+complete_standalone_nested_handoff() (
+  local nested_claim="$1" lock_bin="${POLARIS_FLOCK_BIN:-flock}" uid marker_identity current_identity
+  exec 9>>"$rt/polaris-gamescope.lock" || return 1
+  "$lock_bin" -x 9 || return 1
+  [ -f "$nested_claim" ] && [ ! -L "$nested_claim" ] \
+    && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ] || return 1
+  # The nested owner was already drained and its endpoints were already proved
+  # absent/orphaned before this commit. A live generation must never be erased.
+  ! polaris_validate_marker "$marker" || return 1
+  polaris_reclaim_orphan_gamescope_sockets "$rt" || return 1
+  uid="$(id -u)"
+  if [ -e "$marker" ] || [ -L "$marker" ]; then
+    [ -f "$marker" ] && [ ! -L "$marker" ] \
+      && [ "$(stat -Lc '%u:%h' "$marker" 2>/dev/null)" = "$uid:1" ] || return 1
+    marker_identity="$(stat -Lc '%d:%i:%f' "$marker" 2>/dev/null)" || return 1
+    ! polaris_validate_marker "$marker" || return 1
+    current_identity="$(stat -Lc '%d:%i:%f' "$marker" 2>/dev/null)" || return 1
+    [ "$current_identity" = "$marker_identity" ] || return 1
+  fi
+  if [ -e "$rt/polaris-gamescope.env" ] || [ -L "$rt/polaris-gamescope.env" ]; then
+    [ -f "$rt/polaris-gamescope.env" ] && [ ! -L "$rt/polaris-gamescope.env" ] \
+      && [ "$(stat -Lc '%u:%h' "$rt/polaris-gamescope.env" 2>/dev/null)" = "$uid:1" ] || return 1
+  fi
+  rm -f -- "$marker" "$rt/polaris-gamescope.env" "$nested_claim"
 )
 
 recover_missing_nested_claim() (
-  local lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp persisted persisted_mode extra
+  local lock_bin="${POLARIS_FLOCK_BIN:-flock}" tmp persisted persisted_mode persisted_service_mode extra
   exec 9>>"$rt/polaris-gamescope.lock" || return 1
   "$lock_bin" -x 9 || return 1
   [ ! -e "$rt/polaris-gamescope-wsi-nested" ] || return 0
   if [ -f "$session_state_file" ]; then
-    read -r persisted persisted_mode extra <"$session_state_file" || return 1
+    read -r persisted persisted_mode persisted_service_mode extra <"$session_state_file" || return 1
     [ -z "${extra:-}" ] \
       && [ "$persisted" = "$POLARIS_SESSION_INSTANCE_ID" ] \
       && [ "$persisted_mode" = nested ] || return 1
+    case "${persisted_service_mode:-}" in ''|managed|standalone) ;; *) return 1 ;; esac
   else
     [ -s "$session_id_file" ] \
       && [ "$(tr -d '\r\n' <"$session_id_file")" = "$POLARIS_SESSION_INSTANCE_ID" ] \
@@ -153,12 +203,14 @@ remove_nested_claim() (
 )
 
 load_session_instance_id() {
-  local persisted persisted_mode extra
+  local persisted persisted_mode persisted_service_mode extra
   POLARIS_PERSISTED_SESSION_MODE=""
+  POLARIS_PERSISTED_SERVICE_MODE=""
   if [ -f "$session_state_file" ]; then
-    read -r persisted persisted_mode extra <"$session_state_file" || return 1
+    read -r persisted persisted_mode persisted_service_mode extra <"$session_state_file" || return 1
     [ -z "${extra:-}" ] || return 1
     case "$persisted_mode" in attach|nested) ;; *) return 1 ;; esac
+    case "${persisted_service_mode:-}" in ''|managed|standalone) ;; *) return 1 ;; esac
     [ -n "$persisted" ] || return 1
     if [ -n "${POLARIS_SESSION_INSTANCE_ID:-}" ]; then
       [ "$persisted" = "$POLARIS_SESSION_INSTANCE_ID" ] || return 1
@@ -166,6 +218,7 @@ load_session_instance_id() {
       export POLARIS_SESSION_INSTANCE_ID="$persisted"
     fi
     POLARIS_PERSISTED_SESSION_MODE="$persisted_mode"
+    POLARIS_PERSISTED_SERVICE_MODE="${persisted_service_mode:-}"
     return 0
   fi
   if [ -n "${POLARIS_SESSION_INSTANCE_ID:-}" ]; then
@@ -294,26 +347,8 @@ case "${1:-}" in
       echo "polaris-gamescope-session: complete prior session recovery before new launch" >&2
       # Re-exec via bash so a non-executable script path still works when $0 is the .sh file.
       if ! POLARIS_SESSION_INSTANCE_ID='' bash "$0" stop; then
-        echo "polaris-gamescope-session: stop recovery failed — forcing clean slate" >&2
-        if polaris_validate_marker "$marker" 2>/dev/null; then
-          polaris_stop_marked_gamescope "$marker" "$POLARIS_MARKER_ROLE" "$rt" 2>/dev/null || true
-        fi
-        polaris_reclaim_orphan_gamescope_sockets "$rt" 2>/dev/null || true
-        rm -f -- \
-          "$marker" \
-          "$rt/polaris-gamescope.env" \
-          "$rt/polaris-gamescope-force" \
-          "$rt/polaris-gamescope-wsi-nested" \
-          "$session_state_file" \
-          "$session_id_file" \
-          "$session_mode_file" \
-          "$rt/polaris-gamescope-appid" \
-          "$rt/polaris-gamescope-audio-sink" \
-          "$rt"/polaris-gamescope-steam-wsi*.log \
-          "$rt"/gamescope-0 "$rt"/gamescope-0.lock \
-          "$rt"/gamescope-0-ei "$rt"/gamescope-0-ei.lock \
-          "$rt"/gamescope-1 "$rt"/gamescope-1.lock \
-          "$rt"/gamescope-1-ei "$rt"/gamescope-1-ei.lock
+        echo "polaris-gamescope-session: prior session recovery failed; retaining its exact claim" >&2
+        exit 1
       fi
       POLARIS_SESSION_INSTANCE_ID="$requested_session_id"
       export POLARIS_SESSION_INSTANCE_ID
@@ -862,70 +897,87 @@ case "${1:-}" in
       # durable across every failure so a retry never repeats nested signaling.
       printf '0\n' >"$rt/polaris-gamescope-force"
       polaris_unmask_idle_unit_runtime
-      systemctl --user reset-failed polaris-gamescope-idle.service 2>/dev/null || true
-      if ! systemctl --user start polaris-gamescope-idle.service 2>/dev/null; then
-        echo "polaris-gamescope-session: failed to start idle gamescope; retaining restore-idle claim" >&2
+      current_service_mode="$(polaris_gamescope_service_mode)" || {
+        echo "polaris-gamescope-session: cannot classify post-session gamescope services; retaining restore-idle claim" >&2
+        exit 1
+      }
+      service_mode="${POLARIS_PERSISTED_SERVICE_MODE:-$current_service_mode}"
+      if [ "$service_mode" != "$current_service_mode" ]; then
+        echo "polaris-gamescope-session: gamescope service model changed from $service_mode to $current_service_mode; retaining restore-idle claim" >&2
         exit 1
       fi
-      idle_ready=0
-      for _ in $(seq 1 "${POLARIS_IDLE_WAIT_STEPS:-100}"); do
-        if polaris_validate_marker "$marker" idle \
+      if [ "$service_mode" = standalone ]; then
+        complete_standalone_nested_handoff "$nested_claim" || {
+          echo "polaris-gamescope-session: standalone cleanup could not prove an empty gamescope generation; retaining restore-idle claim" >&2
+          exit 1
+        }
+        echo "polaris-gamescope-session: standalone package runtime restored with no idle gamescope" >&2
+      else
+        systemctl --user reset-failed polaris-gamescope-idle.service 2>/dev/null || true
+        if ! systemctl --user start polaris-gamescope-idle.service 2>/dev/null; then
+          echo "polaris-gamescope-session: failed to start idle gamescope; retaining restore-idle claim" >&2
+          exit 1
+        fi
+        idle_ready=0
+        for _ in $(seq 1 "${POLARIS_IDLE_WAIT_STEPS:-100}"); do
+          if polaris_validate_marker "$marker" idle \
+              && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
+              && polaris_write_runtime_env "$marker" gamescope-0 idle "$rt" 2>/dev/null; then
+            idle_ready=1
+            break
+          fi
+          sleep 0.1
+        done
+        if [ "$idle_ready" != 1 ]; then
+          echo "polaris-gamescope-session: idle gamescope-0 not ready; retaining restore-idle claim" >&2
+          exit 1
+        fi
+        exec 8>>"$rt/polaris-gamescope.lock" || exit 1
+        "${POLARIS_FLOCK_BIN:-flock}" -x 8 || exit 1
+        export POLARIS_GAMESCOPE_LOCK_HELD=1
+        if ! {
+          [ -f "$nested_claim" ] \
+            && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ] \
+            && polaris_validate_marker "$marker" idle \
             && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
-            && polaris_write_runtime_env "$marker" gamescope-0 idle "$rt" 2>/dev/null; then
-          idle_ready=1
-          break
+            && polaris_write_runtime_env "$marker" gamescope-0 idle "$rt"
+        }; then
+          echo "polaris-gamescope-session: idle ownership changed before portal handoff" >&2
+          exit 1
         fi
-        sleep 0.1
-      done
-      if [ "$idle_ready" != 1 ]; then
-        echo "polaris-gamescope-session: idle gamescope-0 not ready; retaining restore-idle claim" >&2
-        exit 1
-      fi
-      exec 8>>"$rt/polaris-gamescope.lock" || exit 1
-      "${POLARIS_FLOCK_BIN:-flock}" -x 8 || exit 1
-      export POLARIS_GAMESCOPE_LOCK_HELD=1
-      if ! {
-        [ -f "$nested_claim" ] \
-          && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ] \
-          && polaris_validate_marker "$marker" idle \
-          && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
-          && polaris_write_runtime_env "$marker" gamescope-0 idle "$rt"
-      }; then
-        echo "polaris-gamescope-session: idle ownership changed before portal handoff" >&2
-        exit 1
-      fi
-      echo "polaris-gamescope-session: idle gamescope restored after nested stop" >&2
+        echo "polaris-gamescope-session: idle gamescope restored after nested stop" >&2
 
-      if ! systemctl --user restart polaris-portal-gamescope.service 2>/dev/null; then
-        echo "polaris-gamescope-session: portal restart failed; retaining restore-idle claim" >&2
-        exit 1
-      fi
-      portal_bus="unix:path=$rt/polaris-portal/bus"
-      portal_ready=0
-      for _ in $(seq 1 "${POLARIS_PORTAL_WAIT_STEPS:-50}"); do
-        if busctl --address="$portal_bus" --no-pager \
-            status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1; then
-          portal_ready=1
-          break
+        if ! systemctl --user restart polaris-portal-gamescope.service 2>/dev/null; then
+          echo "polaris-gamescope-session: portal restart failed; retaining restore-idle claim" >&2
+          exit 1
         fi
-        sleep 0.1
-      done
-      if [ "$portal_ready" != 1 ]; then
-        echo "polaris-gamescope-session: portal did not bind idle generation; retaining restore-idle claim" >&2
-        exit 1
+        portal_bus="unix:path=$rt/polaris-portal/bus"
+        portal_ready=0
+        for _ in $(seq 1 "${POLARIS_PORTAL_WAIT_STEPS:-50}"); do
+          if busctl --address="$portal_bus" --no-pager \
+              status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1; then
+            portal_ready=1
+            break
+          fi
+          sleep 0.1
+        done
+        if [ "$portal_ready" != 1 ]; then
+          echo "polaris-gamescope-session: portal did not bind idle generation; retaining restore-idle claim" >&2
+          exit 1
+        fi
+        if ! {
+          polaris_validate_marker "$marker" idle \
+            && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
+            && [ -f "$nested_claim" ] \
+            && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ]
+        }; then
+          echo "polaris-gamescope-session: ownership changed during portal readiness" >&2
+          exit 1
+        fi
+        rm -f -- "$nested_claim"
+        "${POLARIS_FLOCK_BIN:-flock}" -u 8
+        export POLARIS_GAMESCOPE_LOCK_HELD=0
       fi
-      if ! {
-        polaris_validate_marker "$marker" idle \
-          && polaris_marker_owns_socket "$marker" "$rt/gamescope-0" idle \
-          && [ -f "$nested_claim" ] \
-          && [ "$(tr -d '[:space:]' <"$nested_claim")" = restore-idle ]
-      }; then
-        echo "polaris-gamescope-session: ownership changed during portal readiness" >&2
-        exit 1
-      fi
-      rm -f -- "$nested_claim"
-      "${POLARIS_FLOCK_BIN:-flock}" -u 8
-      export POLARIS_GAMESCOPE_LOCK_HELD=0
     else
       [ "$session_mode" = attach ] || {
         echo "polaris-gamescope-session: nested mode lost its recovery claim; retaining credential" >&2

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -128,9 +128,18 @@ namespace stream_runtime {
         std::ifstream state(state_path);
         std::string session_id;
         std::string mode;
+        std::string service_mode;
         std::string extra;
-        if (!(state >> session_id >> mode) || (state >> extra) || session_id.empty()) {
+        if (!(state >> session_id >> mode) || session_id.empty()) {
           return false;
+        }
+        if (state >> service_mode) {
+          if (service_mode != "managed" && service_mode != "standalone") {
+            return false;
+          }
+          if (state >> extra) {
+            return false;
+          }
         }
         return mode == "attach";
       }

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  if [ -n "${actions:-}" ] && [ -f "$actions" ]; then
+    sed 's/^/  action: /' "$actions" >&2
+  fi
+  exit 1
+}
 work="$(mktemp -d "${TMPDIR:-/tmp}/polaris-gamescope-session-stop.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/bin" "$work/run" "$work/proc"
@@ -45,6 +51,8 @@ cat >"$work/bin/systemctl" <<'EOF'
 #!/usr/bin/env bash
 printf 'systemctl %s\n' "$*" >>"$POLARIS_ACTIONS"
 case "$*" in
+  *'show -p LoadState --value polaris-gamescope-idle.service'*) printf '%s\n' "${IDLE_LOAD_STATE:-loaded}" ;;
+  *'show -p LoadState --value polaris-portal-gamescope.service'*) printf '%s\n' "${PORTAL_LOAD_STATE:-loaded}" ;;
   *'start polaris-gamescope-idle.service'*) [ "${IDLE_START_OK:-1}" = 1 ] ;;
   *'restart polaris-portal-gamescope.service'*) [ "${PORTAL_RESTART_OK:-1}" = 1 ] ;;
   *) exit 0 ;;
@@ -92,6 +100,8 @@ run_stop() {
     IDLE_OWNS_SOCKET="${IDLE_OWNS_SOCKET:-0}" WRITE_ENV_OK="${WRITE_ENV_OK:-0}" \
     IDLE_START_OK="${IDLE_START_OK:-1}" PORTAL_RESTART_OK="${PORTAL_RESTART_OK:-1}" \
     PORTAL_READY="${PORTAL_READY:-1}" \
+    IDLE_LOAD_STATE="${IDLE_LOAD_STATE:-loaded}" \
+    PORTAL_LOAD_STATE="${PORTAL_LOAD_STATE:-loaded}" \
     bash "$script" stop
 }
 reset_state() {
@@ -154,6 +164,79 @@ NESTED_VALID=0 STOP_OK=0 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
 ! grep -qx 'stop-nested' "$actions" || fail "restore-idle retry repeated nested stop"
 grep -qx 'write-idle-env' "$actions" || fail "idle runtime environment was not committed"
 grep -q 'restart polaris-portal-gamescope.service' "$actions" || fail "portal was not rebound"
+
+# Distro packages intentionally lack the Nix-only idle and private-portal
+# units. Once the exact nested owner is gone and sockets are reclaimable, stop
+# must remove only its durable state and return to an empty compositor baseline.
+reset_state
+printf 'session-A nested standalone\n' >"$work/run/polaris-gamescope-session-state"
+rm -f "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode"
+printf '1929404 30063385 nested /usr/bin/gamescope\n' >"$work/run/polaris-gamescope.pid"
+printf 'DISPLAY=:1\n' >"$work/run/polaris-gamescope.env"
+IDLE_LOAD_STATE=not-found PORTAL_LOAD_STATE=not-found \
+  POLARIS_SESSION_INSTANCE_ID= NESTED_VALID=0 RECLAIM_OK=1 run_stop >/dev/null 2>&1 ||
+  fail "standalone package cleanup failed"
+[ ! -e "$work/run/polaris-gamescope-wsi-nested" ] || fail "standalone cleanup retained claim"
+[ ! -e "$work/run/polaris-gamescope-session-state" ] || fail "standalone cleanup retained session state"
+[ ! -e "$work/run/polaris-gamescope.pid" ] || fail "standalone cleanup retained dead marker"
+[ ! -e "$work/run/polaris-gamescope.env" ] || fail "standalone cleanup retained runtime env"
+grep -qx 'unmask-idle' "$actions" || fail "standalone cleanup retained runtime mask"
+! grep -Eq 'start polaris-gamescope-idle|restart polaris-portal|busctl' "$actions" ||
+  fail "standalone cleanup tried to start absent Nix services"
+
+# If the installed service model changes during a launch, do not reinterpret
+# that generation. Keep its exact recovery claim for operator remediation.
+reset_state
+printf 'session-A nested standalone\n' >"$work/run/polaris-gamescope-session-state"
+rm -f "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode"
+if POLARIS_SESSION_INSTANCE_ID= IDLE_LOAD_STATE=loaded PORTAL_LOAD_STATE=loaded \
+    NESTED_VALID=0 RECLAIM_OK=1 run_stop >/dev/null 2>&1; then
+  fail "changed gamescope service model returned success"
+fi
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-wsi-nested")" = restore-idle ] ||
+  fail "changed gamescope service model cleared recovery claim"
+
+# A crash after the standalone cleanup commit but before the outer credential
+# removal leaves only the atomic state record. Retry must reconstruct the claim
+# and finish without inventing a managed idle generation.
+reset_state
+rm -f "$work/run/polaris-gamescope-wsi-nested" "$work/run/polaris-gamescope.pid"
+printf 'session-A nested standalone\n' >"$work/run/polaris-gamescope-session-state"
+rm -f "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode"
+POLARIS_SESSION_INSTANCE_ID= IDLE_LOAD_STATE=not-found PORTAL_LOAD_STATE=not-found \
+  NESTED_VALID=0 RECLAIM_OK=1 run_stop >/dev/null 2>&1 ||
+  fail "standalone post-commit retry failed"
+[ ! -e "$work/run/polaris-gamescope-session-state" ] ||
+  fail "standalone post-commit retry retained session state"
+[ ! -e "$work/run/polaris-gamescope-wsi-nested" ] ||
+  fail "standalone post-commit retry retained reconstructed claim"
+
+# Standalone cleanup never follows or unlinks an untrusted marker symlink.
+reset_state
+foreign_marker="$work/foreign-marker"
+printf 'foreign\n' >"$foreign_marker"
+rm -f "$work/run/polaris-gamescope.pid"
+ln -s "$foreign_marker" "$work/run/polaris-gamescope.pid"
+printf 'session-A nested standalone\n' >"$work/run/polaris-gamescope-session-state"
+rm -f "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode"
+if POLARIS_SESSION_INSTANCE_ID= IDLE_LOAD_STATE=not-found PORTAL_LOAD_STATE=not-found \
+    NESTED_VALID=0 RECLAIM_OK=1 run_stop >/dev/null 2>&1; then
+  fail "standalone cleanup accepted a marker symlink"
+fi
+[ "$(<"$foreign_marker")" = foreign ] || fail "standalone cleanup changed symlink target"
+[ -L "$work/run/polaris-gamescope.pid" ] || fail "standalone cleanup removed marker symlink"
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-wsi-nested")" = restore-idle ] ||
+  fail "standalone symlink rejection cleared recovery claim"
+
+# A partial unit deployment is neither a managed Nix runtime nor a standalone
+# package runtime. Keep the recovery claim instead of guessing a baseline.
+reset_state
+if IDLE_LOAD_STATE=loaded PORTAL_LOAD_STATE=not-found \
+    NESTED_VALID=0 RECLAIM_OK=1 run_stop >/dev/null 2>&1; then
+  fail "partial gamescope service deployment returned success"
+fi
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-wsi-nested")" = restore-idle ] ||
+  fail "partial service deployment cleared recovery claim"
 
 # Enumeration and procfs failures are unknown ownership, never "no Steam".
 reset_state
@@ -345,8 +428,12 @@ grep -Fq 'run_without_session_operation_lock setsid env' "$script" ||
 grep -Fq 'run_without_session_operation_lock setsid -f env' "$script" ||
   fail "attach Steam launch does not drop the operation lock"
 (
+  export PATH="$work/bin:$PATH"
   export XDG_RUNTIME_DIR="$work/run"
   export POLARIS_GAMESCOPE_RUNTIME_LIB="$work/runtime-stub.sh"
+  export POLARIS_ACTIONS="$actions"
+  export IDLE_LOAD_STATE=loaded
+  export PORTAL_LOAD_STATE=loaded
   export POLARIS_SESSION_INSTANCE_ID=session-B
   rm -f "$work/run/polaris-gamescope-session-state" \
     "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode"
@@ -360,10 +447,32 @@ grep -Fq 'run_without_session_operation_lock setsid -f env' "$script" ||
     fail "interrupted publication retained a temporary credential"
   fi
   publish_session_mode nested || fail "atomic session publication retry failed"
-  [ "$(<"$session_state_file")" = 'session-B nested' ] ||
+  [ "$(<"$session_state_file")" = 'session-B nested managed' ] ||
     fail "atomic session record did not contain exact ID and mode"
 )
 rm -f "$work/run/polaris-gamescope-session-state"
+
+# Failed startup recovery is fail-closed. It may not erase the prior claim,
+# marker, socket paths, or credential and continue with a replacement launch.
+reset_state
+printf 'session-old nested\n' >"$work/run/polaris-gamescope-session-state"
+printf 'sentinel\n' >"$work/run/gamescope-0"
+before_state="$(sha256sum "$work/run/polaris-gamescope-session-state" | cut -d' ' -f1)"
+before_claim="$(sha256sum "$work/run/polaris-gamescope-wsi-nested" | cut -d' ' -f1)"
+if env PATH="$work/bin:$PATH" XDG_RUNTIME_DIR="$work/run" \
+    POLARIS_GAMESCOPE_RUNTIME_LIB="$work/runtime-stub.sh" POLARIS_PROC_ROOT="$work/proc" \
+    POLARIS_ACTIONS="$actions" POLARIS_SESSION_INSTANCE_ID=session-new \
+    POLARIS_PGREP_STATUS=0 POLARIS_PGREP_OUTPUT= NESTED_VALID=0 RECLAIM_OK=0 \
+    IDLE_LOAD_STATE=loaded PORTAL_LOAD_STATE=loaded \
+    bash "$script" start 870780 >/dev/null 2>&1; then
+  fail "startup continued after failed prior recovery"
+fi
+[ "$(sha256sum "$work/run/polaris-gamescope-session-state" | cut -d' ' -f1)" = "$before_state" ] ||
+  fail "failed startup recovery rewrote prior credential"
+[ "$(sha256sum "$work/run/polaris-gamescope-wsi-nested" | cut -d' ' -f1)" = "$before_claim" ] ||
+  fail "failed startup recovery rewrote prior claim"
+[ "$(<"$work/run/gamescope-0")" = sentinel ] || fail "failed startup recovery removed socket path"
+! grep -q 'mask' "$actions" || fail "failed startup recovery reached replacement launch"
 
 # A crash after nested mode publication but before transition publication is
 # recoverable only while exact idle ownership proves destruction never began.
@@ -387,8 +496,8 @@ fi
 
 grep -Fq 'if [ -e "$session_state_file" ] || [ -s "$session_id_file" ] || [ -f "$rt/polaris-gamescope-wsi-nested" ]; then' "$script" ||
   fail "start does not recover every atomic or legacy credential before replacement"
-grep -Fq 'stop recovery failed — forcing clean slate' "$script" ||
-  fail "start does not fail-open when prior stop recovery fails"
+grep -Fq 'prior session recovery failed; retaining its exact claim' "$script" ||
+  fail "start does not fail closed when prior stop recovery fails"
 grep -Fq "POLARIS_SESSION_INSTANCE_ID='' bash \"\$0\" stop" "$script" ||
   fail "start does not route persisted attach/nested recovery through credentialed stop"
 transition_line="$(grep -nF 'publish_nested_claim transition absent' "$script" | head -n1 | cut -d: -f1)"
@@ -402,7 +511,7 @@ grep -Fq 'publish_nested_claim nested nested' "$script" ||
 if grep -Eq '^[[:space:]]*publish_nested_claim[[:space:]]*$' "$script"; then
   fail "nested claim helper was called without CAS arguments"
 fi
-grep -Fq "printf '%s %s\\n' \"\$POLARIS_SESSION_INSTANCE_ID\" \"\$mode\" >\"\$tmp\"" "$script" ||
+grep -Fq "printf '%s %s %s\\n' \"\$POLARIS_SESSION_INSTANCE_ID\" \"\$mode\" \"\$service_mode\" >\"\$tmp\"" "$script" ||
   fail "session ID and mode are not assembled into one atomic record"
 grep -Fq 'mv -f -- "$tmp" "$session_state_file"' "$script" ||
   fail "atomic session record is not committed by one rename"

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -392,8 +392,12 @@ TEST(SessionStopContractTests, StartupRecoveryUsesCredentialedStopAndPortalRebin
   EXPECT_NE(session.find("publish_nested_claim transition absent"), std::string::npos);
   EXPECT_NE(session.find("polaris-gamescope-session-mode"), std::string::npos);
   EXPECT_NE(session.find("polaris-gamescope-session-state"), std::string::npos);
-  EXPECT_NE(session.find("printf '%s %s\\n' \"$POLARIS_SESSION_INSTANCE_ID\" \"$mode\""), std::string::npos);
+  EXPECT_NE(session.find("printf '%s %s %s\\n' \"$POLARIS_SESSION_INSTANCE_ID\" \"$mode\" \"$service_mode\""), std::string::npos);
   EXPECT_NE(session.find("mv -f -- \"$tmp\" \"$session_state_file\""), std::string::npos);
+  EXPECT_NE(session.find("runtime services=$service_mode"), std::string::npos);
+  EXPECT_NE(session.find("standalone package runtime restored with no idle gamescope"), std::string::npos);
+  EXPECT_NE(session.find("prior session recovery failed; retaining its exact claim"), std::string::npos);
+  EXPECT_EQ(session.find("forcing clean slate"), std::string::npos);
   EXPECT_NE(session.find("attach recovery could not terminate exact-session Steam"), std::string::npos);
   const auto idle = read_source_for_contract("scripts/install/lib/polaris-gamescope-idle.sh");
   ASSERT_FALSE(idle.empty());
@@ -591,6 +595,21 @@ TEST(SessionStopContractTests, RuntimeAcquisitionRejectsNestedOrIncompleteDurabl
     state << "session-A attach\n";
   }
   EXPECT_TRUE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  {
+    std::ofstream state(dir / "polaris-gamescope-session-state", std::ios::trunc);
+    state << "session-A attach standalone\n";
+  }
+  EXPECT_TRUE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  {
+    std::ofstream state(dir / "polaris-gamescope-session-state", std::ios::trunc);
+    state << "session-A attach managed\n";
+  }
+  EXPECT_TRUE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  {
+    std::ofstream state(dir / "polaris-gamescope-session-state", std::ios::trunc);
+    state << "session-A attach unknown\n";
+  }
+  EXPECT_FALSE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
   {
     std::ofstream claim(dir / "polaris-gamescope-wsi-nested");
     claim << "transition\n";


### PR DESCRIPTION
## Summary

- restore the package-installed Gamescope session to its empty baseline without assuming Nix-only idle or portal units exist
- retain the exact prior-generation claim when recovery fails, so a replacement launch cannot erase ownership evidence or reclaim sockets unsafely
- keep the helper and runtime recovery contract aligned for Polaris v1.3.14

## Exact scope

- base: 6738b2e60a213aceb6434c77e164bcbda48b6b2d
- head: 411e08181bb6179535e9c20a14e3f26b297488b6

## Validation

- Linux BUILD_TESTS and BUILD_FULL_TESTS configurations compiled
- native configured CTest suite passed 3/3
- focused Gamescope session-stop shell coverage passed
- independent exact-head review: CLEAN

This PR is intentionally separate from the issue #532 virtual-display/capture ownership remediation.
