### PR TITLE
refactor: extract shared settings metadata builders from nvhttp

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -195,6 +195,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/thread_safe.h"
         "${CMAKE_SOURCE_DIR}/src/sync.h"
         "${CMAKE_SOURCE_DIR}/src/round_robin.h"
+        "${CMAKE_SOURCE_DIR}/src/settings_metadata.cpp"
+        "${CMAKE_SOURCE_DIR}/src/settings_metadata.h"
         "${CMAKE_SOURCE_DIR}/src/stat_trackers.h"
         "${CMAKE_SOURCE_DIR}/src/stat_trackers.cpp"
         "${CMAKE_SOURCE_DIR}/src/stream_recorder.h"

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -89,6 +89,7 @@
 #include "client_profiles.h"
 #include "client_support_report.h"
 #include "confighttp.h"
+#include "settings_metadata.h"
 #include "stream_stats.h"
 #include "video.h"
 #ifdef __linux__
@@ -732,135 +733,6 @@ namespace nvhttp {
       };
     }
 
-    bool ai_auto_quality_enabled() {
-      // Legacy compatibility field. Launch policy no longer has an AI-owned
-      // mode; adaptive bitrate remains a separate same-stream control.
-      return false;
-    }
-
-    std::string auto_quality_blocked_reason(const std::string &limiting_factor) {
-      const auto normalized = lower_copy(limiting_factor);
-      if (normalized == "host_render") {
-        return "host_render_limited";
-      }
-      if (normalized == "network" ||
-          normalized == "encoder" ||
-          normalized == "decoder") {
-        return normalized;
-      }
-      if (normalized == "pacing" ||
-          normalized == "capture" ||
-          normalized == "hdr") {
-        return "insufficient_signal";
-      }
-      return "none";
-    }
-
-    nlohmann::json build_auto_quality_policy_json(const nlohmann::json &health,
-                                                  const adaptive_bitrate::state_t &adaptive_state,
-                                                  int encoder_bitrate_kbps) {
-      const bool auto_quality_enabled = ai_auto_quality_enabled();
-      const std::string limiting_factor = health.value("limiting_factor", std::string {"none"});
-      const std::string adaptive_state_name = lower_copy(adaptive_state.state);
-      const bool host_render_limited =
-        health.value("host_render_limited", false) ||
-        limiting_factor == "host_render" ||
-        lower_copy(health.value("primary_issue", std::string {})) == "host_render_limited";
-      const bool host_render_recovery =
-        host_render_limited &&
-        health.value("relaunch_recommended", false) &&
-        health.contains("safe_target_fps");
-      const bool blocked =
-        (!host_render_recovery && host_render_limited) ||
-        limiting_factor == "network" ||
-        limiting_factor == "encoder" ||
-        limiting_factor == "decoder";
-      const int live_bitrate_kbps =
-        adaptive_state.target_bitrate_kbps > 0 ? adaptive_state.target_bitrate_kbps : encoder_bitrate_kbps;
-      const int quality_cap_kbps =
-        adaptive_state.base_bitrate_kbps > 0 ? adaptive_state.base_bitrate_kbps : encoder_bitrate_kbps;
-      const bool bitrate_recovering =
-        !blocked &&
-        adaptive_state.enabled &&
-        adaptive_state_name == "recovering" &&
-        live_bitrate_kbps > 0 &&
-        quality_cap_kbps > 0 &&
-        live_bitrate_kbps < quality_cap_kbps;
-
-      std::string state = "holding";
-      std::string blocked_reason = "none";
-      std::string summary = "Auto Quality is holding the current profile.";
-      if (!auto_quality_enabled) {
-        state = "off";
-        summary = "Manual stream tuning is active.";
-      } else if (blocked) {
-        state = "blocked";
-        blocked_reason = auto_quality_blocked_reason(limiting_factor);
-        summary =
-          blocked_reason == "host_render_limited" ?
-            "Holding quality until the host render path reaches the stream FPS target." :
-          blocked_reason == "network" ?
-            "Holding quality while network pressure clears." :
-          blocked_reason == "encoder" ?
-            "Holding quality while encoder pressure clears." :
-          blocked_reason == "decoder" ?
-            "Holding quality while decoder pressure clears." :
-            "Holding quality until the stream has enough clean signal.";
-      } else if (host_render_recovery) {
-        state = "recovery_queued";
-        summary = "AI Recovery Profile ready for the next launch.";
-      } else if (bitrate_recovering) {
-        state = "recovering_bitrate";
-        summary = "Recovering bitrate toward the quality cap.";
-      }
-
-      nlohmann::json policy;
-      policy["enabled"] = auto_quality_enabled;
-      policy["state"] = state;
-      policy["blocked_reason"] = blocked_reason;
-      policy["live_bitrate_kbps"] = live_bitrate_kbps;
-      policy["quality_cap_kbps"] = quality_cap_kbps;
-      policy["relaunch_required"] =
-        auto_quality_enabled && state != "blocked" && health.value("relaunch_recommended", false);
-      policy["can_recover_live"] = state == "recovering_bitrate";
-      policy["summary"] = summary;
-      policy["detail"] = health.value("summary", summary);
-      policy["components"] = {
-        {"optimizer_active", false},
-        {"adaptive_bitrate_active", adaptive_bitrate::is_active()},
-        {"adaptive_state", adaptive_state.state},
-        {"adaptive_reason", adaptive_state.reason},
-        {"target_bitrate_kbps", live_bitrate_kbps}
-      };
-      if (policy["relaunch_required"].get<bool>()) {
-        auto &suggested = policy["suggested_profile"];
-        suggested["target_bitrate_kbps"] = health.value("safe_bitrate_kbps", 0);
-        suggested["display_mode"] = health.value("safe_display_mode", std::string {});
-        if (health.contains("safe_target_fps")) {
-          suggested["target_fps"] = health["safe_target_fps"];
-        }
-        if (health.contains("safe_codec")) {
-          suggested["preferred_codec"] = health["safe_codec"];
-        }
-        if (health.contains("safe_hdr")) {
-          suggested["hdr"] = health["safe_hdr"];
-        }
-      }
-      return policy;
-    }
-
-    bool host_virtual_display_available() {
-#ifdef __linux__
-      return virtual_display::is_available();
-#elif defined(_WIN32)
-      return
-        vDisplayDriverStatus == VDISPLAY::DRIVER_STATUS::OK ||
-        vDisplayDriverStatus == VDISPLAY::DRIVER_STATUS::UNKNOWN;
-#else
-      return false;
-#endif
-    }
-
     bool host_prefers_headless() {
 #ifdef __linux__
       // One resolve_current snapshot for the two flags (no hand-built input_t thrash).
@@ -1352,70 +1224,6 @@ namespace nvhttp {
       return true;
     }
 
-    std::string configured_stream_display_mode_selection() {
-#ifdef __linux__
-      return stream_display_policy::resolve_current().selection;
-#else
-      return "desktop_display";
-#endif
-    }
-
-    std::string effective_stream_display_mode_selection(
-      const stream_stats::stats_t &stats,
-      bool session_uses_virtual_display
-    ) {
-#ifdef __linux__
-      return stream_display_policy::resolve_effective(
-        stream_display_policy::input_t {
-          host_virtual_display_available(),
-          false,
-          stats.runtime_gpu_native_override_active,
-        },
-        stats.streaming,
-        session_uses_virtual_display,
-        stats.runtime_effective_headless
-      ).selection;
-#else
-      (void) stats;
-      (void) session_uses_virtual_display;
-      return configured_stream_display_mode_selection();
-#endif
-    }
-
-    std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats) {
-      return effective_stream_display_mode_selection(stats, proc::proc.session_uses_virtual_display());
-    }
-
-    std::string stream_display_mode_label_for_selection(const std::string &selection) {
-#ifdef __linux__
-      const auto label = stream_display_policy::label_for_selection(selection);
-      return label.empty() ? "Mirror Desktop" : label;
-#else
-      if (selection == "headless_stream") {
-        return "Private Stream";
-      }
-      if (selection == "host_virtual_display") {
-        return "Host Virtual Display";
-      }
-      if (selection == "windowed_stream") {
-        return "Private Stream (GPU-native)";
-      }
-      if (selection == "gamescope_stream") {
-        return "Gamescope Stream";
-      }
-      return "Mirror Desktop";
-#endif
-    }
-
-    std::string stream_display_mode_reason_for_selection(const std::string &selection) {
-#ifdef __linux__
-      return stream_display_policy::reason_for_selection(selection, host_virtual_display_available());
-#else
-      (void) selection;
-      return "Polaris will mirror the current desktop session.";
-#endif
-    }
-
     using persist_config_values_fn_t = std::function<bool(
       const std::unordered_map<std::string, std::string> &
     )>;
