### PR TITLE
Fix nested Gamescope teardown and no-op config writes

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -126,6 +126,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/game_artwork_provider.cpp"
         "${CMAKE_SOURCE_DIR}/src/config.h"
         "${CMAKE_SOURCE_DIR}/src/config.cpp"
+        "${CMAKE_SOURCE_DIR}/src/config_file_update.h"
+        "${CMAKE_SOURCE_DIR}/src/config_file_update.cpp"
         "${CMAKE_SOURCE_DIR}/src/crash_report.cpp"
         "${CMAKE_SOURCE_DIR}/src/crash_report.h"
         "${CMAKE_SOURCE_DIR}/src/client_support_report.cpp"

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -467,6 +467,42 @@ wait_for_nested_gamescope_exit() {
   return 2
 }
 
+retire_marked_nested_gamescope_child_first() {
+  local graceful_exit=0
+  polaris_validate_marker "$marker" nested || return 1
+  if ! kill_session_steam || ! session_steam_absent; then
+    echo "polaris-gamescope-session: exact-session Steam did not reach terminal state" >&2
+    return 1
+  fi
+
+  wait_for_nested_gamescope_exit || graceful_exit=$?
+  case "$graceful_exit" in
+    0)
+      echo "polaris-gamescope-session: nested owner exited after exact-session Steam" >&2
+      return 0
+      ;;
+    1)
+      echo "polaris-gamescope-session: nested owner exceeded graceful exit window; using exact-generation fence" >&2
+      if polaris_stop_marked_gamescope "$marker" nested "$rt"; then
+        return 0
+      fi
+      # The generation may finish between the last wait probe and the fenced
+      # helper's first identity check. Accept only the same safe dead/orphan
+      # proof used by the graceful path.
+      if polaris_validate_marker "$marker" nested \
+          || ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+        return 1
+      fi
+      echo "polaris-gamescope-session: nested owner exited while the fallback was acquiring authority" >&2
+      return 0
+      ;;
+    *)
+      echo "polaris-gamescope-session: nested ownership changed during graceful exit" >&2
+      return 1
+      ;;
+  esac
+}
+
 # True while a real game process for $1 (Steam appid) is running.
 # Steam client / webhelper also inherit SteamAppId — exclude those so
 # Big Picture alone does not count as "game still up".
@@ -776,7 +812,7 @@ case "${1:-}" in
       if [ "$nested_marked" != 1 ]; then
         echo "polaris-gamescope-session: failed to record an exact nested gamescope generation in its private setsid group" >&2
         if [ -f "$marker" ] && polaris_validate_marker "$marker" nested; then
-          polaris_stop_marked_gamescope "$marker" nested "$rt" || true
+          retire_marked_nested_gamescope_child_first || true
         fi
         # Without an exact marker plus PGID/SID proof there is no safe numeric
         # fallback. Preserve the recovery claim and let service/cgroup teardown
@@ -795,7 +831,7 @@ case "${1:-}" in
       done
       if [ "$ready" != 1 ]; then
         echo "polaris-gamescope-session: owned nested gamescope-0/Xwayland not ready — see $steam_log" >&2
-        polaris_stop_marked_gamescope "$marker" nested "$rt" || true
+        retire_marked_nested_gamescope_child_first || true
         exit 1
       fi
       publish_nested_claim nested nested || {
@@ -1024,35 +1060,10 @@ case "${1:-}" in
             # X11 I/O abort path. Signal only credential-bound session Steam,
             # then give the exact compositor generation a bounded graceful
             # exit before using the process-group fence as a fallback.
-            if ! kill_session_steam || ! session_steam_absent; then
-              echo "polaris-gamescope-session: exact-session Steam did not reach terminal state; retaining recovery claim" >&2
+            if ! retire_marked_nested_gamescope_child_first; then
+              echo "polaris-gamescope-session: nested owner did not reach terminal state; retaining recovery claim" >&2
               exit 1
             fi
-            graceful_exit=0
-            wait_for_nested_gamescope_exit || graceful_exit=$?
-            case "$graceful_exit" in
-              0)
-                echo "polaris-gamescope-session: nested owner exited after exact-session Steam" >&2
-                ;;
-              1)
-                echo "polaris-gamescope-session: nested owner exceeded graceful exit window; using exact-generation fence" >&2
-                if ! polaris_stop_marked_gamescope "$marker" nested "$rt"; then
-                  # The generation may finish between the last wait probe and
-                  # the fenced helper's first identity check. Accept only the
-                  # same safe dead/orphan proof used by the graceful path.
-                  if polaris_validate_marker "$marker" nested \
-                      || ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
-                    echo "polaris-gamescope-session: nested owner did not reach terminal state; retaining recovery claim" >&2
-                    exit 1
-                  fi
-                  echo "polaris-gamescope-session: nested owner exited while the fallback was acquiring authority" >&2
-                fi
-                ;;
-              *)
-                echo "polaris-gamescope-session: nested ownership changed during graceful exit; retaining recovery claim" >&2
-                exit 1
-                ;;
-            esac
           else
             if ! kill_session_steam || ! session_steam_absent; then
               echo "polaris-gamescope-session: exact-session Steam did not reach terminal state; retaining recovery claim" >&2

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -437,6 +437,36 @@ kill_session_steam() {
   session_steam_absent
 }
 
