### PR TITLE
release: prepare v1.4.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(POLARIS_PREFER_CLANG AND NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER
     set(CMAKE_CXX_COMPILER "${POLARIS_CLANG_CXX_COMPILER}" CACHE FILEPATH "C++ compiler" FORCE)
 endif()
 
-project(Polaris VERSION 1.4.6
+project(Polaris VERSION 1.4.7
         DESCRIPTION "Self-hosted game stream host for Moonlight"
         HOMEPAGE_URL "https://github.com/papi-ux/polaris")
 

--- a/docs/benchmark-control-openapi.json
+++ b/docs/benchmark-control-openapi.json
@@ -530,7 +530,7 @@
         "example": {
           "schema_version": 1,
           "measurement_spec_id": "measurement-spec-v1",
-          "collector_version": "1.4.6",
+          "collector_version": "1.4.7",
           "clock_domain": "CLOCK_MONOTONIC",
           "run_id": "pair-0001-control",
           "manifest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,21 @@ starts at `v1.0.0`.
 
 ## Unreleased
 
+## v1.4.7 - 2026-09-12
+
+A controller and configuration update matched with Nova v1.4.7. The virtual DualSense maps the way a real one does, and the per-user configuration directory stops being created in a state Polaris then refuses to use. Existing configurations and paired devices remain valid.
+
+- Corrects the virtual DualSense's button and stick mapping. Polaris advertised the HID version a USB DualSense reports while creating the pad on the Bluetooth bus, and that combination matches no entry in the controller database clients read, so they fell back to a layout from before the kernel's PlayStation driver existed: face buttons rotated, and the triggers and the right stick swapped for each other. Clients that reach the pad directly were always correct, which is why the same pad could behave in one game and not the next (#660, #634)
+- Rests the virtual DualSense with its sticks centred and its triggers released. Of the report's six axes only three were given a starting value, so a pad nobody had touched reported both sticks pushed hard left and the right trigger half pulled until the first real input arrived (#660)
+- Repairs a per-user configuration directory that a privileged run left owned by root. `--setup-host` now hands it back to the account Polaris runs as, walking it without following symbolic links, and corrects its permissions as well as its owner (#654, #637)
+- Stops creating that directory in a state Polaris then refuses to use. It is narrowed to the owning account when it is created rather than inheriting whatever the account's umask allows, which on common desktop defaults left it writable by its group and made saving credentials fail from the first run (#659, #637)
+- Names the directory that actually refused, and the remedy that matches the fault. The message reported the directory above the one it had inspected, so it paired one directory's path with another's permissions, and it only ever offered to correct ownership even when ownership was already right (#663, #637)
+- Says which driver was running when the hardware encoder did not start, so a host that silently drops to software encoding names the driver version it found instead of leaving the reason in a discarded log line (#657, #650)
+- Explains that unreadable saved authorization state is not fatal: the host clears it, continues with a new identity, and says that any client paired before then has to pair again (#663)
+- Stops building two files without optimisation on compilers that no longer need the workaround, after measuring that the internal compiler error it existed for is gone (#656)
+- Continues the experimental multiseat foundation, still default off and unreachable in production: a negotiated media contract between worker and controller, and the DRM primary node a nested gamescope seat needs in its device catalog (#648, #662)
+- Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, `Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` as the official package assets
+
 ## v1.4.6 - 2026-09-11
 
 A correctness update for Linux hosts that stream a private display, and for three failures that used to happen in silence. A game's stored virtual-display preference no longer overrides a host that already provides the session's display, a paused session no longer changes what the host recommends to other clients, and an encoder, a driver reading and a refused directory now each say what went wrong. Existing configurations and paired devices remain valid.

--- a/docs/release-notes/v1.4.7.md
+++ b/docs/release-notes/v1.4.7.md
@@ -1,0 +1,78 @@
+# Polaris v1.4.7
+
+A controller and configuration update, matched with Nova v1.4.7. Existing settings and paired devices keep working.
+
+**Fixed**
+
+- A PlayStation controller streamed to Polaris now presses the button you press. The virtual pad had its face buttons rotated and its triggers swapped with the right stick, in some games but not others.
+- That pad no longer starts out with both sticks pushed hard left and a trigger half pulled until you touch it.
+- Polaris stops creating its own settings folder in a state it then refuses to use, which made saving credentials fail from the very first run on some systems.
+- `--setup-host` puts that folder right if an earlier run under sudo left it owned by root, rather than only telling you about it.
+- When Polaris does refuse that folder it now names the one that actually failed, and gives the fix that matches the problem instead of always suggesting the ownership one.
+- A host that quietly drops to software encoding now says which graphics driver it found.
+- Unreadable saved pairing state reads as what it is: Polaris carries on with a new identity and says that anything paired before then has to pair again.
+
+**Heads up**
+
+- The PlayStation pad fix is the mapping. If Steam is claiming your controller and presses arrive as the previous press, that is a separate thing and is still open.
+- Bazzite hosts should still install the Fedora 44 RPM through rpm-ostree. The system extension stays withdrawn.
+- SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+- Steam Input stays manual and read-only.
+- No new hardware validation run for this release. The controller fix was measured on a handheld against a real virtual pad, and the private stream path is unchanged.
+
+<details>
+<summary><b>Install</b> (Fedora 44, Arch / CachyOS, Ubuntu 24.04, SteamOS 3.8)</summary>
+
+### Fedora 44
+
+```bash
+wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.7/Polaris-fedora44-x86_64.rpm &&
+sudo dnf install "./Polaris-fedora44-x86_64.rpm" &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Arch Linux / CachyOS
+
+```bash
+wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.7/Polaris-arch-x86_64.pkg.tar.zst &&
+sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### Ubuntu 24.04
+
+```bash
+wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.7/Polaris-ubuntu24.04-x86_64.deb &&
+sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&
+sudo -H polaris --setup-host &&
+systemctl --user restart polaris
+```
+
+### SteamOS 3.8
+
+Run this in Desktop Mode. It sets up the package keyring when needed and restores the read-only root before starting Polaris.
+
+```bash
+wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.7/Polaris-steamos3.8-x86_64.pkg.tar.zst &&
+(
+set -e
+trap 'sudo steamos-readonly enable' EXIT
+sudo steamos-readonly disable || exit $?
+sudo pacman-key --init || exit $?
+sudo pacman-key --populate || exit $?
+sudo pacman -Sy || exit $?
+sudo pacman -U ./Polaris-steamos3.8-x86_64.pkg.tar.zst || exit $?
+sudo -H polaris --setup-host || exit $?
+sudo steamos-readonly enable || exit $?
+trap - EXIT
+) &&
+systemctl --user enable --now polaris
+```
+
+Bazzite users should follow the [Bazzite guide](https://papi-ux.com/docs/bazzite/) and use the Fedora RPM through rpm-ostree. SteamOS 3.8 users should follow the [SteamOS guide](https://papi-ux.com/docs/steamos/); SteamOS remains experimental Desktop Mode support rather than certified Game Mode support.
+
+</details>
+
+**Assets:** `Polaris-fedora44-x86_64.rpm` · `Polaris-arch-x86_64.pkg.tar.zst` · `Polaris-ubuntu24.04-x86_64.deb` · `Polaris-steamos3.8-x86_64.pkg.tar.zst`

--- a/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
+++ b/packaging/linux/SteamOS/namcap-reviewed-warnings.txt
@@ -1,4 +1,4 @@
-polaris W: ELF file ('usr/bin/polaris-1.4.6') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
+polaris W: ELF file ('usr/bin/polaris-1.4.7') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: ELF file ('usr/bin/polaris-browser-stream-helper') lacks GNU_PROPERTY_X86_FEATURE_1_SHSTK.
 polaris W: Unused shared library '/usr/lib/libresolv.so.2' by file ('usr/bin/polaris-browser-stream-helper')
 polaris W: Dependency included, but may not be needed ('avahi')

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -665,7 +665,7 @@ contributing = strip_html_comments(
 readme = strip_html_comments(Path("README.md").read_text(encoding="utf-8"))
 changelog = strip_html_comments(Path("docs/changelog.md").read_text(encoding="utf-8"))
 release_notes = strip_html_comments(
-    Path("docs/release-notes/v1.4.6.md").read_text(encoding="utf-8")
+    Path("docs/release-notes/v1.4.7.md").read_text(encoding="utf-8")
 )
 
 
@@ -1296,18 +1296,18 @@ for dependency in ("vulkan-headers", "vulkan-icd-loader"):
 
 current_release = markdown_section(
     changelog,
+    "## v1.4.7 - 2026-09-12",
     "## v1.4.6 - 2026-09-11",
-    "## v1.4.5 - 2026-09-10",
 )
 current_release_prose = rendered_markdown(current_release)
 required_release_facts = (
-    "virtual display",
-    "private headless host",
-    "paused-session resume window",
-    "capture backend",
-    "nvidia-smi",
+    "virtual DualSense",
+    "Bluetooth bus",
+    "triggers released",
+    "owned by root",
+    "umask",
     "software encoding",
-    "private state",
+    "pair again",
     "Polaris-arch-x86_64.pkg.tar.zst",
     "Polaris-fedora44-x86_64.rpm",
     "Polaris-steamos3.8-x86_64.pkg.tar.zst",
@@ -1315,7 +1315,7 @@ required_release_facts = (
 )
 for fact in required_release_facts:
     if fact not in current_release_prose:
-        print(f"v1.4.6 changelog is missing final release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.7 changelog is missing final release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 
 asset_phrase = (
@@ -1324,7 +1324,7 @@ asset_phrase = (
     "`Polaris-steamos3.8-x86_64.pkg.tar.zst`, and "
     "`Polaris-ubuntu24.04-x86_64.deb`"
 )
-for label, section in (("v1.4.6 changelog", current_release_prose),):
+for label, section in (("v1.4.7 changelog", current_release_prose),):
     if section.count(asset_phrase) != 1:
         print(f"{label} must contain the exact visible four-asset phrase", file=sys.stderr)
         sys.exit(1)
@@ -1344,7 +1344,7 @@ building_packaging_prose = rendered_markdown(building_packaging)
 asset_pattern = re.compile(r"Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*")
 for label, section, expected_section_assets in (
     ("docs/building.md Packaging", building_packaging_prose, expected_assets),
-    ("v1.4.6 changelog", current_release_prose, expected_changelog_assets),
+    ("v1.4.7 changelog", current_release_prose, expected_changelog_assets),
 ):
     actual_assets = Counter(asset_pattern.findall(section))
     if actual_assets != expected_section_assets:
@@ -1358,23 +1358,23 @@ for label, section, expected_section_assets in (
 # Release notes are the short, user-facing list; the changelog carries the
 # detail. Pin phrases a player would read, never internal identifiers.
 release_notes_facts = (
-    "Nova stays at v1.4.5",
-    "private display",
-    "virtual display",
+    "matched with Nova v1.4.7",
+    "PlayStation controller",
+    "triggers swapped with the right stick",
     "software encoding",
     "Bazzite",
     "rpm-ostree",
     "system extension stays withdrawn",
     "SteamOS",
     "Steam Input",
-    "nvidia-smi",
-    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-fedora44-x86_64.rpm &&",
+    "pair again",
+    "wget --output-document=./Polaris-fedora44-x86_64.rpm https://github.com/papi-ux/polaris/releases/download/v1.4.7/Polaris-fedora44-x86_64.rpm &&",
     "sudo dnf install \"./Polaris-fedora44-x86_64.rpm\" &&",
-    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-arch-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-arch-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.7/Polaris-arch-x86_64.pkg.tar.zst &&",
     "sudo pacman -U ./Polaris-arch-x86_64.pkg.tar.zst &&",
-    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-ubuntu24.04-x86_64.deb &&",
+    "wget --output-document=./Polaris-ubuntu24.04-x86_64.deb https://github.com/papi-ux/polaris/releases/download/v1.4.7/Polaris-ubuntu24.04-x86_64.deb &&",
     "sudo apt install ./Polaris-ubuntu24.04-x86_64.deb &&",
-    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.6/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
+    "wget --output-document=./Polaris-steamos3.8-x86_64.pkg.tar.zst https://github.com/papi-ux/polaris/releases/download/v1.4.7/Polaris-steamos3.8-x86_64.pkg.tar.zst &&",
     "trap 'sudo steamos-readonly enable' EXIT",
     "sudo pacman-key --init || exit $?",
     "sudo pacman-key --populate || exit $?",
@@ -1382,25 +1382,25 @@ release_notes_facts = (
 )
 for fact in release_notes_facts:
     if fact not in release_notes:
-        print(f"v1.4.6 release notes are missing release fact: {fact}", file=sys.stderr)
+        print(f"v1.4.7 release notes are missing release fact: {fact}", file=sys.stderr)
         sys.exit(1)
 release_asset_lines = [
     line for line in release_notes.splitlines() if line.startswith("**Assets:**")
 ]
 if len(release_asset_lines) != 1:
-    print("v1.4.6 release notes must contain exactly one Assets line", file=sys.stderr)
+    print("v1.4.7 release notes must contain exactly one Assets line", file=sys.stderr)
     sys.exit(1)
 release_note_assets = Counter(asset_pattern.findall(release_asset_lines[0]))
 if release_note_assets != expected_assets:
     print(
-        "v1.4.6 release-note Assets line must contain only the four supported packages; "
+        "v1.4.7 release-note Assets line must contain only the four supported packages; "
         f"expected={dict(expected_assets)}, actual={dict(release_note_assets)}",
         file=sys.stderr,
     )
     sys.exit(1)
 if release_notes.count(withdrawn_sysext_asset) != 0:
     print(
-        "v1.4.6 release notes must not name the withdrawn system extension file; that warning lives in v1.4.3",
+        "v1.4.7 release notes must not name the withdrawn system extension file; that warning lives in v1.4.3",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/scripts/ci/build-steamos-package.sh
+++ b/scripts/ci/build-steamos-package.sh
@@ -57,7 +57,7 @@ PACKAGE_NAME="$(sed -n 's/^pkgname = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_VERSION="$(sed -n 's/^pkgver = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_ARCH="$(sed -n 's/^arch = //p' "$RECEIPT_ROOT/.PKGINFO")"
 PACKAGE_IDENTITY="$PACKAGE_NAME|$PACKAGE_VERSION|$PACKAGE_ARCH"
-if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.6-1|x86_64' ]; then
+if [ "$PACKAGE_IDENTITY" != 'polaris|1.4.7-1|x86_64' ]; then
   printf 'unexpected SteamOS package identity: %s\n' "$PACKAGE_IDENTITY" >&2
   exit 1
 fi

--- a/src_assets/common/assets/web/packaging-contracts.test.js
+++ b/src_assets/common/assets/web/packaging-contracts.test.js
@@ -776,7 +776,7 @@ describe('Linux packaging contracts', () => {
     expect(buildScript).toContain("sed -n 's/^pkgname = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^pkgver = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
     expect(buildScript).toContain("sed -n 's/^arch = //p' \"$RECEIPT_ROOT/.PKGINFO\"")
-    expect(buildScript).toContain("'polaris|1.4.6-1|x86_64'")
+    expect(buildScript).toContain("'polaris|1.4.7-1|x86_64'")
     expect(buildScript).toContain('PACKAGE_PATHS=(polaris-[0-9]*-x86_64.pkg.tar.zst)')
     expect(buildScript).toContain('CLONE_URL=https://github.com/papi-ux/polaris.git')
     expect(buildScript).toContain("sed -n 's/^depend = //p' \"$RECEIPT_ROOT/.PKGINFO\"")

--- a/src_assets/common/assets/web/release-v146-contract.test.js
+++ b/src_assets/common/assets/web/release-v146-contract.test.js
@@ -1,17 +1,10 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
-const packageAssets = [
-  'Polaris-arch-x86_64.pkg.tar.zst',
-  'Polaris-fedora44-x86_64.rpm',
-  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
-  'Polaris-ubuntu24.04-x86_64.deb',
-].sort()
-const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
 
-const currentChangelog = () => {
+const historicalRelease = () => {
   const changelog = read('docs/changelog.md')
   const start = changelog.indexOf('## v1.4.6 - 2026-09-11')
   const end = changelog.indexOf('## v1.4.5 - 2026-09-10')
@@ -20,119 +13,51 @@ const currentChangelog = () => {
   return changelog.slice(start, end)
 }
 
-const releaseNotes = () => read('docs/release-notes/v1.4.6.md')
-const installBlocks = () => [...releaseNotes().matchAll(/```bash\n([\s\S]*?)\n```/g)]
-  .map((match) => match[1])
-  .filter((block) => block.includes('wget --output-document='))
+const historicalNotes = () => read('docs/release-notes/v1.4.6.md')
 
-describe('v1.4.6 release contract', () => {
-  it('moves every current release identity to v1.4.6', () => {
-    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.6')
-    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.6"')
-    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain('usr/bin/polaris-1.4.6')
-    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.6-1|x86_64'")
-    expect(read('src_assets/common/assets/web/packaging-contracts.test.js')).toContain("'polaris|1.4.6-1|x86_64'")
-  })
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
 
-  it('makes v1.4.5 historical and promotes the complete v1.4.6 scope', () => {
-    expect(read('src_assets/common/assets/web/release-v145-contract.test.js')).toContain("describe('historical v1.4.5 release contract'")
-    const gate = read('scripts/check-public-docs.sh')
-    expect(gate).toContain('docs/release-notes/v1.4.6.md')
-    expect(gate).toContain('"## v1.4.6 - 2026-09-11"')
-
-    const release = `${currentChangelog()}\n${releaseNotes()}`
+describe('historical v1.4.6 release contract', () => {
+  it('preserves the private display correctness scope and the three silent failures', () => {
+    const evidence = `${historicalRelease()}\n${historicalNotes()}`
     for (const fact of [
       'virtual display',
-      'private display',
+      'private headless host',
       'paused-session resume window',
-      'private state',
+      'capture backend',
       'nvidia-smi',
       'software encoding',
-      'Bazzite',
-      'rpm-ostree',
+      'private state',
       'Nova stays at v1.4.5',
     ]) {
-      expect(release, `release must include: ${fact}`).toContain(fact)
+      expect(evidence, `historical v1.4.6 must include: ${fact}`).toContain(fact)
     }
+    expect(historicalNotes()).toContain('system extension stays withdrawn')
+    expect(historicalNotes()).not.toContain(withdrawnSysextAsset)
   })
 
-  it('keeps the Bazzite install guidance and the system extension withdrawn', () => {
-    const notes = releaseNotes()
-    const bazziteGuide = read('docs/bazzite.md')
-    const handheldsGuide = read('docs/handhelds.md')
-    const workflow = read('.github/workflows/build.yml')
-
-    expect(bazziteGuide).toContain('sudo rpm-ostree install --uninstall=polaris')
-    expect(bazziteGuide).toContain('sudo rpm-ostree rollback')
-    expect(handheldsGuide.length).toBeGreaterThan(0)
-    expect(notes).toContain('system extension stays withdrawn')
-    expect(notes).not.toContain(withdrawnSysextAsset)
-    expect(workflow).not.toContain('sysext-build:')
-    expect(workflow).not.toContain('Polaris-sysext-image')
-    expect(workflow).not.toContain(`release-assets/final/${withdrawnSysextAsset}`)
-  })
-
-  it('pins all four install commands to v1.4.6 and lists only supported package assets', () => {
-    const blocks = installBlocks()
+  it('preserves the exact historical assets and install identities', () => {
+    const notes = historicalNotes()
+    const blocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
     expect(blocks).toHaveLength(4)
-    for (const asset of packageAssets) {
+    for (const asset of expectedAssets) {
       const matches = blocks.filter((block) => block.includes(`/${asset}`))
       expect(matches, `one command block for ${asset}`).toHaveLength(1)
       expect(matches[0]).toContain(`releases/download/v1.4.6/${asset}`)
-      expect(matches[0]).toContain('sudo -H polaris --setup-host')
     }
 
-    for (const asset of [
-      'Polaris-arch-x86_64.pkg.tar.zst',
-      'Polaris-fedora44-x86_64.rpm',
-      'Polaris-ubuntu24.04-x86_64.deb',
-    ]) {
-      const block = blocks.find((candidate) => candidate.includes(`/${asset}`))
-      expect(block).toContain('systemctl --user restart polaris')
-    }
-
-    const steamOs = blocks.find((block) => block.includes('/Polaris-steamos3.8-x86_64.pkg.tar.zst'))
-    expect(steamOs).toContain("trap 'sudo steamos-readonly enable' EXIT")
-    expect(steamOs).toContain('sudo pacman-key --init || exit $?')
-    expect(steamOs).toContain('sudo pacman-key --populate || exit $?')
-    expect(steamOs).toContain('systemctl --user enable --now polaris')
-
-    const assetsLine = releaseNotes().split('\n').find((line) => line.startsWith('**Assets:**'))
+    const assetsLine = notes.split('\n').find((line) => line.startsWith('**Assets:**'))
     expect(assetsLine).toBeDefined()
     const listed = [...new Set((assetsLine ?? '').match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
-    expect(listed.sort()).toEqual(packageAssets)
+    expect(listed.sort()).toEqual(expectedAssets)
     expect(assetsLine).not.toContain(withdrawnSysextAsset)
-  })
-
-  it('publishes release-note guide links that work outside the source tree', () => {
-    const releaseNotesDir = join(process.cwd(), 'docs/release-notes')
-    const notes = readdirSync(releaseNotesDir)
-      .filter((name) => /^v\d+\.\d+\.\d+\.md$/.test(name))
-      .map((name) => read(`docs/release-notes/${name}`))
-      .join('\n')
-
-    expect(notes).not.toMatch(/\]\(\.\.\/(?:bazzite|steamos)\.md(?:[?#][^)]*)?\)/)
-    expect(notes).toContain('[Bazzite guide](https://papi-ux.com/docs/bazzite/)')
-    expect(notes).toContain('[SteamOS guide](https://papi-ux.com/docs/steamos/)')
-  })
-
-  it('keeps publication bound to one verified immutable source', () => {
-    const workflow = read('.github/workflows/build.yml')
-    const ordered = [
-      '- name: Check out exact release source',
-      '- name: Revalidate release tag against packaged source',
-      '- name: Stage curated GitHub release',
-      '- name: Upload release assets to GitHub release',
-      '- name: Verify release assets on GitHub release',
-      '- name: Publish verified draft release',
-    ]
-    const positions = ordered.map((step) => workflow.indexOf(step))
-    expect(positions.every((position) => position >= 0)).toBe(true)
-    expect(positions).toEqual([...positions].sort((a, b) => a - b))
-    expect(workflow).toContain('release_notes="docs/release-notes/${POLARIS_PACKAGE_REF_NAME}.md"')
-    expect(workflow).toContain('tag_commit="$(git rev-parse "refs/tags/${release_tag}^{commit}")"')
-    expect(workflow).toContain('--verify-tag')
-    expect(workflow).toContain('--notes-file "$release_notes"')
-    expect(workflow).toContain('run: gh release edit "${POLARIS_PACKAGE_REF_NAME}" --verify-tag --draft=false')
   })
 })

--- a/src_assets/common/assets/web/release-v147-contract.test.js
+++ b/src_assets/common/assets/web/release-v147-contract.test.js
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const read = (path) => readFileSync(join(process.cwd(), path), 'utf8')
+
+const currentRelease = () => {
+  const changelog = read('docs/changelog.md')
+  const start = changelog.indexOf('## v1.4.7 - 2026-09-12')
+  const end = changelog.indexOf('## v1.4.6 - 2026-09-11')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return changelog.slice(start, end)
+}
+
+const currentNotes = () => read('docs/release-notes/v1.4.7.md')
+
+const expectedAssets = [
+  'Polaris-arch-x86_64.pkg.tar.zst',
+  'Polaris-fedora44-x86_64.rpm',
+  'Polaris-steamos3.8-x86_64.pkg.tar.zst',
+  'Polaris-ubuntu24.04-x86_64.deb',
+].sort()
+const withdrawnSysextAsset = 'Polaris-sysext-x86_64.raw'
+
+describe('v1.4.7 release contract', () => {
+  it('pins the version every packaging surface agrees on', () => {
+    expect(read('CMakeLists.txt')).toContain('project(Polaris VERSION 1.4.7')
+    expect(read('docs/benchmark-control-openapi.json')).toContain('"collector_version": "1.4.7"')
+    expect(read('packaging/linux/SteamOS/namcap-reviewed-warnings.txt')).toContain(
+      'usr/bin/polaris-1.4.7',
+    )
+    expect(read('scripts/ci/build-steamos-package.sh')).toContain("'polaris|1.4.7-1|x86_64'")
+  })
+
+  it('says what the controller fix was, in the words the person who hit it would use', () => {
+    const evidence = `${currentRelease()}\n${currentNotes()}`
+    for (const fact of [
+      'virtual DualSense',
+      'Bluetooth bus',
+      'triggers released',
+      'PlayStation controller',
+      'triggers swapped with the right stick',
+    ]) {
+      expect(evidence, `v1.4.7 must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('says what the configuration directory fixes were', () => {
+    const evidence = `${currentRelease()}\n${currentNotes()}`
+    for (const fact of ['owned by root', 'umask', 'setup-host', 'pair again']) {
+      expect(evidence, `v1.4.7 must include: ${fact}`).toContain(fact)
+    }
+  })
+
+  it('keeps the heads up honest about what is still open and what was not validated', () => {
+    const notes = currentNotes()
+    expect(notes).toContain('that is a separate thing and is still open')
+    expect(notes).toContain('No new hardware validation run for this release')
+    expect(notes).toContain('system extension stays withdrawn')
+    expect(notes).not.toContain(withdrawnSysextAsset)
+  })
+
+  it('ships exactly the four supported packages and installs them from this tag', () => {
+    const notes = currentNotes()
+    const blocks = [...notes.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('wget --output-document='))
+    expect(blocks).toHaveLength(4)
+    for (const asset of expectedAssets) {
+      const matches = blocks.filter((block) => block.includes(`/${asset}`))
+      expect(matches, `one command block for ${asset}`).toHaveLength(1)
+      expect(matches[0]).toContain(`releases/download/v1.4.7/${asset}`)
+    }
+
+    const assetsLine = notes.split('\n').find((line) => line.startsWith('**Assets:**'))
+    expect(assetsLine).toBeDefined()
+    const listed = [...new Set((assetsLine ?? '').match(/Polaris-[A-Za-z0-9][A-Za-z0-9._+-]*/g) ?? [])]
+    expect(listed.sort()).toEqual(expectedAssets)
+    expect(assetsLine).not.toContain(withdrawnSysextAsset)
+  })
+
+  it('closes the changelog section with the exact four-asset sentence', () => {
+    const bullets = currentRelease()
+      .split('\n')
+      .filter((line) => line.startsWith('- '))
+    expect(bullets.at(-1)).toContain(
+      'Keeps exactly `Polaris-arch-x86_64.pkg.tar.zst`, `Polaris-fedora44-x86_64.rpm`, ' +
+        '`Polaris-steamos3.8-x86_64.pkg.tar.zst`, and `Polaris-ubuntu24.04-x86_64.deb` ' +
+        'as the official package assets',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Release prep for Polaris v1.4.7, a controller and configuration release matched with Nova v1.4.7.

**The Unreleased changelog section was empty.** Nine pull requests had merged since v1.4.6 and none of them were recorded, so the changelog section here is written from the merged set rather than assembled from existing entries: #654, #648, #656, #657, #658, #659, #660, #662 and #663.

What the release says, in short: the virtual DualSense maps the way a real one does, and the per-user configuration directory stops being created in a state Polaris then refuses to use.

## Pins moved

Every surface the tag build and the docs gate read, together:

| Pin | To |
|---|---|
| `CMakeLists.txt` project VERSION | 1.4.7 |
| `docs/benchmark-control-openapi.json` collector_version | 1.4.7 |
| `packaging/linux/SteamOS/namcap-reviewed-warnings.txt` | `usr/bin/polaris-1.4.7` |
| `scripts/ci/build-steamos-package.sh` and `packaging-contracts.test.js` | `'polaris\|1.4.7-1\|x86_64'` |
| `scripts/check-public-docs.sh` release block | v1.4.7 headings, notes path, install URLs |

The tag build refuses a tag that does not equal the CMake version, so these have to agree before tagging.

## Both fact lists re-chosen, not carried forward

`required_release_facts` and `release_notes_facts` pinned phrases from v1.4.6, including "Nova stays at v1.4.5" and the nvidia-smi fix that shipped last time. This release says none of that. They now pin phrases this release actually makes: the Bluetooth bus, triggers released, owned by root, umask, pair again, and the words the notes use for the controller fix.

Carrying them forward would have left the gate asserting claims the release does not make.

## The v1.4.6 contract test is demoted, not renamed

The historical form is a genuinely different, shorter file. It keeps only what stays true about that release's own changelog section, notes file and asset line, and drops every assertion about the current docs gate, which has moved on. Modelled on the already-historical `release-v144-contract.test.js`.

`release-v147-contract.test.js` is new and pins the version across every packaging surface, the words the controller and configuration fixes use, the four install blocks resolving to this tag, the single Assets line, and the exact four-asset sentence closing the changelog section.

## Verification

- [x] `scripts/check-public-docs.sh` clean.
- [x] 740 web tests pass, including the new v1.4.7 contract and the demoted v1.4.6 one.
- [x] Release notes carry four wget blocks, three `setup-host &&`, three `restart polaris`, one `enable --now polaris`, and no reference to the previous tag.
- [x] Rebased onto master after #663 landed, and both gates re-run on the rebased tree.

## Heads up in the notes

The notes say plainly that the PlayStation fix is the mapping, and that Steam claiming the controller so presses arrive as the previous press is a separate open issue. They also say there was no new hardware validation run: the controller fix was measured on a handheld against a real virtual pad, and the private stream path is unchanged.
