### PR TITLE
fix(build): pin an FFmpeg whose NVENC reaches the drivers our hosts run

### DIFF
--- a/cmake/dependencies/prepared_ffmpeg.cmake
+++ b/cmake/dependencies/prepared_ffmpeg.cmake
@@ -1,4 +1,4 @@
-set(POLARIS_PREPARED_FFMPEG_RELEASE_TAG "v2026.724.203728" CACHE STRING
+set(POLARIS_PREPARED_FFMPEG_RELEASE_TAG "v2026.713.132551" CACHE STRING
     "LizardByte/build-deps release tag used for prepared FFmpeg archives")
 set(POLARIS_PREPARED_FFMPEG_BASE_URL
     "https://github.com/LizardByte/build-deps/releases/download/${POLARIS_PREPARED_FFMPEG_RELEASE_TAG}"
@@ -8,6 +8,18 @@ set(POLARIS_PREPARED_FFMPEG_CACHE_DIR
     CACHE PATH "Directory for downloaded prepared FFmpeg archives")
 option(POLARIS_DOWNLOAD_PREPARED_FFMPEG
     "Download pinned prepared FFmpeg archives when available for this platform" ON)
+
+# The highest NVENC API version Polaris is willing to ship.
+#
+# libavcodec compiles this version in from the ffnvcodec headers it is built against, then
+# refuses at runtime to talk to any driver that reports an older one. Raising this therefore
+# raises the minimum NVIDIA driver every Polaris host needs for hardware encoding, and a host
+# below it loses NVENC entirely and falls back to VAAPI or software.
+#
+# 13.0 needs driver 570 or newer. 13.1 needs 610, which Maxwell, Pascal and Volta can never
+# reach because 580 is the last branch NVIDIA ships for them.
+set(POLARIS_MAX_SUPPORTED_FFNVCODEC_VERSION "13.0" CACHE STRING
+    "Highest NVENC API version a prepared FFmpeg archive may be built against")
 
 function(polaris_prepared_ffmpeg_asset_name out_var system_name system_processor)
   string(TOLOWER "${system_processor}" processor)
@@ -60,26 +72,65 @@ function(polaris_prepared_ffmpeg_asset_hash out_var asset_name)
 
   set(hash "")
   if(asset_name STREQUAL "Darwin-arm64-ffmpeg.tar.gz")
-    set(hash "f4f72fcef4180f18329351cc1080e3fa1a5a7d084fa1c52defa93586aac88f0f")
+    set(hash "056122301edcdec74e00cfa9a3091bf3135d5fe1472234ce7f46426325081bca")
   elseif(asset_name STREQUAL "Darwin-x86_64-ffmpeg.tar.gz")
-    set(hash "da45523c20c0dd44ef3f54ffc41a16f363da2e2298bd0539e3b502b3e750eef7")
+    set(hash "5b15f4283a2aa94d42abfd55e361cd4520021a7499fcbd693d3533f3ecb0904e")
   elseif(asset_name STREQUAL "FreeBSD-aarch64-ffmpeg.tar.gz")
-    set(hash "3a3527675b09b8537b6997622001df21be61d8d280671dd11a388662699d7ad8")
+    set(hash "0adc7baead743be37ae66ff92c634764f5418fae3d5c5ea2ad4ec962cd45c3ce")
   elseif(asset_name STREQUAL "FreeBSD-amd64-ffmpeg.tar.gz")
-    set(hash "3ca1b26feaa0402b7e89124b0c55ba4013cee31cec8d6ec0ac5e5b846afa0cb0")
+    set(hash "a4dee66179bd72221f83874beb95afd79ea70159782a53adff0579d494c9f0b3")
   elseif(asset_name STREQUAL "Linux-aarch64-ffmpeg.tar.gz")
-    set(hash "fd6492f55d79ae178db97e48d6395b4cac2a2e10b2f157b0d40355cfd7c160e8")
+    set(hash "2bdcfa663bb7a1b241a47665c94aa288ef2ec40c6a212cc0a8ec63904b886c6d")
   elseif(asset_name STREQUAL "Linux-ppc64le-ffmpeg.tar.gz")
-    set(hash "30583f89fc82816872ed4b9ac044e04c2c2f2a79aa63ca3a9facb5a20e15fcec")
+    set(hash "61522f3424311154c6902fc1f427336eff084ff338c7b2d960cfa010183970f7")
   elseif(asset_name STREQUAL "Linux-x86_64-ffmpeg.tar.gz")
-    set(hash "2c27d4694b4ed0e734f497d4bd62f1b3662cbbc4ded2a69f2dc4b703441eebb3")
+    set(hash "66512409857d7c11c18875193c098a5131baec060169c8f8e6397387e7a1af7d")
   elseif(asset_name STREQUAL "Windows-AMD64-ffmpeg.tar.gz")
-    set(hash "b293d7f6bd3f032ea01c7e4451b7db540622f2d603e8b98d336513895842c506")
+    set(hash "6bf702af027d849f326823b9cfe058ddc3eff05d5e424624552bcb71c2415c68")
   elseif(asset_name STREQUAL "Windows-ARM64-ffmpeg.tar.gz")
-    set(hash "53e0dee93a2185fc619425da14cf10a7a328d016ff9cc50c2c52e051bb3895d1")
+    set(hash "8cc219946f6bf45512612785e518814c22d0e73c8fa1235d7e84a795056c76c1")
   endif()
 
   set("${out_var}" "${hash}" PARENT_SCOPE)
+endfunction()
+
+function(polaris_prepared_ffmpeg_nvenc_api_version out_var prepared_dir)
+  set(header "${prepared_dir}/include/ffnvcodec/nvEncodeAPI.h")
+  if(NOT EXISTS "${header}")
+    # Archives for platforms without NVENC ship no ffnvcodec headers at all.
+    set("${out_var}" "" PARENT_SCOPE)
+    return()
+  endif()
+
+  file(READ "${header}" header_text)
+  string(REGEX MATCH "NVENCAPI_MAJOR_VERSION[ \t]+([0-9]+)" _major_match "${header_text}")
+  set(major "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "NVENCAPI_MINOR_VERSION[ \t]+([0-9]+)" _minor_match "${header_text}")
+  set(minor "${CMAKE_MATCH_1}")
+
+  if(major STREQUAL "" OR minor STREQUAL "")
+    set("${out_var}" "" PARENT_SCOPE)
+    return()
+  endif()
+
+  set("${out_var}" "${major}.${minor}" PARENT_SCOPE)
+endfunction()
+
+function(polaris_prepared_ffmpeg_nvenc_floor_violation out_var prepared_dir)
+  polaris_prepared_ffmpeg_nvenc_api_version(bundled "${prepared_dir}")
+  if(bundled STREQUAL "" OR NOT bundled VERSION_GREATER "${POLARIS_MAX_SUPPORTED_FFNVCODEC_VERSION}")
+    set("${out_var}" "" PARENT_SCOPE)
+    return()
+  endif()
+
+  string(CONCAT message
+      "Prepared FFmpeg ${POLARIS_PREPARED_FFMPEG_RELEASE_TAG} is built against NVENC API "
+      "${bundled}, above the ${POLARIS_MAX_SUPPORTED_FFNVCODEC_VERSION} Polaris supports. "
+      "Every host on an NVIDIA driver older than the one that version requires would lose "
+      "hardware encoding silently. Pin an archive built against "
+      "${POLARIS_MAX_SUPPORTED_FFNVCODEC_VERSION} or older, or raise "
+      "POLARIS_MAX_SUPPORTED_FFNVCODEC_VERSION deliberately and say which drivers that drops.")
+  set("${out_var}" "${message}" PARENT_SCOPE)
 endfunction()
 
 function(polaris_validate_prepared_ffmpeg_dir prepared_dir)
@@ -95,6 +146,11 @@ function(polaris_validate_prepared_ffmpeg_dir prepared_dir)
           "Set FFMPEG_PREPARED_BINARIES to a complete prepared FFmpeg directory.")
     endif()
   endforeach()
+
+  polaris_prepared_ffmpeg_nvenc_floor_violation(violation "${prepared_dir}")
+  if(NOT violation STREQUAL "")
+    message(FATAL_ERROR ${violation})
+  endif()
 endfunction()
 
 function(polaris_resolve_prepared_ffmpeg out_var)

--- a/nix/packages/polaris-stream/default.nix
+++ b/nix/packages/polaris-stream/default.nix
@@ -94,7 +94,7 @@ let
   phase2VulkanCuda =
     if enablePortalDmabufLinear == null then enablePhase2VulkanCuda else enablePortalDmabufLinear;
 
-  buildDepsTag = "v2026.724.203728";
+  buildDepsTag = "v2026.713.132551";
   ffmpegArch =
     {
       x86_64-linux = "Linux-x86_64";
@@ -102,12 +102,15 @@ let
     }
     .${stdenv.hostPlatform.system}
       or (throw "polaris-stream: unsupported system ${stdenv.hostPlatform.system} for prebuilt ffmpeg");
+  # fetchzip hashes the unpacked tree, so these are NAR hashes and deliberately differ
+  # from the tarball digests cmake/dependencies/prepared_ffmpeg.cmake pins for the same
+  # archives. Copying the cmake value here is what broke the weekly nix build in #595.
   ffmpegPrebuilt = fetchzip {
     url = "https://github.com/LizardByte/build-deps/releases/download/${buildDepsTag}/${ffmpegArch}-ffmpeg.tar.gz";
     hash =
       {
-        x86_64-linux = "sha256-LCfUaUtO0Oc09JfUvWLxs2Ysu8Te0qafLcS3A0Qe67M=";
-        aarch64-linux = "sha256-/WSS9V15rheNuX5I1jlbTKwqLhCy8Vew1ANVz9fBYOg=";
+        x86_64-linux = "sha256-nHL+JxxMbR5fva/w1tt0BqcDowSAojuV8504he/wbsg=";
+        aarch64-linux = "sha256-/4EW4ZWZxIYbMjIS1XujoCbQTtLmOy4j2roPxJaAXrw=";
       }
       .${stdenv.hostPlatform.system};
   };

--- a/src_assets/common/assets/web/recent-issues.js
+++ b/src_assets/common/assets/web/recent-issues.js
@@ -1,6 +1,24 @@
 const ENCODER_PROBE_START = 'Testing for available encoders, this may generate errors. You can safely ignore those errors.'
 const ENCODER_PROBE_END = 'Ignore any errors mentioned above, they are not relevant.'
 
+/**
+ * Probe failures that are not probe noise.
+ *
+ * The probe window exists because Polaris deliberately tries codec and profile combinations
+ * the host may not have. A driver too old for the NVENC API this build was compiled against
+ * is a different thing: it is not one combination failing, it is every NVIDIA encoder on the
+ * host failing for a reason the person can act on. That is the whole of #650, where a host
+ * dropped to software encoding and the console showed nothing at all.
+ */
+const PROBE_SURVIVING_PATTERNS = [
+  'does not support the required nvenc API version',
+  'minimum required Nvidia driver for nvenc',
+]
+
+function survivesProbeWindow(message) {
+  return PROBE_SURVIVING_PATTERNS.some((pattern) => message.includes(pattern))
+}
+
 function probeBoundary(line) {
   if (line.includes(ENCODER_PROBE_START)) return 'start'
   if (line.includes(ENCODER_PROBE_END)) return 'end'
@@ -26,6 +44,9 @@ function parseIssueLine(line) {
  * that context keeps an identical codec failure visible when it occurs during
  * a real stream. If a bounded log tail begins inside a probe, the first end
  * banner also lets us infer that the leading lines belong to the probe window.
+ *
+ * A few failures are reported even inside a probe window, because they describe the host
+ * rather than the combination being tried. See PROBE_SURVIVING_PATTERNS.
  */
 export function groupRecentIssueLogs(logText, {
   maxSourceLines = 300,
@@ -49,7 +70,8 @@ export function groupRecentIssueLogs(logText, {
     }
 
     const issue = parseIssueLine(line)
-    if (issue && !insideEncoderProbe) visibleIssues.push(issue)
+    if (!issue) continue
+    if (!insideEncoderProbe || survivesProbeWindow(issue.message)) visibleIssues.push(issue)
   }
 
   const grouped = new Map()

--- a/src_assets/common/assets/web/recent-issues.test.js
+++ b/src_assets/common/assets/web/recent-issues.test.js
@@ -24,6 +24,21 @@ describe('recent issue log grouping', () => {
     expect(grouped.some((entry) => entry.message === 'shader probe failed')).toBe(false)
   })
 
+  it('keeps a driver too old for this build visible inside a probe window', () => {
+    const grouped = groupRecentIssueLogs([
+      start,
+      '[2026-08-16 10:00:00.100]: Error: [h264_nvenc @ 0x1] Driver does not support the required nvenc API version. Required: 13.1 Found: 13.0',
+      '[2026-08-16 10:00:00.110]: Error: [h264_nvenc @ 0x1] The minimum required Nvidia driver for nvenc is 610.00 or newer',
+      '[2026-08-16 10:00:00.120]: Error: Could not open codec [h264_nvenc]: Function not implemented',
+      end,
+    ].join('\n'))
+
+    expect(grouped.map((entry) => entry.message)).toEqual([
+      '[h264_nvenc @ 0x1] The minimum required Nvidia driver for nvenc is 610.00 or newer',
+      '[h264_nvenc @ 0x1] Driver does not support the required nvenc API version. Required: 13.1 Found: 13.0',
+    ])
+  })
+
   it('recognizes a bounded tail that begins inside a probe window', () => {
     const grouped = groupRecentIssueLogs([
       '[2026-08-16 10:00:00.100]: Error: expected leading probe failure',

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -544,6 +544,11 @@ configure_polaris_test_target(${PROJECT_NAME}
     ${TEST_FAST_SOURCES}
 )
 
+add_test(
+    NAME polaris_prepared_ffmpeg_cmake
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/tests/cmake/test_prepared_ffmpeg.cmake
+)
+
 if (UNIX AND NOT APPLE)
     add_test(
         NAME polaris_invalid_locale_startup

--- a/tests/cmake/prepared_ffmpeg_floor_guard_case.cmake
+++ b/tests/cmake/prepared_ffmpeg_floor_guard_case.cmake
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Runs polaris_validate_prepared_ffmpeg_dir against one prepared directory and lets its
+# FATAL_ERROR escape, so the caller can prove the guard actually aborts a configure rather
+# than only that the helper returns a message.
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/dependencies/prepared_ffmpeg.cmake")
+
+if(NOT DEFINED prepared_dir)
+  message(FATAL_ERROR "prepared_dir is required")
+endif()
+
+polaris_validate_prepared_ffmpeg_dir("${prepared_dir}")
+message(STATUS "accepted ${prepared_dir}")

--- a/tests/cmake/test_prepared_ffmpeg.cmake
+++ b/tests/cmake/test_prepared_ffmpeg.cmake
@@ -14,6 +14,26 @@ function(assert_exists path message)
   endif()
 endfunction()
 
+function(assert_contains haystack needle message)
+  string(FIND "${haystack}" "${needle}" position)
+  if(position EQUAL -1)
+    message(FATAL_ERROR "${message}: [${needle}] is not in [${haystack}]")
+  endif()
+endfunction()
+
+function(write_prepared_tree tree_dir)
+  file(MAKE_DIRECTORY "${tree_dir}/include" "${tree_dir}/lib")
+  foreach(library IN ITEMS libavcodec.a libswscale.a libavutil.a libcbs.a)
+    file(WRITE "${tree_dir}/lib/${library}" "")
+  endforeach()
+endfunction()
+
+function(write_ffnvcodec_header tree_dir major minor)
+  file(WRITE "${tree_dir}/include/ffnvcodec/nvEncodeAPI.h"
+      "#define NVENCAPI_MAJOR_VERSION ${major}\n"
+      "#define NVENCAPI_MINOR_VERSION ${minor}\n")
+endfunction()
+
 set(test_root "${CMAKE_CURRENT_LIST_DIR}/../../build/cmake-prepared-ffmpeg-test")
 file(REMOVE_RECURSE "${test_root}")
 file(MAKE_DIRECTORY
@@ -66,3 +86,66 @@ set(FFMPEG_PREPARED_BINARIES "${test_root}/override/ffmpeg")
 set(POLARIS_DOWNLOAD_PREPARED_FFMPEG OFF)
 polaris_resolve_prepared_ffmpeg(override_ffmpeg)
 assert_equal("${override_ffmpeg}" "${FFMPEG_PREPARED_BINARIES}" "Explicit FFmpeg override")
+
+# The pinned archive decides the minimum NVIDIA driver every Polaris host needs for hardware
+# encoding, because libavcodec compiles that requirement in from its ffnvcodec headers. A bump
+# that raises it costs every host below that driver its encoder with nothing in the console,
+# which is what #650 was. These cases keep that from happening twice.
+
+assert_equal("${POLARIS_MAX_SUPPORTED_FFNVCODEC_VERSION}" "13.0"
+  "Supported NVENC API ceiling. Raising this drops every driver below what it requires, so it is pinned deliberately")
+
+set(floor_root "${test_root}/nvenc-floor")
+
+write_prepared_tree("${floor_root}/at-ceiling")
+write_ffnvcodec_header("${floor_root}/at-ceiling" 13 0)
+polaris_prepared_ffmpeg_nvenc_api_version(at_ceiling_version "${floor_root}/at-ceiling")
+assert_equal("${at_ceiling_version}" "13.0" "Bundled NVENC API version")
+polaris_prepared_ffmpeg_nvenc_floor_violation(at_ceiling_violation "${floor_root}/at-ceiling")
+assert_equal("${at_ceiling_violation}" "" "An archive at the ceiling is accepted")
+
+write_prepared_tree("${floor_root}/below-ceiling")
+write_ffnvcodec_header("${floor_root}/below-ceiling" 12 0)
+polaris_prepared_ffmpeg_nvenc_floor_violation(below_violation "${floor_root}/below-ceiling")
+assert_equal("${below_violation}" "" "An archive below the ceiling is accepted")
+
+# No ffnvcodec headers at all is how the Darwin and FreeBSD archives ship, and says nothing
+# about NVENC either way.
+write_prepared_tree("${floor_root}/no-nvenc")
+polaris_prepared_ffmpeg_nvenc_api_version(no_nvenc_version "${floor_root}/no-nvenc")
+assert_equal("${no_nvenc_version}" "" "An archive without ffnvcodec headers reports no version")
+polaris_prepared_ffmpeg_nvenc_floor_violation(no_nvenc_violation "${floor_root}/no-nvenc")
+assert_equal("${no_nvenc_violation}" "" "An archive without ffnvcodec headers is accepted")
+
+write_prepared_tree("${floor_root}/above-ceiling")
+write_ffnvcodec_header("${floor_root}/above-ceiling" 13 1)
+polaris_prepared_ffmpeg_nvenc_api_version(above_version "${floor_root}/above-ceiling")
+assert_equal("${above_version}" "13.1" "Bundled NVENC API version")
+polaris_prepared_ffmpeg_nvenc_floor_violation(above_violation "${floor_root}/above-ceiling")
+assert_contains("${above_violation}" "NVENC API 13.1" "The refusal names the version found")
+assert_contains("${above_violation}" "13.0 Polaris supports" "The refusal names the version supported")
+
+# And prove the guard is wired into the validator every resolve path runs, not just reachable
+# as a helper.
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" "-Dprepared_dir=${floor_root}/above-ceiling"
+          -P "${CMAKE_CURRENT_LIST_DIR}/prepared_ffmpeg_floor_guard_case.cmake"
+  RESULT_VARIABLE guard_result
+  OUTPUT_VARIABLE guard_stdout
+  ERROR_VARIABLE guard_stderr
+)
+if(guard_result EQUAL 0)
+  message(FATAL_ERROR "An archive above the ceiling was accepted by polaris_validate_prepared_ffmpeg_dir")
+endif()
+assert_contains("${guard_stderr}" "NVENC API 13.1" "The validator refusal names the version found")
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" "-Dprepared_dir=${floor_root}/at-ceiling"
+          -P "${CMAKE_CURRENT_LIST_DIR}/prepared_ffmpeg_floor_guard_case.cmake"
+  RESULT_VARIABLE accepted_result
+  OUTPUT_VARIABLE accepted_stdout
+  ERROR_VARIABLE accepted_stderr
+)
+assert_equal("${accepted_result}" "0" "An archive at the ceiling passes the validator")
+
+message(STATUS "prepared FFmpeg cmake contract: all cases passed")

--- a/tests/fixtures/nvenc_floor/README.md
+++ b/tests/fixtures/nvenc_floor/README.md
@@ -1,0 +1,61 @@
+# NVENC driver floor harness
+
+A prepared FFmpeg archive decides the minimum NVIDIA driver every Polaris host needs for
+hardware encoding. libavcodec compiles that requirement in from the ffnvcodec headers it was
+built against and then refuses, at runtime, to talk to any driver reporting an older NVENC API.
+A host below the line loses NVENC and falls back to VAAPI or software, which is #650.
+
+`cmake/dependencies/prepared_ffmpeg.cmake` refuses at configure time to pin an archive above
+`POLARIS_MAX_SUPPORTED_FFNVCODEC_VERSION`, and `tests/cmake/test_prepared_ffmpeg.cmake` covers
+that guard. This harness is the other half: it measures the floor of a real archive on a real
+host, including one whose own driver is far newer than the floor being tested.
+
+`fake_nvenc.c` builds a `libnvidia-encode.so.1` that reports whichever NVENC API version you
+ask for and forwards everything else to the real driver library. `nvenc_floor_probe.c` opens
+`h264_nvenc` and says what happened.
+
+## Running it
+
+Needs an NVIDIA host with a working CUDA runtime, and a prepared FFmpeg archive to test.
+
+```bash
+tag=v2026.713.132551
+mkdir -p "$tag" && curl -sL \
+  "https://github.com/LizardByte/build-deps/releases/download/$tag/Linux-x86_64-ffmpeg.tar.gz" \
+  | tar xz -C "$tag"
+
+gcc -shared -fPIC -o libnvidia-encode.so.1 fake_nvenc.c -ldl
+mkdir -p stub && mv libnvidia-encode.so.1 stub/
+
+PKG_CONFIG_PATH="$PWD/$tag/ffmpeg/lib/pkgconfig" \
+  gcc -o "probe-$tag" nvenc_floor_probe.c -I "$tag/ffmpeg/include" -L "$PWD/$tag/ffmpeg/lib" \
+      $(PKG_CONFIG_PATH="$PWD/$tag/ffmpeg/lib/pkgconfig" pkg-config --static --libs \
+        libavcodec libswscale libavutil) -lstdc++
+
+export POLARIS_REAL_NVENC=/lib64/libnvidia-encode.so.1
+for version in 12.0 13.0 13.1; do
+  printf '%s: ' "$version"
+  LD_LIBRARY_PATH="$PWD/stub" POLARIS_FAKE_NVENC_VERSION="$version" "./probe-$tag"
+done
+```
+
+`POLARIS_REAL_NVENC` must be the absolute path of the real library, or the stub finds itself
+through `LD_LIBRARY_PATH` and recurses.
+
+## What it measured for #650
+
+On pc-papi, an RTX 4090 on driver 610.57.04, against the two archives either side of the pin
+the 1.4.1 release moved:
+
+| Driver reports | v2026.724.203728 (ffnvcodec 13.1) | v2026.713.132551 (ffnvcodec 13.0) |
+| --- | --- | --- |
+| NVENC 12.0 | failed | failed |
+| NVENC 12.2 | failed | failed |
+| NVENC 13.0 | failed | **opened** |
+| NVENC 13.1 | opened | opened |
+
+The failing cell prints the reporter's two lines verbatim, `Driver does not support the required
+nvenc API version. Required: 13.1 Found: 13.0` and `The minimum required Nvidia driver for nvenc
+is 610.00 or newer`, and returns `-38`, which is the `ENOSYS` their log shows as `Function not
+implemented`. Both archives open normally against the host's own driver, so the rollback costs
+nothing on a current one.

--- a/tests/fixtures/nvenc_floor/fake_nvenc.c
+++ b/tests/fixtures/nvenc_floor/fake_nvenc.c
@@ -1,0 +1,36 @@
+// A libnvidia-encode.so.1 that reports whatever NVENC API version POLARIS_FAKE_NVENC_VERSION
+// asks for, and forwards everything else to the real driver library. Lets a host on a new
+// driver reproduce what a host on an older one sees.
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void *real_library(void) {
+  static void *handle;
+  if (!handle) {
+    const char *path = getenv("POLARIS_REAL_NVENC");
+    handle = dlopen(path ? path : "libnvidia-encode.so.1", RTLD_NOW);
+  }
+  return handle;
+}
+
+int NvEncodeAPIGetMaxSupportedVersion(uint32_t *version) {
+  unsigned major = 13, minor = 0;
+  const char *wanted = getenv("POLARIS_FAKE_NVENC_VERSION");
+  if (wanted) {
+    sscanf(wanted, "%u.%u", &major, &minor);
+  }
+  *version = (major << 4) | minor;
+  return 0;
+}
+
+int NvEncodeAPICreateInstance(void *function_list) {
+  void *handle = real_library();
+  if (!handle) {
+    return 1;
+  }
+  int (*create)(void *) = (int (*)(void *)) dlsym(handle, "NvEncodeAPICreateInstance");
+  return create ? create(function_list) : 1;
+}

--- a/tests/fixtures/nvenc_floor/nvenc_floor_probe.c
+++ b/tests/fixtures/nvenc_floor/nvenc_floor_probe.c
@@ -1,0 +1,27 @@
+// Opens h264_nvenc against whichever prepared FFmpeg this is linked to, and says what
+// happened. Used to measure the minimum NVIDIA driver a prepared archive demands, by running
+// it against a stub libnvidia-encode that reports a chosen NVENC API version.
+#include <stdio.h>
+#include <libavcodec/avcodec.h>
+
+int main(void) {
+  av_log_set_level(AV_LOG_ERROR);
+
+  const AVCodec *codec = avcodec_find_encoder_by_name("h264_nvenc");
+  if (!codec) {
+    printf("RESULT no-encoder\n");
+    return 2;
+  }
+
+  AVCodecContext *ctx = avcodec_alloc_context3(codec);
+  ctx->width = 640;
+  ctx->height = 480;
+  ctx->time_base = (AVRational) {1, 60};
+  ctx->framerate = (AVRational) {60, 1};
+  ctx->pix_fmt = AV_PIX_FMT_NV12;
+
+  int rc = avcodec_open2(ctx, codec, NULL);
+  printf("RESULT %s rc=%d\n", rc == 0 ? "opened" : "failed", rc);
+  avcodec_free_context(&ctx);
+  return rc == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Closes #650.

- Rolls the prepared FFmpeg pin back from `v2026.724.203728` to `v2026.713.132551`, which is the release before build-deps moved to ffnvcodec 13.1.
- Adds `POLARIS_MAX_SUPPORTED_FFNVCODEC_VERSION`, and makes the directory validator every resolve path already runs refuse an archive built above it.
- Gives the nix pin real NAR hashes. It has been carrying the cmake tarball digests, which is a different thing, and the weekly nix build has been failing on it since 2026-09-07.
- Stops the console hiding this particular failure inside the encoder probe window.
- Adds `tests/fixtures/nvenc_floor`, which measures the driver floor of an archive on a host whose own driver is newer than the floor being tested.

Polaris does not link a distro FFmpeg. It downloads a prebuilt archive from LizardByte/build-deps and every package we ship uses it. `04d5bc37` ("release: prepare Polaris 1.4.1", #595) moved that pin from `v2026.516.30821` to `v2026.724.203728`, and that was the first archive built against ffnvcodec 13.1 rather than 13.0.

libavcodec compiles that number in and then refuses, at runtime, to talk to any driver reporting an older NVENC API. So the bump raised the minimum NVIDIA driver for hardware encoding from 570 to 610 on every host. A host below it loses NVENC, drops to VAAPI or software, and is told nothing. It shipped in v1.4.1 through v1.4.7.

Maxwell, Pascal and Volta cannot be talked out of it, because 580 is the last branch NVIDIA ships for those cards. The reporter is on a GTX 1070 at driver 580.178.04 and got libx264.

`v2026.713.132551` carries the same libavcodec 28.102 as the archive it replaces, so this is a pure NVENC API rollback and nothing else moves.

The authority for which archive is built against what is the `third-party/FFmpeg/nv-codec-headers` submodule inside build-deps at each tag, not the headers the archive happens to bundle:

| build-deps tag | nv-codec-headers | ffnvcodec |
| --- | --- | --- |
| `v2026.516.30821` | `e844e5b26` | 13.0 |
| `v2026.713.132551` | `e844e5b26` | 13.0 |
| `v2026.724.203728` | `0a6fba9a2` | 13.1 |

## Exact candidate

`Commit: c8c151c48abeee74768890f79b98d3f203ab3007`
`Tree: 20b15da3c735d9824ea76527d12d83c1a5a2f3fb`
`Parent: 9a51b7bd2494ffecbcfe7bce48fa942a662a7b16`
`Base: 9a51b7bd2494ffecbcfe7bce48fa942a662a7b16`

## Verification

- [x] **Measured on hardware, not reasoned about.** pc-papi is an RTX 4090 on driver 610.57.04, so it cannot fail naturally. `tests/fixtures/nvenc_floor` supplies a `libnvidia-encode.so.1` that reports a chosen NVENC API version and forwards everything else to the real driver. Against a driver reporting 13.0:

  | Driver reports | `v2026.724.203728` | `v2026.713.132551` |
  | --- | --- | --- |
  | NVENC 12.0 | failed | failed |
  | NVENC 12.2 | failed | failed |
  | NVENC 13.0 | failed | **opened** |
  | NVENC 13.1 | opened | opened |

  The failing cell prints the reporter's two lines verbatim and returns `-38`, which is the `ENOSYS` their log shows as `Function not implemented`. Both archives open against the host's own driver, so the rollback costs nothing on a current one.
- [x] `ctest -j 8` on the CUDA-off tree: 26 of 26 suites passed, including the newly registered `polaris_prepared_ffmpeg_cmake`. `tests/cmake/test_prepared_ffmpeg.cmake` existed but nothing ran it.
- [x] **RED proven twice on the guard.** Unwiring it from the validator fails the wiring case; raising the ceiling to 13.1 fails the pin. Green again when restored.
- [x] `PreparedFfmpegTests.NvencHevcAndAv1ExposeSplitEncodeMode` passes against the rolled-back archive, so `split_encode_mode` is not lost.
- [x] `npx vitest run`: 96 files, 741 tests passed. RED proven on the console filter by restoring the old suppression, which fails the new case alone.
- [x] The nix NAR hashes were computed with an implementation checked against the value nix itself reported for the current pin, `sha256-ERw553AsQ0s/7oEXCiwjJjZEp1hpe9aCgiEBRs0K0R0=`, which it reproduces exactly.

## What is not covered

No Pascal card and no 580 branch driver in the lab. The floor is measured by reporting the API version a driver would, not by running an actually old driver, so this shows libavcodec's own gate moving and not a full encode on that hardware. The reporter's retest is the remaining check.

The nix `polaris-stream` derivation was not built. There is no nix on this host, and that job is manual plus weekly rather than per PR, so the hashes are verified by construction rather than by a build.
