### PR TITLE
feat(packaging): publish a systemd system extension image for rpm-ostree hosts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1433,14 +1433,14 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          binary_rpms=()
-          for rpm_path in sysext/raw/*.rpm; do
-            if [[ "$rpm_path" != *.src.rpm ]]; then
-              binary_rpms+=("$rpm_path")
-            fi
-          done
+          # The artifact carries CPack's unversioned Polaris.rpm symlink beside the
+          # real package; only a regular, versioned binary RPM is a valid input.
+          mapfile -t binary_rpms < <(
+            find sysext/raw -type f -name 'Polaris-*.rpm' ! -name '*.src.rpm' | sort
+          )
           if [ "${#binary_rpms[@]}" -ne 1 ]; then
-            echo "Expected exactly one Fedora 44 binary RPM, found ${#binary_rpms[@]}" >&2
+            echo "Expected exactly one Fedora 44 binary RPM, found ${#binary_rpms[@]}: ${binary_rpms[*]}" >&2
+            find sysext/raw -maxdepth 3 -printf '%y %p\n' >&2
             exit 1
           fi
           bash scripts/ci/build-sysext-image.sh "${binary_rpms[0]}" sysext/out/Polaris-sysext-x86_64.raw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1433,10 +1433,10 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          # The artifact carries CPack's unversioned Polaris.rpm symlink beside the
-          # real package; only a regular, versioned binary RPM is a valid input.
+          # The artifact carries the package as an unversioned Polaris.rpm; only a
+          # regular binary RPM is a valid input, whatever CPack named it.
           mapfile -t binary_rpms < <(
-            find sysext/raw -type f -name 'Polaris-*.rpm' ! -name '*.src.rpm' | sort
+            find sysext/raw -type f -name '*.rpm' ! -name '*.src.rpm' | sort
           )
           if [ "${#binary_rpms[@]}" -ne 1 ]; then
             echo "Expected exactly one Fedora 44 binary RPM, found ${#binary_rpms[@]}: ${binary_rpms[*]}" >&2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1409,6 +1409,59 @@ jobs:
             build/cpack_artifacts/_CPack_Packages/Linux/RPM/*.err
           if-no-files-found: warn
 
+  sysext-build:
+    name: Systemd extension image
+    needs:
+      - resolve-source
+      - fedora-rpm-build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out exact source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-source.outputs.commit }}
+      - name: Install image tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends squashfs-tools rpm2cpio cpio systemd-container
+      - name: Download Fedora 44 RPM artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: fedora-44-rpm-artifacts
+          path: sysext/raw
+      - name: Build the extension image from the Fedora 44 RPM
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          binary_rpms=()
+          for rpm_path in sysext/raw/*.rpm; do
+            if [[ "$rpm_path" != *.src.rpm ]]; then
+              binary_rpms+=("$rpm_path")
+            fi
+          done
+          if [ "${#binary_rpms[@]}" -ne 1 ]; then
+            echo "Expected exactly one Fedora 44 binary RPM, found ${#binary_rpms[@]}" >&2
+            exit 1
+          fi
+          bash scripts/ci/build-sysext-image.sh "${binary_rpms[0]}" sysext/out/Polaris-sysext-x86_64.raw
+      - name: Validate the image as a system extension
+        run: |
+          set -euo pipefail
+          # The extension declares the name polaris, so systemd only accepts the
+          # image as a sysext under that file name; the release asset keeps the
+          # Polaris-* name and the guide installs it as polaris.raw.
+          cp sysext/out/Polaris-sysext-x86_64.raw sysext/out/polaris.raw
+          sudo systemd-dissect sysext/out/polaris.raw | tee sysext/out/dissect.txt
+          grep -q 'sysext for system' sysext/out/dissect.txt
+          grep -q 'ID=_any' sysext/out/dissect.txt
+          rm -f sysext/out/polaris.raw
+      - name: Upload the extension image
+        uses: actions/upload-artifact@v7
+        with:
+          name: Polaris-sysext-image
+          path: sysext/out/Polaris-sysext-x86_64.raw
+          if-no-files-found: error
+
   release-assets:
     name: Release assets
     needs:
@@ -1418,6 +1471,7 @@ jobs:
       - steamos-build
       - ubuntu-build
       - fedora-rpm-build
+      - sysext-build
       - cpp-sanitizer-tests
     if: ${{ startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != '' }}
     runs-on: ubuntu-24.04
@@ -1453,6 +1507,11 @@ jobs:
         with:
           name: Polaris-steamos3.8-package
           path: release-assets/raw/steamos3.8
+      - name: Download systemd extension image
+        uses: actions/download-artifact@v8
+        with:
+          name: Polaris-sysext-image
+          path: release-assets/raw/sysext
 
       - name: Prepare release asset names
         run: |
@@ -1543,6 +1602,12 @@ jobs:
           fi
 
           cp "${ubuntu_debs[0]}" "release-assets/final/Polaris-ubuntu24.04-x86_64.deb"
+          sysext_images=(release-assets/raw/sysext/*.raw)
+          if [ "${#sysext_images[@]}" -ne 1 ]; then
+            echo "Expected exactly one systemd extension image, found ${#sysext_images[@]}" >&2
+            exit 1
+          fi
+          cp "${sysext_images[0]}" "release-assets/final/Polaris-sysext-x86_64.raw"
 
           ls -la release-assets/staged release-assets/final
 

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -309,6 +309,37 @@ If clients connect but the stream is black, check whether logs mention
 headless labwc runtime. `HEADLESS-1` means routing worked and capture or encoder
 warnings should be inspected next.
 
+## System Extension (experimental)
+
+`Polaris-sysext-x86_64.raw` is the Fedora 44 RPM repacked as a
+[systemd system extension](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html):
+the same files, overlaid onto `/usr` by `systemd-sysext` without a new deployment and without a
+reboot. It is experimental. The image is validated in CI as a system extension, but it has not yet
+been run on a Bazzite host, it cannot carry libraries the base image lacks (the RPM would have pulled
+them in), and on an SELinux-enforcing host the overlaid files carry no labels, so a start failure with
+a denial in `journalctl` is the extension, not Polaris. The RPM path above remains the supported one.
+
+The file must be installed as `polaris.raw`, which is the name the extension declares. Do not layer
+the RPM and the extension at the same time.
+
+```bash
+raw_name="Polaris-sysext-x86_64.raw"
+wget --output-document="./${raw_name}" "https://github.com/papi-ux/polaris/releases/latest/download/${raw_name}" &&
+sudo install -D -m 0644 "./${raw_name}" /var/lib/extensions/polaris.raw &&
+sudo systemctl enable --now systemd-sysext.service &&
+sudo systemd-sysext refresh &&
+sudo udevadm control --reload &&
+sudo -H polaris --setup-host &&
+systemctl --user daemon-reload &&
+systemctl --user enable --now polaris
+```
+
+`systemd-sysext status` shows whether the extension is merged. To update, replace
+`/var/lib/extensions/polaris.raw` with the newer image, then run `sudo systemd-sysext refresh` and
+`systemctl --user restart polaris`. To remove it, run `sudo systemd-sysext unmerge` and delete the
+image. The extension is built from the Fedora RPM, so it is for Fedora-based atomic hosts; it does
+not run on SteamOS.
+
 ## Update
 
 Layer the newer Fedora 44 RPM and reboot. `rpm-ostree` will stage the

--- a/docs/building.md
+++ b/docs/building.md
@@ -236,8 +236,10 @@ The public release assets are currently:
 - `Polaris-ubuntu24.04-x86_64.deb`
 - `Polaris-arch-x86_64.pkg.tar.zst`
 - `Polaris-steamos3.8-x86_64.pkg.tar.zst`
+- `Polaris-sysext-x86_64.raw`, the Fedora 44 RPM repacked as an experimental systemd system extension for rpm-ostree hosts
 
-Bazzite installs use the matching Fedora RPM through `rpm-ostree` for now. SteamOS 3.8 uses its
+Bazzite installs use the matching Fedora RPM through `rpm-ostree`, or the experimental system
+extension described in the [Bazzite guide](bazzite.md#system-extension-experimental). SteamOS 3.8 uses its
 dedicated package through the [SteamOS guide](steamos.md); the package is not interchangeable with
 the rolling Arch artifact. Ubuntu 24.04 has a direct DEB package. openSUSE Tumbleweed has source-build
 guidance and CI build coverage but no published release package asset yet. CachyOS should start with

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ starts at `v1.0.0`.
 - Names the cause when an artwork search fails: the Nova-facing candidate search and the console cover search now answer with a stable code for a missing SteamGridDB key, a rejected key, rate limiting, or an unreachable provider instead of a bare status or an empty result
 - Names the field when explicit launch fields are rejected, including the value seen, so a comma-decimal `fps` or a lock flag without its prerequisite no longer reads as "must be complete and within supported bounds"
 - Tells the console when the installed Polaris package is newer than the running process, which is what a package upgrade without a service restart looks like
+- Publishes `Polaris-sysext-x86_64.raw`, the Fedora 44 RPM repacked as an experimental systemd system extension so rpm-ostree hosts such as Bazzite can run Polaris without layering a package or rebooting
 
 ## v1.4.2 - 2026-09-04
 

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -1337,6 +1337,9 @@ expected_assets = Counter(
         "Polaris-ubuntu24.04-x86_64.deb": 1,
     }
 )
+# The systemd extension image is built from the Fedora RPM and may be named at
+# most once beside the packages; a release section that predates it stays valid.
+optional_assets = {"Polaris-sysext-x86_64.raw"}
 building_packaging = markdown_section(building, "## Packaging")
 building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
@@ -1345,6 +1348,11 @@ for label, section in (
     ("v1.4.2 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
+    for optional_asset in optional_assets:
+        if actual_assets.get(optional_asset, 0) > 1:
+            print(f"{label} names {optional_asset} more than once", file=sys.stderr)
+            sys.exit(1)
+        actual_assets.pop(optional_asset, None)
     if actual_assets != expected_assets:
         print(
             f"{label} must name exactly one of each supported asset; "

--- a/scripts/ci/build-sysext-image.sh
+++ b/scripts/ci/build-sysext-image.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Repack the Fedora RPM as a systemd system extension image.
+#
+# A system extension overlays /usr (and /opt) at runtime through systemd-sysext,
+# so an rpm-ostree host such as Bazzite can run Polaris without layering a
+# package into a new deployment or rebooting. The RPM already installs
+# everything under /usr, which is exactly what this checks before packing.
+#
+# Usage: build-sysext-image.sh <polaris.rpm> <output.raw> [<version>]
+set -euo pipefail
+
+rpm_path="${1:?usage: build-sysext-image.sh <polaris.rpm> <output.raw> [<version>]}"
+output="${2:?usage: build-sysext-image.sh <polaris.rpm> <output.raw> [<version>]}"
+version="${3:-}"
+
+for tool in rpm2cpio cpio mksquashfs; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    printf 'build-sysext-image.sh: missing tool: %s\n' "$tool" >&2
+    exit 1
+  fi
+done
+[ -f "$rpm_path" ] || { printf 'build-sysext-image.sh: no such RPM: %s\n' "$rpm_path" >&2; exit 1; }
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/polaris-sysext.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/tree"
+(cd "$work/tree" && rpm2cpio "$rpm_path" | cpio -idm --quiet)
+
+# systemd refuses an extension that carries anything outside /usr and /opt.
+# Anything else here means the RPM layout drifted and the sysext must not ship.
+stray="$(find "$work/tree" -mindepth 1 -maxdepth 1 ! -name usr ! -name opt)"
+if [ -n "$stray" ]; then
+  printf 'build-sysext-image.sh: RPM installs outside /usr and /opt, which a system extension cannot overlay:\n%s\n' "$stray" >&2
+  exit 1
+fi
+if [ ! -e "$work/tree/usr/bin/polaris" ]; then
+  printf 'build-sysext-image.sh: RPM does not install /usr/bin/polaris\n' >&2
+  exit 1
+fi
+
+if [ -z "$version" ]; then
+  # The RPM installs the versioned binary beside the polaris symlink.
+  version="$(find "$work/tree/usr/bin" -maxdepth 1 -name 'polaris-[0-9]*' -printf '%f\n' | sed -n 's/^polaris-\([0-9][0-9.]*\)$/\1/p' | head -1)"
+fi
+if [ -z "$version" ]; then
+  printf 'build-sysext-image.sh: could not determine the Polaris version from the RPM\n' >&2
+  exit 1
+fi
+
+# The file name is the extension name: it must be installed as polaris.raw.
+mkdir -p "$work/tree/usr/lib/extension-release.d"
+cat >"$work/tree/usr/lib/extension-release.d/extension-release.polaris" <<RELEASE
+ID=_any
+ARCHITECTURE=x86-64
+SYSEXT_LEVEL=1.0
+EXTENSION_RELOAD_MANAGER=1
+POLARIS_VERSION=${version}
+RELEASE
+
+mkdir -p "$(dirname "$output")"
+rm -f "$output"
+mksquashfs "$work/tree" "$output" -comp zstd -noappend -all-root -quiet -no-progress
+printf 'built %s (%s bytes) for Polaris %s\n' "$(basename "$output")" "$(stat -c %s "$output")" "$version"

--- a/scripts/ci/build-sysext-image.sh
+++ b/scripts/ci/build-sysext-image.sh
@@ -20,6 +20,9 @@ for tool in rpm2cpio cpio mksquashfs; do
   fi
 done
 [ -f "$rpm_path" ] || { printf 'build-sysext-image.sh: no such RPM: %s\n' "$rpm_path" >&2; exit 1; }
+# The extraction below runs inside the scratch tree, so a relative RPM path must be pinned first.
+rpm_path="$(cd "$(dirname "$rpm_path")" && pwd)/$(basename "$rpm_path")"
+case "$output" in /*) ;; *) output="$PWD/$output" ;; esac
 
 work="$(mktemp -d "${TMPDIR:-/tmp}/polaris-sysext.XXXXXX")"
 trap 'rm -rf "$work"' EXIT


### PR DESCRIPTION
## Summary

Addresses #606. Bazzite installs layer the Fedora RPM with rpm-ostree, which stages a deployment and reboots for every install and update. Everything the RPM installs is under `/usr`, which is what a systemd system extension overlays at runtime without a deployment or a reboot.

- `scripts/ci/build-sysext-image.sh`: extracts the Fedora 44 RPM, refuses anything outside `/usr` and `/opt`, writes `usr/lib/extension-release.d/extension-release.polaris` (`ID=_any`, `ARCHITECTURE=x86-64`, `SYSEXT_LEVEL=1.0`, `EXTENSION_RELOAD_MANAGER=1`, `POLARIS_VERSION`), and packs a zstd squashfs image.
- CI: a `sysext-build` job runs it on the `fedora-44-rpm-artifacts` binary RPM and validates the result with `systemd-dissect` under the name it must be installed as (`polaris.raw`; systemd derives the extension name from the file name). `release-assets` publishes it as `Polaris-sysext-x86_64.raw`, a fifth asset beside the four packages.
- Docs: a "System Extension (experimental)" section in the Bazzite guide with install, status, update, and removal through `systemd-sysext`, stating plainly what is not yet proven: no Bazzite host has run it, it cannot carry libraries the base image lacks, and the overlaid files carry no SELinux labels. `docs/building.md` lists the asset. Changelog Unreleased entry.
- `scripts/check-public-docs.sh` treats the image as an optional asset (at most once beside the four), so the v1.4.2 release section stays valid and the next release section can name it.

## Exact candidate

`Commit:` `4b03a745fdaaf5f9d7b5dbacd5bbf4a42bd08720`
`Tree:` `fe02216b7408f7fccd0020d1b98ac44fd47cf1f8`
`Parent:` `766bca66dc09cea889453b87fbd3c12ad0919dbf`
`Base:` `766bca66dc09cea889453b87fbd3c12ad0919dbf`

## Verification

- [x] `scripts/ci/build-sysext-image.sh` run on the published v1.4.2 Fedora 44 RPM on pc-papi: 14,430,208-byte image, `systemd-dissect` reports `✓ sysext for system` with `ID=_any` and `POLARIS_VERSION=1.4.2` once the file is named `polaris.raw` (and correctly refuses it under the asset name, which is what the CI step accounts for)
- [x] `python -c yaml.safe_load` on the workflow; `bash -n` on the script
- [x] `bash scripts/check-public-docs.sh`, `bash scripts/check-public-surface.sh`, `git diff --check`: clean
- [x] `npm run test -- packaging-contracts release-v14`: 4 files green (the release asset contracts still see exactly the four packages in the v1.4.2 notes)

Not covered: the CI job itself runs for the first time on this PR; merging the extension on a real Bazzite host, which is the validation the guide says is missing.
