### PR TITLE
fix(linux): keep a session display override out of the host's advice

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -839,8 +839,13 @@ namespace nvhttp {
 
     bool host_prefers_headless() {
 #ifdef __linux__
-      // One resolve_current snapshot for the two flags (no hand-built input_t thrash).
-      const auto resolved = stream_display_policy::resolve_current();
+      // The host's own policy, not the session parked on it. A session-scoped
+      // override rewrites the live config, and a paused session keeps it
+      // rewritten for its whole resume window, so reading live values here
+      // would recommend one client's topology to the next one that asks.
+      const auto resolved = stream_display_policy::resolve_host_default(
+        stream_display_policy::input_t {virtual_display::is_available(), false, false}
+      );
       return resolved.uses_labwc() && resolved.requested_headless;
 #else
       return false;
@@ -9929,7 +9934,9 @@ namespace nvhttp {
         }
       }
       if (effective_selection.empty()) {
-        effective_selection = stream_display_policy::configured_selection();
+        // The host default, so a paused session's topology is not echoed back
+        // to this client as the topology it should then assert on /launch.
+        effective_selection = stream_display_policy::host_default_selection();
       }
       if (!effective_selection.empty()) {
         std::string topology_reject_reason;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -843,10 +843,7 @@ namespace nvhttp {
       // override rewrites the live config, and a paused session keeps it
       // rewritten for its whole resume window, so reading live values here
       // would recommend one client's topology to the next one that asks.
-      const auto resolved = stream_display_policy::resolve_host_default(
-        stream_display_policy::input_t {virtual_display::is_available(), false, false}
-      );
-      return resolved.uses_labwc() && resolved.requested_headless;
+      return stream_display_policy::host_default_provides_private_display();
 #else
       return false;
 #endif
@@ -9906,7 +9903,8 @@ namespace nvhttp {
         requested_selection == stream_display_policy::k_host_virtual_display,
         app_virtual_display,
         topology_locked || paired_virtual_lock,
-        false
+        false,
+        stream_display_policy::host_default_provides_private_display()
       );
       if (!mirror_desktop && !requested_selection.empty()) {
         if (effective_selection == requested_selection) {

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -9,15 +9,96 @@
 #include "desktop_takeover.h"
 #include "stream_path.h"
 #include "src/config.h"
+#include "src/logging.h"
 #include "virtual_display.h"
 
 #include <cctype>
+#include <mutex>
+#include <optional>
 
 namespace stream_display_policy {
 
   namespace {
 
     using stream_path::to_lower_copy;
+
+    /**
+     * The host's own display policy, held while a session-scoped override has
+     * rewritten the live config. A paused session keeps that rewrite standing
+     * for as long as it stays resumable, so anything that advises a client what
+     * to ask for reads this instead of the live values.
+     */
+    struct host_default_t {
+      legacy_booleans_t booleans;
+      std::string stream_mode;
+      std::string capture;
+    };
+
+    std::mutex host_default_mutex;
+    std::optional<host_default_t> held_host_default;
+
+    std::optional<host_default_t> load_host_default() {
+      const std::lock_guard<std::mutex> guard {host_default_mutex};
+      return held_host_default;
+    }
+
+    /** One held snapshot resolves to exactly one selection, lock-free. */
+    std::string selection_for_host_default(const host_default_t &held) {
+      if (!held.stream_mode.empty() && stream_path::find(held.stream_mode)) {
+        return stream_path::to_lower_copy(held.stream_mode);
+      }
+      return selection_from_legacy_booleans(held.booleans);
+    }
+
+    legacy_booleans_t live_booleans() {
+      const auto &linux_display = config::video.linux_display;
+      return legacy_booleans_t {
+        linux_display.headless_mode,
+        linux_display.use_cage_compositor,
+        linux_display.prefer_gpu_native_capture,
+      };
+    }
+
+    /** Resolve one explicit policy state rather than whatever config holds now. */
+    resolved_t resolve_for_state(
+      const input_t &input,
+      std::string_view selection,
+      std::string_view stream_mode,
+      const legacy_booleans_t &booleans,
+      std::string_view configured_capture
+    ) {
+      const auto *path = stream_path::find(selection);
+      stream_path::descriptor_t desc {};
+      if (path) {
+        desc = *path;
+      }
+      else {
+        desc = *stream_path::find(stream_path::k_desktop_display);
+      }
+
+      // Edge: legacy !headless + cage without stream_mode -> windowed private labwc.
+      if (stream_mode.empty() &&
+          !booleans.headless_mode &&
+          booleans.use_cage_compositor) {
+        if (const auto *windowed = stream_path::find(stream_path::k_windowed_stream)) {
+          desc = *windowed;
+          desc.request_headless = false;
+        }
+      }
+
+      auto caps = stream_path::probe_host_capabilities();
+      caps.configured_capture = std::string {configured_capture};
+      if (input.virtual_display_available) {
+        caps.virtual_display_available = true;
+      }
+
+      return stream_path::resolve_path(
+        desc,
+        caps,
+        input.active_encoder_requires_gpu_native_capture,
+        input.runtime_gpu_native_override_active
+      );
+    }
 
     void clear_connector_output_authority(bool retire_connectors) {
       auto &linux_display = config::video.linux_display;
@@ -326,10 +407,23 @@ namespace stream_display_policy {
     // profile's separate primary-output authority. EVDI and wlroots create a
     // new output, so their old connector and capture-output pins are retired.
     linux_display.primary_output.clear();
+    const auto previous_capture = config::video.capture;
     config::video.capture = capture_for_host_virtual_display_backend(
       backend,
-      config::video.capture
+      previous_capture
     );
+    if (config::video.capture != previous_capture) {
+      // This discards a capture backend the operator chose. Say so, rather than
+      // leaving them to infer it from a capture path they did not pick.
+      const auto describe = [](const std::string &capture) {
+        return capture.empty() ? std::string {"auto"} : capture;
+      };
+      BOOST_LOG(info) << "stream_display_policy: host virtual display backend ["
+                      << virtual_display::backend_name(backend)
+                      << "] cannot be captured through [" << describe(previous_capture)
+                      << "]; this session uses [" << describe(config::video.capture)
+                      << "] and the host setting is restored at teardown";
+    }
   }
 
   bool host_virtual_backend_creates_output(
@@ -347,36 +441,53 @@ namespace stream_display_policy {
   }
 
   resolved_t resolve(const input_t &input) {
-    const auto selection = configured_selection();
-    const auto *path = stream_path::find(selection);
-    stream_path::descriptor_t desc {};
-    if (path) {
-      desc = *path;
-    }
-    else {
-      desc = *stream_path::find(stream_path::k_desktop_display);
-    }
+    return resolve_for_state(
+      input,
+      configured_selection(),
+      config::video.linux_display.stream_mode,
+      live_booleans(),
+      config::video.capture
+    );
+  }
 
-    // Edge: legacy !headless + cage without stream_mode → windowed private labwc.
-    if (config::video.linux_display.stream_mode.empty() &&
-        !config::video.linux_display.headless_mode &&
-        config::video.linux_display.use_cage_compositor) {
-      if (const auto *windowed = stream_path::find(stream_path::k_windowed_stream)) {
-        desc = *windowed;
-        desc.request_headless = false;
-      }
-    }
+  void remember_host_default(
+      const legacy_booleans_t &booleans,
+      std::string_view stream_mode,
+      std::string_view capture) {
+    const std::lock_guard<std::mutex> guard {host_default_mutex};
+    held_host_default = host_default_t {
+      booleans,
+      std::string {stream_mode},
+      std::string {capture},
+    };
+  }
 
-    auto caps = stream_path::probe_host_capabilities();
-    if (input.virtual_display_available) {
-      caps.virtual_display_available = true;
-    }
+  void forget_host_default() {
+    const std::lock_guard<std::mutex> guard {host_default_mutex};
+    held_host_default.reset();
+  }
 
-    return stream_path::resolve_path(
-      desc,
-      caps,
-      input.active_encoder_requires_gpu_native_capture,
-      input.runtime_gpu_native_override_active
+  std::string host_default_selection() {
+    const auto held = load_host_default();
+    if (!held) {
+      return configured_selection();
+    }
+    return selection_for_host_default(*held);
+  }
+
+  resolved_t resolve_host_default(const input_t &input) {
+    // One read of the held snapshot for the selection and the state it resolves
+    // against, so a teardown landing mid-call cannot mix the two.
+    const auto held = load_host_default();
+    if (!held) {
+      return resolve(input);
+    }
+    return resolve_for_state(
+      input,
+      selection_for_host_default(*held),
+      held->stream_mode,
+      held->booleans,
+      held->capture
     );
   }
 

--- a/src/platform/linux/stream_display_policy.cpp
+++ b/src/platform/linux/stream_display_policy.cpp
@@ -316,7 +316,8 @@ namespace stream_display_policy {
     bool launch_virtual_display,
     bool app_virtual_display,
     bool virtual_display_user_locked,
-    bool virtual_display_optimization_present
+    bool virtual_display_optimization_present,
+    bool host_provides_private_display
   ) {
     if (mirror_desktop) {
       return std::string {k_desktop_display};
@@ -328,6 +329,17 @@ namespace stream_display_policy {
       if (launch_virtual_display) {
         return std::string {k_host_virtual_display};
       }
+    }
+    // An unlocked virtual-display preference, whether the app's stored default
+    // or a client toggle that never locked topology, does not override a host
+    // that already provides the session's display. The private labwc runtime
+    // creates that output itself, so a second one only trades a GPU-native
+    // path for an EVDI one nobody asked for.
+    if (host_provides_private_display) {
+      if (!requested_selection.empty()) {
+        return std::string {requested_selection};
+      }
+      return {};
     }
     if (!virtual_display_optimization_present &&
         app_virtual_display &&
@@ -473,6 +485,15 @@ namespace stream_display_policy {
       return configured_selection();
     }
     return selection_for_host_default(*held);
+  }
+
+  bool host_default_provides_private_display() {
+    const auto resolved = resolve_host_default(input_t {
+      virtual_display::is_available(),
+      false,
+      false,
+    });
+    return resolved.uses_labwc() && resolved.requested_headless;
   }
 
   resolved_t resolve_host_default(const input_t &input) {

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -53,6 +53,13 @@ namespace stream_display_policy {
    * Explicit accepted streamMode and mirrorDesktop remain authoritative. An
    * app default is used only when the client did not explicitly lock the
    * virtual-display choice.
+   *
+   * @param host_provides_private_display The host's own configuration already
+   *        creates the session's output, so an unlocked virtual-display
+   *        preference has nothing to add and is refused. A locked client choice
+   *        and an explicit accepted streamMode still win. Pass
+   *        host_default_provides_private_display(); every call site has to pass
+   *        the same answer or a resume can disagree with its own launch.
    */
   std::string effective_session_selection_for_launch(
     std::string_view requested_selection,
@@ -60,8 +67,19 @@ namespace stream_display_policy {
     bool launch_virtual_display,
     bool app_virtual_display,
     bool virtual_display_user_locked,
-    bool virtual_display_optimization_present = false
+    bool virtual_display_optimization_present = false,
+    bool host_provides_private_display = false
   );
+
+  /**
+   * @brief Whether the host's own configuration already provides the display.
+   *
+   * True for a headless labwc host: the private runtime creates the stream
+   * output itself. Reads the host default rather than the live config, so a
+   * session parked on a virtual display does not make the host stop being a
+   * private host.
+   */
+  bool host_default_provides_private_display();
 
   /**
    * @brief Keep the created virtual connector name when display mapping cannot

--- a/src/platform/linux/stream_display_policy.h
+++ b/src/platform/linux/stream_display_policy.h
@@ -76,8 +76,11 @@ namespace stream_display_policy {
    * @brief Resolve the capture backend required by a host virtual display.
    *
    * Native wlroots headless outputs are capturable directly by output name.
-   * EVDI/KScreen outputs remain on the portal/KWin path unless an operator
-   * explicitly selected another backend.
+   * EVDI and KScreen outputs are reachable only through the portal/KWin path,
+   * so an explicitly configured backend does not apply to them and is replaced
+   * for the session. This discards an operator's choice, which is why
+   * normalize_host_virtual_display_state_for_backend says so in the log; the
+   * caller restores the host setting at teardown.
    */
   std::string capture_for_host_virtual_display_backend(
     virtual_display::backend_e backend,
@@ -214,8 +217,37 @@ namespace stream_display_policy {
 
   /**
    * @brief Return the configured selection after legacy-boolean normalization.
+   *
+   * This reads the live config, which a session-scoped override rewrites in
+   * place. Use host_default_selection() for anything that advises a client.
    */
   std::string configured_selection();
+
+  /**
+   * @brief Remember the host's own display policy while an override stands.
+   *
+   * A session-scoped override rewrites stream_mode, the legacy booleans and the
+   * capture backend in place, and a paused session keeps them rewritten for as
+   * long as it remains resumable. Surfaces that tell a client what to ask for
+   * have to answer for the host rather than for the session parked on it, or
+   * one client's topology silently becomes the next client's recommendation.
+   */
+  void remember_host_default(
+    const legacy_booleans_t &booleans,
+    std::string_view stream_mode,
+    std::string_view capture
+  );
+
+  /** @brief Forget the remembered host policy once the override is restored. */
+  void forget_host_default();
+
+  /**
+   * @brief The host's own configured selection, ignoring any live override.
+   *
+   * Falls back to configured_selection() when no override is standing, so this
+   * is always safe to call.
+   */
+  std::string host_default_selection();
 
   /**
    * @brief Whether a mode creates/owns the stream output refresh rate.
@@ -237,6 +269,11 @@ namespace stream_display_policy {
    */
   resolved_t resolve_current(bool active_encoder_requires_gpu_native_capture = false,
                              bool runtime_gpu_native_override_active = false);
+
+  /**
+   * @brief Resolve the host's own configured mode, ignoring a live override.
+   */
+  resolved_t resolve_host_default(const input_t &input = {});
 
   /**
    * @brief Resolve the effective mode while a session is live.

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -6586,7 +6586,8 @@ namespace proc {
         launch_session->virtual_display,
         app.virtual_display,
         launch_session->user_locked_virtual_display,
-        false
+        false,
+        stream_display_policy::host_default_provides_private_display()
       );
       if (effective_selection.empty()) {
         effective_selection = stream_display_policy::configured_selection();
@@ -6754,7 +6755,8 @@ namespace proc {
           session->virtual_display,
           _app.virtual_display,
           session->user_locked_virtual_display,
-          false
+          false,
+          stream_display_policy::host_default_provides_private_display()
         );
         return selection.empty() ? stream_display_policy::configured_selection() : selection;
       };
@@ -7153,7 +7155,8 @@ namespace proc {
       launch_session->virtual_display,
       app.virtual_display,
       launch_session->user_locked_virtual_display,
-      false
+      false,
+      stream_display_policy::host_default_provides_private_display()
     );
     if (session_mode.empty()) {
       session_mode = configured_session_mode;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7032,6 +7032,27 @@ namespace proc {
   }
 #endif
 
+#ifdef __linux__
+  namespace {
+    /**
+     * Publish the pre-override host display policy, so the surfaces that tell a
+     * client what to ask for keep answering for the host while this session's
+     * override holds the live config rewritten. terminate_impl retires it.
+     */
+    void remember_host_display_default(const proc_t &proc) {
+      stream_display_policy::remember_host_default(
+        stream_display_policy::legacy_booleans_t {
+          proc.initial_headless_mode,
+          proc.initial_use_cage_compositor,
+          proc.initial_prefer_gpu_native_capture,
+        },
+        proc.initial_stream_mode,
+        proc.initial_capture
+      );
+    }
+  }  // namespace
+#endif
+
   int proc_t::execute_impl(
     const ctx_t& app,
     std::shared_ptr<rtsp_stream::launch_session_t> launch_session,
@@ -7188,6 +7209,7 @@ namespace proc {
       config::video.output_name = initial_display;
       config::video.color_range = initial_color_range;
       config::video.nvenc_tune = initial_nvenc_tune;
+      stream_display_policy::forget_host_default();
     };
 
     bool session_mode_applied = false;
@@ -7214,6 +7236,7 @@ namespace proc {
             config::video.capture = session_capture;
           }
           this->initial_linux_display_saved = true;
+          remember_host_display_default(*this);
           session_mode_applied = true;
           BOOST_LOG(info) << "process: final session stream mode override ["sv << session_mode
                           << "] applied in-memory after optimization; host default restored at teardown"sv;
@@ -7951,6 +7974,7 @@ namespace proc {
             linux_vdisplay->backend
           );
           this->initial_linux_display_saved = true;
+          remember_host_display_default(*this);
           launch_session->virtual_display = true;
           this->virtual_display = true;
           this->display_name = linux_vdisplay->output_name;
@@ -10349,6 +10373,8 @@ namespace proc {
       // re-bake it for the restored host default. Teardown above already ran
       // against the session's effective mode, which is why this sits here.
       platf::reevaluate_capture_sources();
+      // The live config is the host default again, so stop holding a copy of it.
+      stream_display_policy::forget_host_default();
 #endif
     }
 

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -344,6 +344,75 @@ TEST(SourceSafetyContracts, LegacyVirtualDisplayPromotionPrecedesCaptureReevalua
   EXPECT_NE(teardown.find("config::video.capture = initial_capture"), std::string::npos);
 }
 
+TEST(SourceSafetyContracts, ASessionDisplayOverrideNeverBecomesTheAdvertisedHostDefault) {
+  // A session override rewrites config::video.linux_display and the capture
+  // backend in place, and a paused session holds that rewrite for its whole
+  // resume window. Every site that arms the override has to publish the host
+  // policy it displaced, and teardown has to retire it, or the host recommends
+  // one client's topology to the next.
+  std::ifstream process_input(fs::path {POLARIS_SOURCE_DIR} / "src/process.cpp");
+  ASSERT_TRUE(process_input.is_open());
+  std::ostringstream process_contents;
+  process_contents << process_input.rdbuf();
+  const auto process_source = process_contents.str();
+
+  const auto armed = [&process_source]() {
+    size_t count = 0;
+    for (size_t at = process_source.find("initial_linux_display_saved = true");
+         at != std::string::npos;
+         at = process_source.find("initial_linux_display_saved = true", at + 1)) {
+      ++count;
+    }
+    return count;
+  }();
+  const auto published = [&process_source]() {
+    size_t count = 0;
+    for (size_t at = process_source.find("remember_host_display_default(*this)");
+         at != std::string::npos;
+         at = process_source.find("remember_host_display_default(*this)", at + 1)) {
+      ++count;
+    }
+    return count;
+  }();
+  EXPECT_EQ(published, armed)
+    << "every site that arms a session display override must publish the host default it displaced";
+  EXPECT_NE(process_source.find("stream_display_policy::forget_host_default()"), std::string::npos)
+    << "teardown must retire the published host default";
+
+  // The advice surfaces must read the host policy, not the live config.
+  std::ifstream nvhttp_input(fs::path {POLARIS_SOURCE_DIR} / "src/nvhttp.cpp");
+  ASSERT_TRUE(nvhttp_input.is_open());
+  std::ostringstream nvhttp_contents;
+  nvhttp_contents << nvhttp_input.rdbuf();
+  const auto nvhttp_source = nvhttp_contents.str();
+
+  const auto prefers = nvhttp_source.find("bool host_prefers_headless()");
+  ASSERT_NE(prefers, std::string::npos);
+  const auto prefers_end = nvhttp_source.find('}', nvhttp_source.find("#endif", prefers));
+  ASSERT_NE(prefers_end, std::string::npos);
+  const auto prefers_body = nvhttp_source.substr(prefers, prefers_end - prefers);
+  EXPECT_NE(prefers_body.find("resolve_host_default"), std::string::npos)
+    << "the launch-mode recommendation must resolve the host default";
+  EXPECT_EQ(prefers_body.find("resolve_current"), std::string::npos)
+    << "resolve_current reads the session-mutated config";
+
+  // And the backend substitution that discards a configured capture must say so.
+  std::ifstream policy_input(fs::path {POLARIS_SOURCE_DIR} / "src/platform/linux/stream_display_policy.cpp");
+  ASSERT_TRUE(policy_input.is_open());
+  std::ostringstream policy_contents;
+  policy_contents << policy_input.rdbuf();
+  const auto policy_source = policy_contents.str();
+
+  const auto normalize = policy_source.find("void normalize_host_virtual_display_state_for_backend(");
+  ASSERT_NE(normalize, std::string::npos);
+  const auto normalize_end = policy_source.find("\n  }", normalize);
+  ASSERT_NE(normalize_end, std::string::npos);
+  const auto normalize_body = policy_source.substr(normalize, normalize_end - normalize);
+  EXPECT_NE(normalize_body.find("previous_capture"), std::string::npos);
+  EXPECT_NE(normalize_body.find("BOOST_LOG"), std::string::npos)
+    << "silently replacing an operator's capture backend is what made this bug invisible";
+}
+
 TEST(SourceSafetyContracts, LinuxVirtualDisplayCreationUsesOnlyTheEffectiveMode) {
   std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/process.cpp");
   ASSERT_TRUE(input.is_open());

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -391,8 +391,8 @@ TEST(SourceSafetyContracts, ASessionDisplayOverrideNeverBecomesTheAdvertisedHost
   const auto prefers_end = nvhttp_source.find('}', nvhttp_source.find("#endif", prefers));
   ASSERT_NE(prefers_end, std::string::npos);
   const auto prefers_body = nvhttp_source.substr(prefers, prefers_end - prefers);
-  EXPECT_NE(prefers_body.find("resolve_host_default"), std::string::npos)
-    << "the launch-mode recommendation must resolve the host default";
+  EXPECT_NE(prefers_body.find("host_default"), std::string::npos)
+    << "the launch-mode recommendation must answer from the host default";
   EXPECT_EQ(prefers_body.find("resolve_current"), std::string::npos)
     << "resolve_current reads the session-mutated config";
 
@@ -411,6 +411,32 @@ TEST(SourceSafetyContracts, ASessionDisplayOverrideNeverBecomesTheAdvertisedHost
   EXPECT_NE(normalize_body.find("previous_capture"), std::string::npos);
   EXPECT_NE(normalize_body.find("BOOST_LOG"), std::string::npos)
     << "silently replacing an operator's capture backend is what made this bug invisible";
+}
+
+TEST(SourceSafetyContracts, EveryLaunchTopologyResolverCallPassesTheHostPrivateDisplayAnswer) {
+  // A resume validates topology with the same resolver its launch used. If one
+  // call site answers "the host already provides the display" and another does
+  // not, a resume can reject the very session its own launch produced.
+  for (const auto *relative : {"src/process.cpp", "src/nvhttp.cpp"}) {
+    std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / relative);
+    ASSERT_TRUE(input.is_open()) << relative;
+    std::ostringstream contents;
+    contents << input.rdbuf();
+    const auto source = contents.str();
+
+    size_t calls = 0;
+    for (size_t at = source.find("effective_session_selection_for_launch(");
+         at != std::string::npos;
+         at = source.find("effective_session_selection_for_launch(", at + 1)) {
+      const auto close = source.find(");", at);
+      ASSERT_NE(close, std::string::npos) << relative;
+      const auto arguments = source.substr(at, close - at);
+      EXPECT_NE(arguments.find("host_default_provides_private_display()"), std::string::npos)
+        << relative << " resolves a launch topology without passing the host's own answer";
+      ++calls;
+    }
+    EXPECT_GT(calls, 0u) << relative << " no longer resolves launch topology at all";
+  }
 }
 
 TEST(SourceSafetyContracts, LinuxVirtualDisplayCreationUsesOnlyTheEffectiveMode) {

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -106,6 +106,13 @@ namespace {
     std::string output_name;
   };
 
+  /** A remembered host default is process-wide; never let one leak out of a test. */
+  struct HeldHostDefaultGuard {
+    ~HeldHostDefaultGuard() {
+      stream_display_policy::forget_host_default();
+    }
+  };
+
   void configure_headless_cage(bool prefer_gpu_native_capture) {
     config::video.linux_display.headless_mode = true;
     config::video.linux_display.use_cage_compositor = true;
@@ -114,6 +121,47 @@ namespace {
     config::video.linux_display.private_runtime = "labwc";
   }
 }  // namespace
+
+TEST(StreamDisplayPolicyTests, HostDefaultOutlivesASessionScopedVirtualDisplayOverride) {
+  LinuxDisplayPolicyGuard guard;
+  HeldHostDefaultGuard held;
+  configure_headless_cage(true);
+
+  // What this host is, before any client launches anything on it.
+  ASSERT_EQ(stream_display_policy::configured_selection(), "windowed_stream");
+
+  // A launch takes the virtual display path. apply_selection rewrites the live
+  // config in place and normalize_host_virtual_display_state_for_backend
+  // replaces the capture backend, and a paused session keeps both rewritten
+  // until its resume window closes. Reproduce that state exactly.
+  stream_display_policy::remember_host_default(
+    stream_display_policy::legacy_booleans_t {true, true, true},
+    "",
+    "wlr"
+  );
+  config::video.linux_display.stream_mode =
+    std::string {stream_display_policy::k_host_virtual_display};
+  config::video.linux_display.use_cage_compositor = false;
+  config::video.capture = "portal";
+
+  EXPECT_EQ(stream_display_policy::configured_selection(), "host_virtual_display")
+    << "the live config is the running session's topology while the override stands";
+  EXPECT_EQ(stream_display_policy::host_default_selection(), "windowed_stream")
+    << "the host default must not become whatever the last client asked for";
+
+  const auto host_default = stream_display_policy::resolve_host_default(
+    stream_display_policy::input_t {}
+  );
+  EXPECT_TRUE(host_default.uses_labwc());
+  EXPECT_TRUE(host_default.requested_headless);
+  EXPECT_FALSE(stream_display_policy::resolve(stream_display_policy::input_t {}).uses_labwc())
+    << "the session's own resolution still follows the live override";
+
+  // Teardown retires the override, and the two answers agree again.
+  stream_display_policy::forget_host_default();
+  EXPECT_EQ(stream_display_policy::host_default_selection(), "host_virtual_display")
+    << "with nothing held, the host default is simply the live configuration";
+}
 
 TEST(StreamDisplayPolicyTests, GpuNativePreferenceLabelsPrivateStreamCaptureCapability) {
   LinuxDisplayPolicyGuard guard;

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -122,6 +122,70 @@ namespace {
   }
 }  // namespace
 
+TEST(StreamDisplayPolicyTests, APrivateHostRefusesAnUnlockedVirtualDisplayPreference) {
+  using stream_display_policy::effective_session_selection_for_launch;
+
+  // A headless labwc host creates the session's output itself. An app's stored
+  // virtual-display default, or a client toggle that never locked topology, has
+  // nothing to add and would trade a GPU-native path for an EVDI one.
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", false, false, true, false, false, true),
+    ""
+  ) << "an app's stored default must not drag a private host onto a virtual display";
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", false, true, false, false, false, true),
+    ""
+  ) << "nor may a client toggle that did not lock topology";
+
+  // A deliberate choice still wins, so the mode stays reachable on this host.
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", false, true, false, true, false, true),
+    "host_virtual_display"
+  ) << "a locked client choice, including the paired always-virtual default, is honored";
+  EXPECT_EQ(
+    effective_session_selection_for_launch("host_virtual_display", false, false, true, false, false, true),
+    "host_virtual_display"
+  ) << "an explicit accepted streamMode is honored on a private host";
+  EXPECT_EQ(
+    effective_session_selection_for_launch("headless_stream", false, false, true, false, false, true),
+    "headless_stream"
+  ) << "and an explicit private streamMode is no longer overridden by the app default";
+
+  // Desktop mirroring still outranks everything.
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", true, true, true, false, false, true),
+    "desktop_display"
+  ) << "mirrorDesktop stays authoritative";
+
+  // Without the host answer, every one of those keeps its old meaning.
+  EXPECT_EQ(
+    effective_session_selection_for_launch("", false, false, true, false, false, false),
+    "host_virtual_display"
+  ) << "a host that does not provide the display still takes the app default";
+}
+
+TEST(StreamDisplayPolicyTests, PrivateHostAnswerReadsTheHostNotTheParkedSession) {
+  LinuxDisplayPolicyGuard guard;
+  HeldHostDefaultGuard held;
+  configure_headless_cage(true);
+
+  EXPECT_TRUE(stream_display_policy::host_default_provides_private_display());
+
+  // Park a virtual-display session on it, exactly as a launch override does.
+  stream_display_policy::remember_host_default(
+    stream_display_policy::legacy_booleans_t {true, true, true},
+    "",
+    "wlr"
+  );
+  config::video.linux_display.stream_mode =
+    std::string {stream_display_policy::k_host_virtual_display};
+  config::video.linux_display.use_cage_compositor = false;
+  config::video.capture = "portal";
+
+  EXPECT_TRUE(stream_display_policy::host_default_provides_private_display())
+    << "a session parked on a virtual display does not stop the host being a private host";
+}
+
 TEST(StreamDisplayPolicyTests, HostDefaultOutlivesASessionScopedVirtualDisplayOverride) {
   LinuxDisplayPolicyGuard guard;
   HeldHostDefaultGuard held;


### PR DESCRIPTION
## Summary

Two related defects on the Linux virtual-display path, found from a host journal where one client's stream dragged a second, unrelated client onto EVDI at 16.7 fps.

**The trigger, second commit.** `effective_session_selection_for_launch` resolved to `host_virtual_display` from an app's stored `virtual-display` flag, or from a client toggle that never locked topology, before anything asked whether the host already provides the session's display. A headless labwc host creates that output itself, so the promotion swapped a GPU-native path for a redundant EVDI one. Twenty of the twenty four apps on the lab host carry the flag. The resolver now takes the host's own answer and refuses an unlocked preference on a private host. A locked client choice, the paired always-virtual default, an explicit accepted `streamMode` and `mirrorDesktop` all still win, so the mode stays reachable by asking for it rather than by inheriting it. All four call sites pass the same answer, because a resume validates topology with the same resolver its launch used and a disagreeing site would reject the session its own launch produced.

This also makes the headless-cage guard in `execute_impl` reachable for the first time. It now fires and reports that the private runtime provides the display, where before `apply_selection` had already cleared the flag it tests.

**The spread, first commit.** A session-scoped override rewrites `config::video.linux_display` and `config::video.capture` in place, and those stay rewritten until `proc_t::terminate_impl`. A paused session holds them for its whole resume window, `disconnect_resume_timeout`, 300 seconds by default. `host_prefers_headless()` and the `/optimize` topology fallback read that live config, so for the length of the window the host recommended the parked session's topology to every other client. A device whose own paired setting is `always_use_virtual_display = false` was steered onto Host Virtual Display by the host's own advice. The host's policy is now published when an override is armed and retired at teardown, and those two surfaces resolve it instead of the live config.

Restoring the policy at stream end was considered and rejected: the session stays resumable and its app is still on that display, so `/resume` needs the override in force. Session resolution is deliberately unchanged and still follows the override. With no override standing, the new functions delegate to the exact previous calls, so this is a no-op outside an override.

**Logging.** `normalize_host_virtual_display_state_for_backend` replaced an explicitly configured capture backend for EVDI and KScreen without saying so, which is what kept this invisible while it was diagnosed. It now logs the substitution, and the header comment no longer claims an operator's backend is honored when it is not.

Measured on pc-papi, 2026-09-10, from the host journal:

| Session | path | evdi pageflip timeouts |
|---|---|---|
| 4K60 labwc | `headless_stream` | 0 |
| 4K60 EVDI | `host_virtual_display` | 161 |
| 4K90 EVDI | `host_virtual_display` | 114 |
| 4K90 labwc | `headless_stream` | 0 |

The second EVDI session began one second after the first one's virtual display was destroyed, from a different client, carrying `host_virtual_display` in a resolved launch profile the host had handed it.

## Exact candidate

`Commit: c20d92cdf9395632cfafd797f2f48978dbddb0c1`
`Tree: 078066c5cc54667ced3d429d80d5331b8cbbd5ce`
`Parent: 03ec857314e078c6c9dd6921a14552325aeceab7`
`Base: master @ ade0e282ae217280dbd6ea473f2d393d4cc6e46b`

## Verification

- [x] `ctest -j 8` in a CUDA-off tree configured with the canonical line: 25 of 25 suites passed, on each commit.
- [x] `ninja -C build` clean; both changed production files confirmed compiled into the `polaris` target and `test_polaris_runtime_objects`, not only the fast test target.
- [x] `StreamDisplayPolicyTests.APrivateHostRefusesAnUnlockedVirtualDisplayPreference` covers the app default, the unlocked client toggle, the locked choice, both explicit `streamMode` values and `mirrorDesktop`, plus the unchanged non-private-host case. RED proven by disabling the refusal branch: three expectations fail, then pass again when restored.
- [x] `StreamDisplayPolicyTests.PrivateHostAnswerReadsTheHostNotTheParkedSession` proves the two commits compose: a parked virtual-display session does not stop the host being a private host.
- [x] `StreamDisplayPolicyTests.HostDefaultOutlivesASessionScopedVirtualDisplayOverride`. RED proven by making the lookup ignore the held snapshot.
- [x] `SourceSafetyContracts.EveryLaunchTopologyResolverCallPassesTheHostPrivateDisplayAnswer`. RED proven by stashing both production files: all four call sites flagged.
- [x] `SourceSafetyContracts.ASessionDisplayOverrideNeverBecomesTheAdvertisedHostDefault`. RED proven by stashing the four production files: six assertions fail.
- [x] The pre-existing `LegacyVirtualDisplayLaunchPromotesOnlyWhenTheClientDidNotChoose` passes unmodified; the new parameter defaults to false, so every existing precedence expectation keeps its meaning.
- [x] The pre-existing teardown location pin in `test_source_safety_contracts.cpp` passes unmodified; the restore statements were not moved.
- [x] The live `~/.config/polaris/polaris.conf` is byte-identical before and after every test run.

Not covered: no two-client hardware rerun. Reproducing the spread needs a paused virtual-display session on one device and a launch from a second inside the resume window, which needs both physical clients. The journal evidence above is the observation; the tests pin the mechanism.

Left alone deliberately: `virtual_display_optimization_present` is still hardcoded `false` at every call site. Wiring it needs the optimization layer's own virtual-display decision, which is resolved after this point in `execute_impl`, and the headless case it was meant to guard is now handled by the host answer instead.
