### PR TITLE
fix(gamescope): classify the scripts/install stack as host-portal

### DIFF
--- a/nix/modules/polaris-gamescope-session.sh
+++ b/nix/modules/polaris-gamescope-session.sh
@@ -71,6 +71,13 @@ polaris_gamescope_service_mode() {
     loaded:loaded)
       printf 'managed\n'
       ;;
+    loaded:not-found)
+      # The scripts/install stack ships the idle compositor unit and leaves the
+      # private portal optional; capture goes through the host XDG portal or
+      # gamescopegrab. The idle unit is masked and restored like a managed
+      # host, and there is no private portal backend to rebind.
+      printf 'host-portal\n'
+      ;;
     not-found:not-found)
       # Distro packages install the nested-session helper without the Nix-only
       # idle compositor/private portal units. Their safe baseline is no
@@ -174,7 +181,7 @@ recover_missing_nested_claim() (
     [ -z "${extra:-}" ] \
       && [ "$persisted" = "$POLARIS_SESSION_INSTANCE_ID" ] \
       && [ "$persisted_mode" = nested ] || return 1
-    case "${persisted_service_mode:-}" in ''|managed|standalone) ;; *) return 1 ;; esac
+    case "${persisted_service_mode:-}" in ''|managed|host-portal|standalone) ;; *) return 1 ;; esac
   else
     [ -s "$session_id_file" ] \
       && [ "$(tr -d '\r\n' <"$session_id_file")" = "$POLARIS_SESSION_INSTANCE_ID" ] \
@@ -210,7 +217,7 @@ load_session_instance_id() {
     read -r persisted persisted_mode persisted_service_mode extra <"$session_state_file" || return 1
     [ -z "${extra:-}" ] || return 1
     case "$persisted_mode" in attach|nested) ;; *) return 1 ;; esac
-    case "${persisted_service_mode:-}" in ''|managed|standalone) ;; *) return 1 ;; esac
+    case "${persisted_service_mode:-}" in ''|managed|host-portal|standalone) ;; *) return 1 ;; esac
     [ -n "$persisted" ] || return 1
     if [ -n "${POLARIS_SESSION_INSTANCE_ID:-}" ]; then
       [ "$persisted" = "$POLARIS_SESSION_INSTANCE_ID" ] || return 1
@@ -238,9 +245,10 @@ prepare_nested_runtime_services() {
   load_session_instance_id || return 1
   [ "$POLARIS_PERSISTED_SESSION_MODE" = nested ] || return 1
   case "$POLARIS_PERSISTED_SERVICE_MODE" in
-    managed)
-      # Only Nix-managed hosts have an idle compositor that can respawn and
-      # therefore needs a runtime mask during the nested handoff.
+    managed|host-portal)
+      # Hosts with an idle compositor unit (Nix-managed, or the scripts/install
+      # stack) can respawn it and therefore need a runtime mask during the
+      # nested handoff.
       polaris_mask_idle_unit_runtime
       ;;
     standalone)
@@ -282,6 +290,11 @@ rebind_private_portal_after_nested_start() {
       else
         echo "polaris-gamescope-session: portal-gamescope rebound to nested gamescope-0" >&2
       fi
+      ;;
+    host-portal)
+      # The scripts/install stack captures through the host XDG portal or
+      # gamescopegrab; there is no private portal backend to rebind.
+      echo "polaris-gamescope-session: host portal in use, no private portal unit to rebind" >&2
       ;;
     standalone)
       # Distro packages ship no private portal unit. Polaris captures this
@@ -1454,23 +1467,29 @@ case "${1:-}" in
         fi
         echo "polaris-gamescope-session: idle gamescope restored after nested stop" >&2
 
-        if ! systemctl --user restart polaris-portal-gamescope.service 2>/dev/null; then
-          echo "polaris-gamescope-session: portal restart failed; retaining restore-idle claim" >&2
-          exit 1
-        fi
-        portal_bus="unix:path=$rt/polaris-portal/bus"
-        portal_ready=0
-        for _ in $(seq 1 "${POLARIS_PORTAL_WAIT_STEPS:-50}"); do
-          if busctl --address="$portal_bus" --no-pager \
-              status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1; then
-            portal_ready=1
-            break
+        if [ "$service_mode" = managed ]; then
+          if ! systemctl --user restart polaris-portal-gamescope.service 2>/dev/null; then
+            echo "polaris-gamescope-session: portal restart failed; retaining restore-idle claim" >&2
+            exit 1
           fi
