### PR TITLE
feat(linux): recognise Game Mode hosts and say how to keep Polaris reachable

### DIFF
--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -490,6 +490,8 @@ list(APPEND PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/linux/labwc_startup_diagnostics.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/gamescope_session_helper.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/gamescope_session_helper.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/game_mode_host.h"
+        "${CMAKE_SOURCE_DIR}/src/platform/linux/game_mode_host.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/display_topology.h"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/display_topology.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/linux/stream_path.h"

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -54,7 +54,9 @@ brings it back.
 
 ## Arch derivatives
 
-CachyOS is expected to work through this package path. If a derivative renames dependencies or ships
+CachyOS is expected to work through this package path. CachyOS handheld edition boots into a Steam
+Game Mode session; read [Handhelds and Game Mode](handhelds.md) before the first mode switch, or
+Polaris goes offline with the desktop. If a derivative renames dependencies or ships
 different runtime helpers, the package may refuse to install or Polaris may fail to find a helper at
 launch. In that case use the local package or source build in
 [Build from source](building.md), and please report the derivative-specific gap with your distro, GPU,

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -210,7 +210,9 @@ stream.
 ## Headless Boot and Deck Images
 
 The packaged service enables into `xdg-desktop-autostart.target`, which only a
-full desktop session fires. Two common Bazzite setups never fire it:
+full desktop session fires. Two common Bazzite setups never fire it (for the
+handheld side of this, including what Game Mode itself supports, see
+[Handhelds and Game Mode](handhelds.md)):
 
 - Deck images that boot straight into the gamescope Steam session. The gamescope
   session does not run XDG autostart, so Polaris only starts once you visit

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Recognises hosts with a Steam Game Mode session (SteamOS, Bazzite deck images, CachyOS handheld edition, other gamescope-session hosts). `--setup-host` says why Polaris goes offline when the host leaves Desktop Mode and prints the headless-boot command, `/api/stats/system` reports `game_mode_host` with Game Mode-aware boot readiness and display-session guidance, and the console names a running Game Mode session instead of asking for a desktop restart. New handhelds guide with the Game Mode validation recipe (#626)
+
 ## v1.4.4 - 2026-09-06
 
 A packaging and setup update matched with Nova v1.4.4. The application menu entry starts the same Polaris service that autostart and headless boot use, and a privileged setup run no longer mistakes root's own device access for a ready desktop account. Existing configurations and paired devices remain valid.

--- a/docs/handhelds.md
+++ b/docs/handhelds.md
@@ -1,0 +1,133 @@
+# Handhelds and Game Mode
+
+A Steam Deck, ROG Ally, Legion Go or similar device runs two kinds of session. Desktop Mode is a
+normal KDE Plasma desktop. Game Mode is gamescope running Steam full screen, with no desktop
+underneath it. Polaris treats the two very differently today, and this page says exactly what
+works so you do not have to find out from a client that reports the host offline.
+
+This applies to SteamOS, Bazzite deck images, CachyOS handheld edition, ChimeraOS, Nobara's
+handheld edition, and any host that installs a gamescope Steam session next to its desktop.
+
+## What works today
+
+| Situation | Status |
+|---|---|
+| Streaming from Desktop Mode | Works as the distro guide describes: [SteamOS](steamos.md), [Bazzite](bazzite.md), [Arch and CachyOS](arch.md). |
+| Polaris staying reachable after switching to Game Mode | Works once Polaris starts at boot. See below. |
+| Streaming what Game Mode shows, or launching games into it | Not supported yet. Tracked in [#626](https://github.com/papi-ux/polaris/issues/626). |
+
+## Why Polaris disappears in Game Mode
+
+The packaged user service starts with desktop autostart, which only a desktop session fires. A
+gamescope session never runs desktop autostart, so:
+
+- a host that boots straight into Game Mode has no Polaris until someone opens Desktop Mode, and
+- a Polaris started from a terminal or from the application menu ends with the desktop session
+  when the host switches back to Game Mode.
+
+Either way the client sees the host go offline. Host setup now recognises a Game Mode session on
+the host and prints the fix, the stats API reports it under `game_mode_host` and `boot_readiness`,
+and the console shows a notice while Game Mode is running.
+
+## Keep Polaris reachable across mode switches
+
+Install the package for your distro from its guide, then make the service independent of the
+session:
+
+```bash
+sudo -H polaris --setup-host --enable-headless-boot
+systemctl --user enable --now polaris
+```
+
+The first command enables lingering for your account and hooks the Polaris user service into
+`default.target`, so it starts at boot before any login. Run it from Desktop Mode's terminal or
+over SSH, as your normal user through sudo. `--disable-headless-boot` undoes the hook later.
+
+Verify after a reboot. Over SSH from another machine:
+
+```bash
+systemctl --user is-active polaris
+journalctl --user -u polaris --since "10 minutes ago" --no-pager
+```
+
+Without SSH, schedule the check from Desktop Mode, switch to Game Mode, wait two minutes, and read
+the file after switching back:
+
+```bash
+systemd-run --user --on-active=90 --collect \
+  bash -c 'systemctl --user is-active polaris > ~/polaris-game-mode.txt 2>&1'
+```
+
+With that in place, streaming from Desktop Mode works exactly as before, and the host no longer
+drops off the client list when it returns to Game Mode.
+
+## What Game Mode itself needs
+
+Streaming from inside Game Mode is a separate piece of work, and none of the current stream paths
+do it:
+
+- Mirror Desktop looks for a desktop compositor to capture, and a gamescope session has none.
+- Private Stream and Gamescope Stream start their own session and their own Steam, and refuse to
+  fight the Steam that Game Mode already has open.
+
+Two capture routes already exist in Polaris that a Game Mode session could use: the PipeWire node
+gamescope exports on its own, and DRM/KMS capture of whatever is on screen. Which one holds up on
+real hardware is the open question, and nobody on the project has a Game Mode host to answer it
+with. Progress lives in [#626](https://github.com/papi-ux/polaris/issues/626).
+
+## Help validate Game Mode streaming
+
+If you have a Game Mode host and ten minutes, this probe answers the open question without any new
+code. It uses KMS capture, which is how Sunshine streams a Steam Deck in Game Mode, and it needs
+the `cap_sys_admin` capability on the Polaris binary, which `--enable-kms` grants and
+`sudo setcap -r "$(readlink -f "$(command -v polaris)")"` removes again.
+
+1. From Desktop Mode, make Polaris boot independent and allow KMS capture:
+
+   ```bash
+   sudo -H polaris --setup-host --enable-headless-boot --enable-kms
+   ```
+
+2. In `~/.config/polaris/polaris.conf`, set the capture backend and the Mirror Desktop path, then
+   restart the service:
+
+   ```ini
+   capture = kms
+   linux_stream_mode = desktop_display
+   ```
+
+   ```bash
+   systemctl --user restart polaris
+   ```
+
+3. Schedule the evidence dump, which fires while Game Mode is active:
+
+   ```bash
+   systemd-run --user --on-active=120 --collect bash -c '
+     pw-cli ls Node > ~/game-mode-nodes.txt 2>&1
+     systemctl --user status polaris --no-pager -l > ~/game-mode-polaris.txt 2>&1'
+   ```
+
+4. Switch to Game Mode. Within two minutes, connect a client to the **Desktop** entry and keep
+   trying for a minute, whether or not video appears.
+
+5. Switch back to Desktop Mode and collect the results:
+
+   ```bash
+   journalctl --user -u polaris --since "20 minutes ago" --no-pager \
+     | grep -iE 'kms|capture|encoder|portal|display|session|error|warn' > ~/game-mode-journal.txt
+   ```
+
+6. Post `~/game-mode-nodes.txt`, `~/game-mode-polaris.txt` and `~/game-mode-journal.txt` on
+   [#626](https://github.com/papi-ux/polaris/issues/626) with the device, distro and image, GPU,
+   client, and Polaris version. Say whether the client got video, audio, and input.
+
+The node list tells us whether Game Mode's gamescope exports its PipeWire stream on your host,
+which decides the capture route. The journal tells us whether KMS capture and the encoder came up
+at all.
+
+## Reporting handheld results
+
+Include the device model, distro and image, Desktop Mode or Game Mode, GPU, client, package
+filename, Polaris version, and the relevant journal lines. Keep package and startup results
+separate from gameplay, display rate, suspend, and update persistence results.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -36,6 +36,7 @@ CachyOS and most pacman-compatible Arch derivatives should start with the Arch p
 |---|---|
 | SteamOS 3.8 | [SteamOS guide](steamos.md) — Desktop Mode validation only |
 | Bazzite 44 | [Bazzite guide](bazzite.md) — layer the Fedora 44 RPM with `rpm-ostree` |
+| Steam Deck, ROG Ally, other handhelds | [Handhelds and Game Mode](handhelds.md), keeps Polaris reachable across mode switches |
 | Ubuntu 24.04 | [Ubuntu guide](ubuntu.md) — experimental tester DEB |
 | openSUSE Tumbleweed | [openSUSE guide](openSUSE.md) — source build |
 | Anything else | [Build from source](building.md) |

--- a/docs/steamos.md
+++ b/docs/steamos.md
@@ -4,7 +4,7 @@ Polaris provides a dedicated x86_64 package for SteamOS 3.8, `Polaris-steamos3.8
 
 ## Validation Status
 
-Initial support covers package installation and Polaris startup in SteamOS Desktop Mode only. It does not certify physical Steam Deck gameplay, Game Mode, OLED 90 Hz behavior, suspend and resume, or persistence across SteamOS updates. Those claims require separate hardware evidence.
+Initial support covers package installation and Polaris startup in SteamOS Desktop Mode only. It does not certify physical Steam Deck gameplay, Game Mode, OLED 90 Hz behavior, suspend and resume, or persistence across SteamOS updates. Those claims require separate hardware evidence. [Handhelds and Game Mode](handhelds.md) explains what a Deck can and cannot do today and how to keep Polaris reachable when it returns to Game Mode.
 
 Continuous integration builds and validates this package inside a clean SteamOS 3.8 root bootstrapped from Valve's repositories. A clean root has none of the packages a shipped SteamOS image already carries, so that gate proves the package builds and its libraries resolve. It does not prove the install transaction is conflict-free on a device, and it did not catch the `libdisplay-info` conflict described under Stream Paths on SteamOS.
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -97,6 +97,7 @@
   #include "platform/linux/gamescope_session_helper.h"
   #include "platform/linux/virtual_display.h"
   #include "platform/linux/session_manager.h"
+  #include "platform/linux/game_mode_host.h"
   #include "platform/linux/stream_runtime.h"
   #include "platform/linux/stream_display_policy.h"
   #include "platform/linux/display_topology.h"
@@ -6715,52 +6716,42 @@ namespace confighttp {
     // Boot readiness: whether this account's Polaris survives a reboot with no
     // monitor or desktop login. Lingering plus a default.target want is what
     // `--setup-host --enable-headless-boot` arranges; either alone is not
-    // enough, so both are reported.
-    bool linger_enabled = false;
-    bool boot_start_linked = false;
-    {
-      std::error_code boot_ec;
-      const auto *pw = getpwuid(geteuid());
-      if (pw && pw->pw_name && pw->pw_name[0] != '\0') {
-        linger_enabled = fs::exists(fs::path("/var/lib/systemd/linger") / pw->pw_name, boot_ec);
-      }
-      fs::path config_home;
-      if (const char *xdg_config = std::getenv("XDG_CONFIG_HOME"); xdg_config && *xdg_config) {
-        config_home = xdg_config;
-      } else if (const char *home = std::getenv("HOME"); home && *home) {
-        config_home = fs::path(home) / ".config";
-      } else if (pw && pw->pw_dir && pw->pw_dir[0] != '\0') {
-        config_home = fs::path(pw->pw_dir) / ".config";
-      }
-      boot_start_linked = (!config_home.empty() && fs::exists(config_home / "systemd/user/default.target.wants/polaris.service", boot_ec)) ||
-                          fs::exists("/etc/systemd/user/default.target.wants/polaris.service", boot_ec);
+    // enough, so both are reported. A host with a Steam Game Mode session is
+    // named as such, because there the missing boot start is the whole reason
+    // clients lose the host after Desktop Mode.
+    // Read the want link where --enable-headless-boot writes it: under the
+    // account's passwd home, not wherever XDG_CONFIG_HOME points in this
+    // process.
+    const auto *pw = getpwuid(geteuid());
+    const std::string account_name = pw && pw->pw_name && pw->pw_name[0] != '\0' ? pw->pw_name : std::string();
+    fs::path account_home;
+    if (pw && pw->pw_dir && pw->pw_dir[0] != '\0') {
+      account_home = pw->pw_dir;
+    } else if (const char *home = std::getenv("HOME"); home && *home) {
+      account_home = home;
     }
-    const bool boot_independent = linger_enabled && boot_start_linked;
-    output["boot_readiness"]["linger_enabled"] = linger_enabled;
-    output["boot_readiness"]["boot_start_linked"] = boot_start_linked;
-    output["boot_readiness"]["status"] = boot_independent ? "boot_independent" : "session_bound";
-    output["boot_readiness"]["summary"] = boot_independent ?
-      "Polaris starts at boot with no monitor or desktop login." :
-      "Polaris starts with the desktop session, so after a reboot it is unavailable until someone logs in.";
-    output["boot_readiness"]["action"] = boot_independent ?
-      "No action needed." :
-      "For a monitor-less or Game Mode host, run: sudo -H polaris --setup-host --enable-headless-boot";
+    const auto boot = platf::game_mode_host::boot_readiness(platf::game_mode_host::default_boot_paths(account_name, account_home));
+    const bool boot_independent = boot.independent();
+    const auto game_mode = platf::game_mode_host::detect_cached();
+    output["game_mode_host"]["installed"] = game_mode.installed;
+    output["game_mode_host"]["session_active"] = game_mode.session_active;
+    output["game_mode_host"]["evidence"] = game_mode.evidence;
 
-    output["display_session"]["status"] = has_wayland_display || has_x11_display ? "healthy" : "missing_display_environment";
-    if (has_wayland_display || has_x11_display) {
-      output["display_session"]["summary"] = has_wayland_display ?
-        "Wayland desktop environment is available to Polaris." :
-        "X11 desktop environment is available to Polaris.";
-      output["display_session"]["action"] = "No action needed.";
-    } else if (boot_independent) {
-      // A headless-boot host has no desktop on purpose; telling it to restart
-      // from the desktop session would be wrong advice.
-      output["display_session"]["summary"] = "No desktop environment is attached, which is expected on a headless-boot host. Private Stream is unaffected.";
-      output["display_session"]["action"] = "To stream the visible desktop instead, log into the desktop and restart Polaris so it inherits the graphical environment.";
-    } else {
-      output["display_session"]["summary"] = "Polaris could not find WAYLAND_DISPLAY or DISPLAY for desktop previews.";
-      output["display_session"]["action"] = "Restart Polaris from the desktop session or run the user service so it inherits the graphical environment.";
-    }
+    const auto boot_guidance = platf::game_mode_host::boot_readiness_guidance(game_mode, boot_independent);
+    output["boot_readiness"]["linger_enabled"] = boot.linger_enabled;
+    output["boot_readiness"]["boot_start_linked"] = boot.boot_start_linked;
+    output["boot_readiness"]["status"] = boot_guidance.status;
+    output["boot_readiness"]["summary"] = boot_guidance.summary;
+    output["boot_readiness"]["action"] = boot_guidance.action;
+
+    // A headless-boot host has no desktop on purpose, and a Game Mode host
+    // has gamescope instead of one; telling either to restart from the
+    // desktop session would be wrong advice. A running Game Mode session
+    // outranks a stale WAYLAND_DISPLAY left over from the desktop.
+    const auto display_guidance = platf::game_mode_host::display_session_guidance(game_mode, boot_independent, has_wayland_display, has_x11_display);
+    output["display_session"]["status"] = display_guidance.status;
+    output["display_session"]["summary"] = display_guidance.summary;
+    output["display_session"]["action"] = display_guidance.action;
     output["display_session"]["environment_repaired"] = display_environment_repaired;
     output["display_session"]["session_type"] = session_type && session_type[0] ? std::string(session_type) : "unknown";
     output["display_session"]["desktop"] = desktop_name && desktop_name[0] ? std::string(desktop_name) : "unknown";

--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -23,6 +23,7 @@
 #include "network.h"
 #include "platform/common.h"
 #ifdef __linux__
+  #include "platform/linux/game_mode_host.h"
   #include "platform/linux/input/input_group_access.h"
 #endif
 
@@ -474,13 +475,43 @@ namespace args {
     // rather than from a controller that silently never appears.
     const auto input_group_advice = platf::input_access::setup_host_input_group_advice();
 
+    // A host that can boot into a Steam Game Mode session loses Polaris the
+    // moment it leaves Desktop Mode unless the service starts at boot. Say so
+    // here, where the person preparing the host is reading, instead of
+    // leaving it to a client that reports the host offline. The advice is
+    // about the account that streams, so like headless boot itself it stays
+    // silent when a bare root login cannot name one.
+    std::string game_mode_advice;
+    if (const auto *target_pw = setup_target_user.empty() || setup_target_user == "root" ? nullptr : getpwnam(setup_target_user.c_str());
+        target_pw && target_pw->pw_dir && target_pw->pw_dir[0] != '\0') {
+      const auto game_mode = platf::game_mode_host::detect(platf::game_mode_host::default_probe(target_pw->pw_uid));
+      const auto boot_before = platf::game_mode_host::boot_readiness(
+        platf::game_mode_host::default_boot_paths(setup_target_user, target_pw->pw_dir)
+      );
+      using state_t = platf::game_mode_host::setup_host_state_t;
+      const auto state = enable_headless_boot ? state_t::headless_boot_enabled_now :
+                         disable_headless_boot ? state_t::headless_boot_disabled_now :
+                         boot_before.independent() ? state_t::already_independent :
+                                                     state_t::needs_headless_boot;
+      game_mode_advice = platf::game_mode_host::setup_host_advice(game_mode, state, exe_path->string());
+    }
+
     const bool headless_boot_requested = enable_headless_boot || disable_headless_boot;
     if (!enable_kms && !headless_boot_requested && udev_from_package && modules_from_package && etc_copies_absent && input_nodes_ready) {
-      std::cout
-        << "Linux host setup: nothing to do."sv << std::endl
-        << "The package provides the udev rules and modules-load configuration, and /dev/uinput"sv << std::endl
-        << "and /dev/uhid are already usable by ["sv << setup_target_user << "]. Re-run with --enable-kms only if you"sv << std::endl
-        << "need DRM/KMS capture."sv << std::endl;
+      if (game_mode_advice.empty()) {
+        std::cout
+          << "Linux host setup: nothing to do."sv << std::endl
+          << "The package provides the udev rules and modules-load configuration, and /dev/uinput"sv << std::endl
+          << "and /dev/uhid are already usable by ["sv << setup_target_user << "]. Re-run with --enable-kms only if you"sv << std::endl
+          << "need DRM/KMS capture."sv << std::endl;
+      } else {
+        // "Nothing to do" would contradict the command that follows.
+        std::cout
+          << "Linux host setup: the package provides the udev rules and modules-load configuration, and /dev/uinput"sv << std::endl
+          << "and /dev/uhid are already usable by ["sv << setup_target_user << "]."sv << std::endl
+          << std::endl
+          << game_mode_advice;
+      }
       if (!input_group_advice.empty()) {
         std::cout << std::endl
                   << input_group_advice << std::endl;
@@ -555,8 +586,14 @@ namespace args {
     }
     std::cout
       << "Existing virtual gamepad nodes keep their previous access policy until recreated; stop active streams and restart Polaris after changing client gamepad seat isolation."sv << std::endl
-      << "Start Polaris directly with `polaris`, or opt into background autostart with `systemctl --user enable --now polaris`."sv << std::endl
-      << "For a host that boots with no monitor or desktop login (Game Mode consoles, dedicated streaming boxes), re-run with --enable-headless-boot."sv << std::endl;
+      << "Start Polaris directly with `polaris`, or opt into background autostart with `systemctl --user enable --now polaris`."sv << std::endl;
+    if (!game_mode_advice.empty()) {
+      std::cout << std::endl
+                << game_mode_advice;
+    } else {
+      std::cout
+        << "For a host that boots with no monitor or desktop login (Game Mode consoles, dedicated streaming boxes), re-run with --enable-headless-boot."sv << std::endl;
+    }
     if (!input_group_advice.empty()) {
       std::cout << std::endl
                 << input_group_advice << std::endl;

--- a/src/platform/linux/game_mode_host.cpp
+++ b/src/platform/linux/game_mode_host.cpp
@@ -1,0 +1,495 @@
+/**
+ * @file src/platform/linux/game_mode_host.cpp
+ * @brief Recognise hosts that boot into a gamescope Steam session (Game Mode) and phrase the guidance they need.
+ */
+#ifdef __linux__
+
+#include "game_mode_host.h"
+
+#include "executable_path.h"
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <cstdlib>
+#include <fstream>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <sys/stat.h>
+#include <system_error>
+#include <unistd.h>
+
+using namespace std::literals;
+namespace fs = std::filesystem;
+
+namespace platf::game_mode_host {
+
+  namespace {
+    constexpr std::size_t max_probe_file_bytes = 64U * 1024U;
+    constexpr auto headless_boot_command = "sudo -H polaris --setup-host --enable-headless-boot"sv;
+
+    /// Read up to max_probe_file_bytes; procfs files report no size, so read until EOF.
+    std::optional<std::string> read_small_file(const fs::path &path) {
+      std::ifstream in(path, std::ios::binary);
+      if (!in) {
+        return std::nullopt;
+      }
+      std::string content;
+      char chunk[4096];
+      while (content.size() < max_probe_file_bytes) {
+        in.read(chunk, sizeof(chunk));
+        const auto got = in.gcount();
+        if (got <= 0) {
+          break;
+        }
+        content.append(chunk, static_cast<std::size_t>(got));
+      }
+      if (content.size() > max_probe_file_bytes) {
+        content.resize(max_probe_file_bytes);
+      }
+      return content;
+    }
+
+    std::string trim(std::string_view text) {
+      const auto is_space = [](unsigned char c) {
+        return std::isspace(c) != 0;
+      };
+      while (!text.empty() && is_space(static_cast<unsigned char>(text.front()))) {
+        text.remove_prefix(1);
+      }
+      while (!text.empty() && is_space(static_cast<unsigned char>(text.back()))) {
+        text.remove_suffix(1);
+      }
+      return std::string(text);
+    }
+
+    std::string lower(std::string text) {
+      std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+      return text;
+    }
+
+    std::string strip_quotes(std::string value) {
+      if (value.size() >= 2 && ((value.front() == '"' && value.back() == '"') || (value.front() == '\'' && value.back() == '\''))) {
+        return value.substr(1, value.size() - 2);
+      }
+      return value;
+    }
+
+    std::string basename_of(std::string_view token) {
+      return fs::path(token).filename().string();
+    }
+
+    /**
+     * `gamescope-session` (SteamOS), `gamescope-session-plus` (ChimeraOS,
+     * Bazzite, CachyOS handheld), `start-gamescope-session` (SteamOS 3.7+).
+     * Polaris' own `polaris-gamescope-session` launcher is not a Game Mode
+     * session and must never match.
+     */
+    bool is_session_tool_name(std::string_view name) {
+      return name.find("gamescope-session"sv) != std::string_view::npos && !name.starts_with("polaris-"sv);
+    }
+
+    bool is_shell_name(std::string_view name) {
+      return name == "bash"sv || name == "sh"sv || name == "dash"sv || name == "zsh"sv;
+    }
+
+    std::vector<std::string> split_nul(const std::string &raw) {
+      std::vector<std::string> tokens;
+      std::size_t start = 0;
+      while (start < raw.size()) {
+        const auto end = raw.find('\0', start);
+        const auto stop = end == std::string::npos ? raw.size() : end;
+        if (stop > start) {
+          tokens.emplace_back(raw.substr(start, stop - start));
+        }
+        if (end == std::string::npos) {
+          break;
+        }
+        start = end + 1;
+      }
+      return tokens;
+    }
+
+    std::vector<std::string> split_lines(const std::string &raw) {
+      std::vector<std::string> lines;
+      std::istringstream stream(raw);
+      std::string line;
+      while (std::getline(stream, line)) {
+        if (!line.empty() && line.back() == '\r') {
+          line.pop_back();
+        }
+        lines.emplace_back(std::move(line));
+      }
+      return lines;
+    }
+
+    /**
+     * Whether any word of an Exec line names a session tool. Entries wrap the
+     * tool in `env` prefixes with options, assignments and quotes, and the
+     * Desktop Entry spec allows all of it; the tool name is the constant.
+     */
+    bool exec_runs_session_tool(std::string_view exec) {
+      std::istringstream stream {std::string(exec)};
+      std::string word;
+      while (stream >> word) {
+        word = strip_quotes(word);
+        if (word.starts_with('-') || word.find('=') != std::string::npos) {
+          continue;
+        }
+        if (is_session_tool_name(basename_of(word))) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    std::optional<std::string> desktop_entry_gamescope_reason(const std::string &content) {
+      for (const auto &raw_line : split_lines(content)) {
+        const auto line = trim(raw_line);
+        if (line.starts_with("Exec="sv) && exec_runs_session_tool(line.substr(5))) {
+          return "Exec=" + trim(line.substr(5));
+        }
+        if (line.starts_with("DesktopNames="sv) && lower(line).find("gamescope"sv) != std::string::npos) {
+          return trim(line);
+        }
+      }
+      return std::nullopt;
+    }
+
+    template<typename visit_t>
+    void for_each_entry(const fs::path &dir, visit_t &&visit) {
+      std::error_code ec;
+      fs::directory_iterator it(dir, ec);
+      const fs::directory_iterator end;
+      for (; !ec && it != end; it.increment(ec)) {
+        visit(*it);
+      }
+    }
+
+    void scan_session_dirs(const probe_t &probe, detection_t &detection) {
+      std::vector<fs::path> entries;
+      for (const auto &dir : probe.session_dirs) {
+        for_each_entry(dir, [&entries](const fs::directory_entry &entry) {
+          if (entry.path().extension() == ".desktop"sv) {
+            entries.push_back(entry.path());
+          }
+        });
+      }
+      std::sort(entries.begin(), entries.end());
+      for (const auto &entry : entries) {
+        const auto content = read_small_file(entry);
+        if (!content) {
+          continue;
+        }
+        if (const auto reason = desktop_entry_gamescope_reason(*content)) {
+          detection.installed = true;
+          detection.evidence.push_back("session entry " + entry.string() + " (" + *reason + ")");
+        }
+      }
+    }
+
+    void scan_path_dirs(const probe_t &probe, detection_t &detection) {
+      std::string search_path;
+      for (const auto &dir : probe.path_dirs) {
+        if (!search_path.empty()) {
+          search_path += ':';
+        }
+        search_path += dir.string();
+      }
+      if (search_path.empty()) {
+        return;
+      }
+      for (const char *tool : {"steamos-session-select", "gamescope-session-plus", "gamescope-session"}) {
+        const auto found = platf::linux_util::find_executable_in_path(tool, search_path.c_str());
+        if (!found.empty()) {
+          detection.installed = true;
+          detection.evidence.push_back(std::string(tool) + " on PATH (" + found + ")");
+        }
+      }
+    }
+
+    void scan_os_release(const probe_t &probe, detection_t &detection) {
+      if (probe.os_release.empty()) {
+        return;
+      }
+      const auto content = read_small_file(probe.os_release);
+      if (!content) {
+        return;
+      }
+      std::string id;
+      std::string variant_id;
+      for (const auto &raw_line : split_lines(*content)) {
+        const auto line = trim(raw_line);
+        const auto eq = line.find('=');
+        if (eq == std::string::npos) {
+          continue;
+        }
+        const auto key = trim(line.substr(0, eq));
+        const auto value = strip_quotes(trim(line.substr(eq + 1)));
+        if (key == "ID"sv) {
+          id = lower(value);
+        } else if (key == "VARIANT_ID"sv) {
+          variant_id = lower(value);
+        }
+      }
+      if (id == "steamos"sv) {
+        detection.installed = true;
+        detection.evidence.push_back("os-release ID=steamos");
+      }
+      if (variant_id.find("deck"sv) != std::string::npos) {
+        detection.installed = true;
+        detection.evidence.push_back("os-release VARIANT_ID=" + variant_id);
+      }
+    }
+
+    /// The session script itself, or a shell running it. `grep gamescope-session` does not count.
+    std::optional<std::string> session_tool_in_cmdline(const std::vector<std::string> &argv) {
+      if (argv.empty()) {
+        return std::nullopt;
+      }
+      const auto first = basename_of(argv[0]);
+      if (is_session_tool_name(first)) {
+        return first;
+      }
+      if (argv.size() >= 2 && is_shell_name(first)) {
+        const auto second = basename_of(argv[1]);
+        if (is_session_tool_name(second)) {
+          return second;
+        }
+      }
+      return std::nullopt;
+    }
+
+    /**
+     * A gamescope-session process is a shell script run by the account, so
+     * its /proc directory is owned by that account (the effective uid equals
+     * the real one); stat() answers the ownership question without opening
+     * anything for every other process on the host.
+     */
+    void scan_processes(const probe_t &probe, detection_t &detection) {
+      if (probe.proc_root.empty()) {
+        return;
+      }
+      std::vector<unsigned long> pids;
+      for_each_entry(probe.proc_root, [&](const fs::directory_entry &entry) {
+        const auto name = entry.path().filename().string();
+        unsigned long pid = 0;
+        const auto [end, err] = std::from_chars(name.data(), name.data() + name.size(), pid);
+        if (err != std::errc() || end != name.data() + name.size()) {
+          return;
+        }
+        struct stat info {};
+        if (::stat(entry.path().c_str(), &info) != 0 || info.st_uid != probe.uid) {
+          return;
+        }
+        pids.push_back(pid);
+      });
+      std::sort(pids.begin(), pids.end());
+      for (const auto pid : pids) {
+        const auto cmdline = read_small_file(probe.proc_root / std::to_string(pid) / "cmdline");
+        if (!cmdline) {
+          continue;
+        }
+        if (const auto tool = session_tool_in_cmdline(split_nul(*cmdline))) {
+          detection.installed = true;
+          detection.session_active = true;
+          detection.evidence.push_back(*tool + " running as this account (pid " + std::to_string(pid) + ")");
+          return;
+        }
+      }
+    }
+
+    std::vector<fs::path> path_dirs_from_environment() {
+      std::vector<fs::path> dirs;
+      const auto push_unique = [&dirs](fs::path dir) {
+        if (dir.empty() || std::find(dirs.begin(), dirs.end(), dir) != dirs.end()) {
+          return;
+        }
+        dirs.push_back(std::move(dir));
+      };
+      if (const char *path = std::getenv("PATH"); path && *path) {
+        std::string_view remaining {path};
+        while (!remaining.empty()) {
+          const auto colon = remaining.find(':');
+          push_unique(fs::path(remaining.substr(0, colon)));
+          if (colon == std::string_view::npos) {
+            break;
+          }
+          remaining.remove_prefix(colon + 1);
+        }
+      }
+      // sudo sanitises PATH and the user service may carry a minimal one; the
+      // session tools live in the system directories either way.
+      push_unique("/usr/bin");
+      push_unique("/usr/local/bin");
+      return dirs;
+    }
+
+    detection_t detect_installed(const probe_t &probe) {
+      detection_t detection;
+      scan_session_dirs(probe, detection);
+      scan_path_dirs(probe, detection);
+      scan_os_release(probe, detection);
+      return detection;
+    }
+  }  // namespace
+
+  probe_t default_probe(uid_t uid) {
+    probe_t probe;
+    probe.session_dirs = {"/usr/share/wayland-sessions", "/usr/local/share/wayland-sessions"};
+    probe.path_dirs = path_dirs_from_environment();
+    probe.os_release = "/etc/os-release";
+    probe.proc_root = "/proc";
+    probe.uid = uid;
+    return probe;
+  }
+
+  detection_t detect(const probe_t &probe) {
+    auto detection = detect_installed(probe);
+    scan_processes(probe, detection);
+    return detection;
+  }
+
+  detection_t detect_cached() {
+    static std::once_flag once;
+    static detection_t installed;
+    std::call_once(once, [] {
+      installed = detect_installed(default_probe(::getuid()));
+    });
+    auto detection = installed;
+    probe_t live;
+    live.proc_root = "/proc";
+    live.uid = ::getuid();
+    scan_processes(live, detection);
+    return detection;
+  }
+
+  std::string headline_evidence(const detection_t &detection) {
+    if (detection.evidence.empty()) {
+      return "no evidence recorded";
+    }
+    std::string headline = detection.evidence.front();
+    if (detection.evidence.size() > 1) {
+      headline += " and " + std::to_string(detection.evidence.size() - 1) + " more signal" + (detection.evidence.size() > 2 ? "s" : "");
+    }
+    return headline;
+  }
+
+  boot_paths_t default_boot_paths(std::string user, const fs::path &home) {
+    return boot_paths_t {
+      "/var/lib/systemd/linger",
+      std::move(user),
+      home.empty() ? fs::path() : home / ".config",
+      "/etc/systemd/user/default.target.wants",
+    };
+  }
+
+  boot_readiness_t boot_readiness(const boot_paths_t &paths) {
+    boot_readiness_t readiness;
+    std::error_code ec;
+    if (!paths.user.empty() && !paths.linger_dir.empty()) {
+      readiness.linger_enabled = fs::exists(paths.linger_dir / paths.user, ec);
+    }
+    const bool user_want = !paths.config_home.empty() &&
+                           fs::exists(paths.config_home / "systemd/user/default.target.wants/polaris.service", ec);
+    const bool system_want = !paths.system_wants_dir.empty() &&
+                             fs::exists(paths.system_wants_dir / "polaris.service", ec);
+    readiness.boot_start_linked = user_want || system_want;
+    return readiness;
+  }
+
+  guidance_t boot_readiness_guidance(const detection_t &detection, bool boot_independent) {
+    if (boot_independent) {
+      return guidance_t {
+        "boot_independent",
+        "Polaris starts at boot with no monitor or desktop login.",
+        "No action needed.",
+      };
+    }
+    if (detection.installed) {
+      return guidance_t {
+        "session_bound",
+        "This host has a Steam Game Mode session, which never starts Polaris. Polaris is only reachable after a Desktop Mode login and goes offline when the host returns to Game Mode.",
+        std::string("Run: ") + std::string(headless_boot_command),
+      };
+    }
+    return guidance_t {
+      "session_bound",
+      "Polaris starts with the desktop session, so after a reboot it is unavailable until someone logs in.",
+      std::string("For a monitor-less or Game Mode host, run: ") + std::string(headless_boot_command),
+    };
+  }
+
+  guidance_t display_session_guidance(
+    const detection_t &detection,
+    bool boot_independent,
+    bool has_wayland_display,
+    bool has_x11_display
+  ) {
+    if (detection.session_active) {
+      return guidance_t {
+        "game_mode_session",
+        "Steam Game Mode is running. Streaming from inside Game Mode is not supported yet.",
+        "Switch to Desktop Mode to stream. The handhelds guide lists what works today.",
+      };
+    }
+    if (has_wayland_display || has_x11_display) {
+      return guidance_t {
+        "healthy",
+        has_wayland_display ? "Wayland desktop environment is available to Polaris." : "X11 desktop environment is available to Polaris.",
+        "No action needed.",
+      };
+    }
+    if (boot_independent) {
+      return guidance_t {
+        "missing_display_environment",
+        "No desktop environment is attached, which is expected on a headless-boot host. Private Stream is unaffected.",
+        "To stream the visible desktop instead, log into the desktop and restart Polaris so it inherits the graphical environment.",
+      };
+    }
+    if (detection.installed) {
+      return guidance_t {
+        "missing_display_environment",
+        "Polaris could not find WAYLAND_DISPLAY or DISPLAY. On a Game Mode host this usually means Polaris started outside the desktop session.",
+        std::string("Restart Polaris from Desktop Mode, then run ") + std::string(headless_boot_command) + " so it stops depending on the session.",
+      };
+    }
+    return guidance_t {
+      "missing_display_environment",
+      "Polaris could not find WAYLAND_DISPLAY or DISPLAY for desktop previews.",
+      "Restart Polaris from the desktop session or run the user service so it inherits the graphical environment.",
+    };
+  }
+
+  std::string setup_host_advice(const detection_t &detection, setup_host_state_t state, std::string_view exe_path) {
+    if (!detection.installed) {
+      return {};
+    }
+    const std::string enable_command = "sudo -H " + std::string(exe_path) + " --setup-host --enable-headless-boot";
+    const std::string not_yet = "Streaming from inside Game Mode is not supported yet; Desktop Mode streams work. See docs/handhelds.md.\n";
+    std::string advice = "Steam Game Mode session detected: " + headline_evidence(detection) + ".\n";
+    switch (state) {
+      case setup_host_state_t::needs_headless_boot:
+        advice += "Game Mode never runs desktop autostart, so Polaris is only reachable after a Desktop Mode login and goes offline when the host returns to Game Mode.\n";
+        advice += "Make it start at boot instead:\n  " + enable_command + "\n";
+        return advice;
+      case setup_host_state_t::already_independent:
+        advice += "Polaris already starts at boot, so switching between Desktop Mode and Game Mode does not take it offline.\n";
+        return advice + not_yet;
+      case setup_host_state_t::headless_boot_enabled_now:
+        advice += "With headless boot on, switching between Desktop Mode and Game Mode no longer takes Polaris offline.\n";
+        return advice + not_yet;
+      case setup_host_state_t::headless_boot_disabled_now:
+        advice += "With headless boot off, Polaris goes offline when the host returns to Game Mode and comes back after a Desktop Mode login.\n";
+        advice += "Turn it back on with:\n  " + enable_command + "\n";
+        return advice;
+    }
+    return advice;
+  }
+
+}  // namespace platf::game_mode_host
+
+#endif

--- a/src/platform/linux/game_mode_host.h
+++ b/src/platform/linux/game_mode_host.h
@@ -1,0 +1,143 @@
+/**
+ * @file src/platform/linux/game_mode_host.h
+ * @brief Recognise hosts that boot into a gamescope Steam session (Game Mode) and phrase the guidance they need.
+ */
+#pragma once
+
+#ifdef __linux__
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+#include <vector>
+
+namespace platf::game_mode_host {
+
+  /**
+   * @brief Where detection looks.
+   *
+   * Production uses default_probe(); tests point every path at scratch
+   * directories so no test ever reads the real host.
+   */
+  struct probe_t {
+    std::vector<std::filesystem::path> session_dirs;  ///< wayland-sessions directories the display manager offers
+    std::vector<std::filesystem::path> path_dirs;  ///< directories searched for the session tools
+    std::filesystem::path os_release;  ///< os-release file
+    std::filesystem::path proc_root;  ///< procfs root for the live-session scan; empty skips it
+    uid_t uid {0};  ///< account whose processes count as a live session
+  };
+
+  struct detection_t {
+    bool installed {false};  ///< the host offers a gamescope Steam session at login, or is running one now
+    bool session_active {false};  ///< a gamescope session is running for the account right now
+    std::vector<std::string> evidence;  ///< what was found, in a stable order
+  };
+
+  /// Real host paths, PATH, os-release, /proc, and the given account.
+  probe_t default_probe(uid_t uid);
+
+  /**
+   * @brief Look for a gamescope Steam session on the host.
+   *
+   * Three install-time signals, any of which counts: a wayland-sessions entry
+   * whose Exec runs a gamescope-session tool or that names the gamescope
+   * desktop (ChimeraOS-style `gamescope-session-plus steam` on Bazzite,
+   * CachyOS handheld edition and Nobara; `start-gamescope-session` with
+   * `DesktopNames=gamescope` on SteamOS), one of those tools or
+   * `steamos-session-select` on PATH, or an os-release that identifies SteamOS
+   * or a deck variant. One live signal, which also counts as installed: a
+   * gamescope-session process owned by the account.
+   */
+  detection_t detect(const probe_t &probe);
+
+  /**
+   * @brief detect() for the calling account, for the long-lived host process.
+   *
+   * The install-time signals cannot change while Polaris runs, so they are
+   * scanned once per process; only the live-session scan repeats.
+   */
+  detection_t detect_cached();
+
+  /// The first signal plus a count of the rest, for one line of terminal output.
+  std::string headline_evidence(const detection_t &detection);
+
+  struct boot_paths_t {
+    std::filesystem::path linger_dir;  ///< /var/lib/systemd/linger
+    std::string user;  ///< account name, the linger file name
+    std::filesystem::path config_home;  ///< the account's config home, as the headless-boot writer sees it
+    std::filesystem::path system_wants_dir;  ///< /etc/systemd/user/default.target.wants
+  };
+
+  /**
+   * @brief Real paths for an account.
+   *
+   * @param home the account's home directory from passwd, which is what
+   * `--enable-headless-boot` writes under; the reader must look where the
+   * writer wrote, not where XDG_CONFIG_HOME in this process happens to point.
+   */
+  boot_paths_t default_boot_paths(std::string user, const std::filesystem::path &home);
+
+  /**
+   * @brief Whether this account's Polaris survives a reboot with no desktop login.
+   *
+   * Lingering plus a default.target want is what `--setup-host
+   * --enable-headless-boot` arranges; either alone is not enough, so both are
+   * reported.
+   */
+  struct boot_readiness_t {
+    bool linger_enabled {false};
+    bool boot_start_linked {false};
+
+    bool independent() const {
+      return linger_enabled && boot_start_linked;
+    }
+  };
+
+  boot_readiness_t boot_readiness(const boot_paths_t &paths);
+
+  struct guidance_t {
+    std::string status;
+    std::string summary;
+    std::string action;
+  };
+
+  /// Boot-readiness copy for the stats API: `boot_independent` or `session_bound`.
+  guidance_t boot_readiness_guidance(const detection_t &detection, bool boot_independent);
+
+  /**
+   * @brief Display-session copy for the stats API.
+   *
+   * `game_mode_session` while a gamescope session runs, whatever the
+   * environment still says (a long-lived Polaris keeps the desktop's
+   * WAYLAND_DISPLAY after the desktop is gone); `healthy` with a display
+   * environment; otherwise `missing_display_environment` with advice that
+   * fits the host: a headless-boot host is told nothing is wrong, a Game Mode
+   * host is pointed at headless boot, and a plain desktop host is told to
+   * restart from the desktop.
+   */
+  guidance_t display_session_guidance(
+    const detection_t &detection,
+    bool boot_independent,
+    bool has_wayland_display,
+    bool has_x11_display
+  );
+
+  /// What `--setup-host` did or found about headless boot on this run.
+  enum class setup_host_state_t {
+    needs_headless_boot,  ///< session-bound and this run did not change that
+    already_independent,  ///< boot start was already in place before this run
+    headless_boot_enabled_now,  ///< this run enabled headless boot
+    headless_boot_disabled_now,  ///< this run disabled headless boot
+  };
+
+  /**
+   * @brief What `--setup-host` prints about a Game Mode host. Empty when the host has none.
+   *
+   * @param exe_path the running binary, for the command to print.
+   */
+  std::string setup_host_advice(const detection_t &detection, setup_host_state_t state, std::string_view exe_path);
+
+}  // namespace platf::game_mode_host
+
+#endif

--- a/src_assets/common/assets/web/composables/useSystemStats.game-mode.test.js
+++ b/src_assets/common/assets/web/composables/useSystemStats.game-mode.test.js
@@ -1,0 +1,76 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSystemStats } from './useSystemStats.js'
+
+function okResponse(payload = {}) {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(payload),
+  }
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function mountComposable(factory) {
+  const exposed = {}
+  const wrapper = mount(defineComponent({
+    setup() {
+      Object.assign(exposed, factory())
+      return () => null
+    },
+  }))
+  return { exposed, wrapper }
+}
+
+describe('useSystemStats game mode host', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('exposes game_mode_host from the stats payload so the console can show a running Game Mode session', async () => {
+    fetch.mockResolvedValueOnce(okResponse({
+      game_mode_host: { installed: true, session_active: true, evidence: ['gamescope-session-plus running as this account (pid 500)'] },
+      display_session: { status: 'game_mode_session' },
+    }))
+
+    const { exposed, wrapper } = mountComposable(() => useSystemStats(1000))
+    await flushPromises()
+
+    expect(exposed.gameModeHost.value).toEqual({
+      installed: true,
+      session_active: true,
+      evidence: ['gamescope-session-plus running as this account (pid 500)'],
+    })
+    expect(exposed.displaySession.value.status).toBe('game_mode_session')
+
+    wrapper.unmount()
+  })
+
+  it('clears game_mode_host when a host stops reporting it', async () => {
+    fetch
+      .mockResolvedValueOnce(okResponse({ game_mode_host: { installed: true, session_active: false, evidence: [] } }))
+      .mockResolvedValueOnce(okResponse({ gpu: null }))
+
+    const { exposed, wrapper } = mountComposable(() => useSystemStats(1000))
+    await flushPromises()
+    expect(exposed.gameModeHost.value.installed).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushPromises()
+    expect(exposed.gameModeHost.value).toBeNull()
+
+    wrapper.unmount()
+  })
+})

--- a/src_assets/common/assets/web/composables/useSystemStats.js
+++ b/src_assets/common/assets/web/composables/useSystemStats.js
@@ -8,7 +8,7 @@ import { ref, onMounted, onUnmounted, watch } from 'vue'
  *
  * @param {number} intervalMs - Poll interval in ms (default: 3000)
  * @param {{ shouldPoll?: (() => boolean) | { value: boolean }, pauseWhenHidden?: boolean, maxBackoffMs?: number }} options
- * @returns {{ gpu: Ref, displays: Ref, audio: Ref, sessionType: Ref, displaySession: Ref, loading: Ref<boolean> }}
+ * @returns {{ gpu: Ref, displays: Ref, audio: Ref, sessionType: Ref, displaySession: Ref, gameModeHost: Ref, loading: Ref<boolean> }}
  */
 export function useSystemStats(intervalMs = 3000, options = {}) {
   const gpu = ref(null)
@@ -16,6 +16,7 @@ export function useSystemStats(intervalMs = 3000, options = {}) {
   const audio = ref(null)
   const sessionType = ref(null)
   const displaySession = ref(null)
+  const gameModeHost = ref(null)
   const loading = ref(true)
 
   const maxBackoffMs = Math.max(intervalMs, options.maxBackoffMs ?? intervalMs * 8)
@@ -84,6 +85,7 @@ export function useSystemStats(intervalMs = 3000, options = {}) {
           audio.value = data.audio || null
           sessionType.value = data.session_type || null
           displaySession.value = data.display_session || null
+          gameModeHost.value = data.game_mode_host || null
           ok = true
         }
       } catch {
@@ -149,5 +151,5 @@ export function useSystemStats(intervalMs = 3000, options = {}) {
     }
   })
 
-  return { gpu, displays, audio, sessionType, displaySession, loading }
+  return { gpu, displays, audio, sessionType, displaySession, gameModeHost, loading }
 }

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -1128,6 +1128,7 @@
     "session_live": "Live compositor mode reported by the host.",
     "session_repaired": "Desktop session environment was repaired automatically.",
     "session_missing_env": "Desktop preview environment is missing. Restart Polaris from the desktop session or run the user service so it inherits Wayland/X11.",
+    "session_game_mode": "Steam Game Mode is running. Streaming from inside Game Mode is not supported yet; switch to Desktop Mode to stream.",
     "recent_issues_review": "Host activity to review",
     "recent_issues_clear": "Nothing needs attention",
     "no_warnings_title": "No warnings or errors",

--- a/src_assets/common/assets/web/system-telemetry.test.js
+++ b/src_assets/common/assets/web/system-telemetry.test.js
@@ -23,12 +23,31 @@ describe('System telemetry display-session guidance', () => {
     // from the desktop.
     const confighttp = readFileSync(join(process.cwd(), 'src/confighttp.cpp'), 'utf8')
 
-    expect(confighttp).toContain('boot_readiness')
-    expect(confighttp).toContain('boot_independent')
-    expect(confighttp).toContain('session_bound')
-    expect(confighttp).toContain('/var/lib/systemd/linger')
-    expect(confighttp).toContain('default.target.wants/polaris.service')
-    expect(confighttp).toContain('sudo -H polaris --setup-host --enable-headless-boot')
-    expect(confighttp).toContain('expected on a headless-boot host')
+    const gameModeHost = readFileSync(join(process.cwd(), 'src/platform/linux/game_mode_host.cpp'), 'utf8')
+
+    expect(confighttp).toContain('output["boot_readiness"]')
+    expect(confighttp).toContain('game_mode_host::boot_readiness_guidance')
+    expect(confighttp).toContain('game_mode_host::display_session_guidance')
+    // The statuses and copy themselves are covered by tests/unit/platform/test_game_mode_host.cpp.
+    expect(gameModeHost).toContain('expected on a headless-boot host')
+  })
+
+  it('names a running Game Mode session instead of asking for a desktop restart', () => {
+    // A handheld that switched to Game Mode still has Polaris up when it boots
+    // independently, but nothing inside that session can be streamed yet. The
+    // console must say so rather than repeat the desktop-restart advice.
+    const home = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/views/HomeView.vue'), 'utf8')
+    const composable = readFileSync(join(process.cwd(), 'src_assets/common/assets/web/composables/useSystemStats.js'), 'utf8')
+    const confighttp = readFileSync(join(process.cwd(), 'src/confighttp.cpp'), 'utf8')
+    const gameModeHost = readFileSync(join(process.cwd(), 'src/platform/linux/game_mode_host.cpp'), 'utf8')
+
+    expect(composable).toContain('data.game_mode_host')
+    expect(composable).toMatch(/return \{[^}]*\bgameModeHost\b[^}]*\}/)
+    expect(home).toContain('gameModeHost?.session_active')
+    expect(home).toContain("$t('index.session_game_mode')")
+    expect(home.indexOf('gameModeHost?.session_active')).toBeLessThan(home.indexOf("displaySession?.status === 'missing_display_environment'"))
+    expect(readFileSync(join(process.cwd(), 'src_assets/common/assets/web/public/assets/locale/en.json'), 'utf8')).toContain('Streaming from inside Game Mode is not supported yet')
+    expect(confighttp).toContain('output["game_mode_host"]')
+    expect(gameModeHost).toContain('"game_mode_session"')
   })
 })

--- a/src_assets/common/assets/web/views/HomeView.vue
+++ b/src_assets/common/assets/web/views/HomeView.vue
@@ -122,7 +122,14 @@
               {{ sessionType ? sessionModeDescription : $t('index.session_mode_idle_desc') }}
             </div>
             <div
-              v-if="displaySession?.environment_repaired"
+              v-if="gameModeHost?.session_active"
+              data-display-session-health
+              class="system-session-health border-warning/30 bg-warning/10 text-warning-bright"
+            >
+              {{ $t('index.session_game_mode') }}
+            </div>
+            <div
+              v-else-if="displaySession?.environment_repaired"
               data-display-session-health
               class="system-session-health border-success/30 bg-success/10 text-success-bright"
             >
@@ -312,7 +319,7 @@ import { resources, legalDocs, sponsor } from '../resource-links.js'
 
 const i18n = inject('i18n')
 
-const { gpu, displays, audio, sessionType, displaySession, loading: systemLoading } = useSystemStats(3000)
+const { gpu, displays, audio, sessionType, displaySession, gameModeHost, loading: systemLoading } = useSystemStats(3000)
 
 const version = ref(null)
 const githubVersion = ref(null)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ set(TEST_PLATFORM_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_desktop_takeover.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_display_topology.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_cuda_gl_encode_device.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_game_mode_host.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_gamescope_session_helper.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_graphics.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_labwc_startup_diagnostics.cpp

--- a/tests/unit/platform/test_game_mode_host.cpp
+++ b/tests/unit/platform/test_game_mode_host.cpp
@@ -1,0 +1,341 @@
+/**
+ * @file tests/unit/platform/test_game_mode_host.cpp
+ * @brief Test gamescope Steam session (Game Mode) host detection and the guidance built on it.
+ */
+#include "../../tests_common.h"
+
+#ifdef __linux__
+
+#include <src/platform/linux/game_mode_host.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using namespace std::literals;
+namespace fs = std::filesystem;
+namespace gm = platf::game_mode_host;
+
+namespace {
+  struct scratch_t {
+    fs::path root;
+
+    scratch_t() {
+      auto pattern = (fs::temp_directory_path() / "polaris-game-mode-host-XXXXXX").string();
+      const char *made = mkdtemp(pattern.data());
+      if (made == nullptr) {
+        throw std::runtime_error("mkdtemp failed");
+      }
+      root = made;
+    }
+
+    ~scratch_t() {
+      std::error_code ec;
+      fs::remove_all(root, ec);
+    }
+
+    fs::path file(const std::string &relative, const std::string &content, bool executable = false) const {
+      const auto path = root / relative;
+      fs::create_directories(path.parent_path());
+      {
+        std::ofstream out(path, std::ios::binary);
+        out << content;
+      }
+      fs::permissions(
+        path,
+        executable ? fs::perms::owner_all | fs::perms::group_read | fs::perms::group_exec | fs::perms::others_read | fs::perms::others_exec :
+                     fs::perms::owner_read | fs::perms::owner_write | fs::perms::group_read | fs::perms::others_read,
+        fs::perm_options::replace
+      );
+      return path;
+    }
+
+    fs::path dir(const std::string &relative) const {
+      const auto path = root / relative;
+      fs::create_directories(path);
+      return path;
+    }
+
+    /// A fake /proc entry owned by the test account: cmdline is NUL separated.
+    void process(unsigned pid, const std::vector<std::string> &argv) const {
+      std::string cmdline;
+      for (const auto &arg : argv) {
+        cmdline += arg;
+        cmdline.push_back('\0');
+      }
+      file("proc/" + std::to_string(pid) + "/cmdline", cmdline);
+    }
+
+    /// The scratch /proc entries are owned by whoever runs the test, so that uid is "this account".
+    gm::probe_t probe(uid_t uid = ::getuid()) const {
+      gm::probe_t probe;
+      probe.session_dirs = {root / "sessions", root / "sessions-local"};
+      probe.path_dirs = {root / "bin"};
+      probe.os_release = root / "os-release";
+      probe.proc_root = root / "proc";
+      probe.uid = uid;
+      return probe;
+    }
+  };
+
+  bool mentions(const std::vector<std::string> &evidence, std::string_view needle) {
+    for (const auto &item : evidence) {
+      if (item.find(needle) != std::string::npos) {
+        return true;
+      }
+    }
+    return false;
+  }
+}  // namespace
+
+TEST(GameModeHostTests, PlainDesktopHostIsNotDetected) {
+  scratch_t scratch;
+  scratch.file("sessions/plasma.desktop", "[Desktop Entry]\nName=Plasma (Wayland)\nExec=/usr/bin/startplasma-wayland\nDesktopNames=KDE\n");
+  scratch.file("bin/gamescope", "#!/bin/sh\n", true);
+  scratch.file("os-release", "NAME=\"Fedora Linux\"\nID=fedora\nVARIANT_ID=kde\n");
+  scratch.process(400, {"/usr/bin/plasmashell"});
+
+  const auto detection = gm::detect(scratch.probe());
+  EXPECT_FALSE(detection.installed);
+  EXPECT_FALSE(detection.session_active);
+  EXPECT_TRUE(detection.evidence.empty());
+}
+
+TEST(GameModeHostTests, ChimeraStyleSessionEntryCountsWithItsExecLine) {
+  scratch_t scratch;
+  scratch.file("sessions/plasma.desktop", "[Desktop Entry]\nExec=/usr/bin/startplasma-wayland\n");
+  scratch.file("sessions/gamescope-session-steam.desktop", "[Desktop Entry]\nName=Steam Big Picture\nExec=gamescope-session-plus steam\nType=Application\nDesktopNames=gamescope\n");
+
+  const auto detection = gm::detect(scratch.probe());
+  EXPECT_TRUE(detection.installed);
+  EXPECT_FALSE(detection.session_active);
+  ASSERT_EQ(detection.evidence.size(), 1U);
+  EXPECT_TRUE(mentions(detection.evidence, "gamescope-session-steam.desktop"));
+  EXPECT_TRUE(mentions(detection.evidence, "Exec=gamescope-session-plus steam"));
+}
+
+TEST(GameModeHostTests, ExecLinesSurviveEnvPrefixesQuotesAndSteamOsNaming) {
+  scratch_t scratch;
+  scratch.file("sessions-local/env-flags.desktop", "[Desktop Entry]\nExec=env -u FOO BAR=1 /usr/bin/gamescope-session\n");
+  scratch.file("sessions-local/quoted.desktop", "[Desktop Entry]\nExec=\"/usr/bin/gamescope-session-plus\" steam\n");
+  // SteamOS 3.7+ ships this Exec; the tool name still contains gamescope-session.
+  scratch.file("sessions-local/gamescope-wayland.desktop", "[Desktop Entry]\nName=Gamescope\nExec=start-gamescope-session\n");
+  // DesktopNames alone is enough when the Exec is unrecognisable.
+  scratch.file("sessions-local/wrapper.desktop", "[Desktop Entry]\nExec=/opt/vendor/launch-steam\nDesktopNames=gamescope\n");
+  // Polaris' own launcher is not a Game Mode session.
+  scratch.file("sessions-local/polaris.desktop", "[Desktop Entry]\nExec=polaris-gamescope-session steam\n");
+
+  const auto detection = gm::detect(scratch.probe());
+  EXPECT_TRUE(detection.installed);
+  ASSERT_EQ(detection.evidence.size(), 4U);
+  EXPECT_TRUE(mentions(detection.evidence, "env-flags.desktop"));
+  EXPECT_TRUE(mentions(detection.evidence, "quoted.desktop"));
+  EXPECT_TRUE(mentions(detection.evidence, "gamescope-wayland.desktop"));
+  EXPECT_TRUE(mentions(detection.evidence, "wrapper.desktop (DesktopNames=gamescope)"));
+  EXPECT_FALSE(mentions(detection.evidence, "polaris.desktop"));
+}
+
+TEST(GameModeHostTests, SessionToolsOnPathCountOnceEachAndMustBeExecutable) {
+  scratch_t scratch;
+  scratch.file("bin/steamos-session-select", "#!/bin/sh\n", true);
+  scratch.file("bin/gamescope-session-plus", "#!/bin/sh\n", false);
+
+  const auto detection = gm::detect(scratch.probe());
+  EXPECT_TRUE(detection.installed);
+  ASSERT_EQ(detection.evidence.size(), 1U);
+  EXPECT_TRUE(mentions(detection.evidence, "steamos-session-select on PATH"));
+  EXPECT_FALSE(mentions(detection.evidence, "gamescope-session-plus"));
+}
+
+TEST(GameModeHostTests, OsReleaseIdentifiesSteamOsAndDeckVariants) {
+  scratch_t steamos;
+  steamos.file("os-release", "NAME=\"SteamOS\"\nID=steamos\nVARIANT_ID=steamdeck\n");
+  const auto deck = gm::detect(steamos.probe());
+  EXPECT_TRUE(deck.installed);
+  EXPECT_TRUE(mentions(deck.evidence, "os-release ID=steamos"));
+  EXPECT_TRUE(mentions(deck.evidence, "os-release VARIANT_ID=steamdeck"));
+
+  scratch_t bazzite;
+  bazzite.file("os-release", "ID=bazzite\nVARIANT_ID=\"bazzite-deck\"\n");
+  const auto image = gm::detect(bazzite.probe());
+  EXPECT_TRUE(image.installed);
+  ASSERT_EQ(image.evidence.size(), 1U);
+  EXPECT_TRUE(mentions(image.evidence, "os-release VARIANT_ID=bazzite-deck"));
+}
+
+TEST(GameModeHostTests, LiveSessionCountsAsInstalledAndOnlyForThisAccount) {
+  scratch_t scratch;
+  scratch.process(500, {"/bin/bash", "/usr/bin/gamescope-session-plus", "steam"});
+  const auto shell_hosted = gm::detect(scratch.probe());
+  EXPECT_TRUE(shell_hosted.session_active);
+  EXPECT_TRUE(shell_hosted.installed) << "a running session is the strongest install signal, even from a prefix nothing else probes";
+  EXPECT_TRUE(mentions(shell_hosted.evidence, "gamescope-session-plus running as this account (pid 500)"));
+
+  const auto other_account = gm::detect(scratch.probe(::getuid() + 1));
+  EXPECT_FALSE(other_account.session_active);
+  EXPECT_FALSE(other_account.installed);
+
+  scratch_t direct;
+  direct.process(20, {"/usr/bin/gamescope-session"});
+  EXPECT_TRUE(gm::detect(direct.probe()).session_active);
+}
+
+TEST(GameModeHostTests, LookalikeProcessesDoNotCountAsALiveSession) {
+  scratch_t scratch;
+  scratch.process(30, {"grep", "gamescope-session"});
+  scratch.process(31, {"/usr/bin/polaris-gamescope-session", "steam"});
+  scratch.process(32, {"/usr/local/bin/polaris-gamescope-idle"});
+  scratch.process(33, {"/usr/bin/gamescope", "--steam", "--", "steam"});
+  scratch.file("proc/not-a-pid/cmdline", "/usr/bin/gamescope-session");
+
+  const auto detection = gm::detect(scratch.probe());
+  EXPECT_FALSE(detection.session_active);
+  EXPECT_FALSE(detection.installed);
+  EXPECT_TRUE(detection.evidence.empty());
+}
+
+TEST(GameModeHostTests, EvidenceOrderIsStableAcrossSignalsAndTheHeadlineCountsTheRest) {
+  scratch_t scratch;
+  scratch.file("sessions/gamescope-session-steam.desktop", "[Desktop Entry]\nExec=gamescope-session-plus steam\n");
+  scratch.file("bin/steamos-session-select", "#!/bin/sh\n", true);
+  scratch.file("os-release", "ID=steamos\n");
+  scratch.process(77, {"/bin/bash", "/usr/bin/gamescope-session-plus", "steam"});
+
+  const auto detection = gm::detect(scratch.probe());
+  ASSERT_EQ(detection.evidence.size(), 4U);
+  EXPECT_NE(detection.evidence[0].find("session entry"), std::string::npos);
+  EXPECT_NE(detection.evidence[1].find("on PATH"), std::string::npos);
+  EXPECT_NE(detection.evidence[2].find("os-release"), std::string::npos);
+  EXPECT_NE(detection.evidence[3].find("running as this account"), std::string::npos);
+  EXPECT_EQ(gm::headline_evidence(detection), detection.evidence[0] + " and 3 more signals");
+
+  gm::detection_t two;
+  two.evidence = {"a", "b"};
+  EXPECT_EQ(gm::headline_evidence(two), "a and 1 more signal");
+  EXPECT_EQ(gm::headline_evidence(gm::detection_t {}), "no evidence recorded");
+}
+
+TEST(GameModeHostTests, DefaultBootPathsReadWhereTheHeadlessBootWriterWrites) {
+  const auto paths = gm::default_boot_paths("deck", "/srv/deck");
+  EXPECT_EQ(paths.linger_dir, fs::path("/var/lib/systemd/linger"));
+  EXPECT_EQ(paths.user, "deck");
+  EXPECT_EQ(paths.config_home, fs::path("/srv/deck/.config"));
+  EXPECT_EQ(paths.system_wants_dir, fs::path("/etc/systemd/user/default.target.wants"));
+  EXPECT_TRUE(gm::default_boot_paths("deck", "").config_home.empty());
+}
+
+TEST(GameModeHostTests, BootReadinessNeedsBothLingerAndTheWantLink) {
+  scratch_t scratch;
+  gm::boot_paths_t paths {scratch.dir("linger"), "deck", scratch.dir("config"), scratch.dir("system-wants")};
+
+  EXPECT_FALSE(gm::boot_readiness(paths).independent());
+
+  scratch.file("linger/deck", "");
+  auto readiness = gm::boot_readiness(paths);
+  EXPECT_TRUE(readiness.linger_enabled);
+  EXPECT_FALSE(readiness.boot_start_linked);
+  EXPECT_FALSE(readiness.independent());
+
+  scratch.file("config/systemd/user/default.target.wants/polaris.service", "");
+  readiness = gm::boot_readiness(paths);
+  EXPECT_TRUE(readiness.independent());
+
+  // A system-wide want counts the same as the account's own link.
+  std::error_code ec;
+  fs::remove(scratch.root / "config/systemd/user/default.target.wants/polaris.service", ec);
+  EXPECT_FALSE(gm::boot_readiness(paths).boot_start_linked);
+  scratch.file("system-wants/polaris.service", "");
+  EXPECT_TRUE(gm::boot_readiness(paths).independent());
+}
+
+TEST(GameModeHostTests, BootReadinessGuidanceNamesGameModeOnlyWhenTheHostHasOne) {
+  gm::detection_t plain;
+  gm::detection_t game_mode;
+  game_mode.installed = true;
+
+  const auto independent = gm::boot_readiness_guidance(game_mode, true);
+  EXPECT_EQ(independent.status, "boot_independent");
+  EXPECT_EQ(independent.action, "No action needed.");
+
+  const auto bound_game_mode = gm::boot_readiness_guidance(game_mode, false);
+  EXPECT_EQ(bound_game_mode.status, "session_bound");
+  EXPECT_NE(bound_game_mode.summary.find("Steam Game Mode session"), std::string::npos);
+  EXPECT_NE(bound_game_mode.summary.find("goes offline when the host returns to Game Mode"), std::string::npos);
+  EXPECT_NE(bound_game_mode.action.find("sudo -H polaris --setup-host --enable-headless-boot"), std::string::npos);
+
+  const auto bound_plain = gm::boot_readiness_guidance(plain, false);
+  EXPECT_EQ(bound_plain.status, "session_bound");
+  EXPECT_EQ(bound_plain.summary.find("Steam Game Mode session"), std::string::npos);
+  EXPECT_NE(bound_plain.action.find("sudo -H polaris --setup-host --enable-headless-boot"), std::string::npos);
+}
+
+TEST(GameModeHostTests, DisplaySessionGuidanceFollowsTheHostKind) {
+  gm::detection_t plain;
+  gm::detection_t installed;
+  installed.installed = true;
+  gm::detection_t live;
+  live.installed = true;
+  live.session_active = true;
+
+  // A live session wins even while the process still carries the desktop's
+  // WAYLAND_DISPLAY from before the mode switch.
+  const auto running = gm::display_session_guidance(live, true, true, false);
+  EXPECT_EQ(running.status, "game_mode_session");
+  EXPECT_NE(running.summary.find("not supported yet"), std::string::npos);
+  EXPECT_NE(running.action.find("Switch to Desktop Mode"), std::string::npos);
+
+  const auto wayland = gm::display_session_guidance(installed, false, true, false);
+  EXPECT_EQ(wayland.status, "healthy");
+  EXPECT_NE(wayland.summary.find("Wayland"), std::string::npos);
+  const auto x11 = gm::display_session_guidance(plain, false, false, true);
+  EXPECT_EQ(x11.status, "healthy");
+  EXPECT_NE(x11.summary.find("X11"), std::string::npos);
+
+  const auto headless = gm::display_session_guidance(plain, true, false, false);
+  EXPECT_EQ(headless.status, "missing_display_environment");
+  EXPECT_NE(headless.summary.find("expected on a headless-boot host"), std::string::npos);
+
+  const auto game_mode_host = gm::display_session_guidance(installed, false, false, false);
+  EXPECT_EQ(game_mode_host.status, "missing_display_environment");
+  EXPECT_NE(game_mode_host.summary.find("Game Mode host"), std::string::npos);
+  EXPECT_NE(game_mode_host.action.find("--enable-headless-boot"), std::string::npos);
+
+  const auto desktop = gm::display_session_guidance(plain, false, false, false);
+  EXPECT_EQ(desktop.status, "missing_display_environment");
+  EXPECT_NE(desktop.action.find("Restart Polaris from the desktop session"), std::string::npos);
+  EXPECT_EQ(desktop.action.find("--enable-headless-boot"), std::string::npos);
+}
+
+TEST(GameModeHostTests, SetupHostAdviceIsSilentOffGameModeHostsAndFollowsWhatTheRunDid) {
+  using state_t = gm::setup_host_state_t;
+  gm::detection_t plain;
+  EXPECT_TRUE(gm::setup_host_advice(plain, state_t::needs_headless_boot, "/usr/bin/polaris").empty());
+
+  gm::detection_t game_mode;
+  game_mode.installed = true;
+  game_mode.evidence = {"steamos-session-select on PATH (/usr/bin/steamos-session-select)"};
+
+  const auto needs_flag = gm::setup_host_advice(game_mode, state_t::needs_headless_boot, "/usr/bin/polaris");
+  EXPECT_NE(needs_flag.find("Steam Game Mode session detected: steamos-session-select on PATH (/usr/bin/steamos-session-select)."), std::string::npos);
+  EXPECT_NE(needs_flag.find("Make it start at boot instead:\n  sudo -H /usr/bin/polaris --setup-host --enable-headless-boot"), std::string::npos);
+  EXPECT_EQ(needs_flag.find("not supported yet"), std::string::npos);
+
+  const auto just_enabled = gm::setup_host_advice(game_mode, state_t::headless_boot_enabled_now, "/usr/bin/polaris");
+  EXPECT_NE(just_enabled.find("With headless boot on"), std::string::npos);
+  EXPECT_NE(just_enabled.find("not supported yet"), std::string::npos);
+  EXPECT_EQ(just_enabled.find("--enable-headless-boot"), std::string::npos);
+
+  const auto already = gm::setup_host_advice(game_mode, state_t::already_independent, "/usr/bin/polaris");
+  EXPECT_NE(already.find("already starts at boot"), std::string::npos);
+  EXPECT_NE(already.find("docs/handhelds.md"), std::string::npos);
+
+  const auto just_disabled = gm::setup_host_advice(game_mode, state_t::headless_boot_disabled_now, "/usr/bin/polaris");
+  EXPECT_NE(just_disabled.find("With headless boot off"), std::string::npos);
+  EXPECT_NE(just_disabled.find("Turn it back on with:\n  sudo -H /usr/bin/polaris --setup-host --enable-headless-boot"), std::string::npos);
+  EXPECT_EQ(just_disabled.find("Make it start at boot instead"), std::string::npos);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Part of #626 (Game Mode hosts). First slice: detection and guidance, no capture changes.

- Adds `platf::game_mode_host` (`src/platform/linux/game_mode_host.{h,cpp}`): recognises a host that boots into a gamescope Steam session from its wayland-sessions entries (`gamescope-session-plus steam`, `start-gamescope-session`, `DesktopNames=gamescope`), the session tools on PATH, and os-release (SteamOS, deck variants), and notices a gamescope-session process running for the account. A live session counts as installed. Install-time signals are scanned once per process; only the live scan repeats per poll, filtered by `stat()` ownership before any file is opened.
- `--setup-host` explains why Polaris goes offline when such a host leaves Desktop Mode and prints the exact headless-boot command, on the nothing-to-do path and after a full run, with copy that follows what the run did (needs the flag, already independent, just enabled, just disabled). It stays silent when a bare root login cannot name the streaming account, matching headless boot itself.
- `/api/stats/system` reports `game_mode_host` (`installed`, `session_active`, `evidence`), phrases `boot_readiness` for the host it is on, and `display_session` reports `game_mode_session` while a session runs, even when the process still carries the desktop's stale `WAYLAND_DISPLAY`. The boot-readiness reader now looks under the account's passwd home, which is where `--enable-headless-boot` writes.
- The console shows a Game Mode notice in the session card instead of the desktop-restart advice; the composable now returns the new ref (the review caught that it did not).
- New `docs/handhelds.md`: what works today, the boot-independent recipe, verification without SSH, and the ten-minute KMS + PipeWire node probe for testers. Linked from the quick start, Arch/CachyOS, SteamOS and Bazzite guides. Changelog entry under Unreleased.

Not in this PR: streaming from inside Game Mode. That is slices 2 to 4 on #626 and waits on the field probe.

## Exact candidate

- `Commit:` `0b486ad9cea8528e9dde1a1760b9473ea67ffb86`
- `Tree:` `48cc992426ffddb4e4b3d74f62aa12e952cdda8d`
- `Parent:` `7cdc9c90e712f1b5113e50dc69212897ca0289a4`
- `Base:` `7cdc9c90e712f1b5113e50dc69212897ca0289a4` (master)

## Verification

On pc-papi (Fedora 44, worktree `gpu-native-initial-convert-retire` at the commit above, canonical CUDA-off configure):

- [x] `ninja polaris test_polaris_platform test_polaris_config test_polaris_http test_polaris` clean, no warnings from the touched files
- [x] `test_polaris_platform --gtest_filter='GameModeHostTests.*'`: 13 passed (session entries incl. env prefixes, quotes and SteamOS naming; PATH tools; os-release; live session per account and lookalike exclusion; evidence order; boot readiness; boot, display-session and setup-host guidance)
- [x] `ctest -j 4 -R 'test_polaris_platform|test_polaris_config|test_polaris_http|^test_polaris$'`: 4/4 passed (one earlier `-j 8` run flaked `test_polaris_http`; it passes alone and under `-j 4`)
- [x] `npm run lint` clean
- [x] `npm run test`: 90 files, 705 passed (includes the new `useSystemStats.game-mode.test.js` and the re-pinned `system-telemetry.test.js`)
- [x] `npm run build` (vite) succeeds
- [x] `scripts/check-public-docs.sh` and `scripts/check-public-surface.sh` clean
- [x] Code-review pass on the branch; all ten findings addressed in this commit

Not covered: no host in the lab runs a gamescope session, so the detection has not been exercised on real SteamOS, Bazzite deck or CachyOS handheld hardware. The unit tests model those layouts from the upstream session packages; field confirmation comes from the #626 probe.
