### PR TITLE
docs: make release notes short, user-facing bullets

### DIFF
--- a/docs/release-notes/TEMPLATE.md
+++ b/docs/release-notes/TEMPLATE.md
@@ -1,0 +1,26 @@
+# Polaris vX.Y.Z
+
+One sentence: what kind of release, and the Nova version it is matched with.
+
+**New**
+
+- One line per user-visible addition. No internal identifiers, no field names, no code paths.
+
+**Fixed**
+
+- One line per fix, said the way the person who hit it would say it.
+
+**Heads up**
+
+- What is not proven yet, and anything that stays deliberately unchanged.
+
+<details>
+<summary><b>Install</b> (Fedora 44, Arch / CachyOS, Ubuntu 24.04, SteamOS 3.8)</summary>
+
+The four version-pinned install blocks, unchanged in shape from the previous release, followed by the Bazzite and SteamOS guide links.
+
+</details>
+
+**Assets:** the release files, backticked, on one line.
+
+Rules: bullets stay under about twenty words; the changelog (`docs/changelog.md`) is where the detail lives; `scripts/check-public-docs.sh` and the release contract test pin a few user-visible phrases plus the install commands, so keep those when you edit; never an em dash.

--- a/docs/release-notes/v1.4.2.md
+++ b/docs/release-notes/v1.4.2.md
@@ -1,14 +1,32 @@
 # Polaris v1.4.2
 
-Polaris v1.4.2 is the matched host release for Nova v1.4.2. It is a stability and diagnostics update: per-game encoder selection for capable clients, a Linux Vulkan Video crash fix at disconnect, and the gamescope session fixes that came out of the first SteamOS 3.8 field report.
+Stability update, matched with Nova v1.4.2. Existing settings and paired devices keep working.
 
-A Nova v1.4.2 client can now choose the encoder backend for a single game from the list the host advertises. Auto is the only per-game choice that may fall back after its live probe; an explicit NVENC, VA-API, Vulkan, or software choice is strict and fails instead of silently switching, and the host default is restored when the session ends. Older clients keep the configured host default.
+**New**
 
-On SteamOS and Arch, gamescope ships with the `cap_sys_nice` file capability. A process that gains a file capability is not dumpable, so `/proc/<pid>/exe` and `/proc/<pid>/fd` become unreadable to the user that launched it, the ownership checks that prove which compositor owns the stream failed, and the teardown then killed a healthy compositor. The private nested compositor now starts with `no_new_privs`, so the capability is never granted to it and the checks pass. Desktop Game Mode keeps its capability and the system binary is untouched.
+- Pick the encoder per game from Nova. Auto can fall back, an explicit choice never switches on you.
+- Doctor and the launch log tell you when a gamescope session helper is stale or shadowed.
 
-Existing v1.4.1 configuration and paired devices remain valid. Steam Input remains manual and read-only.
+**Fixed**
 
-## Fedora 44
+- SteamOS: the nested gamescope session no longer gets killed by gamescope's file capability.
+- Distro packages no longer wedge every launch after one failed session start.
+- Manual (scripts/install) hosts can start nested sessions again.
+- No more eight-second wait on hosts without a private portal.
+- Vulkan Video no longer crashes when the client disconnects.
+- Launches work on hosts with a comma decimal locale.
+- Failed Flatpak and Heroic launches leave evidence instead of a guess.
+
+**Heads up**
+
+- The SteamOS fix still needs a field retest on real hardware.
+- Steam Input stays manual and read-only.
+- Verified with Nova v1.4.2 on a Retroid Pocket 6.
+
+<details>
+<summary><b>Install</b> (Fedora 44, Arch / CachyOS, Ubuntu 24.04, SteamOS 3.8)</summary>
+
+### Fedora 44
 
 ```bash
 wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-fedora44-x86_64.rpm &&
@@ -17,7 +35,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-## Arch Linux / CachyOS
+### Arch Linux / CachyOS
 
 ```bash
 wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-arch-x86_64.pkg.tar.zst &&
