### PR TITLE
feat(library): carry the platform and runtime of imported Heroic titles

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -36,6 +36,7 @@ Saving writes the launcher profile immediately; there is no separate apply step.
 | **Application Name** | The name shown on Moonlight and Nova. |
 | **Image** | The icon, picture, or box image sent to clients. PNG only; when unset, Polaris sends its default box image. |
 | **Game Category** | A classification hint for Auto Quality, detected from Steam genres on import. |
+| **Platform and runtime** | Filled in for titles imported from Heroic. Says what the title installs as and what will execute it, such as Windows through Proton-GE. Left blank when Heroic did not record it. |
 | **Emulated Gamepad Type** | Which gamepad to emulate for this app, overriding the Input tab's default. |
 | **MangoHud Overlay** | Shows GPU, CPU, temperature, and frametime in the stream from the host side. |
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3021,14 +3021,17 @@ namespace confighttp {
         game["runtime_name"] = entry.runtime_name;
       }
     };
-    // The wine or proton choice lives per game under the Heroic config root, two
-    // levels above the library file the entries were parsed from.
+    // The wine or proton choice lives per game under the Heroic config root, and
+    // the library files sit at different depths beneath it: store_cache is one
+    // level down, legendaryConfig/legendary is two. Walk up to the directory that
+    // actually holds GamesConfig rather than assuming a fixed depth.
     const auto attach_heroic_runtime = [](game_library::heroic_game_t &entry, const std::filesystem::path &library_path) {
-      auto runtime = game_library::heroic_runtime_for_app(
-        library_path.parent_path().parent_path(),
-        entry.app_name,
-        entry.platform
-      );
+      const auto config_root = game_library::heroic_config_root_for_library(library_path);
+      if (config_root.empty()) {
+        return;
+      }
+
+      auto runtime = game_library::heroic_runtime_for_app(config_root, entry.app_name, entry.platform);
       entry.runtime = std::move(runtime.runtime);
       entry.runtime_name = std::move(runtime.runtime_name);
     };
