### PR TITLE
fix(input): say so when keyboard and mouse seat isolation does not apply

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,14 @@ membership only applies to new sessions. On ostree hosts such as Bazzite the gro
 in `/usr/lib/group` and `usermod` cannot see it, so use `ujust add-user-to-input-group`
 instead. The startup warning prints whichever command applies.
 
+`client_keyboard_mouse_seat_isolation` marks the virtual keyboard, mouse, touch and pen the same
+way, but it has only the phys marker to work with: unlike gamepads, those devices keep their normal
+names so a compositor configured to ignore them by name keeps working. The marker has to survive
+into the kernel to matter, and a uinput backend that accepts the field without writing it leaves the
+devices on seat0 while the setting still reads back as enabled. Polaris inspects the devices it
+creates and logs a warning naming `client_keyboard_mouse_seat_isolation` when the marker never
+arrived, so check for that line, or run the command below, before relying on the boundary.
+
 #### Verifying that isolation is applied
 
 Check the device, not the seat list:
@@ -114,7 +122,7 @@ udevadm info -q property -n /dev/input/eventN | grep ID_SEAT
 
 `ID_SEAT=seat-polaris` means the rules applied and the device is isolated.
 
-`loginctl list-seats` will keep showing only `seat0`, and that is expected — it is not a sign that
+`loginctl list-seats` will keep showing only `seat0`, and that is expected. It is not a sign that
 isolation failed. logind only materializes a seat that owns a device tagged `master-of-seat`, which
 in practice means a graphics device. `seat-polaris` exists purely as a udev property that keeps
 logind from handing the device to the seat0 session, so it never becomes a seat logind lists.

--- a/src/platform/linux/input/input_seat_isolation.h
+++ b/src/platform/linux/input/input_seat_isolation.h
@@ -16,8 +16,14 @@
  */
 #pragma once
 
+#include <cctype>
+#include <fstream>
+#include <functional>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 namespace platf::input_isolation {
 
@@ -36,6 +42,130 @@ namespace platf::input_isolation {
     }
 
     return std::string {seat_isolated_phys_prefix} + std::string {device};
