### PR TITLE
docs: fix release-note install guide links

### DIFF
--- a/docs/release-notes/v1.3.10.md
+++ b/docs/release-notes/v1.3.10.md
@@ -37,7 +37,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 needs a pacman keyring bootstrap and a read-only restoration trap, and its install command changed in this release; follow the [SteamOS guide](../steamos.md) rather than the Arch command above. SteamOS remains an experimental Desktop Mode package rather than certified Game Mode support.
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 needs a pacman keyring bootstrap and a read-only restoration trap, and its install command changed in this release; follow the [SteamOS guide](https://papi-ux.com/docs/steamos/) rather than the Arch command above. SteamOS remains an experimental Desktop Mode package rather than certified Game Mode support.
 
 ## Changes
 

--- a/docs/release-notes/v1.3.11.md
+++ b/docs/release-notes/v1.3.11.md
@@ -31,7 +31,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 users should follow the [SteamOS guide](../steamos.md), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
 
 ## Changes
 

--- a/docs/release-notes/v1.3.12.md
+++ b/docs/release-notes/v1.3.12.md
@@ -33,7 +33,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 users should follow the [SteamOS guide](../steamos.md), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
 
 ## Changes
 

--- a/docs/release-notes/v1.3.13.md
+++ b/docs/release-notes/v1.3.13.md
@@ -31,7 +31,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 users should follow the [SteamOS guide](../steamos.md), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
 
 ## Changes
 

--- a/docs/release-notes/v1.3.14.md
+++ b/docs/release-notes/v1.3.14.md
@@ -55,7 +55,7 @@ trap - EXIT
 systemctl --user enable --now polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
 
 ## Changes
 

--- a/docs/release-notes/v1.3.5.md
+++ b/docs/release-notes/v1.3.5.md
@@ -47,7 +47,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 already uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md).
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 already uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](https://papi-ux.com/docs/steamos/).
 
 ## Changes
 

--- a/docs/release-notes/v1.3.6.md
+++ b/docs/release-notes/v1.3.6.md
@@ -6,7 +6,7 @@ Polaris v1.3.6 makes the Nova client work against a Polaris host in places it ne
 
 Nothing extra is required beyond the usual upgrade. Two notes are worth reading.
 
-**If you use seat isolation on Bazzite or another ostree host**, the command v1.3.5 told you to run does not work there, and Polaris now prints the one that does. See [controller and input group](../bazzite.md#controller-and-input-group).
+**If you use seat isolation on Bazzite or another ostree host**, the command v1.3.5 told you to run does not work there, and Polaris now prints the one that does. See [controller and input group](https://papi-ux.com/docs/bazzite/#controller-and-input-group).
 
 **If you ran `--setup-host` on any version before v1.3.5**, a copy of the udev rules may still sit in `/etc` and override the packaged ones. Host setup keeps it and warns rather than deleting something it cannot prove is disposable. The check and removal are in [troubleshooting](../troubleshooting.md).
 

--- a/docs/release-notes/v1.3.6.md
+++ b/docs/release-notes/v1.3.6.md
@@ -37,7 +37,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 already uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md).
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 already uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](https://papi-ux.com/docs/steamos/).
 
 ## Changes
 

--- a/docs/release-notes/v1.3.7.md
+++ b/docs/release-notes/v1.3.7.md
@@ -35,7 +35,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 already uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md).
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 already uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](https://papi-ux.com/docs/steamos/).
 
 ## Changes
 

--- a/docs/release-notes/v1.3.8.md
+++ b/docs/release-notes/v1.3.8.md
@@ -35,7 +35,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md). SteamOS remains an experimental Desktop Mode package rather than certified Game Mode support.
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](https://papi-ux.com/docs/steamos/). SteamOS remains an experimental Desktop Mode package rather than certified Game Mode support.
 
 ## Changes
 

--- a/docs/release-notes/v1.3.9.md
+++ b/docs/release-notes/v1.3.9.md
@@ -35,7 +35,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](../bazzite.md). SteamOS 3.8 uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](../steamos.md). SteamOS remains an experimental Desktop Mode package rather than certified Game Mode support.
+Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 uses an exact output target and a read-only restoration trap; follow the [SteamOS guide](https://papi-ux.com/docs/steamos/). SteamOS remains an experimental Desktop Mode package rather than certified Game Mode support.
 
 ## Changes
 

--- a/src_assets/common/assets/web/release-v1314-contract.test.js
+++ b/src_assets/common/assets/web/release-v1314-contract.test.js
@@ -103,7 +103,7 @@ describe('v1.3.14 release contract', () => {
       .map((name) => read(`docs/release-notes/${name}`))
       .join('\n')
 
-    expect(releaseNotes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md\)/)
+    expect(releaseNotes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
     expect(releaseNotes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
     expect(releaseNotes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
   })

--- a/src_assets/common/assets/web/release-v1314-contract.test.js
+++ b/src_assets/common/assets/web/release-v1314-contract.test.js
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
@@ -94,6 +94,18 @@ describe('v1.3.14 release contract', () => {
     const notes = read('docs/release-notes/v1.3.14.md')
     const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
     expect(listed.sort()).toEqual(expectedAssets)
+  })
+
+  it('publishes release-note guide links that work outside the source tree', () => {
+    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
+    const releaseNotes = readdirSync(releaseNotesDir)
+      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
+      .map((name) => read(`docs/release-notes/${name}`))
+      .join('\n')
+
+    expect(releaseNotes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md\)/)
+    expect(releaseNotes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
+    expect(releaseNotes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
   })
 
   it('keeps publication bound to one verified immutable source', () => {


### PR DESCRIPTION
## Summary

- replace release-note-relative Bazzite and SteamOS guide links that resolve to GitHub `/releases/*.md` 404s with canonical `https://papi-ux.com/docs/.../` URLs
- restore the explicit SteamOS guide link in the v1.3.14 notes
- add a release-contract regression covering every versioned release-note source

## Verification

- `npx vitest run src_assets/common/assets/web/release-v1314-contract.test.js src_assets/common/assets/web/release-v1313-contract.test.js src_assets/common/assets/web/packaging-contracts.test.js` (32 passed)
- `bash scripts/check-public-docs.sh`
- `git diff --check`
- canonical Bazzite and SteamOS public guide URLs return HTTP 200

## Boundary

This source fix does not itself edit already-published GitHub release bodies. Any bounded historical release-metadata correction remains a separate explicit action.