+# Give Gamescope a bounded opportunity to finish its normal teardown after the
+# credential-bound Steam child exits. Return 0 only when the exact marker is no
+# longer live and every old socket is absent or safely reclaimable; return 1
+# when the exact generation remains live for the fenced fallback; return 2 when
+# ownership became ambiguous and no destructive fallback is authorized.
+wait_for_nested_gamescope_exit() {
+  local rc
+  for _ in $(seq 1 "${POLARIS_NESTED_EXIT_WAIT_STEPS:-50}"); do
+    if polaris_validate_marker "$marker" nested; then
+      sleep "${POLARIS_NESTED_EXIT_WAIT_INTERVAL:-0.1}"
+      continue
+    fi
+    if polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+      return 0
+    fi
+    return 2
+  done
+
+  if polaris_validate_marker "$marker" nested; then
+    return 1
+  else
+    rc=$?
+  fi
+  [ "$rc" -eq 1 ] || return 2
+  if polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+    return 0
+  fi
+  return 2
+}
+
 # True while a real game process for $1 (Steam appid) is running.
 # Steam client / webhelper also inherit SteamAppId — exclude those so
 # Big Picture alone does not count as "game still up".
@@ -989,14 +1019,40 @@ case "${1:-}" in
         1|nested)
           echo "polaris-gamescope-session: tearing down marked nested WSI gamescope" >&2
           if polaris_validate_marker "$marker" nested; then
-            # Gamescope 3.16 can fault in CVulkanDevice teardown when its
-            # primary Steam child exits. The marker already proves the private
-            # process-group generation, so fence and retire that exact group
-            # before its destructor can race outer process cleanup.
-            if ! polaris_stop_marked_gamescope "$marker" nested "$rt"; then
-              echo "polaris-gamescope-session: nested owner did not reach terminal state; retaining recovery claim" >&2
+            # Normal teardown is child-first. Killing/freezing the compositor
+            # while its XWM/Xwayland children are active can drive Gamescope's
+            # X11 I/O abort path. Signal only credential-bound session Steam,
+            # then give the exact compositor generation a bounded graceful
+            # exit before using the process-group fence as a fallback.
+            if ! kill_session_steam || ! session_steam_absent; then
+              echo "polaris-gamescope-session: exact-session Steam did not reach terminal state; retaining recovery claim" >&2
               exit 1
             fi
+            graceful_exit=0
+            wait_for_nested_gamescope_exit || graceful_exit=$?
+            case "$graceful_exit" in
+              0)
+                echo "polaris-gamescope-session: nested owner exited after exact-session Steam" >&2
+                ;;
+              1)
+                echo "polaris-gamescope-session: nested owner exceeded graceful exit window; using exact-generation fence" >&2
+                if ! polaris_stop_marked_gamescope "$marker" nested "$rt"; then
+                  # The generation may finish between the last wait probe and
+                  # the fenced helper's first identity check. Accept only the
+                  # same safe dead/orphan proof used by the graceful path.
+                  if polaris_validate_marker "$marker" nested \
+                      || ! polaris_reclaim_orphan_gamescope_sockets "$rt"; then
+                    echo "polaris-gamescope-session: nested owner did not reach terminal state; retaining recovery claim" >&2
+                    exit 1
+                  fi
+                  echo "polaris-gamescope-session: nested owner exited while the fallback was acquiring authority" >&2
+                fi
+                ;;
+              *)
+                echo "polaris-gamescope-session: nested ownership changed during graceful exit; retaining recovery claim" >&2
+                exit 1
+                ;;
+            esac
           else
             if ! kill_session_steam || ! session_steam_absent; then
               echo "polaris-gamescope-session: exact-session Steam did not reach terminal state; retaining recovery claim" >&2

