### PR TITLE
feat(gamescope): run the bundled launcher when none is installed, and test the installer

### DIFF
--- a/cmake/packaging/linux.cmake
+++ b/cmake/packaging/linux.cmake
@@ -15,9 +15,10 @@ install(FILES "${POLARIS_SOURCE_ASSETS_DIR}/linux/misc/60-polaris.conf"
 # Reference copies of the gamescope_stream helpers. At launch Polaris compares
 # the polaris-gamescope-session it resolved against these, so a helper left by
 # an older scripts/install run is reported as stale instead of debugged as a
-# Polaris bug. The executable copies that actually run are installed below.
-install(FILES "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-session.sh"
-              "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-runtime-lib.sh"
+# Polaris bug. They are executable so an AppImage or a build-directory run,
+# which has no launcher beside the binary or on PATH, can nest through them.
+install(PROGRAMS "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-session.sh"
+                 "${CMAKE_SOURCE_DIR}/nix/modules/polaris-gamescope-runtime-lib.sh"
         DESTINATION "${POLARIS_ASSETS_DIR}/gamescope")
 
 # Host integration files at their live paths, for everything that is not an

--- a/scripts/install/03-install-gamescope-stack.sh
+++ b/scripts/install/03-install-gamescope-stack.sh
@@ -186,8 +186,12 @@ cat >"$DROPIN_DIR/README-portal.conf.example" <<'EOF'
 # Environment=POLARIS_PORTAL_DBUS_ADDRESS=unix:path=%t/polaris-portal/bus
 EOF
 
-systemctl --user daemon-reload
-log "systemd --user daemon-reload done"
+if [ "${POLARIS_INSTALL_SKIP_SYSTEMD:-0}" = 1 ]; then
+  log "systemd --user daemon-reload skipped (POLARIS_INSTALL_SKIP_SYSTEMD=1)"
+else
+  systemctl --user daemon-reload
+  log "systemd --user daemon-reload done"
+fi
 log "next: ./04-enable-services.sh"
 log "or:    systemctl --user enable --now polaris-gamescope-idle polaris"
 log ""

--- a/src/platform/linux/gamescope_session_helper.cpp
+++ b/src/platform/linux/gamescope_session_helper.cpp
@@ -136,6 +136,11 @@ namespace platf::gamescope_session_helper {
       }
     }
 
+    if (resolution.helper.empty() && !bundled_session.empty() && linux_util::is_executable_file(bundled_session.string())) {
+      resolution.helper = bundled_session;
+      resolution.bundled_fallback = true;
+    }
+
     if (resolution.helper.empty() || !regular_file(bundled_session)) {
       return resolution;
     }
@@ -172,6 +177,10 @@ namespace platf::gamescope_session_helper {
   std::string summary(const resolution_t &resolution) {
     if (resolution.helper.empty()) {
       return "gamescope_stream: no polaris-gamescope-session launcher beside this binary or on PATH";
+    }
+    if (resolution.bundled_fallback) {
+      return "gamescope_stream: no polaris-gamescope-session beside this binary or on PATH; running the reference copy shipped with this build [" +
+             resolution.helper.string() + "]";
     }
     std::string line = "gamescope_stream: polaris-gamescope-session [" + resolution.helper.string() + "] is " +
                        std::string(describe(resolution.session_match));

--- a/src/platform/linux/gamescope_session_helper.h
+++ b/src/platform/linux/gamescope_session_helper.h
@@ -24,6 +24,7 @@ namespace platf::gamescope_session_helper {
     std::filesystem::path shadowed;  ///< a different copy PATH would have picked; empty when none
     std::filesystem::path bundled;  ///< module copy shipped with this build; empty when absent
     std::filesystem::path runtime_lib;  ///< sibling runtime library that was compared; empty when absent
+    bool bundled_fallback {false};  ///< helper is the reference copy itself: nothing was installed beside the binary or on PATH
     bundle_match_t session_match {bundle_match_t::unknown};
     bundle_match_t runtime_lib_match {bundle_match_t::unknown};
   };
@@ -35,7 +36,9 @@ namespace platf::gamescope_session_helper {
    * package ships the binary and the launcher together, so they cannot drift
    * apart, while a copy under ~/.local/bin or /usr/local/bin left by an earlier
    * scripts/install run is never updated by the package manager and would
-   * otherwise shadow the packaged one.
+   * otherwise shadow the packaged one. With neither installed, the executable
+   * reference copy shipped with this build runs, so an AppImage or a
+   * build-directory Polaris can still nest instead of silently attaching.
    *
    * @param executable_dir Directory of the running binary, when known.
    * @param path_candidate What a PATH lookup found, or empty.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -399,6 +399,12 @@ if (UNIX)
                 bash ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamescope_primary_child_shell.sh
     )
     add_test(
+        NAME polaris_install_gamescope_stack_shell
+        COMMAND ${CMAKE_COMMAND} -E env
+                POLARIS_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+                bash ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_install_gamescope_stack_shell.sh
+    )
+    add_test(
         NAME polaris_gamescope_session_geometry_shell
         COMMAND ${CMAKE_COMMAND} -E env
                 POLARIS_SOURCE_DIR=${CMAKE_SOURCE_DIR}

--- a/tests/unit/platform/test_gamescope_session_helper.cpp
+++ b/tests/unit/platform/test_gamescope_session_helper.cpp
@@ -102,6 +102,33 @@ TEST(GamescopeSessionHelperTests, ReportsNothingWhenNoLauncherExists) {
   EXPECT_NE(helper::summary(resolution).find("no polaris-gamescope-session launcher"), std::string::npos);
 }
 
+TEST(GamescopeSessionHelperTests, RunsTheBundledCopyWhenNothingIsInstalled) {
+  scratch_t scratch;
+  fs::create_directories(scratch.root / "AppDir/usr/bin");
+  const auto bundled = scratch.file("AppDir/usr/share/polaris/assets/gamescope/polaris-gamescope-session.sh", module_body, true);
+  const auto bundled_lib = scratch.file("AppDir/usr/share/polaris/assets/gamescope/polaris-gamescope-runtime-lib.sh", library_body, false);
+
+  const auto resolution = helper::resolve(scratch.root / "AppDir/usr/bin", {}, bundled, bundled_lib);
+
+  EXPECT_EQ(resolution.helper, bundled);
+  EXPECT_TRUE(resolution.bundled_fallback);
+  EXPECT_EQ(resolution.session_match, helper::bundle_match_t::exact);
+  EXPECT_TRUE(resolution.shadowed.empty());
+  EXPECT_TRUE(helper::advisories(resolution).empty());
+  EXPECT_NE(helper::summary(resolution).find("reference copy shipped with this build"), std::string::npos);
+}
+
+TEST(GamescopeSessionHelperTests, DoesNotRunANonExecutableBundledCopy) {
+  scratch_t scratch;
+  fs::create_directories(scratch.root / "usr/bin");
+  const auto bundled = scratch.file("assets/gamescope/polaris-gamescope-session.sh", module_body, false);
+
+  const auto resolution = helper::resolve(scratch.root / "usr/bin", {}, bundled, {});
+
+  EXPECT_TRUE(resolution.helper.empty());
+  EXPECT_FALSE(resolution.bundled_fallback);
+}
+
 TEST(GamescopeSessionHelperTests, UnknownBinaryDirectoryUsesPath) {
   scratch_t scratch;
   const auto on_path = scratch.file("usr/local/bin/polaris-gamescope-session", module_body, true);

--- a/tests/unit/platform/test_install_gamescope_stack_shell.sh
+++ b/tests/unit/platform/test_install_gamescope_stack_shell.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# The scripts/install stack had no coverage at all; a classifier change broke
+# every such host for eight days before anyone noticed. This runs the installer
+# into a scratch prefix with the systemd reload skipped and checks what it wrote.
+set -euo pipefail
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+source_dir="${POLARIS_SOURCE_DIR:?}"
+work="$(mktemp -d "${TMPDIR:-/tmp}/polaris-install-stack.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin" "$work/home"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$work/bin/polaris"
+chmod +x "$work/bin/polaris"
+# A systemctl on PATH would prove the skip flag is not honoured.
+printf '#!/usr/bin/env bash\necho "systemctl must not run under POLARIS_INSTALL_SKIP_SYSTEMD" >&2\nexit 97\n' >"$work/bin/systemctl"
+chmod +x "$work/bin/systemctl"
+
+HOME="$work/home" \
+PATH="$work/bin:$PATH" \
+PREFIX="$work/home/.local" \
+SYSTEMD_USER_DIR="$work/home/.config/systemd/user" \
+CONFIG_DIR="$work/home/.config/polaris" \
+POLARIS_INSTALL_SKIP_SYSTEMD=1 \
+  bash "$source_dir/scripts/install/03-install-gamescope-stack.sh" --polaris-bin "$work/bin/polaris" >"$work/install.log" 2>&1 \
+  || fail "installer exited non-zero: $(tail -5 "$work/install.log")"
+
+bin="$work/home/.local/bin"
+for helper in polaris-gamescope-session polaris-gamescope-idle polaris-wait-gamescope polaris-start polaris-gamescope-runtime-lib.sh; do
+  [ -f "$bin/$helper" ] || fail "installer did not write $helper"
+  bash -n "$bin/$helper" || fail "$helper does not parse"
+done
+[ -x "$bin/polaris-gamescope-session" ] || fail "session launcher is not executable"
+# The launcher is the shared module with the non-NixOS header on top: it must
+# still source its runtime library from its own directory.
+grep -q 'polaris-gamescope-runtime-lib.sh' "$bin/polaris-gamescope-session" || fail "launcher lost its runtime library reference"
+grep -q 'export POLARIS_GAMESCOPE_BIN=' "$bin/polaris-gamescope-session" || fail "launcher lost the non-NixOS header"
+grep -q "printf 'host-portal" "$bin/polaris-gamescope-session" || fail "launcher module is not the current shared body"
+module="$source_dir/nix/modules/polaris-gamescope-session.sh"
+tail -c "$(stat -c %s "$module")" "$bin/polaris-gamescope-session" | cmp -s - "$module" \
+  || fail "installed launcher does not end with nix/modules/polaris-gamescope-session.sh verbatim"
+
+units="$work/home/.config/systemd/user"
+[ -f "$units/polaris-gamescope-idle.service" ] || fail "idle unit missing"
+[ -f "$units/polaris.service" ] || fail "polaris unit missing"
+grep -q "^ExecStart=$bin/polaris-gamescope-idle$" "$units/polaris-gamescope-idle.service" || fail "idle unit does not start the installed helper"
+grep -q "^ExecStartPre=$bin/polaris-wait-gamescope$" "$units/polaris.service" || fail "polaris unit does not wait for gamescope"
+grep -q "^ExecStart=$bin/polaris-start$" "$units/polaris.service" || fail "polaris unit does not start through polaris-start"
+grep -q "^Environment=PATH=$bin:" "$units/polaris.service" || fail "polaris unit PATH does not lead with the install prefix"
+[ -f "$work/home/.config/polaris/polaris.conf.gamescope-stream.example" ] || fail "config seed missing"
+grep -q '^linux_stream_mode = gamescope_stream$' "$work/home/.config/polaris/polaris.conf.gamescope-stream.example" || fail "config seed lost the stream mode"
+grep -q 'systemd --user daemon-reload skipped' "$work/install.log" || fail "installer did not report the skipped reload"
+grep -q "$work/bin/polaris" "$bin/polaris-start" || fail "polaris-start does not exec the given binary"
+
+echo "PASS: scripts/install gamescope stack installer"


### PR DESCRIPTION
## Summary

Two items carried from the 1.4.2 follow-up list.

- **Bundled launcher fallback.** The reference copies of `polaris-gamescope-session.sh` and its runtime library under `<assets>/gamescope/` are installed executable (`install(PROGRAMS ...)`), and `gamescope_session_helper::resolve` runs the reference copy when nothing is installed beside the binary or on PATH. An AppImage or a build-directory run can nest instead of silently attaching. The launcher sources its runtime library from its own directory, so the pair beside it is complete. The resolution summary (and therefore the Doctor card) says when the reference copy is what runs; a non-executable copy is never run.
- **Installer smoke test.** `scripts/install/03-install-gamescope-stack.sh` gains `POLARIS_INSTALL_SKIP_SYSTEMD=1` for environments without a user manager. A new ctest, `polaris_install_gamescope_stack_shell`, runs the installer into a scratch prefix with a stub `polaris` and a `systemctl` that fails loudly, then checks: every helper it wrote parses, the launcher is executable and ends with `nix/modules/polaris-gamescope-session.sh` byte for byte, both units point at the installed helpers, the unit PATH leads with the prefix, the config seed carries `gamescope_stream`, and the reload was reported as skipped. This is the lane that had zero coverage when #602's predecessor broke it.

## Exact candidate

`Commit:` `9823d6fb85216da7b0e3aed7a389bf1e54aaff4c`
`Tree:` `c9af43ed91989e668232b097af45e374e2ec2dcb`
`Parent:` `c78459552d40eed6fb716f0a728a5b880caad01e`
`Base:` `c78459552d40eed6fb716f0a728a5b880caad01e`

## Verification

- [x] `ninja polaris test_polaris_platform` on pc-papi (CUDA-off tree), clean
- [x] `test_polaris_platform --gtest_filter=GamescopeSessionHelperTests.*`: 14/14 (two new: bundled fallback runs, non-executable copy does not)
- [x] `ctest -R "install_gamescope|gamescope"`: 5/5; the installer smoke fails against the pre-change script (the stub `systemctl` fires) and passes with it
- [x] `bash scripts/check-public-surface.sh`, `bash scripts/check-public-docs.sh`, `git diff --check`: clean

Not covered: a real AppImage run through the bundled launcher; the resolver path is unit-tested and the file mode change is in packaging CI.