+  }
+
+  /**
+   * @brief Whether a kernel-reported phys value carries the isolation marker.
+   *
+   * The udev rules match on this prefix, so a device whose phys does not start
+   * with it will never be moved off seat0 no matter what was requested.
+   */
+  inline bool phys_carries_isolation_marker(std::string_view phys) {
+    return phys.rfind(seat_isolated_phys_prefix, 0) == 0;
+  }
+
+  /**
+   * @brief Sysfs path holding the kernel-visible phys attribute for an event node.
+   * @param node_path Device node, either `/dev/input/eventN` or a bare `eventN`.
+   * @return The sysfs path, or an empty string when the node is not an event node.
+   *
+   * Anything that is not a plain `eventN` name is rejected rather than joined,
+   * so a surprising node name cannot walk out of the sysfs tree.
+   */
+  inline std::string sysfs_phys_path_for_node(std::string_view node_path, std::string_view sysfs_root = "/sys/class/input") {
+    const auto slash = node_path.find_last_of('/');
+    const auto name = slash == std::string_view::npos ? node_path : node_path.substr(slash + 1);
+    constexpr std::string_view event_prefix = "event";
+    if (name.rfind(event_prefix, 0) != 0 || name.size() <= event_prefix.size()) {
+      return {};
+    }
+
+    for (const char digit : name.substr(event_prefix.size())) {
+      if (!std::isdigit(static_cast<unsigned char>(digit))) {
+        return {};
+      }
+    }
+
+    return std::string {sysfs_root} + "/" + std::string {name} + "/device/phys";
+  }
+
+  /// What the kernel actually did with a seat isolation request.
+  struct isolation_status_t {
+    bool requested = false;  ///< The operator asked for isolation.
+    bool effective = false;  ///< Every inspected device carries the marker.
+    std::vector<std::string> unmarked_nodes;  ///< Nodes the kernel reports without it.
+  };
+
+  /**
+   * @brief Decide whether a seat isolation request took effect.
+   * @param requested Whether the setting is enabled.
+   * @param phys_by_node Each device node paired with the phys the kernel reports.
+   *
+   * Pure so the decision can be tested without a filesystem. A request with no
+   * devices to inspect is not called effective: nothing has proven it works.
+   */
+  inline isolation_status_t evaluate_isolation(bool requested, const std::vector<std::pair<std::string, std::string>> &phys_by_node) {
+    isolation_status_t status;
+    status.requested = requested;
+    if (!requested) {
+      return status;
+    }
+
+    for (const auto &[node, phys] : phys_by_node) {
+      if (!phys_carries_isolation_marker(phys)) {
+        status.unmarked_nodes.push_back(node);
+      }
+    }
+
+    status.effective = !phys_by_node.empty() && status.unmarked_nodes.empty();
+    return status;
+  }
+
+  /// Reads a device's phys attribute. Returns nullopt when sysfs has nothing to say.
+  using phys_reader_t = std::function<std::optional<std::string>(std::string_view)>;
+
+  /// Default reader: the first line of the device's sysfs phys attribute.
+  inline std::optional<std::string> read_device_phys(std::string_view node_path) {
+    const auto path = sysfs_phys_path_for_node(node_path);
+    if (path.empty()) {
+      return std::nullopt;
+    }
+
+    std::ifstream file {path};
+    if (!file) {
+      return std::nullopt;
+    }
+
+    std::string phys;
+    std::getline(file, phys);
+    while (!phys.empty() && (phys.back() == '\n' || phys.back() == '\r' || phys.back() == ' ')) {
+      phys.pop_back();
+    }
+    return phys;
+  }
+
+  /**
+   * @brief Inspect live device nodes and report whether isolation took effect.
+   *
+   * A node sysfs cannot answer for is treated as unmarked, because an unproven
+   * boundary is not a boundary.
+   */
+  inline isolation_status_t inspect_devices(bool requested, const std::vector<std::string> &nodes, const phys_reader_t &reader = read_device_phys) {
+    std::vector<std::pair<std::string, std::string>> phys_by_node;
+    phys_by_node.reserve(nodes.size());
+    for (const auto &node : nodes) {
+      phys_by_node.emplace_back(node, reader(node).value_or(std::string {}));
+    }
+
+    return evaluate_isolation(requested, phys_by_node);
+  }
+
+  /**
+   * @brief One-line explanation for an isolation request that did not take.
+   * @return Empty when isolation is off, or when it is on and working.
+   *
+   * Polaris fills in device_phys on every virtual keyboard, mouse, touch and pen
+   * it creates, but a uinput backend that drops the field leaves the devices on
+   * seat0 with nothing in the logs to say so. This is that missing sentence.
+   */
+  inline std::string isolation_warning(const isolation_status_t &status, std::string_view device_label) {
+    if (!status.requested || status.effective) {
+      return {};
+    }
+
+    return "client_keyboard_mouse_seat_isolation is enabled, but the virtual " + std::string {device_label} +
+           " reports no isolation marker to the kernel, so logind still hands it to the desktop session at seat0. "
+           "The setting is saved and has no effect on this host.";
   }
 
 }  // namespace platf::input_isolation

--- a/src/platform/linux/input/inputtino_common.h
+++ b/src/platform/linux/input/inputtino_common.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <mutex>
+
 // standard includes
 #include <optional>
 
@@ -34,6 +36,31 @@ namespace platf {
     gamepad_feedback_msg_t last_rgb_led;
   };
 