--- a/src/config_file_update.cpp
+++ b/src/config_file_update.cpp
@@ -1,0 +1,146 @@
+/**
+ * @file src/config_file_update.cpp
+ * @brief Lossless text updates for the Polaris configuration file.
+ */
+
+#include "config_file_update.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace config_file_update {
+  namespace {
+    bool horizontal_space(char ch) {
+      return ch == ' ' || ch == '\t';
+    }
+
+    std::string_view newline_for(std::string_view content) {
+      const auto newline = content.find_first_of("\r\n");
+      if (newline == std::string_view::npos) {
+        return "\n";
+      }
+      if (content[newline] == '\r' && newline + 1 < content.size() && content[newline + 1] == '\n') {
+        return "\r\n";
+      }
+      return content.substr(newline, 1);
+    }
+  }  // namespace
+
+  result_t apply(
+    std::string_view existing,
+    const std::unordered_map<std::string, std::string> &updates
+  ) {
+    result_t result {std::string(existing), false};
+    if (updates.empty()) {
+      return result;
+    }
+
+    std::string output;
+    output.reserve(existing.size());
+    std::unordered_set<std::string> handled;
+    std::size_t cursor = 0;
+    int list_depth = 0;
+
+    while (cursor < existing.size()) {
+      const auto line_break = existing.find_first_of("\r\n", cursor);
+      const auto line_end = line_break == std::string_view::npos ? existing.size() : line_break;
+      std::size_t next_line = line_end;
+      if (line_break != std::string_view::npos) {
+        ++next_line;
+        if (existing[line_break] == '\r' && next_line < existing.size() && existing[next_line] == '\n') {
+          ++next_line;
+        }
+      }
+
+      const auto comment = existing.find('#', cursor);
+      const auto code_end = comment != std::string_view::npos && comment < line_end ? comment : line_end;
+      bool consumed = false;
+
+      if (list_depth == 0) {
+        auto key_begin = cursor;
+        while (key_begin < code_end && horizontal_space(existing[key_begin])) {
+          ++key_begin;
+        }
+        const auto equals = existing.find('=', key_begin);
+        if (equals != std::string_view::npos && equals < code_end && equals != key_begin) {
+          auto key_end = equals;
+          while (key_end > key_begin && horizontal_space(existing[key_end - 1])) {
+            --key_end;
+          }
+          const std::string key(existing.substr(key_begin, key_end - key_begin));
+          const auto update = updates.find(key);
+          if (update != updates.end()) {
+            if (update->second.empty()) {
+              result.changed = true;
+              handled.insert(key);
+              consumed = true;
+            } else if (!handled.contains(key)) {
+              auto value_begin = equals + 1;
+              while (value_begin < code_end && horizontal_space(existing[value_begin])) {
+                ++value_begin;
+              }
+              auto value_end = code_end;
+              while (value_end > value_begin && horizontal_space(existing[value_end - 1])) {
+                --value_end;
+              }
+              handled.insert(key);
+              if (existing.substr(value_begin, value_end - value_begin) == update->second) {
+                output.append(existing.substr(cursor, next_line - cursor));
+              } else {
+                output.append(existing.substr(cursor, value_begin - cursor));
+                output.append(update->second);
+                output.append(existing.substr(value_end, next_line - value_end));
+                result.changed = true;
+              }
+              consumed = true;
+            }
+          }
+        }
+      }
+
+      if (!consumed) {
+        output.append(existing.substr(cursor, next_line - cursor));
+      }
+
+      for (auto position = cursor; position < code_end; ++position) {
+        if (existing[position] == '[') {
+          ++list_depth;
+        } else if (existing[position] == ']' && list_depth > 0) {
+          --list_depth;
+        }
+      }
+      cursor = next_line;
+    }
+
+    std::vector<std::pair<std::string, std::string>> additions;
+    additions.reserve(updates.size());
+    for (const auto &[key, value] : updates) {
+      if (!value.empty() && !handled.contains(key)) {
+        additions.emplace_back(key, value);
+      }
+    }
+    std::sort(additions.begin(), additions.end());
+
+    if (!additions.empty()) {
+      const auto newline = newline_for(existing);
+      if (!output.empty() && output.back() != '\n' && output.back() != '\r') {
+        output.append(newline);
+      }
+      for (const auto &[key, value] : additions) {
+        output.append(key);
+        output.append(" = ");
+        output.append(value);
+        output.append(newline);
+      }
+      result.changed = true;
+    }
+
+    result.content = result.changed ? std::move(output) : std::string(existing);
+    return result;
+  }
+
+}  // namespace config_file_update

