### PR TITLE
feat(doctor): show the gamescope session helper Polaris will run

### DIFF
--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -30,6 +30,13 @@ capture latency, and encoder time remain inside the active stream's real FPS bud
 when those measurements show pressure; it does not lower a healthy 120 FPS stream merely because
 its compatibility path is CPU-backed.
 
+On a Linux host configured for `gamescope_stream`, Doctor & Support also shows a **Gamescope Session
+Helper** card. It names the `polaris-gamescope-session` launcher this Polaris will run, warns when a
+stale copy under `~/.local/bin` or `/usr/local/bin` sits ahead of it on PATH, and fails when the
+launcher or its runtime library was installed from a different checkout than the running build,
+which is the state that makes already-fixed session bugs reappear. Reinstall the helpers from this
+Polaris version, or install the distro package, and the card turns green.
+
 ## Pick the offered action
 
 Doctor uses a small action vocabulary so the button says what will happen:

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -92,6 +92,7 @@
 
 #ifdef __linux__
   #include "platform/linux/executable_path.h"
+  #include "platform/linux/gamescope_session_helper.h"
   #include "platform/linux/virtual_display.h"
   #include "platform/linux/session_manager.h"
   #include "platform/linux/stream_runtime.h"
@@ -6889,6 +6890,49 @@ namespace confighttp {
     send_response(response, output);
   }
 