@@ -3136,10 +3139,11 @@ namespace confighttp {
           std::ifstream file(library_path);
           std::stringstream payload;
           payload << file.rdbuf();
-          for (const auto &entry : game_library::parse_heroic_cache_json(payload.str(), store, install)) {
+          for (auto &entry : game_library::parse_heroic_cache_json(payload.str(), store, install)) {
             // Skip what installed.json or the other install already provided
             if (!seen_heroic_keys.insert(entry.store + "/" + entry.app_name).second) continue;
 
+            attach_heroic_runtime(entry, library_path);
             nlohmann::json game;
             game["name"] = entry.name;
             game["app_name"] = entry.app_name;

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3009,6 +3009,28 @@ namespace confighttp {
       if (!entry.hero_url.empty()) {
         game["hero_url"] = entry.hero_url;
       }
+      // What the title installs as and what will execute it. Absent rather than
+      // guessed when Heroic did not record it.
+      if (!entry.platform.empty()) {
+        game["platform"] = entry.platform;
+      }
+      if (!entry.runtime.empty()) {
+        game["runtime"] = entry.runtime;
+      }
+      if (!entry.runtime_name.empty()) {
+        game["runtime_name"] = entry.runtime_name;
+      }
+    };
+    // The wine or proton choice lives per game under the Heroic config root, two
+    // levels above the library file the entries were parsed from.
+    const auto attach_heroic_runtime = [](game_library::heroic_game_t &entry, const std::filesystem::path &library_path) {
+      auto runtime = game_library::heroic_runtime_for_app(
+        library_path.parent_path().parent_path(),
+        entry.app_name,
+        entry.platform
+      );
+      entry.runtime = std::move(runtime.runtime);
+      entry.runtime_name = std::move(runtime.runtime_name);
     };
     const auto heroic_already_imported = [&existing_cmds, &existing_heroic_keys](
                                            const std::string &store,
@@ -3043,6 +3065,7 @@ namespace confighttp {
           std::stringstream cache_payload;
           cache_payload << cache_file.rdbuf();
           for (auto &entry : game_library::parse_heroic_cache_json(cache_payload.str(), store, install)) {
+            attach_heroic_runtime(entry, cache_path);
             heroic_cache_metadata.emplace(
               heroic_cache_key(entry.install, entry.store, entry.app_name),
               std::move(entry)
@@ -3077,6 +3100,9 @@ namespace confighttp {
                 ); cached != heroic_cache_metadata.end()) {
               entry.poster_url = cached->second.poster_url;
               entry.hero_url = cached->second.hero_url;
+              entry.platform = cached->second.platform;
+              entry.runtime = cached->second.runtime;
+              entry.runtime_name = cached->second.runtime_name;
             }
 
             // Both installs can hold the same title, and the launch command follows the

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -477,13 +477,7 @@ namespace game_library {
     return runtime;
   }
 
-  /**
-   * @brief Read the runtime Heroic recorded for one title.
-   *
-   * Heroic keeps the wine or proton choice per game in GamesConfig/<app>.json,
-   * not in the library file, so the platform alone cannot say what will run.
-   * A missing or unreadable config yields no runtime rather than a guess.
-   */
+  /// Walks up to the directory that holds GamesConfig; see the header for why.
   std::filesystem::path heroic_config_root_for_library(const std::filesystem::path &library_path) {
     std::error_code ec;
     auto directory = library_path.parent_path();
@@ -497,6 +491,13 @@ namespace game_library {
     return {};
   }
 
+  /**
+   * @brief Read the runtime Heroic recorded for one title.
+   *
+   * Heroic keeps the wine or proton choice per game in GamesConfig/<app>.json,
+   * not in the library file, so the platform alone cannot say what will run.
+   * A missing or unreadable config yields no runtime rather than a guess.
+   */
   heroic_runtime_t heroic_runtime_for_app(
     const std::filesystem::path &config_root,
     const std::string &app_name,

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -428,6 +428,99 @@ namespace game_library {
     return files;
   }
 
+  std::string normalize_heroic_platform(std::string_view platform, bool linux_native) {
+    std::string lowered;
+    lowered.reserve(platform.size());
+    for (const char c : platform) {
+      lowered.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    }
+
+    if (lowered == "windows" || lowered == "win32" || lowered == "win64") {
+      return "windows";
+    }
+    if (lowered == "linux") {
+      return "linux";
+    }
+    if (lowered == "mac" || lowered == "macos" || lowered == "osx") {
+      return "mac";
+    }
+
+    // Heroic does not always record a platform. The native flag is the only
+    // other thing it tells us, and silence is better than a guess.
+    return linux_native ? "linux" : std::string {};
+  }
+
+  heroic_runtime_t heroic_runtime_from_config(std::string_view wine_type, std::string_view wine_name, std::string_view platform) {
+    heroic_runtime_t runtime;
+    runtime.platform = std::string {platform};
+
+    if (platform == "linux") {
+      runtime.runtime = "native";
+      return runtime;
+    }
+
+    std::string lowered;
+    lowered.reserve(wine_type.size());
+    for (const char c : wine_type) {
+      lowered.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    }
+
+    if (lowered == "proton") {
+      runtime.runtime = "proton";
+    } else if (lowered == "wine" || lowered == "crossover" || lowered == "toolkit") {
+      runtime.runtime = "wine";
+    } else {
+      return runtime;
+    }
+
+    runtime.runtime_name = std::string {wine_name};
+    return runtime;
+  }
+
+  /**
+   * @brief Read the runtime Heroic recorded for one title.
+   *
+   * Heroic keeps the wine or proton choice per game in GamesConfig/<app>.json,
+   * not in the library file, so the platform alone cannot say what will run.
+   * A missing or unreadable config yields no runtime rather than a guess.
+   */
+  heroic_runtime_t heroic_runtime_for_app(
+    const std::filesystem::path &config_root,
+    const std::string &app_name,
+    const std::string &platform
+  ) {
+    if (platform == "linux") {
+      return heroic_runtime_from_config({}, {}, platform);
+    }
+
+    std::error_code ec;
+    const auto config_path = config_root / "GamesConfig" / (app_name + ".json");
+    if (!std::filesystem::is_regular_file(config_path, ec) || ec) {
+      return heroic_runtime_from_config({}, {}, platform);
+    }
+
+    std::ifstream file {config_path};
+    if (!file) {
+      return heroic_runtime_from_config({}, {}, platform);
+    }
+
+    nlohmann::json parsed = nlohmann::json::parse(file, nullptr, false);
+    if (parsed.is_discarded() || !parsed.is_object()) {
+      return heroic_runtime_from_config({}, {}, platform);
+    }
+
+    // The file is keyed by app name, with the settings nested underneath.
+    const auto settings = parsed.contains(app_name) && parsed[app_name].is_object() ? parsed[app_name] : parsed;
+    if (!settings.contains("wineVersion") || !settings["wineVersion"].is_object()) {
+      return heroic_runtime_from_config({}, {}, platform);
+    }
+
+    const auto &wine = settings["wineVersion"];
+    const auto type = wine.contains("type") && wine["type"].is_string() ? wine["type"].get<std::string>() : std::string {};
+    const auto name = wine.contains("name") && wine["name"].is_string() ? wine["name"].get<std::string>() : std::string {};
+    return heroic_runtime_from_config(type, name, platform);
+  }
+
   std::string heroic_install_name(launcher_install_t install) {
     return install == launcher_install_t::flatpak ? "flatpak" : "native";
   }
@@ -613,7 +706,8 @@ namespace game_library {
       const std::string &store,
       launcher_install_t install,
       std::string poster_url = {},
-      std::string hero_url = {}
+      std::string hero_url = {},
+      heroic_runtime_t runtime = {}
     ) {
       const auto runner = heroic_runner_for_store(store);
       const auto command = heroic_launch_command(store, app_name, install);
@@ -630,6 +724,9 @@ namespace game_library {
         .command = command,
         .poster_url = std::move(poster_url),
         .hero_url = std::move(hero_url),
+        .platform = std::move(runtime.platform),
+        .runtime = std::move(runtime.runtime),
+        .runtime_name = std::move(runtime.runtime_name),
       };
     }
 
@@ -671,13 +768,27 @@ namespace game_library {
         return std::nullopt;
       }
 
+      // Heroic records the installed platform under install, and flags Linux
+      // native titles separately. Neither is guaranteed to be present.
+      const auto installed_platform = entry.contains("install") && entry["install"].is_object() &&
+                                          entry["install"].contains("platform") &&
+                                          entry["install"]["platform"].is_string() ?
+                                        entry["install"]["platform"].get<std::string>() :
+                                        std::string {};
+      const auto linux_native = entry.contains("is_linux_native") && entry["is_linux_native"].is_boolean() &&
+                                entry["is_linux_native"].get<bool>();
+
+      heroic_runtime_t runtime;
+      runtime.platform = normalize_heroic_platform(installed_platform, linux_native);
+
       return make_heroic_game(
         app_name,
         entry["title"].get<std::string>(),
         "epic",
         install,
         entry.value("art_square", ""),
-        entry.value("art_cover", "")
+        entry.value("art_cover", ""),
+        std::move(runtime)
       );
     }
   }  // namespace

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -484,6 +484,19 @@ namespace game_library {
    * not in the library file, so the platform alone cannot say what will run.
    * A missing or unreadable config yields no runtime rather than a guess.
    */
+  std::filesystem::path heroic_config_root_for_library(const std::filesystem::path &library_path) {
+    std::error_code ec;
+    auto directory = library_path.parent_path();
+    for (int depth = 0; depth < 4 && !directory.empty(); ++depth) {
+      if (std::filesystem::is_directory(directory / "GamesConfig", ec) && !ec) {
+        return directory;
+      }
+      directory = directory.parent_path();
+    }
+
+    return {};
+  }
+
   heroic_runtime_t heroic_runtime_for_app(
     const std::filesystem::path &config_root,
     const std::string &app_name,
@@ -770,11 +783,16 @@ namespace game_library {
 
       // Heroic records the installed platform under install, and flags Linux
       // native titles separately. Neither is guaranteed to be present.
-      const auto installed_platform = entry.contains("install") && entry["install"].is_object() &&
-                                          entry["install"].contains("platform") &&
-                                          entry["install"]["platform"].is_string() ?
-                                        entry["install"]["platform"].get<std::string>() :
-                                        std::string {};
+      // The store cache nests the platform under install; legendary's own
+      // installed.json puts it at the top level. Accept either.
+      auto installed_platform = entry.contains("install") && entry["install"].is_object() &&
+                                    entry["install"].contains("platform") &&
+                                    entry["install"]["platform"].is_string() ?
+                                  entry["install"]["platform"].get<std::string>() :
+                                  std::string {};
+      if (installed_platform.empty() && entry.contains("platform") && entry["platform"].is_string()) {
+        installed_platform = entry["platform"].get<std::string>();
+      }
       const auto linux_native = entry.contains("is_linux_native") && entry["is_linux_native"].is_boolean() &&
                                 entry["is_linux_native"].get<bool>();
 

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -127,6 +127,17 @@ namespace game_library {
   heroic_runtime_t heroic_runtime_from_config(std::string_view wine_type, std::string_view wine_name, std::string_view platform);
 
   /**
+   * @brief Find the Heroic config root that owns a library file.
+   * @param library_path A Heroic library file, at whatever depth it sits.
+   *
+   * Heroic's library files live at different depths under the same root:
+   * `store_cache/legendary_library.json` is one level down while
+   * `legendaryConfig/legendary/installed.json` is two. Walking up to the
+   * directory that actually holds `GamesConfig` avoids assuming either.
+   */
+  std::filesystem::path heroic_config_root_for_library(const std::filesystem::path &library_path);
+
+  /**
    * @brief Read the runtime Heroic recorded for one title.
    * @param config_root A Heroic config directory, e.g. ~/.config/heroic.
    *

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -89,7 +89,51 @@ namespace game_library {
     std::string command;
     std::string poster_url;
     std::string hero_url;
+    /// Normalised platform the title installs as: "windows", "linux", or empty when unknown.
+    std::string platform;
+    /// How it will actually run: "proton", "wine", "native", or empty when unknown.
+    std::string runtime;
+    /// The runtime's own label, e.g. "Proton-GE Latest". Empty for native titles.
+    std::string runtime_name;
   };
+
+  /// A title's platform and the runtime that will execute it.
+  struct heroic_runtime_t {
+    std::string platform;
+    std::string runtime;
+    std::string runtime_name;
+  };
+
+  /**
+   * @brief Normalise the platform Heroic records for an installed title.
+   * @param platform Heroic's own value, e.g. "Windows", "Linux", "Mac".
+   * @param linux_native Heroic's is_linux_native flag.
+   *
+   * Heroic writes the installed platform in mixed case and only sometimes, so a
+   * title with no recorded platform falls back to the native flag rather than
+   * guessing Windows.
+   */
+  std::string normalize_heroic_platform(std::string_view platform, bool linux_native);
+
+  /**
+   * @brief Decide what a title will run under from its per-game Heroic config.
+   * @param wine_type Heroic's wineVersion.type, e.g. "proton" or "wine".
+   * @param wine_name Heroic's wineVersion.name, e.g. "Proton-GE Latest".
+   * @param platform Normalised platform from normalize_heroic_platform().
+   *
+   * A Linux-native title runs natively whatever a stale wine entry says, and a
+   * Windows title with no usable runtime reports none rather than inventing one.
+   */
+  heroic_runtime_t heroic_runtime_from_config(std::string_view wine_type, std::string_view wine_name, std::string_view platform);
+
+  /**
+   * @brief Read the runtime Heroic recorded for one title.
+   * @param config_root A Heroic config directory, e.g. ~/.config/heroic.
+   *
+   * Heroic keeps the wine or proton choice per game rather than in the library
+   * file, so the platform alone cannot say what will actually run.
+   */
+  heroic_runtime_t heroic_runtime_for_app(const std::filesystem::path &config_root, const std::string &app_name, const std::string &platform);
 
   /** @brief The stable API/storage name for a launcher installation. */
   std::string heroic_install_name(launcher_install_t install);

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -838,3 +838,32 @@ TEST(HeroicRuntimeTests, ParsesThePlatformOutOfTheLegendaryLibraryEntry) {
   EXPECT_EQ(games[0].name, "Alan Wake 2");
   EXPECT_EQ(games[0].platform, "windows");
 }
+
+TEST(HeroicRuntimeTests, FindsTheConfigRootWhateverDepthTheLibraryFileSitsAt) {
+  // Heroic's own layout: store_cache is one level under the root, while
+  // legendaryConfig/legendary is two. Assuming a fixed depth silently picked the
+  // wrong root for Epic's installed manifest.
+  const auto config_root = std::filesystem::temp_directory_path() / "polaris-heroic-root-test";
+  std::filesystem::remove_all(config_root);
+  std::filesystem::create_directories(config_root / "GamesConfig");
+  std::filesystem::create_directories(config_root / "store_cache");
+  std::filesystem::create_directories(config_root / "legendaryConfig" / "legendary");
+
+  EXPECT_EQ(
+    game_library::heroic_config_root_for_library(config_root / "store_cache" / "legendary_library.json"),
+    config_root
+  );
+  EXPECT_EQ(
+    game_library::heroic_config_root_for_library(config_root / "legendaryConfig" / "legendary" / "installed.json"),
+    config_root
+  );
+  std::filesystem::remove_all(config_root);
+}
+
+TEST(HeroicRuntimeTests, ReportsNoConfigRootWhenHeroicIsNotThere) {
+  const auto stray = std::filesystem::temp_directory_path() / "polaris-heroic-no-root" / "store_cache" / "library.json";
+  std::filesystem::remove_all(stray.parent_path().parent_path());
+  std::filesystem::create_directories(stray.parent_path());
+  EXPECT_TRUE(game_library::heroic_config_root_for_library(stray).empty());
+  std::filesystem::remove_all(stray.parent_path().parent_path());
+}

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -790,11 +790,11 @@ TEST(HeroicRuntimeTests, ReadsTheRuntimeFromTheHeroicPerGameConfig) {
       "dc9d2e595d0e4650b35d659f90d41059": {
         "useGameMode": true,
         "wineVersion": {
-          "bin": "/home/player/.local/share/Steam/compatibilitytools.d/Proton-GE Latest/proton",
+          "bin": "/opt/compatibilitytools.d/Proton-GE Latest/proton",
           "name": "Proton-GE Latest",
           "type": "proton"
         },
-        "winePrefix": "/home/player/Games/Heroic/Prefixes/Example Game"
+        "winePrefix": "/games/Heroic/Prefixes/Example Game"
       }
     })";
   }
@@ -830,7 +830,7 @@ TEST(HeroicRuntimeTests, ParsesThePlatformOutOfTheLegendaryLibraryEntry) {
     "runner": "legendary",
     "is_installed": true,
     "is_linux_native": false,
-    "install": {"executable": "AlanWake2.exe", "install_path": "/home/player/Games/Heroic/ExampleGame", "is_dlc": false, "platform": "Windows"}
+    "install": {"executable": "AlanWake2.exe", "install_path": "/games/Heroic/ExampleGame", "is_dlc": false, "platform": "Windows"}
   }]})";
 
   const auto games = game_library::parse_heroic_cache_json(payload, "epic", game_library::launcher_install_t::flatpak);

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -790,11 +790,11 @@ TEST(HeroicRuntimeTests, ReadsTheRuntimeFromTheHeroicPerGameConfig) {
       "dc9d2e595d0e4650b35d659f90d41059": {
         "useGameMode": true,
         "wineVersion": {
-          "bin": "/home/papi/.local/share/Steam/compatibilitytools.d/Proton-GE Latest/proton",
+          "bin": "/home/player/.local/share/Steam/compatibilitytools.d/Proton-GE Latest/proton",
           "name": "Proton-GE Latest",
           "type": "proton"
         },
-        "winePrefix": "/home/papi/Games/Heroic/Prefixes/Alan Wake 2"
+        "winePrefix": "/home/player/Games/Heroic/Prefixes/Example Game"
       }
     })";
   }
@@ -830,7 +830,7 @@ TEST(HeroicRuntimeTests, ParsesThePlatformOutOfTheLegendaryLibraryEntry) {
     "runner": "legendary",
     "is_installed": true,
     "is_linux_native": false,
-    "install": {"executable": "AlanWake2.exe", "install_path": "/home/papi/Games/Heroic/AlanWake2", "is_dlc": false, "platform": "Windows"}
+    "install": {"executable": "AlanWake2.exe", "install_path": "/home/player/Games/Heroic/ExampleGame", "is_dlc": false, "platform": "Windows"}
   }]})";
 
   const auto games = game_library::parse_heroic_cache_json(payload, "epic", game_library::launcher_install_t::flatpak);

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -737,3 +737,104 @@ TEST(HeroicLibraryScannerTests, RefusesAppNamesThatWouldReachTheShell) {
   EXPECT_TRUE(game_library::heroic_launch_command("legendary", "Snow", game_library::launcher_install_t::native).empty());
   EXPECT_TRUE(game_library::heroic_launch_commands("gog", "app; rm -rf ~").empty());
 }
