### PR TITLE
test(e2e): follow the shipped navigation labels and dashboard layout

### DIFF
--- a/tests/e2e/dashboard.spec.js
+++ b/tests/e2e/dashboard.spec.js
@@ -6,10 +6,10 @@ test.describe('dashboard', () => {
     await expect(sidebar.getByRole('link', { name: /mission control/i })).toBeVisible()
     await expect(sidebar.getByRole('link', { name: /library/i })).toBeVisible()
     await expect(sidebar.getByRole('link', { name: /settings/i })).toBeVisible()
-    await expect(sidebar.getByRole('link', { name: /pairing/i })).toBeVisible()
+    await expect(sidebar.getByRole('link', { name: /devices/i })).toBeVisible()
   })
 
-  test('metric chart cards are present when streaming', async ({ loggedInPage }) => {
+  test('live summary strip and GPU gauges render when streaming', async ({ loggedInPage }) => {
     const streamStats = {
       streaming: true,
       client_name: 'QA Client',
@@ -74,15 +74,20 @@ test.describe('dashboard', () => {
 
     await loggedInPage.reload({ waitUntil: 'domcontentloaded' })
 
-    for (const label of ['FPS', 'Bitrate', 'Encode', 'Latency', 'GPU Load', 'Packet Loss']) {
-      await expect(loggedInPage.getByText(label, { exact: false }).first()).toBeVisible()
+    // While streaming, Mission Control renders the stream metrics as the live
+    // summary strip and names the capture path; the GPU gauges belong to the
+    // idle layout and are covered by the partial-metrics test below.
+    for (const metric of ['Quality', 'Latency', 'FPS', 'Loss', 'Bitrate', 'Encode']) {
+      await expect(loggedInPage.locator(`[data-live-summary-metric="${metric}"]`)).toBeVisible()
     }
     await expect(loggedInPage.getByText(/GPU Native/i).first()).toBeVisible()
   })
 
   test('AMD GPU with partial metrics does not render undefined or NaN', async ({ loggedInPage }) => {
+    // Idle host: the GPU gauges and the readiness pill only render on the idle
+    // layout, which is where partial telemetry has to degrade cleanly.
     const streamStats = {
-      streaming: true,
+      streaming: false,
       client_name: 'QA Client',
       client_ip: '127.0.0.1',
       clients: [{ name: 'QA Client', ip: '127.0.0.1', fps: 59.8, latency_ms: 12 }],
@@ -148,20 +153,23 @@ test.describe('dashboard', () => {
 
     await loggedInPage.reload({ waitUntil: 'domcontentloaded' })
 
-    // Wait for the streaming dashboard to render with AMD GPU data.
-    await expect(loggedInPage.locator('.dashboard-metric-tile').filter({ hasText: 'GPU Load' })).toBeVisible({ timeout: 10000 })
-    await expect(loggedInPage.locator('.dashboard-metric-tile').filter({ hasText: 'VRAM' })).toBeVisible({ timeout: 10000 })
+    // Wait for the Host vitals card to render with AMD GPU data: the gauges
+    // that have a value show, the ones without a value are not rendered at all.
+    const vitals = loggedInPage.locator('.section-card', { hasText: 'Host vitals' })
+    await expect(vitals.getByText('GPU', { exact: true })).toBeVisible({ timeout: 10000 })
+    await expect(vitals.getByText('VRAM', { exact: true })).toBeVisible({ timeout: 10000 })
 
-    // Encoder tile must be hidden when encoder_pct is absent
-    await expect(loggedInPage.locator('.dashboard-metric-tile').filter({ hasText: /^Encoder$/ })).not.toBeVisible()
+    // Encoder and temperature gauges must be absent when their metrics are absent
+    await expect(vitals.getByText(/^(NVENC|VCN)$/)).toHaveCount(0)
+    await expect(vitals.getByText('Temp', { exact: true })).toHaveCount(0)
+
+    // Missing temperature and power draw render as '--', not raw numbers
+    await expect(vitals.getByText(/--W/)).toBeVisible()
+    await expect(loggedInPage.locator('[data-dashboard-idle-hero]').getByText(/--°C/)).toBeVisible()
 
     // No raw undefined or NaN values anywhere on the page
     const bodyText = await loggedInPage.locator('body').innerText()
     expect(bodyText).not.toMatch(/\bundefined\b/)
     expect(bodyText).not.toMatch(/\bNaN\b/)
-
-    // Missing temperature should render as '--', not a raw number
-    const tempTile = loggedInPage.locator('.dashboard-metric-tile').filter({ hasText: 'GPU Temp' })
-    await expect(tempTile.getByText('--', { exact: true })).toBeVisible()
   })
 })

--- a/tests/e2e/pairing.spec.js
+++ b/tests/e2e/pairing.spec.js
@@ -11,7 +11,7 @@ test.describe('pairing', () => {
   })
 
   test('supports keyboard switching between pairing methods', async ({ loggedInPage }) => {
-    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^pairing$/i }).click()
+    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^devices$/i }).click()
     await expect(loggedInPage.getByRole('heading', { name: /pair/i }).first()).toBeVisible()
 
     const manualPinButton = loggedInPage.getByRole('button', { name: /manual pin/i })
@@ -57,7 +57,7 @@ test.describe('pairing', () => {
       await route.fulfill({ json: { status: false } })
     })
 
-    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^pairing$/i }).click()
+    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^devices$/i }).click()
 
     await expect(loggedInPage.getByText('Browse & Watch').first()).toBeVisible()
 
@@ -86,11 +86,11 @@ test.describe('pairing', () => {
       })
     })
 
