### PR TITLE
fix(input): preserve DualSense report order and worker lifetime

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,6 @@ Dockerfile text eol=lf
 CLAUDE.md export-ignore
 docs/polaris-ecosystem-design.md export-ignore
 docs/screenshots export-ignore
+
+# Unified-diff context markers include intentional single-space blank lines.
+packaging/linux/patches/inputtino/*.patch whitespace=-blank-at-eol,-blank-at-eof

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Build sanitizer unit tests
         run: |
           cmake --build build-sanitize --target \
-            test_polaris test_polaris_audio test_polaris_audit test_polaris_config \
+            test_inputtino_device test_inputtino_reports test_polaris test_polaris_audio test_polaris_audit test_polaris_config \
             test_polaris_http test_polaris_input test_polaris_network test_polaris_pairing \
             test_polaris_platform test_polaris_steam_shutdown test_polaris_stream test_polaris_video \
             -j"$(nproc)"
@@ -248,7 +248,7 @@ jobs:
         # executable in both this build list and the anchored ctest expression;
         # narrow deliberately only if a suite earns it.
         run: |
-          ctest --test-dir build-sanitize/tests --output-on-failure -R '^(test_polaris|test_polaris_audio|test_polaris_audit|test_polaris_config|test_polaris_http|test_polaris_input|test_polaris_network|test_polaris_pairing|test_polaris_platform|test_polaris_steam_shutdown|test_polaris_stream|test_polaris_video|polaris_gamescope_runtime_shell|polaris_gamescope_session_stop_shell|polaris_gamescope_session_geometry_shell|polaris_gamescope_primary_child_shell)$'
+          ctest --test-dir build-sanitize/tests --output-on-failure -R '^(test_inputtino_device|test_inputtino_reports|test_polaris|test_polaris_audio|test_polaris_audit|test_polaris_config|test_polaris_http|test_polaris_input|test_polaris_network|test_polaris_pairing|test_polaris_platform|test_polaris_steam_shutdown|test_polaris_stream|test_polaris_video|polaris_gamescope_runtime_shell|polaris_gamescope_session_stop_shell|polaris_gamescope_session_geometry_shell|polaris_gamescope_primary_child_shell)$'
 
   arch-build:
     name: Arch build

--- a/cmake/compile_definitions/linux.cmake
+++ b/cmake/compile_definitions/linux.cmake
@@ -444,7 +444,10 @@ endif()
 set(LIBEVDEV_CUSTOM_INCLUDE_DIR "${EVDEV_INCLUDE_DIR}")
 set(LIBEVDEV_CUSTOM_LIBRARY "${EVDEV_LIBRARY}")
 
-add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/inputtino")
+include("${CMAKE_SOURCE_DIR}/cmake/dependencies/inputtino.cmake")
+set(POLARIS_INPUTTINO_SOURCE_DIR "${CMAKE_BINARY_DIR}/dependencies/inputtino-source")
+polaris_prepare_inputtino("${CMAKE_SOURCE_DIR}/third-party/inputtino" "${POLARIS_INPUTTINO_SOURCE_DIR}")
+add_subdirectory("${POLARIS_INPUTTINO_SOURCE_DIR}" "${CMAKE_BINARY_DIR}/dependencies/inputtino-build")
 set_target_properties(libinputtino PROPERTIES
         CXX_STANDARD 23
         CXX_STANDARD_REQUIRED ON)

--- a/cmake/dependencies/inputtino.cmake
+++ b/cmake/dependencies/inputtino.cmake
@@ -1,0 +1,34 @@
+# Apply the reviewed backport to a build-tree copy. The canonical submodule is
+# unchanged, so package archives and ordinary submodule checkout stay portable.
+function(polaris_prepare_inputtino source output)
+    set(paths
+        include/inputtino/input.hpp
+        src/uhid/include/uhid/protected_types.hpp
+        src/uhid/include/uhid/uhid.hpp
+        src/uhid/joypad_ps5.cpp)
+    set(hashes
+        6643a5fd9ff101e9451398bf9cd0f7eb051bd2f10f294e1060a93fa6f3d0ca08
+        2f8de358a4c0f353d97b165afc7f902d10c2ed01929f09e7a21dd2b2c8fd0f22
+        95e6c94c1343e804866a49c9ef666f3c111b75144eecc02c378c1b88efc1fda5
+        1a4445915d5ef58115a588f013472e42fcdbc91eb70e08fb22adbb93db316d52)
+    foreach(index RANGE 0 3)
+        list(GET paths ${index} path)
+        list(GET hashes ${index} expected)
+        file(SHA256 "${source}/${path}" actual)
+        if(NOT actual STREQUAL expected)
+            message(FATAL_ERROR "inputtino backport input changed: ${path}; review the canonical pin and patch")
+        endif()
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${source}/${path}")
+    endforeach()
+    set(backport "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../../packaging/linux/patches/inputtino/0001-serialize-dualsense-reports-and-own-threads.patch")
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${backport}")
+    find_program(POLARIS_PATCH_EXECUTABLE patch REQUIRED)
+    file(COPY "${source}/" DESTINATION "${output}" PATTERN ".git" EXCLUDE)
+    execute_process(
+        COMMAND "${POLARIS_PATCH_EXECUTABLE}" -p1 --batch --forward --fuzz=0 -i "${backport}"
+        WORKING_DIRECTORY "${output}"
+        RESULT_VARIABLE result OUTPUT_VARIABLE patch_output ERROR_VARIABLE patch_error)
+    if(NOT result EQUAL 0)
+        message(FATAL_ERROR "inputtino backport failed: ${patch_output}${patch_error}")
+    endif()
+endfunction()

--- a/packaging/linux/patches/inputtino/0001-serialize-dualsense-reports-and-own-threads.patch
+++ b/packaging/linux/patches/inputtino/0001-serialize-dualsense-reports-and-own-threads.patch
@@ -76,14 +76,33 @@
      }
    }
  };
-@@ -157,7 +156,6 @@
+@@ -110,6 +109,12 @@
+   if (fd < 0) {
+     return inputtino::Error(strerror(errno));
+   }
++
++  // Preserve ownership even if allocation or thread construction throws.
++  struct PendingFd {
++    int fd;
++    ~PendingFd() { if (fd >= 0) close(fd); }
++  } pending{fd};
+ 
+   auto ev = uhid_event{};
+   ev.type = UHID_CREATE2, ev.u.create2.bus = definition.bus, ev.u.create2.vendor = definition.vendor,
+@@ -157,10 +162,10 @@
          }
        }
      });
 -    thread->detach();
-     return inputtino::Result<Device>({std::move(thread), std::move(state)});
+-    return inputtino::Result<Device>({std::move(thread), std::move(state)});
++    auto result = inputtino::Result<Device>({std::move(thread), std::move(state)});
++    pending.fd = -1; // Device now owns both the descriptor and reader.
++    return result;
    } else {
-     close(fd);
+-    close(fd);
+     return inputtino::Error(res.getErrorMessage());
+   }
+ }
 --- a/src/uhid/joypad_ps5.cpp
 +++ b/src/uhid/joypad_ps5.cpp
 @@ -8,6 +8,7 @@
@@ -177,7 +196,20 @@
        }
      }
    }
-@@ -294,7 +307,6 @@
+@@ -281,10 +294,11 @@
+     def.uniq = joypad.get_mac_address();
+   }
+ 
++  // The reader may request reports immediately inside Device::create.
++  joypad._state->is_bluetooth = use_bluetooth;
+   auto dev =
+       uhid::Device::create(def, [state = joypad._state](uhid_event ev, int fd) { on_uhid_event(state, ev, fd); });
+   if (dev) {
+-    joypad._state->is_bluetooth = use_bluetooth;
+     joypad._state->dev = std::make_shared<uhid::Device>(std::move(*dev));
+ 
+     // Readers will expect frequent events event if the state hasn't changed
+@@ -294,7 +308,6 @@
          std::this_thread::sleep_for(std::chrono::milliseconds(10));
        }
      });
@@ -185,7 +217,7 @@
  
      return joypad;
    }
-@@ -390,6 +402,7 @@
+@@ -390,6 +403,7 @@
  }
  
  void PS5Joypad::set_pressed_buttons(unsigned int pressed) {
@@ -193,7 +225,7 @@
    { // First reset everything to non-pressed
      this->_state->current_state.buttons[0] = 0;
      // Don't reset L2 and R2, these are handled in set_triggers
-@@ -463,9 +476,10 @@
+@@ -463,9 +477,10 @@
      if (MISC_FLAG & pressed)
        this->_state->current_state.buttons[2] |= uhid::MIC_MUTE;
    }
@@ -205,7 +237,7 @@
    this->_state->current_state.z = scale_value(left, 0, 255, uhid::PS5_AXIS_MIN, uhid::PS5_AXIS_MAX);
    this->_state->current_state.rz = scale_value(right, 0, 255, uhid::PS5_AXIS_MIN, uhid::PS5_AXIS_MAX);
  
-@@ -479,25 +493,27 @@
+@@ -479,25 +494,27 @@
    else
      this->_state->current_state.buttons[1] |= uhid::R2;
  
@@ -236,7 +268,7 @@
    this->_state->on_rumble = callback;
  }
  
-@@ -510,13 +526,14 @@
+@@ -510,13 +527,14 @@
  }
  
  void PS5Joypad::set_motion(PS5Joypad::MOTION_TYPE type, float x, float y, float z) {
@@ -252,7 +284,7 @@
      break;
    }
    case GYROSCOPE: {
-@@ -524,31 +541,35 @@
+@@ -524,31 +542,35 @@
      this->_state->current_state.gyro[1] = to_le_signed(y, y * uhid::gyro_resolution);
      this->_state->current_state.gyro[2] = to_le_signed(z, z * uhid::gyro_resolution);
  
@@ -290,7 +322,7 @@
    if (finger_nr <= 1) {
      // If this finger was previously unpressed, we should increase the touch id
      if (this->_state->current_state.points[finger_nr].contact == 1) {
-@@ -562,18 +583,19 @@
+@@ -562,18 +584,19 @@
      this->_state->current_state.points[finger_nr].y_lo = static_cast<uint8_t>(y & 0x000F);
      this->_state->current_state.points[finger_nr].y_hi = static_cast<uint8_t>((y & 0x0FF0) >> 4);
  

--- a/packaging/linux/patches/inputtino/0001-serialize-dualsense-reports-and-own-threads.patch
+++ b/packaging/linux/patches/inputtino/0001-serialize-dualsense-reports-and-own-threads.patch
@@ -1,0 +1,314 @@
+--- a/include/inputtino/input.hpp
++++ b/include/inputtino/input.hpp
+@@ -383,6 +383,7 @@
+              .name = "Wolf DualSense (virtual) pad", .vendor_id = 0x054C, .product_id = 0x0CE6, .version = 0x8111});
+   PS5Joypad(PS5Joypad &&j) noexcept : _state(nullptr) {
+     std::swap(j._state, _state);
++    std::swap(j._send_input_thread, _send_input_thread);
+   }
+   ~PS5Joypad() override;
+ 
+--- a/src/uhid/include/uhid/protected_types.hpp
++++ b/src/uhid/include/uhid/protected_types.hpp
+@@ -1,5 +1,7 @@
+ #pragma once
++#include <atomic>
+ #include <functional>
++#include <mutex>
+ #include <inputtino/input.hpp>
+ #include <optional>
+ #include <uhid/ps5.hpp>
+@@ -21,6 +23,9 @@
+   unsigned char mac_address[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+   uint16_t vendor_id;
+ 
++  // Keep mutation, serialization and delivery in one order per virtual pad.
++  std::mutex report_mutex;
++  std::mutex callback_mutex;
+   uhid::dualsense_input_report current_state = {};
+   uint8_t last_touch_id = 0;
+ 
+@@ -30,7 +35,7 @@
+   uint32_t last_left_trigger_event = 0;
+   uint32_t last_right_trigger_event = 0;
+ 
+-  bool stop_repeat_thread = false;
++  std::atomic<bool> stop_repeat_thread{false};
+   bool is_bluetooth = true;
+ };
+ } // namespace inputtino
+--- a/src/uhid/include/uhid/uhid.hpp
++++ b/src/uhid/include/uhid/uhid.hpp
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <atomic>
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <functional>
+@@ -22,7 +23,7 @@
+ struct ThreadState {
+   int fd;
+   std::function<void(const uhid_event &ev, int fd)> on_event;
+-  bool stop_repeat_thread = false;
++  std::atomic<bool> stop_repeat_thread{false};
+ };
+ 
+ struct DeviceDefinition {
+@@ -82,16 +83,14 @@
+ 
+   ~Device() {
+     if (state) {
++      // Join before destroying the kernel device or closing its descriptor.
++      // The event callback owns state which may depend on this device.
++      stop_thread();
+       struct uhid_event ev{};
+       ev.type = UHID_DESTROY;
+       uhid_write(state->fd, &ev);
+ 
+-      close(state->fd); // This should also close the thread by causing a POLLHUP
+-
+-      state->stop_repeat_thread = true;
+-      if (ev_thread->joinable()) {
+-        ev_thread->join(); // let's wait for the thread to finish
+-      }
++      close(state->fd);
+     }
+   }
+ };
+@@ -157,7 +156,6 @@
+         }
+       }
+     });
+-    thread->detach();
+     return inputtino::Result<Device>({std::move(thread), std::move(state)});
+   } else {
+     close(fd);
+--- a/src/uhid/joypad_ps5.cpp
++++ b/src/uhid/joypad_ps5.cpp
+@@ -8,6 +8,7 @@
+ #include <inputtino/input.hpp>
+ #include <iomanip>
+ #include <random>
++#include <tuple>
+ #include <uhid/protected_types.hpp>
+ #include <uhid/ps5.hpp>
+ #include <uhid/uhid.hpp>
+@@ -20,7 +21,8 @@
+   return crc;
+ }
+ 
+-static void send_report(PS5JoypadState &state) {
++// Caller holds report_mutex through the UHID write.
++static void send_report_locked(PS5JoypadState &state) {
+   { // setup timestamp and increase seq_number
+     state.current_state.seq_number++;
+     if (state.current_state.seq_number >= 255) {
+@@ -71,6 +73,11 @@
+   }
+ 
+   state.dev->send(ev);
++}
++
++static void send_report(PS5JoypadState &state) {
++  std::lock_guard<std::mutex> lock(state.report_mutex);
++  send_report_locked(state);
+ }
+ 
+ static void on_uhid_event(std::shared_ptr<PS5JoypadState> state, uhid_event ev, int fd) {
+@@ -127,6 +134,12 @@
+     break;
+   }
+   case UHID_OUTPUT: { // This is sent if the HID device driver wants to send raw data to the device
++    // Registration can overlap the reader. Invoke copied callbacks unlocked.
++    auto callbacks = [&] {
++      std::lock_guard<std::mutex> lock(state->callback_mutex);
++      return std::make_tuple(state->on_rumble, state->on_led, state->on_trigger_effect);
++    }();
++    auto &[on_rumble, on_led, on_trigger_effect] = callbacks;
+     // Here is where we'll get Rumble and LED events
+     // Check the first byte to see if it's a USB or BT report
+     uint8_t report_type = ev.u.output.data[0];
+@@ -158,13 +171,13 @@
+     if (report.valid_flag0 & uhid::MOTOR_OR_COMPATIBLE_VIBRATION || report.valid_flag2 & uhid::COMPATIBLE_VIBRATION) {
+       auto left = (report.motor_left / 255.0f) * 0xFFFF;
+       auto right = (report.motor_right / 255.0f) * 0xFFFF;
+-      if (state->on_rumble) {
+-        (*state->on_rumble)(left, right);
++      if (on_rumble) {
++        (*on_rumble)(left, right);
+       }
+     } else if (report.valid_flag0 == 0 && report.valid_flag1 == 0 && report.valid_flag2 == 0) {
+       // Seems to be a special stop rumble event, let's propagate it
+-      if (state->on_rumble) {
+-        (*state->on_rumble)(0, 0);
++      if (on_rumble) {
++        (*on_rumble)(0, 0);
+       }
+     }
+ 
+@@ -173,7 +186,7 @@
+      */
+     bool right_trigger = report.valid_flag0 & uhid::RIGHT_TRIGGER_EFFECT;
+     bool left_trigger = report.valid_flag0 & uhid::LEFT_TRIGGER_EFFECT;
+-    if ((right_trigger || left_trigger) && state->on_trigger_effect) {
++    if ((right_trigger || left_trigger) && on_trigger_effect) {
+       auto left_array_start = std::begin(report.left_trigger_effect);
+       auto left_array_end = std::end(report.left_trigger_effect);
+       auto right_array_start = std::begin(report.right_trigger_effect);
+@@ -197,7 +210,7 @@
+                                            .type_right = report.right_trigger_effect_type};
+         std::copy(left_array_start, left_array_end, std::begin(effect.left));
+         std::copy(right_array_start, right_array_end, std::begin(effect.right));
+-        (*state->on_trigger_effect)(effect);
++        (*on_trigger_effect)(effect);
+       }
+     }
+ 
+@@ -205,9 +218,9 @@
+      * LED
+      */
+     if (report.valid_flag1 & uhid::LIGHTBAR_ENABLE) {
+-      if (state->on_led) {
++      if (on_led) {
+         // TODO: should we blend brightness?
+-        (*state->on_led)(report.lightbar_red, report.lightbar_green, report.lightbar_blue);
++        (*on_led)(report.lightbar_red, report.lightbar_green, report.lightbar_blue);
+       }
+     }
+   }
+@@ -294,7 +307,6 @@
+         std::this_thread::sleep_for(std::chrono::milliseconds(10));
+       }
+     });
+-    joypad._send_input_thread.detach();
+ 
+     return joypad;
+   }
+@@ -390,6 +402,7 @@
+ }
+ 
+ void PS5Joypad::set_pressed_buttons(unsigned int pressed) {
++  std::lock_guard<std::mutex> lock(this->_state->report_mutex);
+   { // First reset everything to non-pressed
+     this->_state->current_state.buttons[0] = 0;
+     // Don't reset L2 and R2, these are handled in set_triggers
+@@ -463,9 +476,10 @@
+     if (MISC_FLAG & pressed)
+       this->_state->current_state.buttons[2] |= uhid::MIC_MUTE;
+   }
+-  send_report(*this->_state);
++  send_report_locked(*this->_state);
+ }
+ void PS5Joypad::set_triggers(int16_t left, int16_t right) {
++  std::lock_guard<std::mutex> lock(this->_state->report_mutex);
+   this->_state->current_state.z = scale_value(left, 0, 255, uhid::PS5_AXIS_MIN, uhid::PS5_AXIS_MAX);
+   this->_state->current_state.rz = scale_value(right, 0, 255, uhid::PS5_AXIS_MIN, uhid::PS5_AXIS_MAX);
+ 
+@@ -479,25 +493,27 @@
+   else
+     this->_state->current_state.buttons[1] |= uhid::R2;
+ 
+-  send_report(*this->_state);
++  send_report_locked(*this->_state);
+ }
+ void PS5Joypad::set_stick(Joypad::STICK_POSITION stick_type, short x, short y) {
++  std::lock_guard<std::mutex> lock(this->_state->report_mutex);
+   switch (stick_type) {
+   case RS: {
+     this->_state->current_state.rx = scale_value(x, -32768, 32767, uhid::PS5_AXIS_MIN, uhid::PS5_AXIS_MAX);
+     this->_state->current_state.ry = scale_value(-y, -32768, 32767, uhid::PS5_AXIS_MIN, uhid::PS5_AXIS_MAX);
+-    send_report(*this->_state);
++    send_report_locked(*this->_state);
+     break;
+   }
+   case LS: {
+     this->_state->current_state.x = scale_value(x, -32768, 32767, uhid::PS5_AXIS_MIN, uhid::PS5_AXIS_MAX);
+     this->_state->current_state.y = scale_value(-y, -32768, 32767, uhid::PS5_AXIS_MIN, uhid::PS5_AXIS_MAX);
+-    send_report(*this->_state);
++    send_report_locked(*this->_state);
+     break;
+   }
+   }
+ }
+ void PS5Joypad::set_on_rumble(const std::function<void(int, int)> &callback) {
++  std::lock_guard<std::mutex> lock(this->_state->callback_mutex);
+   this->_state->on_rumble = callback;
+ }
+ 
+@@ -510,13 +526,14 @@
+ }
+ 
+ void PS5Joypad::set_motion(PS5Joypad::MOTION_TYPE type, float x, float y, float z) {
++  std::lock_guard<std::mutex> lock(this->_state->report_mutex);
+   switch (type) {
+   case ACCELERATION: {
+     this->_state->current_state.accel[0] = to_le_signed(x, (x * uhid::SDL_STANDARD_GRAVITY_CONST * 100));
+     this->_state->current_state.accel[1] = to_le_signed(y, (y * uhid::SDL_STANDARD_GRAVITY_CONST * 100));
+     this->_state->current_state.accel[2] = to_le_signed(z, (z * uhid::SDL_STANDARD_GRAVITY_CONST * 100));
+ 
+-    send_report(*this->_state);
++    send_report_locked(*this->_state);
+     break;
+   }
+   case GYROSCOPE: {
+@@ -524,31 +541,35 @@
+     this->_state->current_state.gyro[1] = to_le_signed(y, y * uhid::gyro_resolution);
+     this->_state->current_state.gyro[2] = to_le_signed(z, z * uhid::gyro_resolution);
+ 
+-    send_report(*this->_state);
++    send_report_locked(*this->_state);
+     break;
+   }
+   }
+ }
+ 
+ void PS5Joypad::set_battery(PS5Joypad::BATTERY_STATE state, int percentage) {
++  std::lock_guard<std::mutex> lock(this->_state->report_mutex);
+   /*
+    * Each unit of battery data corresponds to 10%
+    * 0 = 0-9%, 1 = 10-19%, .. and 10 = 100%
+    */
+   this->_state->current_state.battery_charge = std::lround((percentage / 10));
+   this->_state->current_state.battery_status = state;
+-  send_report(*this->_state);
++  send_report_locked(*this->_state);
+ }
+ 
+ void PS5Joypad::set_on_led(const std::function<void(int, int, int)> &callback) {
++  std::lock_guard<std::mutex> lock(this->_state->callback_mutex);
+   this->_state->on_led = callback;
+ }
+ 
+ void PS5Joypad::set_on_trigger_effect(const std::function<void(const TriggerEffect &)> &callback) {
++  std::lock_guard<std::mutex> lock(this->_state->callback_mutex);
+   this->_state->on_trigger_effect = callback;
+ }
+ 
+ void PS5Joypad::place_finger(int finger_nr, uint16_t x, uint16_t y) {
++  std::lock_guard<std::mutex> lock(this->_state->report_mutex);
+   if (finger_nr <= 1) {
+     // If this finger was previously unpressed, we should increase the touch id
+     if (this->_state->current_state.points[finger_nr].contact == 1) {
+@@ -562,18 +583,19 @@
+     this->_state->current_state.points[finger_nr].y_lo = static_cast<uint8_t>(y & 0x000F);
+     this->_state->current_state.points[finger_nr].y_hi = static_cast<uint8_t>((y & 0x0FF0) >> 4);
+ 
+-    send_report(*this->_state);
++    send_report_locked(*this->_state);
+   }
+ }
+ 
+ void PS5Joypad::release_finger(int finger_nr) {
++  std::lock_guard<std::mutex> lock(this->_state->report_mutex);
+   if (finger_nr <= 1) {
+     // if it goes above 0x7F we should reset it to 0
+     if (this->_state->last_touch_id >= 0x7E) {
+       this->_state->last_touch_id = 0;
+     }
+     this->_state->current_state.points[finger_nr].contact = 1;
+-    send_report(*this->_state);
++    send_report_locked(*this->_state);
+   }
+ }
+ 

--- a/packaging/linux/patches/inputtino/README.md
+++ b/packaging/linux/patches/inputtino/README.md
@@ -9,10 +9,31 @@ button report. A per-pad lock now spans state mutation, serialization, sequence
 updates and the UHID write. Callback registration uses a separate lock; copied
 callbacks execute outside it. Sender and UHID reader threads remain joinable,
 stop flags are atomic, and moving a pad transfers its sender. Teardown joins the
-threads before releasing the device and descriptor.
+threads before releasing the device and descriptor. Set the transport mode before
+starting its reader and keep a descriptor guard until reader/device ownership
+is established.
+
+Callbacks execute on the reader thread. They may register callbacks or submit
+input; destroying the pad or stopping its reader must remain on an owning
+thread outside the callback. Polaris feedback callbacks already follow this
+ownership rule.
 
 This addresses a reproduced report-order defect during investigation of #634.
 The reporter's selected virtual pad and kernel-side trace are still needed to
 establish whether it caused that report. Xbox and Switch report behavior is
 unchanged. Kernel input delivery, Steam recognition and physical rumble require
 separate hardware validation.
+
+Run the small device-free suite independently on Linux:
+
+```sh
+cmake -S tests/fixtures/inputtino -B build-inputtino
+cmake --build build-inputtino -j2
+ctest --test-dir build-inputtino --output-on-failure
+```
+
+The report test substitutes UHID transport and exercises the real report code,
+repeat loop, moves and teardown. The device test uses private sockets while
+exercising the real UHID poll/read/join owner, including a callback in flight and
+construction failures. Neither test opens an input node. Both run in the native
+ASan/UBSan CI lane. Use a separate build with `-fsanitize=thread` for TSan.

--- a/packaging/linux/patches/inputtino/README.md
+++ b/packaging/linux/patches/inputtino/README.md
@@ -1,0 +1,18 @@
+# DualSense report ordering and thread ownership
+
+The canonical inputtino pin is `504f0abc7da8ebc351f8300fb2ed98db5438ee48`.
+CMake checks the original hashes and applies this backport to a build-directory
+copy. A changed dependency fails configuration until the patch is reviewed.
+
+The periodic sender can serialize old input, then deliver it after a newer
+button report. A per-pad lock now spans state mutation, serialization, sequence
+updates and the UHID write. Callback registration uses a separate lock; copied
+callbacks execute outside it. Sender and UHID reader threads remain joinable,
+stop flags are atomic, and moving a pad transfers its sender. Teardown joins the
+threads before releasing the device and descriptor.
+
+This addresses a reproduced report-order defect during investigation of #634.
+The reporter's selected virtual pad and kernel-side trace are still needed to
+establish whether it caused that report. Xbox and Switch report behavior is
+unchanged. Kernel input delivery, Steam recognition and physical rumble require
+separate hardware validation.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -671,3 +671,8 @@ if (BUILD_FULL_TESTS)
             test_polaris_video
     )
 endif ()