--- a/src/config_file_update.h
+++ b/src/config_file_update.h
@@ -1,0 +1,30 @@
+/**
+ * @file src/config_file_update.h
+ * @brief Lossless text updates for the Polaris configuration file.
+ */
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace config_file_update {
+
+  struct result_t {
+    std::string content;
+    bool changed = false;
+  };
+
+  /**
+   * Update scalar configuration values without reserializing unrelated text.
+   *
+   * Existing comments, ordering, whitespace, newline style, unknown settings,
+   * and list bodies remain byte-for-byte unchanged. An empty value removes all
+   * matching assignments so a duplicate cannot unexpectedly become active.
+   */
+  result_t apply(
+    std::string_view existing,
+    const std::unordered_map<std::string, std::string> &updates
+  );
+
+}  // namespace config_file_update

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -55,6 +55,7 @@
 
 // local includes
 #include "config.h"
+#include "config_file_update.h"
 #include "display_device.h"
 #include "display_planner.h"
 #include "entry_handler.h"
@@ -1289,20 +1290,27 @@ namespace nvhttp {
         return false;
       }
 
-      auto vars = config::parse_config(existing_config);
-      for (const auto &[key, value] : updates) {
-        vars[key] = value;
-      }
-
-      std::stringstream config_stream;
-      for (const auto &[key, value] : vars) {
-        if (value.empty()) {
-          continue;
+      const auto vars = config::parse_config(existing_config);
+      const bool unchanged = std::all_of(
+        updates.begin(), updates.end(),
+        [&](const auto &update) {
+          const auto existing_value = vars.find(update.first);
+          if (update.second.empty()) {
+            return existing_value == vars.end();
+          }
+          return existing_value != vars.end() && existing_value->second == update.second;
         }
-        config_stream << key << " = " << value << std::endl;
+      );
+      if (unchanged) {
+        return true;
       }
 
-      const auto persisted = private_state_file::write_atomic(target, config_stream.str());
+      const auto updated = config_file_update::apply(existing_config, updates);
+      if (!updated.changed) {
+        return true;
+      }
+
+      const auto persisted = private_state_file::write_atomic(target, updated.content);
       if (persisted.status == private_state_file::write_status_e::not_committed) {
         BOOST_LOG(error) << "client_settings: atomic config replacement did not commit: "sv << target;
         return false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/browser_stream_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/crash_report.cpp
     ${CMAKE_SOURCE_DIR}/src/client_support_report.cpp
+    ${CMAKE_SOURCE_DIR}/src/config_file_update.cpp
     ${CMAKE_SOURCE_DIR}/src/doctor_v2.cpp
     ${CMAKE_SOURCE_DIR}/src/doctor_trial.cpp
     ${CMAKE_SOURCE_DIR}/src/file_handler.cpp
@@ -111,6 +112,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_confighttp_benchmark_auth.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_cover_download_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_client_settings_advertisement.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_config_file_update.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_browser_stream_protocol.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_crash_report.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_client_support_report.cpp

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -604,7 +604,7 @@ grep -Fq 'acquire_session_operation_lock' "$script" ||
 grep -Fq 'wait_for_nested_gamescope_exit' "$script" ||
   fail "nested stop does not provide a bounded graceful compositor-exit window"
 steam_stop_line="$(grep -nF 'if ! kill_session_steam || ! session_steam_absent; then' "$script" | head -n1 | cut -d: -f1)"
-fenced_stop_line="$(grep -nF 'polaris_stop_marked_gamescope "$marker" nested "$rt"' "$script" | head -n1 | cut -d: -f1)"
+fenced_stop_line="$(grep -nF 'if ! polaris_stop_marked_gamescope "$marker" nested "$rt"; then' "$script" | head -n1 | cut -d: -f1)"
 [ -n "$steam_stop_line" ] && [ -n "$fenced_stop_line" ] && [ "$steam_stop_line" -lt "$fenced_stop_line" ] ||
   fail "nested stop does not order exact-session Steam before compositor fallback"
 grep -Fq 'polaris_stop_marked_gamescope "$marker" nested "$rt"' "$script" ||

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -89,6 +89,9 @@ if [ "$signal" = -TERM ] && [ "${STEAM_IGNORES_TERM:-0}" = 1 ]; then
   exit 0
 fi
 rm -rf "$POLARIS_PROC_ROOT/$pid"
+if [ "${NESTED_EXITS_WITH_STEAM:-0}" = 1 ]; then
+  : >"$POLARIS_ACTIONS.nested-stopped"
+fi
 EOF
 chmod +x "$work/bin/"*
 
@@ -108,10 +111,12 @@ run_stop() {
     POLARIS_XWAYLAND_PGREP_STATUS="${POLARIS_XWAYLAND_PGREP_STATUS:-0}" \
     POLARIS_STEAM_TERM_STEPS=1 POLARIS_STEAM_KILL_STEPS=1 \
     POLARIS_XWAYLAND_TERM_STEPS=1 POLARIS_XWAYLAND_KILL_STEPS=1 \
+    POLARIS_NESTED_EXIT_WAIT_STEPS=1 POLARIS_NESTED_EXIT_WAIT_INTERVAL=0 \
     POLARIS_IDLE_WAIT_STEPS=2 POLARIS_PORTAL_WAIT_STEPS=2 \
     NESTED_VALID="${NESTED_VALID:-0}" STOP_OK="${STOP_OK:-0}" \
     STOP_DELAY="${STOP_DELAY:-}" \
     STEAM_IGNORES_TERM="${STEAM_IGNORES_TERM:-0}" \
+    NESTED_EXITS_WITH_STEAM="${NESTED_EXITS_WITH_STEAM:-0}" \
     RECLAIM_OK="${RECLAIM_OK:-0}" IDLE_VALID="${IDLE_VALID:-0}" \
     IDLE_OWNS_SOCKET="${IDLE_OWNS_SOCKET:-0}" WRITE_ENV_OK="${WRITE_ENV_OK:-0}" \
     IDLE_START_OK="${IDLE_START_OK:-1}" PORTAL_RESTART_OK="${PORTAL_RESTART_OK:-1}" \
@@ -309,8 +314,8 @@ fi
   fail "unreadable Steam metadata advanced the recovery claim"
 rm -rf "$work/proc/102"
 
-# A live nested generation is retired through the exact process-group fence.
-# Desktop Steam is neither signalled nor removed by session teardown.
+# A live nested generation asks credential-bound Steam to exit before using the
+# exact process-group fence. Desktop Steam is never signalled or removed.
 reset_state
 mkdir -p "$work/proc/100" "$work/proc/101"
 printf '10\n' >"$work/proc/100/start"
@@ -320,23 +325,27 @@ printf 'HOME=/srv/example\0POLARIS_SESSION_INSTANCE_ID=session-A\0' >"$work/proc
 POLARIS_SESSION_INSTANCE_ID=session-A POLARIS_PGREP_OUTPUT=$'100\n101' \
   NESTED_VALID=1 STOP_OK=1 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
   PORTAL_READY=1 run_stop >/dev/null 2>&1 || fail "exact-session Steam handoff failed"
+grep -qx 'kill -TERM 101' "$actions" || fail "nested teardown did not ask exact-session Steam to exit"
 grep -qx 'stop-nested' "$actions" || fail "nested generation did not use its fenced stop"
-! grep -q 'kill .*101' "$actions" || fail "nested teardown bypassed its process-group fence"
 ! grep -q 'kill .*100' "$actions" || fail "desktop Steam was signalled"
 [ -d "$work/proc/100" ] || fail "desktop Steam process was removed"
+steam_line="$(grep -nFx 'kill -TERM 101' "$actions" | head -n1 | cut -d: -f1)"
+fence_line="$(grep -nFx 'stop-nested' "$actions" | head -n1 | cut -d: -f1)"
+[ "$steam_line" -lt "$fence_line" ] || fail "nested compositor fence ran before exact-session Steam exit"
 
-# Even when child exit would normally terminate Gamescope, nested teardown uses
-# the fence so the known Vulkan destructor path cannot produce a fresh core.
+# When child exit terminates Gamescope normally, accept only a dead-marker plus
+# reclaimable-socket proof and never enter the destructive compositor fence.
 reset_state
 mkdir -p "$work/proc/101"
 printf '11\n' >"$work/proc/101/start"
 printf 'POLARIS_SESSION_INSTANCE_ID=session-A\0' >"$work/proc/101/environ"
 POLARIS_SESSION_INSTANCE_ID=session-A POLARIS_PGREP_OUTPUT=101 \
-  NESTED_VALID=1 STOP_OK=1 \
+  NESTED_VALID=1 NESTED_EXITS_WITH_STEAM=1 STOP_OK=0 RECLAIM_OK=1 \
   IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 PORTAL_READY=1 \
-  run_stop >/dev/null 2>&1 || fail "fenced nested exit handoff failed"
-grep -qx 'stop-nested' "$actions" || fail "fenced exit did not retire the compositor group"
-! grep -q 'kill .*101' "$actions" || fail "fenced exit separately signalled Steam"
+  run_stop >/dev/null 2>&1 || fail "graceful nested exit handoff failed"
+grep -qx 'kill -TERM 101' "$actions" || fail "graceful exit did not signal exact-session Steam"
+grep -qx 'reclaim' "$actions" || fail "graceful exit did not prove old sockets reclaimable"
+! grep -qx 'stop-nested' "$actions" || fail "graceful exit unnecessarily fenced the compositor"
 
 # Overlapping stop attempts serialize on one lifecycle lock. The first consumes
 # the durable state; the waiter then observes an idempotently completed stop.
@@ -592,8 +601,12 @@ grep -Fq 'export POLARIS_GAMESCOPE_LOCK_HELD=1' "$script" ||
   fail "portal handoff is not finalized under the ownership lock"
 grep -Fq 'acquire_session_operation_lock' "$script" ||
   fail "nested lifecycle operations are not serialized"
-! grep -Fq 'wait_for_nested_gamescope_exit' "$script" ||
-  fail "nested stop still enters the crashing graceful compositor-exit window"
+grep -Fq 'wait_for_nested_gamescope_exit' "$script" ||
+  fail "nested stop does not provide a bounded graceful compositor-exit window"
+steam_stop_line="$(grep -nF 'if ! kill_session_steam || ! session_steam_absent; then' "$script" | head -n1 | cut -d: -f1)"
+fenced_stop_line="$(grep -nF 'polaris_stop_marked_gamescope "$marker" nested "$rt"' "$script" | head -n1 | cut -d: -f1)"
+[ -n "$steam_stop_line" ] && [ -n "$fenced_stop_line" ] && [ "$steam_stop_line" -lt "$fenced_stop_line" ] ||
+  fail "nested stop does not order exact-session Steam before compositor fallback"
 grep -Fq 'polaris_stop_marked_gamescope "$marker" nested "$rt"' "$script" ||
   fail "nested stop does not use the exact-generation compositor fence"
 

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -604,10 +604,12 @@ grep -Fq 'acquire_session_operation_lock' "$script" ||
 grep -Fq 'wait_for_nested_gamescope_exit' "$script" ||
   fail "nested stop does not provide a bounded graceful compositor-exit window"
 steam_stop_line="$(grep -nF 'if ! kill_session_steam || ! session_steam_absent; then' "$script" | head -n1 | cut -d: -f1)"
-fenced_stop_line="$(grep -nF 'if ! polaris_stop_marked_gamescope "$marker" nested "$rt"; then' "$script" | head -n1 | cut -d: -f1)"
+fenced_stop_line="$(grep -nF 'if polaris_stop_marked_gamescope "$marker" nested "$rt"; then' "$script" | head -n1 | cut -d: -f1)"
 [ -n "$steam_stop_line" ] && [ -n "$fenced_stop_line" ] && [ "$steam_stop_line" -lt "$fenced_stop_line" ] ||
   fail "nested stop does not order exact-session Steam before compositor fallback"
 grep -Fq 'polaris_stop_marked_gamescope "$marker" nested "$rt"' "$script" ||
   fail "nested stop does not use the exact-generation compositor fence"
+[ "$(grep -cF 'retire_marked_nested_gamescope_child_first' "$script")" -ge 4 ] ||
+  fail "nested startup failures do not share child-first teardown"
 
 echo "PASS: gamescope session stop state machine"

--- a/tests/unit/test_config_file_update.cpp
+++ b/tests/unit/test_config_file_update.cpp
@@ -1,0 +1,78 @@
+/**
+ * @file tests/unit/test_config_file_update.cpp
+ * @brief Tests for lossless Polaris configuration updates.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/config_file_update.h"
+
+TEST(ConfigFileUpdate, EqualValuesPreserveEveryByte) {
+  const std::string existing =
+    "# Keep this header and CRLF ordering\r\n"
+    "adaptive_bitrate_enabled = enabled  # paired client\r\n"
+    "unknown_future_setting = keep-me\r\n";
+
+  const auto result = config_file_update::apply(
+    existing,
+    {{"adaptive_bitrate_enabled", "enabled"}}
+  );
+
+  EXPECT_FALSE(result.changed);
+  EXPECT_EQ(result.content, existing);
+}
+
+TEST(ConfigFileUpdate, RealChangesPreserveFormattingAndAppendDeterministically) {
+  const std::string existing =
+    "# Host configuration\n"
+    "adaptive_bitrate_enabled = disabled  # keep this note\n"
+    "unknown_future_setting = keep-me\n";
+
+  const auto result = config_file_update::apply(
+    existing,
+    {
+      {"disconnect_resume_timeout_seconds", "300"},
+      {"adaptive_bitrate_enabled", "enabled"},
+    }
+  );
+
+  ASSERT_TRUE(result.changed);
+  EXPECT_EQ(
+    result.content,
+    "# Host configuration\n"
+    "adaptive_bitrate_enabled = enabled  # keep this note\n"
+    "unknown_future_setting = keep-me\n"
+    "disconnect_resume_timeout_seconds = 300\n"
+  );
+}
+
+TEST(ConfigFileUpdate, ClearingAValueRemovesEveryDuplicateAssignment) {
+  const std::string existing =
+    "output_name = DP-1\n"
+    "# retained comment\n"
+    "output_name = DP-2\n"
+    "capture = portal\n";
+
+  const auto result = config_file_update::apply(existing, {{"output_name", ""}});
+
+  ASSERT_TRUE(result.changed);
+  EXPECT_EQ(result.content, "# retained comment\ncapture = portal\n");
+}
+
+TEST(ConfigFileUpdate, DoesNotTreatAssignmentsInsideListsAsTopLevelSettings) {
+  const std::string existing =
+    "prep_cmds = [\n"
+    "  output_name = nested-value\n"
+    "]\n";
+
+  const auto result = config_file_update::apply(existing, {{"output_name", "DP-3"}});
+
+  ASSERT_TRUE(result.changed);
+  EXPECT_EQ(
+    result.content,
+    "prep_cmds = [\n"
+    "  output_name = nested-value\n"
+    "]\n"
+    "output_name = DP-3\n"
+  );
+}

--- a/tests/unit/test_doctor_reset_contract.cpp
+++ b/tests/unit/test_doctor_reset_contract.cpp
@@ -837,6 +837,9 @@ TEST(DoctorResetContract, ClientSettingsPersistencePreservesExistingConfigAtomic
   EXPECT_NE(persistence.find("input.bad()"), std::string::npos);
   EXPECT_NE(persistence.find("input.close()"), std::string::npos);
   EXPECT_NE(persistence.find("input.fail()"), std::string::npos);
+  EXPECT_NE(persistence.find("const bool unchanged = std::all_of"), std::string::npos);
+  EXPECT_NE(persistence.find("if (unchanged)"), std::string::npos);
+  EXPECT_NE(persistence.find("config_file_update::apply"), std::string::npos);
   EXPECT_NE(persistence.find("private_state_file::write_atomic"), std::string::npos);
   EXPECT_NE(
     persistence.find("private_state_file::write_status_e::not_committed"),


### PR DESCRIPTION
## Summary

- stop credential-bound nested Steam before touching the Gamescope process group, then allow a bounded graceful compositor exit
- retain the exact PID/PGID/marker/socket fence as the fallback and fail closed when ownership becomes ambiguous
- preserve Polaris config bytes for semantic no-ops and update real scalar changes without reserializing comments, ordering, unknown fields, or newline style

This is a containment follow-up to #507 after exact-candidate physical acceptance reproduced the X11 I/O abort signature during nested teardown and detected a byte-only config rewrite.

## Verification

- `polaris_gamescope_session_stop_shell`
- focused `ConfigFileUpdate.*` and client-settings persistence contract tests
- full fast `test_polaris` suite
- full Linux `polaris` executable build
- `git diff --check`

## Scope

No Doctor diagnosis/action policy, launch preset, AI authority, package publication, device deployment, or release state changes.