### PR TITLE
fix: three failures that used to happen in silence

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -340,12 +340,24 @@ namespace logging {
   }
 
 #ifndef __ANDROID__
-  void setup_av_logging(int min_log_level) {
-    if (min_log_level >= 1) {
-      av_log_set_level(AV_LOG_QUIET);
-    } else {
-      av_log_set_level(AV_LOG_DEBUG);
+  int av_log_level_for(int min_log_level) {
+    // This used to silence libavcodec completely at any level above the most
+    // verbose, which threw away the one line that explains an encoder refusing
+    // to open. When the linked FFmpeg wants a newer nvenc API than the driver
+    // provides, FFmpeg itself names both versions and Polaris only ever printed
+    // the resulting "Function not implemented", so the stream silently fell back
+    // to software with nothing saying why. Errors now always come through.
+    if (min_log_level >= 2) {
+      return AV_LOG_ERROR;
     }
+    if (min_log_level == 1) {
+      return AV_LOG_WARNING;
+    }
+    return AV_LOG_DEBUG;
+  }
+
+  void setup_av_logging(int min_log_level) {
+    av_log_set_level(av_log_level_for(min_log_level));
     av_log_set_callback([](void *ptr, int level, const char *fmt, va_list vl) {
       static int print_prefix = 1;
       char buffer[1024];

--- a/src/logging.h
+++ b/src/logging.h
@@ -68,6 +68,15 @@ namespace logging {
   [[nodiscard]] std::unique_ptr<deinit_t> init(int min_log_level, const std::string &log_file);
 
   /**
+   * @brief The libav log level Polaris runs at for a given verbosity.
+   *
+   * Errors always pass, at every verbosity. FFmpeg reports an encoder refusing
+   * to open, and why, through its own log; silencing it turns a diagnosable
+   * failure into a silent fall back to software encoding.
+   */
+  int av_log_level_for(int min_log_level);
+
+  /**
    * @brief Setup AV logging.
    * @param min_log_level The log level.
    */

--- a/src/private_state_file.cpp
+++ b/src/private_state_file.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <iterator>
 #include <random>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -49,21 +50,56 @@ namespace private_state_file {
       return flags;
     }
 
-    bool secure_directory_descriptor(int descriptor, bool final_parent) {
+    /**
+     * @brief Whether this directory may hold private state, and if not, why.
+     *
+     * The reason matters as much as the answer. A single `sudo polaris` leaves
+     * the per-user config directory owned by root, after which every later run
+     * as the user fails here forever, and the only thing the operator sees is
+     * that saving credentials did not work.
+     */
+    bool secure_directory_descriptor(int descriptor, bool final_parent, std::string *reason = nullptr) {
+      const auto refuse = [reason](std::string explanation) {
+        if (reason) {
+          *reason = std::move(explanation);
+        }
+        return false;
+      };
+
       struct stat metadata {};
       if (::fstat(descriptor, &metadata) != 0 || !S_ISDIR(metadata.st_mode)) {
-        return false;
+        return refuse("it is not a directory this process can inspect");
       }
 
       const auto effective_user = ::geteuid();
       const auto writable_by_others = (metadata.st_mode & (S_IWGRP | S_IWOTH)) != 0;
+      const auto describe = [&metadata, effective_user](std::string_view problem) {
+        std::ostringstream detail;
+        detail << problem << " (owner uid " << metadata.st_uid
+               << ", mode 0" << std::oct << (metadata.st_mode & 07777) << std::dec
+               << ", this process runs as uid " << effective_user << ')';
+        return detail.str();
+      };
+
       if (final_parent) {
-        return metadata.st_uid == effective_user && !writable_by_others;
+        if (metadata.st_uid != effective_user) {
+          return refuse(describe("it is owned by another user"));
+        }
+        if (writable_by_others) {
+          return refuse(describe("it is writable by group or other"));
+        }
+        return true;
       }
 
       const auto trusted_owner = metadata.st_uid == 0 || metadata.st_uid == effective_user;
       const auto sticky_when_writable = !writable_by_others || (metadata.st_mode & S_ISVTX) != 0;
-      return trusted_owner && sticky_when_writable;
+      if (!trusted_owner) {
+        return refuse(describe("a parent directory is owned by another user"));
+      }
+      if (!sticky_when_writable) {
+        return refuse(describe("a parent directory is writable by others without the sticky bit"));
+      }
+      return true;
     }
 
     std::filesystem::path trusted_home_symlink() {
@@ -197,9 +233,20 @@ namespace private_state_file {
             parent_entry_needs_sync = true;
             next = ::openat(descriptor_, component.c_str(), directory_open_flags());
           }
-          if (next < 0 || !secure_directory_descriptor(next, final_parent)) {
+          std::string rejection;
+          if (next < 0 || !secure_directory_descriptor(next, final_parent, &rejection)) {
             if (next >= 0) {
               ::close(next);
+            }
+            if (!rejection.empty()) {
+              // The only place this is ever explained. Everything downstream
+              // reports that a write did not commit, which sends people looking
+              // at the file they were saving rather than at the directory.
+              BOOST_LOG(error) << "Refusing to keep private state in ["
+                               << path_.parent_path().string() << "] because "
+                               << rejection << ". If that directory is owned by root, a single "
+                               << "\"sudo polaris\" created it; chown it back to your own user and "
+                               << "run Polaris without sudo.";
             }
             (void) close();
             return;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -862,6 +862,47 @@ namespace video {
       return static_cast<bool>(f);
     }
 
+    /**
+     * @brief A driver version, or nothing at all.
+     *
+     * nvidia-smi prints its NVML failure banner to stdout, not stderr, so an
+     * unvalidated read stores that sentence as the driver string. The driver
+     * cache is keyed on the tool's path and mtime rather than its output, so a
+     * banner captured once outlives every restart and permanently defeats the
+     * driver-change invalidation in load_encoder_cache. Accept only something
+     * shaped like a version.
+     */
+    std::string parse_nvidia_driver_version(std::string_view reported) {
+      auto trimmed = trim_trailing_ascii_whitespace(std::string {reported});
+      if (trimmed.empty() || trimmed.size() > 24) {
+        return {};
+      }
+
+      std::size_t parts = 0;
+      std::size_t digits_in_part = 0;
+      for (const char character : trimmed) {
+        if (character >= '0' && character <= '9') {
+          ++digits_in_part;
+          continue;
+        }
+        if (character != '.' || digits_in_part == 0) {
+          return {};
+        }
+        ++parts;
+        digits_in_part = 0;
+      }
+      if (digits_in_part == 0) {
+        return {};
+      }
+      ++parts;
+
+      // major.minor at least, and nothing longer than 610.57.04.01.
+      if (parts < 2 || parts > 4) {
+        return {};
+      }
+      return trimmed;
+    }
+
     std::string read_driver_version_cache(
       const std::filesystem::path &cache_path,
       const std::filesystem::path &binary_path,
@@ -883,7 +924,9 @@ namespace video {
         return {};
       }
 
-      return trim_trailing_ascii_whitespace(std::move(cached_driver_version));
+      // Validate on the way out too, so a cache poisoned by an older build
+      // heals on its own instead of staying wrong until nvidia-smi is replaced.
+      return parse_nvidia_driver_version(cached_driver_version);
     }
 
     std::string query_nvidia_driver_version_uncached() {
@@ -895,7 +938,7 @@ namespace video {
 
       char buf[128];
       if (fgets(buf, sizeof(buf), pipe)) {
-        driver_version = trim_trailing_ascii_whitespace(buf);
+        driver_version = parse_nvidia_driver_version(buf);
       }
       pclose(pipe);
       return driver_version;
@@ -6063,6 +6106,10 @@ namespace video {
     std::string_view driver_version
   ) {
     return write_driver_version_cache(cache_path, binary_path, binary_mtime, driver_version);
+  }
+
+  std::string parse_nvidia_driver_version_for_tests(std::string_view reported) {
+    return parse_nvidia_driver_version(reported);
   }
 
   std::string read_driver_version_cache_for_tests(

--- a/src/video.h
+++ b/src/video.h
@@ -709,6 +709,8 @@ namespace video {
     std::string_view binary_mtime
   );
 
+  std::string parse_nvidia_driver_version_for_tests(std::string_view reported);
+
   bool write_encoder_probe_cache_for_tests(
     const std::filesystem::path &cache_path,
     std::string_view driver_version,

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -19,6 +19,10 @@
 #include <src/bounded_log_file.h>
 #include <src/logging.h>
 
+extern "C" {
+#include <libavutil/log.h>
+}
+
 namespace {
   std::array log_levels = {
     std::tuple("verbose", &verbose),
@@ -284,4 +288,20 @@ TEST(LoggingOwnerLock, SecondInitFallsBackToConsoleAndLeavesOwnedFilesUntouched)
   PolarisEnvironment::restore_logging();
 
   fs::remove_all(root, error);
+}
+
+TEST(LoggingTests, LibavErrorsSurviveEveryVerbosity) {
+  // Silencing libav at the default verbosity is how an encoder refusing to open
+  // became a silent fall back to software. FFmpeg names the required and the
+  // found nvenc API versions in its own error line; Polaris only ever printed
+  // the resulting "Function not implemented".
+  EXPECT_EQ(logging::av_log_level_for(2), AV_LOG_ERROR);
+  EXPECT_EQ(logging::av_log_level_for(3), AV_LOG_ERROR);
+  EXPECT_EQ(logging::av_log_level_for(1), AV_LOG_WARNING);
+  EXPECT_EQ(logging::av_log_level_for(0), AV_LOG_DEBUG);
+
+  for (int verbosity = 0; verbosity <= 5; ++verbosity) {
+    EXPECT_GE(logging::av_log_level_for(verbosity), AV_LOG_ERROR)
+      << "verbosity " << verbosity << " discards libav errors";
+  }
 }

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -413,6 +413,30 @@ TEST(SourceSafetyContracts, ASessionDisplayOverrideNeverBecomesTheAdvertisedHost
     << "silently replacing an operator's capture backend is what made this bug invisible";
 }
 
+TEST(SourceSafetyContracts, RefusingToKeepPrivateStateSaysWhichDirectoryAndWhy) {
+  // Everything downstream of this rejection reports only that a write did not
+  // commit, which sends people looking at the file they were saving instead of
+  // at the directory that refused it. One sudo run is enough to cause it, and
+  // for one release the failure had no log line at all.
+  std::ifstream input(fs::path {POLARIS_SOURCE_DIR} / "src/private_state_file.cpp");
+  ASSERT_TRUE(input.is_open());
+  std::ostringstream contents;
+  contents << input.rdbuf();
+  const auto source = contents.str();
+
+  const auto guard = source.find("bool secure_directory_descriptor(");
+  ASSERT_NE(guard, std::string::npos);
+  EXPECT_NE(source.find("std::string *reason", guard), std::string::npos)
+    << "the guard must report why it refused, not just that it did";
+
+  EXPECT_NE(source.find("Refusing to keep private state in ["), std::string::npos)
+    << "the rejection must name the directory it refused";
+  EXPECT_NE(source.find("owner uid "), std::string::npos)
+    << "the rejection must name the owner, which is the thing that is wrong";
+  EXPECT_NE(source.find("without sudo"), std::string::npos)
+    << "the rejection must name the remedy";
+}
+
 TEST(SourceSafetyContracts, EveryLaunchTopologyResolverCallPassesTheHostPrivateDisplayAnswer) {
   // A resume validates topology with the same resolver its launch used. If one
   // call site answers "the host already provides the display" and another does

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -161,6 +161,53 @@ TEST(VideoCacheTests, DriverVersionCacheHitRequiresMatchingBinaryMetadata) {
   std::filesystem::remove_all(cache_dir, ec);
 }
 
+TEST(VideoCacheTests, DriverVersionRejectsAnythingThatIsNotAVersion) {
+  // nvidia-smi prints its NVML failure to stdout, so without this the banner
+  // becomes the driver string, and because the cache is keyed on the tool's
+  // path and mtime rather than its output it then survives every restart.
+  EXPECT_EQ(video::parse_nvidia_driver_version_for_tests("610.57.04"), "610.57.04");
+  EXPECT_EQ(video::parse_nvidia_driver_version_for_tests("570.144\n"), "570.144");
+  EXPECT_EQ(video::parse_nvidia_driver_version_for_tests("610.57.04.01"), "610.57.04.01");
+
+  for (const auto *banner : {
+         "NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver.",
+         "Failed to initialize NVML: Driver/library version mismatch",
+         "No devices were found",
+         "",
+         "610",
+         "610.",
+         ".57",
+         "610..57",
+         "610.57.04.01.02",
+       }) {
+    EXPECT_TRUE(video::parse_nvidia_driver_version_for_tests(banner).empty())
+      << "accepted [" << banner << "] as a driver version";
+  }
+}
+
+TEST(VideoCacheTests, DriverVersionCacheHealsItselfWhenAlreadyPoisoned) {
+  // A cache written by an older build outlives the fix otherwise, because the
+  // entry is only reconsidered when nvidia-smi itself changes on disk.
+  const auto cache_dir = std::filesystem::temp_directory_path() / "polaris-video-cache-poison-tests";
+  const auto cache_path = cache_dir / "driver_version_cache.txt";
+  const auto binary_path = cache_dir / "nvidia-smi";
+
+  std::error_code ec;
+  std::filesystem::create_directories(cache_dir, ec);
+  ASSERT_FALSE(ec);
+
+  ASSERT_TRUE(video::write_driver_version_cache_for_tests(
+    cache_path,
+    binary_path,
+    "12345",
+    "NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver."
+  ));
+  EXPECT_TRUE(video::read_driver_version_cache_for_tests(cache_path, binary_path, "12345").empty())
+    << "a poisoned driver cache entry must not be believed";
+
+  std::filesystem::remove_all(cache_dir, ec);
+}
+
 TEST(VideoCacheTests, ResetDisplayRetryDelayBackoffCapsAtTwoHundredMilliseconds) {
   EXPECT_EQ(video::reset_display_retry_delay_for_tests(0), std::chrono::milliseconds(50));
   EXPECT_EQ(video::reset_display_retry_delay_for_tests(1), std::chrono::milliseconds(100));


### PR DESCRIPTION
## Summary

Three failures that all shared one shape: something went wrong, the code knew exactly why, and nothing said so. Each is small, independent, and carries a test whose RED was proven against the real defect rather than a synthetic one.

**nvidia-smi's failure text became the driver version.** The tool prints its NVML failure to stdout rather than stderr, so whenever it is installed but the driver is not answering, the probe captured the banner as the driver string. That is not only log noise: the value is written to the driver version cache, and that cache is keyed on nvidia-smi's own path and mtime rather than on its content. A banner captured once therefore survives every restart until the tool is replaced on disk, and while it sits there the driver-change comparison in the encoder cache can never fire, so stale encoder capabilities are advertised across driver upgrades. The realistic trigger is a driver update followed by a probe before the reboot. The query now accepts only something shaped like a version, and so does the cache read, so a cache an older build already poisoned heals itself instead of staying wrong until the next package update.

**A directory that refused to hold private state never said which one, or why.** A single `sudo polaris` leaves the per-user config directory owned by root, every later run as the user fails the ownership check forever, and all anyone sees is that saving credentials did not work. That sends people looking at the file rather than at the directory. One reporter's only workaround was running the whole daemon as root. The guard already had the owner, the mode and the effective uid in hand and threw all three away behind a bare `bool`. It now reports the reason and the caller logs the directory, its owner, its mode, the user Polaris runs as, and the remedy.

This also restores something that went missing. Until v1.4.5 the rejection at least printed a line naming the path. The refactor in that release removed both log lines without changing the behaviour, so on 1.4.5 the failure is completely silent. That is worth knowing before anyone is told to upgrade to fix it.

**libav errors were silenced at the default verbosity.** Polaris set `AV_LOG_QUIET` at any verbosity above the most verbose, and the default sits above it, so every FFmpeg diagnostic was discarded before reaching the log. That threw away the one line that explains an encoder refusing to open: when the linked FFmpeg wants a newer nvenc API than the installed driver provides, FFmpeg names both the required and the found version, while Polaris printed only the resulting "Function not implemented" and fell back to software. The stream silently loses the hardware encoder and nothing says why. Errors now pass at every verbosity, warnings below that, and the most verbose setting is unchanged.

The cost is honest and worth stating: expected probe failures become visible during encoder probing. That already happens inside a block which prints a banner saying its errors can be ignored.

## Deliberately not included

The system extension repair was considered and dropped. `Polaris-sysext-x86_64.raw` does not ship. It was withdrawn on 2026-09-05 for exactly the missing-library reason anyone would set out to fix, `docs/bazzite.md` records that, and `scripts/check-release-package-dependencies.py` fails the build if the builder or its workflow entries come back. Repairing it is a decision to un-withdraw a release asset, behind its own validation runbook, not a patch-release fix.

The other half of the private-state work is also left out. Making `--setup-host` repair a root-owned config directory means a privileged recursive chown on a user-controlled path that must honour `XDG_CONFIG_HOME` and `CONFIGURATION_DIRECTORY`, is root-only and so effectively untestable in CI, and wants its own review. The preventive half already shipped: `dispatch_setup_host_before_user_state` runs host setup before config parsing so `sudo polaris --setup-host` cannot create the directory as root in the first place.

## Verification

- [x] `ctest -j 8` on a CUDA-off tree: 25 of 25 suites passed.
- [x] `VideoCacheTests.DriverVersionRejectsAnythingThatIsNotAVersion` covers both real banners, the empty case, and the near-misses `610`, `610.`, `.57`, `610..57` and a five-part version. RED proven by bypassing the validator: every banner is accepted, each named in the failure output.
- [x] `VideoCacheTests.DriverVersionCacheHealsItselfWhenAlreadyPoisoned` proves the fix reaches users whose cache is already wrong, which validating only the query would not have done.
- [x] `LoggingTests.LibavErrorsSurviveEveryVerbosity` asserts errors pass at every verbosity. RED proven by restoring `AV_LOG_QUIET`: verbosities 2 and above report discarding libav errors.
- [x] `SourceSafetyContracts.RefusingToKeepPrivateStateSaysWhichDirectoryAndWhy` pins that the guard reports a reason and that the message names the directory, the owner and the remedy. RED proven by stashing the file: all four assertions fail.
- [x] The pre-existing `PrivateStateFileTest.DoesNotCarryUnsupportedWindowsSecurityImplementation` passes unmodified. It pins the POSIX ownership expressions by their source text, so the refactor keeps them character for character rather than rewriting them into an equivalent form.
- [x] The live `~/.config/polaris/polaris.conf` is byte-identical before and after every run.

## What is not covered

No hardware reproduction of the nvidia-smi case. This host's nvidia-smi answers correctly, so triggering the banner would mean unloading the driver module. The tests are the verification, and the failure mode is reproduced exactly as text.

## Exact candidate

`Commit: de5a331bc09cbee6a757926b697f07be8309eb20`
`Tree: 13772ae6c6a389e2a4cd71d3feb25690c2ec1d9f`
`Parent: 4f6b8fcda9ef2b0186f29826486e790927302426`
`Base: master @ 93427368, which carries the topology gate`
