### PR TITLE
feat(linux): explicit headless boot for the user service

### DIFF
--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -201,6 +201,46 @@ Resolution: 7680x2160
 This is expected for the Desktop image before a client launches a headless labwc
 stream.
 
+## Headless Boot and Deck Images
+
+The packaged service enables into `xdg-desktop-autostart.target`, which only a
+full desktop session fires. Two common Bazzite setups never fire it:
+
+- Deck images that boot straight into the gamescope Steam session. The gamescope
+  session does not run XDG autostart, so Polaris only starts once you visit
+  Desktop Mode.
+- A monitor-less host (dedicated streaming box, dummy plug removed). With no
+  graphical session at all, nothing starts the service after a reboot.
+
+For both, make Polaris boot-independent explicitly:
+
+```bash
+sudo -H polaris --setup-host --enable-headless-boot
+```
+
+This enables lingering for your account (your user services start at boot,
+before any login) and hooks the Polaris user service into `default.target`. Run
+it from Desktop Mode's terminal or over SSH, as your normal user via sudo. Undo
+it later with `--disable-headless-boot`.
+
+Verify after a reboot, over SSH if there is no display:
+
+```bash
+systemctl --user is-active polaris
+journalctl --user -u polaris --since "10 minutes ago" --no-pager
+```
+
+Two honest notes:
+
+- Private Stream and Gamescope Stream need no desktop session, so streaming
+  works on a fully headless boot. Streaming the visible desktop (Mirror
+  Desktop, Host Virtual Display) still needs a desktop login, and Polaris must
+  be restarted after that login to see it.
+- You do not need the host to boot into Big Picture to play Big Picture. With
+  Private Stream, launching Steam Big Picture from the client starts it inside
+  the private session at the client's resolution; the host can sit at a black
+  screen. See [Launch modes and capture paths](launch-modes.md).
+
 ## Game Mode Validation
 
 Game Mode remains pending for `bazzite-nvidia-open:stable` Desktop images. A

--- a/docs/launch-modes.md
+++ b/docs/launch-modes.md
@@ -26,7 +26,7 @@ Every card under **Configuration → Audio/Video → Launch mode and capture pat
 
 ### Private Stream
 
