### PR TITLE
fix: harden post-1.4.1 launch and stream diagnostics

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -172,6 +172,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/rtsp.h"
         "${CMAKE_SOURCE_DIR}/src/stream.cpp"
         "${CMAKE_SOURCE_DIR}/src/stream.h"
+        "${CMAKE_SOURCE_DIR}/src/stream_fec.cpp"
+        "${CMAKE_SOURCE_DIR}/src/stream_fec.h"
         "${CMAKE_SOURCE_DIR}/src/video.cpp"
         "${CMAKE_SOURCE_DIR}/src/video.h"
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.cpp"

--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -486,6 +486,8 @@ list(APPEND PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/linux/input/input_group_access.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/cage_display_router.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/cage_display_router.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/labwc_startup_diagnostics.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/labwc_startup_diagnostics.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/display_topology.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/display_topology.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/stream_path.h"

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -234,6 +234,26 @@ load_session_instance_id() {
   export POLARIS_SESSION_INSTANCE_ID="$persisted"
 }
 
+prepare_nested_runtime_services() {
+  load_session_instance_id || return 1
+  [ "$POLARIS_PERSISTED_SESSION_MODE" = nested ] || return 1
+  case "$POLARIS_PERSISTED_SERVICE_MODE" in
+    managed)
+      # Only Nix-managed hosts have an idle compositor that can respawn and
+      # therefore needs a runtime mask during the nested handoff.
+      polaris_mask_idle_unit_runtime
+      ;;
+    standalone)
+      # Distro packages intentionally omit the idle and private-portal units.
+      # Masking an absent unit changes LoadState from not-found to masked and
+      # makes the persisted standalone service model impossible to restore.
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 session_steam_pids() {
   local p pids rc envf env_lines session_id="${POLARIS_SESSION_INSTANCE_ID:-}" proc_root
   [ -n "$session_id" ] || return 2
@@ -909,10 +929,13 @@ case "${1:-}" in
         echo "polaris-gamescope-session: another ownership transition is already active" >&2
         exit 1
       }
-      # Runtime-mask so polaris Wants= / portal-gamescope Wants= cannot respawn
-      # idle while nested needs exclusive gamescope-0 (portal is hard-wired).
-      # Use user.control — plain mask --runtime loses to Hjem ~/.config units.
-      polaris_mask_idle_unit_runtime
+      # Runtime-mask only a managed idle unit so polaris Wants= /
+      # portal-gamescope Wants= cannot respawn it while nested needs exclusive
+      # gamescope-0. Standalone packages have no such unit to mask.
+      prepare_nested_runtime_services || {
+        echo "polaris-gamescope-session: could not prepare nested runtime services" >&2
+        exit 1
+      }
       # Stop only the exact marked owner of gamescope-0. Unknown sockets fail
       # closed instead of risking another user's compositor.
       if polaris_validate_marker "$marker"; then
