### PR TITLE
fix(gamescope): skip standalone portal rebind and flag stale session helpers

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -488,6 +488,8 @@ list(APPEND PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/linux/cage_display_router.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/labwc_startup_diagnostics.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/labwc_startup_diagnostics.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/gamescope_session_helper.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/gamescope_session_helper.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/display_topology.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/display_topology.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/stream_path.h"

--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -12,6 +12,14 @@ install(FILES "${POLARIS_SOURCE_ASSETS_DIR}/linux/misc/60-polaris.rules"
 install(FILES "${POLARIS_SOURCE_ASSETS_DIR}/linux/misc/60-polaris.conf"
         DESTINATION "${POLARIS_ASSETS_DIR}/modules-load.d")
 
+# Reference copies of the gamescope_stream helpers. At launch Polaris compares
+# the polaris-gamescope-session it resolved against these, so a helper left by
+# an older scripts/install run is reported as stale instead of debugged as a
+# Polaris bug. The executable copies that actually run are installed below.
+install(FILES "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-session.sh"
+              "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-runtime-lib.sh"
+        DESTINATION "${POLARIS_ASSETS_DIR}/gamescope")
+
 # Host integration files at their live paths, for everything that is not an
 # AppImage. An AppImage cannot own paths outside its mount, so it keeps relying
 # on `polaris --setup-host` to place these under /etc.
@@ -39,6 +47,9 @@ file(COPY "${POLARIS_SOURCE_ASSETS_DIR}/linux/misc/60-polaris.rules"
         DESTINATION "${CMAKE_BINARY_DIR}/assets/udev/rules.d")
 file(COPY "${POLARIS_SOURCE_ASSETS_DIR}/linux/misc/60-polaris.conf"
         DESTINATION "${CMAKE_BINARY_DIR}/assets/modules-load.d")
+file(COPY "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-session.sh"
+          "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-runtime-lib.sh"
+        DESTINATION "${CMAKE_BINARY_DIR}/assets/gamescope")
 # use symbolic link for shaders directory
 file(CREATE_LINK "${POLARIS_SOURCE_ASSETS_DIR}/linux/assets/shaders"
         "${CMAKE_BINARY_DIR}/assets/shaders" COPY_ON_ERROR SYMBOLIC)

--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -254,6 +254,47 @@ prepare_nested_runtime_services() {
   esac
 }
 
+rebind_private_portal_after_nested_start() {
+  local portal_bus portal_ready
+  case "$POLARIS_PERSISTED_SERVICE_MODE" in
+    managed)
+      # Rebind the private portal backend to this gamescope generation. Without
+      # this, xdg-desktop-portal-gamescope keeps the prior (idle) wayland
+      # connection and Start fails with "gamescope stream not available: failed
+      # to connect to wayland socket" when the compositor was replaced under it.
+      # Restart only the gamescope impl, not the full portal frontend, so we
+      # avoid the udev/controller race that killing xdg-desktop-portal caused.
+      # polaris must Wants= (not Requires=) this unit so rebind never cascade-stops it.
+      systemctl --user restart polaris-portal-gamescope.service 2>/dev/null || true
+      portal_bus="unix:path=$rt/polaris-portal/bus"
+      portal_ready=0
+      for _ in $(seq 1 80); do
+        if busctl --address="$portal_bus" --no-pager \
+            status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1; then
+          portal_ready=1
+          break
+        fi
+        sleep 0.1
+      done
+      if [ "$portal_ready" != 1 ]; then
+        echo "polaris-gamescope-session: portal-gamescope did not rebind after nested start" >&2
+        # Non-fatal: stream may still gamescopegrab the PW node.
+      else
+        echo "polaris-gamescope-session: portal-gamescope rebound to nested gamescope-0" >&2
+      fi
+      ;;
+    standalone)
+      # Distro packages ship no private portal unit. Polaris captures this
+      # generation through the host portal or gamescopegrab, so there is no
+      # backend to rebind and no private bus worth eight seconds of polling.
+      echo "polaris-gamescope-session: standalone package, no private portal unit to rebind" >&2
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 session_steam_pids() {
   local p pids rc envf env_lines session_id="${POLARIS_SESSION_INSTANCE_ID:-}" proc_root
   [ -n "$session_id" ] || return 2
@@ -1108,30 +1149,12 @@ case "${1:-}" in
         echo "polaris-gamescope-session: nested bound gamescope-1 (portal captures gamescope-0) — see $steam_log" >&2
         exit 1
       fi
-      # Rebind private portal backend to this gamescope generation. Without this,
-      # xdg-desktop-portal-gamescope keeps the prior (idle) wayland connection and
-      # Start fails with "gamescope stream not available: failed to connect to
-      # wayland socket" when the compositor was replaced under it.
-      # Restart only the gamescope impl — not the full portal frontend — so we
-      # avoid the udev/controller race that killing xdg-desktop-portal caused.
-      # polaris must Wants= (not Requires=) this unit so rebind never cascade-stops it.
-      systemctl --user restart polaris-portal-gamescope.service 2>/dev/null || true
-      portal_bus="unix:path=$rt/polaris-portal/bus"
-      portal_ready=0
-      for _ in $(seq 1 80); do
-        if busctl --address="$portal_bus" --no-pager \
-            status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1; then
-          portal_ready=1
-          break
-        fi
-        sleep 0.1
-      done
-      if [ "$portal_ready" != 1 ]; then
-        echo "polaris-gamescope-session: portal-gamescope did not rebind after nested start" >&2
-        # Non-fatal: stream may still gamescopegrab the PW node.
-      else
-        echo "polaris-gamescope-session: portal-gamescope rebound to nested gamescope-0" >&2
-      fi
+      # Only a managed (Nix) host has a private portal backend to rebind; a
+      # standalone package has neither the unit nor the bus.
+      rebind_private_portal_after_nested_start || {
+        echo "polaris-gamescope-session: nested runtime services lost their classification before portal rebind" >&2
+        exit 1
+      }
       # Brief settle so Steam's first controller udev events land after portal is up.
       sleep 1
       echo "polaris-gamescope-session: nested ${POLARIS_GAMESCOPE_BIN:-gamescope} ready; WSI logs → $steam_log and ~/.local/share/Steam/logs/console-linux.txt" >&2

--- a/src/platform/linux/gamescope_session_helper.cpp
+++ b/src/platform/linux/gamescope_session_helper.cpp
@@ -1,0 +1,198 @@
+/**
+ * @file src/platform/linux/gamescope_session_helper.cpp
+ * @brief Locate the polaris-gamescope-session launcher and check it against the copy this build ships.
+ */
+
+#include "gamescope_session_helper.h"
+
+#ifdef __linux__
+
+#include <array>
+#include <fstream>
+#include <iterator>
+#include <system_error>
+#include <unistd.h>
+
+#include "executable_path.h"
+
+namespace platf::gamescope_session_helper {
+
+  namespace {
+    namespace fs = std::filesystem;
+
+    constexpr std::string_view launcher_name = "polaris-gamescope-session";
+    constexpr std::string_view runtime_lib_name = "polaris-gamescope-runtime-lib.sh";
+
+    std::string read_text(const fs::path &path) {
+      std::ifstream input(path, std::ios::binary);
+      if (!input) {
+        return {};
+      }
+      return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+    }
+
+    bool same_file(const fs::path &a, const fs::path &b) {
+      std::error_code ec;
+      const bool equivalent = fs::equivalent(a, b, ec);
+      return !ec && equivalent;
+    }
+
+    bool regular_file(const fs::path &path) {
+      std::error_code ec;
+      return !path.empty() && fs::is_regular_file(path, ec) && !ec;
+    }
+
+    std::optional<fs::path> running_executable() {
+      std::array<char, 4096> buffer {};
+      const auto len = readlink("/proc/self/exe", buffer.data(), buffer.size() - 1);
+      if (len <= 0) {
+        return std::nullopt;
+      }
+      buffer[len] = '\0';
+      return fs::path(buffer.data());
+    }
+
+    /**
+     * Mirror the host-asset lookup: the installed assets directory first, then
+     * the assets copied beside a build-directory binary.
+     */
+    fs::path bundled_asset(const std::optional<fs::path> &executable_dir, std::string_view name) {
+      const auto relative = fs::path("gamescope") / name;
+      const auto installed = fs::path(POLARIS_ASSETS_DIR) / relative;
+      if (regular_file(installed)) {
+        return installed;
+      }
+      if (executable_dir) {
+        const auto local_build = *executable_dir / "assets" / relative;
+        if (regular_file(local_build)) {
+          return local_build;
+        }
+      }
+      return {};
+    }
+  }  // namespace
+
+  bundle_match_t compare_with_bundle(std::string_view installed, std::string_view bundled) {
+    if (installed.empty() || bundled.empty()) {
+      return bundle_match_t::unknown;
+    }
+    if (installed == bundled) {
+      return bundle_match_t::exact;
+    }
+    if (installed.find(bundled) != std::string_view::npos) {
+      return bundle_match_t::wrapped;
+    }
+    return bundle_match_t::mismatch;
+  }
+
+  std::string_view describe(bundle_match_t match) {
+    switch (match) {
+      case bundle_match_t::exact:
+        return "identical to the module this build ships";
+      case bundle_match_t::wrapped:
+        return "wraps the module this build ships";
+      case bundle_match_t::mismatch:
+        return "installed from a different checkout";
+      case bundle_match_t::unknown:
+        break;
+    }
+    return "not compared against a bundled copy";
+  }
+
+  resolution_t resolve(
+    const std::optional<fs::path> &executable_dir,
+    const fs::path &path_candidate,
+    const fs::path &bundled_session,
+    const fs::path &bundled_runtime_lib
+  ) {
+    resolution_t resolution;
+
+    if (executable_dir) {
+      const auto beside = *executable_dir / launcher_name;
+      if (linux_util::is_executable_file(beside.string())) {
+        resolution.helper = beside;
+      }
+    }
+
+    if (!path_candidate.empty() && linux_util::is_executable_file(path_candidate.string())) {
+      if (resolution.helper.empty()) {
+        resolution.helper = path_candidate;
+      } else if (!same_file(resolution.helper, path_candidate)) {
+        resolution.shadowed = path_candidate;
+      }
+    }
+
+    if (resolution.helper.empty() || !regular_file(bundled_session)) {
+      return resolution;
+    }
+
+    resolution.bundled = bundled_session;
+    resolution.session_match = compare_with_bundle(read_text(resolution.helper), read_text(bundled_session));
+
+    // The launcher sources its runtime library from its own directory. Nix
+    // inlines the library into the wrapper instead, so a missing sibling is
+    // not a finding.
+    const auto sibling_lib = resolution.helper.parent_path() / runtime_lib_name;
+    if (regular_file(sibling_lib) && regular_file(bundled_runtime_lib)) {
+      resolution.runtime_lib = sibling_lib;
+      resolution.runtime_lib_match = compare_with_bundle(read_text(sibling_lib), read_text(bundled_runtime_lib));
+    }
+
+    return resolution;
+  }
+
+  resolution_t resolve_default() {
+    std::optional<fs::path> executable_dir;
+    if (const auto exe = running_executable()) {
+      executable_dir = exe->parent_path();
+    }
+    const fs::path path_candidate = linux_util::find_executable_in_path(launcher_name);
+    return resolve(
+      executable_dir,
+      path_candidate,
+      bundled_asset(executable_dir, "polaris-gamescope-session.sh"),
+      bundled_asset(executable_dir, runtime_lib_name)
+    );
+  }
+
+  std::string summary(const resolution_t &resolution) {
+    if (resolution.helper.empty()) {
+      return "gamescope_stream: no polaris-gamescope-session launcher beside this binary or on PATH";
+    }
+    std::string line = "gamescope_stream: polaris-gamescope-session [" + resolution.helper.string() + "] is " +
+                       std::string(describe(resolution.session_match));
+    if (!resolution.runtime_lib.empty()) {
+      line += "; runtime library [" + resolution.runtime_lib.string() + "] is " +
+              std::string(describe(resolution.runtime_lib_match));
+    }
+    return line;
+  }
+
+  std::vector<std::string> advisories(const resolution_t &resolution) {
+    std::vector<std::string> lines;
+    if (!resolution.shadowed.empty()) {
+      lines.push_back(
+        "gamescope_stream: using polaris-gamescope-session shipped beside this binary [" +
+        resolution.helper.string() + "]; PATH would have picked [" + resolution.shadowed.string() +
+        "], a separate install that package updates never touch. Remove it if it came from an older scripts/install run."
+      );
+    }
+    if (resolution.session_match == bundle_match_t::mismatch) {
+      lines.push_back(
+        "gamescope_stream: polaris-gamescope-session [" + resolution.helper.string() +
+        "] does not match the launcher this Polaris build ships [" + resolution.bundled.string() +
+        "]; it was installed from a different checkout. Reinstall the gamescope helpers from this Polaris version before reporting gamescope_stream problems."
+      );
+    }
+    if (resolution.runtime_lib_match == bundle_match_t::mismatch) {
+      lines.push_back(
+        "gamescope_stream: polaris-gamescope-runtime-lib.sh [" + resolution.runtime_lib.string() +
+        "] does not match the library this Polaris build ships; the launcher beside it sources it. Reinstall both helpers together."
+      );
+    }
+    return lines;
+  }
+
+}  // namespace platf::gamescope_session_helper
+
+#endif  // __linux__

--- a/src/platform/linux/gamescope_session_helper.h
+++ b/src/platform/linux/gamescope_session_helper.h
@@ -1,0 +1,65 @@
+/**
+ * @file src/platform/linux/gamescope_session_helper.h
+ * @brief Locate the polaris-gamescope-session launcher and check it against the copy this build ships.
+ */
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace platf::gamescope_session_helper {
+
+  enum class bundle_match_t {
+    unknown,  ///< nothing to compare against: no bundled copy, or no installed file
+    exact,  ///< the installed file is byte-identical to the bundled module
+    wrapped,  ///< the installed file embeds the bundled module verbatim (Nix, manual installer)
+    mismatch,  ///< the installed file came from a different checkout
+  };
+
+  struct resolution_t {
+    std::filesystem::path helper;  ///< launcher to run; empty when none is installed
+    std::filesystem::path shadowed;  ///< a different copy PATH would have picked; empty when none
+    std::filesystem::path bundled;  ///< module copy shipped with this build; empty when absent
+    std::filesystem::path runtime_lib;  ///< sibling runtime library that was compared; empty when absent
+    bundle_match_t session_match {bundle_match_t::unknown};
+    bundle_match_t runtime_lib_match {bundle_match_t::unknown};
+  };
+
+  /**
+   * @brief Pick the launcher for this Polaris binary.
+   *
+   * The copy beside the running executable wins over PATH. A distribution
+   * package ships the binary and the launcher together, so they cannot drift
+   * apart, while a copy under ~/.local/bin or /usr/local/bin left by an earlier
+   * scripts/install run is never updated by the package manager and would
+   * otherwise shadow the packaged one.
+   *
+   * @param executable_dir Directory of the running binary, when known.
+   * @param path_candidate What a PATH lookup found, or empty.
+   * @param bundled_session The module copy this build ships, or empty.
+   * @param bundled_runtime_lib The runtime library copy this build ships, or empty.
+   */
+  resolution_t resolve(
+    const std::optional<std::filesystem::path> &executable_dir,
+    const std::filesystem::path &path_candidate,
+    const std::filesystem::path &bundled_session,
+    const std::filesystem::path &bundled_runtime_lib
+  );
+
+  /// Resolve using /proc/self/exe, PATH, and the bundled assets of this build.
+  resolution_t resolve_default();
+
+  bundle_match_t compare_with_bundle(std::string_view installed, std::string_view bundled);
+
+  std::string_view describe(bundle_match_t match);
+
+  /// One line naming the launcher in use and how it relates to the shipped module.
+  std::string summary(const resolution_t &resolution);
+
+  /// Warnings worth a log line: a shadowed copy, or a launcher from another checkout.
+  std::vector<std::string> advisories(const resolution_t &resolution);
+
+}  // namespace platf::gamescope_session_helper

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -83,6 +83,7 @@
   #include "platform/linux/session_launch_linux.h"
   #include "platform/linux/display_topology.h"
   #include "platform/linux/gamescope_process.h"
+  #include "platform/linux/gamescope_session_helper.h"
   #include "platform/linux/input/inputtino_gamepad_isolation.h"
   #include <dirent.h>
   #include <fcntl.h>
@@ -7401,13 +7402,15 @@ namespace proc {
       const auto target_label = nested_target.appid.empty() ?
         "Steam Big Picture"s :
         "Steam appid=" + nested_target.appid;
-      boost::filesystem::path session_bin;
-      try {
-        session_bin = boost::process::v1::search_path("polaris-gamescope-session");
+      // The launcher beside this binary wins over PATH, and whichever copy is
+      // used is checked against the module this build ships, so a helper left
+      // by an older scripts/install run is named instead of silently used.
+      const auto helper = platf::gamescope_session_helper::resolve_default();
+      BOOST_LOG(info) << platf::gamescope_session_helper::summary(helper);
+      for (const auto &advisory : platf::gamescope_session_helper::advisories(helper)) {
+        BOOST_LOG(warning) << advisory;
       }
-      catch (...) {
-        session_bin.clear();
-      }
+      const boost::filesystem::path session_bin {helper.helper.string()};
       if (!session_bin.empty()) {
         nested_wsi_session = true;
         if (!nested_target.appid.empty()) {
@@ -7444,7 +7447,7 @@ namespace proc {
       }
       else {
         BOOST_LOG(warning) << "session_manager: cannot nest " << target_label
-                           << " because polaris-gamescope-session is not on PATH; using attach"sv;
+                           << " because polaris-gamescope-session is neither beside this binary nor on PATH; using attach"sv;
       }
     }
     const auto steam_guard_snapshot = snapshot_steam_big_picture_input_guard(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ set(TEST_PLATFORM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_desktop_takeover.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_display_topology.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_cuda_gl_encode_device.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamescope_session_helper.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_graphics.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_labwc_startup_diagnostics.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_linux_process_argv.cpp

--- a/tests/unit/platform/test_gamescope_session_helper.cpp
+++ b/tests/unit/platform/test_gamescope_session_helper.cpp
@@ -1,0 +1,208 @@
+/**
+ * @file tests/unit/platform/test_gamescope_session_helper.cpp
+ * @brief Test polaris-gamescope-session launcher resolution and bundle coherence checks.
+ */
+#include "../../tests_common.h"
+
+#ifdef __linux__
+
+#include <src/platform/linux/gamescope_session_helper.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace std::literals;
+namespace fs = std::filesystem;
+namespace helper = platf::gamescope_session_helper;
+
+namespace {
+  struct scratch_t {
+    fs::path root;
+
+    scratch_t() {
+      auto pattern = (fs::temp_directory_path() / "polaris-gamescope-helper-XXXXXX").string();
+      const char *made = mkdtemp(pattern.data());
+      if (made == nullptr) {
+        throw std::runtime_error("mkdtemp failed");
+      }
+      root = made;
+    }
+
+    ~scratch_t() {
+      std::error_code ec;
+      fs::remove_all(root, ec);
+    }
+
+    fs::path file(const std::string &relative, const std::string &content, bool executable) const {
+      const auto path = root / relative;
+      fs::create_directories(path.parent_path());
+      {
+        std::ofstream out(path, std::ios::binary);
+        out << content;
+      }
+      fs::permissions(
+        path,
+        executable ? fs::perms::owner_all | fs::perms::group_read | fs::perms::group_exec | fs::perms::others_read | fs::perms::others_exec :
+                     fs::perms::owner_read | fs::perms::owner_write | fs::perms::group_read | fs::perms::others_read,
+        fs::perm_options::replace
+      );
+      return path;
+    }
+  };
+
+  const std::string module_body = "#!/bin/bash\n# shared body\nset -euo pipefail\necho session\n"s;
+  const std::string library_body = "polaris_validate_marker() { :; }\n"s;
+}  // namespace
+
+TEST(GamescopeSessionHelperTests, PrefersLauncherBesideBinaryOverPath) {
+  scratch_t scratch;
+  const auto beside = scratch.file("usr/bin/polaris-gamescope-session", module_body, true);
+  const auto stale = scratch.file("home/.local/bin/polaris-gamescope-session", "old\n", true);
+
+  const auto resolution = helper::resolve(beside.parent_path(), stale, {}, {});
+
+  EXPECT_EQ(resolution.helper, beside);
+  EXPECT_EQ(resolution.shadowed, stale);
+  EXPECT_EQ(resolution.session_match, helper::bundle_match_t::unknown);
+}
+
+TEST(GamescopeSessionHelperTests, FallsBackToPathWhenNothingIsBeside) {
+  scratch_t scratch;
+  fs::create_directories(scratch.root / "usr/bin");
+  const auto on_path = scratch.file("usr/local/bin/polaris-gamescope-session", module_body, true);
+
+  const auto resolution = helper::resolve(scratch.root / "usr/bin", on_path, {}, {});
+
+  EXPECT_EQ(resolution.helper, on_path);
+  EXPECT_TRUE(resolution.shadowed.empty());
+}
+
+TEST(GamescopeSessionHelperTests, IgnoresNonExecutableSibling) {
+  scratch_t scratch;
+  const auto beside = scratch.file("usr/bin/polaris-gamescope-session", module_body, false);
+  const auto on_path = scratch.file("usr/local/bin/polaris-gamescope-session", module_body, true);
+
+  const auto resolution = helper::resolve(beside.parent_path(), on_path, {}, {});
+
+  EXPECT_EQ(resolution.helper, on_path);
+  EXPECT_TRUE(resolution.shadowed.empty());
+}
+
+TEST(GamescopeSessionHelperTests, ReportsNothingWhenNoLauncherExists) {
+  scratch_t scratch;
+  fs::create_directories(scratch.root / "usr/bin");
+
+  const auto resolution = helper::resolve(scratch.root / "usr/bin", {}, {}, {});
+
+  EXPECT_TRUE(resolution.helper.empty());
+  EXPECT_TRUE(resolution.shadowed.empty());
+  EXPECT_TRUE(helper::advisories(resolution).empty());
+  EXPECT_NE(helper::summary(resolution).find("no polaris-gamescope-session launcher"), std::string::npos);
+}
+
+TEST(GamescopeSessionHelperTests, UnknownBinaryDirectoryUsesPath) {
+  scratch_t scratch;
+  const auto on_path = scratch.file("usr/local/bin/polaris-gamescope-session", module_body, true);
+
+  const auto resolution = helper::resolve(std::nullopt, on_path, {}, {});
+
+  EXPECT_EQ(resolution.helper, on_path);
+}
+
+TEST(GamescopeSessionHelperTests, PathHitOnTheSameFileIsNotShadowing) {
+  scratch_t scratch;
+  const auto beside = scratch.file("usr/bin/polaris-gamescope-session", module_body, true);
+  fs::create_directories(scratch.root / "alias");
+  const auto alias = scratch.root / "alias/polaris-gamescope-session";
+  fs::create_symlink(beside, alias);
+
+  const auto resolution = helper::resolve(beside.parent_path(), alias, {}, {});
+
+  EXPECT_EQ(resolution.helper, beside);
+  EXPECT_TRUE(resolution.shadowed.empty());
+  EXPECT_TRUE(helper::advisories(resolution).empty());
+}
+
+TEST(GamescopeSessionHelperTests, PackagedCopyMatchesBundleExactly) {
+  scratch_t scratch;
+  const auto beside = scratch.file("usr/bin/polaris-gamescope-session", module_body, true);
+  const auto lib = scratch.file("usr/bin/polaris-gamescope-runtime-lib.sh", library_body, false);
+  const auto bundled = scratch.file("assets/gamescope/polaris-gamescope-session.sh", module_body, false);
+  const auto bundled_lib = scratch.file("assets/gamescope/polaris-gamescope-runtime-lib.sh", library_body, false);
+
+  const auto resolution = helper::resolve(beside.parent_path(), {}, bundled, bundled_lib);
+
+  EXPECT_EQ(resolution.bundled, bundled);
+  EXPECT_EQ(resolution.session_match, helper::bundle_match_t::exact);
+  EXPECT_EQ(resolution.runtime_lib, lib);
+  EXPECT_EQ(resolution.runtime_lib_match, helper::bundle_match_t::exact);
+  EXPECT_TRUE(helper::advisories(resolution).empty());
+  EXPECT_NE(helper::summary(resolution).find("identical to the module this build ships"), std::string::npos);
+}
+
+TEST(GamescopeSessionHelperTests, WrapperEmbeddingTheBundledModuleIsCurrent) {
+  scratch_t scratch;
+  const auto wrapper = "#!/usr/bin/env bash\nexport POLARIS_GAMESCOPE_BIN=gamescope\n"s + library_body + module_body;
+  const auto on_path = scratch.file("nix/bin/polaris-gamescope-session", wrapper, true);
+  const auto bundled = scratch.file("assets/gamescope/polaris-gamescope-session.sh", module_body, false);
+  const auto bundled_lib = scratch.file("assets/gamescope/polaris-gamescope-runtime-lib.sh", library_body, false);
+
+  const auto resolution = helper::resolve(std::nullopt, on_path, bundled, bundled_lib);
+
+  EXPECT_EQ(resolution.session_match, helper::bundle_match_t::wrapped);
+  // Nix inlines the library, so no sibling exists and nothing is reported.
+  EXPECT_TRUE(resolution.runtime_lib.empty());
+  EXPECT_EQ(resolution.runtime_lib_match, helper::bundle_match_t::unknown);
+  EXPECT_TRUE(helper::advisories(resolution).empty());
+}
+
+TEST(GamescopeSessionHelperTests, LauncherFromAnotherCheckoutIsFlagged) {
+  scratch_t scratch;
+  const auto stale = scratch.file("usr/local/bin/polaris-gamescope-session", "#!/usr/bin/env bash\n# header\nold body\n", true);
+  const auto stale_lib = scratch.file("usr/local/bin/polaris-gamescope-runtime-lib.sh", "old library\n", false);
+  const auto bundled = scratch.file("assets/gamescope/polaris-gamescope-session.sh", module_body, false);
+  const auto bundled_lib = scratch.file("assets/gamescope/polaris-gamescope-runtime-lib.sh", library_body, false);
+  fs::create_directories(scratch.root / "usr/bin");
+
+  const auto resolution = helper::resolve(scratch.root / "usr/bin", stale, bundled, bundled_lib);
+
+  EXPECT_EQ(resolution.helper, stale);
+  EXPECT_EQ(resolution.session_match, helper::bundle_match_t::mismatch);
+  EXPECT_EQ(resolution.runtime_lib, stale_lib);
+  EXPECT_EQ(resolution.runtime_lib_match, helper::bundle_match_t::mismatch);
+
+  const auto advisories = helper::advisories(resolution);
+  ASSERT_EQ(advisories.size(), 2u);
+  EXPECT_NE(advisories[0].find(stale.string()), std::string::npos);
+  EXPECT_NE(advisories[0].find(bundled.string()), std::string::npos);
+  EXPECT_NE(advisories[0].find("different checkout"), std::string::npos);
+  EXPECT_NE(advisories[1].find(stale_lib.string()), std::string::npos);
+}
+
+TEST(GamescopeSessionHelperTests, ShadowedStaleCopyIsNamedButNotUsed) {
+  scratch_t scratch;
+  const auto beside = scratch.file("usr/bin/polaris-gamescope-session", module_body, true);
+  const auto stale = scratch.file("home/.local/bin/polaris-gamescope-session", "old\n", true);
+  const auto bundled = scratch.file("assets/gamescope/polaris-gamescope-session.sh", module_body, false);
+
+  const auto resolution = helper::resolve(beside.parent_path(), stale, bundled, {});
+
+  EXPECT_EQ(resolution.session_match, helper::bundle_match_t::exact);
+  const auto advisories = helper::advisories(resolution);
+  ASSERT_EQ(advisories.size(), 1u);
+  EXPECT_NE(advisories[0].find(beside.string()), std::string::npos);
+  EXPECT_NE(advisories[0].find(stale.string()), std::string::npos);
+  EXPECT_NE(advisories[0].find("scripts/install"), std::string::npos);
+}
+
+TEST(GamescopeSessionHelperTests, CompareWithBundleClassifiesContent) {
+  EXPECT_EQ(helper::compare_with_bundle("", module_body), helper::bundle_match_t::unknown);
+  EXPECT_EQ(helper::compare_with_bundle(module_body, ""), helper::bundle_match_t::unknown);
+  EXPECT_EQ(helper::compare_with_bundle(module_body, module_body), helper::bundle_match_t::exact);
+  EXPECT_EQ(helper::compare_with_bundle("prefix\n" + module_body, module_body), helper::bundle_match_t::wrapped);
+  EXPECT_EQ(helper::compare_with_bundle(module_body.substr(0, module_body.size() - 1), module_body), helper::bundle_match_t::mismatch);
+}
+
+#endif  // __linux__

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -338,6 +338,39 @@ TEST(SessionStopContractTests, UnclassifiedNestedLaunchHasNoNumericGroupKillFall
   ASSERT_NE(recover, std::string::npos);
 }
 
+TEST(SessionStopContractTests, StandalonePackagesSkipPrivatePortalRebind) {
+  // Distro packages ship no polaris-portal-gamescope.service. Restarting the
+  // absent unit and polling its bus cost every nested launch eight seconds
+  // and a warning that read like a failure (#599).
+  const auto source = read_source_for_contract("nix/modules/polaris-gamescope-session.sh");
+  ASSERT_FALSE(source.empty());
+  const auto fn = source.find("rebind_private_portal_after_nested_start() {");
+  ASSERT_NE(fn, std::string::npos);
+  const auto fn_end = source.find("\n}\n", fn);
+  ASSERT_NE(fn_end, std::string::npos);
+  const auto body = source.substr(fn, fn_end - fn);
+  const auto managed = body.find("managed)");
+  const auto restart = body.find("systemctl --user restart polaris-portal-gamescope.service");
+  const auto standalone = body.find("standalone)");
+  ASSERT_NE(managed, std::string::npos);
+  ASSERT_NE(restart, std::string::npos);
+  ASSERT_NE(standalone, std::string::npos);
+  EXPECT_LT(managed, restart);
+  EXPECT_LT(restart, standalone);
+  // The standalone arm neither restarts the unit nor waits for its bus.
+  EXPECT_EQ(body.find("polaris-portal-gamescope.service", standalone), std::string::npos);
+  EXPECT_EQ(body.find("busctl", standalone), std::string::npos);
+
+  // Between the nested launch and readiness the start path only goes through the gate.
+  const auto launch = source.find("setsid env -u WAYLAND_DISPLAY");
+  ASSERT_NE(launch, std::string::npos);
+  const auto ready = source.find("ready; WSI logs", launch);
+  ASSERT_NE(ready, std::string::npos);
+  const auto after_launch = source.substr(launch, ready - launch);
+  EXPECT_EQ(after_launch.find("systemctl --user restart polaris-portal-gamescope.service"), std::string::npos);
+  EXPECT_NE(after_launch.find("rebind_private_portal_after_nested_start"), std::string::npos);
+}
+
 TEST(SessionStopContractTests, WrappedGamescopeIsFrozenBeforeXwaylandGroupTeardown) {
   const auto source = read_source_for_contract("nix/modules/polaris-gamescope-runtime-lib.sh");
   ASSERT_FALSE(source.empty());


### PR DESCRIPTION
## Summary

Addresses the two follow-up notes in #599. The two main fixes from that report shipped in #600.

- The nested start path only restarts and waits for `polaris-portal-gamescope.service` when the persisted service mode is `managed`. A standalone package used to restart the absent unit and then poll its private bus 80 times at 100 ms, so every nested launch spent about eight seconds waiting for a backend that could not exist and then logged `portal-gamescope did not rebind after nested start`, which reads like a failure. Standalone hosts now log that there is no private portal unit and continue. A source contract pins the gate.
- Polaris resolves `polaris-gamescope-session` beside its own binary first and falls back to PATH, so a copy left under `~/.local/bin` or `/usr/local/bin` by an earlier `scripts/install` run no longer shadows the packaged launcher. Packages install reference copies of the two helper modules under `<assets>/gamescope/`, and at launch Polaris compares the resolved launcher and its sibling runtime library against them. Byte identical, or a wrapper that embeds the module verbatim (Nix, the manual installer), is current; anything else is logged as installed from a different checkout with both paths named, and a shadowed copy on PATH is named as well. The launch itself is unchanged; only the log gains the evidence.

## Exact candidate

`Commit:` `61ca388af2be0fc9ada53f5050ee7027ce4b0497`
`Tree:` `05f3ecaa2941aa88df98a4f03346108bb5e6af9a`
`Parent:` `6240510abbe5444d9ee76b5f260a66a23008b506`
`Base:` `6d6c758b93a81c3c1f2ff17f9ed0954c43c0f25f`

## Verification

- [x] `ninja polaris test_polaris_platform test_polaris_http test_polaris` on pc-papi (CUDA-off tree), clean
- [x] `test_polaris_platform --gtest_filter=GamescopeSessionHelperTests.*`: 11/11
- [x] `test_polaris_http --gtest_filter=SessionStopContractTests.*`: 51/51; the new `StandalonePackagesSkipPrivatePortalRebind` fails against the master session script and passes with this branch
- [x] `test_polaris --gtest_filter=*SourceSafety*:*LinuxExecutablePath*:*ProcessMigration*`: 29/29
- [x] `ctest -R gamescope`: 4/4 shell suites (runtime, stop, primary child, geometry)
- [x] `bash -n` on the session script, `git diff --check`, `scripts/check-public-surface.sh`

Not covered: no live nested launch on a standalone package or on NixOS in this pass; the portal gate and the resolver are exercised by unit tests and source contracts. The SteamOS retest requested in #599 is the physical check.
