### PR TITLE
docs: explain the v1.4 player loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ and runtime path in one web console.
 
 ![Polaris Aurora Mission Control ready for a client, with host vitals, launch checks, and quick controls](docs/screenshots/polaris-mission-control-ready-v1.3.8.webp)
 
+## Built for the whole player loop
+
+Polaris is the matched host for Nova. Together they make the whole player loop
+explicit:
+
+- **Where games run is a real choice.** Private Stream, Gamescope Stream, Host
+  Virtual Display, Headless Dongle, and Mirror Desktop are described by their
+  display and privacy impact, and unavailable modes fail closed.
+- **Doctor acts only when it can prove the step is safe.** It can make one
+  reversible same-stream bitrate change, verify the encoder and fresh evidence,
+  and restore the previous target when verification fails. Other findings stay
+  read-only guidance.
+- **Launches are deterministic.** Auto, Quality, High FPS, and Stability resolve
+  into one app- and topology-bound envelope that Nova sends back unchanged.
+- **The Library keeps identity intact.** Native and Flatpak Heroic GOG/Epic
+  imports retain their runner and installation identity, while built-in utility
+  entries keep their shipped artwork unless the player chooses a manual match.
+
+Read the [changelog](docs/changelog.md) for the release-by-release change and
+validation record.
+
 ## Why Polaris
 
 <table>
@@ -54,8 +75,10 @@ and runtime path in one web console.
 
 1. **Choose a game.** Launch from Polaris, Nova, or a compatible Moonlight
    client.
-2. **Create a stream-only runtime.** Polaris starts an isolated compositor and
-   resolves the requested display, capture, and encoder path for that session.
+2. **Resolve where this session runs.** Private and Gamescope modes get a
+   session-owned compositor; Host Virtual Display gets an extra output; Mirror
+   Desktop deliberately uses the physical desktop. Polaris validates the
+   matching capture and encoder path before admitting the stream.
 3. **Observe and recover.** Mission Control reports what actually happened;
    Doctor suggests bounded corrections when live evidence needs attention.
 
@@ -119,7 +142,7 @@ capture path, HDR mode, or experimental Browser Stream setup.
 
 ## Documentation and project links
 
-- [Documentation](https://papi-ux.com/docs/) · [FAQ](https://papi-ux.com/docs/faq/) · [Runtime](https://papi-ux.com/docs/runtime/)
+- [Documentation](https://papi-ux.com/docs/) · [Launch modes](https://papi-ux.com/docs/launch-modes/) · [Doctor](https://papi-ux.com/docs/doctor/) · [FAQ](https://papi-ux.com/docs/faq/)
 - [Roadmap](https://papi-ux.com/docs/roadmap/) · [Website changelog](https://papi-ux.com/docs/changelog/) · [GitHub changelog](docs/changelog.md)
 - [Matrix community](https://matrix.to/#/#papi-ux:papi-ux.com) · [Releases](https://github.com/papi-ux/polaris/releases) · [Issues](https://github.com/papi-ux/polaris/issues) · [Discussions](https://github.com/papi-ux/polaris/discussions)
 - [Security policy](SECURITY.md) · [Contributing](.github/CONTRIBUTING.md) · [Source](https://github.com/papi-ux/polaris)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,8 +31,14 @@ For the shared host-and-client view, see the
 
 ## Now — make Linux streaming dependable
 
+- Watch the public v1.4.0 path in the field and prioritize reproducible install,
+  launch, capture, resume, and teardown regressions over speculative features.
 - Harden start, stop, recovery, and teardown so failed sessions do not leave
   workloads, virtual displays, input devices, or stale state behind.
+- Finish affected-host validation for exact virtual-output capture, including the
+  wlroots connector-order case tracked in
+  [#556](https://github.com/papi-ux/polaris/issues/556), without falling back to a
+  physical monitor when ownership is uncertain.
 - Keep Mission Control diagnostics useful without requiring users to spelunk
   through giant logs.
 - Continue validating headless capture, compositor behavior, input isolation, and
@@ -41,6 +47,9 @@ For the shared host-and-client view, see the
   what is recommended, tested, experimental, or source-build only.
 - Make Polaris and Nova version pairing easier to understand while preserving
   standard Moonlight-client compatibility.
+- Improve Doctor's stage coverage and explanations before expanding its action
+  vocabulary. Same-stream changes must remain one-dimensional, reversible,
+  measured, and subordinate to a newer player choice.
 
 ## Next — make the current path smoother
 


### PR DESCRIPTION
## Summary

- add a concise current-release section covering player-first launch modes, evidence-backed Doctor actions, deterministic presets, Heroic identity, and built-in artwork
- correct the runtime overview so Mirror Desktop and Host Virtual Display are not described as isolated compositor launches
- make the post-v1.4 roadmap explicit about field stabilization, issue #556 validation, and keeping Doctor actions measured and reversible
- keep the older proof screenshots and their provenance labels unchanged

## Verification

- git diff --check
- README and roadmap links reviewed against the published v1.4.0 release and current public docs

Docs-only; no product, package, or release artifact changes.