@@ -997,8 +1020,13 @@ case "${1:-}" in
         exit 1
       }
       (
+        # SteamOS ships Gamescope with cap_sys_nice=eip. Prevent that file
+        # capability from changing procfs ownership/readability: exact marker
+        # publication and socket ownership checks must remain possible for the
+        # same unprivileged user that launched this private compositor.
         run_without_session_operation_lock setsid env -u WAYLAND_DISPLAY -u DISPLAY -u ENABLE_HDR_WSI \
-          "${child_env[@]}" "${POLARIS_GAMESCOPE_BIN:-gamescope}" \
+          "${child_env[@]}" setpriv --no-new-privs -- \
+          "${POLARIS_GAMESCOPE_BIN:-gamescope}" \
           --backend headless \
           "${steam_flags[@]}" \
           --xwayland-count 2 \
@@ -1246,6 +1274,10 @@ case "${1:-}" in
         echo "polaris-gamescope-session: nested owner remains without a durable recovery claim" >&2
         exit 1
       fi
+      # A partial standalone startup may have created a user.control mask
+      # before publishing durable state. Make the idempotent stop path repair
+      # that residue so the next start still classifies absent units correctly.
+      polaris_unmask_idle_unit_runtime
       echo "polaris-gamescope-session: stop already complete" >&2
       exit 0
     fi

--- a/src/ai_optimizer.cpp
+++ b/src/ai_optimizer.cpp
@@ -9,9 +9,11 @@
 #include "logging.h"
 #include "platform/common.h"
 #include "stream_stats.h"
+#include "utility.h"
 
 #include <algorithm>
 #include <array>
+#include <charconv>
 #include <cctype>
 #include <chrono>
 #include <cmath>
@@ -1308,16 +1310,53 @@ namespace ai_optimizer {
   static bool parse_display_mode(const std::string &value, int &width, int &height, int &fps) {
     width = 0;
     height = 0;
-    float fps_value = 0.0f;
-    if (sscanf(value.c_str(), "%dx%dx%f", &width, &height, &fps_value) < 2) {
+    fps = 0;
+
+    const auto first_x = value.find('x');
+    if (first_x == std::string::npos) {
       return false;
     }
-    if (width <= 0 || height <= 0) {
+    const auto second_x = value.find('x', first_x + 1);
+    if (second_x != std::string::npos && value.find('x', second_x + 1) != std::string::npos) {
       return false;
     }
-    if (fps_value <= 0.0f) {
-      fps_value = 60.0f;
+
+    const auto parse_dimension = [](std::string_view text) -> std::optional<int> {
+      if (text.empty()) {
+        return std::nullopt;
+      }
+      int parsed {};
+      const auto *begin = text.data();
+      const auto *end = begin + text.size();
+      const auto [next, error] = std::from_chars(begin, end, parsed);
+      if (error != std::errc {} || next != end || parsed <= 0) {
+        return std::nullopt;
+      }
+      return parsed;
+    };
+
+    const auto parsed_width = parse_dimension(std::string_view {value}.substr(0, first_x));
+    const auto height_end = second_x == std::string::npos ? value.size() : second_x;
+    const auto parsed_height = parse_dimension(
+      std::string_view {value}.substr(first_x + 1, height_end - first_x - 1)
+    );
+    if (!parsed_width || !parsed_height) {
+      return false;
     }
+
+    double fps_value = 60.0;
+    if (second_x != std::string::npos) {
+      const auto parsed_fps = util::parse_decimal<double>(
+        std::string_view {value}.substr(second_x + 1)
+      );
+      if (!parsed_fps || *parsed_fps <= 0.0) {
+        return false;
+      }
+      fps_value = *parsed_fps;
+    }
+
+    width = *parsed_width;
+    height = *parsed_height;
     fps = static_cast<int>(std::round(fps_value));
     return fps > 0;
   }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1054,14 +1054,9 @@ namespace config {
       return;
     }
 
-    char *c_str_p;
-    auto val = std::strtod(tmp.c_str(), &c_str_p);
-
-    if (c_str_p == tmp.c_str()) {
-      return;
+    if (const auto value = util::parse_decimal<double>(tmp)) {
+      input = *value;
     }
-
-    input = val;
   }
 
   void double_between_f(std::unordered_map<std::string, std::string> &vars, const std::string &name, double &input, const std::pair<double, double> &range) {

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -6413,7 +6413,9 @@ namespace confighttp {
           gpu["vram_used_mb"] = std::stoi(fields[4]);
           gpu["vram_total_mb"] = std::stoi(fields[5]);
           gpu["fan_speed_pct"] = std::stoi(fields[6]);
-          gpu["power_draw_w"] = std::stof(fields[7]);
+          if (const auto power_draw = util::parse_decimal<float>(fields[7])) {
+            gpu["power_draw_w"] = *power_draw;
+          }
           gpu["clock_gpu_mhz"] = std::stoi(fields[8]);
           gpu["clock_mem_mhz"] = std::stoi(fields[9]);
           } catch (...) {
@@ -6547,7 +6549,9 @@ namespace confighttp {
     try { gpu["vram_used_mb"] = std::stoll(read_sysfs(dev + "/mem_info_vram_used")) / (1024 * 1024); } catch (...) {}
     try { gpu["vram_total_mb"] = std::stoll(read_sysfs(dev + "/mem_info_vram_total")) / (1024 * 1024); } catch (...) {}
     try { gpu["fan_speed_pct"] = std::stoi(read_sysfs(hwmon + "/pwm1")) * 100 / 255; } catch (...) {}
-    try { gpu["power_draw_w"] = std::stof(read_sysfs(hwmon + "/power1_average")) / 1e6f; } catch (...) {}
+    if (const auto power_draw = util::parse_decimal<float>(read_sysfs(hwmon + "/power1_average"))) {
+      gpu["power_draw_w"] = *power_draw / 1e6f;
+    }
 
     int sclk = active_mhz(dev + "/pp_dpm_sclk");
     int mclk = active_mhz(dev + "/pp_dpm_mclk");

--- a/src/display_planner.cpp
+++ b/src/display_planner.cpp
@@ -3,6 +3,7 @@
  * @brief The display resolution planner, ported from the web UI.
  */
 #include "display_planner.h"
+#include "utility.h"
 
 #include <algorithm>
 #include <cctype>
@@ -128,15 +129,13 @@ namespace display_planner {
       return std::nullopt;
     }
 
-    try {
-      return mode_t {
-        std::stod(std::string {width}),
-        std::stod(std::string {height}),
-        std::stod(std::string {fps}),
-      };
-    } catch (const std::exception &) {
+    const auto parsed_width = util::parse_decimal<double>(width);
+    const auto parsed_height = util::parse_decimal<double>(height);
+    const auto parsed_fps = util::parse_decimal<double>(fps);
+    if (!parsed_width || !parsed_height || !parsed_fps) {
       return std::nullopt;
     }
+    return mode_t {*parsed_width, *parsed_height, *parsed_fps};
   }
 
   std::string format_display_mode(const mode_t &mode) {

--- a/src/launch_profile.cpp
+++ b/src/launch_profile.cpp
@@ -1,6 +1,7 @@
 #include "launch_profile.h"
 
 #include "device_db.h"
+#include "utility.h"
 
 #include <algorithm>
 #include <cctype>
@@ -32,8 +33,11 @@ namespace launch_profile {
           if (index == 0) result.width = std::stoi(segment);
           else if (index == 1) result.height = std::stoi(segment);
           else if (index == 2) {
-            const auto fps = std::stod(segment);
-            result.fps = static_cast<int>(std::round(fps < 1000.0 ? fps * 1000.0 : fps));
+            const auto fps = util::parse_decimal<double>(segment);
+            if (!fps) {
+              return std::nullopt;
+            }
+            result.fps = static_cast<int>(std::round(*fps < 1000.0 ? *fps * 1000.0 : *fps));
           } else {
             return std::nullopt;
           }
@@ -51,9 +55,7 @@ namespace launch_profile {
     std::string format_fps(int fps) {
       if (fps <= 0) return "0";
       if (fps % 1000 == 0) return std::to_string(fps / 1000);
-      std::ostringstream output;
-      output << static_cast<double>(fps) / 1000.0;
-      return output.str();
+      return util::format_decimal(static_cast<double>(fps) / 1000.0);
     }
 
     std::string format_display_mode(const display_mode_t &mode) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
  * @brief Definitions for the main entry point for Sunshine.
  */
 // standard includes
+#include <clocale>
 #include <codecvt>
 #include <csignal>
 #include <exception>
@@ -180,6 +181,10 @@ void mainThreadLoop(const std::shared_ptr<safe::event_t<bool>> &shutdown_event) 
 }
 
 int main(int argc, char *argv[]) {
+  // Polaris protocol and config decimals always use an ASCII full stop. Keep
+  // that invariant even when a desktop toolkit initializes another locale.
+  std::setlocale(LC_NUMERIC, "C");
+
   lifetime::argv = argv;
 
   task_pool_util::TaskPool::task_id_t force_shutdown = nullptr;
@@ -189,7 +194,7 @@ int main(int argc, char *argv[]) {
   // by placing a user-writable directory in the system-wide PATH variable.
   SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
 
-  setlocale(LC_ALL, "C");
+  std::setlocale(LC_ALL, "C");
 #endif
 
 #pragma GCC diagnostic push

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -1647,7 +1647,11 @@ namespace nvhttp {
           } else if (index == 1) {
             height = std::stoi(segment);
           } else if (index == 2) {
-            fps = std::stod(segment);
+            const auto parsed_fps = util::parse_decimal<double>(segment);
+            if (!parsed_fps) {
+              return false;
+            }
+            fps = *parsed_fps;
           } else {
             return false;
           }
@@ -4446,7 +4450,12 @@ namespace nvhttp {
         launch_session->height = atoi(segment.c_str());
       }
       if (x == 2) {
-        auto fps = atof(segment.c_str());
+        const auto parsed_fps = util::parse_decimal<double>(segment);
+        if (!parsed_fps) {
+          x = -1;
+          break;
+        }
+        auto fps = *parsed_fps;
         if (fps < 1000) {
           fps *= 1000;
         };
@@ -9716,30 +9725,20 @@ namespace nvhttp {
       const auto explicit_bitrate = bounded_integer("bitrate_kbps", 1000, 300000);
       std::optional<int> explicit_fps;
       if (const auto it = args.find("fps"); it != args.end()) {
-        try {
-          std::size_t consumed = 0;
-          const auto fps = std::stod(it->second, &consumed);
-          if (consumed != it->second.size() || !std::isfinite(fps) || fps < 15.0 || fps > 240.0) {
-            invalid_argument = true;
-          } else {
-            explicit_fps = static_cast<int>(std::round(fps * 1000.0));
-          }
-        } catch (...) {
+        const auto fps = util::parse_decimal<double>(it->second);
+        if (!fps || *fps < 15.0 || *fps > 240.0) {
           invalid_argument = true;
+        } else {
+          explicit_fps = static_cast<int>(std::round(*fps * 1000.0));
         }
       }
       std::optional<int> client_max_fps;
       if (const auto it = args.find("client_max_fps"); it != args.end()) {
-        try {
-          std::size_t consumed = 0;
-          const auto fps = std::stod(it->second, &consumed);
-          if (consumed != it->second.size() || !std::isfinite(fps) || fps < 15.0 || fps > 360.0) {
-            invalid_argument = true;
-          } else {
-            client_max_fps = static_cast<int>(std::round(fps * 1000.0));
-          }
-        } catch (...) {
+        const auto fps = util::parse_decimal<double>(it->second);
+        if (!fps || *fps < 15.0 || *fps > 360.0) {
           invalid_argument = true;
+        } else {
+          client_max_fps = static_cast<int>(std::round(*fps * 1000.0));
         }
       }
       const bool any_explicit_mode = explicit_width || explicit_height || explicit_fps;

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -19,11 +19,13 @@
 #include "cage_display_router.h"
 #include "../../logging.h"
 #include "../../utility.h"
+#include "labwc_startup_diagnostics.h"
 #include "misc.h"
 #include "private_session_input.h"
 #include "wlgrab_capture_policy.h"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cerrno>
 #include <cctype>
@@ -33,6 +35,8 @@
 #include <dirent.h>
 #include <functional>
 #include <fstream>
+#include <memory>
+#include <mutex>
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
@@ -79,6 +83,8 @@ namespace cage_display_router {
   static std::string cage_wayland_socket;  // e.g., "wayland-5"
   static std::string cage_x11_display;  // e.g., ":1"
   static std::string cage_session_instance_id;
+  static std::mutex startup_diagnostics_mutex;
+  static std::shared_ptr<labwc_startup_diagnostics::collector_t> startup_diagnostics;
 
   // The output mode most recently requested of the running compositor. A
   // resume can carry a different refresh than the launch that started the
@@ -134,6 +140,29 @@ namespace cage_display_router {
   // -----------------------------------------------------------------------
   // Internal helpers
   // -----------------------------------------------------------------------
+
+  static void close_descriptor(int &fd) {
+    if (fd >= 0) {
+      close(fd);
+      fd = -1;
+    }
+  }
+
+  static bool make_inheritable(int fd) {
+    const auto flags = fcntl(fd, F_GETFD);
+    return flags >= 0 && fcntl(fd, F_SETFD, flags & ~FD_CLOEXEC) == 0;
+  }
+
+  static void publish_startup_diagnostics(
+    std::shared_ptr<labwc_startup_diagnostics::collector_t> collector
+  ) {
+    const std::lock_guard lock {startup_diagnostics_mutex};
+    startup_diagnostics = std::move(collector);
+  }
+
+  static void clear_startup_diagnostics() {
+    publish_startup_diagnostics(nullptr);
+  }
 
   /// Open a pidfd for the freshly spawned compositor, if the kernel allows it.
   static void open_cage_pidfd(pid_t pid) {
@@ -597,26 +626,6 @@ namespace cage_display_router {
 
   static bool executable_accessible(const std::string &path) {
     return !path.empty() && access(path.c_str(), X_OK) == 0;
-  }
-
-  static std::string shell_quote(std::string_view value) {
-    const auto quote = std::string(1, static_cast<char>(39));
-    const auto slash = std::string(1, static_cast<char>(92));
-    std::string result = quote;
-
-    for (char ch : value) {
-      if (ch == static_cast<char>(39)) {
-        result += quote;
-        result += slash;
-        result += quote;
-        result += quote;
-      } else {
-        result += ch;
-      }
-    }
-
-    result += quote;
-    return result;
   }
 
   static std::string resolve_executable(const std::string &name) {
@@ -1127,6 +1136,7 @@ namespace cage_display_router {
     cage_wayland_socket.clear();
     cage_x11_display.clear();
     cage_session_instance_id.clear();
+    clear_startup_diagnostics();
     // The mode is unrecorded until this startup settles: a resume racing the
     // launch must see "no recorded mode" and report failure, not silently
     // claim the refresh was applied.
@@ -1251,6 +1261,48 @@ namespace cage_display_router {
         "exec sleep infinity";
     }
 
+    // Capture only a real startup client's stderr and eventual shell status.
+    // The pipes are memory-only and continuously drained, so a noisy launcher
+    // cannot block on a full pipe or leave an unbounded diagnostic file behind.
+    std::array<int, 2> startup_stderr_pipe {-1, -1};
+    std::array<int, 2> startup_status_pipe {-1, -1};
+    std::shared_ptr<labwc_startup_diagnostics::collector_t> startup_collector;
+    std::thread startup_diagnostics_reader;
+    bool startup_diagnostics_enabled = false;
+    if (!game_cmd.empty() && !session_instance_id.empty()) {
+      int diagnostics_error = 0;
+      if (pipe2(startup_stderr_pipe.data(), O_CLOEXEC) != 0) {
+        diagnostics_error = errno;
+      } else if (pipe2(startup_status_pipe.data(), O_CLOEXEC) != 0) {
+        diagnostics_error = errno;
+      } else {
+        try {
+          startup_collector =
+            std::make_shared<labwc_startup_diagnostics::collector_t>(session_instance_id);
+          startup_diagnostics_reader = std::thread {
+            labwc_startup_diagnostics::drain_pipes,
+            startup_stderr_pipe[0],
+            startup_status_pipe[0],
+            startup_collector
+          };
+          startup_diagnostics_enabled = true;
+        } catch (const std::exception &e) {
+          BOOST_LOG(warning) << "labwc: Startup-client diagnostics unavailable: "sv << e.what();
+        }
+      }
+
+      if (!startup_diagnostics_enabled) {
+        close_descriptor(startup_stderr_pipe[0]);
+        close_descriptor(startup_stderr_pipe[1]);
+        close_descriptor(startup_status_pipe[0]);
+        close_descriptor(startup_status_pipe[1]);
+        if (diagnostics_error != 0) {
+          BOOST_LOG(warning) << "labwc: Startup-client diagnostics unavailable: "sv
+                             << strerror(diagnostics_error);
+        }
+      }
+    }
+
     // Snapshot existing sockets to detect the new one labwc creates
     auto sockets_before = snapshot_wayland_sockets();
     auto x11_displays_before = snapshot_x11_displays();
@@ -1302,6 +1354,18 @@ namespace cage_display_router {
       // not KDE's :0. labwc will set its own DISPLAY via XWayland.
       unsetenv("DISPLAY");
 
+      bool child_diagnostics_enabled = startup_diagnostics_enabled;
+      if (child_diagnostics_enabled) {
+        close_descriptor(startup_stderr_pipe[0]);
+        close_descriptor(startup_status_pipe[0]);
+        if (!make_inheritable(startup_stderr_pipe[1]) ||
+            !make_inheritable(startup_status_pipe[1])) {
+          close_descriptor(startup_stderr_pipe[1]);
+          close_descriptor(startup_status_pipe[1]);
+          child_diagnostics_enabled = false;
+        }
+      }
+
       // Redirect stdout/stderr
       int devnull = open("/dev/null", O_RDWR);
       if (devnull >= 0) {
@@ -1315,13 +1379,31 @@ namespace cage_display_router {
       int maxfd = (int)sysconf(_SC_OPEN_MAX);
       if (maxfd < 0) maxfd = 1024;
       for (int fd = 3; fd < maxfd; ++fd) {
+        if (child_diagnostics_enabled &&
+            (fd == startup_stderr_pipe[1] || fd == startup_status_pipe[1])) {
+          continue;
+        }
         close(fd);
       }
 
       // labwc -C: config dir for rc.xml, -s: startup command (game)
-      const auto startup_shell = std::string("bash -c " ) + shell_quote(startup_cmd);
+      const auto effective_startup_cmd = child_diagnostics_enabled ?
+        labwc_startup_diagnostics::instrument_shell_command(
+          startup_cmd,
+          startup_stderr_pipe[1],
+          startup_status_pipe[1]
+        ) :
+        startup_cmd;
+      const auto startup_shell =
+        labwc_startup_diagnostics::make_labwc_startup_command(effective_startup_cmd);
       supervise_labwc(labwc_path, config_dir, startup_shell);
     } else if (pid > 0) {
+      if (startup_diagnostics_enabled) {
+        close_descriptor(startup_stderr_pipe[1]);
+        close_descriptor(startup_status_pipe[1]);
+        startup_diagnostics_reader.detach();
+        publish_startup_diagnostics(std::move(startup_collector));
+      }
       cage_pid = pid;
       open_cage_pidfd(pid);
       // Restore MangoHud in parent (was cleared to prevent labwc crash)
@@ -1330,6 +1412,11 @@ namespace cage_display_router {
       if (!saved_mangohud_config.empty()) setenv("MANGOHUD_CONFIG", saved_mangohud_config.c_str(), 1);
       BOOST_LOG(info) << "labwc: Spawned (pid="sv << pid << ")"sv;
     } else {
+      if (startup_diagnostics_enabled) {
+        close_descriptor(startup_stderr_pipe[1]);
+        close_descriptor(startup_status_pipe[1]);
+        startup_diagnostics_reader.detach();
+      }
       BOOST_LOG(error) << "labwc: fork() failed"sv;
       return false;
     }
@@ -1514,6 +1601,7 @@ namespace cage_display_router {
 
   void stop() {
     if (cage_pid <= 0) {
+      clear_startup_diagnostics();
       return;
     }
 
@@ -1528,6 +1616,7 @@ namespace cage_display_router {
       cage_wayland_socket.clear();
       cage_x11_display.clear();
       cage_session_instance_id.clear();
+      clear_startup_diagnostics();
       cage_runtime_state = {
         .requested_headless = false,
         .effective_headless = false,
@@ -1575,6 +1664,7 @@ namespace cage_display_router {
     cage_wayland_socket.clear();
     cage_x11_display.clear();
     cage_session_instance_id.clear();
+    clear_startup_diagnostics();
     cage_runtime_state = {
       .requested_headless = false,
       .effective_headless = false,
@@ -1593,6 +1683,7 @@ namespace cage_display_router {
     cage_wayland_socket.clear();
     cage_x11_display.clear();
     cage_session_instance_id.clear();
+    clear_startup_diagnostics();
     cage_runtime_state = {
       .requested_headless = false,
       .effective_headless = false,
@@ -1630,6 +1721,17 @@ namespace cage_display_router {
 
   std::string get_session_instance_id() {
     return cage_session_instance_id;
+  }
+
+  std::optional<labwc_startup_diagnostics::snapshot_t> get_startup_client_diagnostics(
+    std::string_view expected_session_instance_id
+  ) {
+    std::shared_ptr<labwc_startup_diagnostics::collector_t> collector;
+    {
+      const std::lock_guard lock {startup_diagnostics_mutex};
+      collector = startup_diagnostics;
+    }
+    return collector ? collector->snapshot(expected_session_instance_id) : std::nullopt;
   }
 
   std::string get_x11_display() {

--- a/src/platform/linux/cage_display_router.cpp
+++ b/src/platform/linux/cage_display_router.cpp
@@ -18,6 +18,7 @@
 
 #include "cage_display_router.h"
 #include "../../logging.h"
+#include "../../utility.h"
 #include "misc.h"
 #include "private_session_input.h"
 #include "wlgrab_capture_policy.h"
@@ -867,16 +868,18 @@ namespace cage_display_router {
       if (line.find(mode) != std::string::npos &&
           (line.find("current") != std::string::npos || line.find('*') != std::string::npos)) {
         const auto hz_pos = line.find(" Hz");
-        const auto comma_pos = line.rfind(',', hz_pos);
-        if (hz_pos == std::string::npos || comma_pos == std::string::npos || comma_pos >= hz_pos) {
+        const auto separator_pos = line.find(" px,");
+        if (hz_pos == std::string::npos || separator_pos == std::string::npos || separator_pos + 4 >= hz_pos) {
           continue;
         }
 
-        try {
-          return std::stod(line.substr(comma_pos + 1, hz_pos - comma_pos - 1));
-        } catch (...) {
-          return std::nullopt;
-        }
+        auto refresh = trimmed(
+          std::string_view {line}.substr(separator_pos + 4, hz_pos - separator_pos - 4)
+        );
+        // wlr-randr may honor a comma-decimal locale even though its field
+        // separator is also a comma. Normalize only the isolated Hz field.
+        std::replace(refresh.begin(), refresh.end(), ',', '.');
+        return util::parse_decimal<double>(refresh);
       }
     }
 

--- a/src/platform/linux/cage_display_router.h
+++ b/src/platform/linux/cage_display_router.h
@@ -8,6 +8,7 @@
 #ifdef __linux__
 
 #include "src/platform/common.h"
+#include "labwc_startup_diagnostics.h"
 #include "wlgrab_capture_policy.h"
 
 #include <optional>
@@ -151,6 +152,13 @@ namespace cage_display_router {
    */
   std::string get_wayland_socket();
   std::string get_session_instance_id();
+
+  /**
+   * @brief Return bounded startup-client evidence only for the exact runtime generation.
+   */
+  std::optional<labwc_startup_diagnostics::snapshot_t> get_startup_client_diagnostics(
+    std::string_view expected_session_instance_id
+  );
 
   /**
    * @brief Returns the XWayland display exposed by cage (e.g., ":1").

--- a/src/platform/linux/labwc_startup_diagnostics.cpp
+++ b/src/platform/linux/labwc_startup_diagnostics.cpp
@@ -1,0 +1,418 @@
+/**
+ * @file src/platform/linux/labwc_startup_diagnostics.cpp
+ * @brief Bounded, generation-scoped evidence from a labwc startup client.
+ */
+
+#include "labwc_startup_diagnostics.h"
+
+#ifdef __linux__
+
+#include <algorithm>
+#include <arpa/inet.h>
+#include <array>
+#include <cerrno>
+#include <charconv>
+#include <limits>
+#include <poll.h>
+#include <regex>
+#include <system_error>
+#include <unistd.h>
+#include <utility>
+
+namespace labwc_startup_diagnostics {
+  namespace {
+    std::string shell_quote(std::string_view value) {
+      std::string result {"'"};
+      for (const char ch : value) {
+        if (ch == '\'') {
+          result += "'\\''";
+        } else {
+          result += ch;
+        }
+      }
+      result += '\'';
+      return result;
+    }
+
+    std::string replace_all(
+      const std::string &input,
+      const std::regex &pattern,
+      std::string_view replacement
+    ) {
+      return std::regex_replace(input, pattern, std::string {replacement});
+    }
+
+    std::optional<int> parse_status_line(std::string_view line) {
+      while (!line.empty() && (line.front() == ' ' || line.front() == '\t')) {
+        line.remove_prefix(1);
+      }
+      while (!line.empty() &&
+             (line.back() == ' ' || line.back() == '\t' || line.back() == '\r')) {
+        line.remove_suffix(1);
+      }
+      int status = -1;
+      const auto parsed = std::from_chars(line.data(), line.data() + line.size(), status);
+      if (parsed.ec != std::errc {} || parsed.ptr != line.data() + line.size() ||
+          status < 0 || status > 255) {
+        return std::nullopt;
+      }
+      return status;
+    }
+
+    bool long_value_character(unsigned char ch) {
+      return (ch >= 'a' && ch <= 'z') ||
+             (ch >= 'A' && ch <= 'Z') ||
+             (ch >= '0' && ch <= '9') ||
+             ch == '_' || ch == '+' || ch == '=' || ch == '-';
+    }
+
+    std::string redact_long_values(std::string_view input) {
+      std::string output;
+      output.reserve(input.size());
+      std::size_t cursor = 0;
+      while (cursor < input.size()) {
+        const auto begin = cursor;
+        while (cursor < input.size() &&
+               long_value_character(static_cast<unsigned char>(input[cursor]))) {
+          ++cursor;
+        }
+        if (cursor - begin >= 40) {
+          output += "[redacted-value]";
+        } else {
+          output.append(input.substr(begin, cursor - begin));
+        }
+        if (cursor < input.size()) {
+          output += input[cursor++];
+        }
+      }
+      return output;
+    }
+
+    bool ip_literal_character(unsigned char ch) {
+      return (ch >= '0' && ch <= '9') ||
+             (ch >= 'a' && ch <= 'f') ||
+             (ch >= 'A' && ch <= 'F') ||
+             ch == ':' || ch == '.';
+    }
+
+    std::string redact_ip_literals(std::string_view input) {
+      std::string output;
+      output.reserve(input.size());
+      std::size_t cursor = 0;
+      while (cursor < input.size()) {
+        if (!ip_literal_character(static_cast<unsigned char>(input[cursor]))) {
+          output += input[cursor++];
+          continue;
+        }
+
+        const auto begin = cursor;
+        while (cursor < input.size() &&
+               ip_literal_character(static_cast<unsigned char>(input[cursor]))) {
+          ++cursor;
+        }
+        const auto address_end = cursor;
+        if (cursor < input.size() && input[cursor] == '%') {
+          ++cursor;
+          while (cursor < input.size()) {
+            const auto ch = static_cast<unsigned char>(input[cursor]);
+            if (!((ch >= 'a' && ch <= 'z') ||
+                  (ch >= 'A' && ch <= 'Z') ||
+                  (ch >= '0' && ch <= '9') ||
+                  ch == '_' || ch == '.' || ch == '-')) {
+              break;
+            }
+            ++cursor;
+          }
+        }
+
+        const std::string candidate {input.substr(begin, address_end - begin)};
+        std::array<unsigned char, 16> parsed {};
+        if (inet_pton(AF_INET6, candidate.c_str(), parsed.data()) == 1 ||
+            inet_pton(AF_INET, candidate.c_str(), parsed.data()) == 1) {
+          output += "[ip]";
+        } else {
+          output.append(input.substr(begin, cursor - begin));
+        }
+      }
+      return output;
+    }
+
+    void close_descriptor(int &fd) {
+      if (fd >= 0) {
+        close(fd);
+        fd = -1;
+      }
+    }
+  }  // namespace
+
+  collector_t::collector_t(std::string session_instance_id):
+      session_instance_id_ {std::move(session_instance_id)} {
+  }
+
+  void collector_t::append_stderr(std::string_view bytes) {
+    if (bytes.empty()) {
+      return;
+    }
+
+    const std::lock_guard lock {mutex_};
+    if (bytes.size() > std::numeric_limits<std::size_t>::max() - stderr_bytes_seen_) {
+      stderr_bytes_seen_ = std::numeric_limits<std::size_t>::max();
+    } else {
+      stderr_bytes_seen_ += bytes.size();
+    }
+
+    if (bytes.size() >= max_retained_stderr_bytes) {
+      stderr_tail_.assign(bytes.end() - max_retained_stderr_bytes, bytes.end());
+      stderr_truncated_ = true;
+      return;
+    }
+
+    const auto overflow = stderr_tail_.size() + bytes.size() > max_retained_stderr_bytes ?
+      stderr_tail_.size() + bytes.size() - max_retained_stderr_bytes :
+      0;
+    if (overflow > 0) {
+      stderr_tail_.erase(0, overflow);
+      stderr_truncated_ = true;
+    }
+    stderr_tail_.append(bytes);
+  }
+
+  void collector_t::record_shell_exit_status(int status) {
+    if (status < 0 || status > 255) {
+      return;
+    }
+    const std::lock_guard lock {mutex_};
+    if (!shell_exit_status_) {
+      shell_exit_status_ = status;
+    }
+  }
+
+  std::optional<snapshot_t> collector_t::snapshot(
+    std::string_view expected_session_instance_id
+  ) const {
+    std::string raw_stderr;
+    snapshot_t result;
+    {
+      const std::lock_guard lock {mutex_};
+      if (expected_session_instance_id.empty() ||
+          expected_session_instance_id != session_instance_id_) {
+        return std::nullopt;
+      }
+      result.shell_exit_status = shell_exit_status_;
+      result.stderr_bytes_seen = stderr_bytes_seen_;
+      result.stderr_truncated = stderr_truncated_;
+      raw_stderr = stderr_tail_;
+    }
+
+    auto redacted = redact_stderr_for_log(raw_stderr);
+    result.stderr_truncated = result.stderr_truncated || redacted.truncated;
+    result.stderr_summary = std::move(redacted.text);
+    return result;
+  }
+
+  redacted_text_t redact_stderr_for_log(std::string_view raw) {
+    constexpr std::size_t max_redaction_input_bytes = max_log_summary_bytes * 2;
+    const bool input_truncated = raw.size() > max_redaction_input_bytes;
+    if (input_truncated) {
+      raw.remove_prefix(raw.size() - max_redaction_input_bytes);
+    }
+
+    std::string normalized;
+    normalized.reserve(raw.size());
+    bool previous_space = true;
+    for (std::size_t i = 0; i < raw.size(); ++i) {
+      const auto ch = static_cast<unsigned char>(raw[i]);
+      if (ch == 0x1b && i + 1 < raw.size() && raw[i + 1] == '[') {
+        i += 2;
+        while (i < raw.size()) {
+          const auto terminal = static_cast<unsigned char>(raw[i]);
+          if (terminal >= 0x40 && terminal <= 0x7e) {
+            break;
+          }
+          ++i;
+        }
+        continue;
+      }
+
+      const bool space = ch <= 0x20 || ch == 0x7f;
+      if (space) {
+        if (!previous_space && !normalized.empty()) {
+          normalized += ' ';
+        }
+        previous_space = true;
+        continue;
+      }
+      normalized += static_cast<char>(ch);
+      previous_space = false;
+    }
+    while (!normalized.empty() && normalized.back() == ' ') {
+      normalized.pop_back();
+    }
+
+    // The retained tail can begin in the middle of a credential or path. Never
+    // log that partial token: without its key/prefix it cannot be redacted with
+    // confidence and carries little diagnostic value anyway.
+    if (input_truncated && !normalized.empty()) {
+      const auto first_space = normalized.find(' ');
+      normalized.replace(
+        0,
+        first_space == std::string::npos ? normalized.size() : first_space,
+        "[truncated-prefix]"
+      );
+    }
+
+    static const std::regex url {
+      R"(\b[A-Za-z][A-Za-z0-9+.-]*://[^ ]+)"
+    };
+    static const std::regex unix_home {R"((/(var/home|home|Users)/)[^ /]+)"};
+    static const std::regex runtime_user {R"((/run/user/)[0-9]+)"};
+    static const std::regex windows_home {R"(([A-Za-z]:\\Users\\)[^ \\]+)"};
+    static const std::regex ipv4 {R"(\b([0-9]{1,3}\.){3}[0-9]{1,3}\b)"};
+    static const std::regex email {
+      R"(\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b)"
+    };
+    static const std::regex bearer {R"((\bbearer[ ]+)[^ ,;]+)", std::regex::icase};
+    static const std::regex sensitive_flag {
+      R"((--(password|passwd|token|secret|api[-_]?key)[ =]+)[^ ,;]+)",
+      std::regex::icase
+    };
+    static const std::regex sensitive_assignment {
+      R"(((authorization|proxy[-_]?authorization|access[-_]?token|refresh[-_]?token|session[-_]?token|api[-_]?key|password|passwd|secret|cookie)[ ]*[:=][ ]*)("[^"]*"|'[^']*'|[^ ,;&]+))",
+      std::regex::icase
+    };
+    static const std::regex identity_assignment {
+      R"((\b(host(name)?|server|endpoint|address|user(name)?)[ ]*[:=][ ]*)("[^"]*"|'[^']*'|[^ ,;&]+))",
+      std::regex::icase
+    };
+
+    normalized = replace_all(normalized, url, "[url]");
+    normalized = replace_all(normalized, unix_home, "$1[user]");
+    normalized = replace_all(normalized, runtime_user, "$1[uid]");
+    normalized = replace_all(normalized, windows_home, "$1[user]");
+    normalized = replace_all(normalized, ipv4, "[ip]");
+    normalized = redact_ip_literals(normalized);
+    normalized = replace_all(normalized, email, "[email]");
+    normalized = replace_all(normalized, bearer, "$1[redacted]");
+    normalized = replace_all(normalized, sensitive_flag, "$1[redacted]");
+    normalized = replace_all(normalized, sensitive_assignment, "$1[redacted]");
+    normalized = replace_all(normalized, identity_assignment, "$1[redacted]");
+    normalized = redact_long_values(normalized);
+
+    redacted_text_t result;
+    result.truncated = input_truncated;
+    if (normalized.size() > max_log_summary_bytes) {
+      result.text = normalized.substr(normalized.size() - max_log_summary_bytes);
+      const auto first_space = result.text.find(' ');
+      result.text.replace(
+        0,
+        first_space == std::string::npos ? result.text.size() : first_space,
+        "[truncated-prefix]"
+      );
+      result.text.resize(std::min(result.text.size(), max_log_summary_bytes));
+      result.truncated = true;
+    } else {
+      result.text = std::move(normalized);
+    }
+    return result;
+  }
+
+  std::string describe_for_log(const snapshot_t &snapshot) {
+    std::string result = "startup_client_exit_status=";
+    result += snapshot.shell_exit_status ?
+      std::to_string(*snapshot.shell_exit_status) :
+      "pending";
+    result += " startup_client_stderr_bytes=" +
+              std::to_string(snapshot.stderr_bytes_seen);
+    result += " startup_client_stderr_truncated=";
+    result += snapshot.stderr_truncated ? "true" : "false";
+    if (!snapshot.stderr_summary.empty()) {
+      result += " startup_client_stderr_tail=[" + snapshot.stderr_summary + ']';
+    }
+    return result;
+  }
+
+  std::string instrument_shell_command(
+    std::string_view command,
+    int stderr_fd,
+    int status_fd
+  ) {
+    if (command.empty() || stderr_fd < 3 || status_fd < 3 || stderr_fd == status_fd) {
+      return std::string {command};
+    }
+
+    const std::string status_variable = "__polaris_startup_status";
+    return "bash -c " + shell_quote(command) +
+           " 2>&" + std::to_string(stderr_fd) +
+           "; " + status_variable + "=$?; printf '%d\\n' \"$" + status_variable +
+           "\" >&" + std::to_string(status_fd) +
+           "; exit \"$" + status_variable + "\"";
+  }
+
+  std::string make_labwc_startup_command(std::string_view shell_program) {
+    return "bash -c " + shell_quote(shell_program);
+  }
+
+  void drain_pipes(
+    int stderr_fd,
+    int status_fd,
+    const std::shared_ptr<collector_t> &collector
+  ) {
+    if (!collector) {
+      close_descriptor(stderr_fd);
+      close_descriptor(status_fd);
+      return;
+    }
+
+    std::string status_buffer;
+    while (stderr_fd >= 0 || status_fd >= 0) {
+      pollfd descriptors[2] {
+        {stderr_fd, static_cast<short>(POLLIN | POLLHUP | POLLERR), 0},
+        {status_fd, static_cast<short>(POLLIN | POLLHUP | POLLERR), 0},
+      };
+      const auto ready = poll(descriptors, 2, -1);
+      if (ready < 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        break;
+      }
+
+      if (stderr_fd >= 0 && descriptors[0].revents != 0) {
+        char buffer[2048];
+        const auto count = read(stderr_fd, buffer, sizeof(buffer));
+        if (count > 0) {
+          collector->append_stderr(std::string_view {buffer, static_cast<std::size_t>(count)});
+        } else if (count == 0 || (errno != EINTR && errno != EAGAIN)) {
+          close_descriptor(stderr_fd);
+        }
+      }
+
+      if (status_fd >= 0 && descriptors[1].revents != 0) {
+        char buffer[32];
+        const auto count = read(status_fd, buffer, sizeof(buffer));
+        if (count > 0) {
+          status_buffer.append(buffer, static_cast<std::size_t>(count));
+          const auto newline = status_buffer.find('\n');
+          if (newline != std::string::npos || status_buffer.size() > 16) {
+            const auto line = std::string_view {status_buffer}.substr(0, newline);
+            if (const auto status = parse_status_line(line)) {
+              collector->record_shell_exit_status(*status);
+            }
+            close_descriptor(status_fd);
+          }
+        } else if (count == 0 || (errno != EINTR && errno != EAGAIN)) {
+          if (const auto status = parse_status_line(status_buffer)) {
+            collector->record_shell_exit_status(*status);
+          }
+          close_descriptor(status_fd);
+        }
+      }
+    }
+
+    close_descriptor(stderr_fd);
+    close_descriptor(status_fd);
+  }
+
+}  // namespace labwc_startup_diagnostics
+
+#endif  // __linux__

--- a/src/platform/linux/labwc_startup_diagnostics.h
+++ b/src/platform/linux/labwc_startup_diagnostics.h
@@ -1,0 +1,94 @@
+/**
+ * @file src/platform/linux/labwc_startup_diagnostics.h
+ * @brief Bounded, generation-scoped evidence from a labwc startup client.
+ */
+#pragma once
+
+#ifdef __linux__
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace labwc_startup_diagnostics {
+
+  inline constexpr std::size_t max_retained_stderr_bytes = 8U * 1024U;
+  inline constexpr std::size_t max_log_summary_bytes = 1024U;
+
+  struct redacted_text_t {
+    std::string text;
+    bool truncated = false;
+  };
+
+  struct snapshot_t {
+    std::optional<int> shell_exit_status;
+    std::size_t stderr_bytes_seen = 0;
+    bool stderr_truncated = false;
+    std::string stderr_summary;
+  };
+
+  /**
+   * @brief Thread-safe in-memory state for one immutable runtime generation.
+   *
+   * The collector retains only the tail of stderr. A caller must present the
+   * exact generation id before receiving a snapshot, preventing a detached
+   * attach watcher from reading evidence from a later private session.
+   */
+  class collector_t {
+  public:
+    explicit collector_t(std::string session_instance_id);
+
+    void append_stderr(std::string_view bytes);
+    void record_shell_exit_status(int status);
+    std::optional<snapshot_t> snapshot(std::string_view expected_session_instance_id) const;
+
+  private:
+    std::string session_instance_id_;
+    mutable std::mutex mutex_;
+    std::string stderr_tail_;
+    std::size_t stderr_bytes_seen_ = 0;
+    bool stderr_truncated_ = false;
+    std::optional<int> shell_exit_status_;
+  };
+
+  /** Flatten log injection and redact common credentials, identities, and endpoints. */
+  redacted_text_t redact_stderr_for_log(std::string_view raw);
+
+  /** Render a stable one-line field set containing only already-redacted evidence. */
+  std::string describe_for_log(const snapshot_t &snapshot);
+
+  /**
+   * @brief Wrap a shell program so its stderr and eventual shell status are
+   *        written to inherited descriptors while preserving its exit status.
+   */
+  std::string instrument_shell_command(
+    std::string_view command,
+    int stderr_fd,
+    int status_fd
+  );
+
+  /**
+   * @brief Encode a shell program for labwc's `-s` argument.
+   *
+   * labwc tokenizes this string with GLib and calls execvp() directly, so the
+   * complete program must be the single argument following `bash -c`.
+   */
+  std::string make_labwc_startup_command(std::string_view shell_program);
+
+  /**
+   * @brief Drain the two read descriptors into @p collector, then close them.
+   *
+   * Intended to run on one detached reader thread for the runtime lifetime.
+   */
+  void drain_pipes(
+    int stderr_fd,
+    int status_fd,
+    const std::shared_ptr<collector_t> &collector
+  );
+
+}  // namespace labwc_startup_diagnostics
+
+#endif  // __linux__

--- a/src/platform/linux/stream_runtime.h
+++ b/src/platform/linux/stream_runtime.h
@@ -7,6 +7,7 @@
 #ifdef __linux__
 
   #include "src/platform/common.h"
+  #include "labwc_startup_diagnostics.h"
   #include "stream_display_policy.h"
   #include "wlgrab_capture_policy.h"
 
@@ -87,6 +88,9 @@ namespace stream_runtime {
     void reset_after_external_stop();
     std::string wayland_socket();
     std::string session_instance_id();
+    std::optional<labwc_startup_diagnostics::snapshot_t> startup_client_diagnostics(
+      std::string_view expected_session_instance_id
+    );
     std::string x11_display();
     platf::runtime_state_t runtime_state();
     int current_output_refresh_hz();

--- a/src/platform/linux/stream_runtime_labwc.cpp
+++ b/src/platform/linux/stream_runtime_labwc.cpp
@@ -72,6 +72,14 @@ namespace stream_runtime {
       return cage_display_router::get_session_instance_id();
     }
 
+    std::optional<labwc_startup_diagnostics::snapshot_t> startup_client_diagnostics(
+      std::string_view expected_session_instance_id
+    ) {
+      return cage_display_router::get_startup_client_diagnostics(
+        expected_session_instance_id
+      );
+    }
+
     std::string x11_display() {
       return cage_display_router::get_x11_display();
     }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -9029,6 +9029,7 @@ namespace proc {
           [socket = std::move(private_socket),
            x11_display = std::move(private_x11_display),
            compositor_pid = private_compositor_pid,
+           runtime_generation = _session_instance_id,
            app_name = _app.name]() {
             const auto started = std::chrono::steady_clock::now();
             bool reported_nested_gamescope = false;
@@ -9083,14 +9084,28 @@ namespace proc {
                                  << app_name << ']';
                 return;
               }
+              const auto startup_diagnostics =
+                stream_runtime::labwc::startup_client_diagnostics(runtime_generation);
               BOOST_LOG(warning) << "private_session: ["sv << app_name
                                  << "] did not expose a managed window in the private session after "sv
                                  << std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
                                  << "s. Polaris cannot confirm whether the app rendered on the host desktop "sv
-                                 << "or used an unenumerated fullscreen/XWayland surface; check the client image before applying the Flatpak portal workaround. See docs/troubleshooting.md."sv;
+                                 << "or used an unenumerated fullscreen/XWayland surface. "sv
+                                 << (startup_diagnostics ?
+                                       "Generation-scoped evidence: "s +
+                                         labwc_startup_diagnostics::describe_for_log(*startup_diagnostics) + ". " :
+                                       "No generation-scoped startup-client evidence was available. "s)
+                                 << "Check the client image before applying the Flatpak portal workaround. See docs/troubleshooting.md."sv;
+              const auto event_message =
+                startup_diagnostics && startup_diagnostics->shell_exit_status &&
+                    *startup_diagnostics->shell_exit_status != 0 ?
+                  app_name + " startup client exited with status " +
+                    std::to_string(*startup_diagnostics->shell_exit_status) +
+                    "; no private-session window appeared" :
+                  app_name + " did not expose a managed private-session window; verify where it rendered";
               confighttp::emit_session_event(
                 "warning",
-                app_name + " did not expose a managed private-session window; verify where it rendered"
+                event_message
               );
               return;
             }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -16,9 +16,11 @@
 #include <cmath>
 #include <cstdlib>
 #include <filesystem>
+#include <format>
 #include <functional>
 #include <fstream>
 #include <iomanip>
+#include <locale>
 #include <mutex>
 #include <set>
 #include <sstream>
@@ -3804,6 +3806,7 @@ namespace proc {
 
       const double fps_value = fps >= 1000 ? static_cast<double>(fps) / 1000.0 : static_cast<double>(fps);
       std::ostringstream stream;
+      stream.imbue(std::locale::classic());
       stream << std::fixed << std::setprecision(fps % 1000 == 0 ? 0 : 3) << fps_value;
       return stream.str();
     }
@@ -7949,10 +7952,7 @@ namespace proc {
       return 409;
     }
 
-    std::string fps_str;
-    char fps_buf[8];
-    snprintf(fps_buf, sizeof(fps_buf), "%.3f", (float)launch_session->fps / 1000.0f);
-    fps_str = fps_buf;
+    const auto fps_str = std::format("{:.3f}", static_cast<double>(launch_session->fps) / 1000.0);
 
     // Add Stream-specific environment variables
     // Polaris Compatibility (legacy Sunshine env vars)
@@ -7960,7 +7960,9 @@ namespace proc {
     _env["POLARIS_APP_NAME"] = _app.name;
     _env["POLARIS_CLIENT_WIDTH"] = std::to_string(render_width);
     _env["POLARIS_CLIENT_HEIGHT"] = std::to_string(render_height);
-    _env["POLARIS_CLIENT_FPS"] = config::sunshine.envvar_compatibility_mode ? std::to_string(std::round((float)launch_session->fps / 1000.0f)) : fps_str;
+    _env["POLARIS_CLIENT_FPS"] = config::sunshine.envvar_compatibility_mode ?
+                                   std::format("{:.6f}", std::round(static_cast<double>(launch_session->fps) / 1000.0)) :
+                                   fps_str;
     _env["POLARIS_CLIENT_HDR"] = launch_session->enable_hdr ? "true" : "false";
     _env["POLARIS_CLIENT_GCMAP"] = std::to_string(launch_session->gcmap);
     _env["POLARIS_CLIENT_HOST_AUDIO"] = launch_session->host_audio ? "true" : "false";

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #endif
 #include "process.h"
 #include "stream.h"
+#include "stream_fec.h"
 #include "stream_recorder.h"
 #include "stream_stats.h"
 #include "sync.h"
@@ -535,6 +536,10 @@ namespace stream {
     // stream_stats uses this to reject a stale write/stop that arrives
     // after this uuid's slot has already been handed to a newer session.
     std::uint64_t session_generation = 0;
+
+    // Accessed only by videoBroadcastThread(). Keeping one tracker per
+    // session prevents multi-client summaries from being combined.
+    fec_warning_tracker_t fec_warning_tracker;
 
     bool watch_only;
     bool temporary_authorization = false;
@@ -1629,6 +1634,8 @@ namespace stream {
         }
       }
 
+      const auto encoded_frame_bytes = payload.size();
+
       video_short_frame_header_t frame_header = {};
       frame_header.headerType = 0x01;  // Short header type
       frame_header.frameType = packet->is_idr()                     ? 2 :
@@ -1675,9 +1682,6 @@ namespace stream {
 
       payload = std::string_view {(char *) concat_buf.data(), concat_buf.size()};
 
-      // There are 2 bits for FEC block count for a maximum of 4 FEC blocks
-      constexpr auto MAX_FEC_BLOCKS = 4;
-
       // The max number of data shards per block is found by solving this system of equations for D:
       // D = 255 - P
       // P = D * F
@@ -1693,13 +1697,56 @@ namespace stream {
 
       // If the number of FEC blocks needed exceeds the protocol limit, turn off FEC for this frame.
       // For normal FEC percentages, this should only happen for enormous frames (over 800 packets at 20%).
-      if (fec_blocks_needed > MAX_FEC_BLOCKS) {
-        BOOST_LOG(warning) << "Skipping FEC for abnormally large encoded frame (needed "sv << fec_blocks_needed << " FEC blocks)"sv;
+      if (fec_blocks_needed > MAX_VIDEO_FEC_BLOCKS) {
+        const auto frame_type = packet->is_idr() ? fec_frame_type_e::idr :
+                                packet->after_ref_frame_invalidation ? fec_frame_type_e::reference_invalidation :
+                                                                       fec_frame_type_e::delta;
+        const oversized_fec_frame_observation_t observation {
+          .encoded_frame_bytes = encoded_frame_bytes,
+          .packetized_frame_bytes = payload.size(),
+          .protected_payload_limit_bytes = max_data_per_fec_block * MAX_VIDEO_FEC_BLOCKS,
+          .required_blocks = fec_blocks_needed,
+          .fec_percentage = fecPercentage,
+          .packet_size = session->config.packetsize,
+          .frame_type = frame_type
+        };
+        if (fecPercentage > 0) {
+          stream_stats::record_oversized_fec_frame(
+            session->session_generation,
+            observation.encoded_frame_bytes,
+            observation.packetized_frame_bytes,
+            observation.protected_payload_limit_bytes,
+            observation.required_blocks,
+            observation.fec_percentage,
+            observation.packet_size,
+            fec_frame_type_name(observation.frame_type)
+          );
+          if (const auto summary = session->fec_warning_tracker.observe(observation)) {
+            BOOST_LOG(warning)
+              << "Skipping FEC for oversized encoded frame(s); frame data is still transmitted without parity "sv
+              << "[frames_since_last_report="sv << summary->frame_count
+              << ", encoded_bytes_max="sv << summary->largest_encoded_frame_bytes
+              << ", packetized_bytes_max="sv << summary->largest_packetized_frame_bytes
+              << ", protected_limit_bytes="sv << summary->protected_payload_limit_bytes
+              << ", required_blocks_max="sv << summary->max_required_blocks
+              << ", protocol_blocks_max="sv << MAX_VIDEO_FEC_BLOCKS
+              << ", largest_frame_type="sv << fec_frame_type_name(summary->largest_frame_type)
+              << ", idr_frames="sv << summary->idr_frame_count
+              << ", reference_invalidation_frames="sv << summary->reference_invalidation_frame_count
+              << ", fec_percentage="sv << summary->fec_percentage
+              << ", packet_size="sv << summary->packet_size
+              << ", stream="sv << session->config.monitor.width << 'x' << session->config.monitor.height
+              << '@' << session->config.monitor.framerate
+              << ", encoder_bitrate_kbps="sv << session->config.monitor.bitrate
+              << "]. This is sender-side frame-size evidence, not proof of packet loss; "sv
+              << "lower bitrate only if client media-loss or pacing telemetry also shows impact."sv;
+          }
+        }
         fecPercentage = 0;
-        fec_blocks_needed = MAX_FEC_BLOCKS;
+        fec_blocks_needed = MAX_VIDEO_FEC_BLOCKS;
       }
 
-      std::array<std::string_view, MAX_FEC_BLOCKS> fec_blocks;
+      std::array<std::string_view, MAX_VIDEO_FEC_BLOCKS> fec_blocks;
       decltype(fec_blocks)::iterator
         fec_blocks_begin = std::begin(fec_blocks),
         fec_blocks_end = std::begin(fec_blocks) + fec_blocks_needed;

--- a/src/stream_fec.cpp
+++ b/src/stream_fec.cpp
@@ -1,0 +1,65 @@
+/**
+ * @file src/stream_fec.cpp
+ * @brief Bounded diagnostics for video frames outside the FEC envelope.
+ */
+
+#include "stream_fec.h"
+
+#include <utility>
+
+namespace stream {
+  fec_warning_tracker_t::fec_warning_tracker_t(
+    std::chrono::steady_clock::duration report_interval
+  ):
+      report_interval_ {report_interval} {
+  }
+
+  void fec_warning_tracker_t::accumulate(
+    oversized_fec_frame_summary_t &summary,
+    const oversized_fec_frame_observation_t &observation
+  ) {
+    ++summary.frame_count;
+    if (observation.frame_type == fec_frame_type_e::idr) {
+      ++summary.idr_frame_count;
+    } else if (observation.frame_type == fec_frame_type_e::reference_invalidation) {
+      ++summary.reference_invalidation_frame_count;
+    }
+
+    const bool new_largest =
+      observation.required_blocks > summary.max_required_blocks ||
+      (observation.required_blocks == summary.max_required_blocks &&
+       observation.packetized_frame_bytes > summary.largest_packetized_frame_bytes);
+    if (new_largest) {
+      summary.largest_encoded_frame_bytes = observation.encoded_frame_bytes;
+      summary.largest_packetized_frame_bytes = observation.packetized_frame_bytes;
+      summary.max_required_blocks = observation.required_blocks;
+      summary.largest_frame_type = observation.frame_type;
+    }
+
+    // These describe the current session envelope. Keep the latest values in
+    // case a future live configuration path changes them between reports.
+    summary.protected_payload_limit_bytes = observation.protected_payload_limit_bytes;
+    summary.fec_percentage = observation.fec_percentage;
+    summary.packet_size = observation.packet_size;
+  }
+
+  std::optional<oversized_fec_frame_summary_t> fec_warning_tracker_t::observe(
+    const oversized_fec_frame_observation_t &observation,
+    clock::time_point now
+  ) {
+    if (!last_report_at_) {
+      oversized_fec_frame_summary_t first;
+      accumulate(first, observation);
+      last_report_at_ = now;
+      return first;
+    }
+
+    accumulate(pending_, observation);
+    if (now - *last_report_at_ < report_interval_) {
+      return std::nullopt;
+    }
+
+    last_report_at_ = now;
+    return std::exchange(pending_, {});
+  }
+}  // namespace stream

--- a/src/stream_fec.h
+++ b/src/stream_fec.h
@@ -1,0 +1,87 @@
+/**
+ * @file src/stream_fec.h
+ * @brief Bounded diagnostics for video frames outside the FEC envelope.
+ */
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace stream {
+  // The wire header dedicates two bits to the FEC block count.
+  inline constexpr std::size_t MAX_VIDEO_FEC_BLOCKS = 4;
+
+  enum class fec_frame_type_e {
+    delta,
+    idr,
+    reference_invalidation
+  };
+
+  constexpr std::string_view fec_frame_type_name(fec_frame_type_e type) {
+    switch (type) {
+      case fec_frame_type_e::idr:
+        return "idr";
+      case fec_frame_type_e::reference_invalidation:
+        return "reference_invalidation";
+      default:
+        return "delta";
+    }
+  }
+
+  struct oversized_fec_frame_observation_t {
+    std::size_t encoded_frame_bytes = 0;
+    std::size_t packetized_frame_bytes = 0;
+    std::size_t protected_payload_limit_bytes = 0;
+    std::size_t required_blocks = 0;
+    int fec_percentage = 0;
+    int packet_size = 0;
+    fec_frame_type_e frame_type = fec_frame_type_e::delta;
+  };
+
+  struct oversized_fec_frame_summary_t {
+    std::uint64_t frame_count = 0;
+    std::uint64_t idr_frame_count = 0;
+    std::uint64_t reference_invalidation_frame_count = 0;
+    std::size_t largest_encoded_frame_bytes = 0;
+    std::size_t largest_packetized_frame_bytes = 0;
+    std::size_t protected_payload_limit_bytes = 0;
+    std::size_t max_required_blocks = 0;
+    int fec_percentage = 0;
+    int packet_size = 0;
+    fec_frame_type_e largest_frame_type = fec_frame_type_e::delta;
+  };
+
+  /**
+   * @brief Emit the first oversized frame immediately, then aggregate repeats.
+   *
+   * One instance belongs to one stream session and is called only from the
+   * video broadcast thread. This keeps the hot path lock-free while preventing
+   * a high-bitrate stream from filling the bounded async logging queue.
+   */
+  class fec_warning_tracker_t {
+  public:
+    using clock = std::chrono::steady_clock;
+
+    explicit fec_warning_tracker_t(
+      std::chrono::steady_clock::duration report_interval = std::chrono::seconds(20)
+    );
+
+    std::optional<oversized_fec_frame_summary_t> observe(
+      const oversized_fec_frame_observation_t &observation,
+      clock::time_point now = clock::now()
+    );
+
+  private:
+    static void accumulate(
+      oversized_fec_frame_summary_t &summary,
+      const oversized_fec_frame_observation_t &observation
+    );
+
+    std::chrono::steady_clock::duration report_interval_;
+    std::optional<clock::time_point> last_report_at_;
+    oversized_fec_frame_summary_t pending_;
+  };
+}  // namespace stream

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -470,6 +470,53 @@ namespace stream_stats {
         [&device_uuid](const session_timing_state_t &s) { return s.device_uuid == device_uuid; });
       return it == session_timings.end() ? nullptr : &*it;
     }
+
+    nlohmann::json fec_protection_json(const fec_protection_stats_t &stats) {
+      return {
+        {"oversized_frames_total", stats.oversized_frames_total},
+        {"oversized_idr_frames_total", stats.oversized_idr_frames_total},
+        {"oversized_reference_invalidation_frames_total", stats.oversized_reference_invalidation_frames_total},
+        {"largest_encoded_frame_bytes", stats.largest_encoded_frame_bytes},
+        {"largest_packetized_frame_bytes", stats.largest_packetized_frame_bytes},
+        {"protected_payload_limit_bytes", stats.protected_payload_limit_bytes},
+        {"max_required_blocks", stats.max_required_blocks},
+        {"protocol_max_blocks", stats.protocol_max_blocks},
+        {"fec_percentage", stats.fec_percentage},
+        {"packet_size", stats.packet_size},
+        {"largest_frame_type", stats.largest_frame_type}
+      };
+    }
+
+    void merge_oversized_fec_frame(fec_protection_stats_t &stats,
+                                    std::size_t encoded_frame_bytes,
+                                    std::size_t packetized_frame_bytes,
+                                    std::size_t protected_payload_limit_bytes,
+                                    std::size_t required_blocks,
+                                    int fec_percentage,
+                                    int packet_size,
+                                    std::string_view frame_type) {
+      ++stats.oversized_frames_total;
+      if (frame_type == "idr") {
+        ++stats.oversized_idr_frames_total;
+      } else if (frame_type == "reference_invalidation") {
+        ++stats.oversized_reference_invalidation_frames_total;
+      }
+
+      const bool new_largest =
+        required_blocks > stats.max_required_blocks ||
+        (required_blocks == stats.max_required_blocks &&
+         packetized_frame_bytes > stats.largest_packetized_frame_bytes);
+      if (new_largest) {
+        stats.largest_encoded_frame_bytes = encoded_frame_bytes;
+        stats.largest_packetized_frame_bytes = packetized_frame_bytes;
+        stats.max_required_blocks = required_blocks;
+        stats.largest_frame_type = frame_type;
+      }
+
+      stats.protected_payload_limit_bytes = protected_payload_limit_bytes;
+      stats.fec_percentage = fec_percentage;
+      stats.packet_size = packet_size;
+    }
   }  // namespace
 
   std::string stats_t::to_json() const {
@@ -555,6 +602,7 @@ namespace stream_stats {
     j["effective_launch_bitrate_kbps"] = effective_launch_bitrate_kbps;
     j["width"] = width;
     j["height"] = height;
+    j["fec_protection"] = fec_protection_json(fec_protection);
     j["latency_ms"] = latency_ms;
     j["packet_loss"] = packet_loss;
     j["packet_loss_available"] = packet_loss_available;
@@ -614,6 +662,7 @@ namespace stream_stats {
       cj["packet_loss_source"] = c.packet_loss_source;
       cj["control_channel_packet_loss"] = c.control_channel_packet_loss;
       cj["bytes_sent"] = c.bytes_sent;
+      cj["fec_protection"] = fec_protection_json(c.fec_protection);
       cj["adaptive_target_bitrate_kbps"] = c.adaptive_target_bitrate_kbps;
       clients_json.push_back(cj);
     }
@@ -1500,6 +1549,26 @@ namespace stream_stats {
         "No current media or control-channel latency sample is available for this stream."
     );
     append_doctor_evidence(evidence, "bitrate", "Live bitrate", live_bitrate_kbps, "kbps", "pass", "stream_stats", stats.adaptive_runtime_update_supported ? "Current live encoder target; Doctor changes it only for confirmed pressure or a verified same-stream restore." : "Applied encoder bitrate; this encoder does not expose live bitrate updates.");
+    const bool has_oversized_fec_frames =
+      stats.fec_protection.oversized_frames_total > 0;
+    const std::string fec_protection_detail = has_oversized_fec_frames ?
+      "The sender transmitted oversized encoded frames without FEC parity because their packetized payload exceeded the four-block protection envelope. The largest encoded frame was " +
+        std::to_string(stats.fec_protection.largest_encoded_frame_bytes) +
+        " bytes and required " + std::to_string(stats.fec_protection.max_required_blocks) +
+        " blocks; the protected packetized limit was " +
+        std::to_string(stats.fec_protection.protected_payload_limit_bytes) +
+        " bytes. This is frame-size evidence, not proof of media packet loss. Lower bitrate only if client media-loss or pacing telemetry also shows impact." :
+      "No encoded frame has exceeded the active video FEC protection envelope.";
+    append_doctor_evidence(
+      evidence,
+      "fec_protection",
+      "Frames outside FEC protection",
+      stats.fec_protection.oversized_frames_total,
+      "frames",
+      has_oversized_fec_frames ? "info" : "pass",
+      "sender_packetizer",
+      fec_protection_detail
+    );
     append_doctor_evidence(
       evidence,
       "live_bitrate_owner",
@@ -1590,9 +1659,10 @@ namespace stream_stats {
     );
 
     auto advanced = nlohmann::json::object();
-    advanced["stream_stats_keys"] = nlohmann::json::array({"capture_path", "capture_path_reason", "capture_transport", "capture_residency", "capture_format", "capture_cpu_copy", "capture_gpu_native", "capture_cross_gpu_dmabuf_risk", "encode_target_device", "encode_target_residency", "fps", "encode_time_ms", "packet_loss", "packet_loss_available", "packet_loss_source", "control_channel_packet_loss", "control_channel_samples", "frame_interval_error_ms", "frame_jitter_ms", "video_policy_sample_count", "pacing_warning_streak"});
+    advanced["stream_stats_keys"] = nlohmann::json::array({"capture_path", "capture_path_reason", "capture_transport", "capture_residency", "capture_format", "capture_cpu_copy", "capture_gpu_native", "capture_cross_gpu_dmabuf_risk", "encode_target_device", "encode_target_residency", "fps", "encode_time_ms", "packet_loss", "packet_loss_available", "packet_loss_source", "control_channel_packet_loss", "control_channel_samples", "frame_interval_error_ms", "frame_jitter_ms", "video_policy_sample_count", "pacing_warning_streak", "fec_protection"});
     advanced["linux_gpu_profile"] = linux_gpu_profile_json(stats);
     advanced["gpu_native_probe"] = gpu_native_probe_json(stats);
+    advanced["fec_protection"] = fec_protection_json(stats.fec_protection);
     advanced["controller_input"] = {
       {"host_controller_isolation", stats.input_host_controller_isolation},
       {"steam_input_status", stats.input_steam_input_status},
@@ -1810,6 +1880,7 @@ namespace stream_stats {
     if (current_stats.clients.size() == 1) {
       current_stats.client_name = client_name;
       current_stats.client_ip = client_ip;
+      current_stats.fec_protection = current_stats.clients.front().fec_protection;
     }
   }
 
@@ -1832,10 +1903,12 @@ namespace stream_stats {
       current_stats.streaming = false;
       current_stats.client_name.clear();
       current_stats.client_ip.clear();
+      current_stats.fec_protection = {};
     } else {
       // Update primary client info to first remaining client
       current_stats.client_name = current_stats.clients.front().name;
       current_stats.client_ip = current_stats.clients.front().ip;
+      current_stats.fec_protection = current_stats.clients.front().fec_protection;
     }
   }
 
@@ -1944,6 +2017,40 @@ namespace stream_stats {
     hot_avg_frame_age_ms.store(avg_frame_age_ms, std::memory_order_relaxed);
     hot_frame_jitter_ms.store(frame_jitter_ms, std::memory_order_relaxed);
     hot_video_sample_revision.fetch_add(1, std::memory_order_release);
+  }
+
+  void record_oversized_fec_frame(std::uint64_t session_generation,
+                                  std::size_t encoded_frame_bytes,
+                                  std::size_t packetized_frame_bytes,
+                                  std::size_t protected_payload_limit_bytes,
+                                  std::size_t required_blocks,
+                                  int fec_percentage,
+                                  int packet_size,
+                                  std::string_view frame_type) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    auto client = std::find_if(
+      current_stats.clients.begin(), current_stats.clients.end(),
+      [session_generation](const client_stats_t &candidate) {
+        return candidate.session_generation == session_generation;
+      }
+    );
+    if (client == current_stats.clients.end()) {
+      return;
+    }
+
+    merge_oversized_fec_frame(
+      client->fec_protection,
+      encoded_frame_bytes,
+      packetized_frame_bytes,
+      protected_payload_limit_bytes,
+      required_blocks,
+      fec_percentage,
+      packet_size,
+      frame_type
+    );
+    if (client == current_stats.clients.begin()) {
+      current_stats.fec_protection = client->fec_protection;
+    }
   }
 
   double packet_loss_percent(uint64_t scaled_loss, uint64_t scale) {

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -9,6 +9,7 @@
 // standard includes
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <mutex>
@@ -22,6 +23,7 @@
 
 // local includes
 #include "platform/common.h"
+#include "stream_fec.h"
 
 namespace stream_stats {
 
@@ -48,6 +50,21 @@ namespace stream_stats {
   double encoder_pressure_frame_budget_ms(double target_fps);
   bool encoder_time_fails_budget(double encode_time_ms, double target_fps);
   bool encoder_time_nears_budget(double encode_time_ms, double target_fps);
+
+  /** Sender-side evidence for encoded frames outside the protocol FEC envelope. */
+  struct fec_protection_stats_t {
+    std::uint64_t oversized_frames_total = 0;
+    std::uint64_t oversized_idr_frames_total = 0;
+    std::uint64_t oversized_reference_invalidation_frames_total = 0;
+    std::size_t largest_encoded_frame_bytes = 0;
+    std::size_t largest_packetized_frame_bytes = 0;
+    std::size_t protected_payload_limit_bytes = 0;
+    std::size_t max_required_blocks = 0;
+    std::size_t protocol_max_blocks = stream::MAX_VIDEO_FEC_BLOCKS;
+    int fec_percentage = 0;
+    int packet_size = 0;
+    std::string largest_frame_type;
+  };
 
   /**
    * @brief Per-client statistics for multi-session tracking.
@@ -76,6 +93,9 @@ namespace stream_stats {
     std::string packet_loss_source = "unavailable";
     double control_channel_packet_loss = 0;
     uint64_t bytes_sent = 0;
+
+    // Sender packetization. This does not claim client-visible media loss.
+    fec_protection_stats_t fec_protection;
 
     // Adaptive bitrate
     int adaptive_target_bitrate_kbps = 0;
@@ -160,6 +180,10 @@ namespace stream_stats {
     int effective_launch_bitrate_kbps = 0;
     int width = 0;
     int height = 0;
+
+    // Encoded frames that were transmitted without parity because the
+    // packetized payload exceeded the four-block wire-format envelope.
+    fec_protection_stats_t fec_protection;
 
     // Network
     double latency_ms = 0;
@@ -403,6 +427,22 @@ namespace stream_stats {
                              double dropped_frame_ratio,
                              double avg_frame_age_ms,
                              double frame_jitter_ms);
+
+  /**
+   * @brief Record one frame that exceeded the video FEC protection envelope.
+   *
+   * The frame was still sent. This is sender-side size evidence only and must
+   * not be treated as measured media loss or authorize an automatic bitrate
+   * change.
+   */
+  void record_oversized_fec_frame(std::uint64_t session_generation,
+                                  std::size_t encoded_frame_bytes,
+                                  std::size_t packetized_frame_bytes,
+                                  std::size_t protected_payload_limit_bytes,
+                                  std::size_t required_blocks,
+                                  int fec_percentage,
+                                  int packet_size,
+                                  std::string_view frame_type);
 
   /**
    * @brief Update network statistics.

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -15,6 +15,7 @@
     #define TRAY_ICON_PAUSING WEB_DIR "images/apollo-pausing.ico"
     #define TRAY_ICON_LOCKED WEB_DIR "images/apollo-locked.ico"
   #elif defined(__linux__) || defined(linux) || defined(__linux)
+    #include <gtk/gtk.h>
     #define TRAY_ICON WEB_DIR "images/polaris-playing.svg"
     #define TRAY_ICON_PLAYING WEB_DIR "images/polaris-playing.svg"
     #define TRAY_ICON_PAUSING WEB_DIR "images/polaris-pausing.svg"
@@ -181,6 +182,12 @@ namespace system_tray {
   };
 
   int init_tray() {
+  #if defined(__linux__) || defined(linux) || defined(__linux)
+    // gtk_init_check() otherwise calls setlocale(LC_ALL, "") and can change
+    // numeric parsing for HTTP workers while Polaris is already running.
+    gtk_disable_setlocale();
+  #endif
+
   #ifdef _WIN32
     // If we're running as SYSTEM, Explorer.exe will not have permission to open our thread handle
     // to monitor for thread termination. If Explorer fails to open our thread, our tray icon

--- a/src/utility.h
+++ b/src/utility.h
@@ -6,6 +6,9 @@
 
 // standard includes
 #include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <concepts>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -13,6 +16,7 @@
 #include <ostream>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <type_traits>
 #include <variant>
 #include <vector>
@@ -455,6 +459,44 @@ namespace util {
     return buf;
   }
 
+  /**
+   * Parse a protocol/config decimal without consulting the process locale.
+   *
+   * Network and persisted values use an ASCII full stop. C-library parsers
+   * follow LC_NUMERIC, which lets a desktop toolkit silently turn "60.0" into
+   * a partial parse on comma-decimal hosts.
+   */
+  template<std::floating_point T>
+  std::optional<T> parse_decimal(std::string_view text) {
+    if (text.empty()) {
+      return std::nullopt;
+    }
+
+    T value {};
+    const auto *begin = text.data();
+    const auto *end = begin + text.size();
+    const auto [next, error] = std::from_chars(begin, end, value, std::chars_format::general);
+    if (error != std::errc {} || next != end || !std::isfinite(value)) {
+      return std::nullopt;
+    }
+    return value;
+  }
+
+  template<std::floating_point T>
+  std::string format_decimal(T value) {
+    if (!std::isfinite(value)) {
+      return {};
+    }
+    char buffer[128];
+    const auto [end, error] = std::to_chars(
+      buffer, buffer + sizeof(buffer), value, std::chars_format::general
+    );
+    if (error != std::errc {}) {
+      return {};
+    }
+    return std::string {buffer, end};
+  }
+
   template<typename T>
   T get_non_string_json_value(const nlohmann::json& j, const std::string& key, const T& default_value = T{}) {
     if (!j.contains(key))
@@ -467,7 +509,8 @@ namespace util {
       if constexpr (std::is_same_v<T, int>) {
         return std::stoi(s);
       } else if constexpr (std::is_same_v<T, double>) {
-        return std::stod(s);
+        const auto parsed = parse_decimal<double>(s);
+        return parsed.value_or(default_value);
       } else if constexpr (std::is_same_v<T, bool>) {
         return s == "true";
       } else if constexpr (std::is_same_v<T, std::string>) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ set(TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/src/log_tail_api.cpp
     ${CMAKE_SOURCE_DIR}/src/private_state_file.cpp
     ${CMAKE_SOURCE_DIR}/src/recovery_profile.cpp
+    ${CMAKE_SOURCE_DIR}/src/stream_fec.cpp
     ${CMAKE_SOURCE_DIR}/src/web_session_store.cpp
     ${CMAKE_SOURCE_DIR}/src/beat_times.cpp
     ${CMAKE_SOURCE_DIR}/src/display_planner.cpp
@@ -140,6 +141,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_rswrapper.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_session_media_gate.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_source_safety_contracts.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_stream_fec.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_doctor_reset_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_doctor_v2.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_doctor_trial.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,6 +181,7 @@ set(TEST_PLATFORM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_display_topology.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_cuda_gl_encode_device.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_graphics.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_labwc_startup_diagnostics.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_linux_process_argv.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_portal_grab_policy.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_private_session_attach.cpp

--- a/tests/unit/platform/test_cage_display_router.cpp
+++ b/tests/unit/platform/test_cage_display_router.cpp
@@ -1035,6 +1035,23 @@ TEST(CageDisplayRouterPolicyTests, OutputModeParserRecognizesRequestedCurrentRef
   EXPECT_DOUBLE_EQ(*reported_refresh, 120.0);
 }
 
+TEST(CageDisplayRouterPolicyTests, OutputModeParserRecognizesLocalizedDecimalComma) {
+  constexpr std::string_view output = R"(HEADLESS-1 "Headless output 1"
+  Enabled: yes
+  Modes:
+    1920x1080 px, 59,940000 Hz (current)
+)";
+
+  const auto reported_refresh = cage_display_router::output_current_refresh_hz_for_tests(
+    output,
+    "HEADLESS-1",
+    1920,
+    1080
+  );
+  ASSERT_TRUE(reported_refresh);
+  EXPECT_DOUBLE_EQ(*reported_refresh, 59.94);
+}
+
 TEST(CageDisplayRouterPolicyTests, OutputModeParserRejectsWrongCurrentRefresh) {
   constexpr std::string_view output = R"(HEADLESS-1 "Headless output 1"
   Enabled: yes

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -48,6 +48,7 @@ polaris_reclaim_orphan_gamescope_sockets() {
   printf 'reclaim\n' >>"$POLARIS_ACTIONS"
   [ "${RECLAIM_OK:-0}" = 1 ]
 }
+polaris_mask_idle_unit_runtime() { printf 'mask-idle\n' >>"$POLARIS_ACTIONS"; }
 polaris_unmask_idle_unit_runtime() { printf 'unmask-idle\n' >>"$POLARIS_ACTIONS"; }
 polaris_marker_owns_socket() { [ "${IDLE_OWNS_SOCKET:-0}" = 1 ]; }
 polaris_write_runtime_env() {
@@ -490,6 +491,16 @@ POLARIS_SESSION_INSTANCE_ID= POLARIS_PGREP_OUTPUT=101 run_stop >/dev/null 2>&1 |
   fail "atomic persisted attach recovery failed"
 [ ! -e "$work/run/polaris-gamescope-session-state" ] || fail "atomic credential survived complete stop"
 
+# An idempotent stop still repairs a runtime mask left before durable state was
+# published, otherwise an absent distro unit is misclassified as masked on the
+# next launch.
+rm -f "$work/run/polaris-gamescope-session-state" \
+  "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode" \
+  "$work/run/polaris-gamescope-wsi-nested"
+: >"$actions"
+NESTED_VALID=0 run_stop >/dev/null 2>&1 || fail "empty stop did not remain idempotent"
+grep -qx 'unmask-idle' "$actions" || fail "empty stop retained a leaked runtime mask"
+
 # Interruption before the one rename leaves no half credential; retry commits one
 # complete ID+mode record.
 prefix="$work/session-functions.sh"
@@ -590,6 +601,36 @@ grep -Fq 'run_without_session_operation_lock setsid -f env' "$script" ||
   [ "$(<"$session_state_file")" = 'session-B nested managed' ] ||
     fail "atomic session record did not contain exact ID and mode"
 )
+
+# The durable service model controls whether nested startup masks an idle unit.
+# Standalone distro packages have no idle/private-portal services and must not
+# manufacture a masked:not-found split by masking the absent unit.
+: >"$actions"
+(
+  export PATH="$work/bin:$PATH"
+  export XDG_RUNTIME_DIR="$work/run"
+  export POLARIS_GAMESCOPE_RUNTIME_LIB="$work/runtime-stub.sh"
+  export POLARIS_ACTIONS="$actions"
+  export POLARIS_SESSION_INSTANCE_ID=session-B
+  # shellcheck source=/dev/null
+  . "$prefix"
+  printf 'session-B nested standalone\n' >"$session_state_file"
+  prepare_nested_runtime_services || fail "standalone nested preparation failed"
+)
+! grep -qx 'mask-idle' "$actions" || fail "standalone nested preparation masked an absent idle unit"
+: >"$actions"
+(
+  export PATH="$work/bin:$PATH"
+  export XDG_RUNTIME_DIR="$work/run"
+  export POLARIS_GAMESCOPE_RUNTIME_LIB="$work/runtime-stub.sh"
+  export POLARIS_ACTIONS="$actions"
+  export POLARIS_SESSION_INSTANCE_ID=session-B
+  # shellcheck source=/dev/null
+  . "$prefix"
+  printf 'session-B nested managed\n' >"$session_state_file"
+  prepare_nested_runtime_services || fail "managed nested preparation failed"
+)
+grep -qx 'mask-idle' "$actions" || fail "managed nested preparation did not mask idle"
 rm -f "$work/run/polaris-gamescope-session-state"
 
 # Failed startup recovery is fail-closed. It may not erase the prior claim,
@@ -640,9 +681,11 @@ grep -Fq 'prior session recovery failed; retaining its exact claim' "$script" ||
   fail "start does not fail closed when prior stop recovery fails"
 grep -Fq "POLARIS_SESSION_INSTANCE_ID='' bash \"\$0\" stop" "$script" ||
   fail "start does not route persisted attach/nested recovery through credentialed stop"
+grep -Fq '"${child_env[@]}" setpriv --no-new-privs -- \' "$script" ||
+  fail "nested Gamescope can still gain file capabilities and hide its procfs identity"
 transition_line="$(grep -nF 'publish_nested_claim transition absent' "$script" | head -n1 | cut -d: -f1)"
-mask_line="$(grep -nF 'polaris_mask_idle_unit_runtime' "$script" | tail -n1 | cut -d: -f1)"
-[ -n "$transition_line" ] && [ -n "$mask_line" ] && [ "$transition_line" -lt "$mask_line" ] ||
+prepare_line="$(grep -nF 'prepare_nested_runtime_services || {' "$script" | tail -n1 | cut -d: -f1)"
+[ -n "$transition_line" ] && [ -n "$prepare_line" ] && [ "$transition_line" -lt "$prepare_line" ] ||
   fail "nested transition claim is not published before idle destruction"
 grep -Fq 'publish_nested_claim nested transition' "$script" ||
   fail "nested launch does not CAS transition ownership before spawn"

--- a/tests/unit/platform/test_labwc_startup_diagnostics.cpp
+++ b/tests/unit/platform/test_labwc_startup_diagnostics.cpp
@@ -1,0 +1,240 @@
+/**
+ * @file tests/unit/platform/test_labwc_startup_diagnostics.cpp
+ * @brief Test bounded labwc startup-client evidence.
+ */
+#include "../../tests_common.h"
+
+#ifdef __linux__
+
+#include <src/platform/linux/labwc_startup_diagnostics.h>
+
+#include <glib.h>
+
+#include <atomic>
+#include <array>
+#include <cerrno>
+#include <memory>
+#include <string>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+
+using namespace std::literals;
+
+TEST(LabwcStartupDiagnosticsTests, KeepsOnlyABoundedTail) {
+  labwc_startup_diagnostics::collector_t collector {"generation-a"};
+  const std::string prefix(
+    labwc_startup_diagnostics::max_retained_stderr_bytes,
+    'a'
+  );
+  collector.append_stderr(prefix);
+  collector.append_stderr("\nthe-useful-tail");
+
+  const auto snapshot = collector.snapshot("generation-a");
+  ASSERT_TRUE(snapshot.has_value());
+  EXPECT_EQ(snapshot->stderr_bytes_seen, prefix.size() + 16);
+  EXPECT_TRUE(snapshot->stderr_truncated);
+  EXPECT_TRUE(snapshot->stderr_summary.ends_with("the-useful-tail"));
+  EXPECT_LE(snapshot->stderr_summary.size(), labwc_startup_diagnostics::max_log_summary_bytes);
+}
+
+TEST(LabwcStartupDiagnosticsTests, RefusesEvidenceFromAnotherGeneration) {
+  labwc_startup_diagnostics::collector_t collector {"generation-a"};
+  collector.append_stderr("one generation only");
+  collector.record_shell_exit_status(7);
+
+  EXPECT_FALSE(collector.snapshot("").has_value());
+  EXPECT_FALSE(collector.snapshot("generation-b").has_value());
+  ASSERT_TRUE(collector.snapshot("generation-a").has_value());
+}
+
+TEST(LabwcStartupDiagnosticsTests, RedactsAndFlattensUntrustedStderr) {
+  const auto private_path = "/"s + "home/example-user/game/file";
+  const auto redacted_private_path = "/"s + "home/[user]/game/file";
+  const auto result = labwc_startup_diagnostics::redact_stderr_for_log(
+    "\x1b[31merror\x1b[0m\n" + private_path + " " +
+    "https://user:pass@example.test/run?access_token=abc "s +
+    "Authorization: Bearer-secret password=hunter2 "
+    "--api-key topsecret 192.168.1.20 peer=[2001:db8::42] user@example.test "
+    "hostname=private-workstation "
+    "0123456789012345678901234567890123456789"
+  );
+
+  EXPECT_EQ(result.text.find('\n'), std::string::npos);
+  EXPECT_EQ(result.text.find("example-user"), std::string::npos);
+  EXPECT_EQ(result.text.find("user:pass"), std::string::npos);
+  EXPECT_EQ(result.text.find("access_token=abc"), std::string::npos);
+  EXPECT_EQ(result.text.find("Bearer-secret"), std::string::npos);
+  EXPECT_EQ(result.text.find("hunter2"), std::string::npos);
+  EXPECT_EQ(result.text.find("topsecret"), std::string::npos);
+  EXPECT_EQ(result.text.find("192.168.1.20"), std::string::npos);
+  EXPECT_EQ(result.text.find("2001:db8::42"), std::string::npos);
+  EXPECT_EQ(result.text.find("user@example.test"), std::string::npos);
+  EXPECT_EQ(result.text.find("private-workstation"), std::string::npos);
+  EXPECT_EQ(result.text.find("0123456789012345678901234567890123456789"), std::string::npos);
+  EXPECT_NE(result.text.find("error"), std::string::npos);
+  EXPECT_NE(result.text.find(redacted_private_path), std::string::npos);
+}
+
+TEST(LabwcStartupDiagnosticsTests, KeepsRedactedSummaryWithinPublishedBound) {
+  std::string input;
+  for (int count = 0; count < 700; ++count) {
+    input += "x ";
+  }
+
+  const auto result = labwc_startup_diagnostics::redact_stderr_for_log(input);
+  EXPECT_TRUE(result.truncated);
+  EXPECT_TRUE(result.text.starts_with("[truncated-prefix]"));
+  EXPECT_LE(result.text.size(), labwc_startup_diagnostics::max_log_summary_bytes);
+}
+
+TEST(LabwcStartupDiagnosticsTests, InstrumentedShellReportsStatusAndStderr) {
+  std::array<int, 2> stderr_pipe {-1, -1};
+  std::array<int, 2> status_pipe {-1, -1};
+  ASSERT_EQ(pipe(stderr_pipe.data()), 0);
+  ASSERT_EQ(pipe(status_pipe.data()), 0);
+
+  const auto private_path = "/"s + "home/example-user/game";
+  const auto redacted_private_path = "/"s + "home/[user]/game";
+  const auto command = labwc_startup_diagnostics::make_labwc_startup_command(
+    labwc_startup_diagnostics::instrument_shell_command(
+      "printf '%s\\n' \"can't launch " + private_path + "\" >&2; exit 7",
+      stderr_pipe[1],
+      status_pipe[1]
+    )
+  );
+
+  gint argc = 0;
+  gchar **argv = nullptr;
+  GError *parse_error = nullptr;
+  ASSERT_TRUE(g_shell_parse_argv(command.c_str(), &argc, &argv, &parse_error));
+  ASSERT_EQ(parse_error, nullptr);
+  ASSERT_EQ(argc, 3);
+  ASSERT_STREQ(argv[0], "bash");
+  ASSERT_STREQ(argv[1], "-c");
+
+  auto collector = std::make_shared<labwc_startup_diagnostics::collector_t>("generation-a");
+  std::thread reader {
+    labwc_startup_diagnostics::drain_pipes,
+    stderr_pipe[0],
+    status_pipe[0],
+    collector
+  };
+
+  const auto child = fork();
+  if (child < 0) {
+    g_strfreev(argv);
+    close(stderr_pipe[1]);
+    close(status_pipe[1]);
+    reader.join();
+    FAIL() << "fork failed";
+    return;
+  }
+  if (child == 0) {
+    close(stderr_pipe[0]);
+    close(status_pipe[0]);
+    execvp(argv[0], argv);
+    _exit(126);
+  }
+
+  g_strfreev(argv);
+  close(stderr_pipe[1]);
+  close(status_pipe[1]);
+  int child_status = 0;
+  const auto waited = waitpid(child, &child_status, 0);
+  reader.join();
+
+  ASSERT_EQ(waited, child);
+  ASSERT_TRUE(WIFEXITED(child_status));
+  EXPECT_EQ(WEXITSTATUS(child_status), 7);
+  const auto snapshot = collector->snapshot("generation-a");
+  ASSERT_TRUE(snapshot.has_value());
+  ASSERT_EQ(snapshot->shell_exit_status, std::optional<int> {7});
+  EXPECT_NE(snapshot->stderr_summary.find("can't launch"), std::string::npos);
+  EXPECT_NE(snapshot->stderr_summary.find(redacted_private_path), std::string::npos);
+}
+
+TEST(LabwcStartupDiagnosticsTests, ContinuouslyDrainsNoisyStderr) {
+  std::array<int, 2> stderr_pipe {-1, -1};
+  std::array<int, 2> status_pipe {-1, -1};
+  ASSERT_EQ(pipe(stderr_pipe.data()), 0);
+  ASSERT_EQ(pipe(status_pipe.data()), 0);
+
+  auto collector = std::make_shared<labwc_startup_diagnostics::collector_t>("generation-a");
+  std::thread reader {
+    labwc_startup_diagnostics::drain_pipes,
+    stderr_pipe[0],
+    status_pipe[0],
+    collector
+  };
+
+  constexpr std::size_t chunk_count = 256;
+  const std::string chunk(4096, 'x');
+  std::atomic_bool write_succeeded {true};
+  std::thread writer {[&]() {
+    for (std::size_t count = 0; count < chunk_count && write_succeeded; ++count) {
+      std::size_t written = 0;
+      while (written < chunk.size()) {
+        const auto result = write(
+          stderr_pipe[1],
+          chunk.data() + written,
+          chunk.size() - written
+        );
+        if (result > 0) {
+          written += static_cast<std::size_t>(result);
+        } else if (result < 0 && errno == EINTR) {
+          continue;
+        } else {
+          write_succeeded = false;
+          break;
+        }
+      }
+    }
+    if (write(status_pipe[1], "23\n", 3) != 3) {
+      write_succeeded = false;
+    }
+    close(stderr_pipe[1]);
+    close(status_pipe[1]);
+  }};
+
+  writer.join();
+  reader.join();
+
+  ASSERT_TRUE(write_succeeded);
+  const auto snapshot = collector->snapshot("generation-a");
+  ASSERT_TRUE(snapshot.has_value());
+  EXPECT_EQ(snapshot->shell_exit_status, std::optional<int> {23});
+  EXPECT_EQ(snapshot->stderr_bytes_seen, chunk.size() * chunk_count);
+  EXPECT_TRUE(snapshot->stderr_truncated);
+  EXPECT_LE(snapshot->stderr_summary.size(), labwc_startup_diagnostics::max_log_summary_bytes);
+}
+
+TEST(LabwcStartupDiagnosticsTests, KeepsTheFirstValidStatus) {
+  labwc_startup_diagnostics::collector_t collector {"generation-a"};
+  collector.record_shell_exit_status(-1);
+  collector.record_shell_exit_status(256);
+  collector.record_shell_exit_status(9);
+  collector.record_shell_exit_status(0);
+
+  const auto snapshot = collector.snapshot("generation-a");
+  ASSERT_TRUE(snapshot.has_value());
+  EXPECT_EQ(snapshot->shell_exit_status, std::optional<int> {9});
+}
+
+TEST(LabwcStartupDiagnosticsTests, DescriptionIsStableAndOneLine) {
+  const labwc_startup_diagnostics::snapshot_t snapshot {
+    .shell_exit_status = 127,
+    .stderr_bytes_seen = 9000,
+    .stderr_truncated = true,
+    .stderr_summary = "flatpak: app is not installed"
+  };
+
+  EXPECT_EQ(
+    labwc_startup_diagnostics::describe_for_log(snapshot),
+    "startup_client_exit_status=127 startup_client_stderr_bytes=9000 "
+    "startup_client_stderr_truncated=true "
+    "startup_client_stderr_tail=[flatpak: app is not installed]"
+  );
+}
+
+#endif  // __linux__

--- a/tests/unit/test_config_parser.cpp
+++ b/tests/unit/test_config_parser.cpp
@@ -6,6 +6,28 @@
 
 #include <src/config.h>
 #include <src/nvenc/nvenc_config.h>
+#include <src/utility.h>
+
+TEST(ConfigParserTests, ProtocolDecimalsUseDotAndRequireTheWholeValue) {
+  const auto fps = util::parse_decimal<double>("60.0");
+  ASSERT_TRUE(fps.has_value());
+  EXPECT_DOUBLE_EQ(*fps, 60.0);
+
+  const auto fractional = util::parse_decimal<double>("59.94");
+  ASSERT_TRUE(fractional.has_value());
+  EXPECT_DOUBLE_EQ(*fractional, 59.94);
+
+  EXPECT_FALSE(util::parse_decimal<double>("60,0").has_value());
+  EXPECT_FALSE(util::parse_decimal<double>("60.0fps").has_value());
+  EXPECT_FALSE(util::parse_decimal<double>(" 60.0").has_value());
+  EXPECT_FALSE(util::parse_decimal<double>("nan").has_value());
+  EXPECT_FALSE(util::parse_decimal<double>("inf").has_value());
+}
+
+TEST(ConfigParserTests, ProtocolDecimalFormattingNeverUsesAComma) {
+  EXPECT_EQ(util::format_decimal(59.94), "59.94");
+  EXPECT_EQ(util::format_decimal(60.0), "60");
+}
 
 TEST(ConfigParserTests, ParsesNvencSplitEncodeModeValues) {
   EXPECT_EQ(config::nv::split_encode_mode_from_view("disabled"), nvenc::nvenc_split_encode_mode::disabled);

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -10,6 +10,7 @@
  * These scan the whole of src/ rather than named files on purpose. A contract
  * that lists the files it knows about only ever covers the bugs already found.
  */
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <regex>
@@ -174,6 +175,61 @@ TEST(SourceSafetyContracts, PackageFortifyFilterFollowsTheGnuCompilerIdentity) {
     EXPECT_NE(text.find("#define __clang__"), std::string::npos) << relative_path;
     EXPECT_EQ(text.find("-dumpfullversion"), std::string::npos) << relative_path;
   }
+}
+
+TEST(SourceSafetyContracts, DecimalParsingDoesNotConsultTheProcessLocale) {
+  constexpr std::array forbidden {
+    "std::stod(",
+    "std::stof(",
+    "std::stold(",
+    "std::strtod(",
+    "std::strtof(",
+    "std::strtold(",
+    "atof(",
+  };
+
+  std::vector<std::string> locale_sensitive;
+  for (const auto &source : all_sources()) {
+    for (const auto needle : forbidden) {
+      std::size_t offset = 0;
+      while ((offset = source.text.find(needle, offset)) != std::string::npos) {
+        if (!inside_string_literal(source.text, offset) && !inside_comment(source.text, offset)) {
+          locale_sensitive.push_back(
+            source.relative_path + ":" + std::to_string(line_of(source.text, offset)) + " uses " + needle
+          );
+        }
+        offset += std::string_view {needle}.size();
+      }
+    }
+  }
+
+  EXPECT_TRUE(locale_sensitive.empty()) << [&] {
+    std::ostringstream out;
+    out << "locale-sensitive decimal parser(s):";
+    for (const auto &site : locale_sensitive) {
+      out << "\n  " << site;
+    }
+    return out.str();
+  }();
+}
+
+TEST(SourceSafetyContracts, GtkCannotChangeTheProtocolNumericLocale) {
+  const auto read = [](const fs::path &path) {
+    std::ifstream input(path);
+    std::ostringstream out;
+    out << input.rdbuf();
+    return out.str();
+  };
+  const auto root = fs::path {POLARIS_SOURCE_DIR};
+  const auto main = read(root / "src/main.cpp");
+  const auto tray = read(root / "src/system_tray.cpp");
+
+  EXPECT_NE(main.find("std::setlocale(LC_NUMERIC, \"C\")"), std::string::npos);
+  const auto disable = tray.find("gtk_disable_setlocale()");
+  const auto initialize = tray.find("tray_init(&tray)");
+  ASSERT_NE(disable, std::string::npos);
+  ASSERT_NE(initialize, std::string::npos);
+  EXPECT_LT(disable, initialize);
 }
 
 TEST(SourceSafetyContracts, GamescopePreviewConsumesBestEffortRepaintResult) {

--- a/tests/unit/test_stream_fec.cpp
+++ b/tests/unit/test_stream_fec.cpp
@@ -1,0 +1,95 @@
+/**
+ * @file tests/unit/test_stream_fec.cpp
+ * @brief Test bounded oversized-frame FEC diagnostics.
+ */
+
+#include <src/stream_fec.h>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+namespace {
+  stream::oversized_fec_frame_observation_t observation(
+    std::size_t encoded_bytes,
+    std::size_t packetized_bytes,
+    std::size_t required_blocks,
+    stream::fec_frame_type_e frame_type = stream::fec_frame_type_e::delta
+  ) {
+    return {
+      .encoded_frame_bytes = encoded_bytes,
+      .packetized_frame_bytes = packetized_bytes,
+      .protected_payload_limit_bytes = 1'006'720,
+      .required_blocks = required_blocks,
+      .fec_percentage = 5,
+      .packet_size = 1024,
+      .frame_type = frame_type
+    };
+  }
+}
+
+TEST(StreamFecWarningTrackerTests, ReportsFirstOversizedFrameImmediately) {
+  stream::fec_warning_tracker_t tracker;
+  const auto now = stream::fec_warning_tracker_t::clock::time_point {};
+
+  const auto report = tracker.observe(
+    observation(1'080'000, 1'100'000, 5, stream::fec_frame_type_e::idr),
+    now
+  );
+
+  ASSERT_TRUE(report.has_value());
+  EXPECT_EQ(report->frame_count, 1);
+  EXPECT_EQ(report->idr_frame_count, 1);
+  EXPECT_EQ(report->largest_encoded_frame_bytes, 1'080'000);
+  EXPECT_EQ(report->largest_packetized_frame_bytes, 1'100'000);
+  EXPECT_EQ(report->protected_payload_limit_bytes, 1'006'720);
+  EXPECT_EQ(report->max_required_blocks, 5);
+  EXPECT_EQ(report->largest_frame_type, stream::fec_frame_type_e::idr);
+}
+
+TEST(StreamFecWarningTrackerTests, CoalescesRepeatsIntoOnePeriodicSummary) {
+  using namespace std::chrono_literals;
+
+  stream::fec_warning_tracker_t tracker {20s};
+  const auto start = stream::fec_warning_tracker_t::clock::time_point {};
+  ASSERT_TRUE(tracker.observe(observation(1'020'000, 1'040'000, 5), start));
+
+  EXPECT_FALSE(tracker.observe(
+    observation(1'250'000, 1'280'000, 6), start + 1s
+  ));
+  EXPECT_FALSE(tracker.observe(
+    observation(1'500'000, 1'540'000, 7, stream::fec_frame_type_e::reference_invalidation),
+    start + 10s
+  ));
+  const auto report = tracker.observe(
+    observation(2'900'000, 2'940'000, 12, stream::fec_frame_type_e::idr),
+    start + 20s
+  );
+
+  ASSERT_TRUE(report.has_value());
+  EXPECT_EQ(report->frame_count, 3);
+  EXPECT_EQ(report->idr_frame_count, 1);
+  EXPECT_EQ(report->reference_invalidation_frame_count, 1);
+  EXPECT_EQ(report->largest_encoded_frame_bytes, 2'900'000);
+  EXPECT_EQ(report->largest_packetized_frame_bytes, 2'940'000);
+  EXPECT_EQ(report->max_required_blocks, 12);
+  EXPECT_EQ(report->largest_frame_type, stream::fec_frame_type_e::idr);
+}
+
+TEST(StreamFecWarningTrackerTests, StartsASecondAggregationWindowAfterReport) {
+  using namespace std::chrono_literals;
+
+  stream::fec_warning_tracker_t tracker {20s};
+  const auto start = stream::fec_warning_tracker_t::clock::time_point {};
+  ASSERT_TRUE(tracker.observe(observation(1'020'000, 1'040'000, 5), start));
+  ASSERT_TRUE(tracker.observe(observation(1'100'000, 1'120'000, 5), start + 20s));
+
+  EXPECT_FALSE(tracker.observe(observation(1'200'000, 1'220'000, 5), start + 21s));
+  const auto report = tracker.observe(
+    observation(1'300'000, 1'320'000, 6), start + 40s
+  );
+
+  ASSERT_TRUE(report.has_value());
+  EXPECT_EQ(report->frame_count, 2);
+  EXPECT_EQ(report->max_required_blocks, 6);
+}

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -780,6 +780,86 @@ TEST(StreamStatsDoctorTests, ClassifiesGpuNativeStreamAsReady) {
   EXPECT_FALSE(doctor.at("safe_recovery_action").at("destructive"));
 }
 
+TEST(StreamStatsDoctorTests, KeepsOversizedFecFramesInformational) {
+  stream_stats::stats_t stats {};
+  stats.streaming = true;
+  stats.capture_transport = platf::frame_transport_e::dmabuf;
+  stats.capture_residency = platf::frame_residency_e::gpu;
+  stats.encode_target_residency = platf::frame_residency_e::gpu;
+  stats.encode_time_ms = 4.0;
+  stats.fec_protection.oversized_frames_total = 288;
+  stats.fec_protection.oversized_idr_frames_total = 4;
+  stats.fec_protection.largest_encoded_frame_bytes = 2'900'000;
+  stats.fec_protection.largest_packetized_frame_bytes = 2'940'000;
+  stats.fec_protection.protected_payload_limit_bytes = 1'006'720;
+  stats.fec_protection.max_required_blocks = 12;
+  stats.fec_protection.fec_percentage = 5;
+  stats.fec_protection.packet_size = 1024;
+  stats.fec_protection.largest_frame_type = "idr";
+
+  const auto doctor = stream_stats::build_doctor_json(
+    stats, nlohmann::json::object()
+  );
+
+  EXPECT_EQ(doctor.at("traffic_light"), "green");
+  EXPECT_EQ(doctor.at("status"), "ok");
+  EXPECT_EQ(doctor.at("severity"), "info");
+  EXPECT_EQ(doctor.at("primary_issue"), "none");
+  EXPECT_EQ(doctor.at("safe_recovery_action").at("id"), "none");
+
+  const auto &fec = *std::find_if(
+    doctor.at("evidence").begin(), doctor.at("evidence").end(),
+    [](const auto &item) { return item.value("id", "") == "fec_protection"; }
+  );
+  EXPECT_EQ(fec.at("status"), "info");
+  EXPECT_EQ(fec.at("source"), "sender_packetizer");
+  EXPECT_EQ(fec.at("value"), 288);
+  EXPECT_NE(
+    fec.at("detail").get<std::string>().find("not proof of media packet loss"),
+    std::string::npos
+  );
+  EXPECT_EQ(
+    doctor.at("advanced_evidence").at("fec_protection").at("max_required_blocks"),
+    12
+  );
+}
+
+TEST(StreamStatsFecProtectionTests, RoutesEvidenceBySessionGeneration) {
+  stream_stats::update_stream_active(false);
+  stream_stats::add_client("198.51.100.40", "Primary", 7401);
+  stream_stats::add_client("198.51.100.41", "Viewer", 7402);
+
+  stream_stats::record_oversized_fec_frame(
+    7402, 1'250'000, 1'280'000, 1'006'720, 6, 5, 1024, "delta"
+  );
+  auto stats = stream_stats::get_current();
+  ASSERT_EQ(stats.clients.size(), 2);
+  EXPECT_EQ(stats.fec_protection.oversized_frames_total, 0);
+  EXPECT_EQ(stats.clients.at(1).fec_protection.oversized_frames_total, 1);
+
+  stream_stats::record_oversized_fec_frame(
+    7401, 2'900'000, 2'940'000, 1'006'720, 12, 5, 1024, "idr"
+  );
+  stats = stream_stats::get_current();
+  EXPECT_EQ(stats.fec_protection.oversized_frames_total, 1);
+  EXPECT_EQ(stats.fec_protection.oversized_idr_frames_total, 1);
+  EXPECT_EQ(stats.fec_protection.max_required_blocks, 12);
+
+  stream_stats::remove_client("198.51.100.40", 7401);
+  stats = stream_stats::get_current();
+  ASSERT_EQ(stats.clients.size(), 1);
+  EXPECT_EQ(stats.client_name, "Viewer");
+  EXPECT_EQ(stats.fec_protection.oversized_frames_total, 1);
+  EXPECT_EQ(stats.fec_protection.max_required_blocks, 6);
+
+  stream_stats::remove_client("198.51.100.41", 7402);
+  stream_stats::update_stream_active(false);
+  EXPECT_EQ(
+    stream_stats::get_current().fec_protection.oversized_frames_total,
+    0
+  );
+}
+
 TEST(StreamStatsDoctorTests, SteamInputFindingSurvivesTheEndOfTheStream) {
   // The conflict is host state, and its one-click fix is only safe with Steam
   // closed -- which is to say, once the stream has ended. Wiping these fields


### PR DESCRIPTION
## What this changes

- makes machine-facing decimal parsing and formatting locale-independent, including `/optimize`, display planning, launch profiles, compositor arguments, and telemetry;
- keeps GTK tray initialization from changing Polaris numeric semantics;
- adds bounded, per-session evidence for encoded frames that exceed the protocol's four-block FEC protection envelope without changing packetization or bitrate policy;
- captures a labwc startup client's exit status and a bounded, redacted stderr tail when no private-session window appears;
- keeps SteamOS file capabilities from hiding the private nested Gamescope process from same-user ownership checks;
- skips idle-unit masking on standalone packages and repairs a leaked runtime mask on idempotent stop;
- keeps capability-only and FEC evidence informational in Doctor unless corroborating media-loss or pacing evidence exists.

## Why these changes travel together

This is the post-1.4.1 reliability batch. It addresses the localized launch failure reported through `papi-ux/nova#275`, makes the high-bitrate FEC behavior measurable, gives failed Flatpak/Heroic private-session launches enough evidence to diagnose without guessing, and addresses the two concrete SteamOS lifecycle failures reported in #599. Each concern remains a separate logical commit.

## Safety boundaries

- No stream protocol, encoder-selection default, or automatic bitrate changes.
- FEC frames retain their existing send-without-parity behavior when they exceed the wire envelope.
- Startup diagnostics are generation-scoped, fail open, stay in memory, retain at most 8 KiB, and log at most a 1 KiB single-line redacted summary.
- `no_new_privs` applies only to the private nested Gamescope process tree. It intentionally suppresses Gamescope's `cap_sys_nice` file capability so exact `/proc` identity and socket ownership remain readable; desktop Game Mode is untouched.
- Standalone packages never mask the absent Nix-only idle unit. Managed Nix sessions retain the existing runtime-mask handoff.
- No Nova, packaging, release, or deployment changes are included.

## Validation

- Production Polaris target built successfully.
- Locale regression coverage passed under `C`, `de_DE.UTF-8`, and `fr_FR.UTF-8` behavior.
- Core, platform, config, and stream CTest suites passed.
- Eight focused labwc diagnostics tests passed, including exact GLib tokenization/`execvp`, generation isolation, redaction, strict bounds, and draining 1 MiB of stderr without blocking.
- Focused FEC warning/coalescing, Doctor informational-status, and multi-session routing tests passed.
- Gamescope runtime, stop-state-machine, primary-child, geometry, and platform tests passed, including managed-versus-standalone masking and leaked-mask recovery.
- `setpriv --no-new-privs` was verified to publish `NoNewPrivs: 1` on the test host; a physical SteamOS retest remains required.
- Public-surface, source-safety, and `git diff --check` gates passed.
- Polaris configuration hashes were unchanged by the test run.