+
+// Heroic records what a title installs as, and separately what will execute it.
+// Polaris reports both or neither, never a guess: the Library page and Nova use
+// this to say "Windows via Proton-GE" instead of leaving the operator to find out
+// at launch.
+TEST(HeroicRuntimeTests, NormalisesThePlatformHeroicRecorded) {
+  EXPECT_EQ(game_library::normalize_heroic_platform("Windows", false), "windows");
+  EXPECT_EQ(game_library::normalize_heroic_platform("windows", false), "windows");
+  EXPECT_EQ(game_library::normalize_heroic_platform("Linux", false), "linux");
+  EXPECT_EQ(game_library::normalize_heroic_platform("Mac", false), "mac");
+}
+
+TEST(HeroicRuntimeTests, FallsBackToTheNativeFlagRatherThanGuessingWindows) {
+  EXPECT_EQ(game_library::normalize_heroic_platform("", true), "linux");
+  EXPECT_TRUE(game_library::normalize_heroic_platform("", false).empty());
+  EXPECT_TRUE(game_library::normalize_heroic_platform("Nintendo", false).empty());
+}
+
+TEST(HeroicRuntimeTests, ReportsProtonAndWineWithTheirOwnLabel) {
+  const auto proton = game_library::heroic_runtime_from_config("proton", "Proton-GE Latest", "windows");
+  EXPECT_EQ(proton.runtime, "proton");
+  EXPECT_EQ(proton.runtime_name, "Proton-GE Latest");
+
+  const auto wine = game_library::heroic_runtime_from_config("wine", "Wine-GE 8", "windows");
+  EXPECT_EQ(wine.runtime, "wine");
+  EXPECT_EQ(wine.runtime_name, "Wine-GE 8");
+}
+
+TEST(HeroicRuntimeTests, CallsALinuxTitleNativeWhateverAStaleWineEntrySays) {
+  const auto native = game_library::heroic_runtime_from_config("proton", "Proton-GE Latest", "linux");
+  EXPECT_EQ(native.runtime, "native");
+  EXPECT_TRUE(native.runtime_name.empty());
+}
+
+TEST(HeroicRuntimeTests, ReportsNoRuntimeRatherThanInventingOne) {
+  const auto unknown = game_library::heroic_runtime_from_config("", "", "windows");
+  EXPECT_TRUE(unknown.runtime.empty());
+  EXPECT_TRUE(unknown.runtime_name.empty());
+  EXPECT_EQ(unknown.platform, "windows");
+}
+
+TEST(HeroicRuntimeTests, ReadsTheRuntimeFromTheHeroicPerGameConfig) {
+  // The shape here mirrors a real Heroic GamesConfig entry: settings nested
+  // under the app name, with wineVersion carrying the choice.
+  const auto config_root = std::filesystem::temp_directory_path() / "polaris-heroic-runtime-test";
+  std::filesystem::remove_all(config_root);
+  std::filesystem::create_directories(config_root / "GamesConfig");
+  {
+    std::ofstream config(config_root / "GamesConfig" / "dc9d2e595d0e4650b35d659f90d41059.json");
+    config << R"({
+      "dc9d2e595d0e4650b35d659f90d41059": {
+        "useGameMode": true,
+        "wineVersion": {
+          "bin": "/home/papi/.local/share/Steam/compatibilitytools.d/Proton-GE Latest/proton",
+          "name": "Proton-GE Latest",
+          "type": "proton"
+        },
+        "winePrefix": "/home/papi/Games/Heroic/Prefixes/Alan Wake 2"
+      }
+    })";
+  }
+
+  const auto runtime = game_library::heroic_runtime_for_app(config_root, "dc9d2e595d0e4650b35d659f90d41059", "windows");
+  EXPECT_EQ(runtime.runtime, "proton");
+  EXPECT_EQ(runtime.runtime_name, "Proton-GE Latest");
+  std::filesystem::remove_all(config_root);
+}
+
+TEST(HeroicRuntimeTests, SaysNothingWhenTheHeroicConfigIsMissingOrUnreadable) {
+  const auto config_root = std::filesystem::temp_directory_path() / "polaris-heroic-runtime-absent";
+  std::filesystem::remove_all(config_root);
+  const auto missing = game_library::heroic_runtime_for_app(config_root, "nothing-here", "windows");
+  EXPECT_TRUE(missing.runtime.empty());
+  EXPECT_EQ(missing.platform, "windows");
+
+  std::filesystem::create_directories(config_root / "GamesConfig");
+  {
+    std::ofstream broken(config_root / "GamesConfig" / "broken.json");
+    broken << "{ not json";
+  }
+  const auto unreadable = game_library::heroic_runtime_for_app(config_root, "broken", "windows");
+  EXPECT_TRUE(unreadable.runtime.empty());
+  std::filesystem::remove_all(config_root);
+}
+
+TEST(HeroicRuntimeTests, ParsesThePlatformOutOfTheLegendaryLibraryEntry) {
+  // Trimmed from the real legendary_library.json on a host with Alan Wake 2.
+  const std::string payload = R"({"library":[{
+    "app_name": "dc9d2e595d0e4650b35d659f90d41059",
+    "title": "Alan Wake 2",
+    "runner": "legendary",
+    "is_installed": true,
+    "is_linux_native": false,
+    "install": {"executable": "AlanWake2.exe", "install_path": "/home/papi/Games/Heroic/AlanWake2", "is_dlc": false, "platform": "Windows"}
+  }]})";
+
+  const auto games = game_library::parse_heroic_cache_json(payload, "epic", game_library::launcher_install_t::flatpak);
+  ASSERT_EQ(games.size(), 1u);
+  EXPECT_EQ(games[0].name, "Alan Wake 2");
+  EXPECT_EQ(games[0].platform, "windows");
+}


