### PR TITLE
refactor(web): extract StatTile, SelectableCard, and status tones

### DIFF
--- a/src_assets/common/assets/web/components/SelectableCard.vue
+++ b/src_assets/common/assets/web/components/SelectableCard.vue
@@ -1,0 +1,31 @@
+<script setup>
+const props = defineProps({
+  selected: {
+    type: Boolean,
+    default: false,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  cardClass: {
+    type: [String, Array, Object],
+    default: '',
+  },
+})
+
+const emit = defineEmits(['click'])
+</script>
+
+<template>
+  <button
+    type="button"
+    class="selectable-card focus-ring"
+    :class="props.cardClass"
+    :disabled="props.disabled"
+    :aria-pressed="props.selected"
+    @click="emit('click')"
+  >
+    <slot></slot>
+  </button>
+</template>

--- a/src_assets/common/assets/web/components/StatTile.vue
+++ b/src_assets/common/assets/web/components/StatTile.vue
@@ -1,0 +1,36 @@
+<script setup>
+const props = defineProps({
+  label: {
+    type: String,
+    default: '',
+  },
+  value: {
+    type: String,
+    default: '',
+  },
+  note: {
+    type: String,
+    default: '',
+  },
+  tileClass: {
+    type: [String, Array, Object],
+    default: '',
+  },
+})
+</script>
+
+<template>
+  <div class="stat-tile-compact" :class="props.tileClass" data-readonly>
+    <slot>
+      <slot name="label">
+        <div v-if="props.label" class="stat-kicker">{{ props.label }}</div>
+      </slot>
+      <slot name="value">
+        <div v-if="props.value" class="mt-1 text-sm font-medium text-silver">{{ props.value }}</div>
+      </slot>
+      <slot name="note">
+        <div v-if="props.note" class="mt-1 text-[11px] text-storm">{{ props.note }}</div>
+      </slot>
+    </slot>
+  </div>
+</template>

--- a/src_assets/common/assets/web/components/StatusBadge.vue
+++ b/src_assets/common/assets/web/components/StatusBadge.vue
@@ -1,0 +1,23 @@
+<script setup>
+import { computed } from 'vue'
+import { statusTone } from '../status-tones.js'
+
+const props = defineProps({
+  status: {
+    type: String,
+    required: true,
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+})
+
+const tone = computed(() => statusTone(props.status))
+</script>
+
+<template>
+  <span class="meta-pill" :class="tone.badge">
+    <slot>{{ props.label || tone.label }}</slot>
+  </span>
+</template>

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -7,6 +7,8 @@ import DisplayOutputSelector from './audiovideo/DisplayOutputSelector.vue'
 import DisplayDeviceOptions from "./audiovideo/DisplayDeviceOptions.vue";
 import VirtualDisplayStatus from "./audiovideo/VirtualDisplayStatus.vue";
 import Checkbox from "../../Checkbox.vue";
+import SelectableCard from '../../components/SelectableCard.vue'
+import StatTile from '../../components/StatTile.vue'
 import {
   applyStreamDisplayModeToConfig,
   resolveClientSettingsSync,
@@ -453,11 +455,10 @@ function updateDisplayPlannerSource(event) {
                   : 'hover:border-storm/70',
               ]"
             >
-              <button
-                type="button"
-                class="selectable-card focus-ring min-h-[132px] w-full p-4"
+              <SelectableCard
+                card-class="min-h-[132px] w-full p-4"
                 :disabled="mode.available === false"
-                :aria-pressed="streamDisplayMode === mode.id"
+                :selected="streamDisplayMode === mode.id"
                 @click="setStreamDisplayMode(mode.id)"
               >
                 <span class="flex items-start justify-between gap-3">
@@ -492,7 +493,7 @@ function updateDisplayPlannerSource(event) {
                 >
                   Unavailable: {{ mode.unavailableReason }}
                 </span>
-              </button>
+              </SelectableCard>
             </article>
           </div>
 
@@ -506,14 +507,16 @@ function updateDisplayPlannerSource(event) {
               <span class="meta-pill shrink-0 border-ice/25 bg-ice/10 text-ice">Selected</span>
             </div>
             <div class="mt-3 grid gap-3 lg:grid-cols-2">
-              <div class="stat-tile-compact py-2.5">
-                <div class="stat-kicker">Player impact</div>
-                <div class="mt-1 text-xs leading-relaxed text-storm">{{ selectedStreamDisplayMode.impact }}</div>
-              </div>
-              <div class="stat-tile-compact py-2.5">
-                <div class="stat-kicker">Capture path</div>
-                <div class="mt-1 text-xs leading-relaxed text-storm">{{ selectedStreamDisplayMode.technical }}</div>
-              </div>
+              <StatTile tile-class="py-2.5" label="Player impact">
+                <template #value>
+                  <div class="mt-1 text-xs leading-relaxed text-storm">{{ selectedStreamDisplayMode.impact }}</div>
+                </template>
+              </StatTile>
+              <StatTile tile-class="py-2.5" label="Capture path">
+                <template #value>
+                  <div class="mt-1 text-xs leading-relaxed text-storm">{{ selectedStreamDisplayMode.technical }}</div>
+                </template>
+              </StatTile>
             </div>
           </div>
 
@@ -624,12 +627,12 @@ function updateDisplayPlannerSource(event) {
             </summary>
 
             <div class="space-y-3 border-t border-storm/20 p-4">
-              <div class="stat-tile-compact p-3" data-capture-path-explainer>
+              <StatTile tile-class="p-3" data-capture-path-explainer>
                 <div class="text-sm font-semibold text-silver">How capture works</div>
                 <p class="mt-1 text-xs leading-relaxed text-storm">
                   Polaris chooses capture after the launch mode is set. GPU-native keeps frames on the GPU; System-memory capture copies through RAM and can be the intended safe path on AMD and Intel. Mission Control reports the path actually used.
                 </p>
-              </div>
+              </StatTile>
 
               <div class="settings-subtle-surface" data-linux-streaming-setup>
                 <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -645,13 +648,13 @@ function updateDisplayPlannerSource(event) {
                 </div>
 
                 <div class="mt-4 grid gap-3 xl:grid-cols-2">
-                  <div v-for="item in linuxStreamingSetupChecklist" :key="item.id" class="stat-tile-compact py-3">
+                  <StatTile v-for="item in linuxStreamingSetupChecklist" :key="item.id" tile-class="py-3">
                     <div class="flex items-start justify-between gap-3">
                       <div class="text-sm font-semibold text-silver">{{ item.title }}</div>
                       <span class="rounded-full border border-storm/30 bg-storm/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow text-storm">{{ item.status }}</span>
                     </div>
                     <div class="mt-2 text-sm leading-relaxed text-storm">{{ item.copy }}</div>
-                  </div>
+                  </StatTile>
                 </div>
               </div>
 
@@ -664,11 +667,7 @@ function updateDisplayPlannerSource(event) {
                   <span class="meta-pill shrink-0" :class="clientSettingsSyncTone">{{ clientSettingsSyncBadge }}</span>
                 </div>
                 <div class="mt-4 grid gap-2 sm:grid-cols-2">
-                  <div v-for="row in clientSettingsRows" :key="row.label" class="stat-tile-compact">
-                    <div class="stat-kicker">{{ row.label }}</div>
-                    <div class="mt-1 text-sm font-medium text-silver">{{ row.value }}</div>
-                    <div class="mt-1 text-[11px] text-storm">{{ row.note }}</div>
-                  </div>
+                  <StatTile v-for="row in clientSettingsRows" :key="row.label" :label="row.label" :value="row.value" :note="row.note" />
                 </div>
               </div>
 
@@ -849,11 +848,7 @@ function updateDisplayPlannerSource(event) {
         </div>
 
         <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-          <div v-for="row in autoQualityRows" :key="row.label" class="stat-tile-compact">
-            <div class="stat-kicker">{{ row.label }}</div>
-            <div class="mt-1 text-sm font-medium text-silver">{{ row.value }}</div>
-            <div class="mt-1 text-[11px] text-storm">{{ row.note }}</div>
-          </div>
+          <StatTile v-for="row in autoQualityRows" :key="row.label" :label="row.label" :value="row.value" :note="row.note" />
         </div>
       </div>
     </section>
@@ -978,15 +973,13 @@ pactl info | grep Source</pre>
           </div>
 
           <div class="grid gap-3 xl:grid-cols-3">
-            <button
+            <SelectableCard
               v-for="choice in displayPlanner.visibleChoices"
               :key="choice.id"
-              type="button"
-              class="selectable-card focus-ring min-h-[126px] rounded-lg border p-4 hover:border-storm/70"
-              :class="activeDisplayPlanId === choice.id
+              :card-class="['min-h-[126px] rounded-lg border p-4 hover:border-storm/70', activeDisplayPlanId === choice.id
                 ? 'border-ice bg-ice/12 shadow-[0_0_0_1px_rgba(224,230,237,0.18)]'
-                : 'border-storm/30 bg-deep/40'"
-              :aria-pressed="activeDisplayPlanId === choice.id"
+                : 'border-storm/30 bg-deep/40']"
+              :selected="activeDisplayPlanId === choice.id"
               @click="applyDisplayPlan(choice)"
             >
               <div class="flex items-start justify-between gap-3">
@@ -1003,7 +996,7 @@ pactl info | grep Source</pre>
                 <div class="eyebrow-label">Target mode</div>
                 <div class="mt-1 font-mono text-xs text-silver">{{ choice.targetMode }}</div>
               </div>
-            </button>
+            </SelectableCard>
           </div>
 
           <div class="flex flex-col gap-3 rounded-lg border border-ice/15 bg-ice/5 p-4 text-sm text-storm lg:flex-row lg:items-center lg:justify-between">
@@ -1024,20 +1017,18 @@ pactl info | grep Source</pre>
               </div>
             </div>
             <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-6">
-              <button
+              <SelectableCard
                 v-for="factor in displayPlanner.advancedScaleFactors"
                 :key="factor.label"
-                type="button"
-                class="selectable-card focus-ring rounded-lg border px-3 py-3"
-                :class="factor.safe ? 'border-storm/30 bg-deep/40 hover:border-storm/70' : 'border-warning/25 bg-warning/10'"
+                :card-class="['rounded-lg border px-3 py-3', factor.safe ? 'border-storm/30 bg-deep/40 hover:border-storm/70' : 'border-warning/25 bg-warning/10']"
                 :disabled="!factor.safe"
-                :aria-pressed="factor.safe && customDisplayScale === factor.scaleFactor"
+                :selected="factor.safe && customDisplayScale === factor.scaleFactor"
                 @click="customDisplayScale = factor.scaleFactor"
               >
                 <div class="text-sm font-semibold text-silver">{{ factor.label }}</div>
                 <div class="mt-1 font-mono text-xs text-storm">{{ factor.targetMode }}</div>
                 <div class="mt-1 text-[11px]" :class="factor.safe ? 'text-storm' : 'text-warning-bright'">{{ factor.safe ? 'Available' : 'Hidden as excessive' }}</div>
-              </button>
+              </SelectableCard>
             </div>
             <label class="block text-sm font-medium text-storm">
               Custom scale factor

--- a/src_assets/common/assets/web/linux-streaming-setup.test.js
+++ b/src_assets/common/assets/web/linux-streaming-setup.test.js
@@ -52,6 +52,10 @@ function mountAudioVideo(config = linuxConfig()) {
         VirtualDisplayStatus: true,
         Checkbox: true,
         PlatformLayout: { template: '<div><slot name="linux" /></div>', props: ['platform'] },
+        // Shared presentational leaves render for real: the assertions below
+        // click their buttons and read their text as an operator would.
+        SelectableCard: false,
+        StatTile: false,
       },
     },
   })

--- a/src_assets/common/assets/web/settings-affordances.test.js
+++ b/src_assets/common/assets/web/settings-affordances.test.js
@@ -31,12 +31,17 @@ describe('settings affordances', () => {
 
   it('keeps read-only tiles off the input-look recipe on the Video/Audio page', () => {
     const source = webSource('configs/tabs/AudioVideo.vue')
+    const statTile = webSource('components/StatTile.vue')
 
     // The old read-only tile literal is nearly indistinguishable from the
-    // editable input recipe; every status tile now uses the stat grammar.
+    // editable input recipe; every status tile now renders through the shared
+    // StatTile component, which is the only holder of the stat grammar here.
     expect(source).not.toContain('border-storm/20 bg-void/25')
-    expect(source).toContain('stat-tile-compact')
-    expect(source).toContain('stat-kicker')
+    expect(source).toContain('<StatTile')
+    expect(source).not.toContain('stat-tile-compact')
+    expect(statTile).toContain('stat-tile-compact')
+    expect(statTile).toContain('stat-kicker')
+    expect(statTile).toContain('data-readonly')
   })
 
   it('routes every editable field through settings-input on the Video/Audio page', () => {
@@ -49,12 +54,32 @@ describe('settings affordances', () => {
 
   it('marks every choice card on the Video/Audio page as selectable with a pressed state', () => {
     const source = webSource('configs/tabs/AudioVideo.vue')
+    const selectableCard = webSource('components/SelectableCard.vue')
 
-    const selectable = source.match(/selectable-card/g) || []
-    const pressed = source.match(/:aria-pressed=/g) || []
+    const selectable = source.match(/<SelectableCard/g) || []
+    const selected = source.match(/:selected=/g) || []
     // Mode picker, planner presets, and advanced scale factors.
     expect(selectable.length).toBeGreaterThanOrEqual(3)
-    expect(pressed.length).toBeGreaterThanOrEqual(3)
+    expect(selected.length).toBeGreaterThanOrEqual(3)
+    // The shared component owns the vocabulary and the pressed-state wiring.
+    expect(selectableCard).toContain('selectable-card focus-ring')
+    expect(selectableCard).toContain('type="button"')
+    expect(selectableCard).toContain(':aria-pressed=')
+  })
+
+  it('publishes the shared status vocabulary as importable components', () => {
+    const statusTones = webSource('status-tones.js')
+    const statusBadge = webSource('components/StatusBadge.vue')
+    const troubleshooting = webSource('views/TroubleshootingView.vue')
+
+    // One tone table serves cards, badges, and labels; views import it
+    // instead of growing private pass/fail/warning switch copies.
+    expect(statusTones).toContain('export function statusTone')
+    expect(statusBadge).toContain('meta-pill')
+    expect(statusBadge).toContain("from '../status-tones.js'")
+    expect(troubleshooting).toContain("from '../status-tones.js'")
+    expect(troubleshooting).not.toContain('selfTestCardClass')
+    expect(troubleshooting).not.toContain('fixMyStreamBadgeClass')
   })
 
   it('labels the planner mono value as a target mode instead of dressing it as an input', () => {

--- a/src_assets/common/assets/web/status-tones.js
+++ b/src_assets/common/assets/web/status-tones.js
@@ -1,0 +1,30 @@
+/**
+ * Shared semantic status tones for self-test cards and badges.
+ *
+ * Doctor & Support checklists and the built-in self tests grade everything as
+ * pass, fail, or warning. These strings are the single source for the tone
+ * classes those grades render with; any status outside the known set keeps
+ * the historical fallback of the warning tone so a new grade degrades to
+ * "check this" instead of rendering unstyled.
+ */
+export const STATUS_TONES = {
+  pass: {
+    card: 'border-success/20',
+    badge: 'border border-success/30 bg-success/10 text-success',
+    label: 'Looks good',
+  },
+  fail: {
+    card: 'border-danger/25',
+    badge: 'border border-danger/30 bg-danger/10 text-danger-bright',
+    label: 'Fix first',
+  },
+  warning: {
+    card: 'border-warning/25',
+    badge: 'border border-warning/30 bg-warning/10 text-warning-bright',
+    label: 'Check',
+  },
+}
+
+export function statusTone(status) {
+  return STATUS_TONES[status] || STATUS_TONES.warning
+}

--- a/src_assets/common/assets/web/status-tones.test.js
+++ b/src_assets/common/assets/web/status-tones.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { STATUS_TONES, statusTone } from './status-tones'
+
+describe('status tones', () => {
+  it('maps pass to the success tone set', () => {
+    expect(statusTone('pass')).toEqual({
+      card: 'border-success/20',
+      badge: 'border border-success/30 bg-success/10 text-success',
+      label: 'Looks good',
+    })
+  })
+
+  it('maps fail to the danger tone set', () => {
+    expect(statusTone('fail')).toEqual({
+      card: 'border-danger/25',
+      badge: 'border border-danger/30 bg-danger/10 text-danger-bright',
+      label: 'Fix first',
+    })
+  })
+
+  it('maps warning to the warning tone set', () => {
+    expect(statusTone('warning')).toEqual({
+      card: 'border-warning/25',
+      badge: 'border border-warning/30 bg-warning/10 text-warning-bright',
+      label: 'Check',
+    })
+  })
+
+  it('falls back to the warning tone for unknown or missing statuses', () => {
+    // Port probes can grade as 'hint' and future grades must stay visible,
+    // matching the historical else-branch of the view-local helpers.
+    expect(statusTone('hint')).toBe(STATUS_TONES.warning)
+    expect(statusTone('')).toBe(STATUS_TONES.warning)
+    expect(statusTone(undefined)).toBe(STATUS_TONES.warning)
+  })
+})

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -98,11 +98,11 @@
           v-for="item in fixMyStreamChecklist"
           :key="item.key"
           class="surface-subtle border p-4"
-          :class="fixMyStreamStatusClass(item.status)"
+          :class="statusTone(item.status).card"
         >
           <div class="flex items-center justify-between gap-3">
             <div class="text-sm font-semibold text-silver">{{ item.label }}</div>
-            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow" :class="fixMyStreamBadgeClass(item.status)">
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow" :class="statusTone(item.status).badge">
               {{ fixMyStreamStatusLabel(item.status) }}
             </span>
           </div>
@@ -125,10 +125,10 @@
       </div>
 
       <div class="grid gap-3 xl:grid-cols-3">
-        <div class="surface-subtle border p-4" :class="selfTestCardClass(networkPathReport.status)">
+        <div class="surface-subtle border p-4" :class="statusTone(networkPathReport.status).card">
           <div class="flex items-center justify-between gap-3">
             <div class="text-sm font-semibold text-silver">Network Path Tester</div>
-            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow" :class="selfTestBadgeClass(networkPathReport.status)">{{ selfTestStatusLabel(networkPathReport.status) }}</span>
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow" :class="statusTone(networkPathReport.status).badge">{{ statusTone(networkPathReport.status).label }}</span>
           </div>
           <p class="mt-2 text-sm leading-relaxed text-storm">{{ networkPathReport.summary }}</p>
           <p class="mt-3 text-xs leading-relaxed text-ice">Recommended ceiling: {{ networkPathReport.recommendedBitrateKbps }} kbps.</p>
@@ -136,7 +136,7 @@
             <summary class="cursor-pointer text-ice">Advanced evidence</summary>
             <div class="mt-2 space-y-2">
               <div v-for="check in networkPathReport.checks" :key="check.key" class="rounded-lg border border-storm/15 bg-void/40 px-3 py-2">
-                <div class="font-medium text-silver">{{ check.label }} · {{ selfTestStatusLabel(check.status) }}</div>
+                <div class="font-medium text-silver">{{ check.label }} · {{ statusTone(check.status).label }}</div>
                 <div>{{ check.detail }}</div>
                 <div class="mt-1 text-ice">{{ check.action }}</div>
               </div>
@@ -145,10 +145,10 @@
           </details>
         </div>
 
-        <div class="surface-subtle border p-4" :class="selfTestCardClass(controllerInputReport.status)">
+        <div class="surface-subtle border p-4" :class="statusTone(controllerInputReport.status).card">
           <div class="flex items-center justify-between gap-3">
             <div class="text-sm font-semibold text-silver">Controller/Input Tester</div>
-            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow" :class="selfTestBadgeClass(controllerInputReport.status)">{{ selfTestStatusLabel(controllerInputReport.status) }}</span>
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow" :class="statusTone(controllerInputReport.status).badge">{{ statusTone(controllerInputReport.status).label }}</span>
           </div>
           <p class="mt-2 text-sm leading-relaxed text-storm">{{ controllerInputReport.summary }}</p>
           <div class="mt-3 flex flex-wrap gap-2">
@@ -160,7 +160,7 @@
             <summary class="cursor-pointer text-ice">Advanced evidence</summary>
             <div class="mt-2 space-y-2">
               <div v-for="check in controllerInputReport.checks" :key="check.key" class="rounded-lg border border-storm/15 bg-void/40 px-3 py-2">
-                <div class="font-medium text-silver">{{ check.label }} · {{ selfTestStatusLabel(check.status) }}</div>
+                <div class="font-medium text-silver">{{ check.label }} · {{ statusTone(check.status).label }}</div>
                 <div>{{ check.detail }}</div>
                 <div class="mt-1 text-ice">{{ check.action }}</div>
               </div>
@@ -168,10 +168,10 @@
           </details>
         </div>
 
-        <div class="surface-subtle border p-4" :class="selfTestCardClass(postSessionReport.status)">
+        <div class="surface-subtle border p-4" :class="statusTone(postSessionReport.status).card">
           <div class="flex items-center justify-between gap-3">
             <div class="text-sm font-semibold text-silver">Post-session Stream Report</div>
-            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow" :class="selfTestBadgeClass(postSessionReport.status)">{{ postSessionReport.issueOwner }}</span>
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow" :class="statusTone(postSessionReport.status).badge">{{ postSessionReport.issueOwner }}</span>
           </div>
           <p class="mt-2 text-sm leading-relaxed text-storm">{{ postSessionReport.mainIssue }}</p>
           <p class="mt-3 text-xs leading-relaxed text-ice">Next launch: {{ postSessionReport.suggestedNextLaunchProfile }}</p>
@@ -489,6 +489,7 @@ import {
 import { AI_DOCTOR_EXPLANATION_CATEGORIES, explainDoctorWithAi } from '../ai-doctor-explanation.js'
 import { createLogTailState, fetchLogTail } from '../log-tail-state.js'
 import { groupRecentIssueLogs } from '../recent-issues.js'
+import { statusTone } from '../status-tones.js'
 
 const { toast: showToast } = useToast()
 const i18n = inject('i18n')
@@ -781,24 +782,6 @@ const supportSelfTestCopy = computed(() => buildSupportSelfTestCopy({
   postSession: postSessionReport.value,
 }))
 
-function selfTestCardClass(status) {
-  if (status === 'pass') return 'border-success/20'
-  if (status === 'fail') return 'border-danger/25'
-  return 'border-warning/25'
-}
-
-function selfTestBadgeClass(status) {
-  if (status === 'pass') return 'border border-success/30 bg-success/10 text-success'
-  if (status === 'fail') return 'border border-danger/30 bg-danger/10 text-danger-bright'
-  return 'border border-warning/30 bg-warning/10 text-warning-bright'
-}
-
-function selfTestStatusLabel(status) {
-  if (status === 'pass') return 'Looks good'
-  if (status === 'fail') return 'Fix first'
-  return 'Check'
-}
-
 function recordControllerEvent(label, pad = 1) {
   controllerEvents.value = [
     ...controllerEvents.value.slice(-15),
@@ -844,18 +827,6 @@ function fixMyStreamStatusLabel(status) {
   if (status === 'pass') return i18n.t('troubleshooting.fix_my_stream_status_pass')
   if (status === 'fail') return i18n.t('troubleshooting.fix_my_stream_status_fail')
   return i18n.t('troubleshooting.fix_my_stream_status_warning')
-}
-
-function fixMyStreamStatusClass(status) {
-  if (status === 'pass') return 'border-success/20'
-  if (status === 'fail') return 'border-danger/25'
-  return 'border-warning/25'
-}
-
-function fixMyStreamBadgeClass(status) {
-  if (status === 'pass') return 'border border-success/30 bg-success/10 text-success'
-  if (status === 'fail') return 'border border-danger/30 bg-danger/10 text-danger-bright'
-  return 'border border-warning/30 bg-warning/10 text-warning-bright'
 }
 
 const sessionSnapshotItems = computed(() => {


### PR DESCRIPTION
## Summary

Part of #571 (settings revamp arc, frontend slice 3). Turns the affordance vocabulary from CSS classes into enforced components; rendered DOM verified identical apart from one intentional marker.

- New `components/StatTile.vue` (read-only stat grammar, `data-readonly` root marker - the inverse of Checkbox's `data-setting-key`), `components/SelectableCard.vue` (real button, pointer cursor, focus ring, disabled state, `aria-pressed` from a `selected` prop), `components/StatusBadge.vue` (meta-pill from the tone table).
- New `status-tones.js`: one `statusTone(status)` table replaces five duplicated pass/fail/warning helpers in TroubleshootingView (`selfTestCardClass`, `selfTestBadgeClass`, `selfTestStatusLabel`, `fixMyStreamStatusClass`, `fixMyStreamBadgeClass`), byte-identical class strings, unknown statuses keep the old else-branch fallback. `fixMyStreamStatusLabel` stays in the view (localized labels).
- Video/Audio renders its five status-tile sites through StatTile and its three choice-card groups through SelectableCard; all 15 pinned data-attributes/strings preserved.
- Source guards move with the vocabulary: components are pinned as the sole holders of the stat/selectable recipes; TroubleshootingView pinned to the shared table. `linux-streaming-setup.test.js` un-stubs the two presentational leaves so its behavioral assertions keep running against real DOM.
- Deliberately not migrated (fits a later adoption slice): AudioVideo's domain-state meta-pills (Bidirectional/Pending relaunch tones are not semantic pass/fail/warning), TroubleshootingView's differently-shaped badge spans, and the per-mode-id badge ladders inside picker cards.

## Exact candidate

- `Commit:` 19c04ecb19c4265ad26a390cc5ddc2e7c43984e3
- `Tree:` 956b79bd2322d445bf6850937b74a2052125f5de
- `Parent:` 1b0a6fd86efb1d60352ef1ae28a646771bf4cd11
- `Base:` 1b0a6fd86efb1d60352ef1ae28a646771bf4cd11

## Verification

- [x] `vitest run` — 552/552 across 72 files (4 new status-tone tests, extended affordance guards)
- [x] `npm run lint` — clean
- [x] `npm run build:budget` — all budgets pass
- [x] Throwaway full-mount DOM comparison (deleted after passing): merged class strings, aria/disabled states, and data attributes identical to pre-refactor markup; only delta is `data-readonly` on StatTile roots
- [x] Tailwind v4 content scan confirmed to pick up `status-tones.js` (all moved tone utilities present in built CSS)