+  /**
+   * @brief Read-only probe of the gamescope_stream session launcher this host would run.
+   *
+   * Doctor shows which polaris-gamescope-session Polaris resolves, whether a
+   * stale copy on PATH shadows it, and whether it matches the module this
+   * build ships, so a helper left by an older scripts/install run is named
+   * instead of debugged as a Polaris bug.
+   */
+  void getGamescopeHelperProbe(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) {
+      return;
+    }
+
+    print_req(request);
+
+    nlohmann::json output;
+    output["status"] = true;
+    output["kind"] = "gamescope-helper";
+#ifdef __linux__
+    namespace helper = platf::gamescope_session_helper;
+    const auto resolution = helper::resolve_default();
+    const auto path_or_null = [](const std::filesystem::path &path) {
+      return path.empty() ? nlohmann::json(nullptr) : nlohmann::json(path.string());
+    };
+    output["platform"] = "linux";
+    output["relevant"] = config::video.linux_display.stream_mode == "gamescope_stream" ||
+                         config::video.linux_display.private_runtime == "gamescope";
+    output["launcher"] = path_or_null(resolution.helper);
+    output["shadowed"] = path_or_null(resolution.shadowed);
+    output["bundled"] = path_or_null(resolution.bundled);
+    output["runtimeLib"] = path_or_null(resolution.runtime_lib);
+    output["sessionMatch"] = std::string(helper::match_key(resolution.session_match));
+    output["runtimeLibMatch"] = std::string(helper::match_key(resolution.runtime_lib_match));
+    output["summary"] = helper::summary(resolution);
+    output["advisories"] = helper::advisories(resolution);
+#else
+    output["platform"] = "other";
+    output["relevant"] = false;
+#endif
+
+    send_response(response, output);
+  }
+
   nlohmann::json augment_stream_stats_json(nlohmann::json stats_json, const stream_stats::stats_t &stats) {
     stats_json["tuning"] = settings_metadata::build_tuning_json(
       adaptive_bitrate::get_state(),
@@ -7265,6 +7309,7 @@ namespace confighttp {
     server.resource["^/api/stats/stream$"]["GET"] = getStreamStats;
     server.resource["^/api/stats/stream-sse$"]["GET"] = getStreamStatsSSE;
     server.resource["^/api/support/network-path-probe$"]["GET"] = getNetworkPathProbe;
+    server.resource["^/api/support/gamescope-helper$"]["GET"] = getGamescopeHelperProbe;
     server.resource["^/api/recording/start$"]["POST"] = withCsrf(startRecording);
     server.resource["^/api/recording/stop$"]["POST"] = withCsrf(stopRecording);
     server.resource["^/api/recording/save-replay$"]["POST"] = withCsrf(saveReplay);

--- a/src/platform/linux/gamescope_session_helper.cpp
+++ b/src/platform/linux/gamescope_session_helper.cpp
@@ -99,6 +99,20 @@ namespace platf::gamescope_session_helper {
     return "not compared against a bundled copy";
   }
 
+  std::string_view match_key(bundle_match_t match) {
+    switch (match) {
+      case bundle_match_t::exact:
+        return "exact";
+      case bundle_match_t::wrapped:
+        return "wrapped";
+      case bundle_match_t::mismatch:
+        return "mismatch";
+      case bundle_match_t::unknown:
+        break;
+    }
+    return "unknown";
+  }
+
   resolution_t resolve(
     const std::optional<fs::path> &executable_dir,
     const fs::path &path_candidate,

--- a/src/platform/linux/gamescope_session_helper.h
+++ b/src/platform/linux/gamescope_session_helper.h
@@ -56,6 +56,9 @@ namespace platf::gamescope_session_helper {
 
   std::string_view describe(bundle_match_t match);
 
+  /// Stable machine word for a match state: exact, wrapped, mismatch, or unknown.
+  std::string_view match_key(bundle_match_t match);
+
   /// One line naming the launcher in use and how it relates to the shipped module.
   std::string summary(const resolution_t &resolution);
 

--- a/src_assets/common/assets/web/diagnostics-export.js
+++ b/src_assets/common/assets/web/diagnostics-export.js
@@ -1062,6 +1062,59 @@ export function buildControllerInputTestReport(input = {}) {
   }
 }
 
+export function buildGamescopeHelperReport(probe = {}) {
+  if (!probe || probe.relevant !== true) return null
+  const launcher = String(probe.launcher || '')
+  const shadowed = String(probe.shadowed || '')
+  const bundled = String(probe.bundled || '')
+  const runtimeLib = String(probe.runtimeLib || '')
+  const sessionMatch = lower(probe.sessionMatch) || 'unknown'
+  const runtimeLibMatch = lower(probe.runtimeLibMatch) || 'unknown'
+  const matchDetail = (match, subject) => ({
+    exact: `${subject} is identical to the module this build ships.`,
+    wrapped: `${subject} wraps the module this build ships (Nix or the manual installer).`,
+    mismatch: `${subject} was installed from a different checkout than this Polaris build.`,
+  })[match] || `${subject} was not compared against a bundled copy.`
+  const checks = [
+    checklistItem('launcher', 'Session launcher', launcher ? 'pass' : 'fail',
+      launcher ? `Polaris runs ${launcher}.` : 'No polaris-gamescope-session launcher beside the Polaris binary or on PATH.',
+      launcher ? 'Every nested gamescope session starts through this launcher.' : 'Install the Polaris package for this distro, or run scripts/install/03-install-gamescope-stack.sh from this Polaris version.'),
+    checklistItem('shadowed', 'Stale copy on PATH', shadowed ? 'warning' : 'pass',
+      shadowed ? `PATH would have picked ${shadowed}; the packaged launcher is used instead.` : 'No other copy of polaris-gamescope-session sits ahead on PATH.',
+      shadowed ? 'Remove that copy if it came from an older scripts/install run so nothing else can pick it up.' : 'Nothing to clean up.'),
+    checklistItem('bundle', 'Launcher matches this build', !launcher ? 'warning' : sessionMatch === 'mismatch' ? 'fail' : sessionMatch === 'unknown' ? 'warning' : 'pass',
+      launcher ? matchDetail(sessionMatch, 'The launcher in use') : 'Nothing to compare without a launcher.',
+      sessionMatch === 'mismatch' ? 'Reinstall the gamescope helpers from this Polaris version before reporting gamescope_stream problems.' : sessionMatch === 'unknown' ? 'This build ships no reference copy to compare against; a distro package or an installed build does.' : 'The session fixes in this Polaris version are the ones that run.'),
+    checklistItem('runtime-lib', 'Runtime library matches this build', runtimeLibMatch === 'mismatch' ? 'fail' : 'pass',
+      runtimeLib ? matchDetail(runtimeLibMatch, 'The runtime library beside the launcher') : 'No sibling runtime library to compare; wrapped installs inline it.',
+      runtimeLibMatch === 'mismatch' ? 'Reinstall both helpers together; the launcher sources this library.' : 'Nothing to do.'),
+  ]
+  const status = worstStatus(checks)
+  const summary = !launcher
+    ? 'gamescope_stream is configured but no session launcher is installed; nested sessions fall back to attach.'
+    : status === 'fail'
+      ? 'The gamescope session helper in use does not match this Polaris build.'
+      : status === 'warning'
+        ? (shadowed ? 'The packaged launcher is in use, but a stale copy on PATH should be removed.' : 'The launcher could not be compared against a bundled copy.')
+        : 'The gamescope session helper matches this Polaris build.'
+  return {
+    kind: 'gamescope-helper',
+    status,
+    classification: status === 'pass' ? 'clean' : 'host',
+    summary,
+    checks,
+    advancedEvidence: sanitizeDiagnosticsValue({
+      launcher,
+      shadowed,
+      bundled,
+      runtimeLib,
+      sessionMatch,
+      runtimeLibMatch,
+      advisories: Array.isArray(probe.advisories) ? probe.advisories : [],
+    }),
+  }
+}
+
 export function buildPostSessionStreamReport({ stats = {}, logs = '', disconnectReason = '' } = {}) {
   const loss = Number(stats.packet_loss)
   const latency = Number(stats.latency_ms)

--- a/src_assets/common/assets/web/diagnostics-export.test.js
+++ b/src_assets/common/assets/web/diagnostics-export.test.js
@@ -5,6 +5,7 @@ import {
   buildAnonymizedDiagnosticsBundle,
   buildControllerInputTestReport,
   buildFixMyStreamChecklist,
+  buildGamescopeHelperReport,
   buildGithubIssueDraft,
   buildGithubIssueUrl,
   buildNetworkPathTestReport,
@@ -634,6 +635,79 @@ describe('support self-service reports', () => {
     expect(report.checks.find((check) => check.key === 'host-isolation').status).toBe('pass')
     expect(report.checks.find((check) => check.key === 'host-isolation').detail).toContain('strict_bwrap')
     expect(report.advancedEvidence.native.virtualControllerKind).toBe('xone')
+  })
+
+  it('reports a packaged gamescope helper that matches the build as clean', () => {
+    const report = buildGamescopeHelperReport({
+      relevant: true,
+      launcher: '/usr/bin/polaris-gamescope-session',
+      shadowed: null,
+      bundled: '/usr/share/polaris/assets/gamescope/polaris-gamescope-session.sh',
+      runtimeLib: '/usr/bin/polaris-gamescope-runtime-lib.sh',
+      sessionMatch: 'exact',
+      runtimeLibMatch: 'exact',
+      advisories: [],
+    })
+
+    expect(report.status).toBe('pass')
+    expect(report.classification).toBe('clean')
+    expect(report.summary).toContain('matches this Polaris build')
+    expect(report.checks.map((check) => check.key)).toEqual(['launcher', 'shadowed', 'bundle', 'runtime-lib'])
+    expect(report.checks.find((check) => check.key === 'launcher').detail).toContain('/usr/bin/polaris-gamescope-session')
+  })
+
+  it('names a stale helper on PATH without failing the packaged launcher', () => {
+    const report = buildGamescopeHelperReport({
+      relevant: true,
+      launcher: '/usr/bin/polaris-gamescope-session',
+      shadowed: '/srv/example/.local/bin/polaris-gamescope-session',
+      bundled: '/usr/share/polaris/assets/gamescope/polaris-gamescope-session.sh',
+      runtimeLib: '/usr/bin/polaris-gamescope-runtime-lib.sh',
+      sessionMatch: 'exact',
+      runtimeLibMatch: 'exact',
+    })
+
+    expect(report.status).toBe('warning')
+    expect(report.summary).toContain('stale copy on PATH')
+    expect(report.checks.find((check) => check.key === 'shadowed').status).toBe('warning')
+    expect(report.checks.find((check) => check.key === 'shadowed').detail).toContain('.local/bin')
+    expect(report.checks.find((check) => check.key === 'bundle').status).toBe('pass')
+  })
+
+  it('fails a helper installed from another checkout and a missing launcher', () => {
+    const stale = buildGamescopeHelperReport({
+      relevant: true,
+      launcher: '/usr/local/bin/polaris-gamescope-session',
+      bundled: '/usr/share/polaris/assets/gamescope/polaris-gamescope-session.sh',
+      runtimeLib: '/usr/local/bin/polaris-gamescope-runtime-lib.sh',
+      sessionMatch: 'mismatch',
+      runtimeLibMatch: 'mismatch',
+    })
+    expect(stale.status).toBe('fail')
+    expect(stale.classification).toBe('host')
+    expect(stale.summary).toContain('does not match this Polaris build')
+    expect(stale.checks.find((check) => check.key === 'bundle').action).toContain('Reinstall the gamescope helpers')
+    expect(stale.checks.find((check) => check.key === 'runtime-lib').status).toBe('fail')
+
+    const missing = buildGamescopeHelperReport({ relevant: true, launcher: null, sessionMatch: 'unknown', runtimeLibMatch: 'unknown' })
+    expect(missing.status).toBe('fail')
+    expect(missing.summary).toContain('no session launcher is installed')
+  })
+
+  it('accepts a wrapped launcher and hides the report when gamescope_stream is not in use', () => {
+    const wrapped = buildGamescopeHelperReport({
+      relevant: true,
+      launcher: '/nix/store/abc-polaris-gamescope-session/bin/polaris-gamescope-session',
+      bundled: '/nix/store/def-polaris/share/polaris/assets/gamescope/polaris-gamescope-session.sh',
+      runtimeLib: null,
+      sessionMatch: 'wrapped',
+      runtimeLibMatch: 'unknown',
+    })
+    expect(wrapped.status).toBe('pass')
+    expect(wrapped.checks.find((check) => check.key === 'runtime-lib').detail).toContain('wrapped installs inline it')
+
+    expect(buildGamescopeHelperReport({ relevant: false, platform: 'other' })).toBeNull()
+    expect(buildGamescopeHelperReport(null)).toBeNull()
   })
 
   it('builds a post-session report with issue owner and next launch profile', () => {

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -1822,6 +1822,7 @@
     "network_path_tester": "Network Path Tester",
     "network_path_ceiling": "Recommended ceiling: {kbps} kbps.",
     "controller_tester": "Controller/Input Tester",
+    "gamescope_helper_tester": "Gamescope Session Helper",
     "controller_detect": "Detect controller",
     "controller_log_a": "Log A press",
     "controller_test_rumble": "Test rumble",

--- a/src_assets/common/assets/web/views/TroubleshootingView.vue
+++ b/src_assets/common/assets/web/views/TroubleshootingView.vue
@@ -187,6 +187,24 @@
           </details>
         </div>
 
+        <div v-if="gamescopeHelperReport" class="surface-subtle border p-4" :class="statusTone(gamescopeHelperReport.status).card" data-readonly>
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-sm font-semibold text-silver">{{ $t('troubleshooting.gamescope_helper_tester') }}</div>
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-eyebrow" :class="statusTone(gamescopeHelperReport.status).badge">{{ statusTone(gamescopeHelperReport.status).label }}</span>
+          </div>
+          <p class="mt-2 text-sm leading-relaxed text-storm">{{ gamescopeHelperReport.summary }}</p>
+          <details class="mt-3 text-xs text-storm">
+            <summary class="cursor-pointer text-ice">{{ $t('troubleshooting.advanced_evidence') }}</summary>
+            <div class="mt-2 space-y-2">
+              <div v-for="check in gamescopeHelperReport.checks" :key="check.key" class="rounded-lg border border-storm/15 bg-void/40 px-3 py-2">
+                <div class="font-medium text-silver">{{ check.label }} · {{ statusTone(check.status).label }}</div>
+                <div>{{ check.detail }}</div>
+                <div class="mt-1 text-ice">{{ check.action }}</div>
+              </div>
+            </div>
+          </details>
+        </div>
+
         <div class="surface-subtle border p-4" :class="statusTone(postSessionReport.status).card" data-readonly>
           <div class="flex items-center justify-between gap-3">
             <div class="text-sm font-semibold text-silver">{{ $t('troubleshooting.post_session_report') }}</div>
@@ -499,6 +517,7 @@ import { requestHostRestart } from '../restart-host.js'
 import {
   buildAnonymizedDiagnosticsBundle,
   buildControllerInputTestReport,
+  buildGamescopeHelperReport,
   buildFixMyStreamChecklist,
   buildGithubIssueDraft,
   buildGithubIssueUrl,
@@ -561,6 +580,7 @@ const requestedConfirmAction = ref(null)
 const controllerEvents = ref([])
 const controllerRumbleSupported = ref(null)
 const nativeNetworkPathProbe = ref(null)
+const gamescopeHelperProbe = ref(null)
 const lastCompletedStreamStats = ref(null)
 const lastDisconnectReason = ref('')
 
@@ -735,6 +755,8 @@ const controllerInputReport = computed(() => buildControllerInputTestReport({
   rumbleSupported: controllerRumbleSupported.value,
 }))
 
+const gamescopeHelperReport = computed(() => buildGamescopeHelperReport(gamescopeHelperProbe.value))
+
 const postSessionReport = computed(() => buildPostSessionStreamReport({
   stats: lastCompletedStreamStats.value || streamStats.value || {},
   logs: logs.value,
@@ -884,6 +906,21 @@ function refreshNetworkPathProbe() {
     .catch((error) => {
       console.error("Error fetching network path probe:", error)
       nativeNetworkPathProbe.value = null
+    })
+}
+
+function refreshGamescopeHelperProbe() {
+  fetch("./api/support/gamescope-helper", { credentials: 'include' })
+    .then((response) => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      return response.json()
+    })
+    .then((probe) => {
+      gamescopeHelperProbe.value = probe?.status === false ? null : probe
+    })
+    .catch((error) => {
+      console.error("Error fetching gamescope helper probe:", error)
+      gamescopeHelperProbe.value = null
     })
 }
 
@@ -1270,6 +1307,7 @@ fetch("/api/config")
 logInterval = setInterval(() => { refreshLogs() }, 5000)
 refreshLogs()
 refreshNetworkPathProbe()
+refreshGamescopeHelperProbe()
 refreshLastRun()
 refreshAiStatus()
 projection.load()

--- a/tests/unit/platform/test_gamescope_session_helper.cpp
+++ b/tests/unit/platform/test_gamescope_session_helper.cpp
@@ -197,6 +197,14 @@ TEST(GamescopeSessionHelperTests, ShadowedStaleCopyIsNamedButNotUsed) {
   EXPECT_NE(advisories[0].find("scripts/install"), std::string::npos);
 }
 
+TEST(GamescopeSessionHelperTests, MatchKeysAreStableWords) {
+  // The Doctor probe publishes these words; the web report switches on them.
+  EXPECT_EQ(helper::match_key(helper::bundle_match_t::exact), "exact");
+  EXPECT_EQ(helper::match_key(helper::bundle_match_t::wrapped), "wrapped");
+  EXPECT_EQ(helper::match_key(helper::bundle_match_t::mismatch), "mismatch");
+  EXPECT_EQ(helper::match_key(helper::bundle_match_t::unknown), "unknown");
+}
+
 TEST(GamescopeSessionHelperTests, CompareWithBundleClassifiesContent) {
   EXPECT_EQ(helper::compare_with_bundle("", module_body), helper::bundle_match_t::unknown);
   EXPECT_EQ(helper::compare_with_bundle(module_body, ""), helper::bundle_match_t::unknown);


### PR DESCRIPTION
## Summary

Surfaces the 1.4.2 stale-helper detection in Doctor & Support instead of leaving it in the launch log.

- `GET /api/support/gamescope-helper`: a read-only, authenticated probe that resolves `polaris-gamescope-session` exactly as a launch does (`platf::gamescope_session_helper::resolve_default`) and reports the launcher in use, a shadowed copy on PATH, the bundled reference copy, and the session/runtime-library match state as stable words (`exact`, `wrapped`, `mismatch`, `unknown`). `relevant` is true only when `linux_stream_mode = gamescope_stream` or the private runtime is gamescope; non-Linux hosts answer `platform: other`.
- `buildGamescopeHelperReport` in `diagnostics-export.js`: four checks (launcher, stale copy on PATH, launcher matches this build, runtime library matches this build) with the same `key/label/status/detail/action` shape as the controller and network reports; a shadowed copy is a warning naming the path to remove, a launcher from another checkout is a failure with the reinstall action, a missing launcher is a failure that explains the attach fallback, a wrapped (Nix/manual installer) launcher passes. Returns `null` when the probe is not relevant, so the card does not render.
- Doctor & Support view: a read-only **Gamescope Session Helper** card after the controller tester, fetched on mount like the network-path probe; `troubleshooting.gamescope_helper_tester` added to `en.json`.
- `docs/doctor.md`: one paragraph on the card.

## Exact candidate

`Commit:` `72f78bbe4f1c0d1b37bb0f53c9978ce793290ad6`
`Tree:` `2f6da539b600a37bc010db91eb0426e56115a79d`
`Parent:` `e8ffc15debcf48d1cb012d8184bf27c0e1185579`
`Base:` `e8ffc15debcf48d1cb012d8184bf27c0e1185579`

## Verification

- [x] `ninja polaris test_polaris_platform` on pc-papi (CUDA-off tree), clean
- [x] `test_polaris_platform --gtest_filter=GamescopeSessionHelperTests.*`: 12/12 (new `MatchKeysAreStableWords`)
- [x] `npm run test -- diagnostics-export doctor-support-affordances dashboard-doctor-layout`: 3 files green, four new builder cases
- [x] `npm run lint`, `bash scripts/check-public-docs.sh`, `git diff --check`: clean
- [x] `bash scripts/check-public-surface.sh`: clean after one fix (the first push carried a literal `/home/` path in a test fixture, which the gate rejects; amended and force-pushed)
- [x] `test_polaris --gtest_filter=*SourceSafety*:*DoctorReset*`: green

Not covered: a live render of the card. pc-papi runs `headless_stream`, so the card is hidden there by design; the endpoint mirrors the network-path probe handler line for line.
