### PR TITLE
feat(library): publish a Heroic launcher entry after an import

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -20,6 +20,8 @@ already published visible so you can spot what is new, and lets you stage severa
 before one import pass. Imported Steam titles keep their app id and take the Linux launch mode
 you have selected when they start.
 
+Importing a Lutris or Heroic title also publishes an entry for the launcher itself, once, using the command that exists on this host. Those imports launch straight into a game, so without it there is no way to reach the launcher from a stream to install something or fix a login. An entry you added by hand is recognised and not duplicated.
+
 **Library health** shows import coverage and the host context the library depends on. Keep
 entries short and recognisable on a handheld screen, use per-app overrides only where a launcher,
 tool, or game needs them, and export `.art` entries when you want favourite launches in another

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2774,6 +2774,64 @@ namespace confighttp {
     }
   }
 
+  /**
+   * @brief Publish a Heroic launcher entry once a Heroic game has been imported.
+   *
+   * The imported games launch straight into a title, which leaves no way to reach
+   * Heroic itself from a stream to install something or fix a login. Mirrors the
+   * Lutris entry, including matching an entry a user added by hand.
+   */
+  void ensure_heroic_library_app(nlohmann::json &file_tree, game_library::launcher_install_t install) {
+    if (!file_tree.contains("apps") || !file_tree["apps"].is_array()) {
+      file_tree["apps"] = nlohmann::json::array();
+    }
+
+    const auto launcher_command = game_library::heroic_launcher_command(install);
+    const auto matches_launcher = [&launcher_command](const std::string &value) {
+      const auto trimmed = boost::trim_copy(value);
+      return boost::iequals(trimmed, launcher_command) ||
+             boost::iequals(trimmed, "heroic") ||
+             boost::iequals(trimmed, "setsid heroic");
+    };
+
+    for (const auto &app : file_tree["apps"]) {
+      if (!app.is_object()) {
+        continue;
+      }
+
+      if (boost::iequals(boost::trim_copy(app.value("name", "")), "Heroic")) {
+        return;
+      }
+
+      if (matches_launcher(app.value("cmd", ""))) {
+        return;
+      }
+
+      if (!app.contains("detached") || !app["detached"].is_array()) {
+        continue;
+      }
+
+      for (const auto &detached : app["detached"]) {
+        if (detached.is_string() && matches_launcher(detached.get<std::string>())) {
+          return;
+        }
+      }
+    }
+
+    nlohmann::json app {
+      {"name", "Heroic"},
+      {"uuid", ""},
+      {"cmd", ""},
+      {"detached", nlohmann::json::array({launcher_command})},
+      {"source", "heroic"},
+      {"auto-detach", true},
+      {"wait-all", true},
+      {"exit-timeout", 5}
+    };
+    proc::migrate_apps(&file_tree, &app);
+    BOOST_LOG(info) << "Added Heroic library launcher to the app list.";
+  }
+
   void ensure_lutris_library_app(nlohmann::json &file_tree) {
     if (!file_tree.contains("apps") || !file_tree["apps"].is_array()) {
       file_tree["apps"] = nlohmann::json::array();
@@ -3207,6 +3265,7 @@ namespace confighttp {
 
       int imported = 0;
       bool imported_lutris_game = false;
+      std::optional<game_library::launcher_install_t> imported_heroic_install;
       for (const auto &game : body["games"]) {
         std::string name = game.value("name", "");
         std::string source = game.value("source", "steam");
@@ -3336,6 +3395,9 @@ namespace confighttp {
           app["heroic-store"] = store;
           app["heroic-runner"] = heroic->runner;
           app["heroic-install"] = install_name;
+          // Remember which packaging produced an import so the launcher entry
+          // published below can use the command that exists on this host.
+          imported_heroic_install = heroic->install;
 
           if (const auto cached = game_library::find_heroic_cached_game(
                 game_library::library_home_roots(),
@@ -3370,6 +3432,10 @@ namespace confighttp {
 
       if (imported_lutris_game) {
         ensure_lutris_library_app(fileTree);
+      }
+
+      if (imported_heroic_install) {
+        ensure_heroic_library_app(fileTree, *imported_heroic_install);
       }
 
       // Write back

--- a/src/game_library_scanner.cpp
+++ b/src/game_library_scanner.cpp
@@ -618,6 +618,15 @@ namespace game_library {
     return "setsid heroic --no-gui --no-sandbox " + uri;
   }
 
+  std::string heroic_launcher_command(launcher_install_t install) {
+    if (install == launcher_install_t::flatpak) {
+      return "setsid flatpak run " + std::string(heroic_flatpak_app_id);
+    }
+
+    // No --no-gui here, unlike a game launch: opening the launcher is the point.
+    return "setsid heroic";
+  }
+
   std::vector<std::string> heroic_launch_commands_for_install(
     const std::string &store,
     const std::string &app_name,

--- a/src/game_library_scanner.h
+++ b/src/game_library_scanner.h
@@ -173,6 +173,15 @@ namespace game_library {
   bool is_heroic_app_name_safe(const std::string &app_name);
 
   /** @brief The `heroic://launch` command for one title, for the install that has it. */
+  /**
+   * @brief The command that opens Heroic itself, with no game attached.
+   * @param install Which packaging of Heroic the library entries came from.
+   *
+   * Unlike a game launch this keeps Heroic's window: the entry exists so a player
+   * can reach the launcher from the stream, install something, or fix a login.
+   */
+  std::string heroic_launcher_command(launcher_install_t install);
+
   std::string heroic_launch_command(const std::string &store, const std::string &app_name, launcher_install_t install);
 
   /** @brief Current and exact older Polaris launch forms for one Heroic installation. */

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -204,6 +204,42 @@ const shellBlockDepths = (commands) => {
   })
 }
 
+// The Heroic launcher entry is assembled in the HTTP layer, where a unit test
+// cannot reach it, so pin the shape that makes it usable: published only after a
+// real import, launched detached, and matched against an entry a user added by
+// hand so a second import does not stack duplicates.
+describe('Heroic library launcher entry', () => {
+  const confighttp = readSource('src/confighttp.cpp')
+
+  it('publishes the entry only when a Heroic import actually happened', () => {
+    expect(confighttp).toContain('std::optional<game_library::launcher_install_t> imported_heroic_install;')
+    expect(confighttp).toContain('imported_heroic_install = heroic->install;')
+    expect(confighttp).toContain('if (imported_heroic_install) {')
+    expect(confighttp).toContain('ensure_heroic_library_app(fileTree, *imported_heroic_install);')
+  })
+
+  it('uses the launcher command for the install that produced the import', () => {
+    expect(confighttp).toContain('game_library::heroic_launcher_command(install)')
+  })
+
+  it('recognises an entry the user already added', () => {
+    expect(confighttp).toContain('boost::iequals(trimmed, "heroic")')
+    expect(confighttp).toContain('boost::iequals(trimmed, "setsid heroic")')
+  })
+
+  it('runs detached with no foreground command, like the Lutris entry', () => {
+    const entry = confighttp.slice(
+      confighttp.indexOf('void ensure_heroic_library_app'),
+      confighttp.indexOf('void ensure_lutris_library_app'),
+    )
+    expect(entry).toContain('{"name", "Heroic"}')
+    expect(entry).toContain('{"source", "heroic"}')
+    expect(entry).toContain('{"cmd", ""}')
+    expect(entry).toContain('nlohmann::json::array({launcher_command})')
+    expect(entry).toContain('{"auto-detach", true}')
+  })
+})
+
 describe('Linux packaging contracts', () => {
   it('lets the user service outlive the desktop session', () => {
     // A streaming host must keep serving when the desktop session ends: a

--- a/tests/unit/test_game_library_scanner.cpp
+++ b/tests/unit/test_game_library_scanner.cpp
@@ -867,3 +867,36 @@ TEST(HeroicRuntimeTests, ReportsNoConfigRootWhenHeroicIsNotThere) {
   EXPECT_TRUE(game_library::heroic_config_root_for_library(stray).empty());
   std::filesystem::remove_all(stray.parent_path().parent_path());
 }
+
+// An imported Heroic title launches straight into the game, which leaves no way to
+// reach Heroic itself from a stream to install something or fix a login. The
+// launcher entry exists for that, so unlike a game launch it must keep the window.
+TEST(HeroicLauncherCommandTests, OpensTheLauncherItselfForEachInstall) {
+  EXPECT_EQ(game_library::heroic_launcher_command(game_library::launcher_install_t::native), "setsid heroic");
+  EXPECT_EQ(
+    game_library::heroic_launcher_command(game_library::launcher_install_t::flatpak),
+    "setsid flatpak run com.heroicgameslauncher.hgl"
+  );
+}
+
+TEST(HeroicLauncherCommandTests, KeepsTheWindowThatAGameLaunchSuppresses) {
+  // A game launch passes --no-gui because it dispatches a protocol URL. Carrying
+  // that flag here would open nothing at all.
+  const auto launcher = game_library::heroic_launcher_command(game_library::launcher_install_t::native);
+  EXPECT_EQ(launcher.find("--no-gui"), std::string::npos);
+  EXPECT_EQ(launcher.find("heroic://"), std::string::npos);
+
+  const auto game = game_library::heroic_launch_command("epic", "abc123", game_library::launcher_install_t::native);
+  EXPECT_NE(game.find("--no-gui"), std::string::npos);
+}
+
+TEST(HeroicLauncherCommandTests, MatchesTheInstallTheLibraryEntriesCameFrom) {
+  // A Flatpak-only host has no heroic on PATH, so the launcher entry has to follow
+  // the packaging that produced the import.
+  const auto flatpak = game_library::heroic_launcher_command(game_library::launcher_install_t::flatpak);
+  EXPECT_NE(flatpak.find("flatpak run"), std::string::npos);
+  EXPECT_NE(
+    game_library::heroic_launch_command("epic", "abc123", game_library::launcher_install_t::flatpak).find("flatpak run"),
+    std::string::npos
+  );
+}


### PR DESCRIPTION
## Summary

An imported Heroic title launches straight into that game. That means a player
streaming the host has no way to reach Heroic itself: no installing anything, no
fixing a login, no finding out why a title disappeared. Lutris imports have
published a launcher entry for exactly this reason since they landed. Heroic never
did.

Importing a Heroic title now publishes one too:

- **It uses the command that exists on this host.** A Flatpak-only host has no
  `heroic` on PATH, so the entry follows the packaging that produced the import.
- **It keeps Heroic's window.** A game launch passes `--no-gui` because it
  dispatches a protocol URL; carrying that flag here would open nothing at all.
- **It recognises an entry you already added by hand**, so a second import does
  not stack duplicates.
- **It is published only after a real import**, never speculatively.

No artwork ships with it, so it uses Polaris's default box image. Bundling
Heroic's logo is a licensing call rather than a technical one, so I left it to you.

## Scope

This is one of the three items left on #452. It does not include serving the
platform and runtime to Nova, which touches the client contract that the 1.4.1
release pull request is currently editing, so it should land after that to avoid
fighting it. Nile and sideload discovery is the third, and is discussed on the
issue: this host has no Amazon or sideloaded titles, so I have no real data to
build it against.

## Exact candidate

Branch `feat/heroic-launcher-entry`, one commit on master `727bc80a`.

## Verification

- 3 new tests pin the launcher command for both installs, that it does not carry
  the `--no-gui` flag or a protocol URL a game launch needs, and that a Flatpak
  import produces a Flatpak command.
- 4 new source-contract tests pin the entry's shape, since it is assembled in the
  HTTP layer where a unit test cannot reach it: published only after an import,
  detached with no foreground command, and matched against a hand-added entry.
- Full Heroic, library, and Lutris suites 34 passing, web suite 674 across 83
  files, lint clean, public surface clean, release package dependency contract
  clean, and the Polaris binary builds.
- `~/.config/polaris` checked before and after the test run and unchanged.

Refs #452.
