### PR TITLE
fix(multiseat): give a gamescope seat the DRM primary node it needs

### DIFF
--- a/containers/multiseat/README.md
+++ b/containers/multiseat/README.md
@@ -423,6 +423,15 @@ steam, heroic, or lutris. The image must contain the separately packaged
 `polaris-seat-input-probe` acceptance helper. GPU device paths must belong to
 the explicit catalog supplied through the physical harness environment.
 
+That catalog must include the GPU's DRM primary node, not only its render node.
+Gamescope's Vulkan backend checks `VkPhysicalDeviceDrmPropertiesEXT::hasPrimary`
+whenever the backend does not present through a Vulkan swapchain, which is the
+case for the Wayland backend this provider uses, and exits with `physical device
+has no primary node` when the node is absent from the container. The harness
+derives the default from the render node's sysfs sibling and refuses a catalog
+without one, because the symptom otherwise arrives as a nested compositor whose
+runtime helper never became ready.
+
 The harness creates a unique deployment and authority root, opens every
 allocated event alias inside both workers, checks major/minor identity and
 absence of other input nodes, and sends bounded synthetic input through the

--- a/multiseat_worker/internal/seatprovider/nested_compositor_linux.go
+++ b/multiseat_worker/internal/seatprovider/nested_compositor_linux.go
@@ -352,6 +352,20 @@ func createGamescopeReadyFIFO(
 	return file, identity, nil
 }
 
