### PR TITLE
fix(linux): harden setup-host and Bazzite validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Verify build scope classifier
         run: tests/scripts/test_classify_native_build.sh
 
+      - name: Verify Bazzite validation receipt gate
+        run: python3 scripts/validation/bazzite/test_validate_receipt.py
+
       - name: Bind release tag to source commit
         id: source
         env:

--- a/scripts/validation/bazzite/README.md
+++ b/scripts/validation/bazzite/README.md
@@ -1,0 +1,159 @@
+# Bazzite validation gate
+
+Publication remains disabled for the standalone Polaris system extension. This directory defines the evidence required before that decision can be reconsidered. Passing structural image checks is not enough.
+
+The supported Fedora 44 RPM path remains separate. Its dependencies may be resolved by `rpm-ostree`; a standalone system extension must carry every runtime dependency not already guaranteed by the target image.
+
+## Required targets
+
+Every candidate is bound to one exact SHA-256 digest and one exact source commit. The same bytes must pass both current Fedora 44 targets:
+
+- `bazzite` for the AMD and Intel image family
+- `bazzite-nvidia-open` for the NVIDIA open-kernel-module image family
+
+VM evidence may satisfy package, boot, reboot, removal, rollback, shared `/var`, recovery, and SELinux lifecycle gates. It cannot satisfy capture, encode, or streaming gates. Those require the matching physical GPU family.
+
+## Safety invariants
+
+1. Use an isolated VM, snapshot, or dedicated validation host. Never experiment on a recovered community machine.
+2. Pin the installer checksum, target image digest, candidate digest, source commit, and every booted deployment checksum in the receipt.
+3. Keep candidate artifacts in a private validation path. Do not upload them to releases or Actions artifacts.
+4. Validate candidate identity before any package-manager or extension operation.
+5. For RPM validation, stage with `rpm-ostree install -r` and inspect the pending deployment before rebooting.
+6. For a future system-extension candidate, prove ELF closure and execution before copying anything into `/var/lib/extensions`.
+7. `setup-host` runs only after the installed deployment boots, package identity matches, every ELF dependency resolves, and SELinux is enforcing.
+8. Never automate a reboot in the same command that stages a deployment. Capture state first, then reboot as a separate controlled transition.
+9. Failed installation or host setup must leave no enabled service, persistent extension, pending deployment, stale staged package, or unexplained host file.
+10. An ostree rollback does not imply `/var` rollback. Test and record shared `/var` behavior explicitly.
+
+## Lifecycle sequence
+
+### 0. Artifact identity
+
+Record the artifact filename, SHA-256, RPM NEVRA or extension metadata, source commit, target image digest, and acquisition URL. The `artifact_identity` result passes only when every later stage references the same candidate digest.
+
+### 1. Dependency and ELF closure
+
+For an RPM candidate, run a package-manager transaction simulation against each target inventory and record the exact dependency transaction as `repo_resolution`. After layering and booting, inventory every ELF executable and shared library from the candidate and require zero unresolved `DT_NEEDED` entries for `elf_closure`.
+
+For a system-extension candidate, `elf_closure` must pass using only the extension payload plus libraries guaranteed by the exact target image. Repository availability does not repair a standalone image.
+
+### 2. Clean baseline
+
+Boot the exact Fedora 44 target and record:
+
+- Bazzite image reference and immutable digest
+- current and rollback deployment checksums
+- `getenforce` output
+- package absence
+- service and host-integration file absence
+- `/var/lib/extensions` inventory
+- a unique shared-`/var` marker
+
+The baseline contributes to `selinux_enforcing` and anchors all later diffs.
+
+### 3. Failure injection before persistence
+
+Exercise two bounded failures on a disposable snapshot:
+
+1. Reject a wrong candidate digest before invoking `rpm-ostree` or `systemd-sysext`.
+2. Force the installation command to fail and verify that no pending deployment, persistent extension, enabled service, or staged candidate remains.
+
+Record `install_failure_cleanup` only after the complete before/after state diff passes.
+
+Then force `polaris --setup-host` to fail after the package has booted but before service startup. Verify that partial udev, module-load, capability, and service state is removed. Record that result as `setup_failure_cleanup`.
+
+### 4. Install and first boot
+
+Stage the candidate without rebooting. Confirm the current deployment is unchanged and the pending deployment is bound to the expected candidate digest. Record `install` only after that inspection.
+
+Reboot as a separate transition. Record `first_boot` only when the expected deployment is booted, package identity matches, the executable starts for a non-streaming probe, `elf_closure` still passes, and `selinux_enforcing` remains true.
+
+Only then run host setup. Capture all files, capabilities, udev state, modules, service state, and audit events it changes.
+
+### 5. Second boot and SELinux
+
+Reboot again without altering the deployment. Record `second_boot` only when the same deployment and candidate digest return healthy.
+
+Exercise the installed binary and host integration. Query AVC and USER_AVC events from the bounded test window. `selinux_avc_clean` passes only when there are no unexplained denials and enforcing mode stayed active for the whole window.
+
+### 6. Deployment rollback and shared `/var`
+
+Keep the unique `/var` marker, then roll back to the clean deployment and reboot. Record `deployment_rollback` only when the package and immutable `/usr` changes are gone.
+
+Record `shared_var_rollback` only after proving the marker persisted across rollback and documenting the state of `/var/lib/extensions`. For a system-extension candidate, prove that rollback alone does not remove the persistent image, then remove it through the tested recovery path before the next boot.
+
+### 7. Removal
+
+Return to the candidate deployment if needed, remove the layered package or validation extension, and reboot. Record `removal` only when the package, service, capabilities, host-integration files, pending deployment, staged candidate, and persistent extension are all absent or explicitly restored to their baseline state.
+
+### 8. Live-media recovery
+
+From a separate live environment, mount the guest or validation host's Btrfs-backed system volume using the same layout exposed by Bazzite. Locate shared `/var`, remove only the validation candidate, flush writes, unmount cleanly, and boot the installed system. Record `live_media_recovery` only after the normal deployment boots and the exact removed path remains absent.
+
+### 9. Physical driver validation
+
+On matching physical hardware for each target, record all three `hardware_results` as pass:
+
+- `capture` - the expected display and capture path initializes
+- `encode` - the expected hardware encoder is selected and produces frames
+- `stream` - a bounded client session connects, renders, accepts input, and disconnects cleanly
+
+Do not translate VM rendering, software encoding, or package-manager success into physical GPU evidence.
+
+## Receipt validation
+
+A final receipt must set every required result to the literal string `pass`. Values such as `skip`, `blocked`, `pending`, `not-applicable`, or `fail` are intentionally rejected.
+
+### Receipt identity contract
+
+The receipt root uses `schema_version: 1` as a JSON integer and records `captured_at_utc` as an exact `YYYY-MM-DDTHH:MM:SSZ` timestamp using ASCII digits.
+
+The `candidate` object records:
+
+- `kind` as `rpm` or `sysext`, with a matching `.rpm` or `.raw` filename
+- `name`, `version`, and the declared artifact SHA-256
+- `candidate.path`, a candidate file path relative to the receipt directory; the validator hashes these exact bytes and requires the basename to match `name`
+- `source_commit` and `source_tree` as exact 40-character lowercase Git object IDs
+- `build_mode` as the literal `release`
+- `acquisition_url` as a stable absolute HTTPS URL with no embedded credentials, query parameters or fragments
+
+Each target records:
+
+- `bazzite_version` in exact `44.YYYYMMDD` form
+- `image_reference` as `ghcr.io/ublue-os/<variant>@<image_digest>`, bound to the target's immutable digest
+- `deployment_checksums` for `baseline`, `first_boot`, `second_boot`, `post_rollback`, and `post_removal`; `second_boot` must equal `first_boot`, while `post_rollback` and `post_removal` must equal `baseline`
+- `first_boot` must differ from `baseline` for RPM candidates, proving the layered deployment actually booted
+- `first_boot` must equal `baseline` for system extensions, which must not alter the OSTree deployment
+- `hardware.environment` as the literal `physical`, plus `gpu_model`, `pci_id`, and `kernel_driver`; the standard image accepts AMD vendor `1002` with `amdgpu` or Intel vendor `8086` with `i915`/`xe`, while NVIDIA-open requires vendor `10de` with `nvidia`
+- every lifecycle `results` and `hardware_results` value as the literal `pass`
+- `evidence`, mapping every required lifecycle and hardware gate to one or more `{path, sha256}` records
+
+JSON parsing rejects duplicate JSON members at every nesting level. Candidate and evidence paths are relative to the receipt directory. Absolute paths, `..` traversal, backslash paths, symlinks, missing files, non-regular files including FIFOs, and SHA-256 mismatches are rejected without blocking. Hashing uses descriptor-relative opens with `O_NOFOLLOW` and `O_NONBLOCK`, hashes the opened descriptor, verifies its metadata did not change during the read, and never reuses a pathname hash cache. One evidence file may support several gates, but reviewers must verify that its contents actually prove each referenced gate.
+
+Run:
+
+```bash
+python3 scripts/validation/bazzite/validate_receipt.py RECEIPT.json
+```
+
+A `ready` result proves that the receipt is complete, internally consistent, and hash-bound to local files. It does not authorize uploading, publishing, or restoring the standalone system-extension release path. Publication remains disabled until an explicit review decision after all evidence is inspected.
+
+The validator requires these target results:
+
+- `artifact_identity`
+- `repo_resolution`
+- `elf_closure`
+- `selinux_enforcing`
+- `selinux_avc_clean`
+- `install_failure_cleanup`
+- `setup_failure_cleanup`
+- `install`
+- `first_boot`
+- `second_boot`
+- `removal`
+- `deployment_rollback`
+- `shared_var_rollback`
+- `live_media_recovery`
+
+It also requires `capture`, `encode`, and `stream` hardware results for both target families. A validator success means the receipt is complete and internally consistent. Reviewers must still inspect the referenced immutable evidence before any publication decision.

