### PR TITLE
release: prepare Polaris 1.4.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
     set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
-project(Polaris VERSION 1.4.4
+project(Polaris VERSION 1.4.5
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/bazzite.md
+++ b/docs/bazzite.md
@@ -332,17 +332,16 @@ an extension stored in `/var`.
 
 | Area | Current scope |
 |:-----|:--------------|
-| Fedora 44 RPM on Bazzite | Supported installation, with explicit update and rollback steps |
-| NVIDIA / KDE Plasma Wayland Desktop Mode | Service, pairing, capture, input isolation, and reconnect evidence exists; a successful desktop stream does not establish private-game acceptance |
+| Fedora 44 RPM on Bazzite | Supported installation, with explicit update and rollback steps, exercised end to end on an NVIDIA host on 2026-09-10 |
+| NVIDIA / KDE Plasma Wayland Desktop Mode | Verified 2026-09-10 on `bazzite-nvidia-open` 44.20260908 with an RTX 4090 and the 1.4.5 RPM: staged install, reboot, host setup, a Private Stream game session at 1920x1080@120 with controller, game audio, and rumble from a Retroid Pocket 6, disconnect and resume, End Session cleanup, rollback to 1.4.4 and back. Capture ran on the system-memory path with NVENC; the GPU-native path needs a CUDA build |
 | Bazzite Deck / Steam Game Mode | Boot-independent service setup is available; end-to-end Game Mode game streaming still needs hardware validation |
 | AMD / Intel Bazzite hosts | Use the matching Fedora RPM; driver-specific capture, encoding, and Game Mode behavior need additional hardware coverage |
 | Standalone system extension | Withdrawn; separate package, SELinux, lifecycle, and physical validation gates remain |
 | Container multiseat | Separate development work; production activation remains off |
 
-The earlier NVIDIA Desktop Mode baseline used `bazzite-nvidia-open:stable`
-`44.20260430`. It was a Plasma Desktop image, not a Game Mode-capable Deck image.
-More recent candidate testing does not certify every released package, GPU, or
-Steam launch path. See [Compatibility](compatibility.md) and
+The NVIDIA Desktop Mode baseline is `bazzite-nvidia-open` `44.20260908`, a Plasma
+Desktop image with autologin, not a Game Mode-capable Deck image. One host and one
+GPU do not certify every released package, GPU, or Steam launch path. See [Compatibility](compatibility.md) and
 [the system-extension validation requirements](../scripts/validation/bazzite/README.md).
 
 ## Troubleshooting

--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -530,7 +530,7 @@
         "example": {
           "schema_version": 1,
           "measurement_spec_id": "measurement-spec-v1",
-          "collector_version": "1.4.4",
+          "collector_version": "1.4.5",
           "clock_domain": "CLOCK_MONOTONIC",
           "run_id": "pair-0001-control",
           "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ starts at `v1.0.0`.
 
 ## v1.4.5 - 2026-09-10
 
-A Bazzite and Live Tuning update matched with Nova v1.4.5. Live Tuning is one saved host preference that every console surface and paired client reads the same way, Bazzite Desktop launches prepare capture before the stream starts, hosts running a Steam Game Mode session learn why they go offline and how headless boot keeps them reachable, and `--setup-host` reports it. Existing configurations and paired devices remain valid.
+A Bazzite and Live Tuning update matched with Nova v1.4.5. Live Tuning is one saved host preference that every console surface and paired client reads the same way, Bazzite Desktop launches prepare capture before the stream starts, hosts running a Steam Game Mode session learn why they go offline and how headless boot keeps them reachable, and `--setup-host` reports it. The supported Bazzite RPM path was exercised end to end on an NVIDIA Open host with a Retroid Pocket 6. Existing configurations and paired devices remain valid.
 
 - Reworks the supported Bazzite RPM guide around staged installation, explicit reboot, local-RPM replacement, and boot-independent service setup; moves the composefs KMS copy into an optional section and keeps Game Mode hardware limits and the withdrawn system extension explicit
 - Shares one saved Live Tuning preference across Quick Controls, the Audio/Video settings page, paired session status, and session events, independent of AI provider sign-in. Clients see the requested bitrate separately from the encoder-confirmed rate, with waiting, measuring, applying, adjusting, stable, unavailable, and unknown states; turning Live Tuning off holds the last confirmed bitrate, and an explicit fixed bitrate supersedes adaptive ownership (#641)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,12 +7,21 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
-- Reworks the supported Bazzite RPM guide around staged installation, explicit reboot, local-RPM replacement, and boot-independent service setup; moves the composefs KMS copy into an optional section and keeps Game Mode hardware limits and the withdrawn system extension explicit
+## v1.4.5 - 2026-09-10
 
+A Bazzite and Live Tuning update matched with Nova v1.4.5. Live Tuning is one saved host preference that every console surface and paired client reads the same way, Bazzite Desktop launches prepare capture before the stream starts, hosts running a Steam Game Mode session learn why they go offline and how headless boot keeps them reachable, and `--setup-host` reports it. Existing configurations and paired devices remain valid.
+
+- Reworks the supported Bazzite RPM guide around staged installation, explicit reboot, local-RPM replacement, and boot-independent service setup; moves the composefs KMS copy into an optional section and keeps Game Mode hardware limits and the withdrawn system extension explicit
+- Shares one saved Live Tuning preference across Quick Controls, the Audio/Video settings page, paired session status, and session events, independent of AI provider sign-in. Clients see the requested bitrate separately from the encoder-confirmed rate, with waiting, measuring, applying, adjusting, stable, unavailable, and unknown states; turning Live Tuning off holds the last confirmed bitrate, and an explicit fixed bitrate supersedes adaptive ownership (#641)
+- Prepares desktop capture before stream startup on Bazzite, normalises the resume policy, keeps native audio ownership with the session, and corrects CUDA conversion ownership and upload ordering, so a Bazzite Desktop launch or resume no longer prepares the portal too late or inherits unsuitable display semantics (#639)
+- Refreshes display capabilities once the host is back after Save + Apply, so Host Virtual Display no longer stays unavailable on the settings page because of a stale capability response; late responses cannot overwrite the new snapshot and Reset Changes keeps the refreshed capabilities (#642, #633)
+- Keeps DualSense reports in order: a periodic report can no longer land after newer button updates and replay stale input; the sender and reader threads are retained and joined, and descriptors close if construction fails (#643, #634)
+- Preserves the configured physical identity of every virtual input device on all nine uinput creation paths and keeps descriptor ownership until destruction, so reserved-device udev rules identify them reliably (#644, #494)
 - Protects unused encoder capability probes from a null-frame flush, adds actual submission/teardown regressions for the first-launch Vulkan crash, and keeps Doctor from telling a stable AMD VA-API/SHM user to switch to Auto with a promised fallback (#628)
 - Repins native PipeWire session audio when the stream omits its PID by resolving its owning client, while preserving session markers, unrelated desktop audio, and the no-default-sink-claim setting (#629)
-
 - Recognises hosts with a Steam Game Mode session (SteamOS, Bazzite deck images, CachyOS handheld edition, other gamescope-session hosts). `--setup-host` says why Polaris goes offline when the host leaves Desktop Mode and prints the headless-boot command, `/api/stats/system` reports `game_mode_host` with Game Mode-aware boot readiness and display-session guidance, and the console names a running Game Mode session instead of asking for a desktop restart. New handhelds guide with the Game Mode validation recipe (#626)
+- Adds the experimental multiseat worker foundation (default off and unwired in production), a maintained offline system-extension assembler with locked inputs, a read-only Bazzite host observer for local acceptance runs, and steadier Doctor CI fixtures (#640, #645, #646)
+- Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official package assets
 
 ## v1.4.4 - 2026-09-06
 

--- a/docs/release-notes/v1.4.5.md
+++ b/docs/release-notes/v1.4.5.md
@@ -20,7 +20,7 @@ A Bazzite and Live Tuning update, matched with Nova v1.4.5. Existing settings an
 **Heads up**
 
 - Bazzite users should use the Fedora 44 RPM through rpm-ostree. The system extension stays withdrawn.
-- Bazzite acceptance on an NVIDIA Open host with Nova v1.4.5 on a Retroid Pocket 6 is in progress for this release; AMD and Intel Bazzite images are not yet covered.
+- Verified on a Bazzite NVIDIA Open host with Nova v1.4.5 on a Retroid Pocket 6: staged install, reboot, a private game stream with controller, audio, and rumble, rollback and back. AMD and Intel Bazzite images are not yet covered. On NVIDIA the shipped RPM captures through the system-memory path with NVENC; the GPU-native path needs a CUDA build.
 - Game Mode hosts are recognised, not yet streamed from inside Game Mode. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
 - Steam Input stays manual and read-only.
 

--- a/docs/release-notes/v1.4.5.md
+++ b/docs/release-notes/v1.4.5.md
@@ -1,0 +1,82 @@
+# Polaris v1.4.5
+
+A Bazzite and Live Tuning update, matched with Nova v1.4.5. Existing settings and paired devices keep working.
+
+**New**
+
+- Live Tuning is one host setting now. Quick Controls, Video/Audio settings, and Nova all show the same state, and the requested bitrate is shown apart from what the encoder confirmed.
+- Hosts running a Steam Game Mode session are recognised. Setup explains why Polaris goes offline outside Desktop Mode and prints the headless boot command.
+- The Bazzite guide walks through staging the RPM, rebooting on purpose, replacing a local RPM in one step, and setting up the host so it survives reboots.
+
+**Fixed**
+
+- Bazzite Desktop launches prepare capture before the stream starts and keep the game's audio with the session.
+- Host Virtual Display no longer stays greyed out on the settings page after Save + Apply.
+- DualSense input arrives in order; a late periodic report can no longer replay stale buttons.
+- Virtual input devices keep their physical identity, so reserved-device rules find them every time.
+- A first launch with Vulkan on AMD no longer crashes on an encoder probe, and Doctor stops telling a stable VA-API user to switch to Auto.
+- Native PipeWire game audio stays with its session when the stream does not report its PID.
+
+**Heads up**
+
+- Bazzite users should use the Fedora 44 RPM through rpm-ostree. The system extension stays withdrawn.
+- Bazzite acceptance on an NVIDIA Open host with Nova v1.4.5 on a Retroid Pocket 6 is in progress for this release; AMD and Intel Bazzite images are not yet covered.
+- Game Mode hosts are recognised, not yet streamed from inside Game Mode. SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+- Steam Input stays manual and read-only.
+
+<details>
+<summary><b>Install</b> (Fedora 44, Arch / CachyOS, Ubuntu 24.04, SteamOS 3.8)</summary>
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### SteamOS 3.8
+
+Run this in Desktop Mode. It sets up the package keyring when needed and restores the read-only root before starting Polaris.
+
+```bash
+wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-steamos3.8-x86_64.pkg.tar.zst &&
+(
+set -e
+trap 'sudo steamos-readonly enable' EXIT
+sudo steamos-readonly disable || exit $?
+sudo pacman-key --init || exit $?
+sudo pacman-key --populate || exit $?
+sudo pacman -Sy || exit $?
+sudo pacman -U ./Polaris-steamos3.8-x86_64.pkg.tar.zst || exit $?
+sudo -H polaris --setup-host || exit $?
+sudo steamos-readonly enable || exit $?
+trap - EXIT
+) &&
+systemctl --user enable --now polaris
+```
+
+Bazzite users should follow the [Bazzite guide](https://papi-ux.com/docs/bazzite/) and use the Fedora RPM through rpm-ostree. SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/); SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+
+</details>
+
+**Assets:** `Polaris-fedora44-x86_64.rpm` · `Polaris-arch-x86_64.pkg.tar.zst` · `Polaris-ubuntu24.04-x86_64.deb` · `Polaris-steamos3.8-x86_64.pkg.tar.zst`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.4.4') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.4.5') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -665,7 +665,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.4.4.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.4.5.md").read_text(encoding="utf-8")
 )
 
 
@@ -1296,17 +1296,18 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.4.5 - 2026-09-10",
     "## v1.4.4 - 2026-09-06",
-    "## v1.4.3 - 2026-09-05",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "application menu",
-    "user service",
+    "Live Tuning",
+    "Bazzite",
+    "Game Mode",
     "headless boot",
     "--setup-host",
-    "input group",
-    "Bazzite",
+    "Host Virtual Display",
+    "DualSense",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
     "Polaris-steamos3.8-x86_64.pkg.tar.zst",
@@ -1314,7 +1315,7 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.4.4 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.5 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1323,7 +1324,7 @@ asset_phrase = (
     "`Polaris-steamos3.8-x86_64.pkg.tar.zst`, and "
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
-for label, section in (("v1.4.4 changelog", current_release_prose),):
+for label, section in (("v1.4.5 changelog", current_release_prose),):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
         sys.exit(1)
@@ -1343,7 +1344,7 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section, expected_section_assets in (
     ("docs/building.md Packaging", building_packaging_prose, expected_assets),
-    ("v1.4.4 changelog", current_release_prose, expected_changelog_assets),
+    ("v1.4.5 changelog", current_release_prose, expected_changelog_assets),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_section_assets:
@@ -1357,24 +1358,23 @@ for label, section, expected_section_assets in (
 # Release notes are the short, user-facing list; the changelog carries the
 # detail. Pin phrases a player would read, never internal identifiers.
 release_notes_facts = (
-    "Nova v1.4.4",
-    "application menu",
-    "user service",
+    "Nova v1.4.5",
+    "Live Tuning",
+    "Game Mode",
     "headless boot",
-    "input group",
     "Bazzite",
     "rpm-ostree",
     "system extension stays withdrawn",
     "SteamOS",
     "Steam Input",
     "Retroid Pocket 6",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-fedora44-x86_64.rpm &&",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
-    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.4/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
     "trap 'sudo steamos-readonly enable' EXIT",
     "sudo pacman-key --init || exit $?",
     "sudo pacman-key --populate || exit $?",
@@ -1382,25 +1382,25 @@ release_notes_facts = (
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.4.4 release notes are missing release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.5 release notes are missing release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 release_asset_lines = [
     line for line in release_notes.splitlines() if line.startswith("**Assets:**")
 ]
 if len(release_asset_lines) != 1:
-    print("v1.4.4 release notes must contain exactly one Assets line", file=sys.stderr)
+    print("v1.4.5 release notes must contain exactly one Assets line", file=sys.stderr)
     sys.exit(1)
 release_note_assets = Counter(asset_pattern.findall(release_asset_lines[0]))
 if release_note_assets != expected_assets:
     print(
-        "v1.4.4 release-note Assets line must contain only the four supported packages; "
+        "v1.4.5 release-note Assets line must contain only the four supported packages; "
         f"expected={dict(expected_assets)}, actual={dict(release_note_assets)}",
         file=sys.stderr,
     )
     sys.exit(1)
 if release_notes.count(withdrawn_sysext_asset) != 0:
     print(
-        "v1.4.4 release notes must not name the withdrawn system extension file; that warning lives in v1.4.3",
+        "v1.4.5 release notes must not name the withdrawn system extension file; that warning lives in v1.4.3",
         file=sys.stderr,
     )
     sys.exit(1)
@@ -1411,19 +1411,19 @@ for forbidden in (
     "AI Auto Quality Preference",
 ):
     if forbidden in current_release_prose or forbidden in release_notes:
-        print(f"v1.4.4 public release scope must exclude: {forbidden}", file=sys.stderr)
+        print(f"v1.4.5 public release scope must exclude: {forbidden}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.4.4 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.4.5 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host || exit $?") != 1:
-    print("v1.4.4 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
+    print("v1.4.5 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.4.4 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.4.5 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user enable --now polaris") != 1:
-    print("v1.4.4 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
+    print("v1.4.5 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
     sys.exit(1)
 
 release_workflow = Path(".github/workflows/build.yml").read_text(encoding="utf-8")

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.4-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.5-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/scripts/validation/bazzite/README.md
+++ b/scripts/validation/bazzite/README.md
@@ -4,6 +4,44 @@ Publication remains disabled for the standalone Polaris system extension. This d
 
 The supported Fedora 44 RPM path remains separate. Its dependencies may be resolved by `rpm-ostree`; a standalone system extension must carry every runtime dependency not already guaranteed by the target image.
 
+## Local host observation
+
+Before a local acceptance run, capture the booted and pending deployments, the
+installed RPM, the actual user-service process, executable hashes, supplementary
+groups, SELinux mode, and the persistent Polaris extension, if present:
+
+```sh
+observation_dir="$(mktemp -d "$HOME/polaris-bazzite-observation.XXXXXX")"
+python3 scripts/validation/bazzite/inspect_host.py \
+  --output "$observation_dir/before.json"
+```
+
+The tool only queries state and writes a new mode-0600 file in an existing private
+directory. It does not install, merge, reboot, alter services, or open input
+devices. It omits service command arguments, environments, configuration contents
+and the large embedded OCI metadata. Keep the report private: it includes local
+paths and process/user identifiers.
+
+An executable with capabilities can make `/proc/PID/exe` unreadable to its own
+user. The report then records the executable comparison as unavailable. When a
+privileged observation is needed, select the normal service user explicitly with
+`sudo python3 ... --user-uid "$(id -u)" --output ...`; never select root's user
+manager. Root observation does not prove desktop-user device access.
+
+Use `--expected-executable-sha256` with the digest from the candidate's actual
+build receipt to distinguish that candidate from an older running preview. The
+report also compares the running executable with `/usr/bin/polaris`, since a local
+service override can keep a preview running while the RPM database reports a
+different package. Service restarts, process changes, missing identity and
+unreadable files remain explicit. A zero exit means a consistent service
+observation, not a passed installation, input, streaming or publication gate.
+
+Run the portable checks locally without a native build:
+
+```sh
+python3 -m unittest discover -s scripts/validation/bazzite -p 'test_*.py'
+```
+
 ## Required targets
 
 Every candidate is bound to one exact SHA-256 digest and one exact source commit. The same bytes must pass both current Fedora 44 targets:

--- a/scripts/validation/bazzite/inspect_host.py
+++ b/scripts/validation/bazzite/inspect_host.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Read-only Bazzite baseline collection; never an installation or readiness gate."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import pwd
+import re
+import stat
+import subprocess
+import sys
+
+
+SERVICE_PROPERTIES = (
+    "LoadState", "ActiveState", "SubState", "MainPID", "InvocationID",
+    "FragmentPath", "DropInPaths", "UnitFileState",
+)
+IDENTITY_PROPERTIES = ("MainPID", "InvocationID", "ActiveState", "SubState")
+DEPLOYMENT_FIELDS = (
+    "booted", "staged", "checksum", "base-checksum", "version",
+    "container-image-reference", "container-image-reference-digest",
+    "requested-local-packages", "requested-packages", "pinned",
+)
+SAFE_ENV = {"PATH": "/usr/sbin:/usr/bin:/sbin:/bin", "LC_ALL": "C"}
+
+
+def command(argv: list[str]) -> dict:
+    try:
+        result = subprocess.run(
+            argv, capture_output=True, text=True, timeout=30, env=SAFE_ENV,
+            check=False,
+        )
+        return {"returncode": result.returncode, "stdout": result.stdout}
+    except (OSError, subprocess.TimeoutExpired) as error:
+        # Command arguments, environments and stderr can contain private data.
+        return {"returncode": None, "error": type(error).__name__, "stdout": ""}
+
+
+def service_command(uid: int) -> list[str]:
+    if uid <= 0 or (os.geteuid() != 0 and uid != os.geteuid()):
+        raise ValueError("Select the normal desktop user's UID, not root or another user")
+    argv = ["systemctl", "--user", "show", "polaris.service"]
+    argv += ["--property=" + name for name in SERVICE_PROPERTIES]
+    argv = [
+        "env", "-i", "PATH=" + SAFE_ENV["PATH"], "LC_ALL=C",
+        f"XDG_RUNTIME_DIR=/run/user/{uid}",
+        f"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{uid}/bus", *argv,
+    ]
+    if os.geteuid() == 0:
+        argv = ["runuser", "--user", pwd.getpwuid(uid).pw_name, "--", *argv]
+    return argv
+
+
+def service_state(uid: int) -> dict:
+    result = command(service_command(uid))
+    if result["returncode"] != 0:
+        return {"available": False, "error": result.get("error", "query_failed")}
+    fields = dict(line.split("=", 1) for line in result["stdout"].splitlines() if "=" in line)
+    return {"available": True, **{name: fields.get(name, "") for name in SERVICE_PROPERTIES}}
+
+
+def file_identity(path: Path, *, no_follow: bool = False) -> dict:
+    try:
+        flags = os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC
+        if no_follow:
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        try:
+            before = os.fstat(fd)
+            if not stat.S_ISREG(before.st_mode) or before.st_size > 512 * 1024 * 1024:
+                return {"available": False, "error": "not_a_bounded_regular_file"}
+            digest = hashlib.sha256()
+            size = 0
+            while chunk := os.read(fd, 1024 * 1024):
+                size += len(chunk)
+                if size > before.st_size:
+                    return {"available": False, "error": "file_changed"}
+                digest.update(chunk)
+            after = os.fstat(fd)
+            fields = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_ctime_ns")
+            if size != before.st_size or any(getattr(before, x) != getattr(after, x) for x in fields):
+                return {"available": False, "error": "file_changed"}
+            return {"available": True, "sha256": digest.hexdigest(), "bytes": size}
+        finally:
+            os.close(fd)
+    except OSError as error:
+        return {"available": False, "error": type(error).__name__}
+
+
+def process_identity(pid: int, proc_root: Path = Path("/proc")) -> dict:
+    if pid <= 0:
+        return {"available": False, "error": "no_running_process"}
+    try:
+        root = proc_root / str(pid)
+        before = (root / "stat").read_text().rsplit(")", 1)[1].split()[19]
+        fields = dict(line.split(":", 1) for line in (root / "status").read_text().splitlines() if ":" in line)
+        credentials = {name: list(map(int, fields[name].split())) for name in ("Uid", "Gid", "Groups")}
+        executable = file_identity(root / "exe")
+        try:
+            executable["path"] = os.readlink(root / "exe")
+        except OSError:
+            pass
+        after = (root / "stat").read_text().rsplit(")", 1)[1].split()[19]
+        if before != after:
+            return {"available": False, "error": "process_changed"}
+        return {
+            "available": True, "pid": pid, "start_ticks": before,
+            "credentials": credentials, "executable": executable,
+            "capabilities": {name: fields.get(name, "").strip() for name in ("CapEff", "CapPrm", "CapAmb", "NoNewPrivs")},
+        }
+    except (OSError, KeyError, IndexError, ValueError) as error:
+        return {"available": False, "error": type(error).__name__}
+
+
+def device_metadata(path: Path) -> dict:
+    try:
+        info = path.lstat()
+        return {
+            "available": True, "character_device": stat.S_ISCHR(info.st_mode),
+            "mode": oct(stat.S_IMODE(info.st_mode)), "uid": info.st_uid, "gid": info.st_gid,
+        }
+    except OSError as error:
+        return {"available": False, "error": type(error).__name__}
+
+
+def deployment_summary(result: dict) -> dict:
+    if result["returncode"] != 0:
+        return {"available": False, "error": result.get("error", "query_failed")}
+    try:
+        data = json.loads(result["stdout"])
+        deployments = data["deployments"]
+        if not isinstance(deployments, list) or not all(isinstance(d, dict) for d in deployments):
+            raise ValueError("Invalid deployment list")
+        return {
+            "available": True,
+            "deployments": [{key: d.get(key) for key in DEPLOYMENT_FIELDS} for d in deployments],
+            "transaction_active": data.get("transaction") is not None,
+        }
+    except (ValueError, KeyError, TypeError):
+        return {"available": False, "error": "invalid_deployment_response"}
+
+
+def assess(before: dict, after: dict, process: dict, uid: int, installed: dict, expected: str | None) -> dict:
+    stable = (
+        before.get("available") is True and after.get("available") is True
+        and all(before.get(k) == after.get(k) for k in IDENTITY_PROPERTIES)
+        and before.get("ActiveState") == "active" and before.get("SubState") == "running"
+        and re.fullmatch("[0-9a-f]{32}", before.get("InvocationID", "")) is not None
+        and process.get("available") is True
+        and str(process.get("pid")) == before.get("MainPID")
+        and process.get("credentials", {}).get("Uid") == [uid] * 4
+    )
+    runtime = process.get("executable", {})
+    runtime_hash = runtime.get("sha256") if stable and runtime.get("available") else None
+    installed_hash = installed.get("sha256") if installed.get("available") else None
+    return {
+        "service_snapshot": "consistent" if stable else "unavailable_or_changed",
+        "runtime_matches_expected": (
+            "not_requested" if expected is None else
+            "unavailable" if runtime_hash is None else
+            "match" if runtime_hash == expected else "mismatch"
+        ),
+        "usr_bin_matches_running_executable": (
+            "unavailable" if runtime_hash is None or installed_hash is None else
+            "match" if runtime_hash == installed_hash else "mismatch"
+        ),
+        "input_access": "not_tested",
+        "installed_lifecycle": "not_tested",
+        "streaming": "not_tested",
+        "scope": "Observation only; matching hashes and device metadata do not establish readiness.",
+    }
+
+
+def collect(uid: int, expected: str | None) -> dict:
+    before = service_state(uid)
+    pid = int(before.get("MainPID") or "0")
+    process = process_identity(pid)
+    installed = file_identity(Path("/usr/bin/polaris"))
+    deployments = deployment_summary(command(["rpm-ostree", "status", "--json"]))
+    package = command(["rpm", "-q", "--qf", "%{NAME}-%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n", "polaris"])
+    selinux = command(["getenforce"])
+    extension = Path("/var/lib/extensions/polaris.raw")
+    process_after = process_identity(pid)
+    after = service_state(uid)
+    process_stable = (
+        process.get("available") is True and process_after.get("available") is True
+        and all(process.get(k) == process_after.get(k) for k in ("pid", "start_ticks", "credentials", "capabilities", "executable"))
+    )
+    assessment = assess(before, after, process, uid, installed, expected)
+    if not process_stable:
+        assessment["service_snapshot"] = "unavailable_or_changed"
+        assessment["runtime_matches_expected"] = "unavailable" if expected else "not_requested"
+        assessment["usr_bin_matches_running_executable"] = "unavailable"
+    return {
+        "schema_version": 1, "kind": "polaris-bazzite-host-observation",
+        "captured_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "collector_uid": os.geteuid(), "service_uid": uid,
+        "boot_id": Path("/proc/sys/kernel/random/boot_id").read_text().strip(),
+        "service_before": before, "service_after": after,
+        "process": process, "process_after": process_after,
+        "usr_bin_polaris": installed, "deployments": deployments,
+        "installed_rpm": package["stdout"].strip() if package["returncode"] == 0 else None,
+        "selinux": selinux["stdout"].strip() if selinux["returncode"] == 0 else None,
+        "persistent_polaris_extension": file_identity(extension, no_follow=True),
+        "input_nodes": {str(p): device_metadata(p) for p in (Path("/dev/uinput"), Path("/dev/uhid"))},
+        "expected_executable_sha256": expected,
+        "assessment": assessment,
+    }
+
+
+def write_observation(path: Path, uid: int, result: dict) -> None:
+    data = (json.dumps(result, indent=2) + "\n").encode()
+    parent_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        info = os.fstat(parent_fd)
+        if info.st_uid not in {os.geteuid(), uid} or info.st_mode & 0o077:
+            raise ValueError("Output parent must be a private directory owned by the collector or selected user")
+        fd = os.open(path.name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600, dir_fd=parent_fd)
+        with os.fdopen(fd, "wb") as output:
+            if os.geteuid() == 0:
+                os.fchown(output.fileno(), uid, pwd.getpwuid(uid).pw_gid)
+            output.write(data)
+            output.flush()
+            os.fsync(output.fileno())
+    finally:
+        os.close(parent_fd)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user-uid", type=int, default=os.geteuid())
+    parser.add_argument("--expected-executable-sha256")
+    parser.add_argument("--output", type=Path, required=True, help="New private observation file; existing files are never replaced")
+    args = parser.parse_args()
+    if args.expected_executable_sha256 and not re.fullmatch("[0-9a-f]{64}", args.expected_executable_sha256):
+        parser.error("Expected executable SHA256 must be 64 lowercase hexadecimal characters")
+    service_command(args.user_uid)  # Validate the selected user before collection.
+    result = collect(args.user_uid, args.expected_executable_sha256)
+    write_observation(args.output, args.user_uid, result)
+    print(json.dumps(result["assessment"]))
+    # A successful observation is deliberately not a successful acceptance receipt.
+    return 0 if result["assessment"]["service_snapshot"] == "consistent" else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/bazzite/test_inspect_host.py
+++ b/scripts/validation/bazzite/test_inspect_host.py
@@ -1,0 +1,191 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import inspect_host as host
+
+
+class AssessmentTests(unittest.TestCase):
+    def setUp(self):
+        self.service = {
+            "available": True, "MainPID": "42", "InvocationID": "a" * 32,
+            "ActiveState": "active", "SubState": "running",
+        }
+        self.process = {
+            "available": True, "pid": 42, "credentials": {"Uid": [1000] * 4},
+            "executable": {"available": True, "sha256": "b" * 64},
+        }
+
+    def assess(self, after=None, expected="b" * 64):
+        return host.assess(self.service, after or self.service, self.process, 1000,
+                           {"available": True, "sha256": "c" * 64}, expected)
+
+    def test_preview_is_distinct_from_usr_bin_without_claiming_readiness(self):
+        result = self.assess()
+        self.assertEqual(result["service_snapshot"], "consistent")
+        self.assertEqual(result["runtime_matches_expected"], "match")
+        self.assertEqual(result["usr_bin_matches_running_executable"], "mismatch")
+        for key in ("input_access", "installed_lifecycle", "streaming"):
+            self.assertEqual(result[key], "not_tested")
+
+    def test_different_candidate_does_not_match_preview(self):
+        self.assertEqual(self.assess(expected="d" * 64)["runtime_matches_expected"], "mismatch")
+
+    def test_restart_or_pid_change_invalidates_runtime_comparison(self):
+        for field, value in [("MainPID", "43"), ("InvocationID", "d" * 32), ("ActiveState", "inactive"), ("SubState", "stop")]:
+            with self.subTest(field=field):
+                after = dict(self.service, **{field: value})
+                result = self.assess(after=after)
+                self.assertEqual(result["service_snapshot"], "unavailable_or_changed")
+                self.assertEqual(result["runtime_matches_expected"], "unavailable")
+
+    def test_missing_invocation_or_wrong_process_user_is_not_consistent(self):
+        for change in ("invocation", "uid", "saved_uid", "pid"):
+            with self.subTest(change=change):
+                self.setUp()
+                if change == "invocation": self.service["InvocationID"] = ""
+                if change == "uid": self.process["credentials"]["Uid"] = [0] * 4
+                if change == "saved_uid": self.process["credentials"]["Uid"][2] = 0
+                if change == "pid": self.process["pid"] = 43
+                self.assertEqual(self.assess()["service_snapshot"], "unavailable_or_changed")
+
+    def test_unreadable_executable_is_unknown_not_matching(self):
+        self.process["executable"] = {"available": False, "error": "PermissionError"}
+        self.assertEqual(self.assess()["runtime_matches_expected"], "unavailable")
+        self.assertEqual(self.assess()["usr_bin_matches_running_executable"], "unavailable")
+
+    def test_no_expected_digest_has_no_implicit_candidate_match(self):
+        self.assertEqual(self.assess(expected=None)["runtime_matches_expected"], "not_requested")
+
+
+class CollectionBoundaryTests(unittest.TestCase):
+    def test_output_is_private_and_does_not_overwrite_existing_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "before.json"
+            host.write_observation(path, os.geteuid(), {"observation": True})
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+            original = path.read_bytes()
+            with self.assertRaises(FileExistsError):
+                host.write_observation(path, os.geteuid(), {"replacement": True})
+            self.assertEqual(path.read_bytes(), original)
+
+    def test_shared_output_directory_is_rejected_before_creating_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            root.chmod(0o755)
+            with self.assertRaises(ValueError):
+                host.write_observation(root / "before.json", os.geteuid(), {})
+            self.assertFalse((root / "before.json").exists())
+
+    def test_output_parent_symlink_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "private"
+            target.mkdir(mode=0o700)
+            (root / "link").symlink_to(target, target_is_directory=True)
+            with self.assertRaises(OSError):
+                host.write_observation(root / "link/before.json", os.geteuid(), {})
+            self.assertFalse((target / "before.json").exists())
+
+    def test_same_service_pid_with_changed_process_invalidates_snapshot(self):
+        service = {"available": True, "MainPID": "42", "InvocationID": "a" * 32,
+                   "ActiveState": "active", "SubState": "running"}
+        process = {"available": True, "pid": 42, "start_ticks": "1",
+                   "credentials": {"Uid": [1000] * 4},
+                   "executable": {"available": True, "sha256": "b" * 64}}
+        changed = dict(process, start_ticks="2")
+        with patch.object(host, "service_state", return_value=service), \
+             patch.object(host, "process_identity", side_effect=[process, changed]), \
+             patch.object(host, "file_identity", return_value=process["executable"]), \
+             patch.object(host, "command", return_value={"returncode": 1, "stdout": ""}), \
+             patch.object(host, "device_metadata", return_value={"available": False}), \
+             patch.object(host.Path, "read_text", return_value="boot"):
+            result = host.collect(1000, "b" * 64)
+        self.assertEqual(result["assessment"]["service_snapshot"], "unavailable_or_changed")
+        self.assertEqual(result["assessment"]["runtime_matches_expected"], "unavailable")
+
+    def test_device_metadata_does_not_open_device(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "uinput"
+            path.write_bytes(b"fixture")
+            with patch.object(host.os, "open", side_effect=AssertionError("device opened")):
+                result = host.device_metadata(path)
+            self.assertFalse(result["character_device"])
+            self.assertNotIn("readable", result)
+
+    def test_extension_symlink_is_not_followed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "polaris.raw"
+            target = Path(directory) / "target"
+            target.write_bytes(b"fixture")
+            path.symlink_to(target)
+            self.assertFalse(host.file_identity(path, no_follow=True)["available"])
+            self.assertEqual(host.file_identity(target)["sha256"], hashlib.sha256(b"fixture").hexdigest())
+
+    def test_missing_or_nonregular_file_is_unavailable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            for path in (Path(directory), Path(directory) / "absent"):
+                self.assertFalse(host.file_identity(path)["available"])
+
+    def test_deployment_snapshot_omits_embedded_oci_manifest_and_keys(self):
+        data = {"deployments": [{"booted": True, "checksum": "d", "base-commit-meta": {"secret": "omit"}}], "transaction": None}
+        result = host.deployment_summary({"returncode": 0, "stdout": json.dumps(data)})
+        self.assertTrue(result["available"])
+        self.assertNotIn("secret", json.dumps(result))
+        self.assertFalse(result["transaction_active"])
+
+    def test_bad_deployment_responses_are_unavailable(self):
+        for result in [{"returncode": 1}, {"returncode": 0, "stdout": "not json"}, {"returncode": 0, "stdout": '{"deployments": "wrong"}'}]:
+            self.assertFalse(host.deployment_summary(result)["available"])
+
+    def test_service_query_rejects_root_or_another_users_manager(self):
+        with patch.object(host.os, "geteuid", return_value=1000):
+            for uid in (0, -1, 1001):
+                with self.assertRaises(ValueError): host.service_command(uid)
+            query = host.service_command(1000)
+            start = query.index("systemctl")
+            self.assertEqual(query[start:start + 4], ["systemctl", "--user", "show", "polaris.service"])
+
+    def test_service_query_selects_desktop_bus_without_ssh_environment(self):
+        with patch.object(host.os, "geteuid", return_value=1000):
+            query = host.service_command(1000)
+        self.assertEqual(query[:2], ["env", "-i"])
+        self.assertIn("XDG_RUNTIME_DIR=/run/user/1000", query)
+        self.assertIn("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus", query)
+
+    def test_root_observation_queries_service_as_selected_desktop_user(self):
+        account = host.pwd.struct_passwd(("desktop", "x", 1000, 1000, "", "", ""))
+        with patch.object(host.os, "geteuid", return_value=0), \
+             patch.object(host.pwd, "getpwuid", return_value=account) as lookup:
+            query = host.service_command(1000)
+            with self.assertRaises(ValueError):
+                host.service_command(0)
+        lookup.assert_called_once_with(1000)
+        self.assertEqual(query[:6], ["runuser", "--user", "desktop", "--", "env", "-i"])
+        self.assertIn("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus", query)
+
+    def test_service_query_omits_command_arguments_and_environment(self):
+        with patch.object(host.os, "geteuid", return_value=1000):
+            query = host.service_command(1000)
+        self.assertNotIn("--property=ExecStart", query)
+        self.assertNotIn("--property=Environment", query)
+
+    def test_proc_stat_handles_spaces_and_parentheses_in_command_name(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "42"
+            root.mkdir()
+            (root / "stat").write_text("42 (some ) process) " + " ".join(["S"] + ["0"] * 18 + ["12345"]))
+            (root / "status").write_text("Uid:\t1000 1000 1000 1000\nGid:\t1000 1000 1000 1000\nGroups:\t10 1000\nCapEff:\t00000000\n")
+            (root / "exe").write_bytes(b"elf fixture")
+            result = host.process_identity(42, Path(directory))
+            self.assertTrue(result["available"])
+            self.assertEqual(result["start_ticks"], "12345")
+            self.assertEqual(result["credentials"]["Groups"], [10, 1000])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -776,7 +776,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.4.4-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.4.5-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v144-contract.test.js
+++ b/src_assets/common/assets/web/release-v144-contract.test.js
@@ -1,17 +1,10 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
-const packageAssets = [
-  'Polaris-arch-x86_64.pkg.tar.zst',
-  'Polaris-fedora44-x86_64.rpm',
-  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
-  'Polaris-ubuntu24.04-x86_64.deb',
-].sort()
-const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
 
-const currentChangelog = () => {
+const historicalRelease = () => {
   const changelog = read('docs/changelog.md')
   const start = changelog.indexOf('## v1.4.4 - 2026-09-06')
   const end = changelog.indexOf('## v1.4.3 - 2026-09-05')
@@ -20,27 +13,19 @@ const currentChangelog = () => {
   return changelog.slice(start, end)
 }
 
-const releaseNotes = () => read('docs/release-notes/v1.4.4.md')
-const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
-  .map((match) => match[1])
-  .filter((block) => block.includes('wget --output-document='))
+const historicalNotes = () => read('docs/release-notes/v1.4.4.md')
 
-describe('v1.4.4 release contract', () => {
-  it('moves every current release identity to v1.4.4', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.4')
-    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.4"')
-    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.4')
-    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.4-1|x86_64'")
-    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.4-1|x86_64'")
-  })
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
 
-  it('makes v1.4.3 historical and promotes the complete v1.4.4 scope', () => {
-    expect(read('src_assets/common/assets/web/release-v143-contract.test.js')).toContain("describe('historical v1.4.3 release contract'")
-    const gate = read('scripts/check-public-docs.sh')
-    expect(gate).toContain('docs/release-notes/v1.4.4.md')
-    expect(gate).toContain('"## v1.4.4 - 2026-09-06"')
-
-    const release = `${currentChangelog()}\n${releaseNotes()}`
+describe('historical v1.4.4 release contract', () => {
+  it('preserves the service-first menu entry, fail-closed setup, and withdrawn extension scope', () => {
+    const evidence = `${historicalRelease()}\n${historicalNotes()}`
     for (const fact of [
       'application menu',
       'user service',
@@ -51,86 +36,28 @@ describe('v1.4.4 release contract', () => {
       'Nova v1.4.4',
       'Retroid Pocket 6',
     ]) {
-      expect(release, `release must include: ${fact}`).toContain(fact)
+      expect(evidence, `historical v1.4.4 must include: ${fact}`).toContain(fact)
     }
+    expect(historicalNotes()).toContain('system extension stays withdrawn')
+    expect(historicalNotes()).not.toContain(withdrawnSysextAsset)
   })
 
-  it('documents the service-first menu entry and the fail-closed setup, and keeps the system extension withdrawn', () => {
-    const notes = releaseNotes()
-    const desktopEntry = read('packaging/linux/dev.polaris-stream.app.Polaris.desktop')
-    const inputGroupAccess = read('src/platform/linux/input/input_group_access.cpp')
-    const workflow = read('.github/workflows/build.yml')
-
-    expect(desktopEntry).toContain('systemctl --user start polaris.service')
-    expect(inputGroupAccess.length).toBeGreaterThan(0)
-    expect(notes).toContain('system extension stays withdrawn')
-    expect(notes).not.toContain(withdrawnSysextAsset)
-    expect(workflow).not.toContain('sysext-build:')
-    expect(workflow).not.toContain('Polaris-sysext-image')
-    expect(workflow).not.toContain(`release-assets/final/${withdrawnSysextAsset}`)
-  })
-
-  it('pins all four install commands to v1.4.4 and lists only supported package assets', () => {
-    const blocks = installBlocks()
+  it('preserves the exact historical assets and install identities', () => {
+    const notes = historicalNotes()
+    const blocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
     expect(blocks).toHaveLength(4)
-    for (const asset of packageAssets) {
+    for (const asset of expectedAssets) {
       const matches = blocks.filter((block) => block.includes(`/${asset}`))
       expect(matches, `one command block for ${asset}`).toHaveLength(1)
       expect(matches[0]).toContain(`releases/download/v1.4.4/${asset}`)
-      expect(matches[0]).toContain('sudo -H polaris --setup-host')
     }
 
-    for (const asset of [
-      'Polaris-arch-x86_64.pkg.tar.zst',
-      'Polaris-fedora44-x86_64.rpm',
-      'Polaris-ubuntu24.04-x86_64.deb',
-    ]) {
-      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
-      expect(block).toContain('systemctl --user restart polaris')
-    }
-
-    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
-    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
-    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
-    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
-    expect(steamOs).toContain('systemctl --user enable --now polaris')
-
-    const assetsLine = releaseNotes().split('\n').find((line) => line.startsWith('**Assets:**'))
+    const assetsLine = notes.split('\n').find((line) => line.startsWith('**Assets:**'))
     expect(assetsLine).toBeDefined()
     const listed = [...new Set((assetsLine ?? '').match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
-    expect(listed.sort()).toEqual(packageAssets)
+    expect(listed.sort()).toEqual(expectedAssets)
     expect(assetsLine).not.toContain(withdrawnSysextAsset)
-  })
-
-  it('publishes release-note guide links that work outside the source tree', () => {
-    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
-    const notes = readdirSync(releaseNotesDir)
-      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
-      .map((name) => read(`docs/release-notes/${name}`))
-      .join('\n')
-
-    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
-    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
-    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
-  })
-
-  it('keeps publication bound to one verified immutable source', () => {
-    const workflow = read('.github/workflows/build.yml')
-    const ordered = [
-      '- name: Check out exact release source',
-      '- name: Revalidate release tag against packaged source',
-      '- name: Stage curated GitHub release',
-      '- name: Upload release assets to GitHub release',
-      '- name: Verify release assets on GitHub release',
-      '- name: Publish verified draft release',
-    ]
-    const positions = ordered.map((step) => workflow.indexOf(step))
-    expect(positions.every((position) => position >= 0)).toBe(true)
-    expect(positions).toEqual([...positions].sort((a, b) => a - b))
-    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
-    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
-    expect(workflow).toContain('--verify-tag')
-    expect(workflow).toContain('--notes-file "$release_notes"')
-    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
   })
 })

--- a/src_assets/common/assets/web/release-v145-contract.test.js
+++ b/src_assets/common/assets/web/release-v145-contract.test.js
@@ -1,0 +1,138 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+const packageAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
+
+const currentChangelog = () => {
+  const changelog = read('docs/changelog.md')
+  const start = changelog.indexOf('## v1.4.5 - 2026-09-10')
+  const end = changelog.indexOf('## v1.4.4 - 2026-09-06')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return changelog.slice(start, end)
+}
+
+const releaseNotes = () => read('docs/release-notes/v1.4.5.md')
+const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
+  .map((match) => match[1])
+  .filter((block) => block.includes('wget --output-document='))
+
+describe('v1.4.5 release contract', () => {
+  it('moves every current release identity to v1.4.5', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.5')
+    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.5"')
+    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.5')
+    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.5-1|x86_64'")
+    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.5-1|x86_64'")
+  })
+
+  it('makes v1.4.4 historical and promotes the complete v1.4.5 scope', () => {
+    expect(read('src_assets/common/assets/web/release-v144-contract.test.js')).toContain("describe('historical v1.4.4 release contract'")
+    const gate = read('scripts/check-public-docs.sh')
+    expect(gate).toContain('docs/release-notes/v1.4.5.md')
+    expect(gate).toContain('"## v1.4.5 - 2026-09-10"')
+
+    const release = `${currentChangelog()}\n${releaseNotes()}`
+    for (const fact of [
+      'Live Tuning',
+      'Game Mode',
+      'headless boot',
+      'Bazzite',
+      'rpm-ostree',
+      'Host Virtual Display',
+      'DualSense',
+      'Nova v1.4.5',
+      'Retroid Pocket 6',
+    ]) {
+      expect(release, `release must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('ships the Bazzite guide rework and the Game Mode guide, and keeps the system extension withdrawn', () => {
+    const notes = releaseNotes()
+    const bazziteGuide = read('docs/bazzite.md')
+    const handheldsGuide = read('docs/handhelds.md')
+    const workflow = read('.github/workflows/build.yml')
+
+    expect(bazziteGuide).toContain('sudo rpm-ostree install --uninstall=polaris')
+    expect(bazziteGuide).toContain('sudo rpm-ostree rollback')
+    expect(handheldsGuide.length).toBeGreaterThan(0)
+    expect(notes).toContain('system extension stays withdrawn')
+    expect(notes).not.toContain(withdrawnSysextAsset)
+    expect(workflow).not.toContain('sysext-build:')
+    expect(workflow).not.toContain('Polaris-sysext-image')
+    expect(workflow).not.toContain(`release-assets/final/${withdrawnSysextAsset}`)
+  })
+
+  it('pins all four install commands to v1.4.5 and lists only supported package assets', () => {
+    const blocks = installBlocks()
+    expect(blocks).toHaveLength(4)
+    for (const asset of packageAssets) {
+      const matches = blocks.filter((block) => block.includes(`/${asset}`))
+      expect(matches, `one command block for ${asset}`).toHaveLength(1)
+      expect(matches[0]).toContain(`releases/download/v1.4.5/${asset}`)
+      expect(matches[0]).toContain('sudo -H polaris --setup-host')
+    }
+
+    for (const asset of [
+      'Polaris-arch-x86_64.pkg.tar.zst',
+      'Polaris-fedora44-x86_64.rpm',
+      'Polaris-ubuntu24.04-x86_64.deb',
+    ]) {
+      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+
+    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
+    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
+    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
+    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
+    expect(steamOs).toContain('systemctl --user enable --now polaris')
+
+    const assetsLine = releaseNotes().split('\n').find((line) => line.startsWith('**Assets:**'))
+    expect(assetsLine).toBeDefined()
+    const listed = [...new Set((assetsLine ?? '').match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+    expect(listed.sort()).toEqual(packageAssets)
+    expect(assetsLine).not.toContain(withdrawnSysextAsset)
+  })
+
+  it('publishes release-note guide links that work outside the source tree', () => {
+    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
+    const notes = readdirSync(releaseNotesDir)
+      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
+      .map((name) => read(`docs/release-notes/${name}`))
+      .join('\n')
+
+    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
+    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
+    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
+  })
+
+  it('keeps publication bound to one verified immutable source', () => {
+    const workflow = read('.github/workflows/build.yml')
+    const ordered = [
+      '- name: Check out exact release source',
+      '- name: Revalidate release tag against packaged source',
+      '- name: Stage curated GitHub release',
+      '- name: Upload release assets to GitHub release',
+      '- name: Verify release assets on GitHub release',
+      '- name: Publish verified draft release',
+    ]
+    const positions = ordered.map((step) => workflow.indexOf(step))
+    expect(positions.every((position) => position >= 0)).toBe(true)
+    expect(positions).toEqual([...positions].sort((a, b) => a - b))
+    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
+    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
+    expect(workflow).toContain('--verify-tag')
+    expect(workflow).toContain('--notes-file "$release_notes"')
+    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
+  })
+})


### PR DESCRIPTION
## Summary

Release prep for Polaris 1.4.5, matched with Nova 1.4.5. Every pin the v14x contract enforces moves to 1.4.5, the changelog gains a dated section covering today's merges (#639, #641, #642, #643, #644, #628, #629, #626, and the internal #640/#645/#646 line), the release notes use the short template, and the v1.4.4 contract test becomes historical.

Also carries the read-only Bazzite host observer (`scripts/validation/bazzite/inspect_host.py` with tests and README) used by the local acceptance run.

Do not merge yet. The Bazzite installed-host gate runs against this PR's `fedora-44-rpm-artifacts` build (a real 1.4.5-1 update over the 1.4.4 layer). Its result lands as a second commit with the `docs/bazzite.md` validation row and the final Heads up. The release is tagged from the merge SHA afterwards.

## Exact candidate

Branch `release/v1.4.5` on master `501a1b7e`. Head SHA in the PR timeline.

## Verification

- `bash scripts/check-public-docs.sh`: clean.
- `python3.14 -m unittest discover -s scripts/validation/bazzite`: 70 tests OK.
- `vitest`: release-v145, release-v144 (historical), release-v143, packaging-contracts.
- `git diff --check`: clean.
- CI on this PR is the build under test on Bazzite 44.20260908 NVIDIA Open.
