### PR TITLE
fix(ai): make Doctor explanations provider-aware

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,7 +31,7 @@ A matched feature release for Nova v1.4.0. Doctor turns measured stream evidence
 - Refuses PipeWire DMA-BUF frames when the running package has no matching encoder importer; CUDA-disabled NVIDIA packages fall back to SHM/CPU capture before the first unusable GPU-only frame can reach the encoder
 - Forwards non-cage detached Steam shutdown through Steam's no-bootstrap remote client, preventing a vanished listener from starting a replacement client while preserving retry authority when generation cleanup is incomplete
 - Restores distro-package Gamescope sessions to their empty compositor baseline without requiring Nix-only services, and retains the exact recovery claim when safe cleanup cannot be proven
-- Restricts AI and Codex CLI output to typed explanatory text that cannot define settings, actions, confidence overrides, or launch policy; subscription `deterministic-fallback` remains informational and quiet
+- Restricts AI and Codex CLI output to typed explanatory text that cannot define settings, actions, confidence overrides, or launch policy; OpenAI subscription mode now invokes the signed-in Codex CLI through a private, bounded explanation-only workspace instead of reporting a configured provider as unavailable, while provider failure remains an informational `deterministic-fallback`
 - Retains the GCC 16, Ubuntu snapshot, exact release-source, sanitizer, Arch, public-hygiene, and CodeQL gates from the protected release base
 - Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,7 +269,13 @@ ai_provider = local
 ai_model = gpt-oss
 ai_auth_mode = none
 ai_base_url = http://127.0.0.1:11434/v1
