### PR TITLE
refactor(web): adopt settings-input vocabulary across settings surfaces

### DIFF
--- a/src_assets/common/assets/web/app.css
+++ b/src_assets/common/assets/web/app.css
@@ -977,52 +977,56 @@ textarea {
   @apply rounded-lg border border-storm/20 bg-deep/30 p-3;
 }
 
-/* The one editable-field recipe. Nothing that cannot receive input may use it. */
-.settings-input {
-  @apply w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none;
-}
+/* Vocabulary classes live in the components layer so per-use utilities
+   (padding, margins, tones) can override them. */
+@layer components {
+  /* The one editable-field recipe. Nothing that cannot receive input may use it. */
+  .settings-input {
+    @apply w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none;
+  }
 
-.settings-disclosure > summary {
-  @apply cursor-pointer list-none;
-}
+  .settings-disclosure > summary {
+    @apply cursor-pointer list-none;
+  }
 
-.settings-disclosure > summary::-webkit-details-marker {
-  display: none;
-}
+  .settings-disclosure > summary::-webkit-details-marker {
+    display: none;
+  }
 
-.settings-disclosure-summary {
-  @apply flex items-center justify-between gap-3;
-}
+  .settings-disclosure-summary {
+    @apply flex items-center justify-between gap-3;
+  }
 
-.settings-disclosure-chevron {
-  @apply transition-transform duration-150;
-}
+  .settings-disclosure-chevron {
+    @apply transition-transform duration-150;
+  }
 
-.settings-disclosure[open] > summary .settings-disclosure-chevron {
-  @apply rotate-180;
-}
+  .settings-disclosure[open] > summary .settings-disclosure-chevron {
+    @apply rotate-180;
+  }
 
-.settings-disclosure-body {
-  @apply mt-4;
-}
+  .settings-disclosure-body {
+    @apply mt-4;
+  }
 
-.settings-summary-copy {
-  @apply mt-1 text-sm leading-relaxed text-storm;
-}
+  .settings-summary-copy {
+    @apply mt-1 text-sm leading-relaxed text-storm;
+  }
 
-/* Interactive choice cards: pointer + hover motion when enabled, inert when not.
-   Pair with :aria-pressed so pressed state is visible to assistive tech. */
-.selectable-card {
-  @apply cursor-pointer text-left transition-[background-color,border-color,color,opacity] duration-150;
-}
+  /* Interactive choice cards: pointer + hover motion when enabled, inert when not.
+     Pair with :aria-pressed so pressed state is visible to assistive tech. */
+  .selectable-card {
+    @apply cursor-pointer text-left transition-[background-color,border-color,color,opacity] duration-150;
+  }
 
-.selectable-card:disabled {
-  @apply cursor-default opacity-60;
-}
+  .selectable-card:disabled {
+    @apply cursor-default opacity-60;
+  }
 
-/* Compact read-only status tile: stat grammar, never the input recipe. */
-.stat-tile-compact {
-  @apply rounded-xl border border-storm/10 bg-deep/40 px-3 py-2;
+  /* Compact read-only status tile: stat grammar, never the input recipe. */
+  .stat-tile-compact {
+    @apply rounded-xl border border-storm/10 bg-deep/40 px-3 py-2;
+  }
 }
 
 .meta-pill {

--- a/src_assets/common/assets/web/configs/tabs/Advanced.vue
+++ b/src_assets/common/assets/web/configs/tabs/Advanced.vue
@@ -21,19 +21,19 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="fec_percentage" class="block text-sm font-medium text-storm mb-1">{{ $t('config.fec_percentage') }}</label>
-        <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="fec_percentage" placeholder="20" v-model="config.fec_percentage" />
+        <input type="text" class="settings-input" id="fec_percentage" placeholder="20" v-model="config.fec_percentage" />
         <div class="text-sm text-storm mt-1">{{ $t('config.fec_percentage_desc') }}</div>
       </div>
 
       <div class="mb-3">
         <label for="qp" class="block text-sm font-medium text-storm mb-1">{{ $t('config.qp') }}</label>
-        <input type="number" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="qp" placeholder="28" v-model="config.qp" />
+        <input type="number" class="settings-input" id="qp" placeholder="28" v-model="config.qp" />
         <div class="text-sm text-storm mt-1">{{ $t('config.qp_desc') }}</div>
       </div>
 
       <div class="mb-3">
         <label for="min_threads" class="block text-sm font-medium text-storm mb-1">{{ $t('config.min_threads') }}</label>
-        <input type="number" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="min_threads" placeholder="2" min="1" v-model="config.min_threads" />
+        <input type="number" class="settings-input" id="min_threads" placeholder="2" min="1" v-model="config.min_threads" />
         <div class="text-sm text-storm mt-1">{{ $t('config.min_threads_desc') }}</div>
       </div>
 
@@ -87,7 +87,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="hevc_mode" class="block text-sm font-medium text-storm mb-1">{{ $t('config.hevc_mode') }}</label>
-        <select id="hevc_mode" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.hevc_mode">
+        <select id="hevc_mode" class="settings-input" v-model="config.hevc_mode">
           <option value="0">{{ $t('config.hevc_mode_0') }}</option>
           <option value="1">{{ $t('config.hevc_mode_1') }}</option>
           <option value="2">{{ $t('config.hevc_mode_2') }}</option>
@@ -98,7 +98,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="av1_mode" class="block text-sm font-medium text-storm mb-1">{{ $t('config.av1_mode') }}</label>
-        <select id="av1_mode" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.av1_mode">
+        <select id="av1_mode" class="settings-input" v-model="config.av1_mode">
           <option value="0">{{ $t('config.av1_mode_0') }}</option>
           <option value="1">{{ $t('config.av1_mode_1') }}</option>
           <option value="2">{{ $t('config.av1_mode_2') }}</option>
@@ -123,7 +123,7 @@ const config = ref(props.config)
 
       <div class="mb-3" v-if="platform !== 'macos'">
         <label for="capture" class="block text-sm font-medium text-storm mb-1">{{ $t('config.capture') }}</label>
-        <select id="capture" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.capture">
+        <select id="capture" class="settings-input" v-model="config.capture">
           <option value="">{{ $t('_common.autodetect') }}</option>
           <PlatformLayout :platform="platform">
             <template #linux>
@@ -143,7 +143,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="encoder" class="block text-sm font-medium text-storm mb-1">{{ $t('config.encoder') }}</label>
-        <select id="encoder" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.encoder">
+        <select id="encoder" class="settings-input" v-model="config.encoder">
           <option value="">{{ $t('_common.autodetect') }}</option>
           <PlatformLayout :platform="platform">
             <template #windows>

--- a/src_assets/common/assets/web/configs/tabs/Files.vue
+++ b/src_assets/common/assets/web/configs/tabs/Files.vue
@@ -28,7 +28,7 @@ const config = ref(props.config)
           <label for="file_apps" class="settings-field-label">{{ $t('config.file_apps') }}</label>
           <InfoHint size="sm" :label="$t('config.file_apps')">{{ $t('config.file_apps_desc') }}</InfoHint>
         </div>
-        <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="file_apps" placeholder="apps.json" v-model="config.file_apps" />
+        <input type="text" class="settings-input" id="file_apps" placeholder="apps.json" v-model="config.file_apps" />
       </div>
 
       <div class="mb-3">
@@ -36,7 +36,7 @@ const config = ref(props.config)
           <label for="log_path" class="settings-field-label">{{ $t('config.log_path') }}</label>
           <InfoHint size="sm" :label="$t('config.log_path')">{{ $t('config.log_path_desc') }}</InfoHint>
         </div>
-        <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="log_path" placeholder="polaris.log" v-model="config.log_path" />
+        <input type="text" class="settings-input" id="log_path" placeholder="polaris.log" v-model="config.log_path" />
       </div>
 
       <div class="mb-3">
@@ -44,7 +44,7 @@ const config = ref(props.config)
           <label for="file_state" class="settings-field-label">{{ $t('config.file_state') }}</label>
           <InfoHint size="sm" :label="$t('config.file_state')">{{ $t('config.file_state_desc') }}</InfoHint>
         </div>
-        <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="file_state" placeholder="polaris_state.json"
+        <input type="text" class="settings-input" id="file_state" placeholder="polaris_state.json"
                v-model="config.file_state" />
       </div>
     </section>
@@ -65,7 +65,7 @@ const config = ref(props.config)
           <label for="credentials_file" class="settings-field-label">{{ $t('config.credentials_file') }}</label>
           <InfoHint size="sm" :label="$t('config.credentials_file')">{{ $t('config.credentials_file_desc') }}</InfoHint>
         </div>
-        <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="credentials_file" placeholder="polaris_state.json" v-model="config.credentials_file" />
+        <input type="text" class="settings-input" id="credentials_file" placeholder="polaris_state.json" v-model="config.credentials_file" />
       </div>
 
       <div class="mb-3">
@@ -73,7 +73,7 @@ const config = ref(props.config)
           <label for="pkey" class="settings-field-label">{{ $t('config.pkey') }}</label>
           <InfoHint size="sm" :label="$t('config.pkey')">{{ $t('config.pkey_desc') }}</InfoHint>
         </div>
-        <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="pkey" placeholder="/dir/pkey.pem" v-model="config.pkey" />
+        <input type="text" class="settings-input" id="pkey" placeholder="/dir/pkey.pem" v-model="config.pkey" />
       </div>
 
       <div class="mb-3">
@@ -81,7 +81,7 @@ const config = ref(props.config)
           <label for="cert" class="settings-field-label">{{ $t('config.cert') }}</label>
           <InfoHint size="sm" :label="$t('config.cert')">{{ $t('config.cert_desc') }}</InfoHint>
         </div>
-        <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="cert" placeholder="/dir/cert.pem" v-model="config.cert" />
+        <input type="text" class="settings-input" id="cert" placeholder="/dir/cert.pem" v-model="config.cert" />
       </div>
     </section>
   </div>

--- a/src_assets/common/assets/web/configs/tabs/General.vue
+++ b/src_assets/common/assets/web/configs/tabs/General.vue
@@ -87,7 +87,7 @@ function handleSteamGridDbKeyInput() {
           Controls the language used by the Polaris web console.
         </InfoHint>
       </div>
-      <select id="locale" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.locale">
+      <select id="locale" class="settings-input" v-model="config.locale">
         <option value="bg">Български (Bulgarian)</option>
         <option value="cs">Čeština (Czech)</option>
         <option value="de">Deutsch (German)</option>
@@ -121,7 +121,7 @@ function handleSteamGridDbKeyInput() {
           Shown to clients and local discovery surfaces.
         </InfoHint>
       </div>
-      <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="sunshine_name" placeholder="Polaris"
+      <input type="text" class="settings-input" id="sunshine_name" placeholder="Polaris"
              v-model="config.sunshine_name" />
     </div>
 
@@ -133,7 +133,7 @@ function handleSteamGridDbKeyInput() {
           Use quieter levels for routine operation and raise this only while debugging.
         </InfoHint>
       </div>
-      <select id="min_log_level" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.min_log_level">
+      <select id="min_log_level" class="settings-input" v-model="config.min_log_level">
         <option value="0">{{ $t('config.min_log_level_0') }}</option>
         <option value="1">{{ $t('config.min_log_level_1') }}</option>
         <option value="2">{{ $t('config.min_log_level_2') }}</option>
@@ -182,10 +182,10 @@ function handleSteamGridDbKeyInput() {
         <tbody>
         <tr v-for="(c, i) in cmds[type]">
           <td>
-            <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm" v-model="c.do" />
+            <input type="text" class="settings-input font-mono text-sm" v-model="c.do" />
           </td>
           <td>
-            <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm" v-model="c.undo" />
+            <input type="text" class="settings-input font-mono text-sm" v-model="c.undo" />
           </td>
           <td v-if="platform === 'windows'" class="align-middle">
             <Checkbox :id="type + '-cmd-admin-' + i"
@@ -233,10 +233,10 @@ function handleSteamGridDbKeyInput() {
         <tbody>
         <tr v-for="(c, i) in serverCmd">
           <td>
-            <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="c.name" />
+            <input type="text" class="settings-input" v-model="c.name" />
           </td>
           <td>
-            <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm" v-model="c.cmd" />
+            <input type="text" class="settings-input font-mono text-sm" v-model="c.cmd" />
           </td>
           <td v-if="platform === 'windows'">
             <div class="flex items-center gap-2">
@@ -333,7 +333,7 @@ function handleSteamGridDbKeyInput() {
           </button>
         </div>
         <input type="password" id="steamgriddb_api_key"
-               class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm"
+               class="settings-input font-mono text-sm"
                v-model="config.steamgriddb_api_key"
                @input="handleSteamGridDbKeyInput"
                placeholder="Enter your SteamGridDB API key" />

--- a/src_assets/common/assets/web/configs/tabs/Inputs.vue
+++ b/src_assets/common/assets/web/configs/tabs/Inputs.vue
@@ -37,7 +37,7 @@ const config = ref(props.config)
         <label for="gamepad" class="settings-field-label">{{ $t('config.gamepad') }}</label>
         <InfoHint size="sm" :label="$t('config.gamepad')">{{ $t('config.gamepad_desc') }}</InfoHint>
       </div>
-      <select id="gamepad" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.gamepad">
+      <select id="gamepad" class="settings-input" v-model="config.gamepad">
         <option value="auto">{{ $t('_common.auto') }}</option>
 
         <PlatformLayout :platform="platform">
@@ -121,7 +121,7 @@ const config = ref(props.config)
         <label for="back_button_timeout" class="settings-field-label">{{ $t('config.back_button_timeout') }}</label>
         <InfoHint size="sm" :label="$t('config.back_button_timeout')">{{ $t('config.back_button_timeout_desc') }}</InfoHint>
       </div>
-      <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="back_button_timeout" placeholder="-1"
+      <input type="text" class="settings-input" id="back_button_timeout" placeholder="-1"
              v-model="config.back_button_timeout" />
       </div>
     </section>
@@ -149,7 +149,7 @@ const config = ref(props.config)
         <label for="key_repeat_delay" class="settings-field-label">{{ $t('config.key_repeat_delay') }}</label>
         <InfoHint size="sm" :label="$t('config.key_repeat_delay')">{{ $t('config.key_repeat_delay_desc') }}</InfoHint>
       </div>
-      <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="key_repeat_delay" placeholder="500"
+      <input type="text" class="settings-input" id="key_repeat_delay" placeholder="500"
              v-model="config.key_repeat_delay" />
       </div>
 
@@ -158,7 +158,7 @@ const config = ref(props.config)
         <label for="key_repeat_frequency" class="settings-field-label">{{ $t('config.key_repeat_frequency') }}</label>
         <InfoHint size="sm" :label="$t('config.key_repeat_frequency')">{{ $t('config.key_repeat_frequency_desc') }}</InfoHint>
       </div>
-      <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="key_repeat_frequency" placeholder="24.9"
+      <input type="text" class="settings-input" id="key_repeat_frequency" placeholder="24.9"
              v-model="config.key_repeat_frequency" />
       </div>
 

--- a/src_assets/common/assets/web/configs/tabs/Network.vue
+++ b/src_assets/common/assets/web/configs/tabs/Network.vue
@@ -50,7 +50,7 @@ const effectivePort = computed(() => Number(config.value?.port) || defaultMoonli
 
       <div class="mb-3">
         <label for="address_family" class="block text-sm font-medium text-storm mb-1">{{ $t('config.address_family') }}</label>
-        <select id="address_family" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.address_family">
+        <select id="address_family" class="settings-input" v-model="config.address_family">
           <option value="ipv4">{{ $t('config.address_family_ipv4') }}</option>
           <option value="both">{{ $t('config.address_family_both') }}</option>
         </select>
@@ -59,7 +59,7 @@ const effectivePort = computed(() => Number(config.value?.port) || defaultMoonli
 
       <div class="mb-3">
         <label for="port" class="block text-sm font-medium text-storm mb-1">{{ $t('config.port') }}</label>
-        <input type="number" min="1029" max="65514" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="port" :placeholder="defaultMoonlightPort"
+        <input type="number" min="1029" max="65514" class="settings-input" id="port" :placeholder="defaultMoonlightPort"
                v-model="config.port" />
         <div class="text-sm text-storm mt-1">{{ $t('config.port_desc') }}</div>
 
@@ -122,7 +122,7 @@ const effectivePort = computed(() => Number(config.value?.port) || defaultMoonli
 
       <div class="mb-3">
         <label for="origin_web_ui_allowed" class="block text-sm font-medium text-storm mb-1">{{ $t('config.origin_web_ui_allowed') }}</label>
-        <select id="origin_web_ui_allowed" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.origin_web_ui_allowed">
+        <select id="origin_web_ui_allowed" class="settings-input" v-model="config.origin_web_ui_allowed">
           <option value="pc">{{ $t('config.origin_web_ui_allowed_pc') }}</option>
           <option value="lan">{{ $t('config.origin_web_ui_allowed_lan') }}</option>
           <option value="wan">{{ $t('config.origin_web_ui_allowed_wan') }}</option>
@@ -132,7 +132,7 @@ const effectivePort = computed(() => Number(config.value?.port) || defaultMoonli
 
       <div class="mb-3">
         <label for="external_ip" class="block text-sm font-medium text-storm mb-1">{{ $t('config.external_ip') }}</label>
-        <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="external_ip" placeholder="123.456.789.12" v-model="config.external_ip" />
+        <input type="text" class="settings-input" id="external_ip" placeholder="123.456.789.12" v-model="config.external_ip" />
         <div class="text-sm text-storm mt-1">{{ $t('config.external_ip_desc') }}</div>
       </div>
     </section>
@@ -150,7 +150,7 @@ const effectivePort = computed(() => Number(config.value?.port) || defaultMoonli
 
       <div class="mb-3">
         <label for="lan_encryption_mode" class="block text-sm font-medium text-storm mb-1">{{ $t('config.lan_encryption_mode') }}</label>
-        <select id="lan_encryption_mode" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.lan_encryption_mode">
+        <select id="lan_encryption_mode" class="settings-input" v-model="config.lan_encryption_mode">
           <option value="0">{{ $t('_common.disabled_def') }}</option>
           <option value="1">{{ $t('config.lan_encryption_mode_1') }}</option>
           <option value="2">{{ $t('config.lan_encryption_mode_2') }}</option>
@@ -160,7 +160,7 @@ const effectivePort = computed(() => Number(config.value?.port) || defaultMoonli
 
       <div class="mb-3">
         <label for="wan_encryption_mode" class="block text-sm font-medium text-storm mb-1">{{ $t('config.wan_encryption_mode') }}</label>
-        <select id="wan_encryption_mode" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.wan_encryption_mode">
+        <select id="wan_encryption_mode" class="settings-input" v-model="config.wan_encryption_mode">
           <option value="0">{{ $t('_common.disabled') }}</option>
           <option value="1">{{ $t('config.wan_encryption_mode_1') }}</option>
           <option value="2">{{ $t('config.wan_encryption_mode_2') }}</option>
@@ -170,7 +170,7 @@ const effectivePort = computed(() => Number(config.value?.port) || defaultMoonli
 
       <div class="mb-3">
         <label for="ping_timeout" class="block text-sm font-medium text-storm mb-1">{{ $t('config.ping_timeout') }}</label>
-        <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="ping_timeout" placeholder="10000" v-model="config.ping_timeout" />
+        <input type="text" class="settings-input" id="ping_timeout" placeholder="10000" v-model="config.ping_timeout" />
         <div class="text-sm text-storm mt-1">{{ $t('config.ping_timeout_desc') }}</div>
       </div>
 
@@ -197,7 +197,7 @@ const effectivePort = computed(() => Number(config.value?.port) || defaultMoonli
           <div v-for="(subnet, index) in config.trusted_subnets" :key="index" class="flex items-center gap-2">
             <input
               type="text"
-              class="flex-1 bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm"
+              class="settings-input flex-1 font-mono text-sm"
               :placeholder="'10.0.0.0/24'"
               v-model="config.trusted_subnets[index]"
             />

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/AdapterNameSelector.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/AdapterNameSelector.vue
@@ -14,7 +14,7 @@ const config = ref(props.config)
 <template>
   <div class="mb-3" v-if="platform !== 'macos'">
     <label for="adapter_name" class="block text-sm font-medium text-storm mb-1">{{ $t('config.adapter_name') }}</label>
-    <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="adapter_name"
+    <input type="text" class="settings-input" id="adapter_name"
            :placeholder="$tp('config.adapter_name_placeholder', '/dev/dri/renderD128')"
            v-model="config.adapter_name" />
     <div class="text-sm text-storm mt-1">

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
@@ -72,7 +72,7 @@ function addRemappingEntry() {
             <label for="dd_configuration_option" class="block text-sm font-medium text-storm mb-1">
               {{ $t('config.dd_configuration_option') }}
             </label>
-            <select id="dd_configuration_option" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.dd_configuration_option">
+            <select id="dd_configuration_option" class="settings-input" v-model="config.dd_configuration_option">
               <option value="disabled">{{ $t('_common.disabled_def') }}</option>
               <option value="verify_only">{{ $t('config.dd_config_verify_only') }}</option>
               <option value="ensure_active">{{ $t('config.dd_config_ensure_active') }}</option>
@@ -86,7 +86,7 @@ function addRemappingEntry() {
               <label for="dd_resolution_option" class="block text-sm font-medium text-storm mb-1">
                 {{ $t('config.dd_resolution_option') }}
               </label>
-              <select id="dd_resolution_option" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.dd_resolution_option">
+              <select id="dd_resolution_option" class="settings-input" v-model="config.dd_resolution_option">
                 <option value="disabled">{{ $t('config.dd_resolution_option_disabled') }}</option>
                 <option value="auto">{{ $t('config.dd_resolution_option_auto') }}</option>
                 <option value="manual">{{ $t('config.dd_resolution_option_manual') }}</option>
@@ -97,7 +97,7 @@ function addRemappingEntry() {
 
               <div class="mt-2" v-if="config.dd_resolution_option === 'manual'">
                 <div class="text-sm text-storm mb-1">{{ $t('config.dd_manual_resolution') }}</div>
-                <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="dd_manual_resolution" placeholder="2560x1440" v-model="config.dd_manual_resolution" />
+                <input type="text" class="settings-input" id="dd_manual_resolution" placeholder="2560x1440" v-model="config.dd_manual_resolution" />
               </div>
             </div>
 
@@ -105,7 +105,7 @@ function addRemappingEntry() {
               <label for="dd_refresh_rate_option" class="block text-sm font-medium text-storm mb-1">
                 {{ $t('config.dd_refresh_rate_option') }}
               </label>
-              <select id="dd_refresh_rate_option" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.dd_refresh_rate_option">
+              <select id="dd_refresh_rate_option" class="settings-input" v-model="config.dd_refresh_rate_option">
                 <option value="disabled">{{ $t('config.dd_refresh_rate_option_disabled') }}</option>
                 <option value="auto">{{ $t('config.dd_refresh_rate_option_auto') }}</option>
                 <option value="manual">{{ $t('config.dd_refresh_rate_option_manual') }}</option>
@@ -113,7 +113,7 @@ function addRemappingEntry() {
 
               <div class="mt-2" v-if="config.dd_refresh_rate_option === 'manual'">
                 <div class="text-sm text-storm mb-1">{{ $t('config.dd_manual_refresh_rate') }}</div>
-                <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="dd_manual_refresh_rate" placeholder="59.9558" v-model="config.dd_manual_refresh_rate" />
+                <input type="text" class="settings-input" id="dd_manual_refresh_rate" placeholder="59.9558" v-model="config.dd_manual_refresh_rate" />
               </div>
             </div>
           </div>
@@ -123,7 +123,7 @@ function addRemappingEntry() {
               <label for="dd_config_revert_delay" class="block text-sm font-medium text-storm mb-1">
                 {{ $t('config.dd_config_revert_delay') }}
               </label>
-              <input type="number" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="dd_config_revert_delay" placeholder="3000" min="0" v-model="config.dd_config_revert_delay" />
+              <input type="number" class="settings-input" id="dd_config_revert_delay" placeholder="3000" min="0" v-model="config.dd_config_revert_delay" />
               <div class="text-sm text-storm mt-1">
                 {{ $t('config.dd_config_revert_delay_desc') }}
               </div>
@@ -178,16 +178,16 @@ function addRemappingEntry() {
                 <tbody>
                   <tr v-for="(value, idx) in config.dd_mode_remapping[getRemappingType()]">
                     <td v-if="getRemappingType() !== REFRESH_RATE_ONLY">
-                      <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm" v-model="value.requested_resolution" :placeholder="'1920x1080'" />
+                      <input type="text" class="settings-input font-mono text-sm" v-model="value.requested_resolution" :placeholder="'1920x1080'" />
                     </td>
                     <td v-if="getRemappingType() !== RESOLUTION_ONLY">
-                      <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm" v-model="value.requested_fps" :placeholder="'60'" />
+                      <input type="text" class="settings-input font-mono text-sm" v-model="value.requested_fps" :placeholder="'60'" />
                     </td>
                     <td v-if="getRemappingType() !== REFRESH_RATE_ONLY">
-                      <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm" v-model="value.final_resolution" :placeholder="'2560x1440'" />
+                      <input type="text" class="settings-input font-mono text-sm" v-model="value.final_resolution" :placeholder="'2560x1440'" />
                     </td>
                     <td v-if="getRemappingType() !== RESOLUTION_ONLY">
-                      <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none font-mono text-sm" v-model="value.final_refresh_rate" :placeholder="'119.95'" />
+                      <input type="text" class="settings-input font-mono text-sm" v-model="value.final_refresh_rate" :placeholder="'119.95'" />
                     </td>
                     <td>
                       <button class="focus-ring rounded-lg border border-danger/30 bg-danger/10 px-3 py-1.5 text-danger-bright transition hover:bg-danger/20" @click="config.dd_mode_remapping[getRemappingType()].splice(idx, 1)">
@@ -209,7 +209,7 @@ function addRemappingEntry() {
         <label for="dd_hdr_option" class="block text-sm font-medium text-storm mb-1">
           {{ $t('config.dd_hdr_option') }}
         </label>
-        <select id="dd_hdr_option" class="mb-3 w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.dd_hdr_option">
+        <select id="dd_hdr_option" class="settings-input mb-3" v-model="config.dd_hdr_option">
           <option value="disabled">{{ $t('config.dd_hdr_option_disabled') }}</option>
           <option value="auto">{{ $t('config.dd_hdr_option_auto') }}</option>
         </select>

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayOutputSelector.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayOutputSelector.vue
@@ -15,7 +15,7 @@ const outputNamePlaceholder = (props.platform === 'windows') ? '{de9bb7e2-186e-5
 <template>
   <div class="mb-3">
     <label for="output_name" class="block text-sm font-medium text-storm mb-1">{{ $tp('config.output_name') }}</label>
-    <input type="text" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="output_name" :placeholder="outputNamePlaceholder"
+    <input type="text" class="settings-input" id="output_name" :placeholder="outputNamePlaceholder"
            v-model="config.output_name"/>
     <div class="text-sm text-storm mt-1">
       {{ $tp('config.output_name_desc') }}

--- a/src_assets/common/assets/web/configs/tabs/encoders/AmdAmfEncoder.vue
+++ b/src_assets/common/assets/web/configs/tabs/encoders/AmdAmfEncoder.vue
@@ -21,7 +21,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="amd_usage" class="block text-sm font-medium text-storm mb-1">{{ $t('config.amd_usage') }}</label>
-        <select id="amd_usage" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.amd_usage">
+        <select id="amd_usage" class="settings-input" v-model="config.amd_usage">
           <option value="transcoding">{{ $t('config.amd_usage_transcoding') }}</option>
           <option value="webcam">{{ $t('config.amd_usage_webcam') }}</option>
           <option value="lowlatency_high_quality">{{ $t('config.amd_usage_lowlatency_high_quality') }}</option>
@@ -35,7 +35,7 @@ const config = ref(props.config)
         <div class="eyebrow-label mb-2">{{ $t('config.amd_rc_group') }}</div>
         <div class="mb-3">
           <label for="amd_rc" class="block text-sm font-medium text-storm mb-1">{{ $t('config.amd_rc') }}</label>
-          <select id="amd_rc" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.amd_rc">
+          <select id="amd_rc" class="settings-input" v-model="config.amd_rc">
             <option value="cbr">{{ $t('config.amd_rc_cbr') }}</option>
             <option value="cqp">{{ $t('config.amd_rc_cqp') }}</option>
             <option value="vbr_latency">{{ $t('config.amd_rc_vbr_latency') }}</option>
@@ -56,7 +56,7 @@ const config = ref(props.config)
         <div class="eyebrow-label mb-2">{{ $t('config.amd_quality_group') }}</div>
         <div class="mb-3">
           <label for="amd_quality" class="block text-sm font-medium text-storm mb-1">{{ $t('config.amd_quality') }}</label>
-          <select id="amd_quality" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.amd_quality">
+          <select id="amd_quality" class="settings-input" v-model="config.amd_quality">
             <option value="speed">{{ $t('config.amd_quality_speed') }}</option>
             <option value="balanced">{{ $t('config.amd_quality_balanced') }}</option>
             <option value="quality">{{ $t('config.amd_quality_quality') }}</option>
@@ -80,7 +80,7 @@ const config = ref(props.config)
 
         <div class="mb-0">
           <label for="amd_coder" class="block text-sm font-medium text-storm mb-1">{{ $t('config.amd_coder') }}</label>
-          <select id="amd_coder" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.amd_coder">
+          <select id="amd_coder" class="settings-input" v-model="config.amd_coder">
             <option value="auto">{{ $t('config.ffmpeg_auto') }}</option>
             <option value="cabac">{{ $t('config.coder_cabac') }}</option>
             <option value="cavlc">{{ $t('config.coder_cavlc') }}</option>

--- a/src_assets/common/assets/web/configs/tabs/encoders/IntelQuickSyncEncoder.vue
+++ b/src_assets/common/assets/web/configs/tabs/encoders/IntelQuickSyncEncoder.vue
@@ -21,7 +21,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="qsv_preset" class="block text-sm font-medium text-storm mb-1">{{ $t('config.qsv_preset') }}</label>
-        <select id="qsv_preset" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.qsv_preset">
+        <select id="qsv_preset" class="settings-input" v-model="config.qsv_preset">
           <option value="veryfast">{{ $t('config.qsv_preset_veryfast') }}</option>
           <option value="faster">{{ $t('config.qsv_preset_faster') }}</option>
           <option value="fast">{{ $t('config.qsv_preset_fast') }}</option>
@@ -34,7 +34,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="qsv_coder" class="block text-sm font-medium text-storm mb-1">{{ $t('config.qsv_coder') }}</label>
-        <select id="qsv_coder" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.qsv_coder">
+        <select id="qsv_coder" class="settings-input" v-model="config.qsv_coder">
           <option value="auto">{{ $t('config.ffmpeg_auto') }}</option>
           <option value="cabac">{{ $t('config.coder_cabac') }}</option>
           <option value="cavlc">{{ $t('config.coder_cavlc') }}</option>

--- a/src_assets/common/assets/web/configs/tabs/encoders/NvidiaNvencEncoder.vue
+++ b/src_assets/common/assets/web/configs/tabs/encoders/NvidiaNvencEncoder.vue
@@ -21,7 +21,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="nvenc_preset" class="block text-sm font-medium text-storm mb-1">{{ $t('config.nvenc_preset') }}</label>
-        <select id="nvenc_preset" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.nvenc_preset">
+        <select id="nvenc_preset" class="settings-input" v-model="config.nvenc_preset">
           <option value="1">P1 {{ $t('config.nvenc_preset_1') }}</option>
           <option value="2">P2</option>
           <option value="3">P3</option>
@@ -35,7 +35,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="nvenc_twopass" class="block text-sm font-medium text-storm mb-1">{{ $t('config.nvenc_twopass') }}</label>
-        <select id="nvenc_twopass" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.nvenc_twopass">
+        <select id="nvenc_twopass" class="settings-input" v-model="config.nvenc_twopass">
           <option value="disabled">{{ $t('config.nvenc_twopass_disabled') }}</option>
           <option value="quarter_res">{{ $t('config.nvenc_twopass_quarter_res') }}</option>
           <option value="full_res">{{ $t('config.nvenc_twopass_full_res') }}</option>
@@ -45,7 +45,7 @@ const config = ref(props.config)
 
       <div v-if="platform === 'linux'" class="mb-3">
         <label for="nvenc_split_encode_mode" class="block text-sm font-medium text-storm mb-1">{{ $t('config.nvenc_split_encode_mode') }}</label>
-        <select id="nvenc_split_encode_mode" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.nvenc_split_encode_mode">
+        <select id="nvenc_split_encode_mode" class="settings-input" v-model="config.nvenc_split_encode_mode">
           <option value="disabled">{{ $t('config.nvenc_split_encode_mode_disabled') }}</option>
           <option value="auto">{{ $t('config.nvenc_split_encode_mode_auto') }}</option>
           <option value="forced">{{ $t('config.nvenc_split_encode_mode_forced') }}</option>
@@ -64,7 +64,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="nvenc_vbv_increase" class="block text-sm font-medium text-storm mb-1">{{ $t('config.nvenc_vbv_increase') }}</label>
-        <input type="number" min="0" max="400" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" id="nvenc_vbv_increase" placeholder="0"
+        <input type="number" min="0" max="400" class="settings-input" id="nvenc_vbv_increase" placeholder="0"
                v-model="config.nvenc_vbv_increase" />
         <div class="text-sm text-storm mt-1">
           {{ $t('config.nvenc_vbv_increase_desc') }}<br><br>
@@ -116,7 +116,7 @@ const config = ref(props.config)
 
       <div>
         <label for="nvenc_h264_cavlc" class="block text-sm font-medium text-storm mb-1">{{ $t('config.nvenc_intra_refresh') }}</label>
-        <select id="nvenc_h264_cavlc" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.nvenc_intra_refresh">
+        <select id="nvenc_h264_cavlc" class="settings-input" v-model="config.nvenc_intra_refresh">
           <option value="disabled">{{ $t('_common.auto') }}</option>
           <option value="enabled">{{ $t('_common.enabled') }}</option>
         </select>

--- a/src_assets/common/assets/web/configs/tabs/encoders/SoftwareEncoder.vue
+++ b/src_assets/common/assets/web/configs/tabs/encoders/SoftwareEncoder.vue
@@ -20,7 +20,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="sw_preset" class="block text-sm font-medium text-storm mb-1">{{ $t('config.sw_preset') }}</label>
-        <select id="sw_preset" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.sw_preset">
+        <select id="sw_preset" class="settings-input" v-model="config.sw_preset">
           <option value="ultrafast">{{ $t('config.sw_preset_ultrafast') }}</option>
           <option value="superfast">{{ $t('config.sw_preset_superfast') }}</option>
           <option value="veryfast">{{ $t('config.sw_preset_veryfast') }}</option>
@@ -36,7 +36,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="sw_tune" class="block text-sm font-medium text-storm mb-1">{{ $t('config.sw_tune') }}</label>
-        <select id="sw_tune" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.sw_tune">
+        <select id="sw_tune" class="settings-input" v-model="config.sw_tune">
           <option value="film">{{ $t('config.sw_tune_film') }}</option>
           <option value="animation">{{ $t('config.sw_tune_animation') }}</option>
           <option value="grain">{{ $t('config.sw_tune_grain') }}</option>

--- a/src_assets/common/assets/web/configs/tabs/encoders/VideotoolboxEncoder.vue
+++ b/src_assets/common/assets/web/configs/tabs/encoders/VideotoolboxEncoder.vue
@@ -21,7 +21,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="vt_coder" class="block text-sm font-medium text-storm mb-1">{{ $t('config.vt_coder') }}</label>
-        <select id="vt_coder" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.vt_coder">
+        <select id="vt_coder" class="settings-input" v-model="config.vt_coder">
           <option value="auto">{{ $t('config.ffmpeg_auto') }}</option>
           <option value="cabac">{{ $t('config.coder_cabac') }}</option>
           <option value="cavlc">{{ $t('config.coder_cavlc') }}</option>
@@ -30,7 +30,7 @@ const config = ref(props.config)
 
       <div class="mb-3">
         <label for="vt_software" class="block text-sm font-medium text-storm mb-1">{{ $t('config.vt_software') }}</label>
-        <select id="vt_software" class="w-full bg-deep border border-storm rounded-lg px-3 py-2 text-silver focus:border-ice focus:outline-none" v-model="config.vt_software">
+        <select id="vt_software" class="settings-input" v-model="config.vt_software">
           <option value="auto">{{ $t('_common.auto') }}</option>
           <option value="disabled">{{ $t('_common.disabled') }}</option>
           <option value="allowed">{{ $t('config.vt_software_allowed') }}</option>

--- a/src_assets/common/assets/web/settings-affordances.test.js
+++ b/src_assets/common/assets/web/settings-affordances.test.js
@@ -6,7 +6,28 @@ const webSource = (relativePath) => readFileSync(
   'utf8',
 )
 
-// The Video/Audio page mixes editable controls with host status. These guards
+// Settings surfaces migrated onto the shared vocabulary. Every file here must
+// route editable fields through .settings-input and stay off the raw literals.
+const migratedSettingsSources = [
+  'configs/tabs/AudioVideo.vue',
+  'configs/tabs/General.vue',
+  'configs/tabs/Network.vue',
+  'configs/tabs/Inputs.vue',
+  'configs/tabs/Files.vue',
+  'configs/tabs/Advanced.vue',
+  'configs/tabs/audiovideo/AdapterNameSelector.vue',
+  'configs/tabs/audiovideo/DisplayDeviceOptions.vue',
+  'configs/tabs/audiovideo/DisplayOutputSelector.vue',
+  'configs/tabs/encoders/AmdAmfEncoder.vue',
+  'configs/tabs/encoders/IntelQuickSyncEncoder.vue',
+  'configs/tabs/encoders/NvidiaNvencEncoder.vue',
+  'configs/tabs/encoders/SoftwareEncoder.vue',
+  'configs/tabs/encoders/VideotoolboxEncoder.vue',
+  'views/PasswordView.vue',
+  'views/PinView.vue',
+]
+
+// The settings pages mix editable controls with host status. These guards
 // keep the two visually distinct: settings look like settings, status looks
 // like status, and nothing renders as a text field unless it accepts input.
 describe('settings affordances', () => {
@@ -22,6 +43,14 @@ describe('settings affordances', () => {
     expect(css).toMatch(/\.stat-tile-compact\s*\{/)
   })
 
+  it('declares the vocabulary in the components layer so utilities can override it', () => {
+    const css = webSource('app.css')
+
+    // Unlayered author CSS beats layered utilities after the build flattens
+    // layers, which silently killed per-use padding overrides like py-2.5.
+    expect(css).toMatch(/@layer components \{[\s\S]*\.settings-input[\s\S]*\.selectable-card[\s\S]*\.stat-tile-compact[\s\S]*\n\}/)
+  })
+
   it('keeps the pointer cursor on interactive cards via selectable-card', () => {
     const css = webSource('app.css')
 
@@ -29,27 +58,33 @@ describe('settings affordances', () => {
     expect(css).toMatch(/\.selectable-card:disabled\s*\{[^}]*cursor-default/s)
   })
 
-  it('keeps read-only tiles off the input-look recipe on the Video/Audio page', () => {
+  it('keeps read-only tiles off the input-look recipe across the settings surfaces', () => {
     const source = webSource('configs/tabs/AudioVideo.vue')
     const statTile = webSource('components/StatTile.vue')
 
     // The old read-only tile literal is nearly indistinguishable from the
     // editable input recipe; every status tile now renders through the shared
     // StatTile component, which is the only holder of the stat grammar here.
-    expect(source).not.toContain('border-storm/20 bg-void/25')
     expect(source).toContain('<StatTile')
     expect(source).not.toContain('stat-tile-compact')
     expect(statTile).toContain('stat-tile-compact')
     expect(statTile).toContain('stat-kicker')
     expect(statTile).toContain('data-readonly')
+
+    for (const path of migratedSettingsSources) {
+      expect(webSource(path), path).not.toContain('border-storm/20 bg-void/25')
+    }
   })
 
-  it('routes every editable field through settings-input on the Video/Audio page', () => {
-    const source = webSource('configs/tabs/AudioVideo.vue')
+  it('routes every editable field through settings-input across the settings surfaces', () => {
+    for (const path of migratedSettingsSources) {
+      const source = webSource(path)
 
-    expect(source).not.toMatch(/border border-storm bg-deep px-3 py-2 text-silver/)
-    expect(source).not.toMatch(/bg-deep border border-storm rounded-lg px-3 py-2/)
-    expect(source).toContain('settings-input')
+      // Both historical orderings of the raw editable-input recipe.
+      expect(source, path).not.toMatch(/border border-storm bg-deep px-3 py-2 text-silver/)
+      expect(source, path).not.toMatch(/bg-deep border border-storm rounded-lg px-3 py-2/)
+      expect(source, path).toContain('settings-input')
+    }
   })
 
   it('marks every choice card on the Video/Audio page as selectable with a pressed state', () => {

--- a/src_assets/common/assets/web/views/PasswordView.vue
+++ b/src_assets/common/assets/web/views/PasswordView.vue
@@ -52,7 +52,7 @@
                 v-model="passwordData.currentUsername"
                 required
                 type="text"
-                class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                class="settings-input"
               />
             </div>
 
@@ -108,7 +108,7 @@
                 id="newUsername"
                 v-model="passwordData.newUsername"
                 type="text"
-                class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                class="settings-input"
               />
             </div>
 

--- a/src_assets/common/assets/web/views/PinView.vue
+++ b/src_assets/common/assets/web/views/PinView.vue
@@ -144,7 +144,7 @@
                   maxlength="4"
                   required
                   title="Enter the 4-digit pairing PIN"
-                  class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                  class="settings-input"
                   :placeholder="$t('pin.pin_code_placeholder')"
                 />
               </div>
@@ -156,7 +156,7 @@
                   v-model="pinDeviceName"
                   name="pairing_device_name"
                   autocomplete="off"
-                  class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                  class="settings-input"
                   :placeholder="$t('pin.device_name_placeholder')"
                 />
               </div>
@@ -203,7 +203,7 @@
                       name="otp_host"
                       autocomplete="off"
                       spellcheck="false"
-                      class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                      class="settings-input"
                       :placeholder="$t('pin.host_address_placeholder')"
                     />
                   </div>
@@ -216,7 +216,7 @@
                       autocomplete="off"
                       inputmode="numeric"
                       spellcheck="false"
-                      class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                      class="settings-input"
                       :placeholder="$t('pin.host_port_placeholder')"
                     />
                   </div>
@@ -250,7 +250,7 @@
                       pattern="[0-9a-zA-Z]{4,}"
                       required
                       spellcheck="false"
-                      class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                      class="settings-input"
                       :placeholder="$t('pin.otp_passphrase_placeholder')"
                     />
                   </div>
@@ -262,7 +262,7 @@
                       v-model="deviceName"
                       name="otp_device_name"
                       autocomplete="off"
-                      class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                      class="settings-input"
                       :placeholder="$t('pin.device_name_placeholder')"
                     />
                   </div>
@@ -464,7 +464,7 @@
                       :id="`client-name-${client.uuid}`"
                       v-model="client.editName"
                       autocomplete="off"
-                      class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                      class="settings-input"
                       :placeholder="$t('pin.device_name_placeholder')"
                       @keyup.enter="saveClient(client)"
                     />
@@ -607,7 +607,7 @@
                         :id="`display-mode-${client.uuid}`"
                         v-model="client.editDisplayMode"
                         autocomplete="off"
-                        class="w-full rounded-lg border border-storm bg-deep px-3 py-2 text-silver focus:border-ice focus:outline-none"
+                        class="settings-input"
                         placeholder="1920x1080x59.94"
                         @input="validateModeOverride"
                       />
@@ -691,7 +691,7 @@
                               v-model="c.cmd"
                               type="text"
                               autocomplete="off"
-                              class="w-full rounded-lg border border-storm bg-deep px-3 py-2 font-mono text-sm text-silver focus:border-ice focus:outline-none"
+                              class="settings-input font-mono text-sm"
                             />
                           </td>
                           <td v-if="platform === 'windows'" class="py-2 pr-2">


### PR DESCRIPTION
## Summary

Part of #571 (settings revamp arc, frontend slice 4). Mechanical vocabulary adoption plus one real cascade fix the migration surfaced.

- 72 editable-input recipe swaps to `.settings-input` across General/Network/Inputs/Files/Advanced, the audiovideo subcomponents, all five populated encoder tabs, and PasswordView/PinView (exact-recipe cases only). Per-use extras (`font-mono`, `text-sm`, margins) preserved as separate utilities. Class-set parity verified against pre-migration backups for all 15 files; single exception is one inert `w-full` on a `flex-1` subnet input.
- **Cascade fix:** the vocabulary block moves into `@layer components`. It was unlayered, and after the build flattens layers, unlayered author CSS lands after the utilities, so overrides like `py-2.5`/`p-3` riding next to `stat-tile-compact` silently lost (verified in the built bundle: utilities sat at offset ~43k, vocabulary at ~106k). In the components layer the utilities win again (re-verified: vocabulary now precedes utilities in the built bundle). A source guard pins the layer wrapper.
- The zero-occurrence result for the read-only tile literal in these files means no StatTile conversions were possible here; candidates found out of scope are listed below.
- Affordance guards broadened to loop all 16 migrated surfaces asserting both raw recipe orderings are gone.

Deliberately left (design variants or out of scope): Login/Welcome auth-glow inputs, VirtualDisplayStatus inset tone variants, PasswordView `pr-20`/dynamic-border fields, PinView compact chips, Network's interactive subnet buttons, AiOptimizer's consistent `bg-void/50` family, `components/QuickControls.vue:201` and TroubleshootingView's `sm:w-72` variant (other slices' files).

## Exact candidate

- `Commit:` 6efb23d93e11eab9ff2e401b8fde1e73a169cba3
- `Tree:` d7589b5152ea4c76da89a12ec79a3448f0731b6f
- `Parent:` c2ead64bb453c85326434b61fbe6f5f57457ff12
- `Base:` c2ead64bb453c85326434b61fbe6f5f57457ff12

## Verification

- [x] `vitest run` — 553/553 across 72 files (new layer guard)
- [x] `npm run lint` — clean
- [x] `npm run build:budget` — all budgets pass
- [x] Built-bundle order check: vocabulary rules precede utility rules after the layer move, restoring per-use overrides
- [x] Class-set parity 15/15 files (throwaway test, deleted; backups retained during review)