+  /**
+   * @brief Log once when a seat isolation request did not reach the kernel.
+   *
+   * Creating the device is not the same as isolating it. The uinput backend can
+   * accept device_phys and never write it, which leaves the operator with a
+   * setting that saves, reads back as enabled, and does nothing.
+   */
+  template<class Device>
+  void warn_if_seat_isolation_inert(const inputtino::Result<Device> &device, std::string_view label) {
+    if (!config::input.client_keyboard_mouse_seat_isolation || !device) {
+      return;
+    }
+
+    const auto status = input_isolation::inspect_devices(true, (*device).get_nodes());
+    const auto warning_text = input_isolation::isolation_warning(status, label);
+    if (warning_text.empty()) {
+      return;
+    }
+
+    static std::once_flag reported;
+    std::call_once(reported, [&warning_text]() {
+      BOOST_LOG(warning) << warning_text;
+    });
+  }
+
   struct input_raw_t {
     input_raw_t():
         gamepads(MAX_GAMEPADS) {
@@ -56,6 +83,7 @@ namespace platf {
         if (!*mouse) {
           BOOST_LOG(warning) << "Unable to create virtual mouse: " << mouse->getErrorMessage();
         }
+        warn_if_seat_isolation_inert(*mouse, "mouse");
       }
       return &*mouse;
     }
@@ -75,6 +103,7 @@ namespace platf {
         if (!*keyboard) {
           BOOST_LOG(warning) << "Unable to create virtual keyboard: " << keyboard->getErrorMessage();
         }
+        warn_if_seat_isolation_inert(*keyboard, "keyboard");
       }
       return &*keyboard;
     }
@@ -118,9 +147,11 @@ namespace platf {
       if (!touch) {
         BOOST_LOG(warning) << "Unable to create virtual touch screen: " << touch.getErrorMessage();
       }
+      warn_if_seat_isolation_inert(touch, "touch screen");
       if (!pen) {
         BOOST_LOG(warning) << "Unable to create virtual pen tablet: " << pen.getErrorMessage();
       }
+      warn_if_seat_isolation_inert(pen, "pen tablet");
     }
 
     input_raw_t *global;

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -509,7 +509,7 @@
     "headless_gamepad_isolation_desc": "Keeps controllers plugged into the host out of Private Stream sessions.",
     "client_gamepad_seat_isolation": "Isolate Client Gamepads from Other Linux Users",
     "client_keyboard_mouse_seat_isolation": "Isolate Client Keyboard and Mouse from the Host Session",
