### PR TITLE
ci: bump pinned Ubuntu snapshot to 20260901

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ env:
   POLARIS_CHECKOUT_REF: ${{ inputs.release_tag || github.ref }}
   POLARIS_PACKAGE_REF_NAME: ${{ inputs.release_tag || github.ref_name }}
   # Advance deliberately only after the full matrix proves a newer snapshot.
-  UBUNTU_APT_SNAPSHOT: 20260818T000000Z
+  UBUNTU_APT_SNAPSHOT: 20260901T000000Z
 
 jobs:
   resolve-source:


### PR DESCRIPTION
## Summary

Unblocks the settings revamp train (#574/#577) and every future C++ CI round.

- The 20260818 apt snapshot is deterministically incompatible with current GitHub runner images: runners now ship `libbz2-1.0 1.0.8-5.1ubuntu0.1` and `util-linux 2.39.3-9ubuntu6.6`, while the snapshot's `-dev` packages depend on the older versions exactly. apt exits 100 (`E: Unable to correct problems`) before the sanitizer job builds anything. Reproduced twice on #574 with identical signatures.
- Bump `UBUNTU_APT_SNAPSHOT` to `20260901T000000Z` (verified live; contains both updated packages).
- Per the pin's advance-deliberately comment: this PR's own run is the proof for the required jobs (sanitizer, Arch, web); the optional distro matrix validates on its next trigger.

## Verification

- [x] `https://snapshot.ubuntu.com/ubuntu/20260901T000000Z/dists/noble/Release` returns 200
- [ ] This PR's sanitizer job passes with the new pin (the workflow change applies to this PR's own run)
