### PR TITLE
fix(pairing): require explicit expiring manual approval requests

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -85,3 +85,23 @@ device connects (**do**) and disconnects (**undo**). Commands run detached.
 Renaming or re-pairing a device can leave a display profile behind under the old name. When that
 happens a **Stale profile aliases** section appears at the bottom of the page listing them;
 **Remove stale** deletes the aliases without unpairing any real device.
+
+## Manual pairing approval API
+
+Manual PIN approval now requires selecting a pending request. Administrative clients must first call authenticated `GET /api/pin`, which returns:
+
+```json
+{"pairings":[{"id":"0123456789abcdef0123456789abcdef","name":"Living room","address":"192.0.2.10"}]}
+```
+
+Names are reported by clients. Check the source address and select the intended request. Submit its exact ID with the PIN using authenticated, CSRF-protected `POST /api/pin`:
+
+```json
+{"pairing_id":"0123456789abcdef0123456789abcdef","pin":"1234","name":"Living room","access_preset":"game_control","temporary_authorization":false}
+```
+
+`pairing_id` is mandatory. Missing or malformed IDs return HTTP 400; expired, cancelled, already approved, or unknown requests return `status: false`. Approval never selects another pending request. Existing access presets and temporary guest authorization retain their behavior. An empty administrative name preserves the client-reported name.
+
+Authenticated, CSRF-protected `DELETE /api/pin` accepts `{"pairing_id":"..."}` and cancels only that pending request. IDs contain 32 random hexadecimal characters. Sessions expire five minutes after creation; the host retains at most 32 and rejects duplicate pending client identifiers. Refresh the request list after an expiration, cancellation, or failed approval.
+
+This administrative API change does not alter Nova or Moonlight's normal pairing protocol. QR/OTP and explicitly requested trusted-network pairing retain their existing behavior.

--- a/playwright.pairing.config.js
+++ b/playwright.pairing.config.js
@@ -1,0 +1,13 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: 'manual-pairing.spec.js',
+  workers: 1,
+  use: { baseURL: 'http://127.0.0.1:49387', ...devices['Desktop Chrome'] },
+  webServer: {
+    command: 'python3 -m http.server 49387 --bind 127.0.0.1 --directory build/assets/web',
+    url: 'http://127.0.0.1:49387',
+    reuseExistingServer: false,
+  },
+})

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -5283,6 +5283,34 @@ namespace confighttp {
     }
   }
 
