### PR TITLE
fix(video): bound capture waits and preserve encoder teardown ownership

### DIFF
--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -38,6 +38,15 @@ namespace safe {
       _cv.notify_all();
     }
 
+    // Consume the current value atomically, without waiting for a producer.
+    status_t try_pop() {
+      std::lock_guard lock {_lock};
+      if (!_continue || !_status) return util::false_v<status_t>;
+      auto value = std::move(_status);
+      _status = util::false_v<status_t>;
+      return value;
+    }
+
     // pop and view should not be used interchangeably
     status_t pop() {
       std::unique_lock ul {_lock};
@@ -143,6 +152,7 @@ namespace safe {
     }
 
     bool peek() {
+      std::lock_guard lock {_lock};
       return _continue && (bool) _status;
     }
 
@@ -163,6 +173,7 @@ namespace safe {
     }
 
     [[nodiscard]] bool running() const {
+      std::lock_guard lock {_lock};
       return _continue;
     }
 
@@ -171,7 +182,7 @@ namespace safe {
     status_t _status {util::false_v<status_t>};
 
     std::condition_variable _cv;
-    std::mutex _lock;
+    mutable std::mutex _lock;
   };
 
   template<class T>
@@ -302,6 +313,7 @@ namespace safe {
     }
 
     bool peek() {
+      std::lock_guard lock {_lock};
       return _continue && !_queue.empty();
     }
 
@@ -359,6 +371,7 @@ namespace safe {
     }
 
     [[nodiscard]] bool running() const {
+      std::lock_guard lock {_lock};
       return _continue;
     }
 
@@ -366,7 +379,7 @@ namespace safe {
     bool _continue {true};
     std::uint32_t _max_elements;
 
-    std::mutex _lock;
+    mutable std::mutex _lock;
     std::condition_variable _cv;
 
     std::vector<T> _queue;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1432,8 +1432,9 @@ namespace video {
         BOOST_LOG(info) << "Vulkan encoder teardown: draining codec"sv;
       }
 
-      // Flush any remaining frames in the encoder
-      const auto flush_status = avcodec_send_frame(avcodec_ctx.get(), nullptr);
+      // Some hardware encoders cannot flush an initialized session that never
+      // accepted a frame (for example, capture aborting before its first frame).
+      const auto flush_status = frame_submitted ? avcodec_send_frame(avcodec_ctx.get(), nullptr) : AVERROR_EOF;
       int drain_status = flush_status;
       std::size_t drained_packets = 0;
       if (flush_status == 0) {
@@ -1465,20 +1466,8 @@ namespace video {
       }
     }
 
-    // Ensure objects are destroyed in the correct order
-    avcodec_encode_session_t &operator=(avcodec_encode_session_t &&other) {
-      converter = std::move(other.converter);
-      avcodec_ctx = std::move(other.avcodec_ctx);
-      replacements = std::move(other.replacements);
-      sps = std::move(other.sps);
-      vps = std::move(other.vps);
-
-      conversion_request = other.conversion_request;
-      inject = other.inject;
-      runtime_bitrate_supported = other.runtime_bitrate_supported;
-
-      return *this;
-    }
+    // Replacing a live session must use its ordered destructor.
+    avcodec_encode_session_t &operator=(avcodec_encode_session_t &&other) = delete;
 
     int convert(frame_t &frame) override {
       if (!converter) {
@@ -1534,7 +1523,8 @@ namespace video {
     std::unique_ptr<encode_device_frame_converter_t<platf::avcodec_encode_device_t>> converter;
     conversion_request_t conversion_request;
 
-    std::vector<packet_raw_t::replace_t> replacements;
+    std::shared_ptr<std::vector<packet_raw_t::replace_t>> replacements = std::make_shared<std::vector<packet_raw_t::replace_t>>();
+    bool frame_submitted = false;
 
     cbs::nal_t sps;
     cbs::nal_t vps;
@@ -2498,6 +2488,19 @@ namespace video {
     }
   }
 
+  bool wait_for_capture_display_release(
+    const std::shared_ptr<platf::display_t> &display,
+    const std::function<bool()> &running,
+    const std::function<void()> &drain_images
+  ) {
+    while (display.use_count() != 1) {
+      if (!running()) return false;
+      drain_images();
+      std::this_thread::sleep_for(20ms);
+    }
+    return running();
+  }
+
   void captureThread(
     std::shared_ptr<safe::queue_t<capture_ctx_t>> capture_ctx_queue,
     sync_util::sync_t<std::weak_ptr<platf::display_t>> &display_wp,
@@ -2754,7 +2757,9 @@ namespace video {
             // display_wp is modified in this thread only
             // Wait for the other shared_ptr's of display to be destroyed.
             // New displays will only be created in this thread.
-            while (display_wp->use_count() != 1) {
+            const auto released = wait_for_capture_display_release(disp, [&] {
+              return capture_ctx_queue->running();
+            }, [&] {
               // Free images that weren't consumed by the encoders. These can reference the display and prevent
               // the ref count from reaching 1. We do this here rather than on the encoder thread to avoid race
               // conditions where the encoding loop might free a good frame after reinitializing if we capture
@@ -2765,15 +2770,15 @@ namespace video {
                   continue;
                 }
 
-                while (capture_ctx->images->peek()) {
-                  capture_ctx->images->pop();
-                }
+                while (capture_ctx->images->try_pop()) {}
 
                 ++capture_ctx;
               });
 
-              std::this_thread::sleep_for(20ms);
-            }
+            });
+            // Stopped packet queues can retain their display until after this
+            // thread joins. Their ownership remains intact while we exit.
+            if (!released) return;
 
             while (capture_ctx_queue->running()) {
               // Release the display before reenumerating displays, since some capture backends
@@ -2892,6 +2897,7 @@ namespace video {
       return -1;
     }
 
+    session.frame_submitted = true;
     while (ret >= 0) {
       auto packet = std::make_unique<packet_raw_avcodec>();
       auto av_packet = packet.get()->av_packet;
@@ -2922,7 +2928,7 @@ namespace video {
           sps = std::move(hevc.sps);
           vps = std::move(hevc.vps);
 
-          session.replacements.emplace_back(
+          session.replacements->emplace_back(
             std::string_view((char *) std::begin(vps.old), vps.old.size()),
             std::string_view((char *) std::begin(vps._new), vps._new.size())
           );
@@ -2930,7 +2936,7 @@ namespace video {
 
         session.inject = 0;
 
-        session.replacements.emplace_back(
+        session.replacements->emplace_back(
           std::string_view((char *) std::begin(sps.old), sps.old.size()),
           std::string_view((char *) std::begin(sps._new), sps._new.size())
         );
@@ -2941,7 +2947,10 @@ namespace video {
         packet->encode_done_timestamp = std::chrono::steady_clock::now();
       }
 
-      packet->replacements = &session.replacements;
+      packet->replacements = session.replacements;
+      // Hardware packet buffers may depend on thread-affine conversion
+      // resources. Detach them here so teardown stays on the encoder thread.
+      if (!packet->detach_encoder_buffer()) return AVERROR(ENOMEM);
       packet->channel_data = channel_data;
       packets->raise(std::move(packet));
     }
@@ -3476,16 +3485,17 @@ namespace video {
     return std::make_unique<nvenc_encode_session_t>(std::move(converter), *conversion_request);
   }
 
-  std::unique_ptr<encode_session_t> make_encode_session(platf::display_t *disp, const encoder_t &encoder, const config_t &config, int width, int height, std::unique_ptr<platf::encode_device_t> encode_device) {
+  std::unique_ptr<encode_session_t> make_encode_session(const std::shared_ptr<platf::display_t> &disp, const encoder_t &encoder, const config_t &config, int width, int height, std::unique_ptr<platf::encode_device_t> encode_device) {
+    std::unique_ptr<encode_session_t> session;
     if (dynamic_cast<platf::avcodec_encode_device_t *>(encode_device.get())) {
       auto avcodec_encode_device = boost::dynamic_pointer_cast<platf::avcodec_encode_device_t>(std::move(encode_device));
-      return make_avcodec_encode_session(disp, encoder, config, width, height, std::move(avcodec_encode_device));
+      session = make_avcodec_encode_session(disp.get(), encoder, config, width, height, std::move(avcodec_encode_device));
+      if (session) session->capture_display_owner = disp;
     } else if (dynamic_cast<platf::nvenc_encode_device_t *>(encode_device.get())) {
       auto nvenc_encode_device = boost::dynamic_pointer_cast<platf::nvenc_encode_device_t>(std::move(encode_device));
-      return make_nvenc_encode_session(encoder, config, std::move(nvenc_encode_device));
+      session = make_nvenc_encode_session(encoder, config, std::move(nvenc_encode_device));
     }
-
-    return nullptr;
+    return session;
   }
 
   void encode_run(
@@ -3501,7 +3511,7 @@ namespace video {
     void *channel_data,
     packet_queue_t packets
   ) {
-    auto session = make_encode_session(disp.get(), encoder, config, disp->width, disp->height, std::move(encode_device));
+    auto session = make_encode_session(disp, encoder, config, disp->width, disp->height, std::move(encode_device));
     if (!session) {
       adaptive_bitrate::set_runtime_update_supported(
         false,
@@ -3584,6 +3594,8 @@ namespace video {
     if (config.input_only) {
       BOOST_LOG(info) << "Input only session, video will not be captured."sv;
 
+      // Recheck after dummy-frame conversion, which can block in a driver.
+      if (shutdown_event->peek() || !images->running() || reinit_event.peek()) return;
       // Encode the dummy img only once
       if (encode(frame_nr++, *session, packets, channel_data, std::chrono::steady_clock::now())) {
         BOOST_LOG(error) << "Could not encode dummy video packet"sv;
@@ -3707,6 +3719,12 @@ namespace video {
         } else if (!images->running()) {
           break;
         }
+      }
+
+      // Capture waits and conversion may span shutdown or display reinit.
+      // Keep the early check too, so a stopped stream never begins another wait.
+      if (shutdown_event->peek() || !images->running() || (reinit_event.peek() && frame_nr > 1)) {
+        break;
       }
 
       {
@@ -4007,7 +4025,7 @@ namespace video {
   }
 
   std::optional<sync_session_t> make_synced_session(
-    platf::display_t *disp,
+    const std::shared_ptr<platf::display_t> &disp,
     const encoder_t &encoder,
     frame_t &frame,
     sync_session_ctx_t &ctx,
@@ -4028,7 +4046,7 @@ namespace video {
     }
 
     // absolute mouse coordinates require that the dimensions of the screen are known
-    ctx.touch_port_events->raise(make_port(disp, ctx.config));
+    ctx.touch_port_events->raise(make_port(disp.get(), ctx.config));
 
     // Update client with our current HDR display state
     ctx.hdr_events->raise(make_hdr_info(*encode_device));
@@ -4163,7 +4181,7 @@ namespace video {
     std::vector<sync_session_t> synced_sessions;
     for (auto &ctx : synced_session_ctxs) {
       bool retired_gpu_native_route = false;
-      auto synced_session = make_synced_session(disp.get(), encoder, initial_frame, *ctx, retired_gpu_native_route);
+      auto synced_session = make_synced_session(disp, encoder, initial_frame, *ctx, retired_gpu_native_route);
       if (!synced_session) {
         // Retiring the route already selected SHM for the next attempt, so
         // reinitialize instead of ending the session with no video.
@@ -4200,7 +4218,7 @@ namespace video {
           synced_session_ctxs.emplace_back(std::make_unique<sync_session_ctx_t>(std::move(*incoming_sync_ctx)));
 
           bool retired_gpu_native_route = false;
-          auto encode_session = make_synced_session(disp.get(), encoder, frame, *synced_session_ctxs.back(), retired_gpu_native_route);
+          auto encode_session = make_synced_session(disp, encoder, frame, *synced_session_ctxs.back(), retired_gpu_native_route);
           if (!encode_session) {
             ec = retired_gpu_native_route ? platf::capture_e::reinit : platf::capture_e::error;
             return false;
@@ -4250,6 +4268,13 @@ namespace video {
             frame_timestamp = frame.timestamp;
           }
 
+          // Conversion can block while shutdown or a display switch arrives.
+          if (!encode_session_ctx_queue.running()) return false;
+          if (ctx->shutdown_event->peek()) continue;
+          if (switch_display_event->peek() && display_switch_allowed_for_exact_capture(exact_display_name)) {
+            ec = platf::capture_e::reinit;
+            return false;
+          }
           if (encode(ctx->frame_nr++, *pos->session, ctx->packets, ctx->channel_data, frame_timestamp)) {
             BOOST_LOG(error) << "Could not encode video packet"sv;
             ctx->shutdown_event->raise(true);
@@ -4491,7 +4516,7 @@ namespace video {
       dynamic_cast<platf::avcodec_encode_device_t *>(encode_device.get()) &&
       !static_cast<platf::avcodec_encode_device_t *>(encode_device.get())->data;
 
-    auto session = make_encode_session(disp.get(), encoder, config, disp->width, disp->height, std::move(encode_device));
+    auto session = make_encode_session(disp, encoder, config, disp->width, disp->height, std::move(encode_device));
     if (!session) {
       return -1;
     }
@@ -5683,7 +5708,7 @@ namespace video {
         return false;
       }
 
-      auto session = make_encode_session(disp.get(), *chosen_encoder, config, frame.width, frame.height, std::move(encode_device));
+      auto session = make_encode_session(disp, *chosen_encoder, config, frame.width, frame.height, std::move(encode_device));
       if (!session) {
         BOOST_LOG(debug) << "Live GPU capture probe could not create an encode session for conversion validation"sv;
         return false;

--- a/src/video.h
+++ b/src/video.h
@@ -308,6 +308,12 @@ namespace video {
     uint32_t flags;
   };
 
+  bool wait_for_capture_display_release(
+    const std::shared_ptr<platf::display_t> &display,
+    const std::function<bool()> &running,
+    const std::function<void()> &drain_images
+  );
+
   struct encode_session_t {
     enum class bitrate_update_e {
       rejected,
@@ -316,6 +322,9 @@ namespace video {
     };
 
     virtual ~encode_session_t() = default;
+
+    // Base members are destroyed after derived codec and converter resources.
+    std::shared_ptr<platf::display_t> capture_display_owner;
 
     virtual int convert(frame_t &frame) = 0;
 
@@ -375,18 +384,19 @@ namespace video {
     virtual size_t data_size() = 0;
 
     struct replace_t {
-      std::string_view old;
-      std::string_view _new;
+      std::string old;
+      std::string _new;
 
       KITTY_DEFAULT_CONSTR_MOVE(replace_t)
 
-      replace_t(std::string_view old, std::string_view _new) noexcept:
+      replace_t(std::string_view old, std::string_view _new):
           old {std::move(old)},
           _new {std::move(_new)} {
       }
     };
 
-    std::vector<replace_t> *replacements = nullptr;
+    // Packets can remain queued after their encoder session has been retired.
+    std::shared_ptr<const std::vector<replace_t>> replacements;
     void *channel_data = nullptr;
     bool after_ref_frame_invalidation = false;
     std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
@@ -407,6 +417,26 @@ namespace video {
 
     ~packet_raw_avcodec() {
       av_packet_free(&this->av_packet);
+    }
+
+    // Copy encoded bytes and side data before releasing any driver-owned
+    // buffer/opaque reference. Call only from the encoder's owning thread.
+    bool detach_encoder_buffer() {
+      AVPacket *detached = av_packet_alloc();
+      if (!detached) return false;
+      if (av_new_packet(detached, av_packet->size) < 0 ||
+          av_packet_copy_props(detached, av_packet) < 0) {
+        av_packet_free(&detached);
+        return false;
+      }
+      if (av_packet->size > 0) std::memcpy(detached->data, av_packet->data, av_packet->size);
+      // Opaque references are never used by packet consumers and may own
+      // hardware state. The remaining metadata is independently allocated.
+      detached->opaque = nullptr;
+      av_buffer_unref(&detached->opaque_ref);
+      av_packet_free(&av_packet);
+      av_packet = detached;
+      return true;
     }
 
     bool is_idr() override {

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -415,3 +415,142 @@ TEST(VideoCacheTests, HeadlessCageUsesDeferredCageTopologyKeyForColdLaunchAdvert
   EXPECT_NE(topology.find(";displays=deferred-cage"), std::string::npos);
 }
 #endif
+
+TEST(CaptureEventLifecycle, AtomicDrainCompetesWithConsumerWithoutWaiting) {
+  for (int iteration = 0; iteration < 100; ++iteration) {
+    safe::event_t<std::shared_ptr<int>> event;
+    auto value = std::make_shared<int>(iteration);
+    std::weak_ptr<int> lifetime = value;
+    event.raise(std::move(value));
+    std::atomic<int> consumed {0};
+    std::atomic<bool> start {false};
+    const auto consume = [&] {
+      while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+      if (event.try_pop()) ++consumed;
+    };
+    std::thread encoder {consume};
+    std::thread drain {consume};
+    start.store(true, std::memory_order_release);
+    encoder.join();
+    drain.join();
+    EXPECT_EQ(consumed.load(), 1);
+    EXPECT_TRUE(lifetime.expired());
+    EXPECT_FALSE(event.try_pop());
+  }
+}
+
+TEST(CaptureEventLifecycle, StopWakesCaptureConsumerAndRejectsFurtherFrames) {
+  safe::event_t<std::shared_ptr<int>> event;
+  std::thread consumer {[&] { EXPECT_FALSE(event.pop()); }};
+  event.stop();
+  consumer.join();
+  event.raise(std::make_shared<int>(1));
+  EXPECT_FALSE(event.peek());
+  EXPECT_FALSE(event.running());
+  EXPECT_FALSE(event.try_pop());
+}
+
+TEST(EncodedPacketLifecycle, ReplacementBytesSurviveTheirSourceAndSession) {
+  auto packet = std::make_unique<video::packet_raw_avcodec>();
+  {
+    std::string original = "old parameter set";
+    std::string replacement = "new parameter set";
+    auto replacements = std::make_shared<std::vector<video::packet_raw_t::replace_t>>();
+    replacements->emplace_back(original, replacement);
+    packet->replacements = replacements;
+    original.assign(4096, 'x');
+    replacement.assign(4096, 'y');
+  }
+  ASSERT_EQ(packet->replacements->size(), 1);
+  EXPECT_EQ(packet->replacements->front().old, "old parameter set");
+  EXPECT_EQ(packet->replacements->front()._new, "new parameter set");
+}
+
+namespace {
+  class LifetimeDisplay final: public platf::display_t {
+  public:
+    explicit LifetimeDisplay(std::vector<std::string> &order): order {order} {}
+    ~LifetimeDisplay() override { order.emplace_back("display"); }
+    platf::capture_e capture(const push_captured_image_cb_t &, const pull_free_image_cb_t &, bool *) override { return platf::capture_e::ok; }
+    std::shared_ptr<platf::img_t> alloc_img() override { return {}; }
+    int dummy_img(platf::img_t *) override { return -1; }
+    std::vector<std::string> &order;
+  };
+  class LifetimeConverter final: public video::frame_converter_t {
+  public:
+    explicit LifetimeConverter(std::vector<std::string> &order): order {order} {}
+    ~LifetimeConverter() override { order.emplace_back("converter"); }
+    std::string_view name() const override { return "lifetime-test"; }
+    bool supports(const video::frame_t &, const video::conversion_request_t &) const override { return false; }
+    int convert(video::frame_t &, const video::conversion_request_t &) override { return -1; }
+    std::vector<std::string> &order;
+  };
+}
+
+TEST(EncodedPacketLifecycle, DriverReferencesReleaseOnEncoderThreadBeforePacketDelivery) {
+  const auto owner = std::this_thread::get_id();
+  std::vector<std::string> order;
+  auto packet = std::make_unique<video::packet_raw_avcodec>();
+  struct DriverBuffer {
+    std::thread::id owner;
+    std::vector<std::string> *order;
+    std::unique_ptr<LifetimeConverter> converter;
+  };
+  auto driver = new DriverBuffer {owner, &order, std::make_unique<LifetimeConverter>(order)};
+  packet->av_packet->buf = av_buffer_create(
+    static_cast<uint8_t *>(av_malloc(AV_INPUT_BUFFER_PADDING_SIZE + 4)), 4,
+    [](void *opaque, uint8_t *data) {
+      auto driver = static_cast<DriverBuffer *>(opaque);
+      EXPECT_EQ(std::this_thread::get_id(), driver->owner);
+      driver->order->emplace_back("driver-buffer");
+      delete driver;
+      av_free(data);
+    }, driver, 0);
+  ASSERT_NE(packet->av_packet->buf, nullptr);
+  packet->av_packet->data = packet->av_packet->buf->data;
+  packet->av_packet->size = 4;
+  std::memcpy(packet->av_packet->data, "data", 4);
+  packet->av_packet->pts = 42;
+  packet->av_packet->flags = AV_PKT_FLAG_KEY;
+  packet->av_packet->opaque_ref = av_buffer_ref(packet->av_packet->buf);
+  auto metadata = av_packet_new_side_data(packet->av_packet, AV_PKT_DATA_STRINGS_METADATA, 4);
+  ASSERT_NE(metadata, nullptr);
+  std::memcpy(metadata, "meta", 4);
+  ASSERT_TRUE(packet->detach_encoder_buffer());
+  EXPECT_EQ(order, (std::vector<std::string> {"driver-buffer", "converter"}));
+  std::thread consumer {[packet = std::move(packet)]() mutable {
+    EXPECT_EQ(packet->frame_index(), 42);
+    EXPECT_TRUE(packet->is_idr());
+    size_t metadata_size = 0;
+    auto metadata = av_packet_get_side_data(packet->av_packet, AV_PKT_DATA_STRINGS_METADATA, &metadata_size);
+    ASSERT_NE(metadata, nullptr);
+    EXPECT_EQ(std::string_view(reinterpret_cast<char *>(metadata), metadata_size), "meta");
+    EXPECT_EQ(std::string_view(reinterpret_cast<char *>(packet->data()), packet->data_size()), "data");
+    packet.reset();
+  }};
+  consumer.join();
+  EXPECT_EQ(order.size(), 2);
+}
+
+TEST(CaptureEventLifecycle, CaptureReinitCanStopWhileConsumerRetainsDisplay) {
+  std::vector<std::string> order;
+  std::shared_ptr<platf::display_t> display = std::make_shared<LifetimeDisplay>(order);
+  safe::queue_t<std::shared_ptr<platf::display_t>> packets;
+  packets.raise(display);
+  packets.stop();
+  EXPECT_FALSE(packets.pop());
+  safe::queue_t<int> capture_control;
+  safe::signal_t draining;
+  bool released = true;
+  std::thread capture {[&] {
+    released = video::wait_for_capture_display_release(display,
+      [&] { return capture_control.running(); }, [&] { draining.raise(true); });
+  }};
+  const auto entered_wait = draining.pop(std::chrono::seconds(1));
+  capture_control.stop();
+  capture.join();
+  EXPECT_TRUE(entered_wait);
+  EXPECT_FALSE(released);
+  EXPECT_TRUE(order.empty());
+  EXPECT_EQ(display.use_count(), 2);
+}


### PR DESCRIPTION
Capture reinitialization could block after checking an image event and then waiting to pop an image another consumer had removed. Teardown could also flush an encoder that never accepted a frame, or leave queued SPS/VPS replacements pointing into a retired session.

This change adds atomic nonblocking capture-event consumption, synchronized event/queue status reads, an interruptible display-reference wait, and shutdown/reinitialization checks immediately before encoding. Empty avcodec sessions skip flushing. Encoded packets own their replacement bytes and detach driver-backed payload/opaque references on the encoder thread before publication; converter destruction stays on its owning thread after codec closure. This introduces a packet allocation/copy whose performance impact needs measurement. Existing conversion ownership, Vulkan teardown order, capture generations, and native NVENC asynchronous teardown remain intact.

Validation: 31 video tests pass under Clang TSan, including competing capture consumers, stopped waits, retained displays, detached driver references, side data, PTS/key flags, and queued replacement bytes. TSan reproduced the queue status race before the fix. Independent lifecycle source review found no remaining material findings after the teardown and thread-affinity corrections. Exact-head Build34152673134, CodeQL34152673138, and Hygiene34152673139 all passed, including C++ sanitizers, native package builds, SteamOS3.8, and web checks. A local rebuild at reviewed commit493d89e passed33 video tests with one unavailable VA-API hardware case skipped. Physical reconnect/display-switch/transport-switch and performance evidence remain part of series acceptance; no physical streaming improvement is claimed by these tests.