+ai_timeout_ms = 60000
 ```
+
+Large local models can need substantially longer than cloud models for their first response while
+weights are loaded. The web UI's local-provider profiles start with a bounded 60-second timeout and
+report inference timeout, connection, authentication, missing-model, and response-format failures
+separately. Lower the timeout after the model is warm if you prefer faster failure.
 
 ## Credential reset
 

--- a/docs/release-notes/v1.4.0.md
+++ b/docs/release-notes/v1.4.0.md
@@ -87,7 +87,7 @@ Bazzite users should follow the exact-output `rpm-ostree` flow in the [Bazzite g
 ### Explanation-only AI
 
 - AI or Codex CLI may translate a structured evidence bundle into explanatory text, but its typed output cannot define actions, settings, confidence overrides, or launch policy.
-- Subscription `deterministic-fallback` remains informational and quiet; deterministic code exclusively owns launch fields and Doctor actions.
+- OpenAI subscription mode invokes the signed-in Codex CLI through a private, bounded explanation-only workspace. Provider metadata and credentials stay server-owned; provider failure remains an informational `deterministic-fallback`; and deterministic code exclusively owns launch fields and Doctor actions.
 
 ### Scope and safety
 

--- a/src/ai_optimizer.cpp
+++ b/src/ai_optimizer.cpp
@@ -45,6 +45,7 @@ namespace ai_optimizer {
   static std::mutex inflight_mutex;
   static std::mutex model_catalog_mutex;
   static std::atomic<int> in_flight_requests {0};
+  static std::atomic<std::uint64_t> codex_temp_sequence {0};
 
   namespace {
     constexpr const char *PROVIDER_ANTHROPIC = "anthropic";
@@ -1381,6 +1382,22 @@ namespace ai_optimizer {
     }
   }
 
+  static void set_provider_test_failure(provider_test_result_t *test_result,
+                                        std::string code,
+                                        std::string error,
+                                        std::string detail,
+                                        std::string action,
+                                        bool retryable = true) {
+    if (!test_result) {
+      return;
+    }
+    test_result->code = std::move(code);
+    test_result->error = std::move(error);
+    test_result->detail = std::move(detail);
+    test_result->action = std::move(action);
+    test_result->retryable = retryable;
+  }
+
   static std::string infer_confidence(const std::string &device_name,
                                       const std::string &game_category,
                                       const std::optional<session_history_t> &history,
@@ -2215,7 +2232,8 @@ namespace ai_optimizer {
       const std::string &gpu_info,
       const std::string &game_category = "",
       const std::optional<session_history_t> &history = std::nullopt,
-      const std::string &mode = "") {
+      const std::string &mode = "",
+      provider_test_result_t *test_result = nullptr) {
 
     nlohmann::json request_body;
     request_body["model"] = active_cfg.model;
@@ -2235,11 +2253,80 @@ namespace ai_optimizer {
     auto response = post_json(join_url(active_cfg.base_url, "/chat/completions"), request_body, active_cfg.timeout_ms, headers);
     if (response.curl_code != CURLE_OK) {
       BOOST_LOG(error) << "ai_optimizer: OpenAI-compatible request failed: "sv << curl_easy_strerror(response.curl_code);
+      if (response.curl_code == CURLE_OPERATION_TIMEDOUT) {
+        const auto timeout_seconds = std::max(1, (active_cfg.timeout_ms + 999) / 1000);
+        set_provider_test_failure(
+          test_result,
+          "inference_timeout",
+          "Model inference timed out after " + std::to_string(timeout_seconds) + " seconds",
+          "The endpoint did not finish the explanation test before the configured timeout. Large local models may still be loading or may need a longer generation window.",
+          "Warm the model once, or raise Provider timeout to 60000 ms, then retry."
+        );
+      } else if (response.curl_code == CURLE_COULDNT_CONNECT) {
+        set_provider_test_failure(
+          test_result,
+          "connection_refused",
+          "Could not connect to the provider endpoint",
+          curl_easy_strerror(response.curl_code),
+          "Start the local model server and confirm the Base URL, then retry."
+        );
+      } else if (response.curl_code == CURLE_COULDNT_RESOLVE_HOST) {
+        set_provider_test_failure(
+          test_result,
+          "host_not_found",
+          "Provider host could not be resolved",
+          curl_easy_strerror(response.curl_code),
+          "Correct the provider Base URL or DNS configuration, then retry."
+        );
+      } else {
+        set_provider_test_failure(
+          test_result,
+          "transport_error",
+          "Provider request failed",
+          curl_easy_strerror(response.curl_code),
+          "Check the provider endpoint and Polaris logs, then retry."
+        );
+      }
       return std::nullopt;
     }
 
     if (response.http_code != 200) {
       BOOST_LOG(error) << "ai_optimizer: OpenAI-compatible endpoint returned HTTP "sv << response.http_code << ": "sv << response.body.substr(0, 200);
+      if (response.http_code == 401 || response.http_code == 403) {
+        set_provider_test_failure(
+          test_result,
+          "authentication_failed",
+          "Provider rejected authentication",
+          "The endpoint returned HTTP " + std::to_string(response.http_code) + ".",
+          "Check the selected authentication mode and API key, then retry.",
+          false
+        );
+      } else if (response.http_code == 404) {
+        set_provider_test_failure(
+          test_result,
+          "model_or_endpoint_not_found",
+          "Provider endpoint or model was not found",
+          "The OpenAI-compatible endpoint returned HTTP 404.",
+          "Refresh the model list, confirm the exact model id and Base URL, then retry.",
+          false
+        );
+      } else if (response.http_code == 429) {
+        set_provider_test_failure(
+          test_result,
+          "rate_limited",
+          "Provider rate limit reached",
+          "The endpoint returned HTTP 429.",
+          "Wait for provider capacity, then retry."
+        );
+      } else {
+        set_provider_test_failure(
+          test_result,
+          "provider_http_error",
+          "Provider returned HTTP " + std::to_string(response.http_code),
+          "The provider rejected the chat-completions request.",
+          "Check the endpoint logs and OpenAI-compatibility settings, then retry."
+        );
+      }
       return std::nullopt;
     }
 
@@ -2248,11 +2335,25 @@ namespace ai_optimizer {
       auto content_text = extract_openai_compatible_text(api_response);
       if (content_text.empty()) {
         BOOST_LOG(error) << "ai_optimizer: Empty response from OpenAI-compatible endpoint"sv;
+        set_provider_test_failure(
+          test_result,
+          "empty_response",
+          "Provider returned no explanation",
+          "The request completed, but the response did not contain assistant text.",
+          "Confirm that the endpoint supports OpenAI-compatible chat completions, then retry."
+        );
         return std::nullopt;
       }
       return parse_optimization_json(content_text, "OpenAI-compatible API");
     } catch (const std::exception &e) {
       BOOST_LOG(error) << "ai_optimizer: Failed to parse OpenAI-compatible response: "sv << e.what();
+      set_provider_test_failure(
+        test_result,
+        "invalid_response",
+        "Provider returned an invalid explanation response",
+        e.what(),
+        "Use a model that follows structured JSON output, or check the provider compatibility mode."
+      );
       return std::nullopt;
     }
   }
@@ -2266,7 +2367,8 @@ namespace ai_optimizer {
       const std::string &gpu_info,
       const std::string &game_category = "",
       const std::optional<session_history_t> &history = std::nullopt,
-      const std::string &mode = "") {
+      const std::string &mode = "",
+      provider_test_result_t *test_result = nullptr) {
     if (active_cfg.provider == PROVIDER_ANTHROPIC) {
       if (active_cfg.auth_mode == AUTH_SUBSCRIPTION) {
         return call_anthropic_cli(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
@@ -2278,7 +2380,7 @@ namespace ai_optimizer {
       return call_openai_codex_cli(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
     }
 
-    return call_openai_compatible_api(active_cfg, device_name, app_name, gpu_info, game_category, history, mode);
+    return call_openai_compatible_api(active_cfg, device_name, app_name, gpu_info, game_category, history, mode, test_result);
   }
 
   static void store_cache_entry(const config_t &active_cfg,
@@ -2366,9 +2468,9 @@ namespace ai_optimizer {
     return future;
   }
 
-  static nlohmann::json doctor_explanation_fallback(const std::string &reason,
-                                                      const nlohmann::json &evidence = nlohmann::json::object(),
-                                                      bool expected_subscription_fallback = false) {
+  static nlohmann::json doctor_explanation_fallback(
+      const std::string &reason,
+      const nlohmann::json &evidence = nlohmann::json::object()) {
     nlohmann::json explanation;
     const auto doctor = evidence.value("doctor", nlohmann::json::object());
     const auto checklist = evidence.value("fix_my_stream_checklist", nlohmann::json::array());
@@ -2415,13 +2517,15 @@ namespace ai_optimizer {
     explanation["destructive_action_allowed"] = false;
 
     return {
-      {"status", expected_subscription_fallback},
+      {"status", false},
       {"fallback", true},
-      {"provider_error", expected_subscription_fallback ? "" : reason},
+      {"authority", "explanation_only"},
+      {"may_define_settings", false},
+      {"provider_error", reason},
       {"source", {
-        {"kind", expected_subscription_fallback ? "deterministic-fallback" : "provider-failure"},
-        {"mode", expected_subscription_fallback ? "openai-subscription" : "error-fallback"},
-        {"informational", expected_subscription_fallback}
+        {"kind", "provider-failure"},
+        {"mode", "error-fallback"},
+        {"informational", false}
       }},
       {"explanation", explanation},
     };
@@ -2446,7 +2550,7 @@ namespace ai_optimizer {
       {"try_first", {{"type", "array"}, {"items", {{"type", "string"}}}}},
       {"advanced_detail", {{"type", "string"}}},
       {"confidence", {{"type", "string"}, {"enum", nlohmann::json::array({"low", "medium", "high"})}}},
-      {"destructive_action_allowed", {{"type", "boolean"}}},
+      {"destructive_action_allowed", {{"type", "boolean"}, {"const", false}}},
     };
     schema["required"] = nlohmann::json::array({"likely_cause", "evidence", "try_first", "advanced_detail", "confidence", "destructive_action_allowed"});
     return {
@@ -2459,10 +2563,195 @@ namespace ai_optimizer {
     };
   }
 
-  static std::optional<std::string> call_doctor_explanation_provider(const config_t &active_cfg,
-                                                                     const std::string &redacted_evidence_json) {
+  namespace {
+    class scoped_codex_temp_directory_t {
+    public:
+      explicit scoped_codex_temp_directory_t(std::string_view purpose) {
+        const auto base = std::filesystem::temp_directory_path();
+        for (int attempt = 0; attempt < 32; ++attempt) {
+          const auto sequence = codex_temp_sequence.fetch_add(1, std::memory_order_relaxed);
+          const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+          auto candidate = base / (
+            "polaris-codex-" + std::string {purpose} + "-" +
+            std::to_string(stamp) + "-" + std::to_string(sequence));
+          std::error_code ec;
+          if (!std::filesystem::create_directory(candidate, ec)) {
+            continue;
+          }
+          std::filesystem::permissions(
+            candidate,
+            std::filesystem::perms::owner_all,
+            std::filesystem::perm_options::replace,
+            ec);
+          if (ec) {
+            std::filesystem::remove_all(candidate, ec);
+            continue;
+          }
+          path_ = std::move(candidate);
+          return;
+        }
+      }
+
+      scoped_codex_temp_directory_t(const scoped_codex_temp_directory_t &) = delete;
+      scoped_codex_temp_directory_t &operator=(const scoped_codex_temp_directory_t &) = delete;
+
+      ~scoped_codex_temp_directory_t() {
+        if (path_.empty()) return;
+        std::error_code ec;
+        std::filesystem::remove_all(path_, ec);
+      }
+
+      explicit operator bool() const {
+        return !path_.empty();
+      }
+
+      const std::filesystem::path &path() const {
+        return path_;
+      }
+
+    private:
+      std::filesystem::path path_;
+    };
+
+    bool write_codex_input_file(const std::filesystem::path &path, const std::string &contents) {
+      std::ofstream output(path, std::ios::binary | std::ios::trunc);
+      if (!output) return false;
+      output << contents;
+      output.close();
+      return output.good();
+    }
+
+    std::optional<std::string> call_openai_codex_doctor_cli(
+      const config_t &active_cfg,
+      const std::string &redacted_evidence_json) {
+      const std::string home = getenv("HOME") ? getenv("HOME") : "/home";
+      const auto codex_bin = resolve_existing_binary(
+        {
+          home + "/.local/bin/codex",
+          "/usr/local/bin/codex",
+          "/usr/bin/codex",
+        },
+        "codex");
+
+      scoped_codex_temp_directory_t workspace {"doctor"};
+      if (!workspace) {
+        BOOST_LOG(error) << "ai_optimizer: Could not create a private Codex Doctor workspace"sv;
+        return std::nullopt;
+      }
+
+      const auto prompt_file = workspace.path() / "prompt.txt";
+      const auto schema_file = workspace.path() / "schema.json";
+      const auto output_file = workspace.path() / "output.json";
+      const auto prompt = doctor_explanation_system_prompt() +
+        "\n\nRedacted Polaris Doctor/support evidence follows. Explain it without adding unsupported facts.\n" +
+        redacted_evidence_json +
+        "\n\nReturn only the JSON object described by the supplied output schema.";
+      const auto schema = doctor_explanation_response_format().at("json_schema").at("schema").dump(2);
+      if (!write_codex_input_file(prompt_file, prompt) ||
+          !write_codex_input_file(schema_file, schema)) {
+        BOOST_LOG(error) << "ai_optimizer: Could not write the private Codex Doctor request files"sv;
+        return std::nullopt;
+      }
+
+      std::string deadline_prefix;
+#ifdef __linux__
+      const auto timeout_bin = resolve_existing_binary({"/usr/bin/timeout", "/bin/timeout"}, "");
+      if (timeout_bin.empty()) {
+        BOOST_LOG(error) << "ai_optimizer: Refusing an unbounded Codex Doctor request because timeout(1) is unavailable"sv;
+        return std::nullopt;
+      }
+      deadline_prefix = "'" + timeout_bin + "' --signal=TERM --kill-after=2s 30s ";
+#endif
+
+      const auto codex_home = active_codex_home(active_cfg);
+      const std::string cmd =
+        shell_env_assignment("CODEX_HOME", codex_home.value_or("")) +
+        deadline_prefix +
+        "'" + codex_bin + "' exec "
+        "--skip-git-repo-check "
+        "--ephemeral "
+        "--ignore-user-config "
+        "--ignore-rules "
+        "--sandbox read-only "
+        "-C '" + shell_escape_single_quotes(workspace.path().string()) + "' "
+        "-m '" + shell_escape_single_quotes(active_cfg.model) + "' "
+        "--output-schema '" + shell_escape_single_quotes(schema_file.string()) + "' "
+        "-o '" + shell_escape_single_quotes(output_file.string()) + "' "
+        "- < '" + shell_escape_single_quotes(prompt_file.string()) + "' "
+        "2>&1";
+
+      BOOST_LOG(debug) << "ai_optimizer: Running bounded Codex CLI Doctor explanation"sv;
+      const auto result = run_command_capture(cmd);
+      if (result.exit_code != 0) {
+        BOOST_LOG(error) << "ai_optimizer: Codex Doctor CLI exited with code "sv << result.exit_code;
+        // CLI diagnostics can echo portions of the supplied support evidence.
+        // Keep the exit code for operators without copying that content into
+        // the long-lived Polaris log.
+        return std::nullopt;
+      }
+
+      std::error_code size_ec;
+      const auto output_size = std::filesystem::file_size(output_file, size_ec);
+      if (size_ec || output_size == 0 || output_size > 64 * 1024) {
+        BOOST_LOG(error) << "ai_optimizer: Codex Doctor CLI returned an empty or oversized response"sv;
+        return std::nullopt;
+      }
+
+      std::ifstream output(output_file, std::ios::binary);
+      return std::string(std::istreambuf_iterator<char>(output), std::istreambuf_iterator<char>());
+    }
+
+    std::optional<std::string> doctor_explanation_contract_error(const nlohmann::json &parsed) {
+      static const std::array<std::string_view, 6> expected_keys {
+        "likely_cause", "evidence", "try_first", "advanced_detail",
+        "confidence", "destructive_action_allowed"
+      };
+      if (!parsed.is_object() || parsed.size() != expected_keys.size()) {
+        return "Doctor explanation must contain exactly the six explanation-only fields";
+      }
+      for (const auto key : expected_keys) {
+        if (!parsed.contains(std::string {key})) {
+          return "Doctor explanation is missing a required field";
+        }
+      }
+      if (!parsed["likely_cause"].is_string() || !parsed["advanced_detail"].is_string() ||
+          !parsed["confidence"].is_string() || !parsed["destructive_action_allowed"].is_boolean()) {
+        return "Doctor explanation contains a field with the wrong type";
+      }
+      for (const auto field : {"evidence", "try_first"}) {
+        if (!parsed[field].is_array() ||
+            !std::all_of(parsed[field].begin(), parsed[field].end(), [](const auto &item) { return item.is_string(); })) {
+          return "Doctor explanation evidence and try_first must be string arrays";
+        }
+      }
+      const auto confidence = parsed["confidence"].get<std::string>();
+      if (confidence != "low" && confidence != "medium" && confidence != "high") {
+        return "Doctor explanation confidence is not allowed";
+      }
+      if (parsed["destructive_action_allowed"].get<bool>()) {
+        return "Doctor explanation attempted to claim destructive-action authority";
+      }
+      return std::nullopt;
+    }
+  }  // namespace
+
+  static std::optional<std::string> call_doctor_explanation_provider(
+      const config_t &active_cfg,
+      const std::string &redacted_evidence_json,
+      provider_test_result_t *test_result = nullptr) {
+    if (active_cfg.provider == PROVIDER_OPENAI && active_cfg.auth_mode == AUTH_SUBSCRIPTION) {
+      return call_openai_codex_doctor_cli(active_cfg, redacted_evidence_json);
+    }
     if (active_cfg.provider == PROVIDER_ANTHROPIC || active_cfg.auth_mode == AUTH_SUBSCRIPTION) {
       BOOST_LOG(warning) << "ai_optimizer: Doctor explanation currently uses OpenAI-compatible local/API endpoints; provider/auth mode not supported for this explanation path"sv;
+      set_provider_test_failure(
+        test_result,
+        "explanation_transport_unsupported",
+        "This provider mode cannot run Doctor explanations",
+        "The selected provider or authentication mode does not expose the supported explanation transport.",
+        "Choose an OpenAI-compatible endpoint or signed-in OpenAI subscription mode.",
+        false
+      );
       return std::nullopt;
     }
 
@@ -2478,22 +2767,114 @@ namespace ai_optimizer {
 
     std::vector<std::string> headers;
     if (active_cfg.auth_mode == AUTH_API_KEY && !active_cfg.api_key.empty()) {
-      headers.push_back("Authorization: *** " + active_cfg.api_key);
+      headers.push_back("Authorization: Bearer " + active_cfg.api_key);
     }
 
     auto response = post_json(join_url(active_cfg.base_url, "/chat/completions"), request_body, active_cfg.timeout_ms, headers);
-    if (response.curl_code != CURLE_OK || response.http_code != 200) {
+    if (response.curl_code != CURLE_OK) {
       BOOST_LOG(error) << "ai_optimizer: Doctor explanation request failed: curl="sv
                        << curl_easy_strerror(response.curl_code) << ", HTTP "sv << response.http_code;
+      if (response.curl_code == CURLE_OPERATION_TIMEDOUT) {
+        const auto timeout_seconds = std::max(1, (active_cfg.timeout_ms + 999) / 1000);
+        set_provider_test_failure(
+          test_result,
+          "inference_timeout",
+          "Model inference timed out after " + std::to_string(timeout_seconds) + " seconds",
+          "The endpoint did not finish the explanation test before the configured timeout. Large local models may still be loading or may need a longer generation window.",
+          "Warm the model once, or raise Provider timeout to 60000 ms, then retry."
+        );
+      } else if (response.curl_code == CURLE_COULDNT_CONNECT) {
+        set_provider_test_failure(
+          test_result,
+          "connection_refused",
+          "Could not connect to the provider endpoint",
+          curl_easy_strerror(response.curl_code),
+          "Start the local model server and confirm the Base URL, then retry."
+        );
+      } else if (response.curl_code == CURLE_COULDNT_RESOLVE_HOST) {
+        set_provider_test_failure(
+          test_result,
+          "host_not_found",
+          "Provider host could not be resolved",
+          curl_easy_strerror(response.curl_code),
+          "Correct the provider Base URL or DNS configuration, then retry."
+        );
+      } else {
+        set_provider_test_failure(
+          test_result,
+          "transport_error",
+          "Provider request failed",
+          curl_easy_strerror(response.curl_code),
+          "Check the provider endpoint and Polaris logs, then retry."
+        );
+      }
       return std::nullopt;
     }
 
-    auto api_response = nlohmann::json::parse(response.body);
-    auto content_text = extract_openai_compatible_text(api_response);
-    if (content_text.empty()) {
+    if (response.http_code != 200) {
+      BOOST_LOG(error) << "ai_optimizer: Doctor explanation endpoint returned HTTP "sv << response.http_code;
+      if (response.http_code == 401 || response.http_code == 403) {
+        set_provider_test_failure(
+          test_result,
+          "authentication_failed",
+          "Provider rejected authentication",
+          "The endpoint returned HTTP " + std::to_string(response.http_code) + ".",
+          "Check the selected authentication mode and API key, then retry.",
+          false
+        );
+      } else if (response.http_code == 404) {
+        set_provider_test_failure(
+          test_result,
+          "model_or_endpoint_not_found",
+          "Provider endpoint or model was not found",
+          "The OpenAI-compatible endpoint returned HTTP 404.",
+          "Refresh the model list, confirm the exact model id and Base URL, then retry.",
+          false
+        );
+      } else if (response.http_code == 429) {
+        set_provider_test_failure(
+          test_result,
+          "rate_limited",
+          "Provider rate limit reached",
+          "The endpoint returned HTTP 429.",
+          "Wait for provider capacity, then retry."
+        );
+      } else {
+        set_provider_test_failure(
+          test_result,
+          "provider_http_error",
+          "Provider returned HTTP " + std::to_string(response.http_code),
+          "The provider rejected the explanation request.",
+          "Check the endpoint logs and OpenAI-compatibility settings, then retry."
+        );
+      }
       return std::nullopt;
     }
-    return content_text;
+
+    try {
+      auto api_response = nlohmann::json::parse(response.body);
+      auto content_text = extract_openai_compatible_text(api_response);
+      if (!content_text.empty()) {
+        return content_text;
+      }
+      set_provider_test_failure(
+        test_result,
+        "empty_response",
+        "Provider returned no explanation",
+        "The request completed, but the response did not contain assistant text.",
+        "Confirm that the endpoint supports OpenAI-compatible chat completions, then retry."
+      );
+      return std::nullopt;
+    } catch (const std::exception &e) {
+      set_provider_test_failure(
+        test_result,
+        "invalid_response",
+        "Provider returned an invalid explanation response",
+        e.what(),
+        "Use a model that follows structured JSON output, or check the provider compatibility mode."
+      );
+      return std::nullopt;
+    }
   }
 
   // ---- Public API ----
@@ -2506,15 +2887,15 @@ namespace ai_optimizer {
         return doctor_explanation_fallback("No structured JSON in AI response").dump();
       }
       auto parsed = nlohmann::json::parse(text.substr(json_start, json_end - json_start + 1));
-      nlohmann::json explanation;
-      explanation["likely_cause"] = parsed.value("likely_cause", std::string {"Polaris Doctor finding"});
-      explanation["evidence"] = parsed.contains("evidence") && parsed["evidence"].is_array() ? parsed["evidence"] : nlohmann::json::array();
-      explanation["try_first"] = parsed.contains("try_first") && parsed["try_first"].is_array() ? parsed["try_first"] : nlohmann::json::array();
-      explanation["advanced_detail"] = parsed.value("advanced_detail", std::string {});
-      const auto confidence = parsed.value("confidence", std::string {"low"});
-      explanation["confidence"] = (confidence == "medium" || confidence == "high") ? confidence : "low";
-      explanation["destructive_action_allowed"] = false;
-      return nlohmann::json {{"status", true}, {"explanation", explanation}}.dump();
+      if (const auto error = doctor_explanation_contract_error(parsed)) {
+        return doctor_explanation_fallback(*error).dump();
+      }
+      return nlohmann::json {
+        {"status", true},
+        {"authority", "explanation_only"},
+        {"may_define_settings", false},
+        {"explanation", parsed}
+      }.dump();
     } catch (const std::exception &e) {
       return doctor_explanation_fallback(e.what()).dump();
     }
@@ -2535,13 +2916,6 @@ namespace ai_optimizer {
     if (!is_config_enabled(active_cfg)) {
       return doctor_explanation_fallback("AI explanations are disabled or not fully configured.", evidence).dump();
     }
-    if (active_cfg.provider == PROVIDER_OPENAI && active_cfg.auth_mode == AUTH_SUBSCRIPTION) {
-      // Codex CLI remains the ordinary optimizer route. Doctor explanations
-      // intentionally stay deterministic in subscription mode so an expected
-      // unsupported explanation transport is informational, not provider noise.
-      return doctor_explanation_fallback(std::string {}, evidence, true).dump();
-    }
-
     try {
       auto provider_text = call_doctor_explanation_provider(active_cfg, evidence.dump());
       if (!provider_text) {
@@ -2551,10 +2925,21 @@ namespace ai_optimizer {
       if (!parsed.value("status", false)) {
         return doctor_explanation_fallback(parsed.value("provider_error", std::string {"Invalid structured output"}), evidence).dump();
       }
+      parsed["authority"] = "explanation_only";
+      parsed["may_define_settings"] = false;
+      parsed["source"] = {
+        {"kind", "ai-explanation"},
+        {"mode", active_cfg.provider + "-" + active_cfg.auth_mode},
+        {"informational", true}
+      };
       return parsed.dump();
     } catch (const std::exception &e) {
       return doctor_explanation_fallback(e.what(), evidence).dump();
     }
+  }
+
+  std::string explain_doctor_json(const std::string &redacted_evidence_json) {
+    return explain_doctor_json_with_config(cfg, redacted_evidence_json);
   }
 
   void init(const config_t &config) {
@@ -2982,12 +3367,80 @@ namespace ai_optimizer {
     const auto latency_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - started_at).count();
     if (!result) {
-      update_provider_runtime_status(false, static_cast<long>(latency_ms), "Draft test returned no optimization result");
+      update_provider_runtime_status(false, static_cast<long>(latency_ms), "Provider returned no optimization result");
       return std::nullopt;
+    }
+    update_provider_runtime_status(true, static_cast<long>(latency_ms));
+    return normalize_optimization(active_cfg, device_name, app_name, game_category, history, *result, false);
+  }
+
+  provider_test_result_t test_provider_with_config(
+      const config_t &config,
+      const std::string &device_name,
+      const std::string &app_name,
+      const std::string &gpu_info,
+      const std::string &game_category,
+      const std::optional<session_history_t> &history,
+      const std::string &mode) {
+    provider_test_result_t test_result;
+    auto active_cfg = resolved_config(config);
+    if (!is_config_enabled(active_cfg)) {
+      test_result.code = "configuration_not_ready";
+      test_result.error = "Provider settings are incomplete";
+      test_result.detail = "The selected provider, model, or authentication settings are not ready for a request.";
+      test_result.action = "Complete the provider settings, then retry.";
+      test_result.retryable = false;
+      return test_result;
+    }
+    const auto started_at = std::chrono::steady_clock::now();
+    const nlohmann::json evidence = {
+      {"deterministic_source_of_truth", {
+        {"primary_issue", "provider_test"},
+        {"summary", "This is a connectivity and explanation-contract test; no stream setting or action is being requested."}
+      }},
+      {"doctor", {
+        {"likely_cause", "Provider test evidence"},
+        {"evidence", nlohmann::json::array({"Polaris supplied a synthetic, non-actionable explanation test."})},
+        {"try_first", nlohmann::json::array({"Confirm that the provider can explain this evidence."})}
+      }},
+      {"test_context", {
+        {"device", device_name},
+        {"app", app_name},
+        {"gpu", gpu_info},
+        {"category", game_category},
+        {"mode", mode}
+      }}
+    };
+    auto result = call_doctor_explanation_provider(active_cfg, evidence.dump(), &test_result);
+    const auto latency_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - started_at).count();
+    if (!result) {
+      if (test_result.error.empty()) {
+        test_result.code = "provider_rejected_response";
+        test_result.error = "Provider did not return a usable explanation";
+        test_result.detail = "The request completed without a valid structured response.";
+        test_result.action = "Check the provider settings and Polaris logs, then retry.";
+      }
+      update_provider_runtime_status(false, static_cast<long>(latency_ms), test_result.error);
+      return test_result;
+    }
+
+    auto parsed = nlohmann::json::parse(parse_doctor_explanation_json(*result));
+    if (!parsed.value("status", false)) {
+      test_result.code = "invalid_response";
+      test_result.error = "Provider returned an invalid explanation response";
+      test_result.detail = parsed.value("provider_error", std::string {"The response did not match the explanation-only schema."});
+      test_result.action = "Use a model that follows structured JSON output, or check the provider compatibility mode.";
+      update_provider_runtime_status(false, static_cast<long>(latency_ms), test_result.error);
+      return test_result;
     }
 
     update_provider_runtime_status(true, static_cast<long>(latency_ms));
-    return normalize_optimization(active_cfg, device_name, app_name, game_category, history, *result, false);
+    parsed["source"] = "ai_explanation_test";
+    parsed["authority"] = "explanation_only";
+    parsed["may_define_settings"] = false;
+    test_result.explanation_json = parsed.dump();
+    return test_result;
   }
 
   std::string get_models_json_with_config(const config_t &config) {

--- a/src/ai_optimizer.h
+++ b/src/ai_optimizer.h
@@ -36,6 +36,15 @@ namespace ai_optimizer {
     int cache_ttl_hours = 168;       ///< Cache TTL (default 1 week)
   };
 
+  struct provider_test_result_t {
+    std::optional<std::string> explanation_json;
+    std::string code;
+    std::string error;
+    std::string detail;
+    std::string action;
+    bool retryable = true;
+  };
+
   /**
    * @brief Resolve the CODEX_HOME value Polaris should use for Codex subscription mode.
    */
@@ -219,6 +228,21 @@ namespace ai_optimizer {
     const std::string &mode = "");
 
   /**
+   * @brief Test draft provider settings and preserve an actionable failure reason.
+   *
+   * Unlike the runtime optimization API, this endpoint distinguishes transport,
+   * timeout, authentication, endpoint, and response-contract failures for the UI.
+   */
+  provider_test_result_t test_provider_with_config(
+    const config_t &config,
+    const std::string &device_name,
+    const std::string &app_name,
+    const std::string &gpu_info,
+    const std::string &game_category = "",
+    const std::optional<session_history_t> &history = std::nullopt,
+    const std::string &mode = "");
+
+  /**
    * @brief Get a provider-aware model catalog as JSON using ad-hoc config.
    * Uses the draft provider settings without mutating live runtime state.
    */
@@ -271,8 +295,8 @@ namespace ai_optimizer {
     const device_db::optimization_t &optimization);
 
   /**
-   * @brief Parse and normalize a Doctor explanation JSON response.
-   * Always forces destructive_action_allowed=false.
+   * @brief Parse and validate a Doctor explanation JSON response.
+   * Rejects any response that does not match the explanation-only schema.
    */
   std::string parse_doctor_explanation_json(const std::string &text);
 
@@ -283,6 +307,15 @@ namespace ai_optimizer {
    */
   std::string explain_doctor_json_with_config(const config_t &config,
                                               const std::string &redacted_evidence_json);
+
+  /**
+   * @brief Explain redacted Doctor/support-bundle evidence with Polaris' active
+   * server-owned provider configuration.
+   *
+   * Browser callers deliberately cannot choose the provider, credentials, or
+   * endpoint for this request.
+   */
+  std::string explain_doctor_json(const std::string &redacted_evidence_json);
 
   /**
    * @brief Get AI status as JSON string.

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3715,17 +3715,24 @@ namespace confighttp {
       auto ai_cfg = parseAiDraftConfig(body);
       ai_cfg.enabled = true;
 
-      auto result = ai_optimizer::request_sync_with_config(ai_cfg, device, app, gpu);
-      if (result) {
-        output["status"] = true;
+      auto test_result = ai_optimizer::test_provider_with_config(ai_cfg, device, app, gpu);
+      if (test_result.explanation_json) {
+        output = nlohmann::json::parse(*test_result.explanation_json);
         output["provider"] = ai_cfg.provider;
         output["model"] = ai_cfg.model;
         output["auth_mode"] = ai_cfg.auth_mode;
         output["base_url"] = ai_cfg.base_url;
-        appendAiExplanationJson(output, *result);
+        const auto explanation = output.value("explanation", nlohmann::json::object());
+        output["reasoning"] = explanation.value("advanced_detail", explanation.value("likely_cause", std::string {}));
+        output["confidence"] = explanation.value("confidence", std::string {"low"});
+        output["signals_used"] = explanation.value("evidence", nlohmann::json::array());
       } else {
         output["status"] = false;
-        output["error"] = "Connection test failed — check provider settings and logs";
+        output["code"] = test_result.code;
+        output["error"] = test_result.error;
+        output["detail"] = test_result.detail;
+        output["action"] = test_result.action;
+        output["retryable"] = test_result.retryable;
       }
     } catch (const std::exception &e) {
       output["status"] = false;
@@ -3756,21 +3763,16 @@ namespace confighttp {
       std::stringstream ss;
       ss << request->content.rdbuf();
       auto body = nlohmann::json::parse(ss.str());
-      ai_optimizer::config_t ai_cfg;
-      const auto provider = body.value("provider", nlohmann::json::object());
-      ai_cfg.enabled = true;
-      ai_cfg.provider = provider.value("provider", std::string {});
-      ai_cfg.model = provider.value("model", std::string {});
-      ai_cfg.auth_mode = provider.value("auth_mode", std::string {});
-      ai_cfg.base_url = provider.value("base_url", std::string {});
-      ai_cfg.timeout_ms = config::video.ai_optimizer.timeout_ms;
-      ai_cfg.cache_ttl_hours = config::video.ai_optimizer.cache_ttl_hours;
-      ai_cfg.api_key = config::video.ai_optimizer.api_key;
-
-      const auto evidence = body.value("evidence", nlohmann::json::object());
+      auto evidence = body.value("evidence", nlohmann::json::object());
+      if (!evidence.is_object()) evidence = nlohmann::json::object();
+      if (body.contains("deterministic_source_of_truth")) {
+        evidence["deterministic_source_of_truth"] = body["deterministic_source_of_truth"];
+      }
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "application/json");
-      response->write(ai_optimizer::explain_doctor_json_with_config(ai_cfg, evidence.dump()), headers);
+      // Provider selection, credentials, and endpoint authority remain on the
+      // host. The browser supplies only anonymized evidence to explain.
+      response->write(ai_optimizer::explain_doctor_json(evidence.dump()), headers);
     } catch (const std::exception &e) {
       nlohmann::json output;
       output["status"] = false;

--- a/src_assets/common/assets/web/ai-doctor-explanation.js
+++ b/src_assets/common/assets/web/ai-doctor-explanation.js
@@ -28,15 +28,6 @@ export const AI_DOCTOR_EXPLANATION_CATEGORIES = Object.freeze([
   'Recent redacted warning/error summaries',
 ])
 
-function providerConfig(config = {}) {
-  return {
-    provider: String(config.ai_provider || '').trim(),
-    model: String(config.ai_model || '').trim(),
-    base_url: String(config.ai_base_url || '').trim(),
-    auth_mode: String(config.ai_auth_mode || '').trim() || (config.ai_provider === 'local' ? 'none' : 'api_key'),
-  }
-}
-
 function hasConfiguredProvider(config = {}) {
   const provider = String(config.ai_provider || '').trim()
   const model = String(config.ai_model || '').trim()
@@ -44,7 +35,7 @@ function hasConfiguredProvider(config = {}) {
   return Boolean(provider && model && (provider !== 'local' || baseUrl))
 }
 
-export function buildAiDoctorExplanationPayload({ config = {}, supportBundle = {}, deterministicSummary = null } = {}) {
+export function buildAiDoctorExplanationPayload({ supportBundle = {}, deterministicSummary = null } = {}) {
   const rawEvidence = {
     ...buildStreamEvidence(supportBundle),
     session_snapshot: supportBundle.session_snapshot || supportBundle.stream_stats || {},
@@ -55,7 +46,6 @@ export function buildAiDoctorExplanationPayload({ config = {}, supportBundle = {
   const evidence = sanitizeDiagnosticsValue(JSON.parse(JSON.stringify(rawEvidence)))
 
   return {
-    provider: providerConfig(config),
     categories: [...AI_DOCTOR_EXPLANATION_CATEGORIES],
     schema: AI_DOCTOR_EXPLANATION_SCHEMA,
     deterministic_source_of_truth: sanitizeDiagnosticsValue(deterministicSummary || supportBundle.deterministic_summary || null),

--- a/src_assets/common/assets/web/ai-doctor-explanation.test.js
+++ b/src_assets/common/assets/web/ai-doctor-explanation.test.js
@@ -45,7 +45,7 @@ describe('AI Doctor explanation payload', () => {
       },
     })
 
-    expect(payload.provider).toEqual({ provider: 'local', model: 'llama3.1', base_url: 'http://127.0.0.1:11434/v1', auth_mode: 'none' })
+    expect(payload).not.toHaveProperty('provider')
     expect(payload.categories).toEqual([
       'Doctor diagnosis and evidence',
       'Fix My Stream checklist',
@@ -58,6 +58,31 @@ describe('AI Doctor explanation payload', () => {
     expect(JSON.stringify(payload)).not.toContain('tok-secret')
     expect(JSON.stringify(payload)).not.toContain('hunter2')
     expect(JSON.stringify(payload)).not.toContain('sk-live-secret')
+  })
+
+  it('keeps subscription provider controls out of the anonymized request', () => {
+    const payload = buildAiDoctorExplanationPayload({
+      config: {
+        ai_provider: 'openai',
+        ai_model: 'gpt-5.6-luna',
+        ai_base_url: 'https://api.openai.com/v1',
+        ai_auth_mode: 'subscription',
+        ai_api_key: 'must-never-cross-the-browser-wire',
+      },
+      supportBundle: {
+        config: {
+          ai_provider: 'openai',
+          ai_auth_mode: '[redacted]',
+        },
+        doctor: { primary_issue: 'frame_pacing' },
+      },
+    })
+
+    const serialized = JSON.stringify(payload)
+    expect(payload).not.toHaveProperty('provider')
+    expect(serialized).not.toContain('subscription')
+    expect(serialized).not.toContain('api.openai.com')
+    expect(serialized).not.toContain('must-never-cross-the-browser-wire')
   })
 })
 

--- a/src_assets/common/assets/web/ai-optimizer-guided-setup.test.js
+++ b/src_assets/common/assets/web/ai-optimizer-guided-setup.test.js
@@ -130,6 +130,27 @@ describe('AI optimizer guided setup', () => {
     expect(wrapper.text()).toContain('Guided step: choose the OpenAI setup that matches your auth')
   })
 
+  it('uses a realistic bounded timeout when selecting a local provider profile', async () => {
+    const config = defaultConfig()
+    const wrapper = mountOptimizer(config)
+    await flushMounted()
+
+    const localCard = wrapper.findAll('button').find(button => button.text().includes('Local'))
+    expect(localCard).toBeTruthy()
+    await localCard.trigger('click')
+    await nextTick()
+
+    const ollamaProfile = wrapper.findAll('button').find(button => button.text().includes('Ollama'))
+    expect(ollamaProfile).toBeTruthy()
+    await ollamaProfile.trigger('click')
+    await nextTick()
+
+    expect(config.ai_provider).toBe('local')
+    expect(config.ai_auth_mode).toBe('none')
+    expect(config.ai_timeout_ms).toBe(60000)
+    expect(wrapper.find('input[type="number"][max="120000"]').exists()).toBe(true)
+  })
+
   it('renders failed draft tests as structured actionable feedback', async () => {
     const config = defaultConfig({
       ai_provider: 'openai',
@@ -159,5 +180,40 @@ describe('AI optimizer guided setup', () => {
     expect(text).toContain('codex CLI is not authorized for this runtime HOME')
     expect(text).toContain('Run codex login or set CODEX_HOME to the signed-in account home.')
     expect(text).toContain('Retry after fixing auth')
+  })
+
+  it('explains a local inference timeout without blaming authentication', async () => {
+    const config = defaultConfig({
+      ai_provider: 'local',
+      ai_model: 'qwen3.8:27b',
+      ai_base_url: 'http://127.0.0.1:11434/v1',
+      ai_auth_mode: 'none',
+      ai_use_subscription: 'disabled',
+      ai_timeout_ms: 5000,
+    })
+    mockAiOptimizer.testConnection.mockResolvedValue({
+      status: false,
+      code: 'inference_timeout',
+      error: 'Model inference timed out after 60 seconds',
+      detail: 'Large local models may still be loading.',
+      action: 'Warm the model once, or raise Provider timeout to 60000 ms, then retry.',
+      retryable: true,
+    })
+
+    const wrapper = mountOptimizer(config)
+    await flushMounted()
+
+    const testButton = wrapper.findAll('button').find(button => button.text().includes('Test explanation'))
+    expect(testButton).toBeTruthy()
+    await testButton.trigger('click')
+    await flushMounted()
+
+    const text = wrapper.text()
+    expect(config.ai_timeout_ms).toBe(60000)
+    expect(text).toContain('Model inference timed out after 60 seconds')
+    expect(text).toContain('Large local models may still be loading.')
+    expect(text).toContain('raise Provider timeout to 60000 ms')
+    expect(text).toContain('Retry test')
+    expect(text).not.toContain('Retry after fixing auth')
   })
 })

--- a/src_assets/common/assets/web/configs/tabs/AiOptimizer.vue
+++ b/src_assets/common/assets/web/configs/tabs/AiOptimizer.vue
@@ -365,6 +365,8 @@ const selectedHistoryEntry = computed(() => {
 
 function optimizationSourceLabel(source) {
   switch (source) {
+    case 'ai_explanation_test':
+      return 'Live explanation'
     case 'ai_live':
       return 'Live AI'
     case 'ai_cached':
@@ -476,6 +478,7 @@ function applyProviderProfile(profile) {
   config.value.ai_model = profile.model || currentProvider.value.defaultModel
   config.value.ai_base_url = profile.baseUrl || currentProvider.value.defaultBaseUrl
   config.value.ai_auth_mode = profile.authMode || currentProvider.value.defaultAuth
+  config.value.ai_timeout_ms = profile.timeoutMs || (currentProvider.value.id === 'local' ? 60000 : 5000)
   config.value.ai_use_subscription = config.value.ai_auth_mode === 'subscription' ? 'enabled' : 'disabled'
 
   if (config.value.ai_auth_mode === 'none') {
@@ -521,6 +524,13 @@ function syncProviderDefaults(previousProviderId) {
     } else {
       config.value.ai_auth_mode = provider.defaultAuth
     }
+  }
+
+  const previousDefaultTimeout = previousProvider?.id === 'local' ? 60000 : 5000
+  const configuredTimeout = Number(config.value.ai_timeout_ms)
+  const legacyLocalDefault = provider.id === 'local' && configuredTimeout === 5000
+  if (!configuredTimeout || legacyLocalDefault || (previousProvider && configuredTimeout === previousDefaultTimeout)) {
+    config.value.ai_timeout_ms = provider.id === 'local' ? 60000 : 5000
   }
 
   config.value.ai_use_subscription = config.value.ai_auth_mode === 'subscription' ? 'enabled' : 'disabled'
@@ -613,13 +623,14 @@ async function testProviderConfig() {
     }
     toast(`${provider.name} explanation provider verified`, 'success')
   } else {
+    const authFailure = result.code === 'authentication_failed' || /auth|authorized|login/i.test(result.error || '')
     testResult.value = {
       success: false,
       label: 'Action needed',
       message: result.error || 'Connection test failed',
       detail: result.detail || '',
       action: result.action || authHelpText.value,
-      retryLabel: result.retryable === false ? 'Review settings' : 'Retry after fixing auth',
+      retryLabel: result.retryable === false ? 'Review settings' : (authFailure ? 'Retry after fixing auth' : 'Retry test'),
       payload: null
     }
     toast(`${provider.name} test failed: ${result.error || 'Unknown error'}`, 'error')
@@ -963,7 +974,7 @@ onBeforeUnmount(() => {
                   v-model="config.ai_timeout_ms"
                   type="number"
                   min="1000"
-                  max="30000"
+                  max="120000"
                   step="500"
                   class="w-32 bg-void/50 border border-storm/50 rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none"
                   placeholder="5000" />
@@ -1019,11 +1030,8 @@ onBeforeUnmount(() => {
                 </div>
               </div>
               <div class="rounded-lg border border-storm/20 bg-void/40 px-3 py-2">
-                <div class="text-[10px] uppercase tracking-wider text-storm">Freshness</div>
-                <div class="text-sm text-silver mt-1">
-                  {{ formatRelativeTime(testResult.payload.generated_at) }}
-                  <span class="text-storm"> · expires {{ formatRelativeTime(testResult.payload.expires_at) }}</span>
-                </div>
+                <div class="text-[10px] uppercase tracking-wider text-storm">Authority</div>
+                <div class="text-sm text-silver mt-1">Explanation only · cannot change settings or actions</div>
               </div>
             </div>
             <div v-if="testResult.success && testResult.payload?.signals_used?.length" class="mt-3 rounded-lg border border-storm/20 bg-void/40 px-3 py-2">

--- a/src_assets/common/assets/web/troubleshooting-support-flow.test.js
+++ b/src_assets/common/assets/web/troubleshooting-support-flow.test.js
@@ -64,4 +64,13 @@ describe('Troubleshooting self-service support flow', () => {
     expect(locale).toContain('Ollama or LM Studio')
     expect(locale).toContain('AI cannot execute recovery actions')
   })
+
+  it('keeps live provider controls separate from the anonymized support bundle', () => {
+    const source = webSource('views/TroubleshootingView.vue')
+
+    expect(source).toContain('const context = await collectSupportContext()')
+    expect(source).toContain('const supportBundle = await createSupportBundle(context)')
+    expect(source).toContain('const config = context.config || {}')
+    expect(source).not.toContain('const config = supportBundle.config || {}')
+  })
 })

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -1210,8 +1210,8 @@ async function collectSupportContext() {
   }
 }
 
-async function createSupportBundle() {
-  const context = await collectSupportContext()
+async function createSupportBundle(providedContext = null) {
+  const context = providedContext || await collectSupportContext()
   return buildAnonymizedDiagnosticsBundle({
     ...context,
     issue_draft: buildGithubIssueDraft(context),
@@ -1250,8 +1250,12 @@ async function downloadIssueDraft() {
 async function requestAiDoctorExplanation() {
   requestingAiDoctorExplanation.value = true
   try {
-    const supportBundle = await createSupportBundle()
-    const config = supportBundle.config || {}
+    // Provider controls stay local to Polaris. The exported support bundle is
+    // intentionally anonymized, so fields such as ai_auth_mode are redacted
+    // and must never be recycled as live provider configuration.
+    const context = await collectSupportContext()
+    const supportBundle = await createSupportBundle(context)
+    const config = context.config || {}
     const result = await explainDoctorWithAi({
       aiEnabled: config.ai_enabled === true || config.ai_enabled === 'enabled' || config.ai_enabled === 'true',
       config,

--- a/tests/unit/test_ai_optimizer.cpp
+++ b/tests/unit/test_ai_optimizer.cpp
@@ -8,10 +8,84 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <optional>
 #include <nlohmann/json.hpp>
 
 namespace {
+#ifndef _WIN32
+  class scoped_fake_codex_t {
+  public:
+    scoped_fake_codex_t() {
+      if (const char *home = std::getenv("HOME")) {
+        previous_home_ = home;
+      }
+      const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+      root_ = std::filesystem::temp_directory_path() /
+        ("polaris-ai-doctor-test-" + std::to_string(stamp));
+      const auto bin = root_ / ".local" / "bin";
+      std::error_code ec;
+      std::filesystem::create_directories(bin, ec);
+      if (ec) return;
+
+      const auto script = bin / "codex";
+      std::ofstream output(script, std::ios::binary | std::ios::trunc);
+      output << R"SH(#!/bin/sh
+output_file=''
+schema_file=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output_file="$2"; shift 2 ;;
+    --output-schema) schema_file="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$output_file" ] || exit 10
+[ -f "$schema_file" ] || exit 11
+prompt="$(cat)"
+printf '%s' "$prompt" | grep -q 'destructive_action_allowed' || exit 12
+cat > "$output_file" <<'JSON'
+{"likely_cause":"Frame pacing pressure","evidence":["Doctor reported frame_pacing"],"try_first":["Use the deterministic Doctor fix"],"advanced_detail":"Explanation only; Doctor retains authority.","confidence":"high","destructive_action_allowed":false}
+JSON
+)SH";
+      output.close();
+      if (!output.good()) return;
+      std::filesystem::permissions(
+        script,
+        std::filesystem::perms::owner_all,
+        std::filesystem::perm_options::replace,
+        ec);
+      if (ec || setenv("HOME", root_.c_str(), 1) != 0) return;
+      ready_ = true;
+    }
+
+    scoped_fake_codex_t(const scoped_fake_codex_t &) = delete;
+    scoped_fake_codex_t &operator=(const scoped_fake_codex_t &) = delete;
+
+    ~scoped_fake_codex_t() {
+      if (previous_home_) {
+        (void) setenv("HOME", previous_home_->c_str(), 1);
+      } else {
+        (void) unsetenv("HOME");
+      }
+      std::error_code ec;
+      std::filesystem::remove_all(root_, ec);
+    }
+
+    bool ready() const {
+      return ready_;
+    }
+
+  private:
+    std::filesystem::path root_;
+    std::optional<std::string> previous_home_;
+    bool ready_ = false;
+  };
+#endif
+
   ai_optimizer::session_history_t make_session(const std::string &grade,
                                                const std::string &end_reason,
                                                int duration_s,
@@ -799,21 +873,40 @@ TEST(AiOptimizerSafeTargetFps, UpgradesLegacyThirtyCapWhenModerateMissCanHoldFor
   );
 }
 
-TEST(AiOptimizerDoctorExplanation, ParsesStructuredOutputAndForcesNonDestructive) {
+TEST(AiOptimizerDoctorExplanation, ParsesStrictExplanationOnlyOutput) {
   auto parsed = nlohmann::json::parse(ai_optimizer::parse_doctor_explanation_json(R"({
     "likely_cause":"Packet loss",
     "evidence":["3.4% packet loss"],
     "try_first":["Lower bitrate"],
     "advanced_detail":"Network evidence is stronger than encoder speculation.",
     "confidence":"high",
-    "destructive_action_allowed":true
+    "destructive_action_allowed":false
   })"));
 
   ASSERT_TRUE(parsed.value("status", false));
+  EXPECT_EQ("explanation_only", parsed.value("authority", ""));
+  EXPECT_FALSE(parsed.value("may_define_settings", true));
   const auto explanation = parsed.at("explanation");
   EXPECT_EQ("Packet loss", explanation.value("likely_cause", ""));
   EXPECT_EQ("high", explanation.value("confidence", ""));
   EXPECT_FALSE(explanation.value("destructive_action_allowed", true));
+}
+
+TEST(AiOptimizerDoctorExplanation, RejectsProviderClaimingDestructiveAuthority) {
+  const auto parsed = nlohmann::json::parse(ai_optimizer::parse_doctor_explanation_json(R"({
+    "likely_cause":"Packet loss",
+    "evidence":["3.4% packet loss"],
+    "try_first":["Delete system files"],
+    "advanced_detail":"Unsafe provider output.",
+    "confidence":"high",
+    "destructive_action_allowed":true
+  })"));
+
+  EXPECT_FALSE(parsed.value("status", true));
+  EXPECT_TRUE(parsed.value("fallback", false));
+  EXPECT_EQ("explanation_only", parsed.value("authority", ""));
+  EXPECT_FALSE(parsed.value("may_define_settings", true));
+  EXPECT_EQ("deterministic-fallback", parsed.at("explanation").value("confidence", ""));
 }
 
 TEST(AiOptimizerDoctorExplanation, DisabledConfigFallsBackToDeterministicEvidence) {
@@ -835,7 +928,11 @@ TEST(AiOptimizerDoctorExplanation, DisabledConfigFallsBackToDeterministicEvidenc
   EXPECT_FALSE(result.at("explanation").value("destructive_action_allowed", true));
 }
 
-TEST(AiOptimizerDoctorExplanation, OpenAiSubscriptionUsesCleanExpectedDeterministicFallback) {
+#ifndef _WIN32
+TEST(AiOptimizerDoctorExplanation, OpenAiSubscriptionRunsBoundedCodexExplanation) {
+  scoped_fake_codex_t fake_codex;
+  ASSERT_TRUE(fake_codex.ready());
+
   ai_optimizer::config_t config;
   config.enabled = true;
   config.provider = "openai";
@@ -847,14 +944,43 @@ TEST(AiOptimizerDoctorExplanation, OpenAiSubscriptionUsesCleanExpectedDeterminis
   })"));
 
   EXPECT_TRUE(result.value("status", false));
-  EXPECT_TRUE(result.value("fallback", false));
-  EXPECT_TRUE(result.value("provider_error", "not-empty").empty());
-  EXPECT_EQ("deterministic-fallback", result.at("source").value("kind", ""));
+  EXPECT_FALSE(result.value("fallback", false));
+  EXPECT_EQ("explanation_only", result.value("authority", ""));
+  EXPECT_FALSE(result.value("may_define_settings", true));
+  EXPECT_EQ("ai-explanation", result.at("source").value("kind", ""));
   EXPECT_EQ("openai-subscription", result.at("source").value("mode", ""));
   EXPECT_TRUE(result.at("source").value("informational", false));
-  EXPECT_EQ("deterministic-fallback", result.at("explanation").value("confidence", ""));
-  EXPECT_EQ("Frame pacing", result.at("explanation").value("likely_cause", ""));
+  EXPECT_EQ("high", result.at("explanation").value("confidence", ""));
+  EXPECT_EQ("Frame pacing pressure", result.at("explanation").value("likely_cause", ""));
 }
+
+TEST(AiOptimizerDoctorExplanation, DraftProviderTestUsesTheExplanationOnlyContract) {
+  scoped_fake_codex_t fake_codex;
+  ASSERT_TRUE(fake_codex.ready());
+
+  ai_optimizer::config_t config;
+  config.enabled = true;
+  config.provider = "openai";
+  config.model = "gpt-5";
+  config.auth_mode = "subscription";
+
+  const auto result = ai_optimizer::test_provider_with_config(
+    config,
+    "NVIDIA Shield TV",
+    "Control",
+    "NVIDIA GPU"
+  );
+
+  ASSERT_TRUE(result.explanation_json.has_value());
+  const auto parsed = nlohmann::json::parse(*result.explanation_json);
+  EXPECT_TRUE(parsed.value("status", false));
+  EXPECT_EQ("explanation_only", parsed.value("authority", ""));
+  EXPECT_FALSE(parsed.value("may_define_settings", true));
+  EXPECT_EQ("ai_explanation_test", parsed.value("source", ""));
+  EXPECT_FALSE(parsed.contains("display_mode"));
+  EXPECT_FALSE(parsed.contains("target_bitrate_kbps"));
+}
+#endif
 
 TEST(AiOptimizerModeAwareCache, LegacyRequestsKeepTheirBucketAndModesGetTheirOwn) {
   const auto legacy = ai_optimizer::cache_key_for_tests(

--- a/tests/unit/test_doctor_reset_contract.cpp
+++ b/tests/unit/test_doctor_reset_contract.cpp
@@ -1086,6 +1086,11 @@ TEST(DoctorResetContract, LegacyAiSurfacesAreExplanationOnly) {
     "void triggerAiOptimize(",
     "void explainDoctorWithAi("
   );
+  const auto doctor_explanation = between(
+    config_http,
+    "void explainDoctorWithAi(",
+    "namespace {"
+  );
   for (const auto *forbidden : {
          "display_mode", "target_bitrate_kbps", "preferred_codec",
          "virtual_display", "nvenc_tune"
@@ -1096,6 +1101,9 @@ TEST(DoctorResetContract, LegacyAiSurfacesAreExplanationOnly) {
   EXPECT_EQ(device_suggestion.find("ai_optimizer::get_cached"), std::string::npos);
   EXPECT_EQ(legacy_optimize.find("request_sync"), std::string::npos);
   EXPECT_NE(legacy_optimize.find("ai_launch_policy_removed"), std::string::npos);
+  EXPECT_NE(doctor_explanation.find("ai_optimizer::explain_doctor_json(evidence.dump())"), std::string::npos);
+  EXPECT_EQ(doctor_explanation.find("body.value(\"provider\""), std::string::npos);
+  EXPECT_EQ(doctor_explanation.find("ai_cfg.api_key"), std::string::npos);
 
   const auto ui = source("src_assets/common/assets/web/configs/tabs/AiOptimizer.vue");
   EXPECT_EQ(ui.find("AI Auto Quality"), std::string::npos);


### PR DESCRIPTION
## Summary

- keep Doctor deterministic while allowing configured AI providers to explain its redacted evidence
- keep provider, endpoint, authentication, and credential authority on the Polaris host
- support signed-in OpenAI subscription explanations through Codex CLI with a private temporary home, read-only sandbox, timeout, output cap, and strict explanation-only schema
- make provider tests exercise the explanation contract and return actionable timeout, transport, authentication, endpoint, rate-limit, empty-response, and schema failures
- use live server configuration for the Troubleshooting AI-availability decision instead of the redacted support-bundle copy
- fix the OpenAI-compatible Authorization header and give local inference a practical timeout range

AI output remains informational: it cannot define launch settings, Doctor actions, rollback behavior, or destructive actions.

## Validation

- focused C++ AI explanation and Doctor authority tests
- 17 focused web tests
- web lint and production build
- public hygiene and dependency checks
- live OpenAI-compatible local-model request returned HTTP 200 and satisfied the exact six-field explanation-only schema within the configured window