+
+# Exercise actual inputtino code with private in-memory/socket transports.
+if(UNIX AND NOT APPLE)
+    add_subdirectory(fixtures/inputtino)
+endif()

--- a/tests/fixtures/inputtino/CMakeLists.txt
+++ b/tests/fixtures/inputtino/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.20)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    project(polaris_inputtino_regressions LANGUAGES CXX)
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        message(FATAL_ERROR "Standalone inputtino regressions require Linux UAPI headers")
+    endif()
+    enable_testing()
+    find_package(Threads REQUIRED)
+    get_filename_component(polaris_root "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+    include("${polaris_root}/cmake/dependencies/inputtino.cmake")
+    set(POLARIS_INPUTTINO_SOURCE_DIR "${CMAKE_BINARY_DIR}/inputtino-source")
+    polaris_prepare_inputtino("${polaris_root}/third-party/inputtino" "${POLARIS_INPUTTINO_SOURCE_DIR}")
+endif()
+
+add_executable(test_inputtino_reports report_order.cpp)
+target_include_directories(test_inputtino_reports PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${POLARIS_INPUTTINO_SOURCE_DIR}/src/uhid/include")
+target_compile_definitions(test_inputtino_reports PRIVATE
+    POLARIS_TEST_INPUTTINO_SOURCE="${POLARIS_INPUTTINO_SOURCE_DIR}/src/uhid/joypad_ps5.cpp")
+
+add_executable(test_inputtino_device device_lifetime.cpp)
+target_compile_definitions(test_inputtino_device PRIVATE
+    POLARIS_TEST_UHID_SOURCE="${POLARIS_INPUTTINO_SOURCE_DIR}/src/uhid/include/uhid/uhid.hpp")
+
+foreach(target test_inputtino_reports test_inputtino_device)
+    target_compile_features(${target} PRIVATE cxx_std_20)
+    target_include_directories(${target} PRIVATE "${POLARIS_INPUTTINO_SOURCE_DIR}/include")
+    target_link_libraries(${target} PRIVATE Threads::Threads)
+    add_test(NAME ${target} COMMAND ${target})
+    set_tests_properties(${target} PROPERTIES TIMEOUT 30)
+endforeach()

--- a/tests/fixtures/inputtino/device_lifetime.cpp
+++ b/tests/fixtures/inputtino/device_lifetime.cpp
@@ -1,0 +1,129 @@
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <condition_variable>
+#include <fcntl.h>
+#include <functional>
+#include <iostream>
+#include <linux/uhid.h>
+#include <memory>
+#include <mutex>
+#include <poll.h>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <termios.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+#include <inputtino/result.hpp>
+
+namespace fixture {
+std::mutex mutex;
+std::condition_variable changed;
+int peer = -1;
+std::atomic<unsigned> closes{0};
+std::atomic<bool> callback_running{false};
+std::atomic<bool> early_close{false};
+bool reject_create = false, release_callback = false;
+void require(bool value, const char *message) {
+  if (!value) throw std::runtime_error(message);
+}
+int open(const char *, int) {
+  int pair[2];
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, pair)) return -1;
+  peer = pair[1];
+  return pair[0];
+}
+ssize_t write(int, const void *, size_t bytes) {
+  if (reject_create) { errno = EIO; return -1; }
+  return bytes;
+}
+int close(int fd) {
+  if (callback_running) early_close = true;
+  ++closes;
+  return ::close(fd);
+}
+struct ThrowOnCopy {
+  std::shared_ptr<bool> armed;
+  explicit ThrowOnCopy(std::shared_ptr<bool> value) : armed(std::move(value)) {}
+  ThrowOnCopy(const ThrowOnCopy &value) : armed(value.armed) {
+    if (*armed) throw std::bad_alloc();
+  }
+  void operator()(const uhid_event &, int) const {}
+};
+}
+// Compile the actual UHID owner, replacing only open/write/close. Its real poll,
+// read, thread and stop/join code runs against a private socket pair.
+#define open fixture::open
+#define write fixture::write
+#define close fixture::close
+#include POLARIS_TEST_UHID_SOURCE
+#undef open
+#undef write
+#undef close
+
+using namespace std::chrono_literals;
+int main() {
+  using namespace fixture;
+  try {
+    const uhid::DeviceDefinition definition{};
+    reject_create = true;
+    require(!uhid::Device::create(definition, [](const uhid_event &, int) {}), "create write failure was ignored");
+    require(closes == 1, "failed creation leaked descriptor");
+    ::close(peer);
+    reject_create = false;
+    auto armed = std::make_shared<bool>(false);
+    const std::function<void(const uhid_event &, int)> throwing = ThrowOnCopy(armed);
+    *armed = true;
+    bool caught = false;
+    try { auto unused = uhid::Device::create(definition, throwing); }
+    catch (const std::bad_alloc &) { caught = true; }
+    require(caught && closes == 2, "exception before reader ownership leaked descriptor");
+    ::close(peer);
+    {
+      auto result = uhid::Device::create(definition, [](const uhid_event &, int) {
+        std::unique_lock lock(mutex);
+        callback_running = true;
+        changed.notify_all();
+        require(changed.wait_for(lock, 3s, [] { return release_callback; }), "callback timed out");
+        callback_running = false;
+      });
+      require(bool(result), "private transport create failed");
+      auto owned = std::make_unique<uhid::Device>(std::move(*result));
+      const uhid_event event{};
+      require(::write(peer, &event, sizeof event) == sizeof event, "private event injection failed");
+      {
+        std::unique_lock lock(mutex);
+        require(changed.wait_for(lock, 3s, [] { return callback_running.load(); }), "reader callback not entered");
+      }
+      std::atomic<bool> started{false}, destroyed{false};
+      std::jthread destroy([device = std::move(owned), &started, &destroyed]() mutable {
+        started = true;
+        changed.notify_all();
+        device.reset();
+        destroyed = true;
+        changed.notify_all();
+      });
+      bool premature;
+      {
+        std::unique_lock lock(mutex);
+        changed.wait_for(lock, 1s, [&] { return started.load(); });
+        changed.wait_for(lock, 100ms, [&] { return destroyed.load(); });
+        premature = destroyed;
+        release_callback = true;
+        changed.notify_all();
+      }
+      destroy.join();
+      require(!premature && !early_close, "device destroyed while callback was active");
+      require(closes == 3 && destroyed, "joined teardown did not close descriptor");
+    }
+    ::close(peer);
+    std::cout << "PASS: real UHID reader move, in-flight callback join and creation failure cleanup\n";
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << "FAIL: " << error.what() << '\n';
+    return 1;
+  }
+}

