### PR TITLE
fix(multiseat): match the kernel and rootless Podman on a real host

### DIFF
--- a/containers/multiseat/Containerfile
+++ b/containers/multiseat/Containerfile
@@ -19,6 +19,10 @@ COPY multiseat_worker/internal ./internal
 COPY multiseat_worker/cmd ./cmd
 COPY containers/multiseat/Containerfile /containers/multiseat/Containerfile
 COPY containers/multiseat/images.lock.json /containers/multiseat/images.lock.json
+# The image contract tests read these two production sources through the same
+# repository-relative path they use for the Containerfile and lock above.
+COPY multiseat_worker/main.go /multiseat_worker/main.go
+COPY multiseat_worker/server.go /multiseat_worker/server.go
 RUN go test -trimpath ./... && \
     go build -trimpath -buildvcs=false \
       -ldflags='-buildid= -s -w' \

--- a/docs/research/container-multiseat-architecture.md
+++ b/docs/research/container-multiseat-architecture.md
@@ -236,7 +236,9 @@ key nor the image may be reinterpreted inside the worker. Each launch is
 immutable and includes:
 
 - a digest-pinned image with pulling disabled;
-- a pre-created opaque profile volume mounted as the only persistent writable
+- a pre-created opaque profile volume, whose existence the backend verifies
+  with `podman volume exists` immediately before launch because `podman run`
+  would otherwise create it silently, mounted as the only persistent writable
   home, with implicit volume creation disabled;
 - explicit allowlisted GPU and virtual-input devices;
 - read-only shared game roots at derived `/mnt/games/<opaque-name>` paths;
@@ -528,7 +530,9 @@ they open no real input device. Their contract:
   relative/absolute mouse pair, optionally admits touch and pen, and bounds
   generic Xbox-style gamepad slots at sixteen;
 - accepts only canonical `/dev/input/eventN` host nodes with unique filesystem
-  inode and character-device identities, exact event-number-to-minor mapping,
+  inode and character-device identities, the kernel's event-number-to-minor
+  mapping (static minor 64 + N for event0 through event31, dynamic minor N
+  from event256 upward, nothing in between),
   Linux input major 13, an exact generation-derived kernel name, and host seat
   `seat-polaris`;
 - maps those nodes to fixed worker-local paths such as

--- a/docs/research/container-multiseat-architecture.md
+++ b/docs/research/container-multiseat-architecture.md
@@ -273,7 +273,33 @@ global-device prototype cannot reconcile as a current worker.
 
 Inventory is two phase and bounded: an exact deployment-label listing returns
 full immutable container IDs, then one JSON inspection validates every ID,
