### PR TITLE
fix(doctor): say why HDR did not engage, where someone will see it

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7450,6 +7450,19 @@ namespace proc {
       return it != preset_resolution.fields.end() && it->is_object() ?
         it->value("source", std::string {}) : std::string {};
     };
+    const auto resolved_field_reason = [&](std::string_view field) -> std::string {
+      const auto it = preset_resolution.fields.find(std::string {field});
+      return it != preset_resolution.fields.end() && it->is_object() ?
+        it->value("reason_code", std::string {}) : std::string {};
+    };
+    // Record why HDR ended up where it did, so Doctor can say so later. A saved setting that
+    // turns HDR off stops the client ever requesting it, which means every capability-based
+    // check downstream stays silent and the user is left with no explanation at all.
+    stream_stats::update_hdr_policy(
+      preset_resolution.hdr,
+      resolved_field_reason("hdr"),
+      launch_session->device_name
+    );
     resolved_optimization.display_mode = parsed_display_mode_t {
       preset_resolution.width,
       preset_resolution.height,

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -568,6 +568,8 @@ namespace stream_stats {
     j["convert_path"] = encode_target_device.empty() ? "unknown" : encode_target_device;
     j["dynamic_range"] = dynamic_range;
     j["display_hdr"] = display_hdr;
+    j["hdr_policy_reason"] = hdr_policy_reason;
+    j["hdr_policy_hdr"] = hdr_policy_hdr;
     j["hdr_metadata_available"] = hdr_metadata_available;
     j["stream_hdr_enabled"] = stream_hdr_enabled;
     j["color_coding"] = color_coding;
@@ -789,6 +791,67 @@ namespace stream_stats {
     }
   #endif
 #endif
+    // A client asked for HDR and did not get it. hdr_downgrade_message already says why, but
+    // only over the session status route, and only while a stream is live. Put it where someone
+    // looking for a reason will actually stand. The wlroots capture classes never override
+    // is_hdr(), so on that path the answer is permanent and worth saying out loud rather than
+    // leaving the user to re-toggle a switch that cannot work.
+    // HDR turned off by something the user saved, rather than by what the hardware can do.
+    // This one has to speak without a client ever asking for HDR, because that is the whole
+    // shape of it: the saved setting stops the request being made at all, so dynamic_range stays
+    // zero and every capability-based check below stays quiet. Name the file, because nothing in
+    // a normal log does.
+    if (!stats.hdr_policy_hdr && !stats.hdr_policy_reason.empty()) {
+      const auto &reason = stats.hdr_policy_reason;
+      const auto device = stats.hdr_policy_device.empty() ? std::string {"this device"} : stats.hdr_policy_device;
+      std::string message;
+      std::string action;
+      if (reason == "paired_device_hdr_unsupported") {
+        message = "HDR is switched off for " + device + " in device_db.json, where hdr_capable is "
+                  "false. Polaris will not ask for HDR for that device however the client is set.";
+        action = "If the device's display really does support HDR, set hdr_capable for it in "
+                 "device_db.json, restart Polaris, and check the HDR row again.";
+      } else if (reason == "client_profile_hdr_lock") {
+        message = "HDR is switched off for " + device + " in its saved client profile, which "
+                  "overrides what the client asks for.";
+        action = "Turn Enable HDR back on for that device on the Devices page, or delete its "
+                 "saved profile, then start a stream and check the HDR row again.";
+      } else if (reason == "host_encoder_hdr_unsupported") {
+        message = "HDR was refused because this host's encoder did not advertise a 10-bit "
+                  "profile when the stream was resolved.";
+        action = "Check the encoder row. If NVENC or VA-API fell back, fix that first; HDR "
+                 "follows the encoder.";
+      }
+      if (!message.empty()) {
+        configuration_warnings.push_back({
+          {"id", "hdr_disabled_by_saved_setting"},
+          {"severity", "info"},
+          {"message", message},
+          {"action", action}
+        });
+      }
+    }
+
+    if (const auto hdr_reason = hdr_downgrade_reason(stats);
+        hdr_reason == "headless_hdr_unavailable" || hdr_reason == "display_not_hdr") {
+      const bool wlroots_capture =
+        config::video.capture == "wlr" ||
+        (config::video.capture.empty() && linux_display.use_cage_compositor);
+      configuration_warnings.push_back({
+        {"id", "hdr_capture_path_cannot_report_hdr"},
+        {"severity", "info"},
+        {"message", wlroots_capture ?
+           "A client asked for HDR and Polaris streamed 10-bit SDR instead. The wlroots capture "
+           "path this host is using does not report display HDR at all, so HDR cannot engage on "
+           "it whatever the monitor, GPU or client can do." :
+           "A client asked for HDR and Polaris streamed 10-bit SDR instead, because the active "
+           "capture display did not report HDR."},
+        {"action", "True HDR needs a capture path that reads the display's HDR metadata, which "
+                   "today means a KMS/DRM path on an HDR-capable output. Private Stream on "
+                   "headless labwc is always SDR. See docs/runtime.md."}
+      });
+    }
+
     if (adapter_pairing_status == "mismatched") {
       configuration_warnings.push_back({
         {"id", "linux_gpu_adapter_mismatch"},
@@ -1658,6 +1721,22 @@ namespace stream_stats {
         stats.input_steam_input_detail
     );
 
+    const auto hdr_reason = hdr_downgrade_reason(stats);
+    append_doctor_evidence(
+      evidence,
+      "hdr",
+      "HDR",
+      hdr_effective_mode(stats),
+      "",
+      stats.stream_hdr_enabled ? "pass" : stats.dynamic_range > 0 ? "watch" : "info",
+      "capture_display",
+      hdr_reason == "none" ?
+        (stats.stream_hdr_enabled ?
+           "Streaming HDR10." :
+           "No client has asked for HDR on this host.") :
+        hdr_downgrade_message(stats)
+    );
+
     auto advanced = nlohmann::json::object();
     advanced["stream_stats_keys"] = nlohmann::json::array({"capture_path", "capture_path_reason", "capture_transport", "capture_residency", "capture_format", "capture_cpu_copy", "capture_gpu_native", "capture_cross_gpu_dmabuf_risk", "encode_target_device", "encode_target_residency", "fps", "encode_time_ms", "packet_loss", "packet_loss_available", "packet_loss_source", "control_channel_packet_loss", "control_channel_samples", "frame_interval_error_ms", "frame_jitter_ms", "video_policy_sample_count", "pacing_warning_streak", "fec_protection"});
     advanced["linux_gpu_profile"] = linux_gpu_profile_json(stats);
@@ -1829,6 +1908,17 @@ namespace stream_stats {
       const auto steam_opt_in = current_stats.input_steam_profiles_with_xbox_support;
       const auto steam_forced = current_stats.input_steam_forced_app_count;
       const auto steam_detail = current_stats.input_steam_input_detail;
+      // The HDR facts describe the host's capture path, not the stream that just ended, and the
+      // person who wants to know why HDR did not engage goes looking for the answer after
+      // disconnecting, not during. Same reasoning as the controller-input fields above.
+      const auto hdr_dynamic_range = current_stats.dynamic_range;
+      const auto hdr_display = current_stats.display_hdr;
+      const auto hdr_metadata = current_stats.hdr_metadata_available;
+      const auto hdr_stream_enabled = current_stats.stream_hdr_enabled;
+      const auto hdr_effective_headless = current_stats.runtime_effective_headless;
+      const auto hdr_policy_reason = current_stats.hdr_policy_reason;
+      const auto hdr_policy_hdr = current_stats.hdr_policy_hdr;
+      const auto hdr_policy_device = current_stats.hdr_policy_device;
 
       current_stats = stats_t {};
       clear_capture_profile_buckets();
@@ -1841,6 +1931,15 @@ namespace stream_stats {
       current_stats.input_steam_profiles_with_xbox_support = steam_opt_in;
       current_stats.input_steam_forced_app_count = steam_forced;
       current_stats.input_steam_input_detail = steam_detail;
+
+      current_stats.dynamic_range = hdr_dynamic_range;
+      current_stats.display_hdr = hdr_display;
+      current_stats.hdr_metadata_available = hdr_metadata;
+      current_stats.stream_hdr_enabled = hdr_stream_enabled;
+      current_stats.runtime_effective_headless = hdr_effective_headless;
+      current_stats.hdr_policy_reason = hdr_policy_reason;
+      current_stats.hdr_policy_hdr = hdr_policy_hdr;
+      current_stats.hdr_policy_device = hdr_policy_device;
     }
   }
 
@@ -2575,6 +2674,13 @@ namespace stream_stats {
   void update_dynamic_range(int dynamic_range) {
     std::lock_guard<std::mutex> lock(stats_mutex);
     current_stats.dynamic_range = dynamic_range;
+  }
+
+  void update_hdr_policy(bool hdr, const std::string &reason_code, const std::string &device) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.hdr_policy_hdr = hdr;
+    current_stats.hdr_policy_reason = reason_code;
+    current_stats.hdr_policy_device = device;
   }
 
   void update_hdr_state(bool display_hdr,

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -152,6 +152,12 @@ namespace stream_stats {
     platf::frame_format_e encode_target_format = platf::frame_format_e::unknown;
     int dynamic_range = 0;
     bool display_hdr = false;
+    /// Why the resolved launch profile turned HDR off, when it did. Empty when policy did
+    /// not decide it. Survives the end of the stream: it describes the host's saved
+    /// settings for a device, not the session that just ended.
+    std::string hdr_policy_reason;
+    bool hdr_policy_hdr = false;
+    std::string hdr_policy_device;
     bool hdr_metadata_available = false;
     bool stream_hdr_enabled = false;
     std::string color_coding;
@@ -736,6 +742,14 @@ namespace stream_stats {
    * @param stream_hdr_enabled Whether Polaris is advertising true HDR for the stream.
    * @param color_coding Human-readable color coding label.
    */
+  /**
+   * @brief Record what the resolved launch profile decided about HDR, and why.
+   * @param hdr Whether the resolved profile enabled HDR.
+   * @param reason_code The launch-profile reason code behind that value.
+   * @param device The paired device the decision was made for.
+   */
+  void update_hdr_policy(bool hdr, const std::string &reason_code, const std::string &device);
+
   void update_hdr_state(bool display_hdr,
                         bool hdr_metadata_available,
                         bool stream_hdr_enabled,

--- a/tests/unit/test_stream_stats.cpp
+++ b/tests/unit/test_stream_stats.cpp
@@ -30,6 +30,7 @@ namespace {
   struct LinuxDisplayConfigGuard {
     LinuxDisplayConfigGuard():
         adapter_name {config::video.adapter_name},
+        capture {config::video.capture},
         encoder {config::video.encoder},
         headless_mode {config::video.linux_display.headless_mode},
         use_cage_compositor {config::video.linux_display.use_cage_compositor},
@@ -38,6 +39,7 @@ namespace {
 
     ~LinuxDisplayConfigGuard() {
       config::video.adapter_name = adapter_name;
+      config::video.capture = capture;
       config::video.encoder = encoder;
       config::video.linux_display.headless_mode = headless_mode;
       config::video.linux_display.use_cage_compositor = use_cage_compositor;
@@ -45,6 +47,7 @@ namespace {
     }
 
     std::string adapter_name;
+    std::string capture;
     std::string encoder;
     bool headless_mode;
     bool use_cage_compositor;
@@ -880,6 +883,147 @@ TEST(StreamStatsFecProtectionTests, RoutesEvidenceBySessionGeneration) {
     stream_stats::get_current().fec_protection.oversized_frames_total,
     0
   );
+}
+
+TEST(StreamStatsDoctorTests, NamesTheCapturePathWhenHdrWasAskedForAndNotDelivered) {
+  // The host already knew why and only ever said so over the session-status route, while a
+  // stream was live. A person who ticks "request HDR", sees SDR and goes looking for a reason
+  // is standing in front of the console with nothing streaming.
+  LinuxDisplayConfigGuard guard;
+  config::video.capture = "wlr";
+  config::video.linux_display.use_cage_compositor = true;
+
+  stream_stats::stats_t stats {};
+  stats.dynamic_range = 1;
+  stats.runtime_effective_headless = true;
+  stats.display_hdr = false;
+  stats.hdr_metadata_available = false;
+  stats.stream_hdr_enabled = false;
+
+  const auto doctor = stream_stats::build_doctor_json(stats, {{"primary_issue", "steady"}, {"grade", "good"}});
+
+  bool saw_hdr_evidence = false;
+  for (const auto &entry : doctor.at("evidence")) {
+    if (entry.at("id") != "hdr") {
+      continue;
+    }
+    saw_hdr_evidence = true;
+    EXPECT_EQ(entry.at("status"), "watch");
+    EXPECT_EQ(entry.at("value"), "sdr_10bit");
+    EXPECT_NE(entry.at("detail").get<std::string>().find("10-bit SDR, not HDR"), std::string::npos);
+  }
+  EXPECT_TRUE(saw_hdr_evidence);
+
+  bool saw_warning = false;
+  for (const auto &warning :
+       doctor.at("advanced_evidence").at("linux_gpu_profile").at("configuration_warnings")) {
+    if (warning.at("id") != "hdr_capture_path_cannot_report_hdr") {
+      continue;
+    }
+    saw_warning = true;
+    EXPECT_EQ(warning.at("severity"), "info");
+    // The wlroots path never overrides is_hdr(), so this is permanent, not a bad moment.
+    EXPECT_NE(warning.at("message").get<std::string>().find("wlroots"), std::string::npos);
+    EXPECT_NE(warning.at("action").get<std::string>().find("KMS/DRM"), std::string::npos);
+  }
+  EXPECT_TRUE(saw_warning);
+}
+
+TEST(StreamStatsDoctorTests, HdrEvidenceStaysInformationalWhenNobodyAskedForHdr) {
+  // Most hosts never ask for HDR. The row still reports, but it must not nag, and it must not
+  // accuse a capture path of failing at something nobody requested.
+  LinuxDisplayConfigGuard guard;
+  config::video.capture = "wlr";
+  config::video.linux_display.use_cage_compositor = true;
+
+  stream_stats::stats_t stats {};
+  stats.dynamic_range = 0;
+
+  const auto doctor = stream_stats::build_doctor_json(stats, {{"primary_issue", "steady"}, {"grade", "good"}});
+
+  bool saw_hdr_evidence = false;
+  for (const auto &entry : doctor.at("evidence")) {
+    if (entry.at("id") != "hdr") {
+      continue;
+    }
+    saw_hdr_evidence = true;
+    EXPECT_EQ(entry.at("status"), "info");
+    EXPECT_EQ(entry.at("value"), "sdr_8bit");
+  }
+  EXPECT_TRUE(saw_hdr_evidence);
+
+  for (const auto &warning :
+       doctor.at("advanced_evidence").at("linux_gpu_profile").at("configuration_warnings")) {
+    EXPECT_NE(warning.at("id"), "hdr_capture_path_cannot_report_hdr");
+  }
+}
+
+TEST(StreamStatsDoctorTests, NamesTheSavedSettingThatSwitchedHdrOff) {
+  // This is the shape that leaves someone with nothing to go on. A saved setting stops HDR being
+  // requested at all, so dynamic_range never leaves zero, hdr_downgrade_reason answers "none",
+  // and every capability-based check stays quiet while the user re-toggles a client switch that
+  // was never the problem. It has to speak without a request having been made.
+  LinuxDisplayConfigGuard guard;
+
+  stream_stats::stats_t stats {};
+  stats.dynamic_range = 0;
+  stats.hdr_policy_hdr = false;
+  stats.hdr_policy_reason = "paired_device_hdr_unsupported";
+  stats.hdr_policy_device = "RetroidPocket6";
+
+  const auto doctor = stream_stats::build_doctor_json(stats, {{"primary_issue", "steady"}, {"grade", "good"}});
+
+  bool saw_warning = false;
+  for (const auto &warning :
+       doctor.at("advanced_evidence").at("linux_gpu_profile").at("configuration_warnings")) {
+    if (warning.at("id") != "hdr_disabled_by_saved_setting") {
+      continue;
+    }
+    saw_warning = true;
+    const auto message = warning.at("message").get<std::string>();
+    EXPECT_NE(message.find("device_db.json"), std::string::npos);
+    EXPECT_NE(message.find("RetroidPocket6"), std::string::npos);
+    EXPECT_NE(warning.at("action").get<std::string>().find("hdr_capable"), std::string::npos);
+  }
+  EXPECT_TRUE(saw_warning);
+}
+
+TEST(StreamStatsDoctorTests, SaysNothingAboutSavedSettingsWhenHdrWasAllowed) {
+  LinuxDisplayConfigGuard guard;
+
+  stream_stats::stats_t stats {};
+  stats.hdr_policy_hdr = true;
+  stats.hdr_policy_reason = "requested_hdr_setting";
+  stats.hdr_policy_device = "RetroidPocket6";
+
+  const auto doctor = stream_stats::build_doctor_json(stats, {{"primary_issue", "steady"}, {"grade", "good"}});
+
+  for (const auto &warning :
+       doctor.at("advanced_evidence").at("linux_gpu_profile").at("configuration_warnings")) {
+    EXPECT_NE(warning.at("id"), "hdr_disabled_by_saved_setting");
+  }
+}
+
+TEST(StreamStatsDoctorTests, HdrVerdictSurvivesTheEndOfTheStream) {
+  // Same reasoning as the Steam Input finding above: the answer describes the host's capture
+  // path, and the person asking the question has already disconnected.
+  stream_stats::update_stream_active(true, "client", "10.0.0.5");
+  stream_stats::update_dynamic_range(1);
+  stream_stats::update_hdr_state(false, false, false, "SDR (Rec. 709)");
+  stream_stats::update_hdr_policy(false, "paired_device_hdr_unsupported", "RetroidPocket6");
+
+  stream_stats::update_stream_active(false, "", "");
+
+  const auto after = stream_stats::get_current();
+  EXPECT_FALSE(after.streaming);
+  EXPECT_EQ(after.dynamic_range, 1);
+  EXPECT_FALSE(after.stream_hdr_enabled);
+  EXPECT_EQ(stream_stats::hdr_effective_mode(after), "sdr_10bit");
+  EXPECT_NE(stream_stats::hdr_downgrade_reason(after), "none");
+  EXPECT_EQ(after.hdr_policy_reason, "paired_device_hdr_unsupported");
+  EXPECT_EQ(after.hdr_policy_device, "RetroidPocket6");
+
+  stream_stats::update_stream_active(false, "", "");
 }
 
 TEST(StreamStatsDoctorTests, SteamInputFindingSurvivesTheEndOfTheStream) {


### PR DESCRIPTION
## Summary

- Adds an `hdr` row to the Doctor report, so HDR has a status at all.
- Adds two host configuration warnings: one naming a capture path that cannot report HDR, one
  naming the saved setting that switched HDR off before anyone could ask for it.
- Carries the HDR facts across the end of the stream, so the answer is still there when the
  person goes looking for it.

Polaris has known why HDR does not engage for a long time and has never shown it to anyone
standing in front of the console. `hdr_downgrade_reason` already classifies the ways it can fail
and `hdr_downgrade_message` already writes a good sentence about each, but both are reachable only
over the paired session-status route, only while a stream is live, and only once a client has
already asked for HDR. Tick "request HDR", watch an SDR stream, disconnect, go looking for a
reason, find nothing.

Two shapes are now covered.

**The capture path cannot carry HDR.** `stream_hdr_enabled` needs the capture display to report
HDR and hand back usable metadata (`video.cpp:742-766`), and only `kmsgrab` and the portal path
override either; the wlroots display classes inherit the `return false` in `platform/common.h:644`.
On that path the answer is permanent, not a bad moment, so the warning says so rather than leaving
someone re-toggling a client switch all evening. It points at the only thing that works today and
at `docs/runtime.md`, which has said this all along.

**A saved setting switched it off, and this is the one that leaves a person with nothing.** A
`device_db` entry with `hdr_capable` false, or a client profile with HDR unchecked, stops the
request being made at all. `dynamic_range` never leaves zero, `hdr_downgrade_reason` answers
`"none"`, every capability check stays quiet, and the switch the user keeps toggling was never what
decided it. The launch profile already computes a reason code for that decision and discarded it;
it now reaches Doctor, which names the file to edit.

This explains the failure. **It does not fix it.** Making HDR work on the default capture path is a
separate and much larger piece of work.

## Exact candidate

`Commit: f5ec7315d366d2c7cb9a74908870891bd1b324b0`
`Tree: 94e66aee8b27f7274fb22a05fb40eee0aed955d0`
`Parent: 2747f4a243503c788a6841d5178afc0bba5d2951`
`Base: 2747f4a243503c788a6841d5178afc0bba5d2951`

## Verification

- [x] `ctest -j 8` on the CUDA-off tree: 25 of 25 suites passed.
- [x] Five new cases in `StreamStatsDoctorTests`: the capture-path warning and its evidence row,
      the informational row when nobody asked for HDR, the saved-setting warning naming
      `device_db.json` and the device, silence when HDR was allowed, and survival across the end
      of the stream.
- [x] **RED proven, one piece at a time.** Removing the evidence row fails the two rows that read
      it; removing the capture-path warning fails only that case; removing the saved-setting
      warning fails only that case; removing the stream-end preservation fails only the survival
      case. Green again when each is restored.
- [x] The reason codes used here are the ones `launch_profile.cpp:536-556` already emits, so the
      vocabulary is not new and not invented for this change.

## What is not covered

Not exercised on hardware. The warnings are driven by stats and config that the tests set
directly, so what is proven is the wording and the gating, not a live session reaching those
states. The wording was written against a real host's saved settings and a real reporter's log,
not imagined.

Two follow-ups are deliberately not here. The host still trusts a stale `hdr_capable: false` over
what the client reports, even though Nova already reports `supports_hdr10_display` from the
streaming session and the host stores it in the client sync record without ever consulting it.
And Nova parses `hdrDowngradeMessage` and displays none of it, so the explanation still does not
reach the handheld. Both are their own changes.
