### PR TITLE
release: prepare Polaris 1.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
     set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
-project(Polaris VERSION 1.4.2
+project(Polaris VERSION 1.4.3
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -530,7 +530,7 @@
         "example": {
           "schema_version": 1,
           "measurement_spec_id": "measurement-spec-v1",
-          "collector_version": "1.4.2",
+          "collector_version": "1.4.3",
           "clock_domain": "CLOCK_MONOTONIC",
           "run_id": "pair-0001-control",
           "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,12 +7,18 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+## v1.4.3 - 2026-09-05
+
+A diagnostics and packaging update matched with Nova v1.4.3. Doctor names the gamescope session helper Polaris will run, the console and Nova get a coded answer when an artwork search fails, partial configuration writes merge instead of rewriting the file, and an experimental systemd system extension image joins the packages for rpm-ostree hosts. Existing configurations and paired devices remain valid.
+
 - Shows a Gamescope Session Helper card in Doctor & Support on Linux hosts configured for `gamescope_stream`, naming the launcher Polaris will run, a stale copy shadowing it on PATH, and a launcher or runtime library installed from a different checkout
+- Falls back to the bundled `polaris-gamescope-session` reference copy when no launcher is installed beside the binary or on PATH, so AppImage and build-tree hosts can start private sessions, and adds a shell test that exercises the gamescope stack installer
 - Adds `PATCH /api/config`, which merges a partial write onto the existing configuration instead of rewriting the file from the request body the way `POST` does, and logs how many existing keys a `POST` left out
 - Names the cause when an artwork search fails: the Nova-facing candidate search and the console cover search now answer with a stable code for a missing SteamGridDB key, a rejected key, rate limiting, or an unreachable provider instead of a bare status or an empty result
 - Names the field when explicit launch fields are rejected, including the value seen, so a comma-decimal `fps` or a lock flag without its prerequisite no longer reads as "must be complete and within supported bounds"
 - Tells the console when the installed Polaris package is newer than the running process, which is what a package upgrade without a service restart looks like
 - Publishes `Polaris-sysext-x86_64.raw`, the Fedora 44 RPM repacked as an experimental systemd system extension so rpm-ostree hosts such as Bazzite can run Polaris without layering a package or rebooting
+- Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official package assets
 
 ## v1.4.2 - 2026-09-04
 

--- a/docs/release-notes/v1.4.3.md
+++ b/docs/release-notes/v1.4.3.md
@@ -1,0 +1,80 @@
+# Polaris v1.4.3
+
+Diagnostics and packaging update, matched with Nova v1.4.3. Existing settings and paired devices keep working.
+
+**New**
+
+- Doctor shows the gamescope session helper Polaris will run and flags a stale or shadowed copy.
+- Hosts without an installed session launcher use the bundled one, so AppImage and build tree runs can start private sessions.
+- Artwork search failures say why: missing SteamGridDB key, rejected key, rate limit, or unreachable provider.
+- Partial settings writes merge into the existing configuration instead of rewriting it.
+- An experimental systemd system extension image for rpm-ostree hosts such as Bazzite, alongside the packages.
+
+**Fixed**
+
+- Rejected launch fields name the field and the value seen instead of a generic bounds message.
+- The console says when the installed package is newer than the running Polaris and a restart is due.
+
+**Heads up**
+
+- The system extension image is unproven on a real Bazzite host.
+- SteamOS: the 1.4.2 gamescope fix is confirmed on a Steam Deck with stock gamescope.
+- Steam Input stays manual and read-only.
+- Verified with Nova v1.4.3 on a Retroid Pocket 6 against a 1.4.2 host; the 1.4.3 host build is CI verified.
+
+<details>
+<summary><b>Install</b> (Fedora 44, Arch / CachyOS, Ubuntu 24.04, SteamOS 3.8)</summary>
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### SteamOS 3.8
+
+Run this in Desktop Mode. It sets up the package keyring when needed and restores the read-only root before starting Polaris.
+
+```bash
+wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-steamos3.8-x86_64.pkg.tar.zst &&
+(
+set -e
+trap 'sudo steamos-readonly enable' EXIT
+sudo steamos-readonly disable || exit $?
+sudo pacman-key --init || exit $?
+sudo pacman-key --populate || exit $?
+sudo pacman -Sy || exit $?
+sudo pacman -U ./Polaris-steamos3.8-x86_64.pkg.tar.zst || exit $?
+sudo -H polaris --setup-host || exit $?
+sudo steamos-readonly enable || exit $?
+trap - EXIT
+) &&
+systemctl --user enable --now polaris
+```
+
+Bazzite users should follow the [Bazzite guide](https://papi-ux.com/docs/bazzite/). SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/); SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+
+</details>
+
+**Assets:** `Polaris-fedora44-x86_64.rpm` · `Polaris-arch-x86_64.pkg.tar.zst` · `Polaris-ubuntu24.04-x86_64.deb` · `Polaris-steamos3.8-x86_64.pkg.tar.zst` · `Polaris-sysext-x86_64.raw` (experimental)

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.4.2') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.4.3') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -665,7 +665,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.4.2.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.4.3.md").read_text(encoding="utf-8")
 )
 
 
@@ -1296,18 +1296,18 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.4.3 - 2026-09-05",
     "## v1.4.2 - 2026-09-04",
-    "## v1.4.1 - 2026-09-03",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "Vulkan Video",
-    "encoder",
-    "locale",
-    "no_new_privs",
-    "host-portal",
+    "Gamescope Session Helper",
     "polaris-gamescope-session",
-    "FEC",
+    "PATCH",
+    "SteamGridDB",
+    "explicit launch fields",
+    "installed Polaris package",
+    "system extension",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
     "Polaris-steamos3.8-x86_64.pkg.tar.zst",
@@ -1315,7 +1315,7 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.4.2 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.3 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1324,7 +1324,7 @@ asset_phrase = (
     "`Polaris-steamos3.8-x86_64.pkg.tar.zst`, and "
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
-for label, section in (("v1.4.2 changelog", current_release_prose),):
+for label, section in (("v1.4.3 changelog", current_release_prose),):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
         sys.exit(1)
@@ -1345,7 +1345,7 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section in (
     ("docs/building.md Packaging", building_packaging_prose),
-    ("v1.4.2 changelog", current_release_prose),
+    ("v1.4.3 changelog", current_release_prose),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     for optional_asset in optional_assets:
@@ -1364,20 +1364,21 @@ for label, section in (
 # Release notes are the short, user-facing list; the changelog carries the
 # detail. Pin phrases a player would read, never internal identifiers.
 release_notes_facts = (
-    "Nova v1.4.2",
-    "Vulkan Video",
-    "comma decimal",
+    "Nova v1.4.3",
+    "SteamGridDB",
+    "system extension",
+    "Bazzite",
     "SteamOS",
     "Steam Input",
     "Retroid Pocket 6",
-    "field retest",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-fedora44-x86_64.rpm &&",
+    "stale or shadowed copy",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
-    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.2/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
     "trap 'sudo steamos-readonly enable' EXIT",
     "sudo pacman-key --init || exit $?",
     "sudo pacman-key --populate || exit $?",
@@ -1385,7 +1386,7 @@ release_notes_facts = (
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.4.2 release notes are missing release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.3 release notes are missing release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 for forbidden in (
     "history_safe",
@@ -1394,19 +1395,19 @@ for forbidden in (
     "AI Auto Quality Preference",
 ):
     if forbidden in current_release_prose or forbidden in release_notes:
-        print(f"v1.4.2 public release scope must exclude: {forbidden}", file=sys.stderr)
+        print(f"v1.4.3 public release scope must exclude: {forbidden}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.4.2 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.4.3 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host || exit $?") != 1:
-    print("v1.4.2 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
+    print("v1.4.3 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.4.2 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.4.3 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user enable --now polaris") != 1:
-    print("v1.4.2 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
+    print("v1.4.3 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
     sys.exit(1)
 
 release_workflow = Path(".github/workflows/build.yml").read_text(encoding="utf-8")

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.2-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.3-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -776,7 +776,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.4.2-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.4.3-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v142-contract.test.js
+++ b/src_assets/common/assets/web/release-v142-contract.test.js
@@ -1,16 +1,10 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
-const expectedAssets = [
-  'Polaris-arch-x86_64.pkg.tar.zst',
-  'Polaris-fedora44-x86_64.rpm',
-  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
-  'Polaris-ubuntu24.04-x86_64.deb',
-].sort()
 
-const currentChangelog = () => {
+const historicalRelease = () => {
   const changelog = read('docs/changelog.md')
   const start = changelog.indexOf('## v1.4.2 - 2026-09-04')
   const end = changelog.indexOf('## v1.4.1 - 2026-09-03')
@@ -19,27 +13,18 @@ const currentChangelog = () => {
   return changelog.slice(start, end)
 }
 
-const releaseNotes = () => read('docs/release-notes/v1.4.2.md')
-const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
-  .map((match) => match[1])
-  .filter((block) => block.includes('wget --output-document='))
+const historicalNotes = () => read('docs/release-notes/v1.4.2.md')
 
-describe('v1.4.2 release contract', () => {
-  it('moves every current release identity to v1.4.2', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.2')
-    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.2"')
-    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.2')
-    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.2-1|x86_64'")
-    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.2-1|x86_64'")
-  })
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
 
-  it('makes v1.4.1 historical and promotes the complete v1.4.2 scope', () => {
-    expect(read('src_assets/common/assets/web/release-v141-contract.test.js')).toContain("describe('historical v1.4.1 release contract'")
-    const gate = read('scripts/check-public-docs.sh')
-    expect(gate).toContain('docs/release-notes/v1.4.2.md')
-    expect(gate).toContain('"## v1.4.2 - 2026-09-04"')
-
-    const release = `${currentChangelog()}\n${releaseNotes()}`
+describe('historical v1.4.2 release contract', () => {
+  it('preserves the strict encoder, locale, and SteamOS capability scope', () => {
+    const evidence = `${historicalRelease()}\n${historicalNotes()}`
     for (const fact of [
       'Vulkan Video',
       'encoder',
@@ -52,81 +37,22 @@ describe('v1.4.2 release contract', () => {
       'Nova v1.4.2',
       'Retroid Pocket 6',
     ]) {
-      expect(release, `release must include: ${fact}`).toContain(fact)
+      expect(evidence, `historical v1.4.2 must include: ${fact}`).toContain(fact)
     }
   })
 
-  it('documents the strict encoder contract and the SteamOS capability fix against the source', () => {
-    const notes = releaseNotes()
-    const session = read('nix/modules/polaris-gamescope-session.sh')
-    const helper = read('src/platform/linux/gamescope_session_helper.cpp')
-
-    expect(notes).toContain('an explicit choice never switches on you')
-    expect(notes).toContain('still needs a field retest')
-    expect(session).toContain('setpriv --no-new-privs')
-    expect(session).toContain("printf 'host-portal\\n'")
-    expect(session).toContain('rebind_private_portal_after_nested_start')
-    expect(helper).toContain('polaris-gamescope-session')
-  })
-
-  it('pins all four install commands to v1.4.2 and preserves platform safety', () => {
-    const blocks = installBlocks()
-    expect(blocks).toHaveLength(4)
-    for (const asset of expectedAssets) {
-      const matches = blocks.filter((block) => block.includes(`/${asset}`))
-      expect(matches, `one command block for ${asset}`).toHaveLength(1)
-      expect(matches[0]).toContain(`releases/download/v1.4.2/${asset}`)
-      expect(matches[0]).toContain('sudo -H polaris --setup-host')
-    }
-
-    for (const asset of [
-      'Polaris-arch-x86_64.pkg.tar.zst',
-      'Polaris-fedora44-x86_64.rpm',
-      'Polaris-ubuntu24.04-x86_64.deb',
-    ]) {
-      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
-      expect(block).toContain('systemctl --user restart polaris')
-    }
-
-    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
-    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
-    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
-    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
-    expect(steamOs).toContain('systemctl --user enable --now polaris')
-
-    const listed = [...new Set(releaseNotes().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+  it('preserves the exact historical assets and install identities', () => {
+    const notes = historicalNotes()
+    const listed = [...new Set(notes.match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
     expect(listed.sort()).toEqual(expectedAssets)
-  })
 
-  it('publishes release-note guide links that work outside the source tree', () => {
-    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
-    const notes = readdirSync(releaseNotesDir)
-      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
-      .map((name) => read(`docs/release-notes/${name}`))
-      .join('\n')
-
-    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
-    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
-    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
-  })
-
-  it('keeps publication bound to one verified immutable source', () => {
-    const workflow = read('.github/workflows/build.yml')
-    const ordered = [
-      '- name: Check out exact release source',
-      '- name: Revalidate release tag against packaged source',
-      '- name: Stage curated GitHub release',
-      '- name: Upload release assets to GitHub release',
-      '- name: Verify release assets on GitHub release',
-      '- name: Publish verified draft release',
-    ]
-    const positions = ordered.map((step) => workflow.indexOf(step))
-    expect(positions.every((position) => position >= 0)).toBe(true)
-    expect(positions).toEqual([...positions].sort((a, b) => a - b))
-    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
-    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
-    expect(workflow).toContain('--verify-tag')
-    expect(workflow).toContain('--notes-file "$release_notes"')
-    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
+    const blocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
+    expect(blocks).toHaveLength(4)
+    for (const block of blocks) {
+      expect(block).toContain('releases/download/v1.4.2/')
+      expect(block).toContain('polaris --setup-host')
+    }
   })
 })

--- a/src_assets/common/assets/web/release-v143-contract.test.js
+++ b/src_assets/common/assets/web/release-v143-contract.test.js
@@ -1,0 +1,135 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+const packageAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+const sysextAsset = 'Polaris-sysext-x86_64.raw'
+
+const currentChangelog = () => {
+  const changelog = read('docs/changelog.md')
+  const start = changelog.indexOf('## v1.4.3 - 2026-09-05')
+  const end = changelog.indexOf('## v1.4.2 - 2026-09-04')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return changelog.slice(start, end)
+}
+
+const releaseNotes = () => read('docs/release-notes/v1.4.3.md')
+const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
+  .map((match) => match[1])
+  .filter((block) => block.includes('wget --output-document='))
+
+describe('v1.4.3 release contract', () => {
+  it('moves every current release identity to v1.4.3', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.3')
+    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.3"')
+    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.3')
+    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.3-1|x86_64'")
+    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.3-1|x86_64'")
+  })
+
+  it('makes v1.4.2 historical and promotes the complete v1.4.3 scope', () => {
+    expect(read('src_assets/common/assets/web/release-v142-contract.test.js')).toContain("describe('historical v1.4.2 release contract'")
+    const gate = read('scripts/check-public-docs.sh')
+    expect(gate).toContain('docs/release-notes/v1.4.3.md')
+    expect(gate).toContain('"## v1.4.3 - 2026-09-05"')
+
+    const release = `${currentChangelog()}\n${releaseNotes()}`
+    for (const fact of [
+      'Gamescope Session Helper',
+      'polaris-gamescope-session',
+      'PATCH',
+      'SteamGridDB',
+      'explicit launch fields',
+      'installed Polaris package',
+      'system extension',
+      'Nova v1.4.3',
+      'Retroid Pocket 6',
+    ]) {
+      expect(release, `release must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('documents the merge write, the coded artwork failures, and the extension image against the source', () => {
+    const notes = releaseNotes()
+    const confighttp = read('src/confighttp.cpp')
+    const artwork = read('src/game_artwork_manual.cpp')
+    const helper = read('src/platform/linux/gamescope_session_helper.cpp')
+    const workflow = read('.github/workflows/build.yml')
+
+    expect(notes).toContain('stale or shadowed copy')
+    expect(notes).toContain('unproven on a real Bazzite host')
+    expect(confighttp).toContain('patchConfig')
+    expect(artwork).toContain('classify_search_failure')
+    expect(helper).toContain('bundled')
+    expect(workflow).toContain('scripts/ci/build-sysext-image.sh')
+    expect(workflow).toContain(`release-assets/final/${sysextAsset}`)
+  })
+
+  it('pins all four install commands to v1.4.3 and lists the extension image beside the packages', () => {
+    const blocks = installBlocks()
+    expect(blocks).toHaveLength(4)
+    for (const asset of packageAssets) {
+      const matches = blocks.filter((block) => block.includes(`/${asset}`))
+      expect(matches, `one command block for ${asset}`).toHaveLength(1)
+      expect(matches[0]).toContain(`releases/download/v1.4.3/${asset}`)
+      expect(matches[0]).toContain('sudo -H polaris --setup-host')
+    }
+
+    for (const asset of [
+      'Polaris-arch-x86_64.pkg.tar.zst',
+      'Polaris-fedora44-x86_64.rpm',
+      'Polaris-ubuntu24.04-x86_64.deb',
+    ]) {
+      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+
+    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
+    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
+    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
+    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
+    expect(steamOs).toContain('systemctl --user enable --now polaris')
+
+    const listed = [...new Set(releaseNotes().match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+    expect(listed.sort()).toEqual([...packageAssets, sysextAsset].sort())
+  })
+
+  it('publishes release-note guide links that work outside the source tree', () => {
+    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
+    const notes = readdirSync(releaseNotesDir)
+      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
+      .map((name) => read(`docs/release-notes/${name}`))
+      .join('\n')
+
+    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
+    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
+    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
+  })
+
+  it('keeps publication bound to one verified immutable source', () => {
+    const workflow = read('.github/workflows/build.yml')
+    const ordered = [
+      '- name: Check out exact release source',
+      '- name: Revalidate release tag against packaged source',
+      '- name: Stage curated GitHub release',
+      '- name: Upload release assets to GitHub release',
+      '- name: Verify release assets on GitHub release',
+      '- name: Publish verified draft release',
+    ]
+    const positions = ordered.map((step) => workflow.indexOf(step))
+    expect(positions.every((position) => position >= 0)).toBe(true)
+    expect(positions).toEqual([...positions].sort((a, b) => a - b))
+    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
+    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
+    expect(workflow).toContain('--verify-tag')
+    expect(workflow).toContain('--notes-file "$release_notes"')
+    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
+  })
+})


### PR DESCRIPTION
## Summary

- Release identities move to 1.4.3: `CMakeLists.txt`, the benchmark collector version, the namcap review file, `build-steamos-package.sh`, and `packaging-contracts.test.js`.
- `docs/changelog.md`: the Unreleased bullets become `## v1.4.3 - 2026-09-05` with a one line summary, a bullet for the bundled launcher fallback from #609 (which shipped without one), and the four asset sentence. `Polaris-sysext-x86_64.raw` is named once in its own bullet, which the gate allows as the optional fifth asset.
- `docs/release-notes/v1.4.3.md` in the short template: New, Fixed, Heads up, the four install blocks pinned to v1.4.3, assets on one line with the experimental extension image beside the packages. Heads up says the extension image is unproven on Bazzite, the SteamOS fix is confirmed on a Steam Deck (#599 retest), and the Nova v1.4.3 device pass ran against a 1.4.2 host.
- `scripts/check-public-docs.sh` moves to the v1.4.3 notes, heading pair, release facts, and install lines; `release-v143-contract.test.js` pins the identities, the phrases, the source (`patchConfig`, `classify_search_failure`, the bundled helper fallback, the sysext workflow step), and the five listed assets; `release-v142-contract.test.js` becomes historical.

## Exact candidate

- `Commit:` fedaed23099cc752c69681b46e8769749dce6b21
- `Tree:` 07fb5c8449811c195de2a3005ada4330025e4f24
- `Parent:` 891b289e6cbce2a0b6ddf2bc3683297e51530b53
- `Base:` master at 891b289e6cbce2a0b6ddf2bc3683297e51530b53

## Verification

- [x] `bash scripts/check-public-docs.sh`: clean
- [x] `npx vitest run` on `release-v143-contract.test.js` (6), `release-v142-contract.test.js` (2), `release-v141-contract.test.js` (2), `packaging-contracts.test.js` (28): 38 passed
- [ ] Tag build: `v1.4.3` will be tagged at the squash merge and must publish the four packages plus `Polaris-sysext-x86_64.raw` with these notes.

The matched Nova 1.4.3 (papi-ux/nova#281 plus the release prep) is cut alongside this.