-label, state, device binding, and cardinality. Podman may reconstruct an
+label, state, device binding, and cardinality. Rootless Podman applies
+`--device` as bind mounts and reports none of them in its inspection output,
+so when a record points at its OCI runtime spec the inventory reads the spec
+and treats it as the device set, and any inspected device list Podman does
+fill in must agree with the spec entry for entry rather than add to it. The
+spec path is accepted only in Podman's `<storage>/<driver>-containers/<id>/
+userdata/config.json` shape with the record's own immutable ID, as a regular
+file owned by the controller uid, never through a symbolic link on its final
+component, and within the command output bound. Every mount in the spec is
+classified: Podman's pseudo-filesystems and the controller's tmpfs mounts may
+not sit on a device directory, nor cover `/dev` or `/` after a device binding,
+because the runtime applies mounts in order; a bind may come only from
+Podman's own per-container files at their known destinations, the worker's
+own profile volume (named by an immutable worker label and anchored to the
+storage root the spec lives in) at its mount point read-write, the
+controller's authority directories and shared game mounts at their exact
+destinations and permissions, Podman's init binary (read-only at
+`/run/podman-init`, an executable regular file, never a device), or a `/dev`
+path, which becomes a device binding that must land on a `/dev` path; any
+other bind, including `/dev` or `/` bound whole, fails the inventory, as does
+a spec that lists device nodes under `linux.devices`. A FIPS-mode host, where
+Podman binds the image's crypto policy from the overlay merged directory, is
+not supported by this classifier and fails closed. A container Podman created
+but never initialized has no spec; once its allocation is gone it is reported
+as stopped so it is reaped rather than blinding the inventory. Inventory
+failures carry the specific reason in the exception so an operator can tell a
+missing spec from drift. Podman may reconstruct an
 equivalent input host path, so input inspection still requires its expected
 major/minor plus the exact worker-local destination. GPU bindings are stricter:
 their host path and full identity must match the immutable admitted baseline,

--- a/multiseat_worker/image_contract_test.go
+++ b/multiseat_worker/image_contract_test.go
@@ -98,6 +98,8 @@ func TestContainerfileUsesLockedOfflineBuildInputs(t *testing.T) {
 		"test -r /usr/share/pipewire/pipewire-pulse.conf",
 		"COPY containers/multiseat/Containerfile /containers/multiseat/Containerfile",
 		"COPY containers/multiseat/images.lock.json /containers/multiseat/images.lock.json",
+		"COPY multiseat_worker/main.go /multiseat_worker/main.go",
+		"COPY multiseat_worker/server.go /multiseat_worker/server.go",
 		"ENTRYPOINT [\"/usr/bin/polaris-seat-worker\"]",
 	} {
 		if !strings.Contains(containerfile, required) {

--- a/src/platform/linux/input/inputtino_multiseat_backend.cpp
+++ b/src/platform/linux/input/inputtino_multiseat_backend.cpp
@@ -111,16 +111,21 @@ namespace multiseat::input {
         return std::nullopt;
       }
       const auto index = canonical_number(suffix);
-      if (!index ||
-          (node_class == input_node_class_e::event &&
-           *index > std::numeric_limits<std::uint32_t>::max() - 64)) {
+      if (!index) {
+        return std::nullopt;
+      }
+      // The kernel names static nodes from a per-driver base and dynamic
+      // nodes after their minor; names in the gap cannot exist.
+      const auto minor = node_class == input_node_class_e::event ?
+                           expected_event_minor(*index) :
+                           expected_joystick_minor(*index);
+      if (!minor) {
         return std::nullopt;
       }
       return parsed_input_node_t {
         .node_class = node_class,
         .index = *index,
-        .character_minor = node_class == input_node_class_e::event ?
-                             64 + *index : *index,
+        .character_minor = *minor,
         .filename = std::string {filename},
       };
     }

--- a/src/platform/linux/multiseat_input_authority.cpp
+++ b/src/platform/linux/multiseat_input_authority.cpp
@@ -293,6 +293,28 @@ namespace multiseat::input {
     return result;
   }
 
+  std::optional<std::uint32_t> expected_event_minor(std::uint64_t event_number) {
+    if (event_number < evdev_static_minor_count) {
+      return evdev_static_minor_base + static_cast<std::uint32_t>(event_number);
+    }
+    if (event_number >= input_first_dynamic_minor &&
+        event_number <= std::numeric_limits<std::uint32_t>::max()) {
+      return static_cast<std::uint32_t>(event_number);
+    }
+    return std::nullopt;
+  }
+
+  std::optional<std::uint32_t> expected_joystick_minor(
+    std::uint64_t joystick_number
+  ) {
+    if (joystick_number < joydev_static_minor_count ||
+        (joystick_number >= input_first_dynamic_minor &&
+         joystick_number <= std::numeric_limits<std::uint32_t>::max())) {
+      return static_cast<std::uint32_t>(joystick_number);
+    }
+    return std::nullopt;
+  }
+
   std::string expected_kernel_name(
     std::string_view input_seat,
     device_kind_e kind,
@@ -348,8 +370,8 @@ namespace multiseat::input {
           !event_number ||
           node.worker_path != worker_path ||
           node.filesystem_device == 0 || node.inode == 0 ||
-          node.character_major != 13 ||
-          node.character_minor != 64 + *event_number ||
+          node.character_major != linux_input_major ||
+          expected_event_minor(*event_number) != node.character_minor ||
           node.kernel_name != expected_kernel_name(
             expectation.input_seat,
             expected_kind,

--- a/src/platform/linux/multiseat_input_authority.h
+++ b/src/platform/linux/multiseat_input_authority.h
@@ -29,6 +29,29 @@ namespace multiseat::input {
   inline constexpr std::string_view multiseat_kernel_device_prefix =
     "Polaris multiseat ";
 
+  /**
+   * Linux input character minors. evdev owns 32 static minors from 64, so
+   * event0 through event31 are minor 64 + N. joydev owns 16 static minors from
+   * 0, so js0 through js15 are minor N. Once a host has more devices than a
+   * static range holds, the kernel allocates dynamic minors from 256 upward
+   * and names the node after the minor, so eventN and jsN with N >= 256 are
+   * minor N. No node exists in the gaps between the ranges.
+   */
+  inline constexpr std::uint32_t linux_input_major = 13;
+  inline constexpr std::uint32_t evdev_static_minor_base = 64;
+  inline constexpr std::uint32_t evdev_static_minor_count = 32;
+  inline constexpr std::uint32_t joydev_static_minor_count = 16;
+  inline constexpr std::uint32_t input_first_dynamic_minor = 256;
+
+  /** Minor the kernel assigns to /dev/input/event<number>, if such a node can exist. */
+  [[nodiscard]] std::optional<std::uint32_t> expected_event_minor(
+    std::uint64_t event_number
+  );
+  /** Minor the kernel assigns to /dev/input/js<number>, if such a node can exist. */
+  [[nodiscard]] std::optional<std::uint32_t> expected_joystick_minor(
+    std::uint64_t joystick_number
+  );
+
   enum class device_kind_e {
     keyboard,
     mouse_relative,

--- a/src/platform/linux/multiseat_podman_backend.cpp
+++ b/src/platform/linux/multiseat_podman_backend.cpp
@@ -842,6 +842,30 @@ namespace multiseat::podman {
     return true;
   }
 
+  std::optional<bool> backend_t::profile_volume_exists(const profile_t &profile) {
+    const auto result = host_.run(
+      {
+        options_.executable.native(),
+        "--remote=false",
+        "volume",
+        "exists",
+        profile.opaque_volume_name,
+      },
+      options_.command_timeout,
+      options_.max_command_output_bytes
+    );
+    if (result.timed_out || result.output_truncated) {
+      return std::nullopt;
+    }
+    if (result.exit_status == 0) {
+      return true;
+    }
+    if (result.exit_status == 1) {
+      return false;
+    }
+    return std::nullopt;
+  }
+
   bool backend_t::launch_host_ready(
     const worker_launch_spec_t &spec,
     const input::allocation_t &input_allocation
@@ -956,7 +980,7 @@ namespace multiseat::podman {
       "--health-max-log-count=" + std::to_string(options_.health_log_count),
       "--health-max-log-size=" + std::to_string(options_.health_log_size),
       "--stop-signal=TERM",
-      "--volume=" + profile.opaque_volume_name + ":/var/lib/polaris-seat:rw,nosuid,nodev,nocreate",
+      "--volume=" + profile.opaque_volume_name + ":/var/lib/polaris-seat:rw,nosuid,nodev",
       "--mount=type=bind,src=" +
         (options_.ipc_root / spec.resources.runtime_namespace / ipc_directory).native() +
         ",dst=" + std::string {container_ipc_directory} +
@@ -1070,6 +1094,21 @@ namespace multiseat::podman {
       }
     } catch (...) {
       return worker_command_result_e::indeterminate;
+    }
+    // podman run silently creates a missing named volume and offers no option
+    // to refuse, so the pre-created-volume contract is checked explicitly here,
+    // before the final identity recheck that stays adjacent to the run.
+    std::optional<bool> volume_present;
+    try {
+      volume_present = profile_volume_exists(*profile);
+    } catch (...) {
+      return worker_command_result_e::indeterminate;
+    }
+    if (!volume_present) {
+      return worker_command_result_e::indeterminate;
+    }
+    if (!*volume_present) {
+      return worker_command_result_e::rejected;
     }
 
     command_result_t result;
@@ -1261,7 +1300,6 @@ namespace multiseat::podman {
       "--remote=false",
       "container",
       "inspect",
-      "--type=container",
     };
     inspect_argv.insert(inspect_argv.end(), ids.begin(), ids.end());
     const auto inspected = host_.run(

--- a/src/platform/linux/multiseat_podman_backend.cpp
+++ b/src/platform/linux/multiseat_podman_backend.cpp
@@ -52,13 +52,19 @@ namespace multiseat::podman {
     constexpr auto label_display_hdr = "io.polaris.multiseat.display-hdr"sv;
     constexpr auto label_compositor = "io.polaris.multiseat.compositor"sv;
     constexpr auto label_encoders = "io.polaris.multiseat.encoders"sv;
+    constexpr auto label_volume = "io.polaris.multiseat.volume"sv;
     constexpr auto capability_file = worker_ipc::authority_capability_file_name;
     constexpr auto ipc_directory = worker_ipc::authority_ipc_directory_name;
     constexpr auto auth_directory = worker_ipc::authority_auth_directory_name;
     constexpr auto container_ipc_directory = "/run/polaris-ipc"sv;
     constexpr auto container_auth_directory = "/run/polaris-auth"sv;
+    constexpr auto podman_init_destination = "/run/podman-init"sv;
+    constexpr auto profile_volume_destination = "/var/lib/polaris-seat"sv;
+    constexpr auto shared_game_mount_root = "/mnt/games/"sv;
     constexpr std::size_t maximum_inspected_devices =
       input::maximum_input_allocations + 64;
+    constexpr std::size_t maximum_runtime_spec_mounts =
+      maximum_inspected_devices + 64;
 
     bool ascii_alphanumeric(char value) {
       return (value >= 'a' && value <= 'z') ||
@@ -107,6 +113,77 @@ namespace multiseat::podman {
 
     bool device_path(const std::filesystem::path &path) {
       return safe_path(path) && path.native().starts_with("/dev/");
+    }
+
+    bool normalized_absolute_path(const std::filesystem::path &path) {
+      return path.is_absolute() && path.lexically_normal() == path;
+    }
+
+    std::vector<std::string> path_components(const std::filesystem::path &path) {
+      std::vector<std::string> components;
+      for (const auto &component : path) {
+        components.push_back(component.native());
+      }
+      return components;
+    }
+
+    /**
+     * Podman stores every container's OCI runtime spec at
+     * `<storage>/<driver>-containers/<id>/userdata/config.json`. The path is
+     * accepted only in that shape, with the record's own immutable ID as the
+     * container directory, so the spec read is bound to the inspected record.
+     */
+    bool runtime_spec_path(
+      const std::filesystem::path &path,
+      std::string_view container_id_value
+    ) {
+      if (!normalized_absolute_path(path)) {
+        return false;
+      }
+      const auto components = path_components(path);
+      const auto count = components.size();
+      return count >= 5 &&
+             components[count - 1] == "config.json" &&
+             components[count - 2] == "userdata" &&
+             components[count - 3] == container_id_value &&
+             components[count - 4].ends_with("-containers");
+    }
+
+    /**
+     * Podman keeps a container's own files (resolv.conf, hosts, hostname,
+     * .containerenv, secrets, shm) under `<root>/<driver>-containers/<id>/
+     * userdata/`, below the storage root or the run root.
+     */
+    bool own_container_userdata_path(
+      const std::filesystem::path &path,
+      std::string_view container_id_value
+    ) {
+      if (!normalized_absolute_path(path)) {
+        return false;
+      }
+      const auto components = path_components(path);
+      for (std::size_t index = 1; index + 3 < components.size(); ++index) {
+        if (components[index].ends_with("-containers") &&
+            components[index + 1] == container_id_value &&
+            components[index + 2] == "userdata") {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /** Where Podman lands its own per-container files inside the worker. */
+    bool podman_own_destination(std::string_view destination) {
+      return destination == "/etc/resolv.conf" || destination == "/etc/hosts" ||
+             destination == "/etc/hostname" || destination == "/dev/shm" ||
+             destination == "/run/.containerenv" || destination == "/run/secrets";
+    }
+
+    /** Destinations that shadow or expose the worker's device set. */
+    bool device_directory_destination(std::string_view destination) {
+      return destination == "/dev/dri" || destination == "/dev/input" ||
+             destination.starts_with("/dev/dri/") ||
+             destination.starts_with("/dev/input/");
     }
 
     bool lowercase_sha256(std::string_view value) {
@@ -457,6 +534,7 @@ namespace multiseat::podman {
         {std::string {label_display_topology}, std::string {display_topology_name}},
         {std::string {label_media_pipeline}, std::string {media_pipeline_name}},
         {std::string {label_runtime_image}, profile.image_reference},
+        {std::string {label_volume}, profile.opaque_volume_name},
         {std::string {label_display_width}, std::to_string(spec.display_mode.width)},
         {std::string {label_display_height}, std::to_string(spec.display_mode.height)},
         {std::string {label_display_refresh}, std::to_string(spec.display_mode.refresh_millihz)},
@@ -816,6 +894,139 @@ namespace multiseat::podman {
     });
   }
 
+  std::vector<backend_t::declared_device_binding_t>
+  backend_t::runtime_spec_device_bindings(
+    const std::filesystem::path &spec_path,
+    const runtime_spec_expectations_t &expectations
+  ) const {
+    if (!runtime_spec_path(spec_path, expectations.container_id)) {
+      throw std::runtime_error {"invalid Podman runtime spec path"};
+    }
+    const auto text = host_.read_owned_regular_file(
+      spec_path,
+      options_.max_command_output_bytes
+    );
+    if (!text) {
+      throw std::runtime_error {"Podman runtime spec is unreadable"};
+    }
+    json spec;
+    try {
+      spec = json::parse(*text);
+    } catch (const json::exception &) {
+      throw std::runtime_error {"invalid Podman runtime spec"};
+    }
+    const auto *mounts = object_member(spec, "mounts");
+    if (!mounts || !mounts->is_array() ||
+        mounts->size() > maximum_runtime_spec_mounts) {
+      throw std::runtime_error {"invalid Podman runtime spec"};
+    }
+    // The storage root is the spec path without its last four components
+    // (`<driver>-containers/<id>/userdata/config.json`), which anchors the
+    // profile volume to the same storage the record lives in.
+    const auto storage_root =
+      spec_path.parent_path().parent_path().parent_path().parent_path();
+    const auto volume_source =
+      (storage_root / "volumes" / expectations.volume_name / "_data").native();
+    std::vector<declared_device_binding_t> bindings;
+    auto device_seen = false;
+    for (const auto &mount : *mounts) {
+      const auto destination = string_member(mount, "destination");
+      const auto type = string_member(mount, "type");
+      const auto source = string_member(mount, "source");
+      if (!destination || !type || !normalized_absolute_path(*destination)) {
+        throw std::runtime_error {"invalid Podman runtime spec mount"};
+      }
+      const auto device_destination = device_directory_destination(*destination);
+      if (*type != "bind") {
+        // Podman's /proc, /dev tmpfs, sysfs, devpts, mqueue, and cgroup, and
+        // the controller's tmpfs mounts. None of them may sit on a device
+        // directory, and the runtime applies mounts in order, so none may
+        // cover /dev or the root after a device binding either.
+        if (device_destination ||
+            (device_seen && (*destination == "/dev" || *destination == "/"))) {
+          throw std::runtime_error {"Podman runtime spec shadows device bindings"};
+        }
+        continue;
+      }
+      if (!source || !normalized_absolute_path(*source)) {
+        throw std::runtime_error {"invalid Podman runtime spec mount"};
+      }
+      std::string permissions {"rw"};
+      if (const auto *options = object_member(mount, "options")) {
+        if (!options->is_array()) {
+          throw std::runtime_error {"invalid Podman runtime spec mount"};
+        }
+        for (const auto &option : *options) {
+          if (!option.is_string()) {
+            throw std::runtime_error {"invalid Podman runtime spec mount"};
+          }
+          const auto value = option.get<std::string>();
+          if (value == "ro" || value == "rw") {
+            permissions = value;
+          }
+        }
+      }
+      if (!device_destination) {
+        // Podman's own per-container files, the worker's profile volume, the
+        // authority directories, and the shared game mounts are the only host
+        // content a worker may see besides its devices and Podman's init
+        // binary, and each must land where the controller asked with the
+        // permission it asked for. Checked before the device rule so a
+        // storage root that itself lives under /dev/shm still passes.
+        if (own_container_userdata_path(*source, expectations.container_id)) {
+          if (!podman_own_destination(*destination)) {
+            throw std::runtime_error {"unexpected Podman runtime spec mount"};
+          }
+          continue;
+        }
+        if (*source == volume_source) {
+          if (*destination != profile_volume_destination || permissions != "rw") {
+            throw std::runtime_error {"unexpected Podman runtime spec mount"};
+          }
+          continue;
+        }
+        if (const auto bind = expectations.controller_binds.find(*source);
+            bind != expectations.controller_binds.end()) {
+          if (*destination != bind->second.destination ||
+              permissions != bind->second.permissions) {
+            throw std::runtime_error {"unexpected Podman runtime spec mount"};
+          }
+          continue;
+        }
+        if (*destination == podman_init_destination) {
+          // `--init` binds the configured init binary read-only; it must be
+          // an executable regular file on the host, never a device.
+          if (source->starts_with("/dev/") || permissions != "ro" ||
+              !host_.executable_file(*source)) {
+            throw std::runtime_error {"invalid Podman init binding"};
+          }
+          continue;
+        }
+        if (!source->starts_with("/dev/")) {
+          throw std::runtime_error {"unexpected Podman runtime spec mount"};
+        }
+      }
+      if (!device_path(*source) || !device_path(*destination)) {
+        throw std::runtime_error {"invalid Podman device binding"};
+      }
+      bindings.push_back({
+        .host_path = *source,
+        .worker_path = *destination,
+        .permissions = std::move(permissions),
+      });
+      device_seen = true;
+    }
+    // A rootless runtime creates no device nodes through the spec's device
+    // node list; a spec that does describes a mode this backend never runs
+    // in, so it is refused rather than reasoned about.
+    const auto *linux_object = object_member(spec, "linux");
+    const auto *devices = linux_object ? object_member(*linux_object, "devices") : nullptr;
+    if (devices && !devices->is_null() && !(devices->is_array() && devices->empty())) {
+      throw std::runtime_error {"Podman runtime spec grants device nodes"};
+    }
+    return bindings;
+  }
+
   bool backend_t::base_host_ready() const {
     return host_.effective_uid() != 0 && host_.executable_file(options_.executable);
   }
@@ -980,7 +1191,8 @@ namespace multiseat::podman {
       "--health-max-log-count=" + std::to_string(options_.health_log_count),
       "--health-max-log-size=" + std::to_string(options_.health_log_size),
       "--stop-signal=TERM",
-      "--volume=" + profile.opaque_volume_name + ":/var/lib/polaris-seat:rw,nosuid,nodev",
+      "--volume=" + profile.opaque_volume_name + ":" +
+        std::string {profile_volume_destination} + ":rw,nosuid,nodev",
       "--mount=type=bind,src=" +
         (options_.ipc_root / spec.resources.runtime_namespace / ipc_directory).native() +
         ",dst=" + std::string {container_ipc_directory} +
@@ -1051,7 +1263,7 @@ namespace multiseat::podman {
     for (const auto &mount : options_.shared_game_mounts) {
       argv.push_back(
         "--mount=type=bind,src=" + mount.host_path.native() +
-        ",dst=/mnt/games/" + mount.mount_name + ",ro=true"
+        ",dst=" + std::string {shared_game_mount_root} + mount.mount_name + ",ro=true"
       );
     }
 
@@ -1371,6 +1583,7 @@ namespace multiseat::podman {
         const auto display_hdr = label_value(labels, label_display_hdr);
         const auto compositor = label_value(labels, label_compositor);
         const auto encoders_text = label_value(labels, label_encoders);
+        const auto volume = label_value(labels, label_volume);
         const auto slot = slot_text ? parse_decimal<std::uint32_t>(*slot_text) : std::nullopt;
         const auto generation = generation_text ?
                                   parse_decimal<std::uint64_t>(*generation_text) :
@@ -1426,8 +1639,18 @@ namespace multiseat::podman {
             !display_hdr || (*display_hdr != "0" && *display_hdr != "1") ||
             !valid_display_mode(display_mode) ||
             !compositor || !valid_compositor_name(*compositor) ||
+            !volume || !opaque_name_token(*volume) ||
             !encoders || *encoders == 0) {
           throw std::runtime_error {"incomplete Podman worker identity labels"};
+        }
+        if (std::none_of(
+              options_.profiles.begin(),
+              options_.profiles.end(),
+              [&volume](const auto &profile) {
+                return profile.opaque_volume_name == *volume;
+              }
+            )) {
+          throw std::runtime_error {"unknown Podman worker volume"};
         }
 
         const seat_handle_t seat_handle {
@@ -1447,10 +1670,18 @@ namespace multiseat::podman {
         // release its seat and the container can be reaped instead of failing
         // every inventory until Podman removes it. A stopped worker whose
         // allocation still resolves keeps the full check.
+        // A container Podman created but never initialized has no runtime
+        // spec yet and can never start under this controller, so it takes
+        // the same path once its allocation is gone: visible as stopped, so
+        // it gets reaped instead of blinding the inventory.
+        const auto lowercase_state = lowercase_ascii(*runtime_state);
+        const bool never_started =
+          lowercase_state == "created" || lowercase_state == "configured";
         const bool released_stopped_worker =
           require_input_authority && !allocation &&
-          observed_state(*runtime_state, std::string {}) ==
-            worker_observed_state_e::stopped;
+          (observed_state(*runtime_state, std::string {}) ==
+             worker_observed_state_e::stopped ||
+           never_started);
         if (require_input_authority && !released_stopped_worker) {
           if (!device_array || !device_array->is_array() ||
               device_array->size() > maximum_inspected_devices) {
@@ -1474,26 +1705,100 @@ namespace multiseat::podman {
             throw std::runtime_error {"Podman input manifest label changed"};
           }
 
-          std::vector<runtime_device_binding_t> bindings;
-          bindings.reserve(device_array->size());
-          std::set<std::filesystem::path> worker_paths;
+          std::vector<declared_device_binding_t> inspected;
+          inspected.reserve(device_array->size());
           for (const auto &device : *device_array) {
             const auto host_path = string_member(device, "PathOnHost");
             const auto worker_path = string_member(device, "PathInContainer");
             const auto permissions = string_member(device, "CgroupPermissions");
-            if (!host_path || !worker_path ||
-                !device_path(*host_path) || !device_path(*worker_path) ||
-                (permissions && !permissions->empty() && *permissions != "rw") ||
-                !worker_paths.emplace(*worker_path).second) {
+            if (!host_path || !worker_path) {
               throw std::runtime_error {"invalid Podman device binding"};
             }
-            const auto identity = host_.read_write_character_device(*host_path);
+            inspected.push_back({
+              .host_path = *host_path,
+              .worker_path = *worker_path,
+              .permissions = permissions.value_or(std::string {}),
+            });
+          }
+          // The OCI runtime spec is what the runtime applied, so it is the
+          // device set when Podman points at it; rootless Podman reports its
+          // device bind mounts nowhere else. An inspected device list, when
+          // Podman fills one in, must then agree with the spec entry for
+          // entry rather than add to it. Without a spec the inspected list
+          // is the device set.
+          std::vector<declared_device_binding_t> declared;
+          if (const auto *spec_path = object_member(container, "OCIConfigPath")) {
+            if (!spec_path->is_string()) {
+              throw std::runtime_error {"invalid Podman runtime spec path"};
+            }
+            runtime_spec_expectations_t expectations {
+              .container_id = *id,
+              .volume_name = *volume,
+            };
+            const auto authority = options_.ipc_root / *runtime;
+            expectations.controller_binds.emplace(
+              (authority / ipc_directory).native(),
+              expected_bind_t {std::string {container_ipc_directory}, "rw"}
+            );
+            expectations.controller_binds.emplace(
+              (authority / auth_directory).native(),
+              expected_bind_t {std::string {container_auth_directory}, "ro"}
+            );
+            for (const auto &mount : options_.shared_game_mounts) {
+              expectations.controller_binds.emplace(
+                mount.host_path.native(),
+                expected_bind_t {
+                  std::string {shared_game_mount_root} + mount.mount_name,
+                  "ro",
+                }
+              );
+            }
+            declared = runtime_spec_device_bindings(
+              spec_path->get<std::string>(),
+              expectations
+            );
+            for (const auto &binding : inspected) {
+              const auto agrees = std::any_of(
+                declared.begin(),
+                declared.end(),
+                [&binding](const auto &candidate) {
+                  return candidate.host_path == binding.host_path &&
+                         candidate.worker_path == binding.worker_path &&
+                         (binding.permissions.empty() ||
+                          binding.permissions == candidate.permissions);
+                }
+              );
+              if (!agrees) {
+                throw std::runtime_error {
+                  "Podman device inventory contradicts the runtime spec"
+                };
+              }
+            }
+          } else {
+            declared = std::move(inspected);
+          }
+          if (declared.size() > maximum_inspected_devices) {
+            throw std::runtime_error {"invalid Podman device inventory"};
+          }
+
+          std::vector<runtime_device_binding_t> bindings;
+          bindings.reserve(declared.size());
+          std::set<std::filesystem::path> worker_paths;
+          for (const auto &binding : declared) {
+            const std::filesystem::path host_path {binding.host_path};
+            const std::filesystem::path worker_path {binding.worker_path};
+            if (!device_path(host_path) || !device_path(worker_path) ||
+                (!binding.permissions.empty() && binding.permissions != "rw") ||
+                !worker_paths.emplace(worker_path).second) {
+              throw std::runtime_error {"invalid Podman device binding"};
+            }
+            const auto identity = host_.read_write_character_device(host_path);
             if (!identity) {
               throw std::runtime_error {"Podman device binding is unavailable"};
             }
             bindings.push_back({
-              .host_path = *host_path,
-              .worker_path = *worker_path,
+              .host_path = host_path,
+              .worker_path = worker_path,
               .identity = *identity,
             });
           }
@@ -1521,7 +1826,9 @@ namespace multiseat::podman {
               },
               .worker_name = *worker,
             },
-            .state = observed_state(*runtime_state, health_state),
+            .state = released_stopped_worker && never_started ?
+                       worker_observed_state_e::stopped :
+                       observed_state(*runtime_state, health_state),
           },
           .runtime_state = lowercase_ascii(*runtime_state),
           .labels = std::move(labels),
@@ -1530,6 +1837,11 @@ namespace multiseat::podman {
       }
       require_current_gpu_catalog();
       return records;
+    } catch (const std::exception &error) {
+      throw std::runtime_error {
+        std::string {"rootless Podman returned invalid worker inventory: "} +
+        error.what()
+      };
     } catch (...) {
       throw std::runtime_error {"rootless Podman returned invalid worker inventory"};
     }

--- a/src/platform/linux/multiseat_podman_backend.h
+++ b/src/platform/linux/multiseat_podman_backend.h
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -58,6 +59,16 @@ namespace multiseat::podman {
     [[nodiscard]] virtual std::optional<character_device_identity_t>
     read_write_character_device(
       const std::filesystem::path &path
+    ) const = 0;
+    /**
+     * Bounded read of a regular file owned by the effective uid. The final
+     * path component is never followed as a symbolic link. Empty when the
+     * file is missing, not a regular file, owned by someone else, unreadable,
+     * or larger than `max_bytes`; an empty file reads as an empty string.
+     */
+    [[nodiscard]] virtual std::optional<std::string> read_owned_regular_file(
+      const std::filesystem::path &path,
+      std::size_t max_bytes
     ) const = 0;
     virtual command_result_t run(
       const std::vector<std::string> &argv,
@@ -199,6 +210,13 @@ namespace multiseat::podman {
       character_device_identity_t identity;
     };
 
+    /** A device binding as Podman declares it, before identity is read. */
+    struct declared_device_binding_t {
+      std::string host_path;
+      std::string worker_path;
+      std::string permissions;
+    };
+
     [[nodiscard]] const gpu_t *gpu_for(const worker_launch_spec_t &spec) const;
     [[nodiscard]] const profile_t *profile_for(const std::string &profile_key) const;
     [[nodiscard]] bool workload_allowed(const workload_plan_t &workload) const;
@@ -222,6 +240,33 @@ namespace multiseat::podman {
       const std::vector<runtime_device_binding_t> &bindings,
       const gpu_t &gpu,
       const input::allocation_t &input_allocation
+    ) const;
+    /** Where and how a controller-requested bind must land in the worker. */
+    struct expected_bind_t {
+      std::string destination;
+      std::string permissions;
+    };
+    /** What a worker's runtime spec may bind besides its devices. */
+    struct runtime_spec_expectations_t {
+      std::string_view container_id;
+      std::string volume_name;
+      /** Exact host sources the controller itself asked Podman to bind. */
+      std::map<std::string, expected_bind_t> controller_binds;
+    };
+    /**
+     * The device bindings the container runtime applied, read from the
+     * container's OCI runtime spec. Rootless Podman implements `--device` as
+     * bind mounts and reports none of them in its inspection output, so the
+     * spec is the only record of what the worker was actually given. Every
+     * mount is classified: Podman's pseudo-filesystems, its own per-container
+     * files at their known destinations, the worker's profile volume, the
+     * controller's authority and game mounts at their exact destinations and
+     * permissions, and Podman's read-only init binary are allowed, device
+     * paths become bindings, anything else fails.
+     */
+    [[nodiscard]] std::vector<declared_device_binding_t> runtime_spec_device_bindings(
+      const std::filesystem::path &spec_path,
+      const runtime_spec_expectations_t &expectations
     ) const;
     [[nodiscard]] std::vector<std::string> launch_argv(
       const worker_launch_spec_t &spec,

--- a/src/platform/linux/multiseat_podman_backend.h
+++ b/src/platform/linux/multiseat_podman_backend.h
@@ -204,6 +204,8 @@ namespace multiseat::podman {
     [[nodiscard]] bool workload_allowed(const workload_plan_t &workload) const;
     [[nodiscard]] bool base_host_ready() const;
     [[nodiscard]] bool gpu_catalog_current() const;
+    /** True/false when the profile volume is present/absent; empty on error. */
+    [[nodiscard]] std::optional<bool> profile_volume_exists(const profile_t &profile);
     [[nodiscard]] bool launch_host_ready(
       const worker_launch_spec_t &spec,
       const input::allocation_t &input_allocation

--- a/src/platform/linux/multiseat_podman_host.cpp
+++ b/src/platform/linux/multiseat_podman_host.cpp
@@ -13,7 +13,10 @@
 #include <sys/sysmacros.h>
 #include <unistd.h>
 
+#include <array>
+#include <cerrno>
 #include <limits>
+#include <string>
 
 namespace multiseat::podman {
   namespace {
@@ -95,6 +98,52 @@ namespace multiseat::podman {
       .character_major = static_cast<std::uint32_t>(character_major),
       .character_minor = static_cast<std::uint32_t>(character_minor),
     };
+  }
+
+  std::optional<std::string> local_host_t::read_owned_regular_file(
+    const std::filesystem::path &path,
+    std::size_t max_bytes
+  ) const {
+    // O_NONBLOCK keeps a FIFO from blocking the open before the type check
+    // can refuse it; it has no effect on a regular file.
+    const auto descriptor = open(
+      path.c_str(),
+      O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NOCTTY | O_NONBLOCK
+    );
+    if (descriptor < 0) {
+      return std::nullopt;
+    }
+    std::optional<std::string> content;
+    struct stat metadata {};
+    if (fstat(descriptor, &metadata) == 0 && S_ISREG(metadata.st_mode) &&
+        metadata.st_uid == geteuid() && metadata.st_size >= 0 &&
+        static_cast<std::uint64_t>(metadata.st_size) <= max_bytes) {
+      std::string buffer;
+      std::array<char, 65536> chunk {};
+      auto complete = false;
+      while (true) {
+        const auto count = read(descriptor, chunk.data(), chunk.size());
+        if (count < 0) {
+          if (errno == EINTR) {
+            continue;
+          }
+          break;
+        }
+        if (count == 0) {
+          complete = true;
+          break;
+        }
+        if (buffer.size() + static_cast<std::size_t>(count) > max_bytes) {
+          break;
+        }
+        buffer.append(chunk.data(), static_cast<std::size_t>(count));
+      }
+      if (complete) {
+        content = std::move(buffer);
+      }
+    }
+    close(descriptor);
+    return content;
   }
 
   command_result_t local_host_t::run(

--- a/src/platform/linux/multiseat_podman_host.h
+++ b/src/platform/linux/multiseat_podman_host.h
@@ -25,6 +25,10 @@ namespace multiseat::podman {
     read_write_character_device(
       const std::filesystem::path &path
     ) const override;
+    [[nodiscard]] std::optional<std::string> read_owned_regular_file(
+      const std::filesystem::path &path,
+      std::size_t max_bytes
+    ) const override;
     command_result_t run(
       const std::vector<std::string> &argv,
       std::chrono::milliseconds timeout,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -256,6 +256,7 @@ if (NOT WIN32 AND NOT APPLE)
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_multiseat_moonlight_worker_adapter.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_multiseat_controller_runtime.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_multiseat_controller_production.cpp
+        ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_multiseat_podman_host.cpp
         ${CMAKE_SOURCE_DIR}/tests/integration/test_multiseat_physical.cpp
     )
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -256,6 +256,7 @@ if (NOT WIN32 AND NOT APPLE)
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_multiseat_moonlight_worker_adapter.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_multiseat_controller_runtime.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_multiseat_controller_production.cpp
+        ${CMAKE_SOURCE_DIR}/tests/integration/test_multiseat_physical.cpp
     )
 endif()
 

--- a/tests/integration/test_multiseat_physical.cpp
+++ b/tests/integration/test_multiseat_physical.cpp
@@ -1,0 +1,364 @@
+/**
+ * @file tests/integration/test_multiseat_physical.cpp
+ * @brief Opt-in physical smoke of the production multiseat composition.
+ *
+ * Skipped unless POLARIS_MULTISEAT_PHYSICAL=1. Everything else about the run
+ * comes from the environment so no host detail is compiled in:
+ *   POLARIS_PHYSICAL_IMAGE         digest-pinned worker image reference
+ *   POLARIS_PHYSICAL_IPC_ROOT      pre-created mode-0700 runtime root
+ *   POLARIS_PHYSICAL_RENDER_NODE   render node path (default /dev/dri/renderD128)
+ *   POLARIS_PHYSICAL_GPU_DEVICES   comma-separated device paths, must include
+ *                                  the render node (default: the render node)
+ *   POLARIS_PHYSICAL_PODMAN        podman executable (default /usr/bin/podman)
+ *   POLARIS_PHYSICAL_VOLUME        pre-created profile volume name
+ *   POLARIS_PHYSICAL_READY_SECONDS seconds to wait for the worker (default 120)
+ *
+ * This drives the real controller with the real rootless Podman host, the real
+ * inputtino backend, and the real worker transport. It creates virtual input
+ * devices on the host and starts one container; it never touches the running
+ * Polaris process.
+ */
+#include "src/platform/linux/multiseat_controller_production.h"
+
+#ifdef __linux__
+
+  #include <chrono>
+  #include <cstdio>
+  #include <cstdlib>
+  #include <filesystem>
+  #include <gtest/gtest.h>
+  #include <iostream>
+  #include <memory>
+  #include <sstream>
+  #include <string>
+  #include <thread>
+  #include <vector>
+
+namespace {
+  using namespace multiseat;
+  namespace input = multiseat::input;
+  namespace podman = multiseat::podman;
+
+  std::string env_or(const char *name, const std::string &fallback) {
+    const auto *value = std::getenv(name);
+    return value && *value ? std::string {value} : fallback;
+  }
+
+  std::vector<std::filesystem::path> split_paths(const std::string &value) {
+    std::vector<std::filesystem::path> paths;
+    std::stringstream stream {value};
+    std::string item;
+    while (std::getline(stream, item, ',')) {
+      if (!item.empty()) {
+        paths.emplace_back(item);
+      }
+    }
+    return paths;
+  }
+
+  std::string shell_output(const std::string &command) {
+    std::string output;
+    if (auto *pipe = ::popen(command.c_str(), "r")) {
+      char buffer[4096];
+      while (auto read = std::fread(buffer, 1, sizeof(buffer), pipe)) {
+        output.append(buffer, read);
+      }
+      ::pclose(pipe);
+    }
+    return output;
+  }
+
+  void log(const std::string &line) {
+    std::cout << "[physical] " << line << std::endl;
+  }
+
+  void log_podman(const std::string &podman, const std::string &deployment) {
+    log("podman ps:\n" + shell_output(
+      podman + " ps -a --filter label=io.polaris.multiseat.deployment=" +
+      deployment + " --format '{{.ID}} {{.Names}} {{.Status}}' 2>&1"
+    ));
+  }
+
+  void log_worker_inspect(const std::string &podman, const std::string &deployment) {
+    const auto ids = shell_output(
+      podman + " ps -a --filter label=io.polaris.multiseat.deployment=" +
+      deployment + " --format '{{.ID}}' 2>/dev/null"
+    );
+    std::stringstream stream {ids};
+    std::string id;
+    while (std::getline(stream, id)) {
+      if (!id.empty()) {
+        log("inspect " + id + ": " + shell_output(
+          podman + " container inspect " + id +
+          " --format 'Name={{.Name}} Status={{.State.Status}} Health={{.State.Health.Status}} "
+          "Devices={{json .HostConfig.Devices}} Mounts={{json .Mounts}}' 2>&1 | cut -c1-1200"
+        ));
+      }
+    }
+  }
+
+  /** Force-remove anything the controller left behind so the host stays clean. */
+  void cleanup_leftovers(
+    const std::string &podman,
+    const std::string &deployment,
+    const std::string &ipc_root
+  ) {
+    const auto ids = shell_output(
+      podman + " ps -a --filter label=io.polaris.multiseat.deployment=" +
+      deployment + " --format '{{.ID}}' 2>/dev/null"
+    );
+    std::stringstream stream {ids};
+    std::string id;
+    while (std::getline(stream, id)) {
+      if (!id.empty()) {
+        log("LEFTOVER container force-removed: " + id + " " +
+            shell_output(podman + " rm -f " + id + " 2>&1"));
+      }
+    }
+    std::error_code ignored;
+    for (const auto &entry : std::filesystem::directory_iterator {ipc_root, ignored}) {
+      if (entry.path().filename().string().starts_with("polaris-runtime-")) {
+        log("LEFTOVER authority directory removed: " + entry.path().string());
+        std::filesystem::remove_all(entry.path(), ignored);
+      }
+    }
+  }
+
+  void log_worker_logs(const std::string &podman, const std::string &deployment) {
+    const auto ids = shell_output(
+      podman + " ps -a --filter label=io.polaris.multiseat.deployment=" +
+      deployment + " --format '{{.ID}}' 2>/dev/null"
+    );
+    std::stringstream stream {ids};
+    std::string id;
+    while (std::getline(stream, id)) {
+      if (!id.empty()) {
+        log("podman logs " + id + ":\n" + shell_output(podman + " logs " + id + " 2>&1 | tail -40"));
+        log("podman inspect state " + id + ": " + shell_output(
+          podman + " inspect --format '{{.State.Status}} health={{.State.Health.Status}} exit={{.State.ExitCode}}' " + id + " 2>&1"
+        ));
+      }
+    }
+  }
+
+  const char *input_status_name(input::status_e status) {
+    switch (status) {
+      case input::status_e::applied: return "applied";
+      case input::status_e::already_applied: return "already_applied";
+      case input::status_e::reconciliation_required: return "reconciliation_required";
+      case input::status_e::invalid_request: return "invalid_request";
+      case input::status_e::not_found: return "not_found";
+      case input::status_e::stale_authority: return "stale_authority";
+      case input::status_e::backend_rejected: return "backend_rejected";
+      case input::status_e::backend_indeterminate: return "backend_indeterminate";
+      case input::status_e::backend_protocol_error: return "backend_protocol_error";
+    }
+    return "?";
+  }
+
+  const char *reconcile_name(controller_reconcile_status_e status) {
+    switch (status) {
+      case controller_reconcile_status_e::ready: return "ready";
+      case controller_reconcile_status_e::controller_shutting_down: return "controller_shutting_down";
+      case controller_reconcile_status_e::invalid_input_expectations: return "invalid_input_expectations";
+      case controller_reconcile_status_e::worker_reconciliation_required: return "worker_reconciliation_required";
+      case controller_reconcile_status_e::input_reconciliation_required: return "input_reconciliation_required";
+    }
+    return "?";
+  }
+
+  std::string describe(const controller_reconcile_result_t &result) {
+    std::ostringstream text;
+    const auto &b = result.worker.broker;
+    text << "status=" << reconcile_name(result.status)
+         << " ready=" << (result.ready() ? "yes" : "no")
+         << " worker.admission_ready=" << result.worker.admission_ready
+         << " startup_recovery=" << result.worker.startup_recovery_complete
+         << " authority_blocked=" << result.worker.authority_blocked
+         << " broker{obs=" << b.observations << " current=" << b.current_workers
+         << " orphan=" << b.orphan_workers << " ready_transitions=" << b.ready_transitions
+         << " missing=" << b.missing_workers << " released=" << b.released_seats
+         << " graceful=" << b.graceful_stop_requests << " force=" << b.force_stop_requests
+         << " stuck=" << b.stuck_workers << " protocol_errors=" << b.protocol_errors
+         << " readiness_rejections=" << b.readiness_rejections
+         << " observation_failed=" << b.backend_observation_failed
+         << " authoritative=" << b.inventory_authoritative << "}"
+         << " endpoints{connect=" << result.worker.endpoint_connections
+         << " fail=" << result.worker.endpoint_failures
+         << " heartbeats=" << result.worker.endpoint_heartbeats << "}";
+    if (result.input) {
+      text << " input{status=" << static_cast<int>(result.input->status)
+           << " admission_ready=" << result.input->report.admission_ready << "}";
+    }
+    return text.str();
+  }
+
+  TEST(MultiseatPhysical, OneRealSupervisorWorkerStartsReportsReadyAndTearsDown) {
+    if (env_or("POLARIS_MULTISEAT_PHYSICAL", "") != "1") {
+      GTEST_SKIP() << "set POLARIS_MULTISEAT_PHYSICAL=1 to run against real Podman";
+    }
+    const auto image = env_or("POLARIS_PHYSICAL_IMAGE", "");
+    const auto ipc_root = env_or("POLARIS_PHYSICAL_IPC_ROOT", "");
+    const auto render_node = env_or("POLARIS_PHYSICAL_RENDER_NODE", "/dev/dri/renderD128");
+    const auto devices = split_paths(env_or("POLARIS_PHYSICAL_GPU_DEVICES", render_node));
+    const auto podman_path = env_or("POLARIS_PHYSICAL_PODMAN", "/usr/bin/podman");
+    const auto volume = env_or("POLARIS_PHYSICAL_VOLUME", "pv-physical-a1b2");
+    const auto ready_seconds = std::stoul(env_or("POLARIS_PHYSICAL_READY_SECONDS", "120"));
+    ASSERT_FALSE(image.empty()) << "POLARIS_PHYSICAL_IMAGE is required";
+    ASSERT_FALSE(ipc_root.empty()) << "POLARIS_PHYSICAL_IPC_ROOT is required";
+    const std::string deployment = "physical-smoke";
+
+    production_controller_options_t options;
+    options.enabled = true;
+    options.gpus = {{
+      .logical_gpu_id = "gpu-physical",
+      .render_node = render_node,
+      .devices = devices,
+      .max_seats = 2,
+      .max_encoder_sessions = 2,
+    }};
+    options.podman.executable = podman_path;
+    options.podman.deployment_id = deployment;
+    options.podman.worker_entrypoint = "/usr/bin/polaris-seat-worker";
+    options.podman.ipc_root = ipc_root;
+    options.podman.profiles = {{
+      .profile_key = "physical-gamescope",
+      .opaque_volume_name = volume,
+      .runtime_profile = runtime_profile_e::gamescope,
+      .image_reference = image,
+    }};
+    options.podman.workloads = {{
+      .kind = workload_kind_e::gamescope,
+      .target_id = "physical-smoke",
+    }};
+
+    log("image=" + image + " ipc_root=" + ipc_root + " render=" + render_node +
+        " devices=" + std::to_string(devices.size()) + " podman=" + podman_path);
+    auto created = create_production_controller_runtime(std::move(options));
+    log("create status=" + std::to_string(static_cast<int>(created.status)));
+    ASSERT_EQ(created.status, controller_runtime_create_status_e::ready_enabled);
+    ASSERT_TRUE(created.runtime);
+    auto controller = std::move(created.runtime);
+
+    const auto initial = controller->reconcile();
+    log("initial reconcile: " + describe(initial));
+    log_podman(podman_path, deployment);
+    ASSERT_TRUE(initial.ready()) << describe(initial);
+
+    seat_request_t request {
+      .client_key = "physical-client",
+      .profile_key = "physical-gamescope",
+      .workload = {.kind = workload_kind_e::gamescope, .target_id = "physical-smoke"},
+      .logical_gpu_id = "gpu-physical",
+      .runtime_profile = runtime_profile_e::gamescope,
+      .data_plane = {
+        .display_topology = display_topology_e::capture_host_with_nested_compositor,
+        .media_pipeline = media_pipeline_e::worker_local_capture_encode,
+      },
+      .display_mode = {1920, 1080, 60000, false},
+      .requested_compositor = compositor_e::gamescope,
+      .encoder_sessions = 1,
+    };
+    const auto admitted = controller->admit(request);
+    log("admit rejection=" + std::to_string(static_cast<int>(admitted.rejection)));
+    ASSERT_TRUE(admitted.accepted());
+    ASSERT_TRUE(admitted.seat);
+    const auto handle = admitted.seat->handle;
+    log("seat epoch=" + handle.controller_epoch + " gpu=" + handle.logical_gpu_id +
+        " slot=" + std::to_string(handle.slot) + " gen=" + std::to_string(handle.generation) +
+        " worker=" + admitted.seat->resources.worker_name +
+        " ns=" + admitted.seat->resources.runtime_namespace +
+        " input_seat=" + admitted.seat->resources.input_seat);
+    ASSERT_EQ(
+      controller->bind_runtime(handle, compositor_e::gamescope, "physical smoke"),
+      mutation_result_e::applied
+    );
+
+    const auto started = controller->start_seat(handle, input::plan_t {.gamepad_slots = 1});
+    log("start status=" + std::to_string(static_cast<int>(started.status)) +
+        " worker=" + (started.worker ? std::to_string(static_cast<int>(*started.worker)) : "none") +
+        " input.status=" + std::to_string(static_cast<int>(started.input.status)) +
+        " authority=" + input_status_name(started.input.input.status) +
+        " nodes=" + (started.input.input.allocation ? std::to_string(started.input.input.allocation->nodes.size()) : std::string {"none"}) +
+        " input.prepared=" + (started.input.input.prepared() ? "yes" : "no"));
+    if (started.input.input.allocation) {
+      for (const auto &node : started.input.input.allocation->nodes) {
+        log("  node " + node.host_path.string() + " -> " + node.worker_path.string() +
+            " kernel_name='" + node.kernel_name + "' seat='" + node.host_seat + "' phys='" + node.phys + "'");
+      }
+    }
+    log_podman(podman_path, deployment);
+    if (!started.started()) {
+      log_worker_logs(podman_path, deployment);
+      const auto report = controller->shutdown();
+      log("shutdown after failed start: status=" + std::to_string(static_cast<int>(report.status)));
+      cleanup_leftovers(podman_path, deployment, ipc_root);
+      FAIL() << "worker did not start";
+    }
+    EXPECT_EQ(controller->seats(), 1U);
+    EXPECT_EQ(controller->managed_workers(), 1U);
+    EXPECT_EQ(controller->input_allocations(), 1U);
+
+    // Poll until the worker is observed ready and its endpoint is connected.
+    bool ready = false;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds {ready_seconds};
+    while (std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::seconds {2});
+      const auto result = controller->reconcile();
+      log("reconcile: " + describe(result));
+      if (result.worker.broker.ready_transitions != 0 ||
+          result.worker.endpoint_connections != 0) {
+        ready = true;
+        break;
+      }
+      if (controller->seats() == 0) {
+        log("seat vanished during startup");
+        break;
+      }
+    }
+    log_podman(podman_path, deployment);
+    log_worker_inspect(podman_path, deployment);
+    log_worker_logs(podman_path, deployment);
+    EXPECT_TRUE(ready) << "worker never became ready within " << ready_seconds << "s";
+
+    // Heartbeat the endpoint a few times if it connected.
+    for (int i = 0; i < 3 && ready; ++i) {
+      std::this_thread::sleep_for(std::chrono::seconds {2});
+      const auto result = controller->reconcile();
+      log("steady reconcile: " + describe(result));
+    }
+
+    const auto stopped = controller->stop_seat(handle);
+    log("stop status=" + std::to_string(static_cast<int>(stopped.status)) +
+        " broker=" + std::to_string(static_cast<int>(stopped.worker.broker)));
+    const auto stop_deadline = std::chrono::steady_clock::now() + std::chrono::seconds {90};
+    while (std::chrono::steady_clock::now() < stop_deadline &&
+           (controller->seats() != 0 || controller->managed_workers() != 0)) {
+      std::this_thread::sleep_for(std::chrono::seconds {2});
+      const auto result = controller->reconcile();
+      log("teardown reconcile: " + describe(result) +
+          " seats=" + std::to_string(controller->seats()) +
+          " managed=" + std::to_string(controller->managed_workers()));
+    }
+    log_podman(podman_path, deployment);
+    EXPECT_EQ(controller->seats(), 0U);
+    EXPECT_EQ(controller->managed_workers(), 0U);
+
+    controller_shutdown_report_t report;
+    for (int attempt = 0; attempt < 5; ++attempt) {
+      report = controller->shutdown();
+      log("shutdown attempt " + std::to_string(attempt) + ": status=" +
+          std::to_string(static_cast<int>(report.status)));
+      if (report.closed()) {
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::seconds {3});
+    }
+    EXPECT_TRUE(report.closed());
+    EXPECT_EQ(controller->input_allocations(), 0U);
+    log_podman(podman_path, deployment);
+    cleanup_leftovers(podman_path, deployment, ipc_root);
+  }
+}  // namespace
+
+#endif

--- a/tests/unit/platform/test_inputtino_multiseat_backend.cpp
+++ b/tests/unit/platform/test_inputtino_multiseat_backend.cpp
@@ -170,6 +170,37 @@ namespace {
     ));
   }
 
+  TEST(LinuxKernelNodeProbe, AcceptsDynamicKernelMinorsAndRejectsTheStaticGap) {
+    fake_kernel_io_t io;
+    io.install("/dev/input/event256", 256, "Polaris multiseat abc keyboard");
+    io.install("/dev/input/event31", 95, "Polaris multiseat abc mouse");
+    io.install("/dev/input/event40", 104, "Polaris multiseat abc touch");
+    io.install("/dev/input/js16", 16, "Polaris multiseat abc gamepad-0", std::nullopt);
+    io.install("/dev/input/js256", 256, "Polaris multiseat abc gamepad-0", std::nullopt);
+    linux_kernel_node_probe_t probe {io};
+
+    const auto dynamic_event = probe.observe("/dev/input/event256");
+    ASSERT_EQ(dynamic_event.status, node_observation_status_e::observed);
+    ASSERT_TRUE(dynamic_event.snapshot.has_value());
+    EXPECT_EQ(dynamic_event.snapshot->character_minor, 256U);
+
+    const auto last_static = probe.observe("/dev/input/event31");
+    ASSERT_EQ(last_static.status, node_observation_status_e::observed);
+    EXPECT_EQ(last_static.snapshot->character_minor, 95U);
+
+    EXPECT_EQ(
+      probe.observe("/dev/input/event40").status,
+      node_observation_status_e::unsafe
+    );
+    EXPECT_EQ(
+      probe.observe("/dev/input/js16").status,
+      node_observation_status_e::unsafe
+    );
+    const auto dynamic_joystick = probe.observe("/dev/input/js256");
+    ASSERT_EQ(dynamic_joystick.status, node_observation_status_e::observed);
+    EXPECT_EQ(dynamic_joystick.snapshot->character_minor, 256U);
+  }
+
   TEST(LinuxKernelNodeProbe, RejectsNoncanonicalOrContradictoryKernelIdentity) {
     fake_kernel_io_t io;
     io.install("/dev/input/event2", 66, "Polaris multiseat abc keyboard");

--- a/tests/unit/platform/test_multiseat_controller_production.cpp
+++ b/tests/unit/platform/test_multiseat_controller_production.cpp
@@ -175,6 +175,7 @@ namespace {
     std::vector<std::vector<std::string>> commands;
     std::size_t probe_calls = 0;
     std::size_t device_identity_calls = 0;
+    std::size_t runtime_spec_reads = 0;
 
     /**
      * Opt-in offline Podman emulation: `run` records a container from its own
@@ -188,6 +189,10 @@ namespace {
       std::string status;
       std::vector<std::pair<std::string, std::string>> labels;
       std::vector<std::array<std::string, 3>> devices;
+      std::vector<std::array<std::string, 3>> binds;
+      std::vector<std::array<std::string, 2>> volumes;
+      std::vector<std::string> tmpfs;
+      bool init = false;
     };
     bool simulate_containers = false;
     bool observe_allocated_input_nodes = false;
@@ -234,6 +239,128 @@ namespace {
       };
   };
 
+  /**
+   * Rootless Podman 5.8 shape: `container inspect` reports no devices in
+   * `HostConfig` and points at the OCI runtime spec, whose bind mounts are
+   * the only record of the `--device` bindings the runtime applied.
+   */
+  std::string runtime_spec_path_for(const std::string &id) {
+    return "/srv/seat-operator/containers/storage/overlay-containers/" +
+           id + "/userdata/config.json";
+  }
+
+  nlohmann::json runtime_spec_for(
+    const production_host_state_t::simulated_container_t &container
+  ) {
+    const auto userdata =
+      "/srv/seat-operator/containers/storage/overlay-containers/" +
+      container.id + "/userdata";
+    const auto run_userdata =
+      "/run/user/1000/containers/overlay-containers/" + container.id + "/userdata";
+    const auto podman_bind = [](std::string destination, std::string source) {
+      return nlohmann::json {
+        {"destination", std::move(destination)},
+        {"type", "bind"},
+        {"source", std::move(source)},
+        {"options", {"bind", "rprivate"}},
+      };
+    };
+    auto mounts = nlohmann::json::array({
+      {
+        {"destination", "/proc"},
+        {"type", "proc"},
+        {"source", "proc"},
+        {"options", {"nosuid", "noexec", "nodev"}},
+      },
+      {
+        {"destination", "/dev"},
+        {"type", "tmpfs"},
+        {"source", "tmpfs"},
+        {"options", {"nosuid", "strictatime", "mode=755", "size=65536k"}},
+      },
+      {
+        {"destination", "/sys"},
+        {"type", "sysfs"},
+        {"source", "sysfs"},
+        {"options", {"nosuid", "noexec", "nodev", "ro"}},
+      },
+      {
+        {"destination", "/dev/pts"},
+        {"type", "devpts"},
+        {"source", "devpts"},
+        {"options", {"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"}},
+      },
+      {
+        {"destination", "/dev/mqueue"},
+        {"type", "mqueue"},
+        {"source", "mqueue"},
+        {"options", {"nosuid", "noexec", "nodev"}},
+      },
+      podman_bind("/etc/resolv.conf", run_userdata + "/resolv.conf"),
+      podman_bind("/etc/hosts", run_userdata + "/hosts"),
+      {
+        {"destination", "/dev/shm"},
+        {"type", "bind"},
+        {"source", userdata + "/shm"},
+        {"options", {"bind", "rprivate", "nosuid", "noexec", "nodev"}},
+      },
+      podman_bind("/run/.containerenv", run_userdata + "/.containerenv"),
+      podman_bind("/run/secrets", run_userdata + "/run/secrets"),
+      podman_bind("/etc/hostname", run_userdata + "/hostname"),
+      {
+        {"destination", "/sys/fs/cgroup"},
+        {"type", "cgroup"},
+        {"source", "cgroup"},
+        {"options", {"rprivate", "nosuid", "noexec", "nodev", "relatime", "ro"}},
+      },
+    });
+    if (container.init) {
+      mounts.push_back({
+        {"destination", "/run/podman-init"},
+        {"type", "bind"},
+        {"source", "/usr/libexec/podman/catatonit"},
+        {"options", {"bind", "ro", "private"}},
+      });
+    }
+    for (const auto &destination : container.tmpfs) {
+      mounts.push_back({
+        {"destination", destination},
+        {"type", "tmpfs"},
+        {"source", "tmpfs"},
+        {"options", {"rw", "rprivate", "nosuid", "nodev", "tmpcopyup"}},
+      });
+    }
+    for (const auto &volume : container.volumes) {
+      mounts.push_back({
+        {"destination", volume.at(1)},
+        {"type", "bind"},
+        {"source", "/srv/seat-operator/containers/storage/volumes/" + volume.at(0) + "/_data"},
+        {"options", {"rw", "rprivate", "nosuid", "nodev", "rbind"}},
+      });
+    }
+    for (const auto &bind : container.binds) {
+      mounts.push_back({
+        {"destination", bind.at(1)},
+        {"type", "bind"},
+        {"source", bind.at(0)},
+        {"options", {bind.at(2), "bind", "private", "nosuid", "nodev"}},
+      });
+    }
+    for (const auto &device : container.devices) {
+      mounts.push_back({
+        {"destination", device.at(1)},
+        {"type", "bind"},
+        {"source", device.at(0)},
+        {"options", {"slave", "nosuid", "noexec", device.at(2), "rbind"}},
+      });
+    }
+    return {
+      {"ociVersion", "1.2.0"},
+      {"mounts", std::move(mounts)},
+      {"linux", nlohmann::json::object()},
+    };
+  }
+
   class production_fake_host_t final : public podman::host_t {
   public:
     explicit production_fake_host_t(
@@ -247,7 +374,7 @@ namespace {
     }
 
     bool executable_file(const std::filesystem::path &path) const override {
-      return path == "/usr/bin/podman";
+      return path == "/usr/bin/podman" || path == "/usr/libexec/podman/catatonit";
     }
 
     bool readable_directory(const std::filesystem::path &) const override {
@@ -273,6 +400,25 @@ namespace {
       const auto found = state_->character_devices.find(path.native());
       return found == state_->character_devices.end() ?
                std::nullopt : std::optional {found->second};
+    }
+
+    std::optional<std::string> read_owned_regular_file(
+      const std::filesystem::path &path,
+      std::size_t max_bytes
+    ) const override {
+      std::scoped_lock lock {state_->mutex};
+      ++state_->runtime_spec_reads;
+      for (const auto &container : state_->containers) {
+        if (runtime_spec_path_for(container.id) != path.native()) {
+          continue;
+        }
+        auto text = runtime_spec_for(container).dump();
+        if (text.size() > max_bytes) {
+          return std::nullopt;
+        }
+        return text;
+      }
+      return std::nullopt;
     }
 
     podman::command_result_t run(
@@ -347,6 +493,34 @@ namespace {
               binding.substr(first + 1, second - first - 1),
               binding.substr(second + 1),
             });
+          } else if (argument.starts_with("--mount=type=bind,src=")) {
+            const auto rest = argument.substr(std::string_view {"--mount=type=bind,src="}.size());
+            const auto separator = rest.find(",dst=");
+            if (separator == std::string::npos) {
+              return failure;
+            }
+            const auto tail = rest.substr(separator + std::string_view {",dst="}.size());
+            container.binds.push_back({
+              rest.substr(0, separator),
+              tail.substr(0, tail.find(',')),
+              tail.find(",ro=true") == std::string::npos ? "rw" : "ro",
+            });
+          } else if (argument == "--init") {
+            container.init = true;
+          } else if (argument.starts_with("--mount=type=tmpfs,dst=")) {
+            const auto rest = argument.substr(std::string_view {"--mount=type=tmpfs,dst="}.size());
+            container.tmpfs.push_back(rest.substr(0, rest.find(',')));
+          } else if (argument.starts_with("--volume=")) {
+            const auto binding = argument.substr(std::string_view {"--volume="}.size());
+            const auto first = binding.find(':');
+            if (first == std::string::npos) {
+              return failure;
+            }
+            const auto tail = binding.substr(first + 1);
+            container.volumes.push_back({
+              binding.substr(0, first),
+              tail.substr(0, tail.find(':')),
+            });
           }
         }
         state_->containers.push_back(std::move(container));
@@ -376,19 +550,12 @@ namespace {
           for (const auto &[key, value] : found->labels) {
             labels[key] = value;
           }
-          auto devices = nlohmann::json::array();
-          for (const auto &device : found->devices) {
-            devices.push_back({
-              {"PathOnHost", device.at(0)},
-              {"PathInContainer", device.at(1)},
-              {"CgroupPermissions", device.at(2)},
-            });
-          }
           document.push_back({
             {"Id", found->id},
             {"Name", found->name},
             {"Config", {{"Labels", std::move(labels)}}},
-            {"HostConfig", {{"Devices", std::move(devices)}}},
+            {"HostConfig", {{"Devices", nlohmann::json::array()}}},
+            {"OCIConfigPath", runtime_spec_path_for(found->id)},
             {"State", {{"Status", found->status}}},
           });
         }
@@ -972,6 +1139,9 @@ namespace {
       std::scoped_lock lock {host_state->mutex};
       ASSERT_EQ(host_state->containers.size(), 1U);
       EXPECT_EQ(host_state->containers.front().status, "running");
+      // The post-run launch check is identity-only; the runtime spec is
+      // evidence for the authoritative inventory, not for launch.
+      EXPECT_EQ(host_state->runtime_spec_reads, 0U);
     }
 
     // One pass: quiesce fences Moonlight first, the graceful stop leaves an
@@ -1002,6 +1172,10 @@ namespace {
       std::scoped_lock lock {host_state->mutex};
       ASSERT_EQ(host_state->containers.size(), 1U);
       EXPECT_EQ(host_state->containers.front().status, "exited");
+      // Rootless Podman reports no devices in HostConfig, so the one
+      // authoritative inventory proved the stopped worker through its OCI
+      // runtime spec.
+      EXPECT_EQ(host_state->runtime_spec_reads, 1U);
       const auto verb_count = [&host_state](std::string_view verb) {
         return std::count_if(
           host_state->commands.begin(),

--- a/tests/unit/platform/test_multiseat_controller_production.cpp
+++ b/tests/unit/platform/test_multiseat_controller_production.cpp
@@ -88,12 +88,12 @@ namespace {
       allocation.nodes.push_back({
         .kind = kind,
         .slot = slot,
-        .host_path = "/dev/input/event" + std::to_string(40 + index),
+        .host_path = "/dev/input/event" + std::to_string(256 + index),
         .worker_path = input::expected_worker_path(kind, slot),
         .filesystem_device = 73,
         .inode = 18000 + index,
         .character_major = 13,
-        .character_minor = static_cast<std::uint32_t>(104 + index),
+        .character_minor = static_cast<std::uint32_t>(256 + index),
         .kernel_name = input::expected_kernel_name(
           expectation.input_seat,
           kind,
@@ -365,9 +365,9 @@ namespace {
           .output = std::move(ids),
         };
       }
-      if (verb == "container" && argv.size() > 5 && argv.at(3) == "inspect") {
+      if (verb == "container" && argv.size() > 4 && argv.at(3) == "inspect") {
         auto document = nlohmann::json::array();
-        for (std::size_t index = 5; index < argv.size(); ++index) {
+        for (std::size_t index = 4; index < argv.size(); ++index) {
           const auto found = find_container_locked(argv.at(index));
           if (found == state_->containers.end()) {
             return failure;
@@ -926,12 +926,12 @@ namespace {
     host_state->observe_allocated_input_nodes = true;
     for (std::uint32_t index = 0; index < 3; ++index) {
       host_state->character_devices.emplace(
-        "/dev/input/event" + std::to_string(40 + index),
+        "/dev/input/event" + std::to_string(256 + index),
         podman::character_device_identity_t {
           .filesystem_device = 73,
           .inode = 18000 + index,
           .character_major = 13,
-          .character_minor = 104 + index,
+          .character_minor = 256 + index,
         }
       );
     }

--- a/tests/unit/platform/test_multiseat_controller_runtime.cpp
+++ b/tests/unit/platform/test_multiseat_controller_runtime.cpp
@@ -172,12 +172,12 @@ namespace {
       allocation.nodes.push_back({
         .kind = kind,
         .slot = slot,
-        .host_path = "/dev/input/event" + std::to_string(identity),
+        .host_path = "/dev/input/event" + std::to_string(256 + identity),
         .worker_path = input::expected_worker_path(kind, slot),
         .filesystem_device = 61,
         .inode = 15000 + identity,
         .character_major = 13,
-        .character_minor = static_cast<std::uint32_t>(64 + identity),
+        .character_minor = static_cast<std::uint32_t>(256 + identity),
         .kernel_name = input::expected_kernel_name(
           expectation.input_seat,
           kind,

--- a/tests/unit/platform/test_multiseat_moonlight_activation.cpp
+++ b/tests/unit/platform/test_multiseat_moonlight_activation.cpp
@@ -68,12 +68,12 @@ namespace {
       allocation.nodes.push_back({
         .kind = kind,
         .slot = slot,
-        .host_path = "/dev/input/event" + std::to_string(identity),
+        .host_path = "/dev/input/event" + std::to_string(256 + identity),
         .worker_path = expected_worker_path(kind, slot),
         .filesystem_device = 41,
         .inode = 5000 + identity,
         .character_major = 13,
-        .character_minor = static_cast<std::uint32_t>(64 + identity),
+        .character_minor = static_cast<std::uint32_t>(256 + identity),
         .kernel_name = expected_kernel_name(
           expectation.input_seat,
           kind,

--- a/tests/unit/platform/test_multiseat_moonlight_coordinator.cpp
+++ b/tests/unit/platform/test_multiseat_moonlight_coordinator.cpp
@@ -107,12 +107,12 @@ namespace {
       allocation.nodes.push_back({
         .kind = kind,
         .slot = slot,
-        .host_path = "/dev/input/event" + std::to_string(identity),
+        .host_path = "/dev/input/event" + std::to_string(256 + identity),
         .worker_path = expected_worker_path(kind, slot),
         .filesystem_device = 43,
         .inode = 7000 + identity,
         .character_major = 13,
-        .character_minor = static_cast<std::uint32_t>(64 + identity),
+        .character_minor = static_cast<std::uint32_t>(256 + identity),
         .kernel_name = expected_kernel_name(
           expectation.input_seat,
           kind,

--- a/tests/unit/platform/test_multiseat_moonlight_runtime.cpp
+++ b/tests/unit/platform/test_multiseat_moonlight_runtime.cpp
@@ -90,12 +90,12 @@ namespace {
       allocation.nodes.push_back({
         .kind = kind,
         .slot = slot,
-        .host_path = "/dev/input/event" + std::to_string(identity),
+        .host_path = "/dev/input/event" + std::to_string(256 + identity),
         .worker_path = expected_worker_path(kind, slot),
         .filesystem_device = 47,
         .inode = 9000 + identity,
         .character_major = 13,
-        .character_minor = static_cast<std::uint32_t>(64 + identity),
+        .character_minor = static_cast<std::uint32_t>(256 + identity),
         .kernel_name = expected_kernel_name(
           expectation.input_seat,
           kind,

--- a/tests/unit/platform/test_multiseat_moonlight_worker_adapter.cpp
+++ b/tests/unit/platform/test_multiseat_moonlight_worker_adapter.cpp
@@ -67,12 +67,12 @@ namespace {
       allocation.nodes.push_back({
         .kind = kind,
         .slot = slot,
-        .host_path = "/dev/input/event" + std::to_string(identity),
+        .host_path = "/dev/input/event" + std::to_string(256 + identity),
         .worker_path = expected_worker_path(kind, slot),
         .filesystem_device = 53,
         .inode = 11000 + identity,
         .character_major = 13,
-        .character_minor = static_cast<std::uint32_t>(64 + identity),
+        .character_minor = static_cast<std::uint32_t>(256 + identity),
         .kernel_name = expected_kernel_name(
           expectation.input_seat,
           kind,

--- a/tests/unit/platform/test_multiseat_podman_backend.cpp
+++ b/tests/unit/platform/test_multiseat_podman_backend.cpp
@@ -765,11 +765,14 @@ TEST(MultiseatPodmanBackend, LaunchRevalidatesIdentityAtInvocationBoundary) {
     changed_authority,
     options_for_tests(),
   };
+  changed_authority_host.push({.exit_status = 0});
   EXPECT_EQ(
     changed_authority_backend.launch(spec),
     worker_command_result_e::rejected
   );
-  EXPECT_TRUE(changed_authority_host.calls.empty());
+  // The authority changed at the recheck that follows the volume check.
+  ASSERT_EQ(changed_authority_host.calls.size(), std::size_t {1});
+  EXPECT_EQ(changed_authority_host.calls.front().at(2), "volume");
 
   fake_host_t changed_kernel_host;
   fake_input_manifest_source_t changed_kernel;
@@ -784,8 +787,10 @@ TEST(MultiseatPodmanBackend, LaunchRevalidatesIdentityAtInvocationBoundary) {
     changed_kernel,
     options_for_tests(),
   };
+  changed_kernel_host.push({.exit_status = 0});
   EXPECT_EQ(changed_kernel_backend.launch(spec), worker_command_result_e::rejected);
-  EXPECT_TRUE(changed_kernel_host.calls.empty());
+  ASSERT_EQ(changed_kernel_host.calls.size(), std::size_t {1});
+  EXPECT_EQ(changed_kernel_host.calls.front().at(2), "volume");
   EXPECT_EQ(changed_kernel.observation_calls, std::size_t {5});
 
   fake_host_t changed_gpu_at_run_host;
@@ -800,11 +805,14 @@ TEST(MultiseatPodmanBackend, LaunchRevalidatesIdentityAtInvocationBoundary) {
     changed_gpu_at_run_inputs,
     options_for_tests(),
   };
+  changed_gpu_at_run_host.push({.exit_status = 0});
   EXPECT_EQ(
     changed_gpu_at_run_backend.launch(spec),
     worker_command_result_e::rejected
   );
-  EXPECT_TRUE(changed_gpu_at_run_host.calls.empty());
+  // Only the volume existence check ran; the run itself never did.
+  ASSERT_EQ(changed_gpu_at_run_host.calls.size(), std::size_t {1});
+  EXPECT_EQ(changed_gpu_at_run_host.calls.front().at(2), "volume");
   EXPECT_GE(changed_gpu_at_run_host.character_device_calls, 7U);
 }
 
@@ -812,15 +820,25 @@ TEST(MultiseatPodmanBackend, LaunchBuildsRootlessIsolatedArgumentVector) {
   fake_host_t host;
   backend_t backend {host, input_manifests_for_tests(), options_for_tests()};
   const auto spec = valid_spec();
+  host.push({.exit_status = 0});
   host.push({
     .exit_status = 0,
     .output = std::string {first_id} + "\n",
   });
 
   ASSERT_EQ(backend.launch(spec), worker_command_result_e::applied);
-  ASSERT_EQ(host.calls.size(), std::size_t {1});
-  const auto &argv = host.calls.front();
+  ASSERT_EQ(host.calls.size(), std::size_t {2});
+  const std::vector<std::string> expected_volume_check {
+    "/usr/bin/podman", "--remote=false", "volume", "exists", "pv-a9f0",
+  };
+  EXPECT_EQ(host.calls.front(), expected_volume_check);
+  const auto &argv = host.calls.at(1);
   ASSERT_GE(argv.size(), std::size_t {3});
+  EXPECT_TRUE(has_argument(
+    argv,
+    "--volume=pv-a9f0:/var/lib/polaris-seat:rw,nosuid,nodev"
+  ));
+  EXPECT_FALSE(any_argument_contains(argv, "nocreate"));
   EXPECT_EQ(argv.at(0), "/usr/bin/podman");
   EXPECT_EQ(argv.at(1), "--remote=false");
   EXPECT_EQ(argv.at(2), "run");
@@ -850,10 +868,6 @@ TEST(MultiseatPodmanBackend, LaunchBuildsRootlessIsolatedArgumentVector) {
   EXPECT_FALSE(has_argument(argv, "--read-only-tmpfs=false"));
   EXPECT_TRUE(has_argument(argv, "--pull=never"));
   EXPECT_TRUE(has_argument(argv, "--rm"));
-  EXPECT_TRUE(has_argument(
-    argv,
-    "--volume=pv-a9f0:/var/lib/polaris-seat:rw,nosuid,nodev,nocreate"
-  ));
   EXPECT_TRUE(has_argument(argv, "--workdir=/var/lib/polaris-seat"));
   EXPECT_TRUE(has_argument(argv, "--env=HOME=/var/lib/polaris-seat"));
   EXPECT_TRUE(has_argument(
@@ -944,14 +958,16 @@ TEST(MultiseatPodmanBackend, ProfileSelectsOneExactRuntimeImageAndTypedWorkerPro
     "profile beta",
     "heroic-game"
   );
+  host.push({.exit_status = 0});
   host.push({
     .exit_status = 0,
     .output = std::string {second_id} + "\n",
   });
 
   ASSERT_EQ(backend.launch(spec), worker_command_result_e::applied);
-  ASSERT_EQ(host.calls.size(), std::size_t {1});
-  const auto &argv = host.calls.front();
+  ASSERT_EQ(host.calls.size(), std::size_t {2});
+  EXPECT_EQ(host.calls.front().at(4), "pv-b8e1");
+  const auto &argv = host.calls.at(1);
   EXPECT_TRUE(has_argument(argv, "--env=POLARIS_RUNTIME_PROFILE=heroic"));
   EXPECT_TRUE(has_argument(
     argv,
@@ -1029,43 +1045,73 @@ TEST(MultiseatPodmanBackend, LaunchRejectsUnknownOrNonConcreteAllocation) {
   EXPECT_TRUE(host.calls.empty());
 }
 
+TEST(MultiseatPodmanBackend, LaunchRequiresPreexistingProfileVolume) {
+  const auto spec = valid_spec();
+
+  fake_host_t absent_host;
+  backend_t absent_backend {absent_host, input_manifests_for_tests(), options_for_tests()};
+  absent_host.push({.exit_status = 1});
+  EXPECT_EQ(absent_backend.launch(spec), worker_command_result_e::rejected);
+  ASSERT_EQ(absent_host.calls.size(), std::size_t {1});
+  const std::vector<std::string> expected_volume_check {
+    "/usr/bin/podman", "--remote=false", "volume", "exists", "pv-a9f0",
+  };
+  EXPECT_EQ(absent_host.calls.front(), expected_volume_check);
+
+  fake_host_t error_host;
+  backend_t error_backend {error_host, input_manifests_for_tests(), options_for_tests()};
+  error_host.push({.exit_status = 125});
+  EXPECT_EQ(error_backend.launch(spec), worker_command_result_e::indeterminate);
+  EXPECT_EQ(error_host.calls.size(), std::size_t {1});
+
+  fake_host_t timeout_host;
+  backend_t timeout_backend {timeout_host, input_manifests_for_tests(), options_for_tests()};
+  timeout_host.push({.exit_status = 124, .timed_out = true});
+  EXPECT_EQ(timeout_backend.launch(spec), worker_command_result_e::indeterminate);
+  EXPECT_EQ(timeout_host.calls.size(), std::size_t {1});
+}
+
 TEST(MultiseatPodmanBackend, TimedOutLaunchIsIndeterminate) {
   fake_host_t host;
   backend_t backend {host, input_manifests_for_tests(), options_for_tests()};
+  host.push({.exit_status = 0});
   host.push({
     .exit_status = 124,
     .timed_out = true,
   });
 
   EXPECT_EQ(backend.launch(valid_spec()), worker_command_result_e::indeterminate);
-  EXPECT_EQ(host.calls.size(), std::size_t {1});
+  EXPECT_EQ(host.calls.size(), std::size_t {2});
 }
 
 TEST(MultiseatPodmanBackend, AmbiguousSuccessfulLaunchOutputIsIndeterminate) {
   fake_host_t host;
   backend_t backend {host, input_manifests_for_tests(), options_for_tests()};
+  host.push({.exit_status = 0});
   host.push({
     .exit_status = 0,
     .output = std::string {first_id} + "\nunexpected output\n",
   });
 
   EXPECT_EQ(backend.launch(valid_spec()), worker_command_result_e::indeterminate);
-  EXPECT_EQ(host.calls.size(), std::size_t {1});
+  EXPECT_EQ(host.calls.size(), std::size_t {2});
 }
 
 TEST(MultiseatPodmanBackend, NonzeroLaunchReconcilesAnExactExistingWorker) {
   fake_host_t host;
   backend_t backend {host, input_manifests_for_tests(), options_for_tests()};
   const auto spec = valid_spec();
+  host.push({.exit_status = 0});
   host.push({
     .exit_status = 125,
   });
   queue_inventory(host, {container_for(spec, first_id, "running", "healthy")});
 
   EXPECT_EQ(backend.launch(spec), worker_command_result_e::already_applied);
-  ASSERT_EQ(host.calls.size(), std::size_t {3});
-  EXPECT_EQ(host.calls.at(1).at(2), "ps");
-  EXPECT_EQ(host.calls.at(2).at(2), "container");
+  ASSERT_EQ(host.calls.size(), std::size_t {4});
+  EXPECT_EQ(host.calls.at(0).at(2), "volume");
+  EXPECT_EQ(host.calls.at(2).at(2), "ps");
+  EXPECT_EQ(host.calls.at(3).at(2), "container");
 }
 
 TEST(MultiseatPodmanBackend, NonzeroLaunchRejectsMissingAndQuarantinesUnsafeWorkers) {
@@ -1073,29 +1119,33 @@ TEST(MultiseatPodmanBackend, NonzeroLaunchRejectsMissingAndQuarantinesUnsafeWork
 
   fake_host_t missing_host;
   backend_t missing_backend {missing_host, input_manifests_for_tests(), options_for_tests()};
+  missing_host.push({.exit_status = 0});
   missing_host.push({.exit_status = 125});
   queue_inventory(missing_host, {});
   EXPECT_EQ(missing_backend.launch(spec), worker_command_result_e::rejected);
-  EXPECT_EQ(missing_host.calls.size(), std::size_t {2});
+  EXPECT_EQ(missing_host.calls.size(), std::size_t {3});
 
   fake_host_t mismatch_host;
   backend_t mismatch_backend {mismatch_host, input_manifests_for_tests(), options_for_tests()};
   auto mismatched = container_for(spec, first_id, "running", "healthy");
   mismatched["Config"]["Labels"]["io.polaris.multiseat.runtime"] =
     "polaris-runtime-controller-a1b2-wrong";
+  mismatch_host.push({.exit_status = 0});
   mismatch_host.push({.exit_status = 125});
   queue_inventory(mismatch_host, {std::move(mismatched)});
   EXPECT_EQ(mismatch_backend.launch(spec), worker_command_result_e::indeterminate);
-  EXPECT_EQ(mismatch_host.calls.size(), std::size_t {3});
+  EXPECT_EQ(mismatch_host.calls.size(), std::size_t {4});
 
   fake_host_t failed_host;
   backend_t failed_backend {failed_host, input_manifests_for_tests(), options_for_tests()};
+  failed_host.push({.exit_status = 0});
   failed_host.push({.exit_status = 125});
   queue_inventory(failed_host, {container_for(spec, first_id, "running", "unhealthy")});
   EXPECT_EQ(failed_backend.launch(spec), worker_command_result_e::indeterminate);
 
   fake_host_t stopped_host;
   backend_t stopped_backend {stopped_host, input_manifests_for_tests(), options_for_tests()};
+  stopped_host.push({.exit_status = 0});
   stopped_host.push({.exit_status = 125});
   queue_inventory(stopped_host, {container_for(spec, first_id, "exited", "")});
   EXPECT_EQ(stopped_backend.launch(spec), worker_command_result_e::rejected);
@@ -1130,11 +1180,12 @@ TEST(MultiseatPodmanBackend, NonzeroLaunchQuarantinesChangedRuntimeBindings) {
     const auto spec = valid_spec();
     auto existing = container_for(spec, first_id, "running", "healthy");
     existing["Config"]["Labels"][mismatch.label] = mismatch.value;
+    host.push({.exit_status = 0});
     host.push({.exit_status = 125});
     queue_inventory(host, {std::move(existing)});
 
     EXPECT_EQ(backend.launch(spec), worker_command_result_e::indeterminate);
-    EXPECT_EQ(host.calls.size(), std::size_t {3});
+    EXPECT_EQ(host.calls.size(), std::size_t {4});
   }
 }
 

--- a/tests/unit/platform/test_multiseat_podman_backend.cpp
+++ b/tests/unit/platform/test_multiseat_podman_backend.cpp
@@ -17,6 +17,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -78,7 +79,7 @@ namespace {
     }
 
     bool executable_file(const std::filesystem::path &path) const override {
-      return executable_ready && path == "/usr/bin/podman";
+      return executable_ready && executable_files.contains(path.native());
     }
 
     bool readable_directory(const std::filesystem::path &path) const override {
@@ -108,6 +109,19 @@ namespace {
                std::nullopt : std::optional {device->second};
     }
 
+    std::optional<std::string> read_owned_regular_file(
+      const std::filesystem::path &path,
+      std::size_t max_bytes
+    ) const override {
+      ++owned_file_reads;
+      last_owned_file_limit = max_bytes;
+      const auto file = owned_files.find(path.native());
+      if (file == owned_files.end() || file->second.size() > max_bytes) {
+        return std::nullopt;
+      }
+      return file->second;
+    }
+
     command_result_t run(
       const std::vector<std::string> &argv,
       std::chrono::milliseconds,
@@ -128,6 +142,10 @@ namespace {
 
     std::uint64_t uid = 1000;
     bool executable_ready = true;
+    std::set<std::string> executable_files {
+      "/usr/bin/podman",
+      "/usr/libexec/podman/catatonit",
+    };
     std::set<std::string> readable_directories {
       "/srv/Games Library",
     };
@@ -157,6 +175,9 @@ namespace {
       {"/dev/input/event23", device_identity(13, 87)},
     };
     mutable std::size_t character_device_calls = 0;
+    std::map<std::string, std::string> owned_files;
+    mutable std::size_t owned_file_reads = 0;
+    mutable std::size_t last_owned_file_limit = 0;
     std::size_t replacement_after_character_device_call = 0;
     std::filesystem::path replacement_character_device_path;
     std::optional<character_device_identity_t>
@@ -538,6 +559,7 @@ namespace {
       {"io.polaris.multiseat.display-height", std::to_string(spec.display_mode.height)},
       {"io.polaris.multiseat.display-refresh-millihz", std::to_string(spec.display_mode.refresh_millihz)},
       {"io.polaris.multiseat.display-hdr", spec.display_mode.hdr ? "1" : "0"},
+      {"io.polaris.multiseat.volume", spec.profile_key == "profile beta" ? "pv-b8e1" : "pv-a9f0"},
       {"io.polaris.multiseat.compositor", "gamescope"},
       {"io.polaris.multiseat.encoders", std::to_string(spec.encoder_sessions)},
     };
@@ -1613,6 +1635,820 @@ TEST(MultiseatPodmanBackend, InventoryRefusesPrivilegedExecutionWithoutCommands)
 
   EXPECT_THROW(backend.inventory(), std::runtime_error);
   EXPECT_TRUE(host.calls.empty());
+}
+
+namespace {
+  constexpr auto storage_root = "/srv/seat-operator/containers/storage";
+  constexpr auto run_root = "/run/user/1000/containers";
+
+  std::string containers_directory_for(std::string_view root, std::string_view id) {
+    return std::string {root} + "/overlay-containers/" + std::string {id};
+  }
+
+  std::string runtime_userdata_for(std::string_view id) {
+    return containers_directory_for(storage_root, id) + "/userdata";
+  }
+
+  std::string run_userdata_for(std::string_view id) {
+    return containers_directory_for(run_root, id) + "/userdata";
+  }
+
+  std::string runtime_spec_path_for(std::string_view id) {
+    return runtime_userdata_for(id) + "/config.json";
+  }
+
+  std::string volume_data_for(std::string_view volume_name) {
+    return std::string {storage_root} + "/volumes/" + std::string {volume_name} + "/_data";
+  }
+
+  json runtime_mount(
+    std::string destination,
+    std::string type,
+    std::string source,
+    std::vector<std::string> options
+  ) {
+    return {
+      {"destination", std::move(destination)},
+      {"type", std::move(type)},
+      {"source", std::move(source)},
+      {"options", std::move(options)},
+    };
+  }
+
+  json podman_bind(std::string destination, std::string source) {
+    return runtime_mount(std::move(destination), "bind", std::move(source), {"bind", "rprivate"});
+  }
+
+  json device_mount(
+    std::string source,
+    std::string destination,
+    std::string access = "rw"
+  ) {
+    return runtime_mount(
+      std::move(destination),
+      "bind",
+      std::move(source),
+      {"slave", "nosuid", "noexec", std::move(access), "rbind"}
+    );
+  }
+
+  /**
+   * The OCI runtime spec rootless Podman 5.8 writes for a worker: its own
+   * pseudo-filesystems and per-container files, the controller's tmpfs,
+   * volume, authority, and game mounts, the init binary, and one bind mount
+   * per `--device`, which is the only place those bindings appear.
+   */
+  json runtime_spec_for(const worker_launch_spec_t &spec, std::string_view id) {
+    const auto userdata = runtime_userdata_for(id);
+    const auto run_userdata = run_userdata_for(id);
+    const auto authority = std::string {"/run/user/1000/polaris-workers/"} +
+                           spec.resources.runtime_namespace;
+    const auto volume = spec.profile_key == "profile beta" ? "pv-b8e1" : "pv-a9f0";
+    json mounts = json::array({
+      runtime_mount("/run", "tmpfs", "tmpfs", {"rw", "rprivate", "nosuid", "nodev", "tmpcopyup"}),
+      runtime_mount("/tmp", "tmpfs", "tmpfs", {"rw", "rprivate", "nosuid", "nodev"}),
+      runtime_mount("/proc", "proc", "proc", {"nosuid", "noexec", "nodev"}),
+      runtime_mount(
+        "/dev",
+        "tmpfs",
+        "tmpfs",
+        {"nosuid", "strictatime", "mode=755", "size=65536k"}
+      ),
+      runtime_mount("/sys", "sysfs", "sysfs", {"nosuid", "noexec", "nodev", "ro"}),
+      runtime_mount(
+        "/run/polaris-auth",
+        "bind",
+        authority + "/auth",
+        {"ro", "bind", "private", "nosuid", "nodev"}
+      ),
+      runtime_mount(
+        "/run/podman-init",
+        "bind",
+        "/usr/libexec/podman/catatonit",
+        {"bind", "ro", "private"}
+      ),
+      runtime_mount("/var/tmp", "tmpfs", "tmpfs", {"rw", "rprivate", "nosuid", "nodev", "tmpcopyup"}),
+      runtime_mount("/run/polaris", "tmpfs", "tmpfs", {"rw", "rprivate", "nosuid", "nodev"}),
+      runtime_mount(
+        "/run/polaris-ipc",
+        "bind",
+        authority + "/ipc",
+        {"rw", "bind", "private", "nosuid", "nodev"}
+      ),
+      runtime_mount(
+        "/dev/pts",
+        "devpts",
+        "devpts",
+        {"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"}
+      ),
+      runtime_mount("/dev/mqueue", "mqueue", "mqueue", {"nosuid", "noexec", "nodev"}),
+      podman_bind("/etc/resolv.conf", run_userdata + "/resolv.conf"),
+      podman_bind("/etc/hosts", run_userdata + "/hosts"),
+      runtime_mount(
+        "/dev/shm",
+        "bind",
+        userdata + "/shm",
+        {"bind", "rprivate", "nosuid", "noexec", "nodev"}
+      ),
+      podman_bind("/run/.containerenv", run_userdata + "/.containerenv"),
+      podman_bind("/run/secrets", run_userdata + "/run/secrets"),
+      podman_bind("/etc/hostname", run_userdata + "/hostname"),
+      runtime_mount(
+        "/sys/fs/cgroup",
+        "cgroup",
+        "cgroup",
+        {"rprivate", "nosuid", "noexec", "nodev", "relatime", "ro"}
+      ),
+      runtime_mount(
+        "/mnt/games/library-a",
+        "bind",
+        "/srv/Games Library",
+        {"ro", "bind", "private", "nosuid", "nodev"}
+      ),
+      device_mount("/dev/dri/renderD128", "/dev/dri/renderD128"),
+      device_mount("/dev/dri/card0", "/dev/dri/card0"),
+    });
+    for (const auto &node : input_allocation_for(spec.identity.seat).nodes) {
+      mounts.push_back(device_mount(node.host_path.native(), node.worker_path.native()));
+    }
+    mounts.push_back(runtime_mount(
+      "/var/lib/polaris-seat",
+      "bind",
+      volume_data_for(volume),
+      {"rw", "nosuid", "nodev", "rprivate", "rbind"}
+    ));
+    return {
+      {"ociVersion", "1.2.0"},
+      {"mounts", std::move(mounts)},
+      {"linux", json::object()},
+    };
+  }
+
+  json rootless_container_for(
+    const worker_launch_spec_t &spec,
+    std::string id,
+    std::string runtime_state,
+    std::string health_state = "healthy"
+  ) {
+    auto container = container_for(
+      spec,
+      id,
+      std::move(runtime_state),
+      std::move(health_state)
+    );
+    container["HostConfig"]["Devices"] = json::array();
+    container["OCIConfigPath"] = runtime_spec_path_for(id);
+    return container;
+  }
+
+  json &runtime_mount_for(json &runtime_spec, std::string_view destination) {
+    for (auto &mount : runtime_spec.at("mounts")) {
+      if (mount.at("destination").get<std::string>() == destination) {
+        return mount;
+      }
+    }
+    throw std::logic_error {"runtime spec mount missing"};
+  }
+
+  void erase_runtime_mount(json &runtime_spec, std::string_view destination) {
+    auto &mounts = runtime_spec.at("mounts");
+    mounts.erase(
+      std::remove_if(
+        mounts.begin(),
+        mounts.end(),
+        [destination](const json &mount) {
+          return mount.at("destination").get<std::string>() == destination;
+        }
+      ),
+      mounts.end()
+    );
+  }
+
+  /** The same spec as stored under another storage root or driver. */
+  json relocated_runtime_spec(
+    const json &runtime_spec,
+    std::string_view from,
+    std::string_view to
+  ) {
+    auto dump = runtime_spec.dump();
+    for (auto at = dump.find(from); at != std::string::npos; at = dump.find(from, at + to.size())) {
+      dump.replace(at, from.size(), to);
+    }
+    return json::parse(dump);
+  }
+
+  std::string relocated(std::string value, std::string_view from, std::string_view to) {
+    for (auto at = value.find(from); at != std::string::npos; at = value.find(from, at + to.size())) {
+      value.replace(at, from.size(), to);
+    }
+    return value;
+  }
+
+  /** Runs one rootless inventory expecting a throw; returns the spec reads. */
+  std::size_t rootless_inventory_rejected(
+    const worker_launch_spec_t &spec,
+    const json &runtime_spec,
+    std::function<void(json &)> mutate_container = {},
+    std::function<void(fake_host_t &)> configure_host = {}
+  ) {
+    auto container = rootless_container_for(spec, first_id, "running", "healthy");
+    if (mutate_container) {
+      mutate_container(container);
+    }
+    fake_host_t host;
+    host.owned_files[runtime_spec_path_for(first_id)] = runtime_spec.dump();
+    if (configure_host) {
+      configure_host(host);
+    }
+    fake_input_manifest_source_t inputs;
+    backend_t backend {host, inputs, options_for_tests()};
+    queue_inventory(host, {std::move(container)});
+    EXPECT_THROW(backend.inventory(), std::runtime_error);
+    return host.owned_file_reads;
+  }
+
+  void expect_rootless_inventory_rejected(
+    const worker_launch_spec_t &spec,
+    const json &runtime_spec,
+    std::size_t expected_spec_reads = 1,
+    std::function<void(json &)> mutate_container = {},
+    std::function<void(fake_host_t &)> configure_host = {}
+  ) {
+    EXPECT_EQ(
+      rootless_inventory_rejected(spec, runtime_spec, mutate_container, configure_host),
+      expected_spec_reads
+    );
+  }
+
+  void expect_rootless_inventory_ready(
+    const worker_launch_spec_t &spec,
+    const json &runtime_spec,
+    std::function<void(json &)> mutate_container = {},
+    std::string spec_path = runtime_spec_path_for(first_id)
+  ) {
+    auto container = rootless_container_for(spec, first_id, "running", "healthy");
+    container["OCIConfigPath"] = spec_path;
+    if (mutate_container) {
+      mutate_container(container);
+    }
+    fake_host_t host;
+    host.owned_files[spec_path] = runtime_spec.dump();
+    fake_input_manifest_source_t inputs;
+    backend_t backend {host, inputs, options_for_tests()};
+    queue_inventory(host, {std::move(container)});
+    const auto observations = backend.inventory();
+    ASSERT_EQ(observations.size(), 1U);
+    EXPECT_EQ(observations.front().identity, spec.identity);
+    EXPECT_EQ(observations.front().state, worker_observed_state_e::ready);
+    EXPECT_EQ(host.owned_file_reads, 1U);
+  }
+}  // namespace
+
+TEST(MultiseatPodmanBackend, InventoryReadsRootlessDeviceBindingsFromTheRuntimeSpec) {
+  fake_host_t host;
+  fake_input_manifest_source_t inputs;
+  backend_t backend {host, inputs, options_for_tests()};
+  const auto spec = valid_spec();
+  host.owned_files[runtime_spec_path_for(first_id)] = runtime_spec_for(spec, first_id).dump();
+  queue_inventory(host, {rootless_container_for(spec, first_id, "running", "healthy")});
+
+  const auto observations = backend.inventory();
+
+  ASSERT_EQ(observations.size(), 1U);
+  EXPECT_EQ(observations.front().identity, spec.identity);
+  EXPECT_EQ(observations.front().state, worker_observed_state_e::ready);
+  EXPECT_EQ(host.owned_file_reads, 1U);
+  EXPECT_EQ(host.last_owned_file_limit, options_for_tests().max_command_output_bytes);
+  EXPECT_EQ(host.calls.size(), 2U);
+}
+
+TEST(MultiseatPodmanBackend, InventoryAcceptsRuntimeSpecShapesPodmanMayEmit) {
+  const auto spec = valid_spec();
+  const auto keyboard = "/dev/input/polaris-keyboard";
+
+  {
+    SCOPED_TRACE("device mount without options");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, keyboard).erase("options");
+    expect_rootless_inventory_ready(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("no linux object");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec.erase("linux");
+    expect_rootless_inventory_ready(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("null device node list");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["linux"]["devices"] = nullptr;
+    expect_rootless_inventory_ready(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("no network files");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    erase_runtime_mount(runtime_spec, "/etc/resolv.conf");
+    erase_runtime_mount(runtime_spec, "/etc/hosts");
+    expect_rootless_inventory_ready(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("inspected device list that agrees with the spec");
+    expect_rootless_inventory_ready(
+      spec,
+      runtime_spec_for(spec, first_id),
+      [&spec](json &container) {
+        container["HostConfig"]["Devices"] = inspected_devices_for(spec);
+      }
+    );
+  }
+  {
+    SCOPED_TRACE("vfs storage driver");
+    expect_rootless_inventory_ready(
+      spec,
+      relocated_runtime_spec(runtime_spec_for(spec, first_id), "overlay-containers", "vfs-containers"),
+      {},
+      relocated(runtime_spec_path_for(first_id), "overlay-containers", "vfs-containers")
+    );
+  }
+  {
+    SCOPED_TRACE("storage root under /dev/shm");
+    const auto shm_root = "/dev/shm/containers/storage";
+    expect_rootless_inventory_ready(
+      spec,
+      relocated_runtime_spec(runtime_spec_for(spec, first_id), storage_root, shm_root),
+      {},
+      relocated(runtime_spec_path_for(first_id), storage_root, shm_root)
+    );
+  }
+}
+
+TEST(MultiseatPodmanBackend, InventoryRejectsRuntimeSpecDeviceDrift) {
+  const auto spec = valid_spec();
+  const auto keyboard = "/dev/input/polaris-keyboard";
+
+  {
+    SCOPED_TRACE("missing device mount");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    erase_runtime_mount(runtime_spec, keyboard);
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("renamed worker path");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, keyboard)["destination"] =
+      "/dev/input/polaris-keyboard-other";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("trailing slash on the worker path");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, keyboard)["destination"] =
+      "/dev/input/polaris-keyboard/";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("changed host device");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, keyboard)["source"] = "/dev/input/event20";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("non-normalized host device");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, keyboard)["source"] = "//dev/input/event10";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("read-only binding");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, keyboard)["options"] =
+      json::array({"slave", "nosuid", "noexec", "ro", "rbind"});
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("same device twice");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(runtime_mount_for(runtime_spec, keyboard));
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("device bound outside /dev");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(device_mount("/dev/input/event20", "/opt/probe"));
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("/dev bound whole");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(device_mount("/dev", "/host-dev"));
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("root bound whole");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(device_mount("/", "/host"));
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("unexpected host file");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(podman_bind("/opt/x", "/srv/seat-operator/x"));
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("another container's files");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/dev/shm")["source"] =
+      runtime_userdata_for(second_id) + "/shm";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("own file at an unexpected destination");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/dev/shm")["destination"] = "/opt/shm";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("another volume");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/var/lib/polaris-seat")["source"] =
+      volume_data_for("pv-other");
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("another profile's volume");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/var/lib/polaris-seat")["source"] =
+      volume_data_for("pv-b8e1");
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("volume from another storage root");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/var/lib/polaris-seat")["source"] =
+      "/srv/other/volumes/pv-a9f0/_data";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("volume landing outside its mount point");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/var/lib/polaris-seat")["destination"] = "/usr";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("authority directory bound read-write");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/run/polaris-auth")["options"] =
+      json::array({"rw", "bind", "private", "nosuid", "nodev"});
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("authority directory at an unexpected destination");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/run/polaris-ipc")["destination"] = "/run/polaris-auth-other";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("game library bound read-write");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/mnt/games/library-a")["options"] =
+      json::array({"rw", "bind", "private", "nosuid", "nodev"});
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("storage file presented as an input device");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(
+      podman_bind("/dev/input/polaris-extra", runtime_userdata_for(first_id) + "/probe")
+    );
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("storage directory over the input directory");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(
+      podman_bind("/dev/input", runtime_userdata_for(first_id) + "/input")
+    );
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("tmpfs over a GPU path");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(
+      runtime_mount("/dev/dri", "tmpfs", "tmpfs", {"nosuid"})
+    );
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("tmpfs over /dev after the devices");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(
+      runtime_mount("/dev", "tmpfs", "tmpfs", {"nosuid", "mode=755"})
+    );
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("raw creation endpoint");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["mounts"].push_back(device_mount("/dev/uinput", "/dev/uinput"));
+    expect_rootless_inventory_rejected(
+      spec,
+      runtime_spec,
+      1,
+      {},
+      [](fake_host_t &host) {
+        host.accessible_devices["/dev/uinput"] = device_identity(10, 223);
+      }
+    );
+  }
+  {
+    SCOPED_TRACE("init binary bound read-write");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/run/podman-init")["options"] =
+      json::array({"bind", "rw", "private"});
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("init binary that is not an executable file");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/run/podman-init")["source"] = "/srv/seat-operator/x";
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("device presented as the init binary");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_mount_for(runtime_spec, "/run/podman-init")["source"] = "/dev/input/event20";
+    expect_rootless_inventory_rejected(
+      spec,
+      runtime_spec,
+      1,
+      {},
+      [](fake_host_t &host) {
+        host.executable_files.insert("/dev/input/event20");
+      }
+    );
+  }
+  {
+    SCOPED_TRACE("device granted as a cgroup node");
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    runtime_spec["linux"]["devices"] = json::array({
+      {{"path", "/dev/input/event20"}, {"type", "c"}, {"major", 13}, {"minor", 84}},
+    });
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("inspected device list that contradicts the spec");
+    expect_rootless_inventory_rejected(
+      spec,
+      runtime_spec_for(spec, first_id),
+      1,
+      [&spec, keyboard](json &container) {
+        auto devices = inspected_devices_for(spec);
+        for (auto &device : devices) {
+          if (device.at("PathInContainer") == keyboard) {
+            device["PathOnHost"] = "/dev/input/event20";
+          }
+        }
+        container["HostConfig"]["Devices"] = std::move(devices);
+      }
+    );
+  }
+  {
+    SCOPED_TRACE("inspected device the spec never mounted");
+    expect_rootless_inventory_rejected(
+      spec,
+      runtime_spec_for(spec, first_id),
+      1,
+      [](json &container) {
+        container["HostConfig"]["Devices"] = json::array({
+          {{"PathOnHost", "/dev/input/event20"}, {"PathInContainer", "/dev/input/polaris-extra"}},
+        });
+      }
+    );
+  }
+}
+
+TEST(MultiseatPodmanBackend, InventoryRequiresTheWorkerVolumeLabel) {
+  const auto spec = valid_spec();
+  const auto valid = runtime_spec_for(spec, first_id);
+  {
+    SCOPED_TRACE("volume label missing");
+    expect_rootless_inventory_rejected(spec, valid, 0, [](json &container) {
+      container["Config"]["Labels"].erase("io.polaris.multiseat.volume");
+    });
+  }
+  {
+    SCOPED_TRACE("volume label naming an unconfigured volume");
+    expect_rootless_inventory_rejected(spec, valid, 0, [](json &container) {
+      container["Config"]["Labels"]["io.polaris.multiseat.volume"] = "pv-other";
+    });
+  }
+  {
+    SCOPED_TRACE("volume label with an unsafe value");
+    expect_rootless_inventory_rejected(spec, valid, 0, [](json &container) {
+      container["Config"]["Labels"]["io.polaris.multiseat.volume"] = "../pv-a9f0";
+    });
+  }
+}
+
+TEST(MultiseatPodmanBackend, InventoryRejectsUnusableRuntimeSpecFiles) {
+  const auto spec = valid_spec();
+  const auto valid = runtime_spec_for(spec, first_id);
+
+  {
+    SCOPED_TRACE("spec missing");
+    fake_host_t host;
+    fake_input_manifest_source_t inputs;
+    backend_t backend {host, inputs, options_for_tests()};
+    queue_inventory(host, {rootless_container_for(spec, first_id, "running", "healthy")});
+    EXPECT_THROW(backend.inventory(), std::runtime_error);
+    EXPECT_EQ(host.owned_file_reads, 1U);
+  }
+  {
+    SCOPED_TRACE("spec of another container");
+    expect_rootless_inventory_rejected(
+      spec,
+      valid,
+      0,
+      [](json &container) {
+        container["OCIConfigPath"] = runtime_spec_path_for(second_id);
+      },
+      [&valid](fake_host_t &host) {
+        host.owned_files[runtime_spec_path_for(second_id)] = valid.dump();
+      }
+    );
+  }
+  const std::vector<std::string> bad_paths {
+    "overlay-containers/" + std::string {first_id} + "/userdata/config.json",
+    containers_directory_for(storage_root, first_id) + "/../" +
+      std::string {first_id} + "/userdata/config.json",
+    runtime_userdata_for(first_id) + "/spec.json",
+    containers_directory_for(storage_root, first_id) + "/config.json",
+    "/" + std::string {first_id} + "/userdata/config.json",
+    "/tmp/" + std::string {first_id} + "/userdata/config.json",
+    runtime_spec_path_for(first_id) + "/",
+  };
+  for (const auto &bad_path : bad_paths) {
+    SCOPED_TRACE(bad_path);
+    expect_rootless_inventory_rejected(
+      spec,
+      valid,
+      0,
+      [&bad_path](json &container) {
+        container["OCIConfigPath"] = bad_path;
+      },
+      [&bad_path, &valid](fake_host_t &host) {
+        host.owned_files[bad_path] = valid.dump();
+      }
+    );
+  }
+  {
+    SCOPED_TRACE("non-string path");
+    expect_rootless_inventory_rejected(spec, valid, 0, [](json &container) {
+      container["OCIConfigPath"] = 7;
+    });
+  }
+  {
+    SCOPED_TRACE("oversized spec");
+    expect_rootless_inventory_rejected(
+      spec,
+      valid,
+      1,
+      {},
+      [&valid](fake_host_t &host) {
+        host.owned_files[runtime_spec_path_for(first_id)] =
+          valid.dump() + std::string(options_for_tests().max_command_output_bytes, ' ');
+      }
+    );
+  }
+  {
+    SCOPED_TRACE("malformed spec");
+    expect_rootless_inventory_rejected(
+      spec,
+      valid,
+      1,
+      {},
+      [](fake_host_t &host) {
+        host.owned_files[runtime_spec_path_for(first_id)] = "{";
+      }
+    );
+  }
+  {
+    SCOPED_TRACE("mounts missing");
+    expect_rootless_inventory_rejected(spec, json {{"ociVersion", "1.2.0"}});
+  }
+  {
+    SCOPED_TRACE("mount without a destination");
+    auto runtime_spec = valid;
+    runtime_mount_for(runtime_spec, "/proc").erase("destination");
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+  {
+    SCOPED_TRACE("bind without a source");
+    auto runtime_spec = valid;
+    runtime_mount_for(runtime_spec, "/etc/hosts").erase("source");
+    expect_rootless_inventory_rejected(spec, runtime_spec);
+  }
+}
+
+TEST(MultiseatPodmanBackend, InventoryFailureCarriesTheReason) {
+  const auto spec = valid_spec();
+  auto runtime_spec = runtime_spec_for(spec, first_id);
+  runtime_spec["mounts"].push_back(device_mount("/dev", "/host-dev"));
+  fake_host_t host;
+  host.owned_files[runtime_spec_path_for(first_id)] = runtime_spec.dump();
+  fake_input_manifest_source_t inputs;
+  backend_t backend {host, inputs, options_for_tests()};
+  queue_inventory(host, {rootless_container_for(spec, first_id, "running", "healthy")});
+
+  std::string reason;
+  try {
+    (void) backend.inventory();
+  } catch (const std::runtime_error &error) {
+    reason = error.what();
+  }
+
+  EXPECT_NE(reason.find("rootless Podman returned invalid worker inventory"), std::string::npos);
+  EXPECT_NE(reason.find("unexpected Podman runtime spec mount"), std::string::npos);
+}
+
+TEST(MultiseatPodmanBackend, ReleasedStoppedRootlessWorkerNeedsNoRuntimeSpec) {
+  const auto spec = valid_spec();
+  fake_host_t host;
+  fake_input_manifest_source_t inputs;
+  inputs.missing = true;
+  backend_t backend {host, inputs, options_for_tests()};
+  queue_inventory(host, {rootless_container_for(spec, first_id, "exited", "")});
+
+  const auto observations = backend.inventory();
+
+  ASSERT_EQ(observations.size(), 1U);
+  EXPECT_EQ(observations.front().identity, spec.identity);
+  EXPECT_EQ(observations.front().state, worker_observed_state_e::stopped);
+  EXPECT_EQ(host.owned_file_reads, 0U);
+}
+
+TEST(MultiseatPodmanBackend, NeverStartedRootlessWorkerIsStoppedOnceItsAllocationIsGone) {
+  const auto spec = valid_spec();
+  for (const auto *state : {"created", "configured"}) {
+    SCOPED_TRACE(state);
+    fake_host_t host;
+    fake_input_manifest_source_t inputs;
+    inputs.missing = true;
+    backend_t backend {host, inputs, options_for_tests()};
+    queue_inventory(host, {rootless_container_for(spec, first_id, state, "")});
+
+    const auto observations = backend.inventory();
+
+    ASSERT_EQ(observations.size(), 1U);
+    EXPECT_EQ(observations.front().identity, spec.identity);
+    EXPECT_EQ(observations.front().state, worker_observed_state_e::stopped);
+    EXPECT_EQ(host.owned_file_reads, 0U);
+  }
+
+  // With its allocation still resolving it is a launch in flight: the missing
+  // spec makes the inventory indeterminate rather than releasing the seat.
+  fake_host_t launching_host;
+  fake_input_manifest_source_t launching_inputs;
+  backend_t launching_backend {launching_host, launching_inputs, options_for_tests()};
+  queue_inventory(launching_host, {rootless_container_for(spec, first_id, "created", "")});
+  EXPECT_THROW(launching_backend.inventory(), std::runtime_error);
+  EXPECT_EQ(launching_host.owned_file_reads, 1U);
+
+  // Without input authority the state stays what Podman reported.
+  fake_host_t stop_host;
+  fake_input_manifest_source_t stop_inputs;
+  stop_inputs.missing = true;
+  backend_t stop_backend {stop_host, stop_inputs, options_for_tests()};
+  queue_inventory(stop_host, {rootless_container_for(spec, first_id, "created", "")});
+  stop_host.push({.exit_status = 0});
+  EXPECT_EQ(
+    stop_backend.stop(spec.identity, worker_stop_mode_e::force),
+    worker_command_result_e::applied
+  );
+  EXPECT_EQ(stop_host.owned_file_reads, 0U);
+}
+
+TEST(MultiseatPodmanBackend, StopNeverReadsTheRuntimeSpec) {
+  const auto spec = valid_spec();
+  fake_host_t host;
+  fake_input_manifest_source_t inputs;
+  backend_t backend {host, inputs, options_for_tests()};
+  queue_inventory(host, {rootless_container_for(spec, first_id, "running", "healthy")});
+  host.push({.exit_status = 0});
+
+  EXPECT_EQ(
+    backend.stop(spec.identity, worker_stop_mode_e::graceful),
+    worker_command_result_e::applied
+  );
+  EXPECT_EQ(host.owned_file_reads, 0U);
+  ASSERT_EQ(host.calls.size(), 3U);
+  EXPECT_EQ(
+    host.calls.back(),
+    (std::vector<std::string> {
+      "/usr/bin/podman", "--remote=false", "kill", "--signal=TERM", first_id,
+    })
+  );
 }
 
 #endif

--- a/tests/unit/platform/test_multiseat_podman_host.cpp
+++ b/tests/unit/platform/test_multiseat_podman_host.cpp
@@ -1,0 +1,96 @@
+/**
+ * @file tests/unit/platform/test_multiseat_podman_host.cpp
+ * @brief Live-host adapter tests for the rootless Podman worker backend.
+ */
+#include "src/platform/linux/multiseat_podman_host.h"
+
+#ifdef __linux__
+
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace {
+  class temporary_directory_t {
+  public:
+    temporary_directory_t() {
+      auto pattern =
+        (std::filesystem::temp_directory_path() / "polaris-podman-host-XXXXXX").string();
+      const auto *created = ::mkdtemp(pattern.data());
+      if (!created) {
+        throw std::runtime_error {"temporary directory could not be created"};
+      }
+      path_ = created;
+    }
+
+    ~temporary_directory_t() {
+      std::error_code ignored;
+      std::filesystem::remove_all(path_, ignored);
+    }
+
+    temporary_directory_t(const temporary_directory_t &) = delete;
+    temporary_directory_t &operator=(const temporary_directory_t &) = delete;
+
+    [[nodiscard]] const std::filesystem::path &path() const {
+      return path_;
+    }
+
+  private:
+    std::filesystem::path path_;
+  };
+
+  void write_file(const std::filesystem::path &path, const std::string &content) {
+    std::ofstream out {path, std::ios::binary | std::ios::trunc};
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+    ASSERT_TRUE(out.good()) << path;
+  }
+}  // namespace
+
+TEST(MultiseatPodmanHost, ReadsOwnedRegularFilesWithinTheBound) {
+  temporary_directory_t root;
+  multiseat::podman::local_host_t host;
+  const std::string content {"{\"mounts\": []}\0tail", 20};
+  write_file(root.path() / "config.json", content);
+  write_file(root.path() / "empty.json", "");
+
+  EXPECT_EQ(
+    host.read_owned_regular_file(root.path() / "config.json", content.size()),
+    content
+  );
+  EXPECT_EQ(
+    host.read_owned_regular_file(root.path() / "config.json", 1U << 20U),
+    content
+  );
+  EXPECT_FALSE(
+    host.read_owned_regular_file(root.path() / "config.json", content.size() - 1)
+  );
+  EXPECT_EQ(host.read_owned_regular_file(root.path() / "empty.json", 16), std::string {});
+}
+
+TEST(MultiseatPodmanHost, RefusesAnythingButAnOwnedRegularFile) {
+  temporary_directory_t root;
+  multiseat::podman::local_host_t host;
+  write_file(root.path() / "config.json", "{}");
+  std::filesystem::create_symlink(root.path() / "config.json", root.path() / "link.json");
+  ASSERT_EQ(::mkfifo((root.path() / "pipe").c_str(), 0600), 0);
+
+  EXPECT_FALSE(host.read_owned_regular_file(root.path() / "link.json", 1024));
+  EXPECT_FALSE(host.read_owned_regular_file(root.path(), 1024));
+  EXPECT_FALSE(host.read_owned_regular_file(root.path() / "pipe", 1024));
+  EXPECT_FALSE(host.read_owned_regular_file(root.path() / "missing.json", 1024));
+  EXPECT_FALSE(host.read_owned_regular_file("/dev/null", 1024));
+  if (::geteuid() != 0) {
+    // Owned by root, readable by everyone, and still refused.
+    EXPECT_FALSE(host.read_owned_regular_file("/proc/version", 1U << 16U));
+  }
+}
+
+#endif

--- a/tests/unit/test_multiseat_input_authority.cpp
+++ b/tests/unit/test_multiseat_input_authority.cpp
@@ -5,6 +5,7 @@
 #include "src/platform/linux/multiseat_input_authority.h"
 
 #include <gtest/gtest.h>
+#include <limits>
 
 #include <algorithm>
 #include <array>
@@ -95,7 +96,7 @@ namespace {
       allocation.nodes.push_back({
         .kind = kind,
         .slot = slot,
-        .host_path = "/dev/input/event" + std::to_string(minor - 64),
+        .host_path = "/dev/input/event" + std::to_string(minor < 96 ? minor - 64 : minor),
         .worker_path = multiseat::input::expected_worker_path(kind, slot),
         .filesystem_device = 41,
         .inode = 10000 + minor,
@@ -144,6 +145,10 @@ namespace {
       }
       auto allocation = allocation_for(expectation, next_minor);
       next_minor += static_cast<std::uint32_t>(allocation.nodes.size()) + 4;
+      if (next_minor > 95 && next_minor < 256) {
+        // The kernel has no minors between the static evdev range and 256.
+        next_minor = 256;
+      }
       if (mutate_created) {
         mutate_created(allocation);
       }
@@ -470,6 +475,52 @@ namespace {
     EXPECT_EQ(authority.release(expectation.handle), status_e::applied);
     EXPECT_FALSE(authority.allocation(expectation.handle).has_value());
     EXPECT_EQ(authority.release(expectation.handle), status_e::not_found);
+  }
+
+  TEST(MultiseatInputAuthority, KernelMinorMappingCoversStaticAndDynamicRanges) {
+    using multiseat::input::expected_event_minor;
+    using multiseat::input::expected_joystick_minor;
+    EXPECT_EQ(expected_event_minor(0), 64U);
+    EXPECT_EQ(expected_event_minor(31), 95U);
+    EXPECT_FALSE(expected_event_minor(32).has_value());
+    EXPECT_FALSE(expected_event_minor(255).has_value());
+    EXPECT_EQ(expected_event_minor(256), 256U);
+    EXPECT_EQ(expected_event_minor(258), 258U);
+    EXPECT_EQ(
+      expected_event_minor(std::numeric_limits<std::uint32_t>::max()),
+      std::numeric_limits<std::uint32_t>::max()
+    );
+    EXPECT_FALSE(expected_event_minor(
+      std::uint64_t {std::numeric_limits<std::uint32_t>::max()} + 1
+    ).has_value());
+    EXPECT_EQ(expected_joystick_minor(0), 0U);
+    EXPECT_EQ(expected_joystick_minor(15), 15U);
+    EXPECT_FALSE(expected_joystick_minor(16).has_value());
+    EXPECT_FALSE(expected_joystick_minor(255).has_value());
+    EXPECT_EQ(expected_joystick_minor(256), 256U);
+  }
+
+  TEST(MultiseatInputAuthority, ValidAllocationAcceptsDynamicMinorsAndRejectsTheGap) {
+    const auto expectation = expectation_for(0, 1);
+    auto dynamic = allocation_for(expectation, 64);
+    ASSERT_TRUE(multiseat::input::valid_allocation(dynamic, expectation));
+    for (std::size_t index = 0; index < dynamic.nodes.size(); ++index) {
+      auto &node = dynamic.nodes[index];
+      node.host_path = "/dev/input/event" + std::to_string(256 + index);
+      node.character_minor = static_cast<std::uint32_t>(256 + index);
+      node.inode = 20000 + index;
+    }
+    EXPECT_TRUE(multiseat::input::valid_allocation(dynamic, expectation));
+
+    auto gap = allocation_for(expectation, 64);
+    gap.nodes.front().host_path = "/dev/input/event40";
+    gap.nodes.front().character_minor = 104;
+    EXPECT_FALSE(multiseat::input::valid_allocation(gap, expectation));
+
+    auto shifted = allocation_for(expectation, 64);
+    shifted.nodes.front().host_path = "/dev/input/event256";
+    shifted.nodes.front().character_minor = 320;
+    EXPECT_FALSE(multiseat::input::valid_allocation(shifted, expectation));
   }
 
   TEST(MultiseatInputAuthority, ReleaseAllAttemptsEveryAllocationAndRetainsFailuresForRetry) {


### PR DESCRIPTION
## Summary

- Refs #22. Follows #619. This is the first physical validation of the container multiseat control plane: the production composition root driven against real rootless Podman 5.8 on pc-papi, with the real inputtino host backend, the real Podman host, and the real worker transport, through one supervisor worker. No production caller is added and the source-tree guard still holds; everything runs through an environment-gated integration test, and the live Polaris service was never touched.
- The real path exposed four contract gaps that no offline test could see, all closed in the first commit with the real behavior pinned in unit tests. The input authority and the backend node parser assumed the legacy evdev formula of minor 64 plus N; Linux evdev owns 32 static minors and then allocates dynamic minors from 256 upward, naming the node after the minor, which is what a host with more than 32 input devices does. Shared `expected_event_minor` and `expected_joystick_minor` helpers now encode both ranges and the gap between them, both call sites use them, and every fixture that synthesized node numbers beyond the static range moved onto the dynamic range. `podman run` has no volume option that refuses to auto-create a named volume, so the `nocreate` flag was rejected outright; the backend now asks `podman volume exists` after host readiness and before the identity recheck that stays adjacent to the run, treating absence as a rejection and errors or timeouts as indeterminate. `podman container inspect` does not accept the `--type` flag, so every authoritative inventory and every stop threw on a real host; the flag is gone. The locked worker image build failed in its own builder stage because the image contract test reads two production sources through a repository-relative path the Containerfile did not mirror; the builder now copies them where the test looks and the test pins those copies.
- The second commit adds `tests/integration/test_multiseat_physical.cpp`, compiled into `test_polaris_stream` and skipped unless `POLARIS_MULTISEAT_PHYSICAL=1`. It composes with the default factories, reconciles, admits and binds a gamescope seat, starts one worker, polls the authoritative reconcile for readiness, stops the seat, and shuts down, logging every controller result, the allocated nodes with their udev seat, podman state, worker inspect and logs. It force-removes any leftover container or authority directory at the end and reports them as findings. Image, runtime root, devices, podman path, and volume come from the environment, so no host detail is compiled in.
- What one run now proves on real infrastructure, leaving nothing behind: production composition with default factories; initial reconcile ready against a real inputtino reconcile and a real Podman inventory; admission; runtime binding; `start_seat` creating four virtual devices that read back `ID_SEAT=seat-polaris` on dynamic minors; the per-generation authority directory with its `ipc` and `auth` children; a rootless `podman run` with the full isolation argv that comes up and passes the worker's own health command; `stop_seat` sending TERM with the container exiting and being reaped by `--rm`; a teardown reconcile reporting the worker missing and the seat released; and `shutdown()` closing on the first attempt with all four input devices destroyed.
- The third commit closes the gap the first physical run left open. Rootless Podman implements `--device` as bind mounts and reports none of them in its inspection output, so the authoritative inventory had no evidence for a running worker and the seat never reached running. When a record points at its OCI runtime spec (`OCIConfigPath`), the inventory now reads the spec as the device set, and any inspected device list Podman does fill in must agree with it entry for entry rather than add to it. The spec path is accepted only in Podman's `<storage>/<driver>-containers/<id>/userdata/config.json` shape with the record's own immutable ID, read through a new bounded host method that refuses anything but a regular file owned by the effective uid, never follows a symbolic link on the final component, opens without blocking, and stays within the command output bound. Every mount in the spec is classified against an allowlist: pseudo-filesystems and the controller's tmpfs mounts may not sit on a device directory, nor cover `/dev` or `/` after a device binding; a bind may come only from Podman's own per-container files at their known destinations, the worker's own profile volume (named by a new immutable worker label, `io.polaris.multiseat.volume`, and anchored to the storage root the spec lives in) at its mount point read-write, the controller's authority directories and shared game mounts at their exact destinations and permissions, Podman's init binary (read-only, an executable regular file, never a device), or a `/dev` path, which becomes a device binding that must land on a `/dev` path. Anything else, including `/dev` or `/` bound whole or another profile's volume, fails the inventory, as does a read-only device, a device declared twice, or a spec that lists device nodes. A container Podman created but never initialized has no spec yet; once its allocation is gone it is reported as stopped so it is reaped instead of blinding every other seat. Inventory failures now carry the specific reason in the exception. The stop path and the released-stopped-worker relaxation never read the spec. The production fake emulates the rootless shape from the launch argv it recorded, and a new live-host test exercises the real file reader.
- With that in place the physical harness goes all the way: the real rootless worker turns healthy within two seconds, the next authoritative reconcile reports the ready transition with the IPC endpoint connected and heartbeats flowing, steady reconciles stay authoritative, `stop_seat` and `shutdown()` close cleanly, and the sweep finds nothing left behind.
- The full findings, host state, and run recipe are in the validation report kept with the review artifacts on MacPapi (`container-multiseat-physical-validation-2026-09-07.md`). The design doc is updated for the kernel minor ranges and the volume precheck.

## Exact candidate

- `Commit:` de955b5d84541acaeae6b2cc106ea31ad35c9cf2
- `Tree:` a71c47a1dbbb3812034ea985fcda76f8dff9a25e
- `Parent:` 1bd3d21b534c8eeb5024d8e03575d43db67f1360
- `Base:` 1b7fde071705c2bf8457a60e63749b76e76ec748 (master, after #619)

## Verification

- [x] Full Debug build on pc-papi (Fedora, GCC) under the repository `-Werror` configuration, every target including the Go worker target, clean.
- [x] Mutation checks on the new evidence rules, fourteen in all: with the unexpected-bind refusal, the device node refusal, the spec path shape check, the spec read itself, the read-only device rejection, the inspected-list consistency check, the device-directory rule for pseudo-filesystems, the init-binding rule, the controller-bind destination and permission check, the volume mount point check, the volume label check, the mount-order rule, the own-file destination check, or the never-started relaxation disabled in turn, the matching cases fail and the rest still pass; the file was restored byte for byte afterwards.
- [x] `ctest --test-dir build --output-on-failure`: 22 of 22 groups pass, run with the default `TMPDIR` because a long one trips the Go worker suite's Unix socket path limit.
- [x] Clang 22 ASan+UBSan with `detect_leaks=1`: `test_multiseat_runtime` 233 of 233; `test_polaris_stream` 410 of 410 with the three tests that leak a retained graph by design excluded and run separately with leak detection off, 3 of 3; the physical test skipping. No sanitizer report.
- [x] Clang 22 TSan: `test_multiseat_runtime` 233 of 233, `test_polaris_stream` 413 of 413. No race report.
- [x] The physical harness itself on pc-papi against rootless Podman 5.8.4, the lab smoke image, and the real inputtino backend: passes end to end in about nine seconds, with the ready transition, one endpoint connection and two heartbeats observed, three steady authoritative reconciles, and an end-of-run sweep that finds no leftover container, authority directory, or virtual input device.
- [x] Two independent read-only review passes by fresh reviewers. The first found the mount classifier was a denylist (a bind of `/dev` or `/` whole slipped through unclassified), which turned it into the allowlist above. The second found that allowlisted controller binds were matched by source only (a read-write authority mount or the volume landing on `/usr` would pass), that any configured profile's volume was accepted, and that a container created but never initialized would blind the inventory; all three are fixed and pinned.
- [x] `scripts/check-public-surface.sh`, `scripts/check-public-docs.sh`, `scripts/check-release-package-dependencies.py`, `scripts/check-nix-patches.py`, and `git diff --check`: clean.
- [x] Go module tests for `multiseat_worker` on the host, including the image contract test with the new COPY pins.
- [x] `git diff --check` and `go vet` clean; the fixtures use `/srv/seat-operator/containers/storage` as the storage root because the public-surface check rejects any `/home/<name>` string.
- [x] The source-guard test `MultiseatBrokerNamespaceUsesDedicatedSeat` still pins exactly one `Polaris multiseat *` udev rule; a duplicate I added during the run was caught by it and reverted.

## Not covered

- A FIPS-mode host, where Podman binds the image's crypto policy from the overlay merged directory, is not a shape the classifier accepts; it fails closed and is documented as unsupported.
- Root-mode Podman is not an evidence source this backend accepts: the backend already refuses uid 0, and a spec that grants cgroup device nodes fails the inventory rather than being interpreted. If a future Podman reports rootless devices differently, the physical harness is the test that shows it.
- Container-side access to mapped input nodes. Inside a worker the mapped input nodes are root:input 0660 and the keep-id user has no supplementary groups, so they are unreadable while the render node is fine. The design deferred this to a deployment decision (keep-groups, a mapped group, or a per-generation ACL) and it stays open here.
- No streaming-capable worker image exists. The locked base-app runtime root lacks PipeWire, GStreamer, and gamescope, so the physical run uses a lab-only smoke image built outside the repository whose supervisor is not streaming-capable. The IPC handshake and heartbeat are now proven against the supervisor; providers and any actual stream remain unproven.
- The physical harness does not run in CI and is skipped by default; it needs a live host with podman, a udev rule for the reserved kernel-name namespace, and a short runtime root, all documented in the report. pc-papi's `/etc/udev/rules.d/60-polaris.rules` override also shadows the packaged seat-isolation rules, which is a host finding, not a repository change.
- The e2e suite under `tests/e2e` was not run.
