### PR TITLE
docs: add launch modes and capture paths user guide

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,13 +35,8 @@ These are the settings behind the recommended Headless Stream mode on a Linux ho
 
 ## Linux display modes
 
-Headless Stream starts apps inside Polaris' private labwc compositor. It is intentionally isolated
-from your normal KDE, GNOME, or wlroots desktop, so the built-in Desktop entry can be empty if no
-desktop shell or app is launched inside that runtime — right-clicking that empty screen opens the
-generated session menu, which says exactly this.
-
-Use Desktop Display mode when you want to stream the visible host desktop session. Use Headless
-Stream when you want a stream-only runtime that leaves the host desktop layout alone.
+This is the config-file summary. For choosing a mode, what each one feels like in practice, and
+AMD/NVIDIA guidance, see [Launch modes and capture paths](launch-modes.md).
 
 | I want | Set `linux_stream_mode` to |
 | --- | --- |
@@ -60,7 +55,7 @@ Two client-facing notes: Moonlight-protocol clients can request the mirror for a
 | `headless_mode` | `enabled` | Request a stream-only session instead of the visible desktop |
 | `linux_use_cage_compositor` | `enabled` | Enable Polaris' private stream runtime |
 | `linux_prefer_gpu_native_capture` | `enabled` | Prefer DMA-BUF/GPU-resident capture on NVIDIA and AMD-capable stacks; Polaris reports SHM/system-memory fallback truthfully when the compositor or driver cannot provide it |
-| `linux_stream_mode` | `headless_stream` | Stream path id for Linux sessions: `headless_stream`, `windowed_stream`, `gamescope_stream`, `host_virtual_display`, `desktop_display`, or `headless_dongle`. Empty derives the path from the legacy booleans above. See [stream paths](stream-paths.md) |
+| `linux_stream_mode` | `headless_stream` | Stream path id for Linux sessions: `headless_stream`, `windowed_stream`, `gamescope_stream`, `host_virtual_display`, `desktop_display`, or `headless_dongle`. Empty derives the path from the legacy booleans above. See [Launch modes and capture paths](launch-modes.md) for choosing, [stream paths](stream-paths.md) for the contract |
 | `linux_private_runtime` | `labwc` | Private compositor used by paths that host the session themselves: `labwc` or `gamescope`. Ignored on host paths |
 | `headless_swap_mode` | `privacy` | Headless Dongle path only: `privacy` makes the dongle primary and blanks the panel, `off` extends onto the dongle and leaves the panel primary |
 | `trusted_subnets` | CIDR list | Enable Trusted Pair on known local networks |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -11,7 +11,7 @@ hosts, HDR, and the optional AI features. If your question is about a specific f
 No. NVIDIA and NVENC are the most heavily tested path today, but AMD and Intel Mesa VAAPI and
 software encode are supported. GPU-native DMA-BUF capture is an optimization request on both NVIDIA
 and AMD-capable stacks, and Polaris reports the actual path when a host falls back to SHM or system
-memory.
+memory. [Launch modes and capture paths](launch-modes.md) has per-vendor recommendations.
 
 ### Can Polaris stream 10-bit to an SDR handheld screen?
 

