### PR TITLE
Build four locked multiseat runtime roots and verifiable OCI artifacts

### DIFF
--- a/.github/workflows/multiseat-images.yml
+++ b/.github/workflows/multiseat-images.yml
@@ -1,0 +1,74 @@
+name: Multiseat runtime images
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'containers/multiseat/**'
+      - 'multiseat_worker/**'
+      - '.github/workflows/multiseat-images.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'containers/multiseat/**'
+      - 'multiseat_worker/**'
+      - '.github/workflows/multiseat-images.yml'
+  workflow_dispatch:
+    inputs:
+      nvidia:
+        type: boolean
+        default: false
+        description: Build the locked NVIDIA userspace variant for the physical lane
+
+permissions:
+  contents: read
+
+concurrency:
+  group: multiseat-images-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  image:
+    name: Image and provider dependencies (${{ matrix.profile }}, linux/amd64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [gamescope, steam, heroic, lutris]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Fetch and verify locked inputs
+        env:
+          PROFILE: ${{ matrix.profile }}
+          NVIDIA: ${{ inputs.nvidia || 'false' }}
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s containers/multiseat -p 'test_*.py'
+          arguments=("$PROFILE")
+          if [ "$NVIDIA" = true ]; then arguments+=(--nvidia); fi
+          python3 containers/multiseat/prepare-inputs.py "${arguments[@]}"
+      - name: Build offline and validate real providers
+        env:
+          PROFILE: ${{ matrix.profile }}
+          NVIDIA: ${{ inputs.nvidia || 'false' }}
+        run: |
+          set -euo pipefail
+          arguments=("$PROFILE")
+          if [ "$NVIDIA" = true ]; then arguments+=(--nvidia); fi
+          python3 containers/multiseat/build-image.py "${arguments[@]}"
+      - name: Downloadable OCI and provenance
+        uses: actions/upload-artifact@v6
+        with:
+          name: polaris-worker-${{ matrix.profile }}-${{ github.event.pull_request.head.sha || github.sha }}
+          compression-level: 0
+          retention-days: 14
+          if-no-files-found: error
+          path: |
+            build/worker-artifacts/**/worker.oci.tar
+            build/worker-artifacts/**/artifact.json
+            build/worker-artifacts/**/packages.tsv
+            build/worker-artifacts/**/sbom.cdx.json
+            build/worker-artifacts/**/providers.json

--- a/containers/multiseat/Containerfile
+++ b/containers/multiseat/Containerfile
@@ -1,9 +1,41 @@
-# syntax=docker/dockerfile:1.7
-
 # Both defaults are immutable OCI index digests mirrored in images.lock.json.
 # The runtime can be replaced only with another digest from that lock file.
 ARG GO_BUILDER_IMAGE=docker.io/library/golang@sha256:e8c859f5632dcfde7b32d2012b4351728f6437930887c2f6a91ea242459e5514
 ARG RUNTIME_IMAGE=ghcr.io/games-on-whales/base-app@sha256:1d7b61da242e767bc5c80c5fe897392b6a9e6854345d3dea6d2f799e7ea98a14
+
+# Each profile compiles its Wayland plugin against its own locked source root.
+# All inputs below have already been fetched and are checked against repo locks.
+FROM ${RUNTIME_IMAGE} AS runtime-root-build
+ARG RUNTIME_PROFILE=gamescope
+USER 0
+COPY containers/multiseat/locks/${RUNTIME_PROFILE}.packages.json /locks/packages.json
+COPY containers/multiseat/locks/rust.json /locks/rust.json
+COPY containers/multiseat/locks/plugin.json /locks/plugin.json
+COPY containers/multiseat/locks/gamescope.json /locks/gamescope.json
+COPY containers/multiseat/verify-inputs.py /verify-inputs.py
+COPY containers/multiseat/install-packages.sh /install-packages.sh
+COPY build/runtime-inputs/${RUNTIME_PROFILE}/build /inputs/packages
+COPY build/runtime-inputs/toolchains/rust-1.89.0-x86_64-unknown-linux-gnu.tar.xz /inputs/rust.tar.xz
+COPY build/runtime-inputs/plugin.tar /inputs/plugin.tar
+COPY build/runtime-inputs/gamescope.tar /inputs/gamescope.tar
+RUN sh /install-packages.sh build && \
+    mkdir -p /toolchain /src && \
+    tar -xf /inputs/rust.tar.xz -C /toolchain --strip-components=1 && \
+    /toolchain/install.sh --prefix=/opt/rust --components=rustc,cargo,rust-std-x86_64-unknown-linux-gnu --disable-ldconfig && \
+    tar -xf /inputs/plugin.tar -C /src
+ENV PATH=/opt/rust/bin:$PATH \
+    CARGO_NET_OFFLINE=true \
+    SOURCE_DATE_EPOCH=1754524800
+WORKDIR /src
+RUN cargo build --frozen --release -p gst-plugin-wayland-display && \
+    test -f target/release/libgstwaylanddisplaysrc.so
+RUN mkdir /gamescope-src && tar -xf /inputs/gamescope.tar -C /gamescope-src && \
+    meson setup /gamescope-src/build /gamescope-src --prefix=/usr --buildtype=release --wrap-mode=nodownload \
+      -Ddefault_library=static -Denable_openvr_support=false -Denable_gamescope_wsi_layer=false \
+      -Dpipewire=enabled -Ddrm_backend=enabled -Dsdl2_backend=disabled -Davif_screenshots=disabled \
+      -Dinput_emulation=disabled -Dbenchmark=disabled -Drt_cap=disabled && \
+    meson compile -C /gamescope-src/build -j 8 && \
+    DESTDIR=/gamescope-root meson install -C /gamescope-src/build --no-rebuild
 
 FROM ${GO_BUILDER_IMAGE} AS worker-build
 WORKDIR /src
@@ -19,6 +51,7 @@ COPY multiseat_worker/internal ./internal
 COPY multiseat_worker/cmd ./cmd
 COPY containers/multiseat/Containerfile /containers/multiseat/Containerfile
 COPY containers/multiseat/images.lock.json /containers/multiseat/images.lock.json
+COPY containers/multiseat/locks /containers/multiseat/locks
 # The image contract tests read these two production sources through the same
 # repository-relative path they use for the Containerfile and lock above.
 COPY multiseat_worker/main.go /multiseat_worker/main.go
@@ -41,13 +74,44 @@ RUN go test -trimpath ./... && \
       -o /out/polaris-seat-display-capture ./cmd/polaris-seat-display-capture && \
     go build -trimpath -buildvcs=false \
       -ldflags='-buildid= -s -w' \
-      -o /out/polaris-seat-nested-compositor ./cmd/polaris-seat-nested-compositor
+      -o /out/polaris-seat-nested-compositor ./cmd/polaris-seat-nested-compositor && \
+    go build -trimpath -buildvcs=false -ldflags='-buildid= -s -w' \
+      -o /out/polaris-seat-input-probe ./cmd/polaris-seat-input-probe && \
+    go test -c -trimpath -o /out/provider-tests ./internal/seatprovider
 
-FROM ${RUNTIME_IMAGE}
+FROM ${RUNTIME_IMAGE} AS runtime-root
+ARG RUNTIME_PROFILE=gamescope
+ARG POLARIS_REVISION=unknown
+USER 0
+COPY containers/multiseat/locks/${RUNTIME_PROFILE}.packages.json /locks/packages.json
+COPY containers/multiseat/verify-inputs.py /verify-inputs.py
+COPY containers/multiseat/install-packages.sh /install-packages.sh
+COPY build/runtime-inputs/${RUNTIME_PROFILE}/runtime /inputs/packages
+RUN sh /install-packages.sh runtime && \
+    mkdir -p /usr/share/polaris/build && \
+    cp /locks/packages.json /usr/share/polaris/build/packages.lock.json && \
+    dpkg-query -W -f='${Package}\t${Version}\t${Architecture}\n' > /usr/share/polaris/build/packages.tsv && \
+    cp -L /usr/bin/Xwayland /tmp/polaris-Xwayland && \
+    rm /usr/bin/Xwayland && \
+    install -m 0755 /tmp/polaris-Xwayland /usr/bin/Xwayland && \
+    rm -rf /inputs /locks /verify-inputs.py /install-packages.sh /tmp/polaris-Xwayland
+COPY --from=runtime-root-build --chmod=0644 /src/target/release/libgstwaylanddisplaysrc.so /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwaylanddisplaysrc.so
+COPY --from=runtime-root-build --chmod=0755 /gamescope-root/usr/bin/gamescope /usr/bin/gamescope
+COPY --from=runtime-root-build /gamescope-root/usr/share/gamescope /usr/share/gamescope
+COPY containers/multiseat/locks/gamescope.json /usr/share/polaris/build/gamescope.lock.json
+COPY containers/multiseat/locks/plugin.json /usr/share/polaris/build/plugin.lock.json
+COPY containers/multiseat/check-runtime.py /check-runtime.py
+RUN python3 /check-runtime.py && rm /check-runtime.py
+
+FROM runtime-root AS worker-base
+ARG RUNTIME_PROFILE=gamescope
 ARG POLARIS_REVISION=unknown
 LABEL org.opencontainers.image.source="https://github.com/papi-ux/polaris" \
       org.opencontainers.image.revision="${POLARIS_REVISION}" \
-      org.opencontainers.image.description="Isolated Polaris multiseat worker"
+      org.opencontainers.image.description="Isolated Polaris multiseat worker" \
+      io.polaris.multiseat.profile="${RUNTIME_PROFILE}" \
+      io.polaris.multiseat.architecture="linux/amd64"
+COPY --from=worker-build --chmod=0555 /out/polaris-seat-input-probe /usr/bin/polaris-seat-input-probe
 COPY --from=worker-build --chmod=0555 /out/polaris-seat-worker /usr/bin/polaris-seat-worker
 COPY --from=worker-build --chmod=0555 /out/polaris-seat-runtime /usr/bin/polaris-seat-runtime
 COPY --from=worker-build --chmod=0555 /out/polaris-seat-session-bus /usr/libexec/polaris-seat/session-bus
@@ -72,3 +136,33 @@ HEALTHCHECK NONE
 STOPSIGNAL SIGTERM
 ENTRYPOINT ["/usr/bin/polaris-seat-worker"]
 CMD ["run"]
+
+# The test executable is not included in produced worker artifacts.
+FROM worker-base AS provider-test
+RUN install -d -m 1777 /tmp/.X11-unix
+COPY --from=worker-build --chmod=0555 /out/provider-tests /usr/bin/provider-tests
+ENV POLARIS_TEST_REQUIRE_REAL_PROVIDERS=1
+ENTRYPOINT ["/usr/bin/provider-tests"]
+CMD ["-test.v", "-test.run=TestReal|TestTwoReal", "-test.timeout=3m"]
+
+# Optional physical-lane userspace, extracted only inside the build container.
+FROM runtime-root-build AS nvidia-userspace
+COPY containers/multiseat/locks/nvidia.json /nvidia.lock.json
+COPY containers/multiseat/package-nvidia.py /package-nvidia.py
+COPY build/runtime-inputs/NVIDIA-Linux-x86_64-610.57.04.run /nvidia.run
+RUN python3 /package-nvidia.py
+
+FROM worker-base AS worker-nvidia
+COPY --from=nvidia-userspace /nvidia-root/ /
+RUN ldconfig
+LABEL io.polaris.multiseat.nvidia.driver="610.57.04"
+
+FROM worker-nvidia AS provider-nvidia-test
+RUN install -d -m 1777 /tmp/.X11-unix
+COPY --from=worker-build --chmod=0555 /out/provider-tests /usr/bin/provider-tests
+ENV POLARIS_TEST_REQUIRE_REAL_PROVIDERS=1
+ENTRYPOINT ["/usr/bin/provider-tests"]
+CMD ["-test.v", "-test.run=TestReal|TestTwoReal", "-test.timeout=3m"]
+
+# Default artifacts preserve the existing launcher roots and automatic drivers.
+FROM worker-base AS worker

--- a/containers/multiseat/README.md
+++ b/containers/multiseat/README.md
@@ -3,30 +3,31 @@
 This directory defines an offline-reviewable image recipe. It does not enable
 multiseat or make the current Polaris process a container controller.
 
-`images.lock.json` contains the only accepted build and runtime inputs. Every
-reference names an immutable OCI index digest; moving tags are intentionally
-absent. The plain Gamescope-capable base and the Steam, Heroic, and Lutris
-variants all receive the same static `polaris-seat-worker`,
+`images.lock.json` distinguishes immutable source roots, dependency locks, and
+produced worker artifacts. The Gamescope, Steam, Heroic, and Lutris source roots
+each receive an offline runtime dependency stage, a Wayland GStreamer plugin
+compiled against that root's ABI, pinned Gamescope 3.16.19, and the same static `polaris-seat-worker`,
 `polaris-seat-runtime` dispatcher, and private session-bus, audio,
 display/capture, and nested Gamescope provider binaries. Keeping the launchers
 separate avoids multiplying package and credential state inside one large
 image.
 
-The build stage has no module or package download step. The worker, dispatcher,
+Final build stages have no module or package download step. The worker, dispatcher,
 and four providers use only the Go standard library, disable CGO and
 module-network access, run their tests, then emit static Linux/amd64 binaries.
 The final stage fails its build unless the locked root supplies the fixed D-Bus,
 PipeWire, `pw-cli`, `pactl`, GStreamer, Gamescope, and Xwayland executables; the
 `waylanddisplaysrc`, `unixfdsink`, `unixfdsrc`, and `fakesink` elements; and both
-trusted PipeWire configuration files. A future image job must select a
-runtime reference from the lock, build at an exact Polaris revision, record
-the resulting image digest, and hand only that final digest to the Podman
-backend. The existing locked application roots have not yet passed that new
-GStreamer dependency gate; no compatible image is claimed by this checkpoint.
+trusted PipeWire configuration files. The image job builds all four Linux/amd64
+profiles at an exact Polaris revision and exports downloadable OCI archives,
+verified manifest and configuration digests, package manifests, CycloneDX SBOMs,
+dependency lock hashes, and isolated real-provider receipts. See
+[RUNTIME-IMAGES.md](RUNTIME-IMAGES.md) for the fetch/build split, NVIDIA physical
+lane, acceptance scope, and lock refresh procedure.
 
 These locks establish immutable byte identity, not publisher trust. No
-signature, attestation, SBOM, vulnerability policy, or license bundle is
-claimed by this spike. A publishable image must add those gates and retain the
+signature, attestation, vulnerability policy, or complete license bundle is
+claimed by this milestone. A publishable image must add those gates and retain the
 resolved upstream manifests as provenance evidence before any lock refresh.
 
 The current entrypoint is intentionally a supervisor and IPC proof. It owns
@@ -225,7 +226,7 @@ but Gamescope 3.16 has no exact render-node-path selector. Exact GPU authority
 therefore remains the container backend's explicit device allowlist and outer
 Wayland binding, not an environment-variable claim.
 
-Gamescope 3.16.25's `--ready-fd` option is a FIFO path despite its name. It
+Gamescope 3.16.19's `--ready-fd` option is a FIFO path despite its name. It
 writes exactly one `DISPLAY WAYLAND_DISPLAY` line only after its Xwayland
 server and compositor context initialize. Polaris creates that FIFO and the
 limiter file under the private runtime, rejects any pre-existing Gamescope

--- a/containers/multiseat/RUNTIME-IMAGES.md
+++ b/containers/multiseat/RUNTIME-IMAGES.md
@@ -96,6 +96,27 @@ NVIDIA support must never import arbitrary CDI-generated mounts. SELinux remains
 enforcing; denied GPU access is a separate admission failure, not permission to
 enable blanket container device access or disable labeling.
 
+For SELinux hosts whose ordinary container domain cannot access NVIDIA nodes,
+`selinux/polaris_nvidia_worker.te` provides a separate opt-in physical-test domain.
+Build it using the host-compatible reference-policy development headers, including
+the installed `container_domain_template` interface, in a private working directory:
+
+```sh
+make -f /usr/share/selinux/devel/Makefile polaris_nvidia_worker.pp
+```
+
+It requires the dedicated input-device type from the input-access policy. Inspect
+the expanded policy and verify the module is absent before temporary installation.
+Record the installed module checksum from `semodule -l -m`. Explicit physical
+containers select `--security-opt=label=type:polaris_nvidia_worker_t` and retain
+Podman's fresh MCS categories, private namespaces, dropped capabilities, and exact
+catalog devices. Verify the effective process label and distinct MCS categories.
+Ordinary `container_t`, existing device labels, and broad device booleans remain
+unchanged. The standard template includes file-management permissions; Linux
+capability removal and mount admission are essential complementary controls.
+After validation, remove only the module matching the recorded checksum, once
+all test containers have stopped. No code installs this policy automatically.
+
 The test-only `provider-nvidia-test` stage includes real-provider tests and a
 private X11 socket-directory fixture. The worker artifact excludes that test
 binary. Run the eight real provider tests with exact device admission, requiring
@@ -111,6 +132,13 @@ input harness must open each seat's exact allocated nodes, receive bounded host
 authority events, reject other-seat and singleton nodes, and stop one worker
 without affecting the other. Repeat that harness for each produced profile,
 including from a user service with its actual supplementary groups.
+
+Providers retain bounded `O_PATH` descriptors for captured artifacts until
+child shutdown and cleanup finish, preventing inode reuse from turning a
+replacement into an apparently owned artifact. Pins are close-on-exec, deduplicate
+aliases, reject symlinks, and fail closed at their descriptor limit. Private
+runtime directories remain part of the trust boundary: inode retention does not
+make a pathname check followed by unlink atomic against a concurrent writer.
 
 None of these receipts proves successful game streaming. Production `run` still
 injects no lifecycle adapters. Virtual-input provider integration, worker-local

--- a/containers/multiseat/RUNTIME-IMAGES.md
+++ b/containers/multiseat/RUNTIME-IMAGES.md
@@ -17,8 +17,10 @@ python3 containers/multiseat/build-image.py gamescope
 ```
 
 Repeat for `steam`, `heroic`, and `lutris`. Both commands accept `--nvidia` for
-the driver-matched physical lane. The build command requires a clean commit.
-`--development` marks exploratory output as dirty and unsuitable for acceptance.
+the driver-matched physical lane. The build command requires a clean commit and materializes sources and locks
+from that exact Git object into a private build context. Ignored files and edits
+made during a build cannot enter the image or change its later provenance.
+Only independently copied and hash-verified locked inputs enter that context.
 The CI matrix fetches exact locked inputs, runs integrity tests, builds with
 `--network=none --pull=never`, validates dependencies, and exercises the real
 session-bus, private-audio, and software-display providers. Dependency skips fail

--- a/containers/multiseat/RUNTIME-IMAGES.md
+++ b/containers/multiseat/RUNTIME-IMAGES.md
@@ -1,0 +1,118 @@
+# Locked runtime images
+
+The four `linux/amd64` profiles retain their existing Games on Whales launcher
+roots. A source-root digest is never a produced-worker digest. Schema 2 in
+`images.lock.json` binds each source root to its package lock and names the
+location of its produced artifact manifest. Production catalog promotion and
+registry publication require separate review and are absent from this job.
+
+## Build and inspect
+
+Use Linux/amd64, Python 3.11 or newer, Git, GNU tar, and rootless Podman. Prepare
+inputs with network access, then build with network access disabled:
+
+```sh
+python3 containers/multiseat/prepare-inputs.py gamescope
+python3 containers/multiseat/build-image.py gamescope
+```
+
+Repeat for `steam`, `heroic`, and `lutris`. Both commands accept `--nvidia` for
+the driver-matched physical lane. The build command requires a clean commit.
+`--development` marks exploratory output as dirty and unsuitable for acceptance.
+The CI matrix fetches exact locked inputs, runs integrity tests, builds with
+`--network=none --pull=never`, validates dependencies, and exercises the real
+session-bus, private-audio, and software-display providers. Dependency skips fail
+the job. Worker binaries use the pinned Go toolchain root, only the standard
+library, and disabled module-network access.
+
+Each `build/worker-artifacts/<profile>/<default|nvidia>/` contains:
+
+- `worker.oci.tar`, a downloadable image with no registry publication;
+- `artifact.json`, binding source revision, profile, architecture, source root,
+  dependency locks, validation scope, and file hashes to that archive;
+- `packages.tsv`, the final root's complete installed package manifest;
+- `sbom.cdx.json`, runtime packages, custom source components, and the declared
+  Rust dependency closure (including build/dev dependencies);
+- `providers.json`, sanitized names and scope of completed real-provider tests.
+
+The private `providers.log` is retained locally and is excluded from uploads.
+`worker_digest` is the exported OCI manifest digest. Podman's local storage
+manifest may differ. Export verification hashes every referenced blob, checks
+sizes and Linux/amd64 configuration, and requires the same configuration digest
+as the validated image. Use the exported digest when importing/promoting that
+artifact; no source root or cached local tag establishes its identity.
+
+## Reproducible inputs
+
+Package locks include exact versions, architecture, HTTPS URLs, SHA-256 values,
+and full added runtime/build dependency closures resolved inside each immutable
+source root. Resolution uses Ubuntu's signed 2026-01-20 snapshot. Historical
+snapshot expiry is disabled only during this explicit resolution step; final
+builds neither resolve packages nor contact repositories. Every `.deb` is
+verified before installation, and `dpkg --audit` must be empty afterward.
+
+`locks/rust.json` pins the compiler archive. `locks/plugin.json` pins the
+Wayland plugin revision, Cargo.lock, Rust version, and canonical vendored archive.
+Preparation runs that pinned Cargo version in a private toolchain directory;
+ambient Cargo is not used. `locks/gamescope.json` pins Gamescope 3.16.19, recursive
+submodules, additional Meson wraps, and its canonical source archive. GNU tar
+normalizes ordering, ownership, and timestamps. A reconstruction mismatch fails
+and preserves the unverified archive for investigation. Final Cargo builds are
+frozen/offline; Meson wraps cannot download.
+
+Each root compiles `waylanddisplaysrc` against its own GStreamer development ABI.
+The installed system plugin directory also supplies `unixfdsink`, `unixfdsrc`,
+`fakesink`, and `videoconvert`. Fixed provider executables, plugin files, and
+PipeWire configurations must be trusted regular files; dynamic library checks
+must resolve. The custom Gamescope executable is `/usr/bin/gamescope`; the
+source root's packaged `/usr/games/gamescope` remains recorded in the package
+manifest but is not selected by the provider. The custom source lock and SBOM
+identify the executable that the provider uses.
+
+Lock refresh is explicit: run `resolve-packages.sh` in each disposable pinned
+root, review `write-package-lock.py` output and source manifests, reconstruct
+source archives with the pinned toolchain, and review every changed source or
+dependency before rebuilding all four profiles. Never replace a failed hash
+with the downloaded value without investigating the difference. Byte identity
+does not establish publisher trust or a vulnerability policy. Final OCI metadata
+uses the source commit timestamp; input reproducibility does not promise identical
+image bytes across different Podman versions or compression implementations.
+
+## NVIDIA physical lane
+
+The optional layer pins NVIDIA 610.57.04 and the official installer archive's
+SHA-256. Extraction occurs only inside a disposable build stage. It copies an
+explicit set of vendor graphics, CUDA, and codec userspace libraries, SONAME
+links, EGL/Vulkan configuration, license, and per-file hashes. Generic GLVND
+frontends remain from the root. Kernel modules, firmware, host configuration,
+and host installer execution are absent. The host driver must match this version.
+
+Physical provider tests require an explicitly admitted render node and the
+matching GPU catalog's device set. Resolve DRM primary/render nodes by their
+physical sysfs device identity; numbering alone does not establish a match.
+NVIDIA support must never import arbitrary CDI-generated mounts. SELinux remains
+enforcing; denied GPU access is a separate admission failure, not permission to
+enable blanket container device access or disable labeling.
+
+The test-only `provider-nvidia-test` stage includes real-provider tests and a
+private X11 socket-directory fixture. The worker artifact excludes that test
+binary. Run the eight real provider tests with exact device admission, requiring
+the nested Gamescope and independent-stack teardown tests to pass. The default
+CI lane validates software capture transport; software Vulkan without
+`VK_EXT_physical_device_drm` is insufficient for the current Gamescope provider.
+
+## Acceptance and next milestone
+
+Dependency checks establish installed ABI compatibility. Isolated provider tests
+establish protocol readiness and owned-resource teardown. The separate physical
+input harness must open each seat's exact allocated nodes, receive bounded host
+authority events, reject other-seat and singleton nodes, and stop one worker
+without affecting the other. Repeat that harness for each produced profile,
+including from a user service with its actual supplementary groups.
+
+None of these receipts proves successful game streaming. Production `run` still
+injects no lifecycle adapters. Virtual-input provider integration, worker-local
+encoding, launcher process management, production media routing, seat-aware
+status, and real concurrent game streams remain the next milestone. Runtime
+startup must also establish the private X11 directory ownership expected by the
+provider before production wiring; the isolated tests provide their own fixture.

--- a/containers/multiseat/build-image.py
+++ b/containers/multiseat/build-image.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """Build, check and export one locked worker profile without network access."""
 import argparse
+import contextlib
 import hashlib
 import json
 import pathlib
 import re
+import shutil
 import subprocess
 import tarfile
+import tempfile
 import tomllib
 import urllib.parse
 
@@ -33,21 +36,76 @@ def write_json(path, value):
     path.write_text(json.dumps(value, indent=2) + '\n')
 
 
-def sbom(packages, profile, revision):
+@contextlib.contextmanager
+def materialized_context(revision, profile_id, nvidia):
+    # An ignored Go file can still be compiled by COPY *.go. Archive the exact
+    # committed sources/locks; neither ignored files nor concurrent edits enter.
+    with tempfile.TemporaryDirectory(prefix='polaris-worker-context-') as temporary:
+        context = pathlib.Path(temporary)
+        archive_path = context / 'source.tar'
+        with archive_path.open('wb') as stream:
+            run(['git', 'archive', revision, 'multiseat_worker', 'containers/multiseat'], stdout=stream)
+        with tarfile.open(archive_path) as archive:
+            for member in archive.getmembers():
+                name = pathlib.PurePosixPath(member.name)
+                if name.is_absolute() or '..' in name.parts or not (member.isfile() or member.isdir()):
+                    raise ValueError('build source must contain only regular files and directories')
+                destination = context / name
+                if member.isdir():
+                    destination.mkdir(parents=True, exist_ok=True)
+                else:
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    with archive.extractfile(member) as source, destination.open('wb') as target:
+                        shutil.copyfileobj(source, target)
+                    destination.chmod(member.mode & 0o755)
+        archive_path.unlink()
+        here = context / 'containers/multiseat'
+        images = json.loads((here / 'images.lock.json').read_text())
+        profile = next(p for p in images['runtime_profiles'] if p['id'] == profile_id)
+        packages = json.loads((here / profile['dependency_lock']).read_text())
+        inputs = []
+        for role in ['runtime', 'build']:
+            for package in packages[role]:
+                filename = package['filename']
+                if pathlib.Path(filename).name != filename:
+                    raise ValueError('unsafe locked input filename')
+                inputs.append((pathlib.Path(profile_id) / role / filename, package['sha256']))
+        for name in ['rust', 'plugin', 'gamescope'] + (['nvidia'] if nvidia else []):
+            lock = json.loads((here / images['dependency_locks'][name]).read_text())
+            filename = pathlib.Path(name + '.tar')
+            if name in ['rust', 'nvidia']:
+                filename = pathlib.Path(pathlib.PurePosixPath(lock['url']).name)
+                if name == 'rust':
+                    filename = pathlib.Path('toolchains') / filename
+            inputs.append((filename, lock['sha256']))
+        for filename, expected in inputs:
+            source = REPO / 'build/runtime-inputs' / filename
+            if source.is_symlink() or not source.is_file():
+                raise ValueError('cached input must be a regular file')
+            destination = context / 'build/runtime-inputs' / filename
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+            if digest(destination) != expected:
+                raise ValueError('copied input differs from committed lock: ' + str(filename))
+        yield context
+
+
+def sbom(packages, profile, revision, context):
+    here = context / 'containers/multiseat'
     components = []
     for line in packages.splitlines():
         name, version, architecture = line.split('\t')
         purl = 'pkg:deb/ubuntu/' + urllib.parse.quote(name, safe='') + '@' + urllib.parse.quote(version, safe='') + '?arch=' + architecture
         components.append({'type': 'library', 'name': name, 'version': version, 'purl': purl, 'bom-ref': purl})
     for name in ['plugin', 'gamescope']:
-        lock = json.loads((HERE / 'locks' / (name + '.json')).read_text())
+        lock = json.loads((here / 'locks' / (name + '.json')).read_text())
         components.append({'type': 'application' if name == 'gamescope' else 'library',
                            'name': name, 'version': lock['revision'], 'bom-ref': name,
                            'externalReferences': [{'type': 'vcs', 'url': lock['url'] + '/tree/' + lock['revision']}],
                            'properties': [{'name': 'polaris:source-archive-sha256', 'value': lock['sha256']}]})
     # Retain the complete reviewed Rust closure, including declared build/dev
     # inputs; this is dependency provenance, not a claim that every crate links.
-    with tarfile.open(REPO / 'build/runtime-inputs/plugin.tar') as archive:
+    with tarfile.open(context / 'build/runtime-inputs/plugin.tar') as archive:
         source = tomllib.loads(archive.extractfile('./Cargo.lock').read().decode())
     for package in source['package']:
         name, version = package['name'], package['version']
@@ -69,31 +127,33 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('profile', choices=['gamescope', 'steam', 'heroic', 'lutris'])
     parser.add_argument('--nvidia', action='store_true')
-    parser.add_argument('--development', action='store_true', help='mark dirty exploratory builds; never acceptance artifacts')
     args = parser.parse_args()
-    images = json.loads((HERE / 'images.lock.json').read_text())
-    profile = next(p for p in images['runtime_profiles'] if p['id'] == args.profile)
-    packages = json.loads((HERE / profile['dependency_lock']).read_text())
-    if images['schema'] != 2 or images['platform'] != 'linux/amd64' or packages['source_root'] != profile['reference']:
-        parser.error('source root, dependency lock and architecture must agree')
     revision = output(['git', 'rev-parse', 'HEAD']).strip()
-    dirty = bool(output(['git', 'status', '--porcelain']))
-    if dirty and not args.development:
+    if output(['git', 'status', '--porcelain']):
         parser.error('commit the reviewed source before producing acceptance artifacts')
-    if dirty:
-        revision += '-dirty'
-    epoch = output(['git', 'show', '-s', '--format=%ct', 'HEAD']).strip()
+    epoch = output(['git', 'show', '-s', '--format=%ct', revision]).strip()
+    with materialized_context(revision, args.profile, args.nvidia) as context:
+        build_artifact(args, revision, epoch, context)
+
+
+def build_artifact(args, revision, epoch, context):
+    here = context / 'containers/multiseat'
+    images = json.loads((here / 'images.lock.json').read_text())
+    profile = next(p for p in images['runtime_profiles'] if p['id'] == args.profile)
+    packages = json.loads((here / profile['dependency_lock']).read_text())
+    if images['schema'] != 2 or images['platform'] != 'linux/amd64' or packages['source_root'] != profile['reference']:
+        raise ValueError('source root, dependency lock and architecture must agree')
     variant = 'nvidia' if args.nvidia else 'default'
     artifact = REPO / 'build/worker-artifacts' / args.profile / variant
     artifact.mkdir(parents=True, exist_ok=True)
     image = 'localhost/polaris-worker-' + args.profile + '-' + variant + ':' + revision[:12]
     command = ['podman', 'build', '--network=none', '--pull=never', '--platform=linux/amd64',
-               '--format=oci', '--timestamp=' + epoch, '-f', 'containers/multiseat/Containerfile',
+               '--format=oci', '--timestamp=' + epoch, '-f', str(here / 'Containerfile'),
                '--build-arg', 'RUNTIME_PROFILE=' + args.profile,
                '--build-arg', 'RUNTIME_IMAGE=' + profile['reference'],
                '--build-arg', 'GO_BUILDER_IMAGE=' + images['builder']['reference'],
                '--build-arg', 'POLARIS_REVISION=' + revision]
-    run(command + ['--target', 'worker-nvidia' if args.nvidia else 'worker', '-t', image, '.'])
+    run(command + ['--target', 'worker-nvidia' if args.nvidia else 'worker', '-t', image, str(context)])
     inspected = json.loads(output(['podman', 'image', 'inspect', image]))[0]
     labels = inspected['Labels']
     if inspected['Architecture'] != 'amd64' or inspected['Os'] != 'linux' or labels.get('org.opencontainers.image.revision') != revision or labels.get('io.polaris.multiseat.profile') != args.profile:
@@ -103,7 +163,7 @@ def main():
     # CI covers all device-free real providers and their independent teardown.
     # Gamescope hardware acceptance is a separate required physical receipt.
     provider_image = image + '-providers'
-    run(command + ['--target', 'provider-nvidia-test' if args.nvidia else 'provider-test', '-t', provider_image, '.'])
+    run(command + ['--target', 'provider-nvidia-test' if args.nvidia else 'provider-test', '-t', provider_image, str(context)])
     provider_inspected = json.loads(output(['podman', 'image', 'inspect', provider_image]))[0]
     worker_layers = inspected['RootFS']['Layers']
     if provider_inspected['RootFS']['Layers'][:len(worker_layers)] != worker_layers:
@@ -133,9 +193,9 @@ def main():
                                '--cap-drop=all', '--security-opt=no-new-privileges',
                                '--entrypoint=/usr/bin/cat', image, '/usr/share/polaris/build/packages.tsv'])
     (artifact / 'packages.tsv').write_text(package_manifest)
-    bill = sbom(package_manifest, args.profile, revision)
+    bill = sbom(package_manifest, args.profile, revision, context)
     if args.nvidia:
-        nvidia = json.loads((HERE / 'locks/nvidia.json').read_text())
+        nvidia = json.loads((here / 'locks/nvidia.json').read_text())
         bill['components'].append({'type': 'library', 'name': 'nvidia-graphics-userspace',
                                    'version': nvidia['version'], 'bom-ref': 'nvidia-userspace',
                                    'properties': [{'name': 'polaris:source-archive-sha256', 'value': nvidia['sha256']}]})
@@ -144,18 +204,18 @@ def main():
     # Podman may rewrite the manifest when exporting. Only the verified digest
     # inside this downloadable archive identifies the delivered worker artifact.
     worker_digest = verify_archive(artifact / 'worker.oci.tar', config_digest)
-    lock_files = [HERE / 'images.lock.json', HERE / profile['dependency_lock']]
-    lock_files += [HERE / path for name, path in images['dependency_locks'].items() if args.nvidia or name != 'nvidia']
+    lock_files = [here / 'images.lock.json', here / profile['dependency_lock']]
+    lock_files += [here / path for name, path in images['dependency_locks'].items() if args.nvidia or name != 'nvidia']
     write_json(artifact / 'artifact.json', {
         'schema': 1, 'source_revision': revision, 'profile': args.profile,
         'platform': 'linux/amd64', 'variant': variant, 'source_root': profile['reference'],
         'worker_digest': worker_digest, 'worker_config_digest': config_digest,
-        'dependency_locks': {str(path.relative_to(REPO)): digest(path) for path in lock_files},
+        'dependency_locks': {str(path.relative_to(context)): digest(path) for path in lock_files},
         'files': {name: {'sha256': digest(artifact / name)} for name in ['worker.oci.tar', 'packages.tsv', 'sbom.cdx.json', 'providers.json']},
         'validation': {'dependencies': 'passed', 'session_bus_audio_display': 'passed',
                        'nested_compositor': 'physical receipt required', 'input': 'physical receipt required',
                        'game_streaming': 'not exercised', 'production_activation': False},
-        'development': dirty, 'publication': 'downloadable artifact; no registry or production catalog mutation',
+        'development': False, 'publication': 'downloadable artifact; no registry or production catalog mutation',
     })
     print(artifact.relative_to(REPO))
 

--- a/containers/multiseat/build-image.py
+++ b/containers/multiseat/build-image.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Build, check and export one locked worker profile without network access."""
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import subprocess
+import tarfile
+import tomllib
+import urllib.parse
+
+from oci_archive import verify_archive
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+
+
+def run(arguments, **kwargs):
+    return subprocess.run(arguments, cwd=REPO, check=True, **kwargs)
+
+
+def output(arguments):
+    return subprocess.check_output(arguments, cwd=REPO, text=True)
+
+
+def digest(path):
+    with path.open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2) + '\n')
+
+
+def sbom(packages, profile, revision):
+    components = []
+    for line in packages.splitlines():
+        name, version, architecture = line.split('\t')
+        purl = 'pkg:deb/ubuntu/' + urllib.parse.quote(name, safe='') + '@' + urllib.parse.quote(version, safe='') + '?arch=' + architecture
+        components.append({'type': 'library', 'name': name, 'version': version, 'purl': purl, 'bom-ref': purl})
+    for name in ['plugin', 'gamescope']:
+        lock = json.loads((HERE / 'locks' / (name + '.json')).read_text())
+        components.append({'type': 'application' if name == 'gamescope' else 'library',
+                           'name': name, 'version': lock['revision'], 'bom-ref': name,
+                           'externalReferences': [{'type': 'vcs', 'url': lock['url'] + '/tree/' + lock['revision']}],
+                           'properties': [{'name': 'polaris:source-archive-sha256', 'value': lock['sha256']}]})
+    # Retain the complete reviewed Rust closure, including declared build/dev
+    # inputs; this is dependency provenance, not a claim that every crate links.
+    with tarfile.open(REPO / 'build/runtime-inputs/plugin.tar') as archive:
+        source = tomllib.loads(archive.extractfile('./Cargo.lock').read().decode())
+    for package in source['package']:
+        name, version = package['name'], package['version']
+        reference = 'rust:' + name + '@' + version
+        component = {'type': 'library', 'name': name, 'version': version, 'bom-ref': reference,
+                     'properties': [{'name': 'polaris:scope', 'value': 'declared plugin build closure'}]}
+        if package.get('source', '').startswith('registry+'):
+            component['purl'] = 'pkg:cargo/' + name + '@' + version
+        if 'checksum' in package:
+            component['hashes'] = [{'alg': 'SHA-256', 'content': package['checksum']}]
+        components.append(component)
+    return {'bomFormat': 'CycloneDX', 'specVersion': '1.6', 'version': 1,
+            'metadata': {'component': {'type': 'application', 'name': 'polaris-worker-' + profile,
+                                       'version': revision, 'bom-ref': 'worker'}},
+            'components': components}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('profile', choices=['gamescope', 'steam', 'heroic', 'lutris'])
+    parser.add_argument('--nvidia', action='store_true')
+    parser.add_argument('--development', action='store_true', help='mark dirty exploratory builds; never acceptance artifacts')
+    args = parser.parse_args()
+    images = json.loads((HERE / 'images.lock.json').read_text())
+    profile = next(p for p in images['runtime_profiles'] if p['id'] == args.profile)
+    packages = json.loads((HERE / profile['dependency_lock']).read_text())
+    if images['schema'] != 2 or images['platform'] != 'linux/amd64' or packages['source_root'] != profile['reference']:
+        parser.error('source root, dependency lock and architecture must agree')
+    revision = output(['git', 'rev-parse', 'HEAD']).strip()
+    dirty = bool(output(['git', 'status', '--porcelain']))
+    if dirty and not args.development:
+        parser.error('commit the reviewed source before producing acceptance artifacts')
+    if dirty:
+        revision += '-dirty'
+    epoch = output(['git', 'show', '-s', '--format=%ct', 'HEAD']).strip()
+    variant = 'nvidia' if args.nvidia else 'default'
+    artifact = REPO / 'build/worker-artifacts' / args.profile / variant
+    artifact.mkdir(parents=True, exist_ok=True)
+    image = 'localhost/polaris-worker-' + args.profile + '-' + variant + ':' + revision[:12]
+    command = ['podman', 'build', '--network=none', '--pull=never', '--platform=linux/amd64',
+               '--format=oci', '--timestamp=' + epoch, '-f', 'containers/multiseat/Containerfile',
+               '--build-arg', 'RUNTIME_PROFILE=' + args.profile,
+               '--build-arg', 'RUNTIME_IMAGE=' + profile['reference'],
+               '--build-arg', 'GO_BUILDER_IMAGE=' + images['builder']['reference'],
+               '--build-arg', 'POLARIS_REVISION=' + revision]
+    run(command + ['--target', 'worker-nvidia' if args.nvidia else 'worker', '-t', image, '.'])
+    inspected = json.loads(output(['podman', 'image', 'inspect', image]))[0]
+    labels = inspected['Labels']
+    if inspected['Architecture'] != 'amd64' or inspected['Os'] != 'linux' or labels.get('org.opencontainers.image.revision') != revision or labels.get('io.polaris.multiseat.profile') != args.profile:
+        raise ValueError('produced worker identity does not match the build')
+    config_digest = 'sha256:' + inspected['Id'].removeprefix('sha256:')
+
+    # CI covers all device-free real providers and their independent teardown.
+    # Gamescope hardware acceptance is a separate required physical receipt.
+    provider_image = image + '-providers'
+    run(command + ['--target', 'provider-test', '-t', provider_image, '.'])
+    test_command = ['podman', 'run', '--rm', '--network=none', '--cap-drop=all',
+                    '--security-opt=no-new-privileges', provider_image, '-test.v',
+                    '-test.run=^TestReal(SessionBus|PrivateAudio|AudioReadiness|Display)', '-test.timeout=2m']
+    with (artifact / 'providers.log').open('w') as log:
+        run(test_command, stdout=log, stderr=subprocess.STDOUT)
+    results = (artifact / 'providers.log').read_text()
+    if '--- SKIP:' in results or results.count('--- PASS:') < 6:
+        raise ValueError('real provider tests skipped or did not all execute')
+    names = re.findall(r'^--- PASS: ([A-Za-z0-9_]+)', results, re.MULTILINE)
+    write_json(artifact / 'providers.json', {'schema': 1, 'result': 'passed', 'tests': names,
+                                            'scope': 'isolated session bus, audio and software display; no game stream'})
+    package_manifest = output(['podman', 'run', '--rm', '--network=none', '--read-only',
+                               '--cap-drop=all', '--security-opt=no-new-privileges',
+                               '--entrypoint=/usr/bin/cat', image, '/usr/share/polaris/build/packages.tsv'])
+    (artifact / 'packages.tsv').write_text(package_manifest)
+    bill = sbom(package_manifest, args.profile, revision)
+    if args.nvidia:
+        nvidia = json.loads((HERE / 'locks/nvidia.json').read_text())
+        bill['components'].append({'type': 'library', 'name': 'nvidia-graphics-userspace',
+                                   'version': nvidia['version'], 'bom-ref': 'nvidia-userspace',
+                                   'properties': [{'name': 'polaris:source-archive-sha256', 'value': nvidia['sha256']}]})
+    write_json(artifact / 'sbom.cdx.json', bill)
+    run(['podman', 'save', '--format=oci-archive', '-o', str(artifact / 'worker.oci.tar'), image])
+    # Podman may rewrite the manifest when exporting. Only the verified digest
+    # inside this downloadable archive identifies the delivered worker artifact.
+    worker_digest = verify_archive(artifact / 'worker.oci.tar', config_digest)
+    lock_files = [HERE / 'images.lock.json', HERE / profile['dependency_lock']]
+    lock_files += [HERE / path for name, path in images['dependency_locks'].items() if args.nvidia or name != 'nvidia']
+    write_json(artifact / 'artifact.json', {
+        'schema': 1, 'source_revision': revision, 'profile': args.profile,
+        'platform': 'linux/amd64', 'variant': variant, 'source_root': profile['reference'],
+        'worker_digest': worker_digest, 'worker_config_digest': config_digest,
+        'dependency_locks': {str(path.relative_to(REPO)): digest(path) for path in lock_files},
+        'files': {name: {'sha256': digest(artifact / name)} for name in ['worker.oci.tar', 'packages.tsv', 'sbom.cdx.json', 'providers.json']},
+        'validation': {'dependencies': 'passed', 'session_bus_audio_display': 'passed',
+                       'nested_compositor': 'physical receipt required', 'input': 'physical receipt required',
+                       'game_streaming': 'not exercised', 'production_activation': False},
+        'development': dirty, 'publication': 'downloadable artifact; no registry or production catalog mutation',
+    })
+    print(artifact.relative_to(REPO))
+
+
+if __name__ == '__main__':
+    main()

--- a/containers/multiseat/build-image.py
+++ b/containers/multiseat/build-image.py
@@ -103,17 +103,31 @@ def main():
     # CI covers all device-free real providers and their independent teardown.
     # Gamescope hardware acceptance is a separate required physical receipt.
     provider_image = image + '-providers'
-    run(command + ['--target', 'provider-test', '-t', provider_image, '.'])
+    run(command + ['--target', 'provider-nvidia-test' if args.nvidia else 'provider-test', '-t', provider_image, '.'])
+    provider_inspected = json.loads(output(['podman', 'image', 'inspect', provider_image]))[0]
+    worker_layers = inspected['RootFS']['Layers']
+    if provider_inspected['RootFS']['Layers'][:len(worker_layers)] != worker_layers:
+        raise ValueError('provider test image does not extend the produced worker filesystem')
     test_command = ['podman', 'run', '--rm', '--network=none', '--cap-drop=all',
                     '--security-opt=no-new-privileges', provider_image, '-test.v',
                     '-test.run=^TestReal(SessionBus|PrivateAudio|AudioReadiness|Display)', '-test.timeout=2m']
     with (artifact / 'providers.log').open('w') as log:
         run(test_command, stdout=log, stderr=subprocess.STDOUT)
     results = (artifact / 'providers.log').read_text()
-    if '--- SKIP:' in results or results.count('--- PASS:') < 6:
-        raise ValueError('real provider tests skipped or did not all execute')
     names = re.findall(r'^--- PASS: ([A-Za-z0-9_]+)', results, re.MULTILINE)
+    required = {
+        'TestRealSessionBusAuthenticatesAndCleansUp',
+        'TestRealPrivateAudioGraphRoutesExactlyAndCleansUp',
+        'TestRealAudioReadinessFailureCleansPartialArtifacts',
+        'TestRealPrivateAudioGraphsRemainIndependent',
+        'TestRealDisplayCaptureProducesFrameAndCleansUp',
+        'TestRealDisplayCapturesRemainIndependent',
+    }
+    if '--- SKIP:' in results or set(names) != required or len(names) != len(required):
+        raise ValueError('real provider tests skipped or did not all execute')
     write_json(artifact / 'providers.json', {'schema': 1, 'result': 'passed', 'tests': names,
+                                            'variant': variant, 'worker_config_digest': config_digest,
+                                            'provider_config_digest': 'sha256:' + provider_inspected['Id'].removeprefix('sha256:'),
                                             'scope': 'isolated session bus, audio and software display; no game stream'})
     package_manifest = output(['podman', 'run', '--rm', '--network=none', '--read-only',
                                '--cap-drop=all', '--security-opt=no-new-privileges',

--- a/containers/multiseat/check-runtime.py
+++ b/containers/multiseat/check-runtime.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Fail image construction if a fixed provider dependency is unsafe or missing."""
+import os
+import pathlib
+import stat
+import subprocess
+
+executables = ['dbus-daemon', 'pipewire', 'pw-cli', 'pactl', 'gst-launch-1.0',
+               'gst-inspect-1.0', 'gamescope', 'Xwayland']
+files = [pathlib.Path('/usr/bin') / name for name in executables]
+files += [pathlib.Path('/usr/share/pipewire') / name for name in ['pipewire.conf', 'pipewire-pulse.conf']]
+plugin = pathlib.Path('/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwaylanddisplaysrc.so')
+files.append(plugin)
+for path in files:
+    status = path.lstat()
+    if not stat.S_ISREG(status.st_mode) or status.st_uid != 0 or status.st_mode & 0o022:
+        raise ValueError('untrusted provider dependency: ' + str(path))
+    if path.parent == pathlib.Path('/usr/bin') and not os.access(path, os.X_OK):
+        raise ValueError('non-executable provider dependency: ' + str(path))
+for path in [pathlib.Path('/usr/bin/gamescope'), pathlib.Path('/usr/bin/Xwayland'), plugin]:
+    linked = subprocess.check_output(['ldd', str(path)], text=True, stderr=subprocess.STDOUT)
+    if 'not found' in linked:
+        raise ValueError('unresolved ELF dependency: ' + str(path))
+for element in ['waylanddisplaysrc', 'unixfdsink', 'unixfdsrc', 'fakesink', 'videoconvert']:
+    subprocess.run(['/usr/bin/gst-inspect-1.0', element], check=True, stdout=subprocess.DEVNULL)
+help_text = subprocess.check_output(['/usr/bin/gamescope', '--help'], stderr=subprocess.STDOUT, text=True)
+if '--keep-alive' not in help_text or '--expose-wayland' not in help_text:
+    raise ValueError('Gamescope lacks the provider lifecycle interface')
+print('All fixed provider dependencies and ELF links passed')

--- a/containers/multiseat/images.lock.json
+++ b/containers/multiseat/images.lock.json
@@ -1,36 +1,61 @@
 {
-  "schema": 1,
+  "schema": 2,
   "platform": "linux/amd64",
-  "resolved_date": "2026-09-04",
+  "resolved_date": "2026-09-07",
   "builder": {
     "id": "go",
     "reference": "docker.io/library/golang@sha256:e8c859f5632dcfde7b32d2012b4351728f6437930887c2f6a91ea242459e5514",
-    "source": "https://github.com/docker-library/golang"
+    "source": "https://github.com/docker-library/golang",
+    "role": "toolchain_root"
   },
   "runtime_profiles": [
     {
       "id": "gamescope",
       "launcher": "none",
       "reference": "ghcr.io/games-on-whales/base-app@sha256:1d7b61da242e767bc5c80c5fe897392b6a9e6854345d3dea6d2f799e7ea98a14",
-      "source": "https://github.com/games-on-whales/gow"
+      "source": "https://github.com/games-on-whales/gow",
+      "role": "source_root",
+      "dependency_lock": "locks/gamescope.packages.json",
+      "produced_worker_manifest": "gamescope/<variant>/artifact.json"
     },
     {
       "id": "steam",
       "launcher": "steam",
       "reference": "ghcr.io/games-on-whales/steam@sha256:ded0b1b47acd9adb8af9f068342f26ac31008904d9bbb91045d1a04e7d66a632",
-      "source": "https://github.com/games-on-whales/gow"
+      "source": "https://github.com/games-on-whales/gow",
+      "role": "source_root",
+      "dependency_lock": "locks/steam.packages.json",
+      "produced_worker_manifest": "steam/<variant>/artifact.json"
     },
     {
       "id": "heroic",
       "launcher": "heroic",
       "reference": "ghcr.io/games-on-whales/heroic-games-launcher@sha256:a207a39367801a8a8bf24b68dac2c9945052d3117cb03b061b27bd6672aab62f",
-      "source": "https://github.com/games-on-whales/gow"
+      "source": "https://github.com/games-on-whales/gow",
+      "role": "source_root",
+      "dependency_lock": "locks/heroic.packages.json",
+      "produced_worker_manifest": "heroic/<variant>/artifact.json"
     },
     {
       "id": "lutris",
       "launcher": "lutris",
       "reference": "ghcr.io/games-on-whales/lutris@sha256:207005d9e1a839814c7c2b91fa25190d40c388c7dc004eec593556bd807f99f2",
-      "source": "https://github.com/games-on-whales/gow"
+      "source": "https://github.com/games-on-whales/gow",
+      "role": "source_root",
+      "dependency_lock": "locks/lutris.packages.json",
+      "produced_worker_manifest": "lutris/<variant>/artifact.json"
     }
-  ]
+  ],
+  "dependency_locks": {
+    "rust": "locks/rust.json",
+    "plugin": "locks/plugin.json",
+    "gamescope": "locks/gamescope.json",
+    "nvidia": "locks/nvidia.json"
+  },
+  "produced_workers": {
+    "directory": "build/worker-artifacts",
+    "digest_field": "worker_digest",
+    "publication": "downloadable OCI artifacts only",
+    "catalog_promotion": "separate review; never inferred from source root or dependency checks"
+  }
 }

--- a/containers/multiseat/install-packages.sh
+++ b/containers/multiseat/install-packages.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+python3 /verify-inputs.py "$1"
+# Prevent image-build package scripts from starting daemons.
+printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d
+chmod 0755 /usr/sbin/policy-rc.d
+export DEBIAN_FRONTEND=noninteractive
+dpkg --force-confold --install /inputs/packages/*.deb
+test -z "$(dpkg --audit)"
+rm /usr/sbin/policy-rc.d

--- a/containers/multiseat/locks/gamescope.json
+++ b/containers/multiseat/locks/gamescope.json
@@ -1,0 +1,33 @@
+{
+  "schema": 1,
+  "url": "https://github.com/ValveSoftware/gamescope",
+  "revision": "c3cc9b8414d4afa8c53217112a71f17a95b939f8",
+  "version": "3.16.19",
+  "archive_epoch": 1754524800,
+  "sha256": "ee5959cd49d3e25e25b5a5e0226df891b0bdceb30e10fc3735f26446d2d030f4",
+  "submodules": [
+    " 696b14cd6006ae9ca174e6164450619ace043283 src/reshade (696b14c)",
+    " de28d93dfa9ebf3e473127c1c657e1920a5345ee src/reshade/deps/d3d12 (de28d93)",
+    " 6926f5a0a78f22d42b074a0ab8032e07736babd4 src/reshade/deps/fpng (6926f5a)",
+    " 3a33275633ce4be433332dc776e6a5b3bdea6506 src/reshade/deps/gl3w (3a33275)",
+    " c6aa051629753f0ef0d26bf775a8b6a92aa213b2 src/reshade/deps/imgui (c6aa051)",
+    " 8fda4f5481fed5797dc2651cd91e238e9b3928c6 src/reshade/deps/minhook (8fda4f5)",
+    " dc1e23937fe45eabcce80f6588cf47449edb29d1 src/reshade/deps/openxr (dc1e239)",
+    " c0df742ec0b8178ad58c68cff3437ad4b6a06e26 src/reshade/deps/spirv (c0df742)",
+    " ae721c50eaf761660b4f90cc590453cdb0c2acd0 src/reshade/deps/stb (ae721c5)",
+    " 6be08bbea14ffa0a5c594257fb6285a054395cd7 src/reshade/deps/utfcpp (6be08bb)",
+    " c4ad4af0946b73ce1a40cbc72205d15d196c7e06 src/reshade/deps/utfcpp/extern/ftest (c4ad4af)",
+    " a6bfc237255a6bac1513f7c1ebde6d8aed6b5191 src/reshade/deps/vma (a6bfc23)",
+    " 7b3466a1f47a9251ac1113efbe022ff016e2f95b src/reshade/deps/vulkan (7b3466a)",
+    " 47a5590e9c4eb35d67651b8c05a55f1a48259329 subprojects/libdisplay-info (47a5590)",
+    " 8b08dc1c14fd019cc90ddabe34ad16596b0691f4 subprojects/libliftoff (8b08dc1)",
+    " ff87f683f41fe26cc9353dd9d9d7028357fd8e1a subprojects/openvr (ff87f68)",
+    " 5106d8a0df95de66cc58dc1ea37e69c99afc9540 subprojects/vkroots (5106d8a)",
+    " 54e844748029d4874e14d0c086d50092c04c8899 subprojects/wlroots (54e8447)",
+    " d790ced752b5bfc06b6988baadef6eb2d16bdf96 thirdparty/SPIRV-Headers (d790ced)"
+  ],
+  "wraps": {
+    "glm": "0af55ccecd98d4e5a8d1fad7de25ba429d60e863",
+    "stb": "5736b15f7ea0ffb08dd38af21067c314d6a3aae9"
+  }
+}

--- a/containers/multiseat/locks/gamescope.packages.json
+++ b/containers/multiseat/locks/gamescope.packages.json
@@ -1,0 +1,2916 @@
+{
+  "schema": 1,
+  "profile": "gamescope",
+  "platform": "linux/amd64",
+  "source_root": "ghcr.io/games-on-whales/base-app@sha256:1d7b61da242e767bc5c80c5fe897392b6a9e6854345d3dea6d2f799e7ea98a14",
+  "snapshot": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/",
+  "source_manifest_sha256": "969b1daf21ad16db16cb64e19fea09520fa23884a9a09908ff581cda1f8ef887",
+  "runtime": [
+    {
+      "name": "gstreamer1.0-plugins-bad",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "800b2b0a8f994098e854413821a4908f301425e165b112994d4ad891e38c828a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-tools",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-tools_1.26.0-3_amd64.deb",
+      "sha256": "ac24b15d6a48bb99097419f4d8d5928430d010af301b0df0b32570e59879f8f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gstreamer1.0-tools_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "libass9",
+      "version": "1:0.17.3-1",
+      "architecture": "amd64",
+      "filename": "libass9_1%3a0.17.3-1_amd64.deb",
+      "sha256": "20fd3f8a675804455ccfffbcc4e488818e016dea8d535ade12031969cd97a62d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libass/libass9_0.17.3-1_amd64.deb"
+    },
+    {
+      "name": "libavtp0",
+      "version": "0.2.0-2",
+      "architecture": "amd64",
+      "filename": "libavtp0_0.2.0-2_amd64.deb",
+      "sha256": "32d5bb7433365eb43c9d3bd49aff8c62295abcd4a3eb45ddbdb8351ce909bc36",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libavtp/libavtp0_0.2.0-2_amd64.deb"
+    },
+    {
+      "name": "libbs2b0",
+      "version": "3.1.0+dfsg-8",
+      "architecture": "amd64",
+      "filename": "libbs2b0_3.1.0+dfsg-8_amd64.deb",
+      "sha256": "7d03829734d659b1167c92e8c00e415e113cb29cdc884576a9ccca611ef4e2b9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libb/libbs2b/libbs2b0_3.1.0%2bdfsg-8_amd64.deb"
+    },
+    {
+      "name": "libchromaprint1",
+      "version": "1.5.1-7",
+      "architecture": "amd64",
+      "filename": "libchromaprint1_1.5.1-7_amd64.deb",
+      "sha256": "a108a4a6e4b49c981975076aa2d1d15d73ed6c0b98122e7b5ceb7703f7851666",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/chromaprint/libchromaprint1_1.5.1-7_amd64.deb"
+    },
+    {
+      "name": "libcpuinfo0",
+      "version": "0.0~git20250203.aaac07e-1",
+      "architecture": "amd64",
+      "filename": "libcpuinfo0_0.0~git20250203.aaac07e-1_amd64.deb",
+      "sha256": "13af6ecf274a2629121a38b06a815cd945c99a586f3a8848bb386c49961b31b7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/cpuinfo/libcpuinfo0_0.0%7egit20250203.aaac07e-1_amd64.deb"
+    },
+    {
+      "name": "libdc1394-25",
+      "version": "2.2.6-4build1",
+      "architecture": "amd64",
+      "filename": "libdc1394-25_2.2.6-4build1_amd64.deb",
+      "sha256": "0f4a0768152636f2f941d3a29d24925be77f869b3d90a13f1694fef792a89810",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdc1394/libdc1394-25_2.2.6-4build1_amd64.deb"
+    },
+    {
+      "name": "libdca0",
+      "version": "0.0.7-2build1",
+      "architecture": "amd64",
+      "filename": "libdca0_0.0.7-2build1_amd64.deb",
+      "sha256": "018867fee029b072ecb3365f5f92c0cb0530d4ab37aa13be127116b6e5c3c06d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdca/libdca0_0.0.7-2build1_amd64.deb"
+    },
+    {
+      "name": "libde265-0",
+      "version": "1.0.15-1build5",
+      "architecture": "amd64",
+      "filename": "libde265-0_1.0.15-1build5_amd64.deb",
+      "sha256": "1a3d3faab069f9bb4051c0d4e5d2ee18c3c41f440ad1569838c338fc12d47e0b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libde265/libde265-0_1.0.15-1build5_amd64.deb"
+    },
+    {
+      "name": "libdnnl3.6",
+      "version": "3.7.1+ds-1",
+      "architecture": "amd64",
+      "filename": "libdnnl3.6_3.7.1+ds-1_amd64.deb",
+      "sha256": "88fd977d7076586d2a2bb89659d24e8875f188f79a15649ce1832764b3232d67",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onednn/libdnnl3.6_3.7.1%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libdvdnav4",
+      "version": "6.1.1-3build1",
+      "architecture": "amd64",
+      "filename": "libdvdnav4_6.1.1-3build1_amd64.deb",
+      "sha256": "09fd1de2985ade2592d4f068774b2249211880aa6d4a71a89e0b4764afe47404",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdnav/libdvdnav4_6.1.1-3build1_amd64.deb"
+    },
+    {
+      "name": "libdvdread8t64",
+      "version": "6.1.3-2",
+      "architecture": "amd64",
+      "filename": "libdvdread8t64_6.1.3-2_amd64.deb",
+      "sha256": "269fe55b0eb5a47b7112c46a5ed3a21bdbd0378224970d733225ecfd3cb5f20e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdread/libdvdread8t64_6.1.3-2_amd64.deb"
+    },
+    {
+      "name": "libfaad2",
+      "version": "2.11.2-1",
+      "architecture": "amd64",
+      "filename": "libfaad2_2.11.2-1_amd64.deb",
+      "sha256": "cdf00ddc8c0f4f6e3dbc46c1d0efba537632609432734deb01113cac3ac1531d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/faad2/libfaad2_2.11.2-1_amd64.deb"
+    },
+    {
+      "name": "libflite1",
+      "version": "2.2-7",
+      "architecture": "amd64",
+      "filename": "libflite1_2.2-7_amd64.deb",
+      "sha256": "3afe2b4ab82dff2330b53fcee83b4b21aa580f6d91a1ce850e917cf8cffc004a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/flite/libflite1_2.2-7_amd64.deb"
+    },
+    {
+      "name": "libfluidsynth3",
+      "version": "2.4.4+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libfluidsynth3_2.4.4+dfsg-1_amd64.deb",
+      "sha256": "2a7177d672b1f717c2b064181cac9e1772aeaf93e0a00db8327954eeeaff9189",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/fluidsynth/libfluidsynth3_2.4.4%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libfreeaptx0",
+      "version": "0.1.1-2build1",
+      "architecture": "amd64",
+      "filename": "libfreeaptx0_0.1.1-2build1_amd64.deb",
+      "sha256": "2280d6fdd41c841701a9da6b5076b77e8a0849e5c10c9c2945f817f753575a42",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libf/libfreeaptx/libfreeaptx0_0.1.1-2build1_amd64.deb"
+    },
+    {
+      "name": "libgme0",
+      "version": "0.6.3-7build1",
+      "architecture": "amd64",
+      "filename": "libgme0_0.6.3-7build1_amd64.deb",
+      "sha256": "a54fa608501f87f9e5064b60c75fc1bb62735c9f9ba9f7680cb804bb5eae2027",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/game-music-emu/libgme0_0.6.3-7build1_amd64.deb"
+    },
+    {
+      "name": "libgomp1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libgomp1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8da90c11d615b01a4a7fc797e8362350617ba289410f8aa1c4ac2d70beeb5bca",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libgomp1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libgsm1",
+      "version": "1.0.22-1build1",
+      "architecture": "amd64",
+      "filename": "libgsm1_1.0.22-1build1_amd64.deb",
+      "sha256": "8cc765587a3275e861f166a98b4b79dd8d5c673f97e17967945ab4d1eb89c89a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libg/libgsm/libgsm1_1.0.22-1build1_amd64.deb"
+    },
+    {
+      "name": "libgssdp-1.6-0",
+      "version": "1.6.3-2",
+      "architecture": "amd64",
+      "filename": "libgssdp-1.6-0_1.6.3-2_amd64.deb",
+      "sha256": "7897db47adc4114a17c44f390d2816c7e58ac8bdd722fa58fa21c659368aece7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gssdp/libgssdp-1.6-0_1.6.3-2_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-gl1.0-0",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-gl1.0-0_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "b764616f2364767c94f4d8c667b9103b288beb3ef562a2a76155509b171a4d85",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-bad1.0-0",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "36c0de48cf25ca31dc21363dabd3fb32e9d4c539467b6b76b4770c5e82822099",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "libgupnp-1.6-0",
+      "version": "1.6.8-2",
+      "architecture": "amd64",
+      "filename": "libgupnp-1.6-0_1.6.8-2_amd64.deb",
+      "sha256": "9346722ae71cc4bce037ef49bf38c609392eb1cfb6eba19fce575673577896c5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gupnp/libgupnp-1.6-0_1.6.8-2_amd64.deb"
+    },
+    {
+      "name": "libgupnp-igd-1.6-0",
+      "version": "1.6.0-4",
+      "architecture": "amd64",
+      "filename": "libgupnp-igd-1.6-0_1.6.0-4_amd64.deb",
+      "sha256": "bf96c3dc6cf586400754dcf51b1e8033399171d5c5a55191ba13cf8c6d8c426e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gupnp-igd/libgupnp-igd-1.6-0_1.6.0-4_amd64.deb"
+    },
+    {
+      "name": "libicu76",
+      "version": "76.1-1ubuntu2",
+      "architecture": "amd64",
+      "filename": "libicu76_76.1-1ubuntu2_amd64.deb",
+      "sha256": "c289a52f92c9ab2a1783b6b5757c928bff228671f20473275a426798446a4ce1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/i/icu/libicu76_76.1-1ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libimath-3-1-29t64",
+      "version": "3.1.12-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb",
+      "sha256": "5b35e6bdfc8f567c3c33b4c5b519ceab2acd1c5c05534f360c33cedcf14c4cf3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/i/imath/libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libinstpatch-1.0-2",
+      "version": "1.1.6-1build2",
+      "architecture": "amd64",
+      "filename": "libinstpatch-1.0-2_1.1.6-1build2_amd64.deb",
+      "sha256": "d48c40a9c428e40d5bbe8762802390322b06a062c735292767e73d1c6ea9007e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libi/libinstpatch/libinstpatch-1.0-2_1.1.6-1build2_amd64.deb"
+    },
+    {
+      "name": "liblc3-1",
+      "version": "1.1.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "liblc3-1_1.1.3+dfsg-1_amd64.deb",
+      "sha256": "0a88ca35cd79b18e42bbb22800e2ea49f2e0123cc709696dd1954486d7694e4d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/liblc3/liblc3-1_1.1.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libldacbt-enc2",
+      "version": "2.0.2.3+git20200429+ed310a0-5",
+      "architecture": "amd64",
+      "filename": "libldacbt-enc2_2.0.2.3+git20200429+ed310a0-5_amd64.deb",
+      "sha256": "7212ed25d4be1782cfc71ef1758a587fa3a3cfb7ba939c7233161cb491946a34",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/libldac/libldacbt-enc2_2.0.2.3%2bgit20200429%2bed310a0-5_amd64.deb"
+    },
+    {
+      "name": "liblilv-0-0",
+      "version": "0.24.26-1",
+      "architecture": "amd64",
+      "filename": "liblilv-0-0_0.24.26-1_amd64.deb",
+      "sha256": "3076146b3bae4bce370c6618ef8ed788383d3d35184dae0bbb9877dcdbb127c2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/lilv/liblilv-0-0_0.24.26-1_amd64.deb"
+    },
+    {
+      "name": "liblrdf0",
+      "version": "0.6.1-4build1",
+      "architecture": "amd64",
+      "filename": "liblrdf0_0.6.1-4build1_amd64.deb",
+      "sha256": "470a5e0e88fd2e7dcfc024c789cd029578b110c65558ae423fd79d7bb4ef01ca",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/liblrdf/liblrdf0_0.6.1-4build1_amd64.deb"
+    },
+    {
+      "name": "libltc11",
+      "version": "1.3.2-1build1",
+      "architecture": "amd64",
+      "filename": "libltc11_1.3.2-1build1_amd64.deb",
+      "sha256": "92f23451cefe159faef9f255f0d24987eff50e52647dc1aa9843ad4c733ca039",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/libltc/libltc11_1.3.2-1build1_amd64.deb"
+    },
+    {
+      "name": "libmjpegutils-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmjpegutils-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "3422b9e3f7aa721a18f1738b33815a7f681fbe1ec0bafb1faf733e625dcbce85",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmjpegutils-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmodplug1",
+      "version": "1:0.8.9.0-3build1",
+      "architecture": "amd64",
+      "filename": "libmodplug1_1%3a0.8.9.0-3build1_amd64.deb",
+      "sha256": "34b383f35def5405069ae1eb6b4e6a7f73c9adafd0d049add82285b0e1a2e1ad",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmodplug/libmodplug1_0.8.9.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libmpcdec6",
+      "version": "2:0.1~r495-3",
+      "architecture": "amd64",
+      "filename": "libmpcdec6_2%3a0.1~r495-3_amd64.deb",
+      "sha256": "35e003823ddf242d8799057d420fc15ed644bb836d63ae18af57bd514699a216",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmpc/libmpcdec6_0.1%7er495-3_amd64.deb"
+    },
+    {
+      "name": "libmpeg2encpp-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmpeg2encpp-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "ec077a7c7fc7abd77d460813f56a9bef1dd68e53148840ef242b1795043d318e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmpeg2encpp-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmplex2-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmplex2-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "8c4324fb9ac9b667559aeaa92e399beeb4396d0cd33627be1b1306b85a31e5e2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmplex2-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libneon27t64",
+      "version": "0.34.0-1",
+      "architecture": "amd64",
+      "filename": "libneon27t64_0.34.0-1_amd64.deb",
+      "sha256": "1710578bc51522b9ee8ccd70624b9e2e266f50e5ac39711d1096757bd23d381f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/neon27/libneon27t64_0.34.0-1_amd64.deb"
+    },
+    {
+      "name": "libnice10",
+      "version": "0.1.22-1",
+      "architecture": "amd64",
+      "filename": "libnice10_0.1.22-1_amd64.deb",
+      "sha256": "3e227906bae81259542732d0af1623a05910855d86e548e5b704e17ea8cb2a17",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libn/libnice/libnice10_0.1.22-1_amd64.deb"
+    },
+    {
+      "name": "libnuma1",
+      "version": "2.0.18-1build1",
+      "architecture": "amd64",
+      "filename": "libnuma1_2.0.18-1build1_amd64.deb",
+      "sha256": "508daa855e99959acaa945e6a89d218e0be6b5727fd28773580942ff37cf5805",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/n/numactl/libnuma1_2.0.18-1build1_amd64.deb"
+    },
+    {
+      "name": "libonnx1t64",
+      "version": "1.17.0-3build1",
+      "architecture": "amd64",
+      "filename": "libonnx1t64_1.17.0-3build1_amd64.deb",
+      "sha256": "c4fcb75e98e7a28dd741d002c640bb3a9891dee2d9ec39ee570f2824d77318ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnx/libonnx1t64_1.17.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libonnxruntime1.21",
+      "version": "1.21.0+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libonnxruntime1.21_1.21.0+dfsg-1_amd64.deb",
+      "sha256": "17e9bfec1e4e86a7456720843ed5443c2eb3bda62b45f0e075ab0c8d89e4ae7b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnxruntime/libonnxruntime1.21_1.21.0%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libopenal-data",
+      "version": "1:1.24.2-1",
+      "architecture": "all",
+      "filename": "libopenal-data_1%3a1.24.2-1_all.deb",
+      "sha256": "2bce384fa3c8fb1193e9ec8c948787263e5a2fc53a4a4715c4aeeab75b98b420",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal-data_1.24.2-1_all.deb"
+    },
+    {
+      "name": "libopenal1",
+      "version": "1:1.24.2-1",
+      "architecture": "amd64",
+      "filename": "libopenal1_1%3a1.24.2-1_amd64.deb",
+      "sha256": "461b8d108f70efa65eefbb3af5c697ac95f831f1959de3b625345b389628bbbb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal1_1.24.2-1_amd64.deb"
+    },
+    {
+      "name": "libopenexr-3-1-30",
+      "version": "3.1.13-2",
+      "architecture": "amd64",
+      "filename": "libopenexr-3-1-30_3.1.13-2_amd64.deb",
+      "sha256": "cae37d566e8d08fdeabdbcac7e9c9a5c68b9541a83974adbd3f50cb654e83390",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openexr/libopenexr-3-1-30_3.1.13-2_amd64.deb"
+    },
+    {
+      "name": "libopenh264-8",
+      "version": "2.6.0+dfsg-2",
+      "architecture": "amd64",
+      "filename": "libopenh264-8_2.6.0+dfsg-2_amd64.deb",
+      "sha256": "bbff1a10312e60e4566c0e34c2d2f98deda75763ea639650518d00e1e028f67e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openh264/libopenh264-8_2.6.0%2bdfsg-2_amd64.deb"
+    },
+    {
+      "name": "libopenjp2-7",
+      "version": "2.5.3-2ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libopenjp2-7_2.5.3-2ubuntu0.1_amd64.deb",
+      "sha256": "612fa2efbcbc6a2ddfd34d1630cac0cdcae8f3062ac5fe5617563a73e527fb35",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/openjpeg2/libopenjp2-7_2.5.3-2ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libopenmpt0t64",
+      "version": "0.7.13-1build1",
+      "architecture": "amd64",
+      "filename": "libopenmpt0t64_0.7.13-1build1_amd64.deb",
+      "sha256": "0a3f0e7060f1777d9865ff1ba23d7ad692f395594388442bde670e4bf435a975",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libo/libopenmpt/libopenmpt0t64_0.7.13-1build1_amd64.deb"
+    },
+    {
+      "name": "libopenni2-0",
+      "version": "2.2.0.33+dfsg-18",
+      "architecture": "amd64",
+      "filename": "libopenni2-0_2.2.0.33+dfsg-18_amd64.deb",
+      "sha256": "bba943fe73b2b0271ebbd6a28d0afb9e7084df75a64748fc06e3f72151ab1b76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openni2/libopenni2-0_2.2.0.33%2bdfsg-18_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-modules",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "f23e9a3ebedfbb846efe210bcc55150668394ac807e6c71f1f2c1d5f728c2f8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libprotobuf32t64",
+      "version": "3.21.12-10ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb",
+      "sha256": "19a6eac6e4d794318608c7e6862c4414119e1be7d3e66b0f8e698c62c78411ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/protobuf/libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpthreadpool0",
+      "version": "0.0~git20240616.560c60d-1",
+      "architecture": "amd64",
+      "filename": "libpthreadpool0_0.0~git20240616.560c60d-1_amd64.deb",
+      "sha256": "a09c04886537cf3db25ae1c0644a0b4cc070d520914521a00f81b86b1254f23f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/p/pthreadpool/libpthreadpool0_0.0%7egit20240616.560c60d-1_amd64.deb"
+    },
+    {
+      "name": "libqrencode4",
+      "version": "4.1.1-2",
+      "architecture": "amd64",
+      "filename": "libqrencode4_4.1.1-2_amd64.deb",
+      "sha256": "d9eed9dc0a75994c2fe4d95f9dae8d700b4a363383f6966a82d6d0225e275280",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/q/qrencode/libqrencode4_4.1.1-2_amd64.deb"
+    },
+    {
+      "name": "libraptor2-0",
+      "version": "2.0.16-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libraptor2-0_2.0.16-4ubuntu1_amd64.deb",
+      "sha256": "ecae495617134e13c098780576db94c89e9475d2ccec3d2bb732799ce958bd87",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/raptor2/libraptor2-0_2.0.16-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libre2-11",
+      "version": "20240501-3build1",
+      "architecture": "amd64",
+      "filename": "libre2-11_20240501-3build1_amd64.deb",
+      "sha256": "b7a4b55a5f2e4ca12d1020b2cd5a0a0540bb1a9b4706eaa8e1294fe52a4112a5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/re2/libre2-11_20240501-3build1_amd64.deb"
+    },
+    {
+      "name": "libroc0.4",
+      "version": "0.4.0+dfsg-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libroc0.4_0.4.0+dfsg-4ubuntu1_amd64.deb",
+      "sha256": "8bec93425075527aa82683dbcf2d1784c39361da46a10c299f0c60afb8625b71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/roc-toolkit/libroc0.4_0.4.0%2bdfsg-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "librsvg2-2",
+      "version": "2.60.0+dfsg-1",
+      "architecture": "amd64",
+      "filename": "librsvg2-2_2.60.0+dfsg-1_amd64.deb",
+      "sha256": "98c3d1393a67b1e78b468dd05db277646f28c27fba5cbe7c028c2fabbdc9a9c9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libr/librsvg/librsvg2-2_2.60.0%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libsbc1",
+      "version": "2.0-1build1",
+      "architecture": "amd64",
+      "filename": "libsbc1_2.0-1build1_amd64.deb",
+      "sha256": "d4d453e7673218fc2f917dbabb2492a5a81155c2305f6fe63a37cadcaa806128",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/sbc/libsbc1_2.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libserd-0-0",
+      "version": "0.32.4-1",
+      "architecture": "amd64",
+      "filename": "libserd-0-0_0.32.4-1_amd64.deb",
+      "sha256": "3d1c23e9effbe22d3edab8c0c2fdc8297d966c134f4d8095ccf0c9da52cc5f33",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/serd/libserd-0-0_0.32.4-1_amd64.deb"
+    },
+    {
+      "name": "libsnapd-glib-2-1",
+      "version": "1.66-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb",
+      "sha256": "b7bd77be1d59bf3a19bbe91b9ab6225ad05736ed72bd9f3b3f56bcd83822e398",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/snapd-glib/libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsord-0-0",
+      "version": "0.16.18-1",
+      "architecture": "amd64",
+      "filename": "libsord-0-0_0.16.18-1_amd64.deb",
+      "sha256": "bfd5ef5bbab2eed986b6f2856c2904db70c3d9e7a34b9f9caffcc1ea36a47a9b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sord/libsord-0-0_0.16.18-1_amd64.deb"
+    },
+    {
+      "name": "libsoundtouch1",
+      "version": "2.3.3+ds-1",
+      "architecture": "amd64",
+      "filename": "libsoundtouch1_2.3.3+ds-1_amd64.deb",
+      "sha256": "cadad56c5398a93f2f8c7080ca1a93725c15242beff0891cfdb029c5e4f305f3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/soundtouch/libsoundtouch1_2.3.3%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libspandsp2t64",
+      "version": "0.0.6+dfsg-2.2",
+      "architecture": "amd64",
+      "filename": "libspandsp2t64_0.0.6+dfsg-2.2_amd64.deb",
+      "sha256": "63a125139f3507ae94faa7cdd10ee6d6c551961937b1ec7fafa4d320e34b71bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spandsp/libspandsp2t64_0.0.6%2bdfsg-2.2_amd64.deb"
+    },
+    {
+      "name": "libspeexdsp1",
+      "version": "1.2.1-3",
+      "architecture": "amd64",
+      "filename": "libspeexdsp1_1.2.1-3_amd64.deb",
+      "sha256": "5b178611a05217d2ba35823aa8f75387d074a7e2d50954dc11464678cd7b2c91",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/speexdsp/libspeexdsp1_1.2.1-3_amd64.deb"
+    },
+    {
+      "name": "libsratom-0-0",
+      "version": "0.6.18-1",
+      "architecture": "amd64",
+      "filename": "libsratom-0-0_0.6.18-1_amd64.deb",
+      "sha256": "848fcfa874c1acb8c2331747a841467f8921334d5b5cbb66f8306d933203f344",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sratom/libsratom-0-0_0.6.18-1_amd64.deb"
+    },
+    {
+      "name": "libsrt1.5-gnutls",
+      "version": "1.5.4-1",
+      "architecture": "amd64",
+      "filename": "libsrt1.5-gnutls_1.5.4-1_amd64.deb",
+      "sha256": "88e58de644fbf38c194494789c4f1e047dae6c43bd71ca245530d721a4a0b5e0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/srt/libsrt1.5-gnutls_1.5.4-1_amd64.deb"
+    },
+    {
+      "name": "libsrtp2-1",
+      "version": "2.5.0-3build1",
+      "architecture": "amd64",
+      "filename": "libsrtp2-1_2.5.0-3build1_amd64.deb",
+      "sha256": "c2e7ee0ae64597f046fbfb197b8f36dfc9a5159b02d27e850f3a4d14a4603d77",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libs/libsrtp2/libsrtp2-1_2.5.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libunibreak6",
+      "version": "6.1-2",
+      "architecture": "amd64",
+      "filename": "libunibreak6_6.1-2_amd64.deb",
+      "sha256": "c904cf437fcad74dac8c9e7fd1a4a9657b0c5d44441848e321e225375b69c4fc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libu/libunibreak/libunibreak6_6.1-2_amd64.deb"
+    },
+    {
+      "name": "libunwind8",
+      "version": "1.6.2-3.1",
+      "architecture": "amd64",
+      "filename": "libunwind8_1.6.2-3.1_amd64.deb",
+      "sha256": "9d48508139a791778c86f341e725f06dd5304dc24e80501080271a734bf970da",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libunwind/libunwind8_1.6.2-3.1_amd64.deb"
+    },
+    {
+      "name": "libusb-1.0-0",
+      "version": "2:1.0.27-2",
+      "architecture": "amd64",
+      "filename": "libusb-1.0-0_2%3a1.0.27-2_amd64.deb",
+      "sha256": "3f8b484e46112ce8804931b0fa468d93c55a8aa8a4df3f8bf8bd2cf93601a037",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.27-2_amd64.deb"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2ubuntu1",
+      "architecture": "amd64",
+      "filename": "libuv1t64_1.50.0-2ubuntu1_amd64.deb",
+      "sha256": "6af9634d05965f60ed7c124d43cef678ef288824b6f36a7b02559dd4097e7c90",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libuv1/libuv1t64_1.50.0-2ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libva-drm2",
+      "version": "2.22.0-3ubuntu2",
+      "architecture": "amd64",
+      "filename": "libva-drm2_2.22.0-3ubuntu2_amd64.deb",
+      "sha256": "fb95623b4c1834a34109966e7f5c85b4ab2f620d5804ea6512b69c25159a45bf",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libva/libva-drm2_2.22.0-3ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libva2",
+      "version": "2.22.0-3ubuntu2",
+      "architecture": "amd64",
+      "filename": "libva2_2.22.0-3ubuntu2_amd64.deb",
+      "sha256": "52bb1274b1cf1dbfe83f85a453363c0c651513d1e45264553edf286b9129d8c6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libva/libva2_2.22.0-3ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libvo-aacenc0",
+      "version": "0.1.3-3",
+      "architecture": "amd64",
+      "filename": "libvo-aacenc0_0.1.3-3_amd64.deb",
+      "sha256": "ea759b3a02552c379424775d5fc5d37d8dff59eb70ceab35118146ef04e857a3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-aacenc/libvo-aacenc0_0.1.3-3_amd64.deb"
+    },
+    {
+      "name": "libvo-amrwbenc0",
+      "version": "0.1.3-2build1",
+      "architecture": "amd64",
+      "filename": "libvo-amrwbenc0_0.1.3-2build1_amd64.deb",
+      "sha256": "30d260bbb56b9340319216529e72ed02a68752de62d5926ad07132ed2459af05",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-amrwbenc/libvo-amrwbenc0_0.1.3-2build1_amd64.deb"
+    },
+    {
+      "name": "libvorbisfile3",
+      "version": "1.3.7-2",
+      "architecture": "amd64",
+      "filename": "libvorbisfile3_1.3.7-2_amd64.deb",
+      "sha256": "6dfc7f0bd9f0c745c2e099aca9121843650ec7c7193801057bc3927c43820e70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-2_amd64.deb"
+    },
+    {
+      "name": "libwebpmux3",
+      "version": "1.5.0-0.1",
+      "architecture": "amd64",
+      "filename": "libwebpmux3_1.5.0-0.1_amd64.deb",
+      "sha256": "a9c741f966e93ee7d857d22895a670c20755f09f72bc6cf9b4fadd4548b750f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libw/libwebp/libwebpmux3_1.5.0-0.1_amd64.deb"
+    },
+    {
+      "name": "libwildmidi2",
+      "version": "0.4.3-1build3",
+      "architecture": "amd64",
+      "filename": "libwildmidi2_0.4.3-1build3_amd64.deb",
+      "sha256": "f44a3f24eb567cf104aefe6cabe2a3385185dc59dd83d64a37c1a04f0e12c771",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/w/wildmidi/libwildmidi2_0.4.3-1build3_amd64.deb"
+    },
+    {
+      "name": "libx265-215",
+      "version": "4.1-2",
+      "architecture": "amd64",
+      "filename": "libx265-215_4.1-2_amd64.deb",
+      "sha256": "7fb455bbdd67cfa604b397c64e3e7893ae128ec12dad84655218e83501502a02",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/x265/libx265-215_4.1-2_amd64.deb"
+    },
+    {
+      "name": "libxnnpack0.20241108",
+      "version": "0.0~git20241108.4ea82e5-1",
+      "architecture": "amd64",
+      "filename": "libxnnpack0.20241108_0.0~git20241108.4ea82e5-1_amd64.deb",
+      "sha256": "0a3eedc79943aadbc036d199230c573e1a0b80f947e07076dbf1db1d4a201297",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/xnnpack/libxnnpack0.20241108_0.0%7egit20241108.4ea82e5-1_amd64.deb"
+    },
+    {
+      "name": "libxslt1.1",
+      "version": "1.1.39-0exp1ubuntu4.1",
+      "architecture": "amd64",
+      "filename": "libxslt1.1_1.1.39-0exp1ubuntu4.1_amd64.deb",
+      "sha256": "7072c3b5e8e36fe949edf29d89cfc1cc4a4a65c6a1fb9e9ddd4abbba0c9c5872",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxslt/libxslt1.1_1.1.39-0exp1ubuntu4.1_amd64.deb"
+    },
+    {
+      "name": "libyajl2",
+      "version": "2.1.0-5build1",
+      "architecture": "amd64",
+      "filename": "libyajl2_2.1.0-5build1_amd64.deb",
+      "sha256": "faa268c632f7d2931509cf7b8b7ddd810aa775adc26ead88ea158e2ede5208f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/y/yajl/libyajl2_2.1.0-5build1_amd64.deb"
+    },
+    {
+      "name": "libzbar0t64",
+      "version": "0.23.93-7",
+      "architecture": "amd64",
+      "filename": "libzbar0t64_0.23.93-7_amd64.deb",
+      "sha256": "9954e12b0e2f1f5a294465c6e5c1eaa46407024f0416b4b90513e554ecd31776",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zbar/libzbar0t64_0.23.93-7_amd64.deb"
+    },
+    {
+      "name": "libzix-0-0",
+      "version": "0.6.2-1",
+      "architecture": "amd64",
+      "filename": "libzix-0-0_0.6.2-1_amd64.deb",
+      "sha256": "54d72b63ae0243dedd47e1946765890deb7764f5cfa2c9332228742b6b406ba9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zix/libzix-0-0_0.6.2-1_amd64.deb"
+    },
+    {
+      "name": "libzvbi-common",
+      "version": "0.2.44-1ubuntu1",
+      "architecture": "all",
+      "filename": "libzvbi-common_0.2.44-1ubuntu1_all.deb",
+      "sha256": "0462d29f8e7291539247179a97693f0098fd7738b26ef1f0e05122595975eee9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zvbi/libzvbi-common_0.2.44-1ubuntu1_all.deb"
+    },
+    {
+      "name": "libzvbi0t64",
+      "version": "0.2.44-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libzvbi0t64_0.2.44-1ubuntu1_amd64.deb",
+      "sha256": "6596415c0581e0b48d34dae7c13990cd57187bd5e0331cb2a237c34ae6ef3949",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zvbi/libzvbi0t64_0.2.44-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libzxing3",
+      "version": "2.3.0-3",
+      "architecture": "amd64",
+      "filename": "libzxing3_2.3.0-3_amd64.deb",
+      "sha256": "66937bdde76f3edf56568d461692c7f6668f057a8ce0ba687570acb32bfd750b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zxing-cpp/libzxing3_2.3.0-3_amd64.deb"
+    },
+    {
+      "name": "pipewire",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "b77fae0221ecdebcc9839cfd08aa5da95359c741a4d2922bfcaf55474b93f0a7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-bin",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "0d16cd14743a2c8fc4c726057ec910ba7eac48e5de65698acc01aeb336d45078",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-pulse",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "611be8d6b8620f5d266e7a8a232bb7cb96f558fc8a73205af7aaec084c3ab8eb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "timgm6mb-soundfont",
+      "version": "1.3-5",
+      "architecture": "all",
+      "filename": "timgm6mb-soundfont_1.3-5_all.deb",
+      "sha256": "b70bc29b8f27adef8f92a2d9c1e26cee977b84c68110f0dd4326d97730a7c3ed",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/t/timgm6mb-soundfont/timgm6mb-soundfont_1.3-5_all.deb"
+    }
+  ],
+  "build": [
+    {
+      "name": "binutils",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "binutils_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "744a214541a5b5063d07914a385abdd2ee09d81a35042f97df44aa4774f050db",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/binutils_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "binutils-common",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "binutils-common_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "4c88f15afb2d59ceda47a9a9cd026d1020bebaae129bca9567e8fe0ea692d98f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/binutils-common_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "binutils-gold",
+      "version": "2.44-2",
+      "architecture": "amd64",
+      "filename": "binutils-gold_2.44-2_amd64.deb",
+      "sha256": "832317652330363576d427f3038663fe3aaa778ac1e5749888aad6b59ec17fd4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils-gold/binutils-gold_2.44-2_amd64.deb"
+    },
+    {
+      "name": "binutils-gold-x86-64-linux-gnu",
+      "version": "2.44-2",
+      "architecture": "amd64",
+      "filename": "binutils-gold-x86-64-linux-gnu_2.44-2_amd64.deb",
+      "sha256": "149f39909d2454e78f5fc6c8e829a756ab4bd6b65e7202e3fecf37bd07309608",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils-gold/binutils-gold-x86-64-linux-gnu_2.44-2_amd64.deb"
+    },
+    {
+      "name": "binutils-x86-64-linux-gnu",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "binutils-x86-64-linux-gnu_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "bab4b7f76496ff8a83ed2552a97aa996b77f38f5f2cc8e802d7b32fbf0c484ad",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "build-essential",
+      "version": "12.12ubuntu1",
+      "architecture": "amd64",
+      "filename": "build-essential_12.12ubuntu1_amd64.deb",
+      "sha256": "6690743c7c255ec97f2ce7373648cebe24e9b83da2b134ce8c53326840757016",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/build-essential/build-essential_12.12ubuntu1_amd64.deb"
+    },
+    {
+      "name": "bzip2",
+      "version": "1.0.8-6",
+      "architecture": "amd64",
+      "filename": "bzip2_1.0.8-6_amd64.deb",
+      "sha256": "b90c1467738ebb2941ab0129ee142de7803e3564196e89485e8c91d11cffd5a4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/bzip2/bzip2_1.0.8-6_amd64.deb"
+    },
+    {
+      "name": "clang",
+      "version": "1:20.0-63ubuntu1",
+      "architecture": "amd64",
+      "filename": "clang_1%3a20.0-63ubuntu1_amd64.deb",
+      "sha256": "63385ed7288cb5148c62000b328c38b6877a0df265e7bad4a32b208afdd89a96",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-defaults/clang_20.0-63ubuntu1_amd64.deb"
+    },
+    {
+      "name": "clang-20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "clang-20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "25100f57ca694598e4eb9fb605b504f1ebf4480bed15a0c79f3944a1deba2c13",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/clang-20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cmake",
+      "version": "3.31.6-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "cmake_3.31.6-1ubuntu1_amd64.deb",
+      "sha256": "eb9a56e821b957179d2d801878668fb56d64dde8ccb3d46e9bd591bddb1d75ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/c/cmake/cmake_3.31.6-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cmake-data",
+      "version": "3.31.6-1ubuntu1",
+      "architecture": "all",
+      "filename": "cmake-data_3.31.6-1ubuntu1_all.deb",
+      "sha256": "52c6d1634243c6648028b04b7f7f241993cdaab48becde16b540b90c80ba31ec",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/c/cmake/cmake-data_3.31.6-1ubuntu1_all.deb"
+    },
+    {
+      "name": "cpp",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "cpp_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "6ecd93b5307ccefe61b5e59c67346b9285ef54314294c1e5e97d5084913462c3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/cpp_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cpp-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "cpp-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "724e139e35d74ddabf5039eb1582b72f6a42b6e323d2fb19ff2bd203a85c7b08",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/cpp-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "cpp-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "cpp-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "af3d711d9b0021d79b0aed799029b4d35b5f215d4c96eaaaa766c1277a2bc7e4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/cpp-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "cpp-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "cpp-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "60a95cc48c0dc91e5abc4d9059209819ab3589373ff28a01199cf46254f1770e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/cpp-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "dpkg-dev",
+      "version": "1.22.18ubuntu2.2",
+      "architecture": "all",
+      "filename": "dpkg-dev_1.22.18ubuntu2.2_all.deb",
+      "sha256": "f17198b313ade86099ad7b35c152875d84ef2de9bda3a5c430a6c17b351991df",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/d/dpkg/dpkg-dev_1.22.18ubuntu2.2_all.deb"
+    },
+    {
+      "name": "g++",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "g++_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "c286c49484a551dfb9514898244e3d7089fd543c11a3f7e1a3227f96f07df14a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/g%2b%2b_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "g++-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "g++-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "b0848a8a8e00fd453c00d6f52b73e1fb9b5f887a71cfa160487a6b252dda1b4e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/g%2b%2b-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "g++-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "g++-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "b9f5de224295cb5ef5b7f641baddb4da943d43192157c831ab9b6f652894438e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/g%2b%2b-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "g++-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "g++-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "7a3aad61f52c6a1c2fab94d7ac313673272c4617c0b8c6edad48188ec06ddf7e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/g%2b%2b-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gcc",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "gcc_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "82abbe21f53a70db6abe947998f07d2e91c36cce62972540dc782c29c86d0702",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/gcc_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gcc-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "gcc-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "209a445434926b1f25221e464108c141950ee2316a8ddf535ec518cb57926f76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/gcc-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "gcc-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "gcc-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "ab71e82506bee4747468cd701940fc4f5dd498605d76e257b89d009c2e4c4413",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/gcc-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "gcc-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "gcc-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "eb69145199e998fae2e6fab23a0759f768f33e7b7b2d21fb28dc0c91bbe3ab2d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/gcc-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gir1.2-glib-2.0-dev",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "gir1.2-glib-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "90e423a6b84c2814102ef749710f1230e76730939ec334ab681559d6a0f69a3b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/gir1.2-glib-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gst-plugins-base-1.0",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "gir1.2-gst-plugins-base-1.0_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "0d52d57f01acbdde1ff600129dcafca59008e500cbc7df3f27f721b318f1b4e4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/gir1.2-gst-plugins-base-1.0_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gstreamer-1.0",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gir1.2-gstreamer-1.0_1.26.0-3_amd64.deb",
+      "sha256": "8078e3a2a9bd916f9448d3333a12f1b5a4788c696248b91bdf1322c579ddea1c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gir1.2-gstreamer-1.0_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gudev-1.0",
+      "version": "1:238-6",
+      "architecture": "amd64",
+      "filename": "gir1.2-gudev-1.0_1%3a238-6_amd64.deb",
+      "sha256": "5759e4ab498311b1ee83a0f38e6aeda415590de45a404c7ba7f5c9d9f8a31d61",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_amd64.deb"
+    },
+    {
+      "name": "girepository-tools",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "girepository-tools_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "002ca31c5e75d96c7c455ad00ac185044f113f32a7037d69a074b5d73425f5e7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/girepository-tools_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "git",
+      "version": "1:2.48.1-0ubuntu1.1",
+      "architecture": "amd64",
+      "filename": "git_1%3a2.48.1-0ubuntu1.1_amd64.deb",
+      "sha256": "f85b919ba73b802a5934719678d3f83f75b06c67187cf0facb262c3b1bdd4721",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/git/git_2.48.1-0ubuntu1.1_amd64.deb"
+    },
+    {
+      "name": "git-man",
+      "version": "1:2.48.1-0ubuntu1.1",
+      "architecture": "all",
+      "filename": "git-man_1%3a2.48.1-0ubuntu1.1_all.deb",
+      "sha256": "3292fe6f57a9620ba7653dfc492f40951ba6824bc1ac4dfc7c96f3f59731fd18",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/git/git-man_2.48.1-0ubuntu1.1_all.deb"
+    },
+    {
+      "name": "glslang-tools",
+      "version": "15.1.0-2",
+      "architecture": "amd64",
+      "filename": "glslang-tools_15.1.0-2_amd64.deb",
+      "sha256": "98d8b12ebaa3a9bcf7e68087d08a43a997356a52c130f01a5624a208fa8ab9d7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/glslang/glslang-tools_15.1.0-2_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-plugins-bad",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "800b2b0a8f994098e854413821a4908f301425e165b112994d4ad891e38c828a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-tools",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-tools_1.26.0-3_amd64.deb",
+      "sha256": "ac24b15d6a48bb99097419f4d8d5928430d010af301b0df0b32570e59879f8f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gstreamer1.0-tools_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "hwdata",
+      "version": "0.393-3",
+      "architecture": "all",
+      "filename": "hwdata_0.393-3_all.deb",
+      "sha256": "ad5beb26ff8b18ff48467b3f09b6e687451911e40430ae89eaef8ace2bfdcf61",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/h/hwdata/hwdata_0.393-3_all.deb"
+    },
+    {
+      "name": "libarchive13t64",
+      "version": "3.7.7-0ubuntu2.3",
+      "architecture": "amd64",
+      "filename": "libarchive13t64_3.7.7-0ubuntu2.3_amd64.deb",
+      "sha256": "a31d7532b90f89c342b3e8d23a922a17aaf9cb6d736c4a8e4773f0be97a7ba5f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/liba/libarchive/libarchive13t64_3.7.7-0ubuntu2.3_amd64.deb"
+    },
+    {
+      "name": "libasan8",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libasan8_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "f13c558b07c3a23d58948e7dee0c49bd8a1ab63147a701104c8e6049e71f5a73",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libasan8_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libass9",
+      "version": "1:0.17.3-1",
+      "architecture": "amd64",
+      "filename": "libass9_1%3a0.17.3-1_amd64.deb",
+      "sha256": "20fd3f8a675804455ccfffbcc4e488818e016dea8d535ade12031969cd97a62d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libass/libass9_0.17.3-1_amd64.deb"
+    },
+    {
+      "name": "libavtp0",
+      "version": "0.2.0-2",
+      "architecture": "amd64",
+      "filename": "libavtp0_0.2.0-2_amd64.deb",
+      "sha256": "32d5bb7433365eb43c9d3bd49aff8c62295abcd4a3eb45ddbdb8351ce909bc36",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libavtp/libavtp0_0.2.0-2_amd64.deb"
+    },
+    {
+      "name": "libbinutils",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libbinutils_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "20c0f5fc6696ae015897a58d6fcc587857892a1470af5f9a8145a25279119062",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libbinutils_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libblkid-dev",
+      "version": "2.40.2-14ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libblkid-dev_2.40.2-14ubuntu1.2_amd64.deb",
+      "sha256": "1f9e20bb7c25eacdbdb6aa057964628c9fa8420ea4faaee9fff476ab8b4e551a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/util-linux/libblkid-dev_2.40.2-14ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libbs2b0",
+      "version": "3.1.0+dfsg-8",
+      "architecture": "amd64",
+      "filename": "libbs2b0_3.1.0+dfsg-8_amd64.deb",
+      "sha256": "7d03829734d659b1167c92e8c00e415e113cb29cdc884576a9ccca611ef4e2b9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libb/libbs2b/libbs2b0_3.1.0%2bdfsg-8_amd64.deb"
+    },
+    {
+      "name": "libc-dev-bin",
+      "version": "2.41-6ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libc-dev-bin_2.41-6ubuntu1.2_amd64.deb",
+      "sha256": "6c5f01366826032936aa16297242046d4d89ef4221ce13c6d921fb973419b8a3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glibc/libc-dev-bin_2.41-6ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libc6-dev",
+      "version": "2.41-6ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libc6-dev_2.41-6ubuntu1.2_amd64.deb",
+      "sha256": "392a66c966e0bd272fe8acd4270e726d835e6fffd85ec322759638c0245743c4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glibc/libc6-dev_2.41-6ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libcap-dev",
+      "version": "1:2.73-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libcap-dev_1%3a2.73-4ubuntu1_amd64.deb",
+      "sha256": "ab6d5ef8d377dc23f2cb49dc66dbde2ee25bc0f00da54a84e3aeb783526e2b4c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libc/libcap2/libcap-dev_2.73-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libcc1-0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libcc1-0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "f84dd605099c5297ed5404553b03f39e4afb443333f27e7c9cdf25628cfa2717",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libcc1-0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libchromaprint1",
+      "version": "1.5.1-7",
+      "architecture": "amd64",
+      "filename": "libchromaprint1_1.5.1-7_amd64.deb",
+      "sha256": "a108a4a6e4b49c981975076aa2d1d15d73ed6c0b98122e7b5ceb7703f7851666",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/chromaprint/libchromaprint1_1.5.1-7_amd64.deb"
+    },
+    {
+      "name": "libclang-20-dev",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-20-dev_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "e0b1c9024a083ae276c23fdb547e057cdec9c76b6de1ff0a9065a4499a4076dc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-20-dev_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-common-20-dev",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-common-20-dev_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "05a6125fdcfc18a9b1f30ecc12378a46f9fa7f25ea782d9006bb23eb79f65e73",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-common-20-dev_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-cpp20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-cpp20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "f19464e350b2a3913c14882408e3495b2ccef81281b7a8abf0b53234d254b739",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-cpp20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-dev",
+      "version": "1:20.0-63ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-dev_1%3a20.0-63ubuntu1_amd64.deb",
+      "sha256": "4699c12ff94eda3fd18b49270edc6a6d7e2a390d5dc0efa32d2bc1119bdcdfc0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-defaults/libclang-dev_20.0-63ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang1-20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang1-20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "ed4bf6b86e21e735d4a2f5564c5dc202a818460be1e1c5b2794790678b7736aa",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang1-20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libcpuinfo0",
+      "version": "0.0~git20250203.aaac07e-1",
+      "architecture": "amd64",
+      "filename": "libcpuinfo0_0.0~git20250203.aaac07e-1_amd64.deb",
+      "sha256": "13af6ecf274a2629121a38b06a815cd945c99a586f3a8848bb386c49961b31b7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/cpuinfo/libcpuinfo0_0.0%7egit20250203.aaac07e-1_amd64.deb"
+    },
+    {
+      "name": "libcrypt-dev",
+      "version": "1:4.4.38-1",
+      "architecture": "amd64",
+      "filename": "libcrypt-dev_1%3a4.4.38-1_amd64.deb",
+      "sha256": "88a4ec0d8bf7b61600165896acbe55d888b54f317e9a5bc2fcb99fe9166b0427",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcrypt/libcrypt-dev_4.4.38-1_amd64.deb"
+    },
+    {
+      "name": "libctf-nobfd0",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libctf-nobfd0_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "1ad75cce74f918e2c2efa56ef68a45f17d65b3d299e1fe5e1beb72324d5e97a9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libctf-nobfd0_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libctf0",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libctf0_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "b624fc8144fc9fb846fef44a21f2882691203ce56292d741b2c5b8c441faa38b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libctf0_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libdc1394-25",
+      "version": "2.2.6-4build1",
+      "architecture": "amd64",
+      "filename": "libdc1394-25_2.2.6-4build1_amd64.deb",
+      "sha256": "0f4a0768152636f2f941d3a29d24925be77f869b3d90a13f1694fef792a89810",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdc1394/libdc1394-25_2.2.6-4build1_amd64.deb"
+    },
+    {
+      "name": "libdca0",
+      "version": "0.0.7-2build1",
+      "architecture": "amd64",
+      "filename": "libdca0_0.0.7-2build1_amd64.deb",
+      "sha256": "018867fee029b072ecb3365f5f92c0cb0530d4ab37aa13be127116b6e5c3c06d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdca/libdca0_0.0.7-2build1_amd64.deb"
+    },
+    {
+      "name": "libde265-0",
+      "version": "1.0.15-1build5",
+      "architecture": "amd64",
+      "filename": "libde265-0_1.0.15-1build5_amd64.deb",
+      "sha256": "1a3d3faab069f9bb4051c0d4e5d2ee18c3c41f440ad1569838c338fc12d47e0b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libde265/libde265-0_1.0.15-1build5_amd64.deb"
+    },
+    {
+      "name": "libdecor-0-dev",
+      "version": "0.2.2-2",
+      "architecture": "amd64",
+      "filename": "libdecor-0-dev_0.2.2-2_amd64.deb",
+      "sha256": "a8a1eed5d20461fa612700c9317a26046f6dd9c00aec432bead3f5f97c9b400b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdecor-0/libdecor-0-dev_0.2.2-2_amd64.deb"
+    },
+    {
+      "name": "libdnnl3.6",
+      "version": "3.7.1+ds-1",
+      "architecture": "amd64",
+      "filename": "libdnnl3.6_3.7.1+ds-1_amd64.deb",
+      "sha256": "88fd977d7076586d2a2bb89659d24e8875f188f79a15649ce1832764b3232d67",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onednn/libdnnl3.6_3.7.1%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libdpkg-perl",
+      "version": "1.22.18ubuntu2.2",
+      "architecture": "all",
+      "filename": "libdpkg-perl_1.22.18ubuntu2.2_all.deb",
+      "sha256": "9d96ff20ee92e976d82834f5e9b52b12b85b6ebddb83da1a641456b00d4afe89",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/d/dpkg/libdpkg-perl_1.22.18ubuntu2.2_all.deb"
+    },
+    {
+      "name": "libdrm-dev",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-dev_2.4.124-2_amd64.deb",
+      "sha256": "1d8d69e8bfd242c0e46bd8910f889b45203ed57b501e81b41faf05e03730643f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-dev_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdrm-nouveau2",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-nouveau2_2.4.124-2_amd64.deb",
+      "sha256": "7eaf5ee5460175ef118dd0dbf246d5b72d19c70f113d0650e3a045aefd968c09",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-nouveau2_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdrm-radeon1",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-radeon1_2.4.124-2_amd64.deb",
+      "sha256": "e45997171485fbf22b3dd0d3d569aa0b7b923a945cba80a93717042da54b4d70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-radeon1_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdvdnav4",
+      "version": "6.1.1-3build1",
+      "architecture": "amd64",
+      "filename": "libdvdnav4_6.1.1-3build1_amd64.deb",
+      "sha256": "09fd1de2985ade2592d4f068774b2249211880aa6d4a71a89e0b4764afe47404",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdnav/libdvdnav4_6.1.1-3build1_amd64.deb"
+    },
+    {
+      "name": "libdvdread8t64",
+      "version": "6.1.3-2",
+      "architecture": "amd64",
+      "filename": "libdvdread8t64_6.1.3-2_amd64.deb",
+      "sha256": "269fe55b0eb5a47b7112c46a5ed3a21bdbd0378224970d733225ecfd3cb5f20e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdread/libdvdread8t64_6.1.3-2_amd64.deb"
+    },
+    {
+      "name": "libdw-dev",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libdw-dev_0.192-4ubuntu1_amd64.deb",
+      "sha256": "d20955250b0efd8ea3f4f908fb91ecc9448f13c353b0aa289599f41c53fd19fd",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libdw-dev_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libdw1t64",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libdw1t64_0.192-4ubuntu1_amd64.deb",
+      "sha256": "4c75709171583eb7c9f437d90ea44a7184f0b2b0f5f23f428f00ba3febeb52e6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libdw1t64_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libegl-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libegl-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "3a0315216bb0d6fc4bbe7f689cf0168c2ffa3e62ac69bff06bbbe49679259990",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libegl-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libelf-dev",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libelf-dev_0.192-4ubuntu1_amd64.deb",
+      "sha256": "410b4385cf6c508bae56eb399148be1d5814be0f20e7e06cbd3e53b1c2943b50",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libelf-dev_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "liberror-perl",
+      "version": "0.17030-1",
+      "architecture": "all",
+      "filename": "liberror-perl_0.17030-1_all.deb",
+      "sha256": "cb85c869fe056e9e466efcfa3403408b0a87db1da1cafa585140a9be59fe58a1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libe/liberror-perl/liberror-perl_0.17030-1_all.deb"
+    },
+    {
+      "name": "libevdev-dev",
+      "version": "1.13.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libevdev-dev_1.13.3+dfsg-1_amd64.deb",
+      "sha256": "425b37d96ee3d595d89f966bcf9758d15f84c30eff21e3279b1a4e0ec9671de6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libe/libevdev/libevdev-dev_1.13.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libfaad2",
+      "version": "2.11.2-1",
+      "architecture": "amd64",
+      "filename": "libfaad2_2.11.2-1_amd64.deb",
+      "sha256": "cdf00ddc8c0f4f6e3dbc46c1d0efba537632609432734deb01113cac3ac1531d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/faad2/libfaad2_2.11.2-1_amd64.deb"
+    },
+    {
+      "name": "libffi-dev",
+      "version": "3.4.7-1",
+      "architecture": "amd64",
+      "filename": "libffi-dev_3.4.7-1_amd64.deb",
+      "sha256": "900ba7b5679f750a6db82c058f69074a684b3b85afa8c9121f3689a469f62a75",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libf/libffi/libffi-dev_3.4.7-1_amd64.deb"
+    },
+    {
+      "name": "libflite1",
+      "version": "2.2-7",
+      "architecture": "amd64",
+      "filename": "libflite1_2.2-7_amd64.deb",
+      "sha256": "3afe2b4ab82dff2330b53fcee83b4b21aa580f6d91a1ce850e917cf8cffc004a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/flite/libflite1_2.2-7_amd64.deb"
+    },
+    {
+      "name": "libfluidsynth3",
+      "version": "2.4.4+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libfluidsynth3_2.4.4+dfsg-1_amd64.deb",
+      "sha256": "2a7177d672b1f717c2b064181cac9e1772aeaf93e0a00db8327954eeeaff9189",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/fluidsynth/libfluidsynth3_2.4.4%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libfreeaptx0",
+      "version": "0.1.1-2build1",
+      "architecture": "amd64",
+      "filename": "libfreeaptx0_0.1.1-2build1_amd64.deb",
+      "sha256": "2280d6fdd41c841701a9da6b5076b77e8a0849e5c10c9c2945f817f753575a42",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libf/libfreeaptx/libfreeaptx0_0.1.1-2build1_amd64.deb"
+    },
+    {
+      "name": "libgbm-dev",
+      "version": "25.0.7-0ubuntu0.25.04.2",
+      "architecture": "amd64",
+      "filename": "libgbm-dev_25.0.7-0ubuntu0.25.04.2_amd64.deb",
+      "sha256": "34bd2a70579a7e795d446d9de2d85185dca058e93926f11ab7f23f27f1e03be4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mesa/libgbm-dev_25.0.7-0ubuntu0.25.04.2_amd64.deb"
+    },
+    {
+      "name": "libgc1",
+      "version": "1:8.2.8-1",
+      "architecture": "amd64",
+      "filename": "libgc1_1%3a8.2.8-1_amd64.deb",
+      "sha256": "d337914b08465d43186dbfe880fde5c9ea23808b0d56ea88397644cd6df84fcf",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgc/libgc1_8.2.8-1_amd64.deb"
+    },
+    {
+      "name": "libgcc-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libgcc-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "10eff4b80bc982518584b67e65e3ab89c8f33c4af7ce0b0071463e4eda410e74",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/libgcc-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libgdbm-compat4t64",
+      "version": "1.24-2",
+      "architecture": "amd64",
+      "filename": "libgdbm-compat4t64_1.24-2_amd64.deb",
+      "sha256": "0693236e9baf295abb8f90a56f44282054a3c91c9946a47c4a095764c073d052",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gdbm/libgdbm-compat4t64_1.24-2_amd64.deb"
+    },
+    {
+      "name": "libgdbm6t64",
+      "version": "1.24-2",
+      "architecture": "amd64",
+      "filename": "libgdbm6t64_1.24-2_amd64.deb",
+      "sha256": "1df38f4993f7f68cee81283af8963e0cb7c885be61be9a93326ab850af15e4f6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gdbm/libgdbm6t64_1.24-2_amd64.deb"
+    },
+    {
+      "name": "libgio-2.0-dev",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libgio-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "8691851455f8820210e7f94ecbd7a889039ef9a617e301bd135f954ea6a463ab",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libgio-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libgio-2.0-dev-bin",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libgio-2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "90346abaaad67a7dc3dc57088c3f0bab298b6e8c58af608da9c33bbc35e0052f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libgio-2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libgirepository-2.0-0",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libgirepository-2.0-0_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "b4c393515b1eade5535349e0104027efdd2502e8045eb0334f40457301350235",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libgirepository-2.0-0_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libgl-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgl-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "b7145fd8f8abe20d5cb436d2eae9b3235bd91be6fbddac581620d16763bd9250",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgl-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgles-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgles-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "ee2ea529c20e28031230c5910281e5bbd7f2c2ca06a2e306ca15e985d4875eb2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgles-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgles1",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgles1_1.7.0-1build1_amd64.deb",
+      "sha256": "3128deef59859a47cfca25244f035bdbedd223640209dcffdd11f1873ef71aff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgles1_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libglib2.0-dev",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libglib2.0-dev_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "42a2d562a0322eec7d12f24a695e10b32b3f0e584cb9f18d82378608b54c1d1d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libglib2.0-dev_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libglib2.0-dev-bin",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libglib2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "deef70c2d233a0bb449be2020990624bfc672650cfd564afc342579fb7cba8e6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libglib2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libglx-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libglx-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "0e2654950a881c20b640a3af590add2e0b612b8c0fdd945761fc695e1b6eb797",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libglx-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgme0",
+      "version": "0.6.3-7build1",
+      "architecture": "amd64",
+      "filename": "libgme0_0.6.3-7build1_amd64.deb",
+      "sha256": "a54fa608501f87f9e5064b60c75fc1bb62735c9f9ba9f7680cb804bb5eae2027",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/game-music-emu/libgme0_0.6.3-7build1_amd64.deb"
+    },
+    {
+      "name": "libgomp1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libgomp1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8da90c11d615b01a4a7fc797e8362350617ba289410f8aa1c4ac2d70beeb5bca",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libgomp1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libgprofng0",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libgprofng0_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "2901fba850cbab74e8d51cf0074405589c7da74d2019599db4e5a047c7e18a71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libgprofng0_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libgsm1",
+      "version": "1.0.22-1build1",
+      "architecture": "amd64",
+      "filename": "libgsm1_1.0.22-1build1_amd64.deb",
+      "sha256": "8cc765587a3275e861f166a98b4b79dd8d5c673f97e17967945ab4d1eb89c89a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libg/libgsm/libgsm1_1.0.22-1build1_amd64.deb"
+    },
+    {
+      "name": "libgssdp-1.6-0",
+      "version": "1.6.3-2",
+      "architecture": "amd64",
+      "filename": "libgssdp-1.6-0_1.6.3-2_amd64.deb",
+      "sha256": "7897db47adc4114a17c44f390d2816c7e58ac8bdd722fa58fa21c659368aece7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gssdp/libgssdp-1.6-0_1.6.3-2_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-gl1.0-0",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-gl1.0-0_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "b764616f2364767c94f4d8c667b9103b288beb3ef562a2a76155509b171a4d85",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-bad1.0-0",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "36c0de48cf25ca31dc21363dabd3fb32e9d4c539467b6b76b4770c5e82822099",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-base1.0-dev",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-base1.0-dev_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "20bf9472c7520737227c983fcc1b6711a98a58ea8f4381d9bb10e11dbe538a2f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-dev_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer1.0-dev",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "libgstreamer1.0-dev_1.26.0-3_amd64.deb",
+      "sha256": "bdfb350621e98cc9b38c4ab5bf3bfe448f635f12244f771bac89966678c2ad94",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/libgstreamer1.0-dev_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "libgudev-1.0-dev",
+      "version": "1:238-6",
+      "architecture": "amd64",
+      "filename": "libgudev-1.0-dev_1%3a238-6_amd64.deb",
+      "sha256": "e4cc1f9f5fe0dcca2c4e9fdeefe799b39f761513efb2bab676fe432b85b6309e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_amd64.deb"
+    },
+    {
+      "name": "libgupnp-1.6-0",
+      "version": "1.6.8-2",
+      "architecture": "amd64",
+      "filename": "libgupnp-1.6-0_1.6.8-2_amd64.deb",
+      "sha256": "9346722ae71cc4bce037ef49bf38c609392eb1cfb6eba19fce575673577896c5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gupnp/libgupnp-1.6-0_1.6.8-2_amd64.deb"
+    },
+    {
+      "name": "libgupnp-igd-1.6-0",
+      "version": "1.6.0-4",
+      "architecture": "amd64",
+      "filename": "libgupnp-igd-1.6-0_1.6.0-4_amd64.deb",
+      "sha256": "bf96c3dc6cf586400754dcf51b1e8033399171d5c5a55191ba13cf8c6d8c426e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gupnp-igd/libgupnp-igd-1.6-0_1.6.0-4_amd64.deb"
+    },
+    {
+      "name": "libhwasan0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libhwasan0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8f6817b2b68c395118bb786c1b6388b1ccc0d76a64a26cab8b9519179277c318",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libhwasan0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libice-dev",
+      "version": "2:1.1.1-1",
+      "architecture": "amd64",
+      "filename": "libice-dev_2%3a1.1.1-1_amd64.deb",
+      "sha256": "68e9b0a566c83e73509d1cebad2dd7e20be32dbe58ec1e4fbcbc7c59b50b9f59",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libi/libice/libice-dev_1.1.1-1_amd64.deb"
+    },
+    {
+      "name": "libicu76",
+      "version": "76.1-1ubuntu2",
+      "architecture": "amd64",
+      "filename": "libicu76_76.1-1ubuntu2_amd64.deb",
+      "sha256": "c289a52f92c9ab2a1783b6b5757c928bff228671f20473275a426798446a4ce1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/i/icu/libicu76_76.1-1ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libimath-3-1-29t64",
+      "version": "3.1.12-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb",
+      "sha256": "5b35e6bdfc8f567c3c33b4c5b519ceab2acd1c5c05534f360c33cedcf14c4cf3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/i/imath/libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libinput-dev",
+      "version": "1.27.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libinput-dev_1.27.1-1ubuntu0.2_amd64.deb",
+      "sha256": "264483d6ded36888d17fdfb6539517fa5cc0547b61d8039438c292ef5edf93db",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libi/libinput/libinput-dev_1.27.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libinstpatch-1.0-2",
+      "version": "1.1.6-1build2",
+      "architecture": "amd64",
+      "filename": "libinstpatch-1.0-2_1.1.6-1build2_amd64.deb",
+      "sha256": "d48c40a9c428e40d5bbe8762802390322b06a062c735292767e73d1c6ea9007e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libi/libinstpatch/libinstpatch-1.0-2_1.1.6-1build2_amd64.deb"
+    },
+    {
+      "name": "libisl23",
+      "version": "0.27-1",
+      "architecture": "amd64",
+      "filename": "libisl23_0.27-1_amd64.deb",
+      "sha256": "bfef9e3c33a616669825dd9e42f7e01435326a8f6b88853bb7c0e1fcabc8ca76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/i/isl/libisl23_0.27-1_amd64.deb"
+    },
+    {
+      "name": "libitm1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libitm1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8a6c6855d2de1480760392f0fc443b65ec41cd811148011de89edd7ae417869a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libitm1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libjansson4",
+      "version": "2.14-2build2",
+      "architecture": "amd64",
+      "filename": "libjansson4_2.14-2build2_amd64.deb",
+      "sha256": "0cf79113f5d193ce9af2be2ff4b2c3b30dd4e55a0b6c47f7d28f6c849ff3aa60",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/j/jansson/libjansson4_2.14-2build2_amd64.deb"
+    },
+    {
+      "name": "liblc3-1",
+      "version": "1.1.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "liblc3-1_1.1.3+dfsg-1_amd64.deb",
+      "sha256": "0a88ca35cd79b18e42bbb22800e2ea49f2e0123cc709696dd1954486d7694e4d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/liblc3/liblc3-1_1.1.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libldacbt-enc2",
+      "version": "2.0.2.3+git20200429+ed310a0-5",
+      "architecture": "amd64",
+      "filename": "libldacbt-enc2_2.0.2.3+git20200429+ed310a0-5_amd64.deb",
+      "sha256": "7212ed25d4be1782cfc71ef1758a587fa3a3cfb7ba939c7233161cb491946a34",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/libldac/libldacbt-enc2_2.0.2.3%2bgit20200429%2bed310a0-5_amd64.deb"
+    },
+    {
+      "name": "liblilv-0-0",
+      "version": "0.24.26-1",
+      "architecture": "amd64",
+      "filename": "liblilv-0-0_0.24.26-1_amd64.deb",
+      "sha256": "3076146b3bae4bce370c6618ef8ed788383d3d35184dae0bbb9877dcdbb127c2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/lilv/liblilv-0-0_0.24.26-1_amd64.deb"
+    },
+    {
+      "name": "liblrdf0",
+      "version": "0.6.1-4build1",
+      "architecture": "amd64",
+      "filename": "liblrdf0_0.6.1-4build1_amd64.deb",
+      "sha256": "470a5e0e88fd2e7dcfc024c789cd029578b110c65558ae423fd79d7bb4ef01ca",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/liblrdf/liblrdf0_0.6.1-4build1_amd64.deb"
+    },
+    {
+      "name": "liblsan0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "liblsan0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "0c1a62b4e6c14f502d3c0c49c8fc009e959ca4fa1a910e3eea40e896e434016e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/liblsan0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libltc11",
+      "version": "1.3.2-1build1",
+      "architecture": "amd64",
+      "filename": "libltc11_1.3.2-1build1_amd64.deb",
+      "sha256": "92f23451cefe159faef9f255f0d24987eff50e52647dc1aa9843ad4c733ca039",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/libltc/libltc11_1.3.2-1build1_amd64.deb"
+    },
+    {
+      "name": "libluajit-5.1-dev",
+      "version": "2.1.0+openresty20250117-2",
+      "architecture": "amd64",
+      "filename": "libluajit-5.1-dev_2.1.0+openresty20250117-2_amd64.deb",
+      "sha256": "8b50af6f5684a57eed58d56be998376c8ef8e7c88379b6b14dffb56a10b4d9b4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/luajit/libluajit-5.1-dev_2.1.0%2bopenresty20250117-2_amd64.deb"
+    },
+    {
+      "name": "liblzma-dev",
+      "version": "5.6.4-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "liblzma-dev_5.6.4-1ubuntu1_amd64.deb",
+      "sha256": "164c8de2bd3c722576116937bea56d6ef0a892ec4c906f032ce366f0bc8409af",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xz-utils/liblzma-dev_5.6.4-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libmjpegutils-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmjpegutils-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "3422b9e3f7aa721a18f1738b33815a7f681fbe1ec0bafb1faf733e625dcbce85",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmjpegutils-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmodplug1",
+      "version": "1:0.8.9.0-3build1",
+      "architecture": "amd64",
+      "filename": "libmodplug1_1%3a0.8.9.0-3build1_amd64.deb",
+      "sha256": "34b383f35def5405069ae1eb6b4e6a7f73c9adafd0d049add82285b0e1a2e1ad",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmodplug/libmodplug1_0.8.9.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libmount-dev",
+      "version": "2.40.2-14ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libmount-dev_2.40.2-14ubuntu1.2_amd64.deb",
+      "sha256": "10263c8a5e18dcf562971c0bae03b7aae5b698233b605a422033bc474a9d6a4a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/util-linux/libmount-dev_2.40.2-14ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libmpc3",
+      "version": "1.3.1-1build2",
+      "architecture": "amd64",
+      "filename": "libmpc3_1.3.1-1build2_amd64.deb",
+      "sha256": "cd4ceaa5f4328131d4a36c2a6ebf8f4661f82d5aa897bb93333e92e6bd1c1bd3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mpclib3/libmpc3_1.3.1-1build2_amd64.deb"
+    },
+    {
+      "name": "libmpcdec6",
+      "version": "2:0.1~r495-3",
+      "architecture": "amd64",
+      "filename": "libmpcdec6_2%3a0.1~r495-3_amd64.deb",
+      "sha256": "35e003823ddf242d8799057d420fc15ed644bb836d63ae18af57bd514699a216",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmpc/libmpcdec6_0.1%7er495-3_amd64.deb"
+    },
+    {
+      "name": "libmpeg2encpp-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmpeg2encpp-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "ec077a7c7fc7abd77d460813f56a9bef1dd68e53148840ef242b1795043d318e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmpeg2encpp-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmpfr6",
+      "version": "4.2.2-1",
+      "architecture": "amd64",
+      "filename": "libmpfr6_4.2.2-1_amd64.deb",
+      "sha256": "5334f5ad406cd0c4432081201c1053e5b391b6866f4f67974cd2b08402d67b70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mpfr4/libmpfr6_4.2.2-1_amd64.deb"
+    },
+    {
+      "name": "libmplex2-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmplex2-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "8c4324fb9ac9b667559aeaa92e399beeb4396d0cd33627be1b1306b85a31e5e2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmplex2-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmtdev-dev",
+      "version": "1.1.7-1",
+      "architecture": "amd64",
+      "filename": "libmtdev-dev_1.1.7-1_amd64.deb",
+      "sha256": "0f3985ae771be368a3cedb7e08d181c293d3e03c97ba8aa5c6742ad70c8d0319",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mtdev/libmtdev-dev_1.1.7-1_amd64.deb"
+    },
+    {
+      "name": "libneon27t64",
+      "version": "0.34.0-1",
+      "architecture": "amd64",
+      "filename": "libneon27t64_0.34.0-1_amd64.deb",
+      "sha256": "1710578bc51522b9ee8ccd70624b9e2e266f50e5ac39711d1096757bd23d381f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/neon27/libneon27t64_0.34.0-1_amd64.deb"
+    },
+    {
+      "name": "libnice10",
+      "version": "0.1.22-1",
+      "architecture": "amd64",
+      "filename": "libnice10_0.1.22-1_amd64.deb",
+      "sha256": "3e227906bae81259542732d0af1623a05910855d86e548e5b704e17ea8cb2a17",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libn/libnice/libnice10_0.1.22-1_amd64.deb"
+    },
+    {
+      "name": "libnuma1",
+      "version": "2.0.18-1build1",
+      "architecture": "amd64",
+      "filename": "libnuma1_2.0.18-1build1_amd64.deb",
+      "sha256": "508daa855e99959acaa945e6a89d218e0be6b5727fd28773580942ff37cf5805",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/n/numactl/libnuma1_2.0.18-1build1_amd64.deb"
+    },
+    {
+      "name": "libobjc-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libobjc-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "5babfef7063527cd3ed5a51dea337b32aa62ab79839940b25c2fb1721125a137",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gcc-14/libobjc-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libobjc4",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libobjc4_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "7e9fc63dcb88da621398110040df2ef9f12f00c4ca532bf583c67af0b7a46e5c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gcc-15/libobjc4_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libonnx1t64",
+      "version": "1.17.0-3build1",
+      "architecture": "amd64",
+      "filename": "libonnx1t64_1.17.0-3build1_amd64.deb",
+      "sha256": "c4fcb75e98e7a28dd741d002c640bb3a9891dee2d9ec39ee570f2824d77318ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnx/libonnx1t64_1.17.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libonnxruntime1.21",
+      "version": "1.21.0+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libonnxruntime1.21_1.21.0+dfsg-1_amd64.deb",
+      "sha256": "17e9bfec1e4e86a7456720843ed5443c2eb3bda62b45f0e075ab0c8d89e4ae7b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnxruntime/libonnxruntime1.21_1.21.0%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libopenal-data",
+      "version": "1:1.24.2-1",
+      "architecture": "all",
+      "filename": "libopenal-data_1%3a1.24.2-1_all.deb",
+      "sha256": "2bce384fa3c8fb1193e9ec8c948787263e5a2fc53a4a4715c4aeeab75b98b420",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal-data_1.24.2-1_all.deb"
+    },
+    {
+      "name": "libopenal1",
+      "version": "1:1.24.2-1",
+      "architecture": "amd64",
+      "filename": "libopenal1_1%3a1.24.2-1_amd64.deb",
+      "sha256": "461b8d108f70efa65eefbb3af5c697ac95f831f1959de3b625345b389628bbbb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal1_1.24.2-1_amd64.deb"
+    },
+    {
+      "name": "libopenexr-3-1-30",
+      "version": "3.1.13-2",
+      "architecture": "amd64",
+      "filename": "libopenexr-3-1-30_3.1.13-2_amd64.deb",
+      "sha256": "cae37d566e8d08fdeabdbcac7e9c9a5c68b9541a83974adbd3f50cb654e83390",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openexr/libopenexr-3-1-30_3.1.13-2_amd64.deb"
+    },
+    {
+      "name": "libopenh264-8",
+      "version": "2.6.0+dfsg-2",
+      "architecture": "amd64",
+      "filename": "libopenh264-8_2.6.0+dfsg-2_amd64.deb",
+      "sha256": "bbff1a10312e60e4566c0e34c2d2f98deda75763ea639650518d00e1e028f67e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openh264/libopenh264-8_2.6.0%2bdfsg-2_amd64.deb"
+    },
+    {
+      "name": "libopenjp2-7",
+      "version": "2.5.3-2ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libopenjp2-7_2.5.3-2ubuntu0.1_amd64.deb",
+      "sha256": "612fa2efbcbc6a2ddfd34d1630cac0cdcae8f3062ac5fe5617563a73e527fb35",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/openjpeg2/libopenjp2-7_2.5.3-2ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libopenmpt0t64",
+      "version": "0.7.13-1build1",
+      "architecture": "amd64",
+      "filename": "libopenmpt0t64_0.7.13-1build1_amd64.deb",
+      "sha256": "0a3f0e7060f1777d9865ff1ba23d7ad692f395594388442bde670e4bf435a975",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libo/libopenmpt/libopenmpt0t64_0.7.13-1build1_amd64.deb"
+    },
+    {
+      "name": "libopenni2-0",
+      "version": "2.2.0.33+dfsg-18",
+      "architecture": "amd64",
+      "filename": "libopenni2-0_2.2.0.33+dfsg-18_amd64.deb",
+      "sha256": "bba943fe73b2b0271ebbd6a28d0afb9e7084df75a64748fc06e3f72151ab1b76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openni2/libopenni2-0_2.2.0.33%2bdfsg-18_amd64.deb"
+    },
+    {
+      "name": "liborc-0.4-dev",
+      "version": "1:0.4.41-1",
+      "architecture": "amd64",
+      "filename": "liborc-0.4-dev_1%3a0.4.41-1_amd64.deb",
+      "sha256": "f9dd934bafb2140adf20e16f8d2ea5106539fbbe1f7b9f5cee6bf3a0cc56cd7c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/orc/liborc-0.4-dev_0.4.41-1_amd64.deb"
+    },
+    {
+      "name": "liborc-0.4-dev-bin",
+      "version": "1:0.4.41-1",
+      "architecture": "amd64",
+      "filename": "liborc-0.4-dev-bin_1%3a0.4.41-1_amd64.deb",
+      "sha256": "6abfb51460346159c83598f869dc27ad2474329cb70a5ebaba875c37bea1eb43",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/orc/liborc-0.4-dev-bin_0.4.41-1_amd64.deb"
+    },
+    {
+      "name": "libpciaccess-dev",
+      "version": "0.17-3ubuntu0.25.04.2",
+      "architecture": "amd64",
+      "filename": "libpciaccess-dev_0.17-3ubuntu0.25.04.2_amd64.deb",
+      "sha256": "345127a67e50bbb3db674e9051788737b8b2ddba4eab00cd316446d874f0732d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libp/libpciaccess/libpciaccess-dev_0.17-3ubuntu0.25.04.2_amd64.deb"
+    },
+    {
+      "name": "libpcre2-16-0",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-16-0_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "53f4d51ada507cce319542226504ba44c6b2ac4d8f561ec5fc908db939a45778",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-16-0_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpcre2-32-0",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-32-0_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "5ef102e3193081bb5553fa30d95329d2fcb091c1b1a782de72de5f60c14d01f7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-32-0_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpcre2-dev",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-dev_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "36605dbb5b4a650093f24f70e5925fab513acb96785b74a666274f43897a1072",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-dev_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpcre2-posix3",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-posix3_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "46c6cf4dc9587af70736ca0e47b4f6919731c02708a57ec41cc37ec1628f0bbc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-posix3_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libperl5.40",
+      "version": "5.40.1-2ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libperl5.40_5.40.1-2ubuntu0.2_amd64.deb",
+      "sha256": "06133408b9abcc6dd4065bfe10cacf051929ca262eea996d504a3228fe669ac2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/perl/libperl5.40_5.40.1-2ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-dev",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-dev_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "a1665a2ead175e9ccf4f9f4098db14ac56110470cb0599b941f679947a1b99d4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-modules",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "f23e9a3ebedfbb846efe210bcc55150668394ac807e6c71f1f2c1d5f728c2f8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libpixman-1-dev",
+      "version": "0.44.0-3",
+      "architecture": "amd64",
+      "filename": "libpixman-1-dev_0.44.0-3_amd64.deb",
+      "sha256": "126d4e5f89bc6a29ebfb296f22c4eb718fd04a3a2522b06c74f7d3e07e9129d3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pixman/libpixman-1-dev_0.44.0-3_amd64.deb"
+    },
+    {
+      "name": "libpkgconf3",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "libpkgconf3_1.8.1-4_amd64.deb",
+      "sha256": "91c46979979aa69e79a6dc64e2cd7c262173331ae58ba69ba29dce611c02c457",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "libprotobuf32t64",
+      "version": "3.21.12-10ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb",
+      "sha256": "19a6eac6e4d794318608c7e6862c4414119e1be7d3e66b0f8e698c62c78411ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/protobuf/libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpthreadpool0",
+      "version": "0.0~git20240616.560c60d-1",
+      "architecture": "amd64",
+      "filename": "libpthreadpool0_0.0~git20240616.560c60d-1_amd64.deb",
+      "sha256": "a09c04886537cf3db25ae1c0644a0b4cc070d520914521a00f81b86b1254f23f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/p/pthreadpool/libpthreadpool0_0.0%7egit20240616.560c60d-1_amd64.deb"
+    },
+    {
+      "name": "libqrencode4",
+      "version": "4.1.1-2",
+      "architecture": "amd64",
+      "filename": "libqrencode4_4.1.1-2_amd64.deb",
+      "sha256": "d9eed9dc0a75994c2fe4d95f9dae8d700b4a363383f6966a82d6d0225e275280",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/q/qrencode/libqrencode4_4.1.1-2_amd64.deb"
+    },
+    {
+      "name": "libquadmath0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libquadmath0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "a980b7bfc6586180d07a5df8a7d9bc97fa41c0790d91b780cee8e6f5f317c934",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libquadmath0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libraptor2-0",
+      "version": "2.0.16-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libraptor2-0_2.0.16-4ubuntu1_amd64.deb",
+      "sha256": "ecae495617134e13c098780576db94c89e9475d2ccec3d2bb732799ce958bd87",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/raptor2/libraptor2-0_2.0.16-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libre2-11",
+      "version": "20240501-3build1",
+      "architecture": "amd64",
+      "filename": "libre2-11_20240501-3build1_amd64.deb",
+      "sha256": "b7a4b55a5f2e4ca12d1020b2cd5a0a0540bb1a9b4706eaa8e1294fe52a4112a5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/re2/libre2-11_20240501-3build1_amd64.deb"
+    },
+    {
+      "name": "librhash1",
+      "version": "1.4.5-1",
+      "architecture": "amd64",
+      "filename": "librhash1_1.4.5-1_amd64.deb",
+      "sha256": "6a51d203f615d3bfa71fba697db4a91700d7cfc04e48c9ab2786f77b96e9614a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/rhash/librhash1_1.4.5-1_amd64.deb"
+    },
+    {
+      "name": "libroc0.4",
+      "version": "0.4.0+dfsg-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libroc0.4_0.4.0+dfsg-4ubuntu1_amd64.deb",
+      "sha256": "8bec93425075527aa82683dbcf2d1784c39361da46a10c299f0c60afb8625b71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/roc-toolkit/libroc0.4_0.4.0%2bdfsg-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "librsvg2-2",
+      "version": "2.60.0+dfsg-1",
+      "architecture": "amd64",
+      "filename": "librsvg2-2_2.60.0+dfsg-1_amd64.deb",
+      "sha256": "98c3d1393a67b1e78b468dd05db277646f28c27fba5cbe7c028c2fabbdc9a9c9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libr/librsvg/librsvg2-2_2.60.0%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libsbc1",
+      "version": "2.0-1build1",
+      "architecture": "amd64",
+      "filename": "libsbc1_2.0-1build1_amd64.deb",
+      "sha256": "d4d453e7673218fc2f917dbabb2492a5a81155c2305f6fe63a37cadcaa806128",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/sbc/libsbc1_2.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libseat-dev",
+      "version": "0.8.0-1",
+      "architecture": "amd64",
+      "filename": "libseat-dev_0.8.0-1_amd64.deb",
+      "sha256": "f0be2c0a66145588838546011a4236e20a277b9a4a52acfca9f0cb7dcf80b812",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/seatd/libseat-dev_0.8.0-1_amd64.deb"
+    },
+    {
+      "name": "libselinux1-dev",
+      "version": "3.7-3ubuntu3",
+      "architecture": "amd64",
+      "filename": "libselinux1-dev_3.7-3ubuntu3_amd64.deb",
+      "sha256": "f627acedca996a63d245e1465e133edc91d0e7da150278f66677b530f984155e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libs/libselinux/libselinux1-dev_3.7-3ubuntu3_amd64.deb"
+    },
+    {
+      "name": "libsepol-dev",
+      "version": "3.7-1",
+      "architecture": "amd64",
+      "filename": "libsepol-dev_3.7-1_amd64.deb",
+      "sha256": "84c6bdaa7b21c8f2dfec5f3b9e7f994fe666e7495ec6ee94cb6812979e9c438d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libs/libsepol/libsepol-dev_3.7-1_amd64.deb"
+    },
+    {
+      "name": "libserd-0-0",
+      "version": "0.32.4-1",
+      "architecture": "amd64",
+      "filename": "libserd-0-0_0.32.4-1_amd64.deb",
+      "sha256": "3d1c23e9effbe22d3edab8c0c2fdc8297d966c134f4d8095ccf0c9da52cc5f33",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/serd/libserd-0-0_0.32.4-1_amd64.deb"
+    },
+    {
+      "name": "libsframe1",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libsframe1_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "6d5646fba6f601fc8e055cf366b24a9e5a7da7dddcc223bdfbeeaa0a2cfceb71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libsframe1_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libsm-dev",
+      "version": "2:1.2.4-1",
+      "architecture": "amd64",
+      "filename": "libsm-dev_2%3a1.2.4-1_amd64.deb",
+      "sha256": "35664bfbf8d5dc4b5a920e7207938073296616b7b56e920254dcf28a995d9e44",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libs/libsm/libsm-dev_1.2.4-1_amd64.deb"
+    },
+    {
+      "name": "libsnapd-glib-2-1",
+      "version": "1.66-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb",
+      "sha256": "b7bd77be1d59bf3a19bbe91b9ab6225ad05736ed72bd9f3b3f56bcd83822e398",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/snapd-glib/libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsord-0-0",
+      "version": "0.16.18-1",
+      "architecture": "amd64",
+      "filename": "libsord-0-0_0.16.18-1_amd64.deb",
+      "sha256": "bfd5ef5bbab2eed986b6f2856c2904db70c3d9e7a34b9f9caffcc1ea36a47a9b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sord/libsord-0-0_0.16.18-1_amd64.deb"
+    },
+    {
+      "name": "libsoundtouch1",
+      "version": "2.3.3+ds-1",
+      "architecture": "amd64",
+      "filename": "libsoundtouch1_2.3.3+ds-1_amd64.deb",
+      "sha256": "cadad56c5398a93f2f8c7080ca1a93725c15242beff0891cfdb029c5e4f305f3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/soundtouch/libsoundtouch1_2.3.3%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libspa-0.2-dev",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libspa-0.2-dev_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "bf84dc575f3beab14b1a86612622525a6f6c45e367edac0e5143ed03106ec959",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libspa-0.2-dev_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libspandsp2t64",
+      "version": "0.0.6+dfsg-2.2",
+      "architecture": "amd64",
+      "filename": "libspandsp2t64_0.0.6+dfsg-2.2_amd64.deb",
+      "sha256": "63a125139f3507ae94faa7cdd10ee6d6c551961937b1ec7fafa4d320e34b71bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spandsp/libspandsp2t64_0.0.6%2bdfsg-2.2_amd64.deb"
+    },
+    {
+      "name": "libspeexdsp1",
+      "version": "1.2.1-3",
+      "architecture": "amd64",
+      "filename": "libspeexdsp1_1.2.1-3_amd64.deb",
+      "sha256": "5b178611a05217d2ba35823aa8f75387d074a7e2d50954dc11464678cd7b2c91",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/speexdsp/libspeexdsp1_1.2.1-3_amd64.deb"
+    },
+    {
+      "name": "libsratom-0-0",
+      "version": "0.6.18-1",
+      "architecture": "amd64",
+      "filename": "libsratom-0-0_0.6.18-1_amd64.deb",
+      "sha256": "848fcfa874c1acb8c2331747a841467f8921334d5b5cbb66f8306d933203f344",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sratom/libsratom-0-0_0.6.18-1_amd64.deb"
+    },
+    {
+      "name": "libsrt1.5-gnutls",
+      "version": "1.5.4-1",
+      "architecture": "amd64",
+      "filename": "libsrt1.5-gnutls_1.5.4-1_amd64.deb",
+      "sha256": "88e58de644fbf38c194494789c4f1e047dae6c43bd71ca245530d721a4a0b5e0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/srt/libsrt1.5-gnutls_1.5.4-1_amd64.deb"
+    },
+    {
+      "name": "libsrtp2-1",
+      "version": "2.5.0-3build1",
+      "architecture": "amd64",
+      "filename": "libsrtp2-1_2.5.0-3build1_amd64.deb",
+      "sha256": "c2e7ee0ae64597f046fbfb197b8f36dfc9a5159b02d27e850f3a4d14a4603d77",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libs/libsrtp2/libsrtp2-1_2.5.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libstdc++-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libstdc++-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "23b377179507d649d55f371cc4b36082b05bce3637a475d9b53a83cc6dcdbcef",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/libstdc%2b%2b-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libsysprof-capture-4-dev",
+      "version": "48.0-2",
+      "architecture": "amd64",
+      "filename": "libsysprof-capture-4-dev_48.0-2_amd64.deb",
+      "sha256": "33ecffc7010439b34fd10bf8e3a3f595eefa49b96a6434354b8eb3517b50e15f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/sysprof/libsysprof-capture-4-dev_48.0-2_amd64.deb"
+    },
+    {
+      "name": "libtsan2",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libtsan2_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "829692d86ed2b1d3f761306fce4b8bebe5b632a018859c8570c3dcdf162a942b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libtsan2_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libubsan1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libubsan1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "ebdb6ab4f035d9b94a633478bec122212388d5f2e155c99bca1fe84831f6a04b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libubsan1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libudev-dev",
+      "version": "257.4-1ubuntu3.2",
+      "architecture": "amd64",
+      "filename": "libudev-dev_257.4-1ubuntu3.2_amd64.deb",
+      "sha256": "ad5f1a66b74f5c17382e449a7792f0228cf50797ebccaec4c6cb72081e60aa97",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/systemd/libudev-dev_257.4-1ubuntu3.2_amd64.deb"
+    },
+    {
+      "name": "libunibreak6",
+      "version": "6.1-2",
+      "architecture": "amd64",
+      "filename": "libunibreak6_6.1-2_amd64.deb",
+      "sha256": "c904cf437fcad74dac8c9e7fd1a4a9657b0c5d44441848e321e225375b69c4fc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libu/libunibreak/libunibreak6_6.1-2_amd64.deb"
+    },
+    {
+      "name": "libunwind-dev",
+      "version": "1.6.2-3.1",
+      "architecture": "amd64",
+      "filename": "libunwind-dev_1.6.2-3.1_amd64.deb",
+      "sha256": "624f0a53bb081487268cf920f0d83ec7f80add528c3ef5ce6e91ced727eb9ce1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libunwind/libunwind-dev_1.6.2-3.1_amd64.deb"
+    },
+    {
+      "name": "libunwind8",
+      "version": "1.6.2-3.1",
+      "architecture": "amd64",
+      "filename": "libunwind8_1.6.2-3.1_amd64.deb",
+      "sha256": "9d48508139a791778c86f341e725f06dd5304dc24e80501080271a734bf970da",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libunwind/libunwind8_1.6.2-3.1_amd64.deb"
+    },
+    {
+      "name": "libusb-1.0-0",
+      "version": "2:1.0.27-2",
+      "architecture": "amd64",
+      "filename": "libusb-1.0-0_2%3a1.0.27-2_amd64.deb",
+      "sha256": "3f8b484e46112ce8804931b0fa468d93c55a8aa8a4df3f8bf8bd2cf93601a037",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.27-2_amd64.deb"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2ubuntu1",
+      "architecture": "amd64",
+      "filename": "libuv1t64_1.50.0-2ubuntu1_amd64.deb",
+      "sha256": "6af9634d05965f60ed7c124d43cef678ef288824b6f36a7b02559dd4097e7c90",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libuv1/libuv1t64_1.50.0-2ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libva-drm2",
+      "version": "2.22.0-3ubuntu2",
+      "architecture": "amd64",
+      "filename": "libva-drm2_2.22.0-3ubuntu2_amd64.deb",
+      "sha256": "fb95623b4c1834a34109966e7f5c85b4ab2f620d5804ea6512b69c25159a45bf",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libva/libva-drm2_2.22.0-3ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libva2",
+      "version": "2.22.0-3ubuntu2",
+      "architecture": "amd64",
+      "filename": "libva2_2.22.0-3ubuntu2_amd64.deb",
+      "sha256": "52bb1274b1cf1dbfe83f85a453363c0c651513d1e45264553edf286b9129d8c6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libva/libva2_2.22.0-3ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libvo-aacenc0",
+      "version": "0.1.3-3",
+      "architecture": "amd64",
+      "filename": "libvo-aacenc0_0.1.3-3_amd64.deb",
+      "sha256": "ea759b3a02552c379424775d5fc5d37d8dff59eb70ceab35118146ef04e857a3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-aacenc/libvo-aacenc0_0.1.3-3_amd64.deb"
+    },
+    {
+      "name": "libvo-amrwbenc0",
+      "version": "0.1.3-2build1",
+      "architecture": "amd64",
+      "filename": "libvo-amrwbenc0_0.1.3-2build1_amd64.deb",
+      "sha256": "30d260bbb56b9340319216529e72ed02a68752de62d5926ad07132ed2459af05",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-amrwbenc/libvo-amrwbenc0_0.1.3-2build1_amd64.deb"
+    },
+    {
+      "name": "libvorbisfile3",
+      "version": "1.3.7-2",
+      "architecture": "amd64",
+      "filename": "libvorbisfile3_1.3.7-2_amd64.deb",
+      "sha256": "6dfc7f0bd9f0c745c2e099aca9121843650ec7c7193801057bc3927c43820e70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-2_amd64.deb"
+    },
+    {
+      "name": "libvulkan-dev",
+      "version": "1.4.304.0-1",
+      "architecture": "amd64",
+      "filename": "libvulkan-dev_1.4.304.0-1_amd64.deb",
+      "sha256": "f557d5cc69add01d3794b1c71bfdcb053d7909febedd58713f9ba355e3f33167",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/v/vulkan-loader/libvulkan-dev_1.4.304.0-1_amd64.deb"
+    },
+    {
+      "name": "libwacom-dev",
+      "version": "2.14.0-1",
+      "architecture": "amd64",
+      "filename": "libwacom-dev_2.14.0-1_amd64.deb",
+      "sha256": "18e8a96b5300885ea8b7013214eeef9f912bbe5d804fda4f236bef3ce3f22fd5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libw/libwacom/libwacom-dev_2.14.0-1_amd64.deb"
+    },
+    {
+      "name": "libwayland-bin",
+      "version": "1.23.1-3",
+      "architecture": "amd64",
+      "filename": "libwayland-bin_1.23.1-3_amd64.deb",
+      "sha256": "f0f8b782d56c44068827e614240ae4d29908864f7b2d10bb54b2a68ba5623562",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb"
+    },
+    {
+      "name": "libwayland-dev",
+      "version": "1.23.1-3",
+      "architecture": "amd64",
+      "filename": "libwayland-dev_1.23.1-3_amd64.deb",
+      "sha256": "4641ae220244fcb7f28d344d6612ec8c961351ba62347484ec354cbae1029f47",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb"
+    },
+    {
+      "name": "libwebpmux3",
+      "version": "1.5.0-0.1",
+      "architecture": "amd64",
+      "filename": "libwebpmux3_1.5.0-0.1_amd64.deb",
+      "sha256": "a9c741f966e93ee7d857d22895a670c20755f09f72bc6cf9b4fadd4548b750f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libw/libwebp/libwebpmux3_1.5.0-0.1_amd64.deb"
+    },
+    {
+      "name": "libwildmidi2",
+      "version": "0.4.3-1build3",
+      "architecture": "amd64",
+      "filename": "libwildmidi2_0.4.3-1build3_amd64.deb",
+      "sha256": "f44a3f24eb567cf104aefe6cabe2a3385185dc59dd83d64a37c1a04f0e12c771",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/w/wildmidi/libwildmidi2_0.4.3-1build3_amd64.deb"
+    },
+    {
+      "name": "libx11-dev",
+      "version": "2:1.8.10-2",
+      "architecture": "amd64",
+      "filename": "libx11-dev_2%3a1.8.10-2_amd64.deb",
+      "sha256": "b93d9e5c357557eba2ab26304ae47337ca163403646e584e0931840f53072b3e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libx11/libx11-dev_1.8.10-2_amd64.deb"
+    },
+    {
+      "name": "libx11-xcb-dev",
+      "version": "2:1.8.10-2",
+      "architecture": "amd64",
+      "filename": "libx11-xcb-dev_2%3a1.8.10-2_amd64.deb",
+      "sha256": "0f82fd0275fe8f8120df2ea231f2bd3fbc312d0e5070d7e126ea15cc9208f7ab",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libx11/libx11-xcb-dev_1.8.10-2_amd64.deb"
+    },
+    {
+      "name": "libx265-215",
+      "version": "4.1-2",
+      "architecture": "amd64",
+      "filename": "libx265-215_4.1-2_amd64.deb",
+      "sha256": "7fb455bbdd67cfa604b397c64e3e7893ae128ec12dad84655218e83501502a02",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/x265/libx265-215_4.1-2_amd64.deb"
+    },
+    {
+      "name": "libxau-dev",
+      "version": "1:1.0.11-1",
+      "architecture": "amd64",
+      "filename": "libxau-dev_1%3a1.0.11-1_amd64.deb",
+      "sha256": "8bb1b0b7e8f2febc90f3cab29b5e5383a7a44ddcf6fa5720334af2e7de2bbbb6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxau/libxau-dev_1.0.11-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-composite0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-composite0-dev_1.17.0-2_amd64.deb",
+      "sha256": "9c7c7e0462fb2814bc50d8e1207e86d499d48e626b7c245019f672d31c7c8056",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-composite0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-ewmh-dev",
+      "version": "0.4.2-1",
+      "architecture": "amd64",
+      "filename": "libxcb-ewmh-dev_0.4.2-1_amd64.deb",
+      "sha256": "6fb409e6c39c6e035de198b20ae1b9f4ee9bfd023c23344165cbadd0f7de335e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xcb-util-wm/libxcb-ewmh-dev_0.4.2-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-icccm4-dev",
+      "version": "0.4.2-1",
+      "architecture": "amd64",
+      "filename": "libxcb-icccm4-dev_0.4.2-1_amd64.deb",
+      "sha256": "9766971d554555864316d05f111eb05afd60c57791a4a655ba04a6600cf9f8ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xcb-util-wm/libxcb-icccm4-dev_0.4.2-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-render0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-render0-dev_1.17.0-2_amd64.deb",
+      "sha256": "e8deb42e07541dbae21f139330327299b8b5f7f70564a61fa706a1f7582a8db4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-render0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-res0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-res0-dev_1.17.0-2_amd64.deb",
+      "sha256": "c0d05fb701c144dddc3b1ec0e27579444e0c905ce1e7bffc4d9f74a747593379",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-res0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-shape0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-shape0-dev_1.17.0-2_amd64.deb",
+      "sha256": "6ad9c5c37a3fd478ed5586486d122cfbf29e687b738a98cd5145caf603656f9c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-shape0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-xfixes0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-xfixes0-dev_1.17.0-2_amd64.deb",
+      "sha256": "85b54851baa1584386a74b68764507d96967edcd119d4680203838550f69e939",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-xfixes0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb1-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb1-dev_1.17.0-2_amd64.deb",
+      "sha256": "2844752ae6cb7b7dec983a53d698b37e3a6268653cba254d69d8fcfa6907fb4c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb1-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcomposite-dev",
+      "version": "1:0.4.6-1",
+      "architecture": "amd64",
+      "filename": "libxcomposite-dev_1%3a0.4.6-1_amd64.deb",
+      "sha256": "6db5444b9409b5e6edb4cb4537640cd33207551a04c389248e86b269571fa258",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcomposite/libxcomposite-dev_0.4.6-1_amd64.deb"
+    },
+    {
+      "name": "libxcursor-dev",
+      "version": "1:1.2.3-1",
+      "architecture": "amd64",
+      "filename": "libxcursor-dev_1%3a1.2.3-1_amd64.deb",
+      "sha256": "f693b31be26a752b901eee46d9cd79c308f3595223a437481287ce0c016a5987",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcursor/libxcursor-dev_1.2.3-1_amd64.deb"
+    },
+    {
+      "name": "libxdamage-dev",
+      "version": "1:1.1.6-1build1",
+      "architecture": "amd64",
+      "filename": "libxdamage-dev_1%3a1.1.6-1build1_amd64.deb",
+      "sha256": "63067acaa7248dd46e67496154a030f38c86aa1cc192116265a8039c358ee20a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxdamage/libxdamage-dev_1.1.6-1build1_amd64.deb"
+    },
+    {
+      "name": "libxdmcp-dev",
+      "version": "1:1.1.5-1",
+      "architecture": "amd64",
+      "filename": "libxdmcp-dev_1%3a1.1.5-1_amd64.deb",
+      "sha256": "b7f218a47a2e50b1835e32a83b2d5dbeaf75034f4b6ec9f82e67eb9260553cc6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_amd64.deb"
+    },
+    {
+      "name": "libxext-dev",
+      "version": "2:1.3.4-1build2",
+      "architecture": "amd64",
+      "filename": "libxext-dev_2%3a1.3.4-1build2_amd64.deb",
+      "sha256": "b5bdb6724f228cb8eee8cf39cbbe1289dd3f8f06dd022748312df7844c94dcf2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxext/libxext-dev_1.3.4-1build2_amd64.deb"
+    },
+    {
+      "name": "libxfixes-dev",
+      "version": "1:6.0.0-2build1",
+      "architecture": "amd64",
+      "filename": "libxfixes-dev_1%3a6.0.0-2build1_amd64.deb",
+      "sha256": "069723527566ef0fc12738f63b789110c211b85bf96c3dbe9a94d9e77f5c479b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxfixes/libxfixes-dev_6.0.0-2build1_amd64.deb"
+    },
+    {
+      "name": "libxi-dev",
+      "version": "2:1.8.2-1",
+      "architecture": "amd64",
+      "filename": "libxi-dev_2%3a1.8.2-1_amd64.deb",
+      "sha256": "5c7bdf2d7abd20858666554c0eca429c1b35a09529c193a52d70c4ebda5ea75b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxi/libxi-dev_1.8.2-1_amd64.deb"
+    },
+    {
+      "name": "libxkbcommon-dev",
+      "version": "1.7.0-2",
+      "architecture": "amd64",
+      "filename": "libxkbcommon-dev_1.7.0-2_amd64.deb",
+      "sha256": "0c366a6dd143cca7dbec02ea7ed466e1c37b44e35e39018268717f5733f7ca29",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.7.0-2_amd64.deb"
+    },
+    {
+      "name": "libxmu-dev",
+      "version": "2:1.1.3-3build2",
+      "architecture": "amd64",
+      "filename": "libxmu-dev_2%3a1.1.3-3build2_amd64.deb",
+      "sha256": "a7b2d7632ba44ba2a9056b5665db0dad20d91fe8c336502db1f434b0b6922acc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxmu/libxmu-dev_1.1.3-3build2_amd64.deb"
+    },
+    {
+      "name": "libxmu-headers",
+      "version": "2:1.1.3-3build2",
+      "architecture": "all",
+      "filename": "libxmu-headers_2%3a1.1.3-3build2_all.deb",
+      "sha256": "6abd2218697cefb602d8273a3df711b297f504f414abff11d366578ddc9fd3d6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxmu/libxmu-headers_1.1.3-3build2_all.deb"
+    },
+    {
+      "name": "libxnnpack0.20241108",
+      "version": "0.0~git20241108.4ea82e5-1",
+      "architecture": "amd64",
+      "filename": "libxnnpack0.20241108_0.0~git20241108.4ea82e5-1_amd64.deb",
+      "sha256": "0a3eedc79943aadbc036d199230c573e1a0b80f947e07076dbf1db1d4a201297",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/xnnpack/libxnnpack0.20241108_0.0%7egit20241108.4ea82e5-1_amd64.deb"
+    },
+    {
+      "name": "libxrender-dev",
+      "version": "1:0.9.10-1.1build1",
+      "architecture": "amd64",
+      "filename": "libxrender-dev_1%3a0.9.10-1.1build1_amd64.deb",
+      "sha256": "839558c9de049636e13e22e409c04f3226614abf176c4a3b7088058576d74848",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxrender/libxrender-dev_0.9.10-1.1build1_amd64.deb"
+    },
+    {
+      "name": "libxres-dev",
+      "version": "2:1.2.1-1build1",
+      "architecture": "amd64",
+      "filename": "libxres-dev_2%3a1.2.1-1build1_amd64.deb",
+      "sha256": "7e7346f017ad871cd2e3a0e9c8742e943e09198867f042cc455465c39240e2ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxres/libxres-dev_1.2.1-1build1_amd64.deb"
+    },
+    {
+      "name": "libxslt1.1",
+      "version": "1.1.39-0exp1ubuntu4.1",
+      "architecture": "amd64",
+      "filename": "libxslt1.1_1.1.39-0exp1ubuntu4.1_amd64.deb",
+      "sha256": "7072c3b5e8e36fe949edf29d89cfc1cc4a4a65c6a1fb9e9ddd4abbba0c9c5872",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxslt/libxslt1.1_1.1.39-0exp1ubuntu4.1_amd64.deb"
+    },
+    {
+      "name": "libxt-dev",
+      "version": "1:1.2.1-1.2build1",
+      "architecture": "amd64",
+      "filename": "libxt-dev_1%3a1.2.1-1.2build1_amd64.deb",
+      "sha256": "77858926454d10dd7896fc4d1ee158b67bb25e830dd41e60e4a59e79f71b8a8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxt/libxt-dev_1.2.1-1.2build1_amd64.deb"
+    },
+    {
+      "name": "libxtst-dev",
+      "version": "2:1.2.5-1",
+      "architecture": "amd64",
+      "filename": "libxtst-dev_2%3a1.2.5-1_amd64.deb",
+      "sha256": "f21eaaa996c266d0d3b96c1a392ac9af7cc4cbfe60601a1c98942bdcb8d5e334",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxtst/libxtst-dev_1.2.5-1_amd64.deb"
+    },
+    {
+      "name": "libxxf86vm-dev",
+      "version": "1:1.1.4-1build4",
+      "architecture": "amd64",
+      "filename": "libxxf86vm-dev_1%3a1.1.4-1build4_amd64.deb",
+      "sha256": "98587402f6928a2526a8fbae6bd8c7297ced187b3a34b4e461ffd3245910f1af",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxxf86vm/libxxf86vm-dev_1.1.4-1build4_amd64.deb"
+    },
+    {
+      "name": "libyajl2",
+      "version": "2.1.0-5build1",
+      "architecture": "amd64",
+      "filename": "libyajl2_2.1.0-5build1_amd64.deb",
+      "sha256": "faa268c632f7d2931509cf7b8b7ddd810aa775adc26ead88ea158e2ede5208f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/y/yajl/libyajl2_2.1.0-5build1_amd64.deb"
+    },
+    {
+      "name": "libzbar0t64",
+      "version": "0.23.93-7",
+      "architecture": "amd64",
+      "filename": "libzbar0t64_0.23.93-7_amd64.deb",
+      "sha256": "9954e12b0e2f1f5a294465c6e5c1eaa46407024f0416b4b90513e554ecd31776",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zbar/libzbar0t64_0.23.93-7_amd64.deb"
+    },
+    {
+      "name": "libzix-0-0",
+      "version": "0.6.2-1",
+      "architecture": "amd64",
+      "filename": "libzix-0-0_0.6.2-1_amd64.deb",
+      "sha256": "54d72b63ae0243dedd47e1946765890deb7764f5cfa2c9332228742b6b406ba9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zix/libzix-0-0_0.6.2-1_amd64.deb"
+    },
+    {
+      "name": "libzstd-dev",
+      "version": "1.5.6+dfsg-2",
+      "architecture": "amd64",
+      "filename": "libzstd-dev_1.5.6+dfsg-2_amd64.deb",
+      "sha256": "45e78999356317e33de5d4b29240c410effdbfd39d543ce15f317d6382046040",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libz/libzstd/libzstd-dev_1.5.6%2bdfsg-2_amd64.deb"
+    },
+    {
+      "name": "libzvbi-common",
+      "version": "0.2.44-1ubuntu1",
+      "architecture": "all",
+      "filename": "libzvbi-common_0.2.44-1ubuntu1_all.deb",
+      "sha256": "0462d29f8e7291539247179a97693f0098fd7738b26ef1f0e05122595975eee9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zvbi/libzvbi-common_0.2.44-1ubuntu1_all.deb"
+    },
+    {
+      "name": "libzvbi0t64",
+      "version": "0.2.44-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libzvbi0t64_0.2.44-1ubuntu1_amd64.deb",
+      "sha256": "6596415c0581e0b48d34dae7c13990cd57187bd5e0331cb2a237c34ae6ef3949",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zvbi/libzvbi0t64_0.2.44-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libzxing3",
+      "version": "2.3.0-3",
+      "architecture": "amd64",
+      "filename": "libzxing3_2.3.0-3_amd64.deb",
+      "sha256": "66937bdde76f3edf56568d461692c7f6668f057a8ce0ba687570acb32bfd750b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zxing-cpp/libzxing3_2.3.0-3_amd64.deb"
+    },
+    {
+      "name": "linux-libc-dev",
+      "version": "6.14.0-37.37",
+      "architecture": "amd64",
+      "filename": "linux-libc-dev_6.14.0-37.37_amd64.deb",
+      "sha256": "e03a0bbe25ebd8b2d618a842f1cef681c38abd22319518c980ab7a742d0e62a8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/l/linux/linux-libc-dev_6.14.0-37.37_amd64.deb"
+    },
+    {
+      "name": "llvm-20-linker-tools",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "llvm-20-linker-tools_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "4675775ec06186e8b2645e2bbe886fda6d330e89bb5fb1979c66dcc43b6d2849",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/llvm-20-linker-tools_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "lto-disabled-list",
+      "version": "57",
+      "architecture": "all",
+      "filename": "lto-disabled-list_57_all.deb",
+      "sha256": "0cc7c3bd22fef2f2dd2afda0d624c900af6dc9cf70e59a486f23b5751f3bf4bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/l/lto-disabled-list/lto-disabled-list_57_all.deb"
+    },
+    {
+      "name": "make",
+      "version": "4.4.1-1",
+      "architecture": "amd64",
+      "filename": "make_4.4.1-1_amd64.deb",
+      "sha256": "d0622880df49e4bfd48e07253a18553aac0214ecbcd24a0841de7315c249cc2e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb"
+    },
+    {
+      "name": "meson",
+      "version": "1.7.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "meson_1.7.0-1ubuntu1_all.deb",
+      "sha256": "669142d3fd9008c583ca2511d4d3db41efeb2ace18642c942bc7e7fa7fd81ece",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/meson/meson_1.7.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "native-architecture",
+      "version": "0.2.6",
+      "architecture": "all",
+      "filename": "native-architecture_0.2.6_all.deb",
+      "sha256": "675f55bc3cbcddb1ba701817eec1a198e1fa38cddfe119efa69b06e8e9a18c1f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/a/architecture-properties/native-architecture_0.2.6_all.deb"
+    },
+    {
+      "name": "ninja-build",
+      "version": "1.12.1-1",
+      "architecture": "amd64",
+      "filename": "ninja-build_1.12.1-1_amd64.deb",
+      "sha256": "8190a977f4e0158c88fc76541737cdd62f74c74e8fd9aa25c6d5a322c7be6b0a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/ninja-build/ninja-build_1.12.1-1_amd64.deb"
+    },
+    {
+      "name": "patch",
+      "version": "2.7.6-7build3",
+      "architecture": "amd64",
+      "filename": "patch_2.7.6-7build3_amd64.deb",
+      "sha256": "fb7d78ed25c2788a607802270f3c28ac5ed6857bfb6cce9f73ad2cafac9159b3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/patch/patch_2.7.6-7build3_amd64.deb"
+    },
+    {
+      "name": "pci.ids",
+      "version": "0.0~2025.03.09-1",
+      "architecture": "all",
+      "filename": "pci.ids_0.0~2025.03.09-1_all.deb",
+      "sha256": "50762fd34c8d1cd4a8e99df09ac35200cbf709d821358eb08697a688f39edca9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pci.ids/pci.ids_0.0%7e2025.03.09-1_all.deb"
+    },
+    {
+      "name": "perl",
+      "version": "5.40.1-2ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "perl_5.40.1-2ubuntu0.2_amd64.deb",
+      "sha256": "d46189a20c6ae13825ee2b6a58efa9c58fe0c95527119d700bffd84d04b97d66",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/perl/perl_5.40.1-2ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "perl-modules-5.40",
+      "version": "5.40.1-2ubuntu0.2",
+      "architecture": "all",
+      "filename": "perl-modules-5.40_5.40.1-2ubuntu0.2_all.deb",
+      "sha256": "00d247d90e3e8f58c4ea9aae279dbf60c6fda16e2a49512050e1471c5931be8e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/perl/perl-modules-5.40_5.40.1-2ubuntu0.2_all.deb"
+    },
+    {
+      "name": "pipewire",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "b77fae0221ecdebcc9839cfd08aa5da95359c741a4d2922bfcaf55474b93f0a7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-bin",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "0d16cd14743a2c8fc4c726057ec910ba7eac48e5de65698acc01aeb336d45078",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-pulse",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "611be8d6b8620f5d266e7a8a232bb7cb96f558fc8a73205af7aaec084c3ab8eb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pkg-config",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkg-config_1.8.1-4_amd64.deb",
+      "sha256": "04b7449b1453626ae918a12afc747b4cc395a734a8db5c6b94468672088d0c14",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pkgconf",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkgconf_1.8.1-4_amd64.deb",
+      "sha256": "0db266c58f3169b3ce5257003e2065b6306630106945587293802098bac78247",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pkgconf-bin",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkgconf-bin_1.8.1-4_amd64.deb",
+      "sha256": "3af3f64647ebed77014036ff676676eccca0f79b8e4763dc0439b46d97e9196b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pnp.ids",
+      "version": "0.393-3",
+      "architecture": "all",
+      "filename": "pnp.ids_0.393-3_all.deb",
+      "sha256": "db21da54953f550393ed42d07a815f7f2ece949ba800865fba9252b3bfdf9d38",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/h/hwdata/pnp.ids_0.393-3_all.deb"
+    },
+    {
+      "name": "python3-jaraco.text",
+      "version": "4.0.0-1",
+      "architecture": "all",
+      "filename": "python3-jaraco.text_4.0.0-1_all.deb",
+      "sha256": "948086d278c565ad8549587b01156ee9f09dadff9623de121dcb5dafe3ddb6cc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/j/jaraco.text/python3-jaraco.text_4.0.0-1_all.deb"
+    },
+    {
+      "name": "python3-packaging",
+      "version": "24.2-1",
+      "architecture": "all",
+      "filename": "python3-packaging_24.2-1_all.deb",
+      "sha256": "dbe200c8fa49f6c4e4c82fc20418e6d26f0689317bdf1edf00854da87ec53d0c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-packaging/python3-packaging_24.2-1_all.deb"
+    },
+    {
+      "name": "python3-setuptools",
+      "version": "75.8.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "python3-setuptools_75.8.0-1ubuntu1_all.deb",
+      "sha256": "5aa98a69aae8caff58cce7b94d73eb3101127ef154f4a5cd4eae45c2c46714a0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/setuptools/python3-setuptools_75.8.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "python3-zipp",
+      "version": "3.21.0-1",
+      "architecture": "all",
+      "filename": "python3-zipp_3.21.0-1_all.deb",
+      "sha256": "f940bd4def06760555cde9c8d27207eb536d1a32211dd8c54223100b0f0242f5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-zipp/python3-zipp_3.21.0-1_all.deb"
+    },
+    {
+      "name": "rpcsvc-proto",
+      "version": "1.4.2-0ubuntu7",
+      "architecture": "amd64",
+      "filename": "rpcsvc-proto_1.4.2-0ubuntu7_amd64.deb",
+      "sha256": "7eb710fe148d224c159ddec1ceb0ba53ead52a80a6793dcdae1474acf20d8f71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-0ubuntu7_amd64.deb"
+    },
+    {
+      "name": "spirv-tools",
+      "version": "2025.1~rc1-1",
+      "architecture": "amd64",
+      "filename": "spirv-tools_2025.1~rc1-1_amd64.deb",
+      "sha256": "e7a487f6e47851bfe86724b14729bf22f3d54b0177bc982063483e5e35a10d8c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spirv-tools/spirv-tools_2025.1%7erc1-1_amd64.deb"
+    },
+    {
+      "name": "timgm6mb-soundfont",
+      "version": "1.3-5",
+      "architecture": "all",
+      "filename": "timgm6mb-soundfont_1.3-5_all.deb",
+      "sha256": "b70bc29b8f27adef8f92a2d9c1e26cee977b84c68110f0dd4326d97730a7c3ed",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/t/timgm6mb-soundfont/timgm6mb-soundfont_1.3-5_all.deb"
+    },
+    {
+      "name": "usb.ids",
+      "version": "2025.01.14-1",
+      "architecture": "all",
+      "filename": "usb.ids_2025.01.14-1_all.deb",
+      "sha256": "fa4a1fd5b24eafda34fe5e11ec2ed182c25bdb484758a5a7731bbb42643f2673",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/usb.ids/usb.ids_2025.01.14-1_all.deb"
+    },
+    {
+      "name": "uuid-dev",
+      "version": "2.40.2-14ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "uuid-dev_2.40.2-14ubuntu1.2_amd64.deb",
+      "sha256": "5408aef7913b669c0d6b3773e89a3f2b08f6beda086730e8ccb49c9a8ef97dd5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/util-linux/uuid-dev_2.40.2-14ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "wayland-protocols",
+      "version": "1.41-1",
+      "architecture": "all",
+      "filename": "wayland-protocols_1.41-1_all.deb",
+      "sha256": "3a0942c89ced71ebc809718c9d21910627d2a257b1277d6a9173a672cf53125f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland-protocols/wayland-protocols_1.41-1_all.deb"
+    },
+    {
+      "name": "x11proto-dev",
+      "version": "2024.1-1",
+      "architecture": "all",
+      "filename": "x11proto-dev_2024.1-1_all.deb",
+      "sha256": "98811486c3f51eb0a6e89c44cdea1edd8b45d7b285f87fa747cb997c4a65b451",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb"
+    },
+    {
+      "name": "xorg-sgml-doctools",
+      "version": "1:1.11-1.1",
+      "architecture": "all",
+      "filename": "xorg-sgml-doctools_1%3a1.11-1.1_all.deb",
+      "sha256": "277f662c6d94606c22078f2af82ac1b6e01386d5a4dec6ca7487bca4c5b23c07",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb"
+    },
+    {
+      "name": "xtrans-dev",
+      "version": "1.4.0-1",
+      "architecture": "all",
+      "filename": "xtrans-dev_1.4.0-1_all.deb",
+      "sha256": "45277c51d5d83db351b61859314b59595c9626ac372fbb2fc0d5542e169d9086",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb"
+    },
+    {
+      "name": "xz-utils",
+      "version": "5.6.4-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "xz-utils_5.6.4-1ubuntu1_amd64.deb",
+      "sha256": "694f9201f670cbcf8d191e2c9c3db5e83b5373e6cb8a9330b0b6b25698da4a88",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xz-utils/xz-utils_5.6.4-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "zlib1g-dev",
+      "version": "1:1.3.dfsg+really1.3.1-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "zlib1g-dev_1%3a1.3.dfsg+really1.3.1-1ubuntu1_amd64.deb",
+      "sha256": "a04e48305134d40f3d42d329296c6458bdfb40805f8adbd789b4140202c0f8f1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/z/zlib/zlib1g-dev_1.3.dfsg%2breally1.3.1-1ubuntu1_amd64.deb"
+    }
+  ]
+}

--- a/containers/multiseat/locks/heroic.packages.json
+++ b/containers/multiseat/locks/heroic.packages.json
@@ -1,0 +1,1508 @@
+{
+  "schema": 1,
+  "profile": "heroic",
+  "platform": "linux/amd64",
+  "source_root": "ghcr.io/games-on-whales/heroic-games-launcher@sha256:a207a39367801a8a8bf24b68dac2c9945052d3117cb03b061b27bd6672aab62f",
+  "snapshot": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/",
+  "source_manifest_sha256": "047c4c6123cbdea9d821ebb1608cd8129cbcad6b72bcc89e76d58a93091fe188",
+  "runtime": [
+    {
+      "name": "gstreamer1.0-tools",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-tools_1.26.0-3_amd64.deb",
+      "sha256": "ac24b15d6a48bb99097419f4d8d5928430d010af301b0df0b32570e59879f8f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gstreamer1.0-tools_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-modules",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "f23e9a3ebedfbb846efe210bcc55150668394ac807e6c71f1f2c1d5f728c2f8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libroc0.4",
+      "version": "0.4.0+dfsg-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libroc0.4_0.4.0+dfsg-4ubuntu1_amd64.deb",
+      "sha256": "8bec93425075527aa82683dbcf2d1784c39361da46a10c299f0c60afb8625b71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/roc-toolkit/libroc0.4_0.4.0%2bdfsg-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsnapd-glib-2-1",
+      "version": "1.66-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb",
+      "sha256": "b7bd77be1d59bf3a19bbe91b9ab6225ad05736ed72bd9f3b3f56bcd83822e398",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/snapd-glib/libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libspeexdsp1",
+      "version": "1.2.1-3",
+      "architecture": "amd64",
+      "filename": "libspeexdsp1_1.2.1-3_amd64.deb",
+      "sha256": "5b178611a05217d2ba35823aa8f75387d074a7e2d50954dc11464678cd7b2c91",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/speexdsp/libspeexdsp1_1.2.1-3_amd64.deb"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2ubuntu1",
+      "architecture": "amd64",
+      "filename": "libuv1t64_1.50.0-2ubuntu1_amd64.deb",
+      "sha256": "6af9634d05965f60ed7c124d43cef678ef288824b6f36a7b02559dd4097e7c90",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libuv1/libuv1t64_1.50.0-2ubuntu1_amd64.deb"
+    },
+    {
+      "name": "pipewire",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "b77fae0221ecdebcc9839cfd08aa5da95359c741a4d2922bfcaf55474b93f0a7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-bin",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "0d16cd14743a2c8fc4c726057ec910ba7eac48e5de65698acc01aeb336d45078",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-pulse",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "611be8d6b8620f5d266e7a8a232bb7cb96f558fc8a73205af7aaec084c3ab8eb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb"
+    }
+  ],
+  "build": [
+    {
+      "name": "binutils-gold",
+      "version": "2.44-2",
+      "architecture": "amd64",
+      "filename": "binutils-gold_2.44-2_amd64.deb",
+      "sha256": "832317652330363576d427f3038663fe3aaa778ac1e5749888aad6b59ec17fd4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils-gold/binutils-gold_2.44-2_amd64.deb"
+    },
+    {
+      "name": "binutils-gold-x86-64-linux-gnu",
+      "version": "2.44-2",
+      "architecture": "amd64",
+      "filename": "binutils-gold-x86-64-linux-gnu_2.44-2_amd64.deb",
+      "sha256": "149f39909d2454e78f5fc6c8e829a756ab4bd6b65e7202e3fecf37bd07309608",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils-gold/binutils-gold-x86-64-linux-gnu_2.44-2_amd64.deb"
+    },
+    {
+      "name": "build-essential",
+      "version": "12.12ubuntu1",
+      "architecture": "amd64",
+      "filename": "build-essential_12.12ubuntu1_amd64.deb",
+      "sha256": "6690743c7c255ec97f2ce7373648cebe24e9b83da2b134ce8c53326840757016",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/build-essential/build-essential_12.12ubuntu1_amd64.deb"
+    },
+    {
+      "name": "bzip2",
+      "version": "1.0.8-6",
+      "architecture": "amd64",
+      "filename": "bzip2_1.0.8-6_amd64.deb",
+      "sha256": "b90c1467738ebb2941ab0129ee142de7803e3564196e89485e8c91d11cffd5a4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/bzip2/bzip2_1.0.8-6_amd64.deb"
+    },
+    {
+      "name": "clang",
+      "version": "1:20.0-63ubuntu1",
+      "architecture": "amd64",
+      "filename": "clang_1%3a20.0-63ubuntu1_amd64.deb",
+      "sha256": "63385ed7288cb5148c62000b328c38b6877a0df265e7bad4a32b208afdd89a96",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-defaults/clang_20.0-63ubuntu1_amd64.deb"
+    },
+    {
+      "name": "clang-20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "clang-20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "25100f57ca694598e4eb9fb605b504f1ebf4480bed15a0c79f3944a1deba2c13",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/clang-20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cmake",
+      "version": "3.31.6-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "cmake_3.31.6-1ubuntu1_amd64.deb",
+      "sha256": "eb9a56e821b957179d2d801878668fb56d64dde8ccb3d46e9bd591bddb1d75ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/c/cmake/cmake_3.31.6-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cmake-data",
+      "version": "3.31.6-1ubuntu1",
+      "architecture": "all",
+      "filename": "cmake-data_3.31.6-1ubuntu1_all.deb",
+      "sha256": "52c6d1634243c6648028b04b7f7f241993cdaab48becde16b540b90c80ba31ec",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/c/cmake/cmake-data_3.31.6-1ubuntu1_all.deb"
+    },
+    {
+      "name": "cpp",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "cpp_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "6ecd93b5307ccefe61b5e59c67346b9285ef54314294c1e5e97d5084913462c3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/cpp_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cpp-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "cpp-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "724e139e35d74ddabf5039eb1582b72f6a42b6e323d2fb19ff2bd203a85c7b08",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/cpp-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "cpp-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "cpp-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "af3d711d9b0021d79b0aed799029b4d35b5f215d4c96eaaaa766c1277a2bc7e4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/cpp-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "cpp-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "cpp-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "60a95cc48c0dc91e5abc4d9059209819ab3589373ff28a01199cf46254f1770e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/cpp-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "dpkg-dev",
+      "version": "1.22.18ubuntu2.2",
+      "architecture": "all",
+      "filename": "dpkg-dev_1.22.18ubuntu2.2_all.deb",
+      "sha256": "f17198b313ade86099ad7b35c152875d84ef2de9bda3a5c430a6c17b351991df",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/d/dpkg/dpkg-dev_1.22.18ubuntu2.2_all.deb"
+    },
+    {
+      "name": "g++",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "g++_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "c286c49484a551dfb9514898244e3d7089fd543c11a3f7e1a3227f96f07df14a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/g%2b%2b_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "g++-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "g++-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "b0848a8a8e00fd453c00d6f52b73e1fb9b5f887a71cfa160487a6b252dda1b4e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/g%2b%2b-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "g++-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "g++-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "b9f5de224295cb5ef5b7f641baddb4da943d43192157c831ab9b6f652894438e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/g%2b%2b-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "g++-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "g++-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "7a3aad61f52c6a1c2fab94d7ac313673272c4617c0b8c6edad48188ec06ddf7e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/g%2b%2b-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gcc",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "gcc_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "82abbe21f53a70db6abe947998f07d2e91c36cce62972540dc782c29c86d0702",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/gcc_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gcc-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "gcc-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "209a445434926b1f25221e464108c141950ee2316a8ddf535ec518cb57926f76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/gcc-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "gcc-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "gcc-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "ab71e82506bee4747468cd701940fc4f5dd498605d76e257b89d009c2e4c4413",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/gcc-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "gcc-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "gcc-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "eb69145199e998fae2e6fab23a0759f768f33e7b7b2d21fb28dc0c91bbe3ab2d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/gcc-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gir1.2-glib-2.0-dev",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "gir1.2-glib-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "90e423a6b84c2814102ef749710f1230e76730939ec334ab681559d6a0f69a3b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/gir1.2-glib-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gst-plugins-base-1.0",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "gir1.2-gst-plugins-base-1.0_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "0d52d57f01acbdde1ff600129dcafca59008e500cbc7df3f27f721b318f1b4e4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/gir1.2-gst-plugins-base-1.0_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gstreamer-1.0",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gir1.2-gstreamer-1.0_1.26.0-3_amd64.deb",
+      "sha256": "8078e3a2a9bd916f9448d3333a12f1b5a4788c696248b91bdf1322c579ddea1c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gir1.2-gstreamer-1.0_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gudev-1.0",
+      "version": "1:238-6",
+      "architecture": "amd64",
+      "filename": "gir1.2-gudev-1.0_1%3a238-6_amd64.deb",
+      "sha256": "5759e4ab498311b1ee83a0f38e6aeda415590de45a404c7ba7f5c9d9f8a31d61",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_amd64.deb"
+    },
+    {
+      "name": "girepository-tools",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "girepository-tools_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "002ca31c5e75d96c7c455ad00ac185044f113f32a7037d69a074b5d73425f5e7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/girepository-tools_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "git",
+      "version": "1:2.48.1-0ubuntu1.1",
+      "architecture": "amd64",
+      "filename": "git_1%3a2.48.1-0ubuntu1.1_amd64.deb",
+      "sha256": "f85b919ba73b802a5934719678d3f83f75b06c67187cf0facb262c3b1bdd4721",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/git/git_2.48.1-0ubuntu1.1_amd64.deb"
+    },
+    {
+      "name": "git-man",
+      "version": "1:2.48.1-0ubuntu1.1",
+      "architecture": "all",
+      "filename": "git-man_1%3a2.48.1-0ubuntu1.1_all.deb",
+      "sha256": "3292fe6f57a9620ba7653dfc492f40951ba6824bc1ac4dfc7c96f3f59731fd18",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/git/git-man_2.48.1-0ubuntu1.1_all.deb"
+    },
+    {
+      "name": "glslang-tools",
+      "version": "15.1.0-2",
+      "architecture": "amd64",
+      "filename": "glslang-tools_15.1.0-2_amd64.deb",
+      "sha256": "98d8b12ebaa3a9bcf7e68087d08a43a997356a52c130f01a5624a208fa8ab9d7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/glslang/glslang-tools_15.1.0-2_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-tools",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-tools_1.26.0-3_amd64.deb",
+      "sha256": "ac24b15d6a48bb99097419f4d8d5928430d010af301b0df0b32570e59879f8f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gstreamer1.0-tools_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "hwdata",
+      "version": "0.393-3",
+      "architecture": "all",
+      "filename": "hwdata_0.393-3_all.deb",
+      "sha256": "ad5beb26ff8b18ff48467b3f09b6e687451911e40430ae89eaef8ace2bfdcf61",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/h/hwdata/hwdata_0.393-3_all.deb"
+    },
+    {
+      "name": "libarchive13t64",
+      "version": "3.7.7-0ubuntu2.3",
+      "architecture": "amd64",
+      "filename": "libarchive13t64_3.7.7-0ubuntu2.3_amd64.deb",
+      "sha256": "a31d7532b90f89c342b3e8d23a922a17aaf9cb6d736c4a8e4773f0be97a7ba5f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/liba/libarchive/libarchive13t64_3.7.7-0ubuntu2.3_amd64.deb"
+    },
+    {
+      "name": "libasan8",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libasan8_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "f13c558b07c3a23d58948e7dee0c49bd8a1ab63147a701104c8e6049e71f5a73",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libasan8_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libblkid-dev",
+      "version": "2.40.2-14ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libblkid-dev_2.40.2-14ubuntu1.2_amd64.deb",
+      "sha256": "1f9e20bb7c25eacdbdb6aa057964628c9fa8420ea4faaee9fff476ab8b4e551a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/util-linux/libblkid-dev_2.40.2-14ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libc-dev-bin",
+      "version": "2.41-6ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libc-dev-bin_2.41-6ubuntu1.2_amd64.deb",
+      "sha256": "6c5f01366826032936aa16297242046d4d89ef4221ce13c6d921fb973419b8a3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glibc/libc-dev-bin_2.41-6ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libc6-dev",
+      "version": "2.41-6ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libc6-dev_2.41-6ubuntu1.2_amd64.deb",
+      "sha256": "392a66c966e0bd272fe8acd4270e726d835e6fffd85ec322759638c0245743c4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glibc/libc6-dev_2.41-6ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libcap-dev",
+      "version": "1:2.73-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libcap-dev_1%3a2.73-4ubuntu1_amd64.deb",
+      "sha256": "ab6d5ef8d377dc23f2cb49dc66dbde2ee25bc0f00da54a84e3aeb783526e2b4c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libc/libcap2/libcap-dev_2.73-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libcc1-0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libcc1-0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "f84dd605099c5297ed5404553b03f39e4afb443333f27e7c9cdf25628cfa2717",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libcc1-0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-20-dev",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-20-dev_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "e0b1c9024a083ae276c23fdb547e057cdec9c76b6de1ff0a9065a4499a4076dc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-20-dev_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-common-20-dev",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-common-20-dev_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "05a6125fdcfc18a9b1f30ecc12378a46f9fa7f25ea782d9006bb23eb79f65e73",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-common-20-dev_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-cpp20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-cpp20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "f19464e350b2a3913c14882408e3495b2ccef81281b7a8abf0b53234d254b739",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-cpp20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-dev",
+      "version": "1:20.0-63ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-dev_1%3a20.0-63ubuntu1_amd64.deb",
+      "sha256": "4699c12ff94eda3fd18b49270edc6a6d7e2a390d5dc0efa32d2bc1119bdcdfc0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-defaults/libclang-dev_20.0-63ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang1-20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang1-20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "ed4bf6b86e21e735d4a2f5564c5dc202a818460be1e1c5b2794790678b7736aa",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang1-20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libcrypt-dev",
+      "version": "1:4.4.38-1",
+      "architecture": "amd64",
+      "filename": "libcrypt-dev_1%3a4.4.38-1_amd64.deb",
+      "sha256": "88a4ec0d8bf7b61600165896acbe55d888b54f317e9a5bc2fcb99fe9166b0427",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcrypt/libcrypt-dev_4.4.38-1_amd64.deb"
+    },
+    {
+      "name": "libdecor-0-dev",
+      "version": "0.2.2-2",
+      "architecture": "amd64",
+      "filename": "libdecor-0-dev_0.2.2-2_amd64.deb",
+      "sha256": "a8a1eed5d20461fa612700c9317a26046f6dd9c00aec432bead3f5f97c9b400b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdecor-0/libdecor-0-dev_0.2.2-2_amd64.deb"
+    },
+    {
+      "name": "libdpkg-perl",
+      "version": "1.22.18ubuntu2.2",
+      "architecture": "all",
+      "filename": "libdpkg-perl_1.22.18ubuntu2.2_all.deb",
+      "sha256": "9d96ff20ee92e976d82834f5e9b52b12b85b6ebddb83da1a641456b00d4afe89",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/d/dpkg/libdpkg-perl_1.22.18ubuntu2.2_all.deb"
+    },
+    {
+      "name": "libdrm-dev",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-dev_2.4.124-2_amd64.deb",
+      "sha256": "1d8d69e8bfd242c0e46bd8910f889b45203ed57b501e81b41faf05e03730643f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-dev_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdrm-nouveau2",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-nouveau2_2.4.124-2_amd64.deb",
+      "sha256": "7eaf5ee5460175ef118dd0dbf246d5b72d19c70f113d0650e3a045aefd968c09",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-nouveau2_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdrm-radeon1",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-radeon1_2.4.124-2_amd64.deb",
+      "sha256": "e45997171485fbf22b3dd0d3d569aa0b7b923a945cba80a93717042da54b4d70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-radeon1_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdw-dev",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libdw-dev_0.192-4ubuntu1_amd64.deb",
+      "sha256": "d20955250b0efd8ea3f4f908fb91ecc9448f13c353b0aa289599f41c53fd19fd",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libdw-dev_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libdw1t64",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libdw1t64_0.192-4ubuntu1_amd64.deb",
+      "sha256": "4c75709171583eb7c9f437d90ea44a7184f0b2b0f5f23f428f00ba3febeb52e6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libdw1t64_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libegl-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libegl-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "3a0315216bb0d6fc4bbe7f689cf0168c2ffa3e62ac69bff06bbbe49679259990",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libegl-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libelf-dev",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libelf-dev_0.192-4ubuntu1_amd64.deb",
+      "sha256": "410b4385cf6c508bae56eb399148be1d5814be0f20e7e06cbd3e53b1c2943b50",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libelf-dev_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "liberror-perl",
+      "version": "0.17030-1",
+      "architecture": "all",
+      "filename": "liberror-perl_0.17030-1_all.deb",
+      "sha256": "cb85c869fe056e9e466efcfa3403408b0a87db1da1cafa585140a9be59fe58a1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libe/liberror-perl/liberror-perl_0.17030-1_all.deb"
+    },
+    {
+      "name": "libevdev-dev",
+      "version": "1.13.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libevdev-dev_1.13.3+dfsg-1_amd64.deb",
+      "sha256": "425b37d96ee3d595d89f966bcf9758d15f84c30eff21e3279b1a4e0ec9671de6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libe/libevdev/libevdev-dev_1.13.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libffi-dev",
+      "version": "3.4.7-1",
+      "architecture": "amd64",
+      "filename": "libffi-dev_3.4.7-1_amd64.deb",
+      "sha256": "900ba7b5679f750a6db82c058f69074a684b3b85afa8c9121f3689a469f62a75",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libf/libffi/libffi-dev_3.4.7-1_amd64.deb"
+    },
+    {
+      "name": "libgbm-dev",
+      "version": "25.0.7-0ubuntu0.25.04.2",
+      "architecture": "amd64",
+      "filename": "libgbm-dev_25.0.7-0ubuntu0.25.04.2_amd64.deb",
+      "sha256": "34bd2a70579a7e795d446d9de2d85185dca058e93926f11ab7f23f27f1e03be4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mesa/libgbm-dev_25.0.7-0ubuntu0.25.04.2_amd64.deb"
+    },
+    {
+      "name": "libgc1",
+      "version": "1:8.2.8-1",
+      "architecture": "amd64",
+      "filename": "libgc1_1%3a8.2.8-1_amd64.deb",
+      "sha256": "d337914b08465d43186dbfe880fde5c9ea23808b0d56ea88397644cd6df84fcf",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgc/libgc1_8.2.8-1_amd64.deb"
+    },
+    {
+      "name": "libgcc-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libgcc-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "10eff4b80bc982518584b67e65e3ab89c8f33c4af7ce0b0071463e4eda410e74",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/libgcc-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libgdbm-compat4t64",
+      "version": "1.24-2",
+      "architecture": "amd64",
+      "filename": "libgdbm-compat4t64_1.24-2_amd64.deb",
+      "sha256": "0693236e9baf295abb8f90a56f44282054a3c91c9946a47c4a095764c073d052",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gdbm/libgdbm-compat4t64_1.24-2_amd64.deb"
+    },
+    {
+      "name": "libgdbm6t64",
+      "version": "1.24-2",
+      "architecture": "amd64",
+      "filename": "libgdbm6t64_1.24-2_amd64.deb",
+      "sha256": "1df38f4993f7f68cee81283af8963e0cb7c885be61be9a93326ab850af15e4f6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gdbm/libgdbm6t64_1.24-2_amd64.deb"
+    },
+    {
+      "name": "libgio-2.0-dev",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libgio-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "8691851455f8820210e7f94ecbd7a889039ef9a617e301bd135f954ea6a463ab",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libgio-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libgio-2.0-dev-bin",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libgio-2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "90346abaaad67a7dc3dc57088c3f0bab298b6e8c58af608da9c33bbc35e0052f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libgio-2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libgirepository-2.0-0",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libgirepository-2.0-0_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "b4c393515b1eade5535349e0104027efdd2502e8045eb0334f40457301350235",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libgirepository-2.0-0_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libgl-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgl-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "b7145fd8f8abe20d5cb436d2eae9b3235bd91be6fbddac581620d16763bd9250",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgl-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgles-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgles-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "ee2ea529c20e28031230c5910281e5bbd7f2c2ca06a2e306ca15e985d4875eb2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgles-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgles1",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgles1_1.7.0-1build1_amd64.deb",
+      "sha256": "3128deef59859a47cfca25244f035bdbedd223640209dcffdd11f1873ef71aff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgles1_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libglib2.0-dev",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libglib2.0-dev_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "42a2d562a0322eec7d12f24a695e10b32b3f0e584cb9f18d82378608b54c1d1d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libglib2.0-dev_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libglib2.0-dev-bin",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libglib2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "deef70c2d233a0bb449be2020990624bfc672650cfd564afc342579fb7cba8e6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libglib2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libglx-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libglx-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "0e2654950a881c20b640a3af590add2e0b612b8c0fdd945761fc695e1b6eb797",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libglx-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-base1.0-dev",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-base1.0-dev_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "20bf9472c7520737227c983fcc1b6711a98a58ea8f4381d9bb10e11dbe538a2f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-dev_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer1.0-dev",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "libgstreamer1.0-dev_1.26.0-3_amd64.deb",
+      "sha256": "bdfb350621e98cc9b38c4ab5bf3bfe448f635f12244f771bac89966678c2ad94",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/libgstreamer1.0-dev_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "libgudev-1.0-dev",
+      "version": "1:238-6",
+      "architecture": "amd64",
+      "filename": "libgudev-1.0-dev_1%3a238-6_amd64.deb",
+      "sha256": "e4cc1f9f5fe0dcca2c4e9fdeefe799b39f761513efb2bab676fe432b85b6309e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_amd64.deb"
+    },
+    {
+      "name": "libhwasan0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libhwasan0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8f6817b2b68c395118bb786c1b6388b1ccc0d76a64a26cab8b9519179277c318",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libhwasan0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libice-dev",
+      "version": "2:1.1.1-1",
+      "architecture": "amd64",
+      "filename": "libice-dev_2%3a1.1.1-1_amd64.deb",
+      "sha256": "68e9b0a566c83e73509d1cebad2dd7e20be32dbe58ec1e4fbcbc7c59b50b9f59",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libi/libice/libice-dev_1.1.1-1_amd64.deb"
+    },
+    {
+      "name": "libinput-dev",
+      "version": "1.27.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libinput-dev_1.27.1-1ubuntu0.2_amd64.deb",
+      "sha256": "264483d6ded36888d17fdfb6539517fa5cc0547b61d8039438c292ef5edf93db",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libi/libinput/libinput-dev_1.27.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libisl23",
+      "version": "0.27-1",
+      "architecture": "amd64",
+      "filename": "libisl23_0.27-1_amd64.deb",
+      "sha256": "bfef9e3c33a616669825dd9e42f7e01435326a8f6b88853bb7c0e1fcabc8ca76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/i/isl/libisl23_0.27-1_amd64.deb"
+    },
+    {
+      "name": "libitm1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libitm1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8a6c6855d2de1480760392f0fc443b65ec41cd811148011de89edd7ae417869a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libitm1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "liblsan0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "liblsan0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "0c1a62b4e6c14f502d3c0c49c8fc009e959ca4fa1a910e3eea40e896e434016e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/liblsan0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libluajit-5.1-dev",
+      "version": "2.1.0+openresty20250117-2",
+      "architecture": "amd64",
+      "filename": "libluajit-5.1-dev_2.1.0+openresty20250117-2_amd64.deb",
+      "sha256": "8b50af6f5684a57eed58d56be998376c8ef8e7c88379b6b14dffb56a10b4d9b4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/luajit/libluajit-5.1-dev_2.1.0%2bopenresty20250117-2_amd64.deb"
+    },
+    {
+      "name": "liblzma-dev",
+      "version": "5.6.4-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "liblzma-dev_5.6.4-1ubuntu1_amd64.deb",
+      "sha256": "164c8de2bd3c722576116937bea56d6ef0a892ec4c906f032ce366f0bc8409af",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xz-utils/liblzma-dev_5.6.4-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libmount-dev",
+      "version": "2.40.2-14ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libmount-dev_2.40.2-14ubuntu1.2_amd64.deb",
+      "sha256": "10263c8a5e18dcf562971c0bae03b7aae5b698233b605a422033bc474a9d6a4a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/util-linux/libmount-dev_2.40.2-14ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libmpc3",
+      "version": "1.3.1-1build2",
+      "architecture": "amd64",
+      "filename": "libmpc3_1.3.1-1build2_amd64.deb",
+      "sha256": "cd4ceaa5f4328131d4a36c2a6ebf8f4661f82d5aa897bb93333e92e6bd1c1bd3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mpclib3/libmpc3_1.3.1-1build2_amd64.deb"
+    },
+    {
+      "name": "libmpfr6",
+      "version": "4.2.2-1",
+      "architecture": "amd64",
+      "filename": "libmpfr6_4.2.2-1_amd64.deb",
+      "sha256": "5334f5ad406cd0c4432081201c1053e5b391b6866f4f67974cd2b08402d67b70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mpfr4/libmpfr6_4.2.2-1_amd64.deb"
+    },
+    {
+      "name": "libmtdev-dev",
+      "version": "1.1.7-1",
+      "architecture": "amd64",
+      "filename": "libmtdev-dev_1.1.7-1_amd64.deb",
+      "sha256": "0f3985ae771be368a3cedb7e08d181c293d3e03c97ba8aa5c6742ad70c8d0319",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mtdev/libmtdev-dev_1.1.7-1_amd64.deb"
+    },
+    {
+      "name": "libobjc-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libobjc-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "5babfef7063527cd3ed5a51dea337b32aa62ab79839940b25c2fb1721125a137",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gcc-14/libobjc-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libobjc4",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libobjc4_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "7e9fc63dcb88da621398110040df2ef9f12f00c4ca532bf583c67af0b7a46e5c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gcc-15/libobjc4_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "liborc-0.4-dev",
+      "version": "1:0.4.41-1",
+      "architecture": "amd64",
+      "filename": "liborc-0.4-dev_1%3a0.4.41-1_amd64.deb",
+      "sha256": "f9dd934bafb2140adf20e16f8d2ea5106539fbbe1f7b9f5cee6bf3a0cc56cd7c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/orc/liborc-0.4-dev_0.4.41-1_amd64.deb"
+    },
+    {
+      "name": "liborc-0.4-dev-bin",
+      "version": "1:0.4.41-1",
+      "architecture": "amd64",
+      "filename": "liborc-0.4-dev-bin_1%3a0.4.41-1_amd64.deb",
+      "sha256": "6abfb51460346159c83598f869dc27ad2474329cb70a5ebaba875c37bea1eb43",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/orc/liborc-0.4-dev-bin_0.4.41-1_amd64.deb"
+    },
+    {
+      "name": "libpciaccess-dev",
+      "version": "0.17-3ubuntu0.25.04.2",
+      "architecture": "amd64",
+      "filename": "libpciaccess-dev_0.17-3ubuntu0.25.04.2_amd64.deb",
+      "sha256": "345127a67e50bbb3db674e9051788737b8b2ddba4eab00cd316446d874f0732d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libp/libpciaccess/libpciaccess-dev_0.17-3ubuntu0.25.04.2_amd64.deb"
+    },
+    {
+      "name": "libpcre2-16-0",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-16-0_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "53f4d51ada507cce319542226504ba44c6b2ac4d8f561ec5fc908db939a45778",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-16-0_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpcre2-32-0",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-32-0_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "5ef102e3193081bb5553fa30d95329d2fcb091c1b1a782de72de5f60c14d01f7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-32-0_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpcre2-dev",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-dev_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "36605dbb5b4a650093f24f70e5925fab513acb96785b74a666274f43897a1072",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-dev_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpcre2-posix3",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-posix3_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "46c6cf4dc9587af70736ca0e47b4f6919731c02708a57ec41cc37ec1628f0bbc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-posix3_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libperl5.40",
+      "version": "5.40.1-2ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libperl5.40_5.40.1-2ubuntu0.2_amd64.deb",
+      "sha256": "06133408b9abcc6dd4065bfe10cacf051929ca262eea996d504a3228fe669ac2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/perl/libperl5.40_5.40.1-2ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-dev",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-dev_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "a1665a2ead175e9ccf4f9f4098db14ac56110470cb0599b941f679947a1b99d4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-modules",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "f23e9a3ebedfbb846efe210bcc55150668394ac807e6c71f1f2c1d5f728c2f8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libpixman-1-dev",
+      "version": "0.44.0-3",
+      "architecture": "amd64",
+      "filename": "libpixman-1-dev_0.44.0-3_amd64.deb",
+      "sha256": "126d4e5f89bc6a29ebfb296f22c4eb718fd04a3a2522b06c74f7d3e07e9129d3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pixman/libpixman-1-dev_0.44.0-3_amd64.deb"
+    },
+    {
+      "name": "libpkgconf3",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "libpkgconf3_1.8.1-4_amd64.deb",
+      "sha256": "91c46979979aa69e79a6dc64e2cd7c262173331ae58ba69ba29dce611c02c457",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "libquadmath0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libquadmath0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "a980b7bfc6586180d07a5df8a7d9bc97fa41c0790d91b780cee8e6f5f317c934",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libquadmath0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "librhash1",
+      "version": "1.4.5-1",
+      "architecture": "amd64",
+      "filename": "librhash1_1.4.5-1_amd64.deb",
+      "sha256": "6a51d203f615d3bfa71fba697db4a91700d7cfc04e48c9ab2786f77b96e9614a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/rhash/librhash1_1.4.5-1_amd64.deb"
+    },
+    {
+      "name": "libroc0.4",
+      "version": "0.4.0+dfsg-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libroc0.4_0.4.0+dfsg-4ubuntu1_amd64.deb",
+      "sha256": "8bec93425075527aa82683dbcf2d1784c39361da46a10c299f0c60afb8625b71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/roc-toolkit/libroc0.4_0.4.0%2bdfsg-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libseat-dev",
+      "version": "0.8.0-1",
+      "architecture": "amd64",
+      "filename": "libseat-dev_0.8.0-1_amd64.deb",
+      "sha256": "f0be2c0a66145588838546011a4236e20a277b9a4a52acfca9f0cb7dcf80b812",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/seatd/libseat-dev_0.8.0-1_amd64.deb"
+    },
+    {
+      "name": "libselinux1-dev",
+      "version": "3.7-3ubuntu3",
+      "architecture": "amd64",
+      "filename": "libselinux1-dev_3.7-3ubuntu3_amd64.deb",
+      "sha256": "f627acedca996a63d245e1465e133edc91d0e7da150278f66677b530f984155e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libs/libselinux/libselinux1-dev_3.7-3ubuntu3_amd64.deb"
+    },
+    {
+      "name": "libsepol-dev",
+      "version": "3.7-1",
+      "architecture": "amd64",
+      "filename": "libsepol-dev_3.7-1_amd64.deb",
+      "sha256": "84c6bdaa7b21c8f2dfec5f3b9e7f994fe666e7495ec6ee94cb6812979e9c438d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libs/libsepol/libsepol-dev_3.7-1_amd64.deb"
+    },
+    {
+      "name": "libsm-dev",
+      "version": "2:1.2.4-1",
+      "architecture": "amd64",
+      "filename": "libsm-dev_2%3a1.2.4-1_amd64.deb",
+      "sha256": "35664bfbf8d5dc4b5a920e7207938073296616b7b56e920254dcf28a995d9e44",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libs/libsm/libsm-dev_1.2.4-1_amd64.deb"
+    },
+    {
+      "name": "libsnapd-glib-2-1",
+      "version": "1.66-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb",
+      "sha256": "b7bd77be1d59bf3a19bbe91b9ab6225ad05736ed72bd9f3b3f56bcd83822e398",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/snapd-glib/libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libspa-0.2-dev",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libspa-0.2-dev_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "bf84dc575f3beab14b1a86612622525a6f6c45e367edac0e5143ed03106ec959",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libspa-0.2-dev_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libspeexdsp1",
+      "version": "1.2.1-3",
+      "architecture": "amd64",
+      "filename": "libspeexdsp1_1.2.1-3_amd64.deb",
+      "sha256": "5b178611a05217d2ba35823aa8f75387d074a7e2d50954dc11464678cd7b2c91",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/speexdsp/libspeexdsp1_1.2.1-3_amd64.deb"
+    },
+    {
+      "name": "libstdc++-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libstdc++-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "23b377179507d649d55f371cc4b36082b05bce3637a475d9b53a83cc6dcdbcef",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/libstdc%2b%2b-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libsysprof-capture-4-dev",
+      "version": "48.0-2",
+      "architecture": "amd64",
+      "filename": "libsysprof-capture-4-dev_48.0-2_amd64.deb",
+      "sha256": "33ecffc7010439b34fd10bf8e3a3f595eefa49b96a6434354b8eb3517b50e15f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/sysprof/libsysprof-capture-4-dev_48.0-2_amd64.deb"
+    },
+    {
+      "name": "libtsan2",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libtsan2_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "829692d86ed2b1d3f761306fce4b8bebe5b632a018859c8570c3dcdf162a942b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libtsan2_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libubsan1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libubsan1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "ebdb6ab4f035d9b94a633478bec122212388d5f2e155c99bca1fe84831f6a04b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libubsan1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libudev-dev",
+      "version": "257.4-1ubuntu3.2",
+      "architecture": "amd64",
+      "filename": "libudev-dev_257.4-1ubuntu3.2_amd64.deb",
+      "sha256": "ad5f1a66b74f5c17382e449a7792f0228cf50797ebccaec4c6cb72081e60aa97",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/systemd/libudev-dev_257.4-1ubuntu3.2_amd64.deb"
+    },
+    {
+      "name": "libunwind-dev",
+      "version": "1.6.2-3.1",
+      "architecture": "amd64",
+      "filename": "libunwind-dev_1.6.2-3.1_amd64.deb",
+      "sha256": "624f0a53bb081487268cf920f0d83ec7f80add528c3ef5ce6e91ced727eb9ce1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libunwind/libunwind-dev_1.6.2-3.1_amd64.deb"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2ubuntu1",
+      "architecture": "amd64",
+      "filename": "libuv1t64_1.50.0-2ubuntu1_amd64.deb",
+      "sha256": "6af9634d05965f60ed7c124d43cef678ef288824b6f36a7b02559dd4097e7c90",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libuv1/libuv1t64_1.50.0-2ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libvulkan-dev",
+      "version": "1.4.304.0-1",
+      "architecture": "amd64",
+      "filename": "libvulkan-dev_1.4.304.0-1_amd64.deb",
+      "sha256": "f557d5cc69add01d3794b1c71bfdcb053d7909febedd58713f9ba355e3f33167",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/v/vulkan-loader/libvulkan-dev_1.4.304.0-1_amd64.deb"
+    },
+    {
+      "name": "libwacom-dev",
+      "version": "2.14.0-1",
+      "architecture": "amd64",
+      "filename": "libwacom-dev_2.14.0-1_amd64.deb",
+      "sha256": "18e8a96b5300885ea8b7013214eeef9f912bbe5d804fda4f236bef3ce3f22fd5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libw/libwacom/libwacom-dev_2.14.0-1_amd64.deb"
+    },
+    {
+      "name": "libwayland-bin",
+      "version": "1.23.1-3",
+      "architecture": "amd64",
+      "filename": "libwayland-bin_1.23.1-3_amd64.deb",
+      "sha256": "f0f8b782d56c44068827e614240ae4d29908864f7b2d10bb54b2a68ba5623562",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb"
+    },
+    {
+      "name": "libwayland-dev",
+      "version": "1.23.1-3",
+      "architecture": "amd64",
+      "filename": "libwayland-dev_1.23.1-3_amd64.deb",
+      "sha256": "4641ae220244fcb7f28d344d6612ec8c961351ba62347484ec354cbae1029f47",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb"
+    },
+    {
+      "name": "libx11-dev",
+      "version": "2:1.8.10-2",
+      "architecture": "amd64",
+      "filename": "libx11-dev_2%3a1.8.10-2_amd64.deb",
+      "sha256": "b93d9e5c357557eba2ab26304ae47337ca163403646e584e0931840f53072b3e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libx11/libx11-dev_1.8.10-2_amd64.deb"
+    },
+    {
+      "name": "libx11-xcb-dev",
+      "version": "2:1.8.10-2",
+      "architecture": "amd64",
+      "filename": "libx11-xcb-dev_2%3a1.8.10-2_amd64.deb",
+      "sha256": "0f82fd0275fe8f8120df2ea231f2bd3fbc312d0e5070d7e126ea15cc9208f7ab",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libx11/libx11-xcb-dev_1.8.10-2_amd64.deb"
+    },
+    {
+      "name": "libxau-dev",
+      "version": "1:1.0.11-1",
+      "architecture": "amd64",
+      "filename": "libxau-dev_1%3a1.0.11-1_amd64.deb",
+      "sha256": "8bb1b0b7e8f2febc90f3cab29b5e5383a7a44ddcf6fa5720334af2e7de2bbbb6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxau/libxau-dev_1.0.11-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-composite0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-composite0-dev_1.17.0-2_amd64.deb",
+      "sha256": "9c7c7e0462fb2814bc50d8e1207e86d499d48e626b7c245019f672d31c7c8056",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-composite0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-ewmh-dev",
+      "version": "0.4.2-1",
+      "architecture": "amd64",
+      "filename": "libxcb-ewmh-dev_0.4.2-1_amd64.deb",
+      "sha256": "6fb409e6c39c6e035de198b20ae1b9f4ee9bfd023c23344165cbadd0f7de335e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xcb-util-wm/libxcb-ewmh-dev_0.4.2-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-icccm4-dev",
+      "version": "0.4.2-1",
+      "architecture": "amd64",
+      "filename": "libxcb-icccm4-dev_0.4.2-1_amd64.deb",
+      "sha256": "9766971d554555864316d05f111eb05afd60c57791a4a655ba04a6600cf9f8ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xcb-util-wm/libxcb-icccm4-dev_0.4.2-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-render0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-render0-dev_1.17.0-2_amd64.deb",
+      "sha256": "e8deb42e07541dbae21f139330327299b8b5f7f70564a61fa706a1f7582a8db4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-render0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-res0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-res0-dev_1.17.0-2_amd64.deb",
+      "sha256": "c0d05fb701c144dddc3b1ec0e27579444e0c905ce1e7bffc4d9f74a747593379",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-res0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-shape0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-shape0-dev_1.17.0-2_amd64.deb",
+      "sha256": "6ad9c5c37a3fd478ed5586486d122cfbf29e687b738a98cd5145caf603656f9c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-shape0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-xfixes0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-xfixes0-dev_1.17.0-2_amd64.deb",
+      "sha256": "85b54851baa1584386a74b68764507d96967edcd119d4680203838550f69e939",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-xfixes0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb1-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb1-dev_1.17.0-2_amd64.deb",
+      "sha256": "2844752ae6cb7b7dec983a53d698b37e3a6268653cba254d69d8fcfa6907fb4c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb1-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcomposite-dev",
+      "version": "1:0.4.6-1",
+      "architecture": "amd64",
+      "filename": "libxcomposite-dev_1%3a0.4.6-1_amd64.deb",
+      "sha256": "6db5444b9409b5e6edb4cb4537640cd33207551a04c389248e86b269571fa258",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcomposite/libxcomposite-dev_0.4.6-1_amd64.deb"
+    },
+    {
+      "name": "libxcursor-dev",
+      "version": "1:1.2.3-1",
+      "architecture": "amd64",
+      "filename": "libxcursor-dev_1%3a1.2.3-1_amd64.deb",
+      "sha256": "f693b31be26a752b901eee46d9cd79c308f3595223a437481287ce0c016a5987",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcursor/libxcursor-dev_1.2.3-1_amd64.deb"
+    },
+    {
+      "name": "libxdamage-dev",
+      "version": "1:1.1.6-1build1",
+      "architecture": "amd64",
+      "filename": "libxdamage-dev_1%3a1.1.6-1build1_amd64.deb",
+      "sha256": "63067acaa7248dd46e67496154a030f38c86aa1cc192116265a8039c358ee20a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxdamage/libxdamage-dev_1.1.6-1build1_amd64.deb"
+    },
+    {
+      "name": "libxdmcp-dev",
+      "version": "1:1.1.5-1",
+      "architecture": "amd64",
+      "filename": "libxdmcp-dev_1%3a1.1.5-1_amd64.deb",
+      "sha256": "b7f218a47a2e50b1835e32a83b2d5dbeaf75034f4b6ec9f82e67eb9260553cc6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_amd64.deb"
+    },
+    {
+      "name": "libxext-dev",
+      "version": "2:1.3.4-1build2",
+      "architecture": "amd64",
+      "filename": "libxext-dev_2%3a1.3.4-1build2_amd64.deb",
+      "sha256": "b5bdb6724f228cb8eee8cf39cbbe1289dd3f8f06dd022748312df7844c94dcf2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxext/libxext-dev_1.3.4-1build2_amd64.deb"
+    },
+    {
+      "name": "libxfixes-dev",
+      "version": "1:6.0.0-2build1",
+      "architecture": "amd64",
+      "filename": "libxfixes-dev_1%3a6.0.0-2build1_amd64.deb",
+      "sha256": "069723527566ef0fc12738f63b789110c211b85bf96c3dbe9a94d9e77f5c479b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxfixes/libxfixes-dev_6.0.0-2build1_amd64.deb"
+    },
+    {
+      "name": "libxi-dev",
+      "version": "2:1.8.2-1",
+      "architecture": "amd64",
+      "filename": "libxi-dev_2%3a1.8.2-1_amd64.deb",
+      "sha256": "5c7bdf2d7abd20858666554c0eca429c1b35a09529c193a52d70c4ebda5ea75b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxi/libxi-dev_1.8.2-1_amd64.deb"
+    },
+    {
+      "name": "libxkbcommon-dev",
+      "version": "1.7.0-2",
+      "architecture": "amd64",
+      "filename": "libxkbcommon-dev_1.7.0-2_amd64.deb",
+      "sha256": "0c366a6dd143cca7dbec02ea7ed466e1c37b44e35e39018268717f5733f7ca29",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.7.0-2_amd64.deb"
+    },
+    {
+      "name": "libxmu-dev",
+      "version": "2:1.1.3-3build2",
+      "architecture": "amd64",
+      "filename": "libxmu-dev_2%3a1.1.3-3build2_amd64.deb",
+      "sha256": "a7b2d7632ba44ba2a9056b5665db0dad20d91fe8c336502db1f434b0b6922acc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxmu/libxmu-dev_1.1.3-3build2_amd64.deb"
+    },
+    {
+      "name": "libxmu-headers",
+      "version": "2:1.1.3-3build2",
+      "architecture": "all",
+      "filename": "libxmu-headers_2%3a1.1.3-3build2_all.deb",
+      "sha256": "6abd2218697cefb602d8273a3df711b297f504f414abff11d366578ddc9fd3d6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxmu/libxmu-headers_1.1.3-3build2_all.deb"
+    },
+    {
+      "name": "libxrender-dev",
+      "version": "1:0.9.10-1.1build1",
+      "architecture": "amd64",
+      "filename": "libxrender-dev_1%3a0.9.10-1.1build1_amd64.deb",
+      "sha256": "839558c9de049636e13e22e409c04f3226614abf176c4a3b7088058576d74848",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxrender/libxrender-dev_0.9.10-1.1build1_amd64.deb"
+    },
+    {
+      "name": "libxres-dev",
+      "version": "2:1.2.1-1build1",
+      "architecture": "amd64",
+      "filename": "libxres-dev_2%3a1.2.1-1build1_amd64.deb",
+      "sha256": "7e7346f017ad871cd2e3a0e9c8742e943e09198867f042cc455465c39240e2ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxres/libxres-dev_1.2.1-1build1_amd64.deb"
+    },
+    {
+      "name": "libxt-dev",
+      "version": "1:1.2.1-1.2build1",
+      "architecture": "amd64",
+      "filename": "libxt-dev_1%3a1.2.1-1.2build1_amd64.deb",
+      "sha256": "77858926454d10dd7896fc4d1ee158b67bb25e830dd41e60e4a59e79f71b8a8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxt/libxt-dev_1.2.1-1.2build1_amd64.deb"
+    },
+    {
+      "name": "libxtst-dev",
+      "version": "2:1.2.5-1",
+      "architecture": "amd64",
+      "filename": "libxtst-dev_2%3a1.2.5-1_amd64.deb",
+      "sha256": "f21eaaa996c266d0d3b96c1a392ac9af7cc4cbfe60601a1c98942bdcb8d5e334",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxtst/libxtst-dev_1.2.5-1_amd64.deb"
+    },
+    {
+      "name": "libxxf86vm-dev",
+      "version": "1:1.1.4-1build4",
+      "architecture": "amd64",
+      "filename": "libxxf86vm-dev_1%3a1.1.4-1build4_amd64.deb",
+      "sha256": "98587402f6928a2526a8fbae6bd8c7297ced187b3a34b4e461ffd3245910f1af",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxxf86vm/libxxf86vm-dev_1.1.4-1build4_amd64.deb"
+    },
+    {
+      "name": "libzstd-dev",
+      "version": "1.5.6+dfsg-2",
+      "architecture": "amd64",
+      "filename": "libzstd-dev_1.5.6+dfsg-2_amd64.deb",
+      "sha256": "45e78999356317e33de5d4b29240c410effdbfd39d543ce15f317d6382046040",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libz/libzstd/libzstd-dev_1.5.6%2bdfsg-2_amd64.deb"
+    },
+    {
+      "name": "linux-libc-dev",
+      "version": "6.14.0-37.37",
+      "architecture": "amd64",
+      "filename": "linux-libc-dev_6.14.0-37.37_amd64.deb",
+      "sha256": "e03a0bbe25ebd8b2d618a842f1cef681c38abd22319518c980ab7a742d0e62a8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/l/linux/linux-libc-dev_6.14.0-37.37_amd64.deb"
+    },
+    {
+      "name": "llvm-20-linker-tools",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "llvm-20-linker-tools_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "4675775ec06186e8b2645e2bbe886fda6d330e89bb5fb1979c66dcc43b6d2849",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/llvm-20-linker-tools_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "lto-disabled-list",
+      "version": "57",
+      "architecture": "all",
+      "filename": "lto-disabled-list_57_all.deb",
+      "sha256": "0cc7c3bd22fef2f2dd2afda0d624c900af6dc9cf70e59a486f23b5751f3bf4bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/l/lto-disabled-list/lto-disabled-list_57_all.deb"
+    },
+    {
+      "name": "make",
+      "version": "4.4.1-1",
+      "architecture": "amd64",
+      "filename": "make_4.4.1-1_amd64.deb",
+      "sha256": "d0622880df49e4bfd48e07253a18553aac0214ecbcd24a0841de7315c249cc2e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb"
+    },
+    {
+      "name": "meson",
+      "version": "1.7.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "meson_1.7.0-1ubuntu1_all.deb",
+      "sha256": "669142d3fd9008c583ca2511d4d3db41efeb2ace18642c942bc7e7fa7fd81ece",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/meson/meson_1.7.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "native-architecture",
+      "version": "0.2.6",
+      "architecture": "all",
+      "filename": "native-architecture_0.2.6_all.deb",
+      "sha256": "675f55bc3cbcddb1ba701817eec1a198e1fa38cddfe119efa69b06e8e9a18c1f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/a/architecture-properties/native-architecture_0.2.6_all.deb"
+    },
+    {
+      "name": "ninja-build",
+      "version": "1.12.1-1",
+      "architecture": "amd64",
+      "filename": "ninja-build_1.12.1-1_amd64.deb",
+      "sha256": "8190a977f4e0158c88fc76541737cdd62f74c74e8fd9aa25c6d5a322c7be6b0a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/ninja-build/ninja-build_1.12.1-1_amd64.deb"
+    },
+    {
+      "name": "patch",
+      "version": "2.7.6-7build3",
+      "architecture": "amd64",
+      "filename": "patch_2.7.6-7build3_amd64.deb",
+      "sha256": "fb7d78ed25c2788a607802270f3c28ac5ed6857bfb6cce9f73ad2cafac9159b3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/patch/patch_2.7.6-7build3_amd64.deb"
+    },
+    {
+      "name": "pci.ids",
+      "version": "0.0~2025.03.09-1",
+      "architecture": "all",
+      "filename": "pci.ids_0.0~2025.03.09-1_all.deb",
+      "sha256": "50762fd34c8d1cd4a8e99df09ac35200cbf709d821358eb08697a688f39edca9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pci.ids/pci.ids_0.0%7e2025.03.09-1_all.deb"
+    },
+    {
+      "name": "perl",
+      "version": "5.40.1-2ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "perl_5.40.1-2ubuntu0.2_amd64.deb",
+      "sha256": "d46189a20c6ae13825ee2b6a58efa9c58fe0c95527119d700bffd84d04b97d66",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/perl/perl_5.40.1-2ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "perl-modules-5.40",
+      "version": "5.40.1-2ubuntu0.2",
+      "architecture": "all",
+      "filename": "perl-modules-5.40_5.40.1-2ubuntu0.2_all.deb",
+      "sha256": "00d247d90e3e8f58c4ea9aae279dbf60c6fda16e2a49512050e1471c5931be8e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/perl/perl-modules-5.40_5.40.1-2ubuntu0.2_all.deb"
+    },
+    {
+      "name": "pipewire",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "b77fae0221ecdebcc9839cfd08aa5da95359c741a4d2922bfcaf55474b93f0a7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-bin",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "0d16cd14743a2c8fc4c726057ec910ba7eac48e5de65698acc01aeb336d45078",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-pulse",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "611be8d6b8620f5d266e7a8a232bb7cb96f558fc8a73205af7aaec084c3ab8eb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pkg-config",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkg-config_1.8.1-4_amd64.deb",
+      "sha256": "04b7449b1453626ae918a12afc747b4cc395a734a8db5c6b94468672088d0c14",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pkgconf",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkgconf_1.8.1-4_amd64.deb",
+      "sha256": "0db266c58f3169b3ce5257003e2065b6306630106945587293802098bac78247",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pkgconf-bin",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkgconf-bin_1.8.1-4_amd64.deb",
+      "sha256": "3af3f64647ebed77014036ff676676eccca0f79b8e4763dc0439b46d97e9196b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pnp.ids",
+      "version": "0.393-3",
+      "architecture": "all",
+      "filename": "pnp.ids_0.393-3_all.deb",
+      "sha256": "db21da54953f550393ed42d07a815f7f2ece949ba800865fba9252b3bfdf9d38",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/h/hwdata/pnp.ids_0.393-3_all.deb"
+    },
+    {
+      "name": "python3-jaraco.text",
+      "version": "4.0.0-1",
+      "architecture": "all",
+      "filename": "python3-jaraco.text_4.0.0-1_all.deb",
+      "sha256": "948086d278c565ad8549587b01156ee9f09dadff9623de121dcb5dafe3ddb6cc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/j/jaraco.text/python3-jaraco.text_4.0.0-1_all.deb"
+    },
+    {
+      "name": "python3-packaging",
+      "version": "24.2-1",
+      "architecture": "all",
+      "filename": "python3-packaging_24.2-1_all.deb",
+      "sha256": "dbe200c8fa49f6c4e4c82fc20418e6d26f0689317bdf1edf00854da87ec53d0c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-packaging/python3-packaging_24.2-1_all.deb"
+    },
+    {
+      "name": "python3-setuptools",
+      "version": "75.8.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "python3-setuptools_75.8.0-1ubuntu1_all.deb",
+      "sha256": "5aa98a69aae8caff58cce7b94d73eb3101127ef154f4a5cd4eae45c2c46714a0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/setuptools/python3-setuptools_75.8.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "python3-zipp",
+      "version": "3.21.0-1",
+      "architecture": "all",
+      "filename": "python3-zipp_3.21.0-1_all.deb",
+      "sha256": "f940bd4def06760555cde9c8d27207eb536d1a32211dd8c54223100b0f0242f5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-zipp/python3-zipp_3.21.0-1_all.deb"
+    },
+    {
+      "name": "rpcsvc-proto",
+      "version": "1.4.2-0ubuntu7",
+      "architecture": "amd64",
+      "filename": "rpcsvc-proto_1.4.2-0ubuntu7_amd64.deb",
+      "sha256": "7eb710fe148d224c159ddec1ceb0ba53ead52a80a6793dcdae1474acf20d8f71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-0ubuntu7_amd64.deb"
+    },
+    {
+      "name": "spirv-tools",
+      "version": "2025.1~rc1-1",
+      "architecture": "amd64",
+      "filename": "spirv-tools_2025.1~rc1-1_amd64.deb",
+      "sha256": "e7a487f6e47851bfe86724b14729bf22f3d54b0177bc982063483e5e35a10d8c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spirv-tools/spirv-tools_2025.1%7erc1-1_amd64.deb"
+    },
+    {
+      "name": "usb.ids",
+      "version": "2025.01.14-1",
+      "architecture": "all",
+      "filename": "usb.ids_2025.01.14-1_all.deb",
+      "sha256": "fa4a1fd5b24eafda34fe5e11ec2ed182c25bdb484758a5a7731bbb42643f2673",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/usb.ids/usb.ids_2025.01.14-1_all.deb"
+    },
+    {
+      "name": "uuid-dev",
+      "version": "2.40.2-14ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "uuid-dev_2.40.2-14ubuntu1.2_amd64.deb",
+      "sha256": "5408aef7913b669c0d6b3773e89a3f2b08f6beda086730e8ccb49c9a8ef97dd5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/util-linux/uuid-dev_2.40.2-14ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "wayland-protocols",
+      "version": "1.41-1",
+      "architecture": "all",
+      "filename": "wayland-protocols_1.41-1_all.deb",
+      "sha256": "3a0942c89ced71ebc809718c9d21910627d2a257b1277d6a9173a672cf53125f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland-protocols/wayland-protocols_1.41-1_all.deb"
+    },
+    {
+      "name": "x11proto-dev",
+      "version": "2024.1-1",
+      "architecture": "all",
+      "filename": "x11proto-dev_2024.1-1_all.deb",
+      "sha256": "98811486c3f51eb0a6e89c44cdea1edd8b45d7b285f87fa747cb997c4a65b451",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb"
+    },
+    {
+      "name": "xorg-sgml-doctools",
+      "version": "1:1.11-1.1",
+      "architecture": "all",
+      "filename": "xorg-sgml-doctools_1%3a1.11-1.1_all.deb",
+      "sha256": "277f662c6d94606c22078f2af82ac1b6e01386d5a4dec6ca7487bca4c5b23c07",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb"
+    },
+    {
+      "name": "xtrans-dev",
+      "version": "1.4.0-1",
+      "architecture": "all",
+      "filename": "xtrans-dev_1.4.0-1_all.deb",
+      "sha256": "45277c51d5d83db351b61859314b59595c9626ac372fbb2fc0d5542e169d9086",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb"
+    },
+    {
+      "name": "zlib1g-dev",
+      "version": "1:1.3.dfsg+really1.3.1-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "zlib1g-dev_1%3a1.3.dfsg+really1.3.1-1ubuntu1_amd64.deb",
+      "sha256": "a04e48305134d40f3d42d329296c6458bdfb40805f8adbd789b4140202c0f8f1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/z/zlib/zlib1g-dev_1.3.dfsg%2breally1.3.1-1ubuntu1_amd64.deb"
+    }
+  ]
+}

--- a/containers/multiseat/locks/lutris.packages.json
+++ b/containers/multiseat/locks/lutris.packages.json
@@ -1,0 +1,2324 @@
+{
+  "schema": 1,
+  "profile": "lutris",
+  "platform": "linux/amd64",
+  "source_root": "ghcr.io/games-on-whales/lutris@sha256:207005d9e1a839814c7c2b91fa25190d40c388c7dc004eec593556bd807f99f2",
+  "snapshot": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/",
+  "source_manifest_sha256": "baeb2caf718517f1300e8a162b08ca6c0c4686d842b99eb6d611daaa819b7803",
+  "runtime": [
+    {
+      "name": "gstreamer1.0-plugins-bad",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "800b2b0a8f994098e854413821a4908f301425e165b112994d4ad891e38c828a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-tools",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-tools_1.26.0-3_amd64.deb",
+      "sha256": "ac24b15d6a48bb99097419f4d8d5928430d010af301b0df0b32570e59879f8f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gstreamer1.0-tools_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "libass9",
+      "version": "1:0.17.3-1",
+      "architecture": "amd64",
+      "filename": "libass9_1%3a0.17.3-1_amd64.deb",
+      "sha256": "20fd3f8a675804455ccfffbcc4e488818e016dea8d535ade12031969cd97a62d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libass/libass9_0.17.3-1_amd64.deb"
+    },
+    {
+      "name": "libavtp0",
+      "version": "0.2.0-2",
+      "architecture": "amd64",
+      "filename": "libavtp0_0.2.0-2_amd64.deb",
+      "sha256": "32d5bb7433365eb43c9d3bd49aff8c62295abcd4a3eb45ddbdb8351ce909bc36",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libavtp/libavtp0_0.2.0-2_amd64.deb"
+    },
+    {
+      "name": "libbs2b0",
+      "version": "3.1.0+dfsg-8",
+      "architecture": "amd64",
+      "filename": "libbs2b0_3.1.0+dfsg-8_amd64.deb",
+      "sha256": "7d03829734d659b1167c92e8c00e415e113cb29cdc884576a9ccca611ef4e2b9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libb/libbs2b/libbs2b0_3.1.0%2bdfsg-8_amd64.deb"
+    },
+    {
+      "name": "libchromaprint1",
+      "version": "1.5.1-7",
+      "architecture": "amd64",
+      "filename": "libchromaprint1_1.5.1-7_amd64.deb",
+      "sha256": "a108a4a6e4b49c981975076aa2d1d15d73ed6c0b98122e7b5ceb7703f7851666",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/chromaprint/libchromaprint1_1.5.1-7_amd64.deb"
+    },
+    {
+      "name": "libcpuinfo0",
+      "version": "0.0~git20250203.aaac07e-1",
+      "architecture": "amd64",
+      "filename": "libcpuinfo0_0.0~git20250203.aaac07e-1_amd64.deb",
+      "sha256": "13af6ecf274a2629121a38b06a815cd945c99a586f3a8848bb386c49961b31b7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/cpuinfo/libcpuinfo0_0.0%7egit20250203.aaac07e-1_amd64.deb"
+    },
+    {
+      "name": "libdc1394-25",
+      "version": "2.2.6-4build1",
+      "architecture": "amd64",
+      "filename": "libdc1394-25_2.2.6-4build1_amd64.deb",
+      "sha256": "0f4a0768152636f2f941d3a29d24925be77f869b3d90a13f1694fef792a89810",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdc1394/libdc1394-25_2.2.6-4build1_amd64.deb"
+    },
+    {
+      "name": "libdca0",
+      "version": "0.0.7-2build1",
+      "architecture": "amd64",
+      "filename": "libdca0_0.0.7-2build1_amd64.deb",
+      "sha256": "018867fee029b072ecb3365f5f92c0cb0530d4ab37aa13be127116b6e5c3c06d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdca/libdca0_0.0.7-2build1_amd64.deb"
+    },
+    {
+      "name": "libdnnl3.6",
+      "version": "3.7.1+ds-1",
+      "architecture": "amd64",
+      "filename": "libdnnl3.6_3.7.1+ds-1_amd64.deb",
+      "sha256": "88fd977d7076586d2a2bb89659d24e8875f188f79a15649ce1832764b3232d67",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onednn/libdnnl3.6_3.7.1%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libdvdnav4",
+      "version": "6.1.1-3build1",
+      "architecture": "amd64",
+      "filename": "libdvdnav4_6.1.1-3build1_amd64.deb",
+      "sha256": "09fd1de2985ade2592d4f068774b2249211880aa6d4a71a89e0b4764afe47404",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdnav/libdvdnav4_6.1.1-3build1_amd64.deb"
+    },
+    {
+      "name": "libdvdread8t64",
+      "version": "6.1.3-2",
+      "architecture": "amd64",
+      "filename": "libdvdread8t64_6.1.3-2_amd64.deb",
+      "sha256": "269fe55b0eb5a47b7112c46a5ed3a21bdbd0378224970d733225ecfd3cb5f20e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdread/libdvdread8t64_6.1.3-2_amd64.deb"
+    },
+    {
+      "name": "libfaad2",
+      "version": "2.11.2-1",
+      "architecture": "amd64",
+      "filename": "libfaad2_2.11.2-1_amd64.deb",
+      "sha256": "cdf00ddc8c0f4f6e3dbc46c1d0efba537632609432734deb01113cac3ac1531d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/faad2/libfaad2_2.11.2-1_amd64.deb"
+    },
+    {
+      "name": "libflite1",
+      "version": "2.2-7",
+      "architecture": "amd64",
+      "filename": "libflite1_2.2-7_amd64.deb",
+      "sha256": "3afe2b4ab82dff2330b53fcee83b4b21aa580f6d91a1ce850e917cf8cffc004a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/flite/libflite1_2.2-7_amd64.deb"
+    },
+    {
+      "name": "libfluidsynth3",
+      "version": "2.4.4+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libfluidsynth3_2.4.4+dfsg-1_amd64.deb",
+      "sha256": "2a7177d672b1f717c2b064181cac9e1772aeaf93e0a00db8327954eeeaff9189",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/fluidsynth/libfluidsynth3_2.4.4%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libfreeaptx0",
+      "version": "0.1.1-2build1",
+      "architecture": "amd64",
+      "filename": "libfreeaptx0_0.1.1-2build1_amd64.deb",
+      "sha256": "2280d6fdd41c841701a9da6b5076b77e8a0849e5c10c9c2945f817f753575a42",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libf/libfreeaptx/libfreeaptx0_0.1.1-2build1_amd64.deb"
+    },
+    {
+      "name": "libgme0",
+      "version": "0.6.3-7build1",
+      "architecture": "amd64",
+      "filename": "libgme0_0.6.3-7build1_amd64.deb",
+      "sha256": "a54fa608501f87f9e5064b60c75fc1bb62735c9f9ba9f7680cb804bb5eae2027",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/game-music-emu/libgme0_0.6.3-7build1_amd64.deb"
+    },
+    {
+      "name": "libgsm1",
+      "version": "1.0.22-1build1",
+      "architecture": "amd64",
+      "filename": "libgsm1_1.0.22-1build1_amd64.deb",
+      "sha256": "8cc765587a3275e861f166a98b4b79dd8d5c673f97e17967945ab4d1eb89c89a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libg/libgsm/libgsm1_1.0.22-1build1_amd64.deb"
+    },
+    {
+      "name": "libgssdp-1.6-0",
+      "version": "1.6.3-2",
+      "architecture": "amd64",
+      "filename": "libgssdp-1.6-0_1.6.3-2_amd64.deb",
+      "sha256": "7897db47adc4114a17c44f390d2816c7e58ac8bdd722fa58fa21c659368aece7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gssdp/libgssdp-1.6-0_1.6.3-2_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-bad1.0-0",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "36c0de48cf25ca31dc21363dabd3fb32e9d4c539467b6b76b4770c5e82822099",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "libgupnp-1.6-0",
+      "version": "1.6.8-2",
+      "architecture": "amd64",
+      "filename": "libgupnp-1.6-0_1.6.8-2_amd64.deb",
+      "sha256": "9346722ae71cc4bce037ef49bf38c609392eb1cfb6eba19fce575673577896c5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gupnp/libgupnp-1.6-0_1.6.8-2_amd64.deb"
+    },
+    {
+      "name": "libgupnp-igd-1.6-0",
+      "version": "1.6.0-4",
+      "architecture": "amd64",
+      "filename": "libgupnp-igd-1.6-0_1.6.0-4_amd64.deb",
+      "sha256": "bf96c3dc6cf586400754dcf51b1e8033399171d5c5a55191ba13cf8c6d8c426e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gupnp-igd/libgupnp-igd-1.6-0_1.6.0-4_amd64.deb"
+    },
+    {
+      "name": "libimath-3-1-29t64",
+      "version": "3.1.12-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb",
+      "sha256": "5b35e6bdfc8f567c3c33b4c5b519ceab2acd1c5c05534f360c33cedcf14c4cf3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/i/imath/libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libinstpatch-1.0-2",
+      "version": "1.1.6-1build2",
+      "architecture": "amd64",
+      "filename": "libinstpatch-1.0-2_1.1.6-1build2_amd64.deb",
+      "sha256": "d48c40a9c428e40d5bbe8762802390322b06a062c735292767e73d1c6ea9007e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libi/libinstpatch/libinstpatch-1.0-2_1.1.6-1build2_amd64.deb"
+    },
+    {
+      "name": "liblc3-1",
+      "version": "1.1.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "liblc3-1_1.1.3+dfsg-1_amd64.deb",
+      "sha256": "0a88ca35cd79b18e42bbb22800e2ea49f2e0123cc709696dd1954486d7694e4d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/liblc3/liblc3-1_1.1.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libldacbt-enc2",
+      "version": "2.0.2.3+git20200429+ed310a0-5",
+      "architecture": "amd64",
+      "filename": "libldacbt-enc2_2.0.2.3+git20200429+ed310a0-5_amd64.deb",
+      "sha256": "7212ed25d4be1782cfc71ef1758a587fa3a3cfb7ba939c7233161cb491946a34",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/libldac/libldacbt-enc2_2.0.2.3%2bgit20200429%2bed310a0-5_amd64.deb"
+    },
+    {
+      "name": "liblilv-0-0",
+      "version": "0.24.26-1",
+      "architecture": "amd64",
+      "filename": "liblilv-0-0_0.24.26-1_amd64.deb",
+      "sha256": "3076146b3bae4bce370c6618ef8ed788383d3d35184dae0bbb9877dcdbb127c2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/lilv/liblilv-0-0_0.24.26-1_amd64.deb"
+    },
+    {
+      "name": "liblrdf0",
+      "version": "0.6.1-4build1",
+      "architecture": "amd64",
+      "filename": "liblrdf0_0.6.1-4build1_amd64.deb",
+      "sha256": "470a5e0e88fd2e7dcfc024c789cd029578b110c65558ae423fd79d7bb4ef01ca",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/liblrdf/liblrdf0_0.6.1-4build1_amd64.deb"
+    },
+    {
+      "name": "libltc11",
+      "version": "1.3.2-1build1",
+      "architecture": "amd64",
+      "filename": "libltc11_1.3.2-1build1_amd64.deb",
+      "sha256": "92f23451cefe159faef9f255f0d24987eff50e52647dc1aa9843ad4c733ca039",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/libltc/libltc11_1.3.2-1build1_amd64.deb"
+    },
+    {
+      "name": "libmjpegutils-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmjpegutils-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "3422b9e3f7aa721a18f1738b33815a7f681fbe1ec0bafb1faf733e625dcbce85",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmjpegutils-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmodplug1",
+      "version": "1:0.8.9.0-3build1",
+      "architecture": "amd64",
+      "filename": "libmodplug1_1%3a0.8.9.0-3build1_amd64.deb",
+      "sha256": "34b383f35def5405069ae1eb6b4e6a7f73c9adafd0d049add82285b0e1a2e1ad",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmodplug/libmodplug1_0.8.9.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libmpcdec6",
+      "version": "2:0.1~r495-3",
+      "architecture": "amd64",
+      "filename": "libmpcdec6_2%3a0.1~r495-3_amd64.deb",
+      "sha256": "35e003823ddf242d8799057d420fc15ed644bb836d63ae18af57bd514699a216",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmpc/libmpcdec6_0.1%7er495-3_amd64.deb"
+    },
+    {
+      "name": "libmpeg2encpp-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmpeg2encpp-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "ec077a7c7fc7abd77d460813f56a9bef1dd68e53148840ef242b1795043d318e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmpeg2encpp-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmplex2-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmplex2-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "8c4324fb9ac9b667559aeaa92e399beeb4396d0cd33627be1b1306b85a31e5e2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmplex2-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libneon27t64",
+      "version": "0.34.0-1",
+      "architecture": "amd64",
+      "filename": "libneon27t64_0.34.0-1_amd64.deb",
+      "sha256": "1710578bc51522b9ee8ccd70624b9e2e266f50e5ac39711d1096757bd23d381f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/neon27/libneon27t64_0.34.0-1_amd64.deb"
+    },
+    {
+      "name": "libnice10",
+      "version": "0.1.22-1",
+      "architecture": "amd64",
+      "filename": "libnice10_0.1.22-1_amd64.deb",
+      "sha256": "3e227906bae81259542732d0af1623a05910855d86e548e5b704e17ea8cb2a17",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libn/libnice/libnice10_0.1.22-1_amd64.deb"
+    },
+    {
+      "name": "libnuma1",
+      "version": "2.0.18-1build1",
+      "architecture": "amd64",
+      "filename": "libnuma1_2.0.18-1build1_amd64.deb",
+      "sha256": "508daa855e99959acaa945e6a89d218e0be6b5727fd28773580942ff37cf5805",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/n/numactl/libnuma1_2.0.18-1build1_amd64.deb"
+    },
+    {
+      "name": "libonnx1t64",
+      "version": "1.17.0-3build1",
+      "architecture": "amd64",
+      "filename": "libonnx1t64_1.17.0-3build1_amd64.deb",
+      "sha256": "c4fcb75e98e7a28dd741d002c640bb3a9891dee2d9ec39ee570f2824d77318ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnx/libonnx1t64_1.17.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libonnxruntime1.21",
+      "version": "1.21.0+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libonnxruntime1.21_1.21.0+dfsg-1_amd64.deb",
+      "sha256": "17e9bfec1e4e86a7456720843ed5443c2eb3bda62b45f0e075ab0c8d89e4ae7b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnxruntime/libonnxruntime1.21_1.21.0%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libopenal-data",
+      "version": "1:1.24.2-1",
+      "architecture": "all",
+      "filename": "libopenal-data_1%3a1.24.2-1_all.deb",
+      "sha256": "2bce384fa3c8fb1193e9ec8c948787263e5a2fc53a4a4715c4aeeab75b98b420",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal-data_1.24.2-1_all.deb"
+    },
+    {
+      "name": "libopenal1",
+      "version": "1:1.24.2-1",
+      "architecture": "amd64",
+      "filename": "libopenal1_1%3a1.24.2-1_amd64.deb",
+      "sha256": "461b8d108f70efa65eefbb3af5c697ac95f831f1959de3b625345b389628bbbb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal1_1.24.2-1_amd64.deb"
+    },
+    {
+      "name": "libopenexr-3-1-30",
+      "version": "3.1.13-2",
+      "architecture": "amd64",
+      "filename": "libopenexr-3-1-30_3.1.13-2_amd64.deb",
+      "sha256": "cae37d566e8d08fdeabdbcac7e9c9a5c68b9541a83974adbd3f50cb654e83390",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openexr/libopenexr-3-1-30_3.1.13-2_amd64.deb"
+    },
+    {
+      "name": "libopenh264-8",
+      "version": "2.6.0+dfsg-2",
+      "architecture": "amd64",
+      "filename": "libopenh264-8_2.6.0+dfsg-2_amd64.deb",
+      "sha256": "bbff1a10312e60e4566c0e34c2d2f98deda75763ea639650518d00e1e028f67e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openh264/libopenh264-8_2.6.0%2bdfsg-2_amd64.deb"
+    },
+    {
+      "name": "libopenmpt0t64",
+      "version": "0.7.13-1build1",
+      "architecture": "amd64",
+      "filename": "libopenmpt0t64_0.7.13-1build1_amd64.deb",
+      "sha256": "0a3f0e7060f1777d9865ff1ba23d7ad692f395594388442bde670e4bf435a975",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libo/libopenmpt/libopenmpt0t64_0.7.13-1build1_amd64.deb"
+    },
+    {
+      "name": "libopenni2-0",
+      "version": "2.2.0.33+dfsg-18",
+      "architecture": "amd64",
+      "filename": "libopenni2-0_2.2.0.33+dfsg-18_amd64.deb",
+      "sha256": "bba943fe73b2b0271ebbd6a28d0afb9e7084df75a64748fc06e3f72151ab1b76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openni2/libopenni2-0_2.2.0.33%2bdfsg-18_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-modules",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "f23e9a3ebedfbb846efe210bcc55150668394ac807e6c71f1f2c1d5f728c2f8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libprotobuf32t64",
+      "version": "3.21.12-10ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb",
+      "sha256": "19a6eac6e4d794318608c7e6862c4414119e1be7d3e66b0f8e698c62c78411ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/protobuf/libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpthreadpool0",
+      "version": "0.0~git20240616.560c60d-1",
+      "architecture": "amd64",
+      "filename": "libpthreadpool0_0.0~git20240616.560c60d-1_amd64.deb",
+      "sha256": "a09c04886537cf3db25ae1c0644a0b4cc070d520914521a00f81b86b1254f23f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/p/pthreadpool/libpthreadpool0_0.0%7egit20240616.560c60d-1_amd64.deb"
+    },
+    {
+      "name": "libqrencode4",
+      "version": "4.1.1-2",
+      "architecture": "amd64",
+      "filename": "libqrencode4_4.1.1-2_amd64.deb",
+      "sha256": "d9eed9dc0a75994c2fe4d95f9dae8d700b4a363383f6966a82d6d0225e275280",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/q/qrencode/libqrencode4_4.1.1-2_amd64.deb"
+    },
+    {
+      "name": "libraptor2-0",
+      "version": "2.0.16-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libraptor2-0_2.0.16-4ubuntu1_amd64.deb",
+      "sha256": "ecae495617134e13c098780576db94c89e9475d2ccec3d2bb732799ce958bd87",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/raptor2/libraptor2-0_2.0.16-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libre2-11",
+      "version": "20240501-3build1",
+      "architecture": "amd64",
+      "filename": "libre2-11_20240501-3build1_amd64.deb",
+      "sha256": "b7a4b55a5f2e4ca12d1020b2cd5a0a0540bb1a9b4706eaa8e1294fe52a4112a5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/re2/libre2-11_20240501-3build1_amd64.deb"
+    },
+    {
+      "name": "libroc0.4",
+      "version": "0.4.0+dfsg-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libroc0.4_0.4.0+dfsg-4ubuntu1_amd64.deb",
+      "sha256": "8bec93425075527aa82683dbcf2d1784c39361da46a10c299f0c60afb8625b71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/roc-toolkit/libroc0.4_0.4.0%2bdfsg-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsbc1",
+      "version": "2.0-1build1",
+      "architecture": "amd64",
+      "filename": "libsbc1_2.0-1build1_amd64.deb",
+      "sha256": "d4d453e7673218fc2f917dbabb2492a5a81155c2305f6fe63a37cadcaa806128",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/sbc/libsbc1_2.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libserd-0-0",
+      "version": "0.32.4-1",
+      "architecture": "amd64",
+      "filename": "libserd-0-0_0.32.4-1_amd64.deb",
+      "sha256": "3d1c23e9effbe22d3edab8c0c2fdc8297d966c134f4d8095ccf0c9da52cc5f33",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/serd/libserd-0-0_0.32.4-1_amd64.deb"
+    },
+    {
+      "name": "libsnapd-glib-2-1",
+      "version": "1.66-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb",
+      "sha256": "b7bd77be1d59bf3a19bbe91b9ab6225ad05736ed72bd9f3b3f56bcd83822e398",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/snapd-glib/libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsord-0-0",
+      "version": "0.16.18-1",
+      "architecture": "amd64",
+      "filename": "libsord-0-0_0.16.18-1_amd64.deb",
+      "sha256": "bfd5ef5bbab2eed986b6f2856c2904db70c3d9e7a34b9f9caffcc1ea36a47a9b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sord/libsord-0-0_0.16.18-1_amd64.deb"
+    },
+    {
+      "name": "libsoundtouch1",
+      "version": "2.3.3+ds-1",
+      "architecture": "amd64",
+      "filename": "libsoundtouch1_2.3.3+ds-1_amd64.deb",
+      "sha256": "cadad56c5398a93f2f8c7080ca1a93725c15242beff0891cfdb029c5e4f305f3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/soundtouch/libsoundtouch1_2.3.3%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libspandsp2t64",
+      "version": "0.0.6+dfsg-2.2",
+      "architecture": "amd64",
+      "filename": "libspandsp2t64_0.0.6+dfsg-2.2_amd64.deb",
+      "sha256": "63a125139f3507ae94faa7cdd10ee6d6c551961937b1ec7fafa4d320e34b71bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spandsp/libspandsp2t64_0.0.6%2bdfsg-2.2_amd64.deb"
+    },
+    {
+      "name": "libspeexdsp1",
+      "version": "1.2.1-3",
+      "architecture": "amd64",
+      "filename": "libspeexdsp1_1.2.1-3_amd64.deb",
+      "sha256": "5b178611a05217d2ba35823aa8f75387d074a7e2d50954dc11464678cd7b2c91",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/speexdsp/libspeexdsp1_1.2.1-3_amd64.deb"
+    },
+    {
+      "name": "libsratom-0-0",
+      "version": "0.6.18-1",
+      "architecture": "amd64",
+      "filename": "libsratom-0-0_0.6.18-1_amd64.deb",
+      "sha256": "848fcfa874c1acb8c2331747a841467f8921334d5b5cbb66f8306d933203f344",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sratom/libsratom-0-0_0.6.18-1_amd64.deb"
+    },
+    {
+      "name": "libsrt1.5-gnutls",
+      "version": "1.5.4-1",
+      "architecture": "amd64",
+      "filename": "libsrt1.5-gnutls_1.5.4-1_amd64.deb",
+      "sha256": "88e58de644fbf38c194494789c4f1e047dae6c43bd71ca245530d721a4a0b5e0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/srt/libsrt1.5-gnutls_1.5.4-1_amd64.deb"
+    },
+    {
+      "name": "libsrtp2-1",
+      "version": "2.5.0-3build1",
+      "architecture": "amd64",
+      "filename": "libsrtp2-1_2.5.0-3build1_amd64.deb",
+      "sha256": "c2e7ee0ae64597f046fbfb197b8f36dfc9a5159b02d27e850f3a4d14a4603d77",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libs/libsrtp2/libsrtp2-1_2.5.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libunibreak6",
+      "version": "6.1-2",
+      "architecture": "amd64",
+      "filename": "libunibreak6_6.1-2_amd64.deb",
+      "sha256": "c904cf437fcad74dac8c9e7fd1a4a9657b0c5d44441848e321e225375b69c4fc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libu/libunibreak/libunibreak6_6.1-2_amd64.deb"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2ubuntu1",
+      "architecture": "amd64",
+      "filename": "libuv1t64_1.50.0-2ubuntu1_amd64.deb",
+      "sha256": "6af9634d05965f60ed7c124d43cef678ef288824b6f36a7b02559dd4097e7c90",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libuv1/libuv1t64_1.50.0-2ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libva-drm2",
+      "version": "2.22.0-3ubuntu2",
+      "architecture": "amd64",
+      "filename": "libva-drm2_2.22.0-3ubuntu2_amd64.deb",
+      "sha256": "fb95623b4c1834a34109966e7f5c85b4ab2f620d5804ea6512b69c25159a45bf",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libva/libva-drm2_2.22.0-3ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libva2",
+      "version": "2.22.0-3ubuntu2",
+      "architecture": "amd64",
+      "filename": "libva2_2.22.0-3ubuntu2_amd64.deb",
+      "sha256": "52bb1274b1cf1dbfe83f85a453363c0c651513d1e45264553edf286b9129d8c6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libva/libva2_2.22.0-3ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libvo-aacenc0",
+      "version": "0.1.3-3",
+      "architecture": "amd64",
+      "filename": "libvo-aacenc0_0.1.3-3_amd64.deb",
+      "sha256": "ea759b3a02552c379424775d5fc5d37d8dff59eb70ceab35118146ef04e857a3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-aacenc/libvo-aacenc0_0.1.3-3_amd64.deb"
+    },
+    {
+      "name": "libvo-amrwbenc0",
+      "version": "0.1.3-2build1",
+      "architecture": "amd64",
+      "filename": "libvo-amrwbenc0_0.1.3-2build1_amd64.deb",
+      "sha256": "30d260bbb56b9340319216529e72ed02a68752de62d5926ad07132ed2459af05",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-amrwbenc/libvo-amrwbenc0_0.1.3-2build1_amd64.deb"
+    },
+    {
+      "name": "libvorbisfile3",
+      "version": "1.3.7-2",
+      "architecture": "amd64",
+      "filename": "libvorbisfile3_1.3.7-2_amd64.deb",
+      "sha256": "6dfc7f0bd9f0c745c2e099aca9121843650ec7c7193801057bc3927c43820e70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-2_amd64.deb"
+    },
+    {
+      "name": "libwildmidi2",
+      "version": "0.4.3-1build3",
+      "architecture": "amd64",
+      "filename": "libwildmidi2_0.4.3-1build3_amd64.deb",
+      "sha256": "f44a3f24eb567cf104aefe6cabe2a3385185dc59dd83d64a37c1a04f0e12c771",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/w/wildmidi/libwildmidi2_0.4.3-1build3_amd64.deb"
+    },
+    {
+      "name": "libx265-215",
+      "version": "4.1-2",
+      "architecture": "amd64",
+      "filename": "libx265-215_4.1-2_amd64.deb",
+      "sha256": "7fb455bbdd67cfa604b397c64e3e7893ae128ec12dad84655218e83501502a02",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/x265/libx265-215_4.1-2_amd64.deb"
+    },
+    {
+      "name": "libxnnpack0.20241108",
+      "version": "0.0~git20241108.4ea82e5-1",
+      "architecture": "amd64",
+      "filename": "libxnnpack0.20241108_0.0~git20241108.4ea82e5-1_amd64.deb",
+      "sha256": "0a3eedc79943aadbc036d199230c573e1a0b80f947e07076dbf1db1d4a201297",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/xnnpack/libxnnpack0.20241108_0.0%7egit20241108.4ea82e5-1_amd64.deb"
+    },
+    {
+      "name": "libyajl2",
+      "version": "2.1.0-5build1",
+      "architecture": "amd64",
+      "filename": "libyajl2_2.1.0-5build1_amd64.deb",
+      "sha256": "faa268c632f7d2931509cf7b8b7ddd810aa775adc26ead88ea158e2ede5208f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/y/yajl/libyajl2_2.1.0-5build1_amd64.deb"
+    },
+    {
+      "name": "libzbar0t64",
+      "version": "0.23.93-7",
+      "architecture": "amd64",
+      "filename": "libzbar0t64_0.23.93-7_amd64.deb",
+      "sha256": "9954e12b0e2f1f5a294465c6e5c1eaa46407024f0416b4b90513e554ecd31776",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zbar/libzbar0t64_0.23.93-7_amd64.deb"
+    },
+    {
+      "name": "libzix-0-0",
+      "version": "0.6.2-1",
+      "architecture": "amd64",
+      "filename": "libzix-0-0_0.6.2-1_amd64.deb",
+      "sha256": "54d72b63ae0243dedd47e1946765890deb7764f5cfa2c9332228742b6b406ba9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zix/libzix-0-0_0.6.2-1_amd64.deb"
+    },
+    {
+      "name": "libzvbi0t64",
+      "version": "0.2.44-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libzvbi0t64_0.2.44-1ubuntu1_amd64.deb",
+      "sha256": "6596415c0581e0b48d34dae7c13990cd57187bd5e0331cb2a237c34ae6ef3949",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zvbi/libzvbi0t64_0.2.44-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libzxing3",
+      "version": "2.3.0-3",
+      "architecture": "amd64",
+      "filename": "libzxing3_2.3.0-3_amd64.deb",
+      "sha256": "66937bdde76f3edf56568d461692c7f6668f057a8ce0ba687570acb32bfd750b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zxing-cpp/libzxing3_2.3.0-3_amd64.deb"
+    },
+    {
+      "name": "pipewire",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "b77fae0221ecdebcc9839cfd08aa5da95359c741a4d2922bfcaf55474b93f0a7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-bin",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "0d16cd14743a2c8fc4c726057ec910ba7eac48e5de65698acc01aeb336d45078",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-pulse",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "611be8d6b8620f5d266e7a8a232bb7cb96f558fc8a73205af7aaec084c3ab8eb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "timgm6mb-soundfont",
+      "version": "1.3-5",
+      "architecture": "all",
+      "filename": "timgm6mb-soundfont_1.3-5_all.deb",
+      "sha256": "b70bc29b8f27adef8f92a2d9c1e26cee977b84c68110f0dd4326d97730a7c3ed",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/t/timgm6mb-soundfont/timgm6mb-soundfont_1.3-5_all.deb"
+    }
+  ],
+  "build": [
+    {
+      "name": "binutils-gold",
+      "version": "2.44-2",
+      "architecture": "amd64",
+      "filename": "binutils-gold_2.44-2_amd64.deb",
+      "sha256": "832317652330363576d427f3038663fe3aaa778ac1e5749888aad6b59ec17fd4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils-gold/binutils-gold_2.44-2_amd64.deb"
+    },
+    {
+      "name": "binutils-gold-x86-64-linux-gnu",
+      "version": "2.44-2",
+      "architecture": "amd64",
+      "filename": "binutils-gold-x86-64-linux-gnu_2.44-2_amd64.deb",
+      "sha256": "149f39909d2454e78f5fc6c8e829a756ab4bd6b65e7202e3fecf37bd07309608",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils-gold/binutils-gold-x86-64-linux-gnu_2.44-2_amd64.deb"
+    },
+    {
+      "name": "build-essential",
+      "version": "12.12ubuntu1",
+      "architecture": "amd64",
+      "filename": "build-essential_12.12ubuntu1_amd64.deb",
+      "sha256": "6690743c7c255ec97f2ce7373648cebe24e9b83da2b134ce8c53326840757016",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/build-essential/build-essential_12.12ubuntu1_amd64.deb"
+    },
+    {
+      "name": "bzip2",
+      "version": "1.0.8-6",
+      "architecture": "amd64",
+      "filename": "bzip2_1.0.8-6_amd64.deb",
+      "sha256": "b90c1467738ebb2941ab0129ee142de7803e3564196e89485e8c91d11cffd5a4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/bzip2/bzip2_1.0.8-6_amd64.deb"
+    },
+    {
+      "name": "clang",
+      "version": "1:20.0-63ubuntu1",
+      "architecture": "amd64",
+      "filename": "clang_1%3a20.0-63ubuntu1_amd64.deb",
+      "sha256": "63385ed7288cb5148c62000b328c38b6877a0df265e7bad4a32b208afdd89a96",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-defaults/clang_20.0-63ubuntu1_amd64.deb"
+    },
+    {
+      "name": "clang-20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "clang-20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "25100f57ca694598e4eb9fb605b504f1ebf4480bed15a0c79f3944a1deba2c13",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/clang-20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cmake",
+      "version": "3.31.6-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "cmake_3.31.6-1ubuntu1_amd64.deb",
+      "sha256": "eb9a56e821b957179d2d801878668fb56d64dde8ccb3d46e9bd591bddb1d75ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/c/cmake/cmake_3.31.6-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cmake-data",
+      "version": "3.31.6-1ubuntu1",
+      "architecture": "all",
+      "filename": "cmake-data_3.31.6-1ubuntu1_all.deb",
+      "sha256": "52c6d1634243c6648028b04b7f7f241993cdaab48becde16b540b90c80ba31ec",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/c/cmake/cmake-data_3.31.6-1ubuntu1_all.deb"
+    },
+    {
+      "name": "dpkg-dev",
+      "version": "1.22.18ubuntu2.2",
+      "architecture": "all",
+      "filename": "dpkg-dev_1.22.18ubuntu2.2_all.deb",
+      "sha256": "f17198b313ade86099ad7b35c152875d84ef2de9bda3a5c430a6c17b351991df",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/d/dpkg/dpkg-dev_1.22.18ubuntu2.2_all.deb"
+    },
+    {
+      "name": "g++",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "g++_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "c286c49484a551dfb9514898244e3d7089fd543c11a3f7e1a3227f96f07df14a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/g%2b%2b_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "g++-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "g++-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "b0848a8a8e00fd453c00d6f52b73e1fb9b5f887a71cfa160487a6b252dda1b4e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/g%2b%2b-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "g++-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "g++-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "b9f5de224295cb5ef5b7f641baddb4da943d43192157c831ab9b6f652894438e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/g%2b%2b-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "g++-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "g++-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "7a3aad61f52c6a1c2fab94d7ac313673272c4617c0b8c6edad48188ec06ddf7e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/g%2b%2b-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gcc",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "gcc_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "82abbe21f53a70db6abe947998f07d2e91c36cce62972540dc782c29c86d0702",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/gcc_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gcc-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "gcc-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "209a445434926b1f25221e464108c141950ee2316a8ddf535ec518cb57926f76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/gcc-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "gcc-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "gcc-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "ab71e82506bee4747468cd701940fc4f5dd498605d76e257b89d009c2e4c4413",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/gcc-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "gcc-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "gcc-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "eb69145199e998fae2e6fab23a0759f768f33e7b7b2d21fb28dc0c91bbe3ab2d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/gcc-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gst-plugins-base-1.0",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "gir1.2-gst-plugins-base-1.0_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "0d52d57f01acbdde1ff600129dcafca59008e500cbc7df3f27f721b318f1b4e4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/gir1.2-gst-plugins-base-1.0_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gstreamer-1.0",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gir1.2-gstreamer-1.0_1.26.0-3_amd64.deb",
+      "sha256": "8078e3a2a9bd916f9448d3333a12f1b5a4788c696248b91bdf1322c579ddea1c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gir1.2-gstreamer-1.0_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gudev-1.0",
+      "version": "1:238-6",
+      "architecture": "amd64",
+      "filename": "gir1.2-gudev-1.0_1%3a238-6_amd64.deb",
+      "sha256": "5759e4ab498311b1ee83a0f38e6aeda415590de45a404c7ba7f5c9d9f8a31d61",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_amd64.deb"
+    },
+    {
+      "name": "git",
+      "version": "1:2.48.1-0ubuntu1.1",
+      "architecture": "amd64",
+      "filename": "git_1%3a2.48.1-0ubuntu1.1_amd64.deb",
+      "sha256": "f85b919ba73b802a5934719678d3f83f75b06c67187cf0facb262c3b1bdd4721",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/git/git_2.48.1-0ubuntu1.1_amd64.deb"
+    },
+    {
+      "name": "git-man",
+      "version": "1:2.48.1-0ubuntu1.1",
+      "architecture": "all",
+      "filename": "git-man_1%3a2.48.1-0ubuntu1.1_all.deb",
+      "sha256": "3292fe6f57a9620ba7653dfc492f40951ba6824bc1ac4dfc7c96f3f59731fd18",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/git/git-man_2.48.1-0ubuntu1.1_all.deb"
+    },
+    {
+      "name": "glslang-tools",
+      "version": "15.1.0-2",
+      "architecture": "amd64",
+      "filename": "glslang-tools_15.1.0-2_amd64.deb",
+      "sha256": "98d8b12ebaa3a9bcf7e68087d08a43a997356a52c130f01a5624a208fa8ab9d7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/glslang/glslang-tools_15.1.0-2_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-plugins-bad",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "800b2b0a8f994098e854413821a4908f301425e165b112994d4ad891e38c828a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-tools",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-tools_1.26.0-3_amd64.deb",
+      "sha256": "ac24b15d6a48bb99097419f4d8d5928430d010af301b0df0b32570e59879f8f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gstreamer1.0-tools_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "hwdata",
+      "version": "0.393-3",
+      "architecture": "all",
+      "filename": "hwdata_0.393-3_all.deb",
+      "sha256": "ad5beb26ff8b18ff48467b3f09b6e687451911e40430ae89eaef8ace2bfdcf61",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/h/hwdata/hwdata_0.393-3_all.deb"
+    },
+    {
+      "name": "libarchive13t64",
+      "version": "3.7.7-0ubuntu2.3",
+      "architecture": "amd64",
+      "filename": "libarchive13t64_3.7.7-0ubuntu2.3_amd64.deb",
+      "sha256": "a31d7532b90f89c342b3e8d23a922a17aaf9cb6d736c4a8e4773f0be97a7ba5f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/liba/libarchive/libarchive13t64_3.7.7-0ubuntu2.3_amd64.deb"
+    },
+    {
+      "name": "libasan8",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libasan8_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "f13c558b07c3a23d58948e7dee0c49bd8a1ab63147a701104c8e6049e71f5a73",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libasan8_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libass9",
+      "version": "1:0.17.3-1",
+      "architecture": "amd64",
+      "filename": "libass9_1%3a0.17.3-1_amd64.deb",
+      "sha256": "20fd3f8a675804455ccfffbcc4e488818e016dea8d535ade12031969cd97a62d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libass/libass9_0.17.3-1_amd64.deb"
+    },
+    {
+      "name": "libavtp0",
+      "version": "0.2.0-2",
+      "architecture": "amd64",
+      "filename": "libavtp0_0.2.0-2_amd64.deb",
+      "sha256": "32d5bb7433365eb43c9d3bd49aff8c62295abcd4a3eb45ddbdb8351ce909bc36",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libavtp/libavtp0_0.2.0-2_amd64.deb"
+    },
+    {
+      "name": "libbs2b0",
+      "version": "3.1.0+dfsg-8",
+      "architecture": "amd64",
+      "filename": "libbs2b0_3.1.0+dfsg-8_amd64.deb",
+      "sha256": "7d03829734d659b1167c92e8c00e415e113cb29cdc884576a9ccca611ef4e2b9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libb/libbs2b/libbs2b0_3.1.0%2bdfsg-8_amd64.deb"
+    },
+    {
+      "name": "libcap-dev",
+      "version": "1:2.73-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libcap-dev_1%3a2.73-4ubuntu1_amd64.deb",
+      "sha256": "ab6d5ef8d377dc23f2cb49dc66dbde2ee25bc0f00da54a84e3aeb783526e2b4c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libc/libcap2/libcap-dev_2.73-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libcc1-0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libcc1-0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "f84dd605099c5297ed5404553b03f39e4afb443333f27e7c9cdf25628cfa2717",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libcc1-0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libchromaprint1",
+      "version": "1.5.1-7",
+      "architecture": "amd64",
+      "filename": "libchromaprint1_1.5.1-7_amd64.deb",
+      "sha256": "a108a4a6e4b49c981975076aa2d1d15d73ed6c0b98122e7b5ceb7703f7851666",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/chromaprint/libchromaprint1_1.5.1-7_amd64.deb"
+    },
+    {
+      "name": "libclang-20-dev",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-20-dev_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "e0b1c9024a083ae276c23fdb547e057cdec9c76b6de1ff0a9065a4499a4076dc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-20-dev_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-common-20-dev",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-common-20-dev_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "05a6125fdcfc18a9b1f30ecc12378a46f9fa7f25ea782d9006bb23eb79f65e73",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-common-20-dev_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-cpp20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-cpp20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "f19464e350b2a3913c14882408e3495b2ccef81281b7a8abf0b53234d254b739",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-cpp20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-dev",
+      "version": "1:20.0-63ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-dev_1%3a20.0-63ubuntu1_amd64.deb",
+      "sha256": "4699c12ff94eda3fd18b49270edc6a6d7e2a390d5dc0efa32d2bc1119bdcdfc0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-defaults/libclang-dev_20.0-63ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang1-20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang1-20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "ed4bf6b86e21e735d4a2f5564c5dc202a818460be1e1c5b2794790678b7736aa",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang1-20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libcpuinfo0",
+      "version": "0.0~git20250203.aaac07e-1",
+      "architecture": "amd64",
+      "filename": "libcpuinfo0_0.0~git20250203.aaac07e-1_amd64.deb",
+      "sha256": "13af6ecf274a2629121a38b06a815cd945c99a586f3a8848bb386c49961b31b7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/cpuinfo/libcpuinfo0_0.0%7egit20250203.aaac07e-1_amd64.deb"
+    },
+    {
+      "name": "libdc1394-25",
+      "version": "2.2.6-4build1",
+      "architecture": "amd64",
+      "filename": "libdc1394-25_2.2.6-4build1_amd64.deb",
+      "sha256": "0f4a0768152636f2f941d3a29d24925be77f869b3d90a13f1694fef792a89810",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdc1394/libdc1394-25_2.2.6-4build1_amd64.deb"
+    },
+    {
+      "name": "libdca0",
+      "version": "0.0.7-2build1",
+      "architecture": "amd64",
+      "filename": "libdca0_0.0.7-2build1_amd64.deb",
+      "sha256": "018867fee029b072ecb3365f5f92c0cb0530d4ab37aa13be127116b6e5c3c06d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdca/libdca0_0.0.7-2build1_amd64.deb"
+    },
+    {
+      "name": "libdecor-0-dev",
+      "version": "0.2.2-2",
+      "architecture": "amd64",
+      "filename": "libdecor-0-dev_0.2.2-2_amd64.deb",
+      "sha256": "a8a1eed5d20461fa612700c9317a26046f6dd9c00aec432bead3f5f97c9b400b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdecor-0/libdecor-0-dev_0.2.2-2_amd64.deb"
+    },
+    {
+      "name": "libdnnl3.6",
+      "version": "3.7.1+ds-1",
+      "architecture": "amd64",
+      "filename": "libdnnl3.6_3.7.1+ds-1_amd64.deb",
+      "sha256": "88fd977d7076586d2a2bb89659d24e8875f188f79a15649ce1832764b3232d67",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onednn/libdnnl3.6_3.7.1%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libdpkg-perl",
+      "version": "1.22.18ubuntu2.2",
+      "architecture": "all",
+      "filename": "libdpkg-perl_1.22.18ubuntu2.2_all.deb",
+      "sha256": "9d96ff20ee92e976d82834f5e9b52b12b85b6ebddb83da1a641456b00d4afe89",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/d/dpkg/libdpkg-perl_1.22.18ubuntu2.2_all.deb"
+    },
+    {
+      "name": "libdrm-dev",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-dev_2.4.124-2_amd64.deb",
+      "sha256": "1d8d69e8bfd242c0e46bd8910f889b45203ed57b501e81b41faf05e03730643f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-dev_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdrm-nouveau2",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-nouveau2_2.4.124-2_amd64.deb",
+      "sha256": "7eaf5ee5460175ef118dd0dbf246d5b72d19c70f113d0650e3a045aefd968c09",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-nouveau2_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdrm-radeon1",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-radeon1_2.4.124-2_amd64.deb",
+      "sha256": "e45997171485fbf22b3dd0d3d569aa0b7b923a945cba80a93717042da54b4d70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-radeon1_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdvdnav4",
+      "version": "6.1.1-3build1",
+      "architecture": "amd64",
+      "filename": "libdvdnav4_6.1.1-3build1_amd64.deb",
+      "sha256": "09fd1de2985ade2592d4f068774b2249211880aa6d4a71a89e0b4764afe47404",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdnav/libdvdnav4_6.1.1-3build1_amd64.deb"
+    },
+    {
+      "name": "libdvdread8t64",
+      "version": "6.1.3-2",
+      "architecture": "amd64",
+      "filename": "libdvdread8t64_6.1.3-2_amd64.deb",
+      "sha256": "269fe55b0eb5a47b7112c46a5ed3a21bdbd0378224970d733225ecfd3cb5f20e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdread/libdvdread8t64_6.1.3-2_amd64.deb"
+    },
+    {
+      "name": "libdw-dev",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libdw-dev_0.192-4ubuntu1_amd64.deb",
+      "sha256": "d20955250b0efd8ea3f4f908fb91ecc9448f13c353b0aa289599f41c53fd19fd",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libdw-dev_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libdw1t64",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libdw1t64_0.192-4ubuntu1_amd64.deb",
+      "sha256": "4c75709171583eb7c9f437d90ea44a7184f0b2b0f5f23f428f00ba3febeb52e6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libdw1t64_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libegl-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libegl-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "3a0315216bb0d6fc4bbe7f689cf0168c2ffa3e62ac69bff06bbbe49679259990",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libegl-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libelf-dev",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libelf-dev_0.192-4ubuntu1_amd64.deb",
+      "sha256": "410b4385cf6c508bae56eb399148be1d5814be0f20e7e06cbd3e53b1c2943b50",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libelf-dev_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "liberror-perl",
+      "version": "0.17030-1",
+      "architecture": "all",
+      "filename": "liberror-perl_0.17030-1_all.deb",
+      "sha256": "cb85c869fe056e9e466efcfa3403408b0a87db1da1cafa585140a9be59fe58a1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libe/liberror-perl/liberror-perl_0.17030-1_all.deb"
+    },
+    {
+      "name": "libevdev-dev",
+      "version": "1.13.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libevdev-dev_1.13.3+dfsg-1_amd64.deb",
+      "sha256": "425b37d96ee3d595d89f966bcf9758d15f84c30eff21e3279b1a4e0ec9671de6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libe/libevdev/libevdev-dev_1.13.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libfaad2",
+      "version": "2.11.2-1",
+      "architecture": "amd64",
+      "filename": "libfaad2_2.11.2-1_amd64.deb",
+      "sha256": "cdf00ddc8c0f4f6e3dbc46c1d0efba537632609432734deb01113cac3ac1531d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/faad2/libfaad2_2.11.2-1_amd64.deb"
+    },
+    {
+      "name": "libflite1",
+      "version": "2.2-7",
+      "architecture": "amd64",
+      "filename": "libflite1_2.2-7_amd64.deb",
+      "sha256": "3afe2b4ab82dff2330b53fcee83b4b21aa580f6d91a1ce850e917cf8cffc004a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/flite/libflite1_2.2-7_amd64.deb"
+    },
+    {
+      "name": "libfluidsynth3",
+      "version": "2.4.4+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libfluidsynth3_2.4.4+dfsg-1_amd64.deb",
+      "sha256": "2a7177d672b1f717c2b064181cac9e1772aeaf93e0a00db8327954eeeaff9189",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/fluidsynth/libfluidsynth3_2.4.4%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libfreeaptx0",
+      "version": "0.1.1-2build1",
+      "architecture": "amd64",
+      "filename": "libfreeaptx0_0.1.1-2build1_amd64.deb",
+      "sha256": "2280d6fdd41c841701a9da6b5076b77e8a0849e5c10c9c2945f817f753575a42",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libf/libfreeaptx/libfreeaptx0_0.1.1-2build1_amd64.deb"
+    },
+    {
+      "name": "libgbm-dev",
+      "version": "25.0.7-0ubuntu0.25.04.2",
+      "architecture": "amd64",
+      "filename": "libgbm-dev_25.0.7-0ubuntu0.25.04.2_amd64.deb",
+      "sha256": "34bd2a70579a7e795d446d9de2d85185dca058e93926f11ab7f23f27f1e03be4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mesa/libgbm-dev_25.0.7-0ubuntu0.25.04.2_amd64.deb"
+    },
+    {
+      "name": "libgc1",
+      "version": "1:8.2.8-1",
+      "architecture": "amd64",
+      "filename": "libgc1_1%3a8.2.8-1_amd64.deb",
+      "sha256": "d337914b08465d43186dbfe880fde5c9ea23808b0d56ea88397644cd6df84fcf",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgc/libgc1_8.2.8-1_amd64.deb"
+    },
+    {
+      "name": "libgcc-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libgcc-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "10eff4b80bc982518584b67e65e3ab89c8f33c4af7ce0b0071463e4eda410e74",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/libgcc-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libgdbm-compat4t64",
+      "version": "1.24-2",
+      "architecture": "amd64",
+      "filename": "libgdbm-compat4t64_1.24-2_amd64.deb",
+      "sha256": "0693236e9baf295abb8f90a56f44282054a3c91c9946a47c4a095764c073d052",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gdbm/libgdbm-compat4t64_1.24-2_amd64.deb"
+    },
+    {
+      "name": "libgdbm6t64",
+      "version": "1.24-2",
+      "architecture": "amd64",
+      "filename": "libgdbm6t64_1.24-2_amd64.deb",
+      "sha256": "1df38f4993f7f68cee81283af8963e0cb7c885be61be9a93326ab850af15e4f6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gdbm/libgdbm6t64_1.24-2_amd64.deb"
+    },
+    {
+      "name": "libgl-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgl-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "b7145fd8f8abe20d5cb436d2eae9b3235bd91be6fbddac581620d16763bd9250",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgl-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgles-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgles-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "ee2ea529c20e28031230c5910281e5bbd7f2c2ca06a2e306ca15e985d4875eb2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgles-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgles1",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgles1_1.7.0-1build1_amd64.deb",
+      "sha256": "3128deef59859a47cfca25244f035bdbedd223640209dcffdd11f1873ef71aff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgles1_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libglx-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libglx-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "0e2654950a881c20b640a3af590add2e0b612b8c0fdd945761fc695e1b6eb797",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libglx-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgme0",
+      "version": "0.6.3-7build1",
+      "architecture": "amd64",
+      "filename": "libgme0_0.6.3-7build1_amd64.deb",
+      "sha256": "a54fa608501f87f9e5064b60c75fc1bb62735c9f9ba9f7680cb804bb5eae2027",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/game-music-emu/libgme0_0.6.3-7build1_amd64.deb"
+    },
+    {
+      "name": "libgsm1",
+      "version": "1.0.22-1build1",
+      "architecture": "amd64",
+      "filename": "libgsm1_1.0.22-1build1_amd64.deb",
+      "sha256": "8cc765587a3275e861f166a98b4b79dd8d5c673f97e17967945ab4d1eb89c89a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libg/libgsm/libgsm1_1.0.22-1build1_amd64.deb"
+    },
+    {
+      "name": "libgssdp-1.6-0",
+      "version": "1.6.3-2",
+      "architecture": "amd64",
+      "filename": "libgssdp-1.6-0_1.6.3-2_amd64.deb",
+      "sha256": "7897db47adc4114a17c44f390d2816c7e58ac8bdd722fa58fa21c659368aece7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gssdp/libgssdp-1.6-0_1.6.3-2_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-bad1.0-0",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "36c0de48cf25ca31dc21363dabd3fb32e9d4c539467b6b76b4770c5e82822099",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-base1.0-dev",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-base1.0-dev_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "20bf9472c7520737227c983fcc1b6711a98a58ea8f4381d9bb10e11dbe538a2f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-dev_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer1.0-dev",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "libgstreamer1.0-dev_1.26.0-3_amd64.deb",
+      "sha256": "bdfb350621e98cc9b38c4ab5bf3bfe448f635f12244f771bac89966678c2ad94",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/libgstreamer1.0-dev_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "libgudev-1.0-dev",
+      "version": "1:238-6",
+      "architecture": "amd64",
+      "filename": "libgudev-1.0-dev_1%3a238-6_amd64.deb",
+      "sha256": "e4cc1f9f5fe0dcca2c4e9fdeefe799b39f761513efb2bab676fe432b85b6309e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_amd64.deb"
+    },
+    {
+      "name": "libgupnp-1.6-0",
+      "version": "1.6.8-2",
+      "architecture": "amd64",
+      "filename": "libgupnp-1.6-0_1.6.8-2_amd64.deb",
+      "sha256": "9346722ae71cc4bce037ef49bf38c609392eb1cfb6eba19fce575673577896c5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gupnp/libgupnp-1.6-0_1.6.8-2_amd64.deb"
+    },
+    {
+      "name": "libgupnp-igd-1.6-0",
+      "version": "1.6.0-4",
+      "architecture": "amd64",
+      "filename": "libgupnp-igd-1.6-0_1.6.0-4_amd64.deb",
+      "sha256": "bf96c3dc6cf586400754dcf51b1e8033399171d5c5a55191ba13cf8c6d8c426e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gupnp-igd/libgupnp-igd-1.6-0_1.6.0-4_amd64.deb"
+    },
+    {
+      "name": "libhwasan0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libhwasan0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8f6817b2b68c395118bb786c1b6388b1ccc0d76a64a26cab8b9519179277c318",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libhwasan0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libimath-3-1-29t64",
+      "version": "3.1.12-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb",
+      "sha256": "5b35e6bdfc8f567c3c33b4c5b519ceab2acd1c5c05534f360c33cedcf14c4cf3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/i/imath/libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libinput-dev",
+      "version": "1.27.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libinput-dev_1.27.1-1ubuntu0.2_amd64.deb",
+      "sha256": "264483d6ded36888d17fdfb6539517fa5cc0547b61d8039438c292ef5edf93db",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libi/libinput/libinput-dev_1.27.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libinstpatch-1.0-2",
+      "version": "1.1.6-1build2",
+      "architecture": "amd64",
+      "filename": "libinstpatch-1.0-2_1.1.6-1build2_amd64.deb",
+      "sha256": "d48c40a9c428e40d5bbe8762802390322b06a062c735292767e73d1c6ea9007e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libi/libinstpatch/libinstpatch-1.0-2_1.1.6-1build2_amd64.deb"
+    },
+    {
+      "name": "libitm1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libitm1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8a6c6855d2de1480760392f0fc443b65ec41cd811148011de89edd7ae417869a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libitm1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "liblc3-1",
+      "version": "1.1.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "liblc3-1_1.1.3+dfsg-1_amd64.deb",
+      "sha256": "0a88ca35cd79b18e42bbb22800e2ea49f2e0123cc709696dd1954486d7694e4d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/liblc3/liblc3-1_1.1.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libldacbt-enc2",
+      "version": "2.0.2.3+git20200429+ed310a0-5",
+      "architecture": "amd64",
+      "filename": "libldacbt-enc2_2.0.2.3+git20200429+ed310a0-5_amd64.deb",
+      "sha256": "7212ed25d4be1782cfc71ef1758a587fa3a3cfb7ba939c7233161cb491946a34",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/libldac/libldacbt-enc2_2.0.2.3%2bgit20200429%2bed310a0-5_amd64.deb"
+    },
+    {
+      "name": "liblilv-0-0",
+      "version": "0.24.26-1",
+      "architecture": "amd64",
+      "filename": "liblilv-0-0_0.24.26-1_amd64.deb",
+      "sha256": "3076146b3bae4bce370c6618ef8ed788383d3d35184dae0bbb9877dcdbb127c2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/lilv/liblilv-0-0_0.24.26-1_amd64.deb"
+    },
+    {
+      "name": "liblrdf0",
+      "version": "0.6.1-4build1",
+      "architecture": "amd64",
+      "filename": "liblrdf0_0.6.1-4build1_amd64.deb",
+      "sha256": "470a5e0e88fd2e7dcfc024c789cd029578b110c65558ae423fd79d7bb4ef01ca",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/liblrdf/liblrdf0_0.6.1-4build1_amd64.deb"
+    },
+    {
+      "name": "liblsan0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "liblsan0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "0c1a62b4e6c14f502d3c0c49c8fc009e959ca4fa1a910e3eea40e896e434016e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/liblsan0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libltc11",
+      "version": "1.3.2-1build1",
+      "architecture": "amd64",
+      "filename": "libltc11_1.3.2-1build1_amd64.deb",
+      "sha256": "92f23451cefe159faef9f255f0d24987eff50e52647dc1aa9843ad4c733ca039",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/libltc/libltc11_1.3.2-1build1_amd64.deb"
+    },
+    {
+      "name": "libluajit-5.1-dev",
+      "version": "2.1.0+openresty20250117-2",
+      "architecture": "amd64",
+      "filename": "libluajit-5.1-dev_2.1.0+openresty20250117-2_amd64.deb",
+      "sha256": "8b50af6f5684a57eed58d56be998376c8ef8e7c88379b6b14dffb56a10b4d9b4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/luajit/libluajit-5.1-dev_2.1.0%2bopenresty20250117-2_amd64.deb"
+    },
+    {
+      "name": "libmjpegutils-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmjpegutils-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "3422b9e3f7aa721a18f1738b33815a7f681fbe1ec0bafb1faf733e625dcbce85",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmjpegutils-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmodplug1",
+      "version": "1:0.8.9.0-3build1",
+      "architecture": "amd64",
+      "filename": "libmodplug1_1%3a0.8.9.0-3build1_amd64.deb",
+      "sha256": "34b383f35def5405069ae1eb6b4e6a7f73c9adafd0d049add82285b0e1a2e1ad",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmodplug/libmodplug1_0.8.9.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libmpcdec6",
+      "version": "2:0.1~r495-3",
+      "architecture": "amd64",
+      "filename": "libmpcdec6_2%3a0.1~r495-3_amd64.deb",
+      "sha256": "35e003823ddf242d8799057d420fc15ed644bb836d63ae18af57bd514699a216",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmpc/libmpcdec6_0.1%7er495-3_amd64.deb"
+    },
+    {
+      "name": "libmpeg2encpp-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmpeg2encpp-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "ec077a7c7fc7abd77d460813f56a9bef1dd68e53148840ef242b1795043d318e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmpeg2encpp-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmplex2-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmplex2-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "8c4324fb9ac9b667559aeaa92e399beeb4396d0cd33627be1b1306b85a31e5e2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmplex2-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmtdev-dev",
+      "version": "1.1.7-1",
+      "architecture": "amd64",
+      "filename": "libmtdev-dev_1.1.7-1_amd64.deb",
+      "sha256": "0f3985ae771be368a3cedb7e08d181c293d3e03c97ba8aa5c6742ad70c8d0319",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mtdev/libmtdev-dev_1.1.7-1_amd64.deb"
+    },
+    {
+      "name": "libneon27t64",
+      "version": "0.34.0-1",
+      "architecture": "amd64",
+      "filename": "libneon27t64_0.34.0-1_amd64.deb",
+      "sha256": "1710578bc51522b9ee8ccd70624b9e2e266f50e5ac39711d1096757bd23d381f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/neon27/libneon27t64_0.34.0-1_amd64.deb"
+    },
+    {
+      "name": "libnice10",
+      "version": "0.1.22-1",
+      "architecture": "amd64",
+      "filename": "libnice10_0.1.22-1_amd64.deb",
+      "sha256": "3e227906bae81259542732d0af1623a05910855d86e548e5b704e17ea8cb2a17",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libn/libnice/libnice10_0.1.22-1_amd64.deb"
+    },
+    {
+      "name": "libnuma1",
+      "version": "2.0.18-1build1",
+      "architecture": "amd64",
+      "filename": "libnuma1_2.0.18-1build1_amd64.deb",
+      "sha256": "508daa855e99959acaa945e6a89d218e0be6b5727fd28773580942ff37cf5805",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/n/numactl/libnuma1_2.0.18-1build1_amd64.deb"
+    },
+    {
+      "name": "libobjc-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libobjc-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "5babfef7063527cd3ed5a51dea337b32aa62ab79839940b25c2fb1721125a137",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gcc-14/libobjc-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libobjc4",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libobjc4_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "7e9fc63dcb88da621398110040df2ef9f12f00c4ca532bf583c67af0b7a46e5c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gcc-15/libobjc4_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libonnx1t64",
+      "version": "1.17.0-3build1",
+      "architecture": "amd64",
+      "filename": "libonnx1t64_1.17.0-3build1_amd64.deb",
+      "sha256": "c4fcb75e98e7a28dd741d002c640bb3a9891dee2d9ec39ee570f2824d77318ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnx/libonnx1t64_1.17.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libonnxruntime1.21",
+      "version": "1.21.0+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libonnxruntime1.21_1.21.0+dfsg-1_amd64.deb",
+      "sha256": "17e9bfec1e4e86a7456720843ed5443c2eb3bda62b45f0e075ab0c8d89e4ae7b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnxruntime/libonnxruntime1.21_1.21.0%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libopenal-data",
+      "version": "1:1.24.2-1",
+      "architecture": "all",
+      "filename": "libopenal-data_1%3a1.24.2-1_all.deb",
+      "sha256": "2bce384fa3c8fb1193e9ec8c948787263e5a2fc53a4a4715c4aeeab75b98b420",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal-data_1.24.2-1_all.deb"
+    },
+    {
+      "name": "libopenal1",
+      "version": "1:1.24.2-1",
+      "architecture": "amd64",
+      "filename": "libopenal1_1%3a1.24.2-1_amd64.deb",
+      "sha256": "461b8d108f70efa65eefbb3af5c697ac95f831f1959de3b625345b389628bbbb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal1_1.24.2-1_amd64.deb"
+    },
+    {
+      "name": "libopenexr-3-1-30",
+      "version": "3.1.13-2",
+      "architecture": "amd64",
+      "filename": "libopenexr-3-1-30_3.1.13-2_amd64.deb",
+      "sha256": "cae37d566e8d08fdeabdbcac7e9c9a5c68b9541a83974adbd3f50cb654e83390",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openexr/libopenexr-3-1-30_3.1.13-2_amd64.deb"
+    },
+    {
+      "name": "libopenh264-8",
+      "version": "2.6.0+dfsg-2",
+      "architecture": "amd64",
+      "filename": "libopenh264-8_2.6.0+dfsg-2_amd64.deb",
+      "sha256": "bbff1a10312e60e4566c0e34c2d2f98deda75763ea639650518d00e1e028f67e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openh264/libopenh264-8_2.6.0%2bdfsg-2_amd64.deb"
+    },
+    {
+      "name": "libopenmpt0t64",
+      "version": "0.7.13-1build1",
+      "architecture": "amd64",
+      "filename": "libopenmpt0t64_0.7.13-1build1_amd64.deb",
+      "sha256": "0a3f0e7060f1777d9865ff1ba23d7ad692f395594388442bde670e4bf435a975",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libo/libopenmpt/libopenmpt0t64_0.7.13-1build1_amd64.deb"
+    },
+    {
+      "name": "libopenni2-0",
+      "version": "2.2.0.33+dfsg-18",
+      "architecture": "amd64",
+      "filename": "libopenni2-0_2.2.0.33+dfsg-18_amd64.deb",
+      "sha256": "bba943fe73b2b0271ebbd6a28d0afb9e7084df75a64748fc06e3f72151ab1b76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openni2/libopenni2-0_2.2.0.33%2bdfsg-18_amd64.deb"
+    },
+    {
+      "name": "liborc-0.4-dev",
+      "version": "1:0.4.41-1",
+      "architecture": "amd64",
+      "filename": "liborc-0.4-dev_1%3a0.4.41-1_amd64.deb",
+      "sha256": "f9dd934bafb2140adf20e16f8d2ea5106539fbbe1f7b9f5cee6bf3a0cc56cd7c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/orc/liborc-0.4-dev_0.4.41-1_amd64.deb"
+    },
+    {
+      "name": "liborc-0.4-dev-bin",
+      "version": "1:0.4.41-1",
+      "architecture": "amd64",
+      "filename": "liborc-0.4-dev-bin_1%3a0.4.41-1_amd64.deb",
+      "sha256": "6abfb51460346159c83598f869dc27ad2474329cb70a5ebaba875c37bea1eb43",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/orc/liborc-0.4-dev-bin_0.4.41-1_amd64.deb"
+    },
+    {
+      "name": "libpciaccess-dev",
+      "version": "0.17-3ubuntu0.25.04.2",
+      "architecture": "amd64",
+      "filename": "libpciaccess-dev_0.17-3ubuntu0.25.04.2_amd64.deb",
+      "sha256": "345127a67e50bbb3db674e9051788737b8b2ddba4eab00cd316446d874f0732d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libp/libpciaccess/libpciaccess-dev_0.17-3ubuntu0.25.04.2_amd64.deb"
+    },
+    {
+      "name": "libperl5.40",
+      "version": "5.40.1-2ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libperl5.40_5.40.1-2ubuntu0.2_amd64.deb",
+      "sha256": "06133408b9abcc6dd4065bfe10cacf051929ca262eea996d504a3228fe669ac2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/perl/libperl5.40_5.40.1-2ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-dev",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-dev_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "a1665a2ead175e9ccf4f9f4098db14ac56110470cb0599b941f679947a1b99d4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-modules",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "f23e9a3ebedfbb846efe210bcc55150668394ac807e6c71f1f2c1d5f728c2f8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libprotobuf32t64",
+      "version": "3.21.12-10ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb",
+      "sha256": "19a6eac6e4d794318608c7e6862c4414119e1be7d3e66b0f8e698c62c78411ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/protobuf/libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpthreadpool0",
+      "version": "0.0~git20240616.560c60d-1",
+      "architecture": "amd64",
+      "filename": "libpthreadpool0_0.0~git20240616.560c60d-1_amd64.deb",
+      "sha256": "a09c04886537cf3db25ae1c0644a0b4cc070d520914521a00f81b86b1254f23f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/p/pthreadpool/libpthreadpool0_0.0%7egit20240616.560c60d-1_amd64.deb"
+    },
+    {
+      "name": "libqrencode4",
+      "version": "4.1.1-2",
+      "architecture": "amd64",
+      "filename": "libqrencode4_4.1.1-2_amd64.deb",
+      "sha256": "d9eed9dc0a75994c2fe4d95f9dae8d700b4a363383f6966a82d6d0225e275280",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/q/qrencode/libqrencode4_4.1.1-2_amd64.deb"
+    },
+    {
+      "name": "libquadmath0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libquadmath0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "a980b7bfc6586180d07a5df8a7d9bc97fa41c0790d91b780cee8e6f5f317c934",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libquadmath0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libraptor2-0",
+      "version": "2.0.16-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libraptor2-0_2.0.16-4ubuntu1_amd64.deb",
+      "sha256": "ecae495617134e13c098780576db94c89e9475d2ccec3d2bb732799ce958bd87",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/raptor2/libraptor2-0_2.0.16-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libre2-11",
+      "version": "20240501-3build1",
+      "architecture": "amd64",
+      "filename": "libre2-11_20240501-3build1_amd64.deb",
+      "sha256": "b7a4b55a5f2e4ca12d1020b2cd5a0a0540bb1a9b4706eaa8e1294fe52a4112a5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/re2/libre2-11_20240501-3build1_amd64.deb"
+    },
+    {
+      "name": "librhash1",
+      "version": "1.4.5-1",
+      "architecture": "amd64",
+      "filename": "librhash1_1.4.5-1_amd64.deb",
+      "sha256": "6a51d203f615d3bfa71fba697db4a91700d7cfc04e48c9ab2786f77b96e9614a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/rhash/librhash1_1.4.5-1_amd64.deb"
+    },
+    {
+      "name": "libroc0.4",
+      "version": "0.4.0+dfsg-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libroc0.4_0.4.0+dfsg-4ubuntu1_amd64.deb",
+      "sha256": "8bec93425075527aa82683dbcf2d1784c39361da46a10c299f0c60afb8625b71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/roc-toolkit/libroc0.4_0.4.0%2bdfsg-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsbc1",
+      "version": "2.0-1build1",
+      "architecture": "amd64",
+      "filename": "libsbc1_2.0-1build1_amd64.deb",
+      "sha256": "d4d453e7673218fc2f917dbabb2492a5a81155c2305f6fe63a37cadcaa806128",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/sbc/libsbc1_2.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libseat-dev",
+      "version": "0.8.0-1",
+      "architecture": "amd64",
+      "filename": "libseat-dev_0.8.0-1_amd64.deb",
+      "sha256": "f0be2c0a66145588838546011a4236e20a277b9a4a52acfca9f0cb7dcf80b812",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/seatd/libseat-dev_0.8.0-1_amd64.deb"
+    },
+    {
+      "name": "libserd-0-0",
+      "version": "0.32.4-1",
+      "architecture": "amd64",
+      "filename": "libserd-0-0_0.32.4-1_amd64.deb",
+      "sha256": "3d1c23e9effbe22d3edab8c0c2fdc8297d966c134f4d8095ccf0c9da52cc5f33",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/serd/libserd-0-0_0.32.4-1_amd64.deb"
+    },
+    {
+      "name": "libsnapd-glib-2-1",
+      "version": "1.66-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb",
+      "sha256": "b7bd77be1d59bf3a19bbe91b9ab6225ad05736ed72bd9f3b3f56bcd83822e398",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/snapd-glib/libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsord-0-0",
+      "version": "0.16.18-1",
+      "architecture": "amd64",
+      "filename": "libsord-0-0_0.16.18-1_amd64.deb",
+      "sha256": "bfd5ef5bbab2eed986b6f2856c2904db70c3d9e7a34b9f9caffcc1ea36a47a9b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sord/libsord-0-0_0.16.18-1_amd64.deb"
+    },
+    {
+      "name": "libsoundtouch1",
+      "version": "2.3.3+ds-1",
+      "architecture": "amd64",
+      "filename": "libsoundtouch1_2.3.3+ds-1_amd64.deb",
+      "sha256": "cadad56c5398a93f2f8c7080ca1a93725c15242beff0891cfdb029c5e4f305f3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/soundtouch/libsoundtouch1_2.3.3%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libspa-0.2-dev",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libspa-0.2-dev_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "bf84dc575f3beab14b1a86612622525a6f6c45e367edac0e5143ed03106ec959",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libspa-0.2-dev_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libspandsp2t64",
+      "version": "0.0.6+dfsg-2.2",
+      "architecture": "amd64",
+      "filename": "libspandsp2t64_0.0.6+dfsg-2.2_amd64.deb",
+      "sha256": "63a125139f3507ae94faa7cdd10ee6d6c551961937b1ec7fafa4d320e34b71bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spandsp/libspandsp2t64_0.0.6%2bdfsg-2.2_amd64.deb"
+    },
+    {
+      "name": "libspeexdsp1",
+      "version": "1.2.1-3",
+      "architecture": "amd64",
+      "filename": "libspeexdsp1_1.2.1-3_amd64.deb",
+      "sha256": "5b178611a05217d2ba35823aa8f75387d074a7e2d50954dc11464678cd7b2c91",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/speexdsp/libspeexdsp1_1.2.1-3_amd64.deb"
+    },
+    {
+      "name": "libsratom-0-0",
+      "version": "0.6.18-1",
+      "architecture": "amd64",
+      "filename": "libsratom-0-0_0.6.18-1_amd64.deb",
+      "sha256": "848fcfa874c1acb8c2331747a841467f8921334d5b5cbb66f8306d933203f344",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sratom/libsratom-0-0_0.6.18-1_amd64.deb"
+    },
+    {
+      "name": "libsrt1.5-gnutls",
+      "version": "1.5.4-1",
+      "architecture": "amd64",
+      "filename": "libsrt1.5-gnutls_1.5.4-1_amd64.deb",
+      "sha256": "88e58de644fbf38c194494789c4f1e047dae6c43bd71ca245530d721a4a0b5e0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/srt/libsrt1.5-gnutls_1.5.4-1_amd64.deb"
+    },
+    {
+      "name": "libsrtp2-1",
+      "version": "2.5.0-3build1",
+      "architecture": "amd64",
+      "filename": "libsrtp2-1_2.5.0-3build1_amd64.deb",
+      "sha256": "c2e7ee0ae64597f046fbfb197b8f36dfc9a5159b02d27e850f3a4d14a4603d77",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libs/libsrtp2/libsrtp2-1_2.5.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libstdc++-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libstdc++-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "23b377179507d649d55f371cc4b36082b05bce3637a475d9b53a83cc6dcdbcef",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/libstdc%2b%2b-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libtsan2",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libtsan2_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "829692d86ed2b1d3f761306fce4b8bebe5b632a018859c8570c3dcdf162a942b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libtsan2_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libubsan1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libubsan1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "ebdb6ab4f035d9b94a633478bec122212388d5f2e155c99bca1fe84831f6a04b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libubsan1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libudev-dev",
+      "version": "257.4-1ubuntu3.2",
+      "architecture": "amd64",
+      "filename": "libudev-dev_257.4-1ubuntu3.2_amd64.deb",
+      "sha256": "ad5f1a66b74f5c17382e449a7792f0228cf50797ebccaec4c6cb72081e60aa97",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/systemd/libudev-dev_257.4-1ubuntu3.2_amd64.deb"
+    },
+    {
+      "name": "libunibreak6",
+      "version": "6.1-2",
+      "architecture": "amd64",
+      "filename": "libunibreak6_6.1-2_amd64.deb",
+      "sha256": "c904cf437fcad74dac8c9e7fd1a4a9657b0c5d44441848e321e225375b69c4fc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libu/libunibreak/libunibreak6_6.1-2_amd64.deb"
+    },
+    {
+      "name": "libunwind-dev",
+      "version": "1.6.2-3.1",
+      "architecture": "amd64",
+      "filename": "libunwind-dev_1.6.2-3.1_amd64.deb",
+      "sha256": "624f0a53bb081487268cf920f0d83ec7f80add528c3ef5ce6e91ced727eb9ce1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libunwind/libunwind-dev_1.6.2-3.1_amd64.deb"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2ubuntu1",
+      "architecture": "amd64",
+      "filename": "libuv1t64_1.50.0-2ubuntu1_amd64.deb",
+      "sha256": "6af9634d05965f60ed7c124d43cef678ef288824b6f36a7b02559dd4097e7c90",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libuv1/libuv1t64_1.50.0-2ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libva-drm2",
+      "version": "2.22.0-3ubuntu2",
+      "architecture": "amd64",
+      "filename": "libva-drm2_2.22.0-3ubuntu2_amd64.deb",
+      "sha256": "fb95623b4c1834a34109966e7f5c85b4ab2f620d5804ea6512b69c25159a45bf",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libva/libva-drm2_2.22.0-3ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libva2",
+      "version": "2.22.0-3ubuntu2",
+      "architecture": "amd64",
+      "filename": "libva2_2.22.0-3ubuntu2_amd64.deb",
+      "sha256": "52bb1274b1cf1dbfe83f85a453363c0c651513d1e45264553edf286b9129d8c6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libva/libva2_2.22.0-3ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libvo-aacenc0",
+      "version": "0.1.3-3",
+      "architecture": "amd64",
+      "filename": "libvo-aacenc0_0.1.3-3_amd64.deb",
+      "sha256": "ea759b3a02552c379424775d5fc5d37d8dff59eb70ceab35118146ef04e857a3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-aacenc/libvo-aacenc0_0.1.3-3_amd64.deb"
+    },
+    {
+      "name": "libvo-amrwbenc0",
+      "version": "0.1.3-2build1",
+      "architecture": "amd64",
+      "filename": "libvo-amrwbenc0_0.1.3-2build1_amd64.deb",
+      "sha256": "30d260bbb56b9340319216529e72ed02a68752de62d5926ad07132ed2459af05",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-amrwbenc/libvo-amrwbenc0_0.1.3-2build1_amd64.deb"
+    },
+    {
+      "name": "libvorbisfile3",
+      "version": "1.3.7-2",
+      "architecture": "amd64",
+      "filename": "libvorbisfile3_1.3.7-2_amd64.deb",
+      "sha256": "6dfc7f0bd9f0c745c2e099aca9121843650ec7c7193801057bc3927c43820e70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-2_amd64.deb"
+    },
+    {
+      "name": "libvulkan-dev",
+      "version": "1.4.304.0-1",
+      "architecture": "amd64",
+      "filename": "libvulkan-dev_1.4.304.0-1_amd64.deb",
+      "sha256": "f557d5cc69add01d3794b1c71bfdcb053d7909febedd58713f9ba355e3f33167",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/v/vulkan-loader/libvulkan-dev_1.4.304.0-1_amd64.deb"
+    },
+    {
+      "name": "libwacom-dev",
+      "version": "2.14.0-1",
+      "architecture": "amd64",
+      "filename": "libwacom-dev_2.14.0-1_amd64.deb",
+      "sha256": "18e8a96b5300885ea8b7013214eeef9f912bbe5d804fda4f236bef3ce3f22fd5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libw/libwacom/libwacom-dev_2.14.0-1_amd64.deb"
+    },
+    {
+      "name": "libwayland-bin",
+      "version": "1.23.1-3",
+      "architecture": "amd64",
+      "filename": "libwayland-bin_1.23.1-3_amd64.deb",
+      "sha256": "f0f8b782d56c44068827e614240ae4d29908864f7b2d10bb54b2a68ba5623562",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb"
+    },
+    {
+      "name": "libwayland-dev",
+      "version": "1.23.1-3",
+      "architecture": "amd64",
+      "filename": "libwayland-dev_1.23.1-3_amd64.deb",
+      "sha256": "4641ae220244fcb7f28d344d6612ec8c961351ba62347484ec354cbae1029f47",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb"
+    },
+    {
+      "name": "libwildmidi2",
+      "version": "0.4.3-1build3",
+      "architecture": "amd64",
+      "filename": "libwildmidi2_0.4.3-1build3_amd64.deb",
+      "sha256": "f44a3f24eb567cf104aefe6cabe2a3385185dc59dd83d64a37c1a04f0e12c771",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/w/wildmidi/libwildmidi2_0.4.3-1build3_amd64.deb"
+    },
+    {
+      "name": "libx11-xcb-dev",
+      "version": "2:1.8.10-2",
+      "architecture": "amd64",
+      "filename": "libx11-xcb-dev_2%3a1.8.10-2_amd64.deb",
+      "sha256": "0f82fd0275fe8f8120df2ea231f2bd3fbc312d0e5070d7e126ea15cc9208f7ab",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libx11/libx11-xcb-dev_1.8.10-2_amd64.deb"
+    },
+    {
+      "name": "libx265-215",
+      "version": "4.1-2",
+      "architecture": "amd64",
+      "filename": "libx265-215_4.1-2_amd64.deb",
+      "sha256": "7fb455bbdd67cfa604b397c64e3e7893ae128ec12dad84655218e83501502a02",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/x265/libx265-215_4.1-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-composite0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-composite0-dev_1.17.0-2_amd64.deb",
+      "sha256": "9c7c7e0462fb2814bc50d8e1207e86d499d48e626b7c245019f672d31c7c8056",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-composite0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-ewmh-dev",
+      "version": "0.4.2-1",
+      "architecture": "amd64",
+      "filename": "libxcb-ewmh-dev_0.4.2-1_amd64.deb",
+      "sha256": "6fb409e6c39c6e035de198b20ae1b9f4ee9bfd023c23344165cbadd0f7de335e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xcb-util-wm/libxcb-ewmh-dev_0.4.2-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-icccm4-dev",
+      "version": "0.4.2-1",
+      "architecture": "amd64",
+      "filename": "libxcb-icccm4-dev_0.4.2-1_amd64.deb",
+      "sha256": "9766971d554555864316d05f111eb05afd60c57791a4a655ba04a6600cf9f8ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xcb-util-wm/libxcb-icccm4-dev_0.4.2-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-res0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-res0-dev_1.17.0-2_amd64.deb",
+      "sha256": "c0d05fb701c144dddc3b1ec0e27579444e0c905ce1e7bffc4d9f74a747593379",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-res0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-shape0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-shape0-dev_1.17.0-2_amd64.deb",
+      "sha256": "6ad9c5c37a3fd478ed5586486d122cfbf29e687b738a98cd5145caf603656f9c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-shape0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-xfixes0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-xfixes0-dev_1.17.0-2_amd64.deb",
+      "sha256": "85b54851baa1584386a74b68764507d96967edcd119d4680203838550f69e939",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-xfixes0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcomposite-dev",
+      "version": "1:0.4.6-1",
+      "architecture": "amd64",
+      "filename": "libxcomposite-dev_1%3a0.4.6-1_amd64.deb",
+      "sha256": "6db5444b9409b5e6edb4cb4537640cd33207551a04c389248e86b269571fa258",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcomposite/libxcomposite-dev_0.4.6-1_amd64.deb"
+    },
+    {
+      "name": "libxcursor-dev",
+      "version": "1:1.2.3-1",
+      "architecture": "amd64",
+      "filename": "libxcursor-dev_1%3a1.2.3-1_amd64.deb",
+      "sha256": "f693b31be26a752b901eee46d9cd79c308f3595223a437481287ce0c016a5987",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcursor/libxcursor-dev_1.2.3-1_amd64.deb"
+    },
+    {
+      "name": "libxdamage-dev",
+      "version": "1:1.1.6-1build1",
+      "architecture": "amd64",
+      "filename": "libxdamage-dev_1%3a1.1.6-1build1_amd64.deb",
+      "sha256": "63067acaa7248dd46e67496154a030f38c86aa1cc192116265a8039c358ee20a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxdamage/libxdamage-dev_1.1.6-1build1_amd64.deb"
+    },
+    {
+      "name": "libxfixes-dev",
+      "version": "1:6.0.0-2build1",
+      "architecture": "amd64",
+      "filename": "libxfixes-dev_1%3a6.0.0-2build1_amd64.deb",
+      "sha256": "069723527566ef0fc12738f63b789110c211b85bf96c3dbe9a94d9e77f5c479b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxfixes/libxfixes-dev_6.0.0-2build1_amd64.deb"
+    },
+    {
+      "name": "libxi-dev",
+      "version": "2:1.8.2-1",
+      "architecture": "amd64",
+      "filename": "libxi-dev_2%3a1.8.2-1_amd64.deb",
+      "sha256": "5c7bdf2d7abd20858666554c0eca429c1b35a09529c193a52d70c4ebda5ea75b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxi/libxi-dev_1.8.2-1_amd64.deb"
+    },
+    {
+      "name": "libxkbcommon-dev",
+      "version": "1.7.0-2",
+      "architecture": "amd64",
+      "filename": "libxkbcommon-dev_1.7.0-2_amd64.deb",
+      "sha256": "0c366a6dd143cca7dbec02ea7ed466e1c37b44e35e39018268717f5733f7ca29",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.7.0-2_amd64.deb"
+    },
+    {
+      "name": "libxmu-dev",
+      "version": "2:1.1.3-3build2",
+      "architecture": "amd64",
+      "filename": "libxmu-dev_2%3a1.1.3-3build2_amd64.deb",
+      "sha256": "a7b2d7632ba44ba2a9056b5665db0dad20d91fe8c336502db1f434b0b6922acc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxmu/libxmu-dev_1.1.3-3build2_amd64.deb"
+    },
+    {
+      "name": "libxmu-headers",
+      "version": "2:1.1.3-3build2",
+      "architecture": "all",
+      "filename": "libxmu-headers_2%3a1.1.3-3build2_all.deb",
+      "sha256": "6abd2218697cefb602d8273a3df711b297f504f414abff11d366578ddc9fd3d6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxmu/libxmu-headers_1.1.3-3build2_all.deb"
+    },
+    {
+      "name": "libxnnpack0.20241108",
+      "version": "0.0~git20241108.4ea82e5-1",
+      "architecture": "amd64",
+      "filename": "libxnnpack0.20241108_0.0~git20241108.4ea82e5-1_amd64.deb",
+      "sha256": "0a3eedc79943aadbc036d199230c573e1a0b80f947e07076dbf1db1d4a201297",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/xnnpack/libxnnpack0.20241108_0.0%7egit20241108.4ea82e5-1_amd64.deb"
+    },
+    {
+      "name": "libxres-dev",
+      "version": "2:1.2.1-1build1",
+      "architecture": "amd64",
+      "filename": "libxres-dev_2%3a1.2.1-1build1_amd64.deb",
+      "sha256": "7e7346f017ad871cd2e3a0e9c8742e943e09198867f042cc455465c39240e2ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxres/libxres-dev_1.2.1-1build1_amd64.deb"
+    },
+    {
+      "name": "libxt-dev",
+      "version": "1:1.2.1-1.2build1",
+      "architecture": "amd64",
+      "filename": "libxt-dev_1%3a1.2.1-1.2build1_amd64.deb",
+      "sha256": "77858926454d10dd7896fc4d1ee158b67bb25e830dd41e60e4a59e79f71b8a8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxt/libxt-dev_1.2.1-1.2build1_amd64.deb"
+    },
+    {
+      "name": "libxtst-dev",
+      "version": "2:1.2.5-1",
+      "architecture": "amd64",
+      "filename": "libxtst-dev_2%3a1.2.5-1_amd64.deb",
+      "sha256": "f21eaaa996c266d0d3b96c1a392ac9af7cc4cbfe60601a1c98942bdcb8d5e334",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxtst/libxtst-dev_1.2.5-1_amd64.deb"
+    },
+    {
+      "name": "libxxf86vm-dev",
+      "version": "1:1.1.4-1build4",
+      "architecture": "amd64",
+      "filename": "libxxf86vm-dev_1%3a1.1.4-1build4_amd64.deb",
+      "sha256": "98587402f6928a2526a8fbae6bd8c7297ced187b3a34b4e461ffd3245910f1af",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxxf86vm/libxxf86vm-dev_1.1.4-1build4_amd64.deb"
+    },
+    {
+      "name": "libyajl2",
+      "version": "2.1.0-5build1",
+      "architecture": "amd64",
+      "filename": "libyajl2_2.1.0-5build1_amd64.deb",
+      "sha256": "faa268c632f7d2931509cf7b8b7ddd810aa775adc26ead88ea158e2ede5208f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/y/yajl/libyajl2_2.1.0-5build1_amd64.deb"
+    },
+    {
+      "name": "libzbar0t64",
+      "version": "0.23.93-7",
+      "architecture": "amd64",
+      "filename": "libzbar0t64_0.23.93-7_amd64.deb",
+      "sha256": "9954e12b0e2f1f5a294465c6e5c1eaa46407024f0416b4b90513e554ecd31776",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zbar/libzbar0t64_0.23.93-7_amd64.deb"
+    },
+    {
+      "name": "libzix-0-0",
+      "version": "0.6.2-1",
+      "architecture": "amd64",
+      "filename": "libzix-0-0_0.6.2-1_amd64.deb",
+      "sha256": "54d72b63ae0243dedd47e1946765890deb7764f5cfa2c9332228742b6b406ba9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zix/libzix-0-0_0.6.2-1_amd64.deb"
+    },
+    {
+      "name": "libzvbi0t64",
+      "version": "0.2.44-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libzvbi0t64_0.2.44-1ubuntu1_amd64.deb",
+      "sha256": "6596415c0581e0b48d34dae7c13990cd57187bd5e0331cb2a237c34ae6ef3949",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zvbi/libzvbi0t64_0.2.44-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libzxing3",
+      "version": "2.3.0-3",
+      "architecture": "amd64",
+      "filename": "libzxing3_2.3.0-3_amd64.deb",
+      "sha256": "66937bdde76f3edf56568d461692c7f6668f057a8ce0ba687570acb32bfd750b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zxing-cpp/libzxing3_2.3.0-3_amd64.deb"
+    },
+    {
+      "name": "llvm-20-linker-tools",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "llvm-20-linker-tools_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "4675775ec06186e8b2645e2bbe886fda6d330e89bb5fb1979c66dcc43b6d2849",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/llvm-20-linker-tools_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "lto-disabled-list",
+      "version": "57",
+      "architecture": "all",
+      "filename": "lto-disabled-list_57_all.deb",
+      "sha256": "0cc7c3bd22fef2f2dd2afda0d624c900af6dc9cf70e59a486f23b5751f3bf4bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/l/lto-disabled-list/lto-disabled-list_57_all.deb"
+    },
+    {
+      "name": "make",
+      "version": "4.4.1-1",
+      "architecture": "amd64",
+      "filename": "make_4.4.1-1_amd64.deb",
+      "sha256": "d0622880df49e4bfd48e07253a18553aac0214ecbcd24a0841de7315c249cc2e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb"
+    },
+    {
+      "name": "meson",
+      "version": "1.7.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "meson_1.7.0-1ubuntu1_all.deb",
+      "sha256": "669142d3fd9008c583ca2511d4d3db41efeb2ace18642c942bc7e7fa7fd81ece",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/meson/meson_1.7.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "ninja-build",
+      "version": "1.12.1-1",
+      "architecture": "amd64",
+      "filename": "ninja-build_1.12.1-1_amd64.deb",
+      "sha256": "8190a977f4e0158c88fc76541737cdd62f74c74e8fd9aa25c6d5a322c7be6b0a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/ninja-build/ninja-build_1.12.1-1_amd64.deb"
+    },
+    {
+      "name": "patch",
+      "version": "2.7.6-7build3",
+      "architecture": "amd64",
+      "filename": "patch_2.7.6-7build3_amd64.deb",
+      "sha256": "fb7d78ed25c2788a607802270f3c28ac5ed6857bfb6cce9f73ad2cafac9159b3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/patch/patch_2.7.6-7build3_amd64.deb"
+    },
+    {
+      "name": "pci.ids",
+      "version": "0.0~2025.03.09-1",
+      "architecture": "all",
+      "filename": "pci.ids_0.0~2025.03.09-1_all.deb",
+      "sha256": "50762fd34c8d1cd4a8e99df09ac35200cbf709d821358eb08697a688f39edca9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pci.ids/pci.ids_0.0%7e2025.03.09-1_all.deb"
+    },
+    {
+      "name": "perl",
+      "version": "5.40.1-2ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "perl_5.40.1-2ubuntu0.2_amd64.deb",
+      "sha256": "d46189a20c6ae13825ee2b6a58efa9c58fe0c95527119d700bffd84d04b97d66",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/perl/perl_5.40.1-2ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "perl-modules-5.40",
+      "version": "5.40.1-2ubuntu0.2",
+      "architecture": "all",
+      "filename": "perl-modules-5.40_5.40.1-2ubuntu0.2_all.deb",
+      "sha256": "00d247d90e3e8f58c4ea9aae279dbf60c6fda16e2a49512050e1471c5931be8e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/perl/perl-modules-5.40_5.40.1-2ubuntu0.2_all.deb"
+    },
+    {
+      "name": "pipewire",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "b77fae0221ecdebcc9839cfd08aa5da95359c741a4d2922bfcaf55474b93f0a7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-bin",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "0d16cd14743a2c8fc4c726057ec910ba7eac48e5de65698acc01aeb336d45078",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-pulse",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "611be8d6b8620f5d266e7a8a232bb7cb96f558fc8a73205af7aaec084c3ab8eb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pkg-config",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkg-config_1.8.1-4_amd64.deb",
+      "sha256": "04b7449b1453626ae918a12afc747b4cc395a734a8db5c6b94468672088d0c14",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pnp.ids",
+      "version": "0.393-3",
+      "architecture": "all",
+      "filename": "pnp.ids_0.393-3_all.deb",
+      "sha256": "db21da54953f550393ed42d07a815f7f2ece949ba800865fba9252b3bfdf9d38",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/h/hwdata/pnp.ids_0.393-3_all.deb"
+    },
+    {
+      "name": "python3-autocommand",
+      "version": "2.2.2-3",
+      "architecture": "all",
+      "filename": "python3-autocommand_2.2.2-3_all.deb",
+      "sha256": "a8dfb00d38d617ac5c20fc42c7382ce85aa563faaac9f6e7ba2a90ad04e06d69",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-autocommand/python3-autocommand_2.2.2-3_all.deb"
+    },
+    {
+      "name": "python3-inflect",
+      "version": "7.3.1-2",
+      "architecture": "all",
+      "filename": "python3-inflect_7.3.1-2_all.deb",
+      "sha256": "f0c8dbb03547a21c9cf9f4fcdd77a7f9fedc59b9cc382805e992314c1d5d6804",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-inflect/python3-inflect_7.3.1-2_all.deb"
+    },
+    {
+      "name": "python3-jaraco.context",
+      "version": "6.0.1-1",
+      "architecture": "all",
+      "filename": "python3-jaraco.context_6.0.1-1_all.deb",
+      "sha256": "315f7335827d6059d879ccb3f1c41bb42f607380644acae6618f6f9ba88dc045",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/j/jaraco.context/python3-jaraco.context_6.0.1-1_all.deb"
+    },
+    {
+      "name": "python3-jaraco.functools",
+      "version": "4.1.0-1",
+      "architecture": "all",
+      "filename": "python3-jaraco.functools_4.1.0-1_all.deb",
+      "sha256": "febcf8a025e6947eaf357e8afb452d0244c18296f82df1946b92559f104d824b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-jaraco.functools/python3-jaraco.functools_4.1.0-1_all.deb"
+    },
+    {
+      "name": "python3-jaraco.text",
+      "version": "4.0.0-1",
+      "architecture": "all",
+      "filename": "python3-jaraco.text_4.0.0-1_all.deb",
+      "sha256": "948086d278c565ad8549587b01156ee9f09dadff9623de121dcb5dafe3ddb6cc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/j/jaraco.text/python3-jaraco.text_4.0.0-1_all.deb"
+    },
+    {
+      "name": "python3-more-itertools",
+      "version": "10.6.0-1",
+      "architecture": "all",
+      "filename": "python3-more-itertools_10.6.0-1_all.deb",
+      "sha256": "0528c67191b9703bc80aab118f12df8ca5a9e22df78b6b72f5143e0a8fed8e27",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/more-itertools/python3-more-itertools_10.6.0-1_all.deb"
+    },
+    {
+      "name": "python3-pkg-resources",
+      "version": "75.8.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "python3-pkg-resources_75.8.0-1ubuntu1_all.deb",
+      "sha256": "aa26d0339c6e564ba511b3db03eeb4adf1a6913ec9d4a7e5b0eb61c53ce59840",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/setuptools/python3-pkg-resources_75.8.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "python3-setuptools",
+      "version": "75.8.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "python3-setuptools_75.8.0-1ubuntu1_all.deb",
+      "sha256": "5aa98a69aae8caff58cce7b94d73eb3101127ef154f4a5cd4eae45c2c46714a0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/setuptools/python3-setuptools_75.8.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "python3-typeguard",
+      "version": "4.4.2-1",
+      "architecture": "all",
+      "filename": "python3-typeguard_4.4.2-1_all.deb",
+      "sha256": "28ff19b5be5e02393cbfe13a6068d0b52f270b511c7a7fb69f15d417415fa1ae",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-typeguard/python3-typeguard_4.4.2-1_all.deb"
+    },
+    {
+      "name": "python3-typing-extensions",
+      "version": "4.12.2-2",
+      "architecture": "all",
+      "filename": "python3-typing-extensions_4.12.2-2_all.deb",
+      "sha256": "3e2c7f01d654ec6a77327d9dc9f3b4572250fb95985db711e8389d0c6ec54018",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-typing-extensions/python3-typing-extensions_4.12.2-2_all.deb"
+    },
+    {
+      "name": "python3-zipp",
+      "version": "3.21.0-1",
+      "architecture": "all",
+      "filename": "python3-zipp_3.21.0-1_all.deb",
+      "sha256": "f940bd4def06760555cde9c8d27207eb536d1a32211dd8c54223100b0f0242f5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-zipp/python3-zipp_3.21.0-1_all.deb"
+    },
+    {
+      "name": "spirv-tools",
+      "version": "2025.1~rc1-1",
+      "architecture": "amd64",
+      "filename": "spirv-tools_2025.1~rc1-1_amd64.deb",
+      "sha256": "e7a487f6e47851bfe86724b14729bf22f3d54b0177bc982063483e5e35a10d8c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spirv-tools/spirv-tools_2025.1%7erc1-1_amd64.deb"
+    },
+    {
+      "name": "timgm6mb-soundfont",
+      "version": "1.3-5",
+      "architecture": "all",
+      "filename": "timgm6mb-soundfont_1.3-5_all.deb",
+      "sha256": "b70bc29b8f27adef8f92a2d9c1e26cee977b84c68110f0dd4326d97730a7c3ed",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/t/timgm6mb-soundfont/timgm6mb-soundfont_1.3-5_all.deb"
+    },
+    {
+      "name": "usb.ids",
+      "version": "2025.01.14-1",
+      "architecture": "all",
+      "filename": "usb.ids_2025.01.14-1_all.deb",
+      "sha256": "fa4a1fd5b24eafda34fe5e11ec2ed182c25bdb484758a5a7731bbb42643f2673",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/usb.ids/usb.ids_2025.01.14-1_all.deb"
+    },
+    {
+      "name": "wayland-protocols",
+      "version": "1.41-1",
+      "architecture": "all",
+      "filename": "wayland-protocols_1.41-1_all.deb",
+      "sha256": "3a0942c89ced71ebc809718c9d21910627d2a257b1277d6a9173a672cf53125f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland-protocols/wayland-protocols_1.41-1_all.deb"
+    },
+    {
+      "name": "xz-utils",
+      "version": "5.6.4-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "xz-utils_5.6.4-1ubuntu1_amd64.deb",
+      "sha256": "694f9201f670cbcf8d191e2c9c3db5e83b5373e6cb8a9330b0b6b25698da4a88",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xz-utils/xz-utils_5.6.4-1ubuntu1_amd64.deb"
+    }
+  ]
+}

--- a/containers/multiseat/locks/nvidia.json
+++ b/containers/multiseat/locks/nvidia.json
@@ -1,0 +1,7 @@
+{
+  "schema": 1,
+  "version": "610.57.04",
+  "url": "https://download.nvidia.com/XFree86/Linux-x86_64/610.57.04/NVIDIA-Linux-x86_64-610.57.04.run",
+  "sha256": "b2e935c66b83bb00c0c857bc8e0ee0fd52de9286b40c9cc1eec29a7ce7eb116d",
+  "scope": "graphics userspace only; no kernel modules or host installation"
+}

--- a/containers/multiseat/locks/plugin.json
+++ b/containers/multiseat/locks/plugin.json
@@ -1,0 +1,10 @@
+{
+  "schema": 1,
+  "url": "https://github.com/games-on-whales/gst-wayland-display",
+  "revision": "081feb5ab8057937b78104668bb1f507ce42e18d",
+  "cargo_lock_sha256": "90b40461f6b9943c0af26262d711852c0ba7c693c4ad9e187a8adfe1760a227d",
+  "sha256": "96da8c6b366147351f86547ddb40b559cf70402535c9797ca17024f6af5b8ffc",
+  "archive_epoch": 1754524800,
+  "rust_version": "1.89.0",
+  "vendor_mode": "cargo vendor --locked --versioned-dirs vendor"
+}

--- a/containers/multiseat/locks/rust.json
+++ b/containers/multiseat/locks/rust.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.89.0",
+  "url": "https://static.rust-lang.org/dist/2025-08-07/rust-1.89.0-x86_64-unknown-linux-gnu.tar.xz",
+  "sha256": "c4f2796b10ee886001f0799bc40caea38746403a33c379d77878c4f4683f9b51"
+}

--- a/containers/multiseat/locks/steam.packages.json
+++ b/containers/multiseat/locks/steam.packages.json
@@ -1,0 +1,2628 @@
+{
+  "schema": 1,
+  "profile": "steam",
+  "platform": "linux/amd64",
+  "source_root": "ghcr.io/games-on-whales/steam@sha256:ded0b1b47acd9adb8af9f068342f26ac31008904d9bbb91045d1a04e7d66a632",
+  "snapshot": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/",
+  "source_manifest_sha256": "dccccf0ca914c47bcfa63f2b157e0d3c16f071cee445892a789ebadc07faacb5",
+  "runtime": [
+    {
+      "name": "gstreamer1.0-plugins-bad",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "800b2b0a8f994098e854413821a4908f301425e165b112994d4ad891e38c828a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-tools",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-tools_1.26.0-3_amd64.deb",
+      "sha256": "ac24b15d6a48bb99097419f4d8d5928430d010af301b0df0b32570e59879f8f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gstreamer1.0-tools_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "libass9",
+      "version": "1:0.17.3-1",
+      "architecture": "amd64",
+      "filename": "libass9_1%3a0.17.3-1_amd64.deb",
+      "sha256": "20fd3f8a675804455ccfffbcc4e488818e016dea8d535ade12031969cd97a62d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libass/libass9_0.17.3-1_amd64.deb"
+    },
+    {
+      "name": "libavtp0",
+      "version": "0.2.0-2",
+      "architecture": "amd64",
+      "filename": "libavtp0_0.2.0-2_amd64.deb",
+      "sha256": "32d5bb7433365eb43c9d3bd49aff8c62295abcd4a3eb45ddbdb8351ce909bc36",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libavtp/libavtp0_0.2.0-2_amd64.deb"
+    },
+    {
+      "name": "libbs2b0",
+      "version": "3.1.0+dfsg-8",
+      "architecture": "amd64",
+      "filename": "libbs2b0_3.1.0+dfsg-8_amd64.deb",
+      "sha256": "7d03829734d659b1167c92e8c00e415e113cb29cdc884576a9ccca611ef4e2b9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libb/libbs2b/libbs2b0_3.1.0%2bdfsg-8_amd64.deb"
+    },
+    {
+      "name": "libchromaprint1",
+      "version": "1.5.1-7",
+      "architecture": "amd64",
+      "filename": "libchromaprint1_1.5.1-7_amd64.deb",
+      "sha256": "a108a4a6e4b49c981975076aa2d1d15d73ed6c0b98122e7b5ceb7703f7851666",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/chromaprint/libchromaprint1_1.5.1-7_amd64.deb"
+    },
+    {
+      "name": "libcpuinfo0",
+      "version": "0.0~git20250203.aaac07e-1",
+      "architecture": "amd64",
+      "filename": "libcpuinfo0_0.0~git20250203.aaac07e-1_amd64.deb",
+      "sha256": "13af6ecf274a2629121a38b06a815cd945c99a586f3a8848bb386c49961b31b7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/cpuinfo/libcpuinfo0_0.0%7egit20250203.aaac07e-1_amd64.deb"
+    },
+    {
+      "name": "libdc1394-25",
+      "version": "2.2.6-4build1",
+      "architecture": "amd64",
+      "filename": "libdc1394-25_2.2.6-4build1_amd64.deb",
+      "sha256": "0f4a0768152636f2f941d3a29d24925be77f869b3d90a13f1694fef792a89810",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdc1394/libdc1394-25_2.2.6-4build1_amd64.deb"
+    },
+    {
+      "name": "libdca0",
+      "version": "0.0.7-2build1",
+      "architecture": "amd64",
+      "filename": "libdca0_0.0.7-2build1_amd64.deb",
+      "sha256": "018867fee029b072ecb3365f5f92c0cb0530d4ab37aa13be127116b6e5c3c06d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdca/libdca0_0.0.7-2build1_amd64.deb"
+    },
+    {
+      "name": "libde265-0",
+      "version": "1.0.15-1build5",
+      "architecture": "amd64",
+      "filename": "libde265-0_1.0.15-1build5_amd64.deb",
+      "sha256": "1a3d3faab069f9bb4051c0d4e5d2ee18c3c41f440ad1569838c338fc12d47e0b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libde265/libde265-0_1.0.15-1build5_amd64.deb"
+    },
+    {
+      "name": "libdnnl3.6",
+      "version": "3.7.1+ds-1",
+      "architecture": "amd64",
+      "filename": "libdnnl3.6_3.7.1+ds-1_amd64.deb",
+      "sha256": "88fd977d7076586d2a2bb89659d24e8875f188f79a15649ce1832764b3232d67",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onednn/libdnnl3.6_3.7.1%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libdvdnav4",
+      "version": "6.1.1-3build1",
+      "architecture": "amd64",
+      "filename": "libdvdnav4_6.1.1-3build1_amd64.deb",
+      "sha256": "09fd1de2985ade2592d4f068774b2249211880aa6d4a71a89e0b4764afe47404",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdnav/libdvdnav4_6.1.1-3build1_amd64.deb"
+    },
+    {
+      "name": "libdvdread8t64",
+      "version": "6.1.3-2",
+      "architecture": "amd64",
+      "filename": "libdvdread8t64_6.1.3-2_amd64.deb",
+      "sha256": "269fe55b0eb5a47b7112c46a5ed3a21bdbd0378224970d733225ecfd3cb5f20e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdread/libdvdread8t64_6.1.3-2_amd64.deb"
+    },
+    {
+      "name": "libfaad2",
+      "version": "2.11.2-1",
+      "architecture": "amd64",
+      "filename": "libfaad2_2.11.2-1_amd64.deb",
+      "sha256": "cdf00ddc8c0f4f6e3dbc46c1d0efba537632609432734deb01113cac3ac1531d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/faad2/libfaad2_2.11.2-1_amd64.deb"
+    },
+    {
+      "name": "libflite1",
+      "version": "2.2-7",
+      "architecture": "amd64",
+      "filename": "libflite1_2.2-7_amd64.deb",
+      "sha256": "3afe2b4ab82dff2330b53fcee83b4b21aa580f6d91a1ce850e917cf8cffc004a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/flite/libflite1_2.2-7_amd64.deb"
+    },
+    {
+      "name": "libfluidsynth3",
+      "version": "2.4.4+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libfluidsynth3_2.4.4+dfsg-1_amd64.deb",
+      "sha256": "2a7177d672b1f717c2b064181cac9e1772aeaf93e0a00db8327954eeeaff9189",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/fluidsynth/libfluidsynth3_2.4.4%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libfreeaptx0",
+      "version": "0.1.1-2build1",
+      "architecture": "amd64",
+      "filename": "libfreeaptx0_0.1.1-2build1_amd64.deb",
+      "sha256": "2280d6fdd41c841701a9da6b5076b77e8a0849e5c10c9c2945f817f753575a42",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libf/libfreeaptx/libfreeaptx0_0.1.1-2build1_amd64.deb"
+    },
+    {
+      "name": "libgme0",
+      "version": "0.6.3-7build1",
+      "architecture": "amd64",
+      "filename": "libgme0_0.6.3-7build1_amd64.deb",
+      "sha256": "a54fa608501f87f9e5064b60c75fc1bb62735c9f9ba9f7680cb804bb5eae2027",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/game-music-emu/libgme0_0.6.3-7build1_amd64.deb"
+    },
+    {
+      "name": "libgssdp-1.6-0",
+      "version": "1.6.3-2",
+      "architecture": "amd64",
+      "filename": "libgssdp-1.6-0_1.6.3-2_amd64.deb",
+      "sha256": "7897db47adc4114a17c44f390d2816c7e58ac8bdd722fa58fa21c659368aece7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gssdp/libgssdp-1.6-0_1.6.3-2_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-bad1.0-0",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "36c0de48cf25ca31dc21363dabd3fb32e9d4c539467b6b76b4770c5e82822099",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "libgupnp-1.6-0",
+      "version": "1.6.8-2",
+      "architecture": "amd64",
+      "filename": "libgupnp-1.6-0_1.6.8-2_amd64.deb",
+      "sha256": "9346722ae71cc4bce037ef49bf38c609392eb1cfb6eba19fce575673577896c5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gupnp/libgupnp-1.6-0_1.6.8-2_amd64.deb"
+    },
+    {
+      "name": "libgupnp-igd-1.6-0",
+      "version": "1.6.0-4",
+      "architecture": "amd64",
+      "filename": "libgupnp-igd-1.6-0_1.6.0-4_amd64.deb",
+      "sha256": "bf96c3dc6cf586400754dcf51b1e8033399171d5c5a55191ba13cf8c6d8c426e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gupnp-igd/libgupnp-igd-1.6-0_1.6.0-4_amd64.deb"
+    },
+    {
+      "name": "libicu76",
+      "version": "76.1-1ubuntu2",
+      "architecture": "amd64",
+      "filename": "libicu76_76.1-1ubuntu2_amd64.deb",
+      "sha256": "c289a52f92c9ab2a1783b6b5757c928bff228671f20473275a426798446a4ce1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/i/icu/libicu76_76.1-1ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libimath-3-1-29t64",
+      "version": "3.1.12-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb",
+      "sha256": "5b35e6bdfc8f567c3c33b4c5b519ceab2acd1c5c05534f360c33cedcf14c4cf3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/i/imath/libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libinstpatch-1.0-2",
+      "version": "1.1.6-1build2",
+      "architecture": "amd64",
+      "filename": "libinstpatch-1.0-2_1.1.6-1build2_amd64.deb",
+      "sha256": "d48c40a9c428e40d5bbe8762802390322b06a062c735292767e73d1c6ea9007e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libi/libinstpatch/libinstpatch-1.0-2_1.1.6-1build2_amd64.deb"
+    },
+    {
+      "name": "liblc3-1",
+      "version": "1.1.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "liblc3-1_1.1.3+dfsg-1_amd64.deb",
+      "sha256": "0a88ca35cd79b18e42bbb22800e2ea49f2e0123cc709696dd1954486d7694e4d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/liblc3/liblc3-1_1.1.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libldacbt-enc2",
+      "version": "2.0.2.3+git20200429+ed310a0-5",
+      "architecture": "amd64",
+      "filename": "libldacbt-enc2_2.0.2.3+git20200429+ed310a0-5_amd64.deb",
+      "sha256": "7212ed25d4be1782cfc71ef1758a587fa3a3cfb7ba939c7233161cb491946a34",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/libldac/libldacbt-enc2_2.0.2.3%2bgit20200429%2bed310a0-5_amd64.deb"
+    },
+    {
+      "name": "liblilv-0-0",
+      "version": "0.24.26-1",
+      "architecture": "amd64",
+      "filename": "liblilv-0-0_0.24.26-1_amd64.deb",
+      "sha256": "3076146b3bae4bce370c6618ef8ed788383d3d35184dae0bbb9877dcdbb127c2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/lilv/liblilv-0-0_0.24.26-1_amd64.deb"
+    },
+    {
+      "name": "liblrdf0",
+      "version": "0.6.1-4build1",
+      "architecture": "amd64",
+      "filename": "liblrdf0_0.6.1-4build1_amd64.deb",
+      "sha256": "470a5e0e88fd2e7dcfc024c789cd029578b110c65558ae423fd79d7bb4ef01ca",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/liblrdf/liblrdf0_0.6.1-4build1_amd64.deb"
+    },
+    {
+      "name": "libltc11",
+      "version": "1.3.2-1build1",
+      "architecture": "amd64",
+      "filename": "libltc11_1.3.2-1build1_amd64.deb",
+      "sha256": "92f23451cefe159faef9f255f0d24987eff50e52647dc1aa9843ad4c733ca039",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/libltc/libltc11_1.3.2-1build1_amd64.deb"
+    },
+    {
+      "name": "libmjpegutils-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmjpegutils-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "3422b9e3f7aa721a18f1738b33815a7f681fbe1ec0bafb1faf733e625dcbce85",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmjpegutils-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmodplug1",
+      "version": "1:0.8.9.0-3build1",
+      "architecture": "amd64",
+      "filename": "libmodplug1_1%3a0.8.9.0-3build1_amd64.deb",
+      "sha256": "34b383f35def5405069ae1eb6b4e6a7f73c9adafd0d049add82285b0e1a2e1ad",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmodplug/libmodplug1_0.8.9.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libmpcdec6",
+      "version": "2:0.1~r495-3",
+      "architecture": "amd64",
+      "filename": "libmpcdec6_2%3a0.1~r495-3_amd64.deb",
+      "sha256": "35e003823ddf242d8799057d420fc15ed644bb836d63ae18af57bd514699a216",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmpc/libmpcdec6_0.1%7er495-3_amd64.deb"
+    },
+    {
+      "name": "libmpeg2encpp-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmpeg2encpp-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "ec077a7c7fc7abd77d460813f56a9bef1dd68e53148840ef242b1795043d318e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmpeg2encpp-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmplex2-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmplex2-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "8c4324fb9ac9b667559aeaa92e399beeb4396d0cd33627be1b1306b85a31e5e2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmplex2-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libneon27t64",
+      "version": "0.34.0-1",
+      "architecture": "amd64",
+      "filename": "libneon27t64_0.34.0-1_amd64.deb",
+      "sha256": "1710578bc51522b9ee8ccd70624b9e2e266f50e5ac39711d1096757bd23d381f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/neon27/libneon27t64_0.34.0-1_amd64.deb"
+    },
+    {
+      "name": "libnice10",
+      "version": "0.1.22-1",
+      "architecture": "amd64",
+      "filename": "libnice10_0.1.22-1_amd64.deb",
+      "sha256": "3e227906bae81259542732d0af1623a05910855d86e548e5b704e17ea8cb2a17",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libn/libnice/libnice10_0.1.22-1_amd64.deb"
+    },
+    {
+      "name": "libonnx1t64",
+      "version": "1.17.0-3build1",
+      "architecture": "amd64",
+      "filename": "libonnx1t64_1.17.0-3build1_amd64.deb",
+      "sha256": "c4fcb75e98e7a28dd741d002c640bb3a9891dee2d9ec39ee570f2824d77318ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnx/libonnx1t64_1.17.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libonnxruntime1.21",
+      "version": "1.21.0+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libonnxruntime1.21_1.21.0+dfsg-1_amd64.deb",
+      "sha256": "17e9bfec1e4e86a7456720843ed5443c2eb3bda62b45f0e075ab0c8d89e4ae7b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnxruntime/libonnxruntime1.21_1.21.0%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libopenal-data",
+      "version": "1:1.24.2-1",
+      "architecture": "all",
+      "filename": "libopenal-data_1%3a1.24.2-1_all.deb",
+      "sha256": "2bce384fa3c8fb1193e9ec8c948787263e5a2fc53a4a4715c4aeeab75b98b420",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal-data_1.24.2-1_all.deb"
+    },
+    {
+      "name": "libopenal1",
+      "version": "1:1.24.2-1",
+      "architecture": "amd64",
+      "filename": "libopenal1_1%3a1.24.2-1_amd64.deb",
+      "sha256": "461b8d108f70efa65eefbb3af5c697ac95f831f1959de3b625345b389628bbbb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal1_1.24.2-1_amd64.deb"
+    },
+    {
+      "name": "libopenexr-3-1-30",
+      "version": "3.1.13-2",
+      "architecture": "amd64",
+      "filename": "libopenexr-3-1-30_3.1.13-2_amd64.deb",
+      "sha256": "cae37d566e8d08fdeabdbcac7e9c9a5c68b9541a83974adbd3f50cb654e83390",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openexr/libopenexr-3-1-30_3.1.13-2_amd64.deb"
+    },
+    {
+      "name": "libopenh264-8",
+      "version": "2.6.0+dfsg-2",
+      "architecture": "amd64",
+      "filename": "libopenh264-8_2.6.0+dfsg-2_amd64.deb",
+      "sha256": "bbff1a10312e60e4566c0e34c2d2f98deda75763ea639650518d00e1e028f67e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openh264/libopenh264-8_2.6.0%2bdfsg-2_amd64.deb"
+    },
+    {
+      "name": "libopenmpt0t64",
+      "version": "0.7.13-1build1",
+      "architecture": "amd64",
+      "filename": "libopenmpt0t64_0.7.13-1build1_amd64.deb",
+      "sha256": "0a3f0e7060f1777d9865ff1ba23d7ad692f395594388442bde670e4bf435a975",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libo/libopenmpt/libopenmpt0t64_0.7.13-1build1_amd64.deb"
+    },
+    {
+      "name": "libopenni2-0",
+      "version": "2.2.0.33+dfsg-18",
+      "architecture": "amd64",
+      "filename": "libopenni2-0_2.2.0.33+dfsg-18_amd64.deb",
+      "sha256": "bba943fe73b2b0271ebbd6a28d0afb9e7084df75a64748fc06e3f72151ab1b76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openni2/libopenni2-0_2.2.0.33%2bdfsg-18_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-modules",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "f23e9a3ebedfbb846efe210bcc55150668394ac807e6c71f1f2c1d5f728c2f8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libprotobuf32t64",
+      "version": "3.21.12-10ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb",
+      "sha256": "19a6eac6e4d794318608c7e6862c4414119e1be7d3e66b0f8e698c62c78411ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/protobuf/libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpthreadpool0",
+      "version": "0.0~git20240616.560c60d-1",
+      "architecture": "amd64",
+      "filename": "libpthreadpool0_0.0~git20240616.560c60d-1_amd64.deb",
+      "sha256": "a09c04886537cf3db25ae1c0644a0b4cc070d520914521a00f81b86b1254f23f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/p/pthreadpool/libpthreadpool0_0.0%7egit20240616.560c60d-1_amd64.deb"
+    },
+    {
+      "name": "libqrencode4",
+      "version": "4.1.1-2",
+      "architecture": "amd64",
+      "filename": "libqrencode4_4.1.1-2_amd64.deb",
+      "sha256": "d9eed9dc0a75994c2fe4d95f9dae8d700b4a363383f6966a82d6d0225e275280",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/q/qrencode/libqrencode4_4.1.1-2_amd64.deb"
+    },
+    {
+      "name": "libraptor2-0",
+      "version": "2.0.16-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libraptor2-0_2.0.16-4ubuntu1_amd64.deb",
+      "sha256": "ecae495617134e13c098780576db94c89e9475d2ccec3d2bb732799ce958bd87",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/raptor2/libraptor2-0_2.0.16-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libre2-11",
+      "version": "20240501-3build1",
+      "architecture": "amd64",
+      "filename": "libre2-11_20240501-3build1_amd64.deb",
+      "sha256": "b7a4b55a5f2e4ca12d1020b2cd5a0a0540bb1a9b4706eaa8e1294fe52a4112a5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/re2/libre2-11_20240501-3build1_amd64.deb"
+    },
+    {
+      "name": "libroc0.4",
+      "version": "0.4.0+dfsg-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libroc0.4_0.4.0+dfsg-4ubuntu1_amd64.deb",
+      "sha256": "8bec93425075527aa82683dbcf2d1784c39361da46a10c299f0c60afb8625b71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/roc-toolkit/libroc0.4_0.4.0%2bdfsg-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsbc1",
+      "version": "2.0-1build1",
+      "architecture": "amd64",
+      "filename": "libsbc1_2.0-1build1_amd64.deb",
+      "sha256": "d4d453e7673218fc2f917dbabb2492a5a81155c2305f6fe63a37cadcaa806128",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/sbc/libsbc1_2.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libserd-0-0",
+      "version": "0.32.4-1",
+      "architecture": "amd64",
+      "filename": "libserd-0-0_0.32.4-1_amd64.deb",
+      "sha256": "3d1c23e9effbe22d3edab8c0c2fdc8297d966c134f4d8095ccf0c9da52cc5f33",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/serd/libserd-0-0_0.32.4-1_amd64.deb"
+    },
+    {
+      "name": "libsnapd-glib-2-1",
+      "version": "1.66-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb",
+      "sha256": "b7bd77be1d59bf3a19bbe91b9ab6225ad05736ed72bd9f3b3f56bcd83822e398",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/snapd-glib/libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsord-0-0",
+      "version": "0.16.18-1",
+      "architecture": "amd64",
+      "filename": "libsord-0-0_0.16.18-1_amd64.deb",
+      "sha256": "bfd5ef5bbab2eed986b6f2856c2904db70c3d9e7a34b9f9caffcc1ea36a47a9b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sord/libsord-0-0_0.16.18-1_amd64.deb"
+    },
+    {
+      "name": "libsoundtouch1",
+      "version": "2.3.3+ds-1",
+      "architecture": "amd64",
+      "filename": "libsoundtouch1_2.3.3+ds-1_amd64.deb",
+      "sha256": "cadad56c5398a93f2f8c7080ca1a93725c15242beff0891cfdb029c5e4f305f3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/soundtouch/libsoundtouch1_2.3.3%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libspandsp2t64",
+      "version": "0.0.6+dfsg-2.2",
+      "architecture": "amd64",
+      "filename": "libspandsp2t64_0.0.6+dfsg-2.2_amd64.deb",
+      "sha256": "63a125139f3507ae94faa7cdd10ee6d6c551961937b1ec7fafa4d320e34b71bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spandsp/libspandsp2t64_0.0.6%2bdfsg-2.2_amd64.deb"
+    },
+    {
+      "name": "libsratom-0-0",
+      "version": "0.6.18-1",
+      "architecture": "amd64",
+      "filename": "libsratom-0-0_0.6.18-1_amd64.deb",
+      "sha256": "848fcfa874c1acb8c2331747a841467f8921334d5b5cbb66f8306d933203f344",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sratom/libsratom-0-0_0.6.18-1_amd64.deb"
+    },
+    {
+      "name": "libsrt1.5-gnutls",
+      "version": "1.5.4-1",
+      "architecture": "amd64",
+      "filename": "libsrt1.5-gnutls_1.5.4-1_amd64.deb",
+      "sha256": "88e58de644fbf38c194494789c4f1e047dae6c43bd71ca245530d721a4a0b5e0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/srt/libsrt1.5-gnutls_1.5.4-1_amd64.deb"
+    },
+    {
+      "name": "libsrtp2-1",
+      "version": "2.5.0-3build1",
+      "architecture": "amd64",
+      "filename": "libsrtp2-1_2.5.0-3build1_amd64.deb",
+      "sha256": "c2e7ee0ae64597f046fbfb197b8f36dfc9a5159b02d27e850f3a4d14a4603d77",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libs/libsrtp2/libsrtp2-1_2.5.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libunibreak6",
+      "version": "6.1-2",
+      "architecture": "amd64",
+      "filename": "libunibreak6_6.1-2_amd64.deb",
+      "sha256": "c904cf437fcad74dac8c9e7fd1a4a9657b0c5d44441848e321e225375b69c4fc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libu/libunibreak/libunibreak6_6.1-2_amd64.deb"
+    },
+    {
+      "name": "libunwind8",
+      "version": "1.6.2-3.1",
+      "architecture": "amd64",
+      "filename": "libunwind8_1.6.2-3.1_amd64.deb",
+      "sha256": "9d48508139a791778c86f341e725f06dd5304dc24e80501080271a734bf970da",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libunwind/libunwind8_1.6.2-3.1_amd64.deb"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2ubuntu1",
+      "architecture": "amd64",
+      "filename": "libuv1t64_1.50.0-2ubuntu1_amd64.deb",
+      "sha256": "6af9634d05965f60ed7c124d43cef678ef288824b6f36a7b02559dd4097e7c90",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libuv1/libuv1t64_1.50.0-2ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libvo-aacenc0",
+      "version": "0.1.3-3",
+      "architecture": "amd64",
+      "filename": "libvo-aacenc0_0.1.3-3_amd64.deb",
+      "sha256": "ea759b3a02552c379424775d5fc5d37d8dff59eb70ceab35118146ef04e857a3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-aacenc/libvo-aacenc0_0.1.3-3_amd64.deb"
+    },
+    {
+      "name": "libvo-amrwbenc0",
+      "version": "0.1.3-2build1",
+      "architecture": "amd64",
+      "filename": "libvo-amrwbenc0_0.1.3-2build1_amd64.deb",
+      "sha256": "30d260bbb56b9340319216529e72ed02a68752de62d5926ad07132ed2459af05",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-amrwbenc/libvo-amrwbenc0_0.1.3-2build1_amd64.deb"
+    },
+    {
+      "name": "libvorbisfile3",
+      "version": "1.3.7-2",
+      "architecture": "amd64",
+      "filename": "libvorbisfile3_1.3.7-2_amd64.deb",
+      "sha256": "6dfc7f0bd9f0c745c2e099aca9121843650ec7c7193801057bc3927c43820e70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-2_amd64.deb"
+    },
+    {
+      "name": "libwildmidi2",
+      "version": "0.4.3-1build3",
+      "architecture": "amd64",
+      "filename": "libwildmidi2_0.4.3-1build3_amd64.deb",
+      "sha256": "f44a3f24eb567cf104aefe6cabe2a3385185dc59dd83d64a37c1a04f0e12c771",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/w/wildmidi/libwildmidi2_0.4.3-1build3_amd64.deb"
+    },
+    {
+      "name": "libxnnpack0.20241108",
+      "version": "0.0~git20241108.4ea82e5-1",
+      "architecture": "amd64",
+      "filename": "libxnnpack0.20241108_0.0~git20241108.4ea82e5-1_amd64.deb",
+      "sha256": "0a3eedc79943aadbc036d199230c573e1a0b80f947e07076dbf1db1d4a201297",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/xnnpack/libxnnpack0.20241108_0.0%7egit20241108.4ea82e5-1_amd64.deb"
+    },
+    {
+      "name": "libxslt1.1",
+      "version": "1.1.39-0exp1ubuntu4.1",
+      "architecture": "amd64",
+      "filename": "libxslt1.1_1.1.39-0exp1ubuntu4.1_amd64.deb",
+      "sha256": "7072c3b5e8e36fe949edf29d89cfc1cc4a4a65c6a1fb9e9ddd4abbba0c9c5872",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxslt/libxslt1.1_1.1.39-0exp1ubuntu4.1_amd64.deb"
+    },
+    {
+      "name": "libyajl2",
+      "version": "2.1.0-5build1",
+      "architecture": "amd64",
+      "filename": "libyajl2_2.1.0-5build1_amd64.deb",
+      "sha256": "faa268c632f7d2931509cf7b8b7ddd810aa775adc26ead88ea158e2ede5208f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/y/yajl/libyajl2_2.1.0-5build1_amd64.deb"
+    },
+    {
+      "name": "libzbar0t64",
+      "version": "0.23.93-7",
+      "architecture": "amd64",
+      "filename": "libzbar0t64_0.23.93-7_amd64.deb",
+      "sha256": "9954e12b0e2f1f5a294465c6e5c1eaa46407024f0416b4b90513e554ecd31776",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zbar/libzbar0t64_0.23.93-7_amd64.deb"
+    },
+    {
+      "name": "libzix-0-0",
+      "version": "0.6.2-1",
+      "architecture": "amd64",
+      "filename": "libzix-0-0_0.6.2-1_amd64.deb",
+      "sha256": "54d72b63ae0243dedd47e1946765890deb7764f5cfa2c9332228742b6b406ba9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zix/libzix-0-0_0.6.2-1_amd64.deb"
+    },
+    {
+      "name": "libzxing3",
+      "version": "2.3.0-3",
+      "architecture": "amd64",
+      "filename": "libzxing3_2.3.0-3_amd64.deb",
+      "sha256": "66937bdde76f3edf56568d461692c7f6668f057a8ce0ba687570acb32bfd750b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zxing-cpp/libzxing3_2.3.0-3_amd64.deb"
+    },
+    {
+      "name": "pipewire",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "b77fae0221ecdebcc9839cfd08aa5da95359c741a4d2922bfcaf55474b93f0a7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-bin",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "0d16cd14743a2c8fc4c726057ec910ba7eac48e5de65698acc01aeb336d45078",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-pulse",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "611be8d6b8620f5d266e7a8a232bb7cb96f558fc8a73205af7aaec084c3ab8eb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "timgm6mb-soundfont",
+      "version": "1.3-5",
+      "architecture": "all",
+      "filename": "timgm6mb-soundfont_1.3-5_all.deb",
+      "sha256": "b70bc29b8f27adef8f92a2d9c1e26cee977b84c68110f0dd4326d97730a7c3ed",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/t/timgm6mb-soundfont/timgm6mb-soundfont_1.3-5_all.deb"
+    }
+  ],
+  "build": [
+    {
+      "name": "binutils",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "binutils_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "744a214541a5b5063d07914a385abdd2ee09d81a35042f97df44aa4774f050db",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/binutils_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "binutils-common",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "binutils-common_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "4c88f15afb2d59ceda47a9a9cd026d1020bebaae129bca9567e8fe0ea692d98f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/binutils-common_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "binutils-gold",
+      "version": "2.44-2",
+      "architecture": "amd64",
+      "filename": "binutils-gold_2.44-2_amd64.deb",
+      "sha256": "832317652330363576d427f3038663fe3aaa778ac1e5749888aad6b59ec17fd4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils-gold/binutils-gold_2.44-2_amd64.deb"
+    },
+    {
+      "name": "binutils-gold-x86-64-linux-gnu",
+      "version": "2.44-2",
+      "architecture": "amd64",
+      "filename": "binutils-gold-x86-64-linux-gnu_2.44-2_amd64.deb",
+      "sha256": "149f39909d2454e78f5fc6c8e829a756ab4bd6b65e7202e3fecf37bd07309608",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils-gold/binutils-gold-x86-64-linux-gnu_2.44-2_amd64.deb"
+    },
+    {
+      "name": "binutils-x86-64-linux-gnu",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "binutils-x86-64-linux-gnu_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "bab4b7f76496ff8a83ed2552a97aa996b77f38f5f2cc8e802d7b32fbf0c484ad",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "build-essential",
+      "version": "12.12ubuntu1",
+      "architecture": "amd64",
+      "filename": "build-essential_12.12ubuntu1_amd64.deb",
+      "sha256": "6690743c7c255ec97f2ce7373648cebe24e9b83da2b134ce8c53326840757016",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/build-essential/build-essential_12.12ubuntu1_amd64.deb"
+    },
+    {
+      "name": "bzip2",
+      "version": "1.0.8-6",
+      "architecture": "amd64",
+      "filename": "bzip2_1.0.8-6_amd64.deb",
+      "sha256": "b90c1467738ebb2941ab0129ee142de7803e3564196e89485e8c91d11cffd5a4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/bzip2/bzip2_1.0.8-6_amd64.deb"
+    },
+    {
+      "name": "clang",
+      "version": "1:20.0-63ubuntu1",
+      "architecture": "amd64",
+      "filename": "clang_1%3a20.0-63ubuntu1_amd64.deb",
+      "sha256": "63385ed7288cb5148c62000b328c38b6877a0df265e7bad4a32b208afdd89a96",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-defaults/clang_20.0-63ubuntu1_amd64.deb"
+    },
+    {
+      "name": "clang-20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "clang-20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "25100f57ca694598e4eb9fb605b504f1ebf4480bed15a0c79f3944a1deba2c13",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/clang-20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cmake",
+      "version": "3.31.6-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "cmake_3.31.6-1ubuntu1_amd64.deb",
+      "sha256": "eb9a56e821b957179d2d801878668fb56d64dde8ccb3d46e9bd591bddb1d75ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/c/cmake/cmake_3.31.6-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "cmake-data",
+      "version": "3.31.6-1ubuntu1",
+      "architecture": "all",
+      "filename": "cmake-data_3.31.6-1ubuntu1_all.deb",
+      "sha256": "52c6d1634243c6648028b04b7f7f241993cdaab48becde16b540b90c80ba31ec",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/c/cmake/cmake-data_3.31.6-1ubuntu1_all.deb"
+    },
+    {
+      "name": "dpkg-dev",
+      "version": "1.22.18ubuntu2.2",
+      "architecture": "all",
+      "filename": "dpkg-dev_1.22.18ubuntu2.2_all.deb",
+      "sha256": "f17198b313ade86099ad7b35c152875d84ef2de9bda3a5c430a6c17b351991df",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/d/dpkg/dpkg-dev_1.22.18ubuntu2.2_all.deb"
+    },
+    {
+      "name": "g++",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "g++_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "c286c49484a551dfb9514898244e3d7089fd543c11a3f7e1a3227f96f07df14a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/g%2b%2b_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "g++-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "g++-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "b0848a8a8e00fd453c00d6f52b73e1fb9b5f887a71cfa160487a6b252dda1b4e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/g%2b%2b-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "g++-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "g++-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "b9f5de224295cb5ef5b7f641baddb4da943d43192157c831ab9b6f652894438e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/g%2b%2b-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "g++-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "g++-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "7a3aad61f52c6a1c2fab94d7ac313673272c4617c0b8c6edad48188ec06ddf7e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/g%2b%2b-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gcc",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "gcc_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "82abbe21f53a70db6abe947998f07d2e91c36cce62972540dc782c29c86d0702",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/gcc_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gcc-14",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "gcc-14_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "209a445434926b1f25221e464108c141950ee2316a8ddf535ec518cb57926f76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/gcc-14_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "gcc-14-x86-64-linux-gnu",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "gcc-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "ab71e82506bee4747468cd701940fc4f5dd498605d76e257b89d009c2e4c4413",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/gcc-14-x86-64-linux-gnu_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "gcc-x86-64-linux-gnu",
+      "version": "4:14.2.0-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "gcc-x86-64-linux-gnu_4%3a14.2.0-1ubuntu1_amd64.deb",
+      "sha256": "eb69145199e998fae2e6fab23a0759f768f33e7b7b2d21fb28dc0c91bbe3ab2d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-defaults/gcc-x86-64-linux-gnu_14.2.0-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "gir1.2-glib-2.0-dev",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "gir1.2-glib-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "90e423a6b84c2814102ef749710f1230e76730939ec334ab681559d6a0f69a3b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/gir1.2-glib-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gst-plugins-base-1.0",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "gir1.2-gst-plugins-base-1.0_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "0d52d57f01acbdde1ff600129dcafca59008e500cbc7df3f27f721b318f1b4e4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/gir1.2-gst-plugins-base-1.0_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gstreamer-1.0",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gir1.2-gstreamer-1.0_1.26.0-3_amd64.deb",
+      "sha256": "8078e3a2a9bd916f9448d3333a12f1b5a4788c696248b91bdf1322c579ddea1c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gir1.2-gstreamer-1.0_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "gir1.2-gudev-1.0",
+      "version": "1:238-6",
+      "architecture": "amd64",
+      "filename": "gir1.2-gudev-1.0_1%3a238-6_amd64.deb",
+      "sha256": "5759e4ab498311b1ee83a0f38e6aeda415590de45a404c7ba7f5c9d9f8a31d61",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-6_amd64.deb"
+    },
+    {
+      "name": "girepository-tools",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "girepository-tools_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "002ca31c5e75d96c7c455ad00ac185044f113f32a7037d69a074b5d73425f5e7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/girepository-tools_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "git",
+      "version": "1:2.48.1-0ubuntu1.1",
+      "architecture": "amd64",
+      "filename": "git_1%3a2.48.1-0ubuntu1.1_amd64.deb",
+      "sha256": "f85b919ba73b802a5934719678d3f83f75b06c67187cf0facb262c3b1bdd4721",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/git/git_2.48.1-0ubuntu1.1_amd64.deb"
+    },
+    {
+      "name": "git-man",
+      "version": "1:2.48.1-0ubuntu1.1",
+      "architecture": "all",
+      "filename": "git-man_1%3a2.48.1-0ubuntu1.1_all.deb",
+      "sha256": "3292fe6f57a9620ba7653dfc492f40951ba6824bc1ac4dfc7c96f3f59731fd18",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/git/git-man_2.48.1-0ubuntu1.1_all.deb"
+    },
+    {
+      "name": "glslang-tools",
+      "version": "15.1.0-2",
+      "architecture": "amd64",
+      "filename": "glslang-tools_15.1.0-2_amd64.deb",
+      "sha256": "98d8b12ebaa3a9bcf7e68087d08a43a997356a52c130f01a5624a208fa8ab9d7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/glslang/glslang-tools_15.1.0-2_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-plugins-bad",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "800b2b0a8f994098e854413821a4908f301425e165b112994d4ad891e38c828a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/gstreamer1.0-plugins-bad_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "gstreamer1.0-tools",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "gstreamer1.0-tools_1.26.0-3_amd64.deb",
+      "sha256": "ac24b15d6a48bb99097419f4d8d5928430d010af301b0df0b32570e59879f8f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/gstreamer1.0-tools_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "hwdata",
+      "version": "0.393-3",
+      "architecture": "all",
+      "filename": "hwdata_0.393-3_all.deb",
+      "sha256": "ad5beb26ff8b18ff48467b3f09b6e687451911e40430ae89eaef8ace2bfdcf61",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/h/hwdata/hwdata_0.393-3_all.deb"
+    },
+    {
+      "name": "libarchive13t64",
+      "version": "3.7.7-0ubuntu2.3",
+      "architecture": "amd64",
+      "filename": "libarchive13t64_3.7.7-0ubuntu2.3_amd64.deb",
+      "sha256": "a31d7532b90f89c342b3e8d23a922a17aaf9cb6d736c4a8e4773f0be97a7ba5f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/liba/libarchive/libarchive13t64_3.7.7-0ubuntu2.3_amd64.deb"
+    },
+    {
+      "name": "libasan8",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libasan8_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "f13c558b07c3a23d58948e7dee0c49bd8a1ab63147a701104c8e6049e71f5a73",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libasan8_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libass9",
+      "version": "1:0.17.3-1",
+      "architecture": "amd64",
+      "filename": "libass9_1%3a0.17.3-1_amd64.deb",
+      "sha256": "20fd3f8a675804455ccfffbcc4e488818e016dea8d535ade12031969cd97a62d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libass/libass9_0.17.3-1_amd64.deb"
+    },
+    {
+      "name": "libavtp0",
+      "version": "0.2.0-2",
+      "architecture": "amd64",
+      "filename": "libavtp0_0.2.0-2_amd64.deb",
+      "sha256": "32d5bb7433365eb43c9d3bd49aff8c62295abcd4a3eb45ddbdb8351ce909bc36",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/liba/libavtp/libavtp0_0.2.0-2_amd64.deb"
+    },
+    {
+      "name": "libbinutils",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libbinutils_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "20c0f5fc6696ae015897a58d6fcc587857892a1470af5f9a8145a25279119062",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libbinutils_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libblkid-dev",
+      "version": "2.40.2-14ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libblkid-dev_2.40.2-14ubuntu1.2_amd64.deb",
+      "sha256": "1f9e20bb7c25eacdbdb6aa057964628c9fa8420ea4faaee9fff476ab8b4e551a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/util-linux/libblkid-dev_2.40.2-14ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libbs2b0",
+      "version": "3.1.0+dfsg-8",
+      "architecture": "amd64",
+      "filename": "libbs2b0_3.1.0+dfsg-8_amd64.deb",
+      "sha256": "7d03829734d659b1167c92e8c00e415e113cb29cdc884576a9ccca611ef4e2b9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libb/libbs2b/libbs2b0_3.1.0%2bdfsg-8_amd64.deb"
+    },
+    {
+      "name": "libc-dev-bin",
+      "version": "2.41-6ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libc-dev-bin_2.41-6ubuntu1.2_amd64.deb",
+      "sha256": "6c5f01366826032936aa16297242046d4d89ef4221ce13c6d921fb973419b8a3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glibc/libc-dev-bin_2.41-6ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libc6-dev",
+      "version": "2.41-6ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libc6-dev_2.41-6ubuntu1.2_amd64.deb",
+      "sha256": "392a66c966e0bd272fe8acd4270e726d835e6fffd85ec322759638c0245743c4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glibc/libc6-dev_2.41-6ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libcap-dev",
+      "version": "1:2.73-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libcap-dev_1%3a2.73-4ubuntu1_amd64.deb",
+      "sha256": "ab6d5ef8d377dc23f2cb49dc66dbde2ee25bc0f00da54a84e3aeb783526e2b4c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libc/libcap2/libcap-dev_2.73-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libcc1-0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libcc1-0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "f84dd605099c5297ed5404553b03f39e4afb443333f27e7c9cdf25628cfa2717",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libcc1-0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libchromaprint1",
+      "version": "1.5.1-7",
+      "architecture": "amd64",
+      "filename": "libchromaprint1_1.5.1-7_amd64.deb",
+      "sha256": "a108a4a6e4b49c981975076aa2d1d15d73ed6c0b98122e7b5ceb7703f7851666",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/chromaprint/libchromaprint1_1.5.1-7_amd64.deb"
+    },
+    {
+      "name": "libclang-20-dev",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-20-dev_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "e0b1c9024a083ae276c23fdb547e057cdec9c76b6de1ff0a9065a4499a4076dc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-20-dev_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-common-20-dev",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-common-20-dev_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "05a6125fdcfc18a9b1f30ecc12378a46f9fa7f25ea782d9006bb23eb79f65e73",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-common-20-dev_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-cpp20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-cpp20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "f19464e350b2a3913c14882408e3495b2ccef81281b7a8abf0b53234d254b739",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang-cpp20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang-dev",
+      "version": "1:20.0-63ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang-dev_1%3a20.0-63ubuntu1_amd64.deb",
+      "sha256": "4699c12ff94eda3fd18b49270edc6a6d7e2a390d5dc0efa32d2bc1119bdcdfc0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-defaults/libclang-dev_20.0-63ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libclang1-20",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libclang1-20_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "ed4bf6b86e21e735d4a2f5564c5dc202a818460be1e1c5b2794790678b7736aa",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/libclang1-20_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libcpuinfo0",
+      "version": "0.0~git20250203.aaac07e-1",
+      "architecture": "amd64",
+      "filename": "libcpuinfo0_0.0~git20250203.aaac07e-1_amd64.deb",
+      "sha256": "13af6ecf274a2629121a38b06a815cd945c99a586f3a8848bb386c49961b31b7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/c/cpuinfo/libcpuinfo0_0.0%7egit20250203.aaac07e-1_amd64.deb"
+    },
+    {
+      "name": "libcrypt-dev",
+      "version": "1:4.4.38-1",
+      "architecture": "amd64",
+      "filename": "libcrypt-dev_1%3a4.4.38-1_amd64.deb",
+      "sha256": "88a4ec0d8bf7b61600165896acbe55d888b54f317e9a5bc2fcb99fe9166b0427",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcrypt/libcrypt-dev_4.4.38-1_amd64.deb"
+    },
+    {
+      "name": "libctf-nobfd0",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libctf-nobfd0_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "1ad75cce74f918e2c2efa56ef68a45f17d65b3d299e1fe5e1beb72324d5e97a9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libctf-nobfd0_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libctf0",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libctf0_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "b624fc8144fc9fb846fef44a21f2882691203ce56292d741b2c5b8c441faa38b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libctf0_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libdc1394-25",
+      "version": "2.2.6-4build1",
+      "architecture": "amd64",
+      "filename": "libdc1394-25_2.2.6-4build1_amd64.deb",
+      "sha256": "0f4a0768152636f2f941d3a29d24925be77f869b3d90a13f1694fef792a89810",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdc1394/libdc1394-25_2.2.6-4build1_amd64.deb"
+    },
+    {
+      "name": "libdca0",
+      "version": "0.0.7-2build1",
+      "architecture": "amd64",
+      "filename": "libdca0_0.0.7-2build1_amd64.deb",
+      "sha256": "018867fee029b072ecb3365f5f92c0cb0530d4ab37aa13be127116b6e5c3c06d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdca/libdca0_0.0.7-2build1_amd64.deb"
+    },
+    {
+      "name": "libde265-0",
+      "version": "1.0.15-1build5",
+      "architecture": "amd64",
+      "filename": "libde265-0_1.0.15-1build5_amd64.deb",
+      "sha256": "1a3d3faab069f9bb4051c0d4e5d2ee18c3c41f440ad1569838c338fc12d47e0b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libde265/libde265-0_1.0.15-1build5_amd64.deb"
+    },
+    {
+      "name": "libdecor-0-dev",
+      "version": "0.2.2-2",
+      "architecture": "amd64",
+      "filename": "libdecor-0-dev_0.2.2-2_amd64.deb",
+      "sha256": "a8a1eed5d20461fa612700c9317a26046f6dd9c00aec432bead3f5f97c9b400b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdecor-0/libdecor-0-dev_0.2.2-2_amd64.deb"
+    },
+    {
+      "name": "libdnnl3.6",
+      "version": "3.7.1+ds-1",
+      "architecture": "amd64",
+      "filename": "libdnnl3.6_3.7.1+ds-1_amd64.deb",
+      "sha256": "88fd977d7076586d2a2bb89659d24e8875f188f79a15649ce1832764b3232d67",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onednn/libdnnl3.6_3.7.1%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libdpkg-perl",
+      "version": "1.22.18ubuntu2.2",
+      "architecture": "all",
+      "filename": "libdpkg-perl_1.22.18ubuntu2.2_all.deb",
+      "sha256": "9d96ff20ee92e976d82834f5e9b52b12b85b6ebddb83da1a641456b00d4afe89",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/d/dpkg/libdpkg-perl_1.22.18ubuntu2.2_all.deb"
+    },
+    {
+      "name": "libdrm-dev",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-dev_2.4.124-2_amd64.deb",
+      "sha256": "1d8d69e8bfd242c0e46bd8910f889b45203ed57b501e81b41faf05e03730643f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-dev_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdrm-nouveau2",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-nouveau2_2.4.124-2_amd64.deb",
+      "sha256": "7eaf5ee5460175ef118dd0dbf246d5b72d19c70f113d0650e3a045aefd968c09",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-nouveau2_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdrm-radeon1",
+      "version": "2.4.124-2",
+      "architecture": "amd64",
+      "filename": "libdrm-radeon1_2.4.124-2_amd64.deb",
+      "sha256": "e45997171485fbf22b3dd0d3d569aa0b7b923a945cba80a93717042da54b4d70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libd/libdrm/libdrm-radeon1_2.4.124-2_amd64.deb"
+    },
+    {
+      "name": "libdvdnav4",
+      "version": "6.1.1-3build1",
+      "architecture": "amd64",
+      "filename": "libdvdnav4_6.1.1-3build1_amd64.deb",
+      "sha256": "09fd1de2985ade2592d4f068774b2249211880aa6d4a71a89e0b4764afe47404",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdnav/libdvdnav4_6.1.1-3build1_amd64.deb"
+    },
+    {
+      "name": "libdvdread8t64",
+      "version": "6.1.3-2",
+      "architecture": "amd64",
+      "filename": "libdvdread8t64_6.1.3-2_amd64.deb",
+      "sha256": "269fe55b0eb5a47b7112c46a5ed3a21bdbd0378224970d733225ecfd3cb5f20e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libd/libdvdread/libdvdread8t64_6.1.3-2_amd64.deb"
+    },
+    {
+      "name": "libdw-dev",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libdw-dev_0.192-4ubuntu1_amd64.deb",
+      "sha256": "d20955250b0efd8ea3f4f908fb91ecc9448f13c353b0aa289599f41c53fd19fd",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libdw-dev_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libegl-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libegl-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "3a0315216bb0d6fc4bbe7f689cf0168c2ffa3e62ac69bff06bbbe49679259990",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libegl-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libelf-dev",
+      "version": "0.192-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libelf-dev_0.192-4ubuntu1_amd64.deb",
+      "sha256": "410b4385cf6c508bae56eb399148be1d5814be0f20e7e06cbd3e53b1c2943b50",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/e/elfutils/libelf-dev_0.192-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "liberror-perl",
+      "version": "0.17030-1",
+      "architecture": "all",
+      "filename": "liberror-perl_0.17030-1_all.deb",
+      "sha256": "cb85c869fe056e9e466efcfa3403408b0a87db1da1cafa585140a9be59fe58a1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libe/liberror-perl/liberror-perl_0.17030-1_all.deb"
+    },
+    {
+      "name": "libevdev-dev",
+      "version": "1.13.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libevdev-dev_1.13.3+dfsg-1_amd64.deb",
+      "sha256": "425b37d96ee3d595d89f966bcf9758d15f84c30eff21e3279b1a4e0ec9671de6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libe/libevdev/libevdev-dev_1.13.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libfaad2",
+      "version": "2.11.2-1",
+      "architecture": "amd64",
+      "filename": "libfaad2_2.11.2-1_amd64.deb",
+      "sha256": "cdf00ddc8c0f4f6e3dbc46c1d0efba537632609432734deb01113cac3ac1531d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/faad2/libfaad2_2.11.2-1_amd64.deb"
+    },
+    {
+      "name": "libffi-dev",
+      "version": "3.4.7-1",
+      "architecture": "amd64",
+      "filename": "libffi-dev_3.4.7-1_amd64.deb",
+      "sha256": "900ba7b5679f750a6db82c058f69074a684b3b85afa8c9121f3689a469f62a75",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libf/libffi/libffi-dev_3.4.7-1_amd64.deb"
+    },
+    {
+      "name": "libflite1",
+      "version": "2.2-7",
+      "architecture": "amd64",
+      "filename": "libflite1_2.2-7_amd64.deb",
+      "sha256": "3afe2b4ab82dff2330b53fcee83b4b21aa580f6d91a1ce850e917cf8cffc004a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/flite/libflite1_2.2-7_amd64.deb"
+    },
+    {
+      "name": "libfluidsynth3",
+      "version": "2.4.4+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libfluidsynth3_2.4.4+dfsg-1_amd64.deb",
+      "sha256": "2a7177d672b1f717c2b064181cac9e1772aeaf93e0a00db8327954eeeaff9189",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/f/fluidsynth/libfluidsynth3_2.4.4%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libfreeaptx0",
+      "version": "0.1.1-2build1",
+      "architecture": "amd64",
+      "filename": "libfreeaptx0_0.1.1-2build1_amd64.deb",
+      "sha256": "2280d6fdd41c841701a9da6b5076b77e8a0849e5c10c9c2945f817f753575a42",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libf/libfreeaptx/libfreeaptx0_0.1.1-2build1_amd64.deb"
+    },
+    {
+      "name": "libgbm-dev",
+      "version": "25.0.7-0ubuntu0.25.04.2",
+      "architecture": "amd64",
+      "filename": "libgbm-dev_25.0.7-0ubuntu0.25.04.2_amd64.deb",
+      "sha256": "34bd2a70579a7e795d446d9de2d85185dca058e93926f11ab7f23f27f1e03be4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mesa/libgbm-dev_25.0.7-0ubuntu0.25.04.2_amd64.deb"
+    },
+    {
+      "name": "libgc1",
+      "version": "1:8.2.8-1",
+      "architecture": "amd64",
+      "filename": "libgc1_1%3a8.2.8-1_amd64.deb",
+      "sha256": "d337914b08465d43186dbfe880fde5c9ea23808b0d56ea88397644cd6df84fcf",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgc/libgc1_8.2.8-1_amd64.deb"
+    },
+    {
+      "name": "libgcc-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libgcc-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "10eff4b80bc982518584b67e65e3ab89c8f33c4af7ce0b0071463e4eda410e74",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/libgcc-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libgio-2.0-dev",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libgio-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "8691851455f8820210e7f94ecbd7a889039ef9a617e301bd135f954ea6a463ab",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libgio-2.0-dev_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libgio-2.0-dev-bin",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libgio-2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "90346abaaad67a7dc3dc57088c3f0bab298b6e8c58af608da9c33bbc35e0052f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libgio-2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libgirepository-2.0-0",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libgirepository-2.0-0_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "b4c393515b1eade5535349e0104027efdd2502e8045eb0334f40457301350235",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libgirepository-2.0-0_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libgl-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgl-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "b7145fd8f8abe20d5cb436d2eae9b3235bd91be6fbddac581620d16763bd9250",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgl-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgles-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgles-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "ee2ea529c20e28031230c5910281e5bbd7f2c2ca06a2e306ca15e985d4875eb2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgles-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgles1",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libgles1_1.7.0-1build1_amd64.deb",
+      "sha256": "3128deef59859a47cfca25244f035bdbedd223640209dcffdd11f1873ef71aff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libgles1_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libglib2.0-bin",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libglib2.0-bin_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "903a168d0fca6f551fa98d7d9f90cb912b3a86700e5552e9543579ef19e73b6f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libglib2.0-bin_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libglib2.0-dev",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libglib2.0-dev_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "42a2d562a0322eec7d12f24a695e10b32b3f0e584cb9f18d82378608b54c1d1d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libglib2.0-dev_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libglib2.0-dev-bin",
+      "version": "2.84.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libglib2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb",
+      "sha256": "deef70c2d233a0bb449be2020990624bfc672650cfd564afc342579fb7cba8e6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/glib2.0/libglib2.0-dev-bin_2.84.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libglx-dev",
+      "version": "1.7.0-1build1",
+      "architecture": "amd64",
+      "filename": "libglx-dev_1.7.0-1build1_amd64.deb",
+      "sha256": "0e2654950a881c20b640a3af590add2e0b612b8c0fdd945761fc695e1b6eb797",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libglvnd/libglx-dev_1.7.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libgme0",
+      "version": "0.6.3-7build1",
+      "architecture": "amd64",
+      "filename": "libgme0_0.6.3-7build1_amd64.deb",
+      "sha256": "a54fa608501f87f9e5064b60c75fc1bb62735c9f9ba9f7680cb804bb5eae2027",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/game-music-emu/libgme0_0.6.3-7build1_amd64.deb"
+    },
+    {
+      "name": "libgprofng0",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libgprofng0_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "2901fba850cbab74e8d51cf0074405589c7da74d2019599db4e5a047c7e18a71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libgprofng0_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libgssdp-1.6-0",
+      "version": "1.6.3-2",
+      "architecture": "amd64",
+      "filename": "libgssdp-1.6-0_1.6.3-2_amd64.deb",
+      "sha256": "7897db47adc4114a17c44f390d2816c7e58ac8bdd722fa58fa21c659368aece7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gssdp/libgssdp-1.6-0_1.6.3-2_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-bad1.0-0",
+      "version": "1.26.0-1ubuntu2.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb",
+      "sha256": "36c0de48cf25ca31dc21363dabd3fb32e9d4c539467b6b76b4770c5e82822099",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gst-plugins-bad1.0/libgstreamer-plugins-bad1.0-0_1.26.0-1ubuntu2.1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer-plugins-base1.0-dev",
+      "version": "1.26.0-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libgstreamer-plugins-base1.0-dev_1.26.0-1ubuntu0.1_amd64.deb",
+      "sha256": "20bf9472c7520737227c983fcc1b6711a98a58ea8f4381d9bb10e11dbe538a2f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-dev_1.26.0-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libgstreamer1.0-dev",
+      "version": "1.26.0-3",
+      "architecture": "amd64",
+      "filename": "libgstreamer1.0-dev_1.26.0-3_amd64.deb",
+      "sha256": "bdfb350621e98cc9b38c4ab5bf3bfe448f635f12244f771bac89966678c2ad94",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gstreamer1.0/libgstreamer1.0-dev_1.26.0-3_amd64.deb"
+    },
+    {
+      "name": "libgudev-1.0-dev",
+      "version": "1:238-6",
+      "architecture": "amd64",
+      "filename": "libgudev-1.0-dev_1%3a238-6_amd64.deb",
+      "sha256": "e4cc1f9f5fe0dcca2c4e9fdeefe799b39f761513efb2bab676fe432b85b6309e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libg/libgudev/libgudev-1.0-dev_238-6_amd64.deb"
+    },
+    {
+      "name": "libgupnp-1.6-0",
+      "version": "1.6.8-2",
+      "architecture": "amd64",
+      "filename": "libgupnp-1.6-0_1.6.8-2_amd64.deb",
+      "sha256": "9346722ae71cc4bce037ef49bf38c609392eb1cfb6eba19fce575673577896c5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gupnp/libgupnp-1.6-0_1.6.8-2_amd64.deb"
+    },
+    {
+      "name": "libgupnp-igd-1.6-0",
+      "version": "1.6.0-4",
+      "architecture": "amd64",
+      "filename": "libgupnp-igd-1.6-0_1.6.0-4_amd64.deb",
+      "sha256": "bf96c3dc6cf586400754dcf51b1e8033399171d5c5a55191ba13cf8c6d8c426e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gupnp-igd/libgupnp-igd-1.6-0_1.6.0-4_amd64.deb"
+    },
+    {
+      "name": "libhwasan0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libhwasan0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8f6817b2b68c395118bb786c1b6388b1ccc0d76a64a26cab8b9519179277c318",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libhwasan0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libice-dev",
+      "version": "2:1.1.1-1",
+      "architecture": "amd64",
+      "filename": "libice-dev_2%3a1.1.1-1_amd64.deb",
+      "sha256": "68e9b0a566c83e73509d1cebad2dd7e20be32dbe58ec1e4fbcbc7c59b50b9f59",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libi/libice/libice-dev_1.1.1-1_amd64.deb"
+    },
+    {
+      "name": "libicu76",
+      "version": "76.1-1ubuntu2",
+      "architecture": "amd64",
+      "filename": "libicu76_76.1-1ubuntu2_amd64.deb",
+      "sha256": "c289a52f92c9ab2a1783b6b5757c928bff228671f20473275a426798446a4ce1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/i/icu/libicu76_76.1-1ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libimath-3-1-29t64",
+      "version": "3.1.12-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb",
+      "sha256": "5b35e6bdfc8f567c3c33b4c5b519ceab2acd1c5c05534f360c33cedcf14c4cf3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/i/imath/libimath-3-1-29t64_3.1.12-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libinput-dev",
+      "version": "1.27.1-1ubuntu0.2",
+      "architecture": "amd64",
+      "filename": "libinput-dev_1.27.1-1ubuntu0.2_amd64.deb",
+      "sha256": "264483d6ded36888d17fdfb6539517fa5cc0547b61d8039438c292ef5edf93db",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libi/libinput/libinput-dev_1.27.1-1ubuntu0.2_amd64.deb"
+    },
+    {
+      "name": "libinstpatch-1.0-2",
+      "version": "1.1.6-1build2",
+      "architecture": "amd64",
+      "filename": "libinstpatch-1.0-2_1.1.6-1build2_amd64.deb",
+      "sha256": "d48c40a9c428e40d5bbe8762802390322b06a062c735292767e73d1c6ea9007e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libi/libinstpatch/libinstpatch-1.0-2_1.1.6-1build2_amd64.deb"
+    },
+    {
+      "name": "libitm1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libitm1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "8a6c6855d2de1480760392f0fc443b65ec41cd811148011de89edd7ae417869a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libitm1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "liblc3-1",
+      "version": "1.1.3+dfsg-1",
+      "architecture": "amd64",
+      "filename": "liblc3-1_1.1.3+dfsg-1_amd64.deb",
+      "sha256": "0a88ca35cd79b18e42bbb22800e2ea49f2e0123cc709696dd1954486d7694e4d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/liblc3/liblc3-1_1.1.3%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libldacbt-enc2",
+      "version": "2.0.2.3+git20200429+ed310a0-5",
+      "architecture": "amd64",
+      "filename": "libldacbt-enc2_2.0.2.3+git20200429+ed310a0-5_amd64.deb",
+      "sha256": "7212ed25d4be1782cfc71ef1758a587fa3a3cfb7ba939c7233161cb491946a34",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libl/libldac/libldacbt-enc2_2.0.2.3%2bgit20200429%2bed310a0-5_amd64.deb"
+    },
+    {
+      "name": "liblilv-0-0",
+      "version": "0.24.26-1",
+      "architecture": "amd64",
+      "filename": "liblilv-0-0_0.24.26-1_amd64.deb",
+      "sha256": "3076146b3bae4bce370c6618ef8ed788383d3d35184dae0bbb9877dcdbb127c2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/lilv/liblilv-0-0_0.24.26-1_amd64.deb"
+    },
+    {
+      "name": "liblrdf0",
+      "version": "0.6.1-4build1",
+      "architecture": "amd64",
+      "filename": "liblrdf0_0.6.1-4build1_amd64.deb",
+      "sha256": "470a5e0e88fd2e7dcfc024c789cd029578b110c65558ae423fd79d7bb4ef01ca",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/liblrdf/liblrdf0_0.6.1-4build1_amd64.deb"
+    },
+    {
+      "name": "liblsan0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "liblsan0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "0c1a62b4e6c14f502d3c0c49c8fc009e959ca4fa1a910e3eea40e896e434016e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/liblsan0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libltc11",
+      "version": "1.3.2-1build1",
+      "architecture": "amd64",
+      "filename": "libltc11_1.3.2-1build1_amd64.deb",
+      "sha256": "92f23451cefe159faef9f255f0d24987eff50e52647dc1aa9843ad4c733ca039",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libl/libltc/libltc11_1.3.2-1build1_amd64.deb"
+    },
+    {
+      "name": "libluajit-5.1-dev",
+      "version": "2.1.0+openresty20250117-2",
+      "architecture": "amd64",
+      "filename": "libluajit-5.1-dev_2.1.0+openresty20250117-2_amd64.deb",
+      "sha256": "8b50af6f5684a57eed58d56be998376c8ef8e7c88379b6b14dffb56a10b4d9b4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/luajit/libluajit-5.1-dev_2.1.0%2bopenresty20250117-2_amd64.deb"
+    },
+    {
+      "name": "liblzma-dev",
+      "version": "5.6.4-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "liblzma-dev_5.6.4-1ubuntu1_amd64.deb",
+      "sha256": "164c8de2bd3c722576116937bea56d6ef0a892ec4c906f032ce366f0bc8409af",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xz-utils/liblzma-dev_5.6.4-1ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libmjpegutils-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmjpegutils-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "3422b9e3f7aa721a18f1738b33815a7f681fbe1ec0bafb1faf733e625dcbce85",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmjpegutils-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmodplug1",
+      "version": "1:0.8.9.0-3build1",
+      "architecture": "amd64",
+      "filename": "libmodplug1_1%3a0.8.9.0-3build1_amd64.deb",
+      "sha256": "34b383f35def5405069ae1eb6b4e6a7f73c9adafd0d049add82285b0e1a2e1ad",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmodplug/libmodplug1_0.8.9.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libmount-dev",
+      "version": "2.40.2-14ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "libmount-dev_2.40.2-14ubuntu1.2_amd64.deb",
+      "sha256": "10263c8a5e18dcf562971c0bae03b7aae5b698233b605a422033bc474a9d6a4a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/util-linux/libmount-dev_2.40.2-14ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "libmpcdec6",
+      "version": "2:0.1~r495-3",
+      "architecture": "amd64",
+      "filename": "libmpcdec6_2%3a0.1~r495-3_amd64.deb",
+      "sha256": "35e003823ddf242d8799057d420fc15ed644bb836d63ae18af57bd514699a216",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libm/libmpc/libmpcdec6_0.1%7er495-3_amd64.deb"
+    },
+    {
+      "name": "libmpeg2encpp-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmpeg2encpp-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "ec077a7c7fc7abd77d460813f56a9bef1dd68e53148840ef242b1795043d318e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmpeg2encpp-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmplex2-2.1-0t64",
+      "version": "1:2.1.0+debian-8.1build1",
+      "architecture": "amd64",
+      "filename": "libmplex2-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb",
+      "sha256": "8c4324fb9ac9b667559aeaa92e399beeb4396d0cd33627be1b1306b85a31e5e2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/mjpegtools/libmplex2-2.1-0t64_2.1.0%2bdebian-8.1build1_amd64.deb"
+    },
+    {
+      "name": "libmtdev-dev",
+      "version": "1.1.7-1",
+      "architecture": "amd64",
+      "filename": "libmtdev-dev_1.1.7-1_amd64.deb",
+      "sha256": "0f3985ae771be368a3cedb7e08d181c293d3e03c97ba8aa5c6742ad70c8d0319",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/mtdev/libmtdev-dev_1.1.7-1_amd64.deb"
+    },
+    {
+      "name": "libneon27t64",
+      "version": "0.34.0-1",
+      "architecture": "amd64",
+      "filename": "libneon27t64_0.34.0-1_amd64.deb",
+      "sha256": "1710578bc51522b9ee8ccd70624b9e2e266f50e5ac39711d1096757bd23d381f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/neon27/libneon27t64_0.34.0-1_amd64.deb"
+    },
+    {
+      "name": "libnice10",
+      "version": "0.1.22-1",
+      "architecture": "amd64",
+      "filename": "libnice10_0.1.22-1_amd64.deb",
+      "sha256": "3e227906bae81259542732d0af1623a05910855d86e548e5b704e17ea8cb2a17",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libn/libnice/libnice10_0.1.22-1_amd64.deb"
+    },
+    {
+      "name": "libobjc-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libobjc-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "5babfef7063527cd3ed5a51dea337b32aa62ab79839940b25c2fb1721125a137",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gcc-14/libobjc-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libobjc4",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libobjc4_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "7e9fc63dcb88da621398110040df2ef9f12f00c4ca532bf583c67af0b7a46e5c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/g/gcc-15/libobjc4_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libonnx1t64",
+      "version": "1.17.0-3build1",
+      "architecture": "amd64",
+      "filename": "libonnx1t64_1.17.0-3build1_amd64.deb",
+      "sha256": "c4fcb75e98e7a28dd741d002c640bb3a9891dee2d9ec39ee570f2824d77318ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnx/libonnx1t64_1.17.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libonnxruntime1.21",
+      "version": "1.21.0+dfsg-1",
+      "architecture": "amd64",
+      "filename": "libonnxruntime1.21_1.21.0+dfsg-1_amd64.deb",
+      "sha256": "17e9bfec1e4e86a7456720843ed5443c2eb3bda62b45f0e075ab0c8d89e4ae7b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/onnxruntime/libonnxruntime1.21_1.21.0%2bdfsg-1_amd64.deb"
+    },
+    {
+      "name": "libopenal-data",
+      "version": "1:1.24.2-1",
+      "architecture": "all",
+      "filename": "libopenal-data_1%3a1.24.2-1_all.deb",
+      "sha256": "2bce384fa3c8fb1193e9ec8c948787263e5a2fc53a4a4715c4aeeab75b98b420",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal-data_1.24.2-1_all.deb"
+    },
+    {
+      "name": "libopenal1",
+      "version": "1:1.24.2-1",
+      "architecture": "amd64",
+      "filename": "libopenal1_1%3a1.24.2-1_amd64.deb",
+      "sha256": "461b8d108f70efa65eefbb3af5c697ac95f831f1959de3b625345b389628bbbb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openal-soft/libopenal1_1.24.2-1_amd64.deb"
+    },
+    {
+      "name": "libopenexr-3-1-30",
+      "version": "3.1.13-2",
+      "architecture": "amd64",
+      "filename": "libopenexr-3-1-30_3.1.13-2_amd64.deb",
+      "sha256": "cae37d566e8d08fdeabdbcac7e9c9a5c68b9541a83974adbd3f50cb654e83390",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openexr/libopenexr-3-1-30_3.1.13-2_amd64.deb"
+    },
+    {
+      "name": "libopenh264-8",
+      "version": "2.6.0+dfsg-2",
+      "architecture": "amd64",
+      "filename": "libopenh264-8_2.6.0+dfsg-2_amd64.deb",
+      "sha256": "bbff1a10312e60e4566c0e34c2d2f98deda75763ea639650518d00e1e028f67e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openh264/libopenh264-8_2.6.0%2bdfsg-2_amd64.deb"
+    },
+    {
+      "name": "libopenmpt0t64",
+      "version": "0.7.13-1build1",
+      "architecture": "amd64",
+      "filename": "libopenmpt0t64_0.7.13-1build1_amd64.deb",
+      "sha256": "0a3f0e7060f1777d9865ff1ba23d7ad692f395594388442bde670e4bf435a975",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libo/libopenmpt/libopenmpt0t64_0.7.13-1build1_amd64.deb"
+    },
+    {
+      "name": "libopenni2-0",
+      "version": "2.2.0.33+dfsg-18",
+      "architecture": "amd64",
+      "filename": "libopenni2-0_2.2.0.33+dfsg-18_amd64.deb",
+      "sha256": "bba943fe73b2b0271ebbd6a28d0afb9e7084df75a64748fc06e3f72151ab1b76",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/o/openni2/libopenni2-0_2.2.0.33%2bdfsg-18_amd64.deb"
+    },
+    {
+      "name": "liborc-0.4-dev",
+      "version": "1:0.4.41-1",
+      "architecture": "amd64",
+      "filename": "liborc-0.4-dev_1%3a0.4.41-1_amd64.deb",
+      "sha256": "f9dd934bafb2140adf20e16f8d2ea5106539fbbe1f7b9f5cee6bf3a0cc56cd7c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/orc/liborc-0.4-dev_0.4.41-1_amd64.deb"
+    },
+    {
+      "name": "liborc-0.4-dev-bin",
+      "version": "1:0.4.41-1",
+      "architecture": "amd64",
+      "filename": "liborc-0.4-dev-bin_1%3a0.4.41-1_amd64.deb",
+      "sha256": "6abfb51460346159c83598f869dc27ad2474329cb70a5ebaba875c37bea1eb43",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/o/orc/liborc-0.4-dev-bin_0.4.41-1_amd64.deb"
+    },
+    {
+      "name": "libpciaccess-dev",
+      "version": "0.17-3ubuntu0.25.04.2",
+      "architecture": "amd64",
+      "filename": "libpciaccess-dev_0.17-3ubuntu0.25.04.2_amd64.deb",
+      "sha256": "345127a67e50bbb3db674e9051788737b8b2ddba4eab00cd316446d874f0732d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libp/libpciaccess/libpciaccess-dev_0.17-3ubuntu0.25.04.2_amd64.deb"
+    },
+    {
+      "name": "libpcre2-16-0",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-16-0_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "53f4d51ada507cce319542226504ba44c6b2ac4d8f561ec5fc908db939a45778",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-16-0_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpcre2-32-0",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-32-0_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "5ef102e3193081bb5553fa30d95329d2fcb091c1b1a782de72de5f60c14d01f7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-32-0_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpcre2-dev",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-dev_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "36605dbb5b4a650093f24f70e5925fab513acb96785b74a666274f43897a1072",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-dev_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpcre2-posix3",
+      "version": "10.45-1ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libpcre2-posix3_10.45-1ubuntu0.1_amd64.deb",
+      "sha256": "46c6cf4dc9587af70736ca0e47b4f6919731c02708a57ec41cc37ec1628f0bbc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pcre2/libpcre2-posix3_10.45-1ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-dev",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-dev_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "a1665a2ead175e9ccf4f9f4098db14ac56110470cb0599b941f679947a1b99d4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libpipewire-0.3-modules",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "f23e9a3ebedfbb846efe210bcc55150668394ac807e6c71f1f2c1d5f728c2f8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libpipewire-0.3-modules_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libpixman-1-dev",
+      "version": "0.44.0-3",
+      "architecture": "amd64",
+      "filename": "libpixman-1-dev_0.44.0-3_amd64.deb",
+      "sha256": "126d4e5f89bc6a29ebfb296f22c4eb718fd04a3a2522b06c74f7d3e07e9129d3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pixman/libpixman-1-dev_0.44.0-3_amd64.deb"
+    },
+    {
+      "name": "libpkgconf3",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "libpkgconf3_1.8.1-4_amd64.deb",
+      "sha256": "91c46979979aa69e79a6dc64e2cd7c262173331ae58ba69ba29dce611c02c457",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "libprotobuf32t64",
+      "version": "3.21.12-10ubuntu0.1",
+      "architecture": "amd64",
+      "filename": "libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb",
+      "sha256": "19a6eac6e4d794318608c7e6862c4414119e1be7d3e66b0f8e698c62c78411ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/protobuf/libprotobuf32t64_3.21.12-10ubuntu0.1_amd64.deb"
+    },
+    {
+      "name": "libpthreadpool0",
+      "version": "0.0~git20240616.560c60d-1",
+      "architecture": "amd64",
+      "filename": "libpthreadpool0_0.0~git20240616.560c60d-1_amd64.deb",
+      "sha256": "a09c04886537cf3db25ae1c0644a0b4cc070d520914521a00f81b86b1254f23f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/p/pthreadpool/libpthreadpool0_0.0%7egit20240616.560c60d-1_amd64.deb"
+    },
+    {
+      "name": "libqrencode4",
+      "version": "4.1.1-2",
+      "architecture": "amd64",
+      "filename": "libqrencode4_4.1.1-2_amd64.deb",
+      "sha256": "d9eed9dc0a75994c2fe4d95f9dae8d700b4a363383f6966a82d6d0225e275280",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/q/qrencode/libqrencode4_4.1.1-2_amd64.deb"
+    },
+    {
+      "name": "libquadmath0",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libquadmath0_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "a980b7bfc6586180d07a5df8a7d9bc97fa41c0790d91b780cee8e6f5f317c934",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libquadmath0_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libraptor2-0",
+      "version": "2.0.16-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libraptor2-0_2.0.16-4ubuntu1_amd64.deb",
+      "sha256": "ecae495617134e13c098780576db94c89e9475d2ccec3d2bb732799ce958bd87",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/raptor2/libraptor2-0_2.0.16-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libre2-11",
+      "version": "20240501-3build1",
+      "architecture": "amd64",
+      "filename": "libre2-11_20240501-3build1_amd64.deb",
+      "sha256": "b7a4b55a5f2e4ca12d1020b2cd5a0a0540bb1a9b4706eaa8e1294fe52a4112a5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/re2/libre2-11_20240501-3build1_amd64.deb"
+    },
+    {
+      "name": "librhash1",
+      "version": "1.4.5-1",
+      "architecture": "amd64",
+      "filename": "librhash1_1.4.5-1_amd64.deb",
+      "sha256": "6a51d203f615d3bfa71fba697db4a91700d7cfc04e48c9ab2786f77b96e9614a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/rhash/librhash1_1.4.5-1_amd64.deb"
+    },
+    {
+      "name": "libroc0.4",
+      "version": "0.4.0+dfsg-4ubuntu1",
+      "architecture": "amd64",
+      "filename": "libroc0.4_0.4.0+dfsg-4ubuntu1_amd64.deb",
+      "sha256": "8bec93425075527aa82683dbcf2d1784c39361da46a10c299f0c60afb8625b71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/roc-toolkit/libroc0.4_0.4.0%2bdfsg-4ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsbc1",
+      "version": "2.0-1build1",
+      "architecture": "amd64",
+      "filename": "libsbc1_2.0-1build1_amd64.deb",
+      "sha256": "d4d453e7673218fc2f917dbabb2492a5a81155c2305f6fe63a37cadcaa806128",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/sbc/libsbc1_2.0-1build1_amd64.deb"
+    },
+    {
+      "name": "libseat-dev",
+      "version": "0.8.0-1",
+      "architecture": "amd64",
+      "filename": "libseat-dev_0.8.0-1_amd64.deb",
+      "sha256": "f0be2c0a66145588838546011a4236e20a277b9a4a52acfca9f0cb7dcf80b812",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/seatd/libseat-dev_0.8.0-1_amd64.deb"
+    },
+    {
+      "name": "libselinux1-dev",
+      "version": "3.7-3ubuntu3",
+      "architecture": "amd64",
+      "filename": "libselinux1-dev_3.7-3ubuntu3_amd64.deb",
+      "sha256": "f627acedca996a63d245e1465e133edc91d0e7da150278f66677b530f984155e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libs/libselinux/libselinux1-dev_3.7-3ubuntu3_amd64.deb"
+    },
+    {
+      "name": "libsepol-dev",
+      "version": "3.7-1",
+      "architecture": "amd64",
+      "filename": "libsepol-dev_3.7-1_amd64.deb",
+      "sha256": "84c6bdaa7b21c8f2dfec5f3b9e7f994fe666e7495ec6ee94cb6812979e9c438d",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libs/libsepol/libsepol-dev_3.7-1_amd64.deb"
+    },
+    {
+      "name": "libserd-0-0",
+      "version": "0.32.4-1",
+      "architecture": "amd64",
+      "filename": "libserd-0-0_0.32.4-1_amd64.deb",
+      "sha256": "3d1c23e9effbe22d3edab8c0c2fdc8297d966c134f4d8095ccf0c9da52cc5f33",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/serd/libserd-0-0_0.32.4-1_amd64.deb"
+    },
+    {
+      "name": "libsframe1",
+      "version": "2.44-3ubuntu1.3",
+      "architecture": "amd64",
+      "filename": "libsframe1_2.44-3ubuntu1.3_amd64.deb",
+      "sha256": "6d5646fba6f601fc8e055cf366b24a9e5a7da7dddcc223bdfbeeaa0a2cfceb71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/b/binutils/libsframe1_2.44-3ubuntu1.3_amd64.deb"
+    },
+    {
+      "name": "libsm-dev",
+      "version": "2:1.2.4-1",
+      "architecture": "amd64",
+      "filename": "libsm-dev_2%3a1.2.4-1_amd64.deb",
+      "sha256": "35664bfbf8d5dc4b5a920e7207938073296616b7b56e920254dcf28a995d9e44",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libs/libsm/libsm-dev_1.2.4-1_amd64.deb"
+    },
+    {
+      "name": "libsnapd-glib-2-1",
+      "version": "1.66-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb",
+      "sha256": "b7bd77be1d59bf3a19bbe91b9ab6225ad05736ed72bd9f3b3f56bcd83822e398",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/snapd-glib/libsnapd-glib-2-1_1.66-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libsord-0-0",
+      "version": "0.16.18-1",
+      "architecture": "amd64",
+      "filename": "libsord-0-0_0.16.18-1_amd64.deb",
+      "sha256": "bfd5ef5bbab2eed986b6f2856c2904db70c3d9e7a34b9f9caffcc1ea36a47a9b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sord/libsord-0-0_0.16.18-1_amd64.deb"
+    },
+    {
+      "name": "libsoundtouch1",
+      "version": "2.3.3+ds-1",
+      "architecture": "amd64",
+      "filename": "libsoundtouch1_2.3.3+ds-1_amd64.deb",
+      "sha256": "cadad56c5398a93f2f8c7080ca1a93725c15242beff0891cfdb029c5e4f305f3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/soundtouch/libsoundtouch1_2.3.3%2bds-1_amd64.deb"
+    },
+    {
+      "name": "libspa-0.2-dev",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "libspa-0.2-dev_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "bf84dc575f3beab14b1a86612622525a6f6c45e367edac0e5143ed03106ec959",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/libspa-0.2-dev_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "libspandsp2t64",
+      "version": "0.0.6+dfsg-2.2",
+      "architecture": "amd64",
+      "filename": "libspandsp2t64_0.0.6+dfsg-2.2_amd64.deb",
+      "sha256": "63a125139f3507ae94faa7cdd10ee6d6c551961937b1ec7fafa4d320e34b71bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spandsp/libspandsp2t64_0.0.6%2bdfsg-2.2_amd64.deb"
+    },
+    {
+      "name": "libsratom-0-0",
+      "version": "0.6.18-1",
+      "architecture": "amd64",
+      "filename": "libsratom-0-0_0.6.18-1_amd64.deb",
+      "sha256": "848fcfa874c1acb8c2331747a841467f8921334d5b5cbb66f8306d933203f344",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/sratom/libsratom-0-0_0.6.18-1_amd64.deb"
+    },
+    {
+      "name": "libsrt1.5-gnutls",
+      "version": "1.5.4-1",
+      "architecture": "amd64",
+      "filename": "libsrt1.5-gnutls_1.5.4-1_amd64.deb",
+      "sha256": "88e58de644fbf38c194494789c4f1e047dae6c43bd71ca245530d721a4a0b5e0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/srt/libsrt1.5-gnutls_1.5.4-1_amd64.deb"
+    },
+    {
+      "name": "libsrtp2-1",
+      "version": "2.5.0-3build1",
+      "architecture": "amd64",
+      "filename": "libsrtp2-1_2.5.0-3build1_amd64.deb",
+      "sha256": "c2e7ee0ae64597f046fbfb197b8f36dfc9a5159b02d27e850f3a4d14a4603d77",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libs/libsrtp2/libsrtp2-1_2.5.0-3build1_amd64.deb"
+    },
+    {
+      "name": "libstdc++-14-dev",
+      "version": "14.2.0-19ubuntu2",
+      "architecture": "amd64",
+      "filename": "libstdc++-14-dev_14.2.0-19ubuntu2_amd64.deb",
+      "sha256": "23b377179507d649d55f371cc4b36082b05bce3637a475d9b53a83cc6dcdbcef",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-14/libstdc%2b%2b-14-dev_14.2.0-19ubuntu2_amd64.deb"
+    },
+    {
+      "name": "libsysprof-capture-4-dev",
+      "version": "48.0-2",
+      "architecture": "amd64",
+      "filename": "libsysprof-capture-4-dev_48.0-2_amd64.deb",
+      "sha256": "33ecffc7010439b34fd10bf8e3a3f595eefa49b96a6434354b8eb3517b50e15f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/sysprof/libsysprof-capture-4-dev_48.0-2_amd64.deb"
+    },
+    {
+      "name": "libtsan2",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libtsan2_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "829692d86ed2b1d3f761306fce4b8bebe5b632a018859c8570c3dcdf162a942b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libtsan2_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libubsan1",
+      "version": "15-20250404-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "libubsan1_15-20250404-0ubuntu1_amd64.deb",
+      "sha256": "ebdb6ab4f035d9b94a633478bec122212388d5f2e155c99bca1fe84831f6a04b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/g/gcc-15/libubsan1_15-20250404-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libudev-dev",
+      "version": "257.4-1ubuntu3.2",
+      "architecture": "amd64",
+      "filename": "libudev-dev_257.4-1ubuntu3.2_amd64.deb",
+      "sha256": "ad5f1a66b74f5c17382e449a7792f0228cf50797ebccaec4c6cb72081e60aa97",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/systemd/libudev-dev_257.4-1ubuntu3.2_amd64.deb"
+    },
+    {
+      "name": "libunibreak6",
+      "version": "6.1-2",
+      "architecture": "amd64",
+      "filename": "libunibreak6_6.1-2_amd64.deb",
+      "sha256": "c904cf437fcad74dac8c9e7fd1a4a9657b0c5d44441848e321e225375b69c4fc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/libu/libunibreak/libunibreak6_6.1-2_amd64.deb"
+    },
+    {
+      "name": "libunwind-dev",
+      "version": "1.6.2-3.1",
+      "architecture": "amd64",
+      "filename": "libunwind-dev_1.6.2-3.1_amd64.deb",
+      "sha256": "624f0a53bb081487268cf920f0d83ec7f80add528c3ef5ce6e91ced727eb9ce1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libunwind/libunwind-dev_1.6.2-3.1_amd64.deb"
+    },
+    {
+      "name": "libunwind8",
+      "version": "1.6.2-3.1",
+      "architecture": "amd64",
+      "filename": "libunwind8_1.6.2-3.1_amd64.deb",
+      "sha256": "9d48508139a791778c86f341e725f06dd5304dc24e80501080271a734bf970da",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libunwind/libunwind8_1.6.2-3.1_amd64.deb"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2ubuntu1",
+      "architecture": "amd64",
+      "filename": "libuv1t64_1.50.0-2ubuntu1_amd64.deb",
+      "sha256": "6af9634d05965f60ed7c124d43cef678ef288824b6f36a7b02559dd4097e7c90",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libu/libuv1/libuv1t64_1.50.0-2ubuntu1_amd64.deb"
+    },
+    {
+      "name": "libvo-aacenc0",
+      "version": "0.1.3-3",
+      "architecture": "amd64",
+      "filename": "libvo-aacenc0_0.1.3-3_amd64.deb",
+      "sha256": "ea759b3a02552c379424775d5fc5d37d8dff59eb70ceab35118146ef04e857a3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-aacenc/libvo-aacenc0_0.1.3-3_amd64.deb"
+    },
+    {
+      "name": "libvo-amrwbenc0",
+      "version": "0.1.3-2build1",
+      "architecture": "amd64",
+      "filename": "libvo-amrwbenc0_0.1.3-2build1_amd64.deb",
+      "sha256": "30d260bbb56b9340319216529e72ed02a68752de62d5926ad07132ed2459af05",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/v/vo-amrwbenc/libvo-amrwbenc0_0.1.3-2build1_amd64.deb"
+    },
+    {
+      "name": "libvorbisfile3",
+      "version": "1.3.7-2",
+      "architecture": "amd64",
+      "filename": "libvorbisfile3_1.3.7-2_amd64.deb",
+      "sha256": "6dfc7f0bd9f0c745c2e099aca9121843650ec7c7193801057bc3927c43820e70",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-2_amd64.deb"
+    },
+    {
+      "name": "libvulkan-dev",
+      "version": "1.4.304.0-1",
+      "architecture": "amd64",
+      "filename": "libvulkan-dev_1.4.304.0-1_amd64.deb",
+      "sha256": "f557d5cc69add01d3794b1c71bfdcb053d7909febedd58713f9ba355e3f33167",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/v/vulkan-loader/libvulkan-dev_1.4.304.0-1_amd64.deb"
+    },
+    {
+      "name": "libwacom-dev",
+      "version": "2.14.0-1",
+      "architecture": "amd64",
+      "filename": "libwacom-dev_2.14.0-1_amd64.deb",
+      "sha256": "18e8a96b5300885ea8b7013214eeef9f912bbe5d804fda4f236bef3ce3f22fd5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libw/libwacom/libwacom-dev_2.14.0-1_amd64.deb"
+    },
+    {
+      "name": "libwayland-bin",
+      "version": "1.23.1-3",
+      "architecture": "amd64",
+      "filename": "libwayland-bin_1.23.1-3_amd64.deb",
+      "sha256": "f0f8b782d56c44068827e614240ae4d29908864f7b2d10bb54b2a68ba5623562",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland/libwayland-bin_1.23.1-3_amd64.deb"
+    },
+    {
+      "name": "libwayland-dev",
+      "version": "1.23.1-3",
+      "architecture": "amd64",
+      "filename": "libwayland-dev_1.23.1-3_amd64.deb",
+      "sha256": "4641ae220244fcb7f28d344d6612ec8c961351ba62347484ec354cbae1029f47",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland/libwayland-dev_1.23.1-3_amd64.deb"
+    },
+    {
+      "name": "libwildmidi2",
+      "version": "0.4.3-1build3",
+      "architecture": "amd64",
+      "filename": "libwildmidi2_0.4.3-1build3_amd64.deb",
+      "sha256": "f44a3f24eb567cf104aefe6cabe2a3385185dc59dd83d64a37c1a04f0e12c771",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/w/wildmidi/libwildmidi2_0.4.3-1build3_amd64.deb"
+    },
+    {
+      "name": "libx11-dev",
+      "version": "2:1.8.10-2",
+      "architecture": "amd64",
+      "filename": "libx11-dev_2%3a1.8.10-2_amd64.deb",
+      "sha256": "b93d9e5c357557eba2ab26304ae47337ca163403646e584e0931840f53072b3e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libx11/libx11-dev_1.8.10-2_amd64.deb"
+    },
+    {
+      "name": "libx11-xcb-dev",
+      "version": "2:1.8.10-2",
+      "architecture": "amd64",
+      "filename": "libx11-xcb-dev_2%3a1.8.10-2_amd64.deb",
+      "sha256": "0f82fd0275fe8f8120df2ea231f2bd3fbc312d0e5070d7e126ea15cc9208f7ab",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libx11/libx11-xcb-dev_1.8.10-2_amd64.deb"
+    },
+    {
+      "name": "libxau-dev",
+      "version": "1:1.0.11-1",
+      "architecture": "amd64",
+      "filename": "libxau-dev_1%3a1.0.11-1_amd64.deb",
+      "sha256": "8bb1b0b7e8f2febc90f3cab29b5e5383a7a44ddcf6fa5720334af2e7de2bbbb6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxau/libxau-dev_1.0.11-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-composite0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-composite0-dev_1.17.0-2_amd64.deb",
+      "sha256": "9c7c7e0462fb2814bc50d8e1207e86d499d48e626b7c245019f672d31c7c8056",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-composite0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-ewmh-dev",
+      "version": "0.4.2-1",
+      "architecture": "amd64",
+      "filename": "libxcb-ewmh-dev_0.4.2-1_amd64.deb",
+      "sha256": "6fb409e6c39c6e035de198b20ae1b9f4ee9bfd023c23344165cbadd0f7de335e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xcb-util-wm/libxcb-ewmh-dev_0.4.2-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-icccm4-dev",
+      "version": "0.4.2-1",
+      "architecture": "amd64",
+      "filename": "libxcb-icccm4-dev_0.4.2-1_amd64.deb",
+      "sha256": "9766971d554555864316d05f111eb05afd60c57791a4a655ba04a6600cf9f8ff",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xcb-util-wm/libxcb-icccm4-dev_0.4.2-1_amd64.deb"
+    },
+    {
+      "name": "libxcb-render0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-render0-dev_1.17.0-2_amd64.deb",
+      "sha256": "e8deb42e07541dbae21f139330327299b8b5f7f70564a61fa706a1f7582a8db4",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-render0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-res0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-res0-dev_1.17.0-2_amd64.deb",
+      "sha256": "c0d05fb701c144dddc3b1ec0e27579444e0c905ce1e7bffc4d9f74a747593379",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-res0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-shape0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-shape0-dev_1.17.0-2_amd64.deb",
+      "sha256": "6ad9c5c37a3fd478ed5586486d122cfbf29e687b738a98cd5145caf603656f9c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-shape0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb-xfixes0-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb-xfixes0-dev_1.17.0-2_amd64.deb",
+      "sha256": "85b54851baa1584386a74b68764507d96967edcd119d4680203838550f69e939",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb-xfixes0-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcb1-dev",
+      "version": "1.17.0-2",
+      "architecture": "amd64",
+      "filename": "libxcb1-dev_1.17.0-2_amd64.deb",
+      "sha256": "2844752ae6cb7b7dec983a53d698b37e3a6268653cba254d69d8fcfa6907fb4c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcb/libxcb1-dev_1.17.0-2_amd64.deb"
+    },
+    {
+      "name": "libxcomposite-dev",
+      "version": "1:0.4.6-1",
+      "architecture": "amd64",
+      "filename": "libxcomposite-dev_1%3a0.4.6-1_amd64.deb",
+      "sha256": "6db5444b9409b5e6edb4cb4537640cd33207551a04c389248e86b269571fa258",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcomposite/libxcomposite-dev_0.4.6-1_amd64.deb"
+    },
+    {
+      "name": "libxcursor-dev",
+      "version": "1:1.2.3-1",
+      "architecture": "amd64",
+      "filename": "libxcursor-dev_1%3a1.2.3-1_amd64.deb",
+      "sha256": "f693b31be26a752b901eee46d9cd79c308f3595223a437481287ce0c016a5987",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxcursor/libxcursor-dev_1.2.3-1_amd64.deb"
+    },
+    {
+      "name": "libxdamage-dev",
+      "version": "1:1.1.6-1build1",
+      "architecture": "amd64",
+      "filename": "libxdamage-dev_1%3a1.1.6-1build1_amd64.deb",
+      "sha256": "63067acaa7248dd46e67496154a030f38c86aa1cc192116265a8039c358ee20a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxdamage/libxdamage-dev_1.1.6-1build1_amd64.deb"
+    },
+    {
+      "name": "libxdmcp-dev",
+      "version": "1:1.1.5-1",
+      "architecture": "amd64",
+      "filename": "libxdmcp-dev_1%3a1.1.5-1_amd64.deb",
+      "sha256": "b7f218a47a2e50b1835e32a83b2d5dbeaf75034f4b6ec9f82e67eb9260553cc6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.5-1_amd64.deb"
+    },
+    {
+      "name": "libxext-dev",
+      "version": "2:1.3.4-1build2",
+      "architecture": "amd64",
+      "filename": "libxext-dev_2%3a1.3.4-1build2_amd64.deb",
+      "sha256": "b5bdb6724f228cb8eee8cf39cbbe1289dd3f8f06dd022748312df7844c94dcf2",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxext/libxext-dev_1.3.4-1build2_amd64.deb"
+    },
+    {
+      "name": "libxfixes-dev",
+      "version": "1:6.0.0-2build1",
+      "architecture": "amd64",
+      "filename": "libxfixes-dev_1%3a6.0.0-2build1_amd64.deb",
+      "sha256": "069723527566ef0fc12738f63b789110c211b85bf96c3dbe9a94d9e77f5c479b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxfixes/libxfixes-dev_6.0.0-2build1_amd64.deb"
+    },
+    {
+      "name": "libxi-dev",
+      "version": "2:1.8.2-1",
+      "architecture": "amd64",
+      "filename": "libxi-dev_2%3a1.8.2-1_amd64.deb",
+      "sha256": "5c7bdf2d7abd20858666554c0eca429c1b35a09529c193a52d70c4ebda5ea75b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxi/libxi-dev_1.8.2-1_amd64.deb"
+    },
+    {
+      "name": "libxkbcommon-dev",
+      "version": "1.7.0-2",
+      "architecture": "amd64",
+      "filename": "libxkbcommon-dev_1.7.0-2_amd64.deb",
+      "sha256": "0c366a6dd143cca7dbec02ea7ed466e1c37b44e35e39018268717f5733f7ca29",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.7.0-2_amd64.deb"
+    },
+    {
+      "name": "libxmu-dev",
+      "version": "2:1.1.3-3build2",
+      "architecture": "amd64",
+      "filename": "libxmu-dev_2%3a1.1.3-3build2_amd64.deb",
+      "sha256": "a7b2d7632ba44ba2a9056b5665db0dad20d91fe8c336502db1f434b0b6922acc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxmu/libxmu-dev_1.1.3-3build2_amd64.deb"
+    },
+    {
+      "name": "libxmu-headers",
+      "version": "2:1.1.3-3build2",
+      "architecture": "all",
+      "filename": "libxmu-headers_2%3a1.1.3-3build2_all.deb",
+      "sha256": "6abd2218697cefb602d8273a3df711b297f504f414abff11d366578ddc9fd3d6",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxmu/libxmu-headers_1.1.3-3build2_all.deb"
+    },
+    {
+      "name": "libxnnpack0.20241108",
+      "version": "0.0~git20241108.4ea82e5-1",
+      "architecture": "amd64",
+      "filename": "libxnnpack0.20241108_0.0~git20241108.4ea82e5-1_amd64.deb",
+      "sha256": "0a3eedc79943aadbc036d199230c573e1a0b80f947e07076dbf1db1d4a201297",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/x/xnnpack/libxnnpack0.20241108_0.0%7egit20241108.4ea82e5-1_amd64.deb"
+    },
+    {
+      "name": "libxrender-dev",
+      "version": "1:0.9.10-1.1build1",
+      "architecture": "amd64",
+      "filename": "libxrender-dev_1%3a0.9.10-1.1build1_amd64.deb",
+      "sha256": "839558c9de049636e13e22e409c04f3226614abf176c4a3b7088058576d74848",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxrender/libxrender-dev_0.9.10-1.1build1_amd64.deb"
+    },
+    {
+      "name": "libxres-dev",
+      "version": "2:1.2.1-1build1",
+      "architecture": "amd64",
+      "filename": "libxres-dev_2%3a1.2.1-1build1_amd64.deb",
+      "sha256": "7e7346f017ad871cd2e3a0e9c8742e943e09198867f042cc455465c39240e2ce",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxres/libxres-dev_1.2.1-1build1_amd64.deb"
+    },
+    {
+      "name": "libxslt1.1",
+      "version": "1.1.39-0exp1ubuntu4.1",
+      "architecture": "amd64",
+      "filename": "libxslt1.1_1.1.39-0exp1ubuntu4.1_amd64.deb",
+      "sha256": "7072c3b5e8e36fe949edf29d89cfc1cc4a4a65c6a1fb9e9ddd4abbba0c9c5872",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxslt/libxslt1.1_1.1.39-0exp1ubuntu4.1_amd64.deb"
+    },
+    {
+      "name": "libxt-dev",
+      "version": "1:1.2.1-1.2build1",
+      "architecture": "amd64",
+      "filename": "libxt-dev_1%3a1.2.1-1.2build1_amd64.deb",
+      "sha256": "77858926454d10dd7896fc4d1ee158b67bb25e830dd41e60e4a59e79f71b8a8f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxt/libxt-dev_1.2.1-1.2build1_amd64.deb"
+    },
+    {
+      "name": "libxtst-dev",
+      "version": "2:1.2.5-1",
+      "architecture": "amd64",
+      "filename": "libxtst-dev_2%3a1.2.5-1_amd64.deb",
+      "sha256": "f21eaaa996c266d0d3b96c1a392ac9af7cc4cbfe60601a1c98942bdcb8d5e334",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxtst/libxtst-dev_1.2.5-1_amd64.deb"
+    },
+    {
+      "name": "libxxf86vm-dev",
+      "version": "1:1.1.4-1build4",
+      "architecture": "amd64",
+      "filename": "libxxf86vm-dev_1%3a1.1.4-1build4_amd64.deb",
+      "sha256": "98587402f6928a2526a8fbae6bd8c7297ced187b3a34b4e461ffd3245910f1af",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libx/libxxf86vm/libxxf86vm-dev_1.1.4-1build4_amd64.deb"
+    },
+    {
+      "name": "libyajl2",
+      "version": "2.1.0-5build1",
+      "architecture": "amd64",
+      "filename": "libyajl2_2.1.0-5build1_amd64.deb",
+      "sha256": "faa268c632f7d2931509cf7b8b7ddd810aa775adc26ead88ea158e2ede5208f8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/y/yajl/libyajl2_2.1.0-5build1_amd64.deb"
+    },
+    {
+      "name": "libzbar0t64",
+      "version": "0.23.93-7",
+      "architecture": "amd64",
+      "filename": "libzbar0t64_0.23.93-7_amd64.deb",
+      "sha256": "9954e12b0e2f1f5a294465c6e5c1eaa46407024f0416b4b90513e554ecd31776",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zbar/libzbar0t64_0.23.93-7_amd64.deb"
+    },
+    {
+      "name": "libzix-0-0",
+      "version": "0.6.2-1",
+      "architecture": "amd64",
+      "filename": "libzix-0-0_0.6.2-1_amd64.deb",
+      "sha256": "54d72b63ae0243dedd47e1946765890deb7764f5cfa2c9332228742b6b406ba9",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zix/libzix-0-0_0.6.2-1_amd64.deb"
+    },
+    {
+      "name": "libzstd-dev",
+      "version": "1.5.6+dfsg-2",
+      "architecture": "amd64",
+      "filename": "libzstd-dev_1.5.6+dfsg-2_amd64.deb",
+      "sha256": "45e78999356317e33de5d4b29240c410effdbfd39d543ce15f317d6382046040",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/libz/libzstd/libzstd-dev_1.5.6%2bdfsg-2_amd64.deb"
+    },
+    {
+      "name": "libzxing3",
+      "version": "2.3.0-3",
+      "architecture": "amd64",
+      "filename": "libzxing3_2.3.0-3_amd64.deb",
+      "sha256": "66937bdde76f3edf56568d461692c7f6668f057a8ce0ba687570acb32bfd750b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/z/zxing-cpp/libzxing3_2.3.0-3_amd64.deb"
+    },
+    {
+      "name": "linux-libc-dev",
+      "version": "6.14.0-37.37",
+      "architecture": "amd64",
+      "filename": "linux-libc-dev_6.14.0-37.37_amd64.deb",
+      "sha256": "e03a0bbe25ebd8b2d618a842f1cef681c38abd22319518c980ab7a742d0e62a8",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/l/linux/linux-libc-dev_6.14.0-37.37_amd64.deb"
+    },
+    {
+      "name": "llvm-20-linker-tools",
+      "version": "1:20.1.2-0ubuntu1",
+      "architecture": "amd64",
+      "filename": "llvm-20-linker-tools_1%3a20.1.2-0ubuntu1_amd64.deb",
+      "sha256": "4675775ec06186e8b2645e2bbe886fda6d330e89bb5fb1979c66dcc43b6d2849",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/l/llvm-toolchain-20/llvm-20-linker-tools_20.1.2-0ubuntu1_amd64.deb"
+    },
+    {
+      "name": "lto-disabled-list",
+      "version": "57",
+      "architecture": "all",
+      "filename": "lto-disabled-list_57_all.deb",
+      "sha256": "0cc7c3bd22fef2f2dd2afda0d624c900af6dc9cf70e59a486f23b5751f3bf4bc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/l/lto-disabled-list/lto-disabled-list_57_all.deb"
+    },
+    {
+      "name": "make",
+      "version": "4.4.1-1",
+      "architecture": "amd64",
+      "filename": "make_4.4.1-1_amd64.deb",
+      "sha256": "d0622880df49e4bfd48e07253a18553aac0214ecbcd24a0841de7315c249cc2e",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb"
+    },
+    {
+      "name": "meson",
+      "version": "1.7.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "meson_1.7.0-1ubuntu1_all.deb",
+      "sha256": "669142d3fd9008c583ca2511d4d3db41efeb2ace18642c942bc7e7fa7fd81ece",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/m/meson/meson_1.7.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "native-architecture",
+      "version": "0.2.6",
+      "architecture": "all",
+      "filename": "native-architecture_0.2.6_all.deb",
+      "sha256": "675f55bc3cbcddb1ba701817eec1a198e1fa38cddfe119efa69b06e8e9a18c1f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/a/architecture-properties/native-architecture_0.2.6_all.deb"
+    },
+    {
+      "name": "ninja-build",
+      "version": "1.12.1-1",
+      "architecture": "amd64",
+      "filename": "ninja-build_1.12.1-1_amd64.deb",
+      "sha256": "8190a977f4e0158c88fc76541737cdd62f74c74e8fd9aa25c6d5a322c7be6b0a",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/n/ninja-build/ninja-build_1.12.1-1_amd64.deb"
+    },
+    {
+      "name": "patch",
+      "version": "2.7.6-7build3",
+      "architecture": "amd64",
+      "filename": "patch_2.7.6-7build3_amd64.deb",
+      "sha256": "fb7d78ed25c2788a607802270f3c28ac5ed6857bfb6cce9f73ad2cafac9159b3",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/patch/patch_2.7.6-7build3_amd64.deb"
+    },
+    {
+      "name": "pipewire",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "b77fae0221ecdebcc9839cfd08aa5da95359c741a4d2922bfcaf55474b93f0a7",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-bin",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "0d16cd14743a2c8fc4c726057ec910ba7eac48e5de65698acc01aeb336d45078",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-bin_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pipewire-pulse",
+      "version": "1.2.7-1ubuntu5.1",
+      "architecture": "amd64",
+      "filename": "pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb",
+      "sha256": "611be8d6b8620f5d266e7a8a232bb7cb96f558fc8a73205af7aaec084c3ab8eb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pipewire/pipewire-pulse_1.2.7-1ubuntu5.1_amd64.deb"
+    },
+    {
+      "name": "pkg-config",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkg-config_1.8.1-4_amd64.deb",
+      "sha256": "04b7449b1453626ae918a12afc747b4cc395a734a8db5c6b94468672088d0c14",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pkgconf",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkgconf_1.8.1-4_amd64.deb",
+      "sha256": "0db266c58f3169b3ce5257003e2065b6306630106945587293802098bac78247",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pkgconf-bin",
+      "version": "1.8.1-4",
+      "architecture": "amd64",
+      "filename": "pkgconf-bin_1.8.1-4_amd64.deb",
+      "sha256": "3af3f64647ebed77014036ff676676eccca0f79b8e4763dc0439b46d97e9196b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb"
+    },
+    {
+      "name": "pnp.ids",
+      "version": "0.393-3",
+      "architecture": "all",
+      "filename": "pnp.ids_0.393-3_all.deb",
+      "sha256": "db21da54953f550393ed42d07a815f7f2ece949ba800865fba9252b3bfdf9d38",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/h/hwdata/pnp.ids_0.393-3_all.deb"
+    },
+    {
+      "name": "python3-autocommand",
+      "version": "2.2.2-3",
+      "architecture": "all",
+      "filename": "python3-autocommand_2.2.2-3_all.deb",
+      "sha256": "a8dfb00d38d617ac5c20fc42c7382ce85aa563faaac9f6e7ba2a90ad04e06d69",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-autocommand/python3-autocommand_2.2.2-3_all.deb"
+    },
+    {
+      "name": "python3-inflect",
+      "version": "7.3.1-2",
+      "architecture": "all",
+      "filename": "python3-inflect_7.3.1-2_all.deb",
+      "sha256": "f0c8dbb03547a21c9cf9f4fcdd77a7f9fedc59b9cc382805e992314c1d5d6804",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-inflect/python3-inflect_7.3.1-2_all.deb"
+    },
+    {
+      "name": "python3-jaraco.context",
+      "version": "6.0.1-1",
+      "architecture": "all",
+      "filename": "python3-jaraco.context_6.0.1-1_all.deb",
+      "sha256": "315f7335827d6059d879ccb3f1c41bb42f607380644acae6618f6f9ba88dc045",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/j/jaraco.context/python3-jaraco.context_6.0.1-1_all.deb"
+    },
+    {
+      "name": "python3-jaraco.functools",
+      "version": "4.1.0-1",
+      "architecture": "all",
+      "filename": "python3-jaraco.functools_4.1.0-1_all.deb",
+      "sha256": "febcf8a025e6947eaf357e8afb452d0244c18296f82df1946b92559f104d824b",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-jaraco.functools/python3-jaraco.functools_4.1.0-1_all.deb"
+    },
+    {
+      "name": "python3-jaraco.text",
+      "version": "4.0.0-1",
+      "architecture": "all",
+      "filename": "python3-jaraco.text_4.0.0-1_all.deb",
+      "sha256": "948086d278c565ad8549587b01156ee9f09dadff9623de121dcb5dafe3ddb6cc",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/j/jaraco.text/python3-jaraco.text_4.0.0-1_all.deb"
+    },
+    {
+      "name": "python3-more-itertools",
+      "version": "10.6.0-1",
+      "architecture": "all",
+      "filename": "python3-more-itertools_10.6.0-1_all.deb",
+      "sha256": "0528c67191b9703bc80aab118f12df8ca5a9e22df78b6b72f5143e0a8fed8e27",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/m/more-itertools/python3-more-itertools_10.6.0-1_all.deb"
+    },
+    {
+      "name": "python3-packaging",
+      "version": "24.2-1",
+      "architecture": "all",
+      "filename": "python3-packaging_24.2-1_all.deb",
+      "sha256": "dbe200c8fa49f6c4e4c82fc20418e6d26f0689317bdf1edf00854da87ec53d0c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-packaging/python3-packaging_24.2-1_all.deb"
+    },
+    {
+      "name": "python3-pkg-resources",
+      "version": "75.8.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "python3-pkg-resources_75.8.0-1ubuntu1_all.deb",
+      "sha256": "aa26d0339c6e564ba511b3db03eeb4adf1a6913ec9d4a7e5b0eb61c53ce59840",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/setuptools/python3-pkg-resources_75.8.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "python3-setuptools",
+      "version": "75.8.0-1ubuntu1",
+      "architecture": "all",
+      "filename": "python3-setuptools_75.8.0-1ubuntu1_all.deb",
+      "sha256": "5aa98a69aae8caff58cce7b94d73eb3101127ef154f4a5cd4eae45c2c46714a0",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/s/setuptools/python3-setuptools_75.8.0-1ubuntu1_all.deb"
+    },
+    {
+      "name": "python3-typeguard",
+      "version": "4.4.2-1",
+      "architecture": "all",
+      "filename": "python3-typeguard_4.4.2-1_all.deb",
+      "sha256": "28ff19b5be5e02393cbfe13a6068d0b52f270b511c7a7fb69f15d417415fa1ae",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-typeguard/python3-typeguard_4.4.2-1_all.deb"
+    },
+    {
+      "name": "python3-zipp",
+      "version": "3.21.0-1",
+      "architecture": "all",
+      "filename": "python3-zipp_3.21.0-1_all.deb",
+      "sha256": "f940bd4def06760555cde9c8d27207eb536d1a32211dd8c54223100b0f0242f5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/p/python-zipp/python3-zipp_3.21.0-1_all.deb"
+    },
+    {
+      "name": "rpcsvc-proto",
+      "version": "1.4.2-0ubuntu7",
+      "architecture": "amd64",
+      "filename": "rpcsvc-proto_1.4.2-0ubuntu7_amd64.deb",
+      "sha256": "7eb710fe148d224c159ddec1ceb0ba53ead52a80a6793dcdae1474acf20d8f71",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-0ubuntu7_amd64.deb"
+    },
+    {
+      "name": "spirv-tools",
+      "version": "2025.1~rc1-1",
+      "architecture": "amd64",
+      "filename": "spirv-tools_2025.1~rc1-1_amd64.deb",
+      "sha256": "e7a487f6e47851bfe86724b14729bf22f3d54b0177bc982063483e5e35a10d8c",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/s/spirv-tools/spirv-tools_2025.1%7erc1-1_amd64.deb"
+    },
+    {
+      "name": "timgm6mb-soundfont",
+      "version": "1.3-5",
+      "architecture": "all",
+      "filename": "timgm6mb-soundfont_1.3-5_all.deb",
+      "sha256": "b70bc29b8f27adef8f92a2d9c1e26cee977b84c68110f0dd4326d97730a7c3ed",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/universe/t/timgm6mb-soundfont/timgm6mb-soundfont_1.3-5_all.deb"
+    },
+    {
+      "name": "usb.ids",
+      "version": "2025.01.14-1",
+      "architecture": "all",
+      "filename": "usb.ids_2025.01.14-1_all.deb",
+      "sha256": "fa4a1fd5b24eafda34fe5e11ec2ed182c25bdb484758a5a7731bbb42643f2673",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/usb.ids/usb.ids_2025.01.14-1_all.deb"
+    },
+    {
+      "name": "uuid-dev",
+      "version": "2.40.2-14ubuntu1.2",
+      "architecture": "amd64",
+      "filename": "uuid-dev_2.40.2-14ubuntu1.2_amd64.deb",
+      "sha256": "5408aef7913b669c0d6b3773e89a3f2b08f6beda086730e8ccb49c9a8ef97dd5",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/u/util-linux/uuid-dev_2.40.2-14ubuntu1.2_amd64.deb"
+    },
+    {
+      "name": "wayland-protocols",
+      "version": "1.41-1",
+      "architecture": "all",
+      "filename": "wayland-protocols_1.41-1_all.deb",
+      "sha256": "3a0942c89ced71ebc809718c9d21910627d2a257b1277d6a9173a672cf53125f",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/w/wayland-protocols/wayland-protocols_1.41-1_all.deb"
+    },
+    {
+      "name": "x11proto-dev",
+      "version": "2024.1-1",
+      "architecture": "all",
+      "filename": "x11proto-dev_2024.1-1_all.deb",
+      "sha256": "98811486c3f51eb0a6e89c44cdea1edd8b45d7b285f87fa747cb997c4a65b451",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb"
+    },
+    {
+      "name": "xorg-sgml-doctools",
+      "version": "1:1.11-1.1",
+      "architecture": "all",
+      "filename": "xorg-sgml-doctools_1%3a1.11-1.1_all.deb",
+      "sha256": "277f662c6d94606c22078f2af82ac1b6e01386d5a4dec6ca7487bca4c5b23c07",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb"
+    },
+    {
+      "name": "xtrans-dev",
+      "version": "1.4.0-1",
+      "architecture": "all",
+      "filename": "xtrans-dev_1.4.0-1_all.deb",
+      "sha256": "45277c51d5d83db351b61859314b59595c9626ac372fbb2fc0d5542e169d9086",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb"
+    },
+    {
+      "name": "zlib1g-dev",
+      "version": "1:1.3.dfsg+really1.3.1-1ubuntu1",
+      "architecture": "amd64",
+      "filename": "zlib1g-dev_1%3a1.3.dfsg+really1.3.1-1ubuntu1_amd64.deb",
+      "sha256": "a04e48305134d40f3d42d329296c6458bdfb40805f8adbd789b4140202c0f8f1",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/pool/main/z/zlib/zlib1g-dev_1.3.dfsg%2breally1.3.1-1ubuntu1_amd64.deb"
+    }
+  ]
+}

--- a/containers/multiseat/oci_archive.py
+++ b/containers/multiseat/oci_archive.py
@@ -1,5 +1,6 @@
 """Read and verify the single-platform OCI artifact without extracting files."""
 import hashlib
+import gzip
 import json
 import re
 import tarfile
@@ -49,6 +50,22 @@ def verify_archive(path, expected_config):
         config = read_json(verify_descriptor(manifest['config']))
         if config['architecture'] != 'amd64' or config['os'] != 'linux':
             raise ValueError('exported worker architecture mismatch')
-        for layer in manifest['layers']:
-            verify_descriptor(layer)
+        rootfs = config.get('rootfs', {})
+        diff_ids = rootfs.get('diff_ids', [])
+        if rootfs.get('type') != 'layers' or len(diff_ids) != len(manifest['layers']):
+            raise ValueError('exported layer count differs from validated configuration')
+        for layer, expected in zip(manifest['layers'], diff_ids):
+            name = verify_descriptor(layer)
+            media_type = layer['mediaType']
+            if media_type not in ('application/vnd.oci.image.layer.v1.tar',
+                                   'application/vnd.oci.image.layer.v1.tar+gzip'):
+                raise ValueError('unsupported OCI layer encoding')
+            with archive.extractfile(members[name]) as raw:
+                if media_type.endswith('+gzip'):
+                    with gzip.GzipFile(fileobj=raw) as stream:
+                        actual = hashlib.file_digest(stream, 'sha256').hexdigest()
+                else:
+                    actual = hashlib.file_digest(raw, 'sha256').hexdigest()
+            if expected != 'sha256:' + actual:
+                raise ValueError('exported layer contents or order differ from validated configuration')
         return descriptor['digest']

--- a/containers/multiseat/oci_archive.py
+++ b/containers/multiseat/oci_archive.py
@@ -1,0 +1,54 @@
+"""Read and verify the single-platform OCI artifact without extracting files."""
+import hashlib
+import json
+import re
+import tarfile
+
+
+def verify_archive(path, expected_config):
+    with tarfile.open(path) as archive:
+        members = {}
+        for member in archive.getmembers():
+            if member.name in members or not (member.isfile() or member.isdir()):
+                raise ValueError('duplicate or non-regular OCI archive member')
+            if member.name.startswith('/') or '..' in member.name.split('/'):
+                raise ValueError('unsafe OCI archive member')
+            members[member.name] = member
+
+        def read_json(name):
+            member = members[name]
+            if not member.isfile() or member.size > 16 * 1024 * 1024:
+                raise ValueError('invalid OCI JSON member')
+            return json.load(archive.extractfile(member))
+
+        def verify_descriptor(descriptor):
+            value = descriptor['digest']
+            if not re.fullmatch(r'sha256:[0-9a-f]{64}', value):
+                raise ValueError('unsupported OCI digest')
+            name = 'blobs/sha256/' + value[7:]
+            member = members[name]
+            if not member.isfile() or member.size != descriptor['size']:
+                raise ValueError('OCI descriptor size mismatch')
+            with archive.extractfile(member) as stream:
+                actual = hashlib.file_digest(stream, 'sha256').hexdigest()
+            if actual != value[7:]:
+                raise ValueError('OCI blob checksum mismatch')
+            return name
+
+        if read_json('oci-layout') != {'imageLayoutVersion': '1.0.0'}:
+            raise ValueError('unsupported OCI layout')
+        index = read_json('index.json')
+        if index['schemaVersion'] != 2 or len(index['manifests']) != 1:
+            raise ValueError('expected a single worker manifest')
+        descriptor = index['manifests'][0]
+        if descriptor['mediaType'] != 'application/vnd.oci.image.manifest.v1+json':
+            raise ValueError('expected an OCI image manifest')
+        manifest = read_json(verify_descriptor(descriptor))
+        if manifest['schemaVersion'] != 2 or manifest['config']['digest'] != expected_config:
+            raise ValueError('exported worker configuration differs from the validated image')
+        config = read_json(verify_descriptor(manifest['config']))
+        if config['architecture'] != 'amd64' or config['os'] != 'linux':
+            raise ValueError('exported worker architecture mismatch')
+        for layer in manifest['layers']:
+            verify_descriptor(layer)
+        return descriptor['digest']

--- a/containers/multiseat/package-nvidia.py
+++ b/containers/multiseat/package-nvidia.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Build the opt-in graphics userspace layer; never run the driver installer."""
+import hashlib
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+
+lock = json.loads(pathlib.Path('/nvidia.lock.json').read_text())
+archive = pathlib.Path('/nvidia.run')
+with archive.open('rb') as source:
+    if hashlib.file_digest(source, 'sha256').hexdigest() != lock['sha256']:
+        raise ValueError('NVIDIA source archive checksum mismatch')
+subprocess.run(['sh', str(archive), '--extract-only', '--target', '/nvidia-source'], check=True)
+source = pathlib.Path('/nvidia-source')
+root = pathlib.Path('/nvidia-root')
+manifest = []
+
+
+def copy_file(path, destination):
+    if not path.is_file() or path.is_symlink():
+        raise ValueError('NVIDIA input must be a regular file: ' + path.name)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(path, destination)
+    destination.chmod(0o644)
+    with destination.open('rb') as content:
+        digest = hashlib.file_digest(content, 'sha256').hexdigest()
+    manifest.append({'path': '/' + str(destination.relative_to(root)), 'sha256': digest})
+
+
+# Keep the root's generic GLVND frontends. Only vendor implementations and their
+# userspace dependencies are selected; kernel, firmware and host tools are absent.
+prefixes = (
+    'libcuda.so.', 'libnvcuvid.so.', 'libnvoptix.so.', 'libEGL_nvidia.so.',
+    'libGLX_nvidia.so.', 'libGLESv1_CM_nvidia.so.', 'libGLESv2_nvidia.so.',
+    'libnvidia-allocator.so.', 'libnvidia-eglcore.so.', 'libnvidia-egl-gbm.so.',
+    'libnvidia-egl-wayland.so.', 'libnvidia-egl-wayland2.so.',
+    'libnvidia-egl-xcb.so.', 'libnvidia-egl-xlib.so.', 'libnvidia-encode.so.',
+    'libnvidia-fbc.so.', 'libnvidia-glcore.so.', 'libnvidia-glsi.so.',
+    'libnvidia-glvkspirv.so.', 'libnvidia-gpucomp.so.', 'libnvidia-ml.so.',
+    'libnvidia-nvvm.so.', 'libnvidia-ptxjitcompiler.so.', 'libnvidia-rtcore.so.',
+    'libnvidia-tls.so.', 'libnvidia-wayland-client.so.', 'libnvidia-present.so.',
+    'libnvidia-sandboxutils.so.',
+)
+for origin, architecture in [(source, 'x86_64-linux-gnu'), (source / '32', 'i386-linux-gnu')]:
+    destination = root / 'usr/lib' / architecture
+    selected = [p for p in sorted(origin.iterdir()) if p.name.startswith(prefixes)]
+    for required in ['libcuda.so.', 'libEGL_nvidia.so.', 'libGLX_nvidia.so.', 'libnvidia-encode.so.']:
+        if not any(p.name.startswith(required) for p in selected):
+            raise ValueError('missing NVIDIA library: ' + required)
+    for path in selected:
+        copy_file(path, destination / path.name)
+        elf = subprocess.check_output(['readelf', '-d', str(path)], text=True)
+        soname = re.search(r'\(SONAME\).*\[([^/\]]+)\]', elf)
+        if not soname:
+            raise ValueError('missing NVIDIA SONAME: ' + path.name)
+        if soname[1] != path.name:
+            (destination / soname[1]).symlink_to(path.name)
+    (destination / 'gbm').mkdir()
+    (destination / 'gbm/nvidia-drm_gbm.so').symlink_to('../libnvidia-allocator.so.1')
+
+configurations = {
+    '10_nvidia.json': 'glvnd/egl_vendor.d',
+    'nvidia_icd.json': 'vulkan/icd.d',
+    'nvidia_layers.json': 'vulkan/implicit_layer.d',
+    **{name: 'egl/egl_external_platform.d' for name in [
+        '09_nvidia_wayland2.json', '10_nvidia_wayland.json', '15_nvidia_gbm.json',
+        '20_nvidia_xcb.json', '20_nvidia_xlib.json',
+    ]},
+}
+for filename, directory in configurations.items():
+    copy_file(source / filename, root / 'usr/share' / directory / filename)
+copy_file(source / 'LICENSE', root / 'usr/share/licenses/polaris-nvidia/LICENSE')
+metadata = root / 'usr/share/polaris/build'
+metadata.mkdir(parents=True)
+(metadata / 'nvidia.lock.json').write_text(json.dumps(lock, indent=2) + '\n')
+(metadata / 'nvidia-files.json').write_text(json.dumps(manifest, indent=2) + '\n')

--- a/containers/multiseat/prepare-inputs.py
+++ b/containers/multiseat/prepare-inputs.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Fetch reviewed inputs before the network-free OCI build (Linux/amd64)."""
+import argparse
+import concurrent.futures
+import configparser
+import hashlib
+import json
+import os
+import pathlib
+import platform
+import shutil
+import subprocess
+import tempfile
+import urllib.request
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+INPUTS = REPO / 'build/runtime-inputs'
+
+
+def digest(path):
+    if path.is_symlink() or not path.is_file():
+        raise ValueError('expected a regular input: ' + str(path))
+    with path.open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def fetch(entry, destination):
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        if digest(destination) != entry['sha256']:
+            raise ValueError('cached input checksum mismatch: ' + destination.name)
+        return
+    if not entry['url'].startswith('https://'):
+        raise ValueError('input URL must use HTTPS')
+    fd, temporary = tempfile.mkstemp(prefix='.download-', dir=destination.parent)
+    try:
+        with os.fdopen(fd, 'wb') as output, urllib.request.urlopen(entry['url'], timeout=120) as response:
+            shutil.copyfileobj(response, output)
+        if digest(pathlib.Path(temporary)) != entry['sha256']:
+            raise ValueError('download checksum mismatch: ' + destination.name)
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, destination)
+    finally:
+        pathlib.Path(temporary).unlink(missing_ok=True)
+
+
+def run(arguments, **kwargs):
+    return subprocess.run(arguments, check=True, **kwargs)
+
+
+def checkout(url, revision, destination):
+    run(['git', 'init', str(destination)])
+    run(['git', '-C', str(destination), 'remote', 'add', 'origin', url])
+    run(['git', '-C', str(destination), 'fetch', '--depth=1', 'origin', revision])
+    run(['git', '-C', str(destination), 'checkout', '--detach', 'FETCH_HEAD'])
+    actual = subprocess.check_output(['git', '-C', str(destination), 'rev-parse', 'HEAD'], text=True).strip()
+    if actual != revision:
+        raise ValueError('source checkout does not match its lock')
+
+
+def canonical_archive(source, destination, lock, excludes):
+    temporary = destination.with_suffix('.unverified.tar')
+    run(['tar', '--format=gnu', '--sort=name', '--mtime=@' + str(lock['archive_epoch']),
+         '--owner=0', '--group=0', '--numeric-owner', *['--exclude=' + p for p in excludes],
+         '-cf', str(temporary), '-C', str(source), '.'])
+    if digest(temporary) != lock['sha256']:
+        raise ValueError('reconstructed source archive differs from its lock: ' + destination.name)
+    temporary.replace(destination)
+
+
+def prepare_plugin(lock, rust):
+    archive = INPUTS / 'plugin.tar'
+    if archive.exists():
+        if digest(archive) != lock['sha256']:
+            raise ValueError('plugin archive checksum mismatch')
+        return
+    with tempfile.TemporaryDirectory(prefix='plugin-', dir=INPUTS) as temporary:
+        temporary = pathlib.Path(temporary)
+        toolchain = temporary / 'toolchain'
+        toolchain.mkdir()
+        run(['tar', '-xf', str(INPUTS / 'toolchains' / pathlib.PurePosixPath(rust['url']).name),
+             '-C', str(toolchain), '--strip-components=1'])
+        prefix = temporary / 'rust'
+        run([str(toolchain / 'install.sh'), '--prefix=' + str(prefix),
+             '--components=rustc,cargo,rust-std-x86_64-unknown-linux-gnu', '--disable-ldconfig'])
+        source = temporary / 'source'
+        checkout(lock['url'], lock['revision'], source)
+        if digest(source / 'Cargo.lock') != lock['cargo_lock_sha256']:
+            raise ValueError('plugin Cargo.lock changed')
+        environment = dict(os.environ, PATH=str(prefix / 'bin') + ':' + os.environ['PATH'],
+                           CARGO_HOME=str(temporary / 'cargo-home'), CARGO_NET_OFFLINE='false',
+                           CARGO_NET_GIT_FETCH_WITH_CLI='true')
+        config = subprocess.check_output([str(prefix / 'bin/cargo'), 'vendor', '--locked',
+                                          '--versioned-dirs', 'vendor'], cwd=source, env=environment)
+        (source / '.cargo').mkdir(exist_ok=True)
+        (source / '.cargo/config.toml').write_bytes(config)
+        canonical_archive(source, archive, lock, ['./.git', './target'])
+
+
+def prepare_gamescope(lock):
+    archive = INPUTS / 'gamescope.tar'
+    if archive.exists():
+        if digest(archive) != lock['sha256']:
+            raise ValueError('Gamescope archive checksum mismatch')
+        return
+    with tempfile.TemporaryDirectory(prefix='gamescope-', dir=INPUTS) as temporary:
+        source = pathlib.Path(temporary) / 'source'
+        checkout(lock['url'], lock['revision'], source)
+        run(['git', '-C', str(source), 'submodule', 'update', '--init', '--recursive', '--depth=1'])
+        for name, revision in lock['wraps'].items():
+            config = configparser.ConfigParser()
+            config.read(source / 'subprojects' / (name + '.wrap'))
+            wrap = config['wrap-git']
+            if wrap['revision'] != revision or wrap['directory'] != name:
+                raise ValueError('Gamescope wrap differs from lock')
+            destination = source / 'subprojects' / name
+            checkout(wrap['url'], revision, destination)
+            shutil.copytree(source / 'subprojects/packagefiles' / name, destination, dirs_exist_ok=True)
+        canonical_archive(source, archive, lock, ['.git', './build'])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('profile', choices=['gamescope', 'steam', 'heroic', 'lutris'])
+    parser.add_argument('--nvidia', action='store_true')
+    args = parser.parse_args()
+    if platform.system() != 'Linux' or platform.machine() not in ('x86_64', 'amd64'):
+        parser.error('prepare inputs on Linux/amd64 with Python 3.11+, GNU tar and git')
+    INPUTS.mkdir(parents=True, exist_ok=True)
+    package_lock = json.loads((HERE / 'locks' / (args.profile + '.packages.json')).read_text())
+    downloads = []
+    for role in ['runtime', 'build']:
+        for package in package_lock[role]:
+            filename = package['filename']
+            if pathlib.Path(filename).name != filename:
+                raise ValueError('unsafe locked filename')
+            downloads.append((package, INPUTS / args.profile / role / filename))
+    rust = json.loads((HERE / 'locks/rust.json').read_text())
+    downloads.append((rust, INPUTS / 'toolchains' / pathlib.PurePosixPath(rust['url']).name))
+    if args.nvidia:
+        nvidia = json.loads((HERE / 'locks/nvidia.json').read_text())
+        downloads.append((nvidia, INPUTS / pathlib.PurePosixPath(nvidia['url']).name))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda item: fetch(*item), downloads))
+    prepare_plugin(json.loads((HERE / 'locks/plugin.json').read_text()), rust)
+    prepare_gamescope(json.loads((HERE / 'locks/gamescope.json').read_text()))
+    images = json.loads((HERE / 'images.lock.json').read_text())
+    profile = next(p for p in images['runtime_profiles'] if p['id'] == args.profile)
+    if images['schema'] != 2 or profile['reference'] != package_lock['source_root']:
+        raise ValueError('package lock does not match the selected source root')
+    for reference in [images['builder']['reference'], profile['reference']]:
+        run(['podman', 'pull', '--platform=linux/amd64', reference])
+    print('Verified all offline inputs for ' + args.profile)
+
+
+if __name__ == '__main__':
+    main()

--- a/containers/multiseat/resolve-packages.sh
+++ b/containers/multiseat/resolve-packages.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Run only in a disposable instance of an exact locked source root.
+# This resolver creates reviewable inputs; final builds never invoke apt update.
+set -eu
+export DEBIAN_FRONTEND=noninteractive
+sed -i 's|http://archive.ubuntu.com/ubuntu/|https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/|g; s|http://security.ubuntu.com/ubuntu/|https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/|g' /etc/apt/sources.list.d/ubuntu.sources
+apt-get -o Acquire::Check-Valid-Until=false update
+runtime='dbus pipewire pipewire-pulse pipewire-bin libspa-0.2-modules libpipewire-0.3-modules pulseaudio-utils gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad libegl1 libgbm1 libgl1 libvulkan1 libwayland-client0 xwayland'
+build='ca-certificates pkg-config build-essential clang libclang-dev libudev-dev libinput-dev libxkbcommon-dev libwayland-dev libegl-dev libgbm-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev meson ninja-build cmake glslang-tools libpipewire-0.3-dev libx11-dev libxdamage-dev libxcomposite-dev libxcursor-dev libxrender-dev libxext-dev libxfixes-dev libxxf86vm-dev libxtst-dev libxres-dev libxmu-dev libxi-dev libdrm-dev libvulkan-dev wayland-protocols libpixman-1-dev libdecor-0-dev libluajit-5.1-dev libseat-dev libxcb-composite0-dev libxcb-icccm4-dev libxcb-res0-dev libxcb-ewmh-dev hwdata git'
+for role in runtime build; do
+  mkdir -p "/out/$role/partial"
+  requested="$runtime"
+  if [ "$role" = build ]; then requested="$runtime $build"; fi
+  # Word splitting is intentional for the fixed package list above.
+  apt-get --yes --no-install-recommends --print-uris install $requested > "/out/$role.uris"
+  apt-get --yes --no-install-recommends --download-only -o "Dir::Cache::archives=/out/$role" install $requested
+  for package in "/out/$role/"*.deb; do
+    [ -f "$package" ] || continue
+    basename "$package"
+    dpkg-deb --show --showformat='${Package}\t${Version}\t${Architecture}\n' "$package"
+    sha256sum "$package"
+  done > "/out/$role.manifest"
+done
+dpkg-query -W -f='${Package}\t${Version}\t${Architecture}\n' > /out/source-packages.tsv
+cp /etc/apt/sources.list.d/ubuntu.sources /out/resolved.sources

--- a/containers/multiseat/selinux/polaris_nvidia_worker.te
+++ b/containers/multiseat/selinux/polaris_nvidia_worker.te
@@ -1,0 +1,16 @@
+policy_module(polaris_nvidia_worker, 1.0.0)
+
+gen_require(`
+    type container_file_t;
+    type xserver_misc_device_t;
+    type polaris_multiseat_input_device_t;
+')
+
+# Opt-in physical worker domain. Preserve the reference policy's container
+# lifecycle and MCS constraints; never widen the generic container_t domain.
+container_domain_template(polaris_nvidia_worker, container)
+
+# Device admission still comes exclusively from the exact GPU catalog. This
+# domain does not create, mount, relabel, or discover additional host devices.
+allow polaris_nvidia_worker_t xserver_misc_device_t:chr_file { getattr open read write ioctl map };
+allow polaris_nvidia_worker_t polaris_multiseat_input_device_t:chr_file { getattr open read };

--- a/containers/multiseat/selinux/polaris_nvidia_worker.te
+++ b/containers/multiseat/selinux/polaris_nvidia_worker.te
@@ -11,6 +11,7 @@ gen_require(`
 container_domain_template(polaris_nvidia_worker, container)
 
 # Device admission still comes exclusively from the exact GPU catalog. This
-# domain does not create, mount, relabel, or discover additional host devices.
+# standard container template retains file-management permissions; dropped Linux
+# capabilities and the mount classifier must constrain those permissions.
 allow polaris_nvidia_worker_t xserver_misc_device_t:chr_file { getattr open read write ioctl map };
 allow polaris_nvidia_worker_t polaris_multiseat_input_device_t:chr_file { getattr open read };

--- a/containers/multiseat/test_artifact_integrity.py
+++ b/containers/multiseat/test_artifact_integrity.py
@@ -1,0 +1,89 @@
+"""Exercise corrupted and substituted inputs at the offline artifact boundary."""
+import hashlib
+import importlib.util
+import io
+import json
+import pathlib
+import tarfile
+import tempfile
+import unittest
+
+from oci_archive import verify_archive
+
+spec = importlib.util.spec_from_file_location('verify_inputs', pathlib.Path(__file__).with_name('verify-inputs.py'))
+inputs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(inputs)
+
+
+class ArtifactIntegrity(unittest.TestCase):
+    def test_offline_packages_reject_substitution(self):
+        for mutation in ['valid', 'modified', 'missing', 'extra', 'symlink', 'traversal', 'duplicate']:
+            with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as temporary:
+                root = pathlib.Path(temporary)
+                (root / 'packages').mkdir()
+                package = root / 'packages/pkg.deb'
+                package.write_bytes(b'locked package')
+                entry = {'filename': 'pkg.deb', 'sha256': hashlib.sha256(package.read_bytes()).hexdigest()}
+                lock = {'platform': 'linux/amd64', 'runtime': [entry]}
+                if mutation == 'modified':
+                    package.write_bytes(b'substituted package')
+                elif mutation == 'missing':
+                    package.unlink()
+                elif mutation == 'extra':
+                    (root / 'packages/extra.deb').write_bytes(b'extra')
+                elif mutation == 'symlink':
+                    package.rename(root / 'other')
+                    package.symlink_to(root / 'other')
+                elif mutation == 'traversal':
+                    entry['filename'] = '../pkg.deb'
+                elif mutation == 'duplicate':
+                    lock['runtime'].append(dict(entry))
+                (root / 'packages.json').write_text(json.dumps(lock))
+                if mutation == 'valid':
+                    inputs.verify_inputs(root, root, 'runtime')
+                else:
+                    with self.assertRaises(ValueError):
+                        inputs.verify_inputs(root, root, 'runtime')
+
+    def test_export_is_bound_to_config_and_all_layers(self):
+        for mutation in ['valid', 'config', 'layer', 'size', 'duplicate', 'symlink']:
+            with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as temporary:
+                blobs = {}
+
+                def blob(data, media_type):
+                    digest = hashlib.sha256(data).hexdigest()
+                    blobs['blobs/sha256/' + digest] = data
+                    return {'digest': 'sha256:' + digest, 'size': len(data), 'mediaType': media_type}
+
+                config = blob(b'{"architecture":"amd64","os":"linux"}', 'application/vnd.oci.image.config.v1+json')
+                layer = blob(b'original layer', 'application/vnd.oci.image.layer.v1.tar')
+                if mutation == 'size':
+                    layer['size'] += 1
+                manifest = blob(json.dumps({'schemaVersion': 2, 'config': config, 'layers': [layer]}).encode(),
+                                'application/vnd.oci.image.manifest.v1+json')
+                if mutation == 'layer':
+                    blobs['blobs/sha256/' + layer['digest'][7:]] = b'tampered layer'
+                blobs['oci-layout'] = b'{"imageLayoutVersion":"1.0.0"}'
+                blobs['index.json'] = json.dumps({'schemaVersion': 2, 'manifests': [manifest]}).encode()
+                path = pathlib.Path(temporary) / 'worker.tar'
+                with tarfile.open(path, 'w') as archive:
+                    for name, data in blobs.items():
+                        member = tarfile.TarInfo(name)
+                        member.size = len(data)
+                        archive.addfile(member, io.BytesIO(data))
+                    if mutation in ['duplicate', 'symlink']:
+                        member = tarfile.TarInfo('index.json' if mutation == 'duplicate' else 'link')
+                        if mutation == 'symlink':
+                            member.type = tarfile.SYMTYPE
+                            member.linkname = '/etc/passwd'
+                        archive.addfile(member)
+                expected = 'sha256:' + '0' * 64 if mutation == 'config' else config['digest']
+                if mutation == 'valid':
+                    self.assertEqual(verify_archive(path, expected), manifest['digest'])
+                else:
+                    with self.assertRaises(ValueError):
+                        verify_archive(path, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/containers/multiseat/test_artifact_integrity.py
+++ b/containers/multiseat/test_artifact_integrity.py
@@ -8,15 +8,60 @@ import pathlib
 import tarfile
 import tempfile
 import unittest
+from unittest import mock
 
 from oci_archive import verify_archive
 
 spec = importlib.util.spec_from_file_location('verify_inputs', pathlib.Path(__file__).with_name('verify-inputs.py'))
 inputs = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(inputs)
+spec = importlib.util.spec_from_file_location('build_image', pathlib.Path(__file__).with_name('build-image.py'))
+build = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build)
 
 
 class ArtifactIntegrity(unittest.TestCase):
+    def test_committed_context_excludes_ignored_injection_and_concurrent_edits(self):
+        with tempfile.TemporaryDirectory() as temporary, mock.patch.object(build, 'REPO', pathlib.Path(temporary)):
+            root = pathlib.Path(temporary)
+            here = root / 'containers/multiseat'
+            (here / 'locks').mkdir(parents=True)
+            (root / 'multiseat_worker').mkdir()
+            (root / '.gitignore').write_text('*sync-conflict*\nbuild/\n')
+            original = 'package main\n'
+            source = root / 'multiseat_worker/main.go'
+            source.write_text(original)
+            checksum = hashlib.sha256(b'locked').hexdigest()
+            packages = {'platform': 'linux/amd64', 'source_root': 'locked-root',
+                        'runtime': [{'filename': 'pkg.deb', 'sha256': checksum}],
+                        'build': [{'filename': 'pkg.deb', 'sha256': checksum}]}
+            (here / 'locks/gamescope.packages.json').write_text(json.dumps(packages))
+            locks = {name: 'locks/' + name + '.json' for name in ['rust', 'plugin', 'gamescope']}
+            for name, path in locks.items():
+                (here / path).write_text(json.dumps({'sha256': checksum, 'url': 'https://example.invalid/rust.tar.xz'}))
+            (here / 'images.lock.json').write_text(json.dumps({
+                'runtime_profiles': [{'id': 'gamescope', 'dependency_lock': 'locks/gamescope.packages.json'}],
+                'dependency_locks': locks}))
+            for filename in ['gamescope/runtime/pkg.deb', 'gamescope/build/pkg.deb',
+                             'toolchains/rust.tar.xz', 'plugin.tar', 'gamescope.tar']:
+                path = root / 'build/runtime-inputs' / filename
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b'locked')
+            build.run(['git', 'init', '-q'])
+            build.run(['git', 'add', '.'])
+            build.run(['git', '-c', 'user.name=Artifact Test', '-c', 'user.email=artifact@example.invalid',
+                       '-c', 'commit.gpgsign=false', 'commit', '-qm', 'fixture'])
+            revision = build.output(['git', 'rev-parse', 'HEAD']).strip()
+            (root / 'multiseat_worker/extra.sync-conflict-local.go').write_text('package main\nfunc init() {}\n')
+            source.write_text('edited during build')
+            (here / 'locks/plugin.json').write_text('{}')
+            with build.materialized_context(revision, 'gamescope', False) as context:
+                self.assertFalse((context / 'multiseat_worker/extra.sync-conflict-local.go').exists())
+                self.assertEqual((context / 'multiseat_worker/main.go').read_text(), original)
+                self.assertEqual(json.loads((context / 'containers/multiseat/locks/plugin.json').read_text())['sha256'], checksum)
+                (root / 'build/runtime-inputs/plugin.tar').write_bytes(b'changed cache')
+                self.assertEqual((context / 'build/runtime-inputs/plugin.tar').read_bytes(), b'locked')
+
     def test_offline_packages_reject_substitution(self):
         for mutation in ['valid', 'modified', 'missing', 'extra', 'symlink', 'traversal', 'duplicate']:
             with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as temporary:

--- a/containers/multiseat/test_artifact_integrity.py
+++ b/containers/multiseat/test_artifact_integrity.py
@@ -1,5 +1,6 @@
 """Exercise corrupted and substituted inputs at the offline artifact boundary."""
 import hashlib
+import gzip
 import importlib.util
 import io
 import json
@@ -46,7 +47,8 @@ class ArtifactIntegrity(unittest.TestCase):
                         inputs.verify_inputs(root, root, 'runtime')
 
     def test_export_is_bound_to_config_and_all_layers(self):
-        for mutation in ['valid', 'config', 'layer', 'size', 'duplicate', 'symlink']:
+        for mutation in ['valid', 'gzip', 'config', 'layer', 'size', 'duplicate', 'symlink',
+                         'substituted', 'additional', 'reordered', 'encoding']:
             with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as temporary:
                 blobs = {}
 
@@ -55,11 +57,25 @@ class ArtifactIntegrity(unittest.TestCase):
                     blobs['blobs/sha256/' + digest] = data
                     return {'digest': 'sha256:' + digest, 'size': len(data), 'mediaType': media_type}
 
-                config = blob(b'{"architecture":"amd64","os":"linux"}', 'application/vnd.oci.image.config.v1+json')
                 layer = blob(b'original layer', 'application/vnd.oci.image.layer.v1.tar')
+                second = blob(b'second original layer', 'application/vnd.oci.image.layer.v1.tar')
+                config = blob(json.dumps({'architecture': 'amd64', 'os': 'linux',
+                                         'rootfs': {'type': 'layers', 'diff_ids': [layer['digest'], second['digest']]}}).encode(),
+                              'application/vnd.oci.image.config.v1+json')
+                layers = [layer, second]
                 if mutation == 'size':
                     layer['size'] += 1
-                manifest = blob(json.dumps({'schemaVersion': 2, 'config': config, 'layers': [layer]}).encode(),
+                elif mutation == 'substituted':
+                    layers[0] = blob(b'self-consistent substitution', 'application/vnd.oci.image.layer.v1.tar')
+                elif mutation == 'additional':
+                    layers.append(blob(b'added layer', 'application/vnd.oci.image.layer.v1.tar'))
+                elif mutation == 'reordered':
+                    layers.reverse()
+                elif mutation == 'encoding':
+                    layer['mediaType'] += '+unsupported'
+                elif mutation == 'gzip':
+                    layers[0] = blob(gzip.compress(b'original layer'), 'application/vnd.oci.image.layer.v1.tar+gzip')
+                manifest = blob(json.dumps({'schemaVersion': 2, 'config': config, 'layers': layers}).encode(),
                                 'application/vnd.oci.image.manifest.v1+json')
                 if mutation == 'layer':
                     blobs['blobs/sha256/' + layer['digest'][7:]] = b'tampered layer'
@@ -78,7 +94,7 @@ class ArtifactIntegrity(unittest.TestCase):
                             member.linkname = '/etc/passwd'
                         archive.addfile(member)
                 expected = 'sha256:' + '0' * 64 if mutation == 'config' else config['digest']
-                if mutation == 'valid':
+                if mutation in ['valid', 'gzip']:
                     self.assertEqual(verify_archive(path, expected), manifest['digest'])
                 else:
                     with self.assertRaises(ValueError):

--- a/containers/multiseat/verify-inputs.py
+++ b/containers/multiseat/verify-inputs.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Verify every offline build input against the repository's reviewed locks."""
+import hashlib
+import json
+import pathlib
+import sys
+
+
+def verify(path, expected):
+    if path.is_symlink() or not path.is_file():
+        raise ValueError('input must be a regular file: ' + str(path))
+    with path.open('rb') as stream:
+        digest = hashlib.file_digest(stream, 'sha256').hexdigest()
+    if digest != expected:
+        raise ValueError('input checksum mismatch: ' + path.name)
+
+
+def verify_inputs(root, locks, role):
+    lock = json.loads((locks / 'packages.json').read_text())
+    if role not in ('build', 'runtime') or lock['platform'] != 'linux/amd64':
+        raise ValueError('unsupported package role or architecture')
+    packages = root / 'packages'
+    if packages.is_symlink() or not packages.is_dir():
+        raise ValueError('expected a regular input directory')
+    expected = set()
+    for package in lock[role]:
+        filename = package['filename']
+        if pathlib.Path(filename).name != filename or not filename.endswith('.deb') or filename in expected:
+            raise ValueError('unsafe or duplicate package filename')
+        expected.add(filename)
+        verify(packages / filename, package['sha256'])
+    actual = {p.name for p in packages.glob('*.deb')}
+    if actual != expected:
+        raise ValueError('unexpected or missing dependency input')
+    if role == 'build':
+        for filename, lockname in [('rust.tar.xz', 'rust.json'), ('plugin.tar', 'plugin.json'), ('gamescope.tar', 'gamescope.json')]:
+            verify(root / filename, json.loads((locks / lockname).read_text())['sha256'])
+
+
+if __name__ == '__main__':
+    verify_inputs(pathlib.Path('/inputs'), pathlib.Path('/locks'), sys.argv[1])

--- a/containers/multiseat/write-package-lock.py
+++ b/containers/multiseat/write-package-lock.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Turn resolver evidence into a hash-pinned, architecture-specific package lock."""
+import argparse
+import hashlib
+import json
+import pathlib
+import shlex
+
+
+def package_lock(root, role):
+    uris = {}
+    for line in (root / (role + '.uris')).read_text().splitlines():
+        if line.startswith("'"):
+            fields = shlex.split(line)
+            uris[fields[1]] = fields[0]
+    entries = []
+    lines = (root / (role + '.manifest')).read_text().splitlines()
+    if len(lines) % 3:
+        raise ValueError('incomplete package manifest')
+    for offset in range(0, len(lines), 3):
+        filename = lines[offset]
+        name, version, architecture = lines[offset + 1].split('\t')
+        digest = lines[offset + 2].split()[0]
+        path = root / role / filename
+        if hashlib.sha256(path.read_bytes()).hexdigest() != digest:
+            raise ValueError('package bytes changed: ' + filename)
+        entries.append(dict(name=name, version=version, architecture=architecture,
+                            filename=filename, sha256=digest, url=uris[filename]))
+    return sorted(entries, key=lambda package: (package['name'], package['architecture']))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('profile')
+    parser.add_argument('input_directory', type=pathlib.Path)
+    parser.add_argument('output', type=pathlib.Path)
+    args = parser.parse_args()
+    lock_path = pathlib.Path(__file__).with_name('images.lock.json')
+    profile = next(p for p in json.loads(lock_path.read_text())['runtime_profiles'] if p['id'] == args.profile)
+    result = dict(schema=1, profile=args.profile, platform='linux/amd64',
+                  source_root=profile['reference'],
+                  snapshot='https://snapshot.ubuntu.com/ubuntu/20260120T000000Z/',
+                  source_manifest_sha256=hashlib.sha256((args.input_directory / 'source-packages.tsv').read_bytes()).hexdigest(),
+                  runtime=package_lock(args.input_directory, 'runtime'),
+                  build=package_lock(args.input_directory, 'build'))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/multiseat_worker/cmd/polaris-seat-input-probe/main.go
+++ b/multiseat_worker/cmd/polaris-seat-input-probe/main.go
@@ -1,0 +1,230 @@
+//go:build linux && amd64
+
+// polaris-seat-input-probe is an opt-in physical acceptance helper. Production
+// worker startup never calls it; it reads only the four reserved seat aliases.
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"syscall"
+	"time"
+)
+
+type device struct {
+	Path  string `json:"path"`
+	Major uint32 `json:"major"`
+	Minor uint32 `json:"minor"`
+}
+type request struct {
+	Token   string   `json:"token"`
+	Devices []device `json:"devices"`
+	Absent  []string `json:"absent"`
+}
+type observation struct {
+	Markers [4]int `json:"markers"`
+	Events  [4]int `json:"events"`
+}
+
+var aliases = [4]string{"/dev/input/polaris-keyboard", "/dev/input/polaris-mouse-relative", "/dev/input/polaris-mouse-absolute", "/dev/input/polaris-gamepad-0"}
+var tokenPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+var eventPattern = regexp.MustCompile(`^/dev/input/event[0-9]+$`)
+
+func marker(index int, kind, code uint16, value int32) bool {
+	switch index {
+	case 0:
+		return kind == 1 && code == 30 && value == 1
+	case 1:
+		return kind == 2 && code == 0 && value == 7
+	case 2:
+		return kind == 3 && code == 0 && value > 0
+	case 3:
+		return kind == 1 && code == 304 && value == 1
+	}
+	return false
+}
+func readyPath(token string) (string, error) {
+	if !tokenPattern.MatchString(token) {
+		return "", errors.New("invalid probe token")
+	}
+	return filepath.Join("/run/polaris", "input-probe-"+token+".ready"), nil
+}
+
+type observationWindow struct{ deadline, drainUntil time.Time }
+
+func (window *observationWindow) advance(now time.Time, finish bool) (bool, error) {
+	if !now.Before(window.deadline) {
+		return false, errors.New("host finish signal did not complete before deadline")
+	}
+	if finish && window.drainUntil.IsZero() {
+		window.drainUntil = now.Add(250 * time.Millisecond)
+	}
+	return !window.drainUntil.IsZero() && !now.Before(window.drainUntil), nil
+}
+func recordEvent(result *observation, index int, event []byte) error {
+	if len(event) != 24 {
+		return errors.New("truncated kernel event")
+	}
+	kind, code := binary.LittleEndian.Uint16(event[16:18]), binary.LittleEndian.Uint16(event[18:20])
+	value := int32(binary.LittleEndian.Uint32(event[20:24]))
+	if kind == 0 && code == 3 {
+		return errors.New("kernel input observation dropped events")
+	}
+	if kind != 0 {
+		result.Events[index]++
+	}
+	if marker(index, kind, code, value) {
+		result.Markers[index]++
+	}
+	if result.Events[index] > 4096 {
+		return errors.New("input observation limit exceeded")
+	}
+	return nil
+}
+
+func observe(req request) (observation, error) {
+	var result observation
+	ready, err := readyPath(req.Token)
+	if err != nil {
+		return result, err
+	}
+	if len(req.Devices) != len(aliases) || len(req.Absent) > 32 {
+		return result, errors.New("invalid device manifest")
+	}
+	for _, path := range append(req.Absent, "/dev/uinput", "/dev/uhid") {
+		if path != "/dev/uinput" && path != "/dev/uhid" && !eventPattern.MatchString(path) {
+			return result, errors.New("invalid excluded node")
+		}
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			return result, errors.New("unallocated input node is visible")
+		}
+	}
+	entries, err := os.ReadDir("/dev/input")
+	if err != nil || len(entries) != len(aliases) {
+		return result, errors.New("unexpected input namespace")
+	}
+	fds := make([]int, 0, len(aliases))
+	defer func() {
+		for _, fd := range fds {
+			syscall.Close(fd)
+		}
+	}()
+	for index, dev := range req.Devices {
+		if dev.Path != aliases[index] {
+			return result, errors.New("unexpected seat alias")
+		}
+		fd, err := syscall.Open(dev.Path, syscall.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+		if err != nil {
+			return result, fmt.Errorf("allocated input %d cannot be opened: %w", index, err)
+		}
+		fds = append(fds, fd)
+		var stat syscall.Stat_t
+		if err := syscall.Fstat(fd, &stat); err != nil {
+			return result, err
+		}
+		major := uint32((stat.Rdev>>8)&0xfff | (stat.Rdev>>32)&0xfffff000)
+		minor := uint32(stat.Rdev&0xff | (stat.Rdev>>12)&0xffffff00)
+		if stat.Mode&syscall.S_IFMT != syscall.S_IFCHR || major != dev.Major || minor != dev.Minor {
+			return result, errors.New("allocated device identity changed")
+		}
+	}
+	fd, err := syscall.Open(ready, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_EXCL|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0600)
+	if err != nil {
+		return result, err
+	}
+	if _, err = syscall.Write(fd, []byte("ready\n")); err != nil {
+		syscall.Close(fd)
+		os.Remove(ready)
+		return result, err
+	}
+	syscall.Close(fd)
+	defer os.Remove(ready)
+	finish := ready + ".finish"
+	defer os.Remove(finish)
+	window := observationWindow{deadline: time.Now().Add(10 * time.Second)}
+	finishSeen := false
+	buffer := make([]byte, 24*64)
+	for {
+		if !finishSeen {
+			if info, err := os.Lstat(finish); err == nil {
+				if !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+					return result, errors.New("invalid finish signal")
+				}
+				finishSeen = true
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return result, err
+			}
+		}
+		for index, fd := range fds {
+			count, err := syscall.Read(fd, buffer)
+			if err == syscall.EAGAIN || err == syscall.EINTR {
+				continue
+			}
+			if err != nil {
+				return result, err
+			}
+			if count%24 != 0 {
+				return result, errors.New("truncated kernel event")
+			}
+			for offset := 0; offset < count; offset += 24 {
+				if err := recordEvent(&result, index, buffer[offset:offset+24]); err != nil {
+					return result, err
+				}
+			}
+		}
+		completed, err := window.advance(time.Now(), finishSeen)
+		if err != nil {
+			return result, err
+		}
+		if completed {
+			return result, nil
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+func run() error {
+	if len(os.Args) != 3 {
+		return errors.New("expected observe manifest or ready token")
+	}
+	if os.Args[1] == "ready" || os.Args[1] == "finish" {
+		path, err := readyPath(os.Args[2])
+		if err != nil {
+			return err
+		}
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+			return errors.New("probe is not ready")
+		}
+		if os.Args[1] == "finish" {
+			fd, err := syscall.Open(path+".finish", syscall.O_WRONLY|syscall.O_CREAT|syscall.O_EXCL|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0600)
+			if err != nil {
+				return err
+			}
+			return syscall.Close(fd)
+		}
+		return nil
+	}
+	if os.Args[1] != "observe" || len(os.Args[2]) > 16384 {
+		return errors.New("invalid observation request")
+	}
+	var req request
+	if err := json.Unmarshal([]byte(os.Args[2]), &req); err != nil {
+		return err
+	}
+	result, err := observe(req)
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(os.Stdout).Encode(result)
+}
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/multiseat_worker/cmd/polaris-seat-input-probe/main_test.go
+++ b/multiseat_worker/cmd/polaris-seat-input-probe/main_test.go
@@ -1,0 +1,64 @@
+//go:build linux && amd64
+
+package main
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+)
+
+func TestOnlyExpectedSyntheticMarkersMatch(t *testing.T) {
+	for index, tuple := range [][3]int32{{1, 30, 1}, {2, 0, 7}, {3, 0, 120}, {1, 304, 1}} {
+		if !marker(index, uint16(tuple[0]), uint16(tuple[1]), tuple[2]) {
+			t.Fatal("expected marker missing", index)
+		}
+		if marker(index, uint16(tuple[0]), uint16(tuple[1]), 0) {
+			t.Fatal("neutral state matched", index)
+		}
+		if marker(index, 0, 0, 0) {
+			t.Fatal("SYN event matched", index)
+		}
+	}
+}
+func TestProbeTokensCannotEscapePrivateRuntime(t *testing.T) {
+	for _, token := range []string{"", "../other", "0123456789abcdef0123456789abcdefff/other"} {
+		if _, err := readyPath(token); err == nil {
+			t.Fatal("unsafe token accepted")
+		}
+	}
+	if _, err := readyPath("0123456789abcdef0123456789abcdef"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDelayedObserverCannotSucceedBeforeHostFinish(t *testing.T) {
+	start := time.Unix(0, 0)
+	window := observationWindow{deadline: start.Add(10 * time.Second)}
+	for _, elapsed := range []time.Duration{0, 3 * time.Second, 5 * time.Second} {
+		if done, err := window.advance(start.Add(elapsed), false); done || err != nil {
+			t.Fatal("observer ended before finish", elapsed, done, err)
+		}
+	}
+	if done, err := window.advance(start.Add(6*time.Second), true); done || err != nil {
+		t.Fatal("finish did not leave drain window", done, err)
+	}
+	if done, err := window.advance(start.Add(6250*time.Millisecond), true); !done || err != nil {
+		t.Fatal("completed drain was not accepted", done, err)
+	}
+}
+func TestTimeoutWithoutHostFinishFailsIsolationEvidence(t *testing.T) {
+	start := time.Unix(0, 0)
+	window := observationWindow{deadline: start.Add(10 * time.Second)}
+	if done, err := window.advance(start.Add(10*time.Second), false); done || err == nil {
+		t.Fatal("timeout became successful isolation evidence")
+	}
+}
+func TestDroppedKernelEventsInvalidateObservation(t *testing.T) {
+	event := make([]byte, 24)
+	binary.LittleEndian.PutUint16(event[18:20], 3)
+	var result observation
+	if err := recordEvent(&result, 0, event); err == nil {
+		t.Fatal("SYN_DROPPED was ignored")
+	}
+}

--- a/multiseat_worker/image_contract_test.go
+++ b/multiseat_worker/image_contract_test.go
@@ -10,10 +10,13 @@ import (
 )
 
 type lockedImage struct {
-	ID        string `json:"id"`
-	Launcher  string `json:"launcher"`
-	Reference string `json:"reference"`
-	Source    string `json:"source"`
+	ID                     string `json:"id"`
+	Launcher               string `json:"launcher"`
+	Reference              string `json:"reference"`
+	Source                 string `json:"source"`
+	Role                   string `json:"role"`
+	DependencyLock         string `json:"dependency_lock"`
+	ProducedWorkerManifest string `json:"produced_worker_manifest"`
 }
 
 type imageLock struct {
@@ -41,7 +44,7 @@ func TestImageInputsAreDigestPinnedAndComplete(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	if lock.Schema != 1 || lock.Platform != "linux/amd64" {
+	if lock.Schema != 2 || lock.Platform != "linux/amd64" {
 		t.Fatalf("unsupported image lock: %+v", lock)
 	}
 	digestReference := regexp.MustCompile(`^[a-z0-9][a-z0-9._/-]*(?::[a-z0-9._-]+)?@sha256:[0-9a-f]{64}$`)
@@ -55,6 +58,35 @@ func TestImageInputsAreDigestPinnedAndComplete(t *testing.T) {
 		}
 		seenIDs[image.ID] = true
 		seenReferences[image.Reference] = true
+	}
+	for _, profile := range lock.RuntimeProfiles {
+		if profile.Role != "source_root" || profile.DependencyLock != "locks/"+profile.ID+".packages.json" ||
+			profile.ProducedWorkerManifest != profile.ID+"/<variant>/artifact.json" {
+			t.Fatalf("source inputs and produced worker artifact are not distinguished: %+v", profile)
+		}
+		var packages struct {
+			SourceRoot string              `json:"source_root"`
+			Platform   string              `json:"platform"`
+			Runtime    []map[string]string `json:"runtime"`
+			Build      []map[string]string `json:"build"`
+		}
+		if err := json.Unmarshal(repositoryFile(t, "containers", "multiseat", profile.DependencyLock), &packages); err != nil {
+			t.Fatal(err)
+		}
+		if packages.SourceRoot != profile.Reference || packages.Platform != lock.Platform || len(packages.Runtime) == 0 || len(packages.Build) == 0 {
+			t.Fatal("package closure is not bound to its source root and architecture")
+		}
+		for _, role := range [][]map[string]string{packages.Runtime, packages.Build} {
+			seen := map[string]bool{}
+			for _, pkg := range role {
+				if pkg["name"] == "" || pkg["version"] == "" || !strings.HasPrefix(pkg["url"], "https://") ||
+					!regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(pkg["sha256"]) ||
+					filepath.Base(pkg["filename"]) != pkg["filename"] || seen[pkg["filename"]] {
+					t.Fatal("dependency input is incomplete or duplicated")
+				}
+				seen[pkg["filename"]] = true
+			}
+		}
 	}
 	for _, required := range []string{"go", "gamescope", "steam", "heroic", "lutris"} {
 		if !seenIDs[required] {

--- a/multiseat_worker/internal/seatprovider/audio_linux.go
+++ b/multiseat_worker/internal/seatprovider/audio_linux.go
@@ -102,7 +102,7 @@ func captureAudioArtifacts(runtime *runtimeDirectory) (map[string]artifactIdenti
 	captured := make(map[string]artifactIdentity, len(audioArtifactSpecs))
 	for _, spec := range audioArtifactSpecs {
 		path := filepath.Join(runtime.path, spec.relative)
-		identity, err := lstatIdentity(path)
+		identity, err := runtime.pins.capture(path)
 		if errors.Is(err, os.ErrNotExist) && !spec.required {
 			continue
 		}
@@ -130,7 +130,7 @@ func cleanupAudioArtifacts(
 			return err
 		}
 		path := filepath.Join(runtime.path, spec.relative)
-		identity, err := lstatIdentity(path)
+		identity, err := runtime.pins.capture(path)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
@@ -154,7 +154,7 @@ func cleanupAudioArtifacts(
 		return err
 	}
 	pulsePath := filepath.Join(runtime.path, pulseSpec.relative)
-	identity, err := lstatIdentity(pulsePath)
+	identity, err := runtime.pins.capture(pulsePath)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}

--- a/multiseat_worker/internal/seatprovider/display_capture_linux.go
+++ b/multiseat_worker/internal/seatprovider/display_capture_linux.go
@@ -114,7 +114,7 @@ func displayProducerArguments(
 	}
 	return append(arguments,
 		displayCaps(request, software), "!", "unixfdsink",
-		"socket-path=" + mediaSocket,
+		"socket-path="+mediaSocket,
 		"sync=false", "async=false", "enable-last-sample=false", "wait-for-connection=false",
 	)
 }
@@ -380,7 +380,7 @@ func prepareDisplayArtifacts(
 		if err := runtime.verify(); err != nil {
 			return known, err
 		}
-		identity, err := lstatIdentity(artifact.path)
+		identity, err := runtime.pins.capture(artifact.path)
 		if err != nil || !validDisplayArtifact(identity, artifact.mode, runtime.uid) {
 			return known, errors.New("runtime display artifact changed before capture")
 		}
@@ -392,7 +392,7 @@ func prepareDisplayArtifacts(
 	if err := os.Link(candidate.sourceSocket, targetSocket); err != nil {
 		return known, errors.New("runtime display socket alias could not be created")
 	}
-	targetIdentity, err := lstatIdentity(targetSocket)
+	targetIdentity, err := runtime.pins.capture(targetSocket)
 	if err != nil || !sameIdentity(targetIdentity, known[candidate.sourceSocket]) {
 		return known, errors.New("runtime display socket alias identity is invalid")
 	}
@@ -467,7 +467,7 @@ func capturePartialDisplayArtifacts(
 		if !displayArtifactMatchesName(path, targetSocket, mediaSocket) {
 			continue
 		}
-		identity, err := lstatIdentity(path)
+		identity, err := runtime.pins.capture(path)
 		if err != nil || identity.uid != runtime.uid || identity.mode&0o077 != 0 {
 			return known, errors.New("runtime display partial artifact is invalid")
 		}

--- a/multiseat_worker/internal/seatprovider/display_capture_linux.go
+++ b/multiseat_worker/internal/seatprovider/display_capture_linux.go
@@ -70,7 +70,7 @@ func displayFrameRate(refreshMillihertz uint32) string {
 func displayCaps(request seatruntime.Request, software bool) string {
 	prefix := "video/x-raw(memory:DMABuf)"
 	if software {
-		prefix = "video/x-raw,format=RGBx"
+		prefix = "video/x-raw,format=BGRx"
 	}
 	return prefix +
 		",width=" + strconv.FormatUint(uint64(request.DisplayWidth), 10) +
@@ -102,20 +102,21 @@ func displayProducerArguments(
 	if software {
 		renderTarget = "software"
 	}
-	return []string{
-		"-q",
-		"waylanddisplaysrc",
-		"render-node=" + renderTarget,
-		"!",
-		displayCaps(request, software),
-		"!",
-		"unixfdsink",
-		"socket-path=" + mediaSocket,
-		"sync=false",
-		"async=false",
-		"enable-last-sample=false",
-		"wait-for-connection=false",
+	arguments := []string{"-q", "waylanddisplaysrc", "render-node=" + renderTarget, "!"}
+	if software {
+		// The plugin's CPU buffers do not carry FDs. A real format conversion
+		// honors unixfdsink's shared-memory allocation proposal on GStreamer
+		// 1.26. The hardware path retains its original DMA-BUF caps unchanged.
+		arguments = append(arguments,
+			strings.Replace(displayCaps(request, true), "format=BGRx", "format=RGBx", 1),
+			"!", "videoconvert", "!",
+		)
 	}
+	return append(arguments,
+		displayCaps(request, software), "!", "unixfdsink",
+		"socket-path=" + mediaSocket,
+		"sync=false", "async=false", "enable-last-sample=false", "wait-for-connection=false",
+	)
 }
 
 func displayProbeArguments(

--- a/multiseat_worker/internal/seatprovider/display_capture_linux_test.go
+++ b/multiseat_worker/internal/seatprovider/display_capture_linux_test.go
@@ -369,7 +369,7 @@ func TestDisplayCapturePipelineIsCanonicalAndPreservesFraction(t *testing.T) {
 	}
 	expectedProbe := []string{
 		"-q", "unixfdsrc", "socket-path=" + mediaSocket, "num-buffers=1", "!",
-		"video/x-raw,format=RGBx,width=1920,height=1080,framerate=2997/50", "!",
+		"video/x-raw,format=BGRx,width=1920,height=1080,framerate=2997/50", "!",
 		"fakesink", "sync=false", "async=false", "enable-last-sample=false",
 	}
 	if actual := displayProbeArguments(request, mediaSocket, true); !reflect.DeepEqual(actual, expectedProbe) {

--- a/multiseat_worker/internal/seatprovider/nested_compositor_linux.go
+++ b/multiseat_worker/internal/seatprovider/nested_compositor_linux.go
@@ -245,6 +245,18 @@ func rejectExistingGamescopeArtifacts(
 	return nil
 }
 
+func captureCreatedArtifact(runtime *runtimeDirectory, path string, descriptor int) (artifactIdentity, error) {
+	var created syscall.Stat_t
+	statError := syscall.Fstat(descriptor, &created)
+	identity, identityError := runtime.pins.capture(path)
+	if statError != nil || identityError != nil || !sameIdentity(identity, artifactIdentity{
+		dev: uint64(created.Dev), ino: created.Ino, mode: created.Mode, uid: created.Uid,
+	}) {
+		return artifactIdentity{rejected: true}, errors.New("runtime Gamescope created artifact was replaced")
+	}
+	return identity, nil
+}
+
 func createGamescopeRegularArtifact(
 	runtime *runtimeDirectory,
 	path string,
@@ -262,12 +274,12 @@ func createGamescopeRegularArtifact(
 		0o600,
 	)
 	if err != nil {
-		return artifactIdentity{}, errors.New("runtime Gamescope artifact could not be created")
+		return artifactIdentity{rejected: true}, errors.New("runtime Gamescope artifact could not be created")
 	}
 	file := os.NewFile(uintptr(descriptor), "polaris-gamescope-artifact")
 	if file == nil {
 		_ = syscall.Close(descriptor)
-		return artifactIdentity{}, errors.New("runtime Gamescope artifact could not be created")
+		return artifactIdentity{rejected: true}, errors.New("runtime Gamescope artifact could not be created")
 	}
 	writeError := error(nil)
 	for remaining := content; len(remaining) > 0; {
@@ -281,11 +293,13 @@ func createGamescopeRegularArtifact(
 	if writeError == nil && len(content) > 0 {
 		writeError = file.Sync()
 	}
+	identity, identityError := captureCreatedArtifact(runtime, path, descriptor)
 	closeError := file.Close()
-	identity, identityError := lstatIdentity(path)
-	if writeError != nil || closeError != nil || identityError != nil ||
-		identity.mode&syscall.S_IFMT != syscall.S_IFREG ||
+	if identityError != nil || identity.mode&syscall.S_IFMT != syscall.S_IFREG ||
 		identity.uid != runtime.uid || identity.mode&0o7777 != 0o600 {
+		return artifactIdentity{rejected: true}, errors.New("runtime Gamescope created artifact ownership is invalid")
+	}
+	if writeError != nil || closeError != nil {
 		return identity, errors.New("runtime Gamescope artifact is invalid")
 	}
 	return identity, nil
@@ -302,12 +316,12 @@ func createGamescopeReadyFIFO(
 		return nil, artifactIdentity{}, err
 	}
 	if err := syscall.Mkfifo(path, 0o600); err != nil {
-		return nil, artifactIdentity{}, errors.New("runtime Gamescope readiness FIFO could not be created")
+		return nil, artifactIdentity{rejected: true}, errors.New("runtime Gamescope readiness FIFO could not be created")
 	}
-	identity, err := lstatIdentity(path)
+	identity, err := runtime.pins.capture(path)
 	if err != nil || identity.mode&syscall.S_IFMT != syscall.S_IFIFO ||
 		identity.uid != runtime.uid || identity.mode&0o7777 != 0o600 {
-		return nil, identity, errors.New("runtime Gamescope readiness FIFO is invalid")
+		return nil, artifactIdentity{rejected: true}, errors.New("runtime Gamescope readiness FIFO is invalid")
 	}
 	descriptor, err := syscall.Open(
 		path,
@@ -321,6 +335,11 @@ func createGamescopeReadyFIFO(
 	if file == nil {
 		_ = syscall.Close(descriptor)
 		return nil, identity, errors.New("runtime Gamescope readiness FIFO is unavailable")
+	}
+	opened, err := captureCreatedArtifact(runtime, path, descriptor)
+	if err != nil || !sameIdentity(opened, identity) {
+		_ = file.Close()
+		return nil, artifactIdentity{rejected: true}, errors.New("runtime Gamescope readiness FIFO was replaced")
 	}
 	return file, identity, nil
 }
@@ -402,7 +421,7 @@ func captureGamescopeArtifacts(
 			continue
 		}
 		path := filepath.Join(runtime.path, entry.Name())
-		identity, err := lstatIdentity(path)
+		identity, err := runtime.pins.capture(path)
 		if err != nil || !validGamescopeArtifact(identity, mode, runtime.uid) {
 			result = errors.Join(
 				result,
@@ -537,7 +556,7 @@ func captureX11Baseline(
 			display,
 		)
 		for _, path := range []string{socketPath, lockPath} {
-			identity, err := lstatIdentity(path)
+			identity, err := socketDirectory.pins.capture(path)
 			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
@@ -589,7 +608,7 @@ func captureGamescopeX11Artifacts(
 		{socketPath, syscall.S_IFSOCK},
 		{lockPath, syscall.S_IFREG},
 	} {
-		identity, err := lstatIdentity(artifact.path)
+		identity, err := socketDirectory.pins.capture(artifact.path)
 		if err != nil || !validGamescopeArtifact(identity, artifact.mode, uid) {
 			return captured, "", errors.New("runtime Gamescope X11 artifact is invalid")
 		}
@@ -635,8 +654,8 @@ func capturePartialGamescopeX11Artifacts(
 			lockDirectory.path,
 			display,
 		)
-		socketIdentity, socketError := lstatIdentity(socketPath)
-		lockIdentity, lockError := lstatIdentity(lockPath)
+		socketIdentity, socketError := socketDirectory.pins.capture(socketPath)
+		lockIdentity, lockError := socketDirectory.pins.capture(lockPath)
 		socketMissing := errors.Is(socketError, os.ErrNotExist)
 		lockMissing := errors.Is(lockError, os.ErrNotExist)
 		if socketMissing && lockMissing {
@@ -868,7 +887,7 @@ func runNestedCompositor(
 	if err := rejectExistingGamescopeArtifacts(runtime, paths); err != nil {
 		return err
 	}
-	parentIdentity, err := lstatIdentity(paths.parentSocket)
+	parentIdentity, err := runtime.pins.capture(paths.parentSocket)
 	if err != nil || !validGamescopeArtifact(
 		parentIdentity,
 		syscall.S_IFSOCK,
@@ -1061,12 +1080,17 @@ func runNestedCompositor(
 	if err != nil {
 		return err
 	}
-	knownRuntime, err = captureGamescopeArtifacts(
+	capturedRuntime, err := captureGamescopeArtifacts(
 		runtime,
 		paths,
 		knownRuntime,
 		true,
 	)
+	// A failed capture omits conflicting paths. Retain their original ownership
+	// so deferred partial cleanup cannot rediscover and adopt the replacements.
+	for path, identity := range capturedRuntime {
+		knownRuntime[path] = identity
+	}
 	if err != nil {
 		return err
 	}

--- a/multiseat_worker/internal/seatprovider/nested_compositor_linux_test.go
+++ b/multiseat_worker/internal/seatprovider/nested_compositor_linux_test.go
@@ -205,12 +205,20 @@ func fakeGamescopeProducer(arguments []string, environment []string, mode string
 	if mode == "exit-early" {
 		return 119
 	}
+	if mode == "replace-limiter" {
+		if err := os.WriteFile(limiterPath+".replacement", []byte("retain"), 0o600); err != nil {
+			return 122
+		}
+		if err := os.Rename(limiterPath+".replacement", limiterPath); err != nil {
+			return 123
+		}
+	}
 	waylandMode := mode
 	if mode == "wrong-wayland-mode" {
 		waylandMode = "wrong-mode"
 	}
 	if mode == "wrong-x-mode" || mode == "socket-only-x" ||
-		mode == "bad-ready" || mode == "wrong-x-display" {
+		mode == "bad-ready" || mode == "wrong-x-display" || mode == "replace-limiter" {
 		waylandMode = "good"
 	}
 	go serveFakeWayland(waylandListener, width, height, refresh, waylandMode)
@@ -407,6 +415,72 @@ func TestGamescopeEnvironmentIsScrubbedAndCarriesExactParent(t *testing.T) {
 	software := gamescopeEnvironment(request, paths, options)
 	if !slices.Contains(software, "XWAYLAND_NO_GLAMOR=1") {
 		t.Fatalf("software Xwayland was allowed to open a GPU: %#v", software)
+	}
+}
+
+func TestFailedGamescopeCreationIsNeverAdoptedByPartialCleanup(t *testing.T) {
+	for _, scenario := range []string{"existing-file", "existing-fifo", "replaced-open-file"} {
+		t.Run(scenario, func(t *testing.T) {
+			directory := privateNestedDirectoryForTest(t)
+			runtime, err := openRuntimeDirectory(directory, uint32(os.Geteuid()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer runtime.close()
+			readyName, limiterName, sessionName := gamescopeScopedNames("failed-creation")
+			paths := gamescopePaths{
+				readyFIFO: filepath.Join(directory, readyName), limiterFile: filepath.Join(directory, limiterName),
+				sessionRecord: filepath.Join(directory, sessionName), targetSocket: filepath.Join(directory, "app-wayland"),
+			}
+			target := paths.sessionRecord
+			var rejected artifactIdentity
+			if scenario == "existing-fifo" {
+				target = paths.readyFIFO
+				if err := syscall.Mkfifo(target, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				_, rejected, err = createGamescopeReadyFIFO(runtime, target)
+			} else if scenario == "existing-file" {
+				if err := os.WriteFile(target, []byte("replacement"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				rejected, err = createGamescopeRegularArtifact(runtime, target, nil)
+			} else {
+				file, openError := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+				if openError != nil {
+					t.Fatal(openError)
+				}
+				defer file.Close()
+				if err := os.Rename(target, filepath.Join(directory, "original")); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(target, []byte("replacement"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				rejected, err = captureCreatedArtifact(runtime, target, int(file.Fd()))
+			}
+			if err == nil {
+				t.Fatal("invalid creation was admitted")
+			}
+			owned, err := createGamescopeRegularArtifact(runtime, paths.limiterFile, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			known := map[string]artifactIdentity{paths.limiterFile: owned}
+			// Match the callers: a zero return would lose the detected rejection.
+			if rejected != (artifactIdentity{}) {
+				known[target] = rejected
+			}
+			if err := cleanupGamescopeRuntimeArtifacts(runtime, paths, known, true); err == nil {
+				t.Fatal("partial cleanup adopted a rejected creation")
+			}
+			if _, err := os.Lstat(target); err != nil {
+				t.Fatalf("detected replacement was removed: %v", err)
+			}
+			if _, err := os.Lstat(paths.limiterFile); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("owned companion artifact was not cleaned: %v", err)
+			}
+		})
 	}
 }
 
@@ -622,6 +696,39 @@ func TestUnexpectedGamescopeArtifactIsRetainedAndReported(t *testing.T) {
 	}
 	stopRealProvider(t, outer)
 	requireEmptyRuntime(t, runtimePath)
+}
+
+func TestFinalCaptureFailureRetainsReplacementDuringPartialCleanup(t *testing.T) {
+	runtimePath := privateDisplayRuntimeDirectoryForTest(t)
+	display := displayRequest("final-capture-replacement", "polaris-capture-final-replacement")
+	outer, _ := startNestedOuterDisplay(t, runtimePath, display)
+	defer stopRealProvider(t, outer)
+	before := snapshotDirectoryIdentities(t, runtimePath)
+	request := nestedRequestFromDisplay(display, "polaris-wayland-final-replacement")
+	options := fakeNestedOptions(t, runtimePath, "replace-limiter")
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	providerContext, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	err = runNestedCompositor(providerContext, request, writer, options)
+	ready, readError := io.ReadAll(reader)
+	_, limiterName, _ := gamescopeScopedNames(request.RuntimeNamespace)
+	replacement := filepath.Join(runtimePath, limiterName)
+	content, contentError := os.ReadFile(replacement)
+	if err == nil || readError != nil || len(ready) != 0 || contentError != nil || string(content) != "retain" {
+		t.Fatalf("final capture rejection was lost during cleanup: %v, %q, %v, %q, %v", err, ready, readError, content, contentError)
+	}
+	if err := os.Remove(replacement); err != nil {
+		t.Fatal(err)
+	}
+	if after := snapshotDirectoryIdentities(t, runtimePath); !reflect.DeepEqual(after, before) {
+		t.Fatalf("owned companions were not cleaned independently: before=%v after=%v", before, after)
+	}
+	requireDirectoryEmpty(t, options.x11SocketDirectory)
+	requireDirectoryEmpty(t, options.x11LockDirectory)
 }
 
 func TestNestedCleanupRefusesReplacementAlias(t *testing.T) {

--- a/multiseat_worker/internal/seatprovider/provider_linux.go
+++ b/multiseat_worker/internal/seatprovider/provider_linux.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -199,6 +200,7 @@ type runtimeDirectory struct {
 	dev  uint64
 	ino  uint64
 	uid  uint32
+	pins artifactPins
 }
 
 func openRuntimeDirectory(path string, expectedUID uint32) (*runtimeDirectory, error) {
@@ -255,15 +257,84 @@ func (runtime *runtimeDirectory) verify() error {
 
 func (runtime *runtimeDirectory) close() {
 	if runtime != nil && runtime.file != nil {
+		runtime.pins.close()
 		_ = runtime.file.Close()
 	}
 }
 
+// Keep captured inodes allocated through child shutdown and cleanup. Comparing
+// dev/ino alone cannot identify an unlinked inode after the kernel reuses it.
+// O_PATH pins grant no read/write access and never reach a provider child.
+type artifactPins struct {
+	mutex  sync.Mutex
+	files  map[[2]uint64]*os.File
+	closed bool
+}
+
+const maximumArtifactPins = 256
+const linuxOPath = 0x200000
+
+func (pins *artifactPins) capture(path string) (artifactIdentity, error) {
+	pins.mutex.Lock()
+	defer pins.mutex.Unlock()
+	if pins.closed {
+		return artifactIdentity{}, errors.New("runtime artifact ownership is closed")
+	}
+	expected, err := lstatIdentity(path)
+	if err != nil {
+		return artifactIdentity{}, err
+	}
+	if expected.mode&syscall.S_IFMT == syscall.S_IFLNK {
+		return artifactIdentity{}, errors.New("runtime artifact cannot be a symlink")
+	}
+	descriptor, err := syscall.Open(path, linuxOPath|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return artifactIdentity{}, err
+	}
+	var status syscall.Stat_t
+	if err := syscall.Fstat(descriptor, &status); err != nil || !sameIdentity(expected, artifactIdentity{
+		dev: uint64(status.Dev), ino: status.Ino, mode: status.Mode, uid: status.Uid,
+	}) {
+		_ = syscall.Close(descriptor)
+		return artifactIdentity{}, errors.New("runtime artifact changed while acquiring ownership")
+	}
+	key := [2]uint64{expected.dev, expected.ino}
+	if _, present := pins.files[key]; present {
+		_ = syscall.Close(descriptor)
+		return expected, nil
+	}
+	if len(pins.files) >= maximumArtifactPins {
+		_ = syscall.Close(descriptor)
+		return artifactIdentity{}, errors.New("runtime artifact ownership limit reached")
+	}
+	file := os.NewFile(uintptr(descriptor), "polaris-artifact-pin")
+	if file == nil {
+		_ = syscall.Close(descriptor)
+		return artifactIdentity{}, errors.New("runtime artifact ownership is unavailable")
+	}
+	if pins.files == nil {
+		pins.files = make(map[[2]uint64]*os.File)
+	}
+	pins.files[key] = file
+	return expected, nil
+}
+
+func (pins *artifactPins) close() {
+	pins.mutex.Lock()
+	defer pins.mutex.Unlock()
+	for _, file := range pins.files {
+		_ = file.Close()
+	}
+	pins.files = nil
+	pins.closed = true
+}
+
 type artifactIdentity struct {
-	dev  uint64
-	ino  uint64
-	mode uint32
-	uid  uint32
+	dev      uint64
+	ino      uint64
+	mode     uint32
+	uid      uint32
+	rejected bool // A detected creation failure must never become partial-cleanup authority.
 }
 
 func lstatIdentity(path string) (artifactIdentity, error) {
@@ -280,6 +351,6 @@ func lstatIdentity(path string) (artifactIdentity, error) {
 }
 
 func sameIdentity(left artifactIdentity, right artifactIdentity) bool {
-	return left.dev == right.dev && left.ino == right.ino &&
+	return !left.rejected && !right.rejected && left.dev == right.dev && left.ino == right.ino &&
 		left.mode == right.mode && left.uid == right.uid
 }

--- a/multiseat_worker/internal/seatprovider/provider_linux.go
+++ b/multiseat_worker/internal/seatprovider/provider_linux.go
@@ -114,8 +114,7 @@ func normalizeProviderOptions(options providerOptions) (providerOptions, error) 
 			!validAbsolutePath(options.softwareVulkanICDPath)) ||
 		options.x11DirectoryMode == 0 || options.x11DirectoryMode > 0o7777 ||
 		(options.softwareGamescope && options.softwareVulkanICDPath == "") ||
-		(!options.softwareGamescope &&
-			(options.softwareVulkanICDPath != "" || options.allowSharedX11)) ||
+		(!options.softwareGamescope && options.softwareVulkanICDPath != "") ||
 		options.startupTimeout <= 0 || options.probeTimeout <= 0 ||
 		options.stopTimeout <= 0 || options.probeInterval <= 0 ||
 		options.probeInterval > options.startupTimeout {

--- a/multiseat_worker/internal/seatprovider/provider_linux_test.go
+++ b/multiseat_worker/internal/seatprovider/provider_linux_test.go
@@ -4,12 +4,14 @@ package seatprovider
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
@@ -376,7 +378,7 @@ func TestCleanupRefusesReplacementArtifacts(t *testing.T) {
 	if err := syscall.Bind(listener, &syscall.SockaddrUnix{Name: busPath}); err != nil {
 		t.Fatal(err)
 	}
-	original, err := lstatIdentity(busPath)
+	original, err := runtime.pins.capture(busPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,11 +408,11 @@ func TestCleanupRefusesReplacementArtifacts(t *testing.T) {
 	if err := os.WriteFile(pidPath, []byte("1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	pulseIdentity, err := lstatIdentity(pulsePath)
+	pulseIdentity, err := runtime.pins.capture(pulsePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	pidIdentity, err := lstatIdentity(pidPath)
+	pidIdentity, err := runtime.pins.capture(pidPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,6 +432,91 @@ func TestCleanupRefusesReplacementArtifacts(t *testing.T) {
 	content, err := os.ReadFile(pidPath)
 	if err != nil || string(content) != "2\n" {
 		t.Fatalf("replacement audio artifact was not retained: %q, %v", content, err)
+	}
+}
+
+func TestArtifactPinsPreserveUnlinkedInodesAndReleaseDescriptors(t *testing.T) {
+	var pins artifactPins
+	defer pins.close()
+	path := filepath.Join(t.TempDir(), "owned")
+	if err := os.WriteFile(path, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	original, err := pins.capture(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pins.capture(path); err != nil || len(pins.files) != 1 {
+		t.Fatalf("same inode was not deduplicated: %v", err)
+	}
+	file := pins.files[[2]uint64{original.dev, original.ino}]
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, file.Fd(), syscall.F_GETFD, 0)
+	if errno != 0 || flags&syscall.FD_CLOEXEC == 0 {
+		t.Fatal("ownership pin could reach a child")
+	}
+	flags, _, errno = syscall.Syscall(syscall.SYS_FCNTL, file.Fd(), syscall.F_GETFL, 0)
+	if errno != 0 || flags&linuxOPath == 0 {
+		t.Fatal("ownership pin grants data access")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := lstatIdentity(path)
+	if err != nil || sameIdentity(original, replacement) {
+		t.Fatalf("unlinked ownership was reused: %v", err)
+	}
+	var status syscall.Stat_t
+	if err := syscall.Fstat(int(file.Fd()), &status); err != nil || status.Nlink != 0 || status.Ino != original.ino {
+		t.Fatalf("original inode was not retained: %v", err)
+	}
+	pins.close()
+	if _, err := file.Stat(); !errors.Is(err, os.ErrClosed) {
+		t.Fatal("ownership descriptor remained open")
+	}
+	if _, err := pins.capture(path); err == nil {
+		t.Fatal("closed ownership scope accepted an artifact")
+	}
+}
+
+func TestArtifactPinsRejectSymlinksAndBoundDescriptorUse(t *testing.T) {
+	var pins artifactPins
+	defer pins.close()
+	directory := t.TempDir()
+	link := filepath.Join(directory, "link")
+	if err := os.Symlink("missing", link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pins.capture(link); err == nil || len(pins.files) != 0 {
+		t.Fatal("symlink acquired ownership")
+	}
+	for index := 0; index <= maximumArtifactPins; index++ {
+		path := filepath.Join(directory, strconv.Itoa(index))
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := pins.capture(path)
+		if (index < maximumArtifactPins) != (err == nil) {
+			t.Fatalf("ownership bound at %d: %v", index, err)
+		}
+	}
+	if len(pins.files) != maximumArtifactPins {
+		t.Fatal("ownership descriptors exceeded their bound")
+	}
+	if _, err := pins.capture(filepath.Join(directory, "0")); err != nil {
+		t.Fatalf("existing ownership lost at capacity: %v", err)
+	}
+	files := make([]*os.File, 0, len(pins.files))
+	for _, file := range pins.files {
+		files = append(files, file)
+	}
+	pins.close()
+	for _, file := range files {
+		if _, err := file.Stat(); err == nil {
+			t.Fatal("bounded ownership leaked a descriptor")
+		}
 	}
 }
 

--- a/multiseat_worker/internal/seatprovider/real_linux_test.go
+++ b/multiseat_worker/internal/seatprovider/real_linux_test.go
@@ -377,7 +377,7 @@ func TestRealDisplayCapturesRemainIndependent(t *testing.T) {
 		displayProbeArguments(
 			secondRequest,
 			filepath.Join(secondPath, secondMediaName),
-			true,
+			secondOptions.softwareDisplay,
 		),
 		displayEnvironment(secondOptions),
 		3*time.Second,

--- a/multiseat_worker/internal/seatprovider/real_linux_test.go
+++ b/multiseat_worker/internal/seatprovider/real_linux_test.go
@@ -28,10 +28,20 @@ type runningRealProvider struct {
 	stopError    error
 }
 
+// Required image acceptance fails on missing dependencies instead of silently
+// turning a provider startup test into a passing job with skipped tests.
+func unavailableRealDependency(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if os.Getenv("POLARIS_TEST_REQUIRE_REAL_PROVIDERS") == "1" {
+		t.Fatalf(format, args...)
+	}
+	t.Skipf(format, args...)
+}
+
 func requireTrustedBinary(t *testing.T, path string, expectedOwnerUID uint32) {
 	t.Helper()
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-		t.Skipf("real provider dependency %s is unavailable", filepath.Base(path))
+		unavailableRealDependency(t, "real provider dependency %s is unavailable", filepath.Base(path))
 	} else if err != nil {
 		t.Fatal(err)
 	}
@@ -274,12 +284,24 @@ func TestRealPrivateAudioGraphsRemainIndependent(t *testing.T) {
 	requireEmptyRuntime(t, secondPath)
 }
 
+// Only opt-in real tests consume the explicitly catalogued hardware node.
+func realDisplayRequest(namespace, socket string) seatruntime.Request {
+	request := displayRequest(namespace, socket)
+	if node := os.Getenv("POLARIS_TEST_PROVIDER_RENDER_NODE"); node != "" {
+		request.RenderNode = node
+	}
+	return request
+}
+
 func realDisplayProviderOptions(t *testing.T, runtimePath string) providerOptions {
 	t.Helper()
 	options := defaultProviderOptions()
 	options.runtimeDirectory = runtimePath
 	options.runtimeOwnerUID = uint32(os.Geteuid())
-	options.softwareDisplay = true
+	options.softwareDisplay = os.Getenv("POLARIS_TEST_PROVIDER_RENDER_NODE") == ""
+	if !options.softwareDisplay && os.Getenv("POLARIS_TEST_GAMESCOPE_ALLOW_DRM") != "1" {
+		t.Fatal("hardware provider validation needs explicit DRM-device authorization")
+	}
 	if pluginPath := os.Getenv("POLARIS_TEST_GST_PLUGIN_PATH"); pluginPath != "" {
 		if !validAbsolutePath(pluginPath) {
 			t.Fatalf("real display plugin path is invalid: %s", pluginPath)
@@ -302,7 +324,7 @@ func realDisplayProviderOptions(t *testing.T, runtimePath string) providerOption
 			environment,
 			3*time.Second,
 		); err != nil {
-			t.Skipf("real display dependency %s is unavailable", element)
+			unavailableRealDependency(t, "real display dependency %s is unavailable: %v", element, err)
 		}
 	}
 	return options
@@ -311,7 +333,7 @@ func realDisplayProviderOptions(t *testing.T, runtimePath string) providerOption
 func TestRealDisplayCaptureProducesFrameAndCleansUp(t *testing.T) {
 	runtimePath := privateDisplayRuntimeDirectoryForTest(t)
 	options := realDisplayProviderOptions(t, runtimePath)
-	request := displayRequest("real-display", "polaris-capture-real")
+	request := realDisplayRequest("real-display", "polaris-capture-real")
 	request.DisplayRefreshMillihertz = 59940
 	provider := startRealProvider(t, func(context context.Context, ready io.WriteCloser) error {
 		return runDisplayCapture(context, request, ready, options)
@@ -333,8 +355,8 @@ func TestRealDisplayCapturesRemainIndependent(t *testing.T) {
 	firstOptions := realDisplayProviderOptions(t, firstPath)
 	secondOptions := firstOptions
 	secondOptions.runtimeDirectory = secondPath
-	firstRequest := displayRequest("real-display-first", "polaris-capture-real-first")
-	secondRequest := displayRequest("real-display-second", "polaris-capture-real-second")
+	firstRequest := realDisplayRequest("real-display-first", "polaris-capture-real-first")
+	secondRequest := realDisplayRequest("real-display-second", "polaris-capture-real-second")
 	secondRequest.DisplayRefreshMillihertz = 97000
 	first := startRealProvider(t, func(context context.Context, ready io.WriteCloser) error {
 		return runDisplayCapture(context, firstRequest, ready, firstOptions)
@@ -370,24 +392,30 @@ func TestRealDisplayCapturesRemainIndependent(t *testing.T) {
 func realNestedCompositorOptions(t *testing.T, runtimePath string) providerOptions {
 	t.Helper()
 	if os.Getenv("POLARIS_TEST_GAMESCOPE_ALLOW_DRM") != "1" {
-		t.Skip("real Gamescope/Xwayland test needs explicit DRM-device authorization")
-	}
-	icdPath := os.Getenv("POLARIS_TEST_GAMESCOPE_SOFTWARE_ICD")
-	if icdPath == "" {
-		t.Skip("POLARIS_TEST_GAMESCOPE_SOFTWARE_ICD is not set")
-	}
-	if !validAbsolutePath(icdPath) {
-		t.Fatalf("real Gamescope software ICD path is invalid: %s", icdPath)
-	}
-	status, err := os.Lstat(icdPath)
-	if err != nil || !status.Mode().IsRegular() || status.Mode().Perm()&0o022 != 0 {
-		t.Fatalf("real Gamescope software ICD is unavailable or writable: %v", err)
+		unavailableRealDependency(t, "real Gamescope/Xwayland test needs explicit DRM-device authorization")
 	}
 	options := defaultProviderOptions()
 	options.runtimeDirectory = runtimePath
 	options.runtimeOwnerUID = uint32(os.Geteuid())
-	options.softwareGamescope = true
-	options.softwareVulkanICDPath = icdPath
+	if node := os.Getenv("POLARIS_TEST_PROVIDER_RENDER_NODE"); node != "" {
+		if err := validateDisplayRenderNode(node); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		icdPath := os.Getenv("POLARIS_TEST_GAMESCOPE_SOFTWARE_ICD")
+		if icdPath == "" {
+			unavailableRealDependency(t, "POLARIS_TEST_GAMESCOPE_SOFTWARE_ICD is not set")
+		}
+		if !validAbsolutePath(icdPath) {
+			t.Fatalf("real Gamescope software ICD path is invalid: %s", icdPath)
+		}
+		status, err := os.Lstat(icdPath)
+		if err != nil || !status.Mode().IsRegular() || status.Mode().Perm()&0o022 != 0 {
+			t.Fatalf("real Gamescope software ICD is unavailable or writable: %v", err)
+		}
+		options.softwareGamescope = true
+		options.softwareVulkanICDPath = icdPath
+	}
 	options.allowSharedX11 = true
 	options.startupTimeout = defaultGamescopeStartupTimeout
 	options.probeTimeout = 3 * time.Second
@@ -558,7 +586,7 @@ func TestRealHeadlessGamescopePublishesBothProtocolsAndCleansUp(t *testing.T) {
 	displayOptions := realDisplayProviderOptions(t, runtimePath)
 	nestedOptions := realNestedCompositorOptions(t, runtimePath)
 	x11Baseline := realX11Baseline(t)
-	display := displayRequest("real-nested", "polaris-capture-real-nested")
+	display := realDisplayRequest("real-nested", "polaris-capture-real-nested")
 	display.DisplayWidth = 1280
 	display.DisplayHeight = 720
 	outer := startRealProvider(t, func(providerContext context.Context, ready io.WriteCloser) error {
@@ -601,10 +629,10 @@ func TestTwoRealHeadlessGamescopeStacksRemainIndependent(t *testing.T) {
 	firstNestedOptions := realNestedCompositorOptions(t, firstRuntime)
 	secondNestedOptions := realNestedCompositorOptions(t, secondRuntime)
 	x11Baseline := realX11Baseline(t)
-	firstDisplay := displayRequest("real-nested-first", "polaris-capture-real-nested-first")
+	firstDisplay := realDisplayRequest("real-nested-first", "polaris-capture-real-nested-first")
 	firstDisplay.DisplayWidth = 1280
 	firstDisplay.DisplayHeight = 720
-	secondDisplay := displayRequest("real-nested-second", "polaris-capture-real-nested-second")
+	secondDisplay := realDisplayRequest("real-nested-second", "polaris-capture-real-nested-second")
 	secondDisplay.DisplayWidth = 960
 	secondDisplay.DisplayHeight = 540
 	secondDisplay.DisplayRefreshMillihertz = 97000

--- a/multiseat_worker/internal/seatprovider/session_bus_linux.go
+++ b/multiseat_worker/internal/seatprovider/session_bus_linux.go
@@ -172,7 +172,7 @@ func captureSessionBusArtifacts(
 	}
 	captured := make(map[string]artifactIdentity, len(sessionBusArtifactSpecs))
 	for _, spec := range sessionBusArtifactSpecs {
-		identity, err := lstatIdentity(filepath.Join(runtime.path, spec.relative))
+		identity, err := runtime.pins.capture(filepath.Join(runtime.path, spec.relative))
 		if errors.Is(err, os.ErrNotExist) && !spec.required {
 			continue
 		}
@@ -197,7 +197,7 @@ func cleanupSessionBus(
 			return err
 		}
 		path := filepath.Join(runtime.path, spec.relative)
-		identity, err := lstatIdentity(path)
+		identity, err := runtime.pins.capture(path)
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
@@ -224,7 +224,7 @@ func cleanupSessionBus(
 		if err := os.Remove(path); err != nil {
 			return errors.New("runtime session bus artifact could not be removed")
 		}
-		if _, err := lstatIdentity(path); !errors.Is(err, os.ErrNotExist) {
+		if _, err := runtime.pins.capture(path); !errors.Is(err, os.ErrNotExist) {
 			return errors.New("runtime session bus artifact removal was not durable")
 		}
 	}

--- a/multiseat_worker/internal/seatprovider/x11_probe_linux.go
+++ b/multiseat_worker/internal/seatprovider/x11_probe_linux.go
@@ -24,6 +24,7 @@ type fixedDirectory struct {
 	ino  uint64
 	uid  uint32
 	mode uint32
+	pins artifactPins
 }
 
 func openFixedDirectory(
@@ -85,6 +86,7 @@ func (directory *fixedDirectory) verify() error {
 
 func (directory *fixedDirectory) close() {
 	if directory != nil && directory.file != nil {
+		directory.pins.close()
 		_ = directory.file.Close()
 	}
 }


### PR DESCRIPTION
The four locked application roots lacked the GStreamer/runtime dependencies required by Polaris's existing providers. Build a dedicated runtime root for Gamescope, Steam, Heroic, and Lutris, then apply the offline worker overlay. Each root receives version/hash-locked package closures, a Wayland plugin built against its own GStreamer ABI with pinned Rust/Cargo, and pinned Gamescope with locked transitive source inputs.

The new CI matrix builds all four Linux/amd64 profiles without network access after input preparation, rejects missing dependencies or skipped real-provider tests, and uploads OCI archives, package manifests, CycloneDX SBOMs, dependency-lock hashes, and sanitized provider receipts. Artifact identity uses the exported OCI manifest digest, verifies every referenced blob, and requires the configuration digest of the tested image. Source roots and produced worker digests are distinct in lock schema 2. No registry publication or production catalog promotion occurs.

An optional NVIDIA 610.57.04 userspace stage extracts the pinned official archive only inside a build container; it never installs a host driver. A dedicated opt-in SELinux domain is under independent review for the physical lane. Exact GPU catalog admission remains required, with no CDI mount expansion, blanket device boolean, or disabled labeling.

Validation so far: all four development NVIDIA images build, pass dependency/ABI checks and six isolated real session-bus/audio/software-display tests, and export verified OCI archives. Two clean reconstructions match the pinned plugin archive; Gamescope source reconstruction matches its lock. Package substitution and OCI corruption/configuration-mismatch regression tests pass; Go suites pass with the race detector. Final exact-commit CI/artifacts, independent provenance review, all-profile input receipts, and GPU-backed nested Gamescope startup/teardown remain acceptance gates.

Production worker adapters remain unwired. These checks do not establish game streaming. Virtual-input provider integration, worker-local encoding, launcher process management, production media routing, seat-aware status, private X11 startup integration, and real concurrent streams remain the next milestone. See `containers/multiseat/RUNTIME-IMAGES.md` for build commands, artifact scope, and reproducible-input details.
