### PR TITLE
fix(linux): expose exact wlroots virtual output capture

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,10 @@ This file tracks the public Polaris release line.
 Older historical tags remain in the repository for continuity, but the current public product line
 starts at `v1.0.0`.
 
+## Unreleased
+
+- Made direct wlroots capture logs identify the exact selected connector even when the compositor supplies no human-readable description, and pinned the Host Virtual Display regression where a physical monitor is enumerated before the generated `POLARIS-HEADLESS-*` output.
+
 ## v1.4.0 - 2026-09-01
 
 A matched feature release for Nova v1.4.0. Doctor turns measured stream evidence into a clear explanation and, only when the evidence supports it, a reversible same-stream fix. Launch fields come from deterministic presets with field-level provenance, while history and AI remain unable to silently change a launch or inject a game-process limiter.

--- a/src/platform/linux/wlgrab.cpp
+++ b/src/platform/linux/wlgrab.cpp
@@ -185,7 +185,12 @@ namespace wl {
       this->env_width = ::wl::env_width;
       this->env_height = ::wl::env_height;
 
-      BOOST_LOG(info) << "Selected monitor ["sv << monitor->description << "] for streaming"sv;
+      const auto selected_monitor_identity = wlgrab_capture_policy::enumerated_monitor_identity(
+        *monitor_index,
+        monitor->name
+      );
+      BOOST_LOG(info) << "Selected monitor ["sv << selected_monitor_identity
+                      << "] for streaming; description=["sv << monitor->description << ']';
       BOOST_LOG(debug) << "Offset: "sv << offset_x << 'x' << offset_y;
       BOOST_LOG(debug) << "Resolution: "sv << width << 'x' << height;
       BOOST_LOG(debug) << "Desktop Resolution: "sv << env_width << 'x' << env_height;

--- a/tests/unit/test_wlgrab_capture_policy.cpp
+++ b/tests/unit/test_wlgrab_capture_policy.cpp
@@ -77,6 +77,28 @@ TEST(WlgrabCapturePolicy, RequestedMonitorSelectionIsExactAndFailClosed) {
   EXPECT_FALSE(wlgrab_capture_policy::select_monitor_index("", {}).has_value());
 }
 
+TEST(WlgrabCapturePolicy, HostVirtualOutputDoesNotFallBackToPhysicalMonitorZero) {
+  // Issue #556: Hyprland advertises the physical monitor first and the newly
+  // created headless connector second. A connector name must never be parsed
+  // as index zero or silently fall back to it.
+  const std::vector<std::string> monitors {
+    "DP-2",
+    "POLARIS-HEADLESS-1627120-0",
+  };
+
+  const auto selected = wlgrab_capture_policy::select_monitor_index(
+    "POLARIS-HEADLESS-1627120-0",
+    monitors
+  );
+
+  ASSERT_TRUE(selected.has_value());
+  EXPECT_EQ(*selected, 1u);
+  EXPECT_FALSE(wlgrab_capture_policy::select_monitor_index(
+    "POLARIS-HEADLESS-unknown",
+    monitors
+  ).has_value());
+}
+
 TEST(WlgrabCapturePolicy, DirectVaapiCaptureUsesRamFallback) {
   EXPECT_EQ(
     wlgrab_capture_policy::select_direct_capture_path(platf::mem_type_e::vaapi, true),


### PR DESCRIPTION
## Summary

- Rebased the issue #556 follow-up onto the released Polaris v1.4.0 master.
- Log the exact wlroots connector selected for capture even when the compositor provides a blank human-readable description.
- Pin the Hyprland ordering where the physical monitor is enumerated first and the generated POLARIS-HEADLESS output second; connector selection remains exact and fail-closed.
- Record the follow-up under Unreleased without rewriting the published v1.4.0 release notes.

## Release boundary

The substantive exact-name capture policy is already present in v1.4.0. This draft improves field evidence and regression coverage for issue #556. It is a v1.4.1 candidate, not a retroactive v1.4.0 change.

## Required validation

- Fresh exact-head sanitizer, native, packaging, and public-hygiene CI.
- An affected AMD/Hyprland host must show Selected monitor [POLARIS-HEADLESS-*], requested virtual dimensions, and no physical-output capture.

Keep this PR draft until both gates pass.

Refs #556.