### PR TITLE
feat(devices): add a gamepad-only access preset

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -26,6 +26,7 @@ access until you edit it.
 | Preset | Can | Cannot |
 |---|---|---|
 | **Viewer Access** | Watch an existing stream | Browse the library, launch games, send input |
+| **Gamepad Access** | Watch an existing stream and play with a controller | Browse the library, launch games, send keyboard, mouse, touch, or pen input |
 | **Browse & Watch** | List the library and join an existing stream | Launch games, send input |
 | **Game Control** | Browse, launch, and control games with controller, keyboard, mouse, touch, and pen | Read or set the clipboard, transfer files, run server commands |
 | **Full Control** | Everything, including clipboard, file transfer, and server commands | Nothing withheld; use only for devices you fully trust |
@@ -34,6 +35,11 @@ access until you edit it.
 list apps, view streams, launch apps, clipboard read and set, server command, and the five input
 kinds. A device whose permissions match no preset shows as
 **Custom Access**.
+
+Gamepad Access exists for handing a controller to a guest: they can join a stream you started
+and play, and they cannot browse what you own, start anything, or reach your keyboard and
+mouse. Pair them with temporary authorization and both the access and the pairing end when
+they disconnect.
 
 A device with Browse & Watch that tries to start a stream gets a permission-denied answer; the
 [troubleshooting entry](troubleshooting.md#paired-client-gets-permission-denied-403-when-starting-a-stream)

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -74,6 +74,7 @@ namespace crypto {
     _all_actions     = list | view | launch,
 
     _default         = view | list,      // Browse and watch without launch or input
+    _gamepad_only    = view | input_controller, // Watch a stream and play, nothing else
     _game_control    = _all_inputs | _all_actions, // Game launch/control without operations
     _no              = 0,                // No permissions are granted
     _all             = _all_inputs | _all_opeiations | _all_actions, // All current permissions

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3018,6 +3018,9 @@ namespace nvhttp {
   using PERM = crypto::PERM;
 
   std::optional<pairing_access_preset_t> pairing_access_preset_from_view(std::string_view preset) {
+    if (preset == "gamepad"sv) {
+      return pairing_access_preset_t::gamepad;
+    }
     if (preset == "standard"sv) {
       return pairing_access_preset_t::standard;
     }
@@ -3032,6 +3035,8 @@ namespace nvhttp {
 
   PERM pairing_access_preset_perm(pairing_access_preset_t preset) {
     switch (preset) {
+      case pairing_access_preset_t::gamepad:
+        return PERM::_gamepad_only;
       case pairing_access_preset_t::standard:
         return PERM::_default;
       case pairing_access_preset_t::game_control:
@@ -3044,6 +3049,8 @@ namespace nvhttp {
 
   std::string_view pairing_access_preset_name(pairing_access_preset_t preset) {
     switch (preset) {
+      case pairing_access_preset_t::gamepad:
+        return "gamepad"sv;
       case pairing_access_preset_t::standard:
         return "standard"sv;
       case pairing_access_preset_t::game_control:

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -200,6 +200,7 @@ namespace nvhttp {
   };
 
   enum class pairing_access_preset_t {
+    gamepad,
     standard,
     game_control,
     full

--- a/src_assets/common/assets/web/composables/useClients.js
+++ b/src_assets/common/assets/web/composables/useClients.js
@@ -22,6 +22,7 @@ export const permissionMapping = {
   _allow_view: 0x06000000,
   _all_actions: 0x07000000,
   _default: 0x03000000,
+  _gamepad_only: 0x02000100,
   _game_control: 0x07001F00,
   _no: 0x00000000,
   _all: 0x071F1F00
@@ -29,6 +30,7 @@ export const permissionMapping = {
 
 export const permissionPresetMasks = {
   viewer: permissionMapping.view,
+  gamepad: permissionMapping._gamepad_only,
   standard: permissionMapping._default,
   game_control: permissionMapping._game_control,
   full: permissionMapping._all,
@@ -44,6 +46,7 @@ export function permissionPresetKey(perm) {
   if ((perm & permissionMapping._all) === permissionMapping._all) return 'full'
   if (perm === permissionMapping._game_control) return 'game_control'
   if (perm === permissionMapping._default) return 'standard'
+  if (perm === permissionMapping._gamepad_only) return 'gamepad'
   if (perm === permissionMapping.view || perm === permissionMapping.list || perm === permissionMapping._allow_view) return 'viewer'
   return 'custom'
 }

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -1500,6 +1500,8 @@
     "full_control_desc": "Game Control plus clipboard, file transfer, and server commands. Use only for fully trusted devices.",
     "game_control_access": "Game Control",
     "game_control_access_desc": "Browse, launch, and control games without clipboard, file, or server-command access.",
+    "gamepad_access": "Gamepad Access",
+    "gamepad_access_desc": "Watch an existing stream and play with a controller. Cannot browse the library, launch games, or send keyboard, mouse, touch, or pen input.",
     "generate_qr": "Generate QR Code",
     "host_address": "Host Address",
     "host_address_placeholder": "e.g. 10.0.0.10",

--- a/src_assets/common/assets/web/useClients.test.js
+++ b/src_assets/common/assets/web/useClients.test.js
@@ -24,6 +24,28 @@ describe('client permission presets', () => {
     expect(permissionPresetKey(mask)).toBe('game_control')
   })
 
+  it('maps Gamepad Access to viewing plus controller input and nothing else', () => {
+    const mask = permissionPresetMask('gamepad')
+
+    expect(mask).toBe(permissionMapping.view | permissionMapping.input_controller)
+    expect(mask & permissionMapping._all_inputs).toBe(permissionMapping.input_controller)
+    expect(mask & permissionMapping.list).toBe(0)
+    expect(mask & permissionMapping.launch).toBe(0)
+    expect(mask & permissionMapping._all_operations).toBe(0)
+    expect(permissionPresetKey(mask)).toBe('gamepad')
+  })
+
+  it('still reads a hand-tuned permission set as Custom Access', () => {
+    // Viewer plus keyboard matches no preset, and must not be mistaken for the gamepad one.
+    const handTuned = permissionMapping.view | permissionMapping.input_kbd
+    expect(permissionPresetKey(handTuned)).toBe('custom')
+  })
+
+  it('maps Viewer Access to viewing alone', () => {
+    expect(permissionPresetMask('viewer')).toBe(permissionMapping.view)
+    expect(permissionPresetKey(permissionMapping.view)).toBe('viewer')
+  })
+
   it('maps Full Control to the existing full permission mask', () => {
     expect(permissionPresetMask('full')).toBe(permissionMapping._all)
     expect(permissionPresetKey(permissionMapping._all)).toBe('full')

--- a/src_assets/common/assets/web/views/PinView.vue
+++ b/src_assets/common/assets/web/views/PinView.vue
@@ -74,7 +74,7 @@
             {{ selectedPairingAccessLabel }}
           </span>
         </div>
-        <div class="mt-4 grid gap-2 lg:grid-cols-3" role="radiogroup" :aria-label="$t('pin.pairing_access_title')">
+        <div class="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4" role="radiogroup" :aria-label="$t('pin.pairing_access_title')">
           <button
             v-for="preset in pairingPermissionPresets"
             :key="preset.key"
@@ -1005,6 +1005,12 @@ const permissionPresets = [
     activeClass: 'border-info/40 bg-info/10 text-info-bright',
   },
   {
+    key: 'gamepad',
+    labelKey: 'pin.gamepad_access',
+    descriptionKey: 'pin.gamepad_access_desc',
+    activeClass: 'border-warning/40 bg-warning/10 text-warning-bright',
+  },
+  {
     key: 'game_control',
     labelKey: 'pin.game_control_access',
     descriptionKey: 'pin.game_control_access_desc',
@@ -1024,7 +1030,7 @@ const permissionPresets = [
     activeClass: 'border-danger/40 bg-danger/10 text-danger-bright',
   },
 ]
-const pairingPermissionPresets = permissionPresets.filter((preset) => ['standard', 'game_control', 'full'].includes(preset.key))
+const pairingPermissionPresets = permissionPresets.filter((preset) => ['gamepad', 'standard', 'game_control', 'full'].includes(preset.key))
 
 let resetOTPTimeout = null
 let qrContainer = null
@@ -1521,6 +1527,8 @@ function accessPresetLabel(perm) {
       return i18n.t('pin.game_control_access')
     case 'standard':
       return i18n.t('pin.standard_access')
+    case 'gamepad':
+      return i18n.t('pin.gamepad_access')
     case 'viewer':
       return i18n.t('pin.viewer_access')
     default:
@@ -1536,6 +1544,8 @@ function accessToneClass(perm) {
       return 'border-success/30 bg-success/10 text-success-bright'
     case 'standard':
       return 'border-ice/30 bg-ice/10 text-ice'
+    case 'gamepad':
+      return 'border-warning/30 bg-warning/10 text-warning-bright'
     case 'viewer':
       return 'border-info/30 bg-info/10 text-info-bright'
     default:

--- a/tests/unit/test_http_pairing.cpp
+++ b/tests/unit/test_http_pairing.cpp
@@ -610,6 +610,24 @@ TEST_F(PairingAccessPresetTest, ParsesAccessPresets) {
   );
   EXPECT_EQ(pairing_access_preset_name(*game_control), "game_control"sv);
 
+  const auto gamepad = pairing_access_preset_from_view("gamepad");
+  ASSERT_TRUE(gamepad);
+  EXPECT_EQ(pairing_access_preset_perm(*gamepad), crypto::PERM::_gamepad_only);
+  EXPECT_EQ(pairing_access_preset_name(*gamepad), "gamepad"sv);
+  // Watching and a controller, nothing else. This is the whole preset, so pin every half of it.
+  EXPECT_EQ(
+    static_cast<uint32_t>(pairing_access_preset_perm(*gamepad) & crypto::PERM::_all_inputs),
+    static_cast<uint32_t>(crypto::PERM::input_controller)
+  );
+  EXPECT_EQ(
+    static_cast<uint32_t>(pairing_access_preset_perm(*gamepad) & crypto::PERM::_all_actions),
+    static_cast<uint32_t>(crypto::PERM::view)
+  );
+  EXPECT_EQ(
+    static_cast<uint32_t>(pairing_access_preset_perm(*gamepad) & crypto::PERM::_all_opeiations),
+    0U
+  );
+
   const auto full = pairing_access_preset_from_view("full");
   ASSERT_TRUE(full);
   EXPECT_EQ(pairing_access_preset_perm(*full), crypto::PERM::_all);


### PR DESCRIPTION
## Summary

Closes #655.

- Adds `PERM::_gamepad_only`, which is `view | input_controller` and nothing else.
- Adds it as a fifth access preset, **Gamepad Access**, in the device editor and at pairing time.
- Documents it in `docs/devices.md`, including what it is for.

Handing a controller to a friend took a manual edit every time. The presets went from watching a stream straight to browsing and launching everything, so sharing a session meant picking Viewer Access and then turning the controller bit back on by hand, per guest, which then read as Custom Access afterwards and said nothing about what had been chosen.

A device on Gamepad Access can join a stream that is already running and play. It cannot see what you own, start anything, reach your keyboard, mouse, touch or pen, read or set your clipboard, move files, or run commands. Paired with temporary authorization it is a guest who is gone when they disconnect.

The permissions it is built from already existed and are already enforced per input packet, so this is a preset over them rather than new plumbing. Devices persist the numeric mask and never a preset name, so nothing migrates, and anyone who had already hand tuned exactly this pair now reads as Gamepad Access instead of Custom Access.

It is offered at pairing time as well as in the editor, which is the point of it. The guest case is a pairing, so leaving it editor only would have kept the per guest manual step the request was about.

Saved user defined presets, the other half of the original ask, are deliberately not here. That one is real machinery, and this may remove most of the reason to want it.

## Exact candidate

`Commit: 82e72a5a59d758fdc9aa5209d1519af7d19901a3`
`Tree: 394f71d65117d286fdc4b2e870c3fc97deeb4c2e`
`Parent: 9a51b7bd2494ffecbcfe7bce48fa942a662a7b16`
`Base: 9a51b7bd2494ffecbcfe7bce48fa942a662a7b16`

## Verification

- [x] `ctest -j 8` on the CUDA-off tree: 25 of 25 suites passed.
- [x] `PairingAccessPresetTest`: 43 tests passed. `ParsesAccessPresets` now pins both halves of the new preset, that the input bits are exactly `input_controller` and the action bits exactly `view`, and that it grants no operation bits.
- [x] **RED proven.** Mapping the preset to `PERM::_default` instead fails `ParsesAccessPresets` on the mask and on both halves. Green again when restored.
- [x] `npx vitest run`: 96 files, 743 tests passed. `useClients.test.js` gains the new preset round trip, a Viewer case it never had, and a case pinning that viewer plus keyboard still reads as Custom Access rather than being mistaken for this one.
- [x] Only `pairing_access_preset_from_view` validates the wire name, so the console, `getOTP` and `savePin` all accept `gamepad` through the same gate. There is no second allow list to keep in step.

## What is not covered

No live pairing run through the console against a real guest device. The mask is the one the fine tune toggles already produce and the enforcement path is unchanged, so what is untested here is the UI journey rather than the permission, but that journey is worth a look before release.

The pairing grid went from three columns to a two by four responsive one to fit a fourth card. That was not checked on a phone width browser.
