### PR TITLE
docs(multiseat): write down what a seat is to the person using it

### DIFF
--- a/docs/research/container-multiseat-user-model.md
+++ b/docs/research/container-multiseat-user-model.md
@@ -1,0 +1,127 @@
+# Container multiseat: the user model
+
+Companion to `container-multiseat-architecture.md`. That document settles how the
+host allocates a seat. This one settles what a seat is to the person using it,
+because the two are not the same question and only the first has been answered.
+
+## Why this is written before the user interface
+
+The encoder provider is the next piece of the arc to be built, and it is built
+against a contract that assumes a seat's identity and its resource reservation.
+Whatever the person on the client is choosing has to be expressible in that
+contract. Getting it wrong is not a screen to redraw, it is a contract to
+rebuild, so it is cheaper to settle now than after.
+
+Nothing here proposes building a user interface yet. Multiseat cannot stream:
+there is no encoder provider, no streaming-capable worker image, and no
+activation key. A screen for any of that would be a screen for nothing.
+
+## Two nouns, not one
+
+Today the vocabulary has one word, "seat", doing two jobs. The architecture
+already forces them apart.
+
+**A profile is what someone owns.** It persists. The storage model lists what
+lives in it: credentials and tokens, the Steam, Heroic and Lutris databases,
+Wine and Proton prefixes, shader and config writes, and save data. It survives
+every session and outlives every container.
+
+**A seat is what someone is using right now.** It is ephemeral: a slot on a
+logical GPU with an encoder session reserved against it, a compositor, an audio
+endpoint, and a set of verified input nodes. It runs from `reserved` to
+`released`, and its identity is deliberately opaque, being a controller epoch
+and a generation rather than anything about the person.
+
+The binding rule between them is already decided, in the storage model rather
+than as a product choice: two active workers must never mount one mutable
+launcher home read-write, so the registry rejects a second active seat for the
+same profile even from a different client. Stated for a person:
+
+> **A profile can be in use in one place at a time.**
+
+That is worth keeping because it is honest about the underlying constraint and
+because Steam enforces the same thing, so it will surprise nobody.
+
+## How a client gets a profile
+
+This is the open question, and the one that needs deciding.
+
+**Recommended: a profile is a property of the pairing, one to one by default,
+reassignable by the operator.**
+
+- A newly paired client gets its own profile. The common case, one person with
+  one device, needs no configuration and behaves exactly as today.
+- The operator may point several paired clients at one profile, so a handheld
+  and a television share one library and one set of saves, accepting that only
+  one of them can stream at a time.
+- The operator may create a profile that no client owns yet, which is what makes
+  a guest or a spare identity possible.
+
+Two alternatives were considered and rejected.
+
+*Per application* does not work because an application is not an identity. Steam
+credentials and Proton prefixes are not per game, and the storage model is
+already organised around the account rather than the title.
+
+*Fully manual, choose a profile at every launch* was rejected because it makes
+the simplest case pay setup cost before the first stream, and because the
+one-active-seat rule means the choice is usually forced anyway.
+
+## What the host operator configures
+
+Deliberately small.
+
+- **Per logical GPU: how many seats, and how many simultaneous encoder
+  sessions.** These are already two independent budgets in the architecture, and
+  an unknown or zero budget must not be read as unlimited.
+- **Profiles: a name, where their storage lives, and which paired clients may
+  claim them.**
+
+Nothing else. Compositor selection, GPU placement and slot numbers stay
+automatic, and the architecture is explicit that a seat receives one final
+render and encode allocation rather than rediscovering devices inside the
+container.
+
+## What a client needs to be told
+
+Before launch, which profile it will use and whether that profile is already in
+use somewhere else.
+
+On refusal, **which of three distinct reasons applies**, because they have
+different fixes and must not collapse into "host unavailable":
+
+| Refusal | What the person can do |
+|---|---|
+| The profile is already streaming elsewhere | Stop the other session, or use a different profile |
+| No free seat on any GPU | Wait, or raise the seat budget |
+| No free encoder session | Wait, or raise the encoder budget |
+
+## What this constrains in the work being built now
+
+1. **The encoder provider accepts its reservation as given.** It does not choose
+   or discover a device. That follows from the architecture's allocation rule and
+   from the encoder-session budget existing separately from the seat budget.
+2. **The activation key is not a boolean over behaviour.** Enabling multiseat
+   with no profiles configured must be a no-op that leaves single-seat streaming
+   exactly as it is, not an error and not a behaviour change. This is why the key
+   comes last: a key that starts seats which announce nothing produces sessions
+   that end themselves.
+3. **Admission refusal needs three distinct reasons on the wire**, before any
+   client can show them.
+4. **The worker still never learns the profile name.** Client and profile keys
+   stay internal routing metadata and never appear in worker, runtime, Wayland,
+   audio or input resource names. The user model adds a concept above that
+   boundary; it does not move the boundary.
+
+## Deliberately not decided here
+
+- Whether profiles map onto real Linux user accounts. The storage model needs
+  isolation, not necessarily separate accounts, and the answer changes the
+  container boundary rather than the user model.
+- Save synchronisation, which the storage model already defers to a separate
+  contract.
+- What happens to a running seat when its profile is reassigned. Refusing the
+  reassignment while streaming is the obvious answer and needs confirming
+  against the lifecycle rules rather than asserted here.
+- Guests and temporary profiles beyond noting that unowned profiles are what
+  make them possible.