+// describeChildExit names how a child finished, so a helper that refused to
+// start says more than that it did not become ready. Gamescope reports the
+// reason itself on stderr, which the supervisor's diagnostic sink keeps.
+func describeChildExit(child *managedChild) string {
+	if child == nil || child.command == nil || child.command.ProcessState == nil {
+		return "an unreported status"
+	}
+	state := child.command.ProcessState
+	if status, ok := state.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+		return "signal " + strconv.Itoa(int(status.Signal()))
+	}
+	return "status " + strconv.Itoa(state.ExitCode())
+}
+
 func waitForGamescopeReadyRecord(
 	parent context.Context,
 	child *managedChild,
@@ -380,7 +394,9 @@ func waitForGamescopeReadyRecord(
 		return "", errors.New("runtime Gamescope startup was canceled")
 	case <-child.done:
 		_ = ready.Close()
-		return "", errors.New("runtime Gamescope exited before readiness")
+		return "", errors.New(
+			"runtime Gamescope exited before readiness with " + describeChildExit(child),
+		)
 	case received := <-result:
 		if received.err != nil {
 			return "", errors.New("runtime Gamescope readiness was invalid")

--- a/multiseat_worker/internal/seatprovider/nested_compositor_linux_test.go
+++ b/multiseat_worker/internal/seatprovider/nested_compositor_linux_test.go
@@ -985,3 +985,34 @@ func TestNestedProviderErrorsDoNotEchoPrivatePaths(t *testing.T) {
 		t.Fatalf("private path leaked through provider error: %v", err)
 	}
 }
+
+// A helper that refuses to start must say how it finished. Gamescope reports the
+// reason on its own stderr, but the provider error carried nothing at all, so a
+// missing DRM primary node read only as a readiness timeout.
+func TestChildExitDescriptionNamesHowAHelperFinished(t *testing.T) {
+	if got := describeChildExit(nil); got != "an unreported status" {
+		t.Fatalf("nil child described as %q", got)
+	}
+	for _, testCase := range []struct {
+		path     string
+		expected string
+	}{
+		{path: "/bin/true", expected: "status 0"},
+		{path: "/bin/false", expected: "status 1"},
+	} {
+		child, err := startManagedChild(testCase.path, 0, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("%s did not start: %v", testCase.path, err)
+		}
+		select {
+		case <-child.done:
+		case <-time.After(10 * time.Second):
+			_ = child.stop(time.Second)
+			t.Fatalf("%s did not exit", testCase.path)
+		}
+		if got := describeChildExit(child); got != testCase.expected {
+			t.Fatalf("%s described as %q, wanted %q", testCase.path, got, testCase.expected)
+		}
+		_ = child.stop(time.Second)
+	}
+}

--- a/tests/integration/test_multiseat_physical.cpp
+++ b/tests/integration/test_multiseat_physical.cpp
@@ -53,6 +53,64 @@ namespace {
     while (std::getline(stream, item, ',')) if (!item.empty()) paths.emplace_back(item);
     return paths;
   }
+  // Gamescope's Vulkan backend refuses to start unless the DRM primary node of
+  // the device it selects is visible to it, so a seat needs more than a render
+  // node. The primary node is the render node's sibling in sysfs.
+  std::string drm_primary_node_for(const std::string &render) {
+    std::error_code error;
+    const auto siblings =
+      std::filesystem::path {"/sys/class/drm"} / std::filesystem::path {render}.filename() / "device/drm";
+    std::filesystem::directory_iterator entries {siblings, error};
+    if (error) return {};
+    for (const auto &entry : entries) {
+      const auto name = entry.path().filename().native();
+      if (name.starts_with("card")) return (std::filesystem::path {"/dev/dri"} / name).native();
+    }
+    return {};
+  }
+  std::string drm_driver_for(const std::string &render) {
+    const auto uevent =
+      std::filesystem::path {"/sys/class/drm"} / std::filesystem::path {render}.filename() / "device/uevent";
+    std::ifstream input {uevent};
+    std::string line;
+    while (std::getline(input, line)) {
+      constexpr std::string_view key = "DRIVER=";
+      if (line.starts_with(key)) return line.substr(key.size());
+    }
+    return {};
+  }
+  // NVIDIA's EGL needs its own character devices as well as the DRM nodes.
+  // Without them the nested compositor fails at eglQueryDevicesEXT rather than
+  // reporting a missing device. The per-GPU node comes from the driver's own
+  // record for this exact PCI address, so a second GPU's node is never claimed
+  // by mistake. The control nodes below are process-wide rather than per-GPU,
+  // which is why a host with more than one GPU supplies its own catalog through
+  // the environment instead of taking this default.
+  std::vector<std::string> nvidia_nodes(const std::string &render) {
+    std::vector<std::string> nodes;
+    for (const auto *shared : {"/dev/nvidiactl", "/dev/nvidia-modeset", "/dev/nvidia-uvm", "/dev/nvidia-uvm-tools"}) {
+      std::error_code error;
+      if (std::filesystem::exists(shared, error)) nodes.emplace_back(shared);
+    }
+    std::error_code error;
+    const auto device = std::filesystem::canonical(
+      std::filesystem::path {"/sys/class/drm"} / std::filesystem::path {render}.filename() / "device", error);
+    if (error) return nodes;
+    std::ifstream information {
+      std::filesystem::path {"/proc/driver/nvidia/gpus"} / device.filename() / "information"};
+    std::string line;
+    while (std::getline(information, line)) {
+      constexpr std::string_view key = "Device Minor:";
+      if (!line.starts_with(key)) continue;
+      const auto first = line.find_first_of("0123456789", key.size());
+      if (first == std::string::npos) break;
+      auto last = first;
+      while (last < line.size() && std::isdigit(static_cast<unsigned char>(line[last]))) ++last;
+      nodes.push_back("/dev/nvidia" + line.substr(first, last - first));
+      break;
+    }
+    return nodes;
+  }
   std::string nonce() { return crypto::rand_alphabet(32, "0123456789abcdef"); }
 
   // Own one unique directory. Only remove it when it is still the same inode
@@ -204,7 +262,21 @@ namespace {
     RecordProperty("physical_game_requested", game ? "true" : "false");
     const auto [profile, kind] = profiles.at(profile_name);
     const auto render = env_or("POLARIS_PHYSICAL_RENDER_NODE", "/dev/dri/renderD128");
-    const auto devices = split_paths(env_or("POLARIS_PHYSICAL_GPU_DEVICES", render));
+    const auto primary_node = drm_primary_node_for(render);
+    auto default_devices = render;
+    if (!primary_node.empty()) default_devices += "," + primary_node;
+    if (drm_driver_for(render) == "nvidia") {
+      for (const auto &node : nvidia_nodes(render)) default_devices += "," + node;
+    }
+    const auto devices = split_paths(env_or("POLARIS_PHYSICAL_GPU_DEVICES", default_devices));
+    // Without this the seat starts, smithay initialises EGL, and gamescope then
+    // exits with "physical device has no primary node" while the only reported
+    // failure is that the runtime helper never became ready.
+    ASSERT_TRUE(std::any_of(devices.begin(), devices.end(), [](const auto &device) {
+      return device.native().starts_with("/dev/dri/card");
+    })) << "a gamescope seat needs the GPU's DRM primary node in its device catalog, not only "
+           "its render node; for " << render << " that is "
+        << (primary_node.empty() ? std::string {"a /dev/dri/card node"} : primary_node);
     const auto executable = env_or("POLARIS_PHYSICAL_PODMAN", "/usr/bin/podman");
     const auto deployment = "physical-" + nonce();
     private_root_t root {parent};


### PR DESCRIPTION
## Summary

The multiseat physical acceptance harness could not pass. Both workers started, smithay initialised EGL and its input backend, and then nothing became observable. The only reported failure was that the nested compositor's runtime helper never became ready, which is true and says nothing.

Gamescope was refusing to start, and saying exactly why on its own stderr:

```
vulkan: physical device supports DRM format modifiers
vulkan: physical device has no primary node
Failed to create backend.
```

Gamescope checks `VkPhysicalDeviceDrmPropertiesEXT::hasPrimary` whenever its backend does not present through a Vulkan swapchain, which is the case for the Wayland backend this provider uses. The harness catalog carried the GPU's render node and, on NVIDIA, its character devices, but never the DRM primary node, so the driver reported no primary node for the device gamescope had selected.

**The catalog default now derives what the host needs from the render node**: the primary node from its sysfs sibling, plus NVIDIA character devices when the render node belongs to that driver, taking the per-GPU node from the driver's own record for that exact PCI address so a second GPU is never claimed by mistake. The harness runs with no GPU environment at all now, where before it needed an exact hand-written list and failed opaquely without one.

A catalog that still has no primary node is refused immediately, naming the node it wanted, instead of spending two minutes reaching a readiness timeout.

**The provider also says how the helper finished.** "Exited before readiness" carried no status, so a helper that refused on its first instruction looked identical to one that hung.

## Verification

Measured on pc-papi against the real containers, at master `210b8092`.

- [x] Control lane passes with no GPU environment variable set, from the derived default alone.
- [x] **The encoded lane passes, which had never been reached before.** 60 encoded and 60 decoded frames per seat through openh264 at 1920x1080 from `worker-capture`, two keyframes each, and the surviving seat still encoding 60 frames after its peer stops.
- [x] Input isolation proven in both directions: the targeted seat observes `events:[2,1,2,2]` while its peer observes `[0,0,0,0]`, then reversed, with `identity_verified` true on both.
- [x] The new guard proven by supplying a render-node-only catalog: it fails in 0 ms naming `/dev/dri/card2`, rather than timing out.
- [x] `TestChildExitDescriptionNamesHowAHelperFinished` covers the nil case and both a zero and a non-zero exit.
- [x] `ctest -j 8`: 25 of 25 suites passed. `go vet ./...` and `go test ./...` clean in the worker module.

## What is not covered

The production device catalog is unchanged. `production_controller_gpu_t` documents only that "the render node must appear in that list", and validating a primary node there would be the more general fix, but that validation is compositor-agnostic and I could not establish whether the headless software lane needs the node: bare gamescope always selects llvmpipe without the provider's environment, so the question needs the software lane exercised rather than guessed. Worth doing next, not guessed at here.

This also does not establish that the earlier unreproduced encode-observation defect was this. The evidence recorded for it no longer exists. What is established is that at this commit, on this host, with the primary node present, the encoded lane passes.

One GPU, one host, one driver. The derived default is deliberately narrow: a multi-GPU host still supplies its own catalog, because the NVIDIA control nodes are process-wide rather than per-GPU and the catalog requires exclusive device identity.

## Exact candidate

`Commit: bccd7493a8e12f58d2022dca277febd487ad34a7`
`Tree: 33e81cef7ce15f53bee54cd06e17df5ccb63f6d5`
`Parent: 210b80921ac4bef9f5065cbe027d27f9b0243ead`
