### PR TITLE
test(linux): gate the class where a private host loses its own topology

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7149,6 +7149,7 @@ namespace proc {
       launch_session->virtual_display ||
       (app.virtual_display && !launch_session->user_locked_virtual_display);
     const auto configured_session_mode = stream_display_policy::configured_selection();
+    const bool host_private = stream_display_policy::host_default_provides_private_display();
     auto session_mode = stream_display_policy::effective_session_selection_for_launch(
       launch_session->stream_mode,
       launch_session->mirror_desktop || app_desktop_mirror_applies(app, *launch_session),
@@ -7156,10 +7157,23 @@ namespace proc {
       app.virtual_display,
       launch_session->user_locked_virtual_display,
       false,
-      stream_display_policy::host_default_provides_private_display()
+      host_private
     );
     if (session_mode.empty()) {
       session_mode = configured_session_mode;
+    }
+    if (!session_mode.empty() && session_mode != configured_session_mode) {
+      // Name the inputs that moved this session off the host's own topology.
+      // Without this line a silent promotion is indistinguishable in the log
+      // from a choice the operator made, which is how one shipped for six
+      // releases. Printed before the flags below are rewritten from the result.
+      BOOST_LOG(info) << "process: session topology ["sv << session_mode
+                      << "] differs from the host default ["sv << configured_session_mode
+                      << "]; requested=["sv << launch_session->stream_mode
+                      << "] app_virtual_display="sv << (app.virtual_display ? 1 : 0)
+                      << " launch_virtual_display="sv << (launch_session->virtual_display ? 1 : 0)
+                      << " user_locked="sv << (launch_session->user_locked_virtual_display ? 1 : 0)
+                      << " private_host="sv << (host_private ? 1 : 0);
     }
     if (!session_mode.empty()) {
       launch_session->virtual_display =

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -431,8 +431,12 @@ TEST(SourceSafetyContracts, EveryLaunchTopologyResolverCallPassesTheHostPrivateD
       const auto close = source.find(");", at);
       ASSERT_NE(close, std::string::npos) << relative;
       const auto arguments = source.substr(at, close - at);
-      EXPECT_NE(arguments.find("host_default_provides_private_display()"), std::string::npos)
-        << relative << " resolves a launch topology without passing the host's own answer";
+      const bool passes_the_host_answer =
+        arguments.find("host_default_provides_private_display()") != std::string::npos ||
+        arguments.find("host_private") != std::string::npos;
+      EXPECT_TRUE(passes_the_host_answer)
+        << relative << " resolves a launch topology without passing the host's own answer, "
+        << "either by calling host_default_provides_private_display() or by passing a host_private local";
       ++calls;
     }
     EXPECT_GT(calls, 0u) << relative << " no longer resolves launch topology at all";

--- a/tests/unit/test_stream_display_policy.cpp
+++ b/tests/unit/test_stream_display_policy.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <vector>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
@@ -121,6 +122,65 @@ namespace {
     config::video.linux_display.private_runtime = "labwc";
   }
 }  // namespace
+
+TEST(StreamDisplayPolicyTests, APrivateHostIsNeverMovedOffItsOwnTopologyWithoutBeingAsked) {
+  // The class of bug this catches: a host configured to provide its own private
+  // display gets silently resolved onto some other topology, and the operator
+  // has no way to tell that from a choice they made. It shipped once already,
+  // as an app's stored virtual-display flag outranking the host, and the cost
+  // was an EVDI path at 16.7 fps that nobody selected.
+  //
+  // The invariant, over every registered path and every combination of the
+  // resolver's inputs: on a private host the answer must either defer to the
+  // host default, or be something the caller explicitly named. Enumerating
+  // stream_path::registry() means a path added later is covered on the day it
+  // is added, without anyone remembering to extend this test.
+  using stream_display_policy::effective_session_selection_for_launch;
+
+  std::vector<std::string> candidates {""};
+  for (const auto &descriptor : stream_path::registry()) {
+    candidates.emplace_back(descriptor.id);
+  }
+  ASSERT_GT(candidates.size(), 1u) << "the path registry is empty, so this gate proves nothing";
+
+  size_t checked = 0;
+  for (const auto &requested : candidates) {
+    for (int bits = 0; bits < 32; ++bits) {
+      const bool mirror_desktop = bits & 1;
+      const bool launch_virtual_display = bits & 2;
+      const bool app_virtual_display = bits & 4;
+      const bool user_locked = bits & 8;
+      const bool optimization_present = bits & 16;
+
+      const auto selection = effective_session_selection_for_launch(
+        requested,
+        mirror_desktop,
+        launch_virtual_display,
+        app_virtual_display,
+        user_locked,
+        optimization_present,
+        true  // the host already provides a private display
+      );
+      ++checked;
+
+      const bool deferred_to_the_host = selection.empty();
+      const bool the_caller_named_it = !requested.empty() && selection == requested;
+      const bool mirroring_won = mirror_desktop &&
+        selection == stream_display_policy::k_desktop_display;
+      const bool a_locked_choice_won = user_locked && launch_virtual_display &&
+        selection == stream_display_policy::k_host_virtual_display;
+
+      EXPECT_TRUE(deferred_to_the_host || the_caller_named_it || mirroring_won || a_locked_choice_won)
+        << "a private host was moved to [" << selection << "] with nothing asking for it: "
+        << "requested=[" << requested << "] mirror=" << mirror_desktop
+        << " launch_vd=" << launch_virtual_display
+        << " app_vd=" << app_virtual_display
+        << " locked=" << user_locked
+        << " optimization=" << optimization_present;
+    }
+  }
+  EXPECT_EQ(checked, candidates.size() * 32);
+}
 
 TEST(StreamDisplayPolicyTests, APrivateHostRefusesAnUnlockedVirtualDisplayPreference) {
   using stream_display_policy::effective_session_selection_for_launch;


### PR DESCRIPTION
## Summary

polaris#649 fixed a defect that no test caught, and the reason is worth more than the fix: the behavior it depended on was itself pinned as correct. `LegacyVirtualDisplayLaunchPromotesOnlyWhenTheClientDidNotChoose` asserts that an unlocked app default must win, with the message "an unlocked paired mode must not override the app's display semantic". It never considered a host that already creates the session's display. Two guards written to stop exactly this were both inert, and nothing asserted either ever fired.

- **The invariant, not another case.** `APrivateHostIsNeverMovedOffItsOwnTopologyWithoutBeingAsked` enumerates every path in `stream_path::registry()` against all thirty two combinations of the resolver's boolean inputs. On a private host the answer must either defer to the host default or be something the caller explicitly named: the requested `streamMode`, `mirrorDesktop`, or a locked virtual-display choice. Anything else is an unexplained topology change and fails.
- **Future paths are covered on the day they are added.** Reading the registry rather than a hand-written id list is the point. Nobody has to remember this file when a path is appended.
- **A launch that leaves the host's own topology now says which input moved it**, naming the requested mode, the app flag, the launch flag, the lock and whether the host is private. Neither session that produced this bug carried such a line, so a silent promotion read in the log exactly like a deliberate choice.

## Exact candidate

`Commit: 79e295f8`
`Base: master @ 2f9d9825, which carries #649`

## Verification

- [x] `ctest -j 8` on a CUDA-off tree: 25 of 25 suites passed.
- [x] **RED proven against the real bug, not a synthetic one.** With the refusal branch removed, which restores the resolver exactly as shipped in 1.4.0 through 1.4.5, the gate reports 34 violations and names each one. Among them, verbatim: `a private host was moved to [host_virtual_display] with nothing asking for it: requested=[] mirror=false launch_vd=false app_vd=true locked=false optimization=false`. That is the case that reached this host's journal on 6 and 10 September.
- [x] Green again when the branch is restored.
- [x] The pre-existing precedence test and the teardown location pin both pass unmodified.
- [x] The live `~/.config/polaris/polaris.conf` is byte-identical before and after every run.

## What this does not cover

No hardware gate. Reproducing the original end to end needs a client that does not lock its topology streaming to a private host with a flagged app, and the RP6 acceptance client locks it. This gate is at the resolver, which is where the decision is actually made; a hardware gate would only re-observe it.
