### PR TITLE
fix(config): stop creating a config directory Polaris then refuses to use

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1755,9 +1755,30 @@ namespace config {
 
     bool config_loaded = false;
     try {
-      // Create appdata folder if it does not exist
+      // Create appdata folder if it does not exist.
+      //
+      // It holds credentials, tokens and session state, and the private-state
+      // guard refuses any directory that is group or other writable. Directory
+      // creation honours the umask, so on a host with umask 002 Polaris would
+      // create this at 0775 and then refuse to write into it, with a failed
+      // credential save as the only symptom. Narrow it on the way in rather
+      // than depending on the umask the user happens to have.
       const auto appdata_dir = platf::appdata();
       file_handler::make_directory(appdata_dir.string());
+      if (std::error_code permissions_error; true) {
+        fs::permissions(
+          appdata_dir,
+          fs::perms::owner_all,
+          fs::perm_options::replace,
+          permissions_error
+        );
+        if (permissions_error) {
+          BOOST_LOG(warning)
+            << "Could not restrict ["sv << appdata_dir.string()
+            << "] to this account: "sv << permissions_error.message()
+            << ". Saving credentials will fail if it is group or other writable."sv;
+        }
+      }
 
       // Migration: if an older Polaris build left a Sunshine-named config in
       // Polaris's own config directory, copy it to polaris.conf once. Keep the

--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -228,6 +228,14 @@ namespace {
       failure = directory.string();
       return false;
     }
+    // Ownership alone is not enough. The private-state guard refuses a group or
+    // other writable directory just as firmly, and that is the more common
+    // failure because directory creation honours the umask.
+    fs::permissions(directory, fs::perms::owner_all, fs::perm_options::replace, ec);
+    if (ec) {
+      failure = directory.string();
+      return false;
+    }
     auto walk = fs::recursive_directory_iterator(
       directory,
       fs::directory_options::skip_permission_denied,
@@ -418,7 +426,8 @@ config_ownership_action_e config_ownership_action(
   bool is_directory,
   bool is_symlink,
   std::uint32_t owner_uid,
-  std::uint32_t account_uid
+  std::uint32_t account_uid,
+  std::uint32_t mode
 ) {
   if (!exists) {
     return config_ownership_action_e::nothing;
@@ -426,8 +435,14 @@ config_ownership_action_e config_ownership_action(
   if (is_symlink || !is_directory) {
     return config_ownership_action_e::refuse;
   }
+  // Group or other writable is refused by the private-state guard just as
+  // firmly as the wrong owner is, and it is the more common way in: directory
+  // creation honours the umask, so a umask of 002 produces 0775 unasked. A
+  // directory the account already owns can be narrowed safely.
+  const bool writable_by_others = (mode & 0022) != 0;
   if (owner_uid == account_uid) {
-    return config_ownership_action_e::nothing;
+    return writable_by_others ? config_ownership_action_e::repair :
+                                config_ownership_action_e::nothing;
   }
   if (owner_uid == 0) {
     return config_ownership_action_e::repair;
@@ -610,14 +625,17 @@ namespace args {
         present && S_ISDIR(metadata.st_mode),
         present && S_ISLNK(metadata.st_mode),
         present ? static_cast<std::uint32_t>(metadata.st_uid) : 0,
-        static_cast<std::uint32_t>(target_pw->pw_uid)
+        static_cast<std::uint32_t>(target_pw->pw_uid),
+        present ? static_cast<std::uint32_t>(metadata.st_mode & 07777) : 0
       )) {
         case config_ownership_action_e::repair: {
           std::string failure;
           if (hand_back_config_directory(config_dir, target_pw->pw_uid, target_pw->pw_gid, failure)) {
             std::cout
-              << "Polaris host setup: ["sv << config_dir.string() << "] was owned by root, which stops"sv << std::endl
-              << "Polaris saving its settings when it runs as "sv << setup_target_user << ". Handed it back."sv << std::endl;
+              << "Polaris host setup: ["sv << config_dir.string() << "] could not hold private state,"sv << std::endl
+              << "which is what stops Polaris saving its settings as "sv << setup_target_user
+              << ". It now belongs to that"sv << std::endl
+              << "account and is readable only by it."sv << std::endl;
           } else {
             BOOST_LOG(error)
               << "Polaris host setup could not hand ["sv << failure << "] back to "sv

--- a/src/entry_handler.h
+++ b/src/entry_handler.h
@@ -201,5 +201,6 @@ config_ownership_action_e config_ownership_action(
   bool is_directory,
   bool is_symlink,
   std::uint32_t owner_uid,
-  std::uint32_t account_uid
+  std::uint32_t account_uid,
+  std::uint32_t mode
 );

--- a/tests/unit/test_entry_handler.cpp
+++ b/tests/unit/test_entry_handler.cpp
@@ -38,35 +38,56 @@ TEST(EntryHandlerTests, HostSetupRepairsOnlyRootOwnedConfigDirectories) {
   constexpr std::uint32_t account = 1000;
   constexpr std::uint32_t someone_else = 1001;
 
+  constexpr std::uint32_t private_mode = 0700;
+  constexpr std::uint32_t group_writable = 0775;
+
   EXPECT_EQ(
-    config_ownership_action(true, true, false, root, account),
+    config_ownership_action(true, true, false, root, account, private_mode),
     config_ownership_action_e::repair
   ) << "a root-owned directory is exactly the mistake this undoes";
 
   EXPECT_EQ(
-    config_ownership_action(true, true, false, account, account),
+    config_ownership_action(true, true, false, account, account, private_mode),
     config_ownership_action_e::nothing
   ) << "a directory already owned by the account needs no privileged rewrite";
 
   EXPECT_EQ(
-    config_ownership_action(false, false, false, root, account),
+    config_ownership_action(false, false, false, root, account, 0),
     config_ownership_action_e::nothing
   ) << "an absent directory is created later by the account itself";
+
+  // The mode matters as much as the owner, and is the more common way in: a
+  // umask of 002 makes directory creation produce 0775 unasked, which the
+  // private-state guard refuses even though the account owns it.
+  EXPECT_EQ(
+    config_ownership_action(true, true, false, account, account, group_writable),
+    config_ownership_action_e::repair
+  ) << "the account's own directory still needs narrowing when it is group writable";
+
+  EXPECT_EQ(
+    config_ownership_action(true, true, false, account, account, 0707),
+    config_ownership_action_e::repair
+  ) << "other-writable is refused by the same guard and must be repaired too";
+
+  EXPECT_EQ(
+    config_ownership_action(true, true, false, account, account, 0755),
+    config_ownership_action_e::nothing
+  ) << "group and other readable is fine; only writable is refused";
 
   // The refusals matter more than the repair. A root process rewriting
   // ownership on a path it cannot explain is worse than the problem it fixes.
   EXPECT_EQ(
-    config_ownership_action(true, true, false, someone_else, account),
+    config_ownership_action(true, true, false, someone_else, account, private_mode),
     config_ownership_action_e::refuse
   ) << "a third account's directory was not created by this mistake";
 
   EXPECT_EQ(
-    config_ownership_action(true, false, true, root, account),
+    config_ownership_action(true, false, true, root, account, private_mode),
     config_ownership_action_e::refuse
   ) << "a symlink must never be followed by a privileged chown";
 
   EXPECT_EQ(
-    config_ownership_action(true, false, false, root, account),
+    config_ownership_action(true, false, false, root, account, private_mode),
     config_ownership_action_e::refuse
   ) << "something that is not a directory is not this directory";
 }


### PR DESCRIPTION
## Summary

Polaris creates its own configuration directory in a mode it then refuses to use.

The private-state guard rejects any directory that is group or other writable, which is right: that directory holds credentials, tokens and session state. But directory creation honours the umask, and `file_handler::make_directory` was called without saying otherwise. On a host with umask 002 that produces `0775`, and every later save is refused. The only visible symptom is that saving credentials does not work.

Measured on the development host:

| umask | created mode | passes the guard |
|---|---|---|
| 002 | 0775 | no |
| 022 | 0755 | yes |

Debian's default for the first user is 002. Fedora and Arch default to 022, which is exactly why this never appeared here.

## This corrects a diagnosis we already gave a user

The reporter on discussion #637 found it. We told them the cause was a root-owned directory left behind by a `sudo polaris` run, and pointed them at `chown`. They came back having found it was the **mode**, and that `chmod 700` fixes it.

That matters beyond the apology, because **the ownership repair merged earlier today in #654 would not have helped them.** Their directory was already theirs; only its mode was wrong, and `config_ownership_action` did not look at the mode at all.

## The fix, both halves

- **The cause.** The appdata directory is narrowed to owner-only when created, with a warning if that fails, rather than depending on whichever umask the user happens to have.
- **The repair.** Host setup now fixes the mode as well as the owner. A directory the account already owns can be narrowed safely, so this is a repair rather than a refusal.

Group and other *readable* stays untouched. Only writable is refused by the guard, and only writable is repaired here.

## Verification

- [x] `ctest -j 8`: 25 of 25 suites passed.
- [x] `EntryHandlerTests.HostSetupRepairsOnlyRootOwnedConfigDirectories` extended to cover the mode: group-writable and other-writable both repair, `0755` is left alone, and all three original refusals still hold.
- [x] **RED proven on the new half.** Disabling the mode check makes both the group-writable and the other-writable cases fail. Green again when restored.
- [x] The live `~/.config/polaris/polaris.conf` is byte-identical before and after, and that host's config directory is unchanged at 0700.

## A test bug caught while writing this

My first version of the other-writable case used `0705`, which grants other read and execute but not write, so the guard correctly did nothing and the test failed for the wrong reason. It now uses `0707`, and a `0755` case was added to pin that merely readable is fine. Worth stating because the failure looked like a code defect and was not.

## What is still open on that thread

The same reporter then hit `Refusing authorization state from polaris_state.json: root must be an object`, which is a separate problem and not addressed here.