--- a/scripts/validation/bazzite/test_validate_receipt.py
+++ b/scripts/validation/bazzite/test_validate_receipt.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+import copy
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("validate_receipt.py")
+ROOT = Path(__file__).resolve().parents[3]
+CANDIDATE_CONTENT = b"private Polaris release candidate\n"
+SHA = hashlib.sha256(CANDIDATE_CONTENT).hexdigest()
+CANDIDATE_PATH = "candidate/Polaris-fedora44-x86_64.rpm"
+SYSEXT_CANDIDATE_PATH = "candidate/Polaris-sysext-x86_64.raw"
+EVIDENCE_CONTENT = b"immutable bazzite validation evidence\n"
+EVIDENCE_PATH = "evidence/validation.log"
+EVIDENCE_SHA = hashlib.sha256(EVIDENCE_CONTENT).hexdigest()
+COMMON_GATES = (
+    "artifact_identity",
+    "repo_resolution",
+    "elf_closure",
+    "selinux_enforcing",
+    "selinux_avc_clean",
+    "install_failure_cleanup",
+    "setup_failure_cleanup",
+    "install",
+    "first_boot",
+    "second_boot",
+    "removal",
+    "deployment_rollback",
+    "shared_var_rollback",
+    "live_media_recovery",
+)
+HARDWARE_GATES = ("capture", "encode", "stream")
+ALL_GATES = COMMON_GATES + HARDWARE_GATES
+
+
+def passing_receipt() -> dict:
+    def target(variant: str, driver: str, image_digest: str) -> dict:
+        return {
+            "variant": variant,
+            "driver": driver,
+            "fedora_version": 44,
+            "bazzite_version": "44.20260902",
+            "image_digest": image_digest,
+            "image_reference": f"ghcr.io/ublue-os/{variant}@{image_digest}",
+            "candidate_sha256": SHA,
+            "deployment_checksums": {
+                "baseline": "d" * 64,
+                "first_boot": "e" * 64,
+                "second_boot": "e" * 64,
+                "post_rollback": "d" * 64,
+                "post_removal": "d" * 64,
+            },
+            "hardware": {
+                "environment": "physical",
+                "gpu_model": (
+                    "NVIDIA GeForce RTX 4090"
+                    if driver == "nvidia-open"
+                    else "AMD Radeon RX 7900 XTX"
+                ),
+                "pci_id": "10de:2684" if driver == "nvidia-open" else "1002:744c",
+                "kernel_driver": "nvidia" if driver == "nvidia-open" else "amdgpu",
+            },
+            "results": {gate: "pass" for gate in COMMON_GATES},
+            "hardware_results": {
+                "capture": "pass",
+                "encode": "pass",
+                "stream": "pass",
+            },
+            "evidence": {
+                gate: [{"path": EVIDENCE_PATH, "sha256": EVIDENCE_SHA}]
+                for gate in ALL_GATES
+            },
+        }
+
+    return {
+        "schema_version": 1,
+        "captured_at_utc": "2026-09-06T01:17:10Z",
+        "candidate": {
+            "kind": "rpm",
+            "name": "Polaris-fedora44-x86_64.rpm",
+            "path": CANDIDATE_PATH,
+            "sha256": SHA,
+            "version": "1.4.3-1",
+            "source_commit": "1" * 40,
+            "source_tree": "2" * 40,
+            "build_mode": "release",
+            "acquisition_url": "https://validation.invalid/polaris/candidate",
+        },
+        "targets": [
+            target("bazzite", "amd-intel", "sha256:" + "b" * 64),
+            target("bazzite-nvidia-open", "nvidia-open", "sha256:" + "c" * 64),
+        ],
+    }
+
+
+class ReceiptValidatorTests(unittest.TestCase):
+    def run_validator(
+        self,
+        receipt: dict,
+        *,
+        candidate_content: bytes | None = CANDIDATE_CONTENT,
+        candidate_relative_path: str = CANDIDATE_PATH,
+        evidence_content: bytes = EVIDENCE_CONTENT,
+        evidence_fifo: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        return self.run_serialized_receipt(
+            json.dumps(receipt),
+            candidate_content=candidate_content,
+            candidate_relative_path=candidate_relative_path,
+            evidence_content=evidence_content,
+            evidence_fifo=evidence_fifo,
+        )
+
+    def run_serialized_receipt(
+        self,
+        serialized_receipt: str,
+        *,
+        candidate_content: bytes | None = CANDIDATE_CONTENT,
+        candidate_relative_path: str = CANDIDATE_PATH,
+        evidence_content: bytes = EVIDENCE_CONTENT,
+        evidence_symlink_target: Path | None = None,
+        evidence_fifo: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            if candidate_content is not None:
+                candidate_path = root / candidate_relative_path
+                candidate_path.parent.mkdir(parents=True)
+                candidate_path.write_bytes(candidate_content)
+            evidence_path = root / EVIDENCE_PATH
+            evidence_path.parent.mkdir(parents=True)
+            if evidence_fifo:
+                os.mkfifo(evidence_path)
+            elif evidence_symlink_target is None:
+                evidence_path.write_bytes(evidence_content)
+            else:
+                evidence_path.symlink_to(evidence_symlink_target)
+            path = root / "receipt.json"
+            path.write_text(serialized_receipt, encoding="utf-8")
+            return subprocess.run(
+                ["python3", str(SCRIPT), str(path)],
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=3,
+            )
+
+    def test_accepts_complete_matrix(self) -> None:
+        result = self.run_validator(passing_receipt())
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["status"], "ready")
+        self.assertEqual(report["candidate_sha256"], SHA)
+        self.assertEqual(report["targets"], ["bazzite", "bazzite-nvidia-open"])
+
+    def test_rejects_non_integer_schema_version(self) -> None:
+        for value in (True, 1.0):
+            with self.subTest(value=value):
+                receipt = passing_receipt()
+                receipt["schema_version"] = value
+                result = self.run_validator(receipt)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("schema_version must be integer 1", result.stderr)
+
+    def test_rejects_duplicate_json_members(self) -> None:
+        serialized = json.dumps(passing_receipt()).replace(
+            '"schema_version": 1',
+            '"schema_version": 99, "schema_version": 1',
+            1,
+        )
+        result = self.run_serialized_receipt(serialized)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("duplicate JSON member: schema_version", result.stderr)
+
+    def test_rejects_missing_gate_evidence(self) -> None:
+        receipt = passing_receipt()
+        del receipt["targets"][0]["evidence"]["first_boot"]
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("bazzite.evidence.first_boot is missing", result.stderr)
+
+    def test_rejects_tampered_evidence_bytes(self) -> None:
+        result = self.run_validator(passing_receipt(), evidence_content=b"tampered\n")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("bazzite.evidence.artifact_identity[0] sha256 mismatch", result.stderr)
+
+    def test_rejects_evidence_path_escape(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["evidence"]["artifact_identity"][0]["path"] = "../outside.log"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.evidence.artifact_identity[0].path must stay below the receipt directory",
+            result.stderr,
+        )
+
+    def test_rejects_symlinked_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            external = Path(directory) / "outside.log"
+            external.write_bytes(EVIDENCE_CONTENT)
+            result = self.run_serialized_receipt(
+                json.dumps(passing_receipt()),
+                evidence_symlink_target=external,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.evidence.artifact_identity[0].path does not exist or is not a regular file",
+            result.stderr,
+        )
+
+    def test_hashing_uses_descriptor_relative_nofollow_opens_without_a_path_cache(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("os.O_NOFOLLOW", source)
+        self.assertIn("dir_fd=", source)
+        self.assertIn("os.fstat", source)
+        self.assertNotIn("hash_cache", source)
+        self.assertNotIn('resolved_path.open("rb")', source)
+
+    def test_rejects_fifo_evidence_without_blocking(self) -> None:
+        result = self.run_validator(passing_receipt(), evidence_fifo=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not exist or is not a regular file", result.stderr)
+
+    def test_rejects_nul_in_evidence_path_without_a_traceback(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["evidence"]["artifact_identity"][0]["path"] = (
+            "evidence/validation.log\x00outside"
+        )
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be a safe relative path", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_rejects_missing_required_gate(self) -> None:
+        receipt = passing_receipt()
+        del receipt["targets"][0]["results"]["live_media_recovery"]
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("bazzite.results.live_media_recovery is missing", result.stderr)
+
+    def test_rejects_nonpassing_gate(self) -> None:
+        for value in ("fail", "blocked", "skip", "pending"):
+            with self.subTest(value=value):
+                receipt = passing_receipt()
+                receipt["targets"][1]["results"]["selinux_avc_clean"] = value
+                result = self.run_validator(receipt)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    f"bazzite-nvidia-open.results.selinux_avc_clean must be pass, got {value}",
+                    result.stderr,
+                )
+
+    def test_rejects_hardware_gate_that_was_not_exercised(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][1]["hardware_results"]["stream"] = "not-applicable"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite-nvidia-open.hardware_results.stream must be pass, got not-applicable",
+            result.stderr,
+        )
+
+    def test_rejects_virtual_hardware_evidence(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["hardware"]["environment"] = "vm"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("bazzite.hardware.environment must be physical, got vm", result.stderr)
+
+    def test_rejects_missing_gpu_model(self) -> None:
+        receipt = passing_receipt()
+        del receipt["targets"][0]["hardware"]["gpu_model"]
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("bazzite.hardware.gpu_model must be a non-empty string", result.stderr)
+
+    def test_rejects_wrong_kernel_driver_for_variant(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][1]["hardware"]["kernel_driver"] = "nouveau"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite-nvidia-open.hardware.kernel_driver must be nvidia, got nouveau",
+            result.stderr,
+        )
+
+    def test_rejects_amd_pci_vendor_for_nvidia_target(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][1]["hardware"]["pci_id"] = "1002:744c"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite-nvidia-open.hardware.pci_id vendor must be 10de, got 1002",
+            result.stderr,
+        )
+
+    def test_rejects_nvidia_pci_vendor_for_standard_target(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["hardware"]["pci_id"] = "10de:2684"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.hardware.pci_id vendor must be 1002 or 8086, got 10de",
+            result.stderr,
+        )
+
+    def test_rejects_malformed_gpu_pci_id(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["hardware"]["pci_id"] = "1002"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.hardware.pci_id must be four lowercase hex digits, a colon, and four lowercase hex digits",
+            result.stderr,
+        )
+
+    def test_rejects_missing_required_variant(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"] = receipt["targets"][:1]
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("required target bazzite-nvidia-open is missing", result.stderr)
+
+    def test_rejects_duplicate_variant(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"].append(copy.deepcopy(receipt["targets"][0]))
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("target variant bazzite appears more than once", result.stderr)
+
+    def test_rejects_fedora_version_other_than_44(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["fedora_version"] = 42
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("bazzite.fedora_version must be 44, got 42", result.stderr)
+
+    def test_rejects_non_integer_fedora_version(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["fedora_version"] = 44.0
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("bazzite.fedora_version must be integer 44", result.stderr)
+
+    def test_rejects_missing_bazzite_version(self) -> None:
+        receipt = passing_receipt()
+        del receipt["targets"][0]["bazzite_version"]
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("bazzite.bazzite_version must be a non-empty string", result.stderr)
+
+    def test_rejects_bazzite_version_with_non_ascii_digits(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["bazzite_version"] = "44.٢٠٢٦٠٩٠٢"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must match 44.YYYYMMDD exactly", result.stderr)
+
+    def test_rejects_image_reference_that_does_not_bind_the_digest(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][1]["image_reference"] = (
+            "ghcr.io/ublue-os/bazzite-nvidia-open@sha256:" + "f" * 64
+        )
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite-nvidia-open.image_reference must exactly match its variant and image_digest",
+            result.stderr,
+        )
+
+    def test_rejects_missing_booted_deployment_checksum(self) -> None:
+        receipt = passing_receipt()
+        del receipt["targets"][0]["deployment_checksums"]["second_boot"]
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.deployment_checksums.second_boot must be 64 lowercase hexadecimal characters",
+            result.stderr,
+        )
+
+    def test_rejects_second_boot_from_a_different_deployment(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["deployment_checksums"]["second_boot"] = "f" * 64
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.deployment_checksums.second_boot must equal first_boot",
+            result.stderr,
+        )
+
+    def test_rejects_rollback_that_does_not_restore_the_baseline_deployment(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["deployment_checksums"]["post_rollback"] = "f" * 64
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.deployment_checksums.post_rollback must equal baseline",
+            result.stderr,
+        )
+
+    def test_rejects_removal_that_does_not_restore_the_baseline_deployment(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][0]["deployment_checksums"]["post_removal"] = "f" * 64
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.deployment_checksums.post_removal must equal baseline",
+            result.stderr,
+        )
+
+    def test_rejects_rpm_first_boot_that_does_not_change_the_deployment(self) -> None:
+        receipt = passing_receipt()
+        for target in receipt["targets"]:
+            baseline = target["deployment_checksums"]["baseline"]
+            target["deployment_checksums"]["first_boot"] = baseline
+            target["deployment_checksums"]["second_boot"] = baseline
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.deployment_checksums.first_boot must differ from baseline for rpm",
+            result.stderr,
+        )
+
+    def test_rejects_sysext_that_changes_the_ostree_deployment(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["kind"] = "sysext"
+        receipt["candidate"]["name"] = "Polaris-sysext-x86_64.raw"
+        receipt["candidate"]["path"] = SYSEXT_CANDIDATE_PATH
+        result = self.run_validator(
+            receipt,
+            candidate_relative_path=SYSEXT_CANDIDATE_PATH,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "bazzite.deployment_checksums.first_boot must equal baseline for sysext",
+            result.stderr,
+        )
+
+    def test_accepts_sysext_without_an_ostree_deployment_change(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["kind"] = "sysext"
+        receipt["candidate"]["name"] = "Polaris-sysext-x86_64.raw"
+        receipt["candidate"]["path"] = SYSEXT_CANDIDATE_PATH
+        for target in receipt["targets"]:
+            baseline = target["deployment_checksums"]["baseline"]
+            target["deployment_checksums"]["first_boot"] = baseline
+            target["deployment_checksums"]["second_boot"] = baseline
+        result = self.run_validator(
+            receipt,
+            candidate_relative_path=SYSEXT_CANDIDATE_PATH,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_malformed_candidate_digest(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["sha256"] = "abc123"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate.sha256 must be 64 lowercase hexadecimal characters", result.stderr)
+
+    def test_rejects_missing_candidate_path(self) -> None:
+        receipt = passing_receipt()
+        del receipt["candidate"]["path"]
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate.path must be a non-empty string", result.stderr)
+
+    def test_rejects_tampered_candidate_bytes(self) -> None:
+        result = self.run_validator(
+            passing_receipt(),
+            candidate_content=b"tampered candidate\n",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate.path sha256 mismatch", result.stderr)
+
+    def test_rejects_candidate_path_escape(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["path"] = "../Polaris-fedora44-x86_64.rpm"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "candidate.path must stay below the receipt directory",
+            result.stderr,
+        )
+
+    def test_rejects_candidate_path_filename_mismatch(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["name"] = "renamed.rpm"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate.path filename must match candidate.name", result.stderr)
+
+    def test_rejects_missing_source_tree(self) -> None:
+        receipt = passing_receipt()
+        del receipt["candidate"]["source_tree"]
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "candidate.source_tree must be 40 lowercase hexadecimal characters",
+            result.stderr,
+        )
+
+    def test_rejects_nonrelease_build_mode(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["build_mode"] = "debug"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate.build_mode must be release, got debug", result.stderr)
+
+    def test_rejects_candidate_acquisition_url_with_credentials(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["acquisition_url"] = "https://user:secret@example.com/build"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate.acquisition_url must not contain credentials", result.stderr)
+
+    def test_rejects_candidate_acquisition_url_with_query_parameters(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["acquisition_url"] = "https://example.com/build?token=secret"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "candidate.acquisition_url must not contain query parameters or fragments",
+            result.stderr,
+        )
+
+    def test_rejects_filename_that_does_not_match_candidate_kind(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["kind"] = "sysext"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate.name must end in .raw for kind sysext", result.stderr)
+
+    def test_rejects_missing_utc_capture_timestamp(self) -> None:
+        receipt = passing_receipt()
+        del receipt["captured_at_utc"]
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("receipt.captured_at_utc must be a non-empty string", result.stderr)
+
+    def test_rejects_unknown_candidate_kind(self) -> None:
+        receipt = passing_receipt()
+        receipt["candidate"]["kind"] = "zip"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate.kind", result.stderr)
+
+    def test_rejects_target_digest_drift(self) -> None:
+        receipt = passing_receipt()
+        receipt["targets"][1]["candidate_sha256"] = "d" * 64
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("bazzite-nvidia-open.candidate_sha256 does not match candidate.sha256", result.stderr)
+
+    def test_workflow_runs_receipt_validator_tests_once(self) -> None:
+        workflow = (ROOT / ".github/workflows/build.yml").read_text(encoding="utf-8")
+        command = "python3 scripts/validation/bazzite/test_validate_receipt.py"
+        self.assertEqual(workflow.count(command), 1)
+
+    def test_rejects_noncanonical_utc_capture_timestamp(self) -> None:
+        receipt = passing_receipt()
+        receipt["captured_at_utc"] = "2026-9-6T1:2:3Z"
+        result = self.run_validator(receipt)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must match YYYY-MM-DDTHH:MM:SSZ exactly", result.stderr)
+
+    def test_runbook_documents_receipt_identity_fields(self) -> None:
+        runbook = (SCRIPT.parent / "README.md").read_text(encoding="utf-8")
+        for field in (
+            "captured_at_utc",
+            "candidate.path",
+            "source_tree",
+            "build_mode",
+            "acquisition_url",
+            "bazzite_version",
+            "image_reference",
+            "deployment_checksums",
+            "hardware.environment",
+            "gpu_model",
+            "pci_id",
+            "kernel_driver",
+            "evidence",
+        ):
+            with self.subTest(field=field):
+                self.assertIn(f"`{field}`", runbook)
+        self.assertIn("relative to the receipt directory", runbook)
+        self.assertIn("query parameters or fragments", runbook)
+        self.assertIn("duplicate JSON members", runbook)
+        self.assertIn("`second_boot` must equal `first_boot`", runbook)
+        self.assertIn(
+            "`post_rollback` and `post_removal` must equal `baseline`",
+            runbook,
+        )
+        self.assertIn("descriptor-relative", runbook)
+        self.assertIn("`O_NOFOLLOW`", runbook)
+        self.assertIn("ASCII digits", runbook)
+        self.assertIn("FIFOs", runbook)
+        self.assertIn(
+            "`first_boot` must differ from `baseline` for RPM",
+            runbook,
+        )
+        self.assertIn(
+            "`first_boot` must equal `baseline` for system extensions",
+            runbook,
+        )
+        for vendor in ("1002", "8086", "10de"):
+            with self.subTest(vendor=vendor):
+                self.assertIn(f"`{vendor}`", runbook)
+
+    def test_runbook_covers_every_required_gate_and_target(self) -> None:
+        runbook = (SCRIPT.parent / "README.md").read_text(encoding="utf-8")
+        for gate in COMMON_GATES:
+            with self.subTest(gate=gate):
+                self.assertIn(f"`{gate}`", runbook)
+        for target in ("bazzite", "bazzite-nvidia-open"):
+            with self.subTest(target=target):
+                self.assertIn(f"`{target}`", runbook)
+        self.assertIn("Publication remains disabled", runbook)
+        self.assertIn("`setup-host` runs only after the installed deployment boots", runbook)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validation/bazzite/validate_receipt.py
+++ b/scripts/validation/bazzite/validate_receipt.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Fail-closed validator for Polaris Bazzite lifecycle evidence receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit
+
+REQUIRED_TARGETS = {
+    "bazzite": "amd-intel",
+    "bazzite-nvidia-open": "nvidia-open",
+}
+REQUIRED_PCI_VENDOR_DRIVERS = {
+    "bazzite": {
+        "1002": {"amdgpu"},
+        "8086": {"i915", "xe"},
+    },
+    "bazzite-nvidia-open": {
+        "10de": {"nvidia"},
+    },
+}
+REQUIRED_RESULTS = (
+    "artifact_identity",
+    "repo_resolution",
+    "elf_closure",
+    "selinux_enforcing",
+    "selinux_avc_clean",
+    "install_failure_cleanup",
+    "setup_failure_cleanup",
+    "install",
+    "first_boot",
+    "second_boot",
+    "removal",
+    "deployment_rollback",
+    "shared_var_rollback",
+    "live_media_recovery",
+)
+REQUIRED_HARDWARE_RESULTS = ("capture", "encode", "stream")
+REQUIRED_DEPLOYMENT_CHECKSUMS = (
+    "baseline",
+    "first_boot",
+    "second_boot",
+    "post_rollback",
+    "post_removal",
+)
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+BAZZITE_VERSION_RE = re.compile(r"44\.[0-9]{8}\Z")
+UTC_TIMESTAMP_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\Z")
+COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+IMAGE_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+PCI_ID_RE = re.compile(r"[0-9a-f]{4}:[0-9a-f]{4}\Z")
+
+
+class ReceiptError(ValueError):
+    """The evidence receipt is incomplete, inconsistent, or malformed."""
+
+
+def reject_duplicate_json_members(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ReceiptError(f"duplicate JSON member: {key}")
+        result[key] = value
+    return result
+
+
+def require_mapping(value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ReceiptError(f"{path} must be an object")
+    return value
+
+
+def require_string(mapping: dict[str, Any], key: str, path: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise ReceiptError(f"{path}.{key} must be a non-empty string")
+    return value
+
+
+def require_sha256(mapping: dict[str, Any], key: str, path: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise ReceiptError(
+            f"{path}.{key} must be 64 lowercase hexadecimal characters"
+        )
+    return value
+
+
+def require_pass(results: dict[str, Any], gate: str, prefix: str) -> None:
+    if gate not in results:
+        raise ReceiptError(f"{prefix}.{gate} is missing")
+    value = results[gate]
+    if value != "pass":
+        raise ReceiptError(f"{prefix}.{gate} must be pass, got {value}")
+
+
+def sha256_relative_file(
+    receipt_dir: Path,
+    relative_path: PurePosixPath,
+    prefix: str,
+) -> str:
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+    file_flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
+    directory_fds: list[int] = []
+    file_fd: int | None = None
+
+    try:
+        current_fd = os.open(receipt_dir, directory_flags)
+        directory_fds.append(current_fd)
+        for component in relative_path.parts[:-1]:
+            current_fd = os.open(component, directory_flags, dir_fd=current_fd)
+            directory_fds.append(current_fd)
+
+        file_fd = os.open(relative_path.parts[-1], file_flags, dir_fd=current_fd)
+        before = os.fstat(file_fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise ReceiptError(
+                f"{prefix}.path does not exist or is not a regular file"
+            )
+
+        before_identity = (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+            before.st_ctime_ns,
+        )
+        digest = hashlib.sha256()
+        while chunk := os.read(file_fd, 1024 * 1024):
+            digest.update(chunk)
+
+        after = os.fstat(file_fd)
+        after_identity = (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        )
+        if after_identity != before_identity:
+            raise ReceiptError(f"{prefix}.path changed while hashing")
+        return digest.hexdigest()
+    except ReceiptError:
+        raise
+    except OSError as error:
+        raise ReceiptError(
+            f"{prefix}.path does not exist or is not a regular file"
+        ) from error
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        for directory_fd in reversed(directory_fds):
+            os.close(directory_fd)
+
+
+def require_hashed_file(
+    relative: str,
+    expected_sha256: str,
+    prefix: str,
+    receipt_dir: Path,
+    *,
+    mismatch_prefix: str | None = None,
+) -> None:
+    if "\x00" in relative:
+        raise ReceiptError(f"{prefix}.path must be a safe relative path")
+
+    relative_path = PurePosixPath(relative)
+    if (
+        not relative_path.parts
+        or relative_path.is_absolute()
+        or ".." in relative_path.parts
+        or "\\" in relative
+    ):
+        raise ReceiptError(f"{prefix}.path must stay below the receipt directory")
+
+    actual_sha256 = sha256_relative_file(receipt_dir, relative_path, prefix)
+    if actual_sha256 != expected_sha256:
+        raise ReceiptError(f"{mismatch_prefix or prefix} sha256 mismatch")
+
+
+def require_gate_evidence(
+    evidence: dict[str, Any],
+    gate: str,
+    prefix: str,
+    receipt_dir: Path,
+) -> None:
+    if gate not in evidence:
+        raise ReceiptError(f"{prefix}.{gate} is missing")
+
+    entries = evidence[gate]
+    if not isinstance(entries, list) or not entries:
+        raise ReceiptError(f"{prefix}.{gate} must be a non-empty array")
+
+    for index, raw_entry in enumerate(entries):
+        entry_prefix = f"{prefix}.{gate}[{index}]"
+        entry = require_mapping(raw_entry, entry_prefix)
+        relative = require_string(entry, "path", entry_prefix)
+        expected_sha256 = require_sha256(entry, "sha256", entry_prefix)
+        require_hashed_file(
+            relative,
+            expected_sha256,
+            entry_prefix,
+            receipt_dir,
+        )
+
+
+def validate_receipt(receipt: Any, receipt_dir: Path) -> dict[str, Any]:
+    receipt_dir = receipt_dir.resolve(strict=True)
+    root = require_mapping(receipt, "receipt")
+    schema_version = root.get("schema_version")
+    if type(schema_version) is not int or schema_version != 1:
+        raise ReceiptError("schema_version must be integer 1")
+
+    captured_at_utc = require_string(root, "captured_at_utc", "receipt")
+    if not UTC_TIMESTAMP_RE.fullmatch(captured_at_utc):
+        raise ReceiptError(
+            "receipt.captured_at_utc must match YYYY-MM-DDTHH:MM:SSZ exactly"
+        )
+    try:
+        datetime.strptime(captured_at_utc, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as error:
+        raise ReceiptError(
+            "receipt.captured_at_utc must match YYYY-MM-DDTHH:MM:SSZ exactly"
+        ) from error
+
+    candidate = require_mapping(root.get("candidate"), "candidate")
+    kind = require_string(candidate, "kind", "candidate")
+    if kind not in {"rpm", "sysext"}:
+        raise ReceiptError(f"candidate.kind must be rpm or sysext, got {kind}")
+    name = require_string(candidate, "name", "candidate")
+    expected_suffix = {"rpm": ".rpm", "sysext": ".raw"}[kind]
+    if not name.endswith(expected_suffix):
+        raise ReceiptError(
+            f"candidate.name must end in {expected_suffix} for kind {kind}"
+        )
+    candidate_path = require_string(candidate, "path", "candidate")
+    if PurePosixPath(candidate_path).name != name:
+        raise ReceiptError("candidate.path filename must match candidate.name")
+    require_string(candidate, "version", "candidate")
+
+    candidate_sha256 = require_string(candidate, "sha256", "candidate")
+    if not SHA256_RE.fullmatch(candidate_sha256):
+        raise ReceiptError(
+            "candidate.sha256 must be 64 lowercase hexadecimal characters"
+        )
+    require_hashed_file(
+        candidate_path,
+        candidate_sha256,
+        "candidate",
+        receipt_dir,
+        mismatch_prefix="candidate.path",
+    )
+
+    source_commit = require_string(candidate, "source_commit", "candidate")
+    if not COMMIT_RE.fullmatch(source_commit):
+        raise ReceiptError(
+            "candidate.source_commit must be 40 lowercase hexadecimal characters"
+        )
+
+    source_tree = candidate.get("source_tree")
+    if not isinstance(source_tree, str) or not COMMIT_RE.fullmatch(source_tree):
+        raise ReceiptError(
+            "candidate.source_tree must be 40 lowercase hexadecimal characters"
+        )
+
+    build_mode = require_string(candidate, "build_mode", "candidate")
+    if build_mode != "release":
+        raise ReceiptError(
+            f"candidate.build_mode must be release, got {build_mode}"
+        )
+
+    acquisition_url = require_string(candidate, "acquisition_url", "candidate")
+    if any(character.isspace() or ord(character) < 32 for character in acquisition_url):
+        raise ReceiptError("candidate.acquisition_url must be an absolute https URL")
+    try:
+        parsed_url = urlsplit(acquisition_url)
+        has_credentials = parsed_url.username is not None or parsed_url.password is not None
+    except ValueError as error:
+        raise ReceiptError(
+            "candidate.acquisition_url must be an absolute https URL"
+        ) from error
+    if parsed_url.scheme != "https" or not parsed_url.netloc:
+        raise ReceiptError("candidate.acquisition_url must be an absolute https URL")
+    if has_credentials:
+        raise ReceiptError("candidate.acquisition_url must not contain credentials")
+    if parsed_url.query or parsed_url.fragment:
+        raise ReceiptError(
+            "candidate.acquisition_url must not contain query parameters or fragments"
+        )
+
+    targets = root.get("targets")
+    if not isinstance(targets, list):
+        raise ReceiptError("targets must be an array")
+
+    by_variant: dict[str, dict[str, Any]] = {}
+    for index, raw_target in enumerate(targets):
+        target = require_mapping(raw_target, f"targets[{index}]")
+        variant = require_string(target, "variant", f"targets[{index}]")
+        if variant in by_variant:
+            raise ReceiptError(f"target variant {variant} appears more than once")
+        by_variant[variant] = target
+
+    for variant, expected_driver in REQUIRED_TARGETS.items():
+        if variant not in by_variant:
+            raise ReceiptError(f"required target {variant} is missing")
+
+        target = by_variant[variant]
+        driver = require_string(target, "driver", variant)
+        if driver != expected_driver:
+            raise ReceiptError(
+                f"{variant}.driver must be {expected_driver}, got {driver}"
+            )
+
+        fedora_version = target.get("fedora_version")
+        if type(fedora_version) is not int:
+            raise ReceiptError(
+                f"{variant}.fedora_version must be integer 44"
+            )
+        if fedora_version != 44:
+            raise ReceiptError(
+                f"{variant}.fedora_version must be 44, got {fedora_version}"
+            )
+
+        bazzite_version = require_string(target, "bazzite_version", variant)
+        if not BAZZITE_VERSION_RE.fullmatch(bazzite_version):
+            raise ReceiptError(
+                f"{variant}.bazzite_version must match 44.YYYYMMDD exactly"
+            )
+
+        image_digest = require_string(target, "image_digest", variant)
+        if not IMAGE_DIGEST_RE.fullmatch(image_digest):
+            raise ReceiptError(
+                f"{variant}.image_digest must be sha256 followed by 64 lowercase hexadecimal characters"
+            )
+
+        image_reference = require_string(target, "image_reference", variant)
+        expected_image_reference = f"ghcr.io/ublue-os/{variant}@{image_digest}"
+        if image_reference != expected_image_reference:
+            raise ReceiptError(
+                f"{variant}.image_reference must exactly match its variant and image_digest"
+            )
+
+        deployments = require_mapping(
+            target.get("deployment_checksums"),
+            f"{variant}.deployment_checksums",
+        )
+        deployment_values = {
+            deployment: require_sha256(
+                deployments,
+                deployment,
+                f"{variant}.deployment_checksums",
+            )
+            for deployment in REQUIRED_DEPLOYMENT_CHECKSUMS
+        }
+        if deployment_values["second_boot"] != deployment_values["first_boot"]:
+            raise ReceiptError(
+                f"{variant}.deployment_checksums.second_boot must equal first_boot"
+            )
+        if deployment_values["post_rollback"] != deployment_values["baseline"]:
+            raise ReceiptError(
+                f"{variant}.deployment_checksums.post_rollback must equal baseline"
+            )
+        if deployment_values["post_removal"] != deployment_values["baseline"]:
+            raise ReceiptError(
+                f"{variant}.deployment_checksums.post_removal must equal baseline"
+            )
+        if (
+            kind == "rpm"
+            and deployment_values["first_boot"] == deployment_values["baseline"]
+        ):
+            raise ReceiptError(
+                f"{variant}.deployment_checksums.first_boot must differ from baseline for rpm"
+            )
+        if (
+            kind == "sysext"
+            and deployment_values["first_boot"] != deployment_values["baseline"]
+        ):
+            raise ReceiptError(
+                f"{variant}.deployment_checksums.first_boot must equal baseline for sysext"
+            )
+
+        target_sha256 = require_string(target, "candidate_sha256", variant)
+        if target_sha256 != candidate_sha256:
+            raise ReceiptError(
+                f"{variant}.candidate_sha256 does not match candidate.sha256"
+            )
+
+        hardware = require_mapping(target.get("hardware"), f"{variant}.hardware")
+        environment = require_string(hardware, "environment", f"{variant}.hardware")
+        if environment != "physical":
+            raise ReceiptError(
+                f"{variant}.hardware.environment must be physical, got {environment}"
+            )
+        require_string(hardware, "gpu_model", f"{variant}.hardware")
+        pci_id = require_string(hardware, "pci_id", f"{variant}.hardware")
+        if not PCI_ID_RE.fullmatch(pci_id):
+            raise ReceiptError(
+                f"{variant}.hardware.pci_id must be four lowercase hex digits, a colon, and four lowercase hex digits"
+            )
+        vendor = pci_id.split(":", 1)[0]
+        vendor_drivers = REQUIRED_PCI_VENDOR_DRIVERS[variant]
+        if vendor not in vendor_drivers:
+            expected_vendors = " or ".join(sorted(vendor_drivers))
+            raise ReceiptError(
+                f"{variant}.hardware.pci_id vendor must be {expected_vendors}, got {vendor}"
+            )
+        kernel_driver = require_string(
+            hardware,
+            "kernel_driver",
+            f"{variant}.hardware",
+        )
+        allowed_drivers = vendor_drivers[vendor]
+        if kernel_driver not in allowed_drivers:
+            expected_drivers = " or ".join(sorted(allowed_drivers))
+            raise ReceiptError(
+                f"{variant}.hardware.kernel_driver must be {expected_drivers}, got {kernel_driver}"
+            )
+
+        results = require_mapping(target.get("results"), f"{variant}.results")
+        for gate in REQUIRED_RESULTS:
+            require_pass(results, gate, f"{variant}.results")
+
+        hardware_results = require_mapping(
+            target.get("hardware_results"), f"{variant}.hardware_results"
+        )
+        for gate in REQUIRED_HARDWARE_RESULTS:
+            require_pass(
+                hardware_results,
+                gate,
+                f"{variant}.hardware_results",
+            )
+
+        evidence = require_mapping(target.get("evidence"), f"{variant}.evidence")
+        for gate in (*REQUIRED_RESULTS, *REQUIRED_HARDWARE_RESULTS):
+            require_gate_evidence(
+                evidence,
+                gate,
+                f"{variant}.evidence",
+                receipt_dir,
+            )
+
+    unknown_targets = sorted(set(by_variant) - set(REQUIRED_TARGETS))
+    if unknown_targets:
+        raise ReceiptError(
+            "unexpected target variants: " + ", ".join(unknown_targets)
+        )
+
+    return {
+        "status": "ready",
+        "candidate_sha256": candidate_sha256,
+        "targets": list(REQUIRED_TARGETS),
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {Path(argv[0]).name} RECEIPT.json", file=sys.stderr)
+        return 2
+
+    try:
+        receipt_path = Path(argv[1])
+        receipt = json.loads(
+            receipt_path.read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_json_members,
+        )
+        report = validate_receipt(receipt, receipt_path.parent)
+    except (OSError, json.JSONDecodeError, ReceiptError) as error:
+        print(f"Bazzite validation receipt rejected: {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -466,8 +466,8 @@ namespace args {
     // actually usable, which is the thing the whole step exists to arrange.
     const bool etc_copies_absent = !fs::exists("/etc/udev/rules.d/60-polaris.rules") &&
                                    !fs::exists("/etc/modules-load.d/60-polaris.conf");
-    const bool input_nodes_ready = access("/dev/uinput", R_OK | W_OK) == 0 &&
-                                   access("/dev/uhid", R_OK | W_OK) == 0;
+    const auto setup_target_user = platf::input_access::setup_host_target_user();
+    const bool input_nodes_ready = platf::input_access::setup_host_target_can_access_input_nodes();
     // Membership is not something host setup can arrange — usermod would have to
     // pick a target account, and this command deliberately never guesses which
     // account streams. It reports it so a user preparing the host learns it here
@@ -479,7 +479,7 @@ namespace args {
       std::cout
         << "Linux host setup: nothing to do."sv << std::endl
         << "The package provides the udev rules and modules-load configuration, and /dev/uinput"sv << std::endl
-        << "and /dev/uhid are already usable by this account. Re-run with --enable-kms only if you"sv << std::endl
+        << "and /dev/uhid are already usable by ["sv << setup_target_user << "]. Re-run with --enable-kms only if you"sv << std::endl
         << "need DRM/KMS capture."sv << std::endl;
       if (!input_group_advice.empty()) {
         std::cout << std::endl

--- a/src/platform/linux/input/input_group_access.cpp
+++ b/src/platform/linux/input/input_group_access.cpp
@@ -81,6 +81,7 @@ namespace platf::input_access {
       groups.resize(static_cast<std::size_t>(count));
       return std::find(groups.begin(), groups.end(), gid) != groups.end();
     }
+
   }  // namespace
 
   seat_isolation_options_t configured_seat_isolation() {
@@ -216,6 +217,33 @@ namespace platf::input_access {
     }
 
     return account_name_for(geteuid());
+  }
+
+  bool setup_host_target_can_access_input_nodes(const input_node_access_probe_t &probe) {
+    if (!probe) {
+      return false;
+    }
+
+    const auto user = setup_host_target_user();
+    // The running process' supplementary groups are the only trustworthy answer
+    // for current access. After sudo, reconstructing groups from the account
+    // database can claim access that the invoking shell does not have until its
+    // next login, so cross-boundary readiness always fails closed.
+    if (user != account_name_for(geteuid())) {
+      return false;
+    }
+
+    constexpr int required_access = R_OK | W_OK;
+    return probe(user, "/dev/uinput", required_access) &&
+           probe(user, "/dev/uhid", required_access);
+  }
+
+  bool setup_host_target_can_access_input_nodes() {
+    return setup_host_target_can_access_input_nodes(
+      [](std::string_view, std::string_view path, int mode) {
+        return access(std::string(path).c_str(), mode) == 0;
+      }
+    );
   }
 
   std::string setup_host_input_group_advice() {

--- a/src/platform/linux/input/input_group_access.h
+++ b/src/platform/linux/input/input_group_access.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <functional>
 #include <string>
 #include <string_view>
 
@@ -104,6 +105,21 @@ namespace platf::input_access {
    * the account that asked for it.
    */
   std::string setup_host_target_user();
+
+  /// Injectable account/path access probe used by the setup-host readiness check.
+  using input_node_access_probe_t =
+    std::function<bool(std::string_view user, std::string_view path, int mode)>;
+
+  /**
+   * @brief Whether the live process account can open both virtual-input nodes.
+   *
+   * The injectable overload keeps the account/path routing contract testable.
+   * If `SUDO_USER` differs from the running process account, readiness is unknown
+   * and fails closed without invoking the probe; database membership cannot prove
+   * which supplementary groups the original shell currently has.
+   */
+  bool setup_host_target_can_access_input_nodes(const input_node_access_probe_t &probe);
+  bool setup_host_target_can_access_input_nodes();
 
   /**
    * @brief Advice for `--setup-host` to print, or empty when the account is ready.

--- a/tests/unit/platform/test_input_group_access.cpp
+++ b/tests/unit/platform/test_input_group_access.cpp
@@ -9,6 +9,9 @@
 
   #include <cstdlib>
   #include <string>
+  #include <tuple>
+  #include <unistd.h>
+  #include <vector>
 
 namespace {
   using platf::input_access::input_group_status_t;
@@ -147,6 +150,63 @@ TEST(InputGroupAccessTests, SetupHostReportsOnTheAccountThatInvokedSudo) {
   if (!restore.empty()) {
     ASSERT_EQ(0, ::setenv("SUDO_USER", restore.c_str(), 1));
   }
+}
+
+TEST(InputGroupAccessTests, SetupHostDoesNotInferVirtualInputAccessAcrossSudo) {
+  using platf::input_access::setup_host_target_can_access_input_nodes;
+
+  constexpr auto sentinel = "polaris-setup-host-access-sentinel";
+  const auto *original = std::getenv("SUDO_USER");
+  const std::string restore = original ? original : "";
+  ASSERT_EQ(0, ::setenv("SUDO_USER", sentinel, 1));
+
+  bool probe_called = false;
+  const bool ready = setup_host_target_can_access_input_nodes(
+    [&probe_called](std::string_view, std::string_view, int) {
+      probe_called = true;
+      return true;
+    }
+  );
+
+  if (!restore.empty()) {
+    ASSERT_EQ(0, ::setenv("SUDO_USER", restore.c_str(), 1));
+  } else {
+    ASSERT_EQ(0, ::unsetenv("SUDO_USER"));
+  }
+
+  EXPECT_FALSE(ready);
+  EXPECT_FALSE(probe_called);
+}
+
+TEST(InputGroupAccessTests, SetupHostChecksVirtualInputForTheLiveProcessAccount) {
+  using platf::input_access::setup_host_target_can_access_input_nodes;
+  using platf::input_access::setup_host_target_user;
+
+  const auto *original = std::getenv("SUDO_USER");
+  const std::string restore = original ? original : "";
+  ASSERT_EQ(0, ::unsetenv("SUDO_USER"));
+  const auto expected_user = setup_host_target_user();
+
+  std::vector<std::tuple<std::string, std::string, int>> probes;
+  const bool ready = setup_host_target_can_access_input_nodes(
+    [&probes](std::string_view user, std::string_view path, int mode) {
+      probes.emplace_back(user, path, mode);
+      return true;
+    }
+  );
+
+  if (!restore.empty()) {
+    ASSERT_EQ(0, ::setenv("SUDO_USER", restore.c_str(), 1));
+  }
+
+  EXPECT_TRUE(ready);
+  ASSERT_EQ(2u, probes.size());
+  EXPECT_EQ(expected_user, std::get<0>(probes[0]));
+  EXPECT_EQ("/dev/uinput", std::get<1>(probes[0]));
+  EXPECT_EQ(R_OK | W_OK, std::get<2>(probes[0]));
+  EXPECT_EQ(expected_user, std::get<0>(probes[1]));
+  EXPECT_EQ("/dev/uhid", std::get<1>(probes[1]));
+  EXPECT_EQ(R_OK | W_OK, std::get<2>(probes[1]));
 }
 
 TEST(InputGroupAccessTests, TheProcessAndDatabaseLookupsAgreeOnThisHost) {


### PR DESCRIPTION
## summary

- stop privileged `--setup-host` runs from treating roots `/dev/uinput` and `/dev/uhid` access as proof that the desktop account is ready
- add a fail-closed Bazzite receipt validator that binds candidate bytes, source identity, immutable evidence, image/driver identity, lifecycle transitions, SELinux results, and physical hardware results
- run the receipt-validator suite before release artifact binding

## validation

- Bazzite receipt validator: 50 passed
- frontend: 87 test files and 696 tests passed
- fast C++ suite: 516 passed
- Linux platform suite: 288 passed, 1 expected CUDA-only skip
- Clang ASan/UBSan focused suite: 13 passed with no skips or findings
- dependency, public-doc, workflow YAML, build, lint, whitespace, and static patch gates passed
- reviewed candidate tree: `94bb12aa9e769ecafe56e4fa9c1abb8cf638edac`

## publication boundary

this does not build, restore, or publish the standalone Polaris sysext. that artifact remains withdrawn. a real label-preserving payload and the physical AMD, Intel, and NVIDIA capture/encode/stream matrix still have to pass before publication can be reconsidered.
