### PR TITLE
feat(web): make the display planner an honest persistent choice

### DIFF
--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -120,6 +120,7 @@ namespace confighttp::validation {
       "dd_manual_resolution"sv,
       "dd_mode_remapping"sv,
       "disconnect_resume_timeout_seconds"sv,
+      "display_plan"sv,
       "dd_refresh_rate_option"sv,
       "dd_resolution_option"sv,
       "dd_wa_hdr_toggle_delay"sv,

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -47,12 +47,20 @@ const displayPlanner = computed(() => buildResolutionPlanner({
   customScale: customDisplayScale.value,
   showAdvanced: showDisplayPlannerAdvanced.value,
 }))
-// Interim active-plan detection until the plan id persists in config: a plan is
-// active when the saved fallback mode matches its target exactly.
+// A plan is active when its persisted id still matches the saved fallback mode;
+// a hand-edited fallback mode clears the id, so a stale pairing never lights up.
+const PERSISTABLE_PLAN_IDS = ['native', 'balanced', 'sharp', 'performance']
 const activeDisplayPlanId = computed(() => {
   const current = String(config.value.fallback_mode || '').trim()
   if (!current) {
     return ''
+  }
+  const savedPlan = String(config.value.display_plan || '').trim()
+  if (savedPlan) {
+    const saved = displayPlanner.value.choices.find((choice) => choice.id === savedPlan)
+    if (saved && saved.targetMode === current) {
+      return saved.id
+    }
   }
   const match = displayPlanner.value.choices.find((choice) => choice.targetMode === current)
   return match ? match.id : ''
@@ -64,6 +72,10 @@ watch(() => config.value.fallback_mode, (mode) => {
     return
   }
   plannerSourceMode.value = mode || ''
+  // A manual fallback-mode edit means the user left the plan.
+  if (config.value.display_plan) {
+    config.value.display_plan = ''
+  }
 }, { flush: 'sync' })
 
 // Primary copy answers the player's question first. Backend vocabulary stays in the
@@ -385,6 +397,8 @@ function applyDisplayPlan(choice) {
   if (!choice?.safe || config.value.fallback_mode === choice.targetMode) return
   applyingDisplayPlan = true
   config.value.fallback_mode = choice.targetMode
+  // Custom scales are not reconstructable after reload, so only preset ids persist.
+  config.value.display_plan = PERSISTABLE_PLAN_IDS.includes(choice.id) ? choice.id : ''
 }
 
 const validateFallbackMode = (event) => {
@@ -952,13 +966,13 @@ pactl info | grep Source</pre>
           <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div>
               <div class="section-kicker">Display Planner</div>
-              <h4 class="mt-2 text-sm font-semibold text-silver">{{ displayPlanner.recommendedTitle }}</h4>
+              <h4 class="mt-2 text-sm font-semibold text-silver">Preset targets</h4>
               <div class="mt-1 text-sm leading-relaxed text-storm">
-                Start from the client panel shape, keep the aspect ratio at {{ displayPlanner.sourceAspectRatio }}, and choose a plain-language target before touching raw WxHxFPS values.
+                Presets scale the saved fallback mode while keeping its {{ displayPlanner.sourceAspectRatio }} aspect ratio, so you choose a plain-language target instead of typing raw WxHxFPS values.
               </div>
             </div>
             <div class="rounded-2xl border border-success/25 bg-success/10 px-3 py-2 text-right text-sm text-success-bright">
-              <div class="text-[10px] font-semibold uppercase tracking-eyebrow">Recommended</div>
+              <div class="text-[10px] font-semibold uppercase tracking-eyebrow">Recommended · {{ displayPlanner.recommendedTitle }}</div>
               <div class="mt-1 font-medium">{{ displayPlanner.recommendedMode }}</div>
             </div>
           </div>

--- a/src_assets/common/assets/web/display-resolution-planner.js
+++ b/src_assets/common/assets/web/display-resolution-planner.js
@@ -10,7 +10,7 @@ export const DISPLAY_PLANNER_PRESETS = [
   {
     id: 'balanced',
     title: 'Balanced',
-    intent: 'Best for this device: preserve aspect ratio while easing encoder and network load.',
+    intent: 'Balanced default: preserve aspect ratio while easing encoder and network load.',
     scaleFactor: 0.75,
   },
   {
@@ -102,7 +102,7 @@ export function buildResolutionPlanner({
     sourceAspectRatio: aspectRatioLabel(base.width, base.height),
     sourceFps: base.fps,
     recommendedId: recommended.id,
-    recommendedTitle: 'Best for this device',
+    recommendedTitle: 'Balanced',
     recommendedMode: recommended.targetMode,
     choices,
     visibleChoices,
@@ -150,7 +150,7 @@ function isSafeMode(target, limits) {
 }
 
 function resolvePresetBadge(id, base, scaleFactor) {
-  if (id === 'balanced') return 'Best for this device'
+  if (id === 'balanced') return 'Recommended'
   if (id === 'native') return `${base.width}×${base.height}`
   if (id === 'sharp') return `${scaleFactor}x supersample`
   if (id === 'performance') return `${scaleFactor}x downscale`

--- a/src_assets/common/assets/web/display-resolution-planner.test.js
+++ b/src_assets/common/assets/web/display-resolution-planner.test.js
@@ -12,7 +12,7 @@ describe('display resolution planner', () => {
     const planner = buildResolutionPlanner({ fallbackMode: '2560x1600x90' })
 
     expect(planner.recommendedId).toBe('balanced')
-    expect(planner.recommendedTitle).toBe('Best for this device')
+    expect(planner.recommendedTitle).toBe('Balanced')
     expect(planner.recommendedMode).toBe('1920x1200x90')
     expect(planner.sourceAspectRatio).toBe('8:5')
     expect(planner.visibleChoices.map((choice) => choice.title)).toEqual([

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -367,6 +367,7 @@ const tabs = ref([
       "adapter_name": "",
       "output_name": "",
       "fallback_mode": "",
+          "display_plan": "",
       "isolated_virtual_display_option": "disabled",
       "dd_configuration_option": "disabled",
       "dd_resolution_option": "auto",


### PR DESCRIPTION
## Summary

Part of #571 (settings revamp arc, frontend slice 2).

- Retitle the planner recommendation from "Best for this device" to "Balanced": it is a constant (always the 0.75x preset, computed from the saved fallback mode), not a device-aware choice. The copy no longer claims to start from the client panel shape. A later arc can reintroduce device language when paired-client data actually feeds the recommendation.
- Persist the chosen preset id in a new `display_plan` config key (added to `allowed_config_keys`, defaulted in ConfigView's Audio/Video options), so the active plan survives a reload. Selection still requires an exact `fallback_mode` match, and a hand-edited fallback mode clears the plan id, so a stale pairing never shows as active.
- Custom scale choices deliberately do not persist a plan id: the custom scale factor itself does not survive a reload.

## Exact candidate

- `Commit:` b3da9f1ec7e34bcc4eadbb4435e1de41496b2f71
- `Tree:` e3bab4d92d7e0e1481d80184aab0007bdb4c178b
- `Parent:` 857b9b6a69d08bc8fd0e9c10916677dfee435242
- `Base:` 857b9b6a69d08bc8fd0e9c10916677dfee435242

## Verification

- [x] `vitest run` — 547/547 across 71 files (planner test repinned to "Balanced")
- [x] `npm run lint` — clean
- [x] `ninja polaris test_polaris` + `test_polaris --gtest_filter=ConfigValidationTests.*` — 12/12 (allowlist accepts `display_plan`)
- [x] Sorted placement of `display_plan` in `allowed_config_keys` verified
