### PR TITLE
Share Live Tuning preference and encoder-confirmed status

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -207,6 +207,8 @@ set(POLARIS_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/sync.h"
         "${CMAKE_SOURCE_DIR}/src/round_robin.h"
         "${CMAKE_SOURCE_DIR}/src/settings_metadata.cpp"
+        "${CMAKE_SOURCE_DIR}/src/configuration_store.cpp"
+        "${CMAKE_SOURCE_DIR}/src/live_tuning.cpp"
         "${CMAKE_SOURCE_DIR}/src/settings_metadata.h"
         "${CMAKE_SOURCE_DIR}/src/stat_trackers.h"
         "${CMAKE_SOURCE_DIR}/src/stat_trackers.cpp"

--- a/docs/live-tuning.md
+++ b/docs/live-tuning.md
@@ -1,0 +1,64 @@
+# Live Tuning
+
+Live Tuning is the host's adaptive bitrate preference. It does not require an AI
+provider or a subscription. Doctor explanations remain a separate feature.
+
+The switch in Quick Controls and Audio/Video settings saves immediately. Nova's
+Command Center uses the same preference. Its HUD shows tuning separately from
+stream health. A saved On preference can be waiting for a stream, measuring,
+adjusting, applying a bitrate, stable, or unavailable for the current encoder.
+Disconnected or invalid status is Unknown; it is not permission to change settings.
+
+The displayed applied bitrate comes from the encoder acknowledgement, not the
+requested target. Turning tuning off holds the last confirmed bitrate. Choosing
+an explicit fixed live bitrate also turns tuning off and supersedes a pending
+Doctor bitrate action. Auto, Quality, High FPS, and Stability launch presets still
+apply at the next explicit launch.
+
+## API contract
+
+`GET /api/live-tuning` requires web administrator authentication. Its response
+contains `status` and `live_tuning`. `POST /api/live-tuning` accepts exactly one
+boolean field, `enabled`, and requires the quoted `configuration_revision` in
+`If-Match`. Cookie-authenticated mutations require the normal CSRF token. Only a
+valid configured bearer credential bypasses cookie CSRF validation.
+
+A stale or absent revision returns HTTP 412 without changing the controller.
+A failed durable commit returns an error without changing the preference. Refresh
+the state before asking the user to retry; do not automatically replay the save.
+`GET /api/config` returns contents and revision from one secure file snapshot.
+Configuration saves preserve the live preference when it is omitted.
+
+The existing paired `/polaris/v1/session/adaptive-bitrate` route accepts
+`configuration_revision` alongside the existing application session ID and
+generation. Its sole-owner, permission, revocation and session-generation checks
+remain mandatory. Legacy paired callers may omit the revision; new Nova sends it.
+
+The additive `live_tuning` version 1 object is shared by web statistics, paired
+session status and session events. It contains:
+
+- `enabled`, `scope` (`host`), `state`, `supported`, and `reason`;
+- `runtime_enabled`, `pending`, `quality_limit_kbps`, `requested_bitrate_kbps`,
+  and `applied_bitrate_kbps`;
+- `app_session_id`, `session_generation`, `configuration_revision`,
+  `host_instance`, and increasing `sequence`.
+
+A shared encoder or a mismatched session cannot claim a supported live actuator
+or another session's applied bitrate. Clients reject malformed values, old
+sequences and retired host instances. The shared conformance examples are in
+`tests/fixtures/live-tuning-v1.json`, also consumed by Nova's unit tests.
+
+Session status advertises `events_https_port`. Nova uses that HTTPS endpoint with
+its existing pinned authenticated client, disables redirects, cancels blocked
+reads on teardown, and requests a fresh status after connection loss or an event
+sequence gap. Events are snapshots, not a replay log. Old connection callbacks
+cannot update a replacement session. Missing or invalid canonical tuning becomes
+Unknown until a successful resynchronization.
+
+## Validation boundary
+
+Unit and isolated transport tests cover conditional saves, failed persistence,
+configuration contention, encoder acknowledgement races, recreation followed by
+disable, owner/session attribution, shared fixtures, and stale UI delivery.
+Physical game streaming and device-specific encoder behavior remain separate
+acceptance checks. This change does not enable container multiseat production.

--- a/docs/live-tuning.md
+++ b/docs/live-tuning.md
@@ -20,8 +20,9 @@ apply at the next explicit launch.
 `GET /api/live-tuning` requires web administrator authentication. Its response
 contains `status` and `live_tuning`. `POST /api/live-tuning` accepts exactly one
 boolean field, `enabled`, and requires the quoted `configuration_revision` in
-`If-Match`. Cookie-authenticated mutations require the normal CSRF token. Only a
-valid configured bearer credential bypasses cookie CSRF validation.
+`If-Match`. Cookie-authenticated mutations require the normal CSRF token. A valid
+configured bearer credential or an authorized verified client certificate bypasses
+cookie CSRF validation; the endpoint still enforces its authentication checks.
 
 A stale or absent revision returns HTTP 412 without changing the controller.
 A failed durable commit returns an error without changing the preference. Refresh

--- a/src/adaptive_bitrate.cpp
+++ b/src/adaptive_bitrate.cpp
@@ -30,6 +30,9 @@ namespace adaptive_bitrate {
   static std::condition_variable state_changed;
 
   static config_t current_config;
+  static std::uint64_t scope_generation = 0;
+  static std::string scope_app_session_id;
+  static bool scope_exclusive = false;
   static std::atomic<bool> enabled {false};
   static std::atomic<bool> runtime_update_supported {false};
   static std::atomic<int> base_bitrate_kbps {0};
@@ -63,6 +66,7 @@ namespace adaptive_bitrate {
   // The encoder thread is the only authority for what was actually applied.
   // Protected by state_mutex.
   static int encoder_applied_bitrate_kbps = 0;
+  static int last_confirmed_bitrate_kbps = 0;
   static std::uint64_t encoder_applied_revision = 0;
   static std::chrono::steady_clock::time_point encoder_applied_at {};
   // -1 is unknown for a new stream, 0 allows quality restoration, and 1 is a
@@ -407,6 +411,12 @@ namespace adaptive_bitrate {
   state_t get_state() {
     std::lock_guard<std::mutex> lock(state_mutex);
     state_t state;
+    state.session_generation = scope_generation;
+    state.app_session_id = scope_app_session_id;
+    state.session_exclusive = scope_exclusive;
+    state.configured_enabled = current_config.enabled;
+    state.feedback_initialized = initialized;
+    state.applied_bitrate_kbps = encoder_applied_bitrate_kbps;
     state.enabled = enabled.load(std::memory_order_relaxed);
     state.runtime_update_supported = runtime_update_supported.load(std::memory_order_relaxed);
     const bool doctor_override = doctor_override_active.load(std::memory_order_relaxed);
@@ -606,6 +616,31 @@ namespace adaptive_bitrate {
     return live_bitrate_request_t {target, operator_revision};
   }
 
+  bool apply_live_bitrate_request(const live_bitrate_request_t &request,
+                                  const std::function<bool()> &apply) {
+    std::lock_guard<std::mutex> lock(state_mutex);
+    if (request.revision != operator_revision ||
+        request.target_bitrate_kbps != target_bitrate_kbps.load(std::memory_order_relaxed) ||
+        !runtime_update_supported.load(std::memory_order_relaxed)) return false;
+    if (apply()) {
+      encoder_applied_bitrate_kbps = request.target_bitrate_kbps;
+      last_confirmed_bitrate_kbps = request.target_bitrate_kbps;
+      encoder_applied_revision = request.revision;
+      encoder_applied_at = std::chrono::steady_clock::now();
+      pending_live_update_active.store(false, std::memory_order_relaxed);
+      state_changed.notify_all();
+    }
+    return true;
+  }
+
+  void set_session_scope(std::uint64_t generation, const std::string &app_session_id,
+                         bool exclusive) {
+    std::lock_guard<std::mutex> lock(state_mutex);
+    scope_generation = generation;
+    scope_app_session_id = app_session_id;
+    scope_exclusive = exclusive;
+  }
+
   bool begin_live_bitrate_session_recreation(
       std::uint64_t revision,
       int bitrate_kbps) {
@@ -637,6 +672,7 @@ namespace adaptive_bitrate {
       return;
     }
     encoder_applied_bitrate_kbps = bitrate_kbps;
+    last_confirmed_bitrate_kbps = bitrate_kbps;
     encoder_applied_revision = revision;
     encoder_applied_at = std::chrono::steady_clock::now();
     pending_live_update_active.store(false, std::memory_order_relaxed);
@@ -730,6 +766,12 @@ namespace adaptive_bitrate {
     std::lock_guard<std::mutex> lock(state_mutex);
     retire_doctor_override_locked();
     explicit_live_override_active.store(false, std::memory_order_relaxed);
+    // Disabling holds what the encoder actually applied, never an unacknowledged
+    // automatic increase. Re-enabling starts from that same live bitrate.
+    if (!enable && last_confirmed_bitrate_kbps > 0) {
+      target_bitrate_kbps.store(last_confirmed_bitrate_kbps, std::memory_order_relaxed);
+    }
+    current_config.enabled = enable;
     config::video.adaptive_bitrate.enabled = enable;
     enabled.store(enable, std::memory_order_relaxed);
     ++action_authority_revision;
@@ -769,6 +811,7 @@ namespace adaptive_bitrate {
     if (supported) {
       if (initial_encoder_bitrate_kbps > 0) {
         encoder_applied_bitrate_kbps = initial_encoder_bitrate_kbps;
+        last_confirmed_bitrate_kbps = initial_encoder_bitrate_kbps;
         encoder_applied_revision = operator_revision;
         encoder_applied_at = std::chrono::steady_clock::now();
       }
@@ -835,6 +878,7 @@ namespace adaptive_bitrate {
     base_bitrate_kbps.store(0, std::memory_order_relaxed);
     target_bitrate_kbps.store(0, std::memory_order_relaxed);
     encoder_applied_bitrate_kbps = 0;
+    last_confirmed_bitrate_kbps = 0;
     encoder_applied_revision = 0;
     encoder_applied_at = {};
     doctor_video_policy_class = -1;

--- a/src/adaptive_bitrate.h
+++ b/src/adaptive_bitrate.h
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include <functional>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -26,6 +27,12 @@ namespace adaptive_bitrate {
   };
 
   struct state_t {
+    std::uint64_t session_generation = 0;
+    std::string app_session_id;
+    bool session_exclusive = false;
+    bool configured_enabled = false;
+    bool feedback_initialized = false;
+    int applied_bitrate_kbps = 0;
     bool enabled = false;
     bool active = false;
     bool runtime_update_supported = false;
@@ -195,6 +202,13 @@ namespace adaptive_bitrate {
 
   /** Return the current encoder request, including one-shot rollback work. */
   std::optional<live_bitrate_request_t> get_live_bitrate_request();
+
+  // The callback may only update the encoder; it must not call this controller.
+  // Validate, apply and acknowledge under one boundary with operator changes.
+  bool apply_live_bitrate_request(const live_bitrate_request_t &request,
+                                  const std::function<bool()> &apply);
+  void set_session_scope(std::uint64_t generation, const std::string &app_session_id,
+                         bool exclusive);
 
   /**
    * Invalidate the retiring encoder session before recreating it for an exact

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,6 +22,7 @@
 
 // local includes
 #include "config.h"
+#include "configuration_store.h"
 #include "confighttp_validation.h"
 #include "entry_handler.h"
 #include "file_handler.h"
@@ -1251,8 +1252,9 @@ namespace config {
     return opts;
   }
 
-  int write_config_with_vaapi_settings(const std::string &path, const std::string &contents) {
-    if (const auto result = file_handler::write_file(path.c_str(), contents); result != 0) return result;
+  int write_config_with_vaapi_settings(const std::string &path, const std::string &contents,
+                                     const std::optional<std::string> &expected) {
+    if (configuration_store::replace(path, contents, expected) != configuration_store::result::committed) return -1;
     vaapi::publish(parse_vaapi_settings(parse_config(contents)));
     return 0;
   }

--- a/src/config.h
+++ b/src/config.h
@@ -426,7 +426,8 @@ namespace config {
    */
   std::optional<bool> parse_bool(std::string_view value);
 
-  int write_config_with_vaapi_settings(const std::string &path, const std::string &contents);
+  int write_config_with_vaapi_settings(const std::string &path, const std::string &contents,
+                                     const std::optional<std::string> &expected = std::nullopt);
 
   vaapi::settings_t parse_vaapi_settings(const std::unordered_map<std::string, std::string> &vars,
                                        vaapi::settings_t initial = {});

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -39,6 +39,8 @@
 
 // local includes
 #include "config.h"
+#include "configuration_store.h"
+#include "live_tuning.h"
 #include "adaptive_bitrate.h"
 #include "browser_stream.h"
 #include "client_support_report.h"
@@ -1388,6 +1390,14 @@ namespace confighttp {
    * This function uses session cookies (if set) and ensures they have not expired.
    * It also supports API key authentication via the Authorization: Bearer header.
    */
+  bool hasValidBearerAuth(req_https_t request) {
+    std::lock_guard credential_lock {s_credential_lifecycle_mutex};
+    const auto header = request->header.find("authorization");
+    return header != request->header.end() && header->second.starts_with("Bearer ") &&
+      !config::sunshine.api_key.empty() &&
+      crypto::constant_time_equals(header->second.substr(7), config::sunshine.api_key);
+  }
+
   bool authenticate(resp_https_t response, req_https_t request, bool needsRedirect = false) {
     std::lock_guard credential_lock {s_credential_lifecycle_mutex};
     if (!checkIPOrigin(response, request))
@@ -1518,12 +1528,7 @@ namespace confighttp {
       return false;
     }
 
-    // Detected by header presence, not re-validation - authenticate() has
-    // already succeeded overall by this point, and a real Bearer token is
-    // the only way that's true when this header is present (a garbage
-    // Authorization header would have made authenticate() fall through to
-    // the cookie check, and fail if that also failed).
-    const bool used_bearer_token_auth = request->header.find("authorization") != request->header.end();
+    const bool used_bearer_token_auth = hasValidBearerAuth(request);
     if (!used_bearer_token_auth && !validateCsrf(request)) {
       BOOST_LOG(warning) << "Benchmark control: ["sv << address << "] -- invalid CSRF token"sv;
       // Inlined rather than calling forbidden() - that helper is defined
@@ -1588,6 +1593,20 @@ namespace confighttp {
 
     response->write(code, tree.dump(), headers);
   }
+
+
+  template<class Handler>
+  auto withCsrf(Handler handler) {
+    return [handler](resp_https_t response, req_https_t request) {
+      if (!hasValidBearerAuth(request) && !hasVerifiedClientCert(request) && !validateCsrf(request)) {
+        BOOST_LOG(warning) << "CSRF token validation failed for "sv << request->path;
+        forbidden(response, request, "CSRF token missing or invalid");
+        return;
+      }
+      handler(response, request);
+    };
+  }
+
 
   void conflict_response(resp_https_t response, const nlohmann::json &tree) {
     constexpr SimpleWeb::StatusCode code = SimpleWeb::StatusCode::client_error_conflict;
@@ -4260,7 +4279,13 @@ namespace confighttp {
 #else
     output_tree["stream_display_mode_options"] = nlohmann::json::array();
 #endif
-    auto vars = config::parse_config(file_handler::read_file(config::sunshine.config_file.c_str()));
+    std::lock_guard configuration_guard(configuration_store::mutex());
+    const auto observed = configuration_store::read(config::sunshine.config_file);
+    if (!observed) {
+      response->write(SimpleWeb::StatusCode::server_error_service_unavailable);
+      return;
+    }
+    auto vars = config::parse_config(observed->contents);
     for (auto &[name, value] : vars) {
       if (is_write_only_secret_config_key(name)) {
         if (name == "ai_api_key") {
@@ -4282,8 +4307,11 @@ namespace confighttp {
     output_tree["has_steamgriddb_api_key"] = output_tree.value("has_steamgriddb_api_key", false);
     output_tree["has_api_key"] = output_tree.value("has_api_key", false);
     output_tree["ai_auto_quality_enabled"] = bool_config_value(ai_optimizer::is_enabled());
-    output_tree["adaptive_bitrate_enabled"] = bool_config_value(adaptive_bitrate::is_enabled());
-    output_tree["ai_enabled"] = bool_config_value(ai_optimizer::is_enabled());
+    output_tree["adaptive_bitrate_enabled"] = bool_config_value(adaptive_bitrate::get_state().configured_enabled);
+    output_tree["ai_enabled"] = bool_config_value(config::video.ai_optimizer.enabled);
+    output_tree["ai_explanations_ready"] = ai_optimizer::is_enabled();
+    output_tree["configuration_revision"] = observed->revision;
+    output_tree["live_tuning"] = live_tuning::snapshot(stream_stats::get_current());
     send_response(response, output_tree);
   }
 
@@ -4424,7 +4452,58 @@ namespace confighttp {
    * keep unmentioned keys must merge them in first (see patchConfig). Answers
    * the request itself on failure and returns false.
    */
-  bool write_config_tree(resp_https_t response, req_https_t request, const nlohmann::json &tree, const std::string &writer) {
+  std::optional<std::string> expected_configuration_revision(req_https_t request) {
+    const auto it = request->header.find("If-Match");
+    if (it == request->header.end()) return std::nullopt;
+    const auto &value = it->second;
+    if (value.size() != 66 || value.front() != '"' || value.back() != '"') return std::string {};
+    return value.substr(1, 64);
+  }
+
+  bool configuration_current(resp_https_t response, req_https_t request, bool required) {
+    const auto expected = expected_configuration_revision(request);
+    if ((!expected && !required) ||
+        (expected && !expected->empty() && *expected == configuration_store::revision(config::sunshine.config_file, true))) return true;
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    append_json_security_headers(headers);
+    response->write(static_cast<SimpleWeb::StatusCode>(412),
+      nlohmann::json({{"status", false}, {"code", "configuration_changed"},
+        {"error", "Settings changed. Refresh before saving."}}).dump(), headers);
+    return false;
+  }
+
+  void liveTuning(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) return;
+    if (request->method == "GET") {
+      auto state = live_tuning::snapshot(stream_stats::get_current());
+      state["can_change"] = true;
+      send_response(response, {{"status", true}, {"live_tuning", state}});
+      return;
+    }
+    if (!validateContentType(response, request, "application/json")) return;
+    try {
+      const auto body = nlohmann::json::parse(request->content.string());
+      if (!body.is_object() || body.size() != 1 || !body.contains("enabled") || !body["enabled"].is_boolean()) {
+        bad_request(response, request, "enabled must be the only field and must be boolean");
+        return;
+      }
+      auto authority = doctor_actions::acquire_admin_global_control();
+      const auto expected = expected_configuration_revision(request);
+      auto result = live_tuning::set_enabled(authority, body["enabled"].get<bool>(),
+        expected.value_or(std::string {}));
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      append_json_security_headers(headers);
+      response->write(static_cast<SimpleWeb::StatusCode>(result.value("http_status", 500)), result.dump(), headers);
+    } catch (const std::exception &error) {
+      bad_request(response, request, error.what());
+    }
+  }
+
+  bool write_config_tree(resp_https_t response, req_https_t request, const nlohmann::json &tree, const std::string &writer,
+                         doctor_actions::paired_global_control_guard_t &authority,
+                         const std::optional<std::string> &observed_revision = std::nullopt) {
+    const auto before = expected_configuration_revision(request).value_or(
+      observed_revision.value_or(configuration_store::revision(config::sunshine.config_file, true)));
     std::stringstream config_stream;
     const auto existing_vars = config::parse_config(file_handler::read_file(config::sunshine.config_file.c_str()));
     std::vector<std::string> written_keys;
@@ -4440,6 +4519,10 @@ namespace confighttp {
       config_stream << k << " = " << (v.is_string() ? v.get<std::string>() : v.dump()) << std::endl;
       written_keys.push_back(k);
     }
+    if (!tree.contains("adaptive_bitrate_enabled")) {
+      config_stream << "adaptive_bitrate_enabled = "
+                    << bool_config_value(adaptive_bitrate::get_state().configured_enabled) << std::endl;
+    }
     std::size_t dropped = 0;
     for (const auto &[key, value] : existing_vars) {
       if (tree.contains(key) || value.empty()) {
@@ -4454,7 +4537,7 @@ namespace confighttp {
     if (dropped > 0) {
       BOOST_LOG(info) << "SaveConfig: "sv << writer << " left "sv << dropped << " existing key(s) out of the payload; they revert to defaults"sv;
     }
-    if (config::write_config_with_vaapi_settings(config::sunshine.config_file, config_stream.str()) != 0) {
+    if (config::write_config_with_vaapi_settings(config::sunshine.config_file, config_stream.str(), before) != 0) {
       const std::string message = "Failed to write config file: " + config::sunshine.config_file;
       BOOST_LOG(error) << "SaveConfig: "sv << message;
       bad_request(response, request, message);
@@ -4462,9 +4545,8 @@ namespace confighttp {
     }
     settings_metadata::note_config_write(writer, std::move(written_keys));
     if (tree.contains("adaptive_bitrate_enabled")) {
-      doctor_actions::set_adaptive_enabled(
-        json_config_enabled(tree["adaptive_bitrate_enabled"])
-      );
+      const bool enabled = json_config_enabled(tree["adaptive_bitrate_enabled"]);
+      if (enabled != adaptive_bitrate::get_state().configured_enabled) authority.set_adaptive_enabled(enabled);
     }
     if (tree.contains("ai_enabled")) {
       ai_optimizer::set_enabled(json_config_enabled(tree["ai_enabled"]));
@@ -4505,11 +4587,18 @@ namespace confighttp {
       if (!read_config_payload(response, request, input_tree)) {
         return;
       }
-      if (!write_config_tree(response, request, input_tree, "web_ui")) {
+      auto authority = doctor_actions::acquire_admin_global_control();
+      std::lock_guard configuration_guard(configuration_store::mutex());
+      const bool changes_tuning = input_tree.contains("adaptive_bitrate_enabled") &&
+        json_config_enabled(input_tree["adaptive_bitrate_enabled"]) != adaptive_bitrate::get_state().configured_enabled;
+      if (!configuration_current(response, request, changes_tuning)) return;
+      if (!write_config_tree(response, request, input_tree, "web_ui", authority)) {
         return;
       }
       nlohmann::json output_tree;
       output_tree["status"] = true;
+      output_tree["configuration_revision"] = configuration_store::revision(config::sunshine.config_file);
+      output_tree["live_tuning"] = live_tuning::snapshot(stream_stats::get_current());
       send_response(response, output_tree);
     } catch (std::exception &e) {
       BOOST_LOG(warning) << "SaveConfig: "sv << e.what();
@@ -4538,13 +4627,21 @@ namespace confighttp {
       if (!read_config_payload(response, request, input_tree)) {
         return;
       }
+      auto authority = doctor_actions::acquire_admin_global_control();
+      std::lock_guard configuration_guard(configuration_store::mutex());
+      const bool changes_tuning = input_tree.contains("adaptive_bitrate_enabled") &&
+        json_config_enabled(input_tree["adaptive_bitrate_enabled"]) != adaptive_bitrate::get_state().configured_enabled;
+      if (!configuration_current(response, request, changes_tuning)) return;
+      const auto observed_revision = configuration_store::revision(config::sunshine.config_file, true);
       const auto existing_vars = config::parse_config(file_handler::read_file(config::sunshine.config_file.c_str()));
       const auto merged = validation::merge_config_patch(existing_vars, input_tree);
-      if (!write_config_tree(response, request, merged, "api_patch")) {
+      if (!write_config_tree(response, request, merged, "api_patch", authority, observed_revision)) {
         return;
       }
       nlohmann::json output_tree;
       output_tree["status"] = true;
+      output_tree["configuration_revision"] = configuration_store::revision(config::sunshine.config_file);
+      output_tree["live_tuning"] = live_tuning::snapshot(stream_stats::get_current());
       send_response(response, output_tree);
     } catch (std::exception &e) {
       BOOST_LOG(warning) << "PatchConfig: "sv << e.what();
@@ -7041,6 +7138,7 @@ namespace confighttp {
       proc::proc.current_app_has_mangohud()
     );
     stats_json["auto_quality"] = nvhttp::auto_quality_status_json();
+    stats_json["live_tuning"] = live_tuning::snapshot(stats);
     return stats_json;
   }
 
@@ -7197,6 +7295,8 @@ namespace confighttp {
         });
         if (header_sent.get_future().get()) return;
 
+        const auto event_instance = uuid_util::uuid_t::generate().string();
+        uint64_t sent_sequence = 0;
         uint64_t last_seq;
         {
           std::lock_guard lk(s_event_mtx);
@@ -7224,19 +7324,20 @@ namespace confighttp {
 #endif
           state["seq"] = current_seq;
           state["session_state"] = get_session_state();
+          state["live_tuning"] = live_tuning::snapshot(stream_stats::get_current());
 
           // Send only events emitted after this SSE client cursor.
           // Older terminal events may still be retained for other clients, but
           // they must not be replayed into a fresh Nova game activity.
           if (!pending_events.empty()) {
             for (const auto &evt : pending_events) {
-              *response << "event: session\ndata: " << evt << "\n\n";
+              *response << "id: " << event_instance << ":" << ++sent_sequence << "\nevent: session\ndata: " << evt << "\n\n";
             }
             last_seq = current_seq;
           }
 
           // Always send heartbeat with state
-          *response << "event: state\ndata: " << state.dump() << "\n\n";
+          *response << "id: " << event_instance << ":" << ++sent_sequence << "\nevent: state\ndata: " << state.dump() << "\n\n";
 
           std::promise<bool> send_err;
           response->send([&send_err](const SimpleWeb::error_code &ec) {
@@ -7299,20 +7400,7 @@ namespace confighttp {
       response->write(output.dump(), headers);
     };
 
-    auto withCsrf = [](auto handler) {
-      return [handler](resp_https_t response, req_https_t request) {
-        // Skip CSRF check for API key auth (Bearer token)
-        auto auth_header = request->header.find("authorization");
-        bool has_bearer = auth_header != request->header.end() &&
-                          auth_header->second.substr(0, 7) == "Bearer ";
-        if (!has_bearer && !hasVerifiedClientCert(request) && !validateCsrf(request)) {
-          BOOST_LOG(warning) << "CSRF token validation failed for "sv << request->path;
-          forbidden(response, request, "CSRF token missing or invalid");
-          return;
-        }
-        handler(response, request);
-      };
-    };
+
 
     server.default_resource["DELETE"] = [](resp_https_t response, req_https_t request) {
       bad_request(response, request);
@@ -7473,6 +7561,8 @@ namespace confighttp {
     server.resource["^/api/polaris/session$"]["GET"] = getPolarisSession;
     server.resource["^/api/polaris/unlock$"]["POST"] = withCsrf(postPolarisUnlock);
     server.resource["^/api/polaris/events$"]["GET"] = getPolarisEventsSSE;
+    server.resource["^/api/live-tuning$"]["GET"] = liveTuning;
+    server.resource["^/api/live-tuning$"]["POST"] = withCsrf(liveTuning);
 
     server.resource["^/images/polaris.ico$"]["GET"] = getFaviconImage;
     server.resource["^/images/logo-polaris-45.png$"]["GET"] = getApolloLogoImage;
@@ -7530,6 +7620,25 @@ namespace confighttp {
   }
 
 #ifdef POLARIS_TESTS
+  void live_tuning_http_for_tests(resp_https_t response, req_https_t request) {
+    withCsrf(liveTuning)(response, request);
+  }
+
+  void with_web_session_for_tests(const std::filesystem::path &path, const std::string &csrf,
+                                  const std::function<void(const std::string &)> &run) {
+    auto previous_store = std::move(s_web_sessions);
+    const auto previous_csrf = csrfToken;
+    auto restore = util::fail_guard([&] {
+      s_web_sessions = std::move(previous_store);
+      csrfToken = previous_csrf;
+    });
+    csrfToken = csrf;
+    s_web_sessions = std::make_unique<web_session_store::manager_t>(path,
+      web_session_credential_fingerprint(), web_session_policy());
+    s_web_sessions->load(web_session_clock_now());
+    run(create_web_session(web_session_credential_fingerprint()).value());
+  }
+
   bool config_request_authorized_for_tests(
     const crypto::p_named_cert_t &candidate,
     std::string_view request_path

--- a/src/confighttp_validation.cpp
+++ b/src/confighttp_validation.cpp
@@ -77,6 +77,7 @@ namespace confighttp::validation {
     // as config_response_only_keys.
     constexpr std::array response_only_config_keys_list {
       "ai_auto_quality_enabled"sv,
+      "ai_explanations_ready"sv,
       "client_settings_authority"sv,
       "client_settings_available"sv,
       "client_settings_effective_stream_display_mode"sv,
@@ -96,9 +97,11 @@ namespace confighttp::validation {
       "client_settings_sync_mode"sv,
       "client_settings_v1"sv,
       "config_response_only_keys"sv,
+      "configuration_revision"sv,
       "has_ai_api_key"sv,
       "has_api_key"sv,
       "has_steamgriddb_api_key"sv,
+      "live_tuning"sv,
       "platform"sv,
       "runtime_backend"sv,
       "runtime_effective_headless"sv,

--- a/src/configuration_store.cpp
+++ b/src/configuration_store.cpp
@@ -1,0 +1,68 @@
+#include "configuration_store.h"
+#include "config_file_update.h"
+#include "crypto.h"
+#include "private_state_file.h"
+#include "utility.h"
+#include "logging.h"
+#include <unordered_map>
+
+namespace configuration_store {
+  namespace {
+    std::recursive_mutex lock;
+    std::unordered_map<std::string, std::string> revisions;
+    std::string digest(const std::string &contents) {
+      return util::hex(crypto::hash(contents)).to_string();
+    }
+  }
+  std::recursive_mutex &mutex() { return lock; }
+  std::optional<snapshot_t> read(const std::string &path) {
+    std::lock_guard guard(lock);
+    const auto value = private_state_file::read_secure(path, 4 * 1024 * 1024, true, false);
+    if (!value) return std::nullopt;
+    auto revision = revisions[path] = digest(value.payload);
+    return snapshot_t {value.payload, std::move(revision)};
+  }
+  std::string revision(const std::string &path, bool refresh) {
+    std::lock_guard guard(lock);
+    if (!refresh && revisions.contains(path)) return revisions.at(path);
+    const auto observed = read(path);
+    return observed ? observed->revision : std::string {};
+  }
+  static result update(const std::string &path, const std::optional<std::string> &expected,
+                       const std::function<std::string(const std::string &)> &transform,
+                       bool require_existing) {
+    std::lock_guard guard(lock);
+    bool conflict = false;
+    std::string next_revision;
+    const auto written = private_state_file::update_atomic(path, 4 * 1024 * 1024,
+      [&](const private_state_file::read_result_t &read) -> std::optional<std::string> {
+        const auto before = revisions[path] = read ? digest(read.payload) : std::string {};
+        if (expected && (expected->empty() || *expected != before)) {
+          conflict = true;
+          return std::nullopt;
+        }
+        if (require_existing && !read) return std::nullopt;
+        auto next = transform(read.payload);
+        next_revision = digest(next);
+        return next;
+      }, true);
+    if (conflict) return result::conflict;
+    if (written.status == private_state_file::write_status_e::not_committed) return result::failed;
+    if (written.status == private_state_file::write_status_e::durability_uncertain) {
+      BOOST_LOG(warning) << "Configuration committed with uncertain directory durability";
+    }
+    revisions[path] = next_revision;
+    return result::committed;
+  }
+  result replace(const std::string &path, const std::string &contents,
+                 const std::optional<std::string> &expected) {
+    return update(path, expected, [&](const auto &) { return contents; }, false);
+  }
+  result patch(const std::string &path,
+               const std::unordered_map<std::string, std::string> &updates,
+               const std::optional<std::string> &expected) {
+    return update(path, expected, [&](const auto &current) {
+      return config_file_update::apply(current, updates).content;
+    }, true);
+  }
+}

--- a/src/configuration_store.h
+++ b/src/configuration_store.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace configuration_store {
+  // Lock order: Doctor/session authority, configuration, adaptive controller.
+  std::recursive_mutex &mutex();
+  struct snapshot_t { std::string contents; std::string revision; };
+  std::optional<snapshot_t> read(const std::string &path);
+  std::string revision(const std::string &path, bool refresh = false);
+  enum class result { committed, conflict, failed };
+  result replace(const std::string &path, const std::string &contents,
+                 const std::optional<std::string> &expected = std::nullopt);
+  result patch(const std::string &path,
+               const std::unordered_map<std::string, std::string> &updates,
+               const std::optional<std::string> &expected = std::nullopt);
+}
+

--- a/src/doctor_actions.cpp
+++ b/src/doctor_actions.cpp
@@ -19,6 +19,8 @@
 #include <nlohmann/json.hpp>
 
 #include "adaptive_bitrate.h"
+#include "config.h"
+#include "configuration_store.h"
 #include "globals.h"
 #include "logging.h"
 #include "recovery_profile.h"
@@ -277,7 +279,10 @@ namespace doctor_actions {
     }
 
     void set_adaptive_enabled_locked(bool enable) {
-      if (action_run.active) {
+      if (action_run.active && !enable) {
+        remember_terminal_locked(action_run, superseded_result(action_run.run_id));
+        action_run = action_run_t {};
+      } else if (action_run.active) {
         const auto run_snapshot = action_run;
         const auto outcome = restore_bitrate_run_locked(action_run);
         if (outcome.status == restore_status_e::encoder_unconfirmed) {
@@ -790,6 +795,10 @@ namespace doctor_actions {
     return true;
   }
 
+  paired_global_control_guard_t acquire_admin_global_control() {
+    return {std::unique_lock<std::mutex>(action_mutex), true};
+  }
+
   bool set_owner_live_bitrate(std::string_view owner_uuid,
                               std::uint64_t session_generation,
                               std::string_view launch_instance_id,
@@ -802,7 +811,11 @@ namespace doctor_actions {
         controller_sessions.front().launch_instance_id != launch_instance_id) {
       return false;
     }
+    std::lock_guard configuration_guard(configuration_store::mutex());
+    if (configuration_store::patch(config::sunshine.config_file,
+          {{"adaptive_bitrate_enabled", "disabled"}}) != configuration_store::result::committed) return false;
     const auto superseded_run = action_run;
+    adaptive_bitrate::set_enabled(false);
     adaptive_bitrate::set_live_bitrate(bitrate_kbps);
     if (superseded_run.active) {
       remember_terminal_locked(
@@ -1669,6 +1682,7 @@ namespace doctor_actions {
     adaptive_bitrate::load_config();
     adaptive_bitrate::reset();
     adaptive_bitrate::set_base_bitrate(base_bitrate_kbps);
+    adaptive_bitrate::set_session_scope(session_generation, std::string {launch_instance_id}, unshared_at_start);
     stream_stats::set_doctor_live_action_scope_available(
       controller_sessions.size() == 1 && controller_sessions.front().auto_fix_eligible
     );
@@ -1703,6 +1717,8 @@ namespace doctor_actions {
       terminal_action = terminal_action_t {};
       terminal_action_history.clear();
     }
+
+    adaptive_bitrate::set_session_scope(0, {}, false);
 
     // Encoder teardown already publishes runtime support loss. Do not change
     // the configured adaptive policy here; the next stream start reloads it,

--- a/src/doctor_actions.h
+++ b/src/doctor_actions.h
@@ -58,9 +58,10 @@ namespace doctor_actions {
     paired_global_control_guard_t(paired_global_control_guard_t &&) noexcept = default;
     paired_global_control_guard_t &operator=(paired_global_control_guard_t &&) noexcept = default;
 
-    explicit operator bool() const noexcept { return authorized_; }
+    explicit operator bool() const noexcept { return authorized_ && lock_.owns_lock(); }
     bool set_adaptive_enabled(bool enabled);
     void release() noexcept {
+      authorized_ = false;
       if (lock_.owns_lock()) lock_.unlock();
     }
 
@@ -70,6 +71,7 @@ namespace doctor_actions {
       std::uint64_t session_generation,
       std::string_view launch_instance_id
     );
+    friend paired_global_control_guard_t acquire_admin_global_control();
 
     paired_global_control_guard_t(std::unique_lock<std::mutex> lock,
                                   bool authorized) noexcept:
@@ -86,6 +88,9 @@ namespace doctor_actions {
     std::uint64_t session_generation = 0,
     std::string_view launch_instance_id = {}
   );
+
+  /** Authenticated web admin: serialize with session handoff and paired writers. */
+  paired_global_control_guard_t acquire_admin_global_control();
 
   /** Atomically apply a live paired-client bitrate only for the sole owner. */
   bool set_owner_live_bitrate(std::string_view owner_uuid,

--- a/src/live_tuning.cpp
+++ b/src/live_tuning.cpp
@@ -1,0 +1,62 @@
+#include "live_tuning.h"
+#include "config.h"
+#include "configuration_store.h"
+#include "settings_metadata.h"
+#include "uuid.h"
+#include <atomic>
+
+namespace live_tuning {
+  nlohmann::json describe(const adaptive_bitrate::state_t &c,
+                         const stream_stats::stats_t &s, bool configured) {
+    const bool matching_session = c.session_exclusive && c.session_generation == s.session_generation &&
+      c.app_session_id == s.app_session_id;
+    const bool supported = s.streaming && matching_session && c.runtime_update_supported;
+    const bool pending = supported && c.target_bitrate_kbps > 0 &&
+      c.target_bitrate_kbps != c.applied_bitrate_kbps;
+    std::string state = !configured ? "off" : !s.streaming ? "waiting" :
+      !supported ? "unavailable" : pending ? "applying" :
+      !c.feedback_initialized ? "measuring" :
+      c.applied_bitrate_kbps < c.base_bitrate_kbps ? "adjusting" : "stable";
+    return {
+      {"version", 1}, {"enabled", configured}, {"scope", "host"},
+      {"state", state}, {"supported", supported},
+      {"reason", !s.streaming ? "no_stream" : !matching_session ? "session_scope_unavailable" : c.reason},
+      {"runtime_enabled", c.enabled}, {"pending", pending},
+      {"quality_limit_kbps", matching_session ? c.base_bitrate_kbps : 0},
+      {"requested_bitrate_kbps", supported ? c.target_bitrate_kbps : 0},
+      {"applied_bitrate_kbps", s.streaming && matching_session ? c.applied_bitrate_kbps : 0},
+      {"session_generation", s.session_generation},
+      {"app_session_id", s.app_session_id}
+    };
+  }
+  nlohmann::json snapshot(const stream_stats::stats_t &stats) {
+    // Serialize preference with its revision; controller telemetry is one snapshot.
+    std::lock_guard guard(configuration_store::mutex());
+    static const auto instance = uuid_util::uuid_t::generate().string();
+    static std::atomic<std::uint64_t> sequence {0};
+    const auto controller = adaptive_bitrate::get_state();
+    auto value = describe(controller, stats, controller.configured_enabled);
+    value["configuration_revision"] = configuration_store::revision(config::sunshine.config_file);
+    value["host_instance"] = instance;
+    value["sequence"] = ++sequence;
+    return value;
+  }
+  nlohmann::json set_enabled(doctor_actions::paired_global_control_guard_t &authority,
+                            bool enabled, const std::optional<std::string> &expected) {
+    if (!authority) return {{"status", false}, {"http_status", 403}, {"code", "active_owner_required"}};
+    std::lock_guard guard(configuration_store::mutex());
+    const auto result = configuration_store::patch(config::sunshine.config_file,
+      {{"adaptive_bitrate_enabled", enabled ? "enabled" : "disabled"}}, expected);
+    if (result != configuration_store::result::committed) return {
+      {"status", false}, {"http_status", result == configuration_store::result::conflict ? 412 : 500},
+      {"code", result == configuration_store::result::conflict ? "configuration_changed" : "save_failed"},
+      {"live_tuning", snapshot(stream_stats::get_current())}
+    };
+    // An identical retry acknowledges intent without superseding a Doctor run.
+    if (enabled != adaptive_bitrate::get_state().configured_enabled && !authority.set_adaptive_enabled(enabled)) {
+      return {{"status", false}, {"http_status", 409}, {"code", "session_changed"}};
+    }
+    settings_metadata::note_config_write("live_tuning", {"adaptive_bitrate_enabled"});
+    return {{"status", true}, {"http_status", 200}, {"live_tuning", snapshot(stream_stats::get_current())}};
+  }
+}

--- a/src/live_tuning.h
+++ b/src/live_tuning.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "adaptive_bitrate.h"
+#include "doctor_actions.h"
+#include "stream_stats.h"
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+
+namespace live_tuning {
+  nlohmann::json describe(const adaptive_bitrate::state_t &controller,
+                         const stream_stats::stats_t &stats,
+                         bool configured_enabled);
+  nlohmann::json snapshot(const stream_stats::stats_t &stats);
+  // Caller must retain the authorized guard across persistence and application.
+  // Legacy paired endpoints may omit expected; new clients must supply it.
+  nlohmann::json set_enabled(doctor_actions::paired_global_control_guard_t &authority,
+                            bool enabled, const std::optional<std::string> &expected = std::nullopt);
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include "beat_times.h"
 #include "client_profiles.h"
 #include "confighttp.h"
+#include "adaptive_bitrate.h"
 #include "crash_report.h"
 #include "display_device.h"
 #include "entry_handler.h"
@@ -235,6 +236,8 @@ int main(int argc, char *argv[]) {
   if (config::parse(argc, argv)) {
     return 0;
   }
+
+  adaptive_bitrate::load_config();
 
   cursor::set_visible(config::input.mouse_cursor_visible);
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -59,6 +59,8 @@
 
 // local includes
 #include "config.h"
+#include "configuration_store.h"
+#include "live_tuning.h"
 #include "config_file_update.h"
 #include "display_device.h"
 #include "display_planner.h"
@@ -1266,78 +1268,10 @@ namespace nvhttp {
     }
 
     bool persist_config_values(const std::unordered_map<std::string, std::string> &updates) {
-      if (updates.empty()) {
-        return true;
-      }
-
-      const fs::path target {config::sunshine.config_file};
-      std::error_code metadata_error;
-      const auto metadata = fs::symlink_status(target, metadata_error);
-      if (metadata_error || !fs::exists(metadata) || !fs::is_regular_file(metadata)) {
-        BOOST_LOG(error) << "client_settings: refusing to replace missing, unreadable, or non-regular config file: "sv
-                         << target;
-        return false;
-      }
-
-      std::ifstream input {target, std::ios::binary};
-      if (!input.is_open()) {
-        BOOST_LOG(error) << "client_settings: failed to open config file for a lossless update: "sv << target;
-        return false;
-      }
-      const std::string existing_config {
-        std::istreambuf_iterator<char> {input},
-        std::istreambuf_iterator<char> {}
-      };
-      if (input.bad()) {
-        BOOST_LOG(error) << "client_settings: failed while reading config file: "sv << target;
-        return false;
-      }
-      input.close();
-      if (input.fail()) {
-        BOOST_LOG(error) << "client_settings: failed to close config file after reading: "sv << target;
-        return false;
-      }
-
-      const auto vars = config::parse_config(existing_config);
-      const bool unchanged = std::all_of(
-        updates.begin(), updates.end(),
-        [&](const auto &update) {
-          const auto existing_value = vars.find(update.first);
-          if (update.second.empty()) {
-            return existing_value == vars.end();
-          }
-          return existing_value != vars.end() && existing_value->second == update.second;
-        }
-      );
-      if (unchanged) {
-        return true;
-      }
-
-      const auto updated = config_file_update::apply(existing_config, updates);
-      if (!updated.changed) {
-        return true;
-      }
-
-      const auto persisted = private_state_file::write_atomic(target, updated.content);
-      if (persisted.status == private_state_file::write_status_e::not_committed) {
-        BOOST_LOG(error) << "client_settings: atomic config replacement did not commit: "sv << target;
-        return false;
-      }
-      if (persisted.status == private_state_file::write_status_e::durability_uncertain) {
-        // rename(2) already made the new config visible. Report the committed
-        // mutation honestly even though the parent-directory fsync/close could
-        // not prove crash durability; claiming unchanged would invite a retry.
-        BOOST_LOG(warning) << "client_settings: config replacement committed with uncertain durability: "sv
-                           << target;
-      }
-
-      std::vector<std::string> written_keys;
-      written_keys.reserve(updates.size());
-      for (const auto &update : updates) {
-        written_keys.push_back(update.first);
-      }
-      settings_metadata::note_config_write("gamestream", std::move(written_keys));
-
+      if (configuration_store::patch(config::sunshine.config_file, updates) != configuration_store::result::committed) return false;
+      std::vector<std::string> keys;
+      for (const auto &[key, value] : updates) keys.push_back(key);
+      settings_metadata::note_config_write("gamestream", std::move(keys));
       return true;
     }
 
@@ -2022,6 +1956,7 @@ namespace nvhttp {
 
       nlohmann::json settings;
       settings["version"] = 1;
+      settings["live_tuning"] = live_tuning::snapshot(stats);
       settings["revision"] = std::to_string(std::hash<std::string> {}(revision_seed));
       settings["desired"] = std::move(desired);
       settings["effective"] = std::move(effective);
@@ -2038,6 +1973,7 @@ namespace nvhttp {
         {"target_bitrate_override", true},
         {"ai_auto_quality_control", false},
         {"adaptive_bitrate_control", true},
+        {"live_tuning_v1", true},
         {"ai_optimizer_control", false},
         {"client_presentation_reporting", true},
         {"optimizer_sync_reporting", true},
@@ -6902,6 +6838,7 @@ namespace nvhttp {
       // Kept as explicit false for older clients. AI may explain evidence but
       // cannot own launch settings in this contract.
       features["ai_auto_quality"] = false;
+      features["live_tuning_v1"] = true;
       features["ai_auto_quality_control"] = false;
       features["ai_optimizer"] = false;
       features["ai_optimizer_control"] = false;
@@ -7043,6 +6980,7 @@ namespace nvhttp {
       const bool owned_by_client = stop_snapshot.owned_by_client;
       const bool stop_in_progress = stop_snapshot.stop_in_progress;
       output["state"] = session_state;
+      output["events_https_port"] = net::map_port(confighttp::PORT_HTTPS);
       output["streaming_active"] = stats.streaming;
       output["shutdown_requested"] = stop_in_progress;
       auto &build = output["build"];
@@ -7349,6 +7287,7 @@ namespace nvhttp {
         "Deprecated recovery record; it cannot affect launch and may be cancelled." :
         "Deprecated recovery record; it cannot affect launch.";
       output["auto_quality"] = health.value("recovery_policy", nlohmann::json::object());
+      output["live_tuning"] = live_tuning::snapshot(stats);
       output["profile_state"] = build_live_profile_state_json(
         health,
         output["auto_quality"],
@@ -7576,6 +7515,7 @@ namespace nvhttp {
             return;
           }
 
+          std::unique_lock configuration_guard(configuration_store::mutex());
           std::optional<std::string> stream_display_mode;
           if (body.contains("stream_display_mode")) {
             const auto reject_stream_display_mode = [&](const std::string &message) {
@@ -7665,16 +7605,11 @@ namespace nvhttp {
               return;
             }
             const bool enabled = body["adaptive_bitrate_enabled"].get<bool>();
-            if (!persist_config_values({{"adaptive_bitrate_enabled", bool_config_value(enabled)}})) {
-              write_json({{"error", "failed to persist adaptive bitrate setting"}}, SimpleWeb::StatusCode::server_error_internal_server_error);
-              return;
-            }
-            if (!global_control_guard.set_adaptive_enabled(enabled)) {
-              write_json(
-                {{"status", false}, {"changed", false}, {"state", "scope_mismatch"},
-                 {"error", "The active stream generation changed before adaptive bitrate could be updated."}},
-                SimpleWeb::StatusCode::client_error_conflict
-              );
+            const auto expected = body.contains("configuration_revision") ?
+              std::optional<std::string>(body.at("configuration_revision").get<std::string>()) : std::nullopt;
+            const auto result = live_tuning::set_enabled(global_control_guard, enabled, expected);
+            if (!result.value("status", false)) {
+              write_json(result, static_cast<SimpleWeb::StatusCode>(result.value("http_status", 500)));
               return;
             }
           }
@@ -7744,6 +7679,7 @@ namespace nvhttp {
           // lifecycle lock used by final resolution and generation install.
           // Per-client durable settings and separately owner-gated live
           // bitrate follow.
+          configuration_guard.unlock();
           global_control_guard.release();
           if (topology_lifecycle_guard.owns_lock()) {
             topology_lifecycle_guard.unlock();
@@ -7776,7 +7712,7 @@ namespace nvhttp {
             }
             paired_device_updated = true;
           }
-          if (target_bitrate_kbps > 0) {
+          if (body.contains("target_bitrate_kbps") && target_bitrate_kbps > 0) {
             // A paired client setting is an explicit newer operator choice.
             // Apply it exactly to the live target instead of preserving an
             // older Doctor/adaptive reduction beneath the new base.
@@ -9410,30 +9346,20 @@ namespace nvhttp {
           response->write(SimpleWeb::StatusCode::client_error_forbidden, err.dump(), headers);
           return;
         }
-        if (!persist_config_values({
-              {"adaptive_bitrate_enabled", bool_config_value(enabled)}
-            })) {
-          nlohmann::json err;
-          err["error"] = "failed to persist adaptive bitrate setting";
+        const auto expected = body.contains("configuration_revision") ?
+          std::optional<std::string>(body.at("configuration_revision").get<std::string>()) : std::nullopt;
+        const auto result = live_tuning::set_enabled(global_control_guard, enabled, expected);
+        if (!result.value("status", false)) {
           SimpleWeb::CaseInsensitiveMultimap headers;
           headers.emplace("Content-Type", "application/json");
-          response->write(SimpleWeb::StatusCode::server_error_internal_server_error, err.dump(), headers);
-          return;
-        }
-        if (!global_control_guard.set_adaptive_enabled(enabled)) {
-          nlohmann::json err {
-            {"status", false}, {"changed", false}, {"state", "scope_mismatch"},
-            {"error", "The active stream generation changed before adaptive bitrate could be updated."}
-          };
-          SimpleWeb::CaseInsensitiveMultimap headers;
-          headers.emplace("Content-Type", "application/json");
-          response->write(SimpleWeb::StatusCode::client_error_conflict, err.dump(), headers);
+          response->write(static_cast<SimpleWeb::StatusCode>(result.value("http_status", 500)), result.dump(), headers);
           return;
         }
         BOOST_LOG(info) << "Adaptive bitrate toggled: " << (enabled ? "enabled" : "disabled");
 
         nlohmann::json output;
         output["status"] = true;
+        output["live_tuning"] = result["live_tuning"];
         output["ai_auto_quality_enabled"] = false;
         output["adaptive_bitrate_enabled"] = adaptive_bitrate::is_enabled();
         output["ai_optimizer_enabled"] = false;

--- a/src/private_state_file.cpp
+++ b/src/private_state_file.cpp
@@ -295,7 +295,7 @@ namespace private_state_file {
 
     class state_file_lock_t {
     public:
-      explicit state_file_lock_t(const directory_handle_t &directory) {
+      explicit state_file_lock_t(const directory_handle_t &directory, bool wait = true) {
         int flags = O_CREAT | O_RDWR | O_NONBLOCK;
 #ifdef O_CLOEXEC
         flags |= O_CLOEXEC;
@@ -320,7 +320,7 @@ namespace private_state_file {
           descriptor_ = -1;
           return;
         }
-        while (::flock(descriptor_, LOCK_EX) != 0) {
+        while (::flock(descriptor_, LOCK_EX | (wait ? 0 : LOCK_NB)) != 0) {
           if (errno == EINTR) {
             continue;
           }
@@ -400,18 +400,8 @@ namespace private_state_file {
     }
   }  // namespace
 
-  read_result_t read_secure(const std::filesystem::path &target, std::size_t max_bytes) {
-    directory_handle_t directory {target};
-    if (!directory) {
-      BOOST_LOG(error) << "Rejected insecure or inaccessible private state directory for " << target;
-      return {.status = read_status_e::io_error};
-    }
-    state_file_lock_t lock {directory};
-    if (!lock) {
-      BOOST_LOG(error) << "Couldn't acquire private state lock for " << target;
-      return {.status = read_status_e::io_error};
-    }
-
+  static read_result_t read_locked(const directory_handle_t &directory, std::size_t max_bytes,
+                                   bool permit_public_read) {
     int flags = O_RDONLY | O_NONBLOCK;
 #ifdef O_CLOEXEC
     flags |= O_CLOEXEC;
@@ -445,7 +435,7 @@ namespace private_state_file {
       return {.status = read_status_e::io_error};
     }
     if (!S_ISREG(metadata.st_mode) || metadata.st_uid != ::geteuid() || metadata.st_nlink != 1 ||
-        (metadata.st_mode & (S_IRWXG | S_IRWXO)) != 0 || metadata.st_size < 0 ||
+        (metadata.st_mode & (permit_public_read ? (S_IWGRP | S_IWOTH) : (S_IRWXG | S_IRWXO))) != 0 || metadata.st_size < 0 ||
         static_cast<std::uintmax_t>(metadata.st_size) > max_bytes) {
       (void) close_descriptor();
       return {.status = read_status_e::rejected};
@@ -483,18 +473,7 @@ namespace private_state_file {
     return {.status = read_status_e::ok, .payload = std::move(payload)};
   }
 
-  write_result_t write_atomic(const std::filesystem::path &target, std::string_view payload) {
-    directory_handle_t directory {target, true};
-    if (!directory) {
-      BOOST_LOG(error) << "Rejected insecure or inaccessible private state directory for " << target;
-      return {write_status_e::not_committed};
-    }
-    state_file_lock_t lock {directory};
-    if (!lock) {
-      BOOST_LOG(error) << "Couldn't acquire private state lock for " << target;
-      return {write_status_e::not_committed};
-    }
-
+  static write_result_t write_locked(directory_handle_t &directory, std::string_view payload) {
 #ifdef POLARIS_TESTS
     const auto injected_fault = write_fault.load(std::memory_order_relaxed);
     if (injected_fault == write_fault_e::open) {
@@ -611,6 +590,38 @@ namespace private_state_file {
       return {write_status_e::durability_uncertain};
     }
     return {write_status_e::committed};
+  }
+
+  read_result_t read_secure(const std::filesystem::path &target, std::size_t max_bytes,
+                            bool permit_public_read, bool wait_for_lock) {
+    directory_handle_t directory {target};
+    if (!directory) return {.status = read_status_e::io_error};
+    state_file_lock_t lock {directory, wait_for_lock};
+    if (!lock) return {.status = read_status_e::io_error};
+    return read_locked(directory, max_bytes, permit_public_read);
+  }
+
+  write_result_t write_atomic(const std::filesystem::path &target, std::string_view payload) {
+    directory_handle_t directory {target, true};
+    if (!directory) return {write_status_e::not_committed};
+    state_file_lock_t lock {directory};
+    if (!lock) return {write_status_e::not_committed};
+    return write_locked(directory, payload);
+  }
+
+  write_result_t update_atomic(const std::filesystem::path &target, std::size_t max_bytes,
+      const std::function<std::optional<std::string>(const read_result_t &)> &update,
+      bool permit_public_read) {
+    directory_handle_t directory {target, true};
+    if (!directory) return {write_status_e::not_committed};
+    state_file_lock_t lock {directory, false};
+    if (!lock) return {write_status_e::not_committed};
+    const auto current = read_locked(directory, max_bytes, permit_public_read);
+    if (!current && current.status != read_status_e::missing) return {write_status_e::not_committed};
+    const auto next = update(current);
+    if (!next || next->size() > max_bytes) return {write_status_e::not_committed};
+    if (current && *next == current.payload) return {write_status_e::committed};
+    return write_locked(directory, *next);
   }
 
 #ifdef POLARIS_TESTS

--- a/src/private_state_file.h
+++ b/src/private_state_file.h
@@ -6,6 +6,8 @@
 
 #include <cstddef>
 #include <filesystem>
+#include <functional>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -40,7 +42,15 @@ namespace private_state_file {
     }
   };
 
-  read_result_t read_secure(const std::filesystem::path &target, std::size_t max_bytes);
+  read_result_t read_secure(const std::filesystem::path &target, std::size_t max_bytes,
+                            bool permit_public_read = false, bool wait_for_lock = true);
+  // One cross-process transaction. Contention fails immediately so callers can
+  // retain session authority without waiting on an unrelated file-lock holder.
+  // The callback must not call another persistence operation on this path.
+  write_result_t update_atomic(const std::filesystem::path &target, std::size_t max_bytes,
+    const std::function<std::optional<std::string>(const read_result_t &)> &update,
+    bool permit_public_read = false);
+
   write_result_t write_atomic(const std::filesystem::path &target, std::string_view payload);
 
 #ifdef POLARIS_TESTS

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -3331,6 +3331,10 @@ namespace stream_stats {
 
       result = current_stats;
     }
+    if (const auto identity = get_single_active_session_identity()) {
+      result.session_generation = identity->session_generation;
+      result.app_session_id = identity->session_token;
+    }
 
     // Doctor-policy video fields are read under the same narrow lock used to
     // publish a policy-class transition. Other hot fields remain independent

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -127,6 +127,8 @@ namespace stream_stats {
   };
 
   struct stats_t {
+    std::uint64_t session_generation = 0;
+    std::string app_session_id;
     // Stream state
     bool streaming = false;
     std::string client_name;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3710,6 +3710,11 @@ namespace video {
     void *channel_data,
     packet_queue_t packets
   ) {
+    // A disable/rollback may have superseded the target while a former
+    // FFmpeg encoder was being retired. Use the latest pending request.
+    if (const auto request = adaptive_bitrate::get_live_bitrate_request()) {
+      config.bitrate = request->target_bitrate_kbps;
+    }
     auto session = make_encode_session(disp, encoder, config, disp->width, disp->height, std::move(encode_device));
     if (!session) {
       adaptive_bitrate::set_runtime_update_supported(
@@ -4007,13 +4012,14 @@ namespace video {
           int effective_bitrate = applied_adaptive_bitrate;
           if (const auto request = adaptive_bitrate::get_live_bitrate_request()) {
             if (request->target_bitrate_kbps != applied_adaptive_bitrate) {
-              switch (session->update_bitrate(request->target_bitrate_kbps)) {
+              auto update = encode_session_t::bitrate_update_e::rejected;
+              const bool current = adaptive_bitrate::apply_live_bitrate_request(*request, [&] {
+                update = session->update_bitrate(request->target_bitrate_kbps);
+                return update == encode_session_t::bitrate_update_e::applied;
+              });
+              if (current) switch (update) {
                 case encode_session_t::bitrate_update_e::applied:
                   applied_adaptive_bitrate = request->target_bitrate_kbps;
-                  adaptive_bitrate::acknowledge_live_bitrate_applied(
-                    request->revision,
-                    applied_adaptive_bitrate
-                  );
                   effective_bitrate = applied_adaptive_bitrate;
                   break;
                 case encode_session_t::bitrate_update_e::recreate_session:

--- a/src_assets/common/assets/web/client-settings-sync.js
+++ b/src_assets/common/assets/web/client-settings-sync.js
@@ -21,6 +21,9 @@ export const CLIENT_SETTINGS_RESPONSE_ONLY_KEYS = [
 ]
 
 export const CONFIG_RESPONSE_ONLY_KEYS = [
+  'configuration_revision',
+  'live_tuning',
+  'ai_explanations_ready',
   'status',
   'platform',
   'version',

--- a/src_assets/common/assets/web/components/LiveTuningControl.test.js
+++ b/src_assets/common/assets/web/components/LiveTuningControl.test.js
@@ -1,0 +1,84 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, vi, expect, afterEach } from 'vitest'
+import fixtures from '../../../../../tests/fixtures/live-tuning-v1.json'
+import LiveTuningControl from './LiveTuningControl.vue'
+
+let wrappers = []
+afterEach(() => { wrappers.forEach(w => w.unmount()); wrappers = []; vi.unstubAllGlobals() })
+describe('Live Tuning switch', () => {
+  it('shares one stream connection and confirms both switches only after save', async () => {
+    const sources = []
+    vi.stubGlobal('EventSource', class { constructor() { sources.push(this) } close() {} })
+    let resolveSave
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(resolve => { resolveSave = resolve })))
+    const a = mount(LiveTuningControl), b = mount(LiveTuningControl)
+    wrappers.push(a, b)
+    expect(sources).toHaveLength(1)
+    const off = { ...fixtures[0].live_tuning, host_instance: 'switch-test-host', sequence: 1 }
+    sources[0].onmessage({ data: JSON.stringify({ live_tuning: off }) })
+    await flushPromises()
+    const button = a.get('[role=switch]')
+    expect(button.attributes('aria-checked')).toBe('false')
+    await button.trigger('click')
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetch.mock.calls[0][1].body)).toEqual({ enabled: true })
+    expect(fetch.mock.calls[0][1].headers['If-Match']).toBe(`"${off.configuration_revision}"`)
+    expect(button.attributes('aria-checked')).toBe('false')
+    expect(b.text()).toContain('Saving')
+    resolveSave({ ok: true, json: async () => ({ status: true, live_tuning: { ...off, enabled: true, state: 'stable', sequence: 2 } }) })
+    await flushPromises()
+    expect(button.attributes('aria-checked')).toBe('true')
+    expect(b.get('[role=switch]').attributes('aria-checked')).toBe('true')
+  })
+  it('keeps the confirmed switch on failure and stops an unused connection', async () => {
+    const sources = []
+    const close = vi.fn()
+    vi.stubGlobal('EventSource', class { constructor() { sources.push(this) } close = close })
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 412, json: async () => ({ status: false }) })))
+    const a = mount(LiveTuningControl); wrappers.push(a)
+    sources[0].onmessage({ data: JSON.stringify({ live_tuning: { ...fixtures[0].live_tuning, host_instance: 'failure-test-host', sequence: 1 } }) })
+    await flushPromises()
+    await a.get('[role=switch]').trigger('click')
+    await flushPromises()
+    expect(a.get('[role=switch]').attributes('aria-checked')).toBe('false')
+    expect(a.get('[role=alert]').text()).toContain('Settings changed')
+    expect(fetch).toHaveBeenCalledTimes(1)
+    a.unmount(); wrappers = []
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+  it('marks a missing or invalid envelope unknown after valid status', async () => {
+    const sources = []
+    vi.stubGlobal('EventSource', class { constructor() { sources.push(this) } close() {} })
+    const a = mount(LiveTuningControl); wrappers.push(a)
+    const live = { ...fixtures[0].live_tuning, host_instance: 'invalid-test', sequence: 1 }
+    const emit = async payload => { sources[0].onmessage({ data: JSON.stringify(payload) }); await flushPromises() }
+    await emit({ live_tuning: live })
+    expect(a.get('[role=switch]').attributes('disabled')).toBeUndefined()
+    await emit({ streaming: true })
+    expect(a.text()).toContain('Unknown')
+    expect(a.get('[role=switch]').attributes('disabled')).toBeDefined()
+    await emit({ live_tuning: { ...live, version: 99, sequence: 2 } })
+    expect(a.text()).toContain('Unknown')
+    await emit({ live_tuning: { ...live, sequence: 3 } })
+    expect(a.get('[role=switch]').attributes('disabled')).toBeUndefined()
+  })
+  it('does not apply or announce an old save after the host restarts', async () => {
+    const sources = []
+    vi.stubGlobal('EventSource', class { constructor() { sources.push(this) } close() {} })
+    let resolveSave
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(resolve => { resolveSave = resolve })))
+    const announced = vi.fn()
+    window.addEventListener('polaris:live-tuning-saved', announced)
+    const a = mount(LiveTuningControl); wrappers.push(a)
+    const old = { ...fixtures[0].live_tuning, host_instance: 'old-save-host', sequence: 1 }
+    sources[0].onmessage({ data: JSON.stringify({ live_tuning: old }) }); await flushPromises()
+    await a.get('[role=switch]').trigger('click')
+    sources[0].onmessage({ data: JSON.stringify({ live_tuning: { ...old, host_instance: 'new-save-host' } }) }); await flushPromises()
+    resolveSave({ ok: true, json: async () => ({ status: true, live_tuning: { ...old, enabled: true, sequence: 100 } }) })
+    await flushPromises()
+    expect(a.get('[role=switch]').attributes('aria-checked')).toBe('false')
+    expect(announced).not.toHaveBeenCalled()
+    window.removeEventListener('polaris:live-tuning-saved', announced)
+  })
+
+})

--- a/src_assets/common/assets/web/components/LiveTuningControl.vue
+++ b/src_assets/common/assets/web/components/LiveTuningControl.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { computed } from 'vue'
+import { useLiveTuning } from '../composables/useLiveTuning'
+defineProps({ compact: Boolean })
+const { state, saving, error, confirmed, setEnabled, label } = useLiveTuning()
+const bitrate = computed(() => state.value?.applied_bitrate_kbps > 0
+  ? `${(state.value.applied_bitrate_kbps / 1000).toFixed(1)} / ${(state.value.quality_limit_kbps / 1000).toFixed(1)} Mbps limit` : '')
+</script>
+<template>
+  <div class="rounded-xl border border-storm/20 bg-deep/35 p-3" data-live-tuning>
+    <button type="button" role="switch" aria-label="Live Tuning" :aria-checked="Boolean(state?.enabled)"
+      :disabled="saving || !confirmed" :aria-busy="saving"
+      class="focus-ring flex w-full items-center justify-between gap-3 text-left disabled:opacity-60"
+      @click="setEnabled(!state.enabled)">
+      <span class="min-w-0">
+        <span class="block text-sm font-medium text-silver">Live Tuning</span>
+        <span class="mt-1 block text-xs text-storm" aria-live="polite">{{ saving ? 'Saving…' : label }}</span>
+      </span>
+      <span class="relative h-5 w-9 shrink-0 rounded-full" :class="confirmed && state?.enabled ? 'bg-accent' : 'bg-storm/40'" aria-hidden="true">
+        <span class="absolute top-0.5 h-4 w-4 rounded-full bg-white transition-transform"
+          :style="{ transform: state?.enabled ? 'translateX(18px)' : 'translateX(2px)' }" />
+      </span>
+    </button>
+    <p v-if="!compact" class="mt-2 text-xs leading-relaxed text-storm">Automatically adjust stream bitrate within your quality limit. This setting applies to the host.</p>
+    <p v-if="confirmed && bitrate" class="mt-2 text-xs text-silver">{{ bitrate }}<span v-if="state.pending"> · Applying requested bitrate</span></p>
+    <p v-if="confirmed && state?.enabled && state?.state === 'unavailable'" class="mt-2 text-xs text-storm">{{ state.reason?.replaceAll('_', ' ') }}</p>
+    <p v-if="error" role="alert" class="mt-2 text-xs text-warning-bright">{{ error }}</p>
+  </div>
+</template>

--- a/src_assets/common/assets/web/components/QuickControls.vue
+++ b/src_assets/common/assets/web/components/QuickControls.vue
@@ -3,9 +3,9 @@ import { computed, ref, onMounted, onUnmounted, inject } from 'vue'
 import { useToast } from '../composables/useToast'
 import {
   resolveClientSettingsSync,
-  stripConfigResponseOnly,
 } from '../client-settings-sync'
 import ConfirmActionDialog from './ConfirmActionDialog.vue'
+import LiveTuningControl from './LiveTuningControl.vue'
 
 const config = ref({})
 const pendingKey = ref(null)
@@ -64,24 +64,11 @@ async function toggle(key) {
   pendingKey.value = key
   const newVal = isEnabled(key) ? 'disabled' : 'enabled'
   try {
-    // Read existing config first, then merge the change
-    // The API overwrites the entire file, so we must send ALL settings
     const existingRes = await fetch('./api/config', { credentials: 'include' })
-    let existing = {}
-    if (existingRes.ok) {
-      existing = await existingRes.json()
-    }
-    const platform = existing.platform || config.value.platform
-
-    // Remove response-only keys injected by getConfig() that aren't real config settings.
-    // These come from the server's status probing, not the config file.
-    stripConfigResponseOnly(existing)
-
-    // Merge the toggle change
-    existing[key] = newVal
-    if (key === 'ai_enabled') {
-      existing.adaptive_bitrate_enabled = newVal
-    }
+    if (!existingRes.ok) throw new Error('refresh-failed')
+    const current = await existingRes.json()
+    const platform = current.platform || config.value.platform
+    const existing = { [key]: newVal }
     if (key === 'headless_mode' && platform === 'linux') {
       existing.linux_use_cage_compositor = newVal
       existing.linux_prefer_gpu_native_capture = 'disabled'
@@ -89,15 +76,13 @@ async function toggle(key) {
 
     const response = await fetch('./api/config', {
       credentials: 'include',
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...(current.configuration_revision
+        ? { 'If-Match': `"${current.configuration_revision}"` } : {}) },
       body: JSON.stringify(existing)
     })
     if (!response.ok) throw new Error('save-failed')
     syncKey(key, newVal)
-    if (key === 'ai_enabled') {
-      syncKey('adaptive_bitrate_enabled', newVal)
-    }
     if (key === 'headless_mode' && platform === 'linux') {
       syncKey('linux_use_cage_compositor', newVal)
       syncKey('linux_prefer_gpu_native_capture', 'disabled')
@@ -157,13 +142,12 @@ onUnmounted(() => {
 
 const toggles = [
   { key: 'headless_mode', requiresRestart: true },
-  { key: 'ai_enabled', requiresRestart: false },
   { key: 'stream_audio', requiresRestart: true },
   { key: 'enable_discovery', requiresRestart: false },
   { key: 'enable_pairing', requiresRestart: false },
 ]
 
-const compactToggleKeys = ['headless_mode', 'ai_enabled', 'stream_audio']
+const compactToggleKeys = ['headless_mode', 'stream_audio']
 const visibleToggles = () => (
   props.compact
     ? toggles.filter((toggle) => compactToggleKeys.includes(toggle.key))
@@ -201,6 +185,7 @@ const syncBadgeTone = computed(() => {
     <div v-if="!props.compact" class="rounded-lg border border-storm/20 bg-void/25 px-3 py-2 text-[11px] leading-relaxed text-storm">
       {{ $t(syncCopyKey) }}
     </div>
+    <LiveTuningControl :compact="props.compact" />
     <button
       v-for="t in visibleToggles()"
       :key="t.key"

--- a/src_assets/common/assets/web/composables/useLiveTuning.js
+++ b/src_assets/common/assets/web/composables/useLiveTuning.js
@@ -1,0 +1,50 @@
+import { ref, computed, watch } from 'vue'
+import { useStreamStats } from './useStreamStats'
+import { createLiveTuningReducer, liveTuningLabel, parseLiveTuning } from '../live-tuning'
+
+const state = ref(null)
+const saving = ref(false)
+const error = ref('')
+const reduce = createLiveTuningReducer()
+function accept(raw) {
+  const next = reduce(raw)
+  if (next) state.value = next
+}
+export function useLiveTuning() {
+  const { stats, connected } = useStreamStats()
+  watch(() => stats.value?.live_tuning, accept, { immediate: true })
+  const confirmed = computed(() => connected.value && !!state.value &&
+    parseLiveTuning(stats.value?.live_tuning)?.host_instance === state.value.host_instance)
+  async function setEnabled(enabled) {
+    if (saving.value || !confirmed.value || typeof enabled !== 'boolean') return false
+    saving.value = true
+    error.value = ''
+    const revision = state.value.configuration_revision
+    const hostInstance = state.value.host_instance
+    try {
+      const response = await fetch('./api/live-tuning', {
+        credentials: 'include', method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'If-Match': `"${revision}"` },
+        body: JSON.stringify({ enabled }),
+      })
+      const result = await response.json()
+      if (state.value?.host_instance === hostInstance && result.live_tuning?.host_instance === hostInstance) accept(result.live_tuning)
+      if (!response.ok || result.status !== true) {
+        throw new Error(response.status === 412 ? 'Settings changed. Review the current state and try again.' : 'Live Tuning could not be saved.')
+      }
+      if (state.value?.host_instance !== hostInstance || !parseLiveTuning(result.live_tuning) || result.live_tuning.host_instance !== hostInstance) {
+        throw new Error('Host changed. Waiting for the current host to confirm the setting.')
+      }
+      window.dispatchEvent(new CustomEvent('polaris:live-tuning-saved', {
+        detail: { previousRevision: revision, revision: result.live_tuning.configuration_revision },
+      }))
+      return true
+    } catch (failure) {
+      error.value = failure instanceof TypeError
+        ? 'Connection lost. Waiting for the host to confirm the current setting.' : failure.message
+      return false
+    } finally { saving.value = false }
+  }
+  return { state, saving, error, confirmed, setEnabled,
+    label: computed(() => liveTuningLabel(state.value, confirmed.value)) }
+}

--- a/src_assets/common/assets/web/composables/useStreamStats.js
+++ b/src_assets/common/assets/web/composables/useStreamStats.js
@@ -1,196 +1,108 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 
-/**
- * Composable for real-time stream statistics using Server-Sent Events (SSE).
- *
- * Connects to the SSE endpoint for push-based updates.
- * Falls back to HTTP polling if SSE fails to connect after the first attempt.
- * The fallback loop waits for each request to settle and backs off after failures.
- *
- * @param {number} pollFallbackMs - Polling interval in ms if SSE is unavailable (default: 1000)
- * @param {{ pauseWhenHidden?: boolean, maxFallbackBackoffMs?: number }} options
- * @returns {{ stats: Ref, connected: Ref<boolean> }}
- */
-export function useStreamStats(pollFallbackMs = 1000, options = {}) {
+// One transport per open host UI, shared by dashboard, Doctor and tuning controls.
+let shared = null
+function createChannel(pollMs, options) {
   const stats = ref(null)
   const connected = ref(false)
-
-  const maxFallbackBackoffMs = Math.max(
-    pollFallbackMs,
-    options.maxFallbackBackoffMs ?? pollFallbackMs * 8,
-  )
-
-  let eventSource = null
-  let pollTimer = null
-  let fallbackInFlight = null
-  let useFallback = false
-  let consecutiveFallbackFailures = 0
-
-  function shouldPauseForVisibility() {
-    return options.pauseWhenHidden !== false && typeof document !== 'undefined' && document.hidden
-  }
-
-  function fallbackDelayMs() {
-    if (consecutiveFallbackFailures <= 0) {
-      return pollFallbackMs
-    }
-    return Math.min(maxFallbackBackoffMs, pollFallbackMs * (2 ** consecutiveFallbackFailures))
-  }
-
-  /**
-   * Start SSE connection to the stream-sse endpoint.
-   */
-  function connectSSE() {
-    if (eventSource || shouldPauseForVisibility()) return
-
-    // EventSource sends cookies automatically for the already-loaded Polaris UI origin.
-    eventSource = new EventSource('./api/stats/stream-sse')
-
-    eventSource.onopen = () => {
-      connected.value = true
-    }
-
-    eventSource.onmessage = (event) => {
-      try {
-        stats.value = JSON.parse(event.data)
-        connected.value = true
-      } catch {
-        // Ignore malformed messages.
-      }
-    }
-
-    let sseErrorCount = 0
-    eventSource.onerror = () => {
-      connected.value = false
-      sseErrorCount++
-
-      // If there are too many errors, give up on SSE and fall back to polling.
-      // This prevents hammering the server when auth has expired or it is under load.
-      if (sseErrorCount > 5 || (!stats.value && !useFallback)) {
-        useFallback = true
-        cleanupSSE()
-        if (!shouldPauseForVisibility()) {
-          startPolling()
-        }
-      }
-    }
-  }
-
-  /**
-   * Clean up the SSE connection.
-   */
-  function cleanupSSE() {
-    if (eventSource) {
-      eventSource.close()
-      eventSource = null
-    }
-  }
-
-  function cleanupPolling() {
-    if (pollTimer) {
-      clearTimeout(pollTimer)
-      pollTimer = null
-    }
-  }
-
-  function scheduleNextPoll(delayMs = fallbackDelayMs()) {
-    cleanupPolling()
-    if (!useFallback || shouldPauseForVisibility()) {
-      return
-    }
-
-    pollTimer = setTimeout(async () => {
-      pollTimer = null
-      const keepPolling = await fetchStats()
-      if (keepPolling) {
-        scheduleNextPoll()
-      }
-    }, delayMs)
-  }
-
-  /**
-   * Fallback: poll the JSON endpoint after each prior request settles.
-   */
-  async function fetchStats() {
-    if (shouldPauseForVisibility()) return false
-    if (fallbackInFlight) return fallbackInFlight
-
-    fallbackInFlight = (async () => {
-      let ok = false
-      let keepPolling = true
-
-      try {
-        const res = await fetch('./api/stats/stream', { credentials: 'include' })
-        if (res.ok) {
-          stats.value = await res.json()
-          connected.value = true
-          ok = true
-        } else if (res.status === 401) {
-          // Session expired so stop polling and redirect to login.
-          cleanupPolling()
-          cleanupSSE()
-          window.location.hash = '#/login'
-          keepPolling = false
-        } else {
-          connected.value = false
-        }
-      } catch {
-        connected.value = false
-      } finally {
-        if (keepPolling) {
-          consecutiveFallbackFailures = ok ? 0 : consecutiveFallbackFailures + 1
-        }
-        fallbackInFlight = null
-      }
-
-      return keepPolling
-    })()
-
-    return fallbackInFlight
-  }
-
-  function startPolling() {
-    if (pollTimer || shouldPauseForVisibility()) return
-    fetchStats().then((keepPolling) => {
-      if (keepPolling) {
-        scheduleNextPoll()
-      }
-    })
-  }
-
-  function start() {
-    if (shouldPauseForVisibility()) return
-    if (useFallback) startPolling()
-    else connectSSE()
-  }
+  let users = 0
+  let source = null
+  let timer = null
+  let watchdog = null
+  let controller = null
+  let epoch = 0
+  let failures = 0
+  let fallback = false
+  const paused = () => options.pauseWhenHidden !== false && document.hidden
+  const active = () => users > 0 && !paused()
+  const maxDelay = Math.max(pollMs, options.maxFallbackBackoffMs ?? pollMs * 8)
 
   function stop() {
-    cleanupSSE()
-    cleanupPolling()
+    ++epoch
+    source?.close()
+    source = null
+    controller?.abort()
+    controller = null
+    clearTimeout(timer)
+    clearTimeout(watchdog)
+    timer = watchdog = null
     connected.value = false
   }
-
-  function handleVisibilityChange() {
-    if (shouldPauseForVisibility()) {
+  function receive(value) {
+    stats.value = value
+    connected.value = true
+    failures = 0
+    clearTimeout(watchdog)
+    watchdog = setTimeout(() => {
       stop()
-    } else {
+      fallback = true
       start()
+    }, Math.max(5000, pollMs * 3))
+  }
+  async function poll() {
+    if (!active() || controller) return
+    const current = epoch
+    const abort = new AbortController()
+    controller = abort
+    try {
+      const response = await fetch('./api/stats/stream', { credentials: 'include', signal: abort.signal })
+      if (current !== epoch || !active()) return
+      if (response.status === 401) {
+        stop()
+        window.location.hash = '#/login'
+        return
+      }
+      if (!response.ok) throw new Error('stats-unavailable')
+      const value = await response.json()
+      if (current === epoch && active()) receive(value)
+    } catch {
+      if (current === epoch) { connected.value = false; failures++ }
+    } finally {
+      if (controller === abort) controller = null
+      if (current === epoch && active()) {
+        timer = setTimeout(poll, Math.min(maxDelay, pollMs * (2 ** failures)))
+      }
     }
   }
-
-  onMounted(() => {
-    start()
-    if (options.pauseWhenHidden !== false && typeof document !== 'undefined') {
-      document.addEventListener('visibilitychange', handleVisibilityChange)
+  function start() {
+    if (!active() || source || controller) return
+    if (fallback || typeof EventSource !== 'function') { poll(); return }
+    const current = epoch
+    const connection = new EventSource('./api/stats/stream-sse')
+    source = connection
+    connection.onmessage = event => {
+      if (current !== epoch || !active()) return
+      try { receive(JSON.parse(event.data)) } catch { connected.value = false }
     }
-  })
-
-  onUnmounted(() => {
-    stop()
-    if (options.pauseWhenHidden !== false && typeof document !== 'undefined') {
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    connection.onerror = () => {
+      if (current !== epoch) return
+      stop()
+      fallback = true
+      start()
     }
-  })
-
-  return { stats, connected }
+    watchdog = setTimeout(() => { stop(); fallback = true; start() }, 5000)
+  }
+  function visibility() { stop(); fallback = false; start() }
+  return {
+    stats, connected,
+    retain() {
+      if (++users === 1) {
+        document.addEventListener('visibilitychange', visibility)
+        start()
+      }
+    },
+    release() {
+      if (--users === 0) {
+        stop()
+        document.removeEventListener('visibilitychange', visibility)
+        shared = null
+      }
+    },
+  }
+}
+export function useStreamStats(pollFallbackMs = 1000, options = {}) {
+  const channel = shared || (shared = createChannel(pollFallbackMs, options))
+  onMounted(channel.retain)
+  onUnmounted(channel.release)
+  return { stats: channel.stats, connected: channel.connected }
 }

--- a/src_assets/common/assets/web/config-pending-changes.test.js
+++ b/src_assets/common/assets/web/config-pending-changes.test.js
@@ -186,7 +186,7 @@ describe('ConfigView pending changes review', () => {
     wrapper.vm.config.sunshine_name = 'Fixed Host'
     await nextTick()
 
-    global.fetch.mockResolvedValueOnce({ status: 200 })
+    global.fetch.mockResolvedValueOnce({ status: 200, json: async () => ({ status: true, configuration_revision: 'a'.repeat(64) }) })
     const result = await wrapper.vm.save()
 
     expect(result).toBe(true)
@@ -275,7 +275,7 @@ describe('ConfigView pending changes review', () => {
     wrapper.vm.config.steamgriddb_api_key = ''
     await nextTick()
 
-    global.fetch.mockResolvedValueOnce({ status: 200 })
+    global.fetch.mockResolvedValueOnce({ status: 200, json: async () => ({ status: true, configuration_revision: 'a'.repeat(64) }) })
 
     const result = await wrapper.vm.save()
 

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -18,12 +18,8 @@ import {
 } from '../../client-settings-sync'
 import { buildResolutionPlanner } from '../../display-resolution-planner'
 import { provenanceLabel, useConfigProjection } from '../../composables/useConfigProjection'
-import { useStreamStats } from '../../composables/useStreamStats'
-import {
-  autoQualityHostStateKey,
-  autoQualityHostTone,
-  buildLiveAutoQualityRows,
-} from '../../auto-quality-live'
+import LiveTuningControl from '../../components/LiveTuningControl.vue'
+import { useLiveTuning } from '../../composables/useLiveTuning'
 
 const $t = inject('i18n').t;
 
@@ -53,15 +49,11 @@ const projection = useConfigProjection()
 onMounted(() => {
   projection.load()
 })
-const liveStreamStats = typeof window !== 'undefined' && typeof window.EventSource === 'function'
-  ? useStreamStats(2000, { pauseWhenHidden: true }).stats
-  : ref(null)
+const tuningControl = useLiveTuning()
 const projectionModes = computed(() => (
   projection.ok.value && Array.isArray(projection.modes.value) ? projection.modes.value : null
 ))
 const hostStreamDisplay = computed(() => (projection.ok.value ? projection.streamDisplay.value : null))
-const liveTuning = computed(() => liveStreamStats.value?.tuning || projection.tuning.value || null)
-const liveAutoQuality = computed(() => liveStreamStats.value?.auto_quality || projection.autoQuality.value || null)
 const provenanceFor = (configKey) => provenanceLabel(projection, configKey)
 const isLinux = computed(() => props.platform === 'linux')
 const isWindows = computed(() => props.platform === 'windows')
@@ -282,86 +274,10 @@ const clientSettingsRows = computed(() => [
   ...(lastConfigWriteRow.value ? [lastConfigWriteRow.value] : []),
 ])
 
-const autoQualityEnabled = computed(() => (
-  config.value.ai_enabled === 'enabled' && config.value.adaptive_bitrate_enabled === 'enabled'
-))
-// The split state is reachable when the config file was edited by hand or an
-// older host upgraded: exactly one of the pair is on.
-const autoQualityPartial = computed(() => (
-  (config.value.ai_enabled === 'enabled') !== (config.value.adaptive_bitrate_enabled === 'enabled')
-))
-// Live strip: present when the host serves the projection and a policy snapshot.
-const autoQualityLive = computed(() => Boolean(projection.ok.value && liveAutoQuality.value))
-const autoQualityLiveStateKey = computed(() => autoQualityHostStateKey(liveAutoQuality.value))
-const autoQualityLiveRows = computed(() => buildLiveAutoQualityRows(
-  { autoQuality: liveAutoQuality.value, tuning: liveTuning.value },
-  $t,
-))
-const autoQualityBadge = computed(() => {
-  if (autoQualityLive.value) {
-    return $t('config.av_auto_quality_badge_live', {
-      state: $t(`config.av_auto_quality_live_state_${autoQualityLiveStateKey.value}`),
-    })
-  }
-  if (autoQualityEnabled.value) return $t('config.av_auto_quality_badge_on')
-  if (autoQualityPartial.value) return $t('config.av_auto_quality_badge_partial')
-  return $t('config.av_auto_quality_badge_manual')
-})
-const autoQualityTone = computed(() => {
-  if (autoQualityLive.value) {
-    const tone = autoQualityHostTone(autoQualityLiveStateKey.value)
-    if (tone === 'pass') return 'border-success/30 bg-success/10 text-success'
-    if (tone === 'warning') return 'border-warning/30 bg-warning/10 text-warning-bright'
-    return 'border-storm/40 bg-storm/10 text-storm'
-  }
-  if (autoQualityEnabled.value) return 'border-success/30 bg-success/10 text-success'
-  if (autoQualityPartial.value) return 'border-warning/30 bg-warning/10 text-warning-bright'
-  return 'border-storm/40 bg-storm/10 text-storm'
-})
-const autoQualityCopy = computed(() => {
-  if (autoQualityEnabled.value) {
-    return $t('config.av_auto_quality_copy_on')
-  }
-  if (autoQualityPartial.value) {
-    return $t('config.av_auto_quality_copy_partial')
-  }
-  return $t('config.av_auto_quality_copy_manual')
-})
-const autoQualityRows = computed(() => [
-  {
-    label: $t('config.av_auto_quality_row_profile'),
-    value: config.value.ai_enabled === 'enabled'
-      ? $t('config.av_auto_quality_profile_auto')
-      : $t('config.av_auto_quality_profile_manual'),
-    note: config.value.ai_enabled === 'enabled'
-      ? $t('config.av_auto_quality_profile_note_auto')
-      : $t('config.av_auto_quality_profile_note_manual'),
-  },
-  {
-    label: $t('config.av_auto_quality_row_bitrate'),
-    value: config.value.adaptive_bitrate_enabled === 'enabled'
-      ? $t('config.av_auto_quality_bitrate_adaptive')
-      : $t('config.av_auto_quality_bitrate_fixed'),
-    note: config.value.adaptive_bitrate_enabled === 'enabled'
-      ? $t('config.av_auto_quality_bitrate_range_note', {
-          min: Number(config.value.adaptive_bitrate_min || 0) / 1000,
-          max: Number(config.value.adaptive_bitrate_max || 0) / 1000,
-        })
-      : $t('config.av_auto_quality_bitrate_cap_note', { cap: Number(config.value.max_bitrate || 0) / 1000 }),
-  },
-  {
-    label: $t('config.av_auto_quality_row_runtime'),
-    value: selectedStreamDisplayMode.value.title,
-    note: selectedStreamDisplayMode.value.badge,
-  },
-  {
-    label: $t('config.av_auto_quality_row_nova'),
-    value: clientSettingsSyncBadge.value,
-    note: clientSettingsSync.value.relaunchRequired
-      ? $t('config.av_auto_quality_nova_note_relaunch')
-      : $t('config.av_auto_quality_nova_note_ready'),
-  },
-])
+const autoQualityEnabled = computed(() => tuningControl.state.value?.enabled === true)
+const autoQualityBadge = tuningControl.label
+const autoQualityTone = computed(() => autoQualityEnabled.value ? 'text-success' : 'text-storm')
+
 const isLabwcPath = computed(() => (
   streamDisplayMode.value === 'headless_stream' || streamDisplayMode.value === 'windowed_stream'
 ))
@@ -429,14 +345,8 @@ const linuxStreamingSetupChecklist = computed(() => {
   return items
 })
 
-function setEnabledConfig(key, enabled) {
-  config.value[key] = enabled ? 'enabled' : 'disabled'
-}
 
-function setAutoQuality(enabled) {
-  setEnabledConfig('adaptive_bitrate_enabled', enabled)
-  setEnabledConfig('ai_enabled', enabled)
-}
+
 
 const dongleOutputs = ref([])
 const dongleDetectStatus = ref('')
@@ -938,54 +848,11 @@ function updateDisplayPlannerSource(event) {
 
     <section class="settings-section">
       <div class="settings-section-header">
-        <div class="section-kicker">Auto Quality</div>
-        <h3 class="settings-section-title">Performance and quality balance</h3>
-        <div class="settings-summary-copy">One primary mode for bitrate, launch profile, and recovery behavior. Advanced controls stay available below.</div>
+        <div class="section-kicker">Live Tuning</div>
+        <h3 class="settings-section-title">Automatic bitrate adjustment</h3>
+        <div class="settings-summary-copy">Applies immediately on supported streams. Launch presets remain separate.</div>
       </div>
-
-      <div class="settings-subtle-surface space-y-4">
-        <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div class="min-w-0">
-            <div class="flex flex-wrap items-center gap-2">
-              <div class="text-base font-semibold text-silver">
-                {{ autoQualityEnabled ? $t('config.av_auto_quality_heading_on') : autoQualityPartial ? $t('config.av_auto_quality_heading_partial') : $t('config.av_auto_quality_heading_manual') }}
-              </div>
-              <span class="meta-pill" :class="autoQualityTone">{{ autoQualityBadge }}</span>
-            </div>
-            <div class="mt-2 max-w-3xl text-sm leading-relaxed text-storm">{{ autoQualityCopy }}</div>
-          </div>
-          <button
-            type="button"
-            class="focus-ring dashboard-action-button"
-            :class="autoQualityEnabled ? 'dashboard-action-button-secondary' : 'dashboard-action-button-primary'"
-            @click="setAutoQuality(!autoQualityEnabled)"
-          >
-            {{ autoQualityEnabled ? $t('config.av_auto_quality_disable_action') : $t('config.av_auto_quality_enable_action') }}
-          </button>
-        </div>
-
-        <div class="flex flex-wrap items-center justify-between gap-2">
-          <div class="section-kicker" :data-auto-quality-strip-source="autoQualityLive ? 'host' : 'saved'">
-            {{ autoQualityLive ? $t('config.av_auto_quality_live_kicker') : $t('config.av_auto_quality_saved_kicker') }}
-          </div>
-          <p
-            v-if="provenanceFor('adaptive_bitrate_enabled')"
-            class="text-[11px] text-storm"
-            data-provenance="adaptive_bitrate_enabled"
-          >
-            {{ $t('config.av_provenance_set_by', { source: provenanceFor('adaptive_bitrate_enabled') }) }}
-          </p>
-        </div>
-        <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-4" data-auto-quality-strip>
-          <StatTile
-            v-for="row in (autoQualityLive ? autoQualityLiveRows : autoQualityRows)"
-            :key="row.label"
-            :label="row.label"
-            :value="row.value"
-            :note="row.note"
-          />
-        </div>
-      </div>
+      <LiveTuningControl />
     </section>
 
     <details class="settings-section settings-disclosure" open>

--- a/src_assets/common/assets/web/dashboard-doctor-layout.test.js
+++ b/src_assets/common/assets/web/dashboard-doctor-layout.test.js
@@ -19,7 +19,7 @@ describe('Dashboard Doctor layout', () => {
     expect(confidence).toBeGreaterThan(metadata)
     expect(optimizer).toBeGreaterThan(confidence)
     expect(dashboard).toContain('data-dashboard-doctor-meta')
-    expect(dashboard).toContain('role="list" aria-label="Doctor confidence and Auto Quality status"')
+    expect(dashboard).toContain('role="list" aria-label="Doctor confidence and Live Tuning status"')
     expect(dashboard.match(/role="listitem"/g)).toHaveLength(3)
     expect(dashboard).toContain('class="mt-3 flex flex-wrap items-center gap-2"')
   })

--- a/src_assets/common/assets/web/linux-streaming-setup.test.js
+++ b/src_assets/common/assets/web/linux-streaming-setup.test.js
@@ -93,7 +93,6 @@ describe('Linux Streaming Setup checklist', () => {
     for (const key of [
       'av_mode_headless_stream_copy',
       'av_checklist_path_title',
-      'av_auto_quality_badge_manual',
       'av_planned_family_mode_copy',
       'av_planner_moonlight_title',
     ]) {
@@ -111,7 +110,7 @@ describe('Linux Streaming Setup checklist', () => {
     expect(checklist.text()).toContain('Linux Streaming Setup')
     expect(checklist.text()).toContain('Pick a stream path')
     expect(checklist.text()).toContain('Encoder and quality')
-    expect(checklist.text()).toContain('Manual')
+    expect(checklist.text()).toContain('Live Tuning: Unknown')
     expect(checklist.text()).toContain('labwc GPU-native capture')
     expect(checklist.text()).toContain('Safe default')
   })
@@ -188,7 +187,7 @@ describe('Linux Streaming Setup checklist', () => {
 
     expect(text).toContain('Private Stream (GPU-native)')
     expect(text).toContain('GPU-native requested')
-    expect(text).toContain('Auto Quality: On')
+    expect(text).toContain('Live Tuning: Unknown')
     expect(text).toContain('DMA-BUF capture GPU-resident')
     expect(text).not.toContain('CUDA')
     expect(text).not.toContain('NVIDIA')

--- a/src_assets/common/assets/web/live-tuning.js
+++ b/src_assets/common/assets/web/live-tuning.js
@@ -1,0 +1,34 @@
+export function parseLiveTuning(value) {
+  if (!value || value.version !== 1 || typeof value.enabled !== 'boolean'
+      || value.scope !== 'host' || typeof value.supported !== 'boolean'
+      || !Number.isSafeInteger(value.sequence) || value.sequence < 1
+      || !Number.isSafeInteger(value.session_generation) || value.session_generation < 0
+      || ['quality_limit_kbps', 'requested_bitrate_kbps', 'applied_bitrate_kbps'].some(key =>
+        !Number.isInteger(value[key]) || value[key] < 0 || value[key] > 2147483647)
+      || typeof value.app_session_id !== 'string'
+      || typeof value.host_instance !== 'string' || !value.host_instance
+      || !/^[a-f0-9]{64}$/i.test(value.configuration_revision || '')
+      || !['off', 'waiting', 'unavailable', 'applying', 'measuring', 'adjusting', 'stable'].includes(value.state)) return null
+  return value
+}
+
+export function liveTuningLabel(value, confirmed = true) {
+  if (!value || !confirmed) return 'Live Tuning: Unknown'
+  if (!value.enabled) return 'Live Tuning Off'
+  const labels = { waiting: 'On — waiting for a stream', unavailable: 'On — unavailable for this stream',
+    applying: 'On — applying bitrate', measuring: 'On — measuring', adjusting: 'On — adjusting', stable: 'Live Tuning On — stable' }
+  return labels[value.state] || 'Live Tuning: Unknown'
+}
+
+export function createLiveTuningReducer() {
+  let current = null
+  const retired = new Set()
+  return (raw) => {
+    const next = parseLiveTuning(raw)
+    if (!next || retired.has(next.host_instance)) return null
+    if (current?.host_instance === next.host_instance && next.sequence <= current.sequence) return null
+    if (current && current.host_instance !== next.host_instance) retired.add(current.host_instance)
+    current = next
+    return next
+  }
+}

--- a/src_assets/common/assets/web/live-tuning.test.js
+++ b/src_assets/common/assets/web/live-tuning.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import fixtures from '../../../../tests/fixtures/live-tuning-v1.json'
+import { parseLiveTuning, createLiveTuningReducer, liveTuningLabel } from './live-tuning'
+
+describe('canonical Live Tuning', () => {
+  it.each(fixtures)('parses the shared $name fixture', row => {
+    expect(parseLiveTuning(row.live_tuning)).toEqual(row.live_tuning)
+    expect(liveTuningLabel(row.live_tuning)).not.toContain('Unknown')
+  })
+  it('keeps explanation readiness and stream health out of enablement', () => {
+    const off = { ...fixtures[0].live_tuning, ai_enabled: true, health: { grade: 'degraded' } }
+    expect(liveTuningLabel(off)).toBe('Live Tuning Off')
+    expect(liveTuningLabel(fixtures[6].live_tuning)).toContain('On')
+  })
+  it('rejects invalid state and distinguishes connection loss from Off', () => {
+    expect(parseLiveTuning({ ...fixtures[0].live_tuning, enabled: 'false' })).toBeNull()
+    expect(liveTuningLabel(fixtures[0].live_tuning, false)).toBe('Live Tuning: Unknown')
+  })
+  it('rejects old observations, including an old host after restart', () => {
+    const accept = createLiveTuningReducer()
+    const row = fixtures[0].live_tuning
+    expect(accept({ ...row, sequence: 4 })).not.toBeNull()
+    expect(accept({ ...row, sequence: 3 })).toBeNull()
+    expect(accept({ ...row, host_instance: 'restarted', sequence: 1 })).not.toBeNull()
+    expect(accept({ ...row, sequence: 99 })).toBeNull()
+  })
+})

--- a/src_assets/common/assets/web/settings-affordances.test.js
+++ b/src_assets/common/assets/web/settings-affordances.test.js
@@ -131,11 +131,7 @@ describe('settings affordances', () => {
     expect(source).not.toMatch(/rounded-md border border-storm\/20 bg-void\/25[^"]*font-mono/)
   })
 
-  it('treats the Auto Quality split state as a real state instead of dead code', () => {
-    const source = webSource('configs/tabs/AudioVideo.vue')
 
-    expect(source).toMatch(/autoQualityPartial[\s\S]{0,200}!==/)
-  })
 })
 
 // F7: the Video/Audio page binds host truth from the settings projection and
@@ -148,11 +144,8 @@ describe('settings projection binding', () => {
     expect(source).toContain('projection.load()')
     expect(source).toContain('projectionModes.value?.find(')
     expect(source).toContain('resolveStreamDisplayModeAvailability(mode.id, config.value.stream_display_mode_options)')
-    expect(source).toContain('data-auto-quality-strip')
     expect(source).toContain("data-provenance=\"max_bitrate\"")
     expect(source).toContain("data-provenance=\"fallback_mode\"")
-    expect(source).toContain("data-provenance=\"adaptive_bitrate_enabled\"")
-    expect(source).toMatch(/autoQualityLive \? autoQualityLiveRows : autoQualityRows/)
   })
 
   it('lets the host name the response-only keys the save path strips', () => {
@@ -170,8 +163,5 @@ describe('attribute interpolation', () => {
     expect(offenders, `mustache inside an attribute in ${relativePath}`).toEqual([])
   })
 
-  it('binds the Auto Quality strip source marker', () => {
-    const source = webSource('configs/tabs/AudioVideo.vue')
-    expect(source).toContain(`:data-auto-quality-strip-source="autoQualityLive ? 'host' : 'saved'"`)
-  })
+
 })

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -882,6 +882,7 @@ async function focusSectionTarget(sectionId) {
 }
 
 async function configSaveFailureMessage(response) {
+  if (response?.status === 412) return 'Settings changed on the host. Refresh Settings and review your changes before saving.'
   const fallbackMessage = 'Failed to save configuration'
   if (!response || typeof response.text !== 'function') return fallbackMessage
 
@@ -914,6 +915,7 @@ function serialize() {
     configCopy.trusted_subnets = configCopy.trusted_subnets.filter(s => s && s.trim()).join(',')
   }
 
+  delete configCopy.adaptive_bitrate_enabled
   stripConfigResponseOnly(configCopy)
 
   return configCopy
@@ -942,11 +944,14 @@ function save() {
 
   return fetch("./api/config", {
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...(config.value.configuration_revision
+      ? { 'If-Match': `"${config.value.configuration_revision}"` } : {}) },
     method: 'POST',
     body: JSON.stringify(configCopy),
   }).then(async (r) => {
     if (r.status === 200) {
+      const result = await r.json()
+      config.value.configuration_revision = result.configuration_revision
       saved.value = true
       initialSerialized.value = JSON.stringify(serialize())
       toast(
@@ -1167,7 +1172,15 @@ function handleHash() {
     }
   }
 
+function acceptOwnLiveTuningSave(event) {
+  if (config.value?.configuration_revision === event.detail?.previousRevision) {
+    config.value.configuration_revision = event.detail.revision
+    responseOnlyConfig.value.configuration_revision = event.detail.revision
+  }
+}
+
 onMounted(() => {
+  window.addEventListener('polaris:live-tuning-saved', acceptOwnLiveTuningSave)
   handleHash()
   window.addEventListener("hashchange", handleHash)
 })
@@ -1188,6 +1201,7 @@ watch(currentTab, async (value) => {
 })
 
 onUnmounted(() => {
+  window.removeEventListener('polaris:live-tuning-saved', acceptOwnLiveTuningSave)
   clearSearchHighlight()
   window.removeEventListener("hashchange", handleHash)
 })

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -100,7 +100,7 @@
                 <span class="mt-1.5 inline-block h-2.5 w-2.5 shrink-0 rounded-full" :class="doctorLightClass" aria-hidden="true"></span>
                 <h3 class="text-xl font-semibold leading-tight text-silver">{{ doctorHeadline }}</h3>
               </div>
-              <div class="mt-3 flex flex-wrap items-center gap-2" data-dashboard-doctor-meta role="list" aria-label="Doctor confidence and Auto Quality status">
+              <div class="mt-3 flex flex-wrap items-center gap-2" data-dashboard-doctor-meta role="list" aria-label="Doctor confidence and Live Tuning status">
                 <div v-if="doctorConfidenceLabel" class="control-chip" role="listitem">{{ doctorConfidenceLabel }}</div>
                 <div class="meta-pill" :class="autoQuality.toneClass" role="listitem">{{ autoQuality.compactLabel }}</div>
                 <div class="inline-flex" role="listitem">
@@ -313,7 +313,7 @@
               <span v-if="lastSessionChip" class="data-pill">{{ lastSessionChip }}</span>
               <span class="data-pill" :class="headlessEnabled ? 'text-accent' : ''">{{ headlessEnabled ? $t('dashboard.headless') : $t('dashboard.windowed') }}</span>
               <span class="data-pill" v-if="gpu">{{ gpu.temperature_c || '--' }}°C · {{ gpu.utilization_pct || 0 }}% · {{ gpu.power_draw_w?.toFixed(0) || '--' }}W</span>
-              <span class="data-pill" :class="aiStatus?.enabled ? 'text-accent' : ''">{{ aiStatus?.enabled ? 'Auto Quality: On' : 'Auto Quality: Manual' }} · {{ sessionHistory.length }} {{ $t('dashboard.sessions') }}</span>
+              <span class="data-pill" :class="aiStatus?.enabled ? 'text-accent' : ''">{{ liveTuningLabel }} · {{ sessionHistory.length }} {{ $t('dashboard.sessions') }}</span>
             </div>
           </div>
           <div class="flex shrink-0 flex-col items-end gap-3">
@@ -550,6 +550,7 @@
 
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { useLiveTuning } from '../composables/useLiveTuning'
 import { useStreamStats } from '../composables/useStreamStats'
 import { useSystemStats } from '../composables/useSystemStats'
 import { useSessionHistory, formatDuration } from '../composables/useSessionHistory'
@@ -573,6 +574,7 @@ import {
 } from '../dashboard-summary'
 
 const { stats } = useStreamStats(1000)
+const { label: liveTuningLabel } = useLiveTuning()
 const { gpu, displays, audio, sessionType } = useSystemStats(3000)
 const { sessions, clearHistory, activeStartedAt } = useSessionHistory(stats)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -239,6 +239,7 @@ set(TEST_PAIRING_SOURCES
 )
 
 set(TEST_HTTP_SOURCES
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_live_tuning_http.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_httpcommon.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_mode_contract.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_launch_response_status.cpp
@@ -257,6 +258,7 @@ set(TEST_AUDIO_SOURCES
 )
 
 set(TEST_STREAM_SOURCES
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_live_tuning.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_adaptive_bitrate.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_ai_optimizer.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_ai_claude_cli.cpp

--- a/tests/e2e/live-tuning.spec.js
+++ b/tests/e2e/live-tuning.spec.js
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+
+const cases = JSON.parse(readFileSync(new URL('../fixtures/live-tuning-v1.json', import.meta.url), 'utf8'))
+for (const width of [390, 1280]) {
+  test(`Live Tuning saves confirmed state and remains readable at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 960 })
+    let live = { ...cases[0].live_tuning, host_instance: 'e2e-host' }
+    await page.addInitScript((initial) => {
+      window.__liveSources = []
+      window.EventSource = class {
+        constructor() {
+          window.__liveSources.push(this)
+          setTimeout(() => { this.onopen?.({}); this.onmessage?.({ data: JSON.stringify({ streaming: false, live_tuning: initial }) }) }, 25)
+        }
+        close() { window.__liveSources = window.__liveSources.filter(source => source !== this) }
+      }
+    }, live)
+    await page.route('**/api/**', async route => {
+      const path = new URL(route.request().url()).pathname
+      if (path === '/api/configLocale') return route.fulfill({ json: { locale: 'en' } })
+      if (path === '/api/config') return route.fulfill({ json: { status: true, platform: 'linux', configuration_revision: live.configuration_revision, live_tuning: live } })
+      if (path === '/api/live-tuning' && route.request().method() === 'POST') {
+        expect(route.request().postDataJSON()).toEqual({ enabled: true })
+        expect(route.request().headers()['if-match']).toBe(`"${live.configuration_revision}"`)
+        live = { ...live, enabled: true, state: 'waiting', supported: false, applied_bitrate_kbps: 0, quality_limit_kbps: 0, sequence: 2 }
+        return route.fulfill({ json: { status: true, live_tuning: live } })
+      }
+      if (path === '/api/stats') return route.fulfill({ json: { streaming: false, live_tuning: live } })
+      if (path === '/api/apps') return route.fulfill({ json: { status: true, apps: [] } })
+      if (path === '/api/clients/list') return route.fulfill({ json: { status: true, named_certs: [] } })
+      return route.fulfill({ json: { status: true } })
+    })
+    await page.goto('/#/')
+    const control = page.getByRole('switch', { name: 'Live Tuning', exact: true }).first()
+    await expect(control).toBeEnabled()
+    await expect(control).toHaveAttribute('aria-checked', 'false')
+    await control.click()
+    await expect(control).toHaveAttribute('aria-checked', 'true')
+    const panel = control.locator('..')
+    await expect(panel).toContainText('waiting for a stream')
+    const box = await panel.boundingBox()
+    expect(box.x).toBeGreaterThanOrEqual(0)
+    expect(box.x + box.width).toBeLessThanOrEqual(width)
+    expect(await panel.evaluate(node => node.scrollWidth <= node.clientWidth + 1)).toBe(true)
+    await panel.screenshot({ path: `test-results/live-tuning-${width}.png` })
+  })
+}

--- a/tests/fixtures/live-tuning-v1.json
+++ b/tests/fixtures/live-tuning-v1.json
@@ -1,0 +1,156 @@
+[
+  {
+    "name": "off",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": false,
+      "scope": "host",
+      "state": "off",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": false,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 0,
+      "applied_bitrate_kbps": 20000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 1
+    }
+  },
+  {
+    "name": "waiting",
+    "streaming": false,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "waiting",
+      "supported": false,
+      "reason": "no_stream",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 0,
+      "requested_bitrate_kbps": 0,
+      "applied_bitrate_kbps": 0,
+      "session_generation": 0,
+      "app_session_id": "",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 2
+    }
+  },
+  {
+    "name": "unavailable",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "unavailable",
+      "supported": false,
+      "reason": "encoder_runtime_update_unsupported",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 0,
+      "applied_bitrate_kbps": 0,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 3
+    }
+  },
+  {
+    "name": "applying",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "applying",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": true,
+      "pending": true,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 14000,
+      "applied_bitrate_kbps": 20000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 4
+    }
+  },
+  {
+    "name": "measuring",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "measuring",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 20000,
+      "applied_bitrate_kbps": 20000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 5
+    }
+  },
+  {
+    "name": "adjusting",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "adjusting",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 14000,
+      "applied_bitrate_kbps": 14000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 6
+    }
+  },
+  {
+    "name": "stable",
+    "streaming": true,
+    "live_tuning": {
+      "version": 1,
+      "enabled": true,
+      "scope": "host",
+      "state": "stable",
+      "supported": true,
+      "reason": "supported",
+      "runtime_enabled": true,
+      "pending": false,
+      "quality_limit_kbps": 20000,
+      "requested_bitrate_kbps": 20000,
+      "applied_bitrate_kbps": 20000,
+      "session_generation": 41,
+      "app_session_id": "fixture-session",
+      "configuration_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "host_instance": "fixture-host",
+      "sequence": 7
+    }
+  }
+]

--- a/tests/unit/test_adaptive_bitrate.cpp
+++ b/tests/unit/test_adaptive_bitrate.cpp
@@ -10,6 +10,7 @@
 
 #include <chrono>
 #include <thread>
+#include <future>
 
 using namespace std::chrono_literals;
 
@@ -748,4 +749,73 @@ TEST(AdaptiveBitrateController, NewerExplicitIncreaseReplacesDoctorTargetExactly
   EXPECT_TRUE(adaptive_bitrate::is_active());
   EXPECT_EQ(adaptive_bitrate::get_target_bitrate_kbps(), 30000);
   EXPECT_GT(after.revision, *doctor_revision);
+}
+
+TEST(AdaptiveBitrateController, DisableRejectsFetchedButUnappliedRequest) {
+  enable_controller();
+  adaptive_bitrate::set_runtime_update_supported(true, {}, 20000);
+  adaptive_bitrate::set_live_bitrate(14000);
+  const auto request = adaptive_bitrate::get_live_bitrate_request();
+  ASSERT_TRUE(request);
+  adaptive_bitrate::set_enabled(false);
+  bool called = false;
+  EXPECT_FALSE(adaptive_bitrate::apply_live_bitrate_request(*request, [&] { called = true; return true; }));
+  EXPECT_FALSE(called);
+  EXPECT_EQ(adaptive_bitrate::get_state().applied_bitrate_kbps, 20000);
+  EXPECT_FALSE(adaptive_bitrate::get_live_bitrate_request());
+}
+
+TEST(AdaptiveBitrateController, DisableHoldsCompletedEncoderApplication) {
+  enable_controller();
+  adaptive_bitrate::set_runtime_update_supported(true, {}, 20000);
+  adaptive_bitrate::set_live_bitrate(14000);
+  const auto request = adaptive_bitrate::get_live_bitrate_request();
+  ASSERT_TRUE(request);
+  ASSERT_TRUE(adaptive_bitrate::apply_live_bitrate_request(*request, [] { return true; }));
+  adaptive_bitrate::set_enabled(false);
+  EXPECT_EQ(adaptive_bitrate::get_state().applied_bitrate_kbps, 14000);
+  EXPECT_FALSE(adaptive_bitrate::get_live_bitrate_request());
+}
+
+TEST(AdaptiveBitrateController, DisableDuringRecreationReconcilesToLastProvenRate) {
+  enable_controller();
+  adaptive_bitrate::set_runtime_update_supported(true, {}, 20000);
+  adaptive_bitrate::set_live_bitrate(14000);
+  const auto request = adaptive_bitrate::get_live_bitrate_request();
+  ASSERT_TRUE(request);
+  ASSERT_TRUE(adaptive_bitrate::begin_live_bitrate_session_recreation(request->revision, 14000));
+  adaptive_bitrate::set_enabled(false);
+  EXPECT_EQ(adaptive_bitrate::get_state().applied_bitrate_kbps, 0);
+  ASSERT_TRUE(adaptive_bitrate::get_live_bitrate_request());
+  EXPECT_EQ(adaptive_bitrate::get_live_bitrate_request()->target_bitrate_kbps, 20000);
+  // If creation already began with the old target, its actual rate remains
+  // visible until the held target is reconciled, even with tuning disabled.
+  adaptive_bitrate::set_runtime_update_supported(true, {}, 14000);
+  const auto reconcile = adaptive_bitrate::get_live_bitrate_request();
+  ASSERT_TRUE(reconcile);
+  ASSERT_TRUE(adaptive_bitrate::apply_live_bitrate_request(*reconcile, [] { return true; }));
+  EXPECT_EQ(adaptive_bitrate::get_state().applied_bitrate_kbps, 20000);
+  EXPECT_FALSE(adaptive_bitrate::get_live_bitrate_request());
+}
+
+TEST(AdaptiveBitrateController, DisableSerializesWithInFlightEncoderApplication) {
+  enable_controller();
+  adaptive_bitrate::set_runtime_update_supported(true, {}, 20000);
+  adaptive_bitrate::set_live_bitrate(14000);
+  const auto request = *adaptive_bitrate::get_live_bitrate_request();
+  std::promise<void> entered, finish;
+  auto resume = finish.get_future();
+  auto update = std::async(std::launch::async, [&] {
+    return adaptive_bitrate::apply_live_bitrate_request(request, [&] {
+      entered.set_value(); resume.wait(); return true;
+    });
+  });
+  entered.get_future().wait();
+  auto disable = std::async(std::launch::async, [] { adaptive_bitrate::set_enabled(false); });
+  EXPECT_EQ(disable.wait_for(20ms), std::future_status::timeout);
+  finish.set_value();
+  EXPECT_TRUE(update.get());
+  disable.get();
+  EXPECT_EQ(adaptive_bitrate::get_state().applied_bitrate_kbps, 14000);
+  EXPECT_FALSE(adaptive_bitrate::get_live_bitrate_request());
 }

--- a/tests/unit/test_config_parser.cpp
+++ b/tests/unit/test_config_parser.cpp
@@ -6,6 +6,7 @@
 
 #include <src/config.h>
 #include <src/nvenc/nvenc_config.h>
+#include <src/private_state_file.h>
 #include <src/utility.h>
 
 TEST(ConfigParserTests, ProtocolDecimalsUseDotAndRequireTheWholeValue) {
@@ -169,27 +170,53 @@ TEST(ConfigParserTests, ConcurrentVaapiSnapshotsNeverMixSavedSettings) {
 #ifdef __linux__
 TEST(ConfigParserTests, FailedConfigWriteDoesNotPublishVaapiSettings) {
   const auto saved = config::vaapi::snapshot();
-  auto restore = util::fail_guard([&] { config::vaapi::publish(saved); });
+  const auto directory = std::filesystem::temp_directory_path() / ("polaris-vaapi-write-failure-" + std::to_string(
+    std::chrono::steady_clock::now().time_since_epoch().count()));
+  auto restore = util::fail_guard([&] {
+    private_state_file::set_write_fault_for_tests(private_state_file::write_fault_e::none);
+    config::vaapi::publish(saved);
+    std::error_code error;
+    std::filesystem::remove_all(directory, error);
+  });
+  ASSERT_TRUE(std::filesystem::create_directory(directory));
+  std::filesystem::permissions(directory, std::filesystem::perms::owner_all);
+  const auto path = (directory / "polaris.conf").string();
   config::vaapi::publish({});
-  // /dev/full opens successfully; buffered output fails only when flushed.
-  ASSERT_NE(config::write_config_with_vaapi_settings("/dev/full",
-    "vaapi_quality = quality\nvaapi_rc = vbr\nvaapi_blbrc = enabled\n"), 0);
-  const auto after = config::vaapi::snapshot();
-  EXPECT_EQ(after.quality, config::vaapi::quality_e::automatic);
-  EXPECT_EQ(after.rc, config::vaapi::rc_e::automatic);
-  EXPECT_FALSE(after.blbrc.has_value());
+  ASSERT_EQ(config::write_config_with_vaapi_settings(path, ""), 0);
+  // The protected writer rejects device nodes before writing. Exercise failures
+  // after admission instead, and verify both the saved file and published state.
+  for (const auto fault : {private_state_file::write_fault_e::short_write,
+         private_state_file::write_fault_e::flush, private_state_file::write_fault_e::sync,
+         private_state_file::write_fault_e::rename}) {
+    SCOPED_TRACE(static_cast<int>(fault));
+    private_state_file::set_write_fault_for_tests(fault);
+    ASSERT_NE(config::write_config_with_vaapi_settings(path,
+      "vaapi_quality = quality\nvaapi_rc = vbr\nvaapi_blbrc = enabled\nvaapi_strict_rc_buffer = enabled\n"), 0);
+    const auto after = config::vaapi::snapshot();
+    EXPECT_EQ(after.quality, config::vaapi::quality_e::automatic);
+    EXPECT_EQ(after.rc, config::vaapi::rc_e::automatic);
+    EXPECT_FALSE(after.blbrc.has_value());
+    EXPECT_FALSE(after.strict_rc_buffer);
+    const auto persisted = private_state_file::read_secure(path, 4096);
+    ASSERT_TRUE(persisted);
+    EXPECT_TRUE(persisted.payload.empty());
+  }
 }
 #endif
 
 TEST(ConfigParserTests, SuccessfulConfigWritePublishesCompleteVaapiSettingsAndClearRestoresDefaults) {
   const auto saved = config::vaapi::snapshot();
-  const auto path = std::filesystem::temp_directory_path() / ("polaris-vaapi-config-" + std::to_string(
+  const auto directory = std::filesystem::temp_directory_path() / ("polaris-vaapi-config-" + std::to_string(
     std::chrono::steady_clock::now().time_since_epoch().count()));
   auto restore = util::fail_guard([&] {
     config::vaapi::publish(saved);
     std::error_code error;
-    std::filesystem::remove(path, error);
+    std::filesystem::remove_all(directory, error);
   });
+  // The atomic writer requires an owned parent that others cannot modify.
+  ASSERT_TRUE(std::filesystem::create_directory(directory));
+  std::filesystem::permissions(directory, std::filesystem::perms::owner_all);
+  const auto path = directory / "polaris.conf";
   ASSERT_EQ(config::write_config_with_vaapi_settings(path.string(),
     "vaapi_quality = balanced\nvaapi_rc = qvbr\nvaapi_blbrc = enabled\nvaapi_strict_rc_buffer = enabled\n"), 0);
   const auto after = config::vaapi::snapshot();

--- a/tests/unit/test_doctor_reset_contract.cpp
+++ b/tests/unit/test_doctor_reset_contract.cpp
@@ -929,23 +929,11 @@ TEST(DoctorResetContract, ClientSettingsPersistencePreservesExistingConfigAtomic
 
   EXPECT_EQ(persistence.find("file_handler::read_file"), std::string::npos);
   EXPECT_EQ(persistence.find("file_handler::write_file"), std::string::npos);
-  EXPECT_NE(persistence.find("fs::symlink_status"), std::string::npos);
-  EXPECT_NE(persistence.find("std::ifstream input"), std::string::npos);
-  EXPECT_NE(persistence.find("input.bad()"), std::string::npos);
-  EXPECT_NE(persistence.find("input.close()"), std::string::npos);
-  EXPECT_NE(persistence.find("input.fail()"), std::string::npos);
-  EXPECT_NE(persistence.find("const bool unchanged = std::all_of"), std::string::npos);
-  EXPECT_NE(persistence.find("if (unchanged)"), std::string::npos);
-  EXPECT_NE(persistence.find("config_file_update::apply"), std::string::npos);
-  EXPECT_NE(persistence.find("private_state_file::write_atomic"), std::string::npos);
-  EXPECT_NE(
-    persistence.find("private_state_file::write_status_e::not_committed"),
-    std::string::npos
-  );
-  EXPECT_NE(
-    persistence.find("private_state_file::write_status_e::durability_uncertain"),
-    std::string::npos
-  );
+  EXPECT_NE(persistence.find("configuration_store::patch"), std::string::npos);
+  const auto store = source("src/configuration_store.cpp");
+  EXPECT_NE(store.find("config_file_update::apply"), std::string::npos);
+  EXPECT_NE(store.find("private_state_file::update_atomic"), std::string::npos);
+
 }
 
 TEST(DoctorResetContract, ExactTopologyAssertionHasItsOwnCapabilityVersion) {

--- a/tests/unit/test_live_tuning.cpp
+++ b/tests/unit/test_live_tuning.cpp
@@ -1,0 +1,162 @@
+#include "src/live_tuning.h"
+#include "src/configuration_store.h"
+#include "src/config.h"
+#include "src/private_state_file.h"
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <future>
+#include <fstream>
+
+namespace {
+  class LiveTuningTest: public testing::Test {
+   protected:
+    std::string old_path;
+    decltype(config::video.adaptive_bitrate) old_config;
+    std::filesystem::path directory;
+    void SetUp() override {
+      old_path = config::sunshine.config_file;
+      old_config = config::video.adaptive_bitrate;
+      directory = std::filesystem::temp_directory_path() /
+        ("polaris-tuning-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+      std::filesystem::create_directory(directory);
+      config::sunshine.config_file = (directory / "polaris.conf").string();
+      ASSERT_TRUE(private_state_file::write_atomic(config::sunshine.config_file,
+        "# Preserve unrelated preferences\nai_enabled = disabled\nadaptive_bitrate_enabled = enabled\n"));
+      config::video.adaptive_bitrate.enabled = true;
+      adaptive_bitrate::load_config();
+      adaptive_bitrate::reset();
+    }
+    void TearDown() override {
+      private_state_file::set_write_fault_for_tests(private_state_file::write_fault_e::none);
+      config::sunshine.config_file = old_path;
+      config::video.adaptive_bitrate = old_config;
+      adaptive_bitrate::load_config();
+      adaptive_bitrate::reset();
+      adaptive_bitrate::set_session_scope(0, "", false);
+      std::filesystem::remove_all(directory);
+    }
+  };
+}
+
+TEST_F(LiveTuningTest, ReportsSavedPreferenceBeforeFirstStreamWithoutAi) {
+  const auto value = live_tuning::snapshot({});
+  EXPECT_EQ(value["enabled"], true);
+  EXPECT_EQ(value["state"], "waiting");
+  EXPECT_EQ(value["applied_bitrate_kbps"], 0);
+}
+
+TEST_F(LiveTuningTest, SaveIsRevisionConditionalAndRetryDoesNotChangeAuthority) {
+  auto authority = doctor_actions::acquire_admin_global_control();
+  const auto revision = configuration_store::revision(config::sunshine.config_file, true);
+  ASSERT_TRUE(live_tuning::set_enabled(authority, false, revision)["status"].get<bool>());
+  const auto saved = private_state_file::read_secure(config::sunshine.config_file, 4096).payload;
+  EXPECT_NE(saved.find("# Preserve unrelated preferences"), std::string::npos);
+  EXPECT_NE(saved.find("ai_enabled = disabled"), std::string::npos);
+  EXPECT_EQ(live_tuning::set_enabled(authority, true, revision)["http_status"], 412);
+  const auto current = adaptive_bitrate::get_doctor_state();
+  ASSERT_TRUE(live_tuning::set_enabled(authority, false)["status"].get<bool>());
+  EXPECT_EQ(adaptive_bitrate::get_doctor_state().revision, current.revision);
+}
+
+TEST_F(LiveTuningTest, FailedCommitDoesNotApplyPreference) {
+  auto authority = doctor_actions::acquire_admin_global_control();
+  private_state_file::set_write_fault_for_tests(private_state_file::write_fault_e::rename);
+  EXPECT_EQ(live_tuning::set_enabled(authority, false)["http_status"], 500);
+  EXPECT_TRUE(adaptive_bitrate::get_state().configured_enabled);
+}
+
+TEST_F(LiveTuningTest, ReleasedAndMovedFromGuardsCannotSave) {
+  auto released = doctor_actions::acquire_admin_global_control();
+  released.release();
+  EXPECT_FALSE(static_cast<bool>(released));
+  EXPECT_EQ(live_tuning::set_enabled(released, false)["http_status"], 403);
+  auto original = doctor_actions::acquire_admin_global_control();
+  auto moved = std::move(original);
+  EXPECT_FALSE(static_cast<bool>(original));
+  EXPECT_EQ(live_tuning::set_enabled(original, false)["http_status"], 403);
+  EXPECT_TRUE(adaptive_bitrate::get_state().configured_enabled);
+}
+
+TEST_F(LiveTuningTest, NeverAttributesAnotherSessionOrSharedEncoderBitrate) {
+  adaptive_bitrate::state_t c;
+  c.session_exclusive = true;
+  c.session_generation = 2;
+  c.app_session_id = "new";
+  c.runtime_update_supported = true;
+  c.applied_bitrate_kbps = 14000;
+  c.target_bitrate_kbps = 20000;
+  stream_stats::stats_t s;
+  s.streaming = true;
+  s.session_generation = 1;
+  s.app_session_id = "old";
+  auto value = live_tuning::describe(c, s, true);
+  EXPECT_EQ(value["supported"], false);
+  EXPECT_EQ(value["applied_bitrate_kbps"], 0);
+  s.session_generation = 2;
+  s.app_session_id = "new";
+  value = live_tuning::describe(c, s, true);
+  EXPECT_EQ(value["state"], "applying");
+  EXPECT_EQ(value["applied_bitrate_kbps"], 14000);
+  c.session_exclusive = false;
+  EXPECT_EQ(live_tuning::describe(c, s, true)["supported"], false);
+}
+
+TEST_F(LiveTuningTest, FullReplacementRejectsAnOversizedOrStaleSnapshot) {
+  const auto path = config::sunshine.config_file;
+  const auto revision = configuration_store::revision(path, true);
+  ASSERT_EQ(configuration_store::patch(path, {{"stream_audio", "disabled"}}, revision), configuration_store::result::committed);
+  EXPECT_EQ(configuration_store::replace(path, "adaptive_bitrate_enabled = disabled\n", revision), configuration_store::result::conflict);
+  EXPECT_EQ(configuration_store::replace(path, std::string(4 * 1024 * 1024 + 1, 'x')), configuration_store::result::failed);
+  EXPECT_NE(configuration_store::revision(path, true), "");
+}
+
+TEST_F(LiveTuningTest, ExternalEditRefreshesConflictRevision) {
+  auto authority = doctor_actions::acquire_admin_global_control();
+  const auto old = configuration_store::revision(config::sunshine.config_file, true);
+  ASSERT_TRUE(private_state_file::write_atomic(config::sunshine.config_file, "adaptive_bitrate_enabled = enabled\nstream_audio = disabled\n"));
+  const auto result = live_tuning::set_enabled(authority, false, old);
+  ASSERT_EQ(result["http_status"], 412);
+  const auto fresh = result["live_tuning"]["configuration_revision"].get<std::string>();
+  EXPECT_NE(old, fresh);
+  EXPECT_TRUE(live_tuning::set_enabled(authority, false, fresh)["status"].get<bool>());
+}
+
+TEST_F(LiveTuningTest, MatchesTheSharedClientFixtures) {
+  std::ifstream input(std::filesystem::path(POLARIS_SOURCE_DIR) / "tests/fixtures/live-tuning-v1.json");
+  ASSERT_TRUE(input.good());
+  for (const auto &row : nlohmann::json::parse(input)) {
+    const auto &expected = row["live_tuning"];
+    adaptive_bitrate::state_t c;
+    c.session_exclusive = true;
+    c.session_generation = expected["session_generation"];
+    c.app_session_id = expected["app_session_id"];
+    c.enabled = expected["runtime_enabled"];
+    c.runtime_update_supported = expected["supported"];
+    c.base_bitrate_kbps = expected["quality_limit_kbps"];
+    c.target_bitrate_kbps = expected["requested_bitrate_kbps"];
+    c.applied_bitrate_kbps = expected["applied_bitrate_kbps"];
+    c.feedback_initialized = row["name"] != "measuring";
+    c.reason = expected["reason"];
+    stream_stats::stats_t stats;
+    stats.streaming = row["streaming"];
+    stats.session_generation = c.session_generation;
+    stats.app_session_id = c.app_session_id;
+    const auto actual = live_tuning::describe(c, stats, expected["enabled"]);
+    for (const auto &[key, value] : actual.items()) EXPECT_EQ(value, expected[key]) << row["name"] << ": " << key;
+  }
+}
+
+TEST_F(LiveTuningTest, ReadRetainsTheRevisionOfItsContentsAcrossAnExternalCommit) {
+  const auto observed = configuration_store::read(config::sunshine.config_file);
+  ASSERT_TRUE(observed);
+  const auto replacement = observed->contents + "stream_audio = disabled\n";
+  ASSERT_TRUE(private_state_file::write_atomic(config::sunshine.config_file, replacement));
+  // This is the read used by GET /api/config. An external commit cannot rebase
+  // its earlier contents onto a later revision before that response is sent.
+  EXPECT_EQ(configuration_store::replace(config::sunshine.config_file, observed->contents, observed->revision),
+    configuration_store::result::conflict);
+  const auto current = configuration_store::read(config::sunshine.config_file);
+  ASSERT_TRUE(current);
+  EXPECT_EQ(current->contents, replacement);
+  EXPECT_NE(current->revision, observed->revision);
+}

--- a/tests/unit/test_live_tuning_http.cpp
+++ b/tests/unit/test_live_tuning_http.cpp
@@ -1,0 +1,83 @@
+#include "../tests_common.h"
+#include "src/config.h"
+#include "src/adaptive_bitrate.h"
+#include "src/crypto.h"
+#include "src/private_state_file.h"
+#include <Simple-Web-Server/server_https.hpp>
+#include <Simple-Web-Server/client_https.hpp>
+#include <nlohmann/json.hpp>
+#include <atomic>
+#include <thread>
+
+namespace confighttp {
+  void live_tuning_http_for_tests(std::shared_ptr<SimpleWeb::Server<SimpleWeb::HTTPS>::Response>,
+                                 std::shared_ptr<SimpleWeb::Server<SimpleWeb::HTTPS>::Request>);
+  void with_web_session_for_tests(const std::filesystem::path &, const std::string &,
+                                 const std::function<void(const std::string &)> &);
+}
+
+TEST(LiveTuningHttp, RealTlsHandlerRequiresAuthenticationCsrfAndCurrentRevision) {
+  const auto old_config = config::sunshine;
+  const auto old_adaptive = config::video.adaptive_bitrate;
+  const auto directory = std::filesystem::temp_directory_path() /
+    ("polaris-tuning-http-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  std::filesystem::create_directory(directory);
+  auto restore = util::fail_guard([&] {
+    config::sunshine = old_config;
+    config::video.adaptive_bitrate = old_adaptive;
+    adaptive_bitrate::load_config();
+    adaptive_bitrate::reset();
+    std::filesystem::remove_all(directory);
+  });
+  config::sunshine.username = "test-admin";
+  config::sunshine.api_key = "isolated-test-api-key";
+  config::sunshine.config_file = (directory / "polaris.conf").string();
+  ASSERT_TRUE(private_state_file::write_atomic(config::sunshine.config_file, "adaptive_bitrate_enabled = enabled\n"));
+  config::video.adaptive_bitrate.enabled = true;
+  adaptive_bitrate::load_config();
+  adaptive_bitrate::reset();
+  const auto credentials = crypto::gen_creds("localhost", 2048);
+  ASSERT_TRUE(private_state_file::write_atomic(directory / "cert.pem", credentials.x509));
+  ASSERT_TRUE(private_state_file::write_atomic(directory / "key.pem", credentials.pkey));
+  confighttp::with_web_session_for_tests(directory / "sessions.json", "test-csrf", [&](const std::string &cookie) {
+    SimpleWeb::Server<SimpleWeb::HTTPS> server((directory / "cert.pem").string(), (directory / "key.pem").string());
+    server.config.address = "127.0.0.1";
+    server.config.port = 0;
+    server.config.timeout_request = 5;
+    server.config.timeout_content = 5;
+    server.resource["^/api/live-tuning$"]["GET"] = confighttp::live_tuning_http_for_tests;
+    server.resource["^/api/live-tuning$"]["POST"] = confighttp::live_tuning_http_for_tests;
+    std::atomic<unsigned short> port {0};
+    std::jthread worker([&] { server.start([&](unsigned short assigned) { port = assigned; }); });
+    auto stop = util::fail_guard([&] { server.stop(); worker.join(); });
+    for (int attempt = 0; attempt < 100 && port == 0; ++attempt) std::this_thread::sleep_for(10ms);
+    ASSERT_NE(port, 0);
+    SimpleWeb::Client<SimpleWeb::HTTPS> client("127.0.0.1:" + std::to_string(port.load()), false);
+    client.config.timeout = 5;
+    const std::string body = R"({"enabled":false})";
+    auto request = [&](std::string method, std::string content, SimpleWeb::CaseInsensitiveMultimap headers) {
+      headers.emplace("Content-Type", "application/json");
+      return client.request(method, "/api/live-tuning", content, headers);
+    };
+    auto code = [](const auto &response) { return std::stoi(response->status_code); };
+    EXPECT_EQ(code(request("GET", "", {})), 401);
+    EXPECT_EQ(code(request("POST", body, {})), 403);
+    EXPECT_EQ(code(request("POST", body, {{"X-CSRF-Token", "test-csrf"}})), 401);
+    auto authenticated = request("GET", "", {{"Cookie", "auth=" + cookie}});
+    ASSERT_EQ(code(authenticated), 200);
+    const auto revision = nlohmann::json::parse(authenticated->content.string())["live_tuning"]["configuration_revision"].get<std::string>();
+    const std::string match = "\"" + revision + "\"";
+    // An invalid bearer prefix must not let a valid cookie bypass CSRF.
+    EXPECT_EQ(code(request("POST", body, {{"Cookie", "auth=" + cookie}, {"Authorization", "Bearer wrong"}, {"If-Match", match}})), 403);
+    EXPECT_EQ(code(request("POST", body, {{"Cookie", "auth=" + cookie}, {"X-CSRF-Token", "test-csrf"}})), 412);
+    EXPECT_EQ(code(request("POST", R"({"enabled":"false"})", {{"Authorization", "Bearer isolated-test-api-key"}, {"If-Match", match}})), 400);
+    EXPECT_EQ(code(request("POST", body, {{"Cookie", "auth=" + cookie}, {"X-CSRF-Token", "test-csrf"}, {"If-Match", match}})), 200);
+    EXPECT_FALSE(adaptive_bitrate::get_state().configured_enabled);
+    EXPECT_EQ(code(request("POST", R"({"enabled":true})", {{"Authorization", "Bearer isolated-test-api-key"}, {"If-Match", match}})), 412);
+    EXPECT_FALSE(adaptive_bitrate::get_state().configured_enabled);
+    auto current = request("GET", "", {{"Authorization", "Bearer isolated-test-api-key"}});
+    const auto fresh = nlohmann::json::parse(current->content.string())["live_tuning"]["configuration_revision"].get<std::string>();
+    EXPECT_EQ(code(request("POST", R"({"enabled":true})", {{"Authorization", "Bearer isolated-test-api-key"}, {"If-Match", "\"" + fresh + "\""}})), 200);
+    EXPECT_TRUE(adaptive_bitrate::get_state().configured_enabled);
+  });
+}

--- a/tests/unit/test_private_state_file.cpp
+++ b/tests/unit/test_private_state_file.cpp
@@ -16,6 +16,8 @@
 #if defined(__linux__)
   #include <csignal>
   #include <sys/stat.h>
+  #include <sys/file.h>
+  #include <fcntl.h>
   #include <sys/wait.h>
   #include <thread>
   #include <unistd.h>
@@ -717,3 +719,38 @@ TEST_F(PrivateStateFileTest, DirectoryCloseFaultFailsClosedAfterVisibleReplaceme
   ASSERT_EQ(result.status, private_state_file::read_status_e::ok);
   EXPECT_EQ(result.payload, "new");
 }
+#ifdef __linux__
+TEST_F(PrivateStateFileTest, TransactionFailsPromptlyWhileAnotherProcessHoldsLock) {
+  ASSERT_TRUE(private_state_file::write_atomic(target, "before"));
+  int ready[2], release[2];
+  ASSERT_EQ(::pipe(ready), 0);
+  ASSERT_EQ(::pipe(release), 0);
+  const auto pid = ::fork();
+  ASSERT_GE(pid, 0);
+  if (pid == 0) {
+    ::close(ready[0]); ::close(release[1]);
+    int lock = ::open((target.string() + ".lock").c_str(), O_RDWR);
+    if (lock < 0 || ::flock(lock, LOCK_EX) != 0) _exit(1);
+    char byte = 'x';
+    if (::write(ready[1], &byte, 1) != 1) _exit(2);
+    if (::read(release[0], &byte, 1) != 1) _exit(3);
+    ::close(lock); _exit(0);
+  }
+  ::close(ready[1]); ::close(release[0]);
+  char byte;
+  ASSERT_EQ(::read(ready[0], &byte, 1), 1);
+  const auto began = std::chrono::steady_clock::now();
+  bool called = false;
+  const auto result = private_state_file::update_atomic(target, 4096, [&](const auto &) {
+    called = true; return std::optional<std::string>("after");
+  });
+  EXPECT_LT(std::chrono::steady_clock::now() - began, std::chrono::seconds(1));
+  EXPECT_FALSE(called);
+  EXPECT_EQ(result.status, private_state_file::write_status_e::not_committed);
+  EXPECT_EQ(::write(release[1], &byte, 1), 1);
+  ::close(ready[0]); ::close(release[1]);
+  int status; ASSERT_EQ(::waitpid(pid, &status, 0), pid);
+  EXPECT_EQ(status, 0);
+  EXPECT_EQ(private_state_file::read_secure(target, 4096).payload, "before");
+}
+#endif

--- a/tests/unit/test_settings_projection_contract.cpp
+++ b/tests/unit/test_settings_projection_contract.cpp
@@ -212,7 +212,7 @@ TEST_F(SettingsProjectionContract, StatsChannelAugmentationAddsTuningAndAutoQual
     EXPECT_EQ(augmented.at(key), value) << key;
   }
   // Exactly the two additive keys appear, nothing else.
-  EXPECT_EQ(augmented.size(), original.size() + 2);
+  EXPECT_EQ(augmented.size(), original.size() + 3);
   ASSERT_TRUE(augmented.contains("tuning"));
   ASSERT_TRUE(augmented.contains("auto_quality"));
 

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -7,6 +7,7 @@
 #include <src/config.h>
 #include <src/doctor_actions.h>
 #include <src/adaptive_bitrate.h>
+#include <src/private_state_file.h>
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -73,6 +74,21 @@ namespace {
     }
 
     std::filesystem::path path;
+  };
+
+  struct LiveConfigurationGuard {
+    std::string old = config::sunshine.config_file;
+    std::filesystem::path directory = std::filesystem::temp_directory_path() /
+      ("polaris-live-config-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    LiveConfigurationGuard() {
+      std::filesystem::create_directory(directory);
+      config::sunshine.config_file = (directory / "polaris.conf").string();
+      (void) private_state_file::write_atomic(config::sunshine.config_file, "adaptive_bitrate_enabled = disabled\n");
+    }
+    ~LiveConfigurationGuard() {
+      config::sunshine.config_file = old;
+      std::filesystem::remove_all(directory);
+    }
   };
 
   void mark_doctor_pacing_window_confirmed(stream_stats::stats_t &stats) {
@@ -2621,6 +2637,7 @@ TEST(DoctorActionTests, OlderStreamCannotAutoFixAfterTheNewestViewerLeaves) {
 }
 
 TEST(DoctorActionTests, IdempotentAutoFixCannotOverwriteANewerOwnerBitrate) {
+  LiveConfigurationGuard live_configuration;
   config::video.adaptive_bitrate.enabled = false;
   config::video.adaptive_bitrate.min_bitrate_kbps = 2000;
   config::video.adaptive_bitrate.max_bitrate_kbps = 100000;
@@ -2706,6 +2723,7 @@ TEST(DoctorActionTests, IdempotentAutoFixCannotOverwriteANewerOwnerBitrate) {
 }
 
 TEST(DoctorActionTests, StaleControllerRevisionCannotOverrideANewerOwnerChoice) {
+  LiveConfigurationGuard live_configuration;
   config::video.adaptive_bitrate.enabled = false;
   config::video.adaptive_bitrate.min_bitrate_kbps = 2000;
   config::video.adaptive_bitrate.max_bitrate_kbps = 100000;
@@ -2842,6 +2860,7 @@ TEST(DoctorActionTests, EquivalentFreshTelemetryCannotMakeAutoFixUnclickable) {
 }
 
 TEST(DoctorActionTests, EveryRequestIdRemainsIdempotentForTheWholeStreamGeneration) {
+  LiveConfigurationGuard live_configuration;
   config::video.adaptive_bitrate.enabled = false;
   config::video.adaptive_bitrate.min_bitrate_kbps = 2000;
   config::video.adaptive_bitrate.max_bitrate_kbps = 100000;


### PR DESCRIPTION
Live Tuning now uses one saved host preference across Quick Controls, Audio/Video settings, paired session status, and session events. It is independent of AI provider sign-in. Clients see requested bitrate separately from the encoder-confirmed rate, plus waiting, measuring, applying, adjusting, stable, unavailable, and Unknown states.

Web saves use CSRF-protected, revision-conditional mutations. Configuration contents and their revision come from one secure snapshot; writes compare and commit under one bounded file lock. Paired calls retain sole-owner, permission, revocation, and session-generation checks. Disable holds the last confirmed bitrate; an explicit fixed bitrate supersedes adaptive/Doctor ownership. Existing launch presets still apply at the next explicit launch.

Stacked on `feat/bazzite-offline-readiness`; companion Nova changes use the same versioned fixtures and state. Production multiseat activation is unchanged.

Validation: all 12 rebuilt native suites; affected fast/HTTP/stream ASan+UBSan suites with leak detection; 725 web tests; lint and production size budget; two Playwright viewport tests; actual TLS authentication/CSRF/revision regression; encoder update/recreation races; independent host source review. Independent host and Nova immutable-source reviews cleared the commits. After the build host returned, all 44 targeted TSan checks passed. The commit-stamped host rebuild also passed 527 fast native checks and produced a local validation RPM. Physical paired-client game acceptance and PR CI remain separate gates.

Stack: based on Bazzite #639, which is based on #638. Paired client implementation: papi-ux/nova#293. Experimental multiseat #640 and Nova Steam follow-up papi-ux/nova#294 remain separate.
