### PR TITLE
feat(apps): per-app close-desktop-steam for private launches

### DIFF
--- a/docs/launch-modes.md
+++ b/docs/launch-modes.md
@@ -117,6 +117,9 @@ You do not need to change the host mode to briefly share your desktop. Any Moonl
 
 The exception is Headless Dongle: its layout is physical, so per-launch overrides are ignored there.
 
+> [!TIP]
+> The reverse situation has a switch too: a private launch is refused when desktop Steam is already running on the host, because starting Steam in the private session would fight the one on your screen. If you would rather have Polaris quit desktop Steam and continue, turn on **Close desktop Steam for private launches** on that app in the Apps editor. Polaris waits for Steam to fully exit before starting the stream. Clients can also request it per launch with `closeDesktopSteamForPrivate=1`.
+
 ## Under the hood (optional reading)
 
 - [Runtime and Streaming Model](runtime.md): how capture paths and fallback decisions actually work.

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -402,6 +402,7 @@ namespace confighttp::validation {
       "per-client-app-identity"sv,
       "terminate-on-pause"sv,
       "use-app-identity"sv,
+      "close-desktop-steam-for-private"sv,
       "desktop-mirror"sv,
       "virtual-display"sv,
       "virtual-display-primary"sv,

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -513,7 +513,7 @@ namespace nvhttp {
       return proc::resolve_desktop_launch_safety_policy(
         private_stream_requested,
         mirror_desktop_requested,
-        force_private_after_desktop_steam_shutdown_requested(args),
+        force_private_after_desktop_steam_shutdown_requested(args) || app.close_desktop_steam_for_private,
         app,
         proc::desktop_steam_client_active(),
         active_desktop_game
@@ -551,7 +551,7 @@ namespace nvhttp {
       return proc::resolve_desktop_launch_safety_policy(
         private_stream_requested,
         mirror_desktop_requested,
-        force_private_after_desktop_steam_shutdown_requested(body),
+        force_private_after_desktop_steam_shutdown_requested(body) || app.close_desktop_steam_for_private,
         app,
         proc::desktop_steam_client_active(),
         active_desktop_game

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -10396,7 +10396,8 @@ namespace proc {
    * Legacy versions of Sunshine/Apollo stored boolean and integer values as strings.
    * The following keys are converted:
    *   - Boolean keys: "exclude-global-prep-cmd", "elevated", "auto-detach", "wait-all",
-   *                     "use-app-identity", "per-client-app-identity", "desktop-mirror", "virtual-display"
+   *                     "use-app-identity", "per-client-app-identity", "desktop-mirror", "virtual-display",
+   *                     "close-desktop-steam-for-private"
    *   - Integer keys: "exit-timeout"
    *
    * A migration version is stored in the file tree (under "version") so that future changes can be applied.
@@ -10486,6 +10487,7 @@ namespace proc {
         {"use-app-identity", false},
         {"per-client-app-identity", false},
         {"desktop-mirror", false},
+        {"close-desktop-steam-for-private", false},
         {"virtual-display", false},
         {"virtual-display-primary", false},
         {"terminate-on-pause", false}
@@ -11132,6 +11134,7 @@ namespace proc {
           ctx.exit_timeout = std::chrono::seconds { app_node.value("exit-timeout", 5) };
           ctx.virtual_display = app_node.value("virtual-display", false);
           ctx.desktop_mirror = app_node.value("desktop-mirror", false);
+          ctx.close_desktop_steam_for_private = app_node.value("close-desktop-steam-for-private", false);
           ctx.scale_factor = app_node.value("scale-factor", 100);
           ctx.use_app_identity = app_node.value("use-app-identity", false);
           ctx.per_client_app_identity = app_node.value("per-client-app-identity", false);

--- a/src/process.h
+++ b/src/process.h
@@ -592,6 +592,10 @@ namespace proc {
     bool virtual_display;
     bool virtual_display_primary;
     bool desktop_mirror = false;
+    // Per-app twin of the closeDesktopSteamForPrivate launch parameter: when
+    // desktop Steam blocks a private launch of this app, shut it down and
+    // proceed instead of refusing.
+    bool close_desktop_steam_for_private = false;
     bool use_app_identity;
     bool per_client_app_identity;
     bool allow_client_commands;

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -49,6 +49,8 @@
     "close": "Terminate",
     "close_warning": "Are you sure to terminate the current running app?",
     "close_failed": "App termination failed.",
+    "close_desktop_steam_for_private": "Close desktop Steam for private launches",
+    "close_desktop_steam_for_private_desc": "If desktop Steam is running when this app starts a private stream, quit it and wait for it to fully exit instead of refusing the launch. Anything unsaved in the desktop Steam session is closed.",
     "cmd": "Command",
     "cmd_desc": "The main application to start. If blank, no application will be started.",
     "cmd_note": "If the path to the command executable contains spaces, you must enclose it in quotes.",

--- a/src_assets/common/assets/web/views/AppsView.vue
+++ b/src_assets/common/assets/web/views/AppsView.vue
@@ -990,6 +990,7 @@
               <Checkbox class="app-editor-toggle-card" id="waitAll" label="apps.wait_all" desc="apps.wait_all_desc" desc-as-hint v-model="editForm['wait-all']" default="true"></Checkbox>
               <Checkbox class="app-editor-toggle-card" id="terminateOnPause" label="apps.terminate_on_pause" desc="apps.terminate_on_pause_desc" desc-as-hint v-model="editForm['terminate-on-pause']" default="false"></Checkbox>
               <Checkbox class="app-editor-toggle-card" id="virtualDisplay" label="apps.virtual_display" desc="apps.virtual_display_desc" desc-as-hint v-model="editForm['virtual-display']" default="false"></Checkbox>
+              <Checkbox class="app-editor-toggle-card" id="closeDesktopSteamForPrivate" label="apps.close_desktop_steam_for_private" desc="apps.close_desktop_steam_for_private_desc" desc-as-hint v-model="editForm['close-desktop-steam-for-private']" default="false"></Checkbox>
               <Checkbox class="app-editor-toggle-card" id="useAppIdentity" label="apps.use_app_identity" desc="apps.use_app_identity_desc" desc-as-hint v-model="editForm['use-app-identity']" default="false"></Checkbox>
               <Checkbox class="app-editor-toggle-card" v-if="editForm['use-app-identity']" id="perClientAppIdentity" label="apps.per_client_app_identity" desc="apps.per_client_app_identity_desc" desc-as-hint v-model="editForm['per-client-app-identity']" default="false"></Checkbox>
               <div class="app-editor-field">
@@ -1165,6 +1166,7 @@ const newAppTemplate = {
   "per-client-app-identity": false,
   "allow-client-commands": true,
   "virtual-display": false,
+  "close-desktop-steam-for-private": false,
   "terminate-on-pause": false,
   "gamepad": "",
   "game-category": ""

--- a/tests/unit/test_steam_shutdown_state_machine.cpp
+++ b/tests/unit/test_steam_shutdown_state_machine.cpp
@@ -737,4 +737,37 @@ TEST(SteamShutdownStateMachineTests, BothNvhttpRoutesGateOnLiveRefreshedPolicy) 
   ASSERT_NE(api_gate, std::string::npos);
   EXPECT_LT(api_refresh, api_gate);
 }
+
+TEST(SteamShutdownStateMachineTests, PerAppCloseDesktopSteamReachesBothNvhttpRoutes) {
+  // The per-app "close-desktop-steam-for-private" flag is the only way a
+  // standard Moonlight client (which cannot add launch parameters) can opt
+  // into close-desktop-Steam-then-launch. It must enter the policy exactly
+  // where the request-side closeDesktopSteamForPrivate parameter does, in
+  // BOTH nvhttp wrappers, so the shutdown-and-re-resolve flow the routes
+  // already implement applies to it unchanged. It must not be OR-ed into the
+  // post-shutdown recheck, which deliberately re-resolves with the force flag
+  // off.
+  const auto nvhttp = read_source_file("src/nvhttp.cpp");
+  ASSERT_FALSE(nvhttp.empty());
+  EXPECT_NE(
+    nvhttp.find("force_private_after_desktop_steam_shutdown_requested(args) || app.close_desktop_steam_for_private"),
+    std::string::npos
+  );
+  EXPECT_NE(
+    nvhttp.find("force_private_after_desktop_steam_shutdown_requested(body) || app.close_desktop_steam_for_private"),
+    std::string::npos
+  );
+
+  // The flag only exists if apps.json parsing and payload validation both
+  // know the key; losing either silently turns the toggle into a no-op.
+  const auto process = read_source_file("src/process.cpp");
+  ASSERT_FALSE(process.empty());
+  EXPECT_NE(
+    process.find("app_node.value(\"close-desktop-steam-for-private\", false)"),
+    std::string::npos
+  );
+  const auto validation = read_source_file("src/confighttp_validation.cpp");
+  ASSERT_FALSE(validation.empty());
+  EXPECT_NE(validation.find("\"close-desktop-steam-for-private\"sv"), std::string::npos);
+}
 #endif


### PR DESCRIPTION
## Summary

- Add a per-app `close-desktop-steam-for-private` boolean (discussion #553): when desktop Steam blocks a private launch of that app, Polaris shuts it down, waits for real quiescence, and proceeds, instead of refusing with `desktop_active_private_stream_refused`. This is the per-app twin of the existing `closeDesktopSteamForPrivate=1` launch parameter, which no client currently sends and which standard Moonlight clients cannot send at all.
- The flag enters the policy at the same point the request parameter does, OR-ed in both nvhttp `resolve_streaming_launch_safety_policy` wrappers, exactly mirroring the existing `explicit_mirror_desktop_requested(...) || app.desktop_mirror` per-app pattern one line above. Both launch routes' existing shutdown-and-re-resolve flow applies unchanged; the post-shutdown recheck still re-resolves with the force flag off.
- The key is learned by the apps.json parser, the legacy boolean migration list, and `validate_app_payload`'s `bool_keys`, and the Apps editor gains the checkbox under Runtime behavior (template default false, locale strings state plainly that unsaved desktop Steam state is closed).
- The web-UI `launchApp` route is deliberately untouched: it never implemented the shutdown-and-re-resolve branch (pre-existing asymmetry), so with the toggle set the web Launch button keeps refusing exactly as today rather than proceeding without a shutdown.
- Docs: a short TIP in the launch modes guide covering the toggle and the launch parameter.

## Verification

- `ninja` clean; `ctest`: `test_polaris_steam_shutdown` (includes the new `PerAppCloseDesktopSteamReachesBothNvhttpRoutes` source pin), `test_polaris_config` (desktop launch policy suite), `test_polaris_http` all pass.
- The new pinning test holds all four load-bearing sites (both route ORs, parser key, validator key), so no single refactor can silently turn the toggle into a no-op.
- `npm test` green: 69 files, 519 tests. `bash scripts/check-public-docs.sh` clean.

## Scope

App schema, two one-line policy-input ORs, Apps editor checkbox, docs, and a pinning test. No changes to the guard's detection, the shutdown state machine, or the post-shutdown recheck semantics.
