### PR TITLE
release: Polaris v1.4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
     set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
-project(Polaris VERSION 1.4.3
+project(Polaris VERSION 1.4.4
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -530,7 +530,7 @@
         "example": {
           "schema_version": 1,
           "measurement_spec_id": "measurement-spec-v1",
-          "collector_version": "1.4.3",
+          "collector_version": "1.4.4",
           "clock_domain": "CLOCK_MONOTONIC",
           "run_id": "pair-0001-control",
           "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,14 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
-- Launching Polaris from the application menu now starts the packaged user service instead of a second process. A desktop launch used to make the running service instance exit, and nothing brought it back once that window was quit or the session ended, which left a host that had been streaming fine with no Polaris until the next login. The menu entry, autostart, and headless boot now all point at the one service
+## v1.4.4 - 2026-09-06
+
+A packaging and setup update matched with Nova v1.4.4. The application menu entry starts the same Polaris service that autostart and headless boot use, and a privileged setup run no longer mistakes root's own device access for a ready desktop account. Existing configurations and paired devices remain valid.
+
+- Starts the packaged user service instead of a second process. A desktop launch used to make the running service instance exit, and nothing brought it back once that window was quit or the session ended, which left a host that had been streaming fine with no Polaris until the next login. The menu entry, autostart, and headless boot now all point at the one service
+- Stops a privileged `--setup-host` run from treating root's own access to `/dev/uinput` and `/dev/uhid` as proof that the desktop account is ready, so a user still missing the input group is reported instead of passed
+- Adds a fail-closed Bazzite validation receipt checker that binds candidate bytes, source identity, image and driver identity, SELinux results, and physical hardware results, and runs it before release artifacts are bound
+- Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official package assets
 
 ## v1.4.3 - 2026-09-05
 

--- a/docs/release-notes/v1.4.4.md
+++ b/docs/release-notes/v1.4.4.md
@@ -1,0 +1,72 @@
+# Polaris v1.4.4
+
+Packaging and setup update, matched with Nova v1.4.4. Existing settings and paired devices keep working.
+
+**Fixed**
+
+- Launching Polaris from the application menu starts the same user service that autostart and headless boot use, instead of a second copy that left the host with no Polaris once that window was closed.
+- A privileged setup run no longer treats root's own access to the input devices as proof that your desktop account is ready. A missing input group is reported instead of passed.
+
+**Heads up**
+
+- Bazzite users should use the Fedora 44 RPM through rpm-ostree. The experimental system extension stays withdrawn.
+- SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+- Steam Input stays manual and read-only.
+- Verified with Nova v1.4.4 on a Retroid Pocket 6 against a 1.4.3 host; the 1.4.4 host build is CI verified.
+
+<details>
+<summary><b>Install</b> (Fedora 44, Arch / CachyOS, Ubuntu 24.04, SteamOS 3.8)</summary>
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### SteamOS 3.8
+
+Run this in Desktop Mode. It sets up the package keyring when needed and restores the read-only root before starting Polaris.
+
+```bash
+wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-steamos3.8-x86_64.pkg.tar.zst &&
+(
+set -e
+trap 'sudo steamos-readonly enable' EXIT
+sudo steamos-readonly disable || exit $?
+sudo pacman-key --init || exit $?
+sudo pacman-key --populate || exit $?
+sudo pacman -Sy || exit $?
+sudo pacman -U ./Polaris-steamos3.8-x86_64.pkg.tar.zst || exit $?
+sudo -H polaris --setup-host || exit $?
+sudo steamos-readonly enable || exit $?
+trap - EXIT
+) &&
+systemctl --user enable --now polaris
+```
+
+Bazzite users should follow the [Bazzite guide](https://papi-ux.com/docs/bazzite/) and use the Fedora RPM through rpm-ostree. SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/); SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+
+</details>
+
+**Assets:** `Polaris-fedora44-x86_64.rpm` · `Polaris-arch-x86_64.pkg.tar.zst` · `Polaris-ubuntu24.04-x86_64.deb` · `Polaris-steamos3.8-x86_64.pkg.tar.zst`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.4.3') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.4.4') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -665,7 +665,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.4.3.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.4.4.md").read_text(encoding="utf-8")
 )
 
 
@@ -1296,18 +1296,17 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.4.4 - 2026-09-06",
     "## v1.4.3 - 2026-09-05",
-    "## v1.4.2 - 2026-09-04",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "Gamescope Session Helper",
-    "polaris-gamescope-session",
-    "PATCH",
-    "SteamGridDB",
-    "explicit launch fields",
-    "installed Polaris package",
-    "system extension",
+    "application menu",
+    "user service",
+    "headless boot",
+    "--setup-host",
+    "input group",
+    "Bazzite",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
     "Polaris-steamos3.8-x86_64.pkg.tar.zst",
@@ -1315,7 +1314,7 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.4.3 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.4 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1324,7 +1323,7 @@ asset_phrase = (
     "`Polaris-steamos3.8-x86_64.pkg.tar.zst`, and "
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
-for label, section in (("v1.4.3 changelog", current_release_prose),):
+for label, section in (("v1.4.4 changelog", current_release_prose),):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
         sys.exit(1)
@@ -1339,13 +1338,12 @@ expected_assets = Counter(
 )
 withdrawn_sysext_asset = "Polaris-sysext-x86_64.raw"
 expected_changelog_assets = expected_assets.copy()
-expected_changelog_assets[withdrawn_sysext_asset] = 1
 building_packaging = markdown_section(building, "## Packaging")
 building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section, expected_section_assets in (
     ("docs/building.md Packaging", building_packaging_prose, expected_assets),
-    ("v1.4.3 changelog", current_release_prose, expected_changelog_assets),
+    ("v1.4.4 changelog", current_release_prose, expected_changelog_assets),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_section_assets:
@@ -1359,24 +1357,24 @@ for label, section, expected_section_assets in (
 # Release notes are the short, user-facing list; the changelog carries the
 # detail. Pin phrases a player would read, never internal identifiers.
 release_notes_facts = (
-    "Nova v1.4.3",
-    "SteamGridDB",
-    "system extension",
+    "Nova v1.4.4",
+    "application menu",
+    "user service",
+    "headless boot",
+    "input group",
     "Bazzite",
-    "Bazzite system extension withdrawn on September 5, 2026",
-    "Do not use cached copies",
-    "The supported Bazzite install remains the Fedora 44 RPM through rpm-ostree",
+    "rpm-ostree",
+    "system extension stays withdrawn",
     "SteamOS",
     "Steam Input",
     "Retroid Pocket 6",
-    "stale or shadowed copy",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-fedora44-x86_64.rpm &&",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
-    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.3/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
     "trap 'sudo steamos-readonly enable' EXIT",
     "sudo pacman-key --init || exit $?",
     "sudo pacman-key --populate || exit $?",
@@ -1384,25 +1382,25 @@ release_notes_facts = (
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.4.3 release notes are missing release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.4 release notes are missing release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 release_asset_lines = [
     line for line in release_notes.splitlines() if line.startswith("**Assets:**")
 ]
 if len(release_asset_lines) != 1:
-    print("v1.4.3 release notes must contain exactly one Assets line", file=sys.stderr)
+    print("v1.4.4 release notes must contain exactly one Assets line", file=sys.stderr)
     sys.exit(1)
 release_note_assets = Counter(asset_pattern.findall(release_asset_lines[0]))
 if release_note_assets != expected_assets:
     print(
-        "v1.4.3 release-note Assets line must contain only the four supported packages; "
+        "v1.4.4 release-note Assets line must contain only the four supported packages; "
         f"expected={dict(expected_assets)}, actual={dict(release_note_assets)}",
         file=sys.stderr,
     )
     sys.exit(1)
-if release_notes.count(withdrawn_sysext_asset) != 1:
+if release_notes.count(withdrawn_sysext_asset) != 0:
     print(
-        "v1.4.3 release notes must name the withdrawn system extension exactly once in the warning",
+        "v1.4.4 release notes must not name the withdrawn system extension file; that warning lives in v1.4.3",
         file=sys.stderr,
     )
     sys.exit(1)
@@ -1413,19 +1411,19 @@ for forbidden in (
     "AI Auto Quality Preference",
 ):
     if forbidden in current_release_prose or forbidden in release_notes:
-        print(f"v1.4.3 public release scope must exclude: {forbidden}", file=sys.stderr)
+        print(f"v1.4.4 public release scope must exclude: {forbidden}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.4.3 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.4.4 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host || exit $?") != 1:
-    print("v1.4.3 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
+    print("v1.4.4 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.4.3 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.4.4 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user enable --now polaris") != 1:
-    print("v1.4.3 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
+    print("v1.4.4 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
     sys.exit(1)
 
 release_workflow = Path(".github/workflows/build.yml").read_text(encoding="utf-8")

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.3-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.4-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -776,7 +776,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.4.3-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.4.4-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v143-contract.test.js
+++ b/src_assets/common/assets/web/release-v143-contract.test.js
@@ -1,17 +1,10 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
-const packageAssets = [
-  'Polaris-arch-x86_64.pkg.tar.zst',
-  'Polaris-fedora44-x86_64.rpm',
-  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
-  'Polaris-ubuntu24.04-x86_64.deb',
-].sort()
-const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
 
-const currentChangelog = () => {
+const historicalRelease = () => {
   const changelog = read('docs/changelog.md')
   const start = changelog.indexOf('## v1.4.3 - 2026-09-05')
   const end = changelog.indexOf('## v1.4.2 - 2026-09-04')
@@ -20,27 +13,19 @@ const currentChangelog = () => {
   return changelog.slice(start, end)
 }
 
-const releaseNotes = () => read('docs/release-notes/v1.4.3.md')
-const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
-  .map((match) => match[1])
-  .filter((block) => block.includes('wget --output-document='))
+const historicalNotes = () => read('docs/release-notes/v1.4.3.md')
 
-describe('v1.4.3 release contract', () => {
-  it('moves every current release identity to v1.4.3', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.3')
-    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.3"')
-    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.3')
-    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.3-1|x86_64'")
-    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.3-1|x86_64'")
-  })
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
 
-  it('makes v1.4.2 historical and promotes the complete v1.4.3 scope', () => {
-    expect(read('src_assets/common/assets/web/release-v142-contract.test.js')).toContain("describe('historical v1.4.2 release contract'")
-    const gate = read('scripts/check-public-docs.sh')
-    expect(gate).toContain('docs/release-notes/v1.4.3.md')
-    expect(gate).toContain('"## v1.4.3 - 2026-09-05"')
-
-    const release = `${currentChangelog()}\n${releaseNotes()}`
+describe('historical v1.4.3 release contract', () => {
+  it('preserves the diagnostics, merge-write, and system-extension withdrawal scope', () => {
+    const evidence = `${historicalRelease()}\n${historicalNotes()}`
     for (const fact of [
       'Gamescope Session Helper',
       'polaris-gamescope-session',
@@ -52,90 +37,30 @@ describe('v1.4.3 release contract', () => {
       'Nova v1.4.3',
       'Retroid Pocket 6',
     ]) {
-      expect(release, `release must include: ${fact}`).toContain(fact)
+      expect(evidence, `historical v1.4.3 must include: ${fact}`).toContain(fact)
     }
   })
 
-  it('documents the merge write, coded artwork failures, and system-extension withdrawal', () => {
-    const notes = releaseNotes()
-    const confighttp = read('src/confighttp.cpp')
-    const artwork = read('src/game_artwork_manual.cpp')
-    const helper = read('src/platform/linux/gamescope_session_helper.cpp')
-    const workflow = read('.github/workflows/build.yml')
-
-    expect(notes).toContain('stale or shadowed copy')
+  it('preserves the withdrawal warning and the exact historical assets and install identities', () => {
+    const notes = historicalNotes()
     expect(notes).toContain('Bazzite system extension withdrawn on September 5, 2026')
     expect(notes).toContain('Do not use cached copies')
     expect(notes).toContain(withdrawnSysextAsset)
-    expect(confighttp).toContain('patchConfig')
-    expect(artwork).toContain('classify_search_failure')
-    expect(helper).toContain('bundled')
-    expect(workflow).not.toContain('sysext-build:')
-    expect(workflow).not.toContain('Polaris-sysext-image')
-    expect(workflow).not.toContain(`release-assets/final/${withdrawnSysextAsset}`)
-  })
 
-  it('pins all four install commands to v1.4.3 and lists only supported package assets', () => {
-    const blocks = installBlocks()
+    const blocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
     expect(blocks).toHaveLength(4)
-    for (const asset of packageAssets) {
+    for (const asset of expectedAssets) {
       const matches = blocks.filter((block) => block.includes(`/${asset}`))
       expect(matches, `one command block for ${asset}`).toHaveLength(1)
       expect(matches[0]).toContain(`releases/download/v1.4.3/${asset}`)
-      expect(matches[0]).toContain('sudo -H polaris --setup-host')
     }
 
-    for (const asset of [
-      'Polaris-arch-x86_64.pkg.tar.zst',
-      'Polaris-fedora44-x86_64.rpm',
-      'Polaris-ubuntu24.04-x86_64.deb',
-    ]) {
-      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
-      expect(block).toContain('systemctl --user restart polaris')
-    }
-
-    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
-    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
-    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
-    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
-    expect(steamOs).toContain('systemctl --user enable --now polaris')
-
-    const assetsLine = releaseNotes().split('\n').find((line) => line.startsWith('**Assets:**'))
+    const assetsLine = notes.split('\n').find((line) => line.startsWith('**Assets:**'))
     expect(assetsLine).toBeDefined()
     const listed = [...new Set((assetsLine ?? '').match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
-    expect(listed.sort()).toEqual(packageAssets)
+    expect(listed.sort()).toEqual(expectedAssets)
     expect(assetsLine).not.toContain(withdrawnSysextAsset)
-  })
-
-  it('publishes release-note guide links that work outside the source tree', () => {
-    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
-    const notes = readdirSync(releaseNotesDir)
-      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
-      .map((name) => read(`docs/release-notes/${name}`))
-      .join('\n')
-
-    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
-    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
-    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
-  })
-
-  it('keeps publication bound to one verified immutable source', () => {
-    const workflow = read('.github/workflows/build.yml')
-    const ordered = [
-      '- name: Check out exact release source',
-      '- name: Revalidate release tag against packaged source',
-      '- name: Stage curated GitHub release',
-      '- name: Upload release assets to GitHub release',
-      '- name: Verify release assets on GitHub release',
-      '- name: Publish verified draft release',
-    ]
-    const positions = ordered.map((step) => workflow.indexOf(step))
-    expect(positions.every((position) => position >= 0)).toBe(true)
-    expect(positions).toEqual([...positions].sort((a, b) => a - b))
-    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
-    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
-    expect(workflow).toContain('--verify-tag')
-    expect(workflow).toContain('--notes-file "$release_notes"')
-    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
   })
 })

--- a/src_assets/common/assets/web/release-v144-contract.test.js
+++ b/src_assets/common/assets/web/release-v144-contract.test.js
@@ -1,0 +1,136 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+const packageAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
+
+const currentChangelog = () => {
+  const changelog = read('docs/changelog.md')
+  const start = changelog.indexOf('## v1.4.4 - 2026-09-06')
+  const end = changelog.indexOf('## v1.4.3 - 2026-09-05')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return changelog.slice(start, end)
+}
+
+const releaseNotes = () => read('docs/release-notes/v1.4.4.md')
+const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
+  .map((match) => match[1])
+  .filter((block) => block.includes('wget --output-document='))
+
+describe('v1.4.4 release contract', () => {
+  it('moves every current release identity to v1.4.4', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.4')
+    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.4"')
+    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.4')
+    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.4-1|x86_64'")
+    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.4-1|x86_64'")
+  })
+
+  it('makes v1.4.3 historical and promotes the complete v1.4.4 scope', () => {
+    expect(read('src_assets/common/assets/web/release-v143-contract.test.js')).toContain("describe('historical v1.4.3 release contract'")
+    const gate = read('scripts/check-public-docs.sh')
+    expect(gate).toContain('docs/release-notes/v1.4.4.md')
+    expect(gate).toContain('"## v1.4.4 - 2026-09-06"')
+
+    const release = `${currentChangelog()}\n${releaseNotes()}`
+    for (const fact of [
+      'application menu',
+      'user service',
+      'headless boot',
+      'setup-host',
+      'input group',
+      'Bazzite',
+      'Nova v1.4.4',
+      'Retroid Pocket 6',
+    ]) {
+      expect(release, `release must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('documents the service-first menu entry and the fail-closed setup, and keeps the system extension withdrawn', () => {
+    const notes = releaseNotes()
+    const desktopEntry = read('packaging/linux/dev.polaris-stream.app.Polaris.desktop')
+    const inputGroupAccess = read('src/platform/linux/input/input_group_access.cpp')
+    const workflow = read('.github/workflows/build.yml')
+
+    expect(desktopEntry).toContain('systemctl --user start polaris.service')
+    expect(inputGroupAccess.length).toBeGreaterThan(0)
+    expect(notes).toContain('system extension stays withdrawn')
+    expect(notes).not.toContain(withdrawnSysextAsset)
+    expect(workflow).not.toContain('sysext-build:')
+    expect(workflow).not.toContain('Polaris-sysext-image')
+    expect(workflow).not.toContain(`release-assets/final/${withdrawnSysextAsset}`)
+  })
+
+  it('pins all four install commands to v1.4.4 and lists only supported package assets', () => {
+    const blocks = installBlocks()
+    expect(blocks).toHaveLength(4)
+    for (const asset of packageAssets) {
+      const matches = blocks.filter((block) => block.includes(`/${asset}`))
+      expect(matches, `one command block for ${asset}`).toHaveLength(1)
+      expect(matches[0]).toContain(`releases/download/v1.4.4/${asset}`)
+      expect(matches[0]).toContain('sudo -H polaris --setup-host')
+    }
+
+    for (const asset of [
+      'Polaris-arch-x86_64.pkg.tar.zst',
+      'Polaris-fedora44-x86_64.rpm',
+      'Polaris-ubuntu24.04-x86_64.deb',
+    ]) {
+      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+
+    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
+    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
+    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
+    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
+    expect(steamOs).toContain('systemctl --user enable --now polaris')
+
+    const assetsLine = releaseNotes().split('\n').find((line) => line.startsWith('**Assets:**'))
+    expect(assetsLine).toBeDefined()
+    const listed = [...new Set((assetsLine ?? '').match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+    expect(listed.sort()).toEqual(packageAssets)
+    expect(assetsLine).not.toContain(withdrawnSysextAsset)
+  })
+
+  it('publishes release-note guide links that work outside the source tree', () => {
+    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
+    const notes = readdirSync(releaseNotesDir)
+      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
+      .map((name) => read(`docs/release-notes/${name}`))
+      .join('\n')
+
+    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
+    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
+    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
+  })
+
+  it('keeps publication bound to one verified immutable source', () => {
+    const workflow = read('.github/workflows/build.yml')
+    const ordered = [
+      '- name: Check out exact release source',
+      '- name: Revalidate release tag against packaged source',
+      '- name: Stage curated GitHub release',
+      '- name: Upload release assets to GitHub release',
+      '- name: Verify release assets on GitHub release',
+      '- name: Publish verified draft release',
+    ]
+    const positions = ordered.map((step) => workflow.indexOf(step))
+    expect(positions.every((position) => position >= 0)).toBe(true)
+    expect(positions).toEqual([...positions].sort((a, b) => a - b))
+    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
+    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
+    expect(workflow).toContain('--verify-tag')
+    expect(workflow).toContain('--notes-file "$release_notes"')
+    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
+  })
+})


### PR DESCRIPTION
## Summary

- Cuts Polaris v1.4.4, matched with Nova v1.4.4. Contents since v1.4.3: the application menu entry starts the packaged user service instead of a second process (#617), a privileged `--setup-host` run no longer treats root's own `/dev/uinput` and `/dev/uhid` access as proof that the desktop account is ready (#616), and the Bazzite validation receipt checker runs before release artifacts are bound (#616). The system extension withdrawal (#614, #615) stays as documented in the v1.4.3 notes.
- Every release identity moves to 1.4.4: CMake project version, benchmark collector version, SteamOS namcap review and package identity pins, and the packaging contract test.
- `docs/changelog.md` gains the dated v1.4.4 section with an empty Unreleased above it. `docs/release-notes/v1.4.4.md` follows the short template: Fixed, Heads up, the four install blocks folded in details, one Assets line.
- The public docs gate reads the v1.4.4 notes, requires the v1.4.4 facts, and expects exactly the four package assets. The v1.4.4 notes say the system extension stays withdrawn without naming the file; the gate rejects the file name there, since that warning lives in v1.4.3.
- `release-v143-contract` becomes historical (scope facts, the withdrawal warning, and the exact v1.4.3 install identities). `release-v144-contract` pins the new identities, the service-first desktop entry, the fail-closed input group source, the four install commands, and the unchanged publication binding.

## Exact candidate

- `Commit:` 3066c8826d8e1dec6ad67982f9f16605962bb69d d8ae172e5ad4a755822bfb3c9a3ffbe580cddc00
- `Tree:` 
- `Parent:` a4140449
- `Base:` a4140449 (master)

## Verification

- [x] `bash scripts/check-public-docs.sh`: pass on the v1.4.4 tree
- [x] `bash scripts/check-public-surface.sh`: pass
- [x] `npx vitest run release-v14 packaging-contracts`: 6 files, 42 tests pass (v1.4.0 through v1.4.4 contracts plus packaging contracts)
- [ ] CI packaging jobs (Arch, Fedora 44 RPM, SteamOS 3.8, Ubuntu) on this PR before merge; the tag build refuses a tag that does not equal `v${CMake version}`
- [ ] After merge: `git tag -a v1.4.4 <merge sha>` on the `polaris` remote; the tag build publishes the four packages with these notes

## Not covered

- No C++ change in this PR. The setup-host and receipt-validator changes were verified in #616.
- The notes' "Verified with Nova v1.4.4 on a Retroid Pocket 6 against a 1.4.3 host" reflects the Nova 1.4.4 candidate streaming against pc-papi's 1.4.3 RPM tonight; the published Nova 1.4.4 APK gets a smoke pass on the RP6 before this tag is pushed.