--- a/docs/launch-modes.md
+++ b/docs/launch-modes.md
@@ -1,0 +1,124 @@
+# Launch modes and capture paths
+
+Which launch mode to pick for your GPU and setup, what each mode feels like in practice, and how to check what your stream is actually using.
+
+Every card under **Configuration → Audio/Video → Launch mode and capture path** answers three questions at once: where your game runs, how Polaris grabs the frames, and whether your monitors get touched. You do not need to configure those pieces separately. Pick the card that matches your setup and Polaris wires the rest.
+
+## Which mode should I use?
+
+| Your setup | Start with |
+|---|---|
+| NVIDIA gaming PC | Private Stream (GPU-native) |
+| AMD gaming PC | Private Stream |
+| Intel GPU | Private Stream |
+| Streaming mostly to a handheld | Private Stream |
+| Steam-first host, Deck-style sessions | Gamescope Stream |
+| Two GPUs in the host | Private Stream, then see [the multi-GPU note](#if-you-have-an-amd-card) |
+| Dedicated streaming PC with a dummy plug | Headless Dongle |
+| "I want my actual desktop on the stream" | Mirror Desktop |
+| An extra screen sized to the client | Host Virtual Display |
+| Several family members at once | Not available yet, see [Family Mode](#family-mode-isolated) |
+
+> [!TIP]
+> When in doubt, pick **Private Stream**. Switching is one click in the web UI and fully reversible, and Polaris always [shows you what it actually started](#check-what-your-stream-is-using), so experimenting is cheap.
+
+## The modes
+
+### Private Stream
+
+Your game runs in its own invisible session. Your desktop never flickers, resizes, or shows the game, and nothing you do on the desktop leaks into the stream.
+
+- **Best for:** most setups, and the preferred path when you stream to a handheld.
+- **One caveat:** the built-in Desktop entry looks like an empty screen until you launch something into it. That is normal, not broken. Right-click the empty screen to open the session menu, or use Mirror Desktop if you actually wanted your desktop.
+
+### Private Stream (GPU-native)
+
+The same private session, tuned so frames can stay on the GPU the whole way from game to encoder, which is the fastest capture Polaris has. To keep that path, the private session may run as a window under your host desktop instead of fully hidden.
+
+- **Best for:** NVIDIA cards. This is the recommended NVIDIA mode.
+- **One caveat:** in its windowed form it needs a desktop session running on the host, so it is not a fit for a machine that sits at the login screen unattended.
+
+### Gamescope Stream
+
+Gamescope is the small compositor Valve built for the Steam Deck's Game Mode: it runs one game at a time, fullscreen, in a session it fully owns, and handles scaling and frame pacing itself. This mode runs your games under Gamescope and streams that session, either by joining a Gamescope that is already idle on the host or by starting its own.
+
+- **Best for:** Steam-first hosts and games that behave best inside Game Mode.
+- **One caveat:** it needs `gamescope` installed on the host. The card is greyed out until it is. Some packages install a helper for this; see [Building Polaris](building.md).
+
+### Family Mode (isolated)
+
+Not selectable yet. The card is visible so the option has a home in the UI, but the per-person isolated sessions it describes are reserved for community work that has not landed ([PR #226](https://github.com/papi-ux/polaris/pull/226)). No dates promised. The closest thing today is Private Stream, which isolates the stream from the desktop but not one family member from another.
+
+### Host Virtual Display
+
+Adds an extra screen to your real desktop, sized to match the client, and streams that screen. Your desktop stays usable on the physical monitors while the stream gets its own space.
+
+- **Best for:** using the stream like a second monitor for your normal desktop session.
+- **One caveat:** adding and removing a display can make your desktop icons and windows rearrange, exactly as plugging in a real monitor can.
+
+### Headless EVDI
+
+Not selectable yet. Reserved for the same community work as Family Mode ([PR #226](https://github.com/papi-ux/polaris/pull/226)).
+
+### Headless Dongle
+
+For hosts with a dummy plug (an HDMI or DisplayPort dongle): the desktop moves onto the dongle and the real panel goes dark, so someone in the room sees a black screen while you stream.
+
+- **Best for:** a dedicated streaming PC in a shared room, where privacy matters.
+- **One caveat:** it needs the dongle plugged in and both a streaming output and a primary output configured. Clients also cannot switch a Headless Dongle host into another mode for a single launch, because the layout is physical.
+
+### Mirror Desktop
+
+Streams the desktop you see, like a remote desktop tool. Whatever is on screen is on the stream.
+
+- **Best for:** non-gaming use, quick checks, and "I just want my computer from the couch".
+- **One caveat:** zero isolation. Notifications, chats, and everything else on your desktop are visible to the client. This is also the mode Polaris falls back to when it does not recognize the configured mode.
+
+Setting modes from the config file instead of the web UI? The key and value names live in [Configuration](configuration.md#linux-display-modes).
+
+## If you have an NVIDIA card
+
+Pick **Private Stream (GPU-native)**. NVIDIA with NVENC is the most heavily tested Polaris path, and it supports the fast capture route where frames never leave the GPU.
+
+Use the official packages when you can. If you build from source, build with CUDA enabled; without it, capture takes a slower copy through system memory, and the log says so ([Troubleshooting](troubleshooting.md#nvidia-kms-capture-issues) shows the exact line).
+
+> [!WARNING]
+> Plain **Private Stream** with GPU-native capture off can refuse the very first launch on a fresh NVIDIA setup with a 503 error, even though the GPU is healthy. If that happens, switch to Private Stream (GPU-native), restart Polaris, and retry. [Troubleshooting](troubleshooting.md#headless-session-does-not-start-cleanly) explains why.
+
+## If you have an AMD card
+
+Pick **Private Stream** and expect it to just work. AMD hosts encode with VA-API through the Mesa drivers your distro already ships, so there is usually nothing to install.
+
+One thing to know, stated plainly: Polaris deliberately uses a slower-but-stable capture path on AMD, because the faster GPU-native path has crashed real machines and stays off until it is proven safe per driver generation. Seeing **SHM** as the capture path on an AMD host is the intended, healthy state, not a misconfiguration. At 4K and high refresh rates this safe path can become the frame rate limit; at 1080p and 1440p it usually is not.
+
+Two practical settings:
+
+- Keep HDR off for now (`hdr_mode = 0` in the config file) and prefer HEVC. AMD HDR handling is still being validated.
+- Two GPUs in the machine (for example a Ryzen iGPU plus a Radeon card)? Tell Polaris which one to use with `adapter_name`. [Stream paths](stream-paths.md#render-device-labwc-runtime) explains how the device is chosen.
+
+### Intel
+
+Same advice as AMD: Private Stream, Mesa VA-API, expect SHM capture. On an Arc discrete card, set `adapter_name` so Polaris picks the Arc GPU rather than the integrated one.
+
+## Check what your stream is using
+
+Mission Control shows the mode Polaris actually started and the capture path it is using, and never pretends: if you asked for one thing and the host could only do another, both are shown.
+
+Reading the capture path:
+
+- **GPU-native** means frames stay on the GPU from game to encoder. This is the fast path.
+- **SHM** means frames take a copy through system memory. Slower, not broken, and the expected state on AMD and Intel hosts.
+
+If a stream misbehaves, the exact reason codes and what to do about them are in [Troubleshooting](troubleshooting.md#vaapi-or-software-encode-fallback).
+
+## Streaming your desktop just once
+
+You do not need to change the host mode to briefly share your desktop. Any Moonlight-protocol client can add `mirrorDesktop=1` to a launch request to mirror the desktop for that single session, and Nova exposes this as a launch option. The host configuration is untouched.
+
+The exception is Headless Dongle: its layout is physical, so per-launch overrides are ignored there.
+
+## Under the hood (optional reading)
+
+- [Runtime and Streaming Model](runtime.md): how capture paths and fallback decisions actually work.
+- [Configuration](configuration.md): every key and value, including the legacy booleans.
+- [Stream paths (plugin contract)](stream-paths.md): the developer contract behind the mode cards.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,12 +52,19 @@ credentials exist, **https://localhost:47990** opens the normal console.
 
 ## 3. Confirm the recommended Linux path
 
-In the first-run setup, confirm the three settings that put games in a private runtime instead of on
-your desktop:
+In the first-run setup, put games in a private runtime instead of on your desktop: under
+**Configuration → Audio/Video → Launch mode and capture path**, pick **Private Stream**. On an
+NVIDIA card, pick **Private Stream (GPU-native)** instead; it is the best-tested path and keeps
+capture on the GPU. In the config file, those two cards correspond to:
 
 ```ini
-headless_mode = enabled
-linux_use_cage_compositor = enabled
+# Private Stream (the default recommendation)
+linux_stream_mode = headless_stream
+```
+
+```ini
+# Private Stream (GPU-native), the NVIDIA pick
+linux_stream_mode = windowed_stream
 linux_prefer_gpu_native_capture = enabled
 ```
 
@@ -67,8 +74,9 @@ linux_prefer_gpu_native_capture = enabled
 > the host desktop at host resolution, and `host_virtual_display` adds an extra display sized to the
 > client. Both are one click in the web UI under Configuration → Audio/Video.
 
-[Configuration](configuration.md) explains every setting, and
-[Runtime and Streaming Model](runtime.md) explains what these three actually change.
+To pick a different mode later, such as Gamescope, a virtual display, or a dummy plug, see
+[Launch modes and capture paths](launch-modes.md). [Configuration](configuration.md) explains every
+setting, and [Runtime and Streaming Model](runtime.md) explains what these keys actually change.
 
 ## 4. Pair a client
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -29,9 +29,11 @@ linux_use_cage_compositor = enabled
 | `headless_dongle` | Swap desktop onto a dummy-plug connector for KMS capture (needs streaming + primary outputs) |
 | `family_isolated` / `headless_evdi` | Reserved slots for community Family Mode + EVDI-as-primary |
 
+Picking a mode by setup, in plain language, is covered in [Launch modes and capture paths](launch-modes.md); this page is the technical model behind it.
+
 - `linux_stream_mode` is the source of truth when set; otherwise Polaris derives the mode from the legacy booleans.
 - `linux_private_runtime` selects the nested compositor for private modes (`labwc` or `gamescope`).
-- `linux_prefer_gpu_native_capture = enabled` asks Polaris to prefer DMA-BUF/GPU-resident capture on capable NVIDIA and AMD/Mesa stacks. If a compositor or driver cannot provide it, Polaris should report the real SHM/system-memory fallback instead of pretending the stream is GPU-native.
+- `linux_prefer_gpu_native_capture = enabled` asks Polaris to prefer DMA-BUF/GPU-resident capture where the driver stack is proven safe (see [Capture and Encode](#capture-and-encode) for how that is gated today). If a compositor or driver cannot provide it, Polaris should report the real SHM/system-memory fallback instead of pretending the stream is GPU-native.
 - Capture (wlroots screencopy, portal, KMS) stays orthogonal to which private runtime owns the session.
 
 See [Stream paths (plugin contract)](stream-paths.md) for how to add a new mode (runtime × capture × topology) without more boolean soup.
@@ -75,11 +77,13 @@ Important runtime fields:
 | Frame format | The captured pixel format |
 | Encoder | The active backend, such as NVENC, VAAPI, or software |
 
+How the GPU-native DMA-BUF path is granted today: automatic DMA-BUF capture is limited to CUDA/NVENC hosts. VAAPI routes (AMD and Intel) deliberately stay on the SHM/system-memory copy path until the DMA-BUF import boundary has proof from affected hosts, because re-enabling it has previously crashed real RDNA machines (issues #367 and #409 track this). Portal/PipeWire capture applies the same vendor gate; `POLARIS_PORTAL_DMABUF=1` is an explicit, unvalidated expert opt-in for testing that boundary, and `POLARIS_PORTAL_DMABUF=0` forces the CPU path. When a GPU-native path is requested but cannot be granted, `capture.reason` reports the real fallback (for example `gpu_native_requested_shm_fallback`) rather than pretending.
+
 Deferred headless encoder capabilities are primed before first launch negotiation so Main10 support is advertised correctly on the first real launch. On Linux, Polaris uses RealtimeKit when available so thread-priority elevation can still succeed when the user service inherits conservative limits.
 
 ## Linux LTS Headless Fallback Matrix
 
-The 1.1.x validation target is the existing labwc Headless Stream architecture, not an Xvfb or gamescope replacement. Use Xvfb/gamescope only as investigation tools if this matrix exposes a real target environment that the current path cannot cover.
+This matrix validates the labwc Headless Stream architecture on long-term-support distributions; it is not an Xvfb or gamescope replacement. Use Xvfb/gamescope only as investigation tools if this matrix exposes a real target environment that the current path cannot cover.
 
 | Environment | Expected runtime | Expected capture decision | Required packages / caveats |
 |---|---|---|---|

--- a/docs/stream-paths.md
+++ b/docs/stream-paths.md
@@ -1,5 +1,7 @@
 # Linux stream paths (plugin contract)
 
+This is the developer contract. User-facing guidance on choosing a mode lives in [Launch modes and capture paths](launch-modes.md).
+
 Polaris models each user-facing Linux streaming option as a **stream path**: a stable id plus three orthogonal concerns.
 
 | Concern | Meaning | Examples |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -70,6 +70,21 @@ private compositor. If the client connects but shows an empty or black desktop w
 that usually means the headless runtime is alive but nothing visible has been launched in it. Use
 Desktop Display mode when you want to stream the already-running host desktop session.
 
+Unsure which mode you should be running in the first place? Start with
+[Launch modes and capture paths](launch-modes.md).
+
+### NVIDIA true-headless first launch fails with 503
+
+On NVIDIA/NVENC hosts running true-headless labwc with GPU-native capture disabled, the very first
+launch can fail with a 503 encoder-initialization error even though NVENC is healthy. On headless
+paths the encoder probe is deferred and served from an on-disk cache; when that cache is cold or
+missing, priming it can fail and the launch is refused. The host configuration warnings surface this
+as `nvidia_headless_gpu_native_disabled`.
+
+The fix matches the warning's own advice: set `linux_prefer_gpu_native_capture = enabled` (or pick
+the **Private Stream (GPU-native)** card in the web UI), restart Polaris, and retry, before chasing
+CUDA or NVENC driver issues.
+
 ## Fullscreen Proton or Wine game renders on the physical monitor
 
 The stream connects, audio and input reach the private session correctly, and the client shows an
@@ -288,7 +303,9 @@ stream capture path. Repeated failures are rate-limited in the log, and the dash
 preview refreshes after failed captures. If the preview is missing, confirm `grim` is installed with
 `command -v grim`.
 
-For capture performance, check `/polaris/v1/session/status`; its `capture` object includes
+For what the capture paths mean in plain terms and which mode fits your GPU, see
+[Launch modes and capture paths](launch-modes.md). For capture performance, check
+`/polaris/v1/session/status`; its `capture` object includes
 `path`, `reason`, `reason_message`, `cpu_copy`, `gpu_native`, and nested `decision` fields.
 `/polaris/v1/stream-policy` exposes the same data as `capture_path`, `capture_path_reason`,
 `capture_path_reason_message`, `capture_cpu_copy`, `capture_gpu_native`, and `capture_decision`.

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -411,7 +411,10 @@ function updateDisplayPlannerSource(event) {
           <div class="flex items-start justify-between gap-4">
             <div class="min-w-0">
               <div class="section-kicker">Stream Display Mode</div>
-              <div class="mt-2 text-sm text-storm">Choose where Polaris starts and captures Linux sessions.</div>
+              <div class="mt-2 text-sm text-storm">
+                Choose where Polaris starts and captures Linux sessions.
+                <a href="https://papi-ux.com/docs/launch-modes/" target="_blank" class="focus-ring text-ice hover:underline">Launch mode guide</a>
+              </div>
             </div>
             <span class="rounded-full border border-ice/20 bg-ice/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow text-ice">
               {{ selectedStreamDisplayMode.title }}

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -1086,6 +1086,7 @@
   "resource_card": {
     "website": "Website",
     "documentation": "Documentation",
+    "launch_mode_guide": "Launch Mode Guide",
     "troubleshooting_guide": "Troubleshooting Guide",
     "github": "GitHub",
     "releases": "Releases",

--- a/src_assets/common/assets/web/resource-links.js
+++ b/src_assets/common/assets/web/resource-links.js
@@ -13,6 +13,7 @@
 export const resources = [
   { href: 'https://papi-ux.com/', labelKey: 'resource_card.website' },
   { href: 'https://papi-ux.com/docs/', labelKey: 'resource_card.documentation' },
+  { href: 'https://papi-ux.com/docs/launch-modes/', labelKey: 'resource_card.launch_mode_guide' },
   { href: 'https://papi-ux.com/docs/troubleshooting/', labelKey: 'resource_card.troubleshooting_guide' },
   { href: 'https://github.com/papi-ux/polaris', labelKey: 'resource_card.github' },
   { href: 'https://github.com/papi-ux/polaris/releases', labelKey: 'resource_card.releases' },

--- a/src_assets/common/assets/web/resource-links.test.js
+++ b/src_assets/common/assets/web/resource-links.test.js
@@ -6,10 +6,11 @@ const all = [...resources, ...legalDocs]
 
 describe('resource links', () => {
   it('offers the docs site for the pages it actually renders', () => {
-    // papi-ux.com renders the repository's own docs/, so these two are the
+    // papi-ux.com renders the repository's own docs/, so these are the
     // better destination than the wiki for the same subjects.
     const hrefs = resources.map((entry) => entry.href)
     expect(hrefs).toContain('https://papi-ux.com/docs/')
+    expect(hrefs).toContain('https://papi-ux.com/docs/launch-modes/')
     expect(hrefs).toContain('https://papi-ux.com/docs/troubleshooting/')
   })
 


### PR DESCRIPTION
## Summary

- Add `docs/launch-modes.md`, a recommendation-first user guide for the Audio/Video launch mode cards: a pick-by-setup table, plain-language descriptions of all eight modes (including the two reserved ones, stated honestly), a Gamescope primer, NVIDIA/AMD/Intel guidance, how to read the capture path, and per-launch desktop mirroring. Deep mechanics stay in `runtime.md` and `stream-paths.md` behind links, so the page reads end-to-end for a non-expert.
- Keep one home per fact across the docs set: `configuration.md`'s display-modes section becomes a config-file summary pointing at the new page; `runtime.md` gains the honest statement of how the GPU-native DMA-BUF path is gated today (CUDA-only, VAAPI held on SHM pending affected-host proof, `POLARIS_PORTAL_DMABUF` opt-in) and loses the stale 1.1.x framing on the LTS matrix intro; `troubleshooting.md` gains a named subsection for the NVIDIA true-headless cold-cache 503 (`nvidia_headless_gpu_native_disabled`); `faq.md` and `stream-paths.md` gain pointers.
- Fix the quickstart step 3 contradiction: the recommended ini triple was `windowed_stream`'s mapping (the GPU-native card) while reading as plain Private Stream. Step 3 now recommends the actual cards, with the two config equivalents shown separately.
- Link the guide from the web UI: the Stream Display Mode section header and the resources list (`resource-links.js`, locale string, pinned in `resource-links.test.js`).

## Verification

- `bash scripts/check-public-docs.sh` clean.
- `npm test` green: 68 files, 515 tests, including the updated `resource-links.test.js`.
- All relative links target top-level `docs/*.md` pages that the site sync publishes; anchors match GitHub/Starlight slugs (`#capture-and-encode`, `#linux-display-modes`, `#nvidia-kms-capture-issues`, `#headless-session-does-not-start-cleanly`, `#vaapi-or-software-encode-fallback`, `#render-device-labwc-runtime`).
- The first paragraph of the new page is 141 characters of plain prose, inside the site sync's 157-character description budget.
- Mode facts checked against `client-settings-sync.js` card mappings, `stream_path.cpp` registry, `wlgrab_capture_policy.h` DMA-BUF gating, and the `stream_stats.cpp` warning copy. PR #226 is closed unmerged, so the reserved modes are described as reserved with no dates.

## Scope

This pull request changes documentation, one settings-view template string, and the shared resource-links list plus its test and locale entry. No stream, capture, or config behavior changes. The companion papi-ux.github.io sidebar entry lands separately after this merges, since the site deploy re-syncs docs from master at build time.
