### PR TITLE
fix(gamescope): allow bounded teardown to finish

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -122,14 +122,16 @@ namespace proc {
 
   constexpr auto nested_gamescope_start_timeout = 120s;
 
-  // Teardown gets its own, much shorter budget than startup. The stop path in
-  // polaris-gamescope-session.sh waits up to about 15s of its own accord
-  // (POLARIS_IDLE_WAIT_STEPS and POLARIS_PORTAL_WAIT_STEPS, both at 0.1s), so a
-  // 5s caller can terminate it mid-drain. This leaves headroom over that budget
-  // while staying far below the startup timeout, because undo runs while the
-  // session lifecycle lock is held and a two-minute teardown would be worse than
-  // the stall it prevents.
-  constexpr auto nested_gamescope_stop_timeout = 30s;
+  // Teardown gets its own bounded budget below startup. The nested stop phases
+  // are deliberately sequential: retire exact-session Steam and its primary
+  // child, fence every private Gamescope group, retire exact-session Xwayland,
+  // prove orphan sockets safe, then commit the standalone/managed handoff. A
+  // physical full-session teardown exhausted the old 30s caller budget after
+  // the compositor fence had already committed, so Polaris killed a healthy
+  // recovery transaction before it could publish completion. Sixty seconds
+  // covers the helper's default bounded waits and ownership scans without
+  // permitting the two-minute startup budget to become a teardown stall.
+  constexpr auto nested_gamescope_stop_timeout = 60s;
 
   session_stop_outcome_t evaluate_session_stop_request(
     bool can_launch,

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -5066,12 +5066,13 @@ TEST(GamescopeNestedSessionContract, TeardownGetsTheSameBudgetAndVisibilityAsSta
   const auto collapsed_source = collapse_whitespace(source);
 
   // Startup got a dedicated budget. Teardown was left on the app's exit-timeout,
-  // which defaults to 5s, while the stop path in polaris-gamescope-session.sh
-  // waits up to about 15s of its own accord (POLARIS_IDLE_WAIT_STEPS plus
-  // POLARIS_PORTAL_WAIT_STEPS). A 5s caller could terminate it mid-drain and
-  // leave the session needing manual recovery. Both halves of the lifecycle get
-  // their own visible budget, or neither should.
-  EXPECT_NE(source.find("constexpr auto nested_gamescope_stop_timeout = 30s;"), std::string::npos);
+  // which defaults to 5s, while the nested stop serially fences Steam, private
+  // process groups, Xwayland, orphan sockets, and the runtime handoff. The old
+  // 30s budget was also shorter than a measured full-session teardown, so the
+  // caller could kill a healthy recovery transaction after its compositor fence
+  // committed. Both halves of the lifecycle need their own honest visible
+  // budget, with teardown still bounded well below startup.
+  EXPECT_NE(source.find("constexpr auto nested_gamescope_stop_timeout = 60s;"), std::string::npos);
   EXPECT_NE(
     collapsed_source.find(
       "const auto undo_timeout = critical_nested_session_undo ? nested_gamescope_stop_timeout : _app.exit_timeout;"


### PR DESCRIPTION
## Summary

- extend the nested Gamescope stop caller budget from 30 seconds to 60 seconds
- keep teardown bounded at half the existing 120-second startup budget
- update the source-contract regression to pin the new explicit budget

## Why

Physical acceptance reproduced a healthy nested teardown that had already fenced the compositor but was killed by Polaris at the old 30-second caller deadline while it completed its remaining bounded ownership and socket cleanup. The helper then surfaced a teardown timeout even though game, Steam, Gamescope, and the stream were gone cleanly.

This patch changes only the caller budget. It does not change process ownership, signal targets, helper phases, launch resolution, Doctor behavior, or limiter policy.

## Validation

- Clang ASan/UBSan process and configuration suite: 308 of 308 passed
- focused teardown budget contract: passed
- Gamescope runtime, stop ownership, primary-child, and geometry shell suites: 4 of 4 passed
- general native assertions: 472 of 472 passed; the local Clang process then reported an unrelated existing one-byte logging deinit leak
- git diff --check: clean

## Acceptance gate

Repeat the exact Control end-session physical acceptance on the exact approved candidate and require the stop helper to complete without a caller timeout before release approval.