-Your game runs in its own invisible session. Your desktop never flickers, resizes, or shows the game, and nothing you do on the desktop leaks into the stream.
+Your game runs in its own invisible session. Your desktop never flickers, resizes, or shows the game, and nothing you do on the desktop leaks into the stream. It even works on a host with no monitor attached and nobody logged in: pair it with `sudo -H polaris --setup-host --enable-headless-boot` for a console-style box that streams straight from power-on ([Bazzite guide](bazzite.md#headless-boot-and-deck-images) has the walkthrough).
 
 - **Best for:** most setups, and the preferred path when you stream to a handheld.
 - **One caveat:** the built-in Desktop entry looks like an empty screen until you launch something into it. That is normal, not broken. Right-click the empty screen to open the session menu, or use Mirror Desktop if you actually wanted your desktop.

--- a/packaging/linux/polaris.service.in
+++ b/packaging/linux/polaris.service.in
@@ -1,7 +1,11 @@
 [Unit]
 Description=@PROJECT_DESCRIPTION@
+# Ordering only, deliberately without PartOf=graphical-session.target: a
+# streaming host must outlive the desktop session. With lingering enabled
+# (--setup-host --enable-headless-boot) there may be no graphical session at
+# all, and stop propagation would end an active remote stream on desktop
+# logout even though Private Stream never needed the desktop.
 After=graphical-session.target
-PartOf=graphical-session.target
 StartLimitIntervalSec=500
 StartLimitBurst=5
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -82,6 +82,7 @@
   #include <Windows.h>
 #elif __linux__
   #include "platform/linux/session_media.h"
+  #include <pwd.h>
   #include <sys/stat.h>
   #include <unistd.h>
 #elif __APPLE__
@@ -6166,14 +6167,56 @@ namespace confighttp {
     const char *session_type = std::getenv("XDG_SESSION_TYPE");
     const bool has_wayland_display = wayland_display && wayland_display[0] != '\0';
     const bool has_x11_display = x11_display && x11_display[0] != '\0';
-    output["display_session"]["status"] = has_wayland_display || has_x11_display ? "healthy" : "missing_display_environment";
-    output["display_session"]["summary"] = has_wayland_display ?
-      "Wayland desktop environment is available to Polaris." :
-      (has_x11_display ? "X11 desktop environment is available to Polaris." :
-                         "Polaris could not find WAYLAND_DISPLAY or DISPLAY for desktop previews.");
-    output["display_session"]["action"] = has_wayland_display || has_x11_display ?
+
+    // Boot readiness: whether this account's Polaris survives a reboot with no
+    // monitor or desktop login. Lingering plus a default.target want is what
+    // `--setup-host --enable-headless-boot` arranges; either alone is not
+    // enough, so both are reported.
+    bool linger_enabled = false;
+    bool boot_start_linked = false;
+    {
+      std::error_code boot_ec;
+      const auto *pw = getpwuid(geteuid());
+      if (pw && pw->pw_name && pw->pw_name[0] != '\0') {
+        linger_enabled = fs::exists(fs::path("/var/lib/systemd/linger") / pw->pw_name, boot_ec);
+      }
+      fs::path config_home;
+      if (const char *xdg_config = std::getenv("XDG_CONFIG_HOME"); xdg_config && *xdg_config) {
+        config_home = xdg_config;
+      } else if (const char *home = std::getenv("HOME"); home && *home) {
+        config_home = fs::path(home) / ".config";
+      } else if (pw && pw->pw_dir && pw->pw_dir[0] != '\0') {
+        config_home = fs::path(pw->pw_dir) / ".config";
+      }
+      boot_start_linked = (!config_home.empty() && fs::exists(config_home / "systemd/user/default.target.wants/polaris.service", boot_ec)) ||
+                          fs::exists("/etc/systemd/user/default.target.wants/polaris.service", boot_ec);
+    }
+    const bool boot_independent = linger_enabled && boot_start_linked;
+    output["boot_readiness"]["linger_enabled"] = linger_enabled;
+    output["boot_readiness"]["boot_start_linked"] = boot_start_linked;
+    output["boot_readiness"]["status"] = boot_independent ? "boot_independent" : "session_bound";
+    output["boot_readiness"]["summary"] = boot_independent ?
+      "Polaris starts at boot with no monitor or desktop login." :
+      "Polaris starts with the desktop session, so after a reboot it is unavailable until someone logs in.";
+    output["boot_readiness"]["action"] = boot_independent ?
       "No action needed." :
-      "Restart Polaris from the desktop session or run the user service so it inherits the graphical environment.";
+      "For a monitor-less or Game Mode host, run: sudo -H polaris --setup-host --enable-headless-boot";
+
+    output["display_session"]["status"] = has_wayland_display || has_x11_display ? "healthy" : "missing_display_environment";
+    if (has_wayland_display || has_x11_display) {
+      output["display_session"]["summary"] = has_wayland_display ?
+        "Wayland desktop environment is available to Polaris." :
+        "X11 desktop environment is available to Polaris.";
+      output["display_session"]["action"] = "No action needed.";
+    } else if (boot_independent) {
+      // A headless-boot host has no desktop on purpose; telling it to restart
+      // from the desktop session would be wrong advice.
+      output["display_session"]["summary"] = "No desktop environment is attached, which is expected on a headless-boot host. Private Stream is unaffected.";
+      output["display_session"]["action"] = "To stream the visible desktop instead, log into the desktop and restart Polaris so it inherits the graphical environment.";
+    } else {
+      output["display_session"]["summary"] = "Polaris could not find WAYLAND_DISPLAY or DISPLAY for desktop previews.";
+      output["display_session"]["action"] = "Restart Polaris from the desktop session or run the user service so it inherits the graphical environment.";
+    }
     output["display_session"]["environment_repaired"] = display_environment_repaired;
     output["display_session"]["session_type"] = session_type && session_type[0] ? std::string(session_type) : "unknown";
     output["display_session"]["desktop"] = desktop_name && desktop_name[0] ? std::string(desktop_name) : "unknown";

--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <vector>
 
 // local includes
 #include "config.h"
@@ -27,6 +28,7 @@
 
 extern "C" {
 #ifdef __linux__
+  #include <pwd.h>
   #include <unistd.h>
 #endif
 #ifdef _WIN32
@@ -196,9 +198,152 @@ namespace {
     return true;
   }
 
+  struct headless_boot_account_t {
+    std::string name;
+    uid_t uid;
+    gid_t gid;
+    fs::path home;
+  };
+
+  /**
+   * @brief Resolve the account headless boot should apply to.
+   *
+   * Host setup runs as root, but lingering and the default.target hook belong
+   * to the account that streams. SUDO_USER identifies it when the command is
+   * run the documented way; a bare root login cannot name it, and this command
+   * deliberately never guesses which account streams.
+   */
+  std::optional<headless_boot_account_t> resolve_headless_boot_account() {
+    const auto user = platf::input_access::setup_host_target_user();
+    if (user.empty() || user == "root") {
+      BOOST_LOG(error) << "Headless boot applies to the account that streams, and root is not it. "
+                          "Run this via [sudo -H] from that account so SUDO_USER identifies it."sv;
+      return std::nullopt;
+    }
+
+    const auto *pw = getpwnam(user.c_str());
+    if (!pw || !pw->pw_dir || pw->pw_dir[0] == '\0') {
+      BOOST_LOG(error) << "Headless boot could not resolve a home directory for ["sv << user << ']';
+      return std::nullopt;
+    }
+
+    return headless_boot_account_t {user, pw->pw_uid, pw->pw_gid, fs::path(pw->pw_dir)};
+  }
+
+  std::optional<fs::path> installed_user_unit_path() {
+    for (const auto *candidate : {"/usr/lib/systemd/user/polaris.service", "/usr/local/lib/systemd/user/polaris.service", "/etc/systemd/user/polaris.service"}) {
+      std::error_code ec;
+      if (fs::exists(candidate, ec)) {
+        return fs::path(candidate);
+      }
+    }
+    return std::nullopt;
+  }
+
+  fs::path headless_boot_wants_link(const headless_boot_account_t &account) {
+    return account.home / ".config/systemd/user/default.target.wants/polaris.service";
+  }
+
+  /**
+   * @brief Start the account's Polaris user service at boot.
+   *
+   * Two pieces, both explicit: lingering, so the account's user manager runs
+   * from boot without a login, and a default.target want for the packaged unit.
+   * The want is the same symlink `systemctl --user add-wants` would create,
+   * written directly because a root process cannot reliably talk to another
+   * account's user manager. The packaged [Install] section stays pointed at
+   * xdg-desktop-autostart.target on purpose: desktop hosts get the late,
+   * environment-complete start they have today, and only hosts that opt in
+   * here start at boot.
+   */
+  bool enable_headless_boot_for(const headless_boot_account_t &account) {
+    const auto unit = installed_user_unit_path();
+    if (!unit) {
+      BOOST_LOG(error) << "Headless boot needs the packaged user unit (usr/lib/systemd/user/polaris.service), which was not found. Install the Polaris package first."sv;
+      return false;
+    }
+
+    if (!run_host_command(std::format("enable lingering for {}", account.name), std::format("loginctl enable-linger {}", account.name))) {
+      return false;
+    }
+
+    const auto link_path = headless_boot_wants_link(account);
+    const auto wants_dir = link_path.parent_path();
+
+    // Track which directories are about to be created so ownership can be
+    // handed to the account; root-owned directories inside the home would
+    // break the account's own later `systemctl --user` edits.
+    std::vector<fs::path> created_dirs;
+    std::error_code ec;
+    for (auto dir = wants_dir; !fs::exists(dir, ec) && dir != account.home && !dir.empty(); dir = dir.parent_path()) {
+      created_dirs.push_back(dir);
+    }
+    fs::create_directories(wants_dir, ec);
+    if (ec) {
+      BOOST_LOG(error) << "Headless boot could not create ["sv << wants_dir << "]: "sv << ec.message();
+      return false;
+    }
+    for (auto it = created_dirs.rbegin(); it != created_dirs.rend(); ++it) {
+      if (chown(it->c_str(), account.uid, account.gid) != 0) {
+        BOOST_LOG(warning) << "Headless boot could not hand ["sv << *it << "] to "sv << account.name;
+      }
+    }
+
+    if (fs::is_symlink(link_path, ec)) {
+      if (fs::read_symlink(link_path, ec) == *unit) {
+        BOOST_LOG(info) << "Headless boot: the default.target want already points at ["sv << *unit << ']';
+        return true;
+      }
+      fs::remove(link_path, ec);
+    } else if (fs::exists(link_path, ec)) {
+      BOOST_LOG(error) << "Headless boot: ["sv << link_path << "] exists and is not a symlink; refusing to replace it"sv;
+      return false;
+    }
+
+    fs::create_symlink(*unit, link_path, ec);
+    if (ec) {
+      BOOST_LOG(error) << "Headless boot could not create ["sv << link_path << "]: "sv << ec.message();
+      return false;
+    }
+    if (lchown(link_path.c_str(), account.uid, account.gid) != 0) {
+      BOOST_LOG(warning) << "Headless boot could not hand ["sv << link_path << "] to "sv << account.name;
+    }
+
+    std::cout
+      << "Headless boot enabled for "sv << account.name << '.' << std::endl
+      << "Polaris now starts at boot with no monitor, desktop login, or Game Mode session."sv << std::endl
+      << "Verify after the next reboot with: systemctl --user is-active polaris"sv << std::endl
+      << "To start it right now without rebooting, run as "sv << account.name << ':' << std::endl
+      << "  systemctl --user daemon-reload && systemctl --user start polaris"sv << std::endl
+      << "Note: Private Stream and Gamescope Stream need no desktop. Streaming the visible"sv << std::endl
+      << "desktop (Mirror Desktop, Host Virtual Display) still needs a desktop login, and"sv << std::endl
+      << "Polaris must be restarted after that login to see it."sv << std::endl;
+    return true;
+  }
+
+  bool disable_headless_boot_for(const headless_boot_account_t &account) {
+    const auto link_path = headless_boot_wants_link(account);
+    std::error_code ec;
+    if (!fs::is_symlink(link_path, ec) && !fs::exists(link_path, ec)) {
+      std::cout << "Headless boot was not enabled for "sv << account.name << "; nothing to remove."sv << std::endl;
+      return true;
+    }
+
+    if (!fs::remove(link_path, ec) || ec) {
+      BOOST_LOG(error) << "Headless boot could not remove ["sv << link_path << "]: "sv << ec.message();
+      return false;
+    }
+
+    std::cout
+      << "Headless boot disabled for "sv << account.name << "; the user service returns to starting with the desktop session."sv << std::endl
+      << "Lingering was left enabled because other user services may rely on it. If nothing"sv << std::endl
+      << "else needs it: loginctl disable-linger "sv << account.name << std::endl;
+    return true;
+  }
+
   void print_setup_host_help(const char *name) {
     std::cout
-      << "Usage: "sv << name << " --setup-host [--enable-kms]"sv << std::endl
+      << "Usage: "sv << name << " --setup-host [--enable-kms] [--enable-headless-boot | --disable-headless-boot]"sv << std::endl
       << std::endl
       << "  Applies Linux host integration explicitly instead of relying on package scripts."sv << std::endl
       << "  Steps:"sv << std::endl
@@ -211,10 +356,17 @@ namespace {
       << "    - load uinput and uhid now via modprobe"sv << std::endl
       << "    - report whether the calling account is in the input group, which seat isolation needs"sv << std::endl
       << "    - optionally apply cap_sys_admin for DRM/KMS capture"sv << std::endl
+      << "    - optionally make the invoking account's Polaris user service start at boot,"sv << std::endl
+      << "      with no monitor, desktop login, or Game Mode session required"sv << std::endl
       << std::endl
       << "  Options:"sv << std::endl
-      << "    --enable-kms  Also run setcap cap_sys_admin+ep on the Polaris binary"sv << std::endl
-      << "    help          Print this help"sv << std::endl;
+      << "    --enable-kms            Also run setcap cap_sys_admin+ep on the Polaris binary"sv << std::endl
+      << "    --enable-headless-boot  Enable lingering for the invoking account and hook the"sv << std::endl
+      << "                            Polaris user service into default.target, so it starts at"sv << std::endl
+      << "                            boot before anyone logs in"sv << std::endl
+      << "    --disable-headless-boot Remove the boot-start hook again; lingering is left as"sv << std::endl
+      << "                            configured because other user services may rely on it"sv << std::endl
+      << "    help                    Print this help"sv << std::endl;
   }
 }  // namespace
 #endif
@@ -261,6 +413,8 @@ namespace args {
 #ifdef __linux__
   int setup_host(const char *name, int argc, char *argv[]) {
     bool enable_kms = false;
+    bool enable_headless_boot = false;
+    bool disable_headless_boot = false;
 
     for (int i = 0; i < argc; ++i) {
       const auto arg = std::string_view(argv[i]);
@@ -272,8 +426,22 @@ namespace args {
         enable_kms = true;
         continue;
       }
+      if (arg == "--enable-headless-boot"sv || arg == "enable-headless-boot"sv) {
+        enable_headless_boot = true;
+        continue;
+      }
+      if (arg == "--disable-headless-boot"sv || arg == "disable-headless-boot"sv) {
+        disable_headless_boot = true;
+        continue;
+      }
 
       BOOST_LOG(error) << "Unknown --setup-host option: "sv << arg;
+      print_setup_host_help(name);
+      return 1;
+    }
+
+    if (enable_headless_boot && disable_headless_boot) {
+      BOOST_LOG(error) << "--enable-headless-boot and --disable-headless-boot are mutually exclusive"sv;
       print_setup_host_help(name);
       return 1;
     }
@@ -306,7 +474,8 @@ namespace args {
     // rather than from a controller that silently never appears.
     const auto input_group_advice = platf::input_access::setup_host_input_group_advice();
 
-    if (!enable_kms && udev_from_package && modules_from_package && etc_copies_absent && input_nodes_ready) {
+    const bool headless_boot_requested = enable_headless_boot || disable_headless_boot;
+    if (!enable_kms && !headless_boot_requested && udev_from_package && modules_from_package && etc_copies_absent && input_nodes_ready) {
       std::cout
         << "Linux host setup: nothing to do."sv << std::endl
         << "The package provides the udev rules and modules-load configuration, and /dev/uinput"sv << std::endl
@@ -327,6 +496,12 @@ namespace args {
         << "  sudo -H "sv << exe_path->string() << " --setup-host"sv;
       if (enable_kms) {
         std::cout << " --enable-kms"sv;
+      }
+      if (enable_headless_boot) {
+        std::cout << " --enable-headless-boot"sv;
+      }
+      if (disable_headless_boot) {
+        std::cout << " --disable-headless-boot"sv;
       }
       std::cout << std::endl;
       return 1;
@@ -355,6 +530,17 @@ namespace args {
       BOOST_LOG(info) << "Linux host setup: skipping cap_sys_admin. Re-run with --enable-kms only if you need DRM/KMS capture."sv;
     }
 
+    if (headless_boot_requested) {
+      const auto account = resolve_headless_boot_account();
+      if (!account) {
+        ok = false;
+      } else if (enable_headless_boot) {
+        ok &= enable_headless_boot_for(*account);
+      } else {
+        ok &= disable_headless_boot_for(*account);
+      }
+    }
+
     if (!ok) {
       BOOST_LOG(error) << "Linux host setup did not complete successfully"sv;
       return 1;
@@ -369,7 +555,8 @@ namespace args {
     }
     std::cout
       << "Existing virtual gamepad nodes keep their previous access policy until recreated; stop active streams and restart Polaris after changing client gamepad seat isolation."sv << std::endl
-      << "Start Polaris directly with `polaris`, or opt into background autostart with `systemctl --user enable --now polaris`."sv << std::endl;
+      << "Start Polaris directly with `polaris`, or opt into background autostart with `systemctl --user enable --now polaris`."sv << std::endl
+      << "For a host that boots with no monitor or desktop login (Game Mode consoles, dedicated streaming boxes), re-run with --enable-headless-boot."sv << std::endl;
     if (!input_group_advice.empty()) {
       std::cout << std::endl
                 << input_group_advice << std::endl;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -439,7 +439,7 @@ namespace logging {
       << "    --help                    | print help"sv << std::endl
       << "    --creds username password | set Web UI credentials; restart Polaris afterwards"sv << std::endl
 #ifdef __linux__
-      << "    --setup-host [--enable-kms] | apply Linux udev/modules setup explicitly"sv << std::endl
+      << "    --setup-host [--enable-kms] [--enable-headless-boot] | apply Linux udev/modules setup explicitly; optionally start at boot with no desktop login"sv << std::endl
 #endif
       << "    --version                 | print the version of sunshine"sv << std::endl
       << std::endl

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -205,6 +205,25 @@ const shellBlockDepths = (commands) => {
 }
 
 describe('Linux packaging contracts', () => {
+  it('lets the user service outlive the desktop session', () => {
+    // A streaming host must keep serving when the desktop session ends: a
+    // headless-boot host never has one, and PartOf= stop propagation would end
+    // an active remote stream on desktop logout. Ordering (After=) stays, and
+    // the desktop-autostart install target stays so desktop hosts keep the
+    // late, environment-complete start; boot start is the explicit
+    // --setup-host --enable-headless-boot opt-in.
+    const unit = readSource('packaging/linux/polaris.service.in')
+    expect(unit).toMatch(/^After=graphical-session\.target$/m)
+    expect(unit).not.toMatch(/^PartOf=/m)
+    expect(unit).toMatch(/^WantedBy=xdg-desktop-autostart\.target$/m)
+
+    const entryHandler = readSource('src/entry_handler.cpp')
+    expect(entryHandler).toContain('--enable-headless-boot')
+    expect(entryHandler).toContain('--disable-headless-boot')
+    expect(entryHandler).toContain('default.target.wants/polaris.service')
+    expect(entryHandler).toContain('loginctl enable-linger')
+  })
+
   it('keeps portal/PipeWire capture independent while gating Wayland helpers', () => {
     const cmake = readSource('cmake/compile_definitions/linux.cmake')
     const portalGrab = readSource('src/platform/linux/portal_grab.cpp')

--- a/src_assets/common/assets/web/system-telemetry.test.js
+++ b/src_assets/common/assets/web/system-telemetry.test.js
@@ -14,4 +14,20 @@ describe('System telemetry display-session guidance', () => {
     expect(home).toContain('missing_display_environment')
     expect(home).toContain('Restart Polaris from the desktop session')
   })
+
+  it('reports boot readiness and keeps headless-boot hosts off the restart-from-desktop advice', () => {
+    // /api/stats/system must say whether this host survives a reboot with no
+    // desktop login, and a host that deliberately boots headless must not be
+    // told its missing desktop environment is a problem to fix by restarting
+    // from the desktop.
+    const confighttp = readFileSync(join(process.cwd(), 'src/confighttp.cpp'), 'utf8')
+
+    expect(confighttp).toContain('boot_readiness')
+    expect(confighttp).toContain('boot_independent')
+    expect(confighttp).toContain('session_bound')
+    expect(confighttp).toContain('/var/lib/systemd/linger')
+    expect(confighttp).toContain('default.target.wants/polaris.service')
+    expect(confighttp).toContain('sudo -H polaris --setup-host --enable-headless-boot')
+    expect(confighttp).toContain('expected on a headless-boot host')
+  })
 })

--- a/tests/unit/platform/test_setup_host_home_isolation.sh
+++ b/tests/unit/platform/test_setup_host_home_isolation.sh
@@ -56,3 +56,39 @@ assert_invalid_prefix_does_not_dispatch() {
 
 assert_invalid_prefix_does_not_dispatch unsupported-short 'Unrecognized flag: [x]' -x
 assert_invalid_prefix_does_not_dispatch malformed-option 'Usage:' '=invalid'
+
+# The headless-boot flags must reach dispatch, refuse to act without root, echo
+# themselves in the sudo hint, and touch nothing in the caller's home. Skipped
+# under a root test runner because the command would then really enable
+# lingering for the invoking account.
+if [[ "$(id -u)" -ne 0 ]]; then
+  headless_home="$root/headless-home"
+  headless_xdg="$root/headless-xdg"
+  mkdir -m 700 -- "$headless_home" "$headless_xdg"
+
+  set +e
+  output="$(env HOME="$headless_home" XDG_CONFIG_HOME="$headless_xdg" \
+    "$POLARIS_TEST_BINARY" --setup-host --enable-headless-boot 2>&1)"
+  rc=$?
+  set -e
+
+  if [[ $rc -eq 0 ]]; then
+    printf '%s\n' '--enable-headless-boot succeeded without root' >&2
+    exit 1
+  fi
+  if ! grep -Fq 'Polaris host setup requires root' <<<"$output"; then
+    printf '%s\n' '--enable-headless-boot did not reach the root gate' >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+  if ! grep -Fq -- '--enable-headless-boot' <<<"$output"; then
+    printf '%s\n' 'the sudo hint dropped --enable-headless-boot' >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+  if [[ -n "$(find "$headless_home" "$headless_xdg" -mindepth 1 -print -quit)" ]]; then
+    printf '%s\n' '--enable-headless-boot wrote per-user state without root' >&2
+    find "$headless_home" "$headless_xdg" -mindepth 1 -print >&2
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Summary

- Drop `PartOf=graphical-session.target` from the packaged user unit. Stop propagation ended an active remote stream whenever a desktop session exited, and a headless-boot host has no graphical session at all. Ordering (`After=`) and the `xdg-desktop-autostart.target` install target stay, so desktop hosts keep the late, environment-complete start they have today.
- Add `--setup-host --enable-headless-boot` / `--disable-headless-boot`: explicit, root-gated opt-in that enables lingering for the invoking account (resolved via `SUDO_USER` through the existing `setup_host_target_user()`, never guessed) and writes the `default.target` want symlink for the packaged unit with ownership handed to the account. Disable removes the hook and deliberately leaves lingering alone since other user services may rely on it. Help text, sudo hints, and the setup summary all carry the new flags.
- Report `boot_readiness` from `/api/stats/system` (`linger_enabled`, `boot_start_linked`, `status` of `boot_independent`/`session_bound`, summary, action), and make the display-session guidance headless-aware: a deliberately headless-boot host with no desktop environment is no longer told to fix it by restarting from the desktop.
- Docs: new "Headless Boot and Deck Images" section in the Bazzite guide (deck images booting straight into gamescope never fire XDG autostart, which is why Polaris seemed to need Desktop Mode), and a console-style-host pointer in the launch modes guide.
- Tests: the home-isolation CTest now proves the new flag reaches dispatch, refuses without root, echoes itself in the sudo hint, and writes nothing to the caller's home; `packaging-contracts.test.js` pins the unit shape (no `PartOf=` directive, ordering and install target present) and the setup-host surface; `system-telemetry.test.js` pins the boot-readiness API and the headless-aware advice.

## Verification

- `ninja -C build polaris` clean; binary stamped with this commit.
- `ctest -R polaris_setup_host_home_isolation` passes, including the new non-root headless-boot case.
- Live smoke on a real host: non-root `--setup-host --enable-headless-boot` refuses with the flag echoed in the sudo hint; `sudo -A -H ... --setup-host --disable-headless-boot` resolves the invoking account, reports nothing to remove, and touches nothing.
- `npm test` green: 69 files, 519 tests.
- `bash scripts/check-public-docs.sh` clean (all `--setup-host` examples use `sudo -H`).

## Scope

Packaged unit, `--setup-host` surface, one system-stats endpoint, docs, and pinning tests. No stream, capture, or session behavior changes. The `window_system` startup snapshot (`platf::init`) is untouched: a boot-started service still needs a restart after a desktop login before wlr/X11 host capture works, which the new guidance states instead of hiding.