@@ -1486,75 +1294,6 @@ namespace nvhttp {
       error = "stream display mode selection is only supported on Linux";
       return stream_display_mode_apply_result_e::rejected;
 #endif
-    }
-
-    nlohmann::json stream_display_mode_options_json() {
-      nlohmann::json modes = nlohmann::json::array();
-#ifdef __linux__
-      for (const auto &option : stream_display_policy::mode_options(host_virtual_display_available())) {
-        bool available = option.available;
-        if (option.value == "host_virtual_display") {
-          available = available && host_virtual_display_available();
-        }
-        std::string unavailable_reason;
-        if (!available) {
-          unavailable_reason = option.unavailable_reason;
-          if (option.value == "host_virtual_display") {
-            // The backend probe knows exactly why creation would fail; the
-            // policy layer only knows that it would.
-            const auto backend_reason = virtual_display::unavailable_reason();
-            if (!backend_reason.empty()) {
-              unavailable_reason = backend_reason;
-            }
-          }
-          if (unavailable_reason.empty()) {
-            unavailable_reason = "This mode is not available on this host right now.";
-          }
-        }
-        modes.push_back({
-          {"value", option.value},
-          {"label", option.label},
-          {"available", available},
-          {"unavailable_reason", unavailable_reason},
-          {"restart_required", true},
-          {"reason", option.reason},
-          {"group", option.group},
-          {"runtime", option.runtime},
-          {"capture", option.capture},
-          {"topology", option.topology},
-          // Available and session-overridable are different questions. A dongle
-          // swap is a perfectly valid host default while still being something a
-          // single client must not switch on for one launch, and a client that
-          // cannot see the difference offers a choice the host will silently drop.
-          {"session_overridable", stream_display_policy::selection_session_overridable(option.value)},
-        });
-      }
-#else
-      for (const auto &selection : {
-             "headless_stream"s,
-             "desktop_display"s,
-             "host_virtual_display"s,
-             "windowed_stream"s
-           }) {
-        const bool available = selection != "host_virtual_display" || host_virtual_display_available();
-        const bool private_group = selection == "headless_stream" || selection == "windowed_stream";
-        modes.push_back({
-          // Same shape as the Linux branch so clients parse one contract;
-          // the runtime/capture/topology vocabulary is Linux-only and empty here.
-          {"value", selection},
-          {"label", stream_display_mode_label_for_selection(selection)},
-          {"available", available},
-          {"unavailable_reason", available ? "" : "Host virtual display is not available on this host."},
-          {"restart_required", true},
-          {"reason", stream_display_mode_reason_for_selection(selection)},
-          {"group", private_group ? "private" : "host"},
-          {"runtime", ""},
-          {"capture", ""},
-          {"topology", ""},
-        });
-      }
-#endif
-      return modes;
     }
 
     nlohmann::json build_client_settings_sync_status(const crypto::named_cert_t &client,
@@ -1824,7 +1563,7 @@ namespace nvhttp {
       const std::string policy_state = lower_copy(auto_quality.value("state", std::string {}));
       std::string state = "stable";
       std::string label = "Quality";
-      if (!auto_quality.value("enabled", ai_auto_quality_enabled())) {
+      if (!auto_quality.value("enabled", settings_metadata::ai_auto_quality_enabled())) {
         state = "manual_override";
         label = "Manual";
       } else if (policy_state == "upgrade_available") {
@@ -1981,7 +1720,7 @@ namespace nvhttp {
       const auto capture_reason = stream_stats::capture_path_reason(stats);
       const bool capture_cpu_copy = stream_stats::capture_path_uses_cpu_copy(stats);
       const bool capture_gpu_native = stream_stats::capture_path_is_gpu_native(stats);
-      const bool auto_quality_enabled = ai_auto_quality_enabled();
+      const bool auto_quality_enabled = settings_metadata::ai_auto_quality_enabled();
       const auto hdr_effective_mode = stream_stats::hdr_effective_mode(stats);
       const auto hdr_downgrade_reason = stream_stats::hdr_downgrade_reason(stats);
       const auto hdr_downgrade_message = stream_stats::hdr_downgrade_message(stats);
@@ -2059,10 +1798,10 @@ namespace nvhttp {
 
       nlohmann::json policy;
       policy["version"] = 1;
-      const auto policy_stream_display_mode = effective_stream_display_mode_selection(stats);
+      const auto policy_stream_display_mode = settings_metadata::effective_stream_display_mode_selection(stats);
       policy["mode"] = policy_stream_display_mode;
-      policy["mode_label"] = stream_display_mode_label_for_selection(policy_stream_display_mode);
-      policy["mode_reason"] = stream_display_mode_reason_for_selection(policy_stream_display_mode);
+      policy["mode_label"] = settings_metadata::stream_display_mode_label_for_selection(policy_stream_display_mode);
+      policy["mode_reason"] = settings_metadata::stream_display_mode_reason_for_selection(policy_stream_display_mode);
       policy["source"] = source;
       policy["source_label"] = stream_policy_source_label(source);
       policy["optimization_source"] = stats.optimization_source;
@@ -2113,16 +1852,16 @@ namespace nvhttp {
                                               const stream_stats::stats_t &stats,
                                               const nlohmann::json &health) {
       const auto policy = build_stream_policy_json(client, stats, health);
-      const auto configured_mode = configured_stream_display_mode_selection();
-      const auto effective_mode = effective_stream_display_mode_selection(stats);
+      const auto configured_mode = settings_metadata::configured_stream_display_mode_selection();
+      const auto effective_mode = settings_metadata::effective_stream_display_mode_selection(stats);
       const bool relaunch_required =
         rtsp_stream::session_count() != 0 && configured_mode != effective_mode;
       const auto client_sync = client_sync_report_for(client.uuid);
 
       nlohmann::json desired;
       desired["stream_display_mode"] = configured_mode;
-      desired["stream_display_mode_label"] = stream_display_mode_label_for_selection(configured_mode);
-      desired["stream_display_mode_reason"] = stream_display_mode_reason_for_selection(configured_mode);
+      desired["stream_display_mode_label"] = settings_metadata::stream_display_mode_label_for_selection(configured_mode);
+      desired["stream_display_mode_reason"] = settings_metadata::stream_display_mode_reason_for_selection(configured_mode);
       desired["display_mode"] = client.display_mode;
       desired["target_bitrate_kbps"] = client.target_bitrate_kbps;
       desired["ai_auto_quality_enabled"] = false;
@@ -2134,8 +1873,8 @@ namespace nvhttp {
 
       nlohmann::json effective;
       effective["stream_display_mode"] = effective_mode;
-      effective["stream_display_mode_label"] = stream_display_mode_label_for_selection(effective_mode);
-      effective["stream_display_mode_reason"] = stream_display_mode_reason_for_selection(effective_mode);
+      effective["stream_display_mode_label"] = settings_metadata::stream_display_mode_label_for_selection(effective_mode);
+      effective["stream_display_mode_reason"] = settings_metadata::stream_display_mode_reason_for_selection(effective_mode);
       effective["display_mode"] = policy.value("selected_display_mode", std::string {});
       effective["target_bitrate_kbps"] = policy.value("target_bitrate_kbps", 0);
       effective["target_bitrate_source"] = policy.value("target_bitrate_source", std::string {"client_request"});
@@ -2171,7 +1910,7 @@ namespace nvhttp {
         settings["doctor"] = health["doctor"];
       }
       settings["capabilities"] = {
-        {"modes", stream_display_mode_options_json()},
+        {"modes", settings_metadata::stream_display_mode_options_json()},
         {"display_mode_override", true},
         {"target_bitrate_override", true},
         {"ai_auto_quality_control", false},
@@ -2498,7 +2237,7 @@ namespace nvhttp {
       if (safe_codec) {
         health["safe_codec"] = *safe_codec;
       }
-      health["recovery_policy"] = build_auto_quality_policy_json(
+      health["recovery_policy"] = settings_metadata::build_auto_quality_policy_json(
         health,
         adaptive_bitrate::get_state(),
         stats.bitrate_kbps
@@ -2523,7 +2262,7 @@ namespace nvhttp {
 
   std::string effective_stream_display_mode_for_action(const stream_stats::stats_t &stats,
                                                        bool current_virtual_display) {
-    return effective_stream_display_mode_selection(stats, current_virtual_display);
+    return settings_metadata::effective_stream_display_mode_selection(stats, current_virtual_display);
   }
 
 #ifdef POLARIS_TESTS
@@ -2881,7 +2620,7 @@ namespace nvhttp {
       return build_launch_mode_contract(
         app.virtual_display,
         app.name,
-        host_virtual_display_available(),
+        settings_metadata::host_virtual_display_available(),
         host_prefers_headless()
       );
     }
@@ -6832,24 +6571,14 @@ namespace nvhttp {
       controls["client_commands_enabled"] = status_snapshot.client_commands_enabled;
       controls["device_commands_enabled"] = named_cert_p->allow_client_commands;
 
-      auto &tuning = output["tuning"];
-      tuning["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
-      tuning["adaptive_bitrate_active"] = adaptive_state.active;
-      tuning["adaptive_runtime_update_supported"] = adaptive_state.runtime_update_supported;
-      tuning["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
-      tuning["adaptive_base_bitrate_kbps"] = adaptive_state.base_bitrate_kbps;
-      tuning["adaptive_min_bitrate_kbps"] = adaptive_state.min_bitrate_kbps;
-      tuning["adaptive_max_bitrate_kbps"] = adaptive_state.max_bitrate_kbps;
-      tuning["adaptive_bitrate_state"] = adaptive_state.state;
-      tuning["adaptive_bitrate_reason"] = adaptive_state.reason;
-      tuning["adaptive_packet_loss_ewma"] = adaptive_state.ewma_packet_loss;
-      tuning["adaptive_rtt_ewma_ms"] = adaptive_state.ewma_rtt_ms;
-      tuning["ai_auto_quality_enabled"] = false;
-      tuning["ai_optimizer_enabled"] = false;
-      tuning["mangohud_configured"] = status_snapshot.mangohud_configured;
+      output["tuning"] = settings_metadata::build_tuning_json(
+        adaptive_state,
+        stats,
+        status_snapshot.mangohud_configured
+      );
 
       auto &display_mode = output["display_mode"];
-      const auto stream_display_mode = effective_stream_display_mode_selection(
+      const auto stream_display_mode = settings_metadata::effective_stream_display_mode_selection(
         stats,
         status_snapshot.virtual_display
       );
@@ -6869,8 +6598,8 @@ namespace nvhttp {
         status_snapshot.display_mode_explicit ?
           (status_snapshot.virtual_display ? "virtual_display" : "headless") :
           "auto";
-      display_mode["label"] = stream_display_mode_label_for_selection(stream_display_mode);
-      display_mode["reason"] = stream_display_mode_reason_for_selection(stream_display_mode);
+      display_mode["label"] = settings_metadata::stream_display_mode_label_for_selection(stream_display_mode);
+      display_mode["reason"] = settings_metadata::stream_display_mode_reason_for_selection(stream_display_mode);
       display_mode["paired_display_mode_override"] = named_cert_p->display_mode;
       display_mode["paired_display_mode_locked"] = !named_cert_p->display_mode.empty();
       display_mode["paired_target_bitrate_kbps"] = named_cert_p->target_bitrate_kbps;
@@ -8603,7 +8332,7 @@ namespace nvhttp {
         }},
         {"transport", {{"bytes_sent", stats.bytes_sent}}},
         {"effective_settings", {
-          {"topology", effective_stream_display_mode_selection(stats, proc::proc.session_uses_virtual_display())},
+          {"topology", settings_metadata::effective_stream_display_mode_selection(stats, proc::proc.session_uses_virtual_display())},
           {"width", stats.width}, {"height", stats.height},
           {"target_fps", stats.session_target_fps > 0.0 ? stats.session_target_fps : stats.fps},
           {"bitrate_kbps", stats.bitrate_kbps}, {"codec", stats.codec},
@@ -8613,7 +8342,7 @@ namespace nvhttp {
       };
       const auto evidence = doctor_v2::status(named_cert_p->uuid, app_uuid, host_evidence);
       doctor_trial::effective_settings_t settings {
-        .topology = effective_stream_display_mode_selection(stats, proc::proc.session_uses_virtual_display()),
+        .topology = settings_metadata::effective_stream_display_mode_selection(stats, proc::proc.session_uses_virtual_display()),
         .width = stats.width,
         .height = stats.height,
         .target_fps = static_cast<int>(std::round(
@@ -8961,7 +8690,7 @@ namespace nvhttp {
           .app_name = app_name,
           .launch_instance_id = proc::proc.get_session_token(),
           .session_generation = timing.session_generation,
-          .effective_stream_display_mode = effective_stream_display_mode_selection(stats, virtual_display),
+          .effective_stream_display_mode = settings_metadata::effective_stream_display_mode_selection(stats, virtual_display),
           .state_path = platf::appdata() / "recovery_profiles.json",
           .stats = stats,
           .health = health,
@@ -9788,7 +9517,7 @@ namespace nvhttp {
       bool virtual_display_supported = false;
       bool host_requires_virtual_display = false;
 #if defined(_WIN32)
-      virtual_display_supported = host_virtual_display_available();
+      virtual_display_supported = settings_metadata::host_virtual_display_available();
       host_requires_virtual_display =
         config::video.linux_display.headless_mode ||
         !video::allow_encoder_probing();

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -618,6 +618,7 @@ namespace stream_display_policy {
       mode_option_t option;
       option.value = std::string {path.id};
       option.label = std::string {path.label};
+      option.badge = std::string {path.badge};
       option.reason = reason_for_selection(path.id, virtual_display_available);
       option.available = path.available &&
         (path.id != stream_path::k_host_virtual_display || virtual_display_available);

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -31,6 +31,7 @@ namespace stream_display_policy {
   struct mode_option_t {
     std::string value;
     std::string label;
+    std::string badge;
     std::string reason;
     bool available = true;
     std::string unavailable_reason;

--- a/src/settings_metadata.cpp
+++ b/src/settings_metadata.cpp
@@ -1,0 +1,322 @@
+/**
+ * @file src/settings_metadata.cpp
+ * @brief Shared settings metadata builders for the HTTP servers.
+ */
+#include "settings_metadata.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include "adaptive_bitrate.h"
+#include "process.h"
+#include "stream_stats.h"
+#ifdef __linux__
+  #include "platform/linux/stream_display_policy.h"
+  #include "platform/linux/virtual_display.h"
+#endif
+
+using namespace std::literals;
+
+namespace settings_metadata {
+  namespace {
+    std::string lower_copy(std::string value) {
+      std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+      return value;
+    }
+  }  // namespace
+
+  bool ai_auto_quality_enabled() {
+    // Legacy compatibility field. Launch policy no longer has an AI-owned
+    // mode; adaptive bitrate remains a separate same-stream control.
+    return false;
+  }
+
+  std::string auto_quality_blocked_reason(const std::string &limiting_factor) {
+    const auto normalized = lower_copy(limiting_factor);
+    if (normalized == "host_render") {
+      return "host_render_limited";
+    }
+    if (normalized == "network" ||
+        normalized == "encoder" ||
+        normalized == "decoder") {
+      return normalized;
+    }
+    if (normalized == "pacing" ||
+        normalized == "capture" ||
+        normalized == "hdr") {
+      return "insufficient_signal";
+    }
+    return "none";
+  }
+
+  nlohmann::json build_auto_quality_policy_json(const nlohmann::json &health,
+                                                const adaptive_bitrate::state_t &adaptive_state,
+                                                int encoder_bitrate_kbps) {
+    const bool auto_quality_enabled = ai_auto_quality_enabled();
+    const std::string limiting_factor = health.value("limiting_factor", std::string {"none"});
+    const std::string adaptive_state_name = lower_copy(adaptive_state.state);
+    const bool host_render_limited =
+      health.value("host_render_limited", false) ||
+      limiting_factor == "host_render" ||
+      lower_copy(health.value("primary_issue", std::string {})) == "host_render_limited";
+    const bool host_render_recovery =
+      host_render_limited &&
+      health.value("relaunch_recommended", false) &&
+      health.contains("safe_target_fps");
+    const bool blocked =
+      (!host_render_recovery && host_render_limited) ||
+      limiting_factor == "network" ||
+      limiting_factor == "encoder" ||
+      limiting_factor == "decoder";
+    const int live_bitrate_kbps =
+      adaptive_state.target_bitrate_kbps > 0 ? adaptive_state.target_bitrate_kbps : encoder_bitrate_kbps;
+    const int quality_cap_kbps =
+      adaptive_state.base_bitrate_kbps > 0 ? adaptive_state.base_bitrate_kbps : encoder_bitrate_kbps;
+    const bool bitrate_recovering =
+      !blocked &&
+      adaptive_state.enabled &&
+      adaptive_state_name == "recovering" &&
+      live_bitrate_kbps > 0 &&
+      quality_cap_kbps > 0 &&
+      live_bitrate_kbps < quality_cap_kbps;
+
+    std::string state = "holding";
+    std::string blocked_reason = "none";
+    std::string summary = "Auto Quality is holding the current profile.";
+    if (!auto_quality_enabled) {
+      state = "off";
+      summary = "Manual stream tuning is active.";
+    } else if (blocked) {
+      state = "blocked";
+      blocked_reason = auto_quality_blocked_reason(limiting_factor);
+      summary =
+        blocked_reason == "host_render_limited" ?
+          "Holding quality until the host render path reaches the stream FPS target." :
+        blocked_reason == "network" ?
+          "Holding quality while network pressure clears." :
+        blocked_reason == "encoder" ?
+          "Holding quality while encoder pressure clears." :
+        blocked_reason == "decoder" ?
+          "Holding quality while decoder pressure clears." :
+          "Holding quality until the stream has enough clean signal.";
+    } else if (host_render_recovery) {
+      state = "recovery_queued";
+      summary = "AI Recovery Profile ready for the next launch.";
+    } else if (bitrate_recovering) {
+      state = "recovering_bitrate";
+      summary = "Recovering bitrate toward the quality cap.";
+    }
+
+    nlohmann::json policy;
+    policy["enabled"] = auto_quality_enabled;
+    policy["state"] = state;
+    policy["blocked_reason"] = blocked_reason;
+    policy["live_bitrate_kbps"] = live_bitrate_kbps;
+    policy["quality_cap_kbps"] = quality_cap_kbps;
+    policy["relaunch_required"] =
+      auto_quality_enabled && state != "blocked" && health.value("relaunch_recommended", false);
+    policy["can_recover_live"] = state == "recovering_bitrate";
+    policy["summary"] = summary;
+    policy["detail"] = health.value("summary", summary);
+    policy["components"] = {
+      {"optimizer_active", false},
+      {"adaptive_bitrate_active", adaptive_bitrate::is_active()},
+      {"adaptive_state", adaptive_state.state},
+      {"adaptive_reason", adaptive_state.reason},
+      {"target_bitrate_kbps", live_bitrate_kbps}
+    };
+    if (policy["relaunch_required"].get<bool>()) {
+      auto &suggested = policy["suggested_profile"];
+      suggested["target_bitrate_kbps"] = health.value("safe_bitrate_kbps", 0);
+      suggested["display_mode"] = health.value("safe_display_mode", std::string {});
+      if (health.contains("safe_target_fps")) {
+        suggested["target_fps"] = health["safe_target_fps"];
+      }
+      if (health.contains("safe_codec")) {
+        suggested["preferred_codec"] = health["safe_codec"];
+      }
+      if (health.contains("safe_hdr")) {
+        suggested["hdr"] = health["safe_hdr"];
+      }
+    }
+    return policy;
+  }
+
+  bool host_virtual_display_available() {
+#ifdef __linux__
+    return virtual_display::is_available();
+#elif defined(_WIN32)
+    return
+      proc::vDisplayDriverStatus == VDISPLAY::DRIVER_STATUS::OK ||
+      proc::vDisplayDriverStatus == VDISPLAY::DRIVER_STATUS::UNKNOWN;
+#else
+    return false;
+#endif
+  }
+
+  std::string configured_stream_display_mode_selection() {
+#ifdef __linux__
+    return stream_display_policy::resolve_current().selection;
+#else
+    return "desktop_display";
+#endif
+  }
+
+  std::string effective_stream_display_mode_selection(
+    const stream_stats::stats_t &stats,
+    bool session_uses_virtual_display
+  ) {
+#ifdef __linux__
+    return stream_display_policy::resolve_effective(
+      stream_display_policy::input_t {
+        host_virtual_display_available(),
+        false,
+        stats.runtime_gpu_native_override_active,
+      },
+      stats.streaming,
+      session_uses_virtual_display,
+      stats.runtime_effective_headless
+    ).selection;
+#else
+    (void) stats;
+    (void) session_uses_virtual_display;
+    return configured_stream_display_mode_selection();
+#endif
+  }
+
+  std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats) {
+    return effective_stream_display_mode_selection(stats, proc::proc.session_uses_virtual_display());
+  }
+
+  std::string stream_display_mode_label_for_selection(const std::string &selection) {
+#ifdef __linux__
+    const auto label = stream_display_policy::label_for_selection(selection);
+    return label.empty() ? "Mirror Desktop" : label;
+#else
+    if (selection == "headless_stream") {
+      return "Private Stream";
+    }
+    if (selection == "host_virtual_display") {
+      return "Host Virtual Display";
+    }
+    if (selection == "windowed_stream") {
+      return "Private Stream (GPU-native)";
+    }
+    if (selection == "gamescope_stream") {
+      return "Gamescope Stream";
+    }
+    return "Mirror Desktop";
+#endif
+  }
+
+  std::string stream_display_mode_reason_for_selection(const std::string &selection) {
+#ifdef __linux__
+    return stream_display_policy::reason_for_selection(selection, host_virtual_display_available());
+#else
+    (void) selection;
+    return "Polaris will mirror the current desktop session.";
+#endif
+  }
+
+  nlohmann::json stream_display_mode_options_json() {
+    nlohmann::json modes = nlohmann::json::array();
+#ifdef __linux__
+    for (const auto &option : stream_display_policy::mode_options(host_virtual_display_available())) {
+      bool available = option.available;
+      if (option.value == "host_virtual_display") {
+        available = available && host_virtual_display_available();
+      }
+      std::string unavailable_reason;
+      if (!available) {
+        unavailable_reason = option.unavailable_reason;
+        if (option.value == "host_virtual_display") {
+          // The backend probe knows exactly why creation would fail; the
+          // policy layer only knows that it would.
+          const auto backend_reason = virtual_display::unavailable_reason();
+          if (!backend_reason.empty()) {
+            unavailable_reason = backend_reason;
+          }
+        }
+        if (unavailable_reason.empty()) {
+          unavailable_reason = "This mode is not available on this host right now.";
+        }
+      }
+      modes.push_back({
+        {"value", option.value},
+        {"label", option.label},
+        {"badge", option.badge},
+        {"available", available},
+        {"unavailable_reason", unavailable_reason},
+        {"restart_required", true},
+        {"reason", option.reason},
+        {"group", option.group},
+        {"runtime", option.runtime},
+        {"capture", option.capture},
+        {"topology", option.topology},
+        // Available and session-overridable are different questions. A dongle
+        // swap is a perfectly valid host default while still being something a
+        // single client must not switch on for one launch, and a client that
+        // cannot see the difference offers a choice the host will silently drop.
+        {"session_overridable", stream_display_policy::selection_session_overridable(option.value)},
+      });
+    }
+#else
+    for (const auto &selection : {
+           "headless_stream"s,
+           "desktop_display"s,
+           "host_virtual_display"s,
+           "windowed_stream"s
+         }) {
+      const bool available = selection != "host_virtual_display" || host_virtual_display_available();
+      const bool private_group = selection == "headless_stream" || selection == "windowed_stream";
+      const std::string badge =
+        selection == "headless_stream" ? "Recommended" :
+        selection == "host_virtual_display" ? "Compatibility" :
+        selection == "windowed_stream" ? "Advanced capture" :
+        "Advanced";
+      modes.push_back({
+        // Same shape as the Linux branch so clients parse one contract;
+        // the runtime/capture/topology vocabulary is Linux-only and empty here.
+        {"value", selection},
+        {"label", stream_display_mode_label_for_selection(selection)},
+        {"badge", badge},
+        {"available", available},
+        {"unavailable_reason", available ? "" : "Host virtual display is not available on this host."},
+        {"restart_required", true},
+        {"reason", stream_display_mode_reason_for_selection(selection)},
+        {"group", private_group ? "private" : "host"},
+        {"runtime", ""},
+        {"capture", ""},
+        {"topology", ""},
+      });
+    }
+#endif
+    return modes;
+  }
+
+  nlohmann::json build_tuning_json(const adaptive_bitrate::state_t &adaptive_state,
+                                   const stream_stats::stats_t &stats,
+                                   bool mangohud_configured) {
+    nlohmann::json tuning;
+    tuning["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
+    tuning["adaptive_bitrate_active"] = adaptive_state.active;
+    tuning["adaptive_runtime_update_supported"] = adaptive_state.runtime_update_supported;
+    tuning["adaptive_target_bitrate_kbps"] = stats.adaptive_target_bitrate_kbps;
+    tuning["adaptive_base_bitrate_kbps"] = adaptive_state.base_bitrate_kbps;
+    tuning["adaptive_min_bitrate_kbps"] = adaptive_state.min_bitrate_kbps;
+    tuning["adaptive_max_bitrate_kbps"] = adaptive_state.max_bitrate_kbps;
+    tuning["adaptive_bitrate_state"] = adaptive_state.state;
+    tuning["adaptive_bitrate_reason"] = adaptive_state.reason;
+    tuning["adaptive_packet_loss_ewma"] = adaptive_state.ewma_packet_loss;
+    tuning["adaptive_rtt_ewma_ms"] = adaptive_state.ewma_rtt_ms;
+    tuning["ai_auto_quality_enabled"] = false;
+    tuning["ai_optimizer_enabled"] = false;
+    tuning["mangohud_configured"] = mangohud_configured;
+    return tuning;
+  }
+}  // namespace settings_metadata

--- a/src/settings_metadata.h
+++ b/src/settings_metadata.h
@@ -1,0 +1,76 @@
+/**
+ * @file src/settings_metadata.h
+ * @brief Shared settings metadata builders for the HTTP servers.
+ */
+#pragma once
+
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include "adaptive_bitrate.h"
+#include "stream_stats.h"
+
+namespace settings_metadata {
+  /**
+   * @brief Legacy compatibility field. Launch policy no longer has an AI-owned mode.
+   */
+  bool ai_auto_quality_enabled();
+
+  /**
+   * @brief Map a session-health limiting factor onto the served blocked reason.
+   */
+  std::string auto_quality_blocked_reason(const std::string &limiting_factor);
+
+  /**
+   * @brief Build the auto-quality policy JSON served with session health.
+   */
+  nlohmann::json build_auto_quality_policy_json(const nlohmann::json &health,
+                                                const adaptive_bitrate::state_t &adaptive_state,
+                                                int encoder_bitrate_kbps);
+
+  /**
+   * @brief Whether this host can create or use a virtual display right now.
+   */
+  bool host_virtual_display_available();
+
+  /**
+   * @brief The configured (desired) stream display mode selection id.
+   */
+  std::string configured_stream_display_mode_selection();
+
+  /**
+   * @brief The effective stream display mode selection for a live session.
+   */
+  std::string effective_stream_display_mode_selection(
+    const stream_stats::stats_t &stats,
+    bool session_uses_virtual_display
+  );
+
+  /**
+   * @brief Convenience overload reading the live session virtual-display flag.
+   */
+  std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats);
+
+  /**
+   * @brief Human label for a stream display mode selection id.
+   */
+  std::string stream_display_mode_label_for_selection(const std::string &selection);
+
+  /**
+   * @brief Reason copy for a stream display mode selection id.
+   */
+  std::string stream_display_mode_reason_for_selection(const std::string &selection);
+
+  /**
+   * @brief The capabilities modes catalog served to clients.
+   */
+  nlohmann::json stream_display_mode_options_json();
+
+  /**
+   * @brief Build the session-status tuning JSON block.
+   */
+  nlohmann::json build_tuning_json(const adaptive_bitrate::state_t &adaptive_state,
+                                   const stream_stats::stats_t &stats,
+                                   bool mangohud_configured);
+}  // namespace settings_metadata

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -233,6 +233,7 @@ set(TEST_AUDIO_SOURCES
 set(TEST_STREAM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_adaptive_bitrate.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_ai_optimizer.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_settings_metadata.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_stream.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_stream_display_policy.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_recovery_doctor_actions.cpp

--- a/tests/unit/test_doctor_reset_contract.cpp
+++ b/tests/unit/test_doctor_reset_contract.cpp
@@ -34,7 +34,7 @@ TEST(DoctorResetContract, OptimizeCannotReadHistoryAiSettingsOrRecoveryOverlay) 
   const auto serializer = between(
     nvhttp,
     "void append_deterministic_optimization_json(",
-    "bool ai_auto_quality_enabled()"
+    "bool host_prefers_headless()"
   );
   for (const auto *forbidden : {
          "get_session_history", "get_cached", "request_sync",
@@ -847,7 +847,7 @@ TEST(DoctorResetContract, ClientSettingsPersistencePreservesExistingConfigAtomic
   const auto persistence = between(
     nvhttp,
     "bool persist_config_values(",
-    "std::string configured_stream_display_mode_selection()"
+    "using persist_config_values_fn_t"
   );
 
   EXPECT_EQ(persistence.find("file_handler::read_file"), std::string::npos);

--- a/tests/unit/test_process_migration.cpp
+++ b/tests/unit/test_process_migration.cpp
@@ -341,16 +341,19 @@ TEST(ProcessRuntimeConfigTests, PolarisV1SessionStopContractIsAdvertisedAndRoute
        }) {
     EXPECT_EQ(status_handler.find(loose_read), std::string::npos);
   }
-  const auto captured_display_helper_start = source.find(
-    "std::string effective_stream_display_mode_selection(\n      const stream_stats::stats_t &stats,"
+  // The captured-display helper moved to the shared settings_metadata unit;
+  // its two-argument overload must still never read live proc session state.
+  const auto metadata_source = read_source_file_for_contract("src/settings_metadata.cpp");
+  const auto captured_display_helper_start = metadata_source.find(
+    "std::string effective_stream_display_mode_selection(\n    const stream_stats::stats_t &stats,"
   );
-  const auto captured_display_helper_end = source.find(
+  const auto captured_display_helper_end = metadata_source.find(
     "std::string effective_stream_display_mode_selection(const stream_stats::stats_t &stats)",
     captured_display_helper_start
   );
   ASSERT_NE(captured_display_helper_start, std::string::npos);
   ASSERT_NE(captured_display_helper_end, std::string::npos);
-  const auto captured_display_helper = source.substr(
+  const auto captured_display_helper = metadata_source.substr(
     captured_display_helper_start,
     captured_display_helper_end - captured_display_helper_start
   );

--- a/tests/unit/test_settings_metadata.cpp
+++ b/tests/unit/test_settings_metadata.cpp
@@ -1,0 +1,139 @@
+/**
+ * @file tests/unit/test_settings_metadata.cpp
+ * @brief Test shared settings metadata builders.
+ */
+
+#include <src/adaptive_bitrate.h>
+#include <src/settings_metadata.h>
+#include <src/stream_stats.h>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace {
+  adaptive_bitrate::state_t make_adaptive_state() {
+    adaptive_bitrate::state_t state;
+    state.enabled = true;
+    state.active = true;
+    state.runtime_update_supported = true;
+    state.base_bitrate_kbps = 9000;
+    state.target_bitrate_kbps = 7000;
+    state.min_bitrate_kbps = 2000;
+    state.max_bitrate_kbps = 100000;
+    state.ewma_packet_loss = 0.25;
+    state.ewma_rtt_ms = 18.5;
+    state.state = "recovering";
+    state.reason = "packet loss cleared";
+    return state;
+  }
+}  // namespace
+
+TEST(SettingsMetadataTests, AutoQualityBlockedReasonMapsLimitingFactors) {
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("host_render"), "host_render_limited");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("network"), "network");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("encoder"), "encoder");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("decoder"), "decoder");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("pacing"), "insufficient_signal");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("capture"), "insufficient_signal");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("hdr"), "insufficient_signal");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("none"), "none");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason(""), "none");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("something_else"), "none");
+  // The mapping normalizes case before matching.
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("HOST_RENDER"), "host_render_limited");
+  EXPECT_EQ(settings_metadata::auto_quality_blocked_reason("Network"), "network");
+}
+
+TEST(SettingsMetadataTests, AutoQualityPolicyReportsOffStateEvenUnderPressure) {
+  // ai_auto_quality_enabled() is a hardcoded legacy false on this master, so
+  // every reachable policy lands in the "off" state regardless of health
+  // pressure or adaptive recovery signals. Pin that contract.
+  const nlohmann::json health {
+    {"limiting_factor", "network"},
+    {"relaunch_recommended", true},
+    {"summary", "Network pressure detected."},
+    {"safe_bitrate_kbps", 5000},
+    {"safe_display_mode", "headless_stream"},
+    {"safe_target_fps", 60},
+  };
+  const auto adaptive_state = make_adaptive_state();
+  const auto policy = settings_metadata::build_auto_quality_policy_json(health, adaptive_state, 20000);
+
+  EXPECT_FALSE(policy.at("enabled").get<bool>());
+  EXPECT_EQ(policy.at("state").get<std::string>(), "off");
+  EXPECT_EQ(policy.at("blocked_reason").get<std::string>(), "none");
+  EXPECT_EQ(policy.at("summary").get<std::string>(), "Manual stream tuning is active.");
+  EXPECT_EQ(policy.at("detail").get<std::string>(), "Network pressure detected.");
+  EXPECT_EQ(policy.at("live_bitrate_kbps").get<int>(), 7000);
+  EXPECT_EQ(policy.at("quality_cap_kbps").get<int>(), 9000);
+  EXPECT_FALSE(policy.at("relaunch_required").get<bool>());
+  EXPECT_FALSE(policy.at("can_recover_live").get<bool>());
+  EXPECT_FALSE(policy.contains("suggested_profile"));
+
+  const auto &components = policy.at("components");
+  EXPECT_FALSE(components.at("optimizer_active").get<bool>());
+  EXPECT_TRUE(components.at("adaptive_bitrate_active").is_boolean());
+  EXPECT_EQ(components.at("adaptive_state").get<std::string>(), "recovering");
+  EXPECT_EQ(components.at("adaptive_reason").get<std::string>(), "packet loss cleared");
+  EXPECT_EQ(components.at("target_bitrate_kbps").get<int>(), 7000);
+}
+
+TEST(SettingsMetadataTests, AutoQualityPolicyFallsBackToEncoderBitrate) {
+  const adaptive_bitrate::state_t adaptive_state;
+  const auto policy = settings_metadata::build_auto_quality_policy_json(
+    nlohmann::json::object(),
+    adaptive_state,
+    15000
+  );
+
+  EXPECT_EQ(policy.at("state").get<std::string>(), "off");
+  EXPECT_EQ(policy.at("live_bitrate_kbps").get<int>(), 15000);
+  EXPECT_EQ(policy.at("quality_cap_kbps").get<int>(), 15000);
+  // With no health summary the detail falls back to the state summary.
+  EXPECT_EQ(policy.at("detail").get<std::string>(), "Manual stream tuning is active.");
+  EXPECT_FALSE(policy.contains("suggested_profile"));
+}
+
+TEST(SettingsMetadataTests, BuildTuningJsonMirrorsAdaptiveStateAndSnapshotFlags) {
+  const auto adaptive_state = make_adaptive_state();
+  stream_stats::stats_t stats;
+  stats.adaptive_target_bitrate_kbps = 7500;
+
+  const auto tuning = settings_metadata::build_tuning_json(adaptive_state, stats, true);
+
+  EXPECT_EQ(tuning.size(), 14u);
+  EXPECT_EQ(tuning.at("adaptive_bitrate_enabled").get<bool>(), adaptive_bitrate::is_enabled());
+  EXPECT_TRUE(tuning.at("adaptive_bitrate_active").get<bool>());
+  EXPECT_TRUE(tuning.at("adaptive_runtime_update_supported").get<bool>());
+  EXPECT_EQ(tuning.at("adaptive_target_bitrate_kbps").get<int>(), 7500);
+  EXPECT_EQ(tuning.at("adaptive_base_bitrate_kbps").get<int>(), 9000);
+  EXPECT_EQ(tuning.at("adaptive_min_bitrate_kbps").get<int>(), 2000);
+  EXPECT_EQ(tuning.at("adaptive_max_bitrate_kbps").get<int>(), 100000);
+  EXPECT_EQ(tuning.at("adaptive_bitrate_state").get<std::string>(), "recovering");
+  EXPECT_EQ(tuning.at("adaptive_bitrate_reason").get<std::string>(), "packet loss cleared");
+  EXPECT_DOUBLE_EQ(tuning.at("adaptive_packet_loss_ewma").get<double>(), 0.25);
+  EXPECT_DOUBLE_EQ(tuning.at("adaptive_rtt_ewma_ms").get<double>(), 18.5);
+  EXPECT_FALSE(tuning.at("ai_auto_quality_enabled").get<bool>());
+  EXPECT_FALSE(tuning.at("ai_optimizer_enabled").get<bool>());
+  EXPECT_TRUE(tuning.at("mangohud_configured").get<bool>());
+
+  const auto without_mangohud = settings_metadata::build_tuning_json(adaptive_state, stats, false);
+  EXPECT_FALSE(without_mangohud.at("mangohud_configured").get<bool>());
+}
+
+TEST(SettingsMetadataTests, StreamDisplayModeOptionsCarryBadges) {
+  const auto modes = settings_metadata::stream_display_mode_options_json();
+  ASSERT_TRUE(modes.is_array());
+  ASSERT_FALSE(modes.empty());
+  bool saw_headless = false;
+  for (const auto &mode : modes) {
+    ASSERT_TRUE(mode.contains("badge")) << mode.value("value", std::string {});
+    EXPECT_TRUE(mode.at("badge").is_string());
+    if (mode.value("value", std::string {}) == "headless_stream") {
+      saw_headless = true;
+      EXPECT_EQ(mode.at("badge").get<std::string>(), "Recommended");
+    }
+  }
+  EXPECT_TRUE(saw_headless);
+}

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -776,6 +776,7 @@ TEST(StreamDisplayPolicyTests, ModeOptionsExposeRuntimeCaptureTopologyForPlugins
   ASSERT_NE(headless, options.end());
   EXPECT_EQ(headless->runtime, "labwc");
   EXPECT_EQ(headless->capture, "wlroots");
+  EXPECT_EQ(headless->badge, "Recommended");
   EXPECT_EQ(headless->available, stream_display_policy::selection_available("headless_stream"));
   if (!headless->available) {
     EXPECT_FALSE(headless->unavailable_reason.empty());


### PR DESCRIPTION
## Summary

Part of #571 (settings revamp arc, backend slice 2). Mechanical extraction, no behavior change except one additive JSON key.

- New `src/settings_metadata.{h,cpp}` unit holding the builders the web UI's server will project in the next slice: the mode-selection facades, `stream_display_mode_options_json`, `build_auto_quality_policy_json` + `auto_quality_blocked_reason`, `host_virtual_display_available`, and a new `build_tuning_json` extracted verbatim from the session-status handler's inline tuning block. Bodies moved unchanged; 24 nvhttp call sites qualified.
- `mode_option_t` gains `badge`, populated from the stream_path registry descriptor, so the host's real badges (including "Recommended" on `headless_stream`) reach the mode options JSON instead of being dropped. Additive key only; Moonlight-lineage clients ignore unknown keys. The non-Linux fallback branch mirrors the registry values.
- `vDisplayDriverStatus` in the moved Windows branch is now `proc::`-qualified, matching every other consumer (the old unqualified spelling had no using-directive to resolve it).
- Two source-guard tests that pinned moved bodies by nvhttp source text are re-pointed at `settings_metadata.cpp` with their invariants intact (notably: the two-argument effective-selection overload must not read live proc session state).
- New `test_settings_metadata.cpp` (TEST_STREAM_SOURCES): blocked-reason matrix, off-state policy contract (the only reachable state while the legacy AI flag is hardcoded off - not inventing reachability), tuning JSON 14-key pin, badge propagation.
- CMake: both new files in `POLARIS_TARGET_FILES`; test registered in `tests/CMakeLists.txt`.

## Exact candidate

- `Commit:` 4ba45e5c3876c74a0de9803ee6df8b092c0e0658
- `Tree:` e2697eafc5c269d6ce573fd54e6aa7bc2877cfd9
- `Parent:` 1b0a6fd86efb1d60352ef1ae28a646771bf4cd11
- `Base:` 1b0a6fd86efb1d60352ef1ae28a646771bf4cd11

## Verification

- [x] `cmake .` + `ninja polaris test_polaris test_polaris_stream` — clean
- [x] `test_polaris_stream --gtest_filter="*SettingsMetadata*"` — 5/5
- [x] `test_polaris --gtest_filter="*DoctorResetContract*"` — 35/35 (re-anchored guard)
- [x] `ctest -R "test_polaris_stream|test_polaris_http|test_polaris_config" -j 3` — 3/3 under BUILD_FULL_TESTS=ON
- Windows/#else branches compile-checked by inspection only (no Windows builder here); CI's matrix covers them.
