### PR TITLE
fix: single-source response-only config keys and repair live/restart field names

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,6 +22,7 @@
 
 // local includes
 #include "config.h"
+#include "confighttp_validation.h"
 #include "entry_handler.h"
 #include "file_handler.h"
 #include "logging.h"
@@ -78,22 +79,6 @@ namespace config {
 
     return value.empty() ? "(empty)"s : "[redacted]"s;
   }
-
-  namespace {
-    bool is_response_only_config_key(const std::string_view key) {
-      return key == "status"sv ||
-             key == "platform"sv ||
-             key == "version"sv ||
-             key == "vdisplayStatus"sv ||
-             key == "vdisplayAvailable"sv ||
-             key == "vdisplayBackend"sv ||
-             key == "runtime_backend"sv ||
-             key == "runtime_requested_headless"sv ||
-             key == "runtime_effective_headless"sv ||
-             key == "runtime_gpu_native_override_active"sv ||
-             key == "stream_display_mode"sv;
-    }
-  }  // namespace
 
   namespace nv {
 
@@ -1273,7 +1258,7 @@ namespace config {
 #endif
 
     for (auto it = vars.begin(); it != vars.end();) {
-      if (is_response_only_config_key(it->first)) {
+      if (confighttp::validation::is_response_only_config_key(it->first)) {
         it = vars.erase(it);
       } else {
         ++it;

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -4058,15 +4058,24 @@ namespace confighttp {
     output_tree["client_settings_effective_stream_display_mode"] = effective_mode;
     output_tree["client_settings_stream_display_mode_label"] = stream_display_mode_label(configured_mode);
     output_tree["client_settings_effective_stream_display_mode_label"] = stream_display_mode_label(effective_mode);
+    // Config keys, not GameStream sync-field names: the web UI checks its own
+    // pending config keys against these to render apply-live vs restart badges.
     output_tree["client_settings_live_fields"] = nlohmann::json::array({
-      "target_bitrate_kbps",
+      "max_bitrate",
       "adaptive_bitrate_enabled",
-      "ai_optimizer_enabled"
+      "ai_enabled"
     });
     output_tree["client_settings_restart_fields"] = nlohmann::json::array({
-      "stream_display_mode",
-      "display_mode"
+      "linux_stream_mode",
+      "fallback_mode"
     });
+    {
+      auto response_only_keys = nlohmann::json::array();
+      for (const auto key : validation::response_only_config_keys()) {
+        response_only_keys.emplace_back(key);
+      }
+      output_tree["config_response_only_keys"] = std::move(response_only_keys);
+    }
 #ifdef _WIN32
     output_tree["vdisplayStatus"] = (int)proc::vDisplayDriverStatus;
 #endif
@@ -4186,45 +4195,9 @@ namespace confighttp {
       std::stringstream config_stream;
       nlohmann::json output_tree;
       nlohmann::json input_tree = nlohmann::json::parse(ss);
-      const auto is_response_only_config_key = [](const std::string_view key) {
-        return key == "status"sv ||
-               key == "platform"sv ||
-               key == "version"sv ||
-               key == "has_ai_api_key"sv ||
-               key == "has_steamgriddb_api_key"sv ||
-               key == "has_api_key"sv ||
-               key == "vdisplayStatus"sv ||
-               key == "vdisplayAvailable"sv ||
-               key == "vdisplayBackend"sv ||
-               key == "runtime_backend"sv ||
-               key == "runtime_requested_headless"sv ||
-               key == "runtime_effective_headless"sv ||
-               key == "runtime_gpu_native_override_active"sv ||
-               key == "stream_display_mode_options"sv ||
-               key == "client_settings_available"sv ||
-               key == "client_settings_v1"sv ||
-               key == "client_settings_endpoint"sv ||
-               key == "client_settings_endpoint_path"sv ||
-               key == "client_settings_endpoint_origin"sv ||
-               key == "client_settings_endpoint_same_origin"sv ||
-               key == "client_settings_endpoint_https_port"sv ||
-               key == "client_settings_endpoint_base_url"sv ||
-               key == "client_settings_endpoint_url"sv ||
-               key == "client_settings_sync_mode"sv ||
-               key == "client_settings_authority"sv ||
-               key == "client_settings_relaunch_required"sv ||
-               key == "client_settings_stream_display_mode"sv ||
-               key == "client_settings_effective_stream_display_mode"sv ||
-               key == "client_settings_stream_display_mode_label"sv ||
-               key == "client_settings_effective_stream_display_mode_label"sv ||
-               key == "client_settings_live_fields"sv ||
-               key == "client_settings_restart_fields"sv ||
-               key == "ai_auto_quality_enabled"sv ||
-               key == "stream_display_mode"sv;
-      };
       std::string validation_error;
       for (auto it = input_tree.begin(); it != input_tree.end();) {
-        if (is_response_only_config_key(it.key())) {
+        if (validation::is_response_only_config_key(it.key())) {
           it = input_tree.erase(it);
         } else {
           ++it;

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -71,6 +71,53 @@ namespace confighttp::validation {
       return true;
     }
 
+    // Sorted and unique; the single source of truth for response-only keys.
+    // confighttp's saveConfig and config.cpp's apply_config both consume this
+    // through the public helpers below, and getConfig serves it to the web UI
+    // as config_response_only_keys.
+    constexpr std::array response_only_config_keys_list {
+      "ai_auto_quality_enabled"sv,
+      "client_settings_authority"sv,
+      "client_settings_available"sv,
+      "client_settings_effective_stream_display_mode"sv,
+      "client_settings_effective_stream_display_mode_label"sv,
+      "client_settings_endpoint"sv,
+      "client_settings_endpoint_base_url"sv,
+      "client_settings_endpoint_https_port"sv,
+      "client_settings_endpoint_origin"sv,
+      "client_settings_endpoint_path"sv,
+      "client_settings_endpoint_same_origin"sv,
+      "client_settings_endpoint_url"sv,
+      "client_settings_live_fields"sv,
+      "client_settings_relaunch_required"sv,
+      "client_settings_restart_fields"sv,
+      "client_settings_stream_display_mode"sv,
+      "client_settings_stream_display_mode_label"sv,
+      "client_settings_sync_mode"sv,
+      "client_settings_v1"sv,
+      "config_response_only_keys"sv,
+      "has_ai_api_key"sv,
+      "has_api_key"sv,
+      "has_steamgriddb_api_key"sv,
+      "platform"sv,
+      "runtime_backend"sv,
+      "runtime_effective_headless"sv,
+      "runtime_gpu_native_override_active"sv,
+      "runtime_requested_headless"sv,
+      "status"sv,
+      "stream_display_mode"sv,
+      "stream_display_mode_options"sv,
+      "stream_path_id"sv,
+      "stream_path_label"sv,
+      "vdisplayAvailable"sv,
+      "vdisplayBackend"sv,
+      "vdisplayStatus"sv,
+      "version"sv,
+    };
+
+    static_assert(std::ranges::is_sorted(response_only_config_keys_list), "response-only key list must stay sorted");
+    static_assert(std::ranges::adjacent_find(response_only_config_keys_list) == response_only_config_keys_list.end(), "response-only key list must stay unique");
+
     constexpr std::array allowed_config_keys {
       "adapter_name"sv,
       "adaptive_bitrate_enabled"sv,
@@ -569,5 +616,13 @@ namespace confighttp::validation {
     }
 
     return true;
+  }
+
+  std::span<const std::string_view> response_only_config_keys() {
+    return response_only_config_keys_list;
+  }
+
+  bool is_response_only_config_key(const std::string_view key) {
+    return std::ranges::binary_search(response_only_config_keys_list, key);
   }
 }  // namespace confighttp::validation

--- a/src/confighttp_validation.h
+++ b/src/confighttp_validation.h
@@ -4,7 +4,9 @@
  */
 #pragma once
 
+#include <span>
 #include <string>
+#include <string_view>
 
 #include <nlohmann/json.hpp>
 
@@ -12,4 +14,10 @@ namespace confighttp::validation {
   bool validate_app_payload(const nlohmann::json &payload, std::string &error);
   bool validate_config_payload(const nlohmann::json &payload, std::string &error);
   void normalize_write_only_secret_payload(nlohmann::json &payload);
+
+  // Keys that appear in GET /api/config responses but are derived state, not
+  // settings. They must never be written: saveConfig strips them from POST
+  // payloads and config load scrubs any that leaked into the config file.
+  std::span<const std::string_view> response_only_config_keys();
+  bool is_response_only_config_key(std::string_view key);
 }  // namespace confighttp::validation

--- a/tests/unit/test_confighttp_validation.cpp
+++ b/tests/unit/test_confighttp_validation.cpp
@@ -4,6 +4,9 @@
  */
 #include "../tests_common.h"
 
+#include <algorithm>
+#include <array>
+
 #include <src/confighttp_validation.h>
 
 TEST(ConfigValidationTests, RejectsConfigKeysThatCanBreakSerialization) {
@@ -143,6 +146,83 @@ TEST(ConfigValidationTests, AcceptsClientGamepadSeatIsolationConfigKey) {
 
   std::string error;
   EXPECT_TRUE(confighttp::validation::validate_config_payload(payload, error)) << error;
+}
+
+TEST(ResponseOnlyConfigKeyTests, CoversEveryKeyTheLegacyListsScrubbed) {
+  // Union of the two lists previously hardcoded in confighttp.cpp (saveConfig)
+  // and config.cpp (apply_config). Removing any of these from the canonical
+  // list would let derived state leak back into the config file.
+  constexpr std::array legacy_keys {
+    "ai_auto_quality_enabled",
+    "client_settings_authority",
+    "client_settings_available",
+    "client_settings_effective_stream_display_mode",
+    "client_settings_effective_stream_display_mode_label",
+    "client_settings_endpoint",
+    "client_settings_endpoint_base_url",
+    "client_settings_endpoint_https_port",
+    "client_settings_endpoint_origin",
+    "client_settings_endpoint_path",
+    "client_settings_endpoint_same_origin",
+    "client_settings_endpoint_url",
+    "client_settings_live_fields",
+    "client_settings_relaunch_required",
+    "client_settings_restart_fields",
+    "client_settings_stream_display_mode",
+    "client_settings_stream_display_mode_label",
+    "client_settings_sync_mode",
+    "client_settings_v1",
+    "has_ai_api_key",
+    "has_api_key",
+    "has_steamgriddb_api_key",
+    "platform",
+    "runtime_backend",
+    "runtime_effective_headless",
+    "runtime_gpu_native_override_active",
+    "runtime_requested_headless",
+    "status",
+    "stream_display_mode",
+    "stream_display_mode_options",
+    "vdisplayAvailable",
+    "vdisplayBackend",
+    "vdisplayStatus",
+    "version",
+  };
+
+  for (const auto key : legacy_keys) {
+    EXPECT_TRUE(confighttp::validation::is_response_only_config_key(key)) << key;
+  }
+}
+
+TEST(ResponseOnlyConfigKeyTests, ScrubsStreamPathIdentityAndSelfDescribingKeys) {
+  // getConfig emits these, but before the canonical list neither C++ scrub
+  // covered them, so a full-config POST persisted them into the config file.
+  EXPECT_TRUE(confighttp::validation::is_response_only_config_key("stream_path_id"));
+  EXPECT_TRUE(confighttp::validation::is_response_only_config_key("stream_path_label"));
+  EXPECT_TRUE(confighttp::validation::is_response_only_config_key("config_response_only_keys"));
+}
+
+TEST(ResponseOnlyConfigKeyTests, LeavesRealConfigKeysWritable) {
+  // The GameStream sync-field name ai_auto_quality_enabled is response-only,
+  // but the config keys behind it must stay writable.
+  constexpr std::array writable_keys {
+    "adaptive_bitrate_enabled",
+    "ai_enabled",
+    "audio_sink",
+    "fallback_mode",
+    "linux_stream_mode",
+    "max_bitrate",
+  };
+
+  for (const auto key : writable_keys) {
+    EXPECT_FALSE(confighttp::validation::is_response_only_config_key(key)) << key;
+  }
+}
+
+TEST(ResponseOnlyConfigKeyTests, ListStaysSortedAndUnique) {
+  const auto keys = confighttp::validation::response_only_config_keys();
+  EXPECT_TRUE(std::ranges::is_sorted(keys));
+  EXPECT_EQ(std::ranges::adjacent_find(keys), keys.end());
 }
 
 TEST(AppValidationTests, AcceptsAWellFormedAppPayload) {


### PR DESCRIPTION
## Summary

Part of #571 (settings revamp arc, backend slice 1).

- Move the response-only config key list into `confighttp_validation` as the single canonical source (sorted, unique, static-asserted), replacing the drifted copies in confighttp's `saveConfig` lambda and config.cpp's `apply_config` helper.
- Scrub `stream_path_id` and `stream_path_label`: getConfig emits them but neither C++ list covered them, so a client POSTing the full config object back persisted derived stream-path state into the config file.
- Serve the canonical list as `config_response_only_keys` in `GET /api/config` so the web UI can retire its hardcoded mirror in `client-settings-sync.js`.
- Repair `client_settings_live_fields` / `client_settings_restart_fields`: they carried GameStream sync-field names (`target_bitrate_kbps`, `ai_optimizer_enabled`, `stream_display_mode`, `display_mode`) while the web UI matches them against pending config keys, so the applies-live badge never fired. They now carry the config keys the UI writes: `max_bitrate`, `adaptive_bitrate_enabled`, `ai_enabled`, `linux_stream_mode`, `fallback_mode`.

## Exact candidate

- `Commit:` 8cdab2dbfacc9b570fc5908dd2158aa495e3219e
- `Tree:` 3044c05122a10d1cbeac35c290e324aa610a835f
- `Parent:` e82654c7f1c90f441910146d0e6d1d1612a9c16d
- `Base:` e82654c7f1c90f441910146d0e6d1d1612a9c16d

## Verification

- [x] `ninja polaris` links clean (polaris-1.4.0.e82654c7.dirty)
- [x] `test_polaris --gtest_filter="ConfigValidationTests.*:ResponseOnlyConfigKeyTests.*"` — 16/16 passed (4 new tests: legacy-union coverage, stream_path scrub, writable-key negatives, sorted+unique invariant)
- [x] `ctest -R "test_polaris_http|test_polaris_config"` under BUILD_FULL_TESTS=ON — 2/2 passed (compiles confighttp.cpp and config.cpp through the full runtime objects, CI-sanitizer parity)
- No new source files, so no CMake list changes were needed.
