### PR TITLE
fix: name rejected launch fields and say when the installed package is not running

### DIFF
--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -320,6 +320,12 @@ wget --output-document="./${rpm_name}" "https://github.com/papi-ux/polaris/relea
 sudo rpm-ostree install -r "./${rpm_name}"
 ```
 
+If you installed without `-r`, or rolled back a deployment and installed again, the
+new package is only staged: the running deployment, and the version the dashboard
+reports, do not change until you reboot. `rpm-ostree status` lists the staged
+deployment above the booted one. `rpm-ostree install` answering "already installed"
+while the dashboard still shows the old version means exactly this.
+
 After the reboot, refresh `/usr/local/bin/polaris-kms` and its capability using
 the copy and `setcap` steps from [Install](#install), restart the service, and
 return to `https://127.0.0.1:47990/#/login` with the existing credentials. Do not

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,12 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Shows a Gamescope Session Helper card in Doctor & Support on Linux hosts configured for `gamescope_stream`, naming the launcher Polaris will run, a stale copy shadowing it on PATH, and a launcher or runtime library installed from a different checkout
+- Adds `PATCH /api/config`, which merges a partial write onto the existing configuration instead of rewriting the file from the request body the way `POST` does, and logs how many existing keys a `POST` left out
+- Names the cause when an artwork search fails: the Nova-facing candidate search and the console cover search now answer with a stable code for a missing SteamGridDB key, a rejected key, rate limiting, or an unreachable provider instead of a bare status or an empty result
+- Names the field when explicit launch fields are rejected, including the value seen, so a comma-decimal `fps` or a lock flag without its prerequisite no longer reads as "must be complete and within supported bounds"
+- Tells the console when the installed Polaris package is newer than the running process, which is what a package upgrade without a service restart looks like
+
 ## v1.4.2 - 2026-09-04
 
 A stability and diagnostics update matched with Nova v1.4.2. Polaris lets a capable Nova client choose the encoder for a single game, closes a Linux Vulkan Video crash at disconnect, keeps SteamOS's gamescope file capability from breaking private streams, and stops stale helper installs from being debugged as Polaris bugs. Existing configurations and paired devices remain valid.

