### PR TITLE
Fix native PipeWire session repinning and cover unused encoder teardown

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+- Protects unused encoder capability probes from a null-frame flush, adds actual submission/teardown regressions for the first-launch Vulkan crash, and keeps Doctor from telling a stable AMD VA-API/SHM user to switch to Auto with a promised fallback (#628)
+
 - Recognises hosts with a Steam Game Mode session (SteamOS, Bazzite deck images, CachyOS handheld edition, other gamescope-session hosts). `--setup-host` says why Polaris goes offline when the host leaves Desktop Mode and prints the headless-boot command, `/api/stats/system` reports `game_mode_host` with Game Mode-aware boot readiness and display-session guidance, and the console names a running Game Mode session instead of asking for a desktop restart. New handhelds guide with the Game Mode validation recipe (#626)
 
 ## v1.4.4 - 2026-09-06

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ starts at `v1.0.0`.
 ## Unreleased
 
 - Protects unused encoder capability probes from a null-frame flush, adds actual submission/teardown regressions for the first-launch Vulkan crash, and keeps Doctor from telling a stable AMD VA-API/SHM user to switch to Auto with a promised fallback (#628)
+- Repins native PipeWire session audio when the stream omits its PID by resolving its owning client, while preserving session markers, unrelated desktop audio, and the no-default-sink-claim setting (#629)
 
 - Recognises hosts with a Steam Game Mode session (SteamOS, Bazzite deck images, CachyOS handheld edition, other gamescope-session hosts). `--setup-host` says why Polaris goes offline when the host leaves Desktop Mode and prints the headless-boot command, `/api/stats/system` reports `game_mode_host` with Game Mode-aware boot readiness and display-session guidance, and the console names a running Game Mode session instead of asking for a desktop restart. New handhelds guide with the Game Mode validation recipe (#626)
 

--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -39,6 +39,7 @@
 #endif
 
 // local includes
+#include "audio_process_id.h"
 #include "src/audio.h"
 #include "src/config.h"
 #include "src/logging.h"
@@ -1256,6 +1257,28 @@ namespace platf {
         return sink_index;
       }
 
+      std::optional<pid_t> client_process_id(std::uint32_t client_index) {
+        if (client_index == PA_INVALID_INDEX) return std::nullopt;
+        std::optional<pid_t> result;
+        bool failed = false;
+        cb_t<pa_client_info *> client_f = [&](ctx_t::pointer, const pa_client_info *info, int eol) {
+          if (eol < 0) {
+            failed = true;
+            return;
+          }
+          if (!info) return;
+          if (info->index != client_index || !info->proplist) {
+            failed = true;
+            return;
+          }
+          result = audio_process_id::client(info->proplist);
+        };
+        mainloop_lock_t lock {loop.get()};
+        op_t operation {pa_context_get_client_info(ctx.get(), client_index, cb<pa_client_info *>, &client_f)};
+        if (!operation || !wait_for_operation(operation) || failed) return std::nullopt;
+        return result;
+      }
+
       void route_process_audio_to_sink(const std::string &sink) override {
         auto target_sink = sink_index_by_name(sink);
         if (!target_sink) {
@@ -1270,7 +1293,8 @@ namespace platf {
         struct sink_input_route_t {
           std::uint32_t index;
           std::uint32_t current_sink;
-          pid_t pid;
+          std::uint32_t client;
+          audio_process_id::property_t stream_pid;
           std::string app_name;
         };
 
@@ -1278,10 +1302,16 @@ namespace platf {
         auto alarm = safe::make_alarm<int>();
 
         cb_t<pa_sink_input_info *> input_f = [&](ctx_t::pointer ctx, const pa_sink_input_info *input_info, int eol) {
+          if (eol < 0) {
+            BOOST_LOG(error) << "Couldn't complete pulseaudio sink input list: "sv << pa_strerror(pa_context_errno(ctx));
+            alarm->ring(-1);
+            return;
+          }
           if (!input_info) {
             if (!eol) {
               BOOST_LOG(error) << "Couldn't get pulseaudio sink input info: "sv << pa_strerror(pa_context_errno(ctx));
               alarm->ring(-1);
+              return;
             }
 
             alarm->ring(0);
@@ -1292,33 +1322,12 @@ namespace platf {
           if (input_info->sink == *target_sink) {
             return;
           }
-          const char *pid_text = pa_proplist_gets(input_info->proplist, PA_PROP_APPLICATION_PROCESS_ID);
-          if (!pid_text || !*pid_text) {
-            return;
-          }
-
-          char *end = nullptr;
-          const auto pid_long = std::strtol(pid_text, &end, 10);
-          if (end == pid_text || pid_long <= 1 || pid_long > std::numeric_limits<pid_t>::max()) {
-            return;
-          }
-
-          const auto pid = static_cast<pid_t>(pid_long);
-          // PulseAudio recycles sink-input indices. Apply the EasyEffects
-          // cooldown only when the index still belongs to the same process.
-          if (const auto it = routed_sink_inputs.find(input_info->index);
-              it != routed_sink_inputs.end() && it->second.pid == pid) {
-            return;
-          }
-          if (!process_env_has_session_audio_sink(pid, sink)) {
-            return;
-          }
-
-          const char *app_name = pa_proplist_gets(input_info->proplist, PA_PROP_APPLICATION_NAME);
+          const auto *app_name = input_info->proplist ? pa_proplist_gets(input_info->proplist, PA_PROP_APPLICATION_NAME) : nullptr;
           routes.push_back(sink_input_route_t {
             input_info->index,
             input_info->sink,
-            pid,
+            input_info->client,
+            audio_process_id::property(input_info->proplist, PA_PROP_APPLICATION_PROCESS_ID),
             app_name ? app_name : "unknown"
           });
         };
@@ -1338,11 +1347,26 @@ namespace platf {
           return;
         }
 
+        // Resolve clients only after the sink-input list callback has retired.
+        // Nesting a blocking Pulse operation inside that callback can deadlock
+        // its mainloop. Cache only this pass: client indices can be recycled.
+        std::unordered_map<std::uint32_t, std::optional<pid_t>> clients;
+        const audio_process_id::client_lookup_t lookup = [&](std::uint32_t index) {
+          auto [it, inserted] = clients.try_emplace(index);
+          if (inserted) it->second = client_process_id(index);
+          return it->second;
+        };
         for (const auto &route : routes) {
-          routed_sink_inputs[route.index] = routed_sink_input_t {route.pid, std::chrono::steady_clock::now()};
+          const auto pid = audio_process_id::sink_input(route.stream_pid, route.client, lookup);
+          if (!pid) continue;
+          // Keep the existing session markers and ancestor checks authoritative
+          // for every PID source; a client association alone grants no route.
+          if (const auto it = routed_sink_inputs.find(route.index);
+              it != routed_sink_inputs.end() && it->second.pid == *pid) continue;
+          if (!process_env_has_session_audio_sink(*pid, sink)) continue;
 
           BOOST_LOG(info) << "Linux audio isolation: moving session audio stream ["sv
-                          << route.app_name << "] pid="sv << route.pid
+                          << route.app_name << "] pid="sv << *pid
                           << " sink_input="sv << route.index
                           << " from sink #"sv << route.current_sink
                           << " to ["sv << sink << "] (10s re-pin cooldown)"sv;
@@ -1368,8 +1392,10 @@ namespace platf {
           const bool move_completed = wait_for_operation(move_op);
           if (!move_completed || !move_alarm->status() || *move_alarm->status()) {
             BOOST_LOG(warning) << "Linux audio isolation: failed to move session audio stream ["sv
-                               << route.app_name << "] pid="sv << route.pid
+                               << route.app_name << "] pid="sv << *pid
                                << " to ["sv << sink << "]: "sv << pa_strerror(pa_context_errno(ctx.get()));
+          } else {
+            routed_sink_inputs[route.index] = routed_sink_input_t {*pid, std::chrono::steady_clock::now()};
           }
         }
       }

--- a/src/platform/linux/audio_process_id.h
+++ b/src/platform/linux/audio_process_id.h
@@ -1,0 +1,72 @@
+/** @file src/platform/linux/audio_process_id.h
+ * Resolve stream ownership without treating missing metadata as a PID.
+ */
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+#include <pulse/proplist.h>
+
+namespace platf::audio_process_id {
+  inline std::optional<pid_t> parse(std::string_view value) {
+    if (value.empty()) return std::nullopt;
+    pid_t pid = 0;
+    const auto result = std::from_chars(value.data(), value.data() + value.size(), pid);
+    if (result.ec != std::errc {} || result.ptr != value.data() + value.size() || pid <= 1) {
+      return std::nullopt;
+    }
+    return pid;
+  }
+
+  struct property_t {
+    std::optional<std::string> value;
+    bool malformed = false;
+  };
+
+  inline property_t property(const pa_proplist *properties, const char *key) {
+    if (!properties || !pa_proplist_contains(properties, key)) return {};
+    const auto *value = pa_proplist_gets(properties, key);
+    // gets() also returns null for present binary or malformed strings. Keep
+    // that distinct from absence so a bad explicit identity cannot fall back.
+    if (!value) return {std::nullopt, true};
+    return {std::string(value), false};
+  }
+
+  inline std::optional<pid_t> client(const pa_proplist *properties) {
+    const auto api = property(properties, "client.api");
+    if (api.malformed) return std::nullopt;
+    auto pid = property(properties, PA_PROP_APPLICATION_PROCESS_ID);
+    // The native protocol's host PID handles PID namespaces. For Pulse proxy
+    // clients, those credentials identify pipewire-pulse itself: use the
+    // application PID instead, and never fall back to the proxy daemon.
+    if (api.value != "pipewire-pulse") {
+      const auto security_pid = property(properties, "pipewire.sec.pid");
+      if (security_pid.malformed || security_pid.value) pid = security_pid;
+    }
+    if (pid.malformed || !pid.value) return std::nullopt;
+    return parse(*pid.value);
+  }
+
+  using client_lookup_t = std::function<std::optional<pid_t>(std::uint32_t)>;
+
+  inline std::optional<pid_t> sink_input(
+    const property_t &stream_pid,
+    std::uint32_t client_index,
+    const client_lookup_t &lookup
+  ) {
+    // A stream can identify a different process from its client (for example,
+    // a launcher proxy). Preserve that explicit association when present.
+    if (stream_pid.malformed) return std::nullopt;
+    if (stream_pid.value) return parse(*stream_pid.value);
+    if (client_index == std::numeric_limits<std::uint32_t>::max() || !lookup) {
+      return std::nullopt;
+    }
+    return lookup(client_index);
+  }
+}

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -782,9 +782,9 @@ namespace stream_stats {
         amd_vaapi && config::video.encoder == "vaapi") {
       configuration_warnings.push_back({
         {"id", "amd_private_explicit_vaapi_shm"},
-        {"severity", "warning"},
-        {"message", "AMD Private Stream is explicitly pinned to VA-API while capture is crossing SHM/system-memory frames; this compatibility path can be throughput-limited at high resolution or refresh rate."},
-        {"action", "Set Force a Specific Encoder to Autodetect (recommended), restart Polaris, and start a fresh Private Stream. Auto will live-probe Vulkan Video and fall back to VA-API if the exact GPU-native path is unavailable."}
+        {"severity", "info"},
+        {"message", "AMD Private Stream is using the explicitly selected VA-API compatibility path with SHM/system-memory capture. This can limit throughput at high resolution or refresh rate, but is not itself a configuration error."},
+        {"action", "Keep VA-API selected if it provides stable streaming. If throughput is insufficient, first reduce resolution, frame rate, or bitrate. Change encoder only after checking a current build on this GPU and driver; a successful fallback cannot be assumed if a hardware probe crashes."}
       });
     }
   #endif

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1429,7 +1429,9 @@ namespace video {
       const bool vulkan_codec = avcodec_ctx->codec && avcodec_ctx->codec->name &&
                                 std::string_view {avcodec_ctx->codec->name}.ends_with("_vulkan"sv);
       if (vulkan_codec) {
-        BOOST_LOG(info) << "Vulkan encoder teardown: draining codec"sv;
+        BOOST_LOG(info) << (frame_submitted ?
+          "Vulkan encoder teardown: draining codec"sv :
+          "Vulkan encoder teardown: skipping drain; no frame was accepted"sv);
       }
 
       // Some hardware encoders cannot flush an initialized session that never
@@ -5747,6 +5749,26 @@ namespace video {
   }
 
 #ifdef POLARIS_TESTS
+  std::vector<int> encode_and_destroy_avcodec_session_for_tests(
+    avcodec_ctx_t context,
+    std::unique_ptr<platf::avcodec_encode_device_t> device,
+    std::size_t frame_count
+  ) {
+    // Exercise the real submission path and destructor without creating a
+    // display or opening a hardware device. Tests own the codec-call boundary.
+    auto converter = std::make_unique<encode_device_frame_converter_t<platf::avcodec_encode_device_t>>(
+      "lifecycle-test", std::move(device), conversion_request_t {}
+    );
+    avcodec_encode_session_t session {std::move(context), std::move(converter), {}, 0, false};
+    auto mailbox = std::make_shared<safe::mail_raw_t>();
+    auto packets = mailbox->queue<packet_t>(mail::video_packets);
+    std::vector<int> results;
+    for (std::size_t index = 0; index < frame_count; ++index) {
+      results.push_back(encode_avcodec(index, session, packets, nullptr, std::nullopt));
+    }
+    return results;
+  }
+
   int hevc_profile_for_input_for_tests(int bit_depth, int chroma_sampling_type) {
     return hevc_profile_for_input(bit_depth, chroma_sampling_type);
   }

--- a/src/video.h
+++ b/src/video.h
@@ -633,6 +633,13 @@ namespace video {
   bool active_encoder_runtime_supports_live_gpu_capture(const config_t &config);
 
 #ifdef POLARIS_TESTS
+  /** Own the supplied codec/converter through real frame submission and teardown. */
+  std::vector<int> encode_and_destroy_avcodec_session_for_tests(
+    avcodec_ctx_t context,
+    std::unique_ptr<platf::avcodec_encode_device_t> device,
+    std::size_t frame_count
+  );
+
   int hevc_profile_for_input_for_tests(int bit_depth, int chroma_sampling_type);
 
   struct encoder_probe_cache_snapshot_t {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -613,6 +613,14 @@ if (BUILD_FULL_TESTS)
     configure_polaris_full_test_target(test_polaris_video
         ${TEST_VIDEO_SOURCES}
     )
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_sources(test_polaris_video PRIVATE
+            ${CMAKE_SOURCE_DIR}/tests/unit/test_avcodec_session_lifecycle.cpp)
+        target_link_options(test_polaris_video PRIVATE
+            -Wl,--wrap=avcodec_send_frame
+            -Wl,--wrap=avcodec_receive_packet
+            -Wl,--wrap=avcodec_free_context)
+    endif()
 
     # Keep the historical target name as a build aggregate while the runtime coverage
     # lives in smaller executables that are easier to run and debug independently.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -605,6 +605,10 @@ if (BUILD_FULL_TESTS)
     configure_polaris_full_test_target(test_polaris_audio
         ${TEST_AUDIO_SOURCES}
     )
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_sources(test_polaris_audio PRIVATE
+            ${CMAKE_SOURCE_DIR}/tests/unit/platform/test_audio_process_id.cpp)
+    endif()
 
     configure_polaris_full_test_target(test_polaris_stream
         ${TEST_STREAM_SOURCES}

--- a/tests/integration/test_private_audio_routing.py
+++ b/tests/integration/test_private_audio_routing.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Exercise Linux repinning against device-free, temporary PipeWire servers.
+
+Usage: python3 tests/integration/test_private_audio_routing.py \
+    --binary build/native/tests/test_polaris_audio --evidence build/audio-routing
+Requires PipeWire, pipewire-pulse, WirePlumber, pw-cat, pacat and pactl.
+The evidence directory must be new. Logs may contain local process metadata.
+"""
+import argparse
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+
+
+class Interruptions:
+    def __init__(self):
+        self.deferring = False
+        self.pending = None
+
+    def __call__(self, number, _frame):
+        if self.deferring:
+            self.pending = number
+        else:
+            raise RuntimeError(f"Private fixture interrupted by signal {number}")
+
+    @contextmanager
+    def defer(self):
+        self.deferring = True
+        try:
+            yield
+        finally:
+            self.deferring = False
+            if self.pending is not None:
+                self(self.pending, None)
+
+
+@contextmanager
+def private_runtime(receipt, evidence):
+    directory = tempfile.TemporaryDirectory(prefix="polaris-audio629-", dir="/tmp")
+    root = Path(directory.name)
+    interruptions = Interruptions()
+    handlers = {number: signal.signal(number, interruptions)
+                for number in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)}
+    try:
+        yield directory.name, interruptions
+    finally:
+        try:
+            directory.cleanup()
+        except Exception as error:
+            receipt["cleanup_errors"].append(f"runtime cleanup: {error}")
+        receipt["runtime_removed"] = not root.exists()
+        try:
+            (evidence / "receipt.json").write_text(json.dumps(receipt, indent=2) + "\n")
+        finally:
+            for number, handler in handlers.items():
+                signal.signal(number, handler)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", required=True, type=Path)
+    parser.add_argument("--evidence", required=True, type=Path)
+    parser.add_argument("--interrupt-after-ready", choices=("SIGTERM", "SIGHUP"),
+                        help="Exercise cleanup after real producers start; intentionally exits nonzero")
+    args = parser.parse_args()
+    binary = args.binary.resolve(strict=True)
+    evidence = args.evidence.resolve()
+    evidence.mkdir(mode=0o700, parents=True, exist_ok=False)
+    executables = {name: shutil.which(name) for name in
+                   ("pipewire", "pipewire-pulse", "wireplumber", "pw-cat", "pacat", "pactl")}
+    if not all(executables.values()):
+        raise RuntimeError("Missing private audio fixture dependency")
+    children, logs = [], []
+    receipt = {"routing_passed": False, "host_service_changes": False, "cleanup_errors": []}
+    with private_runtime(receipt, evidence) as (tmp, interruptions):
+        root = Path(tmp)
+        os.chmod(root, 0o700)
+        env = os.environ.copy()
+        for key in tuple(env):
+            if key.startswith(("PULSE_", "PIPEWIRE_", "POLARIS_SESSION_", "WIREPLUMBER_")):
+                env.pop(key)
+        config = root / "config"
+        wp_config = config / "wireplumber/wireplumber.conf.d"
+        wp_config.mkdir(parents=True)
+        pw_config = root / "pwconf"
+        pw_config.mkdir()
+        for name in ("pipewire.conf", "pipewire-pulse.conf", "client.conf"):
+            shutil.copyfile(Path("/usr/share/pipewire") / name, pw_config / name)
+        (wp_config / "99-isolated.conf").write_text("""wireplumber.profiles = {
+          polaris-test = {
+            inherits = [ base, mixin.systemwide-session, mixin.stateless ]
+            metadata.sm-settings = required
+            policy.standard = required
+            hardware.audio = disabled
+            hardware.bluetooth = disabled
+            hardware.video-capture = disabled
+            support.dbus = disabled
+          }
+        }
+        """)
+        env.update(XDG_RUNTIME_DIR=tmp, PIPEWIRE_RUNTIME_DIR=tmp,
+                   PULSE_RUNTIME_PATH=tmp + "/pulse", PULSE_SERVER="unix:" + tmp + "/pulse/native",
+                   XDG_CONFIG_HOME=str(config), XDG_CONFIG_DIRS=str(root / "etc"),
+                   XDG_STATE_HOME=str(root / "state"), XDG_CACHE_HOME=str(root / "cache"),
+                   PIPEWIRE_CONFIG_DIR=str(pw_config),
+                   DBUS_SESSION_BUS_ADDRESS="unix:path=" + tmp + "/no-bus",
+                   DBUS_SYSTEM_BUS_ADDRESS="unix:path=" + tmp + "/no-system-bus",
+                   POLARIS_TEST_PRIVATE_AUDIO_ROUTING="1", POLARIS_STREAM_SINK="0")
+        isolation = ("{ support.dbus=false module.jackdbus-detect=false module.portal=false "
+                     "module.x11.bell=false module.raop=false }")
+
+        def spawn(name, command, child_env, stdin=None):
+            log = (evidence / (name + ".log")).open("w")
+            logs.append(log)
+            # Register the child before a Python signal handler may unwind.
+            # The child keeps normal signal dispositions and masks.
+            with interruptions.defer():
+                process = subprocess.Popen(command, env=child_env, stdin=stdin, stdout=log,
+                                           stderr=subprocess.STDOUT, start_new_session=True)
+                children.append(process)
+            return process
+
+        def command(arguments):
+            return subprocess.check_output(arguments, env=env, text=True,
+                                           stderr=subprocess.PIPE, timeout=5)
+
+        def pactl(*arguments):
+            return command([executables["pactl"], *arguments])
+
+        def wait(check, message):
+            deadline = time.monotonic() + 8
+            while time.monotonic() < deadline:
+                if check():
+                    return
+                time.sleep(.05)
+            raise RuntimeError(message)
+
+        def inputs():
+            return json.loads(pactl("-f", "json", "list", "sink-inputs"))
+
+        def snapshot():
+            return {"streams": inputs(),
+                    "clients": json.loads(pactl("-f", "json", "list", "clients")),
+                    "default": pactl("get-default-sink").strip()}
+
+        def route(name):
+            process = spawn(name, [str(binary), "--gtest_filter=AudioProcessRouting.PrivatePipeWireFixture"], env)
+            if process.wait(timeout=20) != 0:
+                raise RuntimeError("Native routing bridge failed")
+
+        marked = {"polaris-routing-session", "polaris-routing-legacy"}
+
+        def assert_routes(snap, sinks, routed):
+            assert snap["default"] == "polaris-routing-host", "Default sink changed"
+            assert len(snap["streams"]) == 5, "Unexpected stream count"
+            assert {stream["properties"]["application.name"] for stream in snap["streams"]} == {
+                "polaris-routing-session", "polaris-routing-desktop", "polaris-routing-other",
+                "polaris-routing-legacy", "polaris-routing-pulse-desktop"
+            }, "Unexpected producers"
+            for stream in snap["streams"]:
+                name = stream["properties"]["application.name"]
+                destination = "polaris-routing-session" if routed and name in marked else "polaris-routing-host"
+                assert stream["sink"] == sinks[destination], f"Wrong destination for {name}"
+
+        try:
+            spawn("pipewire", [executables["pipewire"], "-c", "pipewire.conf", "-P", isolation], env)
+            wait(lambda: (root / "pipewire-0").is_socket(), "Private PipeWire did not start")
+            spawn("wireplumber", [executables["wireplumber"], "--profile=polaris-test"], env)
+            spawn("pulse", [executables["pipewire-pulse"], "-c", "pipewire-pulse.conf", "-P", isolation], env)
+            wait(lambda: (root / "pulse/native").is_socket(), "Private Pulse did not start")
+            for sink in ("polaris-routing-host", "polaris-routing-session"):
+                pactl("load-module", "module-null-sink", "sink_name=" + sink, "channels=2")
+            pactl("set-default-sink", "polaris-routing-host")
+            sinks = {sink["name"]: sink["index"] for sink in json.loads(pactl("-f", "json", "list", "sinks"))}
+            assert set(sinks) == {"polaris-routing-host", "polaris-routing-session"}, "Unexpected sink"
+            assert json.loads(pactl("-f", "json", "list", "cards")) == [], "Private server discovered hardware"
+            zero = open("/dev/zero", "rb")
+            logs.append(zero)
+            native_session = None
+            for name, marker in (("session", "polaris-routing-session"), ("desktop", None), ("other", "another-session")):
+                app_env = env.copy()
+                if marker:
+                    app_env["POLARIS_SESSION_AUDIO_SINK"] = marker
+                process = spawn(name, [executables["pw-cat"], "--playback", "--raw", "--format", "s16",
+                                       "--rate", "48000", "--channels", "2", "--properties",
+                                       "{ application.name=polaris-routing-" + name + " }", "-"], app_env, zero)
+                if name == "session":
+                    native_session = process
+            pulse_env = dict(env, POLARIS_SESSION_AUDIO_SINK="polaris-routing-session")
+            for name, app_env in (("legacy", pulse_env), ("pulse-desktop", env)):
+                spawn(name, [executables["pacat"], "--playback", "--raw", "--rate=48000", "--channels=2",
+                             "--client-name=polaris-routing-" + name], app_env, zero)
+            wait(lambda: len(inputs()) == 5, "Private producers did not start")
+            (evidence / "producer-metadata.json").write_text(json.dumps(snapshot(), indent=2) + "\n")
+            before = snapshot()
+            assert_routes(before, sinks, False)
+            clients = {client["index"]: client["properties"] for client in before["clients"]}
+            for stream in before["streams"]:
+                name = stream["properties"]["application.name"]
+                if name in {"polaris-routing-session", "polaris-routing-desktop", "polaris-routing-other"}:
+                    assert "application.process.id" not in stream["properties"], "Fixture has an explicit stream PID"
+                    client = clients[int(stream["client"])]
+                    assert int(client["application.process.id"]) > 1
+                if name == "polaris-routing-legacy":
+                    client = clients[int(stream["client"])]
+                    assert client["client.api"] == "pipewire-pulse"
+                    assert client["application.process.id"] != client["pipewire.sec.pid"], "Fixture does not distinguish proxy PID"
+                    assert stream["properties"]["application.process.id"] == client["application.process.id"]
+            (evidence / "before.json").write_text(json.dumps(before, indent=2) + "\n")
+            if args.interrupt_after_ready:
+                os.kill(os.getpid(), getattr(signal, args.interrupt_after_ready))
+            route("route-first")
+            after = snapshot()
+            assert_routes(after, sinks, True)
+            (evidence / "after.json").write_text(json.dumps(after, indent=2) + "\n")
+            # Force a session stream back to the private desktop sink and prove
+            # a later control instance repins without changing other streams.
+            for stream in after["streams"]:
+                if stream["properties"]["application.name"] == "polaris-routing-session":
+                    pactl("move-sink-input", str(stream["index"]), "polaris-routing-host")
+            route("route-repin")
+            assert_routes(snapshot(), sinks, True)
+            # Retire a native client and create a replacement; per-pass client
+            # ownership must follow the new server object, not an old cache.
+            native_session.terminate()
+            native_session.wait(timeout=3)
+            wait(lambda: len(inputs()) == 4, "Retired stream did not disappear")
+            spawn("session-reconnect", [executables["pw-cat"], "--playback", "--raw", "--format", "s16",
+                  "--rate", "48000", "--channels", "2", "--properties",
+                  "{ application.name=polaris-routing-session }", "-"], pulse_env, zero)
+            wait(lambda: len(inputs()) == 5, "Replacement stream did not appear")
+            route("route-reconnect")
+            assert_routes(snapshot(), sinks, True)
+            receipt["routing_passed"] = True
+            receipt["native_missing_pid"] = True
+            receipt["legacy_explicit_pid"] = True
+            receipt["unmarked_and_other_session_unchanged"] = True
+            receipt["default_sink_unchanged"] = True
+            receipt["repin_and_reconnect"] = True
+        finally:
+            # A second signal must not abandon the remaining owned children.
+            for number in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+                signal.signal(number, signal.SIG_IGN)
+            for process in reversed(children):
+                try:
+                    if process.poll() is None:
+                        process.terminate()
+                except Exception as error:
+                    receipt["cleanup_errors"].append(f"terminate {process.pid}: {error}")
+            for process in reversed(children):
+                try:
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    try:
+                        process.kill()
+                        process.wait(timeout=3)
+                    except Exception as error:
+                        receipt["cleanup_errors"].append(f"kill/reap {process.pid}: {error}")
+                except Exception as error:
+                    receipt["cleanup_errors"].append(f"reap {process.pid}: {error}")
+            for log in logs:
+                try:
+                    log.close()
+                except Exception as error:
+                    receipt["cleanup_errors"].append(f"close log: {error}")
+            receipt["all_children_exited"] = all(process.poll() is not None for process in children)
+    assert receipt["all_children_exited"] and receipt["runtime_removed"] and not receipt["cleanup_errors"], "Private fixture cleanup failed"
+    print(json.dumps(receipt))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/platform/test_audio_process_id.cpp
+++ b/tests/unit/platform/test_audio_process_id.cpp
@@ -1,0 +1,139 @@
+/** @file tests/unit/platform/test_audio_process_id.cpp
+ * Audio ownership metadata and opt-in private server routing regressions.
+ */
+#include "src/platform/linux/audio_process_id.h"
+#include "src/platform/common.h"
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace {
+  using namespace platf::audio_process_id;
+  using properties_t = std::unique_ptr<pa_proplist, decltype(&pa_proplist_free)>;
+
+  properties_t properties() {
+    return {pa_proplist_new(), pa_proplist_free};
+  }
+
+  property_t stream_property(const char *value) {
+    auto props = properties();
+    if (value) pa_proplist_sets(props.get(), PA_PROP_APPLICATION_PROCESS_ID, value);
+    return property(props.get(), PA_PROP_APPLICATION_PROCESS_ID);
+  }
+
+  std::optional<pid_t> client_pid(const char *application, const char *security, const char *api = nullptr) {
+    auto props = properties();
+    if (application) pa_proplist_sets(props.get(), PA_PROP_APPLICATION_PROCESS_ID, application);
+    if (security) pa_proplist_sets(props.get(), "pipewire.sec.pid", security);
+    if (api) pa_proplist_sets(props.get(), "client.api", api);
+    return client(props.get());
+  }
+}
+
+TEST(AudioProcessId, ParsesOnlyCompletePositiveProcessIds) {
+  EXPECT_EQ(parse("42"), 42);
+  EXPECT_EQ(parse(std::to_string(std::numeric_limits<pid_t>::max())), std::numeric_limits<pid_t>::max());
+  for (const auto text : {"", "0", "1", "-2", "+42", " 42", "42 ", "42junk", "999999999999999999999"}) {
+    EXPECT_FALSE(parse(text)) << text;
+  }
+  EXPECT_FALSE(parse(std::string_view {"42\0extra", 8}));
+}
+
+TEST(AudioProcessId, ExplicitStreamPidTakesPrecedenceAndNeverQueriesClient) {
+  int lookups = 0;
+  const client_lookup_t lookup = [&](std::uint32_t) { ++lookups; return 900; };
+  EXPECT_EQ(sink_input(stream_property("42"), 7, lookup), 42);
+  for (const auto text : {"42junk", "1", ""}) {
+    EXPECT_FALSE(sink_input(stream_property(text), 7, lookup));
+  }
+  EXPECT_EQ(lookups, 0);
+}
+
+TEST(AudioProcessId, MissingStreamPidResolvesOnlyItsOwningClient) {
+  std::vector<std::uint32_t> requested;
+  const client_lookup_t lookup = [&](std::uint32_t index) -> std::optional<pid_t> {
+    requested.push_back(index);
+    if (index == 7) return client_pid("42", nullptr);
+    if (index == 8) return client_pid(nullptr, "43");
+    return std::nullopt;
+  };
+  EXPECT_EQ(sink_input(stream_property(nullptr), 7, lookup), 42);
+  EXPECT_EQ(sink_input(stream_property(nullptr), 8, lookup), 43);
+  EXPECT_FALSE(sink_input(stream_property(nullptr), 9, lookup));
+  EXPECT_EQ(requested, (std::vector<std::uint32_t> {7, 8, 9}));
+}
+
+TEST(AudioProcessId, MissingClientAndMalformedClientPidFailClosed) {
+  const client_lookup_t lookup = [](std::uint32_t) { ADD_FAILURE() << "Invalid client queried"; return 42; };
+  EXPECT_FALSE(sink_input({}, std::numeric_limits<std::uint32_t>::max(), lookup));
+  EXPECT_FALSE(sink_input({}, 7, {}));
+  EXPECT_FALSE(client_pid(nullptr, nullptr));
+  EXPECT_FALSE(client_pid("42junk", nullptr));
+  EXPECT_FALSE(client_pid("42", "43junk"));
+  EXPECT_FALSE(client_pid("42", ""));
+}
+
+TEST(AudioProcessId, NativeProtocolHostPidPrecedesClientNamespacePid) {
+  EXPECT_EQ(client_pid("2", "4300"), 4300);
+  EXPECT_EQ(client_pid("42", nullptr), 42);
+  EXPECT_EQ(client_pid("2", "4300", "pipewire"), 4300);
+}
+
+TEST(AudioProcessId, PulseProxyUsesApplicationPidAndNeverDaemonPid) {
+  EXPECT_EQ(client_pid("42", "4300", "pipewire-pulse"), 42);
+  EXPECT_FALSE(client_pid(nullptr, "4300", "pipewire-pulse"));
+  EXPECT_FALSE(client_pid("", "4300", "pipewire-pulse"));
+  EXPECT_FALSE(client_pid("42junk", "4300", "pipewire-pulse"));
+}
+
+TEST(AudioProcessId, PresentBinaryPropertiesCannotBecomeMissingAndEnableFallback) {
+  const client_lookup_t lookup = [](std::uint32_t) { ADD_FAILURE() << "Malformed stream queried client"; return 42; };
+  for (const auto &raw : {std::string {}, std::string {"42"}, std::string {"42\0extra\0", 9}, std::string {"\xff\0", 2}}) {
+    auto props = properties();
+    ASSERT_EQ(pa_proplist_set(props.get(), PA_PROP_APPLICATION_PROCESS_ID, raw.data(), raw.size()), 0);
+    EXPECT_FALSE(sink_input(property(props.get(), PA_PROP_APPLICATION_PROCESS_ID), 7, lookup));
+    EXPECT_FALSE(client(props.get()));
+    ASSERT_EQ(pa_proplist_sets(props.get(), PA_PROP_APPLICATION_PROCESS_ID, "42"), 0);
+    ASSERT_EQ(pa_proplist_set(props.get(), "pipewire.sec.pid", raw.data(), raw.size()), 0);
+    EXPECT_FALSE(client(props.get()));
+    ASSERT_EQ(pa_proplist_sets(props.get(), "pipewire.sec.pid", "43"), 0);
+    ASSERT_EQ(pa_proplist_set(props.get(), "client.api", raw.data(), raw.size()), 0);
+    EXPECT_FALSE(client(props.get()));
+  }
+}
+
+class AudioProcessRouting: public testing::Test {
+protected:
+  std::string runtime;
+  void SetUp() override {
+    if (!std::getenv("POLARIS_TEST_PRIVATE_AUDIO_ROUTING")) {
+      GTEST_SKIP() << "Requires the isolated PipeWire routing harness";
+    }
+    const auto *directory = std::getenv("XDG_RUNTIME_DIR");
+    const auto *server = std::getenv("PULSE_SERVER");
+    ASSERT_NE(directory, nullptr);
+    ASSERT_NE(server, nullptr);
+    runtime = directory;
+    ASSERT_TRUE(runtime.starts_with("/tmp/polaris-audio629-"));
+    ASSERT_EQ(std::string(server), "unix:" + runtime + "/pulse/native");
+    struct stat info {};
+    ASSERT_EQ(::lstat(runtime.c_str(), &info), 0);
+    ASSERT_TRUE(S_ISDIR(info.st_mode));
+    ASSERT_EQ(info.st_uid, ::geteuid());
+    ASSERT_EQ(info.st_mode & 0777, 0700);
+  }
+};
+
+TEST_F(AudioProcessRouting, PrivatePipeWireFixture) {
+  auto control = platf::audio_control();
+  ASSERT_NE(control, nullptr);
+  control->route_process_audio_to_sink("polaris-routing-session");
+  control->route_process_audio_to_sink("polaris-routing-session");
+  // The outer harness verifies real streams and the unchanged default.
+}

--- a/tests/unit/test_avcodec_session_lifecycle.cpp
+++ b/tests/unit/test_avcodec_session_lifecycle.cpp
@@ -1,0 +1,125 @@
+/** @file tests/unit/test_avcodec_session_lifecycle.cpp
+ * Real session submission and destruction with a bounded codec-call fixture.
+ */
+#include "src/video.h"
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+  struct codec_calls_t {
+    AVCodecContext *context = nullptr;
+    std::vector<int> submissions;
+    std::size_t submitted = 0;
+    int flush_status = 0;
+    int flushes = 0;
+    int receives = 0;
+    int drain_packets = 2;
+    std::vector<std::string> retirement;
+  };
+  thread_local codec_calls_t *calls = nullptr;
+
+  struct frame_device_t: platf::avcodec_encode_device_t {
+    codec_calls_t &observed;
+    explicit frame_device_t(codec_calls_t &observed): observed(observed) {
+      frame = av_frame_alloc();
+    }
+    ~frame_device_t() override {
+      observed.retirement.push_back("converter");
+      av_frame_free(&frame);
+    }
+  };
+
+  class AvcodecSessionLifecycle: public testing::Test {
+  protected:
+    codec_calls_t observed;
+    void SetUp() override {
+      ASSERT_EQ(calls, nullptr);
+      calls = &observed;
+    }
+    void TearDown() override {
+      calls = nullptr;
+    }
+    void exercise(std::vector<int> submissions = {}) {
+      observed.submissions = std::move(submissions);
+      // Finding/allocating a codec does not open it or touch a GPU. Prefer the
+      // reported codec so the Vulkan-specific diagnostic branch is covered.
+      const auto *codec = avcodec_find_encoder_by_name("h264_vulkan");
+      video::avcodec_ctx_t context {avcodec_alloc_context3(codec)};
+      ASSERT_NE(context, nullptr);
+      observed.context = context.get();
+      auto device = std::make_unique<frame_device_t>(observed);
+      ASSERT_NE(device->frame, nullptr);
+      const auto results = video::encode_and_destroy_avcodec_session_for_tests(
+        std::move(context), std::move(device), observed.submissions.size()
+      );
+      ASSERT_EQ(results.size(), observed.submissions.size());
+      for (std::size_t i = 0; i < results.size(); ++i) {
+        EXPECT_EQ(results[i], observed.submissions[i] < 0 ? -1 : 0);
+      }
+      EXPECT_EQ(observed.retirement, (std::vector<std::string> {"codec", "converter"}));
+      EXPECT_EQ(observed.submitted, observed.submissions.size());
+    }
+  };
+}
+
+extern "C" {
+  int __real_avcodec_send_frame(AVCodecContext *, const AVFrame *);
+  int __real_avcodec_receive_packet(AVCodecContext *, AVPacket *);
+  void __real_avcodec_free_context(AVCodecContext **);
+
+  int __wrap_avcodec_send_frame(AVCodecContext *context, const AVFrame *frame) {
+    if (!calls || calls->context != context) return __real_avcodec_send_frame(context, frame);
+    if (!frame) {
+      ++calls->flushes;
+      return calls->flush_status;
+    }
+    if (calls->submitted >= calls->submissions.size()) {
+      ADD_FAILURE() << "Unexpected frame submission";
+      return AVERROR(EINVAL);
+    }
+    return calls->submissions[calls->submitted++];
+  }
+
+  int __wrap_avcodec_receive_packet(AVCodecContext *context, AVPacket *packet) {
+    if (!calls || calls->context != context) return __real_avcodec_receive_packet(context, packet);
+    ++calls->receives;
+    if (!calls->flushes) return AVERROR(EAGAIN);
+    return calls->drain_packets-- > 0 ? 0 : AVERROR_EOF;
+  }
+
+  void __wrap_avcodec_free_context(AVCodecContext **context) {
+    if (calls && context && *context == calls->context) {
+      calls->retirement.push_back("codec");
+    }
+    __real_avcodec_free_context(context);
+  }
+}
+
+TEST_F(AvcodecSessionLifecycle, UnusedCapabilityProbeNeverFlushesOrReceives) {
+  exercise();
+  EXPECT_EQ(observed.flushes, 0);
+  EXPECT_EQ(observed.receives, 0);
+}
+
+TEST_F(AvcodecSessionLifecycle, RejectedFirstFramesNeverWarmTheCodec) {
+  exercise({AVERROR(EAGAIN), AVERROR(EINVAL)});
+  EXPECT_EQ(observed.flushes, 0);
+  EXPECT_EQ(observed.receives, 0);
+}
+
+TEST_F(AvcodecSessionLifecycle, AcceptedFrameStillDrainsAfterALaterRejection) {
+  exercise({0, AVERROR(EAGAIN)});
+  EXPECT_EQ(observed.flushes, 1);
+  EXPECT_EQ(observed.receives, 4); // One encode receive, two packets, then EOF.
+}
+
+TEST_F(AvcodecSessionLifecycle, FailedFlushStillClosesCodecBeforeConverter) {
+  observed.flush_status = AVERROR(EIO);
+  exercise({0});
+  EXPECT_EQ(observed.flushes, 1);
+  EXPECT_EQ(observed.receives, 1); // No drain read after the failed flush.
+}

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -230,7 +230,7 @@ TEST(StreamStatsLinuxGpuProfileTests, WarnsWhenNvidiaTrueHeadlessDisablesGpuNati
 }
 
 #if defined(__linux__) && defined(POLARIS_BUILD_VULKAN)
-TEST(StreamStatsLinuxGpuProfileTests, RecommendsAutoVulkanForExplicitAmdVaapiShmPrivateStream) {
+TEST(StreamStatsLinuxGpuProfileTests, PreservesExplicitAmdVaapiCompatibilityChoice) {
   LinuxDisplayConfigGuard guard;
   config::video.encoder = "vaapi";
   config::video.linux_display.use_cage_compositor = true;
@@ -251,9 +251,13 @@ TEST(StreamStatsLinuxGpuProfileTests, RecommendsAutoVulkanForExplicitAmdVaapiShm
   });
 
   ASSERT_NE(recommendation, warnings.end());
-  EXPECT_NE(recommendation->at("action").get<std::string>().find("Autodetect"), std::string::npos);
-  EXPECT_NE(recommendation->at("action").get<std::string>().find("Vulkan Video"), std::string::npos);
-  EXPECT_NE(recommendation->at("action").get<std::string>().find("fall back to VA-API"), std::string::npos);
+  EXPECT_EQ(recommendation->at("severity"), "info");
+  const auto action = recommendation->at("action").get<std::string>();
+  EXPECT_NE(action.find("Keep VA-API selected"), std::string::npos);
+  EXPECT_NE(action.find("reduce resolution, frame rate, or bitrate"), std::string::npos);
+  EXPECT_EQ(action.find("Autodetect"), std::string::npos);
+  EXPECT_EQ(action.find("will live-probe"), std::string::npos);
+  EXPECT_EQ(config::video.encoder, "vaapi");
 }
 #endif
 


### PR DESCRIPTION
## Summary

Native PipeWire streams without a per-stream PID now resolve the PID through their exact owning client before session audio repinning. Malformed properties fail closed, existing session-marker/ancestor checks remain in force, and only successful moves start the cooldown.

Also covers actual encoder-session teardown before the first accepted frame, records skipped probe drains, and corrects Doctor guidance for an explicitly selected AMD VA-API encoder. The accepted-frame flush guard itself is already present from #623.

Fixes #629. Refs #628.

## Testing

- [x] Affected native suites: 17 audio, 35 video, and 413 stream tests passed; one opt-in physical test skipped.
- [x] ASan/UBSan passed for the affected suites and real private PipeWire routing. Three pre-existing intentional-retention destructor tests were checked separately with leak detection disabled.
- [x] Private PipeWire routing verified native missing-PID and ordinary Pulse streams, other-session/desktop separation, repinning, reconnect, and cleanup. Regression variants fail before the fix and pass after it.
- [x] Public surface, docs, package/SteamOS dependency contracts, and offline Nix checks passed.
- [x] User-facing guidance and changelog updated; independent source review cleared both commits.

## Notes

TSan passes all 17 audio/PID unit tests. Complete private routing under TSan remains incomplete against stock uninstrumented libpulse: the initialization report reproduces in a standalone Pulse-only program and was independently reviewed. No suppression was added. AMD cold-launch hardware acceptance is still outstanding for #628; no performance or physical streaming improvement is claimed.
