### PR TITLE
release: prepare Polaris 1.4.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
     set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
-project(Polaris VERSION 1.4.5
+project(Polaris VERSION 1.4.6
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -530,7 +530,7 @@
         "example": {
           "schema_version": 1,
           "measurement_spec_id": "measurement-spec-v1",
-          "collector_version": "1.4.5",
+          "collector_version": "1.4.6",
           "clock_domain": "CLOCK_MONOTONIC",
           "run_id": "pair-0001-control",
           "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,20 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+## v1.4.6 - 2026-09-11
+
+A correctness update for Linux hosts that stream a private display, and for three failures that used to happen in silence. A game's stored virtual-display preference no longer overrides a host that already provides the session's display, a paused session no longer changes what the host recommends to other clients, and an encoder, a driver reading and a refused directory now each say what went wrong. Existing configurations and paired devices remain valid.
+
+- Stops an app's stored virtual-display preference, or a client that never locked its topology, from moving a private headless host onto the host virtual display. A locked client choice, the paired always-virtual default, an explicit session stream mode and desktop mirroring all still win, so the mode stays reachable by asking for it rather than by inheriting it (#649)
+- Keeps a session-scoped display override out of the topology the host recommends to other clients. The override stays in force for its own session, including the whole paused-session resume window, but is no longer read back as the host's own default, so one client's choice can no longer become the next client's recommendation (#649)
+- Reports when a host virtual display backend replaces an explicitly configured capture backend for that session, instead of substituting it silently (#649)
+- Records which input moved a session off the host's own topology, so a silent promotion no longer reads in the log exactly like a deliberate choice (#651)
+- Adds a contract over the launch topology resolver: across every registered path and every combination of the resolver's inputs, a private host must either defer to its own default or return a topology the caller named (#651)
+- Rejects nvidia-smi's failure banner as a driver version. The banner was stored in the driver cache, which is keyed on the tool's path and modification time rather than its content, so a single bad reading survived restarts and stopped the encoder cache from noticing a driver change; an already-poisoned cache now heals itself
+- Names the directory that refused to hold private state, along with its owner, its mode, the user Polaris runs as, and the remedy. One run under sudo leaves the per-user configuration directory owned by root, after which saving credentials fails permanently, and since v1.4.5 it failed with nothing in the log at all
+- Keeps libav errors at the default verbosity instead of silencing them. An encoder that cannot start because the graphics driver is older than the linked FFmpeg's nvenc API now reports both versions, rather than falling back to software encoding without explanation
+- Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official package assets
+
 ## v1.4.5 - 2026-09-10
 
 A Bazzite and Live Tuning update matched with Nova v1.4.5. Live Tuning is one saved host preference that every console surface and paired client reads the same way, Bazzite Desktop launches prepare capture before the stream starts, hosts running a Steam Game Mode session learn why they go offline and how headless boot keeps them reachable, and `--setup-host` reports it. The supported Bazzite RPM path was exercised end to end on an NVIDIA Open host with a Retroid Pocket 6. Existing configurations and paired devices remain valid.

--- a/docs/release-notes/v1.4.6.md
+++ b/docs/release-notes/v1.4.6.md
@@ -1,0 +1,76 @@
+# Polaris v1.4.6
+
+A correctness update for Linux hosts that stream a private display. Nova stays at v1.4.5 and needs no update. Existing settings and paired devices keep working.
+
+**Fixed**
+
+- A game set to prefer its own virtual display no longer moves a host that already provides a private display onto one. Choosing it deliberately still works.
+- One client's display choice no longer becomes the mode the host recommends to the next client, including while a paused session is still resumable.
+- Saving credentials names the directory that refused it, who owns it and how to put it right, instead of failing with nothing in the log.
+- An encoder that cannot start because the graphics driver is older than Polaris expects now reports both versions, instead of dropping to software encoding without saying why.
+- A failed reading from nvidia-smi is no longer stored as the driver version, where it used to survive restarts and hide a driver upgrade from the encoder.
+- Polaris says when a virtual display backend has to replace the capture backend you chose, rather than swapping it quietly.
+
+**Heads up**
+
+- Bazzite hosts should still install the Fedora 44 RPM through rpm-ostree. The system extension stays withdrawn.
+- SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+- Steam Input stays manual and read-only.
+- No new hardware validation run for this release. The display fix is covered by an automated contract across every stream path, and the private stream path on NVIDIA is unchanged.
+
+<details>
+<summary><b>Install</b> (Fedora 44, Arch / CachyOS, Ubuntu 24.04, SteamOS 3.8)</summary>
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### SteamOS 3.8
+
+Run this in Desktop Mode. It sets up the package keyring when needed and restores the read-only root before starting Polaris.
+
+```bash
+wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-steamos3.8-x86_64.pkg.tar.zst &&
+(
+set -e
+trap 'sudo steamos-readonly enable' EXIT
+sudo steamos-readonly disable || exit $?
+sudo pacman-key --init || exit $?
+sudo pacman-key --populate || exit $?
+sudo pacman -Sy || exit $?
+sudo pacman -U ./Polaris-steamos3.8-x86_64.pkg.tar.zst || exit $?
+sudo -H polaris --setup-host || exit $?
+sudo steamos-readonly enable || exit $?
+trap - EXIT
+) &&
+systemctl --user enable --now polaris
+```
+
+Bazzite users should follow the [Bazzite guide](https://papi-ux.com/docs/bazzite/) and use the Fedora RPM through rpm-ostree. SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/); SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+
+</details>
+
+**Assets:** `Polaris-fedora44-x86_64.rpm` · `Polaris-arch-x86_64.pkg.tar.zst` · `Polaris-ubuntu24.04-x86_64.deb` · `Polaris-steamos3.8-x86_64.pkg.tar.zst`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.4.5') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.4.6') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -665,7 +665,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.4.5.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.4.6.md").read_text(encoding="utf-8")
 )
 
 
@@ -1296,18 +1296,18 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.4.6 - 2026-09-11",
     "## v1.4.5 - 2026-09-10",
-    "## v1.4.4 - 2026-09-06",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "Live Tuning",
-    "Bazzite",
-    "Game Mode",
-    "headless boot",
-    "--setup-host",
-    "Host Virtual Display",
-    "DualSense",
+    "virtual display",
+    "private headless host",
+    "paused-session resume window",
+    "capture backend",
+    "nvidia-smi",
+    "software encoding",
+    "private state",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
     "Polaris-steamos3.8-x86_64.pkg.tar.zst",
@@ -1315,7 +1315,7 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.4.5 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.6 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1324,7 +1324,7 @@ asset_phrase = (
     "`Polaris-steamos3.8-x86_64.pkg.tar.zst`, and "
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
-for label, section in (("v1.4.5 changelog", current_release_prose),):
+for label, section in (("v1.4.6 changelog", current_release_prose),):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
         sys.exit(1)
@@ -1344,7 +1344,7 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section, expected_section_assets in (
     ("docs/building.md Packaging", building_packaging_prose, expected_assets),
-    ("v1.4.5 changelog", current_release_prose, expected_changelog_assets),
+    ("v1.4.6 changelog", current_release_prose, expected_changelog_assets),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_section_assets:
@@ -1358,23 +1358,23 @@ for label, section, expected_section_assets in (
 # Release notes are the short, user-facing list; the changelog carries the
 # detail. Pin phrases a player would read, never internal identifiers.
 release_notes_facts = (
-    "Nova v1.4.5",
-    "Live Tuning",
-    "Game Mode",
-    "headless boot",
+    "Nova stays at v1.4.5",
+    "private display",
+    "virtual display",
+    "software encoding",
     "Bazzite",
     "rpm-ostree",
     "system extension stays withdrawn",
     "SteamOS",
     "Steam Input",
-    "Retroid Pocket 6",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-fedora44-x86_64.rpm &&",
+    "nvidia-smi",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
-    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.5/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
     "trap 'sudo steamos-readonly enable' EXIT",
     "sudo pacman-key --init || exit $?",
     "sudo pacman-key --populate || exit $?",
@@ -1382,25 +1382,25 @@ release_notes_facts = (
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.4.5 release notes are missing release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.6 release notes are missing release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 release_asset_lines = [
     line for line in release_notes.splitlines() if line.startswith("**Assets:**")
 ]
 if len(release_asset_lines) != 1:
-    print("v1.4.5 release notes must contain exactly one Assets line", file=sys.stderr)
+    print("v1.4.6 release notes must contain exactly one Assets line", file=sys.stderr)
     sys.exit(1)
 release_note_assets = Counter(asset_pattern.findall(release_asset_lines[0]))
 if release_note_assets != expected_assets:
     print(
-        "v1.4.5 release-note Assets line must contain only the four supported packages; "
+        "v1.4.6 release-note Assets line must contain only the four supported packages; "
         f"expected={dict(expected_assets)}, actual={dict(release_note_assets)}",
         file=sys.stderr,
     )
     sys.exit(1)
 if release_notes.count(withdrawn_sysext_asset) != 0:
     print(
-        "v1.4.5 release notes must not name the withdrawn system extension file; that warning lives in v1.4.3",
+        "v1.4.6 release notes must not name the withdrawn system extension file; that warning lives in v1.4.3",
         file=sys.stderr,
     )
     sys.exit(1)
@@ -1411,19 +1411,19 @@ for forbidden in (
     "AI Auto Quality Preference",
 ):
     if forbidden in current_release_prose or forbidden in release_notes:
-        print(f"v1.4.5 public release scope must exclude: {forbidden}", file=sys.stderr)
+        print(f"v1.4.6 public release scope must exclude: {forbidden}", file=sys.stderr)
         sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host &&") != 3:
-    print("v1.4.5 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
+    print("v1.4.6 release notes must chain setup-host in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("sudo -H polaris --setup-host || exit $?") != 1:
-    print("v1.4.5 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
+    print("v1.4.6 release notes must chain setup-host in the SteamOS command", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user restart polaris") != 3:
-    print("v1.4.5 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
+    print("v1.4.6 release notes must restart Polaris in all three mutable package commands", file=sys.stderr)
     sys.exit(1)
 if release_notes.count("systemctl --user enable --now polaris") != 1:
-    print("v1.4.5 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
+    print("v1.4.6 release notes must start Polaris once after SteamOS read-only restoration", file=sys.stderr)
     sys.exit(1)
 
 release_workflow = Path(".github/workflows/build.yml").read_text(encoding="utf-8")

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.5-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.6-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -776,7 +776,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.4.5-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.4.6-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v145-contract.test.js
+++ b/src_assets/common/assets/web/release-v145-contract.test.js
@@ -1,17 +1,10 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
-const packageAssets = [
-  'Polaris-arch-x86_64.pkg.tar.zst',
-  'Polaris-fedora44-x86_64.rpm',
-  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
-  'Polaris-ubuntu24.04-x86_64.deb',
-].sort()
-const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
 
-const currentChangelog = () => {
+const historicalRelease = () => {
   const changelog = read('docs/changelog.md')
   const start = changelog.indexOf('## v1.4.5 - 2026-09-10')
   const end = changelog.indexOf('## v1.4.4 - 2026-09-06')
@@ -20,27 +13,19 @@ const currentChangelog = () => {
   return changelog.slice(start, end)
 }
 
-const releaseNotes = () => read('docs/release-notes/v1.4.5.md')
-const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
-  .map((match) => match[1])
-  .filter((block) => block.includes('wget --output-document='))
+const historicalNotes = () => read('docs/release-notes/v1.4.5.md')
 
-describe('v1.4.5 release contract', () => {
-  it('moves every current release identity to v1.4.5', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.5')
-    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.5"')
-    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.5')
-    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.5-1|x86_64'")
-    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.5-1|x86_64'")
-  })
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
 
-  it('makes v1.4.4 historical and promotes the complete v1.4.5 scope', () => {
-    expect(read('src_assets/common/assets/web/release-v144-contract.test.js')).toContain("describe('historical v1.4.4 release contract'")
-    const gate = read('scripts/check-public-docs.sh')
-    expect(gate).toContain('docs/release-notes/v1.4.5.md')
-    expect(gate).toContain('"## v1.4.5 - 2026-09-10"')
-
-    const release = `${currentChangelog()}\n${releaseNotes()}`
+describe('historical v1.4.5 release contract', () => {
+  it('preserves the Live Tuning, Bazzite and Game Mode scope and the withdrawn extension', () => {
+    const evidence = `${historicalRelease()}\n${historicalNotes()}`
     for (const fact of [
       'Live Tuning',
       'Game Mode',
@@ -52,87 +37,28 @@ describe('v1.4.5 release contract', () => {
       'Nova v1.4.5',
       'Retroid Pocket 6',
     ]) {
-      expect(release, `release must include: ${fact}`).toContain(fact)
+      expect(evidence, `historical v1.4.5 must include: ${fact}`).toContain(fact)
     }
+    expect(historicalNotes()).toContain('system extension stays withdrawn')
+    expect(historicalNotes()).not.toContain(withdrawnSysextAsset)
   })
 
-  it('ships the Bazzite guide rework and the Game Mode guide, and keeps the system extension withdrawn', () => {
-    const notes = releaseNotes()
-    const bazziteGuide = read('docs/bazzite.md')
-    const handheldsGuide = read('docs/handhelds.md')
-    const workflow = read('.github/workflows/build.yml')
-
-    expect(bazziteGuide).toContain('sudo rpm-ostree install --uninstall=polaris')
-    expect(bazziteGuide).toContain('sudo rpm-ostree rollback')
-    expect(handheldsGuide.length).toBeGreaterThan(0)
-    expect(notes).toContain('system extension stays withdrawn')
-    expect(notes).not.toContain(withdrawnSysextAsset)
-    expect(workflow).not.toContain('sysext-build:')
-    expect(workflow).not.toContain('Polaris-sysext-image')
-    expect(workflow).not.toContain(`release-assets/final/${withdrawnSysextAsset}`)
-  })
-
-  it('pins all four install commands to v1.4.5 and lists only supported package assets', () => {
-    const blocks = installBlocks()
+  it('preserves the exact historical assets and install identities', () => {
+    const notes = historicalNotes()
+    const blocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
     expect(blocks).toHaveLength(4)
-    for (const asset of packageAssets) {
+    for (const asset of expectedAssets) {
       const matches = blocks.filter((block) => block.includes(`/${asset}`))
       expect(matches, `one command block for ${asset}`).toHaveLength(1)
       expect(matches[0]).toContain(`releases/download/v1.4.5/${asset}`)
-      expect(matches[0]).toContain('sudo -H polaris --setup-host')
     }
 
-    for (const asset of [
-      'Polaris-arch-x86_64.pkg.tar.zst',
-      'Polaris-fedora44-x86_64.rpm',
-      'Polaris-ubuntu24.04-x86_64.deb',
-    ]) {
-      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
-      expect(block).toContain('systemctl --user restart polaris')
-    }
-
-    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
-    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
-    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
-    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
-    expect(steamOs).toContain('systemctl --user enable --now polaris')
-
-    const assetsLine = releaseNotes().split('\n').find((line) => line.startsWith('**Assets:**'))
+    const assetsLine = notes.split('\n').find((line) => line.startsWith('**Assets:**'))
     expect(assetsLine).toBeDefined()
     const listed = [...new Set((assetsLine ?? '').match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
-    expect(listed.sort()).toEqual(packageAssets)
+    expect(listed.sort()).toEqual(expectedAssets)
     expect(assetsLine).not.toContain(withdrawnSysextAsset)
-  })
-
-  it('publishes release-note guide links that work outside the source tree', () => {
-    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
-    const notes = readdirSync(releaseNotesDir)
-      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
-      .map((name) => read(`docs/release-notes/${name}`))
-      .join('\n')
-
-    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
-    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
-    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
-  })
-
-  it('keeps publication bound to one verified immutable source', () => {
-    const workflow = read('.github/workflows/build.yml')
-    const ordered = [
-      '- name: Check out exact release source',
-      '- name: Revalidate release tag against packaged source',
-      '- name: Stage curated GitHub release',
-      '- name: Upload release assets to GitHub release',
-      '- name: Verify release assets on GitHub release',
-      '- name: Publish verified draft release',
-    ]
-    const positions = ordered.map((step) => workflow.indexOf(step))
-    expect(positions.every((position) => position >= 0)).toBe(true)
-    expect(positions).toEqual([...positions].sort((a, b) => a - b))
-    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
-    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
-    expect(workflow).toContain('--verify-tag')
-    expect(workflow).toContain('--notes-file "$release_notes"')
-    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
   })
 })

--- a/src_assets/common/assets/web/release-v146-contract.test.js
+++ b/src_assets/common/assets/web/release-v146-contract.test.js
@@ -1,0 +1,138 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+const packageAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
+
+const currentChangelog = () => {
+  const changelog = read('docs/changelog.md')
+  const start = changelog.indexOf('## v1.4.6 - 2026-09-11')
+  const end = changelog.indexOf('## v1.4.5 - 2026-09-10')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return changelog.slice(start, end)
+}
+
+const releaseNotes = () => read('docs/release-notes/v1.4.6.md')
+const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
+  .map((match) => match[1])
+  .filter((block) => block.includes('wget --output-document='))
+
+describe('v1.4.6 release contract', () => {
+  it('moves every current release identity to v1.4.6', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.6')
+    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.6"')
+    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.6')
+    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.6-1|x86_64'")
+    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.6-1|x86_64'")
+  })
+
+  it('makes v1.4.5 historical and promotes the complete v1.4.6 scope', () => {
+    expect(read('src_assets/common/assets/web/release-v145-contract.test.js')).toContain("describe('historical v1.4.5 release contract'")
+    const gate = read('scripts/check-public-docs.sh')
+    expect(gate).toContain('docs/release-notes/v1.4.6.md')
+    expect(gate).toContain('"## v1.4.6 - 2026-09-11"')
+
+    const release = `${currentChangelog()}\n${releaseNotes()}`
+    for (const fact of [
+      'virtual display',
+      'private display',
+      'paused-session resume window',
+      'private state',
+      'nvidia-smi',
+      'software encoding',
+      'Bazzite',
+      'rpm-ostree',
+      'Nova stays at v1.4.5',
+    ]) {
+      expect(release, `release must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('keeps the Bazzite install guidance and the system extension withdrawn', () => {
+    const notes = releaseNotes()
+    const bazziteGuide = read('docs/bazzite.md')
+    const handheldsGuide = read('docs/handhelds.md')
+    const workflow = read('.github/workflows/build.yml')
+
+    expect(bazziteGuide).toContain('sudo rpm-ostree install --uninstall=polaris')
+    expect(bazziteGuide).toContain('sudo rpm-ostree rollback')
+    expect(handheldsGuide.length).toBeGreaterThan(0)
+    expect(notes).toContain('system extension stays withdrawn')
+    expect(notes).not.toContain(withdrawnSysextAsset)
+    expect(workflow).not.toContain('sysext-build:')
+    expect(workflow).not.toContain('Polaris-sysext-image')
+    expect(workflow).not.toContain(`release-assets/final/${withdrawnSysextAsset}`)
+  })
+
+  it('pins all four install commands to v1.4.6 and lists only supported package assets', () => {
+    const blocks = installBlocks()
+    expect(blocks).toHaveLength(4)
+    for (const asset of packageAssets) {
+      const matches = blocks.filter((block) => block.includes(`/${asset}`))
+      expect(matches, `one command block for ${asset}`).toHaveLength(1)
+      expect(matches[0]).toContain(`releases/download/v1.4.6/${asset}`)
+      expect(matches[0]).toContain('sudo -H polaris --setup-host')
+    }
+
+    for (const asset of [
+      'Polaris-arch-x86_64.pkg.tar.zst',
+      'Polaris-fedora44-x86_64.rpm',
+      'Polaris-ubuntu24.04-x86_64.deb',
+    ]) {
+      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
+      expect(block).toContain('systemctl --user restart polaris')
+    }
+
+    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
+    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
+    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
+    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
+    expect(steamOs).toContain('systemctl --user enable --now polaris')
+
+    const assetsLine = releaseNotes().split('\n').find((line) => line.startsWith('**Assets:**'))
+    expect(assetsLine).toBeDefined()
+    const listed = [...new Set((assetsLine ?? '').match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+    expect(listed.sort()).toEqual(packageAssets)
+    expect(assetsLine).not.toContain(withdrawnSysextAsset)
+  })
+
+  it('publishes release-note guide links that work outside the source tree', () => {
+    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
+    const notes = readdirSync(releaseNotesDir)
+      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
+      .map((name) => read(`docs/release-notes/${name}`))
+      .join('\n')
+
+    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
+    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
+    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
+  })
+
+  it('keeps publication bound to one verified immutable source', () => {
+    const workflow = read('.github/workflows/build.yml')
+    const ordered = [
+      '- name: Check out exact release source',
+      '- name: Revalidate release tag against packaged source',
+      '- name: Stage curated GitHub release',
+      '- name: Upload release assets to GitHub release',
+      '- name: Verify release assets on GitHub release',
+      '- name: Publish verified draft release',
+    ]
+    const positions = ordered.map((step) => workflow.indexOf(step))
+    expect(positions.every((position) => position >= 0)).toBe(true)
+    expect(positions).toEqual([...positions].sort((a, b) => a - b))
+    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
+    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
+    expect(workflow).toContain('--verify-tag')
+    expect(workflow).toContain('--notes-file "$release_notes"')
+    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
+  })
+})


### PR DESCRIPTION
## Summary

Cuts Polaris v1.4.6. A correctness release for Linux hosts that stream a private display, plus three failures that used to happen in silence.

- A game's stored virtual-display preference, or a client that never locked its topology, no longer moves a private headless host onto the host virtual display. A locked client choice, the paired always-virtual default, an explicit session stream mode and desktop mirroring all still win.
- A session-scoped display override no longer leaks into the topology the host recommends to other clients, including for the whole paused-session resume window.
- nvidia-smi's failure banner is no longer stored as the driver version, where it survived restarts and stopped the encoder cache noticing a driver change.
- A directory that refuses to hold private state now names itself, its owner, its mode and the remedy.
- libav errors are no longer silenced at the default verbosity, so an encoder refusing to open because the driver predates the linked FFmpeg's nvenc API says so instead of dropping to software.

**Scope worth recording.** The display defect is not a 1.4.5 regression. It shipped in 1.4.0 through 1.4.5 and fired on the lab host on 6 September, four days before 1.4.5 was cut. The EVDI symptom goes back to 10 August. Nothing caught it because the behaviour was pinned as correct by its own unit test, and two guards written to prevent it were both inert.

**Nova stays at v1.4.5.** Its master is identical to that tag, so a matched release would be an empty version bump. The release notes say so.

## Exact candidate

`Commit: b47bdc09`
`Base: master @ aff529c1`

## Verification

- [x] `scripts/check-public-docs.sh` passes.
- [x] `npm test`: 95 of 95 test files, 738 of 738 tests, including the new `release-v146-contract.test.js` and the rewritten historical v1.4.5 contract.
- [x] Every pin moved together: project version, collector version, SteamOS namcap path, both package-identity strings, the changelog section with its exact four-asset sentence, the release notes, the docs gate's release block, and both of the gate's fact lists.
- [x] The previous release's contract test was rewritten into the historical shape rather than renamed. A rename alone leaves it asserting that the docs gate still points at v1.4.5, which fails the moment the gate moves. That failure is what caught it here.
- [x] Both gate fact lists now name phrases this release actually states, checked against the rendered changelog and notes rather than carried over from 1.4.5.
- [x] No `1.4.5` pin remains in `src/` or `tests/`.

## What is not covered

No new hardware validation run, and the notes say so rather than implying one happened. The display fix is covered by a contract over every registered stream path and by the full suite; the private stream path on this NVIDIA host is unchanged and was exercised while the fixes were developed.

One deliberate follow-up: a client that asks for Host Virtual Display explicitly on a headless-capable host should still get it, since the new refusal only rejects unlocked preferences. That is reasoning rather than evidence, and it is worth one stream from a real client before this is announced widely.