--- a/src/launch_profile.cpp
+++ b/src/launch_profile.cpp
@@ -10,6 +10,139 @@
 
 namespace launch_profile {
   namespace {
+    std::string shown_field_value(std::string_view value) {
+      std::string shown;
+      for (const unsigned char ch : value.substr(0, 32)) {
+        shown.push_back((ch < 0x20 || ch == 0x7f) ? '?' : static_cast<char>(ch));
+      }
+      if (value.size() > 32) {
+        shown += "...";
+      }
+      return shown;
+    }
+
+    std::string lowercase_copy(std::string_view value) {
+      std::string lowered(value);
+      std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+      });
+      return lowered;
+    }
+  }  // namespace
+
+  explicit_launch_fields_t parse_explicit_launch_fields(const explicit_field_lookup_t &lookup) {
+    explicit_launch_fields_t fields;
+    const auto problem = [&](std::string_view field, std::string reason) {
+      fields.problems.push_back({std::string(field), std::move(reason)});
+    };
+    const auto bounded_integer = [&](std::string_view name, long long minimum, long long maximum) -> std::optional<int> {
+      const auto raw = lookup(name);
+      if (!raw) {
+        return std::nullopt;
+      }
+      const auto reject = [&]() {
+        problem(name, std::string(name) + " must be a whole number between " + std::to_string(minimum) + " and " +
+                        std::to_string(maximum) + "; got '" + shown_field_value(*raw) + "'");
+        return std::optional<int> {};
+      };
+      try {
+        std::size_t consumed = 0;
+        const auto value = std::stoll(*raw, &consumed);
+        if (consumed != raw->size() || value < minimum || value > maximum) {
+          return reject();
+        }
+        return static_cast<int>(value);
+      } catch (...) {
+        return reject();
+      }
+    };
+    const auto bounded_fps = [&](std::string_view name, int minimum, int maximum) -> std::optional<int> {
+      const auto raw = lookup(name);
+      if (!raw) {
+        return std::nullopt;
+      }
+      const auto fps = util::parse_decimal<double>(*raw);
+      if (!fps || *fps < minimum || *fps > maximum) {
+        problem(name, std::string(name) + " must be a number between " + std::to_string(minimum) + " and " +
+                        std::to_string(maximum) + " with a dot as the decimal separator; got '" + shown_field_value(*raw) + "'");
+        return std::nullopt;
+      }
+      return static_cast<int>(std::round(*fps * 1000.0));
+    };
+    const auto exact_flag = [&](std::string_view name) -> bool {
+      const auto raw = lookup(name);
+      if (!raw) {
+        return false;
+      }
+      const auto lowered = lowercase_copy(*raw);
+      if (lowered == "1" || lowered == "true") {
+        return true;
+      }
+      if (lowered == "0" || lowered == "false") {
+        return false;
+      }
+      problem(name, std::string(name) + " must be 1 or 0; got '" + shown_field_value(*raw) + "'");
+      return false;
+    };
+
+    fields.width = bounded_integer("width", 320, 16384);
+    fields.height = bounded_integer("height", 240, 16384);
+    fields.bitrate_kbps = bounded_integer("bitrate_kbps", 1000, 300000);
+    fields.fps_millihertz = bounded_fps("fps", 15, 240);
+    fields.client_max_fps_millihertz = bounded_fps("client_max_fps", 15, 360);
+    fields.display_locked = exact_flag("display_locked");
+    fields.bitrate_locked = exact_flag("bitrate_locked");
+    fields.topology_locked = exact_flag("topology_locked");
+    if (const auto raw = lookup("hdr")) {
+      const auto lowered = lowercase_copy(*raw);
+      if (lowered == "1" || lowered == "true" || lowered == "on" || lowered == "yes") {
+        fields.hdr = true;
+      } else if (lowered == "0" || lowered == "false" || lowered == "off" || lowered == "no") {
+        fields.hdr = false;
+      } else {
+        problem("hdr", "hdr must be 1 or 0; got '" + shown_field_value(*raw) + "'");
+      }
+    }
+
+    const auto mode_field_already_failed = std::any_of(fields.problems.begin(), fields.problems.end(), [](const auto &entry) {
+      return entry.field == "width" || entry.field == "height" || entry.field == "fps";
+    });
+    if (fields.any_explicit_mode() && !fields.complete_explicit_mode() && !mode_field_already_failed) {
+      std::string missing;
+      for (const auto &[name, present] : {std::pair {"width", fields.width.has_value()},
+                                          std::pair {"height", fields.height.has_value()},
+                                          std::pair {"fps", fields.fps_millihertz.has_value()}}) {
+        if (!present) {
+          missing += (missing.empty() ? "" : ", ") + std::string(name);
+        }
+      }
+      problem("width/height/fps", "width, height, and fps must be sent together; missing " + missing);
+    }
+    if (fields.display_locked && !fields.complete_explicit_mode()) {
+      problem("display_locked", "display_locked requires width, height, and fps");
+    }
+    if (fields.bitrate_locked && !fields.bitrate_kbps) {
+      problem("bitrate_locked", "bitrate_locked requires bitrate_kbps");
+    }
+    return fields;
+  }
+
+  std::string describe_explicit_launch_rejection(const explicit_launch_fields_t &fields) {
+    if (fields.problems.empty()) {
+      return "Explicit launch fields must be complete and within supported bounds.";
+    }
+    std::string text = "Explicit launch fields were rejected: ";
+    for (std::size_t index = 0; index < fields.problems.size(); ++index) {
+      if (index > 0) {
+        text += "; ";
+      }
+      text += fields.problems[index].reason;
+    }
+    text += ".";
+    return text;
+  }
+
+  namespace {
     struct display_mode_t {
       int width = 0;
       int height = 0;

--- a/src/launch_profile.h
+++ b/src/launch_profile.h
@@ -6,8 +6,11 @@
 
 #include <nlohmann/json.hpp>
 
+#include <functional>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace launch_profile {
 
@@ -64,6 +67,46 @@ namespace launch_profile {
     std::string reason_code = "platform_desktop_only";
     bool normalized = false;
   };
+
+  /** One explicit launch field the client sent that Polaris cannot honor, and why. */
+  struct explicit_field_problem_t {
+    std::string field;
+    std::string reason;
+  };
+
+  /** The explicit launch fields of an optimize request, parsed and bound-checked once. */
+  struct explicit_launch_fields_t {
+    std::optional<int> width;
+    std::optional<int> height;
+    std::optional<int> bitrate_kbps;
+    std::optional<int> fps_millihertz;
+    std::optional<int> client_max_fps_millihertz;
+    bool display_locked = false;
+    bool bitrate_locked = false;
+    bool topology_locked = false;
+    std::optional<bool> hdr;
+    std::vector<explicit_field_problem_t> problems;
+
+    [[nodiscard]] bool any_explicit_mode() const {
+      return width.has_value() || height.has_value() || fps_millihertz.has_value();
+    }
+
+    [[nodiscard]] bool complete_explicit_mode() const {
+      return width.has_value() && height.has_value() && fps_millihertz.has_value();
+    }
+  };
+
+  using explicit_field_lookup_t = std::function<std::optional<std::string>(std::string_view)>;
+
+  /**
+   * Parse the explicit launch fields of a request. Every problem names the
+   * field and the value seen, so a rejection can say which field failed
+   * instead of the one generic sentence that hid a comma-decimal fps for weeks.
+   */
+  explicit_launch_fields_t parse_explicit_launch_fields(const explicit_field_lookup_t &lookup);
+
+  /** The sentence a client is shown for rejected explicit fields; generic when nothing is named. */
+  std::string describe_explicit_launch_rejection(const explicit_launch_fields_t &fields);
 
   std::string normalize_preset(std::string preset);
   std::string preset_label(const std::string &preset);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -9716,70 +9716,31 @@ namespace nvhttp {
         reply_bad_request("invalid_or_unavailable_encoder", encoder_reject_reason);
         return;
       }
-      bool invalid_argument = false;
-      auto bounded_integer = [&](const char *name, int minimum, int maximum) -> std::optional<int> {
-        const auto it = args.find(name);
-        if (it == args.end()) return std::nullopt;
-        try {
-          std::size_t consumed = 0;
-          const auto value = std::stoll(it->second, &consumed);
-          if (consumed != it->second.size() || value < minimum || value > maximum) {
-            invalid_argument = true;
+      const auto explicit_fields = launch_profile::parse_explicit_launch_fields(
+        [&](std::string_view name) -> std::optional<std::string> {
+          const auto it = args.find(std::string(name));
+          if (it == args.end()) {
             return std::nullopt;
           }
-          return static_cast<int>(value);
-        } catch (...) {
-          invalid_argument = true;
-          return std::nullopt;
+          return it->second;
         }
-      };
-      const auto explicit_width = bounded_integer("width", 320, 16384);
-      const auto explicit_height = bounded_integer("height", 240, 16384);
-      const auto explicit_bitrate = bounded_integer("bitrate_kbps", 1000, 300000);
-      std::optional<int> explicit_fps;
-      if (const auto it = args.find("fps"); it != args.end()) {
-        const auto fps = util::parse_decimal<double>(it->second);
-        if (!fps || *fps < 15.0 || *fps > 240.0) {
-          invalid_argument = true;
-        } else {
-          explicit_fps = static_cast<int>(std::round(*fps * 1000.0));
-        }
-      }
-      std::optional<int> client_max_fps;
-      if (const auto it = args.find("client_max_fps"); it != args.end()) {
-        const auto fps = util::parse_decimal<double>(it->second);
-        if (!fps || *fps < 15.0 || *fps > 360.0) {
-          invalid_argument = true;
-        } else {
-          client_max_fps = static_cast<int>(std::round(*fps * 1000.0));
-        }
-      }
-      const bool any_explicit_mode = explicit_width || explicit_height || explicit_fps;
-      const bool complete_explicit_mode = explicit_width && explicit_height && explicit_fps;
-      const auto exact_flag = [&](const char *name) {
-        const auto it = args.find(name);
-        if (it == args.end()) return false;
-        if (it->second == "1" || boost::iequals(it->second, "true")) return true;
-        if (it->second == "0" || boost::iequals(it->second, "false")) return false;
-        invalid_argument = true;
-        return false;
-      };
-      const bool display_locked = exact_flag("display_locked");
-      const bool bitrate_locked = exact_flag("bitrate_locked");
-      const bool topology_locked = exact_flag("topology_locked");
-      std::optional<bool> explicit_hdr;
-      if (const auto it = args.find("hdr"); it != args.end()) {
-        const auto value = lower_copy(it->second);
-        if (value == "1" || value == "true" || value == "on" || value == "yes") explicit_hdr = true;
-        else if (value == "0" || value == "false" || value == "off" || value == "no") explicit_hdr = false;
-        else invalid_argument = true;
-      }
-      if (invalid_argument || (any_explicit_mode && !complete_explicit_mode) ||
-          (display_locked && !complete_explicit_mode) ||
-          (bitrate_locked && !explicit_bitrate)) {
-        reply_bad_request("invalid_explicit_launch_fields");
+      );
+      if (!explicit_fields.problems.empty()) {
+        const auto reason = launch_profile::describe_explicit_launch_rejection(explicit_fields);
+        BOOST_LOG(info) << "launch_profile: rejecting explicit launch fields for ["sv << device << "]: "sv << reason;
+        reply_bad_request("invalid_explicit_launch_fields", reason);
         return;
       }
+      const auto explicit_width = explicit_fields.width;
+      const auto explicit_height = explicit_fields.height;
+      const auto explicit_bitrate = explicit_fields.bitrate_kbps;
+      const auto explicit_fps = explicit_fields.fps_millihertz;
+      const auto client_max_fps = explicit_fields.client_max_fps_millihertz;
+      const bool complete_explicit_mode = explicit_fields.complete_explicit_mode();
+      const bool display_locked = explicit_fields.display_locked;
+      const bool bitrate_locked = explicit_fields.bitrate_locked;
+      const bool topology_locked = explicit_fields.topology_locked;
+      const auto explicit_hdr = explicit_fields.hdr;
       if (!named_cert_p->name.empty()) {
         if (device != named_cert_p->name) {
           BOOST_LOG(info) << "launch_profile: Optimize API using paired client profile ["sv

--- a/src/update_status.cpp
+++ b/src/update_status.cpp
@@ -5,7 +5,9 @@
 #include "update_status.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -242,6 +244,62 @@ namespace update_status {
     };
   }
 
+  std::string parse_installed_package_version(std::string_view package_family, std::string_view query_output) {
+    const auto trim = [](std::string text) {
+      const auto is_space = [](unsigned char ch) { return std::isspace(ch) != 0; };
+      while (!text.empty() && is_space(text.back())) text.pop_back();
+      std::size_t start = 0;
+      while (start < text.size() && is_space(text[start])) ++start;
+      return text.substr(start);
+    };
+    std::string text = trim(std::string(query_output));
+    if (text.empty()) {
+      return {};
+    }
+    if (package_family == "arch" || package_family == "steamos") {
+      // pacman -Q prints "polaris 1.4.2-1".
+      const auto space = text.find(' ');
+      if (space == std::string::npos) {
+        return {};
+      }
+      text = trim(text.substr(space + 1));
+    }
+    if (const auto epoch = text.find(':'); epoch != std::string::npos) {
+      text = text.substr(epoch + 1);
+    }
+    if (const auto release = text.find('-'); release != std::string::npos) {
+      text = text.substr(0, release);
+    }
+    const bool version_like = !text.empty() && std::all_of(text.begin(), text.end(), [](unsigned char ch) {
+      return std::isdigit(ch) != 0 || ch == '.';
+    });
+    return version_like ? text : std::string {};
+  }
+
+  std::string installed_package_version(const distro_info_t &distro) {
+#ifdef __linux__
+    const auto family = package_family(distro);
+    const char *command = "rpm -q --qf '%{VERSION}' polaris 2>/dev/null";
+    if (family == "arch" || family == "steamos") {
+      command = "pacman -Q polaris 2>/dev/null";
+    } else if (family == "ubuntu" || family == "debian") {
+      command = "dpkg-query -W -f='${Version}' polaris 2>/dev/null";
+    }
+    std::string output;
+    if (FILE *pipe = popen(command, "r")) {
+      std::array<char, 256> buffer {};
+      while (output.size() < 4096 && std::fgets(buffer.data(), static_cast<int>(buffer.size()), pipe)) {
+        output += buffer.data();
+      }
+      pclose(pipe);
+    }
+    return parse_installed_package_version(family, output);
+#else
+    (void) distro;
+    return {};
+#endif
+  }
+
   nlohmann::json host_update_status() {
     const auto distro = detect_host_distro();
 
@@ -254,6 +312,9 @@ namespace update_status {
       {"status", true},
       {"platform", POLARIS_PLATFORM},
       {"version", PROJECT_VERSION},
+      // The package database can be ahead of the running process after an
+      // install without a restart; the console turns that into a plain hint.
+      {"installed_package_version", installed_package_version(distro)},
       // A host with the repository configured is no longer on the download-a-
       // file path, so this stops claiming otherwise.
       {"manual_install_only", !repository},

--- a/src/update_status.h
+++ b/src/update_status.h
@@ -38,6 +38,15 @@ namespace update_status {
   nlohmann::json distro_json(const distro_info_t &distro);
   nlohmann::json host_update_status();
 
+  /**
+   * The Polaris version the OS package database reports, or empty when it
+   * reports none. Debian epochs and package releases are not part of it.
+   */
+  std::string parse_installed_package_version(std::string_view package_family, std::string_view query_output);
+
+  /** Query the host package manager for the installed polaris package; empty when unknown. */
+  std::string installed_package_version(const distro_info_t &distro);
+
 #ifdef POLARIS_TESTS
   inline distro_info_t parse_os_release_for_tests(std::string_view content) {
     return parse_os_release(content);

--- a/src_assets/common/assets/web/update-center.js
+++ b/src_assets/common/assets/web/update-center.js
@@ -189,6 +189,16 @@ function buildActionMetadata(status, asset, installCommand, releaseUrl) {
     }
   }
 
+  if (status === 'restart_required') {
+    return {
+      statusTone: 'restart',
+      statusLightLabel: 'Installed version is not running',
+      primaryActionLabel: 'Details',
+      primaryActionKind: 'scroll_to_update_center',
+      primaryActionSummary: 'A newer Polaris package is installed than the one running.',
+    }
+  }
+
   if (status === 'ahead') {
     return {
       statusTone: 'ahead',
@@ -236,6 +246,15 @@ function isReleaseGreater(release, version, includeIncremental = false) {
   if (!release || !version) return false
   try {
     return new PolarisVersion(release, null).isGreater(new PolarisVersion(null, version), includeIncremental)
+  } catch {
+    return false
+  }
+}
+
+function isInstalledNewerThanRunning(installedVersion, runningVersion) {
+  if (!installedVersion || !runningVersion) return false
+  try {
+    return new PolarisVersion(null, installedVersion).isGreater(new PolarisVersion(null, runningVersion))
   } catch {
     return false
   }
@@ -305,6 +324,17 @@ export function buildUpdateCenterState({ currentVersion = '', latestRelease = nu
     summary = 'This host is running a build newer than the selected release channel.'
   }
 
+  // The package database can be ahead of the running process: dnf, apt, and
+  // pacman replace the binary but leave the old process running, and rpm-ostree
+  // hosts keep running the booted deployment. That confusion reads like a
+  // failed update, so it gets its own state ahead of everything else.
+  const installedVersion = String(host.installed_package_version || '').trim()
+  if (installedVersion && isInstalledNewerThanRunning(installedVersion, currentVersion)) {
+    status = 'restart_required'
+    statusLabel = 'Installed, not running'
+    summary = `Polaris ${installedVersion} is installed but this host is still running ${currentVersion}. Restart Polaris to use it.`
+  }
+
   const asset = selectReleaseAsset(candidateRelease, host)
   const packageFamily = normalizeToken(asset?.packageFamily || inferPackageFamily(host))
   // A configured repository wins over the download command: it upgrades the
@@ -341,6 +371,8 @@ export function updateStatusLightClass(statusTone) {
       return 'bg-ice shadow-[0_0_18px_color-mix(in_srgb,var(--color-ice)_75%,transparent)] animate-pulse'
     case 'ahead':
       return 'bg-accent shadow-[0_0_14px_color-mix(in_srgb,var(--color-accent)_55%,transparent)]'
+    case 'restart':
+      return 'bg-ice shadow-[0_0_14px_color-mix(in_srgb,var(--color-ice)_55%,transparent)]'
     case 'warning':
       return 'bg-warning shadow-[0_0_14px_color-mix(in_srgb,var(--color-warning)_55%,transparent)]'
     case 'disabled':

--- a/src_assets/common/assets/web/update-center.test.js
+++ b/src_assets/common/assets/web/update-center.test.js
@@ -8,6 +8,7 @@ import {
   buildRepositoryUpgradeCommand,
   buildUpdateCenterState,
   selectReleaseAsset,
+  updateStatusLightClass,
 } from './update-center.js'
 
 const release = {
@@ -223,6 +224,39 @@ const expectFailureSafeSteamOsCommand = (failSudo, failedCommand) => {
 }
 
 describe('Update Center release awareness', () => {
+  it('says when the installed package is newer than the running process', () => {
+    const state = buildUpdateCenterState({
+      currentVersion: '1.4.1',
+      latestRelease: { ...release, tag_name: 'v1.4.2', name: 'v1.4.2' },
+      host: {
+        platform: 'linux',
+        distro: { id: 'fedora', version_id: '44' },
+        installed_package_version: '1.4.2',
+      },
+    })
+
+    expect(state.status).toBe('restart_required')
+    expect(state.statusLabel).toBe('Installed, not running')
+    expect(state.summary).toContain('1.4.2 is installed but this host is still running 1.4.1')
+    expect(state.statusTone).toBe('restart')
+    expect(state.primaryActionKind).toBe('scroll_to_update_center')
+    expect(updateStatusLightClass('restart')).toContain('bg-ice')
+
+    const current = buildUpdateCenterState({
+      currentVersion: '1.4.2',
+      latestRelease: { ...release, tag_name: 'v1.4.2', name: 'v1.4.2' },
+      host: { platform: 'linux', distro: { id: 'fedora', version_id: '44' }, installed_package_version: '1.4.2' },
+    })
+    expect(current.status).toBe('current')
+
+    const unknown = buildUpdateCenterState({
+      currentVersion: '1.4.2',
+      latestRelease: { ...release, tag_name: 'v1.4.2', name: 'v1.4.2' },
+      host: { platform: 'linux', distro: { id: 'fedora', version_id: '44' }, installed_package_version: '' },
+    })
+    expect(unknown.status).toBe('current')
+  })
+
   it('detects a stable update and selects the Arch/CachyOS package', () => {
     const state = buildUpdateCenterState({
       currentVersion: '1.2.1',

--- a/tests/unit/test_launch_profile.cpp
+++ b/tests/unit/test_launch_profile.cpp
@@ -355,3 +355,78 @@ TEST(LaunchProfileTests, HostHdrCapabilityCanNormalizeAnExplicitRequest) {
   EXPECT_TRUE(resolved.fields.at("hdr").at("locked").get<bool>());
   EXPECT_TRUE(resolved.fields.at("hdr").at("normalized").get<bool>());
 }
+
+namespace {
+  launch_profile::explicit_field_lookup_t lookup_from(std::vector<std::pair<std::string, std::string>> args) {
+    return [args = std::move(args)](std::string_view name) -> std::optional<std::string> {
+      for (const auto &[key, value] : args) {
+        if (key == name) {
+          return value;
+        }
+      }
+      return std::nullopt;
+    };
+  }
+}  // namespace
+
+TEST(LaunchProfileExplicitFields, NamesACommaDecimalFpsInsteadOfTheGenericSentence) {
+  // nova#275: a host running under a comma-decimal locale rejected every
+  // launch with "must be complete and within supported bounds".
+  const auto fields = launch_profile::parse_explicit_launch_fields(
+    lookup_from({{"width", "1920"}, {"height", "1080"}, {"fps", "60,0"}, {"bitrate_kbps", "20000"}})
+  );
+  ASSERT_EQ(fields.problems.size(), 1u);
+  EXPECT_EQ(fields.problems[0].field, "fps");
+  EXPECT_NE(fields.problems[0].reason.find("got '60,0'"), std::string::npos);
+  EXPECT_NE(fields.problems[0].reason.find("dot as the decimal separator"), std::string::npos);
+  const auto text = launch_profile::describe_explicit_launch_rejection(fields);
+  EXPECT_NE(text.find("Explicit launch fields were rejected: fps"), std::string::npos);
+  EXPECT_EQ(text.find("must be complete and within supported bounds"), std::string::npos);
+}
+
+TEST(LaunchProfileExplicitFields, AcceptsACompleteRequestAndKeepsTheOldUnits) {
+  const auto fields = launch_profile::parse_explicit_launch_fields(lookup_from({
+    {"width", "2560"}, {"height", "1440"}, {"fps", "119.88"}, {"bitrate_kbps", "35000"},
+    {"client_max_fps", "120"}, {"display_locked", "TRUE"}, {"bitrate_locked", "0"}, {"topology_locked", "1"}, {"hdr", "on"},
+  }));
+  EXPECT_TRUE(fields.problems.empty());
+  EXPECT_EQ(fields.width, 2560);
+  EXPECT_EQ(fields.height, 1440);
+  EXPECT_EQ(fields.fps_millihertz, 119880);
+  EXPECT_EQ(fields.client_max_fps_millihertz, 120000);
+  EXPECT_EQ(fields.bitrate_kbps, 35000);
+  EXPECT_TRUE(fields.display_locked);
+  EXPECT_FALSE(fields.bitrate_locked);
+  EXPECT_TRUE(fields.topology_locked);
+  EXPECT_EQ(fields.hdr, true);
+  EXPECT_TRUE(fields.complete_explicit_mode());
+  EXPECT_EQ(launch_profile::describe_explicit_launch_rejection(fields), "Explicit launch fields must be complete and within supported bounds.");
+}
+
+TEST(LaunchProfileExplicitFields, NamesMissingModeFieldsAndLockPrerequisites) {
+  const auto partial = launch_profile::parse_explicit_launch_fields(lookup_from({{"width", "1920"}, {"display_locked", "1"}}));
+  ASSERT_EQ(partial.problems.size(), 2u);
+  EXPECT_EQ(partial.problems[0].field, "width/height/fps");
+  EXPECT_NE(partial.problems[0].reason.find("missing height, fps"), std::string::npos);
+  EXPECT_EQ(partial.problems[1].field, "display_locked");
+
+  const auto locked = launch_profile::parse_explicit_launch_fields(lookup_from({{"bitrate_locked", "true"}}));
+  ASSERT_EQ(locked.problems.size(), 1u);
+  EXPECT_EQ(locked.problems[0].reason, "bitrate_locked requires bitrate_kbps");
+
+  const auto flag = launch_profile::parse_explicit_launch_fields(lookup_from({{"topology_locked", "maybe"}}));
+  ASSERT_EQ(flag.problems.size(), 1u);
+  EXPECT_NE(flag.problems[0].reason.find("topology_locked must be 1 or 0; got 'maybe'"), std::string::npos);
+}
+
+TEST(LaunchProfileExplicitFields, BoundsAndEchoesOnlyASafeSliceOfTheValue) {
+  const std::string hostile = std::string(40, 'x') + "\x01\n";
+  const auto fields = launch_profile::parse_explicit_launch_fields(lookup_from({{"bitrate_kbps", hostile}, {"width", "100000"}}));
+  ASSERT_EQ(fields.problems.size(), 2u);
+  EXPECT_EQ(fields.problems[0].field, "width");
+  EXPECT_NE(fields.problems[0].reason.find("between 320 and 16384; got '100000'"), std::string::npos);
+  EXPECT_EQ(fields.problems[1].field, "bitrate_kbps");
+  EXPECT_NE(fields.problems[1].reason.find(std::string(32, 'x') + "...'"), std::string::npos);
+  EXPECT_EQ(fields.problems[1].reason.find('\n'), std::string::npos);
+  EXPECT_EQ(fields.problems[1].reason.find('\x01'), std::string::npos);
+}

--- a/tests/unit/test_update_status.cpp
+++ b/tests/unit/test_update_status.cpp
@@ -98,3 +98,15 @@ TEST(UpdateStatusTests, RepositoryUpgradeCommandFollowsTheHostShape) {
   // No repository is served for Ubuntu, so there is no command to offer.
   EXPECT_EQ(update_status::repository_upgrade_command_for_tests(ubuntu, false), "");
 }
+
+TEST(UpdateStatusTests, ParsesInstalledPackageVersionsAcrossPackageFamilies) {
+  using update_status::parse_installed_package_version;
+  EXPECT_EQ(parse_installed_package_version("fedora", "1.4.2\n"), "1.4.2");
+  EXPECT_EQ(parse_installed_package_version("ubuntu", "1:1.4.2-1\n"), "1.4.2");
+  EXPECT_EQ(parse_installed_package_version("arch", "polaris 1.4.2-1\n"), "1.4.2");
+  EXPECT_EQ(parse_installed_package_version("steamos", "polaris 1.4.2-1"), "1.4.2");
+  EXPECT_EQ(parse_installed_package_version("fedora", ""), "");
+  EXPECT_EQ(parse_installed_package_version("fedora", "package polaris is not installed\n"), "");
+  EXPECT_EQ(parse_installed_package_version("arch", "error: package 'polaris' was not found"), "");
+  EXPECT_EQ(parse_installed_package_version("ubuntu", "dpkg-query: no packages found matching polaris"), "");
+}


### PR DESCRIPTION
## Summary

Two support-driven changes plus the docs that go with them.

- **Launch rejections name the field.** `launch_profile::parse_explicit_launch_fields` parses the explicit fields of an optimize request once and records, for every problem, the field and the value it saw (bounded to 32 safe characters). The handler answers `invalid_explicit_launch_fields` with a sentence such as `Explicit launch fields were rejected: fps must be a number between 15 and 240 with a dot as the decimal separator; got '60,0'.` instead of the generic one nova#275 saw. Codes, bounds, and accepted values are unchanged; the parsing moved verbatim (`stoll` with full consumption, `util::parse_decimal` for fps) and gained names.
- **"Installed, not running" in the update center.** `update_status::host_update_status` reports `installed_package_version` from the host package database (rpm, dpkg-query, or pacman by family; parsed by a pure function that strips Debian epochs and package releases). `buildUpdateCenterState` turns an installed version newer than the running one into `restart_required` with the hint to restart Polaris, ahead of the update-available state. This is the plain-Fedora shape of polaris#605 too: `dnf install` leaves the old process running.
- Bazzite guide: the staged-deployment paragraph (install without `-r`, or rollback then install, keeps the old deployment running until a reboot).
- Changelog: Unreleased entries for #604, #607, and this change.

## Exact candidate

`Commit:` `7473dfbc6852a46cc6feb0b7e276dad94bfef4ee`
`Tree:` `d9b95d3c93ba105dcb68b91ae64087762bfa86e0`
`Parent:` `c78459552d40eed6fb716f0a728a5b880caad01e`
`Base:` `c78459552d40eed6fb716f0a728a5b880caad01e`

## Verification

- [x] `ninja polaris test_polaris` on pc-papi (CUDA-off tree), clean
- [x] `test_polaris --gtest_filter=LaunchProfileExplicitFields*:UpdateStatusTests*:*LaunchProfile*:*SourceSafety*:*DoctorReset*`: green (four new explicit-field cases including the comma-decimal fps, one new package-version parsing case)
- [x] `npm run test -- update-center`: green with the new restart_required case; `npm run lint`: clean
- [x] `bash scripts/check-public-docs.sh`, `bash scripts/check-public-surface.sh`, `git diff --check`: clean

Not covered: a live optimize request with a bad field (the handler change is a mechanical swap onto the tested parser), and a live host where the package database is ahead of the process.
