### PR TITLE
fix(web): refresh display capabilities after Apply

### DIFF
--- a/src_assets/common/assets/web/composables/use-config-projection.test.js
+++ b/src_assets/common/assets/web/composables/use-config-projection.test.js
@@ -34,6 +34,20 @@ const respond = (status, body) => async (url, init) => ({
 })
 
 describe('useConfigProjection', () => {
+  it.each([true, false])('ignores metadata from before a newer refresh (old response ok=%s)', async (oldOk) => {
+    const pending = []
+    const projection = useConfigProjection({ fetchImpl: () => new Promise((resolve) => pending.push(resolve)) })
+    const old = projection.load()
+    const current = projection.load()
+    const refreshed = { ...payload(), modes: [{ value: 'host_virtual_display', available: true }] }
+    pending[1]({ ok: true, json: async () => refreshed })
+    expect(await current).toBe(true)
+    pending[0]({ ok: oldOk, status: 503, json: async () => payload() })
+    expect(await old).toBe(false)
+    expect(projection.ok.value).toBe(true)
+    expect(projection.modes.value[0].available).toBe(true)
+    expect(projection.error.value).toBeNull()
+  })
   it('binds the host projection when the endpoint answers with version 1', async () => {
     const calls = []
     const projection = useConfigProjection({

--- a/src_assets/common/assets/web/composables/useConfigProjection.js
+++ b/src_assets/common/assets/web/composables/useConfigProjection.js
@@ -24,8 +24,10 @@ export function useConfigProjection({ fetchImpl } = {}) {
   const ok = ref(false)
   const loading = ref(false)
   const error = ref(null)
+  let requestGeneration = 0
 
   async function load(clientUuid = '') {
+    const generation = ++requestGeneration
     const doFetch = fetchImpl || ((...args) => fetch(...args))
     const url = clientUuid
       ? `${SETTINGS_METADATA_ENDPOINT}?client=${encodeURIComponent(clientUuid)}`
@@ -35,6 +37,7 @@ export function useConfigProjection({ fetchImpl } = {}) {
     try {
       const response = await doFetch(url, {
         credentials: 'include',
+        cache: 'no-store',
         headers: { Accept: 'application/json' },
       })
       if (!response.ok) {
@@ -44,14 +47,16 @@ export function useConfigProjection({ fetchImpl } = {}) {
       if (!isValidSettingsMetadata(body)) {
         throw new Error('settings metadata has an unexpected shape')
       }
+      if (generation !== requestGeneration) return false
       payload.value = body
       ok.value = true
     } catch (cause) {
+      if (generation !== requestGeneration) return false
       payload.value = null
       ok.value = false
       error.value = cause
     } finally {
-      loading.value = false
+      if (generation === requestGeneration) loading.value = false
     }
     return ok.value
   }

--- a/src_assets/common/assets/web/config-pending-changes.test.js
+++ b/src_assets/common/assets/web/config-pending-changes.test.js
@@ -124,6 +124,62 @@ describe('ConfigView pending changes review', () => {
     expect(Number(tab.attributes('host-generation'))).toBe(outcome === 'onReady' ? 1 : 0)
     wrapper.unmount()
   })
+  it('refreshes legacy capabilities with A/V closed and retains them through Reset Changes', async () => {
+    const oldOptions = [{ value: 'host_virtual_display', available: false }]
+    const readyOptions = [{ value: 'host_virtual_display', available: true }]
+    const wrapper = mountConfigView({ stream_display_mode_options: oldOptions })
+    await flushConfigLoad()
+    let callbacks
+    requestHostRestart.mockImplementationOnce((value) => { callbacks = value; return Promise.resolve() })
+    global.fetch.mockResolvedValueOnce({ status: 200, json: async () => ({ status: true }) })
+    wrapper.vm.apply()
+    await flushPromises()
+    expect(wrapper.findComponent({ name: 'AudioVideo' }).exists()).toBe(false)
+    wrapper.vm.config.max_bitrate = 42000
+    global.fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ stream_display_mode_options: readyOptions, max_bitrate: 1 }) })
+    callbacks.onReady()
+    await flushPromises()
+    expect(wrapper.vm.config.max_bitrate).toBe(42000)
+    expect(wrapper.vm.config.stream_display_mode_options).toEqual(readyOptions)
+    wrapper.vm.resetLocalChanges()
+    await nextTick()
+    expect(wrapper.vm.config.max_bitrate).toBe(0)
+    expect(wrapper.vm.config.stream_display_mode_options).toEqual(readyOptions)
+    wrapper.vm.currentTab = 'av'
+    await nextTick()
+    expect(wrapper.findComponent({ name: 'AudioVideo' }).props('config').stream_display_mode_options).toEqual(readyOptions)
+    wrapper.unmount()
+  })
+
+  it.each(['newer restart', 'unmount'])('ignores a retired legacy response after %s', async (reason) => {
+    const wrapper = mountConfigView({ stream_display_mode_options: [] })
+    await flushConfigLoad()
+    const config = wrapper.vm.config
+    let callbacks
+    requestHostRestart.mockImplementation((value) => { callbacks = value; return Promise.resolve() })
+    global.fetch.mockResolvedValueOnce({ status: 200, json: async () => ({ status: true }) })
+    wrapper.vm.apply()
+    await flushPromises()
+    let resolveOld
+    global.fetch.mockImplementationOnce(() => new Promise((resolve) => { resolveOld = resolve }))
+    callbacks.onReady()
+    const readyOptions = [{ value: 'host_virtual_display', available: true }]
+    if (reason === 'newer restart') {
+      global.fetch.mockResolvedValueOnce({ status: 200, json: async () => ({ status: true }) })
+      wrapper.vm.apply()
+      await flushPromises()
+      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ stream_display_mode_options: readyOptions }) })
+      callbacks.onReady()
+      await flushPromises()
+    } else {
+      wrapper.unmount()
+    }
+    resolveOld({ ok: true, json: async () => ({ stream_display_mode_options: [{ value: 'host_virtual_display', available: false }] }) })
+    await flushPromises()
+    expect(config.stream_display_mode_options).toEqual(reason === 'newer restart' ? readyOptions : [])
+    if (reason === 'newer restart') wrapper.unmount()
+  })
+
   afterEach(() => {
     document.body.innerHTML = ''
     mockToast.mockClear()

--- a/src_assets/common/assets/web/config-pending-changes.test.js
+++ b/src_assets/common/assets/web/config-pending-changes.test.js
@@ -1,8 +1,9 @@
-import { shallowMount } from '@vue/test-utils'
+import { flushPromises, shallowMount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import ConfigView from './views/ConfigView.vue'
+import { requestHostRestart } from './restart-host.js'
 
 const mockToast = vi.fn()
 
@@ -86,7 +87,7 @@ function mountConfigView(config = {}) {
       stubs: {
         Skeleton: { template: '<div />' },
         General: { props: ['config'], template: '<div><input id="sunshine_name" data-setting-key="sunshine_name" v-model="config.sunshine_name"></div>' },
-        AudioVideo: { props: ['config'], template: '<div><input id="max_bitrate" data-setting-key="max_bitrate" v-model="config.max_bitrate"></div>' },
+        AudioVideo: { name: 'AudioVideo', props: ['config'], template: '<div><input id="max_bitrate" data-setting-key="max_bitrate" v-model="config.max_bitrate"></div>' },
         Inputs: { template: '<div />' },
         Network: { template: '<div />' },
         Files: { template: '<div />' },
@@ -99,6 +100,30 @@ function mountConfigView(config = {}) {
 }
 
 describe('ConfigView pending changes review', () => {
+  it.each(['onReady', 'onTimeout'])('refreshes host capabilities only after restart readiness (%s)', async (outcome) => {
+    const wrapper = mountConfigView()
+    await flushConfigLoad()
+    wrapper.vm.currentTab = 'av'
+    wrapper.vm.config.linux_streaming_output = 'DP-2'
+    global.fetch.mockResolvedValueOnce({ status: 200, json: async () => ({ status: true, configuration_revision: 'b'.repeat(64) }) })
+    let restartCallbacks
+    requestHostRestart.mockImplementationOnce((callbacks) => {
+      restartCallbacks = callbacks
+      return Promise.resolve()
+    })
+    wrapper.vm.apply()
+    await flushPromises()
+    expect(restartCallbacks).toBeDefined()
+    expect(wrapper.vm.hostGeneration).toBe(0)
+    wrapper.vm.config.max_bitrate = 42000
+    restartCallbacks[outcome]()
+    await nextTick()
+    expect(wrapper.vm.hostGeneration).toBe(outcome === 'onReady' ? 1 : 0)
+    expect(wrapper.vm.config.max_bitrate).toBe(42000)
+    const tab = wrapper.findComponent({ name: 'AudioVideo' })
+    expect(Number(tab.attributes('host-generation'))).toBe(outcome === 'onReady' ? 1 : 0)
+    wrapper.unmount()
+  })
   afterEach(() => {
     document.body.innerHTML = ''
     mockToast.mockClear()

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -50,25 +50,7 @@ const projection = useConfigProjection()
 onMounted(() => {
   projection.load()
 })
-watch(() => props.hostGeneration, async (generation) => {
-  // Older hosts have no metadata endpoint. Refresh only their read-only mode
-  // options; replacing the form would discard edits made during the restart.
-  await Promise.all([
-    projection.load(),
-    (async () => {
-      try {
-        const response = await fetch('./api/config', { credentials: 'include', cache: 'no-store' })
-        if (!response.ok) return
-        const data = await response.json()
-        if (generation === props.hostGeneration && Array.isArray(data.stream_display_mode_options)) {
-          config.value.stream_display_mode_options = data.stream_display_mode_options
-        }
-      } catch {
-        // Keep the last host capability snapshot when the refresh is unavailable.
-      }
-    })(),
-  ])
-})
+watch(() => props.hostGeneration, () => projection.load())
 const tuningControl = useLiveTuning()
 const projectionModes = computed(() => (
   projection.ok.value && Array.isArray(projection.modes.value) ? projection.modes.value : null

--- a/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
+++ b/src_assets/common/assets/web/configs/tabs/AudioVideo.vue
@@ -28,6 +28,7 @@ const props = defineProps([
   'config',
   'vdisplay',
   'min_fps_factor',
+  'hostGeneration',
 ])
 
 const sudovdaStatus = {
@@ -48,6 +49,25 @@ const config = ref(props.config)
 const projection = useConfigProjection()
 onMounted(() => {
   projection.load()
+})
+watch(() => props.hostGeneration, async (generation) => {
+  // Older hosts have no metadata endpoint. Refresh only their read-only mode
+  // options; replacing the form would discard edits made during the restart.
+  await Promise.all([
+    projection.load(),
+    (async () => {
+      try {
+        const response = await fetch('./api/config', { credentials: 'include', cache: 'no-store' })
+        if (!response.ok) return
+        const data = await response.json()
+        if (generation === props.hostGeneration && Array.isArray(data.stream_display_mode_options)) {
+          config.value.stream_display_mode_options = data.stream_display_mode_options
+        }
+      } catch {
+        // Keep the last host capability snapshot when the refresh is unavailable.
+      }
+    })(),
+  ])
 })
 const tuningControl = useLiveTuning()
 const projectionModes = computed(() => (
@@ -1091,6 +1111,7 @@ pactl info | grep Source</pre>
         <VirtualDisplayStatus
           :platform="platform"
           :config="config"
+          :host-generation="hostGeneration"
         />
       </div>
     </details>

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/VirtualDisplayStatus.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/VirtualDisplayStatus.vue
@@ -1,47 +1,56 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { presentVirtualDisplayStatus } from '../../../virtual-display-status.js'
 
-defineProps({
+const props = defineProps({
   platform: String,
   config: Object,
+  hostGeneration: Number,
 })
 
 const loading = ref(true)
 const error = ref(null)
 const vdStatus = ref(null)
 const backends = ref([])
+let requestGeneration = 0
 const presentation = computed(() => presentVirtualDisplayStatus(vdStatus.value || {}))
 
-async function fetchStatus() {
+async function fetchStatus(generation = requestGeneration) {
   try {
-    const resp = await fetch('./api/vdisplay/status', { credentials: 'include' })
+    const resp = await fetch('./api/vdisplay/status', { credentials: 'include', cache: 'no-store' })
     if (resp.ok) {
-      vdStatus.value = await resp.json()
-    } else {
+      const data = await resp.json()
+      if (generation === requestGeneration) vdStatus.value = data
+    } else if (generation === requestGeneration) {
       error.value = 'Failed to fetch virtual display status'
     }
   } catch (e) {
-    error.value = 'Virtual display API not available'
+    if (generation === requestGeneration) error.value = 'Virtual display API not available'
   }
 }
 
-async function fetchBackends() {
+async function fetchBackends(generation = requestGeneration) {
   try {
-    const resp = await fetch('./api/vdisplay/backends', { credentials: 'include' })
+    const resp = await fetch('./api/vdisplay/backends', { credentials: 'include', cache: 'no-store' })
     if (resp.ok) {
       const data = await resp.json()
-      backends.value = data.backends || []
+      if (generation === requestGeneration) backends.value = data.backends || []
     }
   } catch (e) {
     // Non-critical: backends list is supplementary
   }
 }
 
-onMounted(async () => {
-  await Promise.all([fetchStatus(), fetchBackends()])
-  loading.value = false
-})
+async function refresh() {
+  const generation = ++requestGeneration
+  loading.value = true
+  error.value = null
+  await Promise.all([fetchStatus(generation), fetchBackends(generation)])
+  if (generation === requestGeneration) loading.value = false
+}
+
+onMounted(refresh)
+watch(() => props.hostGeneration, refresh)
 </script>
 
 <template>

--- a/src_assets/common/assets/web/linux-streaming-setup.test.js
+++ b/src_assets/common/assets/web/linux-streaming-setup.test.js
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { shallowMount } from '@vue/test-utils'
+import { flushPromises, shallowMount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive, ref } from 'vue'
 
@@ -81,6 +81,55 @@ function mountAudioVideo(config = linuxConfig()) {
 describe('Linux Streaming Setup checklist', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('refreshes saved KScreen readiness after the host restarts without discarding local edits', async () => {
+    let ready = false
+    vi.stubGlobal('fetch', vi.fn(async (url) => ({
+      ok: true,
+      json: async () => String(url).includes('/settings/metadata')
+        ? {
+            status: true, version: 1, fields: {},
+            modes: [{ value: 'host_virtual_display', available: ready,
+              unavailable_reason: ready ? '' : 'Set linux_streaming_output' }],
+          }
+        : { status: true },
+    })))
+    const config = reactive(linuxConfig({ linux_streaming_output: '' }))
+    const wrapper = mountAudioVideo(config)
+    await flushPromises()
+    const virtualCard = () => wrapper.findAll('article').find((card) => card.text().includes('Host Virtual Display'))
+    expect(virtualCard().find('button').attributes('disabled')).toBeDefined()
+    config.linux_streaming_output = 'DP-2'
+    await nextTick()
+    expect(virtualCard().find('button').attributes('disabled')).toBeDefined()
+    ready = true
+    config.max_bitrate = 42000
+    await wrapper.setProps({ hostGeneration: 1 })
+    await flushPromises()
+    expect(virtualCard().find('button').attributes('disabled')).toBeUndefined()
+    expect(config.max_bitrate).toBe(42000)
+    await virtualCard().find('button').trigger('click')
+    expect(config.linux_stream_mode).toBe('host_virtual_display')
+    wrapper.unmount()
+  })
+
+  it('refreshes mode options for older hosts without settings metadata', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url) => ({
+      ok: !String(url).includes('/settings/metadata'), status: 404,
+      json: async () => ({ stream_display_mode_options: [{ value: 'host_virtual_display', available: true }] }),
+    })))
+    const config = reactive(linuxConfig({
+      stream_display_mode_options: [{ value: 'host_virtual_display', available: false }],
+    }))
+    const wrapper = mountAudioVideo(config)
+    await flushPromises()
+    const virtualCard = () => wrapper.findAll('article').find((card) => card.text().includes('Host Virtual Display'))
+    expect(virtualCard().find('button').attributes('disabled')).toBeDefined()
+    await wrapper.setProps({ hostGeneration: 1 })
+    await flushPromises()
+    expect(virtualCard().find('button').attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
   })
 
   it('renders the en.json copy for strings routed through the locale system', () => {

--- a/src_assets/common/assets/web/linux-streaming-setup.test.js
+++ b/src_assets/common/assets/web/linux-streaming-setup.test.js
@@ -114,24 +114,6 @@ describe('Linux Streaming Setup checklist', () => {
     wrapper.unmount()
   })
 
-  it('refreshes mode options for older hosts without settings metadata', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url) => ({
-      ok: !String(url).includes('/settings/metadata'), status: 404,
-      json: async () => ({ stream_display_mode_options: [{ value: 'host_virtual_display', available: true }] }),
-    })))
-    const config = reactive(linuxConfig({
-      stream_display_mode_options: [{ value: 'host_virtual_display', available: false }],
-    }))
-    const wrapper = mountAudioVideo(config)
-    await flushPromises()
-    const virtualCard = () => wrapper.findAll('article').find((card) => card.text().includes('Host Virtual Display'))
-    expect(virtualCard().find('button').attributes('disabled')).toBeDefined()
-    await wrapper.setProps({ hostGeneration: 1 })
-    await flushPromises()
-    expect(virtualCard().find('button').attributes('disabled')).toBeUndefined()
-    wrapper.unmount()
-  })
-
   it('renders the en.json copy for strings routed through the locale system', () => {
     const wrapper = mountAudioVideo()
     const text = wrapper.text()

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -286,6 +286,7 @@ const restarted = ref(false)
 const saving = ref(false)
 const restarting = ref(false)
 const hostGeneration = ref(0)
+let disposed = false
 const config = ref(null)
 const responseOnlyConfig = ref({})
 const currentTab = ref("general")
@@ -976,6 +977,23 @@ function save() {
   })
 }
 
+async function refreshHostCapabilities(generation) {
+  // Own legacy capabilities beside the reset snapshot, even while A/V is closed.
+  // Refresh only response fields so edits made during restart remain intact.
+  try {
+    const response = await fetch('./api/config', { credentials: 'include', cache: 'no-store' })
+    if (!response.ok) return
+    const data = await response.json()
+    if (disposed || generation !== hostGeneration.value) return
+    if (Array.isArray(data.stream_display_mode_options)) {
+      config.value.stream_display_mode_options = data.stream_display_mode_options
+      responseOnlyConfig.value.stream_display_mode_options = data.stream_display_mode_options
+    }
+  } catch {
+    // Keep the last capability snapshot if the restarted host is unavailable.
+  }
+}
+
 function apply() {
   if (restarting.value) return
   saved.value = false
@@ -991,7 +1009,8 @@ function apply() {
         onReady: () => {
           // Capabilities depend on the newly loaded host configuration. Keep
           // local form edits, but retire status fetched before this restart.
-          ++hostGeneration.value
+          if (disposed) return
+          refreshHostCapabilities(++hostGeneration.value)
           saved.value = false
           restarted.value = false
           restarting.value = false
@@ -1206,6 +1225,7 @@ watch(currentTab, async (value) => {
 })
 
 onUnmounted(() => {
+  disposed = true
   window.removeEventListener('polaris:live-tuning-saved', acceptOwnLiveTuningSave)
   clearSearchHighlight()
   window.removeEventListener("hashchange", handleHash)

--- a/src_assets/common/assets/web/views/ConfigView.vue
+++ b/src_assets/common/assets/web/views/ConfigView.vue
@@ -216,6 +216,7 @@
           :config="config"
           :platform="platform"
           :vdisplay="vdisplayStatus"
+          :host-generation="hostGeneration"
         >
         </audio-video>
 
@@ -284,6 +285,7 @@ const saved = ref(false)
 const restarted = ref(false)
 const saving = ref(false)
 const restarting = ref(false)
+const hostGeneration = ref(0)
 const config = ref(null)
 const responseOnlyConfig = ref({})
 const currentTab = ref("general")
@@ -987,6 +989,9 @@ function apply() {
       toast(i18n.t('config.restart_note') || 'Polaris is restarting...', 'info', 5000)
       requestHostRestart({
         onReady: () => {
+          // Capabilities depend on the newly loaded host configuration. Keep
+          // local form edits, but retire status fetched before this restart.
+          ++hostGeneration.value
           saved.value = false
           restarted.value = false
           restarting.value = false

--- a/src_assets/common/assets/web/virtual-display-status.test.js
+++ b/src_assets/common/assets/web/virtual-display-status.test.js
@@ -10,6 +10,27 @@ describe('virtual display status presentation', () => {
     vi.unstubAllGlobals()
   })
 
+  it('recovers its status after restart instead of retaining an earlier failure', async () => {
+    let ready = false
+    vi.stubGlobal('fetch', vi.fn(async (url) => ({
+      ok: ready,
+      json: async () => String(url).includes('/status')
+        ? { available: true, backend_detected: true, backend: 'kscreen-doctor', policy_mode: 'host_virtual_display' }
+        : { backends: [] },
+    })))
+    const config = reactive({ linux_streaming_output: 'DP-2' })
+    const wrapper = shallowMount(VirtualDisplayStatus, { props: { platform: 'linux', config, hostGeneration: 0 } })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Failed to fetch virtual display status')
+    ready = true
+    await wrapper.setProps({ hostGeneration: 1 })
+    await flushPromises()
+    expect(wrapper.text()).not.toContain('Failed to fetch virtual display status')
+    expect(wrapper.text()).toContain('kscreen-doctor')
+    expect(config.linux_streaming_output).toBe('DP-2')
+    wrapper.unmount()
+  })
+
   it('explains that Private Stream intentionally bypasses host virtual displays', () => {
     const state = presentVirtualDisplayStatus({
       policy_mode: 'headless_stream',


### PR DESCRIPTION
After Save + Apply restarts Polaris, Host Virtual Display can remain unavailable because the settings page still has the previous capability response. Refresh display capabilities once the host is ready, keep legacy response fields with the settings owner, and preserve edits made during restart. Late responses cannot overwrite the new snapshot, and Reset Changes retains refreshed capabilities.

Addresses the stale settings-page behavior in #633. Reporter hardware confirmation remains open.

Validation: 734 web tests, lint, build-size budgets, public surface/docs checks, and independent source review passed. Includes regressions for restart timeout, tab changes, response ordering, older hosts, and Reset Changes.

Stacked on #641; no release publication.
