### PR TITLE
docs: add the Moonlight and Devices guides and a per-tab settings reference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,6 +177,77 @@ account ids, installed app ids, profile filenames, or filesystem paths, and it d
 configuration. Close Steam before changing the setting through Steam or by another supported tool so
 the running client cannot overwrite the update.
 
+## Settings by tab
+
+The web UI groups the keys above by area. Each Settings tab links to its section here.
+
+### General tab
+
+Host identity (the name clients see, the web console language, the log level), automation
+(commands that run before an app launches and are undone after the session, commands that run
+when the host changes session state, and server shortcuts a paired client may trigger), desktop
+behaviour (pre-release update notifications, the tray icon, and whether the tray shows the force
+stop, restart, and quit controls), and metadata integrations (a SteamGridDB key for artwork on
+non-Steam entries, and whether Polaris may ask How Long To Beat for titles missing from its local
+completion dataset). Keys: `sunshine_name`, `notify_pre_releases`, `system_tray`,
+`hide_tray_controls`, `steamgriddb_api_key`, `beat_times_lookup`.
+
+### Input tab
+
+Gamepads (whether clients may control the host with a controller, DualShock and DualSense
+mapping, and the isolation switches that keep host-wired controllers out of private streams and
+client pads off other Linux seats), keyboard (passthrough, repeat delay and rate, scancodes for
+non-US layouts, right Alt as the Windows key), pointer and touch (mouse capture, the separately
+composited host cursor that DRM/KMS capture needs, high-resolution scrolling, native pen and touch
+events), and extras (an input-only app entry for TV workflows, rumble forwarding). Keys:
+`controller`, `headless_gamepad_isolation`, `client_gamepad_seat_isolation`, `keyboard`,
+`key_repeat_delay`, `key_repeat_frequency`, `always_send_scancodes`, `mouse`,
+`mouse_cursor_visible`, `high_resolution_scrolling`, `native_pen_touch`,
+`client_keyboard_mouse_seat_isolation`, `enable_input_only_mode`, `forward_rumble`,
+`back_button_timeout`.
+
+### Network tab
+
+Exposure (whether the host announces itself for discovery, whether pairing is enabled, UPnP port
+forwarding, the address family, the base port and the port map derived from it, which origins may
+reach the web UI, and an external IP for clients outside the network) and transport security (the
+encryption mode for LAN and WAN sessions, Trusted Subnet Auto-Pairing, and the trusted subnet
+list in CIDR form). Keys: `enable_discovery`, `enable_pairing`, `upnp`, `address_family`, `port`,
+`origin_web_ui_allowed`, `external_ip`, `lan_encryption_mode`, `wan_encryption_mode`,
+`trusted_subnets`.
+
+### Audio and video tab
+
+Everything the stream is made of: the launch mode and its runtime, host audio capture and the
+sink Polaris captures, the display outputs and fallback mode the Display Planner writes, Auto
+Quality, advanced tuning such as the maximum bitrate and the adaptive range, and how long a paused
+session waits for a client to resume. The mode cards, the live Auto Quality strip, and the planner
+are explained in [Launch modes and capture paths](launch-modes.md). Keys: `linux_stream_mode`,
+`headless_mode`, `linux_use_cage_compositor`, `linux_prefer_gpu_native_capture`, `fallback_mode`,
+`display_plan`, `adaptive_bitrate_enabled`, `disconnect_resume_timeout_seconds`.
+
+### Advanced tab
+
+Load handling (limit the capture frame rate to what the client asked for), compatibility switches
+for older tools and clients (environment variable compatibility, legacy app ordering, streaming on
+even when encoder probing fails, the experimental browser stream), and the capture and encoder
+overrides that force a specific path when automatic selection is wrong. Keys: `limit_framerate`,
+`envvar_compatibility_mode`, `legacy_ordering`, `ignore_encoder_probe_failure`,
+`browser_streaming`, `encoder`.
+
+### Files tab
+
+Where Polaris keeps its app library, its log, its runtime state, and, optionally, the web
+credentials separately from the state file. The defaults are listed under [Files](#files). Keys:
+`file_apps`, `log_path`, `file_state`, `credentials_file`.
+
+### AI and Encoder Profiles tabs
+
+The AI tab is covered under [AI provider settings](#ai-provider-settings); the encoder tabs under
+[NVIDIA NVENC Encoder](#nvidia-nvenc-encoder) and [Linux HDR and Main10](#linux-hdr-and-main10),
+with the codec switches (`hevc_mode`, `av1_mode`), the quantisation fallback (`qp`), and the
+software encoder thread floor (`min_threads`) on the encoder pages themselves.
+
 ## Linux HDR and Main10
 
 On Linux, treat sessions that log `stream_hdr_enabled=false` as SDR even if the client requests HDR.

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -1,0 +1,82 @@
+# Pair and manage devices
+
+The **Devices** page is where clients get paired and where each paired device keeps its access
+level, display profile, and per-device automation. This page explains the three pairing routes,
+what the access presets allow, and what the device editor changes.
+
+## Pairing routes
+
+| Route | For | How it works |
+|---|---|---|
+| **Nova QR** | Nova on Android | Generate a passphrase; Nova scans a QR code that carries the host address, the PIN, and the pairing context. The fastest path for Nova on your network. |
+| **Trusted Network** | Devices on a subnet you control | Any device inside a listed trusted subnet pairs without a PIN. Enable it under **Settings, Network, Trusted Subnet Auto-Pairing** and list the subnets in CIDR form. Off by default. |
+| **Manual PIN** | Standard Moonlight clients | The client shows a four-digit PIN; enter it here and choose **Send**. The classic Moonlight flow, described step by step in [Play with Moonlight](moonlight.md). |
+
+Every route applies the access preset selected under **Access for this device** at pairing time.
+
+## Access presets
+
+New devices get **Game Control** unless you choose otherwise. Existing devices keep their saved
+access until you edit it.
+
+| Preset | Can | Cannot |
+|---|---|---|
+| **Viewer Access** | Watch an existing stream | Browse the library, launch games, send input |
+| **Browse & Watch** | List the library and join an existing stream | Launch games, send input |
+| **Game Control** | Browse, launch, and control games with controller, keyboard, mouse, touch, and pen | Read or set the clipboard, transfer files, run server commands |
+| **Full Control** | Everything, including clipboard, file transfer, and server commands | Nothing withheld; use only for devices you fully trust |
+
+**Fine-Tune Permissions** in the editor exposes the individual permissions behind the presets:
+list apps, view streams, launch apps, clipboard read and set, server command, and the five input
+kinds. A device whose permissions match no preset shows as
+**Custom Access**.
+
+A device with Browse & Watch that tries to start a stream gets a permission-denied answer; the
+[troubleshooting entry](troubleshooting.md#paired-client-gets-permission-denied-403-when-starting-a-stream)
+walks through it.
+
+## The saved-devices list
+
+Each card shows the device name, whether it is connected, its access preset, the client family
+(Nova or a standard client), and whether its display profile matches the recommendation for that
+device. Below that, five tiles summarise permissions, display profile, client commands, when it was
+paired, and when it was last seen.
+
+The card's actions: **Wake** sends a Wake-on-LAN packet when the device has a MAC address in its
+profile, **Disconnect** ends its active session, **Edit Access** opens the editor, and the trash
+control unpairs the single device. **Unpair All** at the top removes every device.
+
+## Editing a device
+
+**Edit Access** opens a dialog with three areas.
+
+**Host view** is read from the host, not from the form. It shows what Polaris actually applies for
+this device: display mode, target bitrate, stream display mode, adaptive bitrate, and the resume
+window, each with its source and whether it is applied live or at the next launch. A host without
+the settings projection says so instead of guessing.
+
+**Identity & Access** holds the device name, the access preset buttons, the fine-tune permissions,
+and three switches: legacy app ordering for clients that cannot handle UTF-8, a virtual display
+on every connection (Windows hosts), and whether client commands may run for this device.
+
+**Display Profile** overrides what the client asks for:
+
+- **Display Mode Override**, as `WxHxFPS`, makes Polaris ignore the client's requested mode and
+  configure displays to this value. Leave it blank for automatic matching.
+- **Output Name** pins the device to a specific host output.
+- **Color Range** forces limited or full range when a client reports it wrong.
+- **WoL MAC Address** enables the Wake action.
+- **Enable HDR** requests an HDR-capable configuration for this device; see
+  [Linux HDR and Main10](configuration.md#linux-hdr-and-main10) for the host side.
+
+**AI Suggest** proposes a profile from the device database or, when AI is configured, from the
+provider. It only fills the form; nothing is saved until you choose **Save**.
+
+**Client Commands**, shown when client commands are allowed, runs host-side commands when this
+device connects (**do**) and disconnects (**undo**). Commands run detached.
+
+## Stale profile aliases
+
+Renaming or re-pairing a device can leave a display profile behind under the old name. When that
+happens a **Stale profile aliases** section appears at the bottom of the page listing them;
+**Remove stale** deletes the aliases without unpairing any real device.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -39,6 +39,25 @@ No. Moonlight can request higher frame rates on clients that expose them, and Po
 client's requested display mode as the ceiling. If a client requests `1280x800x60`, Polaris will not
 force a 90 FPS optimization above that request even when the device profile supports it.
 
+### Which Moonlight settings matter with Polaris?
+
+Resolution and frame rate, because Polaris treats the request as a ceiling and falls back to the
+host's Display Planner mode when it cannot be met; bitrate, because Auto Quality starts from it;
+codec and HDR, because the host has to offer the matching encoder profile. The full table is in
+[Play with Moonlight](moonlight.md#5-match-the-stream-to-the-device).
+
+### Can Moonlight choose the launch mode?
+
+No. The host's saved launch mode applies to every standard Moonlight session; only Nova can pick a
+mode per launch. A protocol client can still ask for a one-off desktop mirror by adding
+`mirrorDesktop=1` to its launch request, without changing the host setting.
+
+### Moonlight shows the library but cannot start anything
+
+The device has **Browse & Watch** access, which lists the library and joins an existing stream but
+cannot launch or send input. Open **Devices**, choose **Edit Access** on that device, and pick
+**Game Control**. The presets are explained in [Pair and manage devices](devices.md#access-presets).
+
 ### Can multiple people watch the same stream?
 
 Yes. Set `max_sessions` above `1`. Polaris tracks owner and viewer roles explicitly, and passive

--- a/docs/moonlight.md
+++ b/docs/moonlight.md
@@ -1,0 +1,103 @@
+# Play with Moonlight
+
+Polaris speaks the Moonlight protocol, so any Moonlight client can pair with it: the official
+Moonlight apps on Android, iOS, Windows, macOS, and Linux, the Steam Deck build, and forks such as
+Artemis. This guide takes a standard Moonlight client from install to a tuned stream. Nova, the
+Android client built alongside Polaris, has its own [quick start](https://papi-ux.com/docs/nova/quickstart/) and adds
+launch modes, watch mode, and live tuning that the Moonlight protocol cannot carry.
+
+## 1. Install Moonlight on the device
+
+Install the Moonlight client for your platform from the [Moonlight project](https://moonlight-stream.org/)
+or your platform's store. Any current release works; Polaris needs nothing beyond the standard
+protocol, and there is no Polaris-specific client plugin.
+
+Make sure the client and the host share a network, or that the host is reachable through the ports
+listed in [Ports](#ports) if you stream across networks.
+
+## 2. Add the host
+
+Open Moonlight. If the host and the client are on the same network and **Enable Discovery** is on
+under **Settings, Network**, the Polaris host appears by itself. If it does not, add it by hand
+with the host's IP address or hostname.
+
+Moonlight shows a four-digit PIN and waits.
+
+## 3. Pair with the PIN
+
+In the Polaris web UI open **Devices**, choose **Manual PIN**, type the PIN Moonlight is showing,
+give the device a label if you want one, keep **Game Control** selected, and choose **Send**.
+
+Moonlight finishes the handshake and shows the host as paired. If its library does not appear
+immediately, refresh the host in Moonlight.
+
+Two alternatives:
+
+- **Trusted Pair** skips the PIN for devices already inside a subnet you list under
+  **Settings, Network, Trusted Subnet Auto-Pairing**. Use it only on networks you control.
+- **Nova QR** is for Nova only; standard Moonlight clients cannot scan it.
+
+What the access presets mean, and how to change a device's access later, is in
+[Pair and manage devices](devices.md).
+
+## 4. Start a stream
+
+Moonlight lists what Polaris publishes: the **Desktop** entry, **Steam Big Picture** if you use
+it, and every game in your library. Pick one.
+
+Which display the game lands on is decided by the host's launch mode, not by Moonlight. The
+default **Private Stream** runs the game on a private display without touching the host
+monitors; **Mirror Desktop** streams the visible desktop instead. The modes and how to choose
+one are in [Launch modes and capture paths](launch-modes.md). Moonlight cannot switch modes per
+launch the way Nova can; the host's saved choice applies.
+
+Disconnecting does not end the game. Polaris keeps it paused for the resume window
+(**Settings, Audio/Video, Disconnect Resume Timeout**, five minutes by default) so a reconnect
+resumes the session. A second client can join an existing stream as a viewer when
+**Browse & Watch** access allows it and `max_sessions` is above one.
+
+## 5. Match the stream to the device
+
+Moonlight's own settings decide what it asks for; Polaris decides what it can honour. The
+combinations that matter:
+
+| Moonlight setting | What Polaris does with it |
+|---|---|
+| Resolution and frame rate | Treated as the ceiling. Polaris streams at the requested mode when the host can provide it, and never optimises above it. If the request cannot be met, the host's fallback mode applies; set it with the **Display Planner** under **Settings, Audio/Video**. |
+| Bitrate | Used as the starting target. With **Auto Quality** on, the host lowers the bitrate under packet loss and recovers it afterwards, live where the session supports it and otherwise at the next launch; the strip on the Audio/Video page shows the live value. |
+| Video codec | H.264, HEVC, and AV1 are offered when the host encoder supports them and the matching option is on under **Encoder Profiles**. Let Moonlight choose automatically unless a device decodes one codec badly. |
+| HDR | Needs a Main10-capable codec on both sides and the host side set up as described in [Linux HDR and Main10](configuration.md#linux-hdr-and-main10). SDR handhelds should leave it off. |
+| Audio configuration | Stereo, 5.1, and 7.1 are all served. The host captures the sink chosen under **Settings, Audio/Video, Host audio capture**; leave it empty to let Polaris pick a virtual sink that matches the client's channel count. |
+| Controller | Moonlight sends controller input; the host emulates a gamepad for the game (see **Settings, Input**). Controllers plugged into the host are hidden from private streams by default so the emulated pad is the only one the game sees. |
+
+Start with Moonlight's defaults, stream once, then open **Mission Control** on the host: the live
+strip shows latency, frame rate, loss, and bitrate, and Doctor names the limiting factor if there
+is one. Change one Moonlight setting at a time and watch that strip.
+
+## 6. When it does not look right
+
+- Open **Doctor & Support** on the host while the stream is still running. Doctor separates
+  network, host, and client evidence and offers the safest fix; the details are in
+  [Fix a bad stream with Doctor](doctor.md).
+- Permission denied when starting a stream means the device has **Browse & Watch** access; see
+  [the troubleshooting entry](troubleshooting.md#paired-client-gets-permission-denied-403-when-starting-a-stream).
+- No controller in the game, a game on the wrong screen, a black Steam Big Picture, or missing
+  audio each have an entry in [Troubleshooting](troubleshooting.md).
+
+## Ports
+
+Polaris listens on a block of ports derived from its base port (47989 by default). The web UI
+lists the live map under **Settings, Network**.
+
+| Port | Protocol | Purpose |
+|---|---|---|
+| 47984 | TCP | HTTPS pairing and control |
+| 47989 | TCP | HTTP discovery and launch |
+| 47990 | TCP | Web UI |
+| 48010 | TCP | RTSP session setup |
+| 47998 to 48000 | UDP | Video, control, and audio |
+
+Across networks, forward those ports to the host or let **UPnP** under **Settings, Network** do
+it, and set the encryption mode for WAN sessions on the same page. The web UI itself stays
+reachable only from the host or the local network unless **Web UI origin** on that page allows
+more.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -103,6 +103,10 @@ leave its displayed four-digit PIN open. In the Polaris web UI, open **Devices â
 that PIN, keep **Game Control** selected, and choose **Send**. Return to Moonlight and refresh the
 host if its library does not appear immediately. Steam is not required on the client.
 
+The Moonlight flow step by step, including which client settings matter, is in
+[Play with Moonlight](moonlight.md). The access presets and the device editor are in
+[Pair and manage devices](devices.md).
+
 ## 5. Start a game and verify the path
 
 Launch from the Polaris library, Nova, or a Moonlight client, then watch the live session dashboard

--- a/src_assets/common/assets/web/configs/tabs/Advanced.vue
+++ b/src_assets/common/assets/web/configs/tabs/Advanced.vue
@@ -14,7 +14,7 @@ const config = ref(props.config)
 <template>
   <div class="config-page">
     <p class="-mt-3 text-right text-xs text-storm" data-tab-docs-link>
-      <a href="https://papi-ux.com/docs/configuration/#common-options" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('config.advanced_docs_link') }}</a>
+      <a href="https://papi-ux.com/docs/configuration/#advanced-tab" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('config.advanced_docs_link') }}</a>
     </p>
     <section class="settings-section">
       <div class="settings-section-header">

--- a/src_assets/common/assets/web/configs/tabs/General.vue
+++ b/src_assets/common/assets/web/configs/tabs/General.vue
@@ -68,7 +68,7 @@ function handleSteamGridDbKeyInput() {
 <template>
   <div id="general" class="config-page space-y-4">
     <p class="-mt-3 text-right text-xs text-storm" data-tab-docs-link>
-      <a href="https://papi-ux.com/docs/configuration/#common-options" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('config.general_docs_link') }}</a>
+      <a href="https://papi-ux.com/docs/configuration/#general-tab" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('config.general_docs_link') }}</a>
     </p>
     <section class="settings-section">
       <div class="settings-section-header">

--- a/src_assets/common/assets/web/configs/tabs/Inputs.vue
+++ b/src_assets/common/assets/web/configs/tabs/Inputs.vue
@@ -15,7 +15,7 @@ const config = ref(props.config)
 <template>
   <div id="input" class="config-page">
     <p class="-mt-3 text-right text-xs text-storm" data-tab-docs-link>
-      <a href="https://papi-ux.com/docs/troubleshooting/#input-does-not-work" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('config.inputs_docs_link') }}</a>
+      <a href="https://papi-ux.com/docs/configuration/#input-tab" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('config.inputs_docs_link') }}</a>
     </p>
     <section class="settings-section">
       <div class="settings-section-header">

--- a/src_assets/common/assets/web/configs/tabs/Network.vue
+++ b/src_assets/common/assets/web/configs/tabs/Network.vue
@@ -17,7 +17,7 @@ const effectivePort = computed(() => Number(config.value?.port) || defaultMoonli
 <template>
   <div id="network" class="config-page">
     <p class="-mt-3 text-right text-xs text-storm" data-tab-docs-link>
-      <a href="https://papi-ux.com/docs/configuration/#common-options" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('config.network_docs_link') }}</a>
+      <a href="https://papi-ux.com/docs/configuration/#network-tab" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('config.network_docs_link') }}</a>
     </p>
     <section class="settings-section">
       <div class="settings-section-header">