@@ -26,7 +44,7 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-## Ubuntu 24.04
+### Ubuntu 24.04
 
 ```bash
 wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-ubuntu24.04-x86_64.deb &&
@@ -35,9 +53,9 @@ sudo -H polaris --setup-host &&
 systemctl --user restart polaris
 ```
 
-## SteamOS 3.8
+### SteamOS 3.8
 
-Open a terminal in Desktop Mode and run this exact version-pinned command. It initializes the package keyring when needed and restores the read-only root before starting Polaris.
+Run this in Desktop Mode. It sets up the package keyring when needed and restores the read-only root before starting Polaris.
 
 ```bash
 wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-steamos3.8-x86_64.pkg.tar.zst &&
@@ -56,37 +74,8 @@ trap - EXIT
 systemctl --user enable --now polaris
 ```
 
-Bazzite users should follow the exact-output [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/), including its keyring bootstrap and read-only-root restoration. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+Bazzite users should follow the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/); SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
 
-## Changes
+</details>
 
-### Encoding and streaming
-
-- Advertises the encoder backends compiled into the host and accepts a per-session encoder request from a capable client: the host default, explicit Auto with a live probe and fallback, or a strict named backend that fails instead of switching. The request is bound to the deterministic launch envelope, reported in session status, and the host configuration is restored at teardown.
-- Closes FFmpeg's codec-owned picture views before releasing the Vulkan converter and device resources, fixing a Linux Vulkan Video crash at client disconnect, and records bounded teardown phase markers for field verification.
-- Keeps harmless low-latency LAN RTT jitter from reducing the Auto Safe bitrate, and keeps a clean Auto Safe recovery informational in Doctor while confirmed media loss still warns.
-- Records bounded per-session evidence for encoded frames that exceed the four-block FEC protection envelope, without changing packetization or bitrate policy.
-
-### Launch reliability
-
-- Makes machine-facing decimal parsing and formatting locale-independent across `/optimize`, display planning, launch profiles, compositor arguments, and telemetry, and keeps GTK tray initialization from changing Polaris's numeric semantics. A host running under a comma-decimal locale could not launch before this.
-- Captures a labwc startup client's exit status and a bounded, redacted stderr tail when no private-session window appears, so a failed Flatpak or Heroic private-session launch leaves evidence instead of a guess.
-
-### Gamescope sessions on SteamOS, Arch, and manual installs
-
-- Starts the private nested gamescope with `no_new_privs`, keeping the `cap_sys_nice` file capability from hiding the compositor's `/proc` identity from same-user ownership checks. Game Mode is untouched.
-- Runtime-masks the idle compositor unit only on hosts that have one, and repairs a leaked runtime mask on the idempotent stop path, so a standalone package no longer wedges every later launch with `inconsistent gamescope services idle=masked` after one failed start.
-- Classifies the scripts/install layout, an idle compositor unit with the host XDG portal and no private portal unit, as `host-portal` instead of refusing it as inconsistent. That stack had been unable to start a nested session since 2026-08-27.
-- Skips the private portal rebind on hosts without a private portal unit instead of polling an absent bus for eight seconds on every launch and logging a warning that read like a failure.
-- Resolves `polaris-gamescope-session` beside the Polaris binary before PATH, so a copy left under `~/.local/bin` by an earlier manual install cannot shadow the packaged launcher, ships reference copies of the helper modules, and reports at launch when the launcher in use is shadowed or was installed from a different checkout.
-
-## Validation boundary
-
-The SteamOS `no_new_privs` change was verified on the maintainer's NVIDIA host and by the field report's own measurements through a wrapper script, but it has not yet received physical SteamOS validation in packaged form; the reporter's retest on the stock gamescope binary is pending. The scripts/install `host-portal` mode is covered by the stop state machine harness and source contracts rather than a live manual-install host. The encoder selection contract passed the Retroid Pocket 6 Control smoke at 1920x1080, 120 FPS, HEVC with strict NVENC and no fallback, using the per-game encoder client that ships in Nova v1.4.2. Final publication still requires exact merge-SHA CI and signed package verification.
-
-## Official assets
-
-- `Polaris-arch-x86_64.pkg.tar.zst`
-- `Polaris-fedora44-x86_64.rpm`
-- `Polaris-steamos3.8-x86_64.pkg.tar.zst`
-- `Polaris-ubuntu24.04-x86_64.deb`
+**Assets:** `Polaris-fedora44-x86_64.rpm` · `Polaris-arch-x86_64.pkg.tar.zst` · `Polaris-ubuntu24.04-x86_64.deb` · `Polaris-steamos3.8-x86_64.pkg.tar.zst`

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -1361,17 +1361,16 @@ for label, section in (
         )
         sys.exit(1)
 