+  /** @brief List manual pairing requests for an authenticated administrator. */
+  void getPendingPairings(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) return;
+    nlohmann::json output;
+    output["pairings"] = nlohmann::json::array();
+    for (const auto &pairing : nvhttp::get_pending_pairings()) {
+      output["pairings"].push_back({{"id", pairing.id}, {"name", pairing.name}, {"address", pairing.address}});
+    }
+    send_response(response, output);
+  }
+
+  void cancelPairing(resp_https_t response, req_https_t request) {
+    if (!validateContentType(response, request, "application/json") || !authenticate(response, request)) return;
+    try {
+      std::stringstream ss;
+      ss << request->content.rdbuf();
+      const auto body = nlohmann::json::parse(ss.str());
+      const auto pairing_id = body.value("pairing_id", "");
+      if (!nvhttp::is_valid_pairing_id(pairing_id)) {
+        bad_request(response, request, "pairing_id must contain exactly 32 hexadecimal characters");
+        return;
+      }
+      send_response(response, nlohmann::json {{"status", nvhttp::cancel_pairing(pairing_id)}});
+    } catch (const std::exception &e) {
+      bad_request(response, request, e.what());
+    }
+  }
+
   /**
    * @brief Send a PIN code to the host.
    * @param response The HTTP response object.
@@ -5291,12 +5319,13 @@ namespace confighttp {
    * The body for the POST request should be JSON serialized in the following format:
    * @code{.json}
    * {
+   *   "pairing_id": "<pending request ID>",
    *   "pin": "<pin>",
    *   "name": "Friendly Client Name"
    * }
    * @endcode
    *
-   * @api_examples{/api/pin| POST| {"pin":"1234","name":"My PC"}}
+   * @api_examples{/api/pin| POST| {"pairing_id":"0123456789abcdef0123456789abcdef","pin":"1234","name":"My PC"}}
    */
   void savePin(resp_https_t response, req_https_t request) {
     if (!validateContentType(response, request, "application/json") || !authenticate(response, request)) {
@@ -5310,6 +5339,11 @@ namespace confighttp {
       ss << request->content.rdbuf();
       nlohmann::json input_tree = nlohmann::json::parse(ss.str());
       nlohmann::json output_tree;
+      const auto pairing_id = input_tree.value("pairing_id", "");
+      if (!nvhttp::is_valid_pairing_id(pairing_id)) {
+        bad_request(response, request, "pairing_id must contain exactly 32 hexadecimal characters");
+        return;
+      }
       std::string pin = input_tree.value("pin", "");
       std::string name = input_tree.value("name", "");
       const bool temporary_authorization = input_tree.value("temporary_authorization", false);
@@ -5324,6 +5358,7 @@ namespace confighttp {
       }
 
       output_tree["status"] = nvhttp::pin(
+        pairing_id,
         pin,
         name,
         nvhttp::pairing_access_preset_perm(*access_preset),
@@ -7316,7 +7351,9 @@ namespace confighttp {
     // Login is exempt from CSRF (it's the entry point; rate limiting protects it instead)
     server.resource["^/api/login"]["POST"] = login;
     server.resource["^/api/logout$"]["POST"] = withCsrf(logout);
+    server.resource["^/api/pin$"]["GET"] = getPendingPairings;
     server.resource["^/api/pin$"]["POST"] = withCsrf(savePin);
+    server.resource["^/api/pin$"]["DELETE"] = withCsrf(cancelPairing);
     server.resource["^/api/otp$"]["POST"] = withCsrf(getOTP);
     server.resource["^/api/apps$"]["GET"] = getApps;
     server.resource["^/api/apps$"]["POST"] = withCsrf(saveApp);

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -4630,15 +4630,146 @@ namespace nvhttp {
     return launch_session;
   }
 
+  bool write_pairing_response(pair_session_t &sess, const pt::ptree &tree) {
+    std::ostringstream data;
+    pt::write_xml(data, tree);
+
+    auto &response = sess.async_insert_pin.response;
+    if (response.has_left() && response.left()) {
+      response.left()->close_connection_after_response = true;
+      response.left()->write(data.str());
+    } else if (response.has_right() && response.right()) {
+      response.right()->close_connection_after_response = true;
+      response.right()->write(data.str());
+    } else {
+      return false;
+    }
+
+    response = std::monostate {};
+    return true;
+  }
+
+  /**
+   * @brief Expire stale pairing sessions while the session mutex is held.
+   *
+   * @param now Monotonic time used to evaluate session deadlines.
+   */
+  void expire_pair_sessions_unlocked(const std::chrono::steady_clock::time_point now) {
+    for (auto it = map_id_sess.begin(); it != map_id_sess.end();) {
+      if (it->second.async_insert_pin.expires_at > now) {
+        ++it;
+        continue;
+      }
+
+      pt::ptree tree;
+      tree.put("root.paired", 0);
+      tree.put("root.<xmlattr>.status_code", 408);
+      tree.put("root.<xmlattr>.status_message", "Pairing session expired");
+      write_pairing_response(it->second, tree);
+      it = map_id_sess.erase(it);
+    }
+  }
+
+  pair_session_insert_e insert_pair_session(pair_session_t sess, std::string &pairing_id) {
+    std::scoped_lock lock {client_state_mutex};
+    const auto now = std::chrono::steady_clock::now();
+    expire_pair_sessions_unlocked(now);
+    pairing_id.clear();
+
+    if (map_id_sess.contains(sess.client.uniqueID)) {
+      return pair_session_insert_e::ALREADY_EXISTS;
+    }
+    if (map_id_sess.size() >= MAX_PENDING_PAIRING_SESSIONS) {
+      return pair_session_insert_e::FULL;
+    }
+
+    do {
+      pairing_id = crypto::rand_alphabet(PAIRING_ID_SIZE, "0123456789abcdef"sv);
+    } while (std::ranges::any_of(map_id_sess, [&](const auto &entry) {
+      return entry.second.async_insert_pin.id == pairing_id;
+    }));
+
+    sess.async_insert_pin.id = pairing_id;
+    sess.async_insert_pin.expires_at = now + PAIRING_SESSION_TIMEOUT;
+    map_id_sess.emplace(sess.client.uniqueID, std::move(sess));
+    return pair_session_insert_e::ADDED;
+  }
+
+  bool is_valid_pairing_id(const std::string_view pairing_id) {
+    return pairing_id.size() == PAIRING_ID_SIZE && std::ranges::all_of(pairing_id, [](const char character) {
+             return (character >= '0' && character <= '9') || (character >= 'a' && character <= 'f') || (character >= 'A' && character <= 'F');
+           });
+  }
+
+  void expire_pair_sessions(const std::chrono::steady_clock::time_point now) {
+    std::scoped_lock lock {client_state_mutex};
+    expire_pair_sessions_unlocked(now);
+  }
+
+  std::vector<pending_pairing_t> get_pending_pairings() {
+    std::scoped_lock lock {client_state_mutex};
+    expire_pair_sessions_unlocked(std::chrono::steady_clock::now());
+
+    std::vector<const pair_session_t *> pending_sessions;
+    pending_sessions.reserve(map_id_sess.size());
+    for (const auto &[_, sess] : map_id_sess) {
+      if (sess.last_phase == PAIR_PHASE::NONE) {
+        pending_sessions.push_back(&sess);
+      }
+    }
+    std::ranges::sort(pending_sessions, {}, [](const pair_session_t *sess) {
+      return sess->async_insert_pin.expires_at;
+    });
+
+    std::vector<pending_pairing_t> result;
+    result.reserve(pending_sessions.size());
+    for (const auto *sess : pending_sessions) {
+      result.push_back({
+        .id = sess->async_insert_pin.id,
+        .name = sess->async_insert_pin.device_name,
+        .address = sess->async_insert_pin.address,
+      });
+    }
+    return result;
+  }
+
+  bool cancel_pairing(const std::string_view pairing_id) {
+    if (!is_valid_pairing_id(pairing_id)) {
+      return false;
+    }
+
+    std::scoped_lock lock {client_state_mutex};
+    expire_pair_sessions_unlocked(std::chrono::steady_clock::now());
+
+    const auto sess_it = std::ranges::find_if(map_id_sess, [&](const auto &entry) {
+      return entry.second.last_phase == PAIR_PHASE::NONE && entry.second.async_insert_pin.id == pairing_id;
+    });
+    if (sess_it == map_id_sess.end()) {
+      return false;
+    }
+
+    pt::ptree tree;
+    tree.put("root.paired", 0);
+    tree.put("root.<xmlattr>.status_code", 400);
+    tree.put("root.<xmlattr>.status_message", "Pairing request cancelled by operator");
+    write_pairing_response(sess_it->second, tree);
+    map_id_sess.erase(sess_it);
+    return true;
+  }
+
   void remove_session(const pair_session_t &sess) {
-    map_id_sess.erase(sess.client.uniqueID);
+    std::lock_guard lock {client_state_mutex};
+    const auto it = map_id_sess.find(sess.client.uniqueID);
+    if (it != map_id_sess.end() && it->second.async_insert_pin.id == sess.async_insert_pin.id) {
+      map_id_sess.erase(it);
+    }
   }
 
   void fail_pair(pair_session_t &sess, pt::ptree &tree, const std::string status_msg) {
     tree.put("root.paired", 0);
     tree.put("root.<xmlattr>.status_code", 400);
     tree.put("root.<xmlattr>.status_message", status_msg);
-    remove_session(sess);  // Security measure, delete the session when something went wrong and force a re-pair
+    sess.failed = true;  // The owning handler removes it after its last access.
     BOOST_LOG(warning) << "Pair attempt failed due to " << status_msg;
   }
 
@@ -4807,7 +4938,7 @@ namespace nvhttp {
       BOOST_LOG(warning) << "Pair attempt failed due to same_hash: " << same_hash << ", verify: " << verify;
     }
 
-    remove_session(sess);
+    // The owning handler removes the completed session after its last access.
   }
 
   template<class T>
@@ -5039,7 +5170,11 @@ namespace nvhttp {
     }
 
     const auto unique_id = unique_id_it->second;
-    const bool removed_session = map_id_sess.erase(unique_id) > 0;
+    bool removed_session;
+    {
+      std::lock_guard lock {client_state_mutex};
+      removed_session = map_id_sess.erase(unique_id) > 0;
+    }
 
     bool removed_paired_client = false;
     bool revocation_failed = false;
@@ -5100,18 +5235,29 @@ namespace nvhttp {
       return;
     }
 
+    std::unique_lock session_lock {client_state_mutex};
+    expire_pair_sessions_unlocked(std::chrono::steady_clock::now());
+    const auto session_key = uniqID;
+    std::string handler_pairing_id;
+    auto cleanup_session = util::fail_guard([&] {
+      // Helpers never erase the session backing their reference. This guard
+      // runs after the handler's final use, including a failed PIN attempt.
+      if (!session_lock.owns_lock()) session_lock.lock();
+      const auto entry = map_id_sess.find(session_key);
+      if (entry != map_id_sess.end() && !handler_pairing_id.empty() &&
+          entry->second.async_insert_pin.id == handler_pairing_id &&
+          (entry->second.failed || entry->second.last_phase == PAIR_PHASE::CLIENTPAIRINGSECRET)) {
+        map_id_sess.erase(entry);
+      }
+    });
+
     args_t::const_iterator it;
     if (it = args.find("phrase"); it != std::end(args)) {
       if (it->second == "getservercert"sv) {
-        auto existing_session = map_id_sess.find(uniqID);
-        if (existing_session != std::end(map_id_sess)) {
-          BOOST_LOG(info) << "pair: restarting in-flight session for uniqueid "sv << uniqID;
-          map_id_sess.erase(existing_session);
-        }
-
         pair_session_t sess;
 
         auto deviceName { get_arg(args, "devicename") };
+        sess.async_insert_pin.device_name = deviceName;
         const bool trusted_pair_requested = util::from_view(get_arg(args, "trustedpair", "0"));
         const auto remote_addr = request->remote_endpoint().address();
         const auto remote_addr_str = net::addr_to_normalized_string(remote_addr);
@@ -5127,7 +5273,18 @@ namespace nvhttp {
         sess.client.cert = util::from_hex_vec(get_arg(args, "clientcert"), true);
 
         BOOST_LOG(debug) << sess.client.cert;
-        auto ptr = map_id_sess.emplace(sess.client.uniqueID, std::move(sess)).first;
+        sess.async_insert_pin.address = remote_addr_str;
+        std::string pairing_id;
+        const auto inserted = insert_pair_session(std::move(sess), pairing_id);
+        if (inserted != pair_session_insert_e::ADDED) {
+          tree.put("root.paired", 0);
+          tree.put("root.<xmlattr>.status_code", inserted == pair_session_insert_e::ALREADY_EXISTS ? 409 : 503);
+          tree.put("root.<xmlattr>.status_message", inserted == pair_session_insert_e::ALREADY_EXISTS
+            ? "A pairing session with this uniqueid already exists" : "Too many pending pairing sessions");
+          return;
+        }
+        handler_pairing_id = pairing_id;
+        auto ptr = map_id_sess.find(session_key);
 
         ptr->second.async_insert_pin.salt = std::move(get_arg(args, "salt"));
         BOOST_LOG(info) << "pair: getservercert uniqueid="sv << ptr->second.client.uniqueID
@@ -5158,9 +5315,19 @@ namespace nvhttp {
         if (config::sunshine.flags[config::flag::PIN_STDIN]) {
           std::string pin;
 
+          // Do not hold the authorization lock while waiting for terminal input.
+          session_lock.unlock();
           std::cout << "Please insert pin: "sv;
           std::getline(std::cin, pin);
-
+          session_lock.lock();
+          expire_pair_sessions_unlocked(std::chrono::steady_clock::now());
+          ptr = map_id_sess.find(session_key);
+          if (ptr == map_id_sess.end() || ptr->second.async_insert_pin.id != pairing_id) {
+            tree.put("root.paired", 0);
+            tree.put("root.<xmlattr>.status_code", 408);
+            tree.put("root.<xmlattr>.status_message", "Pairing session expired or cancelled");
+            return;
+          }
           getservercert(ptr->second, tree, pin);
           return;
         } else {
@@ -5209,6 +5376,7 @@ namespace nvhttp {
       return;
     }
 
+    handler_pairing_id = sess_it->second.async_insert_pin.id;
     if (it = args.find("clientchallenge"); it != std::end(args)) {
       auto challenge = util::from_hex_vec(it->second, true);
       clientchallenge(sess_it->second, tree, challenge);
@@ -5225,63 +5393,34 @@ namespace nvhttp {
   }
 
   bool pin(
+    std::string_view pairing_id,
     std::string pin,
     std::string name,
     std::optional<PERM> pairing_perm,
     bool temporary_authorization
   ) {
-    pt::ptree tree;
-    if (map_id_sess.empty()) {
+    if (!is_valid_pairing_id(pairing_id) || pin.size() != 4 ||
+        !std::ranges::all_of(pin, [](char c) { return c >= '0' && c <= '9'; })) {
       return false;
     }
+    std::lock_guard lock {client_state_mutex};
+    expire_pair_sessions_unlocked(std::chrono::steady_clock::now());
+    const auto it = std::ranges::find_if(map_id_sess, [&](const auto &entry) {
+      return entry.second.last_phase == PAIR_PHASE::NONE &&
+             entry.second.async_insert_pin.id == pairing_id;
+    });
+    if (it == map_id_sess.end()) return false;
 
-    // ensure pin is 4 digits
-    if (pin.size() != 4) {
-      tree.put("root.paired", 0);
-      tree.put("root.<xmlattr>.status_code", 400);
-      tree.put(
-        "root.<xmlattr>.status_message",
-        std::format("Pin must be 4 digits, {} provided", pin.size())
-      );
-      return false;
-    }
-
-    // ensure all pin characters are numeric
-    if (!std::all_of(pin.begin(), pin.end(), ::isdigit)) {
-      tree.put("root.paired", 0);
-      tree.put("root.<xmlattr>.status_code", 400);
-      tree.put("root.<xmlattr>.status_message", "Pin must be numeric");
-      return false;
-    }
-
-    auto &sess = std::begin(map_id_sess)->second;
-    if (pairing_perm) {
-      sess.pairing_perm = *pairing_perm;
-    }
+    auto &sess = it->second;
+    if (pairing_perm) sess.pairing_perm = *pairing_perm;
     sess.temporary_authorization = temporary_authorization;
+    pt::ptree tree;
     getservercert(sess, tree, pin);
-
-    if (!name.empty()) {
-      sess.client.name = name;
-    }
-
-    // response to the request for pin
-    std::ostringstream data;
-    pt::write_xml(data, tree);
-
-    auto &async_response = sess.async_insert_pin.response;
-    if (async_response.has_left() && async_response.left()) {
-      async_response.left()->write(data.str());
-    } else if (async_response.has_right() && async_response.right()) {
-      async_response.right()->write(data.str());
-    } else {
-      return false;
-    }
-
-    // reset async_response
-    async_response = std::decay_t<decltype(async_response.left())>();
-    // response to the current request
-    return true;
+    if (!sess.failed && !name.empty()) sess.client.name = std::move(name);
+    const bool response_written = write_pairing_response(sess, tree);
+    const bool success = response_written && !sess.failed;
+    if (!success) map_id_sess.erase(it);
+    return success;
   }
 
   template<class T>
@@ -10093,8 +10232,8 @@ namespace nvhttp {
     ssl.join();
     tcp.join();
 
-    // Only once the server threads are joined: an in-flight pair() holds a
-    // reference into this map for the rest of its handler.
+    // Configuration API requests can still access pending sessions here.
+    std::lock_guard lock {client_state_mutex};
     map_id_sess.clear();
   }
 
@@ -10123,6 +10262,26 @@ namespace nvhttp {
   }
 
 #ifdef POLARIS_TESTS
+  nlohmann::json pairing_options_for_tests(std::string_view id) {
+    std::lock_guard lock {client_state_mutex};
+    for (const auto &[_, session] : map_id_sess) {
+      if (session.async_insert_pin.id == id || session.client.uniqueID == id) {
+        return {{"name", session.client.name},
+                {"family", session.client.family_hint},
+                {"perm", static_cast<std::uint32_t>(session.pairing_perm.value_or(PERM::_no))},
+                {"temporary_authorization", session.temporary_authorization}};
+      }
+    }
+    return nullptr;
+  }
+
+  void pair_http_for_tests(
+    std::shared_ptr<SimpleWeb::ServerBase<SimpleWeb::HTTP>::Response> response,
+    std::shared_ptr<SimpleWeb::ServerBase<SimpleWeb::HTTP>::Request> request
+  ) {
+    pair<SimpleWeb::HTTP>(std::move(response), std::move(request));
+  }
+
   bool is_in_trusted_subnet_for_tests(const boost::asio::ip::address &addr) {
     return is_in_trusted_subnet(addr);
   }

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -206,6 +206,22 @@ namespace nvhttp {
   crypto::PERM pairing_access_preset_perm(pairing_access_preset_t preset);
   std::string_view pairing_access_preset_name(pairing_access_preset_t preset);
 
+  inline constexpr std::size_t PAIRING_ID_SIZE = 32;
+  inline constexpr std::size_t MAX_PENDING_PAIRING_SESSIONS = 32;
+  inline constexpr auto PAIRING_SESSION_TIMEOUT = 5min;
+
+  struct pending_pairing_t {
+    std::string id;
+    std::string name;
+    std::string address;
+  };
+
+  enum class pair_session_insert_e { ADDED, ALREADY_EXISTS, FULL };
+  bool is_valid_pairing_id(std::string_view pairing_id);
+  std::vector<pending_pairing_t> get_pending_pairings();
+  bool cancel_pairing(std::string_view pairing_id);
+  void expire_pair_sessions(std::chrono::steady_clock::time_point now);
+
   struct pair_session_t {
     struct {
       std::string uniqueID = {};
@@ -226,6 +242,11 @@ namespace nvhttp {
         std::shared_ptr<typename SimpleWeb::ServerBase<PolarisHTTPS>::Response>>
         response;
       std::string salt = {};
+      std::string id = {};
+      std::string device_name = {};
+      std::string address = {};
+      std::chrono::steady_clock::time_point expires_at = {};
+
     } async_insert_pin;
 
     std::optional<crypto::PERM> pairing_perm = {};
@@ -235,6 +256,7 @@ namespace nvhttp {
      * @brief used as a security measure to prevent out of order calls
      */
     PAIR_PHASE last_phase = PAIR_PHASE::NONE;
+    bool failed = false;
   };
 
   /**
@@ -242,6 +264,7 @@ namespace nvhttp {
    * @param sess
    */
   void remove_session(const pair_session_t &sess);
+  pair_session_insert_e insert_pair_session(pair_session_t sess, std::string &pairing_id);
 
   /**
    * @brief Pair, phase 1
@@ -300,10 +323,11 @@ namespace nvhttp {
    * @param name The user supplied name.
    * @return `true` if the pin is correct, `false` otherwise.
    * @examples
-   * bool pin_status = nvhttp::pin("1234", "laptop");
+   * bool pin_status = nvhttp::pin(pairing_id, "1234", "laptop");
    * @examples_end
    */
   bool pin(
+    std::string_view pairing_id,
     std::string pin,
     std::string name,
     std::optional<crypto::PERM> pairing_perm = std::nullopt,
@@ -455,6 +479,11 @@ namespace nvhttp {
   nlohmann::json auto_quality_status_json();
 
 #ifdef POLARIS_TESTS
+  nlohmann::json pairing_options_for_tests(std::string_view id);
+  void pair_http_for_tests(
+    std::shared_ptr<SimpleWeb::ServerBase<SimpleWeb::HTTP>::Response> response,
+    std::shared_ptr<SimpleWeb::ServerBase<SimpleWeb::HTTP>::Request> request
+  );
   bool is_in_trusted_subnet_for_tests(const boost::asio::ip::address &addr);
   bool pairing_unique_id_valid_for_tests(std::string_view unique_id);
   enum class pairing_state_write_fault_t {

--- a/src_assets/common/assets/web/composables/usePendingPairings.js
+++ b/src_assets/common/assets/web/composables/usePendingPairings.js
@@ -1,0 +1,55 @@
+import { onScopeDispose, ref, watch } from 'vue'
+
+export function usePendingPairings(active) {
+  const pendingPairings = ref([])
+  const selectedPairingId = ref('')
+  const pairingListError = ref('')
+  let timer = null
+  let request = null
+  let disposed = false
+
+  async function refreshPairings() {
+    if (disposed || request) return
+    const controller = new AbortController()
+    request = controller
+    try {
+      const response = await fetch('./api/pin', { credentials: 'include', signal: controller.signal })
+      if (!response.ok) throw new Error('Could not load pending pairing requests.')
+      const body = await response.json()
+      if (!Array.isArray(body.pairings)) throw new Error('Could not load pending pairing requests.')
+      if (disposed || controller.signal.aborted) return
+      pendingPairings.value = body.pairings
+      pairingListError.value = ''
+      if (!body.pairings.some((pairing) => pairing.id === selectedPairingId.value)) {
+        selectedPairingId.value = ''
+      }
+    } catch (error) {
+      if (disposed || controller.signal.aborted) return
+      pendingPairings.value = []
+      selectedPairingId.value = ''
+      pairingListError.value = error.message
+    } finally {
+      if (request === controller) request = null
+    }
+  }
+
+  watch(active, (enabled) => {
+    clearInterval(timer)
+    request?.abort()
+    request = null
+    pendingPairings.value = []
+    selectedPairingId.value = ''
+    if (enabled) {
+      refreshPairings()
+      timer = setInterval(refreshPairings, 3000)
+    }
+  }, { immediate: true })
+
+  onScopeDispose(() => {
+    disposed = true
+    clearInterval(timer)
+    request?.abort()
+  })
+
+  return { pendingPairings, selectedPairingId, pairingListError, refreshPairings }
+}

--- a/src_assets/common/assets/web/composables/usePendingPairings.test.js
+++ b/src_assets/common/assets/web/composables/usePendingPairings.test.js
@@ -1,0 +1,73 @@
+import { effectScope, nextTick, ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { usePendingPairings } from './usePendingPairings'
+
+const first = { id: 'a'.repeat(32), name: 'Same client name', address: '192.0.2.1' }
+const second = { id: 'b'.repeat(32), name: 'Same client name', address: '192.0.2.2' }
+
+describe('manual pairing request selection', () => {
+  let scope
+  let active
+  let state
+  let requests
+  beforeEach(() => {
+    vi.useFakeTimers()
+    requests = [first, second]
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ pairings: requests }) })))
+    scope = effectScope()
+    active = ref(true)
+    scope.run(() => { state = usePendingPairings(active) })
+  })
+  afterEach(() => {
+    scope.stop()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('requires explicit selection even with one pending request', async () => {
+    await flushPromises()
+    expect(state.pendingPairings.value).toEqual([first, second])
+    expect(state.selectedPairingId.value).toBe('')
+    requests = [first]
+    await state.refreshPairings()
+    expect(state.selectedPairingId.value).toBe('')
+  })
+
+  it('preserves the selected ID across reorder and clears it on expiration without selecting a replacement', async () => {
+    await flushPromises()
+    state.selectedPairingId.value = first.id
+    requests = [second, first]
+    await state.refreshPairings()
+    expect(state.selectedPairingId.value).toBe(first.id)
+    requests = [second]
+    await state.refreshPairings()
+    expect(state.selectedPairingId.value).toBe('')
+  })
+
+  it('clears stale requests and selection if authentication or loading fails', async () => {
+    await flushPromises()
+    state.selectedPairingId.value = first.id
+    fetch.mockResolvedValueOnce({ ok: false })
+    await state.refreshPairings()
+    expect(state.pendingPairings.value).toEqual([])
+    expect(state.selectedPairingId.value).toBe('')
+    expect(state.pairingListError.value).toBeTruthy()
+  })
+
+  it('polls only while manual pairing is active and stops after disposal', async () => {
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(fetch).toHaveBeenCalledTimes(2)
+    active.value = false
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(fetch).toHaveBeenCalledTimes(2)
+    active.value = true
+    await nextTick()
+    await flushPromises()
+    expect(fetch).toHaveBeenCalledTimes(3)
+    scope.stop()
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(fetch).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -1633,7 +1633,18 @@
     "ai_no_suggestion": "No suggestion available, device not recognized",
     "ai_applied": "AI suggestion applied to profile",
     "stale_removed": "Removed stale client profile aliases",
-    "stale_remove_failed": "Failed to remove stale client profile aliases"
+    "stale_remove_failed": "Failed to remove stale client profile aliases",
+    "pending_request": "Pending request",
+    "pending_select": "Select the device you intend to pair",
+    "pending_identity_help": "Names are reported by clients. Check the source address before approving. Requests expire after five minutes.",
+    "pending_empty": "Start pairing on your client to create a request.",
+    "pending_unnamed": "Unnamed client",
+    "pending_refresh": "Refresh requests",
+    "pending_cancel": "Cancel request",
+    "pending_load_failed": "Could not load pending pairing requests.",
+    "pending_approval_failed": "Pairing request expired, was cancelled, or could not be approved. Refresh the requests and select the intended device.",
+    "pending_already_handled": "This request has already expired or been handled.",
+    "pending_cancelled": "Pairing request cancelled."
   },
   "resource_card": {
     "website": "Website",

--- a/src_assets/common/assets/web/views/PinView.vue
+++ b/src_assets/common/assets/web/views/PinView.vue
@@ -159,6 +159,19 @@
 
             <div class="mt-5 grid gap-4">
               <div>
+                <label for="pairing-request" class="mb-1 block text-sm font-medium text-storm">{{ $t('pin.pending_request') }}</label>
+                <select id="pairing-request" v-model="selectedPairingId" class="settings-input" required :disabled="pinSubmitting">
+                  <option value="" disabled>{{ $t('pin.pending_select') }}</option>
+                  <option v-for="pairing in pendingPairings" :key="pairing.id" :value="pairing.id">
+                    {{ pairing.name || $t('pin.pending_unnamed') }} — {{ pairing.address }}
+                  </option>
+                </select>
+                <p class="mt-2 text-sm text-storm">{{ $t('pin.pending_identity_help') }}</p>
+                <p v-if="!pendingPairings.length" class="mt-2 text-sm text-storm">{{ $t('pin.pending_empty') }}</p>
+                <p v-if="pairingListError" role="alert" class="mt-2 text-sm text-danger">{{ $t('pin.pending_load_failed') }}</p>
+                <button type="button" class="focus-ring mt-2 text-sm text-ice" @click="refreshPairings">{{ $t('pin.pending_refresh') }}</button>
+              </div>
+              <div>
                 <label for="pin-input" class="mb-1 block text-sm font-medium text-storm">{{ $t('pin.pin_code') }}</label>
                 <input
                   id="pin-input"
@@ -190,10 +203,12 @@
               <div class="flex flex-wrap items-center gap-3">
                 <button
                   type="submit"
+                  :disabled="!selectedPairingId || pinSubmitting"
                   class="focus-ring dashboard-action-button dashboard-action-button-primary"
                 >
                   {{ $t('pin.send') }}
                 </button>
+                <button type="button" class="focus-ring dashboard-action-button" :disabled="!selectedPairingId || pinSubmitting" @click="cancelSelectedPairing">{{ $t('pin.pending_cancel') }}</button>
               </div>
             </div>
 
@@ -951,6 +966,7 @@ import Checkbox from '../Checkbox.vue'
 import Skeleton from '../components/Skeleton.vue'
 import SelectableCard from '../components/SelectableCard.vue'
 import StatTile from '../components/StatTile.vue'
+import { usePendingPairings } from '../composables/usePendingPairings'
 import { useConfigProjection } from '../composables/useConfigProjection'
 import { buildClientHostSyncRows } from '../client-host-sync.js'
 import { useToast } from '../composables/useToast'
@@ -1350,37 +1366,70 @@ async function saveHost() {
   saveHostCacheFn(hostAddr.value, hostPort.value, true)
 }
 
-function registerDevice() {
+const { pendingPairings, selectedPairingId, pairingListError, refreshPairings } = usePendingPairings(
+  computed(() => currentTab.value === 'PIN')
+)
+const pinSubmitting = ref(false)
+
+async function registerDevice() {
+  const pairingId = selectedPairingId.value
+  if (!pairingId || pinSubmitting.value) return
   pinMessage.value = ''
-  fetch('./api/pin', {
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
-    method: 'POST',
-    body: JSON.stringify({
-      pin: pinCode.value,
-      name: pinDeviceName.value,
-      access_preset: selectedAccessPreset.value,
-      temporary_authorization: temporaryAuthorization.value,
+  pinSubmitting.value = true
+  try {
+    const response = await fetch('./api/pin', {
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      body: JSON.stringify({
+        pairing_id: pairingId,
+        pin: pinCode.value,
+        name: pinDeviceName.value,
+        access_preset: selectedAccessPreset.value,
+        temporary_authorization: temporaryAuthorization.value,
+      })
     })
-  })
-    .then((response) => response.json())
-    .then((response) => {
-      if (response.status === true) {
-        pinStatus.value = 'success'
-        pinMessage.value = i18n.t('pin.pair_success_access_applied', { access: selectedPairingAccessLabel.value })
-        pinCode.value = ''
-        pinDeviceName.value = ''
-        setTimeout(() => refreshClients(), 1000)
-        showToast(i18n.t('pin.pair_success_access_applied', { access: selectedPairingAccessLabel.value }), 'success')
-      } else {
-        pinStatus.value = 'error'
-        pinMessage.value = i18n.t('pin.pair_failure')
-      }
+    const result = await response.json()
+    if (!response.ok || result.status !== true) throw new Error(i18n.t('pin.pending_approval_failed'))
+    pinStatus.value = 'success'
+    pinMessage.value = i18n.t('pin.pair_success_access_applied', { access: selectedPairingAccessLabel.value })
+    pinCode.value = ''
+    pinDeviceName.value = ''
+    if (selectedPairingId.value === pairingId) selectedPairingId.value = ''
+    setTimeout(() => refreshClients(), 1000)
+    showToast(pinMessage.value, 'success')
+  } catch (error) {
+    pinStatus.value = 'error'
+    pinMessage.value = error.message
+  } finally {
+    pinSubmitting.value = false
+    await refreshPairings()
+  }
+}
+
+async function cancelSelectedPairing() {
+  const pairingId = selectedPairingId.value
+  if (!pairingId || pinSubmitting.value) return
+  pinSubmitting.value = true
+  try {
+    const response = await fetch('./api/pin', {
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      method: 'DELETE',
+      body: JSON.stringify({ pairing_id: pairingId }),
     })
-    .catch(() => {
-      pinStatus.value = 'error'
-      pinMessage.value = i18n.t('pin.pair_failure')
-    })
+    const result = await response.json()
+    if (!response.ok || result.status !== true) throw new Error(i18n.t('pin.pending_already_handled'))
+    pinStatus.value = 'success'
+    pinMessage.value = i18n.t('pin.pending_cancelled')
+    if (selectedPairingId.value === pairingId) selectedPairingId.value = ''
+  } catch (error) {
+    pinStatus.value = 'error'
+    pinMessage.value = error.message
+  } finally {
+    pinSubmitting.value = false
+    await refreshPairings()
+  }
 }
 
 async function requestOTP() {

--- a/tests/e2e/manual-pairing.spec.js
+++ b/tests/e2e/manual-pairing.spec.js
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+
+const first = { id: 'a'.repeat(32), name: 'Same name', address: '192.0.2.1' }
+const second = { id: 'b'.repeat(32), name: 'Same name', address: '192.0.2.2' }
+
+test('approves only the explicitly selected request and preserves access settings', async ({ page }) => {
+  let requests = [first, second]
+  let approval = null
+  let cancellation = null
+  await page.route('**/api/**', async (route) => {
+    const path = new URL(route.request().url()).pathname
+    if (path === '/api/pin') {
+      if (route.request().method() === 'GET') return route.fulfill({ json: { pairings: requests } })
+      const body = route.request().postDataJSON()
+      if (route.request().method() === 'POST') approval = body
+      if (route.request().method() === 'DELETE') cancellation = body
+      requests = requests.filter((request) => request.id !== body.pairing_id)
+      return route.fulfill({ json: { status: true } })
+    }
+    if (path === '/api/clients/list') return route.fulfill({ json: { status: true, platform: 'linux', named_certs: [] } })
+    if (path === '/api/config') return route.fulfill({ json: { status: true, platform: 'linux' } })
+    return route.fulfill({ json: {} })
+  })
+  await page.goto('/#/pin?method=PIN')
+  const send = page.getByRole('button', { name: /^send$/i })
+  await expect(send).toBeDisabled()
+  await expect(page.locator('#pairing-request option')).toHaveCount(3)
+  await page.locator('#pairing-request').selectOption(second.id)
+  await page.locator('#pin-input').fill('1234')
+  await page.locator('#name-input').fill('Approved client')
+  await page.locator('#temporary-pairing-authorization').check()
+  await send.click()
+  await expect.poll(() => approval).toMatchObject({
+    pairing_id: second.id, pin: '1234', name: 'Approved client',
+    access_preset: 'game_control', temporary_authorization: true,
+  })
+  await expect(send).toBeDisabled()
+  await page.locator('#pairing-request').selectOption(first.id)
+  await page.getByRole('button', { name: 'Cancel request', exact: true }).click()
+  await expect.poll(() => cancellation).toEqual({ pairing_id: first.id })
+  await expect(send).toBeDisabled()
+  await expect(page.getByText('Start pairing on your client to create a request.')).toBeVisible()
+})

--- a/tests/e2e/pairing.spec.js
+++ b/tests/e2e/pairing.spec.js
@@ -121,16 +121,26 @@ test.describe('pairing', () => {
   test('manual PIN approval defaults to Game Control', async ({ loggedInPage }) => {
     let payload = null
     await loggedInPage.route('**/api/pin', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ json: { pairings: [
+          { id: 'a'.repeat(32), name: 'Same name', address: '192.0.2.1' },
+          { id: 'b'.repeat(32), name: 'Same name', address: '192.0.2.2' },
+        ] } })
+        return
+      }
       payload = route.request().postDataJSON()
       await route.fulfill({ json: { status: true, access_preset: 'game_control' } })
     })
 
     await loggedInPage.getByRole('navigation').getByRole('link', { name: /^devices$/i }).click()
     await loggedInPage.getByRole('button', { name: /manual pin/i }).click()
+    await expect(loggedInPage.getByRole('button', { name: /^send$/i })).toBeDisabled()
+    await loggedInPage.locator('#pairing-request').selectOption('b'.repeat(32))
     await loggedInPage.locator('#pin-input').fill('1234')
     await loggedInPage.getByRole('button', { name: /^send$/i }).click()
 
     await expect.poll(() => payload?.access_preset).toBe('game_control')
+    await expect.poll(() => payload?.pairing_id).toBe('b'.repeat(32))
   })
 
   test('shows existing Game Control clients as a named preset', async ({ loggedInPage }) => {

--- a/tests/unit/test_http_pairing.cpp
+++ b/tests/unit/test_http_pairing.cpp
@@ -7,6 +7,10 @@
 #include "../certificate_test_utils.h"
 
 #include <atomic>
+#include <condition_variable>
+#include <future>
+#include <Simple-Web-Server/client_http.hpp>
+#include <Simple-Web-Server/server_http.hpp>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -1543,4 +1547,514 @@ TEST_F(PairingAccessPresetTest, LegacyPairingDefaultsEveryNewClientToGameControl
   ASSERT_EQ(clients.size(), 2);
   EXPECT_EQ(clients[0]["perm"].get<uint32_t>(), static_cast<uint32_t>(crypto::PERM::_game_control));
   EXPECT_EQ(clients[1]["perm"].get<uint32_t>(), static_cast<uint32_t>(crypto::PERM::_game_control));
+}
+
+namespace {
+  /**
+   * @brief Stream buffer that holds console input until a pairing test releases it.
+   */
+  class gated_input_buffer: public std::streambuf {
+  public:
+    /**
+     * @brief Make the buffered input available to its reader.
+     */
+    void release() {
+      {
+        std::lock_guard lock {mutex_};
+        released_ = true;
+      }
+      condition_.notify_all();
+    }
+
+  protected:
+    /**
+     * @brief Wait for release and expose the buffered PIN to the input stream.
+     *
+     * @return The first buffered character, or end-of-file after it is consumed.
+     */
+    int_type underflow() override {
+      std::unique_lock lock {mutex_};
+      condition_.wait(lock, [this]() {
+        return released_;
+      });
+      if (gptr() == nullptr) {
+        setg(input_.data(), input_.data(), input_.data() + input_.size());
+      }
+      return gptr() == egptr() ? traits_type::eof() : traits_type::to_int_type(*gptr());
+    }
+
+  private:
+    std::string input_ = "1234\n";  ///< PIN text released to the pairing handler.
+    std::mutex mutex_;  ///< Protects the release flag.
+    std::condition_variable condition_;  ///< Wakes the blocked input reader.
+    bool released_ = false;  ///< Whether the reader may consume the PIN.
+  };
+
+  /**
+   * @brief Restore the process input stream after a console-PIN test.
+   */
+  class cin_buffer_guard {
+  public:
+    /**
+     * @brief Redirect standard input to a test buffer.
+     *
+     * @param replacement Stream buffer to read during the test.
+     */
+    explicit cin_buffer_guard(std::streambuf *replacement):
+        original_(std::cin.rdbuf(replacement)) {
+      std::cin.clear();
+    }
+
+    /**
+     * @brief Restore the original standard-input buffer and stream state.
+     */
+    ~cin_buffer_guard() noexcept {
+      try {
+        std::cin.rdbuf(original_);
+        std::cin.clear();
+      } catch (const std::ios_base::failure &stream_error) {
+        ADD_FAILURE() << "Failed to restore the standard-input buffer: " << stream_error.what();
+      }
+    }
+
+    cin_buffer_guard(const cin_buffer_guard &) = delete;
+    cin_buffer_guard &operator=(const cin_buffer_guard &) = delete;
+
+  private:
+    std::streambuf *original_;  ///< Process input buffer restored at scope exit.
+  };
+
+  /**
+   * @brief Build a pairing session that is awaiting operator approval.
+   *
+   * @param unique_id Client-controlled GameStream unique identifier.
+   * @param device_name Client-reported device name.
+   * @param address Network address associated with the request.
+   * @return Pairing session ready for insertion into pending storage.
+   */
+  pair_session_t pending_session(std::string unique_id, std::string device_name, std::string address) {
+    return {
+      .client = {
+        .uniqueID = std::move(unique_id),
+      },
+      .async_insert_pin = {
+        .salt = "ff5dc6eda99339a8a0793e216c4257c4",
+        .device_name = std::move(device_name),
+        .address = std::move(address),
+      },
+    };
+  }
+
+  /**
+   * @brief Fixture that isolates tests using global pending-pairing storage.
+   */
+  class PairingSessionRegistryTest: public testing::Test {
+  protected:
+    void SetUp() override {
+      expire_pair_sessions(std::chrono::steady_clock::time_point::max());
+    }
+
+    void TearDown() override {
+      expire_pair_sessions(std::chrono::steady_clock::time_point::max());
+    }
+  };
+
+  /**
+   * @brief Exercise the production pairing dispatcher through a local HTTP server.
+   */
+  class PairingHttpHandlerTest: public testing::Test {
+  protected:
+    /**
+     * @brief Start an isolated plain-HTTP pairing endpoint.
+     */
+    void SetUp() override {
+      setup(PRIVATE_KEY, PUBLIC_CERT);
+      expire_pair_sessions(std::chrono::steady_clock::time_point::max());
+      original_pin_stdin_ = config::sunshine.flags[config::flag::PIN_STDIN];
+      config::sunshine.flags[config::flag::PIN_STDIN] = false;
+
+      server_ = std::make_unique<SimpleWeb::Server<SimpleWeb::HTTP>>();
+      server_->config.address = "127.0.0.1";
+      server_->config.port = 0;
+      server_->config.reuse_address = true;
+      server_->config.timeout_request = 5;
+      server_->config.timeout_content = 5;
+      server_->resource["^/pair$"]["GET"] = nvhttp::pair_http_for_tests;
+      server_thread_ = std::jthread([this]() {
+        server_->start([this](const unsigned short assigned_port) {
+          port_ = assigned_port;
+        });
+      });
+
+      for (int attempt = 0; attempt < 100 && port_ == 0; ++attempt) {
+        std::this_thread::sleep_for(std::chrono::milliseconds {10});
+      }
+      ASSERT_NE(port_, 0) << "Pairing test server failed to start";
+
+      client_ = std::make_unique<SimpleWeb::Client<SimpleWeb::HTTP>>(std::format("localhost:{}", port_.load()));
+      client_->config.timeout = 5;
+    }
+
+    /**
+     * @brief Stop the endpoint and restore pairing configuration.
+     */
+    void TearDown() override {
+      expire_pair_sessions(std::chrono::steady_clock::time_point::max());
+      if (server_) {
+        server_->stop();
+      }
+      if (server_thread_.joinable()) {
+        server_thread_.join();
+      }
+      client_.reset();
+      server_.reset();
+      config::sunshine.flags[config::flag::PIN_STDIN] = original_pin_stdin_;
+
+    }
+
+    /**
+     * @brief Build the query for the initial certificate phase.
+     *
+     * @param unique_id Client pairing identifier.
+     * @param salt Hexadecimal PIN salt.
+     * @return Request target for the local pairing endpoint.
+     */
+    static std::string server_certificate_target(const std::string_view unique_id, const std::string_view salt = "ff5dc6eda99339a8a0793e216c4257c4") {
+      return std::format(
+        "/pair?uniqueid={}&phrase=getservercert&clientcert={}&salt={}&devicename=TestClient",
+        unique_id,
+        util::hex_vec(PUBLIC_CERT, true),
+        salt
+      );
+    }
+
+    /**
+     * @brief Read the response body from the local pairing endpoint.
+     *
+     * @param target Request target including query parameters.
+     * @return XML response body.
+     */
+    std::string request(const std::string_view target) {
+      return client_->request("GET", std::string {target})->content.string();
+    }
+
+    /**
+     * @brief Wait for a request to enter the pending pairing registry.
+     *
+     * @return The operator-facing pairing identifier, or an empty string on timeout.
+     */
+    static std::string wait_for_pending_pairing() {
+      for (int attempt = 0; attempt < 100; ++attempt) {
+        if (const auto pending = get_pending_pairings(); !pending.empty()) {
+          return pending.front().id;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds {10});
+      }
+      return {};
+    }
+
+  private:
+    std::unique_ptr<SimpleWeb::Server<SimpleWeb::HTTP>> server_;  ///< Local pairing HTTP server.
+    std::unique_ptr<SimpleWeb::Client<SimpleWeb::HTTP>> client_;  ///< Client connected to the local server.
+    std::jthread server_thread_;  ///< Thread running the local server event loop.
+    std::atomic<unsigned short> port_ {0};  ///< Ephemeral port assigned to the local server.
+    bool original_pin_stdin_;  ///< Console-PIN flag restored after each test.
+  };
+}  // namespace
+
+TEST_F(PairingHttpHandlerTest, ImmediateRequestsReturnExpectedStatus) {
+  EXPECT_NE(request("/pair"sv).find("status_code=\"400\""), std::string::npos);
+  EXPECT_NE(request("/pair?uniqueid=challenge&phrase=pairchallenge"sv).find("status_code=\"200\""), std::string::npos);
+  EXPECT_NE(request("/pair?uniqueid=missing"sv).find("Invalid uniqueid"), std::string::npos);
+
+  std::string pairing_id;
+  ASSERT_EQ(insert_pair_session(pending_session("out-of-order", "Client", "192.0.2.10"), pairing_id), pair_session_insert_e::ADDED);
+  EXPECT_NE(request("/pair?uniqueid=out-of-order&clientchallenge=00"sv).find("Out of order"), std::string::npos);
+}
+
+TEST_F(PairingHttpHandlerTest, WebApprovalRequestRemainsPendingUntilCancelled) {
+  std::packaged_task<std::string()> request_task {[this]() {
+    return request(server_certificate_target("pending"));
+  }};
+  auto response = request_task.get_future();
+  std::jthread request_thread {std::move(request_task)};
+
+  const auto pairing_id = wait_for_pending_pairing();
+  ASSERT_FALSE(pairing_id.empty());
+  EXPECT_TRUE(cancel_pairing(pairing_id));
+  EXPECT_NE(response.get().find("cancelled by operator"), std::string::npos);
+}
+
+TEST_F(PairingHttpHandlerTest, DuplicateAndCapacityErrorsReturnImmediately) {
+  std::string pairing_id;
+  ASSERT_EQ(insert_pair_session(pending_session("duplicate", "Original", "192.0.2.10"), pairing_id), pair_session_insert_e::ADDED);
+  EXPECT_NE(request(server_certificate_target("duplicate")).find("status_code=\"409\""), std::string::npos);
+
+  expire_pair_sessions(std::chrono::steady_clock::time_point::max());
+  for (std::size_t index = 0; index < MAX_PENDING_PAIRING_SESSIONS; ++index) {
+    ASSERT_EQ(
+      insert_pair_session(pending_session(std::format("full-{}", index), "Client", "192.0.2.10"), pairing_id),
+      pair_session_insert_e::ADDED
+    );
+  }
+  EXPECT_NE(request(server_certificate_target("overflow")).find("status_code=\"503\""), std::string::npos);
+}
+
+TEST_F(PairingHttpHandlerTest, ConsolePinCompletesOrRejectsTheCertificatePhase) {
+  setup(PRIVATE_KEY, PUBLIC_CERT);
+  config::sunshine.flags[config::flag::PIN_STDIN] = true;
+
+  std::istringstream input {"5338\n0000\n"};
+  const cin_buffer_guard input_guard {input.rdbuf()};
+  EXPECT_NE(request(server_certificate_target("console-success")).find("status_code=\"200\""), std::string::npos);
+  EXPECT_NE(request(server_certificate_target("console-failure", "00")).find("status_code=\"400\""), std::string::npos);
+}
+
+TEST_F(PairingHttpHandlerTest, ConsolePinReportsSessionExpiration) {
+  config::sunshine.flags[config::flag::PIN_STDIN] = true;
+  gated_input_buffer input;
+  const cin_buffer_guard input_guard {&input};
+  std::packaged_task<std::string()> request_task {[this]() {
+    return request(server_certificate_target("expired"));
+  }};
+  auto response = request_task.get_future();
+  std::jthread request_thread {std::move(request_task)};
+  auto release_input = util::fail_guard([&] { input.release(); });
+
+  ASSERT_FALSE(wait_for_pending_pairing().empty());
+  expire_pair_sessions(std::chrono::steady_clock::time_point::max());
+  input.release();
+  EXPECT_NE(response.get().find("status_code=\"408\""), std::string::npos);
+}
+
+TEST_F(PairingSessionRegistryTest, PinApprovalTargetsExplicitPairingId) {
+  std::string legitimate_pairing_id;
+  ASSERT_EQ(
+    insert_pair_session(pending_session("legitimate", "Living Room", "192.0.2.10"), legitimate_pairing_id),
+    pair_session_insert_e::ADDED
+  );
+
+  std::string attacker_pairing_id;
+  ASSERT_EQ(
+    insert_pair_session(pending_session("attacker", "Living Room", "192.0.2.20"), attacker_pairing_id),
+    pair_session_insert_e::ADDED
+  );
+  ASSERT_NE(legitimate_pairing_id, attacker_pairing_id);
+
+  // Unit-test sessions have no parked HTTP response, so pin() returns false after
+  // consuming the explicitly selected session. The competing request must remain untouched.
+  EXPECT_FALSE(pin(legitimate_pairing_id, "1234", "Approved client"));
+
+  const auto pending = get_pending_pairings();
+  ASSERT_EQ(pending.size(), 1);
+  EXPECT_EQ(pending.front().id, attacker_pairing_id);
+  EXPECT_EQ(pending.front().address, "192.0.2.20");
+}
+
+TEST_F(PairingSessionRegistryTest, InvalidApprovalCannotConsumePendingSession) {
+  std::string pairing_id;
+  ASSERT_EQ(
+    insert_pair_session(pending_session("legitimate", "Laptop", "192.0.2.10"), pairing_id),
+    pair_session_insert_e::ADDED
+  );
+
+  EXPECT_FALSE(pin("unknown-approval", "1234", "Laptop"));
+  EXPECT_FALSE(pin(pairing_id, "123", "Laptop"));
+  EXPECT_FALSE(pin(pairing_id, "12a4", "Laptop"));
+
+  const auto pending = get_pending_pairings();
+  ASSERT_EQ(pending.size(), 1);
+  EXPECT_EQ(pending.front().id, pairing_id);
+}
+
+TEST_F(PairingSessionRegistryTest, PairingIdsAreValidatedAndIdlessApprovalIsRejected) {
+  EXPECT_TRUE(is_valid_pairing_id("0123456789ABCDEF0123456789abcdef"));
+  EXPECT_FALSE(is_valid_pairing_id(std::string(31, 'a')));
+  EXPECT_FALSE(is_valid_pairing_id(std::string(33, 'a')));
+  EXPECT_FALSE(is_valid_pairing_id(std::string(32, 'g')));
+  std::string id;
+  ASSERT_EQ(insert_pair_session(pending_session("idless", "Client", "192.0.2.1"), id), pair_session_insert_e::ADDED);
+  EXPECT_FALSE(pin("", "1234", "Client"));
+  EXPECT_EQ(get_pending_pairings().size(), 1);
+}
+
+TEST_F(PairingSessionRegistryTest, DuplicateUniqueIdIsRejectedWithoutReplacingOriginal) {
+  std::string original_pairing_id;
+  ASSERT_EQ(
+    insert_pair_session(pending_session("duplicate", "Original", "192.0.2.10"), original_pairing_id),
+    pair_session_insert_e::ADDED
+  );
+
+  std::string rejected_pairing_id;
+  EXPECT_EQ(
+    insert_pair_session(pending_session("duplicate", "Replacement", "192.0.2.20"), rejected_pairing_id),
+    pair_session_insert_e::ALREADY_EXISTS
+  );
+  EXPECT_TRUE(rejected_pairing_id.empty());
+
+  const auto pending = get_pending_pairings();
+  ASSERT_EQ(pending.size(), 1);
+  EXPECT_EQ(pending.front().id, original_pairing_id);
+  EXPECT_EQ(pending.front().name, "Original");
+}
+
+TEST_F(PairingSessionRegistryTest, PendingSessionStorageIsBounded) {
+  for (std::size_t index = 0; index < MAX_PENDING_PAIRING_SESSIONS; ++index) {
+    std::string pairing_id;
+    ASSERT_EQ(
+      insert_pair_session(pending_session(std::format("client-{}", index), "Client", "192.0.2.10"), pairing_id),
+      pair_session_insert_e::ADDED
+    );
+    EXPECT_FALSE(pairing_id.empty());
+  }
+
+  std::string overflow_pairing_id;
+  EXPECT_EQ(
+    insert_pair_session(pending_session("overflow", "Overflow", "192.0.2.20"), overflow_pairing_id),
+    pair_session_insert_e::FULL
+  );
+  EXPECT_EQ(get_pending_pairings().size(), MAX_PENDING_PAIRING_SESSIONS);
+}
+
+TEST_F(PairingSessionRegistryTest, ExpiredApprovalCannotConsumeLaterSession) {
+  const auto expiration_check = std::chrono::steady_clock::now() + PAIRING_SESSION_TIMEOUT + std::chrono::seconds {1};
+  std::string expired_pairing_id;
+  ASSERT_EQ(
+    insert_pair_session(pending_session("expired", "Old client", "192.0.2.10"), expired_pairing_id),
+    pair_session_insert_e::ADDED
+  );
+  expire_pair_sessions(expiration_check);
+  EXPECT_TRUE(get_pending_pairings().empty());
+
+  std::string current_pairing_id;
+  ASSERT_EQ(
+    insert_pair_session(pending_session("current", "Current client", "192.0.2.20"), current_pairing_id),
+    pair_session_insert_e::ADDED
+  );
+  EXPECT_FALSE(pin(expired_pairing_id, "1234", "Old client"));
+
+  const auto pending = get_pending_pairings();
+  ASSERT_EQ(pending.size(), 1);
+  EXPECT_EQ(pending.front().id, current_pairing_id);
+}
+
+TEST_F(PairingSessionRegistryTest, CancellationRemovesOnlySelectedPendingSession) {
+  std::string first_pairing_id;
+  ASSERT_EQ(
+    insert_pair_session(pending_session("first", "First", "192.0.2.10"), first_pairing_id),
+    pair_session_insert_e::ADDED
+  );
+  std::string second_pairing_id;
+  ASSERT_EQ(
+    insert_pair_session(pending_session("second", "Second", "192.0.2.20"), second_pairing_id),
+    pair_session_insert_e::ADDED
+  );
+
+  EXPECT_TRUE(cancel_pairing(first_pairing_id));
+  EXPECT_FALSE(cancel_pairing(first_pairing_id));
+
+  const auto pending = get_pending_pairings();
+  ASSERT_EQ(pending.size(), 1);
+  EXPECT_EQ(pending.front().id, second_pairing_id);
+}
+
+TEST_F(PairingSessionRegistryTest, RemoveSessionErasesItsUniqueId) {
+  auto session = pending_session("removable", "Client", "192.0.2.10");
+  pair_session_t session_key;
+  session_key.client.uniqueID = session.client.uniqueID;
+  std::string pairing_id;
+  ASSERT_EQ(insert_pair_session(std::move(session), pairing_id), pair_session_insert_e::ADDED);
+
+  session_key.async_insert_pin.id = pairing_id;
+  remove_session(session_key);
+  EXPECT_TRUE(get_pending_pairings().empty());
+}
+
+TEST_F(PairingSessionRegistryTest, ConcurrentInsertionAndCancellationLeaveConsistentState) {
+  constexpr std::size_t session_count = 16;
+  std::atomic<std::size_t> successful_cancellations {0};
+  std::vector<std::jthread> workers;
+  workers.reserve(session_count);
+
+  for (std::size_t index = 0; index < session_count; ++index) {
+    workers.emplace_back([index, &successful_cancellations]() {
+      std::string pairing_id;
+      if (insert_pair_session(pending_session(std::format("concurrent-{}", index), "Client", "192.0.2.10"), pairing_id) == pair_session_insert_e::ADDED && cancel_pairing(pairing_id)) {
+        ++successful_cancellations;
+      }
+    });
+  }
+  workers.clear();
+
+  EXPECT_EQ(successful_cancellations, session_count);
+  EXPECT_TRUE(get_pending_pairings().empty());
+}
+
+TEST_F(PairingHttpHandlerTest, ManualApprovalPreservesAccessAndGuestOptions) {
+  std::packaged_task<std::string()> request_task {[this] {
+    return request(server_certificate_target("manual-access"));
+  }};
+  auto response = request_task.get_future();
+  std::jthread worker {std::move(request_task)};
+  const auto id = wait_for_pending_pairing();
+  ASSERT_FALSE(id.empty());
+  EXPECT_TRUE(pin(id, "5338", "Approved guest", crypto::PERM::_default, true));
+  EXPECT_NE(response.get().find("status_code=\"200\""), std::string::npos);
+  const auto options = pairing_options_for_tests(id);
+  EXPECT_EQ(options.at("name"), "Approved guest");
+  EXPECT_EQ(options.at("perm"), static_cast<std::uint32_t>(crypto::PERM::_default));
+  EXPECT_EQ(options.at("temporary_authorization"), true);
+  EXPECT_FALSE(cancel_pairing(id));
+  EXPECT_FALSE(pin(id, "5338", "Other", crypto::PERM::_all, false));
+}
+
+TEST_F(PairingSessionRegistryTest, ConcurrentApprovalAndCancellationConsumeExactlyOneRequest) {
+  std::string id;
+  ASSERT_EQ(insert_pair_session(pending_session("race", "Client", "192.0.2.1"), id), pair_session_insert_e::ADDED);
+  std::atomic<bool> start {false};
+  std::jthread approving([&] {
+    while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+    (void) pin(id, "5338", "Approved", crypto::PERM::_default, true);
+  });
+  std::jthread cancelling([&] {
+    while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+    (void) cancel_pairing(id);
+  });
+  start.store(true, std::memory_order_release);
+  approving.join();
+  cancelling.join();
+  EXPECT_TRUE(get_pending_pairings().empty());
+}
+
+TEST_F(PairingHttpHandlerTest, OtpHandlerPreservesAccessAndGuestOptions) {
+  const auto otp = request_otp("fixture passphrase", "OTP guest", crypto::PERM::_default, true);
+  const auto auth = util::hex(crypto::hash(otp + "ff5dc6eda99339a8a0793e216c4257c4" + "fixture passphrase"), true).to_string();
+  EXPECT_NE(request(server_certificate_target("otp-options") + "&otpauth=" + auth).find("status_code=\"200\""), std::string::npos);
+  EXPECT_TRUE(get_pending_pairings().empty());
+  const auto options = pairing_options_for_tests("otp-options");
+  EXPECT_EQ(options.at("name"), "OTP guest");
+  EXPECT_EQ(options.at("perm"), static_cast<std::uint32_t>(crypto::PERM::_default));
+  EXPECT_EQ(options.at("temporary_authorization"), true);
+}
+
+TEST_F(PairingHttpHandlerTest, TrustedNetworkHandlerStillRequiresClientOptIn) {
+  const auto old_enabled = config::nvhttp.trusted_subnet_auto_pairing;
+  auto old_subnets = config::nvhttp.trusted_subnets;
+  auto restore = util::fail_guard([&] {
+    config::nvhttp.trusted_subnet_auto_pairing = old_enabled;
+    config::nvhttp.trusted_subnets = std::move(old_subnets);
+  });
+  config::nvhttp.trusted_subnet_auto_pairing = true;
+  config::nvhttp.trusted_subnets = {"127.0.0.0/8"};
+  EXPECT_NE(request(server_certificate_target("trusted-options") + "&trustedpair=1").find("status_code=\"200\""), std::string::npos);
+  EXPECT_TRUE(get_pending_pairings().empty());
+  EXPECT_EQ(pairing_options_for_tests("trusted-options").at("family"), "nova");
+
+  std::packaged_task<std::string()> request_task {[this] { return request(server_certificate_target("manual-optin")); }};
+  auto response = request_task.get_future();
+  std::jthread worker {std::move(request_task)};
+  const auto id = wait_for_pending_pairing();
+  ASSERT_FALSE(id.empty());
+  EXPECT_TRUE(cancel_pairing(id));
+  EXPECT_NE(response.get().find("cancelled by operator"), std::string::npos);
 }


### PR DESCRIPTION
Manual PIN approval previously selected the first pending client, so overlapping requests could authorize the wrong device. The administrator now explicitly selects a random, expiring request ID; approval and cancellation operate only on that request. The synchronized registry rejects duplicate client IDs and limits pending sessions to 32 for five minutes.

Adds authenticated request listing, mandatory `pairing_id` for POST, CSRF-protected DELETE, an explicitly selected web request, and API migration documentation. Existing permission presets, temporary guests, QR/OTP and trusted-network opt-in behavior remain intact; the normal client pairing protocol is unchanged.

Validation: 71 native pairing tests, also passing under Clang ThreadSanitizer; 702 web tests; web lint and production build; isolated browser approval/cancellation; public surface/docs checks. Independent source review found no remaining material findings. Native tests exercise real pending HTTP connections, expiration, stdin re-entry, OTP, and trusted-network behavior. The browser test mocks administrative APIs, so it does not establish server authentication or CSRF rejection. Exact-head CI passed: C++ sanitizers, web, Arch, SteamOS 3.8, Ubuntu, Fedora Clang/RPM, CodeQL, and public hygiene.