### PR DESCRIPTION
## Summary

An imported Heroic entry said nothing about what it actually was. A Windows title
running under Proton and a Linux native build looked identical in the Library, so
the first sign of which one you had was the launch.

Heroic keeps the two halves in different places, which is why the scanner never
had this: the library file records the installed platform and whether the build is
Linux native, while the per-game file under `GamesConfig` records the wine or
proton choice. Polaris now reads both and carries `platform`, `runtime`, and the
runtime's own label through the scan, the cache join, and the import response.

Nothing is guessed:

- A title with no recorded platform falls back to Heroic's native flag rather
  than assuming Windows.
- A Linux native title is reported as native whatever a stale wine entry claims.
- A Windows title whose runtime cannot be read reports no runtime at all, and the
  field is omitted rather than sent empty.

## Scope, and what is deliberately missing

This is part of #452, not all of it. **Playtime and the completion estimate are
not included, because the data does not exist locally.** Heroic keeps no playtime
for Epic titles in any of its caches. The library file has no such field, and the
only playtime artifact it writes is a GOG sync queue, which is empty on a host
with no GOG library. Getting playtime would mean talking to the Epic or GOG
account APIs, which is a separate feature with credentials attached, so I have not
faked it from file timestamps.

Still open from that issue: serving the platform and runtime onward to Nova, a
Heroic launcher app entry to match the Lutris one, and nile and sideload
discovery.

## Exact candidate

Branch `feat/heroic-runtime-metadata`, one commit on master `c957d404`.

## Verification

- 8 new tests covering platform normalisation, the native-flag fallback, proton
  and wine labelling, a Linux title outranking a stale wine entry, the missing and
  malformed config cases, and the platform parsed out of a real library entry.
- Verified against the real Heroic install on the dev host with a temporary test
  that was removed before committing. Alan Wake 2, an Epic title installed through
  the Flatpak Heroic, reports `platform=windows`, `runtime=proton`,
  `runtime_name=Proton-GE Latest`, read from the actual files rather than a
  fixture.
- Full scanner and library suites 29 passing, web suite 670 across 83 files, and
  the Polaris binary builds.
- `~/.config/polaris` checked before and after every test run and unchanged, since
  this suite has deleted real host state before.

Refs #452.
