### PR TITLE
Fix Gamescope primary-child reaper ancestry

### DIFF
--- a/nix/modules/polaris-gamescope-runtime-lib.sh
+++ b/nix/modules/polaris-gamescope-runtime-lib.sh
@@ -85,6 +85,36 @@ polaris_headless_gamescope_pid() {
   POLARIS_GAMESCOPE_EXECUTABLE="$exe_path"
 }
 
+# Gamescope 3.16 does not exec the command after `--` as its direct child.
+# It starts gamescopereaper, which becomes a subreaper and then starts the
+# primary command. Keep that process explicit in the ownership chain: treating
+# the command wrapper as a direct Gamescope child rejects the normal upstream
+# launch shape and makes Gamescope enter its unsafe primary-child shutdown.
+polaris_gamescope_reaper_pid() {
+  local pid="$1" arg first=1 executable=""
+  local exe_path exe_name
+  exe_path="$(readlink "$(polaris_proc_root)/$pid/exe" 2>/dev/null)" || return 1
+  exe_name="${exe_path##*/}"
+  case "$exe_name" in
+    gamescopereaper|.gamescopereaper-wrapped) ;;
+    *) return 1 ;;
+  esac
+  while IFS= read -r arg; do
+    if [ "$first" = 1 ]; then
+      executable="${arg##*/}"
+      first=0
+      break
+    fi
+  done < <(tr '\0' '\n' <"$(polaris_proc_root)/$pid/cmdline" 2>/dev/null) || return 1
+  case "$executable" in
+    gamescopereaper|.gamescopereaper-wrapped) ;;
+    *) return 1 ;;
+  esac
+  # Consumed by the session helper after sourcing this library.
+  # shellcheck disable=SC2034
+  POLARIS_GAMESCOPE_REAPER_EXECUTABLE="$exe_path"
+}
+
 # Nix wrapProgram: /proc/pid/exe may be ".../bin/gamescope" or
 # ".../bin/.gamescope-wrapped" depending on when we sample.
 polaris_gamescope_executables_match() {

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -458,7 +458,10 @@ publish_nested_primary_child_exit() (
 
 run_nested_primary_child() {
   local steam_pid="" steam_rc=0 wait_pid="" steam_spawn_started=0
-  local primary_parent_pid="$PPID" primary_parent_start_time=""
+  local primary_reaper_pid="$PPID" primary_reaper_start_time=""
+  local primary_reaper_parent_pid="" primary_reaper_executable=""
+  local primary_gamescope_pid="" primary_gamescope_start_time=""
+  local primary_gamescope_executable=""
   local primary_group_id="" primary_session_id=""
   local primary_wrapper_pid="$$" primary_wrapper_start_time=""
   local primary_fence_armed=0
@@ -543,31 +546,58 @@ run_nested_primary_child() {
     fi
     exit 0
   }
-  # setpriv gives this wrapper a parent-death signal from Gamescope. If the
-  # compositor itself dies, retire the direct Steam launcher rather than
-  # leaving a keepalive orphan behind.
+  # setpriv gives this wrapper a parent-death signal from Gamescope's
+  # gamescopereaper. The reaper has its own parent-death signal from Gamescope,
+  # so compositor death is relayed through the exact upstream ownership chain.
   trap nested_primary_parent_gone TERM INT HUP
   # PR_SET_PDEATHSIG cannot report a parent that died before setpriv armed the
-  # signal. Re-prove the immediate parent after exec and before Steam starts;
-  # a later parent death is covered by the already-installed trap above.
-  if ! polaris_headless_gamescope_pid "$primary_parent_pid"; then
+  # signal. Re-prove Gamescope -> gamescopereaper -> this wrapper after exec and
+  # before Steam starts; later parent death is covered by the installed trap.
+  if ! polaris_gamescope_reaper_pid "$primary_reaper_pid"; then
     trap - TERM INT HUP
-    echo "polaris-gamescope-session: primary child lost its exact Gamescope parent before Steam launch" >&2
+    echo "polaris-gamescope-session: primary child lost its exact Gamescope reaper before Steam launch" >&2
     return 1
   fi
-  if polaris_process_fields "$primary_parent_pid" 2>/dev/null; then
-    primary_parent_start_time="$POLARIS_PROCESS_START_TIME"
-    [ "$POLARIS_PROCESS_PGID" = "$primary_parent_pid" ] \
-      && [ "$POLARIS_PROCESS_SESSION_ID" = "$primary_parent_pid" ] || {
-        trap - TERM INT HUP
-        echo "polaris-gamescope-session: primary child refused a non-private Gamescope parent" >&2
-        return 1
-      }
+  if polaris_process_fields "$primary_reaper_pid" 2>/dev/null; then
+    primary_reaper_start_time="$POLARIS_PROCESS_START_TIME"
+    primary_reaper_parent_pid="$POLARIS_PROCESS_PPID"
     primary_group_id="$POLARIS_PROCESS_PGID"
     primary_session_id="$POLARIS_PROCESS_SESSION_ID"
-    if ! polaris_headless_gamescope_pid "$primary_parent_pid" \
-        || ! polaris_process_fields "$primary_parent_pid" \
-        || [ "$POLARIS_PROCESS_START_TIME" != "$primary_parent_start_time" ] \
+    primary_reaper_executable="$POLARIS_GAMESCOPE_REAPER_EXECUTABLE"
+    primary_gamescope_pid="$primary_reaper_parent_pid"
+    if ! polaris_headless_gamescope_pid "$primary_gamescope_pid" \
+        || ! polaris_process_fields "$primary_gamescope_pid"; then
+      trap - TERM INT HUP
+      echo "polaris-gamescope-session: primary child lost its exact Gamescope generation before Steam launch" >&2
+      return 1
+    fi
+    primary_gamescope_start_time="$POLARIS_PROCESS_START_TIME"
+    primary_gamescope_executable="$POLARIS_GAMESCOPE_EXECUTABLE"
+    [ "$POLARIS_PROCESS_PGID" = "$primary_gamescope_pid" ] \
+      && [ "$POLARIS_PROCESS_SESSION_ID" = "$primary_gamescope_pid" ] \
+      && [ "$primary_group_id" = "$primary_gamescope_pid" ] \
+      && [ "$primary_session_id" = "$primary_gamescope_pid" ] || {
+        trap - TERM INT HUP
+        echo "polaris-gamescope-session: primary child refused a non-private Gamescope chain" >&2
+        return 1
+      }
+    if ! polaris_gamescope_reaper_pid "$primary_reaper_pid" \
+        || ! polaris_gamescope_executables_match \
+          "$POLARIS_GAMESCOPE_REAPER_EXECUTABLE" "$primary_reaper_executable" \
+        || ! polaris_process_fields "$primary_reaper_pid" \
+        || [ "$POLARIS_PROCESS_START_TIME" != "$primary_reaper_start_time" ] \
+        || [ "$POLARIS_PROCESS_PPID" != "$primary_gamescope_pid" ] \
+        || [ "$POLARIS_PROCESS_PGID" != "$primary_group_id" ] \
+        || [ "$POLARIS_PROCESS_SESSION_ID" != "$primary_session_id" ]; then
+      trap - TERM INT HUP
+      echo "polaris-gamescope-session: primary child lost its private Gamescope reaper before Steam launch" >&2
+      return 1
+    fi
+    if ! polaris_headless_gamescope_pid "$primary_gamescope_pid" \
+        || ! polaris_gamescope_executables_match \
+          "$POLARIS_GAMESCOPE_EXECUTABLE" "$primary_gamescope_executable" \
+        || ! polaris_process_fields "$primary_gamescope_pid" \
+        || [ "$POLARIS_PROCESS_START_TIME" != "$primary_gamescope_start_time" ] \
         || [ "$POLARIS_PROCESS_PGID" != "$primary_group_id" ] \
         || [ "$POLARIS_PROCESS_SESSION_ID" != "$primary_session_id" ]; then
       trap - TERM INT HUP
@@ -575,6 +605,7 @@ run_nested_primary_child() {
       return 1
     fi
     if ! polaris_process_fields "$primary_wrapper_pid" \
+        || [ "$POLARIS_PROCESS_PPID" != "$primary_reaper_pid" ] \
         || [ "$POLARIS_PROCESS_PGID" != "$primary_group_id" ] \
         || [ "$POLARIS_PROCESS_SESSION_ID" != "$primary_session_id" ] \
         || [ "$POLARIS_PROCESS_STATE" = Z ]; then

--- a/tests/unit/platform/fake_gamescope_parent.c
+++ b/tests/unit/platform/fake_gamescope_parent.c
@@ -1,4 +1,7 @@
+#include <errno.h>
 #include <signal.h>
+#include <libgen.h>
+#include <sys/prctl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,7 +19,7 @@ static int wait_for_file(const char *path) {
   return -1;
 }
 
-int main(int argc, char **argv) {
+static int find_separator(int argc, char **argv) {
   int separator = -1;
   for (int i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "--") == 0) {
@@ -24,15 +27,17 @@ int main(int argc, char **argv) {
       break;
     }
   }
+  return separator;
+}
+
+static int run_fake_reaper(int argc, char **argv) {
+  int separator = find_separator(argc, argv);
   if (separator < 0 || separator + 1 >= argc) {
     return 2;
   }
 
-  /* Production launches Gamescope as the leader of a private session and
-   * process group. Model that boundary so the child can safely fence the
-   * complete group when this fake compositor exits. */
-  if (setsid() < 0) {
-    return 8;
+  if (prctl(PR_SET_PDEATHSIG, SIGTERM) != 0 || getppid() == 1) {
+    return 9;
   }
 
   pid_t child = fork();
@@ -45,25 +50,88 @@ int main(int argc, char **argv) {
   }
 
   const char *pid_file = getenv("POLARIS_FAKE_CHILD_PID_FILE");
-  const char *started_file = getenv("POLARIS_STEAM_STARTED_FILE");
-  const char *exit_gate_file = getenv("POLARIS_FAKE_PARENT_EXIT_GATE_FILE");
-  if (pid_file == NULL || started_file == NULL) {
+  if (pid_file == NULL) {
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
     return 4;
   }
   FILE *out = fopen(pid_file, "w");
   if (out == NULL) {
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
     return 5;
   }
   fprintf(out, "%ld\n", (long) child);
   if (fclose(out) != 0) {
+    kill(child, SIGKILL);
+    waitpid(child, NULL, 0);
     return 6;
+  }
+
+  int status = 0;
+  for (;;) {
+    if (waitpid(child, &status, 0) >= 0) {
+      break;
+    }
+    if (errno != EINTR) {
+      return 10;
+    }
+  }
+  return 0;
+}
+
+static int run_fake_gamescope(int argc, char **argv) {
+  int separator = find_separator(argc, argv);
+  if (separator < 0 || separator + 1 >= argc) {
+    return 2;
+  }
+
+  /* Production launches Gamescope as the leader of a private session and
+   * process group. Gamescope then launches gamescopereaper, and the reaper
+   * launches the primary command. Model the full upstream ancestry so the
+   * wrapper proves the same chain exercised on a real host. */
+  if (setsid() < 0) {
+    return 8;
+  }
+
+  pid_t reaper = fork();
+  if (reaper < 0) {
+    return 3;
+  }
+  if (reaper == 0) {
+    size_t command_count = (size_t) (argc - separator - 1);
+    char **reaper_argv = calloc(command_count + 3, sizeof(char *));
+    if (reaper_argv == NULL) {
+      _exit(126);
+    }
+    reaper_argv[0] = (char *) "gamescopereaper";
+    reaper_argv[1] = (char *) "--";
+    for (size_t i = 0; i < command_count; ++i) {
+      reaper_argv[i + 2] = argv[separator + 1 + (int) i];
+    }
+    execvp(reaper_argv[0], reaper_argv);
+    _exit(127);
+  }
+
+  const char *started_file = getenv("POLARIS_STEAM_STARTED_FILE");
+  const char *exit_gate_file = getenv("POLARIS_FAKE_PARENT_EXIT_GATE_FILE");
+  if (started_file == NULL) {
+    return 4;
   }
 
   if (wait_for_file(started_file) == 0
       && (exit_gate_file == NULL || wait_for_file(exit_gate_file) == 0)) {
     return 0;
   }
-  kill(child, SIGKILL);
-  waitpid(child, NULL, 0);
+  kill(reaper, SIGKILL);
+  waitpid(reaper, NULL, 0);
   return 7;
+}
+
+int main(int argc, char **argv) {
+  char *program = basename(argv[0]);
+  if (strcmp(program, "gamescopereaper") == 0) {
+    return run_fake_reaper(argc, argv);
+  }
+  return run_fake_gamescope(argc, argv);
 }

--- a/tests/unit/platform/test_gamescope_primary_child_shell.sh
+++ b/tests/unit/platform/test_gamescope_primary_child_shell.sh
@@ -48,7 +48,7 @@ mkdir -p "$work/bin" "$work/run"
 
 printf '%s\n' \
   'polaris_validate_marker() { return 1; }' \
-  'polaris_headless_gamescope_pid() { [ "${1:-}" = "${POLARIS_TEST_GAMESCOPE_PID:-}" ]; }' \
+  'polaris_gamescope_reaper_pid() { [ "${1:-}" = "${POLARIS_TEST_GAMESCOPE_PID:-}" ]; }' \
   >"$work/runtime-stub.sh"
 printf '%s\n' \
   '#!/usr/bin/env bash' \
@@ -167,6 +167,9 @@ if [ "$(uname -s)" = Linux ] && command -v setpriv >/dev/null 2>&1 && [ -r "/pro
   "${CC:-cc}" -std=c11 -D_DEFAULT_SOURCE -O2 -Wall -Wextra -Werror \
     "$POLARIS_SOURCE_DIR/tests/unit/platform/fake_gamescope_parent.c" \
     -o "$work/bin/gamescope"
+  "${CC:-cc}" -std=c11 -D_DEFAULT_SOURCE -O2 -Wall -Wextra -Werror \
+    "$POLARIS_SOURCE_DIR/tests/unit/platform/fake_gamescope_parent.c" \
+    -o "$work/bin/gamescopereaper"
   "${CC:-cc}" -std=c11 -D_DEFAULT_SOURCE -O2 -Wall -Wextra -Werror \
     "$POLARIS_SOURCE_DIR/tests/unit/platform/fake_leaderless_session_member.c" \
     -o "$work/bin/leaderless-session-member"

--- a/tests/unit/platform/test_gamescope_runtime_shell.sh
+++ b/tests/unit/platform/test_gamescope_runtime_shell.sh
@@ -57,6 +57,23 @@ write_process() {
 # marker/generation validator used before signalling.
 write_process_with_group 1 0 1 1 14 /usr/lib/systemd/systemd --system
 
+# Gamescope's primary command is parented by gamescopereaper, not directly by
+# the compositor. Accept only that exact executable/argv identity so the
+# session helper can prove the complete upstream ownership chain.
+write_process_with_group 409 410 410 410 8999 /usr/bin/gamescopereaper -- steam
+polaris_gamescope_reaper_pid 409 || fail "exact gamescopereaper was rejected"
+[ "$POLARIS_GAMESCOPE_REAPER_EXECUTABLE" = /usr/bin/gamescopereaper ] ||
+  fail "gamescopereaper executable identity was not published"
+write_process_with_group 409 410 410 410 8999 /usr/bin/gamescopereaper-wrapper -- steam
+if polaris_gamescope_reaper_pid 409; then
+  fail "lookalike gamescopereaper executable was accepted"
+fi
+write_process_with_group 409 410 410 410 8999 /usr/bin/gamescopereaper-wrapper gamescopereaper -- steam
+if polaris_gamescope_reaper_pid 409; then
+  fail "gamescopereaper argv spoof was accepted"
+fi
+rm -rf "$POLARIS_PROC_ROOT/409"
+
 write_unix_header() {
   printf 'Num RefCount Protocol Flags Type St Inode Path\n' >"$POLARIS_PROC_NET_UNIX"
 }


### PR DESCRIPTION
## Summary

- model the Gamescope 3.16 process tree as Gamescope -> gamescopereaper -> primary wrapper
- validate exact executable, parent PID, start time, process group, and session identity before Steam starts
- retain the parent-death cleanup fence after Steam returns
- make the Linux fixture reproduce the upstream reaper layer and keep the leaderless-descendant teardown checks

## Why

The exact merged candidate passed CI but failed physical launch before Steam started. The helper treated the wrapper as a direct Gamescope child; Gamescope 3.16.25 actually starts the command through gamescopereaper. The false rejection made the primary command return and drove Gamescope into the shutdown path this containment was intended to avoid.

Upstream process implementation:
- https://github.com/ValveSoftware/gamescope/blob/3.16.25/src/steamcompmgr.cpp#L8296-L8316
- https://github.com/ValveSoftware/gamescope/blob/3.16.25/src/Apps/gamescopereaper.cpp#L131-L157

## Verification

- focused Linux primary-child production-shape fixture passes
- Gamescope parent death still drains Steam, an ordinary descendant, and a leaderless sibling-group member
- runtime ownership and display-routing shell suite passes
- shell syntax and diff checks pass

## Scope

This is a narrow follow-up to #561. It does not change Doctor, AI, launch presets, bitrate policy, or release publication. The failed candidate remains rolled back; physical reactivation waits for exact-head review and CI.