-          sleep 0.1
-        done
-        if [ "$portal_ready" != 1 ]; then
-          echo "polaris-gamescope-session: portal did not bind idle generation; retaining restore-idle claim" >&2
-          exit 1
+          portal_bus="unix:path=$rt/polaris-portal/bus"
+          portal_ready=0
+          for _ in $(seq 1 "${POLARIS_PORTAL_WAIT_STEPS:-50}"); do
+            if busctl --address="$portal_bus" --no-pager \
+                status org.freedesktop.impl.portal.desktop.gamescope >/dev/null 2>&1; then
+              portal_ready=1
+              break
+            fi
+            sleep 0.1
+          done
+          if [ "$portal_ready" != 1 ]; then
+            echo "polaris-gamescope-session: portal did not bind idle generation; retaining restore-idle claim" >&2
+            exit 1
+          fi
+        else
+          # host-portal: the host XDG portal owns capture, so restoring idle
+          # gamescope-0 is the whole handoff; there is no backend to rebind.
+          echo "polaris-gamescope-session: host portal in use; idle gamescope-0 restored without a private portal rebind" >&2
         fi
         if ! {
           polaris_validate_marker "$marker" idle \

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -89,6 +89,8 @@ NixOS/hjem can run a **private** gamescope ScreenCast bus at
 
 On typical desktops, Polaris uses the **host** XDG Desktop Portal + PipeWire, or **gamescopegrab** when the idle compositor exposes a PW node. That is enough for many non-NixOS hosts.
 
+The session helper records this layout as `host-portal` (idle unit present, no private portal unit) and logs `runtime services=host-portal` on each start. It masks and restores the idle compositor exactly as on a NixOS host and skips the private portal rebind. `managed` means both units are installed; `standalone` means neither, which is what distro packages ship.
+
 If you later deploy a private portal, set:
 
 ```ini

--- a/src/platform/linux/stream_runtime_gamescope.cpp
+++ b/src/platform/linux/stream_runtime_gamescope.cpp
@@ -134,7 +134,7 @@ namespace stream_runtime {
           return false;
         }
         if (state >> service_mode) {
-          if (service_mode != "managed" && service_mode != "standalone") {
+          if (service_mode != "managed" && service_mode != "host-portal" && service_mode != "standalone") {
             return false;
           }
           if (state >> extra) {

--- a/tests/unit/platform/test_gamescope_session_stop_shell.sh
+++ b/tests/unit/platform/test_gamescope_session_stop_shell.sh
@@ -203,6 +203,36 @@ NESTED_VALID=0 STOP_OK=0 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
 grep -qx 'write-idle-env' "$actions" || fail "idle runtime environment was not committed"
 grep -q 'restart polaris-portal-gamescope.service' "$actions" || fail "portal was not rebound"
 
+# The scripts/install stack has the idle unit but no private portal unit.
+# Stop must restore the idle compositor exactly like a managed host and
+# commit without touching the absent portal backend.
+reset_state
+printf 'session-A nested host-portal\n' >"$work/run/polaris-gamescope-session-state"
+rm -f "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode"
+: >"$actions"
+IDLE_LOAD_STATE=loaded PORTAL_LOAD_STATE=not-found \
+  POLARIS_SESSION_INSTANCE_ID= NESTED_VALID=1 STOP_OK=1 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
+  run_stop >/dev/null 2>&1 || fail "host-portal restore failed"
+[ ! -e "$work/run/polaris-gamescope-wsi-nested" ] || fail "host-portal handoff retained nested claim"
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-force")" = 0 ] || fail "host-portal handoff did not reset force"
+grep -qx 'unmask-idle' "$actions" || fail "host-portal handoff did not unmask idle"
+grep -q 'start polaris-gamescope-idle.service' "$actions" || fail "host-portal handoff did not restart idle gamescope"
+grep -qx 'write-idle-env' "$actions" || fail "host-portal handoff did not commit idle runtime environment"
+! grep -Eq 'restart polaris-portal|busctl' "$actions" || fail "host-portal handoff touched the absent private portal"
+
+# A persisted host-portal session is not restored against a host whose units
+# now classify as something else.
+reset_state
+printf 'session-A nested host-portal\n' >"$work/run/polaris-gamescope-session-state"
+rm -f "$work/run/polaris-gamescope-session-id" "$work/run/polaris-gamescope-session-mode"
+if IDLE_LOAD_STATE=loaded PORTAL_LOAD_STATE=loaded \
+    POLARIS_SESSION_INSTANCE_ID= NESTED_VALID=1 STOP_OK=1 IDLE_VALID=1 IDLE_OWNS_SOCKET=1 WRITE_ENV_OK=1 \
+    run_stop >/dev/null 2>&1; then
+  fail "host-portal session restored against a managed host"
+fi
+[ "$(tr -d '[:space:]' <"$work/run/polaris-gamescope-wsi-nested")" = restore-idle ] ||
+  fail "service model change did not retain restore-idle claim"
+
 # Distro packages intentionally lack the Nix-only idle and private-portal
 # units. Once the exact nested owner is gone and sockets are reclaimable, stop
 # must remove only its durable state and return to an empty compositor baseline.

--- a/tests/unit/test_session_stop_contract.cpp
+++ b/tests/unit/test_session_stop_contract.cpp
@@ -371,6 +371,65 @@ TEST(SessionStopContractTests, StandalonePackagesSkipPrivatePortalRebind) {
   EXPECT_NE(after_launch.find("rebind_private_portal_after_nested_start"), std::string::npos);
 }
 
+TEST(SessionStopContractTests, HostPortalStackKeepsIdleUnitAndSkipsPrivatePortal) {
+  // scripts/install ships the idle unit and no private portal unit. That is
+  // loaded:not-found, which the classifier rejected as inconsistent, so every
+  // start on that stack failed at publish_session_mode.
+  const auto source = read_source_for_contract("nix/modules/polaris-gamescope-session.sh");
+  ASSERT_FALSE(source.empty());
+  const auto npos = std::string::npos;
+
+  const auto classify = source.find("polaris_gamescope_service_mode() {");
+  ASSERT_NE(classify, npos);
+  const auto classify_end = source.find("\n}\n", classify);
+  ASSERT_NE(classify_end, npos);
+  const auto classifier = source.substr(classify, classify_end - classify);
+  const auto idle_only = classifier.find("loaded:not-found)");
+  const auto neither = classifier.find("not-found:not-found)");
+  const auto verdict = classifier.find("printf 'host-portal\\n'");
+  ASSERT_NE(idle_only, npos);
+  ASSERT_NE(neither, npos);
+  ASSERT_NE(verdict, npos);
+  EXPECT_LT(idle_only, verdict);
+  EXPECT_LT(verdict, neither);
+
+  // Both persisted-state validators accept the word.
+  std::size_t validators = 0;
+  for (auto at = source.find("''|managed|host-portal|standalone)"); at != npos; at = source.find("''|managed|host-portal|standalone)", at + 1)) {
+    ++validators;
+  }
+  EXPECT_EQ(validators, 2u);
+
+  // The idle unit is masked for nested on any host that has it.
+  const auto prepare = source.find("prepare_nested_runtime_services() {");
+  ASSERT_NE(prepare, npos);
+  const auto prepare_end = source.find("\n}\n", prepare);
+  const auto prepare_body = source.substr(prepare, prepare_end - prepare);
+  const auto mask_arm = prepare_body.find("managed|host-portal)");
+  const auto mask = prepare_body.find("polaris_mask_idle_unit_runtime");
+  ASSERT_NE(mask_arm, npos);
+  ASSERT_NE(mask, npos);
+  EXPECT_LT(mask_arm, mask);
+
+  // The private portal is neither rebound after start nor waited for on stop.
+  const auto rebind = source.find("rebind_private_portal_after_nested_start() {");
+  ASSERT_NE(rebind, npos);
+  const auto rebind_end = source.find("\n}\n", rebind);
+  const auto rebind_body = source.substr(rebind, rebind_end - rebind);
+  const auto host_arm = rebind_body.find("host-portal)");
+  ASSERT_NE(host_arm, npos);
+  EXPECT_EQ(rebind_body.find("polaris-portal-gamescope.service", host_arm), npos);
+  EXPECT_EQ(rebind_body.find("busctl", host_arm), npos);
+
+  const auto restored = source.find("idle gamescope restored after nested stop");
+  ASSERT_NE(restored, npos);
+  const auto managed_gate = source.find("if [ \"$service_mode\" = managed ]; then", restored);
+  const auto portal_restart = source.find("systemctl --user restart polaris-portal-gamescope.service", restored);
+  ASSERT_NE(managed_gate, npos);
+  ASSERT_NE(portal_restart, npos);
+  EXPECT_LT(managed_gate, portal_restart);
+}
+
 TEST(SessionStopContractTests, WrappedGamescopeIsFrozenBeforeXwaylandGroupTeardown) {
   const auto source = read_source_for_contract("nix/modules/polaris-gamescope-runtime-lib.sh");
   ASSERT_FALSE(source.empty());
@@ -653,6 +712,11 @@ TEST(SessionStopContractTests, RuntimeAcquisitionRejectsNestedOrIncompleteDurabl
   {
     std::ofstream state(dir / "polaris-gamescope-session-state", std::ios::trunc);
     state << "session-A attach managed\n";
+  }
+  EXPECT_TRUE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
+  {
+    std::ofstream state(dir / "polaris-gamescope-session-state", std::ios::trunc);
+    state << "session-A attach host-portal\n";
   }
   EXPECT_TRUE(stream_runtime::gamescope_runtime_acquisition_allowed_for_tests());
   {


### PR DESCRIPTION
## Summary

The nested session helper only accepted two runtime service layouts: `managed` (idle compositor unit and private portal unit both loaded) and `standalone` (neither). The `scripts/install` stack ships the idle unit and documents the private portal as optional, so it presents `loaded:not-found`, which `polaris_gamescope_service_mode()` rejected as inconsistent. Every start on that stack has failed at `publish_session_mode` since 411e0818 (2026-08-27). Found while working #599; that reporter is on a distro package and was not affected.

- `loaded:not-found` is now its own persisted service mode, `host-portal`. It masks the idle unit during nested and restores it on stop exactly like `managed`, and skips the private portal rebind after start and the portal bus wait on stop, because there is no backend to rebind.
- Both persisted-state validators in the helper and the runtime acquisition reader in `stream_runtime_gamescope.cpp` accept the word. A persisted `host-portal` session is still refused against a host whose units classify differently at stop.
- `scripts/install/README.md` names the three modes next to the optional private portal section.

## Exact candidate

`Commit:` `26f54dda3722fc8fb96a875757cf5bcaa713f6b4`
`Tree:` `13af81b500ba0eedeebf315e695f53cd97653970`
`Parent:` `5cbe1e23b8722fc87e4d1842237772fb4a36804d`
`Base:` `5cbe1e23b8722fc87e4d1842237772fb4a36804d`

## Verification

- [x] `ninja polaris test_polaris_http` on pc-papi (CUDA-off tree), clean
- [x] `test_polaris_http --gtest_filter=SessionStopContractTests.*`: 52/52, including the acquisition reader accepting `host-portal`; the new `HostPortalStackKeepsIdleUnitAndSkipsPrivatePortal` fails against the master session script and passes here
- [x] `tests/unit/platform/test_gamescope_session_stop_shell.sh`: two new cases (host-portal restore commits without touching the portal; a persisted host-portal session is refused on a host that now classifies as managed); the restore case fails against the master script and passes here
- [x] `ctest -R gamescope`: 4/4 shell suites
- [x] `test_polaris --gtest_filter=*SourceSafety*`: 26/26
- [x] `bash -n`, `git diff --check`, `scripts/check-public-surface.sh`

Not covered: no live start/stop on a real scripts/install host in this pass. The classifier, mask, rebind, and restore branches are exercised by the stop state machine harness and source contracts.
