### PR TITLE
fix(hdr): believe a client's own display over an uncorrected device record

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -112,6 +112,10 @@ namespace crypto {
     /// pad preallocated before the app launches can be the one it actually asked for.
     /// Zero means never observed, which is what a first session from a new device looks like.
     int controller_type = 0;
+    /// Whether this client reported its own display can do HDR10. A device record's
+    /// hdr_capable is a curated default that is false until somebody edits it; the client
+    /// measured the actual panel, so it outranks the record.
+    bool client_reports_hdr10_display = false;
     std::string display_mode;
     int target_bitrate_kbps = 0;
     std::int64_t paired_at = 0;

--- a/src/launch_profile.cpp
+++ b/src/launch_profile.cpp
@@ -541,10 +541,16 @@ namespace launch_profile {
       result.hdr = false;
       add_field(result.fields, "hdr", false, "capability_validation",
                 "host_encoder_hdr_unsupported", resolved_hdr_locked, true);
-    } else if (result.hdr && device && !device->hdr_capable) {
+    } else if (result.hdr && device && !device->hdr_capable && !request.client_reports_hdr10_display) {
       result.hdr = false;
       add_field(result.fields, "hdr", false, "capability_validation",
                 "paired_device_hdr_unsupported", resolved_hdr_locked, true);
+    } else if (result.hdr && device && !device->hdr_capable) {
+      // The curated record says the device cannot do HDR and the device itself says it can.
+      // hdr_capable defaults to false and stays there until somebody edits the file by hand,
+      // while the client measured its own panel, so the client wins.
+      add_field(result.fields, "hdr", result.hdr, "client_reported_capability",
+                "paired_device_hdr_reported_by_client", resolved_hdr_locked, false);
     } else if (hdr_from_explicit_lock) {
       add_field(result.fields, "hdr", result.hdr,
                 "explicit_launch_request", "requested_hdr_lock", true);

--- a/src/launch_profile.h
+++ b/src/launch_profile.h
@@ -44,6 +44,9 @@ namespace launch_profile {
     bool hdr_locked = false;
     std::optional<bool> host_hdr_capable;
     std::optional<bool> client_profile_hdr;
+    /// The client reported an HDR10-capable display, which outranks an uncorrected
+    /// device record whose hdr_capable has simply never been edited.
+    bool client_reports_hdr10_display = false;
     std::optional<int> color_range;
   };
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -4010,6 +4010,7 @@ namespace nvhttp {
         named_cert_node["last_seen_at"] = named_cert_p->last_seen_at.load(std::memory_order_relaxed);
         named_cert_node["client_family"] = named_cert_p->client_family;
         named_cert_node["controller_type"] = named_cert_p->controller_type;
+        named_cert_node["client_reports_hdr10_display"] = named_cert_p->client_reports_hdr10_display;
         named_cert_node["display_mode"] = named_cert_p->display_mode;
         named_cert_node["target_bitrate_kbps"] = named_cert_p->target_bitrate_kbps;
         named_cert_node["perm"] = static_cast<uint32_t>(named_cert_p->perm);
@@ -4172,6 +4173,7 @@ namespace nvhttp {
           named_cert->last_seen_persisted_at.store(last_seen_at, std::memory_order_relaxed);
           named_cert->client_family = entry.value("client_family", "");
           named_cert->controller_type = entry.value("controller_type", 0);
+          named_cert->client_reports_hdr10_display = entry.value("client_reports_hdr10_display", false);
           named_cert->display_mode = entry.value("display_mode", "");
           named_cert->target_bitrate_kbps = util::get_non_string_json_value<int>(entry, "target_bitrate_kbps", 0);
           named_cert->perm = (PERM)(util::get_non_string_json_value<uint32_t>(entry, "perm", (uint32_t)PERM::_all)) & PERM::_all;
@@ -4218,6 +4220,7 @@ namespace nvhttp {
     clone->cert = source->cert;
     clone->client_family = source->client_family;
     clone->controller_type = source->controller_type;
+    clone->client_reports_hdr10_display = source->client_reports_hdr10_display;
     clone->display_mode = source->display_mode;
     clone->target_bitrate_kbps = source->target_bitrate_kbps;
     clone->paired_at = source->paired_at;
@@ -4431,6 +4434,7 @@ namespace nvhttp {
 
     launch_session->device_name = named_cert_p->name.empty() ? "PolarisDisplay"s : named_cert_p->name;
     launch_session->controller_type = named_cert_p->controller_type;
+    launch_session->client_reports_hdr10_display = named_cert_p->client_reports_hdr10_display;
     launch_session->unique_id = named_cert_p->uuid;
     launch_session->temporary_authorization = named_cert_p->temporary_authorization;
     launch_session->profile_preference = launch_profile::normalize_preset(
@@ -7667,6 +7671,15 @@ namespace nvhttp {
               write_json({{"error", error}}, SimpleWeb::StatusCode::client_error_bad_request);
               return;
             }
+            // The client just told us what its own panel can do. Keep it, so the answer outlives
+            // this process and the next launch does not fall back to an uncorrected record.
+            if (const auto capabilities = body.value("device_capabilities", nlohmann::json::object());
+                capabilities.is_object()) {
+              remember_client_hdr10_display(
+                named_cert_p->uuid,
+                capabilities.value("supports_hdr10_display", false)
+              );
+            }
           }
 
           if (stream_display_mode) {
@@ -10533,6 +10546,36 @@ namespace nvhttp {
     BOOST_LOG(info) << "Remembered controller type ["sv << controller_type
                     << "] for client ["sv << uuid
                     << "]; the pad created before the next launch will match it"sv;
+    return true;
+  }
+
+  bool remember_client_hdr10_display(const std::string_view uuid, const bool supports_hdr10_display) {
+    if (!supports_hdr10_display) {
+      // A client that says no, or says nothing, must not clear a capability already observed.
+      // Nova reports false for an external display it cannot inspect, among other things.
+      return false;
+    }
+    {
+      std::lock_guard lock(client_state_mutex);
+      const auto client = std::find_if(
+        client_root.named_devices.begin(),
+        client_root.named_devices.end(),
+        [&](const crypto::p_named_cert_t &candidate) {
+          return candidate->uuid == uuid;
+        }
+      );
+      if (client == client_root.named_devices.end() ||
+          (*client)->client_reports_hdr10_display) {
+        return false;
+      }
+      (*client)->client_reports_hdr10_display = true;
+      if (!save_state()) {
+        return false;
+      }
+    }
+    BOOST_LOG(info) << "Client ["sv << uuid
+                    << "] reported an HDR10-capable display; it will no longer be refused HDR "
+                       "because of an uncorrected device record"sv;
     return true;
   }
 

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -362,6 +362,12 @@ namespace nvhttp {
   bool remember_client_controller_type(std::string_view uuid, int controller_type);
 
   /**
+   * @brief Remember that a paired client reported an HDR10-capable display.
+   * @return True when the stored value changed and was persisted.
+   */
+  bool remember_client_hdr10_display(std::string_view uuid, bool supports_hdr10_display);
+
+  /**
    * @brief Remove single client.
    * @param uuid The UUID of the client to remove.
    * @examples

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -7439,6 +7439,8 @@ namespace proc {
     preset_request.hdr_requested = launch_session->enable_hdr;
     preset_request.hdr_locked = launch_session->resolved_profile_from_client;
     preset_request.client_profile_hdr = client_profile_hdr;
+    preset_request.client_reports_hdr10_display =
+      launch_session && launch_session->client_reports_hdr10_display;
     preset_request.host_hdr_capable = launch_session->host_hdr_capable;
     if (resolved_optimization.color_range) {
       preset_request.color_range = resolved_optimization.color_range;

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -57,6 +57,8 @@ namespace rtsp_stream {
     /// Controller type this client declared last time it streamed, so the pad created
     /// before the app starts can match. Zero when nothing has been observed yet.
     int controller_type = 0;
+    /// Whether this client has reported an HDR10-capable display of its own.
+    bool client_reports_hdr10_display = false;
     // Explicit deterministic launch preset. This is never populated from
     // Doctor history or AI output.
     std::string profile_preference = "auto";

--- a/tests/unit/test_http_pairing.cpp
+++ b/tests/unit/test_http_pairing.cpp
@@ -685,6 +685,24 @@ TEST_F(PairingAccessPresetTest, RemembersTheControllerTypeAClientDeclared) {
   EXPECT_FALSE(remember_client_controller_type(uuid_util::uuid_t::generate().string(), LI_CTYPE_PS));
 }
 
+TEST_F(PairingAccessPresetTest, RemembersThatAClientReportedAnHdr10Display) {
+  auto client = std::make_shared<crypto::named_cert_t>();
+  client->cert = PUBLIC_CERT;
+  client->name = "hdr-memory";
+  client->uuid = uuid_util::uuid_t::generate().string();
+  ASSERT_TRUE(add_authorized_client_for_tests(client));
+
+  EXPECT_TRUE(remember_client_hdr10_display(client->uuid, true));
+  // Writing the same answer again must not churn the state file on every report.
+  EXPECT_FALSE(remember_client_hdr10_display(client->uuid, true));
+  // A later false must not erase what was already observed: Nova reports false for an external
+  // display it cannot inspect, and that is not evidence the panel lost HDR.
+  EXPECT_FALSE(remember_client_hdr10_display(client->uuid, false));
+  EXPECT_FALSE(remember_client_hdr10_display(client->uuid, true));
+
+  EXPECT_FALSE(remember_client_hdr10_display(uuid_util::uuid_t::generate().string(), true));
+}
+
 TEST_F(PairingAccessPresetTest, CanonicallyEquivalentCertificateReplacesAuthorization) {
   auto original = std::make_shared<crypto::named_cert_t>();
   original->cert = PUBLIC_CERT;

--- a/tests/unit/test_launch_profile.cpp
+++ b/tests/unit/test_launch_profile.cpp
@@ -197,6 +197,49 @@ TEST(LaunchProfileTests, HardHdrCapabilityNormalizesAnExplicitLockLast) {
   EXPECT_TRUE(field.at("normalized"));
 }
 
+TEST(LaunchProfileTests, AClientReportingHdr10OutranksAnUncorrectedDeviceRecord) {
+  // hdr_capable defaults to false in device_db and stays there until somebody edits the file by
+  // hand, so it is not evidence that a device cannot do HDR. The client measured its own panel.
+  // A stale default silently refusing HDR, with no log line naming it, is what made this
+  // impossible to diagnose from the outside.
+  launch_profile::request_t request;
+  request.device_name = "RetroidPocket6";
+  request.preset = "quality";
+  request.requested_width = 1920;
+  request.requested_height = 1080;
+  request.requested_fps = 120000;
+  request.hdr_requested = true;
+  request.hdr_locked = true;
+  request.client_reports_hdr10_display = true;
+
+  const auto resolved = launch_profile::resolve(request);
+
+  EXPECT_TRUE(resolved.hdr);
+  const auto &field = resolved.fields.at("hdr");
+  EXPECT_EQ(field.at("source"), "client_reported_capability");
+  EXPECT_EQ(field.at("reason_code"), "paired_device_hdr_reported_by_client");
+  // Not a normalization: nothing was taken away from what the client asked for.
+  EXPECT_FALSE(field.at("normalized").get<bool>());
+}
+
+TEST(LaunchProfileTests, ADeviceRecordStillRefusesHdrWhenTheClientHasNotReported) {
+  // The override must depend on the client actually having said so, not on the field existing.
+  launch_profile::request_t request;
+  request.device_name = "RetroidPocket6";
+  request.preset = "quality";
+  request.requested_width = 1920;
+  request.requested_height = 1080;
+  request.requested_fps = 120000;
+  request.hdr_requested = true;
+  request.hdr_locked = true;
+  request.client_reports_hdr10_display = false;
+
+  const auto resolved = launch_profile::resolve(request);
+
+  EXPECT_FALSE(resolved.hdr);
+  EXPECT_EQ(resolved.fields.at("hdr").at("reason_code"), "paired_device_hdr_unsupported");
+}
+
 TEST(LaunchProfileTests, MeteredBitrateLockWinsOverStabilityPreset) {
   launch_profile::request_t request;
   request.device_name = "RetroidPocket6";


### PR DESCRIPTION
## Summary

- A client that reports an HDR10-capable display is remembered on its paired record.
- That report outranks a `device_db` entry whose `hdr_capable` has never been corrected.
- A device that has reported nothing is refused exactly as before.

`device_db`'s `hdr_capable` defaults to false (`device_db.cpp:270`, `device_db.h:28`) and stays
false until somebody edits the file by hand. `launch_profile.cpp:544` treats it as a hard
capability check anyway, so a curated default nobody corrected silently refuses HDR for a device
whose panel can do it. The refusal surfaces nowhere a user looks, only as a `reason_code` inside a
resolved profile. On this host both paired devices carry `hdr_capable: false`, and one of them is a
Retroid Pocket 6 whose panel reports `mSupportedHdrTypes=[2,3]` at 420 nits.

Meanwhile the client had already told us. Nova sends `supports_hdr10_display` in the
`device_capabilities` blob it posts to `/polaris/v1/client-settings`
(`StreamSyncManager.kt:415`), Polaris stores the whole blob in the client sync record
(`nvhttp.cpp:1215-1265`), surfaces it in the status fields (`:1455-1460`, `:1513`), and never once
consults it when deciding whether the device can do HDR.

So consult it. The capability is persisted on `named_cert_t` beside the controller type and display
mode already kept there, rather than left in the in-memory sync map, so it survives a restart and
the first launch afterwards does not fall back to the uncorrected record.

**The memory only grows.** A client reporting false does not clear a capability already observed.
Nova reports false for an external display it cannot inspect, among other cases, and that is not
evidence the panel lost HDR.

**This does not make HDR work.** On a wlroots capture path nothing can, and #672 now says so. What
it does is stop a stale default from answering a question the device itself had already answered,
so the blocker a user is shown is the real one.

## Exact candidate

`Commit: 7d6f1db27eca503be201d97de75c5d2e8953c81e`
`Tree: 8acfcc7b7cf145923847ec96c28d7e921b46d6b3`
`Parent: 1d3acef1de90dca35b5ed496262ac2b056a9459a`
`Base: 1d3acef1de90dca35b5ed496262ac2b056a9459a`

## Verification

- [x] `ctest -j 8` on the CUDA-off tree: 26 of 26 suites passed.
- [x] `LaunchProfileTests.AClientReportingHdr10OutranksAnUncorrectedDeviceRecord` pins the override
      and its provenance, including that it is *not* marked normalized, since nothing was taken
      away from what the client asked for.
- [x] `LaunchProfileTests.ADeviceRecordStillRefusesHdrWhenTheClientHasNotReported` pins that the
      override depends on the client having actually reported, not on the field existing.
- [x] `PairingAccessPresetTest.RemembersThatAClientReportedAnHdr10Display` covers the store: first
      report kept, same report again refused so a disconnect does not churn the state file, a later
      false does not erase it, unknown uuid refused.
- [x] **RED proven.** Dropping the `client_reports_hdr10_display` term from the veto fails the
      override test; letting the store rewrite an unchanged value fails the persistence test. Green
      again when each is restored.

## What is not covered

No live session. What is proven is that a reported capability is stored, carried onto the launch
session and consulted by the resolver, not that a real Nova report end to end flips a real launch.
That wants the handheld, and the host it would run on is currently in use by another session.

The reverse case is deliberately unhandled: a device whose record says `hdr_capable: true` while
the client reports no HDR display is still allowed through, because the resolver has always trusted
the record in that direction and narrowing it is a behaviour change this PR should not smuggle in.