-    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^pairing$/i }).click()
+    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^devices$/i }).click()
     await loggedInPage.locator('#otp-passphrase').fill('abcd')
     await loggedInPage.getByRole('button', { name: /generate qr/i }).click()
 
-    await expect(loggedInPage.getByRole('radio', { name: /game control/i })).toHaveAttribute('aria-checked', 'true')
+    await expect(loggedInPage.getByRole('radio', { name: /^game control/i })).toHaveAttribute('aria-checked', 'true')
     await expect.poll(() => payload?.access_preset).toBe('game_control')
   })
 
@@ -110,7 +110,7 @@ test.describe('pairing', () => {
       })
     })
 
-    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^pairing$/i }).click()
+    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^devices$/i }).click()
     await loggedInPage.getByRole('radio', { name: /browse & watch/i }).click()
     await loggedInPage.locator('#otp-passphrase').fill('abcd')
     await loggedInPage.getByRole('button', { name: /generate qr/i }).click()
@@ -125,7 +125,7 @@ test.describe('pairing', () => {
       await route.fulfill({ json: { status: true, access_preset: 'game_control' } })
     })
 
-    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^pairing$/i }).click()
+    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^devices$/i }).click()
     await loggedInPage.getByRole('button', { name: /manual pin/i }).click()
     await loggedInPage.locator('#pin-input').fill('1234')
     await loggedInPage.getByRole('button', { name: /^send$/i }).click()
@@ -157,7 +157,7 @@ test.describe('pairing', () => {
       })
     })
 
-    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^pairing$/i }).click()
+    await loggedInPage.getByRole('navigation').getByRole('link', { name: /^devices$/i }).click()
 
     const clientCard = loggedInPage.locator('article').filter({ hasText: 'QA Client' }).first()
     await expect(clientCard.getByText('Game Control').first()).toBeVisible()

