### PR TITLE
fix(security): validate input packets and require paired certificate identity

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -71,9 +71,19 @@ namespace crypto {
    * @return nullptr if the certificate is valid, otherwise an error string.
    */
   const char * cert_chain_t::verify(x509_t::element_type *cert, p_named_cert_t& named_cert_out) {
-    int err_code = 0;
+    named_cert_out.reset();
+    const auto presented_fingerprint = x509_fingerprint(cert);
+    if (!presented_fingerprint) {
+      return "Invalid client certificate";
+    }
+    int err_code = X509_V_ERR_CERT_REJECTED;
     std::lock_guard lock {_certs_mutex};
     for (auto &[fingerprint, named_cert_p, x509_store] : _certs) {
+      // Pairing trusts one canonical certificate, not certificates it can sign.
+      // Compare the DER fingerprint so equivalent PEM encodings keep working.
+      if (fingerprint != *presented_fingerprint) {
+        continue;
+      }
       x509_store_ctx_t cert_ctx { X509_STORE_CTX_new() };
       if (!cert_ctx) {
         return "Unable to allocate certificate verification context";

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -183,11 +183,12 @@ namespace input {
 
     input_t(
       safe::mail_raw_t::event_t<input::touch_port_t> touch_port_event,
-      platf::feedback_queue_t feedback_queue
+      platf::feedback_queue_t feedback_queue,
+      std::unique_ptr<platf::client_input_t> client_context
     ):
         shortcutFlags {},
         gamepads(MAX_GAMEPADS),
-        client_context {platf::allocate_client_input_context(platf_input)},
+        client_context {std::move(client_context)},
         touch_port_event {std::move(touch_port_event)},
         feedback_queue {std::move(feedback_queue)},
         mouse_left_button_timeout {},
@@ -1289,6 +1290,81 @@ namespace input {
     gamepad.gamepad_state = gamepad_state;
   }
 
+  /**
+   * @brief Validate the declared and available sizes of a fixed-size input packet.
+   *
+   * @tparam Packet Protocol packet structure.
+   * @param packet Raw packet bytes.
+   * @param declared_size Packet size declared after the size field.
+   * @return True when both sizes safely contain the fixed packet structure.
+   */
+  template<typename Packet>
+  bool validate_fixed_input_packet(std::span<const std::uint8_t> packet, std::uint32_t declared_size) {
+    if (constexpr auto expected_size = static_cast<std::uint32_t>(sizeof(Packet) - sizeof(std::uint32_t)); declared_size != expected_size) {
+      return false;
+    }
+    return packet.size() >= sizeof(Packet);
+  }
+
+  /**
+   * @brief Validate an input packet before any typed access or batching.
+   *
+   * @param packet Raw packet bytes.
+   * @param parsed_header Optional destination for the safely copied packet header.
+   * @return True when the packet is large enough for its declared and protocol-specific fields.
+   */
+  bool validate_input_packet(std::span<const std::uint8_t> packet, NV_INPUT_HEADER *parsed_header = nullptr) {
+    if (packet.size() < sizeof(NV_INPUT_HEADER)) {
+      return false;
+    }
+
+    NV_INPUT_HEADER header {};
+    std::memcpy(&header, packet.data(), sizeof(header));
+    if (parsed_header) {
+      *parsed_header = header;
+    }
+
+    const auto declared_size = util::endian::big(header.size);
+    if (declared_size < sizeof(header.magic) || declared_size > packet.size() - sizeof(header.size)) {
+      return false;
+    }
+
+    switch (util::endian::little(header.magic)) {
+      case MOUSE_MOVE_REL_MAGIC_GEN5:
+        return validate_fixed_input_packet<NV_REL_MOUSE_MOVE_PACKET>(packet, declared_size);
+      case MOUSE_MOVE_ABS_MAGIC:
+        return validate_fixed_input_packet<NV_ABS_MOUSE_MOVE_PACKET>(packet, declared_size);
+      case MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5:
+      case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
+        return validate_fixed_input_packet<NV_MOUSE_BUTTON_PACKET>(packet, declared_size);
+      case SCROLL_MAGIC_GEN5:
+        return validate_fixed_input_packet<NV_SCROLL_PACKET>(packet, declared_size);
+      case SS_HSCROLL_MAGIC:
+        return validate_fixed_input_packet<SS_HSCROLL_PACKET>(packet, declared_size);
+      case KEY_DOWN_EVENT_MAGIC:
+      case KEY_UP_EVENT_MAGIC:
+        return validate_fixed_input_packet<NV_KEYBOARD_PACKET>(packet, declared_size);
+      case UTF8_TEXT_EVENT_MAGIC:
+        return declared_size - sizeof(header.magic) <= UTF8_TEXT_EVENT_MAX_COUNT;
+      case MULTI_CONTROLLER_MAGIC_GEN5:
+        return validate_fixed_input_packet<NV_MULTI_CONTROLLER_PACKET>(packet, declared_size);
+      case SS_TOUCH_MAGIC:
+        return validate_fixed_input_packet<SS_TOUCH_PACKET>(packet, declared_size);
+      case SS_PEN_MAGIC:
+        return validate_fixed_input_packet<SS_PEN_PACKET>(packet, declared_size);
+      case SS_CONTROLLER_ARRIVAL_MAGIC:
+        return validate_fixed_input_packet<SS_CONTROLLER_ARRIVAL_PACKET>(packet, declared_size);
+      case SS_CONTROLLER_TOUCH_MAGIC:
+        return validate_fixed_input_packet<SS_CONTROLLER_TOUCH_PACKET>(packet, declared_size);
+      case SS_CONTROLLER_MOTION_MAGIC:
+        return validate_fixed_input_packet<SS_CONTROLLER_MOTION_PACKET>(packet, declared_size);
+      case SS_CONTROLLER_BATTERY_MAGIC:
+        return validate_fixed_input_packet<SS_CONTROLLER_BATTERY_PACKET>(packet, declared_size);
+      default:
+        return true;
+    }
+  }
+
   enum class batch_result_e {
     batched,  ///< This entry was batched with the source entry
     not_batchable,  ///< Not eligible to batch but continue attempts to batch
@@ -1305,10 +1381,10 @@ namespace input {
     short deltaX, deltaY;
 
     // Batching is safe as long as the result doesn't overflow a 16-bit integer
-    if (!__builtin_add_overflow(util::endian::big(dest->deltaX), util::endian::big(src->deltaX), &deltaX)) {
+    if (__builtin_add_overflow(util::endian::big(dest->deltaX), util::endian::big(src->deltaX), &deltaX)) {
       return batch_result_e::terminate_batch;
     }
-    if (!__builtin_add_overflow(util::endian::big(dest->deltaY), util::endian::big(src->deltaY), &deltaY)) {
+    if (__builtin_add_overflow(util::endian::big(dest->deltaY), util::endian::big(src->deltaY), &deltaY)) {
       return batch_result_e::terminate_batch;
     }
 
@@ -1345,7 +1421,7 @@ namespace input {
     short scrollAmt;
 
     // Batching is safe as long as the result doesn't overflow a 16-bit integer
-    if (!__builtin_add_overflow(util::endian::big(dest->scrollAmt1), util::endian::big(src->scrollAmt1), &scrollAmt)) {
+    if (__builtin_add_overflow(util::endian::big(dest->scrollAmt1), util::endian::big(src->scrollAmt1), &scrollAmt)) {
       return batch_result_e::terminate_batch;
     }
 
@@ -1365,7 +1441,7 @@ namespace input {
     short scrollAmt;
 
     // Batching is safe as long as the result doesn't overflow a 16-bit integer
-    if (!__builtin_add_overflow(util::endian::big(dest->scrollAmount), util::endian::big(src->scrollAmount), &scrollAmt)) {
+    if (__builtin_add_overflow(util::endian::big(dest->scrollAmount), util::endian::big(src->scrollAmount), &scrollAmt)) {
       return batch_result_e::terminate_batch;
     }
 
@@ -1673,6 +1749,12 @@ namespace input {
    * @param input_data The input message.
    */
   void passthrough(std::shared_ptr<input_t> &input, std::vector<std::uint8_t> &&input_data, const crypto::PERM& permission) {
+    // Copy and validate the common header before permission-dependent reads,
+    // diagnostics, or queue admission. Every queued entry is safe to batch.
+    if (!validate_input_packet(input_data)) {
+      return;
+    }
+
     // No input permissions at all
     if (!(permission & crypto::PERM::_all_inputs)) {
       return;
@@ -1790,7 +1872,8 @@ namespace input {
   std::shared_ptr<input_t> alloc(safe::mail_t mail) {
     auto input = std::make_shared<input_t>(
       mail->event<input::touch_port_t>(mail::touch_port),
-      mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback)
+      mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback),
+      platf::allocate_client_input_context(platf_input)
     );
 
     bool adopted_preallocated_gamepad = false;
@@ -1823,4 +1906,30 @@ namespace input {
 
     return input;
   }
+#ifdef POLARIS_TESTS
+  bool is_valid_input_packet_for_tests(std::span<const std::uint8_t> packet) {
+    return validate_input_packet(packet);
+  }
+
+  std::shared_ptr<input_t> alloc_queue_for_tests() {
+    auto mail = std::make_shared<safe::mail_raw_t>();
+    return std::make_shared<input_t>(
+      mail->event<input::touch_port_t>(mail::touch_port),
+      mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback), nullptr);
+  }
+
+  std::size_t queued_input_packet_count_for_tests(const std::shared_ptr<input_t> &input) {
+    std::lock_guard lock {input->input_queue_lock};
+    return input->input_queue.size();
+  }
+
+  bool batch_input_packets_for_tests(std::vector<std::uint8_t> &dest, const std::vector<std::uint8_t> &src) {
+    if (!validate_input_packet(dest) || !validate_input_packet(src)) {
+      return false;
+    }
+    auto source = src;
+    return batch(reinterpret_cast<PNV_INPUT_HEADER>(dest.data()),
+                 reinterpret_cast<PNV_INPUT_HEADER>(source.data())) == batch_result_e::batched;
+  }
+#endif
 }  // namespace input

--- a/src/input.h
+++ b/src/input.h
@@ -7,6 +7,7 @@
 // standard includes
 #include <functional>
 #include <optional>
+#include <span>
 
 // local includes
 #include "platform/common.h"
@@ -26,6 +27,13 @@ namespace input {
 
   void preallocate_gamepad();
   std::shared_ptr<input_t> alloc(safe::mail_t mail);
+
+#ifdef POLARIS_TESTS
+  bool is_valid_input_packet_for_tests(std::span<const std::uint8_t> packet);
+  std::shared_ptr<input_t> alloc_queue_for_tests();
+  std::size_t queued_input_packet_count_for_tests(const std::shared_ptr<input_t> &input);
+  bool batch_input_packets_for_tests(std::vector<std::uint8_t> &dest, const std::vector<std::uint8_t> &src);
+#endif
 
   struct touch_port_t: public platf::touch_port_t {
     int env_width, env_height;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -201,6 +201,7 @@ if (NOT WIN32 AND NOT APPLE)
 endif()
 
 set(TEST_INPUT_SOURCES
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_input_packet.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_gamepad_feedback_router.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_mouse.cpp
 )

--- a/tests/certificate_test_utils.h
+++ b/tests/certificate_test_utils.h
@@ -1,0 +1,90 @@
+/**
+ * @file tests/certificate_test_utils.h
+ * @brief Certificate fixtures shared by Polaris security tests.
+ */
+#pragma once
+
+// standard includes
+#include <algorithm>
+
+// lib includes
+#include <openssl/x509v3.h>
+
+// local includes
+#include <src/crypto.h>
+
+namespace test_utils::certificates {
+  /**
+   * @brief Generate a self-signed certificate that OpenSSL may use as a certificate authority.
+   *
+   * @param common_name Common name for the generated certificate.
+   * @return PEM-encoded certificate-authority credentials.
+   */
+  inline crypto::creds_t generate_ca_credentials(const std::string_view common_name = "Polaris Test Client CA") {
+    auto credentials = crypto::gen_creds(common_name, 2048);
+    auto certificate = crypto::x509(credentials.x509);
+    auto private_key = crypto::pkey(credentials.pkey);
+
+    util::safe_ptr<BASIC_CONSTRAINTS, &BASIC_CONSTRAINTS_free> constraints {BASIC_CONSTRAINTS_new()};
+    constraints->ca = 1;
+    X509_add1_ext_i2d(certificate.get(), NID_basic_constraints, constraints.get(), 1, X509V3_ADD_DEFAULT);
+    X509_sign(certificate.get(), private_key.get(), EVP_sha256());
+    credentials.x509 = crypto::pem(certificate);
+    return credentials;
+  }
+
+  /**
+   * @brief Generate a leaf certificate signed by the supplied certificate authority.
+   *
+   * @param issuer_credentials PEM-encoded issuer certificate and private key.
+   * @return PEM-encoded leaf credentials.
+   */
+  inline crypto::creds_t generate_derived_leaf(const crypto::creds_t &issuer_credentials) {
+    auto credentials = crypto::gen_creds("Polaris Test Derived Client", 2048);
+    auto certificate = crypto::x509(credentials.x509);
+    auto issuer_certificate = crypto::x509(issuer_credentials.x509);
+    auto issuer_private_key = crypto::pkey(issuer_credentials.pkey);
+
+    X509_set_issuer_name(certificate.get(), X509_get_subject_name(issuer_certificate.get()));
+    X509_sign(certificate.get(), issuer_private_key.get(), EVP_sha256());
+    credentials.x509 = crypto::pem(certificate);
+    return credentials;
+  }
+
+  /**
+   * @brief Change a certificate's validity period so it is already expired.
+   *
+   * @param credentials PEM-encoded certificate and its signing key.
+   * @return The supplied credentials with an expired, re-signed certificate.
+   */
+  inline crypto::creds_t expire_credentials(crypto::creds_t credentials) {
+    auto certificate = crypto::x509(credentials.x509);
+    auto private_key = crypto::pkey(credentials.pkey);
+    constexpr long two_hours = 2 * 60 * 60;
+    constexpr long one_hour = 60 * 60;
+
+    X509_gmtime_adj(X509_getm_notBefore(certificate.get()), -two_hours);
+    X509_gmtime_adj(X509_getm_notAfter(certificate.get()), -one_hour);
+    X509_sign(certificate.get(), private_key.get(), EVP_sha256());
+    credentials.x509 = crypto::pem(certificate);
+    return credentials;
+  }
+
+  /**
+   * @brief Convert canonical PEM line endings to CRLF without changing certificate identity.
+   *
+   * @param pem Canonical PEM text.
+   * @return Equivalent PEM text using CRLF line endings.
+   */
+  inline std::string to_crlf_pem(const std::string_view pem) {
+    std::string converted;
+    converted.reserve(pem.size() + std::ranges::count(pem, '\n'));
+    for (const char character : pem) {
+      if (character == '\n') {
+        converted.push_back('\r');
+      }
+      converted.push_back(character);
+    }
+    return converted;
+  }
+}  // namespace test_utils::certificates

--- a/tests/unit/test_http_pairing.cpp
+++ b/tests/unit/test_http_pairing.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "../tests_common.h"
+#include "../certificate_test_utils.h"
 
 #include <atomic>
 #include <filesystem>
@@ -434,6 +435,51 @@ TEST(CertChainTest, CanonicallyEquivalentCertificateReplacesExistingIdentity) {
   EXPECT_EQ(verified.get(), replacement.get());
 }
 
+TEST(CertChainTest, RequiresExactPairedIdentityAndClearsFailedOutput) {
+  const auto issuer = test_utils::certificates::generate_ca_credentials();
+  const auto derived = test_utils::certificates::generate_derived_leaf(issuer);
+  auto paired_cert = crypto::x509(issuer.x509);
+  auto derived_cert = crypto::x509(derived.x509);
+  auto named = std::make_shared<crypto::named_cert_t>();
+  named->cert = issuer.x509;
+  crypto::cert_chain_t chain;
+  chain.add(named);
+
+  crypto::p_named_cert_t verified;
+  ASSERT_EQ(chain.verify(paired_cert.get(), verified), nullptr);
+  ASSERT_EQ(verified, named);
+  EXPECT_NE(chain.verify(derived_cert.get(), verified), nullptr);
+  EXPECT_FALSE(verified);
+
+  // A directly paired leaf is allowed even when its issuer is also paired.
+  auto paired_leaf = std::make_shared<crypto::named_cert_t>();
+  paired_leaf->cert = derived.x509;
+  chain.add(paired_leaf);
+  ASSERT_EQ(chain.verify(derived_cert.get(), verified), nullptr);
+  EXPECT_EQ(verified, paired_leaf);
+
+  verified = named;
+  EXPECT_NE(chain.verify(nullptr, verified), nullptr);
+  EXPECT_FALSE(verified);
+
+  chain.clear();
+  EXPECT_NE(chain.verify(paired_cert.get(), verified), nullptr);
+  EXPECT_FALSE(verified);
+}
+
+TEST(CertChainTest, PreservesExpiredPairedCertificatesForClientsWithoutAccurateClocks) {
+  const auto credentials = test_utils::certificates::expire_credentials(
+    crypto::gen_creds("Expired paired client", 2048));
+  auto certificate = crypto::x509(credentials.x509);
+  auto named = std::make_shared<crypto::named_cert_t>();
+  named->cert = credentials.x509;
+  crypto::cert_chain_t chain;
+  chain.add(named);
+  crypto::p_named_cert_t verified;
+  EXPECT_EQ(chain.verify(certificate.get(), verified), nullptr);
+  EXPECT_EQ(verified, named);
+}
+
 struct PairingAccessPresetTest: testing::Test {
   void SetUp() override {
     previous_fresh_state = config::sunshine.flags.test(config::flag::FRESH_STATE);
@@ -646,6 +692,38 @@ TEST_F(PairingAccessPresetTest, EstablishedRequestSnapshotIsRejectedAfterRevocat
   EXPECT_FALSE(resolve_authorized_client_for_tests(request_snapshot, "/serverinfo"));
   EXPECT_FALSE(game_stream_request_authorized_for_tests(request_snapshot, "/serverinfo"));
   EXPECT_FALSE(confighttp::config_request_authorized_for_tests(request_snapshot, "/api/clients/list"));
+}
+
+TEST_F(PairingAccessPresetTest, ConcurrentRevocationRejectsEstablishedAuthorization) {
+  auto session = successful_pairing_session("concurrent-revocation");
+  complete_successful_pairing(session);
+  const auto clients = get_all_clients();
+  ASSERT_EQ(clients.size(), 1);
+  auto certificate = crypto::x509(PUBLIC_CERT);
+  auto snapshot = verify_client_cert_for_tests(certificate.get(), 1);
+  ASSERT_TRUE(snapshot);
+  std::atomic<bool> started {false};
+  std::atomic<bool> revoked {false};
+  std::atomic<int> stale_authorizations {0};
+  std::thread reader([&] {
+    started.store(true, std::memory_order_release);
+    while (!revoked.load(std::memory_order_acquire)) {
+      (void) resolve_authorized_client_for_tests(snapshot, "/serverinfo");
+    }
+    for (int i = 0; i < 100; ++i) {
+      if (resolve_authorized_client_for_tests(snapshot, "/serverinfo")) {
+        ++stale_authorizations;
+      }
+    }
+  });
+  while (!started.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  const auto result = unpair_client_result(clients[0]["uuid"].get<std::string>());
+  revoked.store(true, std::memory_order_release);
+  reader.join();
+  EXPECT_EQ(result, client_mutation_result_t::success);
+  EXPECT_EQ(stale_authorizations.load(), 0);
 }
 
 TEST_F(PairingAccessPresetTest, SameUuidDifferentCertificateRejectsEstablishedRequestSnapshot) {

--- a/tests/unit/test_input_packet.cpp
+++ b/tests/unit/test_input_packet.cpp
@@ -1,0 +1,265 @@
+/**
+ * @file tests/unit/test_input.cpp
+ * @brief Tests for retained stream input and virtual gamepad lifecycle behavior.
+ */
+
+// test includes
+#include "../tests_common.h"
+
+// standard includes
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+// moonlight-common-c includes
+extern "C" {
+#include <moonlight-common-c/src/Input.h>
+}
+
+// local includes
+#include "src/config.h"
+#include "src/input.h"
+#include "src/utility.h"
+
+namespace {
+  /**
+   * @brief Protocol metadata for a fixed-size input packet.
+   */
+  struct input_packet_spec_t {
+    std::uint32_t magic;  ///< Packet type identifier.
+    std::size_t size;  ///< Complete fixed packet size.
+  };
+
+  /**
+   * @brief Create raw input bytes with a caller-selected header and buffer size.
+   *
+   * @param magic Packet type identifier.
+   * @param declared_size Packet size declared after the size field.
+   * @param actual_size Number of bytes available in the packet buffer.
+   * @return Raw packet bytes.
+   */
+  std::vector<std::uint8_t> make_input_packet(std::uint32_t magic, std::uint32_t declared_size, std::size_t actual_size) {
+    std::vector<std::uint8_t> packet(actual_size);
+    const NV_INPUT_HEADER header {
+      util::endian::big(declared_size),
+      util::endian::little(magic),
+    };
+    if (!packet.empty()) {
+      std::memcpy(packet.data(), &header, std::min(packet.size(), sizeof(header)));
+    }
+    return packet;
+  }
+
+}  // namespace
+
+TEST(InputPacketValidationTest, RejectsEveryBufferShorterThanTheHeader) {
+  for (std::size_t actual_size = 0; actual_size < sizeof(NV_INPUT_HEADER); ++actual_size) {
+    const auto packet = make_input_packet(UTF8_TEXT_EVENT_MAGIC, sizeof(std::uint32_t), actual_size);
+    EXPECT_FALSE(input::is_valid_input_packet_for_tests(packet)) << "actual_size=" << actual_size;
+  }
+}
+
+TEST(InputPacketValidationTest, RejectsDeclaredSizesOutsideTheAvailableBuffer) {
+  constexpr std::uint32_t unknown_magic = 0x12345678;
+  for (std::uint32_t declared_size = 0; declared_size < sizeof(std::uint32_t); ++declared_size) {
+    const auto packet = make_input_packet(unknown_magic, declared_size, sizeof(NV_INPUT_HEADER));
+    EXPECT_FALSE(input::is_valid_input_packet_for_tests(packet)) << "declared_size=" << declared_size;
+  }
+
+  const auto truncated_packet = make_input_packet(unknown_magic, sizeof(std::uint32_t) + 1, sizeof(NV_INPUT_HEADER));
+  EXPECT_FALSE(input::is_valid_input_packet_for_tests(truncated_packet));
+
+  const auto overflowing_size = make_input_packet(
+    unknown_magic,
+    std::numeric_limits<std::uint32_t>::max(),
+    sizeof(NV_INPUT_HEADER)
+  );
+  EXPECT_FALSE(input::is_valid_input_packet_for_tests(overflowing_size));
+}
+
+TEST(InputPacketValidationTest, ValidatesUnicodePacketBoundsWithoutOverflow) {
+  const auto empty_packet = make_input_packet(UTF8_TEXT_EVENT_MAGIC, sizeof(std::uint32_t), sizeof(NV_INPUT_HEADER));
+  EXPECT_TRUE(input::is_valid_input_packet_for_tests(empty_packet));
+
+  constexpr std::uint32_t maximum_declared_size = sizeof(std::uint32_t) + UTF8_TEXT_EVENT_MAX_COUNT;
+  const auto maximum_packet = make_input_packet(
+    UTF8_TEXT_EVENT_MAGIC,
+    maximum_declared_size,
+    sizeof(std::uint32_t) + maximum_declared_size
+  );
+  EXPECT_TRUE(input::is_valid_input_packet_for_tests(maximum_packet));
+
+  const auto oversized_text = make_input_packet(
+    UTF8_TEXT_EVENT_MAGIC,
+    maximum_declared_size + 1,
+    sizeof(std::uint32_t) + maximum_declared_size + 1
+  );
+  EXPECT_FALSE(input::is_valid_input_packet_for_tests(oversized_text));
+
+  const auto truncated_text = make_input_packet(UTF8_TEXT_EVENT_MAGIC, maximum_declared_size, sizeof(NV_INPUT_HEADER));
+  EXPECT_FALSE(input::is_valid_input_packet_for_tests(truncated_text));
+}
+
+TEST(InputPacketValidationTest, EnforcesEveryFixedPacketSize) {
+  constexpr std::array packet_specs {
+    input_packet_spec_t {MOUSE_MOVE_REL_MAGIC_GEN5, sizeof(NV_REL_MOUSE_MOVE_PACKET)},
+    input_packet_spec_t {MOUSE_MOVE_ABS_MAGIC, sizeof(NV_ABS_MOUSE_MOVE_PACKET)},
+    input_packet_spec_t {MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5, sizeof(NV_MOUSE_BUTTON_PACKET)},
+    input_packet_spec_t {MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5, sizeof(NV_MOUSE_BUTTON_PACKET)},
+    input_packet_spec_t {SCROLL_MAGIC_GEN5, sizeof(NV_SCROLL_PACKET)},
+    input_packet_spec_t {SS_HSCROLL_MAGIC, sizeof(SS_HSCROLL_PACKET)},
+    input_packet_spec_t {KEY_DOWN_EVENT_MAGIC, sizeof(NV_KEYBOARD_PACKET)},
+    input_packet_spec_t {KEY_UP_EVENT_MAGIC, sizeof(NV_KEYBOARD_PACKET)},
+    input_packet_spec_t {MULTI_CONTROLLER_MAGIC_GEN5, sizeof(NV_MULTI_CONTROLLER_PACKET)},
+    input_packet_spec_t {SS_TOUCH_MAGIC, sizeof(SS_TOUCH_PACKET)},
+    input_packet_spec_t {SS_PEN_MAGIC, sizeof(SS_PEN_PACKET)},
+    input_packet_spec_t {SS_CONTROLLER_ARRIVAL_MAGIC, sizeof(SS_CONTROLLER_ARRIVAL_PACKET)},
+    input_packet_spec_t {SS_CONTROLLER_TOUCH_MAGIC, sizeof(SS_CONTROLLER_TOUCH_PACKET)},
+    input_packet_spec_t {SS_CONTROLLER_MOTION_MAGIC, sizeof(SS_CONTROLLER_MOTION_PACKET)},
+    input_packet_spec_t {SS_CONTROLLER_BATTERY_MAGIC, sizeof(SS_CONTROLLER_BATTERY_PACKET)},
+  };
+
+  for (const auto &[magic, size] : packet_specs) {
+    const auto declared_size = static_cast<std::uint32_t>(size - sizeof(std::uint32_t));
+    const auto valid_packet = make_input_packet(magic, declared_size, size);
+    EXPECT_TRUE(input::is_valid_input_packet_for_tests(valid_packet)) << "magic=" << magic;
+
+    const auto trailing_bytes = make_input_packet(magic, declared_size, size + 8);
+    EXPECT_TRUE(input::is_valid_input_packet_for_tests(trailing_bytes)) << "magic=" << magic;
+
+    const auto wrong_declared_size = make_input_packet(magic, declared_size - 1, size);
+    EXPECT_FALSE(input::is_valid_input_packet_for_tests(wrong_declared_size)) << "magic=" << magic;
+
+    const auto oversized_declared_size = make_input_packet(magic, declared_size + 1, size + 1);
+    EXPECT_FALSE(input::is_valid_input_packet_for_tests(oversized_declared_size)) << "magic=" << magic;
+
+    const auto truncated_packet = make_input_packet(magic, declared_size, size - 1);
+    EXPECT_FALSE(input::is_valid_input_packet_for_tests(truncated_packet)) << "magic=" << magic;
+  }
+}
+
+TEST(InputPacketValidationTest, PreservesUnknownPacketHandlingWithinDeclaredBounds) {
+  constexpr std::uint32_t unknown_magic = 0x12345678;
+  const auto packet = make_input_packet(unknown_magic, sizeof(std::uint32_t), sizeof(NV_INPUT_HEADER));
+  EXPECT_TRUE(input::is_valid_input_packet_for_tests(packet));
+}
+
+
+namespace {
+  class InputPacketAdmissionTest: public testing::Test {
+  protected:
+    void TearDown() override {
+      // The test environment never starts task_pool. Discard queued work so
+      // admission can be observed without opening or sending to input devices.
+      while (task_pool.pop()) {}
+    }
+  };
+}
+
+TEST_F(InputPacketAdmissionTest, ValidatesBeforePermissionsAndQueueing) {
+  constexpr std::array permissions {
+    crypto::PERM::_no, crypto::PERM::input_mouse, crypto::PERM::_all_inputs,
+  };
+  for (const auto permission : permissions) {
+    auto queue = input::alloc_queue_for_tests();
+    for (std::size_t size = 0; size < sizeof(NV_REL_MOUSE_MOVE_PACKET); ++size) {
+      auto packet = make_input_packet(MOUSE_MOVE_REL_MAGIC_GEN5, sizeof(NV_REL_MOUSE_MOVE_PACKET) - 4, size);
+      input::passthrough(queue, std::move(packet), permission);
+    }
+    EXPECT_EQ(input::queued_input_packet_count_for_tests(queue), 0);
+    auto valid = make_input_packet(MOUSE_MOVE_REL_MAGIC_GEN5, sizeof(NV_REL_MOUSE_MOVE_PACKET) - 4, sizeof(NV_REL_MOUSE_MOVE_PACKET));
+    input::passthrough(queue, std::move(valid), permission);
+    const auto expected = permission == crypto::PERM::_no ? 0 : 1;
+    EXPECT_EQ(input::queued_input_packet_count_for_tests(queue), expected);
+    auto truncated = make_input_packet(MOUSE_MOVE_REL_MAGIC_GEN5, sizeof(NV_REL_MOUSE_MOVE_PACKET) - 4, sizeof(NV_REL_MOUSE_MOVE_PACKET) - 1);
+    input::passthrough(queue, std::move(truncated), permission);
+    EXPECT_EQ(input::queued_input_packet_count_for_tests(queue), expected);
+  }
+}
+
+TEST_F(InputPacketAdmissionTest, PreservesEachExtensionPermissionBoundary) {
+  struct spec_t {
+    std::uint32_t magic;
+    std::size_t size;
+    crypto::PERM permission;
+  };
+  constexpr std::array specs {
+    spec_t {KEY_DOWN_EVENT_MAGIC, sizeof(NV_KEYBOARD_PACKET), crypto::PERM::input_kbd},
+    spec_t {UTF8_TEXT_EVENT_MAGIC, sizeof(NV_UNICODE_PACKET), crypto::PERM::input_kbd},
+    spec_t {SS_HSCROLL_MAGIC, sizeof(SS_HSCROLL_PACKET), crypto::PERM::input_mouse},
+    spec_t {SS_TOUCH_MAGIC, sizeof(SS_TOUCH_PACKET), crypto::PERM::input_touch},
+    spec_t {SS_PEN_MAGIC, sizeof(SS_PEN_PACKET), crypto::PERM::input_pen},
+    spec_t {MULTI_CONTROLLER_MAGIC_GEN5, sizeof(NV_MULTI_CONTROLLER_PACKET), crypto::PERM::input_controller},
+    spec_t {SS_CONTROLLER_ARRIVAL_MAGIC, sizeof(SS_CONTROLLER_ARRIVAL_PACKET), crypto::PERM::input_controller},
+    spec_t {SS_CONTROLLER_TOUCH_MAGIC, sizeof(SS_CONTROLLER_TOUCH_PACKET), crypto::PERM::input_controller},
+    spec_t {SS_CONTROLLER_MOTION_MAGIC, sizeof(SS_CONTROLLER_MOTION_PACKET), crypto::PERM::input_controller},
+    spec_t {SS_CONTROLLER_BATTERY_MAGIC, sizeof(SS_CONTROLLER_BATTERY_PACKET), crypto::PERM::input_controller},
+  };
+  for (const auto &[magic, size, permission] : specs) {
+    auto queue = input::alloc_queue_for_tests();
+    auto valid = make_input_packet(magic, size - 4, size);
+    input::passthrough(queue, std::move(valid), permission);
+    EXPECT_EQ(input::queued_input_packet_count_for_tests(queue), 1) << magic;
+    auto denied = make_input_packet(magic, size - 4, size);
+    const auto other_permission = permission == crypto::PERM::input_mouse ? crypto::PERM::input_kbd : crypto::PERM::input_mouse;
+    input::passthrough(queue, std::move(denied), other_permission);
+    EXPECT_EQ(input::queued_input_packet_count_for_tests(queue), 1) << magic;
+  }
+}
+
+TEST(InputPacketValidationTest, PreservesBatchingAndStateChangeBoundaries) {
+  auto relative = make_input_packet(MOUSE_MOVE_REL_MAGIC_GEN5, sizeof(NV_REL_MOUSE_MOVE_PACKET) - 4, sizeof(NV_REL_MOUSE_MOVE_PACKET));
+  NV_REL_MOUSE_MOVE_PACKET movement {};
+  std::memcpy(&movement, relative.data(), sizeof(movement));
+  movement.deltaX = util::endian::big<short>(2);
+  std::memcpy(relative.data(), &movement, sizeof(movement));
+  auto second = relative;
+  EXPECT_TRUE(input::batch_input_packets_for_tests(relative, second));
+  std::memcpy(&movement, relative.data(), sizeof(movement));
+  EXPECT_EQ(util::endian::big(movement.deltaX), 4);
+
+  auto button = make_input_packet(MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5, sizeof(NV_MOUSE_BUTTON_PACKET) - 4, sizeof(NV_MOUSE_BUTTON_PACKET));
+  EXPECT_FALSE(input::batch_input_packets_for_tests(relative, button));
+  auto truncated = second;
+  truncated.pop_back();
+  EXPECT_FALSE(input::batch_input_packets_for_tests(relative, truncated));
+  EXPECT_FALSE(input::batch_input_packets_for_tests(truncated, relative));
+}
+
+TEST(InputPacketValidationTest, NeverBatchesOverflowingRelativeMotion) {
+  auto first = make_input_packet(MOUSE_MOVE_REL_MAGIC_GEN5, sizeof(NV_REL_MOUSE_MOVE_PACKET) - 4, sizeof(NV_REL_MOUSE_MOVE_PACKET));
+  NV_REL_MOUSE_MOVE_PACKET movement {};
+  std::memcpy(&movement, first.data(), sizeof(movement));
+  movement.deltaX = util::endian::big<short>(std::numeric_limits<short>::max());
+  movement.deltaY = movement.deltaX;
+  std::memcpy(first.data(), &movement, sizeof(movement));
+  const auto unchanged = first;
+  EXPECT_FALSE(input::batch_input_packets_for_tests(first, unchanged));
+  EXPECT_EQ(first, unchanged);
+}
+
+TEST(InputPacketValidationTest, BatchesScrollOnlyWhenTheSumFits) {
+  for (const auto magic : {SCROLL_MAGIC_GEN5, SS_HSCROLL_MAGIC}) {
+    const auto size = magic == SCROLL_MAGIC_GEN5 ? sizeof(NV_SCROLL_PACKET) : sizeof(SS_HSCROLL_PACKET);
+    auto packet = make_input_packet(magic, size - 4, size);
+    // Both protocols store their first signed big-endian delta after the header.
+    const auto amount = util::endian::big<short>(7);
+    std::memcpy(packet.data() + sizeof(NV_INPUT_HEADER), &amount, sizeof(amount));
+    const auto original = packet;
+    ASSERT_TRUE(input::batch_input_packets_for_tests(packet, original));
+    short sum;
+    std::memcpy(&sum, packet.data() + sizeof(NV_INPUT_HEADER), sizeof(sum));
+    EXPECT_EQ(util::endian::big(sum), 14);
+
+    const auto maximum = util::endian::big<short>(std::numeric_limits<short>::max());
+    std::memcpy(packet.data() + sizeof(NV_INPUT_HEADER), &maximum, sizeof(maximum));
+    const auto unchanged = packet;
+    EXPECT_FALSE(input::batch_input_packets_for_tests(packet, original));
+    EXPECT_EQ(packet, unchanged);
+  }
+}


### PR DESCRIPTION
Decrypted input could reach typed permission checks, batching, and logging without structural validation, and a certificate signed by a paired identity could inherit its authorization. Validate packet headers, declared/fixed lengths, and Unicode bounds before queue admission, and require the presented certificate's canonical DER fingerprint to match the stored identity before chain verification. Preserve extension packets, canonical PEM equivalence, permissions, guest expiry, revocation, and concurrent authorization.

Regression coverage also exposed reversed overflow checks in relative-motion and scroll batching; safe sums now batch and overflow leaves the original packet unchanged. Security validation is adapted from [Sunshine v2026.906.222525](https://github.com/LizardByte/Sunshine/releases/tag/v2026.906.222525); the overflow correction was discovered during this adaptation.

Validation: baseline derived-certificate regression failed as expected while 41 existing/compatibility tests passed; modified Linux full pairing suite passes 56 tests and input suite passes 14 with 4 existing hardware skips. Targeted Clang ThreadSanitizer passes all 8 certificate/concurrent authorization tests. Public surface/docs checks and diff whitespace checks pass. Independent source review found no material issues. Exact-head sanitizer/native/package CI remains required before merge. No live service or production multiseat activation changes.
