### PR TITLE
fix(multiseat): preserve trusted worker input credentials

### DIFF
--- a/containers/multiseat/Containerfile
+++ b/containers/multiseat/Containerfile
@@ -41,13 +41,17 @@ RUN go test -trimpath ./... && \
       -o /out/polaris-seat-display-capture ./cmd/polaris-seat-display-capture && \
     go build -trimpath -buildvcs=false \
       -ldflags='-buildid= -s -w' \
-      -o /out/polaris-seat-nested-compositor ./cmd/polaris-seat-nested-compositor
+      -o /out/polaris-seat-nested-compositor ./cmd/polaris-seat-nested-compositor && \
+    go build -trimpath -buildvcs=false \
+      -ldflags='-buildid= -s -w' \
+      -o /out/polaris-seat-input-probe ./cmd/polaris-seat-input-probe
 
 FROM ${RUNTIME_IMAGE}
 ARG POLARIS_REVISION=unknown
 LABEL org.opencontainers.image.source="https://github.com/papi-ux/polaris" \
       org.opencontainers.image.revision="${POLARIS_REVISION}" \
       org.opencontainers.image.description="Isolated Polaris multiseat worker"
+COPY --from=worker-build --chmod=0555 /out/polaris-seat-input-probe /usr/bin/polaris-seat-input-probe
 COPY --from=worker-build --chmod=0555 /out/polaris-seat-worker /usr/bin/polaris-seat-worker
 COPY --from=worker-build --chmod=0555 /out/polaris-seat-runtime /usr/bin/polaris-seat-runtime
 COPY --from=worker-build --chmod=0555 /out/polaris-seat-session-bus /usr/libexec/polaris-seat/session-bus

--- a/containers/multiseat/README.md
+++ b/containers/multiseat/README.md
@@ -150,10 +150,10 @@ real stream session, constructs the hub as the inputtino sink, or supplies the
 mailbox endpoint which reaches a client's control thread. The singleton runtime
 constructs none of these classes. The worker's older opaque input/feedback test adapter is
 deliberately not treated as injection authority. Mediated Steam Input also
-remains missing. Rootless supplementary-group and SELinux access require an
-explicit deployment decision and physical validation; this source checkpoint
-does not add `keep-groups`, change host policy, or claim that an image can use
-the mapped nodes.
+remains missing. Rootless launches now require trusted crun, the actual launching UID and
+`keep-groups`. The optional policy under `selinux/` labels only reserved
+multiseat event nodes. Policy installation remains explicit; the isolated
+harness must establish device access for each selected final image.
 
 The dispatcher and worker share one canonical stage parser and environment
 builder. Before it can touch a provider, the dispatcher rejects reordered or
@@ -339,3 +339,45 @@ it audits at most 256 root entries through no-follow descriptors and recovers
 only valid signed records absent from that authoritative inventory. Active,
 ambiguous, malformed, replaced, unexpected, or live-socket state is retained
 and blocks admission rather than being deleted by name or recursively.
+
+## Isolated input acceptance with crun
+
+The Linux worker backend explicitly selects `/usr/bin/crun` and combines
+`--group-add=keep-groups` with `--userns=keep-id`. The runtime must be a
+root-owned regular executable below root-owned directories that are not
+writable by other users. Launch reads the calling process's supplementary
+groups with `getgroups()` and rechecks that snapshot and device access at
+invocation. Account membership alone is insufficient: a user service must
+actually inherit the needed groups. Runtime and group failures reject new
+launches; stopping an existing worker remains available.
+
+Authoritative inventory requires the selected crun path and the OCI
+`run.oci.keep_original_groups=1` annotation. Podman consumes `keep-groups`
+while creating the OCI specification, so its inspected `HostConfig.GroupAdd`
+is empty. OCI `additionalGids` describe namespace IDs and are not evidence
+that host supplementary groups were retained. The existing exact device and
+mount classifier still applies. SELinux stays enforcing.
+
+`MultiseatPhysical.TwoWorkersReadOnlyTheirAllocatedInputAndStopIndependently`
+is an opt-in acceptance test. Set `POLARIS_MULTISEAT_PHYSICAL=1`, an exact
+`POLARIS_PHYSICAL_IMAGE`, a private `POLARIS_PHYSICAL_IPC_ROOT` parent, and
+two distinct pre-created profile volumes through `POLARIS_PHYSICAL_VOLUME`
+and `POLARIS_PHYSICAL_VOLUME_B`. `POLARIS_PHYSICAL_PROFILE` selects gamescope,
+steam, heroic, or lutris. The image must contain the separately packaged
+`polaris-seat-input-probe` acceptance helper. GPU device paths must belong to
+the explicit catalog supplied through the physical harness environment.
+
+The harness creates a unique deployment and authority root, opens every
+allocated event alias inside both workers, checks major/minor identity and
+absence of other input nodes, and sends bounded synthetic input through the
+host authority. It checks the second worker again after stopping the first.
+Any forced container cleanup fails acceptance; cleanup only targets captured
+container IDs and never recursively removes caller-provided authority roots.
+Passing this test establishes isolated input and worker lifecycle. Production
+provider selection and multiseat activation remain off; it does not establish
+successful game streaming.
+
+The worker UID is passed explicitly, because an image `USER` can override
+Podman's implicit `keep-id` choice. Live inventory requires matching Config.User
+and OCI process.user.uid evidence. Use a short private IPC parent for the
+physical harness so both generated Unix socket paths fit Linux's 108-byte limit.

--- a/containers/multiseat/selinux/97-polaris-multiseat-input.rules
+++ b/containers/multiseat/selinux/97-polaris-multiseat-input.rules
@@ -1,0 +1,3 @@
+# Opt-in companion to polaris_multiseat_input.cil; install the policy first.
+# 60-polaris.rules reserves these names and assigns seat-polaris before this rule.
+SUBSYSTEM=="input", KERNEL=="event[0-9]*", ATTRS{name}=="Polaris multiseat *", ENV{ID_SEAT}=="seat-polaris", SECLABEL{selinux}="system_u:object_r:polaris_multiseat_input_device_t:s0"

--- a/containers/multiseat/selinux/README.md
+++ b/containers/multiseat/selinux/README.md
@@ -1,0 +1,38 @@
+# Optional SELinux policy for reserved input nodes
+
+Use this only when an enforcing SELinux host independently denies a correctly
+mounted event node after the launching service and worker have been shown to
+retain their actual supplementary groups. The runtime uses trusted crun,
+`--userns=keep-id`, an explicit launching UID, and `--group-add=keep-groups`.
+An account database entry alone does not establish running-process membership.
+
+The CIL module allows containers to open and read one dedicated device type.
+The companion udev rule labels only event nodes with the reserved
+`Polaris multiseat ` name and `seat-polaris` assignment from `60-polaris.rules`.
+The controller must still authenticate each allocation and mount only its
+exact devices. This policy does not grant ioctl or write access, generic input
+access, or access to uinput/uhid. It does not enable any multiseat adapter.
+
+Administrators opt in explicitly, with all multiseat workers stopped. Confirm
+that the module and destination rule are absent first; preserve any existing
+local policy instead of overwriting it. Record the installed module checksum
+and rule hash so removal can verify ownership of both artifacts. After loading,
+inspect effective permissions, including those inherited through `device_node`.
+Only read/open/getattr should be granted to `container_t` for this type:
+
+```sh
+sudo semodule -i containers/multiseat/selinux/polaris_multiseat_input.cil
+sudo install -o root -g root -m 0644 \
+  containers/multiseat/selinux/97-polaris-multiseat-input.rules \
+  /etc/udev/rules.d/97-polaris-multiseat-input.rules
+sudo udevadm control --reload-rules
+```
+
+Create fresh allocations, verify their labels, then run the isolated physical
+harness. Do not relabel the host's existing event nodes or trigger every input
+device. Keep SELinux enforcing and the `container_use_devices` boolean off.
+
+To remove the policy, first stop every multiseat worker and verify every
+reserved virtual device was destroyed. Remove only the matching installed
+rule, reload udev rules, then run `sudo semodule -r polaris_multiseat_input`.
+No package or service installs this policy automatically.

--- a/containers/multiseat/selinux/polaris_multiseat_input.cil
+++ b/containers/multiseat/selinux/polaris_multiseat_input.cil
@@ -1,0 +1,6 @@
+; Opt-in event reading for explicitly mounted, reserved multiseat nodes.
+; No generic event_device_t, input_device_t, uinput or device write permission.
+(type polaris_multiseat_input_device_t)
+(typeattributeset device_node (polaris_multiseat_input_device_t))
+(roletype object_r polaris_multiseat_input_device_t)
+(allow container_t polaris_multiseat_input_device_t (chr_file (getattr open read)))