--- a/tests/fixtures/inputtino/report_order.cpp
+++ b/tests/fixtures/inputtino/report_order.cpp
@@ -1,0 +1,178 @@
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <numeric>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+#include <linux/input.h>
+#include POLARIS_TEST_INPUTTINO_SOURCE
+
+using namespace std::chrono_literals;
+namespace inputtino_test {
+bool fail_create = false;
+struct Report { unsigned buttons; unsigned sequence; };
+std::mutex mutex;
+std::condition_variable changed;
+std::vector<Report> reports;
+std::function<void(const uhid_event &, int)> callback;
+bool gate = false, waiting = false, release = false, transport_stopped = false;
+thread_local bool setter = false;
+void require(bool value, const char *message) {
+  if (!value) throw std::runtime_error(message);
+}
+void opened(const std::function<void(const uhid_event &, int)> &value) {
+  std::lock_guard lock(mutex);
+  callback = value;
+  transport_stopped = false;
+}
+void stopped() {
+  std::lock_guard lock(mutex);
+  transport_stopped = true;
+  callback = {}; // release the callback's shared pad state, as the real reader does
+}
+inputtino::Result<bool> accept(const uhid_event &ev) {
+  require(ev.type == UHID_INPUT2, "unexpected report type");
+  const auto offset = sizeof(uhid::dualsense_input_report_bt_header);
+  require(ev.u.input2.size >= offset + sizeof(uhid::dualsense_input_report) + 4 &&
+          ev.u.input2.size <= UHID_DATA_MAX, "invalid report length");
+  uhid::dualsense_input_report report{};
+  std::memcpy(&report, ev.u.input2.data + offset, sizeof report);
+  const auto end = ev.u.input2.size - 4;
+  uint32_t actual;
+  std::memcpy(&actual, ev.u.input2.data + end, 4);
+  require(actual == inputtino::sign_crc32(uhid::PS_INPUT_CRC32, ev.u.input2.data, end), "invalid CRC");
+  unsigned buttons = 0;
+  if (report.buttons[0] & uhid::CROSS) buttons |= inputtino::Joypad::A;
+  if (report.buttons[0] & uhid::CIRCLE) buttons |= inputtino::Joypad::B;
+  if ((report.buttons[0] & 15) == uhid::HAT_E) buttons |= inputtino::Joypad::DPAD_RIGHT;
+  std::unique_lock lock(mutex);
+  require(!transport_stopped, "report after transport stopped");
+  if (gate && !setter) {
+    waiting = true;
+    changed.notify_all();
+    require(changed.wait_for(lock, 3s, [] { return release; }), "report gate timed out");
+  }
+  reports.push_back({buttons, report.seq_number});
+  changed.notify_all();
+  return true;
+}
+void reset() {
+  std::lock_guard lock(mutex);
+  reports.clear();
+  gate = waiting = release = false;
+}
+void verify_order() {
+  std::lock_guard lock(mutex);
+  require(!reports.empty(), "no reports");
+  for (size_t i = 1; i < reports.size(); ++i)
+    require(reports[i].sequence == (reports[i - 1].sequence + 1) % 255, "report sequence went backwards or skipped");
+}
+}
+
+int main() {
+  using namespace inputtino_test;
+  try {
+    setter = true;
+    fail_create = true;
+    require(!inputtino::PS5Joypad::create(), "failed create unexpectedly succeeded");
+    fail_create = false;
+    // Real create/move/repeat/destruction run each time, without a kernel device.
+    for (int iteration = 0; iteration < 5; ++iteration) {
+      reset();
+      {
+        auto result = inputtino::PS5Joypad::create();
+        require(bool(result), "fixture create failed");
+        inputtino::PS5Joypad first(std::move(*result));
+        inputtino::PS5Joypad pad(std::move(first));
+        pad.set_pressed_buttons(inputtino::Joypad::A);
+        {
+          std::unique_lock lock(mutex);
+          gate = true;
+          require(changed.wait_for(lock, 3s, [] { return waiting; }), "repeat sender did not reach gate");
+        }
+        std::atomic<bool> started = false, complete = false;
+        std::jthread updates([&] {
+          setter = true;
+          started = true;
+          changed.notify_all();
+          pad.set_pressed_buttons(inputtino::Joypad::B);
+          pad.set_pressed_buttons(inputtino::Joypad::DPAD_RIGHT);
+          complete = true;
+          changed.notify_all();
+        });
+        {
+          std::unique_lock lock(mutex);
+          changed.wait_for(lock, 1s, [&] { return started.load(); });
+          // Give the competing setters a bounded window to attempt delivery.
+          // Old code completes here; fixed code waits for the held report.
+          changed.wait_for(lock, 100ms, [&] { return complete.load(); });
+          release = true;
+          gate = false;
+          changed.notify_all();
+        }
+        updates.join();
+        verify_order();
+        {
+          std::lock_guard lock(mutex);
+          require(reports.back().buttons == inputtino::Joypad::DPAD_RIGHT, "stale buttons after completed setters");
+        }
+      }
+      size_t count;
+      { std::lock_guard lock(mutex); count = reports.size(); }
+      std::this_thread::sleep_for(20ms);
+      { std::lock_guard lock(mutex); require(count == reports.size(), "sender survived pad destruction"); }
+    }
+    reset();
+    {
+      auto result = inputtino::PS5Joypad::create();
+      require(bool(result), "stress create failed");
+      inputtino::PS5Joypad pad(std::move(*result));
+      std::function<void(const uhid_event &, int)> reader;
+      { std::lock_guard lock(mutex); reader = callback; }
+      std::barrier start(2);
+      std::atomic<unsigned> feedback{0};
+      pad.set_on_rumble([&](int, int) { ++feedback; });
+      std::jthread output([&] {
+        start.arrive_and_wait();
+        uhid_event ev{};
+        ev.type = UHID_OUTPUT;
+        auto *report = reinterpret_cast<uhid::dualsense_output_report_usb *>(ev.u.output.data);
+        ev.u.output.data[0] = uhid::DS_OUTPUT_REPORT_USB;
+        report->common.valid_flag0 = uhid::MOTOR_OR_COMPATIBLE_VIBRATION;
+        for (int i = 0; i < 10000; ++i) reader(ev, -1);
+      });
+      start.arrive_and_wait();
+      for (int i = 0; i < 10000; ++i) {
+        pad.set_pressed_buttons(i % 2 ? inputtino::Joypad::A : inputtino::Joypad::B);
+        pad.set_triggers(i % 256, (i + 1) % 256);
+        pad.set_stick(inputtino::Joypad::LS, i % 30000, i % 30000);
+        pad.set_motion(inputtino::PS5Joypad::ACCELERATION, 1, 2, 3);
+        pad.set_battery(inputtino::PS5Joypad::BATTERY_FULL, 100);
+        pad.place_finger(0, i % 1920, i % 1080);
+        pad.release_finger(0);
+        pad.set_on_rumble([&](int, int) {
+          ++feedback;
+          // Reentrant registration must not deadlock under the callback lock.
+          pad.set_on_led([](int, int, int) {});
+        });
+      }
+      output.join();
+      require(feedback > 0, "feedback callback never exercised");
+      verify_order();
+    }
+    std::cout << "PASS: report order, CRC, concurrent setters/feedback, failed create, move and repeat teardown\n";
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << "FAIL: " << error.what() << '\n';
+    return 1;
+  }
+}

