### PR TITLE
test: stabilize Doctor idempotency and exception reporting

### DIFF
--- a/tests/tests_events.h
+++ b/tests/tests_events.h
@@ -27,7 +27,10 @@ struct PolarisEventListener: testing::EmptyTestEventListener {
   }
 
   void OnTestPartResult(const testing::TestPartResult &test_part_result) override {
-    std::string file = test_part_result.file_name();
+    const char *file = test_part_result.file_name();
+    if (file == nullptr) {
+      file = "<unknown file>";
+    }
     BOOST_LOG(tests) << "At " << file << ":" << test_part_result.line_number();
 
     auto result_text = test_part_result.passed()            ? "Success" :

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -8,6 +8,8 @@
 #include <src/doctor_actions.h>
 #include <src/adaptive_bitrate.h>
 #include <src/private_state_file.h>
+#include <src/utility.h>
+#include "../tests_events.h"
 
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
@@ -2859,6 +2861,25 @@ TEST(DoctorActionTests, EquivalentFreshTelemetryCannotMakeAutoFixUnclickable) {
   stream_stats::update_stream_active(false);
 }
 
+TEST(PolarisEventListenerTests, ReportsExceptionsWithoutASourceLocation) {
+  PolarisEventListener listener;
+  const testing::TestPartResult result(
+    testing::TestPartResult::kFatalFailure, nullptr, -1, "test exception"
+  );
+  listener.OnTestProgramStart(*testing::UnitTest::GetInstance());
+  const auto cleanup = util::fail_guard([&] {
+    listener.OnTestProgramEnd(*testing::UnitTest::GetInstance());
+  });
+  EXPECT_NO_THROW(listener.OnTestPartResult(result));
+  std::string output;
+  {
+    const auto backend = listener.sink->locked_backend();
+    output = listener.sink_buffer->str();
+  }
+  EXPECT_NE(output.find("<unknown file>"), std::string::npos);
+  EXPECT_NE(output.find("test exception"), std::string::npos);
+}
+
 TEST(DoctorActionTests, EveryRequestIdRemainsIdempotentForTheWholeStreamGeneration) {
   LiveConfigurationGuard live_configuration;
   config::video.adaptive_bitrate.enabled = false;
@@ -2879,6 +2900,11 @@ TEST(DoctorActionTests, EveryRequestIdRemainsIdempotentForTheWholeStreamGenerati
   doctor_actions::session_started("client-owner", generation, "launch-423", 20000);
   adaptive_bitrate::set_runtime_update_supported(true, {}, 20000);
   stream_stats::start_session_timing("client-owner", generation, "launch-423");
+  const auto cleanup = util::fail_guard([&] {
+    doctor_actions::session_ended("client-owner", generation);
+    stream_stats::stop_session_timing("client-owner", generation);
+    stream_stats::update_stream_active(false);
+  });
 
   doctor_actions::recovery_action_context_t context;
   context.active_owner = true;
@@ -2891,27 +2917,40 @@ TEST(DoctorActionTests, EveryRequestIdRemainsIdempotentForTheWholeStreamGenerati
 
   nlohmann::json first_request;
   for (int i = 0; i < 128; ++i) {
+    // Owner updates persist configuration. A slow filesystem must not age the
+    // synthetic observation out while this test fills the receipt history.
+    stream_stats::update_network_stats(52.0, 3.4, 1000);
     context.stats = stream_stats::get_current();
     const auto request = trusted_doctor_action_request(context);
+    ASSERT_EQ(request.value("action_id", ""), "lower_bitrate") << request.dump();
     if (i == 0) first_request = request;
     const auto applied = doctor_actions::execute(request, context);
-    ASSERT_TRUE(applied.at("status").get<bool>());
+    ASSERT_TRUE(applied.at("status").get<bool>()) << applied.dump();
     ASSERT_EQ(applied.at("state"), "applying");
     ASSERT_TRUE(doctor_actions::set_owner_live_bitrate(
       "client-owner", generation, "launch-423", 20000
     ));
   }
 
+  // Capacity and retained idempotency receipts do not depend on live telemetry.
+  // Reuse an admitted action envelope with a new ID rather than deriving an
+  // action from expired evidence, which correctly offers no new live fix.
+  stream_stats::age_latest_network_observation_for_tests(std::chrono::seconds(3));
   context.stats = stream_stats::get_current();
+  ASSERT_GE(context.stats.network_last_received_age_ms, 2000);
+  ASSERT_GE(context.stats.media_loss_last_received_age_ms, 2000);
+  auto capacity_request = first_request;
+  capacity_request["request_id"] = "test-doctor-request-over-capacity";
   const auto over_capacity = doctor_actions::execute(
-    trusted_doctor_action_request(context), context
+    capacity_request, context
   );
-  EXPECT_FALSE(over_capacity.at("status").get<bool>());
+  ASSERT_FALSE(over_capacity.at("status").get<bool>()) << over_capacity.dump();
+  ASSERT_TRUE(over_capacity.contains("state")) << over_capacity.dump();
   EXPECT_EQ(over_capacity.at("state"), "generation_action_limit");
   EXPECT_EQ(over_capacity.at("code"), "doctor_idempotency_capacity_reached");
 
   const auto oldest_retry = doctor_actions::execute(first_request, context);
-  EXPECT_TRUE(oldest_retry.at("status").get<bool>());
+  ASSERT_TRUE(oldest_retry.at("status").get<bool>()) << oldest_retry.dump();
   EXPECT_FALSE(oldest_retry.at("changed").get<bool>());
   EXPECT_EQ(oldest_retry.at("state"), "superseded");
   EXPECT_EQ(
@@ -2920,9 +2959,6 @@ TEST(DoctorActionTests, EveryRequestIdRemainsIdempotentForTheWholeStreamGenerati
   );
   EXPECT_EQ(adaptive_bitrate::get_doctor_state().live_bitrate_kbps, 20000);
 
-  doctor_actions::session_ended("client-owner", generation);
-  stream_stats::stop_session_timing("client-owner", generation);
-  stream_stats::update_stream_active(false);
 }
 
 TEST(DoctorActionTests, AdaptiveToggleRestoresDoctorTargetBeforeChangingPolicy) {


### PR DESCRIPTION
The Doctor idempotency test could age its synthetic network evidence out while persisting 128 owner updates, then derive an empty action instead of testing capacity. GoogleTest reports the resulting exception without a filename, which also crashed the test event listener.

Refresh observations before each new action, and use a retained action envelope with a new request ID to test capacity and oldest-request idempotency after deliberately aging telemetry. Add scoped cleanup and make the listener handle missing source locations.

Validation: both failures reproduced with the old fixtures; all 26 Doctor action tests plus the new listener regression passed as a non-root user with the corrected fixtures. Production freshness and persistence behavior are unchanged. CI will validate the complete source and sanitizer suites.