--- a/multiseat_worker/cmd/polaris-seat-input-probe/main.go
+++ b/multiseat_worker/cmd/polaris-seat-input-probe/main.go
@@ -1,0 +1,230 @@
+//go:build linux && amd64
+
+// polaris-seat-input-probe is an opt-in physical acceptance helper. Production
+// worker startup never calls it; it reads only the four reserved seat aliases.
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"syscall"
+	"time"
+)
+
+type device struct {
+	Path  string `json:"path"`
+	Major uint32 `json:"major"`
+	Minor uint32 `json:"minor"`
+}
+type request struct {
+	Token   string   `json:"token"`
+	Devices []device `json:"devices"`
+	Absent  []string `json:"absent"`
+}
+type observation struct {
+	Markers [4]int `json:"markers"`
+	Events  [4]int `json:"events"`
+}
+
+var aliases = [4]string{"/dev/input/polaris-keyboard", "/dev/input/polaris-mouse-relative", "/dev/input/polaris-mouse-absolute", "/dev/input/polaris-gamepad-0"}
+var tokenPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+var eventPattern = regexp.MustCompile(`^/dev/input/event[0-9]+$`)
+
+func marker(index int, kind, code uint16, value int32) bool {
+	switch index {
+	case 0:
+		return kind == 1 && code == 30 && value == 1
+	case 1:
+		return kind == 2 && code == 0 && value == 7
+	case 2:
+		return kind == 3 && code == 0 && value > 0
+	case 3:
+		return kind == 1 && code == 304 && value == 1
+	}
+	return false
+}
+func readyPath(token string) (string, error) {
+	if !tokenPattern.MatchString(token) {
+		return "", errors.New("invalid probe token")
+	}
+	return filepath.Join("/run/polaris", "input-probe-"+token+".ready"), nil
+}
+
+type observationWindow struct{ deadline, drainUntil time.Time }
+
+func (window *observationWindow) advance(now time.Time, finish bool) (bool, error) {
+	if !now.Before(window.deadline) {
+		return false, errors.New("host finish signal did not complete before deadline")
+	}
+	if finish && window.drainUntil.IsZero() {
+		window.drainUntil = now.Add(250 * time.Millisecond)
+	}
+	return !window.drainUntil.IsZero() && !now.Before(window.drainUntil), nil
+}
+func recordEvent(result *observation, index int, event []byte) error {
+	if len(event) != 24 {
+		return errors.New("truncated kernel event")
+	}
+	kind, code := binary.LittleEndian.Uint16(event[16:18]), binary.LittleEndian.Uint16(event[18:20])
+	value := int32(binary.LittleEndian.Uint32(event[20:24]))
+	if kind == 0 && code == 3 {
+		return errors.New("kernel input observation dropped events")
+	}
+	if kind != 0 {
+		result.Events[index]++
+	}
+	if marker(index, kind, code, value) {
+		result.Markers[index]++
+	}
+	if result.Events[index] > 4096 {
+		return errors.New("input observation limit exceeded")
+	}
+	return nil
+}
+
+func observe(req request) (observation, error) {
+	var result observation
+	ready, err := readyPath(req.Token)
+	if err != nil {
+		return result, err
+	}
+	if len(req.Devices) != len(aliases) || len(req.Absent) > 32 {
+		return result, errors.New("invalid device manifest")
+	}
+	for _, path := range append(req.Absent, "/dev/uinput", "/dev/uhid") {
+		if path != "/dev/uinput" && path != "/dev/uhid" && !eventPattern.MatchString(path) {
+			return result, errors.New("invalid excluded node")
+		}
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			return result, errors.New("unallocated input node is visible")
+		}
+	}
+	entries, err := os.ReadDir("/dev/input")
+	if err != nil || len(entries) != len(aliases) {
+		return result, errors.New("unexpected input namespace")
+	}
+	fds := make([]int, 0, len(aliases))
+	defer func() {
+		for _, fd := range fds {
+			syscall.Close(fd)
+		}
+	}()
+	for index, dev := range req.Devices {
+		if dev.Path != aliases[index] {
+			return result, errors.New("unexpected seat alias")
+		}
+		fd, err := syscall.Open(dev.Path, syscall.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+		if err != nil {
+			return result, fmt.Errorf("allocated input %d cannot be opened: %w", index, err)
+		}
+		fds = append(fds, fd)
+		var stat syscall.Stat_t
+		if err := syscall.Fstat(fd, &stat); err != nil {
+			return result, err
+		}
+		major := uint32((stat.Rdev>>8)&0xfff | (stat.Rdev>>32)&0xfffff000)
+		minor := uint32(stat.Rdev&0xff | (stat.Rdev>>12)&0xffffff00)
+		if stat.Mode&syscall.S_IFMT != syscall.S_IFCHR || major != dev.Major || minor != dev.Minor {
+			return result, errors.New("allocated device identity changed")
+		}
+	}
+	fd, err := syscall.Open(ready, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_EXCL|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0600)
+	if err != nil {
+		return result, err
+	}
+	if _, err = syscall.Write(fd, []byte("ready\n")); err != nil {
+		syscall.Close(fd)
+		os.Remove(ready)
+		return result, err
+	}
+	syscall.Close(fd)
+	defer os.Remove(ready)
+	finish := ready + ".finish"
+	defer os.Remove(finish)
+	window := observationWindow{deadline: time.Now().Add(10 * time.Second)}
+	finishSeen := false
+	buffer := make([]byte, 24*64)
+	for {
+		if !finishSeen {
+			if info, err := os.Lstat(finish); err == nil {
+				if !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+					return result, errors.New("invalid finish signal")
+				}
+				finishSeen = true
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return result, err
+			}
+		}
+		for index, fd := range fds {
+			count, err := syscall.Read(fd, buffer)
+			if err == syscall.EAGAIN || err == syscall.EINTR {
+				continue
+			}
+			if err != nil {
+				return result, err
+			}
+			if count%24 != 0 {
+				return result, errors.New("truncated kernel event")
+			}
+			for offset := 0; offset < count; offset += 24 {
+				if err := recordEvent(&result, index, buffer[offset:offset+24]); err != nil {
+					return result, err
+				}
+			}
+		}
+		completed, err := window.advance(time.Now(), finishSeen)
+		if err != nil {
+			return result, err
+		}
+		if completed {
+			return result, nil
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+func run() error {
+	if len(os.Args) != 3 {
+		return errors.New("expected observe manifest or ready token")
+	}
+	if os.Args[1] == "ready" || os.Args[1] == "finish" {
+		path, err := readyPath(os.Args[2])
+		if err != nil {
+			return err
+		}
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+			return errors.New("probe is not ready")
+		}
+		if os.Args[1] == "finish" {
+			fd, err := syscall.Open(path+".finish", syscall.O_WRONLY|syscall.O_CREAT|syscall.O_EXCL|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0600)
+			if err != nil {
+				return err
+			}
+			return syscall.Close(fd)
+		}
+		return nil
+	}
+	if os.Args[1] != "observe" || len(os.Args[2]) > 16384 {
+		return errors.New("invalid observation request")
+	}
+	var req request
+	if err := json.Unmarshal([]byte(os.Args[2]), &req); err != nil {
+		return err
+	}
+	result, err := observe(req)
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(os.Stdout).Encode(result)
+}
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/multiseat_worker/cmd/polaris-seat-input-probe/main_test.go
+++ b/multiseat_worker/cmd/polaris-seat-input-probe/main_test.go
@@ -1,0 +1,64 @@
+//go:build linux && amd64
+
+package main
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+)
+
+func TestOnlyExpectedSyntheticMarkersMatch(t *testing.T) {
+	for index, tuple := range [][3]int32{{1, 30, 1}, {2, 0, 7}, {3, 0, 120}, {1, 304, 1}} {
+		if !marker(index, uint16(tuple[0]), uint16(tuple[1]), tuple[2]) {
+			t.Fatal("expected marker missing", index)
+		}
+		if marker(index, uint16(tuple[0]), uint16(tuple[1]), 0) {
+			t.Fatal("neutral state matched", index)
+		}
+		if marker(index, 0, 0, 0) {
+			t.Fatal("SYN event matched", index)
+		}
+	}
+}
+func TestProbeTokensCannotEscapePrivateRuntime(t *testing.T) {
+	for _, token := range []string{"", "../other", "0123456789abcdef0123456789abcdefff/other"} {
+		if _, err := readyPath(token); err == nil {
+			t.Fatal("unsafe token accepted")
+		}
+	}
+	if _, err := readyPath("0123456789abcdef0123456789abcdef"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDelayedObserverCannotSucceedBeforeHostFinish(t *testing.T) {
+	start := time.Unix(0, 0)
+	window := observationWindow{deadline: start.Add(10 * time.Second)}
+	for _, elapsed := range []time.Duration{0, 3 * time.Second, 5 * time.Second} {
+		if done, err := window.advance(start.Add(elapsed), false); done || err != nil {
+			t.Fatal("observer ended before finish", elapsed, done, err)
+		}
+	}
+	if done, err := window.advance(start.Add(6*time.Second), true); done || err != nil {
+		t.Fatal("finish did not leave drain window", done, err)
+	}
+	if done, err := window.advance(start.Add(6250*time.Millisecond), true); !done || err != nil {
+		t.Fatal("completed drain was not accepted", done, err)
+	}
+}
+func TestTimeoutWithoutHostFinishFailsIsolationEvidence(t *testing.T) {
+	start := time.Unix(0, 0)
+	window := observationWindow{deadline: start.Add(10 * time.Second)}
+	if done, err := window.advance(start.Add(10*time.Second), false); done || err == nil {
+		t.Fatal("timeout became successful isolation evidence")
+	}
+}
+func TestDroppedKernelEventsInvalidateObservation(t *testing.T) {
+	event := make([]byte, 24)
+	binary.LittleEndian.PutUint16(event[18:20], 3)
+	var result observation
+	if err := recordEvent(&result, 0, event); err == nil {
+		t.Fatal("SYN_DROPPED was ignored")
+	}
+}

--- a/src/platform/linux/multiseat_podman_backend.cpp
+++ b/src/platform/linux/multiseat_podman_backend.cpp
@@ -915,6 +915,16 @@ namespace multiseat::podman {
     } catch (const json::exception &) {
       throw std::runtime_error {"invalid Podman runtime spec"};
     }
+    const auto *process = object_member(spec, "process");
+    const auto *user = process ? object_member(*process, "user") : nullptr;
+    if (!user || !user->contains("uid") || !(*user)["uid"].is_number_unsigned() ||
+        (*user)["uid"].get<std::uint64_t>() != host_.effective_uid()) {
+      throw std::runtime_error {"Podman runtime spec does not preserve the launching uid"};
+    }
+    const auto *annotations = object_member(spec, "annotations");
+    if (!annotations || string_member(*annotations, "run.oci.keep_original_groups") != "1") {
+      throw std::runtime_error {"Podman runtime spec does not preserve supplementary groups"};
+    }
     const auto *mounts = object_member(spec, "mounts");
     if (!mounts || !mounts->is_array() ||
         mounts->size() > maximum_runtime_spec_mounts) {
@@ -1081,7 +1091,7 @@ namespace multiseat::podman {
     const worker_launch_spec_t &spec,
     const input::allocation_t &input_allocation
   ) const {
-    if (!base_host_ready()) {
+    if (!base_host_ready() || !host_.trusted_runtime_file(options_.runtime_executable)) {
       return false;
     }
     const auto worker_authority_directory =
@@ -1151,6 +1161,7 @@ namespace multiseat::podman {
     std::vector<std::string> argv {
       options_.executable.native(),
       "--remote=false",
+      "--runtime=" + options_.runtime_executable.native(),
       "run",
       "--detach",
       "--rm",
@@ -1159,6 +1170,8 @@ namespace multiseat::podman {
       "--name=" + spec.identity.worker_name,
       "--hostname=" + spec.identity.worker_name,
       "--userns=keep-id",
+      "--user=" + std::to_string(host_.effective_uid()),
+      "--group-add=keep-groups",
       "--network=none",
       "--no-hosts",
       "--http-proxy=false",
@@ -1300,8 +1313,10 @@ namespace multiseat::podman {
     if (!input_fingerprint) {
       return worker_command_result_e::rejected;
     }
+    std::optional<std::vector<std::uint64_t>> launching_groups;
     try {
-      if (!launch_host_ready(spec, *input_allocation)) {
+      launching_groups = host_.supplementary_groups();
+      if (!launching_groups || !launch_host_ready(spec, *input_allocation)) {
         return worker_command_result_e::rejected;
       }
     } catch (...) {
@@ -1332,8 +1347,9 @@ namespace multiseat::podman {
         *input_allocation,
         *input_fingerprint
       );
-      if (!gpu_catalog_current() ||
-          !input_allocation_current(*input_allocation)) {
+      if (!host_.trusted_runtime_file(options_.runtime_executable) ||
+          host_.supplementary_groups() != launching_groups ||
+          !gpu_catalog_current() || !input_allocation_current(*input_allocation)) {
         return worker_command_result_e::rejected;
       }
       result = host_.run(
@@ -1477,6 +1493,9 @@ namespace multiseat::podman {
   ) {
     if (!base_host_ready()) {
       throw std::runtime_error {"rootless Podman is unavailable"};
+    }
+    if (require_input_authority && !host_.trusted_runtime_file(options_.runtime_executable)) {
+      throw std::runtime_error {"the admitted crun runtime is unavailable"};
     }
     const auto require_current_gpu_catalog = [this, require_input_authority]() {
       if (require_input_authority && !gpu_catalog_current()) {
@@ -1683,6 +1702,13 @@ namespace multiseat::podman {
              worker_observed_state_e::stopped ||
            never_started);
         if (require_input_authority && !released_stopped_worker) {
+          const auto oci_runtime = string_member(container, "OCIRuntime");
+          const auto *groups = host_config ? object_member(*host_config, "GroupAdd") : nullptr;
+          if (string_member(*config, "User") != std::to_string(host_.effective_uid()) ||
+              !oci_runtime || *oci_runtime != options_.runtime_executable.native() ||
+              !groups || !groups->is_array() || !groups->empty()) {
+            throw std::runtime_error {"Podman worker does not use the admitted input access policy"};
+          }
           if (!device_array || !device_array->is_array() ||
               device_array->size() > maximum_inspected_devices) {
             throw std::runtime_error {"invalid Podman device inventory"};
@@ -1724,8 +1750,8 @@ namespace multiseat::podman {
           // device set when Podman points at it; rootless Podman reports its
           // device bind mounts nowhere else. An inspected device list, when
           // Podman fills one in, must then agree with the spec entry for
-          // entry rather than add to it. Without a spec the inspected list
-          // is the device set.
+          // entry rather than add to it. A live worker also needs the OCI
+          // keep-groups annotation, so inspection alone is insufficient.
           std::vector<declared_device_binding_t> declared;
           if (const auto *spec_path = object_member(container, "OCIConfigPath")) {
             if (!spec_path->is_string()) {
@@ -1775,7 +1801,7 @@ namespace multiseat::podman {
               }
             }
           } else {
-            declared = std::move(inspected);
+            throw std::runtime_error {"Podman worker is missing its OCI input access evidence"};
           }
           if (declared.size() > maximum_inspected_devices) {
             throw std::runtime_error {"invalid Podman device inventory"};

--- a/src/platform/linux/multiseat_podman_backend.h
+++ b/src/platform/linux/multiseat_podman_backend.h
@@ -49,6 +49,10 @@ namespace multiseat::podman {
 
     [[nodiscard]] virtual std::uint64_t effective_uid() const = 0;
     [[nodiscard]] virtual bool executable_file(const std::filesystem::path &path) const = 0;
+    /** Root-owned regular executable under root-owned, non-writable directories. */
+    [[nodiscard]] virtual bool trusted_runtime_file(const std::filesystem::path &path) const = 0;
+    /** Actual calling process groups; absence means the snapshot failed. */
+    [[nodiscard]] virtual std::optional<std::vector<std::uint64_t>> supplementary_groups() const = 0;
     [[nodiscard]] virtual bool readable_directory(const std::filesystem::path &path) const = 0;
     [[nodiscard]] virtual bool private_read_write_directory(
       const std::filesystem::path &path
@@ -149,6 +153,7 @@ namespace multiseat::podman {
 
   struct options_t {
     std::filesystem::path executable {"/usr/bin/podman"};
+    std::filesystem::path runtime_executable {"/usr/bin/crun"};
     std::string deployment_id;
     std::filesystem::path worker_entrypoint {"/usr/bin/polaris-seat-worker"};
     std::filesystem::path ipc_root;

--- a/src/platform/linux/multiseat_podman_host.cpp
+++ b/src/platform/linux/multiseat_podman_host.cpp
@@ -13,6 +13,7 @@
 #include <sys/sysmacros.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <array>
 #include <cerrno>
 #include <limits>
@@ -50,6 +51,33 @@ namespace multiseat::podman {
 
   bool local_host_t::executable_file(const std::filesystem::path &path) const {
     return accessible_as(path, S_IFREG, X_OK);
+  }
+
+  bool local_host_t::trusted_runtime_file(const std::filesystem::path &path) const {
+    if (!path.is_absolute() || path.lexically_normal() != path || path.filename() != "crun") return false;
+    struct stat metadata {};
+    if (lstat(path.c_str(), &metadata) != 0 || !S_ISREG(metadata.st_mode) ||
+        metadata.st_uid != 0 || (metadata.st_mode & (S_IWGRP | S_IWOTH | S_ISUID | S_ISGID)) != 0 ||
+        faccessat(AT_FDCWD, path.c_str(), X_OK, AT_EACCESS) != 0) return false;
+    for (auto directory = path.parent_path();; directory = directory.parent_path()) {
+      if (lstat(directory.c_str(), &metadata) != 0 || !S_ISDIR(metadata.st_mode) ||
+          metadata.st_uid != 0 || (metadata.st_mode & (S_IWGRP | S_IWOTH)) != 0) return false;
+      if (directory == directory.root_path()) break;
+    }
+    return true;
+  }
+
+  std::optional<std::vector<std::uint64_t>> local_host_t::supplementary_groups() const {
+    const auto count = getgroups(0, nullptr);
+    if (count < 0 || count > 65536) return std::nullopt;
+    // Allocate at least one element: getgroups(0, ...) only queries the size.
+    std::vector<gid_t> groups(std::max(count, 1));
+    const auto received = getgroups(static_cast<int>(groups.size()), groups.data());
+    if (received < 0 || received > count) return std::nullopt;
+    std::vector<std::uint64_t> result(groups.begin(), groups.begin() + received);
+    std::sort(result.begin(), result.end());
+    result.erase(std::unique(result.begin(), result.end()), result.end());
+    return result;
   }
 
   bool local_host_t::readable_directory(const std::filesystem::path &path) const {

--- a/src/platform/linux/multiseat_podman_host.h
+++ b/src/platform/linux/multiseat_podman_host.h
@@ -14,6 +14,8 @@ namespace multiseat::podman {
   public:
     [[nodiscard]] std::uint64_t effective_uid() const override;
     [[nodiscard]] bool executable_file(const std::filesystem::path &path) const override;
+    [[nodiscard]] bool trusted_runtime_file(const std::filesystem::path &path) const override;
+    [[nodiscard]] std::optional<std::vector<std::uint64_t>> supplementary_groups() const override;
     [[nodiscard]] bool readable_directory(const std::filesystem::path &path) const override;
     [[nodiscard]] bool private_read_write_directory(
       const std::filesystem::path &path

--- a/tests/integration/test_multiseat_physical.cpp
+++ b/tests/integration/test_multiseat_physical.cpp
@@ -1,364 +1,348 @@
 /**
  * @file tests/integration/test_multiseat_physical.cpp
- * @brief Opt-in physical smoke of the production multiseat composition.
- *
- * Skipped unless POLARIS_MULTISEAT_PHYSICAL=1. Everything else about the run
- * comes from the environment so no host detail is compiled in:
- *   POLARIS_PHYSICAL_IMAGE         digest-pinned worker image reference
- *   POLARIS_PHYSICAL_IPC_ROOT      pre-created mode-0700 runtime root
- *   POLARIS_PHYSICAL_RENDER_NODE   render node path (default /dev/dri/renderD128)
- *   POLARIS_PHYSICAL_GPU_DEVICES   comma-separated device paths, must include
- *                                  the render node (default: the render node)
- *   POLARIS_PHYSICAL_PODMAN        podman executable (default /usr/bin/podman)
- *   POLARIS_PHYSICAL_VOLUME        pre-created profile volume name
- *   POLARIS_PHYSICAL_READY_SECONDS seconds to wait for the worker (default 120)
- *
- * This drives the real controller with the real rootless Podman host, the real
- * inputtino backend, and the real worker transport. It creates virtual input
- * devices on the host and starts one container; it never touches the running
- * Polaris process.
+ * @brief Opt-in two-seat input acceptance through the isolated controller.
+ * Required: POLARIS_MULTISEAT_PHYSICAL=1, POLARIS_PHYSICAL_IMAGE (digest),
+ * POLARIS_PHYSICAL_IPC_ROOT (private parent), POLARIS_PHYSICAL_VOLUME and
+ * POLARIS_PHYSICAL_VOLUME_B (distinct pre-created volumes). PROFILE selects
+ * gamescope/steam/heroic/lutris. No launcher or production adapter is activated.
  */
 #include "src/platform/linux/multiseat_controller_production.h"
+#include "src/platform/linux/multiseat_podman_host.h"
+#include "src/platform/linux/multiseat_moonlight_activation.h"
+#include "src/rtsp.h"
+#include "src/stream.h"
 
 #ifdef __linux__
-
-  #include <chrono>
-  #include <cstdio>
-  #include <cstdlib>
-  #include <filesystem>
-  #include <gtest/gtest.h>
-  #include <iostream>
-  #include <memory>
-  #include <sstream>
-  #include <string>
-  #include <thread>
-  #include <vector>
+extern "C" {
+  #include <moonlight-common-c/src/Input.h>
+}
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cctype>
+#include <fstream>
+#include <map>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
 
 namespace {
   using namespace multiseat;
+  using namespace std::chrono_literals;
+  using json = nlohmann::json;
   namespace input = multiseat::input;
   namespace podman = multiseat::podman;
+  constexpr auto probe = "/usr/bin/polaris-seat-input-probe";
 
-  std::string env_or(const char *name, const std::string &fallback) {
+  std::string env_or(const char *name, const std::string &fallback = {}) {
     const auto *value = std::getenv(name);
-    return value && *value ? std::string {value} : fallback;
+    return value && *value ? value : fallback;
   }
-
   std::vector<std::filesystem::path> split_paths(const std::string &value) {
     std::vector<std::filesystem::path> paths;
     std::stringstream stream {value};
     std::string item;
-    while (std::getline(stream, item, ',')) {
-      if (!item.empty()) {
-        paths.emplace_back(item);
-      }
-    }
+    while (std::getline(stream, item, ',')) if (!item.empty()) paths.emplace_back(item);
     return paths;
   }
+  std::string nonce() { return crypto::rand_alphabet(32, "0123456789abcdef"); }
 
-  std::string shell_output(const std::string &command) {
-    std::string output;
-    if (auto *pipe = ::popen(command.c_str(), "r")) {
-      char buffer[4096];
-      while (auto read = std::fread(buffer, 1, sizeof(buffer), pipe)) {
-        output.append(buffer, read);
-      }
-      ::pclose(pipe);
+  // Own one unique directory. Only remove it when it is still the same inode
+  // and empty; controller reconciliation owns all authority-file cleanup.
+  class private_root_t {
+  public:
+    explicit private_root_t(const std::filesystem::path &parent) {
+      podman::local_host_t host;
+      if (!host.private_read_write_directory(parent)) throw std::runtime_error {"private IPC parent is unavailable"};
+      auto pattern = (parent / "physical-XXXXXX").string();
+      const auto created = mkdtemp(pattern.data());
+      if (!created) throw std::runtime_error {"private IPC root creation failed"};
+      path = created;
+      if (lstat(path.c_str(), &identity) != 0) throw std::runtime_error {"private root identity failed"};
     }
-    return output;
-  }
-
-  void log(const std::string &line) {
-    std::cout << "[physical] " << line << std::endl;
-  }
-
-  void log_podman(const std::string &podman, const std::string &deployment) {
-    log("podman ps:\n" + shell_output(
-      podman + " ps -a --filter label=io.polaris.multiseat.deployment=" +
-      deployment + " --format '{{.ID}} {{.Names}} {{.Status}}' 2>&1"
-    ));
-  }
-
-  void log_worker_inspect(const std::string &podman, const std::string &deployment) {
-    const auto ids = shell_output(
-      podman + " ps -a --filter label=io.polaris.multiseat.deployment=" +
-      deployment + " --format '{{.ID}}' 2>/dev/null"
-    );
-    std::stringstream stream {ids};
-    std::string id;
-    while (std::getline(stream, id)) {
-      if (!id.empty()) {
-        log("inspect " + id + ": " + shell_output(
-          podman + " container inspect " + id +
-          " --format 'Name={{.Name}} Status={{.State.Status}} Health={{.State.Health.Status}} "
-          "Devices={{json .HostConfig.Devices}} Mounts={{json .Mounts}}' 2>&1 | cut -c1-1200"
-        ));
+    bool remove_empty() {
+      struct stat current {};
+      if (lstat(path.c_str(), &current) != 0 || current.st_dev != identity.st_dev || current.st_ino != identity.st_ino) return false;
+      if (rmdir(path.c_str()) != 0) return false;
+      return lstat(path.c_str(), &current) != 0 && errno == ENOENT;
+    }
+    ~private_root_t() {
+      struct stat current {};
+      if (lstat(path.c_str(), &current) == 0 && current.st_dev == identity.st_dev && current.st_ino == identity.st_ino) {
+        // rmdir cannot recursively erase residue or another run's state.
+        (void) rmdir(path.c_str());
       }
     }
+    std::filesystem::path path;
+    struct stat identity {};
+  };
+
+  // Delegate every authority check to the real host, retaining only bounded
+  // command failure output in private test evidence (never argv or auth files).
+  class observed_host_t final : public podman::host_t {
+  public:
+    explicit observed_host_t(std::string &failure): failure_(failure) {}
+    std::uint64_t effective_uid() const override { return host_.effective_uid(); }
+    bool executable_file(const std::filesystem::path &path) const override { const auto result = host_.executable_file(path); if (!result) failure_ = "executable_file: " + path.filename().string(); return result; }
+    bool trusted_runtime_file(const std::filesystem::path &path) const override { const auto result = host_.trusted_runtime_file(path); if (!result) failure_ = "trusted_runtime_file: " + path.filename().string(); return result; }
+    std::optional<std::vector<std::uint64_t>> supplementary_groups() const override { return host_.supplementary_groups(); }
+    bool readable_directory(const std::filesystem::path &path) const override { const auto result = host_.readable_directory(path); if (!result) failure_ = "readable_directory: " + path.filename().string(); return result; }
+    bool private_read_write_directory(const std::filesystem::path &path) const override { const auto result = host_.private_read_write_directory(path); if (!result) failure_ = "private_read_write_directory: " + path.filename().string(); return result; }
+    bool private_readable_file(const std::filesystem::path &path) const override { const auto result = host_.private_readable_file(path); if (!result) failure_ = "private_readable_file: " + path.filename().string(); return result; }
+    std::optional<podman::character_device_identity_t> read_write_character_device(const std::filesystem::path &path) const override { const auto result = host_.read_write_character_device(path); if (!result) failure_ = "device access: " + path.filename().string(); return result; }
+    std::optional<std::string> read_owned_regular_file(const std::filesystem::path &path, std::size_t maximum) const override { return host_.read_owned_regular_file(path, maximum); }
+    podman::command_result_t run(const std::vector<std::string> &argv, std::chrono::milliseconds timeout, std::size_t maximum) override {
+      auto result = host_.run(argv, timeout, maximum);
+      if (result.exit_status != 0 || result.timed_out) failure_ = result.output.substr(0,4096);
+      return result;
+    }
+  private:
+    podman::local_host_t host_;
+    std::string &failure_;
+  };
+
+  using bytes = std::vector<std::uint8_t>;
+  void le16(bytes &out, std::uint16_t value) { out.push_back(value); out.push_back(value >> 8); }
+  void be16(bytes &out, std::uint16_t value) { out.push_back(value >> 8); out.push_back(value); }
+  bytes packet(std::uint32_t magic, bytes body) {
+    const auto length = static_cast<std::uint32_t>(body.size() + 4);
+    bytes result {static_cast<std::uint8_t>(length >> 24), static_cast<std::uint8_t>(length >> 16), static_cast<std::uint8_t>(length >> 8), static_cast<std::uint8_t>(length)};
+    for (int byte = 0; byte < 4; ++byte) result.push_back(magic >> (8*byte));
+    result.insert(result.end(), body.begin(), body.end());
+    return result;
+  }
+  bytes keyboard(bool released) { return packet(released ? KEY_UP_EVENT_MAGIC : KEY_DOWN_EVENT_MAGIC, {0, 0x41, 0, 0, 0, 0}); }
+  bytes gamepad(bool pressed) {
+    bytes body;
+    for (auto word : {MC_HEADER_B, 0, 1, MC_MID_B, pressed ? 0x1000 : 0}) le16(body, word);
+    body.resize(20, 0);
+    le16(body, MC_TAIL_A); le16(body, 0); le16(body, MC_TAIL_B);
+    return packet(MULTI_CONTROLLER_MAGIC_GEN5, body);
+  }
+  void send_markers(stream::session_t &stream, int position) {
+    EXPECT_TRUE(stream::session::route_multiseat_input_for_tests(stream, keyboard(false)));
+    bytes relative; be16(relative, 7); be16(relative, 0);
+    EXPECT_TRUE(stream::session::route_multiseat_input_for_tests(stream, packet(MOUSE_MOVE_REL_MAGIC_GEN5, relative)));
+    bytes absolute; for (auto value : {position, 700, 0, 1920, 1080}) be16(absolute, value);
+    EXPECT_TRUE(stream::session::route_multiseat_input_for_tests(stream, packet(MOUSE_MOVE_ABS_MAGIC, absolute)));
+    EXPECT_TRUE(stream::session::route_multiseat_input_for_tests(stream, gamepad(true)));
+    EXPECT_TRUE(stream::session::route_multiseat_input_for_tests(stream, keyboard(true)));
+    EXPECT_TRUE(stream::session::route_multiseat_input_for_tests(stream, gamepad(false)));
   }
 
-  /** Force-remove anything the controller left behind so the host stays clean. */
-  void cleanup_leftovers(
-    const std::string &podman,
-    const std::string &deployment,
-    const std::string &ipc_root
-  ) {
-    const auto ids = shell_output(
-      podman + " ps -a --filter label=io.polaris.multiseat.deployment=" +
-      deployment + " --format '{{.ID}}' 2>/dev/null"
-    );
-    std::stringstream stream {ids};
-    std::string id;
-    while (std::getline(stream, id)) {
-      if (!id.empty()) {
-        log("LEFTOVER container force-removed: " + id + " " +
-            shell_output(podman + " rm -f " + id + " 2>&1"));
-      }
-    }
-    std::error_code ignored;
-    for (const auto &entry : std::filesystem::directory_iterator {ipc_root, ignored}) {
-      if (entry.path().filename().string().starts_with("polaris-runtime-")) {
-        log("LEFTOVER authority directory removed: " + entry.path().string());
-        std::filesystem::remove_all(entry.path(), ignored);
-      }
-    }
+  bool container_id_valid(std::string_view id) {
+    return id.size() == 64 && std::all_of(id.begin(),id.end(),[](char c){return (c>='0'&&c<='9')||(c>='a'&&c<='f');});
   }
 
-  void log_worker_logs(const std::string &podman, const std::string &deployment) {
-    const auto ids = shell_output(
-      podman + " ps -a --filter label=io.polaris.multiseat.deployment=" +
-      deployment + " --format '{{.ID}}' 2>/dev/null"
-    );
-    std::stringstream stream {ids};
-    std::string id;
-    while (std::getline(stream, id)) {
-      if (!id.empty()) {
-        log("podman logs " + id + ":\n" + shell_output(podman + " logs " + id + " 2>&1 | tail -40"));
-        log("podman inspect state " + id + ": " + shell_output(
-          podman + " inspect --format '{{.State.Status}} health={{.State.Health.Status}} exit={{.State.ExitCode}}' " + id + " 2>&1"
-        ));
-      }
-    }
-  }
+  struct seat_t {
+    seat_snapshot_t snapshot;
+    input::allocation_t allocation;
+    std::string container_id;
+    std::shared_ptr<rtsp_stream::launch_session_t> launch;
+    std::shared_ptr<stream::session_t> stream;
+  };
 
-  const char *input_status_name(input::status_e status) {
-    switch (status) {
-      case input::status_e::applied: return "applied";
-      case input::status_e::already_applied: return "already_applied";
-      case input::status_e::reconciliation_required: return "reconciliation_required";
-      case input::status_e::invalid_request: return "invalid_request";
-      case input::status_e::not_found: return "not_found";
-      case input::status_e::stale_authority: return "stale_authority";
-      case input::status_e::backend_rejected: return "backend_rejected";
-      case input::status_e::backend_indeterminate: return "backend_indeterminate";
-      case input::status_e::backend_protocol_error: return "backend_protocol_error";
-    }
-    return "?";
-  }
-
-  const char *reconcile_name(controller_reconcile_status_e status) {
-    switch (status) {
-      case controller_reconcile_status_e::ready: return "ready";
-      case controller_reconcile_status_e::controller_shutting_down: return "controller_shutting_down";
-      case controller_reconcile_status_e::invalid_input_expectations: return "invalid_input_expectations";
-      case controller_reconcile_status_e::worker_reconciliation_required: return "worker_reconciliation_required";
-      case controller_reconcile_status_e::input_reconciliation_required: return "input_reconciliation_required";
-    }
-    return "?";
-  }
-
-  std::string describe(const controller_reconcile_result_t &result) {
-    std::ostringstream text;
-    const auto &b = result.worker.broker;
-    text << "status=" << reconcile_name(result.status)
-         << " ready=" << (result.ready() ? "yes" : "no")
-         << " worker.admission_ready=" << result.worker.admission_ready
-         << " startup_recovery=" << result.worker.startup_recovery_complete
-         << " authority_blocked=" << result.worker.authority_blocked
-         << " broker{obs=" << b.observations << " current=" << b.current_workers
-         << " orphan=" << b.orphan_workers << " ready_transitions=" << b.ready_transitions
-         << " missing=" << b.missing_workers << " released=" << b.released_seats
-         << " graceful=" << b.graceful_stop_requests << " force=" << b.force_stop_requests
-         << " stuck=" << b.stuck_workers << " protocol_errors=" << b.protocol_errors
-         << " readiness_rejections=" << b.readiness_rejections
-         << " observation_failed=" << b.backend_observation_failed
-         << " authoritative=" << b.inventory_authoritative << "}"
-         << " endpoints{connect=" << result.worker.endpoint_connections
-         << " fail=" << result.worker.endpoint_failures
-         << " heartbeats=" << result.worker.endpoint_heartbeats << "}";
-    if (result.input) {
-      text << " input{status=" << static_cast<int>(result.input->status)
-           << " admission_ready=" << result.input->report.admission_ready << "}";
-    }
-    return text.str();
-  }
-
-  TEST(MultiseatPhysical, OneRealSupervisorWorkerStartsReportsReadyAndTearsDown) {
-    if (env_or("POLARIS_MULTISEAT_PHYSICAL", "") != "1") {
-      GTEST_SKIP() << "set POLARIS_MULTISEAT_PHYSICAL=1 to run against real Podman";
-    }
-    const auto image = env_or("POLARIS_PHYSICAL_IMAGE", "");
-    const auto ipc_root = env_or("POLARIS_PHYSICAL_IPC_ROOT", "");
-    const auto render_node = env_or("POLARIS_PHYSICAL_RENDER_NODE", "/dev/dri/renderD128");
-    const auto devices = split_paths(env_or("POLARIS_PHYSICAL_GPU_DEVICES", render_node));
-    const auto podman_path = env_or("POLARIS_PHYSICAL_PODMAN", "/usr/bin/podman");
-    const auto volume = env_or("POLARIS_PHYSICAL_VOLUME", "pv-physical-a1b2");
-    const auto ready_seconds = std::stoul(env_or("POLARIS_PHYSICAL_READY_SECONDS", "120"));
-    ASSERT_FALSE(image.empty()) << "POLARIS_PHYSICAL_IMAGE is required";
-    ASSERT_FALSE(ipc_root.empty()) << "POLARIS_PHYSICAL_IPC_ROOT is required";
-    const std::string deployment = "physical-smoke";
-
+  TEST(MultiseatPhysical, TwoWorkersReadOnlyTheirAllocatedInputAndStopIndependently) {
+    if (env_or("POLARIS_MULTISEAT_PHYSICAL") != "1") GTEST_SKIP() << "opt-in physical harness";
+    const auto image = env_or("POLARIS_PHYSICAL_IMAGE");
+    const auto parent = env_or("POLARIS_PHYSICAL_IPC_ROOT");
+    const std::array volumes {env_or("POLARIS_PHYSICAL_VOLUME"), env_or("POLARIS_PHYSICAL_VOLUME_B")};
+    ASSERT_FALSE(image.empty()); ASSERT_FALSE(parent.empty());
+    RecordProperty("worker_image", image);
+    RecordProperty("access_policy", "crun-keep-groups-explicit-uid");
+    ASSERT_FALSE(volumes[0].empty()); ASSERT_FALSE(volumes[1].empty()); ASSERT_NE(volumes[0], volumes[1]);
+    const auto profile_name = env_or("POLARIS_PHYSICAL_PROFILE", "gamescope");
+    const std::map<std::string, std::pair<runtime_profile_e, workload_kind_e>> profiles {
+      {"gamescope", {runtime_profile_e::gamescope, workload_kind_e::gamescope}},
+      {"steam", {runtime_profile_e::steam, workload_kind_e::steam}},
+      {"heroic", {runtime_profile_e::heroic, workload_kind_e::heroic}},
+      {"lutris", {runtime_profile_e::lutris, workload_kind_e::lutris}},
+    };
+    ASSERT_TRUE(profiles.contains(profile_name));
+    RecordProperty("runtime_profile", profile_name);
+    const auto [profile, kind] = profiles.at(profile_name);
+    const auto render = env_or("POLARIS_PHYSICAL_RENDER_NODE", "/dev/dri/renderD128");
+    const auto devices = split_paths(env_or("POLARIS_PHYSICAL_GPU_DEVICES", render));
+    const auto executable = env_or("POLARIS_PHYSICAL_PODMAN", "/usr/bin/podman");
+    const auto deployment = "physical-" + nonce();
+    private_root_t root {parent};
+    podman::local_host_t host;
+    const auto command = [&](std::vector<std::string> arguments, std::chrono::milliseconds timeout = 5s) {
+      arguments.insert(arguments.begin(), {executable, "--remote=false"});
+      return host.run(arguments, timeout, 1024*1024);
+    };
     production_controller_options_t options;
     options.enabled = true;
-    options.gpus = {{
-      .logical_gpu_id = "gpu-physical",
-      .render_node = render_node,
-      .devices = devices,
-      .max_seats = 2,
-      .max_encoder_sessions = 2,
-    }};
-    options.podman.executable = podman_path;
+    options.gpus = {{.logical_gpu_id="physical-gpu", .render_node=render, .devices=devices, .max_seats=2, .max_encoder_sessions=2}};
+    options.podman.executable = executable;
+    options.podman.runtime_executable = env_or("POLARIS_PHYSICAL_CRUN", "/usr/bin/crun");
     options.podman.deployment_id = deployment;
-    options.podman.worker_entrypoint = "/usr/bin/polaris-seat-worker";
-    options.podman.ipc_root = ipc_root;
-    options.podman.profiles = {{
-      .profile_key = "physical-gamescope",
-      .opaque_volume_name = volume,
-      .runtime_profile = runtime_profile_e::gamescope,
-      .image_reference = image,
-    }};
-    options.podman.workloads = {{
-      .kind = workload_kind_e::gamescope,
-      .target_id = "physical-smoke",
-    }};
-
-    log("image=" + image + " ipc_root=" + ipc_root + " render=" + render_node +
-        " devices=" + std::to_string(devices.size()) + " podman=" + podman_path);
-    auto created = create_production_controller_runtime(std::move(options));
-    log("create status=" + std::to_string(static_cast<int>(created.status)));
+    options.podman.ipc_root = root.path;
+    for (int index = 0; index < 2; ++index) options.podman.profiles.push_back({
+      .profile_key="physical-profile-"+std::to_string(index), .opaque_volume_name=volumes[index], .runtime_profile=profile, .image_reference=image});
+    options.podman.workloads = {{.kind=kind, .target_id="physical-input-proof"}};
+    ASSERT_TRUE(host.trusted_runtime_file(options.podman.runtime_executable));
+    std::string command_failure;
+    production_controller_factories_t factories;
+    factories.podman_host = [&] { return std::make_unique<observed_host_t>(command_failure); };
+    auto created = create_production_controller_runtime(std::move(options), std::move(factories));
     ASSERT_EQ(created.status, controller_runtime_create_status_e::ready_enabled);
-    ASSERT_TRUE(created.runtime);
     auto controller = std::move(created.runtime);
-
-    const auto initial = controller->reconcile();
-    log("initial reconcile: " + describe(initial));
-    log_podman(podman_path, deployment);
-    ASSERT_TRUE(initial.ready()) << describe(initial);
-
-    seat_request_t request {
-      .client_key = "physical-client",
-      .profile_key = "physical-gamescope",
-      .workload = {.kind = workload_kind_e::gamescope, .target_id = "physical-smoke"},
-      .logical_gpu_id = "gpu-physical",
-      .runtime_profile = runtime_profile_e::gamescope,
-      .data_plane = {
-        .display_topology = display_topology_e::capture_host_with_nested_compositor,
-        .media_pipeline = media_pipeline_e::worker_local_capture_encode,
-      },
-      .display_mode = {1920, 1080, 60000, false},
-      .requested_compositor = compositor_e::gamescope,
-      .encoder_sessions = 1,
+    ASSERT_TRUE(controller);
+    std::array<seat_t, 2> seats;
+    // Scoped failure recovery never scans another deployment or recursively
+    // removes authority. A fallback is test failure, followed by exact-ID reap.
+    auto cleanup = util::fail_guard([&] {
+      for (auto &seat : seats) if (seat.stream) { stream::session::stop(*seat.stream); seat.stream.reset(); }
+      for (int attempt = 0; attempt < 5 && !controller->closed(); ++attempt) {
+        (void) controller->shutdown();
+        if (!controller->closed()) std::this_thread::sleep_for(100ms);
+      }
+      if (!controller->closed()) {
+        ADD_FAILURE() << "controller cleanup required exact-container fallback";
+        for (const auto &seat : seats) if (container_id_valid(seat.container_id)) (void) command({"rm", "--force", "--", seat.container_id});
+        (void) controller->reconcile();
+        (void) controller->shutdown();
+      }
+    });
+    ASSERT_TRUE(controller->reconcile().ready()) << command_failure;
+    for (int index = 0; index < 2; ++index) {
+      seat_request_t request {
+        .client_key="physical-client-"+std::to_string(index), .profile_key="physical-profile-"+std::to_string(index),
+        .workload={.kind=kind, .target_id="physical-input-proof"}, .logical_gpu_id="physical-gpu", .runtime_profile=profile,
+        .data_plane={.display_topology=display_topology_e::capture_host_with_nested_compositor, .media_pipeline=media_pipeline_e::worker_local_capture_encode},
+        .display_mode={1920,1080,60000,false}, .requested_compositor=compositor_e::gamescope, .encoder_sessions=1};
+      const auto admission = controller->admit(request);
+      ASSERT_TRUE(admission.accepted()); ASSERT_TRUE(admission.seat);
+      auto &seat = seats[index]; seat.snapshot = *admission.seat;
+      ASSERT_LT((root.path / seat.snapshot.resources.runtime_namespace / "ipc/control.sock").native().size(), 108U) << "choose a shorter private IPC parent";
+      ASSERT_EQ(controller->bind_runtime(seat.snapshot.handle, compositor_e::gamescope, "isolated input acceptance"), mutation_result_e::applied);
+      const auto started = controller->start_seat(seat.snapshot.handle, {.gamepad_slots=1});
+      ASSERT_TRUE(started.input.input.allocation);
+      seat.allocation = *started.input.input.allocation;
+      ASSERT_TRUE(started.started()) << "status=" << static_cast<int>(started.status) << " worker=" << (started.worker ? static_cast<int>(*started.worker) : -1) << " " << command_failure;
+      const auto inspected = command({"inspect", "--format={{.Id}}", seat.snapshot.resources.worker_name});
+      ASSERT_EQ(inspected.exit_status, 0) << inspected.output;
+      auto candidate_id = inspected.output;
+      while (!candidate_id.empty() && std::isspace(static_cast<unsigned char>(candidate_id.back()))) candidate_id.pop_back();
+      ASSERT_TRUE(container_id_valid(candidate_id));
+      seat.container_id = std::move(candidate_id);
+    }
+    ASSERT_NE(seats[0].container_id, seats[1].container_id);
+    ASSERT_NE(seats[0].snapshot.resources.runtime_namespace, seats[1].snapshot.resources.runtime_namespace);
+    ASSERT_NE(seats[0].snapshot.resources.audio_sink, seats[1].snapshot.resources.audio_sink);
+    const auto deadline = std::chrono::steady_clock::now()+120s;
+    bool selected = false;
+    while (std::chrono::steady_clock::now()<deadline) {
+      (void) controller->reconcile(); selected = true;
+      for (int index=0; index<2; ++index) {
+        auto &seat=seats[index];
+        if (seat.stream) continue;
+        if (!seat.launch) {
+          seat.launch=std::make_shared<rtsp_stream::launch_session_t>();
+          seat.launch->id=100+index; seat.launch->lifecycle_generation=200+index;
+          seat.launch->unique_id="physical-client-"+std::to_string(index);
+          seat.launch->device_name="isolated-input-proof"; seat.launch->session_token=nonce();
+          seat.launch->gcm_key.resize(16); seat.launch->iv.resize(16);
+          seat.launch->perm=static_cast<crypto::PERM>(static_cast<std::uint32_t>(crypto::PERM::input_kbd) | static_cast<std::uint32_t>(crypto::PERM::input_mouse) | static_cast<std::uint32_t>(crypto::PERM::input_controller)); seat.launch->watch_only=false;
+        }
+        if (!controller->select_authenticated_launch(seat.launch,seat.snapshot.handle).selected()) { selected=false; continue; }
+        stream::config_t stream_config {};
+        seat.stream=stream::session::alloc(stream_config,*seat.launch); ASSERT_TRUE(seat.stream);
+        ASSERT_EQ(input::activate_registered_moonlight_session(*seat.stream),input::moonlight_session_activation_status_e::bound);
+      }
+      if (selected) break;
+      std::this_thread::sleep_for(100ms);
+    }
+    ASSERT_TRUE(selected) << "workers did not reach authenticated input readiness";
+    int observation_round = 0;
+    const auto observe = [&](int target, bool both) {
+      std::array<podman::command_result_t,2> results;
+      std::array<std::string,2> tokens {nonce(),nonce()};
+      std::vector<std::jthread> readers;
+      for (int index=0; index<2; ++index) {
+        if (!both && index!=target) continue;
+        json manifest {{"token",tokens[index]}, {"devices",json::array()}, {"absent",json::array()}};
+        for (const auto &node: seats[index].allocation.nodes) manifest["devices"].push_back({{"path",node.worker_path.native()},{"major",node.character_major},{"minor",node.character_minor}});
+        for (const auto &other: seats) for (const auto &node:other.allocation.nodes) manifest["absent"].push_back(node.host_path.native());
+        readers.emplace_back([&,index,body=manifest.dump()] {
+          results[index]=command({"exec","--tty",seats[index].container_id,probe,"observe",body},12s);
+        });
+      }
+      bool ready=false;
+      const auto deadline=std::chrono::steady_clock::now()+2s;
+      while (std::chrono::steady_clock::now()<deadline) {
+        ready=true;
+        for (int index=0; index<2; ++index) if (both || index==target) {
+          if (command({"exec",seats[index].container_id,probe,"ready",tokens[index]},1s).exit_status!=0) ready=false;
+        }
+        if (ready) break;
+        std::this_thread::sleep_for(20ms);
+      }
+      EXPECT_TRUE(ready) << "input readers could not open every allocated node";
+      if (ready) send_markers(*seats[target].stream, 1000 + 100 * observation_round++);
+      // No observer can report success before this host signal, issued only
+      // after every ready observer covered the injection boundary.
+      for (int index=0; index<2; ++index) if (both || index==target) {
+        EXPECT_EQ(command({"exec",seats[index].container_id,probe,"finish",tokens[index]},1s).exit_status,0);
+      }
+      readers.clear(); // join before parsing the completed bounded observation
+      for (int index=0; index<2; ++index) if (both || index==target) {
+        ASSERT_EQ(results[index].exit_status,0) << results[index].output;
+        const auto observation=json::parse(results[index].output);
+        RecordProperty("observation_" + std::to_string(observation_round) + "_seat_" + std::to_string(index), observation.dump());
+        for (int device=0;device<4;++device) {
+          if (index==target) EXPECT_GT(observation["markers"][device].get<int>(),0);
+          else EXPECT_EQ(observation["events"][device].get<int>(),0);
+        }
+      }
     };
-    const auto admitted = controller->admit(request);
-    log("admit rejection=" + std::to_string(static_cast<int>(admitted.rejection)));
-    ASSERT_TRUE(admitted.accepted());
-    ASSERT_TRUE(admitted.seat);
-    const auto handle = admitted.seat->handle;
-    log("seat epoch=" + handle.controller_epoch + " gpu=" + handle.logical_gpu_id +
-        " slot=" + std::to_string(handle.slot) + " gen=" + std::to_string(handle.generation) +
-        " worker=" + admitted.seat->resources.worker_name +
-        " ns=" + admitted.seat->resources.runtime_namespace +
-        " input_seat=" + admitted.seat->resources.input_seat);
-    ASSERT_EQ(
-      controller->bind_runtime(handle, compositor_e::gamescope, "physical smoke"),
-      mutation_result_e::applied
-    );
-
-    const auto started = controller->start_seat(handle, input::plan_t {.gamepad_slots = 1});
-    log("start status=" + std::to_string(static_cast<int>(started.status)) +
-        " worker=" + (started.worker ? std::to_string(static_cast<int>(*started.worker)) : "none") +
-        " input.status=" + std::to_string(static_cast<int>(started.input.status)) +
-        " authority=" + input_status_name(started.input.input.status) +
-        " nodes=" + (started.input.input.allocation ? std::to_string(started.input.input.allocation->nodes.size()) : std::string {"none"}) +
-        " input.prepared=" + (started.input.input.prepared() ? "yes" : "no"));
-    if (started.input.input.allocation) {
-      for (const auto &node : started.input.input.allocation->nodes) {
-        log("  node " + node.host_path.string() + " -> " + node.worker_path.string() +
-            " kernel_name='" + node.kernel_name + "' seat='" + node.host_seat + "' phys='" + node.phys + "'");
+    observe(0,true);
+    observe(1,true);
+    stream::session::stop(*seats[0].stream); seats[0].stream.reset();
+    (void) controller->stop_seat(seats[0].snapshot.handle);
+    const auto stop_deadline=std::chrono::steady_clock::now()+30s;
+    while (controller->seats()>1 && std::chrono::steady_clock::now()<stop_deadline) {
+      (void) controller->reconcile(); std::this_thread::sleep_for(100ms);
+    }
+    ASSERT_EQ(controller->seats(),1U);
+    observe(1,false);
+    stream::session::stop(*seats[1].stream); seats[1].stream.reset();
+    (void) controller->stop_seat(seats[1].snapshot.handle);
+    for (int attempt=0;attempt<300 && controller->seats()!=0;++attempt) {
+      (void) controller->reconcile(); std::this_thread::sleep_for(100ms);
+    }
+    EXPECT_EQ(controller->seats(),0U); EXPECT_EQ(controller->managed_workers(),0U);
+    EXPECT_TRUE(controller->shutdown().closed()); EXPECT_EQ(controller->input_allocations(),0U);
+    const auto listed=command({"ps","--all","--no-trunc","--filter=label=io.polaris.multiseat.deployment="+deployment,"--format={{.ID}}"});
+    EXPECT_EQ(listed.exit_status,0); EXPECT_TRUE(listed.output.empty());
+    EXPECT_TRUE(std::filesystem::is_empty(root.path));
+    for (const auto &seat:seats) for (const auto &node:seat.allocation.nodes) {
+      struct stat current {};
+      if (lstat(node.host_path.c_str(),&current)==0) {
+        EXPECT_FALSE(S_ISCHR(current.st_mode) && static_cast<std::uint64_t>(current.st_dev)==node.filesystem_device && static_cast<std::uint64_t>(current.st_ino)==node.inode);
+      } else {
+        EXPECT_EQ(errno, ENOENT);
+      }
+      const auto sysfs_name = std::filesystem::path {"/sys/dev/char"} /
+        (std::to_string(node.character_major)+":"+std::to_string(node.character_minor)) / "device/name";
+      std::error_code error;
+      const auto exists = std::filesystem::exists(sysfs_name,error);
+      EXPECT_FALSE(error);
+      if (exists) {
+        std::ifstream source {sysfs_name};
+        std::string name;
+        ASSERT_TRUE(static_cast<bool>(std::getline(source,name)));
+        EXPECT_NE(name,node.kernel_name);
       }
     }
-    log_podman(podman_path, deployment);
-    if (!started.started()) {
-      log_worker_logs(podman_path, deployment);
-      const auto report = controller->shutdown();
-      log("shutdown after failed start: status=" + std::to_string(static_cast<int>(report.status)));
-      cleanup_leftovers(podman_path, deployment, ipc_root);
-      FAIL() << "worker did not start";
-    }
-    EXPECT_EQ(controller->seats(), 1U);
-    EXPECT_EQ(controller->managed_workers(), 1U);
-    EXPECT_EQ(controller->input_allocations(), 1U);
-
-    // Poll until the worker is observed ready and its endpoint is connected.
-    bool ready = false;
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds {ready_seconds};
-    while (std::chrono::steady_clock::now() < deadline) {
-      std::this_thread::sleep_for(std::chrono::seconds {2});
-      const auto result = controller->reconcile();
-      log("reconcile: " + describe(result));
-      if (result.worker.broker.ready_transitions != 0 ||
-          result.worker.endpoint_connections != 0) {
-        ready = true;
-        break;
-      }
-      if (controller->seats() == 0) {
-        log("seat vanished during startup");
-        break;
-      }
-    }
-    log_podman(podman_path, deployment);
-    log_worker_inspect(podman_path, deployment);
-    log_worker_logs(podman_path, deployment);
-    EXPECT_TRUE(ready) << "worker never became ready within " << ready_seconds << "s";
-
-    // Heartbeat the endpoint a few times if it connected.
-    for (int i = 0; i < 3 && ready; ++i) {
-      std::this_thread::sleep_for(std::chrono::seconds {2});
-      const auto result = controller->reconcile();
-      log("steady reconcile: " + describe(result));
-    }
-
-    const auto stopped = controller->stop_seat(handle);
-    log("stop status=" + std::to_string(static_cast<int>(stopped.status)) +
-        " broker=" + std::to_string(static_cast<int>(stopped.worker.broker)));
-    const auto stop_deadline = std::chrono::steady_clock::now() + std::chrono::seconds {90};
-    while (std::chrono::steady_clock::now() < stop_deadline &&
-           (controller->seats() != 0 || controller->managed_workers() != 0)) {
-      std::this_thread::sleep_for(std::chrono::seconds {2});
-      const auto result = controller->reconcile();
-      log("teardown reconcile: " + describe(result) +
-          " seats=" + std::to_string(controller->seats()) +
-          " managed=" + std::to_string(controller->managed_workers()));
-    }
-    log_podman(podman_path, deployment);
-    EXPECT_EQ(controller->seats(), 0U);
-    EXPECT_EQ(controller->managed_workers(), 0U);
-
-    controller_shutdown_report_t report;
-    for (int attempt = 0; attempt < 5; ++attempt) {
-      report = controller->shutdown();
-      log("shutdown attempt " + std::to_string(attempt) + ": status=" +
-          std::to_string(static_cast<int>(report.status)));
-      if (report.closed()) {
-        break;
-      }
-      std::this_thread::sleep_for(std::chrono::seconds {3});
-    }
-    EXPECT_TRUE(report.closed());
-    EXPECT_EQ(controller->input_allocations(), 0U);
-    log_podman(podman_path, deployment);
-    cleanup_leftovers(podman_path, deployment, ipc_root);
+    EXPECT_TRUE(root.remove_empty()) << "private authority root was not removed";
   }
-}  // namespace
-
+}
 #endif

--- a/tests/unit/platform/test_multiseat_controller_production.cpp
+++ b/tests/unit/platform/test_multiseat_controller_production.cpp
@@ -356,6 +356,8 @@ namespace {
     }
     return {
       {"ociVersion", "1.2.0"},
+      {"annotations", {{"run.oci.keep_original_groups", "1"}}},
+      {"process", {{"user", {{"uid", 1000}}}}},
       {"mounts", std::move(mounts)},
       {"linux", nlohmann::json::object()},
     };
@@ -375,6 +377,14 @@ namespace {
 
     bool executable_file(const std::filesystem::path &path) const override {
       return path == "/usr/bin/podman" || path == "/usr/libexec/podman/catatonit";
+    }
+
+    bool trusted_runtime_file(const std::filesystem::path &path) const override {
+      return path == "/usr/bin/crun";
+    }
+
+    std::optional<std::vector<std::uint64_t>> supplementary_groups() const override {
+      return std::vector<std::uint64_t> {104, 105};
     }
 
     bool readable_directory(const std::filesystem::path &) const override {
@@ -434,7 +444,9 @@ namespace {
           .output = {},
         };
       }
-      return simulate_locked(argv);
+      auto command = argv;
+      if (command.at(2) == "--runtime=/usr/bin/crun") command.erase(command.begin() + 2);
+      return simulate_locked(command);
     }
 
   private:
@@ -553,8 +565,9 @@ namespace {
           document.push_back({
             {"Id", found->id},
             {"Name", found->name},
-            {"Config", {{"Labels", std::move(labels)}}},
-            {"HostConfig", {{"Devices", nlohmann::json::array()}}},
+            {"Config", {{"Labels", std::move(labels)}, {"User", "1000"}}},
+            {"OCIRuntime", "/usr/bin/crun"},
+            {"HostConfig", {{"Devices", nlohmann::json::array()}, {"GroupAdd", nlohmann::json::array()}}},
             {"OCIConfigPath", runtime_spec_path_for(found->id)},
             {"State", {{"Status", found->status}}},
           });
@@ -1062,7 +1075,7 @@ namespace {
         host_state->commands.begin(),
         host_state->commands.end(),
         [](const auto &command) {
-          return command.size() > 2 && command.at(2) == "run";
+          return command.size() > 3 && command.at(2) == "--runtime=/usr/bin/crun" && command.at(3) == "run";
         }
       ));
     }
@@ -1181,7 +1194,8 @@ namespace {
           host_state->commands.begin(),
           host_state->commands.end(),
           [verb](const auto &command) {
-            return command.size() > 2 && command.at(2) == verb;
+            const auto index = command.size() > 2 && command.at(2) == "--runtime=/usr/bin/crun" ? 3U : 2U;
+            return command.size() > index && command.at(index) == verb;
           }
         );
       };

--- a/tests/unit/platform/test_multiseat_podman_backend.cpp
+++ b/tests/unit/platform/test_multiseat_podman_backend.cpp
@@ -74,12 +74,24 @@ namespace {
 
   class fake_host_t final : public host_t {
   public:
+    fake_host_t();
+
     std::uint64_t effective_uid() const override {
       return uid;
     }
 
     bool executable_file(const std::filesystem::path &path) const override {
       return executable_ready && executable_files.contains(path.native());
+    }
+
+    bool trusted_runtime_file(const std::filesystem::path &path) const override {
+      return runtime_ready && path == "/usr/bin/crun";
+    }
+
+    std::optional<std::vector<std::uint64_t>> supplementary_groups() const override {
+      ++group_reads;
+      if (groups_change_on_recheck && group_reads > 1) return std::vector<std::uint64_t> {};
+      return groups;
     }
 
     bool readable_directory(const std::filesystem::path &path) const override {
@@ -142,6 +154,10 @@ namespace {
 
     std::uint64_t uid = 1000;
     bool executable_ready = true;
+    bool runtime_ready = true;
+    bool groups_change_on_recheck = false;
+    mutable int group_reads = 0;
+    std::optional<std::vector<std::uint64_t>> groups = std::vector<std::uint64_t> {39, 104, 105};
     std::set<std::string> executable_files {
       "/usr/bin/podman",
       "/usr/libexec/podman/catatonit",
@@ -585,6 +601,8 @@ namespace {
     return devices;
   }
 
+  std::string runtime_spec_path_for(std::string_view id);
+
   json container_for(
     const worker_launch_spec_t &spec,
     std::string id,
@@ -599,10 +617,12 @@ namespace {
       {"Status", std::move(health_state)},
     };
     return {
+      {"OCIConfigPath", runtime_spec_path_for(id)},
       {"Id", std::move(id)},
       {"Name", spec.identity.worker_name},
-      {"Config", {{"Labels", labels_for(spec)}}},
-      {"HostConfig", {{"Devices", inspected_devices_for(spec)}}},
+      {"Config", {{"Labels", labels_for(spec)}, {"User", "1000"}}},
+      {"OCIRuntime", "/usr/bin/crun"},
+      {"HostConfig", {{"Devices", inspected_devices_for(spec)}, {"GroupAdd", json::array()}}},
       {"State", std::move(state)},
     };
   }
@@ -863,8 +883,11 @@ TEST(MultiseatPodmanBackend, LaunchBuildsRootlessIsolatedArgumentVector) {
   EXPECT_FALSE(any_argument_contains(argv, "nocreate"));
   EXPECT_EQ(argv.at(0), "/usr/bin/podman");
   EXPECT_EQ(argv.at(1), "--remote=false");
-  EXPECT_EQ(argv.at(2), "run");
+  EXPECT_EQ(argv.at(2), "--runtime=/usr/bin/crun");
+  EXPECT_EQ(argv.at(3), "run");
+  EXPECT_TRUE(has_argument(argv, "--group-add=keep-groups"));
   EXPECT_TRUE(has_argument(argv, "--userns=keep-id"));
+  EXPECT_TRUE(has_argument(argv, "--user=1000"));
   EXPECT_TRUE(has_argument(argv, "--network=none"));
   EXPECT_TRUE(has_argument(argv, "--no-hosts"));
   EXPECT_TRUE(has_argument(argv, "--http-proxy=false"));
@@ -965,7 +988,7 @@ TEST(MultiseatPodmanBackend, LaunchBuildsRootlessIsolatedArgumentVector) {
   EXPECT_FALSE(any_argument_contains(argv, "/dev/uinput"));
   EXPECT_FALSE(any_argument_contains(argv, "/dev/uhid"));
   EXPECT_FALSE(has_argument(argv, "--device=/dev/input:/dev/input:rw"));
-  EXPECT_FALSE(any_argument_contains(argv, "keep-groups"));
+  EXPECT_TRUE(has_argument(argv, "--group-add=keep-groups"));
   EXPECT_FALSE(any_argument_contains(argv, "POLARIS_AUTH_TOKEN"));
   EXPECT_FALSE(any_argument_contains(argv, std::string(64, '0')));
 }
@@ -1223,7 +1246,15 @@ TEST(MultiseatPodmanBackend, InventoryRejectsChangedInputManifestAndBindings) {
   missing_binding["HostConfig"]["Devices"].erase(
     missing_binding["HostConfig"]["Devices"].end() - 1
   );
-  expect_inventory_rejected(std::move(missing_binding));
+  expect_inventory_rejected(std::move(missing_binding), [](fake_host_t &host) {
+    auto &text = host.owned_files.at(runtime_spec_path_for(first_id));
+    auto spec = json::parse(text);
+    auto &mounts = spec["mounts"];
+    mounts.erase(std::remove_if(mounts.begin(), mounts.end(), [](const json &mount) {
+      return mount["destination"] == "/dev/input/polaris-gamepad-0";
+    }), mounts.end());
+    text = spec.dump();
+  });
 
   auto changed_alias = container_for(spec, first_id, "running", "healthy");
   changed_alias["HostConfig"]["Devices"][2]["PathInContainer"] =
@@ -1294,6 +1325,11 @@ TEST(MultiseatPodmanBackend, InventoryAcceptsEquivalentReconstructedHostNode) {
   auto container = container_for(spec, first_id, "running", "healthy");
   container["HostConfig"]["Devices"][2]["PathOnHost"] =
     "/dev/input/reconstructed-event10";
+  auto oci_spec = json::parse(host.owned_files.at(runtime_spec_path_for(first_id)));
+  for (auto &mount : oci_spec["mounts"]) {
+    if (mount["destination"] == "/dev/input/polaris-keyboard") mount["source"] = "/dev/input/reconstructed-event10";
+  }
+  host.owned_files[runtime_spec_path_for(first_id)] = oci_spec.dump();
   queue_inventory(host, {std::move(container)});
 
   const auto observations = backend.inventory();
@@ -1779,9 +1815,17 @@ namespace {
     ));
     return {
       {"ociVersion", "1.2.0"},
+      {"annotations", {{"run.oci.keep_original_groups", "1"}}},
+      {"process", {{"user", {{"uid", 1000}}}}},
       {"mounts", std::move(mounts)},
       {"linux", json::object()},
     };
+  }
+
+  fake_host_t::fake_host_t() {
+    owned_files[runtime_spec_path_for(first_id)] = runtime_spec_for(valid_spec(), first_id).dump();
+    owned_files[runtime_spec_path_for(second_id)] = runtime_spec_for(
+      valid_spec(1, 2, "polaris-worker-controller-a1b2-2", "profile beta", "heroic-game"), second_id).dump();
   }
 
   json rootless_container_for(
@@ -2258,6 +2302,7 @@ TEST(MultiseatPodmanBackend, InventoryRejectsUnusableRuntimeSpecFiles) {
   {
     SCOPED_TRACE("spec missing");
     fake_host_t host;
+    host.owned_files.clear();
     fake_input_manifest_source_t inputs;
     backend_t backend {host, inputs, options_for_tests()};
     queue_inventory(host, {rootless_container_for(spec, first_id, "running", "healthy")});
@@ -2409,6 +2454,7 @@ TEST(MultiseatPodmanBackend, NeverStartedRootlessWorkerIsStoppedOnceItsAllocatio
   // With its allocation still resolving it is a launch in flight: the missing
   // spec makes the inventory indeterminate rather than releasing the seat.
   fake_host_t launching_host;
+  launching_host.owned_files.clear();
   fake_input_manifest_source_t launching_inputs;
   backend_t launching_backend {launching_host, launching_inputs, options_for_tests()};
   queue_inventory(launching_host, {rootless_container_for(spec, first_id, "created", "")});
@@ -2449,6 +2495,92 @@ TEST(MultiseatPodmanBackend, StopNeverReadsTheRuntimeSpec) {
       "/usr/bin/podman", "--remote=false", "kill", "--signal=TERM", first_id,
     })
   );
+}
+
+TEST(MultiseatPodmanBackend, LaunchRequiresTrustedCrunAndActualProcessGroupSnapshot) {
+  for (int failure = 0; failure < 4; ++failure) {
+    const auto spec = valid_spec();
+    fake_host_t host;
+    fake_input_manifest_source_t inputs;
+    auto options = options_for_tests();
+    if (failure == 0) host.runtime_ready = false;
+    if (failure == 1) options.runtime_executable = "/usr/bin/runc";
+    if (failure == 2) host.groups.reset();
+    if (failure == 3) {
+      host.groups_change_on_recheck = true;
+      host.push({.exit_status = 0}); // Existing profile volume.
+    }
+    backend_t backend {host, inputs, options};
+    EXPECT_EQ(backend.launch(spec), worker_command_result_e::rejected);
+    EXPECT_EQ(host.calls.size(), failure == 3 ? 1U : 0U);
+  }
+}
+
+TEST(MultiseatPodmanBackend, CleanupSurvivesLostRuntimeAndGroups) {
+  const auto spec = valid_spec();
+  fake_host_t host;
+  host.runtime_ready = false;
+  host.groups.reset();
+  fake_input_manifest_source_t inputs;
+  inputs.missing = true;
+  auto options = options_for_tests();
+  options.runtime_executable = "/usr/bin/missing-crun";
+  backend_t backend {host, inputs, options};
+  auto container = rootless_container_for(spec, first_id, "running");
+  container["OCIRuntime"] = "runc";
+  container["HostConfig"]["GroupAdd"] = json::array();
+  queue_inventory(host, {container});
+  host.push({.exit_status = 0});
+  EXPECT_EQ(backend.stop(spec.identity, worker_stop_mode_e::force), worker_command_result_e::applied);
+  EXPECT_EQ(host.group_reads, 0);
+  EXPECT_EQ(host.owned_file_reads, 0U);
+}
+
+TEST(MultiseatPodmanBackend, InventoryRequiresCrunAndKeepGroupsEvidence) {
+  const auto spec = valid_spec();
+  const auto valid = runtime_spec_for(spec, first_id);
+  for (int failure = 0; failure < 5; ++failure) {
+    auto runtime_spec = valid;
+    if (failure == 0) runtime_spec.erase("annotations");
+    if (failure == 1) runtime_spec["annotations"]["run.oci.keep_original_groups"] = "0";
+    expect_rootless_inventory_rejected(spec, runtime_spec, failure < 2 ? 1U : 0U,
+      [failure](json &container) {
+        if (failure == 2) container["OCIRuntime"] = "runc";
+        if (failure == 3) container["HostConfig"].erase("GroupAdd");
+        if (failure == 4) container["HostConfig"]["GroupAdd"] = json::array({"keep-groups", "104"});
+      });
+  }
+}
+
+TEST(MultiseatPodmanBackend, InventoryRejectsImageUserOverrideOrChangedOciUid) {
+  const auto spec = valid_spec();
+  for (int failure = 0; failure < 5; ++failure) {
+    auto runtime_spec = runtime_spec_for(spec, first_id);
+    if (failure == 0) runtime_spec.erase("process");
+    if (failure == 1) runtime_spec["process"]["user"]["uid"] = 0;
+    if (failure == 2) runtime_spec["process"]["user"]["uid"] = "1000";
+    expect_rootless_inventory_rejected(spec, runtime_spec, failure < 3 ? 1U : 0U,
+      [failure](json &container) {
+        if (failure == 3) container["Config"]["User"] = "0";
+        if (failure == 4) container["Config"].erase("User");
+      });
+  }
+}
+
+TEST(MultiseatPodmanBackend, RecoveryRejectsUnsupportedOrUntrustedRuntimeBeforeObservation) {
+  for (const auto path : {"/usr/bin/runc", "/tmp/crun", "/usr/bin/crun"}) {
+    fake_host_t host;
+    host.runtime_ready = false;
+    fake_input_manifest_source_t inputs;
+    auto options = options_for_tests();
+    options.runtime_executable = path;
+    backend_t backend {host, inputs, options};
+    auto container = container_for(valid_spec(), first_id, "running");
+    container["OCIRuntime"] = path;
+    queue_inventory(host, {container});
+    EXPECT_THROW(backend.inventory(), std::runtime_error);
+    EXPECT_TRUE(host.calls.empty());
+  }
 }
 
 #endif

--- a/tests/unit/platform/test_multiseat_podman_host.cpp
+++ b/tests/unit/platform/test_multiseat_podman_host.cpp
@@ -93,4 +93,35 @@ TEST(MultiseatPodmanHost, RefusesAnythingButAnOwnedRegularFile) {
   }
 }
 
+TEST(MultiseatPodmanHost, ReadsRunningProcessGroupsInsteadOfAccountMembership) {
+  multiseat::podman::local_host_t host;
+  const auto actual = host.supplementary_groups();
+  ASSERT_TRUE(actual);
+  const auto count = getgroups(0, nullptr);
+  ASSERT_GE(count, 0);
+  std::vector<gid_t> groups(std::max(count, 1));
+  const auto received = getgroups(static_cast<int>(groups.size()), groups.data());
+  ASSERT_GE(received, 0);
+  std::vector<std::uint64_t> expected(groups.begin(), groups.begin() + received);
+  std::sort(expected.begin(), expected.end());
+  expected.erase(std::unique(expected.begin(), expected.end()), expected.end());
+  EXPECT_EQ(*actual, expected);
+}
+
+TEST(MultiseatPodmanHost, RefusesUserControlledOrIndirectRuntime) {
+  temporary_directory_t root;
+  multiseat::podman::local_host_t host;
+  write_file(root.path() / "crun", "executable");
+  ASSERT_EQ(chmod((root.path() / "crun").c_str(), 0755), 0);
+  std::filesystem::create_directory(root.path() / "links");
+  std::filesystem::create_symlink(root.path() / "crun", root.path() / "links/crun");
+  std::filesystem::create_directory_symlink("/usr/bin", root.path() / "bin-link");
+  EXPECT_FALSE(host.trusted_runtime_file(root.path() / "crun"));
+  EXPECT_FALSE(host.trusted_runtime_file(root.path() / "links/crun"));
+  EXPECT_FALSE(host.trusted_runtime_file(root.path() / "bin-link/crun"));
+  EXPECT_FALSE(host.trusted_runtime_file("crun"));
+  EXPECT_FALSE(host.trusted_runtime_file("/usr/bin/runc"));
+  EXPECT_FALSE(host.trusted_runtime_file("/usr/bin/../bin/crun"));
+}
+
 #endif


### PR DESCRIPTION
Rootless workers need the launching service's actual supplementary groups to read their reserved event nodes. Require a trusted crun executable, preserve groups with `keep-groups`, and explicitly pin the launching UID so an image `USER` cannot replace the paired input identity. Authoritative inventory checks the selected runtime, keep-groups annotation, and both container/OCI UID evidence. Cleanup remains available after runtime, group, or input authority disappears.

Adds an opt-in SELinux policy limited to reading the dedicated reserved device type and a matching udev rule. Nothing installs the policy or enables production adapters automatically. The existing mount classifier and exact GPU/input inventory remain in force.

The isolated harness now runs two workers, opens all four allocated aliases, injects bounded host-authorized events, checks the other seat and singleton devices are absent, stops one worker while the other continues, and verifies worker/authority/device teardown. A packaged Go probe requires a post-injection finish signal and rejects timeouts, dropped events, and unexpected nodes.

Validation: 238 native multiseat tests; 15 production/host tests; Go probe tests with the race detector; independent authority and harness review. A development Gamescope image passed the physical harness both directly and through a user service with SELinux enforcing. A controlled policy comparison established the device-label denial; effective policy grants only read/open/getattr. Final exact-source checks and four-profile artifact acceptance remain pending. These results do not establish game streaming.
