### PR TITLE
release: prepare Polaris 1.4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
     set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
-project(Polaris VERSION 1.4.1
+project(Polaris VERSION 1.4.2
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -530,7 +530,7 @@
         "example": {
           "schema_version": 1,
           "measurement_spec_id": "measurement-spec-v1",
-          "collector_version": "1.4.1",
+          "collector_version": "1.4.2",
           "clock_domain": "CLOCK_MONOTONIC",
           "run_id": "pair-0001-control",
           "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,8 +7,20 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
-- Fixes a Linux Vulkan Video crash at client disconnect by closing FFmpeg's codec-owned picture views before releasing Polaris's converter resources, and records bounded teardown phase markers for field verification.
-- Advertises the encoder backends compiled into the host and lets a capable Nova client choose one for a single game without rewriting `polaris.conf`. Among per-game choices, Auto is the only fallback policy; an explicit backend is live-probed strictly, bound to the deterministic launch envelope, reported in session status, and restored to the host default at teardown. Persisted host choices retain their existing fallback behavior, except Vulkan which remains strict.
+## v1.4.2 - 2026-09-04
+
+A stability and diagnostics update matched with Nova v1.4.2. Polaris lets a capable Nova client choose the encoder for a single game, closes a Linux Vulkan Video crash at disconnect, keeps SteamOS's gamescope file capability from breaking private streams, and stops stale helper installs from being debugged as Polaris bugs. Existing configurations and paired devices remain valid.
+
+- Fixes a Linux Vulkan Video crash at client disconnect by closing FFmpeg's codec-owned picture views before releasing Polaris's converter resources, and records bounded teardown phase markers for field verification
+- Advertises the encoder backends compiled into the host and lets a capable Nova client choose one for a single game without rewriting `polaris.conf`. Among per-game choices, Auto is the only fallback policy; an explicit backend is live-probed strictly, bound to the deterministic launch envelope, reported in session status, and restored to the host default at teardown. Persisted host choices retain their existing fallback behavior, except Vulkan which remains strict
+- Keeps harmless low-latency LAN RTT jitter from reducing the Auto Safe bitrate, and keeps a clean Auto Safe recovery informational in Doctor while confirmed media loss still warns
+- Makes machine-facing decimal parsing and formatting locale-independent across `/optimize`, display planning, launch profiles, compositor arguments, and telemetry, so a host running under a comma-decimal locale can launch again, and keeps GTK tray initialization from changing Polaris's numeric semantics
+- Starts the private nested gamescope compositor with `no_new_privs`, so the `cap_sys_nice` file capability SteamOS and Arch ship on gamescope can no longer hide `/proc` ownership from the same-user checks that prove which compositor owns the stream; desktop Game Mode keeps its capability
+- Runtime-masks the idle compositor unit only where one exists, repairs a leaked runtime mask on the idempotent stop path, and classifies the scripts/install layout of an idle unit with the host portal as `host-portal` instead of refusing it as inconsistent, so standalone packages and manual installs no longer wedge after a failed start
+- Skips the private portal rebind on hosts without a private portal unit instead of polling an absent bus for eight seconds and logging a warning that read like a failure
+- Resolves `polaris-gamescope-session` beside the Polaris binary before PATH, ships reference copies of the helper modules, and reports at launch when the launcher in use is shadowed by a stale copy or was installed from a different checkout
+- Captures a labwc startup client's exit status and a bounded, redacted stderr tail when no private-session window appears, and records bounded per-session evidence for encoded frames that exceed the four-block FEC protection envelope; both stay informational in Doctor unless corroborating media-loss or pacing evidence exists
+- Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official release assets
 
 ## v1.4.1 - 2026-09-03
 

--- a/docs/release-notes/v1.4.2.md
+++ b/docs/release-notes/v1.4.2.md
@@ -1,0 +1,92 @@
+# Polaris v1.4.2
+
+Polaris v1.4.2 is the matched host release for Nova v1.4.2. It is a stability and diagnostics update: per-game encoder selection for capable clients, a Linux Vulkan Video crash fix at disconnect, and the gamescope session fixes that came out of the first SteamOS 3.8 field report.
+
+A Nova v1.4.2 client can now choose the encoder backend for a single game from the list the host advertises. Auto is the only per-game choice that may fall back after its live probe; an explicit NVENC, VA-API, Vulkan, or software choice is strict and fails instead of silently switching, and the host default is restored when the session ends. Older clients keep the configured host default.
+
+On SteamOS and Arch, gamescope ships with the `cap_sys_nice` file capability. A process that gains a file capability is not dumpable, so `/proc/<pid>/exe` and `/proc/<pid>/fd` become unreadable to the user that launched it, the ownership checks that prove which compositor owns the stream failed, and the teardown then killed a healthy compositor. The private nested compositor now starts with `no_new_privs`, so the capability is never granted to it and the checks pass. Desktop Game Mode keeps its capability and the system binary is untouched.
+
+Existing v1.4.1 configuration and paired devices remain valid. Steam Input remains manual and read-only.
+
+## Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+## Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+## Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+## SteamOS 3.8
+
+Open a terminal in Desktop Mode and run this exact version-pinned command. It initializes the package keyring when needed and restores the read-only root before starting Polaris.
+
+```bash
+wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-steamos3.8-x86_64.pkg.tar.zst &&
+(
+set -e
+trap 'sudo steamos-readonly enable' EXIT
+sudo steamos-readonly disable || exit $?
+sudo pacman-key --init || exit $?
+sudo pacman-key --populate || exit $?
+sudo pacman -Sy || exit $?
+sudo pacman -U ./Polaris-steamos3.8-x86_64.pkg.tar.zst || exit $?
+sudo -H polaris --setup-host || exit $?
+sudo steamos-readonly enable || exit $?
+trap - EXIT
+) &&
+systemctl --user enable --now polaris
+```
+
+Bazzite users should follow the exact-output [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+
+## Changes
+
+### Encoding and streaming
+
+- Advertises the encoder backends compiled into the host and accepts a per-session encoder request from a capable client: the host default, explicit Auto with a live probe and fallback, or a strict named backend that fails instead of switching. The request is bound to the deterministic launch envelope, reported in session status, and the host configuration is restored at teardown.
+- Closes FFmpeg's codec-owned picture views before releasing the Vulkan converter and device resources, fixing a Linux Vulkan Video crash at client disconnect, and records bounded teardown phase markers for field verification.
+- Keeps harmless low-latency LAN RTT jitter from reducing the Auto Safe bitrate, and keeps a clean Auto Safe recovery informational in Doctor while confirmed media loss still warns.
+- Records bounded per-session evidence for encoded frames that exceed the four-block FEC protection envelope, without changing packetization or bitrate policy.
+
+### Launch reliability
+
+- Makes machine-facing decimal parsing and formatting locale-independent across `/optimize`, display planning, launch profiles, compositor arguments, and telemetry, and keeps GTK tray initialization from changing Polaris's numeric semantics. A host running under a comma-decimal locale could not launch before this.
+- Captures a labwc startup client's exit status and a bounded, redacted stderr tail when no private-session window appears, so a failed Flatpak or Heroic private-session launch leaves evidence instead of a guess.
+
+### Gamescope sessions on SteamOS, Arch, and manual installs
+
+- Starts the private nested gamescope with `no_new_privs`, keeping the `cap_sys_nice` file capability from hiding the compositor's `/proc` identity from same-user ownership checks. Game Mode is untouched.
+- Runtime-masks the idle compositor unit only on hosts that have one, and repairs a leaked runtime mask on the idempotent stop path, so a standalone package no longer wedges every later launch with `inconsistent gamescope services idle=masked` after one failed start.
+- Classifies the scripts/install layout, an idle compositor unit with the host XDG portal and no private portal unit, as `host-portal` instead of refusing it as inconsistent. That stack had been unable to start a nested session since 2026-08-27.
+- Skips the private portal rebind on hosts without a private portal unit instead of polling an absent bus for eight seconds on every launch and logging a warning that read like a failure.
+- Resolves `polaris-gamescope-session` beside the Polaris binary before PATH, so a copy left under `~/.local/bin` by an earlier manual install cannot shadow the packaged launcher, ships reference copies of the helper modules, and reports at launch when the launcher in use is shadowed or was installed from a different checkout.
+
+## Validation boundary
+
+The SteamOS `no_new_privs` change was verified on the maintainer's NVIDIA host and by the field report's own measurements through a wrapper script, but it has not yet received physical SteamOS validation in packaged form; the reporter's retest on the stock gamescope binary is pending. The scripts/install `host-portal` mode is covered by the stop state machine harness and source contracts rather than a live manual-install host. The encoder selection contract passed the Retroid Pocket 6 Control smoke at 1920x1080, 120 FPS, HEVC with strict NVENC and no fallback, using the per-game encoder client that ships in Nova v1.4.2. Final publication still requires exact merge-SHA CI and signed package verification.
+
+## Official assets
+
+- `Polaris-arch-x86_64.pkg.tar.zst`
+- `Polaris-fedora44-x86_64.rpm`
+- `Polaris-steamos3.8-x86_64.pkg.tar.zst`
+- `Polaris-ubuntu24.04-x86_64.deb`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.4.1') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.4.2') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -665,7 +665,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.4.1.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.4.2.md").read_text(encoding="utf-8")
 )
 
 
@@ -1296,18 +1296,18 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.4.2 - 2026-09-04",
     "## v1.4.1 - 2026-09-03",
-    "## v1.4.0 - 2026-09-01",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
     "Vulkan Video",
-    "DRM/KMS",
-    "guest pairing",
-    "Desktop Takeover",
-    "frame-pacing",
-    "Heroic",
-    "npm audit",
+    "encoder",
+    "locale",
+    "no_new_privs",
+    "host-portal",
+    "polaris-gamescope-session",
+    "FEC",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
     "Polaris-steamos3.8-x86_64.pkg.tar.zst",
@@ -1315,7 +1315,7 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.4.1 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.2 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1324,7 +1324,7 @@ asset_phrase = (
     "`Polaris-steamos3.8-x86_64.pkg.tar.zst`, and "
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
-for label, section in (("v1.4.1 changelog", current_release_prose),):
+for label, section in (("v1.4.2 changelog", current_release_prose),):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
         sys.exit(1)
@@ -1342,7 +1342,7 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
     ("docs/building.md Packaging", building_packaging_prose),
-    ("v1.4.1 changelog", current_release_prose),
+    ("v1.4.2 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_assets:
@@ -1354,24 +1354,23 @@ for label, section in (
         sys.exit(1)
 
 release_notes_facts = (
-    "v1.4.0",
-    "Nova v1.4.1",
+    "v1.4.1",
+    "Nova v1.4.2",
     "Vulkan Video",
-    "DRM/KMS",
-    "temporary_authorization",
-    "Desktop Takeover",
-    "live_bitrate_control",
+    "no_new_privs",
+    "cap_sys_nice",
+    "host-portal",
+    "polaris-gamescope-session",
     "Steam Input",
     "Retroid Pocket 6",
-    "physical AMD-host validation",
-    "npm audit",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.1/Polaris-fedora44-x86_64.rpm &&",
+    "physical SteamOS validation",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.1/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.1/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
-    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.1/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
     "trap 'sudo steamos-readonly enable' EXIT",
     "sudo pacman-key --init || exit $?",
     "sudo pacman-key --populate || exit $?",
@@ -1379,7 +1378,7 @@ release_notes_facts = (
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.4.1 release notes are missing release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.2 release notes are missing release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 for forbidden in (
     "history_safe",
@@ -1388,19 +1387,19 @@ for forbidden in (
     "AI Auto Quality Preference",
 ):
     if forbidden in current_release_prose or forbidden in release_notes:
-        print(f"v1.4.1 public release scope must exclude: {forbidden}", file=sys.stderr)
+        print(f"v1.4.2 public release scope must exclude: {forbidden}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.4.1 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.4.2 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host || exit $?") != 1:
-    print("v1.4.1 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
+    print("v1.4.2 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.4.1 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.4.2 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user enable --now polaris") != 1:
-    print("v1.4.1 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
+    print("v1.4.2 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
     sys.exit(1)
 
 release_workflow = Path(".github/workflows/build.yml").read_text(encoding="utf-8")

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.1-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.2-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -776,7 +776,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.4.1-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.4.2-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v141-contract.test.js
+++ b/src_assets/common/assets/web/release-v141-contract.test.js
@@ -1,16 +1,10 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
-const expectedAssets = [
-  'Polaris-arch-x86_64.pkg.tar.zst',
-  'Polaris-fedora44-x86_64.rpm',
-  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
-  'Polaris-ubuntu24.04-x86_64.deb',
-].sort()
 
-const currentChangelog = () => {
+const historicalRelease = () => {
   const changelog = read('docs/changelog.md')
   const start = changelog.indexOf('## v1.4.1 - 2026-09-03')
   const end = changelog.indexOf('## v1.4.0 - 2026-09-01')
@@ -19,27 +13,18 @@ const currentChangelog = () => {
   return changelog.slice(start, end)
 }
 
-const releaseNotes = () => read('docs/release-notes/v1.4.1.md')
-const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
-  .map((match) => match[1])
-  .filter((block) => block.includes('wget --output-document='))
+const historicalNotes = () => read('docs/release-notes/v1.4.1.md')
 
-describe('v1.4.1 release contract', () => {
-  it('moves every current release identity to v1.4.1', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.1')
-    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.1"')
-    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.1')
-    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.1-1|x86_64'")
-    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.1-1|x86_64'")
-  })
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
 
-  it('makes v1.4.0 historical and promotes the complete v1.4.1 scope', () => {
-    expect(read('src_assets/common/assets/web/release-v140-contract.test.js')).toContain("describe('historical v1.4.0 release contract'")
-    const gate = read('scripts/check-public-docs.sh')
-    expect(gate).toContain('docs/release-notes/v1.4.1.md')
-    expect(gate).toContain('"## v1.4.1 - 2026-09-03"')
-
-    const release = `${currentChangelog()}\n${releaseNotes()}`
+describe('historical v1.4.1 release contract', () => {
+  it('preserves the guarded Vulkan, guest pairing, and Desktop Takeover scope', () => {
+    const evidence = `${historicalRelease()}\n${historicalNotes()}`
     for (const fact of [
       'Vulkan Video',
       'DRM/KMS',
@@ -52,92 +37,22 @@ describe('v1.4.1 release contract', () => {
       'Nova v1.4.1',
       'Retroid Pocket 6',
     ]) {
-      expect(release, `release must include: ${fact}`).toContain(fact)
+      expect(evidence, `historical v1.4.1 must include: ${fact}`).toContain(fact)
     }
   })
 
-  it('documents explicit Vulkan breadth and bounded automatic selection', () => {
-    const notes = releaseNotes()
-    const policy = read('src/platform/linux/encoder_auto_policy.h')
-    const portal = read('src/platform/linux/portal_grab.cpp')
-
-    expect(notes).toContain('DRM/KMS, wlroots, and Portal')
-    expect(notes).toContain('NVIDIA remains on NVENC by default')
-    expect(notes).toContain('Intel remains on VA-API')
-    expect(notes).toContain('has not received physical AMD-host validation')
-    expect(policy).toMatch(/kernel_driver == "amdgpu" && private_compositor_live_probe_available[\s\S]*fallback_encoder = "vaapi"/)
-    expect(portal).toContain('make_avcodec_encode_device_ram')
-  })
-
-  it('keeps requested wlroots output selection exact and observable', () => {
-    const wlgrab = read('src/platform/linux/wlgrab.cpp')
-    const policyTests = read('tests/unit/test_wlgrab_capture_policy.cpp')
-
-    expect(wlgrab).toContain('Selected monitor [')
-    expect(wlgrab).toContain('selected_monitor_identity')
-    expect(wlgrab).toContain('description=[')
-    expect(policyTests).toContain('HostVirtualOutputDoesNotFallBackToPhysicalMonitorZero')
-    expect(policyTests).toContain('POLARIS-HEADLESS-unknown')
-  })
-
-  it('pins all four install commands to v1.4.1 and preserves platform safety', () => {
-    const blocks = installBlocks()
-    expect(blocks).toHaveLength(4)
-    for (const asset of expectedAssets) {
-      const matches = blocks.filter((block) => block.includes(`/${asset}`))
-      expect(matches, `one command block for ${asset}`).toHaveLength(1)
-      expect(matches[0]).toContain(`releases/download/v1.4.1/${asset}`)
-      expect(matches[0]).toContain('sudo -H polaris --setup-host')
-    }
-
-    for (const asset of [
-      'Polaris-arch-x86_64.pkg.tar.zst',
-      'Polaris-fedora44-x86_64.rpm',
-      'Polaris-ubuntu24.04-x86_64.deb',
-    ]) {
-      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
-      expect(block).toContain('systemctl --user restart polaris')
-    }
-
-    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
-    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
-    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
-    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
-    expect(steamOs).toContain('systemctl --user enable --now polaris')
-
-    const listed = [...new Set(releaseNotes().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+  it('preserves the exact historical assets and install identities', () => {
+    const notes = historicalNotes()
+    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
     expect(listed.sort()).toEqual(expectedAssets)
-  })
 
-  it('publishes release-note guide links that work outside the source tree', () => {
-    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
-    const notes = readdirSync(releaseNotesDir)
-      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
-      .map((name) => read(`docs/release-notes/${name}`))
-      .join('\n')
-
-    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
-    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
-    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
-  })
-
-  it('keeps publication bound to one verified immutable source', () => {
-    const workflow = read('.github/workflows/build.yml')
-    const ordered = [
-      '- name: Check out exact release source',
-      '- name: Revalidate release tag against packaged source',
-      '- name: Stage curated GitHub release',
-      '- name: Upload release assets to GitHub release',
-      '- name: Verify release assets on GitHub release',
-      '- name: Publish verified draft release',
-    ]
-    const positions = ordered.map((step) => workflow.indexOf(step))
-    expect(positions.every((position) => position >= 0)).toBe(true)
-    expect(positions).toEqual([...positions].sort((a, b) => a - b))
-    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
-    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
-    expect(workflow).toContain('--verify-tag')
-    expect(workflow).toContain('--notes-file "$release_notes"')
-    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
+    const blocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
+    expect(blocks).toHaveLength(4)
+    for (const block of blocks) {
+      expect(block).toContain('releases/download/v1.4.1/')
+      expect(block).toContain('polaris --setup-host')
+    }
   })
 })

--- a/src_assets/common/assets/web/release-v142-contract.test.js
+++ b/src_assets/common/assets/web/release-v142-contract.test.js
@@ -1,0 +1,132 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+
+const currentChangelog = () => {
+  const changelog = read('docs/changelog.md')
+  const start = changelog.indexOf('## v1.4.2 - 2026-09-04')
+  const end = changelog.indexOf('## v1.4.1 - 2026-09-03')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return changelog.slice(start, end)
+}
+
+const releaseNotes = () => read('docs/release-notes/v1.4.2.md')
+const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
+  .map((match) => match[1])
+  .filter((block) => block.includes('wget --output-document='))
+
+describe('v1.4.2 release contract', () => {
+  it('moves every current release identity to v1.4.2', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.2')
+    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.2"')
+    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.2')
+    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.2-1|x86_64'")
+    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.2-1|x86_64'")
+  })
+
+  it('makes v1.4.1 historical and promotes the complete v1.4.2 scope', () => {
+    expect(read('src_assets/common/assets/web/release-v141-contract.test.js')).toContain("describe('historical v1.4.1 release contract'")
+    const gate = read('scripts/check-public-docs.sh')
+    expect(gate).toContain('docs/release-notes/v1.4.2.md')
+    expect(gate).toContain('"## v1.4.2 - 2026-09-04"')
+
+    const release = `${currentChangelog()}\n${releaseNotes()}`
+    for (const fact of [
+      'Vulkan Video',
+      'encoder',
+      'locale',
+      'no_new_privs',
+      'cap_sys_nice',
+      'host-portal',
+      'polaris-gamescope-session',
+      'FEC',
+      'Nova v1.4.2',
+      'Retroid Pocket 6',
+    ]) {
+      expect(release, `release must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('documents the strict encoder contract and the SteamOS capability fix against the source', () => {
+    const notes = releaseNotes()
+    const session = read('nix/modules/polaris-gamescope-session.sh')
+    const helper = read('src/platform/linux/gamescope_session_helper.cpp')
+
+    expect(notes).toContain('Auto is the only per-game choice that may fall back')
+    expect(notes).toContain('has not yet received physical SteamOS validation')
+    expect(session).toContain('setpriv --no-new-privs')
+    expect(session).toContain("printf 'host-portal\\n'")
+    expect(session).toContain('rebind_private_portal_after_nested_start')
+    expect(helper).toContain('polaris-gamescope-session')
+  })
+
+  it('pins all four install commands to v1.4.2 and preserves platform safety', () => {
+    const blocks = installBlocks()
+    expect(blocks).toHaveLength(4)
+    for (const asset of expectedAssets) {
+      const matches = blocks.filter((block) => block.includes(`/${asset}`))
+      expect(matches, `one command block for ${asset}`).toHaveLength(1)
+      expect(matches[0]).toContain(`releases/download/v1.4.2/${asset}`)
+      expect(matches[0]).toContain('sudo -H polaris --setup-host')
+    }
+
+    for (const asset of [
+      'Polaris-arch-x86_64.pkg.tar.zst',
+      'Polaris-fedora44-x86_64.rpm',
+      'Polaris-ubuntu24.04-x86_64.deb',
+    ]) {
+      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+
+    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
+    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
+    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
+    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
+    expect(steamOs).toContain('systemctl --user enable --now polaris')
+
+    const listed = [...new Set(releaseNotes().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+    expect(listed.sort()).toEqual(expectedAssets)
+  })
+
+  it('publishes release-note guide links that work outside the source tree', () => {
+    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
+    const notes = readdirSync(releaseNotesDir)
+      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
+      .map((name) => read(`docs/release-notes/${name}`))
+      .join('\n')
+
+    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
+    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
+    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
+  })
+
+  it('keeps publication bound to one verified immutable source', () => {
+    const workflow = read('.github/workflows/build.yml')
+    const ordered = [
+      '- name: Check out exact release source',
+      '- name: Revalidate release tag against packaged source',
+      '- name: Stage curated GitHub release',
+      '- name: Upload release assets to GitHub release',
+      '- name: Verify release assets on GitHub release',
+      '- name: Publish verified draft release',
+    ]
+    const positions = ordered.map((step) => workflow.indexOf(step))
+    expect(positions.every((position) => position >= 0)).toBe(true)
+    expect(positions).toEqual([...positions].sort((a, b) => a - b))
+    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
+    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
+    expect(workflow).toContain('--verify-tag')
+    expect(workflow).toContain('--notes-file "$release_notes"')
+    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
+  })
+})


### PR DESCRIPTION
## Summary

Prepares Polaris 1.4.2, the matched host release for Nova 1.4.2. No product code changes; this is the release identity, the changelog, the curated notes, and the gates that pin them.

- Version identity moves to 1.4.2 in `CMakeLists.txt`, `docs/benchmark-control-openapi.json` (`collector_version`), the SteamOS package identity in `scripts/ci/build-steamos-package.sh` and `packaging-contracts.test.js`, and `namcap-reviewed-warnings.txt`.
- `docs/changelog.md` gains `## v1.4.2 - 2026-09-04` from the Unreleased entries (#598) plus #600, #601, and #602, with the exact four-asset sentence the docs gate requires; `## Unreleased` stays as an empty heading, as after 1.4.1.
- `docs/release-notes/v1.4.2.md` carries the four version-pinned install commands, the change summary, and an honest validation boundary: the SteamOS `no_new_privs` fix is still awaiting the #599 reporter's physical retest, and `host-portal` is covered by harness and contracts rather than a live manual install.
- `scripts/check-public-docs.sh` and a new `release-v142-contract.test.js` pin the 1.4.2 identity, facts, and install commands; `release-v141-contract.test.js` becomes the historical contract, mirroring what #595 did for 1.4.0.

Tagging `v1.4.2` on the merge commit follows; the tag build publishes the four assets with these notes.

## Exact candidate

`Commit:` `ec6eaa172a82131a0f977a52eb2fb7bc98c9c532`
`Tree:` `51dfb14b34b01fb1a1ddf6f28c8a03c76ce63494`
`Parent:` `ea5669446d5ea8a503d91488533b2c35ffce236c`
`Base:` `ea5669446d5ea8a503d91488533b2c35ffce236c`

## Verification

- [x] `bash scripts/check-public-docs.sh`: clean
- [x] `bash scripts/check-public-surface.sh`: clean
- [x] `npm run lint`: clean
- [x] `npm run test`: 86/86 files, including the new v1.4.2 contract, the historical v1.4.1 contract, and the packaging contracts
- [x] `git diff --check`: clean

Not covered: the tag build itself (SteamOS/Arch/Fedora/Ubuntu packaging under the 1.4.2 identity) runs in CI on this PR and again on the tag.
