### PR TITLE
fix(state): name the directory that refused private state, and its own remedy

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -4052,7 +4052,12 @@ namespace nvhttp {
     const std::filesystem::path state_path {config::nvhttp.file_state};
     state_file_lock_t interprocess_lock {state_path};
     const auto fail_closed = [&](std::string_view reason) {
-      BOOST_LOG(error) << "Refusing authorization state from "sv << state_path << ": "sv << reason;
+      // This reads as fatal and is not: the host carries on with a fresh
+      // identity. A reporter on discussion #637 hit it right after fixing a
+      // directory mode and took it for a new failure.
+      BOOST_LOG(error) << "Refusing authorization state from "sv << state_path << ": "sv << reason
+                       << ". Continuing with a new host identity, so any client paired before "
+                          "now has to pair again."sv;
       clear_authorization_state_locked();
       http::uuid = uuid_util::uuid_t::generate();
       http::unique_id = http::uuid.string();

--- a/src/private_state_file.cpp
+++ b/src/private_state_file.cpp
@@ -58,17 +58,29 @@ namespace private_state_file {
      * as the user fails here forever, and the only thing the operator sees is
      * that saving credentials did not work.
      */
-    bool secure_directory_descriptor(int descriptor, bool final_parent, std::string *reason = nullptr) {
-      const auto refuse = [reason](std::string explanation) {
-        if (reason) {
-          *reason = std::move(explanation);
+    enum class directory_remedy_e {
+      none,  ///< Nothing actionable; the directory could not even be inspected.
+      take_ownership,  ///< Owned by another user, usually one "sudo polaris".
+      restrict_permissions,  ///< Group or other writable, usually a 002 umask.
+    };
+
+    struct directory_refusal_t {
+      std::string reason;
+      directory_remedy_e remedy = directory_remedy_e::none;
+    };
+
+    bool secure_directory_descriptor(int descriptor, bool final_parent, directory_refusal_t *refusal = nullptr) {
+      const auto refuse = [refusal](std::string explanation, directory_remedy_e remedy) {
+        if (refusal) {
+          refusal->reason = std::move(explanation);
+          refusal->remedy = remedy;
         }
         return false;
       };
 
       struct stat metadata {};
       if (::fstat(descriptor, &metadata) != 0 || !S_ISDIR(metadata.st_mode)) {
-        return refuse("it is not a directory this process can inspect");
+        return refuse("it is not a directory this process can inspect", directory_remedy_e::none);
       }
 
       const auto effective_user = ::geteuid();
@@ -83,10 +95,10 @@ namespace private_state_file {
 
       if (final_parent) {
         if (metadata.st_uid != effective_user) {
-          return refuse(describe("it is owned by another user"));
+          return refuse(describe("it is owned by another user"), directory_remedy_e::take_ownership);
         }
         if (writable_by_others) {
-          return refuse(describe("it is writable by group or other"));
+          return refuse(describe("it is writable by group or other"), directory_remedy_e::restrict_permissions);
         }
         return true;
       }
@@ -94,10 +106,10 @@ namespace private_state_file {
       const auto trusted_owner = metadata.st_uid == 0 || metadata.st_uid == effective_user;
       const auto sticky_when_writable = !writable_by_others || (metadata.st_mode & S_ISVTX) != 0;
       if (!trusted_owner) {
-        return refuse(describe("a parent directory is owned by another user"));
+        return refuse(describe("a parent directory is owned by another user"), directory_remedy_e::take_ownership);
       }
       if (!sticky_when_writable) {
-        return refuse(describe("a parent directory is writable by others without the sticky bit"));
+        return refuse(describe("a parent directory is writable by others without the sticky bit"), directory_remedy_e::restrict_permissions);
       }
       return true;
     }
@@ -203,7 +215,7 @@ namespace private_state_file {
         }
 
         descriptor_ = ::open(path_.is_absolute() ? "/" : ".", directory_open_flags());
-        if (descriptor_ < 0 || !secure_directory_descriptor(descriptor_, components.empty())) {
+        if (descriptor_ < 0 || !secure_directory_descriptor(descriptor_, components.empty(), nullptr)) {
           (void) close();
           return;
         }
@@ -233,20 +245,39 @@ namespace private_state_file {
             parent_entry_needs_sync = true;
             next = ::openat(descriptor_, component.c_str(), directory_open_flags());
           }
-          std::string rejection;
-          if (next < 0 || !secure_directory_descriptor(next, final_parent, &rejection)) {
+          directory_refusal_t refusal;
+          if (next < 0 || !secure_directory_descriptor(next, final_parent, &refusal)) {
             if (next >= 0) {
               ::close(next);
             }
-            if (!rejection.empty()) {
+            if (!refusal.reason.empty()) {
               // The only place this is ever explained. Everything downstream
               // reports that a write did not commit, which sends people looking
               // at the file they were saving rather than at the directory.
+              //
+              // Name the directory the walk actually refused. Reporting the
+              // state file's parent instead sent one reporter to a directory
+              // whose mode was fine while quoting the mode of another.
+              auto rejected = path_.is_absolute() ? std::filesystem::path {"/"} : std::filesystem::path {};
+              for (std::size_t walked = 0; walked <= index; ++walked) {
+                rejected /= components[walked];
+              }
+              std::string remedy;
+              switch (refusal.remedy) {
+                case directory_remedy_e::take_ownership:
+                  remedy = ". Take it back with \"sudo chown -R \"$USER\": " + rejected.string() +
+                           "\" and start Polaris without sudo; one \"sudo polaris\" is enough to leave it root-owned.";
+                  break;
+                case directory_remedy_e::restrict_permissions:
+                  remedy = ". Restrict it with \"chmod 700 " + rejected.string() +
+                           "\"; a umask of 002 is enough to leave it group writable.";
+                  break;
+                case directory_remedy_e::none:
+                  break;
+              }
               BOOST_LOG(error) << "Refusing to keep private state in ["
-                               << path_.parent_path().string() << "] because "
-                               << rejection << ". If that directory is owned by root, a single "
-                               << "\"sudo polaris\" created it; chown it back to your own user and "
-                               << "run Polaris without sudo.";
+                               << rejected.string() << "] because "
+                               << refusal.reason << remedy;
             }
             (void) close();
             return;

--- a/tests/unit/test_private_state_file.cpp
+++ b/tests/unit/test_private_state_file.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <atomic>
 #include <cerrno>
+#include <cstring>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -23,10 +24,47 @@
   #include <unistd.h>
 #endif
 
+#include <boost/core/null_deleter.hpp>
+#include <boost/log/core.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_ostream_backend.hpp>
+#include <boost/smart_ptr/make_shared_object.hpp>
+#include <boost/smart_ptr/shared_ptr.hpp>
+
 #include <src/private_state_file.h>
 
 namespace {
   std::atomic_uint64_t path_counter {0};
+
+  // Reads back what an operator would see, because the whole point of this
+  // message is the person in the terminal.
+  class log_capture_t {
+  public:
+    log_capture_t():
+        stream_ {boost::make_shared<std::ostringstream>()} {
+      auto backend = boost::make_shared<boost::log::sinks::text_ostream_backend>();
+      backend->add_stream(boost::shared_ptr<std::ostream> {stream_.get(), boost::null_deleter {}});
+      backend->auto_flush(true);
+      sink_ = boost::make_shared<sink_t>(backend);
+      boost::log::core::get()->add_sink(sink_);
+    }
+
+    ~log_capture_t() {
+      boost::log::core::get()->remove_sink(sink_);
+    }
+
+    log_capture_t(const log_capture_t &) = delete;
+    log_capture_t &operator=(const log_capture_t &) = delete;
+
+    [[nodiscard]] std::string text() const {
+      return stream_->str();
+    }
+
+  private:
+    using sink_t = boost::log::sinks::synchronous_sink<boost::log::sinks::text_ostream_backend>;
+    boost::shared_ptr<std::ostringstream> stream_;
+    boost::shared_ptr<sink_t> sink_;
+  };
 
   class PrivateStateFileTest: public testing::Test {
   protected:
@@ -752,5 +790,39 @@ TEST_F(PrivateStateFileTest, TransactionFailsPromptlyWhileAnotherProcessHoldsLoc
   int status; ASSERT_EQ(::waitpid(pid, &status, 0), pid);
   EXPECT_EQ(status, 0);
   EXPECT_EQ(private_state_file::read_secure(target, 4096).payload, "before");
+}
+#endif
+
+#if defined(__linux__)
+// A reporter on discussion #637 was sent to the wrong directory by this very
+// message: it named the state file's parent, whose mode was fine, while quoting
+// the mode of the directory that actually failed. It also only ever offered
+// chown, and their directory was correctly owned and merely group writable.
+TEST_F(PrivateStateFileTest, RefusalNamesTheDirectoryThatFailedAndItsOwnRemedy) {
+  const auto offending = directory / "inner";
+  ASSERT_TRUE(std::filesystem::create_directory(offending));
+  ASSERT_EQ(::chmod(offending.c_str(), 0775), 0) << std::strerror(errno);
+
+  std::string captured;
+  {
+    log_capture_t capture;
+    const auto result = private_state_file::write_atomic(offending / "state.json", "{}");
+    EXPECT_FALSE(bool(result));
+    captured = capture.text();
+  }
+
+  EXPECT_NE(captured.find("Refusing to keep private state in [" + offending.string() + "]"), std::string::npos)
+    << "the refusal must name the directory that failed, not its parent; got:\n"
+    << captured;
+  EXPECT_EQ(captured.find("[" + directory.string() + "]"), std::string::npos)
+    << "the refusal must not name a directory whose mode it did not read; got:\n"
+    << captured;
+  EXPECT_NE(captured.find("it is writable by group or other"), std::string::npos) << captured;
+  EXPECT_NE(captured.find("chmod 700 " + offending.string()), std::string::npos)
+    << "a group-writable directory is fixed by chmod, not by chown; got:\n"
+    << captured;
+  EXPECT_EQ(captured.find("chown"), std::string::npos)
+    << "offering chown for a correctly owned directory is what confused the reporter; got:\n"
+    << captured;
 }
 #endif

--- a/tests/unit/test_source_safety_contracts.cpp
+++ b/tests/unit/test_source_safety_contracts.cpp
@@ -426,15 +426,25 @@ TEST(SourceSafetyContracts, RefusingToKeepPrivateStateSaysWhichDirectoryAndWhy) 
 
   const auto guard = source.find("bool secure_directory_descriptor(");
   ASSERT_NE(guard, std::string::npos);
-  EXPECT_NE(source.find("std::string *reason", guard), std::string::npos)
-    << "the guard must report why it refused, not just that it did";
+  EXPECT_NE(source.find("directory_refusal_t *refusal", guard), std::string::npos)
+    << "the guard must report why it refused and which remedy applies, not just that it did; "
+       "the two faults it detects are fixed by different commands";
 
   EXPECT_NE(source.find("Refusing to keep private state in ["), std::string::npos)
     << "the rejection must name the directory it refused";
   EXPECT_NE(source.find("owner uid "), std::string::npos)
-    << "the rejection must name the owner, which is the thing that is wrong";
+    << "the rejection must name the owner and the mode, which is what is wrong";
   EXPECT_NE(source.find("without sudo"), std::string::npos)
-    << "the rejection must name the remedy";
+    << "a directory owned by another user must still point at running without sudo";
+  EXPECT_NE(source.find("chmod 700 "), std::string::npos)
+    << "a group-writable directory is fixed by chmod, not chown; offering only chown sent a "
+       "reporter on discussion #637 looking for an ownership problem they did not have";
+  // Which directory the message names is pinned behaviourally by
+  // PrivateStateFileTest.RefusalNamesTheDirectoryThatFailedAndItsOwnRemedy,
+  // because naming the state file's parent instead of the refused component is
+  // exactly the defect that shipped.
+  EXPECT_EQ(source.find("path_.parent_path().string() << \"] because\""), std::string::npos)
+    << "the refused directory is the one the walk stopped on, not the state file's parent";
 }
 
 TEST(SourceSafetyContracts, EveryLaunchTopologyResolverCallPassesTheHostPrivateDisplayAnswer) {


### PR DESCRIPTION
## Summary

The diagnostic added in 1.4.6 sent its first reporter to the wrong directory. On discussion #637 it printed:

```
Refusing to keep private state in [/home/reyxil/.config] because it is
writable by group or other (owner uid 1000, mode 0775, this process runs as uid 1000).
If that directory is owned by root, a single "sudo polaris" created it;
chown it back to your own user and run Polaris without sudo.
```

Their `.config` was mode 0700. The directory at 0775 was `.config/polaris`, one level down. The walk descends the ancestors and stops on the component that fails, but the message always printed the state file's parent, so it paired one directory's path with another directory's mode. A message written specifically so nobody had to guess made them guess.

It also offered only one remedy. The guard refuses for two different reasons, wrong owner and group or other writable, and the text assumed the first. Their directory was correctly owned and merely group writable, so the advice did not apply to the fault being reported. They worked it out themselves and needed `chmod 700`.

The refusal now names the component the walk stopped on and carries the remedy matching the fault: `chmod` for a permissive mode, `chown` for foreign ownership. The guard reports which of the two applies rather than only that it refused.

**One more message from the same report.** After fixing the mode they hit `Refusing authorization state from polaris_state.json: root must be an object` and read it as a fresh breakage. It is not fatal: the host clears its authorization state and carries on with a new identity. It now says so.

## Verification

- [x] `PrivateStateFileTest.RefusalNamesTheDirectoryThatFailedAndItsOwnRemedy` reads the log an operator would read, through a scoped Boost.Log sink, against a real group-writable directory one level below the fixture root. It asserts the refusal names that directory, does **not** name its parent, says the mode is the problem, offers `chmod 700 <that directory>`, and does not mention `chown`.
- [x] RED against the shipped code reproduces the reporter's message exactly, naming the parent at mode 0755 while quoting mode 0775, and fails all four assertions.
- [x] `SourceSafetyContracts.RefusingToKeepPrivateStateSaysWhichDirectoryAndWhy` re-pinned to the new guard shape, and now also pins that `chmod` is offered and that the message does not derive the refused directory from the state file's parent.
- [x] The pre-existing `PrivateStateFileTest.DoesNotCarryUnsupportedWindowsSecurityImplementation` passes unmodified; it pins POSIX expressions by source text and this change does not touch them.
- [x] `ctest -j 8`: 25 of 25 suites passed. The live `~/.config/polaris/polaris.conf` is untouched.

## Also confirmed from the same thread

The reporter found that `~/.config/polaris` was being created at 0775, which is a umask of 002 reaching `create_directories`. That cause is already fixed on master by #659, which narrows the directory to owner-only on the way in rather than depending on the operator's umask. It is unreleased, which is why they still hit it.

## Deliberately not included

`load_state` discards the unreadable file's contents: it clears authorization state and the next save overwrites it, so a merely truncated state file takes its pairings with it and leaves nothing to inspect. Preserving it as a backup first is the better behaviour and matches how other recoveries in this codebase are handled, but that is a change to pairing-state handling rather than to a message, and it deserves its own review rather than riding along here.

## Exact candidate

`Commit: f7b31349365a9a7ca14f8172b3392358e34bfe00`
`Tree: 16882d4c3e9ec480e02bbf2b3a96a2755b892bf4`
`Parent: 210b80921ac4bef9f5065cbe027d27f9b0243ead`
