### PR TITLE
fix(packaging): start the user service from the application menu instead of a second process

### DIFF
--- a/docs/arch.md
+++ b/docs/arch.md
@@ -48,6 +48,10 @@ rather than deleting it; see [Troubleshooting](troubleshooting.md) for the check
 systemctl --user enable --now polaris
 ```
 
+The application menu entry starts this same user service, so a desktop launch and autostart never
+run two copies. Quitting from the tray stops it; the menu entry or `systemctl --user start polaris`
+brings it back.
+
 ## Arch derivatives
 
 CachyOS is expected to work through this package path. If a derivative renames dependencies or ships

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -229,6 +229,10 @@ before any login) and hooks the Polaris user service into `default.target`. Run
 it from Desktop Mode's terminal or over SSH, as your normal user via sudo. Undo
 it later with `--disable-headless-boot`.
 
+Opening Polaris from the Desktop Mode application menu starts this same user
+service rather than a second process, so a desktop launch does not replace the
+boot instance with one that ends when you quit it or log out.
+
 Verify after a reboot, over SSH if there is no display:
 
 ```bash

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Launching Polaris from the application menu now starts the packaged user service instead of a second process. A desktop launch used to make the running service instance exit, and nothing brought it back once that window was quit or the session ended, which left a host that had been streaming fine with no Polaris until the next login. The menu entry, autostart, and headless boot now all point at the one service
+
 ## v1.4.3 - 2026-09-05
 
 A diagnostics and packaging update matched with Nova v1.4.3. Doctor names the gamescope session helper Polaris will run, the console and Nova get a coded answer when an artwork search fails, and partial configuration writes merge instead of rewriting the file. The standalone system extension initially shipped with this release and was withdrawn on September 5, 2026 because it did not include the runtime dependencies required by Bazzite. Existing configurations and paired devices remain valid.

--- a/docs/fedora.md
+++ b/docs/fedora.md
@@ -51,6 +51,11 @@ systemctl --user enable --now polaris
 Polaris runs as a user service, so it starts with your graphical session and has access to it. Check
 status with `systemctl --user status polaris`.
 
+The application menu entry starts this same service, so opening Polaris from the desktop and
+autostart never run two copies. Quitting from the tray stops it; the menu entry, the next login, or
+`systemctl --user start polaris` brings it back. For a host that boots with no desktop at all, see
+[Headless Boot](bazzite.md#headless-boot-and-deck-images).
+
 ## Verify the stream path
 
 Confirm the recommended Linux configuration in the first-run wizard or

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,7 +54,8 @@ first-run installation. If the credentials are no longer known, use the bounded 
 > [!TIP]
 > If you changed `port` in `~/.config/polaris/polaris.conf`, the web UI is at
 > `https://localhost:<port + 1>`. For background autostart, enable the user service with
-> `systemctl --user enable --now polaris`.
+> `systemctl --user enable --now polaris`. The application menu entry starts that same service,
+> so a desktop launch and autostart never run two copies.
 
 ## 3. Confirm the recommended Linux path
 

--- a/packaging/linux/dev.polaris-stream.app.Polaris.desktop
+++ b/packaging/linux/dev.polaris-stream.app.Polaris.desktop
@@ -2,7 +2,7 @@
 Actions=RunInTerminal;
 Categories=RemoteAccess;Network;
 Comment=@PROJECT_DESCRIPTION@
-Exec=polaris
+Exec=sh -c "systemctl --user start polaris.service 2>/dev/null || exec polaris"
 Icon=@POLARIS_DESKTOP_ICON@
 Keywords=gamestream;stream;moonlight;remote play;
 Name=@PROJECT_NAME@


### PR DESCRIPTION
## Summary

- The application menu entry now runs `sh -c "systemctl --user start polaris.service 2>/dev/null || exec polaris"`. It starts the packaged user service, and only runs the binary directly where there is no systemd user manager to ask.
- Why: a desktop launch ran a second polaris process beside the service. The service instance noticed and exited clean, `Restart=on-failure` did not treat that as a failure, and when the desktop instance was quit from the tray or ended with the session nothing brought the service back. pc-papi sat with no Polaris from Sep 5 21:00 (tray quit) until Sep 6 12:32 for exactly this reason, and Nova's wake button had nothing to find.
- Autostart, `--enable-headless-boot`, and the menu entry now all point at the one service. Quitting from the tray is the only way it stops, and the same menu entry brings it back.
- Docs: the Fedora, Arch, and quickstart autostart notes and the Bazzite headless-boot section say so; changelog entry under Unreleased.

## Exact candidate

- `Commit:` 6ddb0ed1d3884d952506fce35c792064374d8482
- `Tree:` c665b834d3d01953a246b6757357d0844f079e61
- `Parent:` a3494944854b77030a34ec1275016a55b48f8c57
- `Base:` a3494944 (master)

## Verification

- [x] `desktop-file-validate` on the rendered entry with this Exec line: ok. The same rendered file is installed as a per-user override on pc-papi under `~/.local/share/applications/`, so that host already launches this way.
- [x] Launcher path dry run on pc-papi with the service active: `sh -c "systemctl --user start polaris.service 2>/dev/null || exec polaris"` returned 0, one polaris process, service still active. No second instance.
- [x] `sudo -H polaris --setup-host --enable-headless-boot` on pc-papi: lingering on, `default.target.wants/polaris.service` linked, service active.
- [ ] Not run: a click through KDE's launcher (ssh only). The Fedora packaging job's `desktop-file-validate` covers the packaged file.

## Not covered

- The AppImage keeps its own `.desktop`; it has no packaged user unit to start.
- Running `polaris` by hand in a terminal beside the service behaves as before: the second one yields.
- No C++ change, no unit test change.
