### PR TITLE
fix(setup): hand a root-owned config directory back to its account

### DIFF
--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -214,6 +214,38 @@ namespace {
    * run the documented way; a bare root login cannot name it, and this command
    * deliberately never guesses which account streams.
    */
+  /**
+   * @brief Hand a root-owned per-user directory back to its account.
+   *
+   * Walks without following symlinks and uses lchown, so a link planted inside
+   * can only ever have its own ownership changed, never its target's. The
+   * directory is root-owned at this point, which is what makes the walk safe to
+   * start; entries below it may be anything.
+   */
+  bool hand_back_config_directory(const fs::path &directory, uid_t uid, gid_t gid, std::string &failure) {
+    std::error_code ec;
+    if (lchown(directory.c_str(), uid, gid) != 0) {
+      failure = directory.string();
+      return false;
+    }
+    auto walk = fs::recursive_directory_iterator(
+      directory,
+      fs::directory_options::skip_permission_denied,
+      ec
+    );
+    if (ec) {
+      failure = directory.string();
+      return false;
+    }
+    for (const auto &entry : walk) {
+      if (lchown(entry.path().c_str(), uid, gid) != 0) {
+        failure = entry.path().string();
+        return false;
+      }
+    }
+    return true;
+  }
+
   std::optional<headless_boot_account_t> resolve_headless_boot_account() {
     const auto user = platf::input_access::setup_host_target_user();
     if (user.empty() || user == "root") {
@@ -381,6 +413,28 @@ void launch_ui(const std::optional<std::string> &path) {
   platf::open_url(url);
 }
 
+config_ownership_action_e config_ownership_action(
+  bool exists,
+  bool is_directory,
+  bool is_symlink,
+  std::uint32_t owner_uid,
+  std::uint32_t account_uid
+) {
+  if (!exists) {
+    return config_ownership_action_e::nothing;
+  }
+  if (is_symlink || !is_directory) {
+    return config_ownership_action_e::refuse;
+  }
+  if (owner_uid == account_uid) {
+    return config_ownership_action_e::nothing;
+  }
+  if (owner_uid == 0) {
+    return config_ownership_action_e::repair;
+  }
+  return config_ownership_action_e::refuse;
+}
+
 namespace args {
   int creds(const char *name, int argc, char *argv[]) {
     if (argc < 2 || argv[0] == "help"sv || argv[1] == "help"sv) {
@@ -539,6 +593,51 @@ namespace args {
     }
 
     bool ok = true;
+    // A single earlier `sudo polaris` leaves this directory owned by root, and
+    // from then on Polaris cannot save anything when it runs as the account
+    // that streams. Setup already holds the privilege needed to undo it, so it
+    // does, rather than leaving someone to infer it from a failed credential
+    // save. Only the default location is checked: a session that moved it with
+    // XDG_CONFIG_HOME is not visible from a root setup run, so nothing here
+    // claims to have checked one.
+    if (const auto *target_pw = setup_target_user.empty() || setup_target_user == "root" ? nullptr : getpwnam(setup_target_user.c_str());
+        target_pw && target_pw->pw_dir && target_pw->pw_dir[0] != '\0') {
+      const auto config_dir = fs::path(target_pw->pw_dir) / ".config" / "polaris";
+      struct stat metadata {};
+      const bool present = ::lstat(config_dir.c_str(), &metadata) == 0;
+      switch (config_ownership_action(
+        present,
+        present && S_ISDIR(metadata.st_mode),
+        present && S_ISLNK(metadata.st_mode),
+        present ? static_cast<std::uint32_t>(metadata.st_uid) : 0,
+        static_cast<std::uint32_t>(target_pw->pw_uid)
+      )) {
+        case config_ownership_action_e::repair: {
+          std::string failure;
+          if (hand_back_config_directory(config_dir, target_pw->pw_uid, target_pw->pw_gid, failure)) {
+            std::cout
+              << "Polaris host setup: ["sv << config_dir.string() << "] was owned by root, which stops"sv << std::endl
+              << "Polaris saving its settings when it runs as "sv << setup_target_user << ". Handed it back."sv << std::endl;
+          } else {
+            BOOST_LOG(error)
+              << "Polaris host setup could not hand ["sv << failure << "] back to "sv
+              << setup_target_user << "; run: sudo chown -R "sv << setup_target_user << ' '
+              << config_dir.string();
+            ok = false;
+          }
+          break;
+        }
+        case config_ownership_action_e::refuse:
+          BOOST_LOG(warning)
+            << "Polaris host setup: ["sv << config_dir.string() << "] is not a directory owned by "sv
+            << setup_target_user << " or by root, so setup will not change it. Polaris cannot save its "sv
+            << "settings there until it belongs to "sv << setup_target_user << '.';
+          break;
+        case config_ownership_action_e::nothing:
+          break;
+      }
+    }
+
     if (udev_from_package) {
       retire_shadowing_etc_asset("/etc/udev/rules.d/60-polaris.rules", udev_source, "udev rules");
     } else {

--- a/src/entry_handler.h
+++ b/src/entry_handler.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // standard includes
 #include <atomic>
 #include <string>
@@ -174,3 +176,30 @@ namespace service_ctrl {
   bool wait_for_ui_ready();
 }  // namespace service_ctrl
 #endif
+
+/** What host setup may do about the ownership of a per-user directory. */
+enum class config_ownership_action_e {
+  nothing,  ///< Absent, or already owned by the account that streams.
+  repair,  ///< Owned by root, which only a privileged run can have caused.
+  refuse,  ///< Owned by a third account, or not a plain directory.
+};
+
+/**
+ * @brief Decide whether host setup may hand a per-user directory back.
+ *
+ * One `sudo polaris` creates the per-user configuration directory as root, and
+ * every later run as the account then fails its ownership check, with saving
+ * credentials as the visible symptom. Host setup already runs as root, so it is
+ * the one place that can undo it.
+ *
+ * Root ownership is the only case repaired. A directory owned by some third
+ * account was not created by this mistake, and a root process rewriting
+ * ownership on a path it cannot explain is worse than the problem.
+ */
+config_ownership_action_e config_ownership_action(
+  bool exists,
+  bool is_directory,
+  bool is_symlink,
+  std::uint32_t owner_uid,
+  std::uint32_t account_uid
+);

--- a/tests/unit/test_entry_handler.cpp
+++ b/tests/unit/test_entry_handler.cpp
@@ -28,3 +28,46 @@ TEST(EntryHandlerTests, LogPublisherDataTest) {
   ASSERT_TRUE(log_checker::line_starts_with(test_paths::log_file().string(), "Info: Publisher Website: "));
   ASSERT_TRUE(log_checker::line_starts_with(test_paths::log_file().string(), "Info: Get support: "));
 }
+
+TEST(EntryHandlerTests, HostSetupRepairsOnlyRootOwnedConfigDirectories) {
+  // A single `sudo polaris` creates the per-user configuration directory as
+  // root, and from then on running as the account fails its ownership check
+  // with a failed credential save as the only symptom. Host setup is already
+  // privileged, so it is the one place that can undo it.
+  constexpr std::uint32_t root = 0;
+  constexpr std::uint32_t account = 1000;
+  constexpr std::uint32_t someone_else = 1001;
+
+  EXPECT_EQ(
+    config_ownership_action(true, true, false, root, account),
+    config_ownership_action_e::repair
+  ) << "a root-owned directory is exactly the mistake this undoes";
+
+  EXPECT_EQ(
+    config_ownership_action(true, true, false, account, account),
+    config_ownership_action_e::nothing
+  ) << "a directory already owned by the account needs no privileged rewrite";
+
+  EXPECT_EQ(
+    config_ownership_action(false, false, false, root, account),
+    config_ownership_action_e::nothing
+  ) << "an absent directory is created later by the account itself";
+
+  // The refusals matter more than the repair. A root process rewriting
+  // ownership on a path it cannot explain is worse than the problem it fixes.
+  EXPECT_EQ(
+    config_ownership_action(true, true, false, someone_else, account),
+    config_ownership_action_e::refuse
+  ) << "a third account's directory was not created by this mistake";
+
+  EXPECT_EQ(
+    config_ownership_action(true, false, true, root, account),
+    config_ownership_action_e::refuse
+  ) << "a symlink must never be followed by a privileged chown";
+
+  EXPECT_EQ(
+    config_ownership_action(true, false, false, root, account),
+    config_ownership_action_e::refuse
+  ) << "something that is not a directory is not this directory";
+}
+


### PR DESCRIPTION
## Summary

Closes the gap behind a promise already made in public on discussion #637: that host setup would not leave the per-user configuration directory owned by root.

One `sudo polaris` creates that directory as root. Every later run as the account fails its ownership check, and the only symptom is that saving credentials does not work, which sends people looking at the file rather than at the directory. The reporter's only workaround was running the whole daemon as root.

Host setup already runs as root and already resolves which account streams, so it is the one place that can undo it. It now checks that directory and hands it back, saying what it did. v1.4.6 made the failure legible by naming the directory, its owner and the remedy; this makes setup fix it.

**The refusals are the substance, not the repair.** Only root ownership is repaired, because that is the only ownership this mistake produces. A directory owned by a third account was not created this way, and a privileged process rewriting ownership on a path it cannot explain is worse than the problem. A symlink is refused outright, and the walk uses `lchown` throughout, so a link planted inside the tree can only ever have its own ownership changed, never its target's.

**Scope stated honestly.** Only the default `~/.config/polaris` is checked. A session that relocated its configuration with `XDG_CONFIG_HOME` is not visible from a root setup run, so nothing in the output claims to have checked one.

The preventive half already existed and is unchanged: `dispatch_setup_host_before_user_state` runs host setup before config parsing, so `sudo polaris --setup-host` never creates the directory as root in the first place. What was missing was repairing the damage a plain `sudo polaris` had already done.

## Exact candidate

`Commit: 2153a2d9`
`Base: master @ c35a9dc9`

## Verification

- [x] `ctest -j 8`: 25 of 25 suites passed.
- [x] `EntryHandlerTests.HostSetupRepairsOnlyRootOwnedConfigDirectories` covers the repair, both no-op cases, and all three refusals.
- [x] **RED proven on the refusals, which is where the risk lives.** Removing the guards so anything not already owned by the account is repaired makes three assertions fail, including the symlink case and the third-account case. Green again when restored.
- [x] The live `~/.config/polaris/polaris.conf` is byte-identical before and after every run.

## What is not covered

The repair path itself is root-only, so CI cannot execute it. The decision is a pure function and is fully tested; the walk that acts on that decision is reviewed rather than exercised. It is worth one run on a host with a deliberately root-owned config directory before this is pointed at the reporter.
