### PR TITLE
fix: migrate legacy Desktop mirror semantics

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -10470,6 +10470,62 @@ namespace proc {
     }
   }
 
+  std::size_t migrate_legacy_bundled_desktop(nlohmann::json &fileTree) {
+    if (!fileTree.contains("apps") || !fileTree["apps"].is_array()) {
+      return 0;
+    }
+
+    std::size_t migrated = 0;
+    for (auto &app : fileTree["apps"]) {
+      if (!app.is_object() || app.contains("desktop-mirror")) {
+        continue;
+      }
+
+      const auto absent_or_empty_string = [&app](const char *key) {
+        return !app.contains(key) || (app[key].is_string() && app[key].get<std::string>().empty());
+      };
+      const auto absent_or_empty_array = [&app](const char *key) {
+        return !app.contains(key) || (app[key].is_array() && app[key].empty());
+      };
+      const auto absent_or_false = [&app](const char *key) {
+        return !app.contains(key) || (app[key].is_boolean() && !app[key].get<bool>());
+      };
+      const bool manual_source = !app.contains("source") ||
+                                 (app["source"].is_string() && boost::iequals(app["source"].get<std::string>(), "manual"));
+
+      const bool legacy_desktop_identity =
+        app.contains("name") && app["name"].is_string() && app["name"].get<std::string>() == "Desktop" &&
+        app.contains("image-path") && app["image-path"].is_string() && app["image-path"].get<std::string>() == "desktop.png" &&
+        manual_source &&
+        absent_or_empty_string("cmd") &&
+        absent_or_empty_string("steam-appid") &&
+        absent_or_empty_array("detached") &&
+        absent_or_empty_array("prep-cmd") &&
+        absent_or_empty_array("state-cmd");
+      const bool malformed_virtual_display = app.contains("virtual-display") && !app["virtual-display"].is_boolean();
+      const bool malformed_client_commands = app.contains("allow-client-commands") && !app["allow-client-commands"].is_boolean();
+      if (legacy_desktop_identity && (malformed_virtual_display || malformed_client_commands)) {
+        // The parser's legacy recovery pass coerces string booleans. Record an
+        // explicit non-mirror decision first so malformed modern fields cannot
+        // become eligible after that retry.
+        app["desktop-mirror"] = false;
+        continue;
+      }
+
+      const bool exact_legacy_desktop =
+        legacy_desktop_identity &&
+        absent_or_false("virtual-display") &&
+        absent_or_false("allow-client-commands");
+      if (exact_legacy_desktop) {
+        app["desktop-mirror"] = true;
+        BOOST_LOG(info) << "Migrated the bundled legacy Desktop app to explicit desktop-mirror launch semantics.";
+        ++migrated;
+      }
+    }
+
+    return migrated;
+  }
+
   void migration_v6(nlohmann::json &fileTree) {
     // The bundled Desktop app predates an explicit launch semantic. Preserve
     // that exact legacy entry as a desktop mirror without inferring behavior
@@ -10480,48 +10536,7 @@ namespace proc {
       return;
     }
 
-    if (!fileTree.contains("apps") || !fileTree["apps"].is_array()) {
-      fileTree["version"] = this_version;
-      return;
-    }
-
-    for (auto &app : fileTree["apps"]) {
-      if (!app.is_object() || app.contains("desktop-mirror")) {
-        continue;
-      }
-
-      const auto name = json_string_member_or(app, "name");
-      const auto image_path = json_string_member_or(app, "image-path");
-      const auto source = json_string_member_or(app, "source", "manual");
-      const auto cmd = json_string_member_or(app, "cmd");
-      const auto steam_appid = json_string_member_or(app, "steam-appid");
-      const bool no_detached = !app.contains("detached") ||
-                               (app["detached"].is_array() && app["detached"].empty());
-      const bool no_prep = !app.contains("prep-cmd") ||
-                           (app["prep-cmd"].is_array() && app["prep-cmd"].empty());
-      const bool no_state = !app.contains("state-cmd") ||
-                            (app["state-cmd"].is_array() && app["state-cmd"].empty());
-      const bool virtual_display = app.contains("virtual-display") &&
-                                   coerce_json_bool(app["virtual-display"], false);
-      const bool client_commands = !app.contains("allow-client-commands") ||
-                                   coerce_json_bool(app["allow-client-commands"], true);
-
-      const bool exact_legacy_desktop =
-        name == "Desktop" &&
-        image_path == "desktop.png" &&
-        boost::iequals(source, "manual") &&
-        cmd.empty() &&
-        steam_appid.empty() &&
-        no_detached &&
-        no_prep &&
-        no_state &&
-        !virtual_display &&
-        !client_commands;
-      if (exact_legacy_desktop) {
-        app["desktop-mirror"] = true;
-        BOOST_LOG(info) << "Migrated the bundled legacy Desktop app to explicit desktop-mirror launch semantics.";
-      }
-    }
+    migrate_legacy_bundled_desktop(fileTree);
 
     fileTree["version"] = this_version;
   }
@@ -10569,8 +10584,25 @@ namespace proc {
     }
   }
 
