### PR TITLE
fix(input): give a client the controller it asked for, from its second launch on

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -107,6 +107,10 @@ namespace crypto {
     std::string uuid;
     std::string cert;
     std::string client_family;
+    /// Last controller type this client declared on arrival (an LI_CTYPE_* value), so the
+    /// pad preallocated before the app launches can be the one it actually asked for.
+    /// Zero means never observed, which is what a first session from a new device looks like.
+    int controller_type = 0;
     std::string display_mode;
     int target_bitrate_kbps = 0;
     std::int64_t paired_at = 0;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -251,7 +251,7 @@ namespace input {
     return true;
   }
 
-  void preallocate_gamepad() {
+  void preallocate_gamepad(int client_controller_type) {
     if (!config::input.controller) {
       return;
     }
@@ -272,7 +272,12 @@ namespace input {
     }
 
     constexpr int controller_number = 0;
-    if (platf::alloc_gamepad(platf_input, {id, static_cast<std::uint8_t>(controller_number)}, {}, preallocated_gamepad_feedback_queue)) {
+    const platf::gamepad_arrival_t remembered {
+      static_cast<std::uint8_t>(client_controller_type),
+      0,
+      0
+    };
+    if (platf::alloc_gamepad(platf_input, {id, static_cast<std::uint8_t>(controller_number)}, remembered, preallocated_gamepad_feedback_queue)) {
       free_id(gamepadMask, id);
       update_controller_diagnostics(false, controller_number, "ControllerNumber [0] could not be preallocated before app launch.");
       BOOST_LOG(warning) << "ControllerNumber [0] could not be preallocated before app launch"sv;
@@ -961,6 +966,11 @@ namespace input {
     }
 
     if (input->gamepads[packet->controllerNumber].id >= 0) {
+      // The pad was preallocated before the app launched, which is the only way a game sees a
+      // controller at startup, so this arrival is too late to change it. Remember what the
+      // client asked for instead, and say so, because silently emulating the wrong pad for a
+      // whole session used to leave nothing in the log at all.
+      stream_stats::update_client_declared_controller_type(packet->type);
       BOOST_LOG(debug) << "ControllerNumber already allocated ["sv << packet->controllerNumber << ']';
       return;
     }

--- a/src/input.h
+++ b/src/input.h
@@ -25,7 +25,14 @@ namespace input {
 
   bool probe_gamepads();
 
-  void preallocate_gamepad();
+  /**
+   * @brief Create controller 0 before the app launches.
+   * @param client_controller_type An LI_CTYPE_* the client declared on a previous session,
+   *        or 0 when nothing is known. The pad has to exist before the app starts so the
+   *        game sees it at startup, which is earlier than the client's own arrival packet,
+   *        so the only way to get the right pad is to remember the last one.
+   */
+  void preallocate_gamepad(int client_controller_type = 0);
   std::shared_ptr<input_t> alloc(safe::mail_t mail);
 
 #ifdef POLARIS_TESTS

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -4002,6 +4002,7 @@ namespace nvhttp {
         named_cert_node["paired_at"] = named_cert_p->paired_at;
         named_cert_node["last_seen_at"] = named_cert_p->last_seen_at.load(std::memory_order_relaxed);
         named_cert_node["client_family"] = named_cert_p->client_family;
+        named_cert_node["controller_type"] = named_cert_p->controller_type;
         named_cert_node["display_mode"] = named_cert_p->display_mode;
         named_cert_node["target_bitrate_kbps"] = named_cert_p->target_bitrate_kbps;
         named_cert_node["perm"] = static_cast<uint32_t>(named_cert_p->perm);
@@ -4163,6 +4164,7 @@ namespace nvhttp {
           named_cert->last_seen_at.store(last_seen_at, std::memory_order_relaxed);
           named_cert->last_seen_persisted_at.store(last_seen_at, std::memory_order_relaxed);
           named_cert->client_family = entry.value("client_family", "");
+          named_cert->controller_type = entry.value("controller_type", 0);
           named_cert->display_mode = entry.value("display_mode", "");
           named_cert->target_bitrate_kbps = util::get_non_string_json_value<int>(entry, "target_bitrate_kbps", 0);
           named_cert->perm = (PERM)(util::get_non_string_json_value<uint32_t>(entry, "perm", (uint32_t)PERM::_all)) & PERM::_all;
@@ -4208,6 +4210,7 @@ namespace nvhttp {
     clone->uuid = source->uuid;
     clone->cert = source->cert;
     clone->client_family = source->client_family;
+    clone->controller_type = source->controller_type;
     clone->display_mode = source->display_mode;
     clone->target_bitrate_kbps = source->target_bitrate_kbps;
     clone->paired_at = source->paired_at;
@@ -4420,6 +4423,7 @@ namespace nvhttp {
     launch_session->requested_fps = launch_session->fps;
 
     launch_session->device_name = named_cert_p->name.empty() ? "PolarisDisplay"s : named_cert_p->name;
+    launch_session->controller_type = named_cert_p->controller_type;
     launch_session->unique_id = named_cert_p->uuid;
     launch_session->temporary_authorization = named_cert_p->temporary_authorization;
     launch_session->profile_preference = launch_profile::normalize_preset(
@@ -10494,6 +10498,34 @@ namespace nvhttp {
     }
     BOOST_LOG(info) << "Expired temporary authorization for client ["sv << uuid << ']';
     rtsp_stream::finish_cancelled_launch(cancelled_launch);
+    return true;
+  }
+
+  bool remember_client_controller_type(const std::string_view uuid, const int controller_type) {
+    if (controller_type == 0) {
+      return false;
+    }
+    {
+      std::lock_guard lock(client_state_mutex);
+      const auto client = std::find_if(
+        client_root.named_devices.begin(),
+        client_root.named_devices.end(),
+        [&](const crypto::p_named_cert_t &candidate) {
+          return candidate->uuid == uuid;
+        }
+      );
+      if (client == client_root.named_devices.end() ||
+          (*client)->controller_type == controller_type) {
+        return false;
+      }
+      (*client)->controller_type = controller_type;
+      if (!save_state()) {
+        return false;
+      }
+    }
+    BOOST_LOG(info) << "Remembered controller type ["sv << controller_type
+                    << "] for client ["sv << uuid
+                    << "]; the pad created before the next launch will match it"sv;
     return true;
   }
 

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -353,6 +353,14 @@ namespace nvhttp {
   bool is_temporary_client_authorization(std::string_view uuid);
 
   /**
+   * @brief Remember the controller type a paired client declared, for its next launch.
+   * @param uuid The paired client.
+   * @param controller_type An LI_CTYPE_* value.
+   * @return True when the stored value changed and was persisted.
+   */
+  bool remember_client_controller_type(std::string_view uuid, int controller_type);
+
+  /**
    * @brief Remove single client.
    * @param uuid The UUID of the client to remove.
    * @examples

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -8974,7 +8974,7 @@ namespace proc {
     start_steam_big_picture_input_guard(_env, steam_guard_snapshot);
 
     if (has_launch_commands) {
-      input::preallocate_gamepad();
+      input::preallocate_gamepad(launch_session ? launch_session->controller_type : 0);
     }
 
     // Start private runtime, then launch detached app commands into it.

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -54,6 +54,9 @@ namespace rtsp_stream {
 
     std::string device_name;
     std::string unique_id;
+    /// Controller type this client declared last time it streamed, so the pad created
+    /// before the app starts can match. Zero when nothing has been observed yet.
+    int controller_type = 0;
     // Explicit deterministic launch preset. This is never populated from
     // Doctor history or AI output.
     std::string profile_preference = "auto";

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2911,6 +2911,13 @@ namespace stream {
       auto remaining = --running_sessions;
       BOOST_LOG(info) << "Session ended for ["sv << session.device_name << "] [active sessions: "sv << remaining << "]"sv;
 
+      // The client told us which pad it wanted, after the pad it got had already been
+      // created. Keep it, so the next launch from this device starts the right one.
+      nvhttp::remember_client_controller_type(
+        session.device_uuid,
+        stream_stats::client_declared_controller_type()
+      );
+
       bool temporary_authorization_expired = false;
       if (session.temporary_authorization ||
           nvhttp::is_temporary_client_authorization(session.device_uuid)) {

--- a/src/stream_stats.cpp
+++ b/src/stream_stats.cpp
@@ -2676,6 +2676,16 @@ namespace stream_stats {
     current_stats.dynamic_range = dynamic_range;
   }
 
+  void update_client_declared_controller_type(int controller_type) {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    current_stats.client_declared_controller_type = controller_type;
+  }
+
+  int client_declared_controller_type() {
+    std::lock_guard<std::mutex> lock(stats_mutex);
+    return current_stats.client_declared_controller_type;
+  }
+
   void update_hdr_policy(bool hdr, const std::string &reason_code, const std::string &device) {
     std::lock_guard<std::mutex> lock(stats_mutex);
     current_stats.hdr_policy_hdr = hdr;

--- a/src/stream_stats.h
+++ b/src/stream_stats.h
@@ -151,6 +151,9 @@ namespace stream_stats {
     platf::frame_residency_e encode_target_residency = platf::frame_residency_e::unknown;
     platf::frame_format_e encode_target_format = platf::frame_format_e::unknown;
     int dynamic_range = 0;
+    /// An LI_CTYPE_* the client declared after the pad had already been created, so it was
+    /// too late to honour. Zero when no arrival was dropped.
+    int client_declared_controller_type = 0;
     bool display_hdr = false;
     /// Why the resolved launch profile turned HDR off, when it did. Empty when policy did
     /// not decide it. Survives the end of the stream: it describes the host's saved
@@ -748,6 +751,16 @@ namespace stream_stats {
    * @param reason_code The launch-profile reason code behind that value.
    * @param device The paired device the decision was made for.
    */
+  /**
+   * @brief Record the controller type a client declared too late for the preallocated pad.
+   */
+  void update_client_declared_controller_type(int controller_type);
+
+  /**
+   * @brief The controller type a client declared too late, or 0.
+   */
+  int client_declared_controller_type();
+
   void update_hdr_policy(bool hdr, const std::string &reason_code, const std::string &device);
 
   void update_hdr_state(bool display_hdr,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,7 @@ set(TEST_FAST_SOURCES
     ${CMAKE_SOURCE_DIR}/tests/unit/test_kmsgrab_logging_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_kms_capture_metadata.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_video_hdr_probe_guard_source.cpp
+    ${CMAKE_SOURCE_DIR}/tests/unit/test_preallocated_gamepad_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_egl_ctx_release_guard_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_labwc_render_device_source.cpp
     ${CMAKE_SOURCE_DIR}/tests/unit/test_linux_platform_hardening_source.cpp

--- a/tests/unit/test_http_pairing.cpp
+++ b/tests/unit/test_http_pairing.cpp
@@ -647,6 +647,26 @@ TEST_F(PairingAccessPresetTest, RepairingSameCertificateReplacesAuthorizationWit
   EXPECT_EQ(clients[0]["paired_at"].get<std::int64_t>(), original_paired_at);
 }
 
+TEST_F(PairingAccessPresetTest, RemembersTheControllerTypeAClientDeclared) {
+  // The pad is created before the app launches, which is before the client can say what it
+  // wants, so the only way to start the right one is to remember the last answer.
+  auto client = std::make_shared<crypto::named_cert_t>();
+  client->cert = PUBLIC_CERT;
+  client->name = "pad-memory";
+  client->uuid = uuid_util::uuid_t::generate().string();
+  ASSERT_TRUE(add_authorized_client_for_tests(client));
+
+  // Nothing observed yet is the honest state of a device that has never streamed.
+  EXPECT_FALSE(remember_client_controller_type(client->uuid, 0));
+
+  EXPECT_TRUE(remember_client_controller_type(client->uuid, LI_CTYPE_PS));
+  // Writing the same answer again must not churn the state file on every disconnect.
+  EXPECT_FALSE(remember_client_controller_type(client->uuid, LI_CTYPE_PS));
+  EXPECT_TRUE(remember_client_controller_type(client->uuid, LI_CTYPE_XBOX));
+
+  EXPECT_FALSE(remember_client_controller_type(uuid_util::uuid_t::generate().string(), LI_CTYPE_PS));
+}
+
 TEST_F(PairingAccessPresetTest, CanonicallyEquivalentCertificateReplacesAuthorization) {
   auto original = std::make_shared<crypto::named_cert_t>();
   original->cert = PUBLIC_CERT;

--- a/tests/unit/test_preallocated_gamepad_source.cpp
+++ b/tests/unit/test_preallocated_gamepad_source.cpp
@@ -1,0 +1,69 @@
+/**
+ * @file tests/unit/test_preallocated_gamepad_source.cpp
+ * @brief Source guard: the pad created before an app launches must carry the controller type
+ *        the client last declared, and an arrival that arrives too late must not be discarded
+ *        in silence.
+ *
+ * The pad has to exist before the app starts, or a game does not see a controller at startup.
+ * The client's own SS_CONTROLLER_ARRIVAL only comes once the stream is up, which is later. For
+ * a long time preallocate_gamepad() closed that gap by passing an empty arrival, which made
+ * every auto-detect branch of the type ladder in inputtino_gamepad.cpp unreachable and silently
+ * emulated an Xbox pad for every client, including the ones asking for a DualSense. Under strict
+ * isolation the pad cannot be swapped afterwards either, because bubblewrap binds the device node
+ * list at exec time, so remembering the last declared type is the only route to the right pad.
+ *
+ * Creating a uinput device is not something a unit test can do on every runner, so the invariant
+ * is guarded at the source level, the same way test_video_hdr_probe_guard_source.cpp guards its
+ * non-fatal-probe contract.
+ */
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+  std::string read_input_source() {
+    const auto path = std::filesystem::path {POLARIS_SOURCE_DIR} / "src/input.cpp";
+    std::ifstream file {path};
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+  }
+
+}  // namespace
+
+TEST(PreallocatedGamepadSource, PreallocationDoesNotPassAnEmptyArrival) {
+  const auto source = read_input_source();
+  ASSERT_FALSE(source.empty()) << "could not read src/input.cpp via POLARIS_SOURCE_DIR";
+
+  const auto preallocate = source.find("void preallocate_gamepad(");
+  ASSERT_NE(preallocate, std::string::npos);
+  const auto body_end = source.find("\n  }", preallocate);
+  ASSERT_NE(body_end, std::string::npos);
+  const auto body = source.substr(preallocate, body_end - preallocate);
+
+  // An empty brace here is the whole defect: type 0 is LI_CTYPE_UNKNOWN and capabilities 0, so
+  // the ladder falls through every auto branch to the Xbox default.
+  EXPECT_EQ(body.find("platf_input, {id, static_cast<std::uint8_t>(controller_number)}, {},"), std::string::npos)
+    << "preallocate_gamepad is passing an empty gamepad_arrival_t again";
+  EXPECT_NE(body.find("client_controller_type"), std::string::npos)
+    << "preallocate_gamepad no longer uses the remembered controller type";
+}
+
+TEST(PreallocatedGamepadSource, ALateArrivalIsRecordedRatherThanOnlyDropped) {
+  const auto source = read_input_source();
+  ASSERT_FALSE(source.empty());
+
+  const auto already = source.find("ControllerNumber already allocated");
+  ASSERT_NE(already, std::string::npos);
+
+  // The record has to happen before the early return, or the client's declared type is lost for
+  // the next session too and the user never gets the pad they asked for.
+  const auto window_start = already > 700 ? already - 700 : 0;
+  const auto window = source.substr(window_start, already - window_start);
+  EXPECT_NE(window.find("update_client_declared_controller_type"), std::string::npos)
+    << "the dropped controller arrival is no longer recorded for the next launch";
+}


### PR DESCRIPTION
## Summary

Closes #671.

- A paired client now remembers the controller type it last declared, next to the display mode
  and bitrate it already carried.
- The pad preallocated before an app launches starts as that type instead of always Xbox One.
- A controller arrival that lands too late to be honoured is recorded for next time rather than
  only dropped.

> **Stacked on #672.** Its base is `polaris/hdr-doctor-finding` because both commits touch
> `stream_stats`. It retargets to master on its own once #672 merges.

Polaris creates the virtual gamepad before the app starts, because a game that enumerates
controllers at startup has to find one there. The client only says which pad it wants once the
stream is up, which is later. That gap was closed by preallocating with an empty arrival
(`input.cpp:275`), so `type` was `LI_CTYPE_UNKNOWN` and `capabilities` were zero, every
auto-detect branch of the ladder at `inputtino_gamepad.cpp:134-148` was unreachable, and the
answer was always the Xbox One default at `:149`. The client's real arrival then landed and was
dropped at `input.cpp:963-965` behind a `debug` line nobody reads.

So on the default `gamepad = auto` a DualSense client got an Xbox pad and lost its touchpad, its
motion sensors and its adaptive triggers, with nothing in a normal log to say why. The
host-global `gamepad = ds5` was the only way out, and it is wrong for everyone else who connects.
Preallocation is gated on `has_launch_commands` alone (`process.cpp:8840`), so this is every Linux
launch that has a command, not only Private Stream.

The pad cannot simply be swapped once the arrival lands. Under strict isolation bubblewrap binds
the device node list when it execs (`inputtino_gamepad_isolation.cpp:566-631`), so a pad destroyed
and re-created after the app started is invisible to it. What is possible is remembering. A device
streaming for the first time still gets Xbox, which is the same as today and the only honest
answer when nothing has been observed; every session after that is right.

The route stays inside the existing layering. `input.cpp` records what the client declared through
`stream_stats`, which it already depends on. `stream.cpp` persists it at teardown, where the client
uuid already lives and where temporary authorizations are already expired. `nvhttp` carries it onto
the launch session from the paired cert, the same way it already carries `device_name`, so
`process.cpp` needs nothing new to reach it.

## Exact candidate

`Commit: adcaaeee`
`Parent: f5ec7315d366d2c7cb9a74908870891bd1b324b0`
`Base: polaris/hdr-doctor-finding`

## Verification

- [x] `ctest -j 8` on the CUDA-off tree: 25 of 25 suites passed.
- [x] `PairingAccessPresetTest.RemembersTheControllerTypeAClientDeclared` covers the store: a
      never-observed device is left alone, a first answer is kept, the same answer again is
      refused so a disconnect does not churn the state file, a changed answer is kept, and an
      unknown uuid is refused.
- [x] Two source guards in `tests/unit/test_preallocated_gamepad_source.cpp`, since creating a
      uinput device is not something every runner can do. They pin that preallocation does not
      pass an empty arrival again, and that the late arrival is recorded before the early return.
- [x] **RED proven, one piece at a time.** Restoring the empty `{}` arrival fails the first guard;
      removing the late-arrival record fails the second; making the store always refuse fails the
      pairing test. Green again when each is restored.

## What is not covered

No hardware run. The type ladder in `inputtino_gamepad.cpp` is not exercised by any test in this
repo today and still is not, so what is proven is that the remembered type is stored, carried onto
the launch session and handed to preallocation, not that a DualSense appears on a second launch.
That wants a device and is the obvious next check.

The first session from any new device still gets an Xbox pad. That is unchanged behaviour rather
than a fix, and a client that never sends an arrival never teaches the host anything.