--- a/src_assets/common/assets/web/settings-surfaces-affordances.test.js
+++ b/src_assets/common/assets/web/settings-surfaces-affordances.test.js
@@ -31,7 +31,9 @@ describe('settings surfaces affordances', () => {
   })
 
   it('points each surface at its guide', () => {
-    expect(webSource('views/PinView.vue')).toContain('href="https://papi-ux.com/docs/quickstart/#4-pair-a-client"')
+    expect(webSource('views/PinView.vue')).toContain('href="https://papi-ux.com/docs/devices/"')
+    expect(readFileSync(join(process.cwd(), 'docs/devices.md'), 'utf8')).toContain('# Pair and manage devices')
+    expect(readFileSync(join(process.cwd(), 'docs/moonlight.md'), 'utf8')).toContain('# Play with Moonlight')
     expect(webSource('views/PinView.vue')).toContain('href="https://papi-ux.com/docs/troubleshooting/#paired-client-gets-permission-denied-403-when-starting-a-stream"')
     expect(webSource('views/HomeView.vue')).toContain('href="https://papi-ux.com/docs/repositories/#after-install-or-upgrade"')
     expect(webSource('views/PasswordView.vue')).toContain('href="https://papi-ux.com/docs/configuration/#credential-reset"')

--- a/src_assets/common/assets/web/settings-tabs-affordances.test.js
+++ b/src_assets/common/assets/web/settings-tabs-affordances.test.js
@@ -13,10 +13,10 @@ const templateOf = (source) => {
 }
 
 const tabs = {
-  'configs/tabs/General.vue': 'https://papi-ux.com/docs/configuration/#common-options',
-  'configs/tabs/Inputs.vue': 'https://papi-ux.com/docs/troubleshooting/#input-does-not-work',
-  'configs/tabs/Network.vue': 'https://papi-ux.com/docs/configuration/#common-options',
-  'configs/tabs/Advanced.vue': 'https://papi-ux.com/docs/configuration/#common-options',
+  'configs/tabs/General.vue': 'https://papi-ux.com/docs/configuration/#general-tab',
+  'configs/tabs/Inputs.vue': 'https://papi-ux.com/docs/configuration/#input-tab',
+  'configs/tabs/Network.vue': 'https://papi-ux.com/docs/configuration/#network-tab',
+  'configs/tabs/Advanced.vue': 'https://papi-ux.com/docs/configuration/#advanced-tab',
   'configs/tabs/Files.vue': 'https://papi-ux.com/docs/configuration/#files',
   'configs/tabs/AiOptimizer.vue': 'https://papi-ux.com/docs/configuration/#ai-provider-settings',
 }
@@ -45,6 +45,9 @@ describe('settings tabs affordances', () => {
     const configuration = readFileSync(join(process.cwd(), 'docs/configuration.md'), 'utf8')
     const troubleshooting = readFileSync(join(process.cwd(), 'docs/troubleshooting.md'), 'utf8')
     expect(configuration).toContain('## Common options')
+    for (const tab of ['General', 'Input', 'Network', 'Advanced']) {
+      expect(configuration).toContain(`### ${tab} tab`)
+    }
     expect(configuration).toContain('## Files')
     expect(configuration).toContain('## AI provider settings')
     expect(troubleshooting).toContain('## Input does not work')

--- a/src_assets/common/assets/web/views/PinView.vue
+++ b/src_assets/common/assets/web/views/PinView.vue
@@ -6,7 +6,7 @@
         <h1 class="page-title">{{ $t('pin.page_title') }}</h1>
         <p class="page-subtitle">
           {{ $t('pin.page_subtitle') }}
-          <a href="https://papi-ux.com/docs/quickstart/#4-pair-a-client" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('pin.pairing_docs_link') }}</a>
+          <a href="https://papi-ux.com/docs/devices/" target="_blank" rel="noopener" class="focus-ring text-ice hover:underline">{{ $t('pin.pairing_docs_link') }}</a>
         </p>
         <div class="page-meta">
           <span class="meta-pill">{{ $t('pin.saved_count', { count: pairedCount }) }}</span>

--- a/tests/unit/test_doctor_reset_contract.cpp
+++ b/tests/unit/test_doctor_reset_contract.cpp
@@ -1105,11 +1105,17 @@ TEST(DoctorResetContract, LegacyAiSurfacesAreExplanationOnly) {
   EXPECT_EQ(doctor_explanation.find("body.value(\"provider\""), std::string::npos);
   EXPECT_EQ(doctor_explanation.find("ai_cfg.api_key"), std::string::npos);
 
+  // The AI tab copy moved into the locale file too: the banned phrase is
+  // checked in both places, and the "AI explanations" switch is pinned by its
+  // locale key in the source and its English text in the locale.
   const auto ui = source("src_assets/common/assets/web/configs/tabs/AiOptimizer.vue");
+  const auto ui_locale = source("src_assets/common/assets/web/public/assets/locale/en.json");
   EXPECT_EQ(ui.find("AI Auto Quality"), std::string::npos);
+  EXPECT_EQ(ui_locale.find("AI Auto Quality"), std::string::npos);
   EXPECT_EQ(ui.find("testResult.payload.display_mode"), std::string::npos);
   EXPECT_EQ(ui.find("testResult.payload.target_bitrate_kbps"), std::string::npos);
-  EXPECT_NE(ui.find("AI explanations"), std::string::npos);
+  EXPECT_NE(ui.find("config.ai_explanations"), std::string::npos);
+  EXPECT_NE(ui_locale.find("\"ai_explanations\": \"AI explanations\""), std::string::npos);
 
   // The Video/Audio page copy moved into the locale file, so the banned
   // legacy phrase is checked in both places and the required adaptive


### PR DESCRIPTION
## Summary

The console now sends readers into the docs at exactly the places where its own long explanations used to be, so the docs have to carry that depth. This PR adds the two guides that were missing and gives the configuration reference per-tab anchors.

- **Play with Moonlight** (new page): a standard Moonlight client from install through PIN pairing to a tuned stream. It covers adding the host, the three pairing routes, what decides which display a game lands on, the resume window, the table of Moonlight-side settings and what Polaris does with each (resolution and frame rate as the ceiling, bitrate as the Auto Quality starting point, codec and HDR needing the matching encoder profile, audio channel matching, controller emulation), the port map, and where to look when a stream misbehaves.
- **Pair and manage devices** (new page): the three pairing routes, the four access presets with what each can and cannot do and the permissions behind them, the saved-devices list and its actions, the device editor (host view, identity and access, display profile, AI Suggest, client commands), and stale profile aliases.
- **Configuration**: a new "Settings by tab" section with one subsection per tab (General, Input, Network, Audio and video, Advanced, Files, AI and Encoder Profiles), each naming what the tab controls in plain language and the keys it writes. The General, Input, Network, and Advanced tabs now link to their own anchors instead of all landing on the key table.
- **FAQ**: which Moonlight settings matter, whether Moonlight can choose the launch mode, and why a client can see the library but not launch.
- **Quick start**: the pairing step links to both guides.
- **Devices page**: its guide pointer now targets the new Devices guide. The two affordance guards pin the retargeted anchors and the presence of both guides.

Every fact in the guides comes from the shipped UI and locale (ports from the Network tab's port map, presets and editor fields from the Devices page, option behaviour from the option descriptions). No backend changes.

**Also in this PR, because this is the first PR to run the C++ jobs since #587:** `DoctorResetContract.LegacyAiSurfacesAreExplanationOnly` pinned the literal text "AI explanations" in the AI tab source, which #587 moved into the locale. The C++ jobs skip on web-only pull requests, so master has carried that red test since then. The second commit pins the switch by its locale key in the source and its English text in the locale, and checks the banned legacy phrase in the locale too, the same way the test already handles the Video/Audio page.

## Exact candidate

Branch `docs/player-guides`, two commits on top of master 6b9cc75e. The squash of this PR is the candidate. Docs, four tab pointer hrefs, one Devices pointer href, two guard tests, and the contract test re-pin.

## Verification

- Every relative link in the changed docs resolves to a file, and every anchor the guides and the tabs point at exists as a heading.
- `scripts/check-public-docs.sh` (the `public-hygiene` check): passes.
- `npm test` and `npm run build` on pc-papi: green.
- `test_polaris --gtest_filter=DoctorResetContract.*` on pc-papi after the re-pin: all pass, including the one that was red on master.
- After merge: the site's Polaris pin gets bumped and the two new pages added to the "Play and tune" sidebar group, the same way the earlier docs pin bumps went.