+  void migration_v8(nlohmann::json &fileTree) {
+    // v10 introduced the Desktop semantic, but v11 catalogs already written by
+    // Polaris skipped that migration. Re-run only the exact legacy bundled
+    // identity so those catalogs cannot inherit a paired virtual-display mode.
+    static const int this_version = 12;
+    const int file_version = json_int_member_or(fileTree, "version", 0);
+    if (file_version >= this_version) {
+      return;
+    }
+
+    const auto migrated = migrate_legacy_bundled_desktop(fileTree);
+    fileTree["version"] = this_version;
+    if (migrated > 0) {
+      BOOST_LOG(info) << "Migrated " << migrated << " bundled legacy Desktop app(s) to explicit desktop-mirror launch semantics (v12).";
+    }
+  }
+
   void migrate(nlohmann::json& fileTree, const std::string& fileName) {
-    int last_version = 11;
+    int last_version = 12;
 
     int file_version = json_int_member_or(fileTree, "version", 0);
     if (fileTree.contains("version") && !coerce_json_int(fileTree["version"]).has_value()) {
@@ -10584,6 +10616,7 @@ namespace proc {
       migration_v5(fileTree);
       migration_v6(fileTree);
       migration_v7(fileTree);
+      migration_v8(fileTree);
       file_handler::write_file(fileName.c_str(), fileTree.dump(4));
     }
   }

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -4120,7 +4120,7 @@ TEST(ProcessMigrationTests, ParseRepairsMalformedLegacyAppsJson) {
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
   ASSERT_TRUE(migrated_tree.contains("version"));
-  EXPECT_EQ(migrated_tree["version"], 11);
+  EXPECT_EQ(migrated_tree["version"], 12);
   ASSERT_TRUE(migrated_tree.contains("apps"));
   ASSERT_TRUE(migrated_tree["apps"].is_array());
   ASSERT_EQ(migrated_tree["apps"].size(), 1);
@@ -4185,7 +4185,7 @@ TEST(ProcessMigrationTests, LegacyBundledDesktopGetsExplicitMirrorSemanticOnlyFo
   ASSERT_TRUE(parsed_proc.has_value());
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(migrated_tree["version"], 11);
+  EXPECT_EQ(migrated_tree["version"], 12);
   EXPECT_TRUE(migrated_tree["apps"][0].value("desktop-mirror", false));
   EXPECT_FALSE(migrated_tree["apps"][1].contains("desktop-mirror"));
 
@@ -4202,6 +4202,80 @@ TEST(ProcessMigrationTests, LegacyBundledDesktopGetsExplicitMirrorSemanticOnlyFo
   EXPECT_FALSE(custom->desktop_mirror);
 
   std::filesystem::remove(file_path);
+}
+
+TEST(ProcessMigrationTests, VersionTenAndElevenCatalogsRepairOnlyTheExactLegacyBundledDesktop) {
+  for (const int input_version : {10, 11}) {
+    const auto file_path = test_paths::root() /
+                           ("v" + std::to_string(input_version) + "_legacy_desktop_mirror_migration.json");
+    const nlohmann::json legacy_apps = {
+      {"version", input_version},
+      {"apps", {
+        {
+          {"name", "Desktop"},
+          {"uuid", "1B198836-52DF-F804-2E0A-7FA204BFA52F"},
+          {"image-path", "desktop.png"},
+          {"prep-cmd", nlohmann::json::array()}
+        },
+        {
+          {"name", "Desktop"},
+          {"uuid", "22222222-2222-4222-8222-222222222222"},
+          {"image-path", "desktop.png"},
+          {"allow-client-commands", true}
+        },
+        {
+          {"name", "Desktop"},
+          {"uuid", "33333333-3333-4333-8333-333333333333"},
+          {"image-path", "desktop.png"},
+          {"desktop-mirror", false}
+        },
+        {
+          {"name", "Desktop"},
+          {"uuid", "44444444-4444-4444-8444-444444444444"},
+          {"image-path", "desktop.png"},
+          {"virtual-display", "false"}
+        },
+        {
+          {"name", "Desktop"},
+          {"uuid", "55555555-5555-4555-8555-555555555555"},
+          {"image-path", "desktop.png"},
+          {"allow-client-commands", "false"}
+        }
+      }}
+    };
+
+    ASSERT_EQ(file_handler::write_file(file_path.string().c_str(), legacy_apps.dump(2)), 0);
+    auto parsed_proc = proc::parse(file_path.string());
+    ASSERT_TRUE(parsed_proc.has_value());
+
+    const auto first_payload = file_handler::read_file(file_path.string().c_str());
+    const auto migrated_tree = nlohmann::json::parse(first_payload);
+    EXPECT_EQ(migrated_tree["version"], 12);
+    EXPECT_TRUE(migrated_tree["apps"][0].value("desktop-mirror", false));
+    EXPECT_FALSE(migrated_tree["apps"][1].contains("desktop-mirror"));
+    EXPECT_FALSE(migrated_tree["apps"][2].value("desktop-mirror", true));
+    EXPECT_FALSE(migrated_tree["apps"][3].value("desktop-mirror", true));
+    EXPECT_FALSE(migrated_tree["apps"][4].value("desktop-mirror", true));
+
+    const auto &apps = parsed_proc->get_apps();
+    const auto desktop_mirror_for = [&apps](const std::string &uuid) {
+      const auto app = std::find_if(apps.begin(), apps.end(), [&uuid](const auto &candidate) {
+        return candidate.uuid == uuid;
+      });
+      return app != apps.end() && app->desktop_mirror;
+    };
+    EXPECT_TRUE(desktop_mirror_for("1B198836-52DF-F804-2E0A-7FA204BFA52F"));
+    EXPECT_FALSE(desktop_mirror_for("22222222-2222-4222-8222-222222222222"));
+    EXPECT_FALSE(desktop_mirror_for("33333333-3333-4333-8333-333333333333"));
+    EXPECT_FALSE(desktop_mirror_for("44444444-4444-4444-8444-444444444444"));
+    EXPECT_FALSE(desktop_mirror_for("55555555-5555-4555-8555-555555555555"));
+
+    auto parsed_again = proc::parse(file_path.string());
+    ASSERT_TRUE(parsed_again.has_value());
+    EXPECT_EQ(file_handler::read_file(file_path.string().c_str()), first_payload);
+
+    std::filesystem::remove(file_path);
+  }
 }
 
 TEST(ProcessMigrationTests, MigratesOnlyExactLegacyHeroicImportsAndIsIdempotent) {
@@ -4255,7 +4329,7 @@ TEST(ProcessMigrationTests, MigratesOnlyExactLegacyHeroicImportsAndIsIdempotent)
 
   const auto first_payload = file_handler::read_file(file_path.string().c_str());
   const auto migrated_tree = nlohmann::json::parse(first_payload);
-  EXPECT_EQ(migrated_tree["version"], 11);
+  EXPECT_EQ(migrated_tree["version"], 12);
   ASSERT_EQ(migrated_tree["apps"].size(), 5u);
 
   const auto &epic = migrated_tree["apps"][0];
@@ -4468,7 +4542,7 @@ TEST(ProcessMigrationTests, ParseNormalizesSteamLibraryLaunchAndAddsShutdownUndo
   EXPECT_EQ(steam_ctx->source, "steam");
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(migrated_tree["version"], 11);
+  EXPECT_EQ(migrated_tree["version"], 12);
 
   std::filesystem::remove(file_path);
 }
@@ -4519,7 +4593,7 @@ TEST(ProcessMigrationTests, ParseNormalizesCurrentSteamLibraryLaunchWithoutBigPi
   EXPECT_EQ(steam_ctx->prep_cmds.front().undo_cmd, expected_steam_shutdown_command());
 
   const auto parsed_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(parsed_tree["version"], 11);
+  EXPECT_EQ(parsed_tree["version"], 12);
 
   std::filesystem::remove(file_path);
 }
@@ -4732,7 +4806,7 @@ TEST(ProcessMigrationTests, ParseAddsLutrisLauncherWhenLutrisGamesExist) {
   ASSERT_TRUE(parsed_proc.has_value());
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(migrated_tree["version"], 11);
+  EXPECT_EQ(migrated_tree["version"], 12);
   ASSERT_TRUE(migrated_tree.contains("apps"));
 
   const auto &migrated_apps = migrated_tree["apps"];
@@ -4798,7 +4872,7 @@ TEST(ProcessMigrationTests, ParseUnwrapsPolarisHdrSessionLibraryHardwire) {
   ASSERT_TRUE(parsed_proc.has_value());
 
   const auto migrated_tree = nlohmann::json::parse(file_handler::read_file(file_path.string().c_str()));
-  EXPECT_EQ(migrated_tree["version"], 11);
+  EXPECT_EQ(migrated_tree["version"], 12);
 
   const auto &migrated_apps = migrated_tree["apps"];
   const auto lib_app = std::find_if(migrated_apps.begin(), migrated_apps.end(), [](const auto &app) {


### PR DESCRIPTION
## Summary

- add a v12 apps catalog migration that repairs the exact bundled legacy Desktop identity in existing v10 and v11 catalogs
- keep custom Desktop entries and explicit desktop-mirror choices untouched
- fail closed on malformed virtual-display and allow-client-commands values, including through the legacy parser retry
- preserve the v11 Heroic migration ordering and advance the catalog schema to v12

## Physical failure addressed

The frozen v1.3.14 candidate upgraded the live legacy Desktop catalog without applying the older v10 semantic migration. The stock Desktop then inherited the paired virtual-display preference and launched a private labwc Headless output instead of mirroring the physical desktop.

## Validation

- git diff --check
- Linux exact-SHA build of test_polaris_config
- ProcessMigrationTests: 15/15 passed
- full test_polaris_config: 296/296 passed
- test fixture covers the exact live v10 Desktop shape, already-upgraded v11 shape, custom entries, explicit false, malformed booleans, and idempotency

## Release gate

This PR is not sufficient to resume release publication. After merge it requires exact-merge-SHA CI, independent review, and a fresh reversible physical gate. No tag, release, package publication, or production cutover is authorized by this PR.