### PR DESCRIPTION
## Summary

Adds `docs/research/container-multiseat-user-model.md`, a companion to the architecture spike. The spike settles how the host allocates a seat; this settles what a seat is to the person using it. Those are different questions and only the first had an answer.

**Why now, before any interface work.** The encoder provider is the next piece of this arc, and it is built against a contract that assumes a seat's identity and its resource reservation. Whatever the person on the client is choosing has to be expressible in that contract. Getting it wrong later is a contract to rebuild, not a screen to redraw.

No user interface is proposed here, and the document says so. Multiseat cannot stream: there is no encoder provider, no streaming-capable worker image, and no activation key.

## The substantive finding

The vocabulary has one word, "seat", doing two jobs, and the architecture already forces them apart.

- A **profile** is what someone owns and it persists: credentials and tokens, the Steam, Heroic and Lutris databases, Proton prefixes, shader writes, saves.
- A **seat** is what someone is using right now and it is ephemeral: a slot on a logical GPU with an encoder session reserved against it, a compositor, an audio endpoint, verified input nodes.

The rule binding them was already decided, in the storage model rather than as a product choice: two active workers must never mount one mutable launcher home read-write, so the registry rejects a second active seat for the same profile. Stated for a person, a profile can be in use in one place at a time. Steam enforces the same constraint, so it will surprise nobody.

That means less of this was open than it looked. The genuinely open question was only how a client gets a profile, and the recommendation is that a profile is a property of the pairing: one to one by default so the common case needs no configuration, reassignable by the operator so a handheld and a television can share one library, and creatable without an owner so a guest is possible.

## What it constrains in the work already queued

1. The encoder provider accepts its reservation as given rather than discovering a device.
2. The activation key is not a boolean over behaviour. Enabling multiseat with no profiles configured must be a no-op, not an error and not a behaviour change.
3. Admission refusal needs three distinct reasons on the wire, because "profile busy", "no free seat" and "no free encoder session" have different fixes and must not collapse into "host unavailable".
4. The worker still never learns the profile name. The model adds a concept above that boundary without moving it.

## Verification

- [x] `scripts/check-public-docs.sh` passes, so the new research page does not disturb the published docs contract.
- [x] Every claim about existing behaviour is quoted from or derived from `container-multiseat-architecture.md`, specifically its seat identity and lifecycle, GPU admission and storage model sections, rather than invented. Where the architecture already decided something, the document says so and does not re-decide it.

## What it deliberately leaves open

Whether profiles map onto real Linux accounts, save synchronisation, what happens to a running seat when its profile is reassigned, and guest profiles beyond noting that unowned profiles are what make them possible. Each is called out by name so the next person knows it was considered rather than missed.