--- a/tests/e2e/polaris-ui-sweep.spec.js
+++ b/tests/e2e/polaris-ui-sweep.spec.js
@@ -26,7 +26,7 @@ const routes = [
   { name: 'settings', path: '/#/config', heading: /Settings/i },
   { name: 'pairing', path: '/#/pin', heading: /Pair/i },
   { name: 'browser-stream', path: '/#/browser-stream', heading: /Browser Stream/i },
-  { name: 'troubleshooting', path: '/#/troubleshooting', heading: /Troubleshooting/i },
+  { name: 'troubleshooting', path: '/#/troubleshooting', heading: /Doctor & Support/i },
 ]
 
 async function gotoRoute(page, route) {

--- a/tests/e2e/troubleshooting.spec.js
+++ b/tests/e2e/troubleshooting.spec.js
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures/auth.js'
 
 test.describe('troubleshooting', () => {
   test('renders self-service Doctor support actions without auto-submitting issues', async ({ loggedInPage }) => {
-    await loggedInPage.getByRole('link', { name: /troubleshooting/i }).click()
+    await loggedInPage.getByRole('link', { name: /doctor & support/i }).click()
     await expect(loggedInPage).toHaveURL(/#\/troubleshooting/)
 
     await expect(loggedInPage.getByRole('heading', { name: /^fix my stream$/i })).toBeVisible({ timeout: 15000 })
@@ -16,9 +16,9 @@ test.describe('troubleshooting', () => {
   })
 
   test('log filters remain keyboard reachable', async ({ loggedInPage }) => {
-    await loggedInPage.getByRole('link', { name: /troubleshooting/i }).click()
+    await loggedInPage.getByRole('link', { name: /doctor & support/i }).click()
     await expect(loggedInPage).toHaveURL(/#\/troubleshooting/)
-    await expect(loggedInPage.getByRole('heading', { name: /^troubleshooting$/i })).toBeVisible({ timeout: 15000 })
+    await expect(loggedInPage.getByRole('heading', { name: /^doctor & support$/i })).toBeVisible({ timeout: 15000 })
     await expect(loggedInPage.getByRole('heading', { name: /^quick recovery$/i })).toBeVisible({ timeout: 15000 })
 
     const fatalFilter = loggedInPage.getByRole('button', { name: /^fatal$/i })


### PR DESCRIPTION
## Summary

The Playwright e2e suite is not part of CI, so it rotted against the live UI without anyone noticing. Run against a real host, 19 of its 68 tests failed deterministically before this PR (plus one flaky capture), and none of the failures was a product bug:

- The sidebar renamed "Pairing" to "Devices" and "Troubleshooting" to "Doctor & Support"; six pairing tests, both troubleshooting tests, eight ui-sweep captures of the troubleshooting route, and the dashboard sidebar test still looked for the old names.
- Mission Control's redesign replaced the old metric tiles with the live summary strip (streaming) and gauge arcs in the Host vitals card (idle). Both dashboard telemetry tests still looked for `.dashboard-metric-tile` and a "GPU Load" label.
- One pairing test hit a strict-mode violation: "Full Control" describes itself with the words "game control", so the unanchored radio lookup matched two radios.

This PR updates the specs to the shipped UI and keeps every test's original intent:

- Nav lookups use the current labels.
- The streaming dashboard test asserts the six live summary metrics and the "GPU Native" capture label. The partial-metrics test now drives the idle layout, which is where the GPU gauges live, and asserts that gauges without data are absent, that missing temperature and power render as "--", and that nothing renders as undefined or NaN.
- The Game Control radio lookup is anchored to the start of the accessible name.

No product code changes.

## Exact candidate

Branch `fix/e2e-nav-labels`, one commit on top of master 49c8ade4, touching only the four spec files under `tests/e2e/`.

## Verification

- `npx eslint` on the four spec files: clean.
- Full Playwright e2e against the live pc-papi host (master build 49c8ade4 under polaris.service): 68 passed, 0 failed, 0 flaky.
- Before the fix, the same suite on the same host: 19 failed (6 pairing, 3 dashboard, 2 troubleshooting, 8 ui-sweep troubleshooting captures), plus the phone-portrait library capture flaking once under full-suite load and passing alone.