+# Release notes are the short, user-facing list; the changelog carries the
+# detail. Pin phrases a player would read, never internal identifiers.
 release_notes_facts = (
-    "v1.4.1",
     "Nova v1.4.2",
     "Vulkan Video",
-    "no_new_privs",
-    "cap_sys_nice",
-    "host-portal",
-    "polaris-gamescope-session",
+    "comma decimal",
+    "SteamOS",
     "Steam Input",
     "Retroid Pocket 6",
-    "physical SteamOS validation",
+    "field retest",
     "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
     "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-arch-x86_64.pkg.tar.zst &&",

--- a/src_assets/common/assets/web/release-v142-contract.test.js
+++ b/src_assets/common/assets/web/release-v142-contract.test.js
@@ -61,8 +61,8 @@ describe('v1.4.2 release contract', () => {
     const session = read('nix/modules/polaris-gamescope-session.sh')
     const helper = read('src/platform/linux/gamescope_session_helper.cpp')
 
-    expect(notes).toContain('Auto is the only per-game choice that may fall back')
-    expect(notes).toContain('has not yet received physical SteamOS validation')
+    expect(notes).toContain('an explicit choice never switches on you')
+    expect(notes).toContain('still needs a field retest')
     expect(session).toContain('setpriv --no-new-privs')
     expect(session).toContain("printf 'host-portal\\n'")
     expect(session).toContain('rebind_private_portal_after_nested_start')


### PR DESCRIPTION
## Summary

Release notes become the short, user-facing list; the changelog stays the detailed record.

- `docs/release-notes/v1.4.2.md` rewritten: one-line summary, short **New** / **Fixed** / **Heads up** bullets with no internal identifiers, the four install blocks folded behind a `<details>` block (unchanged commands, still version-pinned), assets on one line. 374 words, down from 966. The GitHub release body for v1.4.2 gets the same text once this merges.
- `docs/release-notes/TEMPLATE.md`: the shape and the rules for the next release (the sync script and the contract tests only consider `vX.Y.Z.md` files, so the template is inert).
- `scripts/check-public-docs.sh`: the v1.4.2 release-notes facts are now user-visible phrases (`Nova v1.4.2`, `Vulkan Video`, `comma decimal`, `SteamOS`, `Steam Input`, `Retroid Pocket 6`, `field retest`) plus the install commands; the internal tokens (`no_new_privs`, `cap_sys_nice`, `host-portal`, `polaris-gamescope-session`) stay pinned through the changelog section, which is unchanged.
- `release-v142-contract.test.js`: the two notes sentences it pinned move to their short forms; the install-block, asset, guide-link, and publication contracts are untouched.

## Exact candidate

`Commit:` `042ee991fd824783bc17599f35cf511adfe1dacc`
`Tree:` `ca7484cbdd43d95e31810c31ca0f60bd038da13c`
`Parent:` `b5673d7ce481c6be252180f204827e0a424d6429`
`Base:` `b5673d7ce481c6be252180f204827e0a424d6429`

## Verification

- [x] `bash scripts/check-public-docs.sh`: clean (all four install commands, setup-host chains, and restart/enable counts still verified)
- [x] `npm run test -- release-v14 packaging-contracts`: 4 files green
- [x] `bash scripts/check-public-surface.sh`, `git diff --check`: clean
- [x] No em dashes, no spaced-hyphen connectors

Follow-ups after merge: `gh release edit v1.4.2 --notes-file docs/release-notes/v1.4.2.md`, and a site PR that re-pins the Polaris notes page to the new commit.