-    "client_keyboard_mouse_seat_isolation_desc": "Puts the client's virtual keyboard and mouse on their own Linux seat so they do not also drive the host desktop.",
+    "client_keyboard_mouse_seat_isolation_desc": "Puts the client's virtual keyboard and mouse on their own Linux seat so they do not also drive the host desktop, where the input backend supports it.",
     "client_gamepad_seat_isolation_desc": "Puts client gamepads on their own Linux seat so the local desktop user does not get automatic access.",
     "global_prep_cmd": "Command Preparations",
     "global_prep_cmd_desc": "Configure a list of commands to be executed before or after running any application. If any of the specified preparation commands fail, the application launch process will be aborted.",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -187,6 +187,7 @@ set(TEST_PLATFORM_SOURCES
 
 if (NOT WIN32 AND NOT APPLE)
     list(APPEND TEST_PLATFORM_SOURCES
+        ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_input_seat_isolation.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamepad_isolation.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_input_group_access.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_wayland_virtual_input.cpp

--- a/tests/unit/platform/test_input_seat_isolation.cpp
+++ b/tests/unit/platform/test_input_seat_isolation.cpp
@@ -1,0 +1,107 @@
+/**
+ * @file tests/unit/platform/test_input_seat_isolation.cpp
+ * @brief Seat isolation is only real when the kernel agrees it happened.
+ */
+#include "../../tests_common.h"
+
+#ifdef __linux__
+
+  #include "src/platform/linux/input/input_seat_isolation.h"
+
+  #include <optional>
+  #include <string>
+  #include <string_view>
+  #include <vector>
+
+namespace {
+
+  using namespace platf::input_isolation;
+
+  TEST(InputSeatIsolationMarker, BuildsTheMarkerOnlyWhenIsolationIsEnabled) {
+    EXPECT_EQ(client_input_phys_marker(true, "keyboard"), "polaris/client-input-seat-isolated/keyboard");
+    EXPECT_TRUE(client_input_phys_marker(false, "keyboard").empty());
+  }
+
+  TEST(InputSeatIsolationMarker, RecognisesOnlyTheMarkerTheUdevRulesMatch) {
+    EXPECT_TRUE(phys_carries_isolation_marker("polaris/client-input-seat-isolated/mouse"));
+    EXPECT_FALSE(phys_carries_isolation_marker("polaris/client-gamepad-seat-isolated/xbox"));
+    EXPECT_FALSE(phys_carries_isolation_marker(""));
+    EXPECT_FALSE(phys_carries_isolation_marker("usb-0000:00:14.0-3/input0"));
+  }
+
+  TEST(InputSeatIsolationSysfs, DerivesThePhysPathFromAnEventNode) {
+    EXPECT_EQ(sysfs_phys_path_for_node("/dev/input/event7"), "/sys/class/input/event7/device/phys");
+    EXPECT_EQ(sysfs_phys_path_for_node("event12"), "/sys/class/input/event12/device/phys");
+  }
+
+  TEST(InputSeatIsolationSysfs, RefusesAnythingThatIsNotAnEventNode) {
+    // A surprising node name must be rejected rather than joined onto the sysfs
+    // root, so nothing can walk out of the tree.
+    EXPECT_TRUE(sysfs_phys_path_for_node("/dev/input/mouse0").empty());
+    EXPECT_TRUE(sysfs_phys_path_for_node("/dev/input/event").empty());
+    EXPECT_TRUE(sysfs_phys_path_for_node("../../etc/shadow").empty());
+    EXPECT_TRUE(sysfs_phys_path_for_node("event7/../../..").empty());
+    EXPECT_TRUE(sysfs_phys_path_for_node("").empty());
+  }
+
+  TEST(InputSeatIsolationEvaluation, StaysQuietWhenIsolationWasNeverRequested) {
+    const auto status = evaluate_isolation(false, {{"event7", ""}});
+    EXPECT_FALSE(status.requested);
+    EXPECT_FALSE(status.effective);
+    EXPECT_TRUE(isolation_warning(status, "mouse").empty());
+  }
+
+  TEST(InputSeatIsolationEvaluation, IsEffectiveOnlyWhenEveryDeviceCarriesTheMarker) {
+    const auto all_marked = evaluate_isolation(true, {
+      {"event7", "polaris/client-input-seat-isolated/mouse"},
+      {"event8", "polaris/client-input-seat-isolated/mouse"},
+    });
+    EXPECT_TRUE(all_marked.effective);
+    EXPECT_TRUE(all_marked.unmarked_nodes.empty());
+    EXPECT_TRUE(isolation_warning(all_marked, "mouse").empty());
+
+    const auto one_missing = evaluate_isolation(true, {
+      {"event7", "polaris/client-input-seat-isolated/mouse"},
+      {"event8", ""},
+    });
+    EXPECT_FALSE(one_missing.effective);
+    EXPECT_EQ(one_missing.unmarked_nodes, std::vector<std::string> {"event8"});
+  }
+
+  TEST(InputSeatIsolationEvaluation, DoesNotCallAnUnprovenRequestEffective) {
+    // No devices means nothing demonstrated the boundary exists.
+    const auto status = evaluate_isolation(true, {});
+    EXPECT_TRUE(status.requested);
+    EXPECT_FALSE(status.effective);
+  }
+
+  TEST(InputSeatIsolationEvaluation, WarnsThatTheSavedSettingDoesNothing) {
+    const auto status = evaluate_isolation(true, {{"event7", ""}});
+    const auto warning = isolation_warning(status, "keyboard");
+    ASSERT_FALSE(warning.empty());
+    EXPECT_NE(warning.find("client_keyboard_mouse_seat_isolation"), std::string::npos);
+    EXPECT_NE(warning.find("keyboard"), std::string::npos);
+    EXPECT_NE(warning.find("no effect on this host"), std::string::npos);
+  }
+
+  TEST(InputSeatIsolationInspection, TreatsAnUnreadableDeviceAsUnisolated) {
+    // sysfs having nothing to say is not proof of isolation.
+    const phys_reader_t silent = [](std::string_view) {
+      return std::nullopt;
+    };
+    const auto status = inspect_devices(true, {"event7"}, silent);
+    EXPECT_FALSE(status.effective);
+    EXPECT_EQ(status.unmarked_nodes, std::vector<std::string> {"event7"});
+  }
+
+  TEST(InputSeatIsolationInspection, ReadsEachNodeThroughTheInjectedReader) {
+    const phys_reader_t marked = [](std::string_view node) -> std::optional<std::string> {
+      return std::string {client_input_phys_marker(true, "mouse")} + std::string {node.empty() ? "" : ""};
+    };
+    const auto status = inspect_devices(true, {"event7", "event8"}, marked);
+    EXPECT_TRUE(status.effective);
+  }
+
+}  // namespace
+
+#endif  // __linux__


### PR DESCRIPTION
## Summary

Enabling **Isolate Client Keyboard and Mouse from the Host Session** saves, reads
back as enabled, and on many hosts does nothing. A client keeps typing into the
desktop session logged in at the machine, which is exactly what the setting says
it prevents.

Polaris does its half correctly. It fills in `device_phys` on the virtual
keyboard, mouse, touch and pen, and `60-polaris.rules` matches that marker to move
the devices to `seat-polaris`. The half that fails is underneath: a uinput backend
that accepts `device_phys` and never writes it leaves every one of those devices
on seat0, and the udev rule has nothing to match. Client gamepads escape this only
because they also carry Polaris-specific device names, which is a workaround the
keyboard and mouse path never received. The configuration guide already says as
much about gamepads.

Nothing reported the gap. Not the console, not the log, not Doctor.

This does not invent a boundary that is not there. It makes Polaris check whether
the one it asked for exists, and say so when it does not:

- After creating each virtual device with isolation enabled, Polaris reads back
  the kernel's `phys` attribute and logs one warning naming
  `client_keyboard_mouse_seat_isolation` when the marker never arrived.
- A device whose sysfs cannot be read counts as unisolated, and a request with no
  devices to inspect is not called effective. An unproven boundary is not a
  boundary.
- The console description now says the setting depends on host support, and the
  configuration guide explains why the keyboard and mouse path differs from
  gamepads and how to verify it.

The real fix is upstream, in the pull request that teaches the uinput backend to
honour physical paths. When that lands and the submodule moves, this code stops
warning on its own, with no further change.

## Exact candidate

Branch `fix/seat-isolation-truth`, one commit on master `c957d404`. Header-only
detection, so no build lists move except the new test registration.

## Verification

- 10 new tests in `test_polaris_platform`, all passing. They cover marker
  recognition, sysfs path derivation, the rejection of any node name that is not
  a plain `eventN` so nothing can walk out of the sysfs tree, the unreadable
  device case, the empty request case, and the warning text naming the setting.
- The decision is a pure function over the phys each node reports, and the reader
  is injected, so none of it touches a filesystem.
- Full platform suite 246 passing, `DoctorResetContract` 35 passing, web suite 670
  across 83 files, lint clean, and the Polaris binary builds.
- `~/.config/polaris` was checked before and after every test run and is unchanged,
  since this suite has deleted real host state before.

Refs #494.
