### PR TITLE
fix(api): merge PATCH /api/config and name SteamGridDB search failures

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -8,6 +8,7 @@
 
 // standard includes
 #include <array>
+#include <cctype>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -50,6 +51,7 @@
 #include "entry_handler.h"
 #include "file_handler.h"
 #include "game_artwork.h"
+#include "game_artwork_manual.h"
 #include "globals.h"
 #include "httpcommon.h"
 #include "logging.h"
@@ -4413,76 +4415,99 @@ namespace confighttp {
    *
    * @api_examples{/api/config| POST| {"key":"value"}}
    */
+  /**
+   * @brief Serialize `tree` into the config file and apply the live toggles it carries.
+   *
+   * Every key comes from `tree`; only write-only secrets the payload leaves
+   * alone are carried over from the existing file. A writer that wants to
+   * keep unmentioned keys must merge them in first (see patchConfig). Answers
+   * the request itself on failure and returns false.
+   */
+  bool write_config_tree(resp_https_t response, req_https_t request, const nlohmann::json &tree, const std::string &writer) {
+    std::stringstream config_stream;
+    const auto existing_vars = config::parse_config(file_handler::read_file(config::sunshine.config_file.c_str()));
+    std::vector<std::string> written_keys;
+    for (const auto &[k, v] : tree.items()) {
+      if (v.is_null()) {
+        continue;
+      }
+      if (v.is_string() && v.get<std::string>().empty() && !is_write_only_secret_config_key(k)) {
+        continue;
+      }
+      // v.dump() will dump valid json, which we do not want for strings in the config right now
+      // we should migrate the config file to straight json and get rid of all this nonsense
+      config_stream << k << " = " << (v.is_string() ? v.get<std::string>() : v.dump()) << std::endl;
+      written_keys.push_back(k);
+    }
+    std::size_t dropped = 0;
+    for (const auto &[key, value] : existing_vars) {
+      if (tree.contains(key) || value.empty()) {
+        continue;
+      }
+      if (is_write_only_secret_config_key(key)) {
+        config_stream << key << " = " << value << std::endl;
+        continue;
+      }
+      ++dropped;
+    }
+    if (dropped > 0) {
+      BOOST_LOG(info) << "SaveConfig: "sv << writer << " left "sv << dropped << " existing key(s) out of the payload; they revert to defaults"sv;
+    }
+    if (file_handler::write_file(config::sunshine.config_file.c_str(), config_stream.str()) != 0) {
+      const std::string message = "Failed to write config file: " + config::sunshine.config_file;
+      BOOST_LOG(error) << "SaveConfig: "sv << message;
+      bad_request(response, request, message);
+      return false;
+    }
+    settings_metadata::note_config_write(writer, std::move(written_keys));
+    if (tree.contains("adaptive_bitrate_enabled")) {
+      doctor_actions::set_adaptive_enabled(
+        json_config_enabled(tree["adaptive_bitrate_enabled"])
+      );
+    }
+    if (tree.contains("ai_enabled")) {
+      ai_optimizer::set_enabled(json_config_enabled(tree["ai_enabled"]));
+    }
+    return true;
+  }
+
+  /**
+   * @brief Parse and validate a config write body, or answer the request and return false.
+   */
+  bool read_config_payload(resp_https_t response, req_https_t request, nlohmann::json &input_tree) {
+    std::stringstream ss;
+    ss << request->content.rdbuf();
+    input_tree = nlohmann::json::parse(ss);
+    std::string validation_error;
+    for (auto it = input_tree.begin(); it != input_tree.end();) {
+      if (validation::is_response_only_config_key(it.key())) {
+        it = input_tree.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    if (!validation::validate_config_payload(input_tree, validation_error)) {
+      bad_request(response, request, validation_error);
+      return false;
+    }
+    validation::normalize_write_only_secret_payload(input_tree);
+    return true;
+  }
+
   void saveConfig(resp_https_t response, req_https_t request) {
     if (!validateContentType(response, request, "application/json") || !authenticate(response, request)) {
       return;
     }
-
     print_req(request);
-
-    std::stringstream ss;
-    ss << request->content.rdbuf();
     try {
-      std::stringstream config_stream;
+      nlohmann::json input_tree;
+      if (!read_config_payload(response, request, input_tree)) {
+        return;
+      }
+      if (!write_config_tree(response, request, input_tree, "web_ui")) {
+        return;
+      }
       nlohmann::json output_tree;
-      nlohmann::json input_tree = nlohmann::json::parse(ss);
-      std::string validation_error;
-      for (auto it = input_tree.begin(); it != input_tree.end();) {
-        if (validation::is_response_only_config_key(it.key())) {
-          it = input_tree.erase(it);
-        } else {
-          ++it;
-        }
-      }
-      if (!validation::validate_config_payload(input_tree, validation_error)) {
-        bad_request(response, request, validation_error);
-        return;
-      }
-      validation::normalize_write_only_secret_payload(input_tree);
-      const auto existing_vars = config::parse_config(file_handler::read_file(config::sunshine.config_file.c_str()));
-      for (const auto &[k, v] : input_tree.items()) {
-        if (v.is_null()) {
-          continue;
-        }
-
-        if (v.is_string() && v.get<std::string>().empty() && !is_write_only_secret_config_key(k)) {
-          continue;
-        }
-
-        // v.dump() will dump valid json, which we do not want for strings in the config right now
-        // we should migrate the config file to straight json and get rid of all this nonsense
-        config_stream << k << " = " << (v.is_string() ? v.get<std::string>() : v.dump()) << std::endl;
-      }
-      for (const auto &[key, value] : existing_vars) {
-        if (!is_write_only_secret_config_key(key) || input_tree.contains(key) || value.empty()) {
-          continue;
-        }
-        config_stream << key << " = " << value << std::endl;
-      }
-      if (file_handler::write_file(config::sunshine.config_file.c_str(), config_stream.str()) != 0) {
-        const std::string message = "Failed to write config file: " + config::sunshine.config_file;
-        BOOST_LOG(error) << "SaveConfig: "sv << message;
-        bad_request(response, request, message);
-        return;
-      }
-      {
-        std::vector<std::string> written_keys;
-        for (const auto &[k, v] : input_tree.items()) {
-          if (v.is_null() || (v.is_string() && v.get<std::string>().empty() && !is_write_only_secret_config_key(k))) {
-            continue;
-          }
-          written_keys.push_back(k);
-        }
-        settings_metadata::note_config_write("web_ui", std::move(written_keys));
-      }
-      if (input_tree.contains("adaptive_bitrate_enabled")) {
-        doctor_actions::set_adaptive_enabled(
-          json_config_enabled(input_tree["adaptive_bitrate_enabled"])
-        );
-      }
-      if (input_tree.contains("ai_enabled")) {
-        ai_optimizer::set_enabled(json_config_enabled(input_tree["ai_enabled"]));
-      }
       output_tree["status"] = true;
       send_response(response, output_tree);
     } catch (std::exception &e) {
@@ -4491,6 +4516,40 @@ namespace confighttp {
     }
   }
 
+  /**
+   * @brief Update part of the configuration.
+   *
+   * Unlike POST, which rewrites the file from its body alone, keys absent from
+   * a PATCH body keep their current values. A key set to null or an empty
+   * string is removed and reverts to its default. Write-only secrets follow
+   * the POST rules: an empty value leaves the stored secret alone unless the
+   * matching clear flag is set.
+   *
+   * @api_examples{/api/config| PATCH| {"steamgriddb_api_key":"..."}}
+   */
+  void patchConfig(resp_https_t response, req_https_t request) {
+    if (!validateContentType(response, request, "application/json") || !authenticate(response, request)) {
+      return;
+    }
+    print_req(request);
+    try {
+      nlohmann::json input_tree;
+      if (!read_config_payload(response, request, input_tree)) {
+        return;
+      }
+      const auto existing_vars = config::parse_config(file_handler::read_file(config::sunshine.config_file.c_str()));
+      const auto merged = validation::merge_config_patch(existing_vars, input_tree);
+      if (!write_config_tree(response, request, merged, "api_patch")) {
+        return;
+      }
+      nlohmann::json output_tree;
+      output_tree["status"] = true;
+      send_response(response, output_tree);
+    } catch (std::exception &e) {
+      BOOST_LOG(warning) << "PatchConfig: "sv << e.what();
+      bad_request(response, request, e.what());
+    }
+  }
   /**
    * @brief Upload a cover image.
    * @param response The HTTP response object.
@@ -4626,11 +4685,19 @@ namespace confighttp {
 
     nlohmann::json output;
 
-    if (config::sunshine.steamgriddb_api_key.empty()) {
+    const auto answer_search_failure = [&](const game_artwork::manual::search_failure_t &failure) {
       output["status"] = false;
-      output["error"] = "SteamGridDB API key not configured. Set steamgriddb_api_key in config.";
+      output["code"] = failure.code;
+      output["error"] = failure.message;
       output["covers"] = nlohmann::json::array();
       send_response(response, output);
+    };
+    const auto &configured_key = config::sunshine.steamgriddb_api_key;
+    const bool key_present = std::any_of(configured_key.begin(), configured_key.end(), [](unsigned char ch) {
+      return !std::isspace(ch);
+    });
+    if (!key_present) {
+      answer_search_failure(game_artwork::manual::classify_search_failure(false, std::nullopt));
       return;
     }
 
@@ -4674,9 +4741,17 @@ namespace confighttp {
     if (res != CURLE_OK) {
       curl_easy_cleanup(curl);
       curl_slist_free_all(headers);
-      output["status"] = false;
-      output["error"] = "SteamGridDB search failed";
-      send_response(response, output);
+      answer_search_failure(game_artwork::manual::classify_search_failure(true, std::nullopt));
+      return;
+    }
+    long search_status = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &search_status);
+    if (search_status < 200 || search_status >= 300) {
+      // A rejected key comes back as 401 with no `data`; answering "no covers"
+      // there hid the real cause from the console and from Nova.
+      curl_easy_cleanup(curl);
+      curl_slist_free_all(headers);
+      answer_search_failure(game_artwork::manual::classify_search_failure(true, search_status));
       return;
     }
 
@@ -7274,6 +7349,7 @@ namespace confighttp {
     server.resource["^/api/settings/metadata$"]["GET"] = getSettingsMetadata;
     server.resource["^/api/update-status$"]["GET"] = getUpdateStatus;
     server.resource["^/api/config$"]["POST"] = withCsrf(saveConfig);
+    server.resource["^/api/config$"]["PATCH"] = withCsrf(patchConfig);
     server.resource["^/api/configLocale$"]["GET"] = getLocale;
     server.resource["^/api/restart$"]["POST"] = withCsrf(restart);
     server.resource["^/api/quit$"]["POST"] = withCsrf(quit);

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -459,6 +459,37 @@ namespace confighttp::validation {
     }
   }
 
+  nlohmann::json merge_config_patch(
+    const std::unordered_map<std::string, std::string> &existing,
+    const nlohmann::json &patch
+  ) {
+    static constexpr std::array<std::string_view, 3> write_only_secret_keys {"ai_api_key", "api_key", "steamgriddb_api_key"};
+    const auto is_secret = [&](std::string_view key) {
+      return std::find(write_only_secret_keys.begin(), write_only_secret_keys.end(), key) != write_only_secret_keys.end();
+    };
+    nlohmann::json merged = nlohmann::json::object();
+    for (const auto &[key, value] : existing) {
+      if (!value.empty()) {
+        merged[key] = value;
+      }
+    }
+    if (!patch.is_object()) {
+      return merged;
+    }
+    for (const auto &[key, value] : patch.items()) {
+      const bool emptied = value.is_null() || (value.is_string() && value.get_ref<const std::string &>().empty());
+      if (emptied) {
+        merged.erase(key);
+        if (value.is_string() && is_secret(key)) {
+          merged[key] = "";
+        }
+        continue;
+      }
+      merged[key] = value;
+    }
+    return merged;
+  }
+
   bool validate_app_payload(const nlohmann::json &payload, std::string &error) {
     if (!payload.is_object()) {
       error = "App payload must be a JSON object";

--- a/src/confighttp_validation.h
+++ b/src/confighttp_validation.h
@@ -7,6 +7,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include <nlohmann/json.hpp>
 
@@ -14,6 +15,16 @@ namespace confighttp::validation {
   bool validate_app_payload(const nlohmann::json &payload, std::string &error);
   bool validate_config_payload(const nlohmann::json &payload, std::string &error);
   void normalize_write_only_secret_payload(nlohmann::json &payload);
+
+  // Merge a partial config write onto the existing file contents. Keys the
+  // patch does not mention keep their current values; a key set to null or an
+  // empty string is dropped so it reverts to its default. Secrets arrive
+  // already normalized, so an empty secret is an explicit clear and stays in
+  // the result as an empty assignment.
+  nlohmann::json merge_config_patch(
+    const std::unordered_map<std::string, std::string> &existing,
+    const nlohmann::json &patch
+  );
 
   // Keys that appear in GET /api/config responses but are derived state, not
   // settings. They must never be written: saveConfig strips them from POST

--- a/src/game_artwork_manual.cpp
+++ b/src/game_artwork_manual.cpp
@@ -277,4 +277,22 @@ namespace game_artwork::manual {
     std::lock_guard lock(mutex_);
     return entries_.size();
   }
+  search_failure_t classify_search_failure(bool key_present, std::optional<long> upstream_status) {
+    if (!key_present) {
+      return {"steamgriddb_key_missing", "SteamGridDB is not configured on the host. Add a SteamGridDB API key in Polaris settings.", 503};
+    }
+    if (!upstream_status) {
+      return {"steamgriddb_unreachable", "Polaris could not reach SteamGridDB.", 502};
+    }
+    switch (*upstream_status) {
+      case 401:
+      case 403:
+        return {"steamgriddb_unauthorized", "SteamGridDB rejected the host's API key. Update it in Polaris settings.", 502};
+      case 429:
+        return {"steamgriddb_rate_limited", "SteamGridDB is rate limiting this host. Try again in a minute.", 502};
+      default:
+        return {"steamgriddb_unavailable", "SteamGridDB did not answer (HTTP " + std::to_string(*upstream_status) + ").", 502};
+    }
+  }
+
 }  // namespace game_artwork::manual

--- a/src/game_artwork_manual.h
+++ b/src/game_artwork_manual.h
@@ -53,6 +53,19 @@ namespace game_artwork::manual {
     const std::vector<std::pair<std::string, std::string>> &query
   );
   [[nodiscard]] std::optional<std::string> sanitize_search_query(std::string_view query);
+
+  /** Why a SteamGridDB search could not answer, in a shape clients can act on. */
+  struct search_failure_t {
+    std::string code;  ///< stable machine word: steamgriddb_key_missing, steamgriddb_unauthorized, steamgriddb_rate_limited, steamgriddb_unreachable, steamgriddb_unavailable
+    std::string message;  ///< player-facing sentence naming the fix
+    int http_status;  ///< status Polaris answers with (503 without a key, 502 for upstream trouble)
+  };
+
+  /**
+   * Classify a failed search from the host's key state and the upstream status.
+   * Callers pass std::nullopt when SteamGridDB could not be reached at all.
+   */
+  [[nodiscard]] search_failure_t classify_search_failure(bool key_present, std::optional<long> upstream_status);
   [[nodiscard]] std::optional<match_selection_t> parse_match_selection(std::string_view body);
 
   class preview_cache_t {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -7991,6 +7991,13 @@ namespace nvhttp {
       response->write(manifest.dump(), headers);
     };
 
+    // A failed artwork search answers with a body Nova can act on instead of a bare status.
+    static const auto write_artwork_search_failure = [](resp_https_t response, const game_artwork::manual::search_failure_t &failure) {
+      nlohmann::json body {{"status", false}, {"code", failure.code}, {"error", failure.message}};
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "application/json");
+      response->write(static_cast<SimpleWeb::StatusCode>(failure.http_status), body.dump(), headers);
+    };
     auto polarisSearchGameArtworkMatches = [](resp_https_t response, req_https_t request) {
       print_req<PolarisHTTPS>(request);
       if (!get_verified_cert(request)) {
@@ -8012,7 +8019,7 @@ namespace nvhttp {
       }
       const auto api_key = config::sunshine.steamgriddb_api_key;
       if (!nonblank_artwork_api_key(api_key)) {
-        response->write(SimpleWeb::StatusCode::server_error_service_unavailable);
+        write_artwork_search_failure(response, game_artwork::manual::classify_search_failure(false, std::nullopt));
         return;
       }
       const auto args = request->parse_query_string();
@@ -8036,7 +8043,13 @@ namespace nvhttp {
             !game_artwork::is_allowed_provider_url(
               game_artwork::provider_e::steamgriddb,
               search_response->final_url.empty() ? search_request->url : search_response->final_url)) {
-          response->write(SimpleWeb::StatusCode::server_error_bad_gateway);
+          write_artwork_search_failure(
+            response,
+            game_artwork::manual::classify_search_failure(
+              true,
+              search_response ? std::optional<long>(static_cast<long>(search_response->status_code)) : std::optional<long> {}
+            )
+          );
           return;
         }
         const std::string search_body(search_response->body.begin(), search_response->body.end());

--- a/tests/unit/test_confighttp_validation.cpp
+++ b/tests/unit/test_confighttp_validation.cpp
@@ -277,3 +277,43 @@ TEST(AppValidationTests, RejectsUnexpectedCommandShapes) {
   EXPECT_FALSE(confighttp::validation::validate_app_payload(payload, error));
   EXPECT_NE(error.find("unsupported field"), std::string::npos);
 }
+
+TEST(ConfigValidationTests, PatchMergeKeepsUnmentionedKeysAndDropsEmptiedOnes) {
+  // POST /api/config rewrites the file from its body; a one-key PATCH must
+  // not do that. Found the hard way when a single-key POST truncated a live
+  // config to two lines.
+  const std::unordered_map<std::string, std::string> existing {
+    {"port", "47989"},
+    {"encoder", "nvenc"},
+    {"steamgriddb_api_key", "kept-secret"},
+    {"already_blank", ""},
+  };
+  const nlohmann::json patch {
+    {"encoder", "vaapi"},
+    {"port", nullptr},
+    {"max_sessions", 2},
+    {"headless_mode", ""},
+  };
+  const auto merged = confighttp::validation::merge_config_patch(existing, patch);
+  EXPECT_EQ(merged.value("encoder", ""), "vaapi");
+  EXPECT_FALSE(merged.contains("port"));
+  EXPECT_EQ(merged.value("max_sessions", 0), 2);
+  EXPECT_EQ(merged.value("steamgriddb_api_key", ""), "kept-secret");
+  EXPECT_FALSE(merged.contains("already_blank"));
+  EXPECT_FALSE(merged.contains("headless_mode"));
+}
+
+TEST(ConfigValidationTests, PatchMergeClearsASecretOnlyThroughAnExplicitEmptyValue) {
+  const std::unordered_map<std::string, std::string> existing {
+    {"steamgriddb_api_key", "old-secret"},
+    {"ai_api_key", "other-secret"},
+    {"port", "47989"},
+  };
+  // After normalize_write_only_secret_payload, an empty secret means "clear".
+  const nlohmann::json patch {{"steamgriddb_api_key", ""}, {"port", ""}};
+  const auto merged = confighttp::validation::merge_config_patch(existing, patch);
+  ASSERT_TRUE(merged.contains("steamgriddb_api_key"));
+  EXPECT_EQ(merged["steamgriddb_api_key"], "");
+  EXPECT_EQ(merged.value("ai_api_key", ""), "other-secret");
+  EXPECT_FALSE(merged.contains("port"));
+}

--- a/tests/unit/test_game_artwork_manual.cpp
+++ b/tests/unit/test_game_artwork_manual.cpp
@@ -116,6 +116,24 @@ TEST(GameArtworkManualLogging, RedactsCredentialFieldsAndOpaquePreviewTokens) {
     "/polaris/v1/games/123e4567-e89b-12d3-a456-426614174000/artwork/candidate/[REDACTED]/poster?token=[REDACTED]&query=Portal 2");
 }
 
+TEST(GameArtworkManualSearchFailure, NamesTheCauseWithAStableCode) {
+  using game_artwork::manual::classify_search_failure;
+  const auto missing = classify_search_failure(false, std::nullopt);
+  EXPECT_EQ(missing.code, "steamgriddb_key_missing");
+  EXPECT_EQ(missing.http_status, 503);
+  EXPECT_NE(missing.message.find("Polaris settings"), std::string::npos);
+
+  const auto rejected = classify_search_failure(true, 401L);
+  EXPECT_EQ(rejected.code, "steamgriddb_unauthorized");
+  EXPECT_EQ(rejected.http_status, 502);
+  EXPECT_NE(rejected.message.find("rejected"), std::string::npos);
+  EXPECT_EQ(classify_search_failure(true, 403L).code, "steamgriddb_unauthorized");
+  EXPECT_EQ(classify_search_failure(true, 429L).code, "steamgriddb_rate_limited");
+  EXPECT_EQ(classify_search_failure(true, 500L).code, "steamgriddb_unavailable");
+  EXPECT_NE(classify_search_failure(true, 500L).message.find("500"), std::string::npos);
+  EXPECT_EQ(classify_search_failure(true, std::nullopt).code, "steamgriddb_unreachable");
+}
+
 TEST(GameArtworkManualPreviewCache, IsBoundedScopedOpaqueAndExpiring) {
   const std::array tokens {
     std::string("00000000000000000000000000000001"),


### PR DESCRIPTION
## Summary

Two follow-ups from the SteamGridDB incident on 2026-09-04.

- **`PATCH /api/config`** merges instead of replacing. `POST /api/config` rewrites the file from its body alone (the console posts the whole document and relies on omitted keys reverting to defaults, so POST keeps that contract); a scripted single-key POST truncated a live 23-line config to 2 lines. PATCH keeps keys the body does not mention, drops a key set to `null` or `""`, and follows the POST rules for write-only secrets. Both verbs share `write_config_tree`, which now logs how many existing keys a POST left out. `validation::merge_config_patch` is the pure merge, unit-tested.
- **SteamGridDB failures are named.** The Nova-facing `games/<id>/artwork/candidates` route answered a bare 503 (no key) or 502 (upstream error), and the console's `/api/covers/search` answered `status: true, covers: []` on a 401 because the error body has no `data`. Both now return `{"status": false, "code": "...", "error": "..."}` with a stable code from `game_artwork::manual::classify_search_failure` (`steamgriddb_key_missing` 503, `steamgriddb_unauthorized` / `steamgriddb_rate_limited` / `steamgriddb_unreachable` / `steamgriddb_unavailable` 502). A genuinely empty result stays `status: true`. The companion Nova PR maps the codes to specific messages.

## Exact candidate

`Commit:` `a361a2270b727752d9950ac380ce24139237732f`
`Tree:` `f043d2e2a8000cfe4e2a66329b783a056ad025b8`
`Parent:` `edb48ccefbd8e203bc19629fb859e4254649ec65`
`Base:` `edb48ccefbd8e203bc19629fb859e4254649ec65`

## Verification

- [x] `ninja polaris test_polaris test_polaris_http` on pc-papi (CUDA-off tree), clean
- [x] `ConfigValidationTests.*` (two new merge cases), `GameArtworkManual*` (new failure classification case), `*SourceSafety*`, `*DoctorReset*`: green in both test binaries
- [x] `bash scripts/check-public-surface.sh`, `bash scripts/check-public-docs.sh`, `git diff --check`: clean

Not covered: a live PATCH against a running host and a live 401 from SteamGridDB; the handlers are thin over the tested pure functions and mirror the existing JSON-body responses in `nvhttp`.
