### PR TITLE
ci: resolve the build source to a published commit on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,16 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  POLARIS_CHECKOUT_REF: ${{ inputs.release_tag || github.ref }}
+  # On a pull request github.ref is refs/pull/<n>/merge, and that merge commit
+  # is published nowhere: it is advertised only in GitHub's pull request refs,
+  # so a clone of this repository cannot resolve it and the SteamOS package
+  # build, which sources from such a clone, dies reading its tree. Resolve the
+  # head branch instead, which is a published commit. Master requires branches
+  # to be up to date before merging, so the head already carries master.
+  POLARIS_CHECKOUT_REF: ${{ inputs.release_tag
+    || (github.event.pull_request.head.repo.full_name == github.repository
+    && format('refs/heads/{0}', github.head_ref))
+    || github.ref }}
   POLARIS_PACKAGE_REF_NAME: ${{ inputs.release_tag || github.ref_name }}
   # Advance deliberately only after the full matrix proves a newer snapshot.
   UBUNTU_APT_SNAPSHOT: 20260901T000000Z
@@ -785,7 +794,14 @@ jobs:
   steamos-build:
     name: SteamOS 3.8 build
     needs: [resolve-source, web-checks, cpp-sanitizer-tests, arch-build]
-    if: needs.resolve-source.outputs.native_required == 'true'
+    # The package is built from a clone of the published repository, so the
+    # commit under test has to be published here. A pull request opened from a
+    # fork has no commit on a branch of this repository, and CI never packages
+    # an unpublished tree, so the job cannot speak for a fork.
+    if: >-
+      needs.resolve-source.outputs.native_required == 'true'
+      && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
 
     steps:

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -726,6 +726,17 @@ describe('Linux packaging contracts', () => {
 
     expect(steamOs).toContain('git fetch --no-tags --force origin "$POLARIS_CHECKOUT_REF"')
     expect(steamOs).toContain("git rev-parse 'FETCH_HEAD^{commit}'")
+    expect(steamOs).toContain('test "$(git rev-parse HEAD)" = "$POLARIS_BUILD_COMMIT"')
+    // A fork's head commit is published nowhere in this repository, and CI never
+    // packages an unpublished tree, so the job must not claim to speak for one.
+    expect(steamOs).toContain(
+      'github.event.pull_request.head.repo.full_name == github.repository',
+    )
+    // Every package must come from a published commit. On a pull request that is
+    // the head branch, never GitHub's merge commit, which no clone can resolve.
+    expect(workflow).toContain(
+      "format('refs/heads/{0}', github.head_ref)",
+    )
     expect(steamOs).toContain('--env "POLARIS_BUILD_COMMIT=$POLARIS_BUILD_COMMIT"')
     expect(bootstrap).toContain('${POLARIS_BUILD_COMMIT:?POLARIS_BUILD_COMMIT is required}')
     expect(bootstrap).not.toMatch(/(?:^|\n)POLARIS_BUILD_COMMIT=/)


### PR DESCRIPTION
## Summary

`SteamOS 3.8 build` has failed on every pull request for weeks while passing on
every push to master, always with the same message, never with anything that
looked like a real error:

```
  -> Creating working copy of polaris git repo...
fatal: unable to read tree (9dc7168134a16bbdd4b2c01ed342c2d6bc11d759)
```

That object is not corrupt and it is not a tree. It is the synthetic merge
commit GitHub builds for a pull request. `git ls-remote` proves the point:

```
$ git ls-remote <repo> | grep 9dc7168134a16bbdd4b2c01ed342c2d6bc11d759
   (nothing: no clone can ever see it)
$ git ls-remote <repo> | grep 7761c6a7          # an open pull request head
7761c6a7...  refs/heads/docs/console-hints-to-docs
7761c6a7...  refs/pull/589/head
```

The SteamOS job is the only one that does not build purely from its own
checkout. Its PKGBUILD sources from a clone of this repository:

```
source=("$pkgname::git+@GITHUB_CLONE_URL@#commit=${_commit}")
```

A clone fetches `refs/heads` and `refs/tags`. The merge commit is in neither, so
makepkg aborts. On a push the commit is an ordinary branch commit and the job
passes.

`POLARIS_CHECKOUT_REF` now resolves to the pull request's head branch instead of
the merge ref. The head is a published commit every clone can find. Because
master requires branches to be up to date before merging, the head already
carries master, so the merge commit was buying no coverage that the head does
not already give.

A pull request from a fork has no commit on a branch of this repository, so the
job is skipped there rather than failing in a way it cannot fix.

## What this deliberately does not do

Two earlier attempts were wrong, and the repository's own guards caught both:

- Building pull requests from the mounted checkout, which is what the Arch job
  does, is forbidden by the packaging contract: unpublished candidate sourcing
  is local-only and must be absent from CI.
- Pointing the SteamOS checkout at the head commit directly is forbidden by the
  release package guard: all six packaging jobs must check out the immutable
  `resolve-source` output and nothing else.

Both rules survive here untouched. `resolve-source` stays the single authority,
the SteamOS job body is byte for byte what it was, and the only behavioural
change is which published ref the whole workflow resolves.

## Exact candidate

Branch `ci/steamos-pr-source`, one commit on master `838e8318`. One `env` entry
in `.github/workflows/build.yml`, one `if` on the SteamOS job, and the contract
pins for both rules.

## Verification

- `python3 scripts/check-release-package-dependencies.py` passes, which is the
  guard that rejected the second attempt.
- 662 web tests across 83 files pass, including `packaging-contracts.test.js`,
  which is the guard that rejected the first attempt. It now pins the published
  source ref and the fork exclusion, so neither wrong approach can come back.
- The mechanism was confirmed against the live remote with `git ls-remote`, as
  quoted above: the merge commit is advertised on no ref a clone fetches, and an
  open pull request head is advertised as a real branch.
- This pull request edits a non-web path, so it is classified as a native build
  and runs the SteamOS job itself. That run is the end-to-end proof.

Closes #590