--- a/tests/fixtures/inputtino/uhid/uhid.hpp
+++ b/tests/fixtures/inputtino/uhid/uhid.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include <linux/uhid.h>
+#include <functional>
+#include <inputtino/result.hpp>
+#include <string>
+#include <vector>
+
+// Only the kernel transport is replaced. The test compiles the same patched
+// serializer, setters, repeat loop and pad move/destructor as the host build.
+namespace inputtino_test {
+extern bool fail_create;
+void opened(const std::function<void(const uhid_event &, int)> &callback);
+void stopped();
+inputtino::Result<bool> accept(const uhid_event &);
+}
+namespace uhid {
+struct DeviceDefinition {
+  std::string name, phys, uniq;
+  uint16_t bus;
+  uint32_t vendor, product, version, country;
+  std::vector<unsigned char> report_description;
+};
+inline inputtino::Result<bool> uhid_write(int, const uhid_event *ev) {
+  return inputtino_test::accept(*ev);
+}
+class Device {
+public:
+  static inputtino::Result<Device> create(const DeviceDefinition &,
+      const std::function<void(const uhid_event &, int)> &callback) {
+    if (inputtino_test::fail_create) return inputtino::Error("fixture creation failure");
+    inputtino_test::opened(callback);
+    return Device{};
+  }
+  inputtino::Result<bool> send(const uhid_event &ev) { return inputtino_test::accept(ev); }
+  void stop_thread() { inputtino_test::stopped(); }
+};
+}


### PR DESCRIPTION
A periodic DualSense report can be delivered after newer button updates, replaying stale input. Serialize state changes through the UHID write, retain and join the sender and reader threads, transfer sender ownership when moving a pad, initialize transport mode before reader startup, and close descriptors if construction fails. Callback registration is synchronized and callbacks run outside that lock.

Keep the canonical inputtino pin and apply a hash-checked backport to a build-tree copy. Includes actual-source regressions for report order/CRC, concurrent input and feedback, move/destruction, an in-flight reader callback, and failed construction. The tests use memory/private sockets and open no input devices.

Validation: independent source review; macOS ASan/UBSan and targeted TSan passed (LeakSanitizer unsupported there); Linux ASan/UBSan/LeakSanitizer passed in the Fedora 44 builder. Native sanitizer CI includes both maintained tests. Physical controller/Steam/rumble validation remains pending.

Related to #634: this fixes a reproduced DualSense defect; the reporter's virtual pad type and kernel trace are still required for attribution. Stacked on #642.
